### PR TITLE
feat(pacquet): support the changed-packages filter selector (`[<since>]`)

### DIFF
--- a/.changeset/changed-packages-filter-hardening.md
+++ b/.changeset/changed-packages-filter-hardening.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.projects-filter": patch
+"pnpm": patch
+---
+
+The changed-packages filter (`--filter "...[<since>]"`) no longer allows an option-like `<since>` value (such as `--output=<path>`) to be interpreted as a git option — git now rejects it as a bad revision. The repository root is also resolved to the nearest `.git` entry, so the filter works in a git worktree checked out inside another repository's tree.

--- a/.changeset/pacquet-changed-packages-filter.md
+++ b/.changeset/pacquet-changed-packages-filter.md
@@ -1,5 +1,0 @@
----
-"pnpm": patch
----
-
-The native pnpm CLI now supports the changed-packages filter selector (`--filter "...[<since>]"`), selecting the workspace projects whose files changed since the given git ref. The `testPattern` and `changedFilesIgnorePattern` settings (and the `--test-pattern` / `--changed-files-ignore-pattern` flags) are honored, matching the TypeScript CLI.

--- a/.changeset/pacquet-changed-packages-filter.md
+++ b/.changeset/pacquet-changed-packages-filter.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+The native pnpm CLI now supports the changed-packages filter selector (`--filter "...[<since>]"`), selecting the workspace projects whose files changed since the given git ref. The `testPattern` and `changedFilesIgnorePattern` settings (and the `--test-pattern` / `--changed-files-ignore-pattern` flags) are honored, matching the TypeScript CLI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5087,6 +5087,8 @@ dependencies = [
  "pacquet-testing-utils",
  "pacquet-workspace-projects-graph",
  "pathdiff",
+ "tempfile",
+ "wax",
 ]
 
 [[package]]

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -144,6 +144,20 @@ pub struct CliArgs {
     #[clap(long = "filter-prod", global = true)]
     pub filter_prod: Vec<String>,
 
+    /// `--test-pattern` glob patterns naming test files, consumed by
+    /// the `[<since>]` changed-packages `--filter` selector. Overrides
+    /// [`pacquet_config::Config::test_pattern`] when given.
+    #[clap(long = "test-pattern", global = true)]
+    pub test_pattern: Vec<String>,
+
+    /// `--changed-files-ignore-pattern` glob patterns of changed files
+    /// the `[<since>]` changed-packages `--filter` selector ignores.
+    /// Overrides
+    /// [`pacquet_config::Config::changed_files_ignore_pattern`] when
+    /// given.
+    #[clap(long = "changed-files-ignore-pattern", global = true)]
+    pub changed_files_ignore_pattern: Vec<String>,
+
     /// Keep recursive workspace projects sorted topologically.
     #[clap(long = "sort", global = true, overrides_with = "no_sort")]
     pub sort: bool,

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -458,6 +458,9 @@ fn select_project(config: &Config, workspace_dir: &Path) -> miette::Result<Selec
             prefix: workspace_dir.to_path_buf(),
             link_workspace_packages,
             use_glob_dir_filtering: false,
+            workspace_dir: workspace_dir.to_path_buf(),
+            test_pattern: config.test_pattern.clone(),
+            changed_files_ignore_pattern: config.changed_files_ignore_pattern.clone(),
         },
     )
     .map_err(miette::Report::new)

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -128,6 +128,8 @@ impl CliArgs {
             reporter,
             filter,
             filter_prod,
+            test_pattern,
+            changed_files_ignore_pattern,
             version: _,
             color: _,
             yes: _,
@@ -205,6 +207,15 @@ impl CliArgs {
                     cfg.recursive = recursive;
                     cfg.filter.clone_from(&filter);
                     cfg.filter_prod.clone_from(&filter_prod);
+                    // Unlike the CLI-only selectors above, these two are
+                    // genuine config keys — the flag overrides yaml / env
+                    // only when actually given.
+                    if !test_pattern.is_empty() {
+                        cfg.test_pattern.clone_from(&test_pattern);
+                    }
+                    if !changed_files_ignore_pattern.is_empty() {
+                        cfg.changed_files_ignore_pattern.clone_from(&changed_files_ignore_pattern);
+                    }
                     if let Some(workspace_concurrency) = workspace_concurrency {
                         cfg.workspace_concurrency =
                             pacquet_config::resolve_child_concurrency(Some(workspace_concurrency));

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -306,12 +306,26 @@ pub fn select_recursive_projects<'a>(
     };
 
     let root_in_prod = !config.filter_prod.is_empty();
+    let walk_opts = FilterWorkspaceProjectsOptions {
+        // Glob dir filtering (the default, the inverse of
+        // `legacyDirFiltering`) is load-bearing for the
+        // `!{<workspace-root>}` augmentation: glob matching excludes only
+        // the project whose dir equals the workspace root, whereas the
+        // legacy subtree match would also drop every nested package.
+        // `legacyDirFiltering` is not surfaced by `Config` yet, so this
+        // stays at the default.
+        use_glob_dir_filtering: true,
+        workspace_dir: config.workspace_dir.as_deref().unwrap_or(prefix).to_path_buf(),
+        test_pattern: config.test_pattern.clone(),
+        changed_files_ignore_pattern: config.changed_files_ignore_pattern.clone(),
+    };
     let regular_selected = filter_against(
         &all,
         &config.filter,
         root_exclusion.as_deref().filter(|_| !root_in_prod),
         false,
         prefix,
+        &walk_opts,
     )?;
     let prod_selected = match &prod_all {
         Some(prod_all) => filter_against(
@@ -320,6 +334,7 @@ pub fn select_recursive_projects<'a>(
             root_exclusion.as_deref().filter(|_| root_in_prod),
             true,
             prefix,
+            &walk_opts,
         )?,
         None => Vec::new(),
     };
@@ -375,6 +390,7 @@ fn filter_against<Pkg: BaseProject>(
     root_exclusion: Option<&str>,
     follow_prod_deps_only: bool,
     prefix: &Path,
+    walk_opts: &FilterWorkspaceProjectsOptions,
 ) -> miette::Result<Vec<PathBuf>> {
     if filters.is_empty() && root_exclusion.is_none() {
         return Ok(Vec::new());
@@ -389,19 +405,9 @@ fn filter_against<Pkg: BaseProject>(
             selector
         })
         .collect();
-    // Glob dir filtering (the default, the inverse of `legacyDirFiltering`) is
-    // load-bearing for the `!{<workspace-root>}` augmentation: glob matching
-    // excludes only the project whose dir equals the workspace root, whereas
-    // the legacy subtree match would also drop every nested package.
-    // `legacyDirFiltering` is not surfaced by `Config` yet, so this stays at
-    // the default.
-    let selected = filter_workspace_projects(
-        graph,
-        &selectors,
-        &FilterWorkspaceProjectsOptions { use_glob_dir_filtering: true },
-    )
-    .map_err(miette::Report::new)
-    .wrap_err("filtering workspace projects")?;
+    let selected = filter_workspace_projects(graph, &selectors, walk_opts)
+        .map_err(miette::Report::new)
+        .wrap_err("filtering workspace projects")?;
     Ok(selected.selected_projects)
 }
 

--- a/pnpm/crates/cli/tests/exec_recursive.rs
+++ b/pnpm/crates/cli/tests/exec_recursive.rs
@@ -133,33 +133,50 @@ fn filter_without_recursive_flag_enters_recursive_exec() {
     drop(root);
 }
 
-/// A `[<since>]` changed-packages selector is not supported by pacquet's
-/// filter engine yet, so a recursive `exec` surfaces the
-/// `UnsupportedDiffSelector` error instead of swallowing it. This
-/// exercises the error-propagation (`?`) out of `select_recursive_projects`.
+/// A `[<since>]` changed-packages selector scopes a recursive `exec` to
+/// the projects the git diff touches.
 #[test]
-fn recursive_exec_diff_selector_is_unsupported() {
+fn recursive_exec_diff_selector_selects_changed_projects() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    write_workspace(&workspace, &["project-1"]);
+    write_workspace(&workspace, &["project-1", "project-2"]);
+    let git = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&workspace)
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    };
+    git(&["init", "--initial-branch=main"]);
+    git(&["config", "user.email", "x@y.z"]);
+    git(&["config", "user.name", "xyz"]);
+    git(&["add", "."]);
+    git(&["commit", "-m", "base", "--no-gpg-sign"]);
+    fs::write(workspace.join("project-1").join("changed.js"), "").expect("write changed file");
+    git(&["add", "."]);
+    git(&["commit", "-m", "change project-1", "--no-gpg-sign"]);
 
-    let output = pacquet
+    pacquet
         .with_arg("-r")
         .with_arg("--filter")
-        .with_arg("[main]")
+        .with_arg("[HEAD~1]")
         .with_arg("exec")
         .with_arg("touch")
         .with_arg("ran.txt")
-        .output()
-        .expect("spawn pacquet");
-    assert!(!output.status.success(), "a [<since>] diff selector is unsupported and must fail");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+        .assert()
+        .success();
+
     assert!(
-        stderr.contains("Changed-package filter selectors"),
-        "stderr should explain the diff selector is unsupported, got: {stderr}",
+        workspace.join("project-1").join("ran.txt").exists(),
+        "the changed project-1 should run the command",
     );
     assert!(
-        !workspace.join("project-1").join("ran.txt").exists(),
-        "exec must reject the selector before dispatching the command, so no marker is written",
+        !workspace.join("project-2").join("ran.txt").exists(),
+        "the unchanged project-2 must stay outside the selection",
     );
 
     drop(root);

--- a/pnpm/crates/cli/tests/list.rs
+++ b/pnpm/crates/cli/tests/list.rs
@@ -1,3 +1,4 @@
+use assert_cmd::cargo::CommandCargoExt;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;
 use serde_json::{Value, json};
@@ -92,6 +93,103 @@ fn recursive_list_depth_minus_one_json_keeps_project_only_output_with_package_pa
     assert_eq!(
         names,
         BTreeSet::from(["project-1".to_string(), "project-2".to_string(), "root".to_string()]),
+    );
+
+    drop(root);
+}
+
+/// Port of upstream's `changedFilesIgnorePattern is respected`
+/// (`pnpm/test/monorepo/index.ts`): files matching the
+/// `changedFilesIgnorePattern` workspace setting don't count as changes
+/// for a `[<since>]` filter, and an empty `--changed-files-ignore-pattern=`
+/// CLI override disables the yaml patterns.
+#[test]
+fn changed_files_ignore_pattern_is_respected() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let projects = [
+        "project-1-no-changes",
+        "project-2-change-is-never-ignored",
+        "project-3-ignored-by-pattern",
+        "project-4-ignored-by-pattern",
+        "project-5-ignored-by-pattern",
+    ];
+    for name in projects {
+        let dir = workspace.join(name);
+        fs::create_dir_all(&dir).expect("create project dir");
+        fs::write(
+            dir.join("package.json"),
+            json!({ "name": name, "version": "1.0.0" }).to_string(),
+        )
+        .expect("write package.json");
+    }
+    let write_workspace_yaml = |extra: &str| {
+        fs::write(workspace.join("pnpm-workspace.yaml"), format!("packages:\n  - '*'\n{extra}"))
+            .expect("write pnpm-workspace.yaml");
+    };
+    write_workspace_yaml("");
+
+    let git = |args: &[&str]| {
+        let output =
+            Command::new("git").args(args).current_dir(&workspace).output().expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    };
+    let remote = root.path().join("remote");
+    fs::create_dir_all(&remote).expect("create remote dir");
+    git(&["init", "--initial-branch=main"]);
+    git(&["config", "user.email", "x@y.z"]);
+    git(&["config", "user.name", "xyz"]);
+    git(&["init", "--bare", &remote.to_string_lossy()]);
+    git(&["add", "."]);
+    git(&["commit", "-m", "init", "--no-gpg-sign"]);
+    git(&["remote", "add", "origin", &remote.to_string_lossy()]);
+    git(&["push", "-u", "origin", "main"]);
+
+    fs::write(workspace.join("project-2-change-is-never-ignored").join("index.js"), "")
+        .expect("write changed file");
+    fs::write(workspace.join("project-3-ignored-by-pattern").join("index.spec.js"), "")
+        .expect("write changed file");
+    fs::write(workspace.join("project-3-ignored-by-pattern").join("README.md"), "")
+        .expect("write changed file");
+    let buildscript_dir = workspace.join("project-4-ignored-by-pattern").join("a/b/c");
+    fs::create_dir_all(&buildscript_dir).expect("create nested dirs");
+    fs::write(buildscript_dir.join("buildscript.js"), "").expect("write changed file");
+    let cache_dir = workspace.join("project-5-ignored-by-pattern").join("cache/a/b");
+    fs::create_dir_all(&cache_dir).expect("create nested dirs");
+    fs::write(cache_dir.join("index.js"), "").expect("write changed file");
+    git(&["add", "."]);
+    git(&["commit", "-m", "changes", "--no-gpg-sign"]);
+
+    // Left uncommitted, like upstream: `git diff <since>` also sees
+    // working-tree changes to tracked files.
+    write_workspace_yaml(
+        "changedFilesIgnorePattern:\n  - '**/{*.spec.js,*.md}'\n  - '**/buildscript.js'\n  - '**/cache/**'\n",
+    );
+
+    let changed_project_names = |extra_args: &[&str]| {
+        let pacquet = Command::cargo_bin("pacquet")
+            .expect("find the pacquet binary")
+            .with_current_dir(&workspace);
+        recursive_project_names(pacquet, &[&["--filter", "[origin/main]"], extra_args].concat())
+    };
+
+    assert_eq!(
+        changed_project_names(&[]),
+        BTreeSet::from(["project-2-change-is-never-ignored".to_string()]),
+    );
+
+    // The empty CLI value overrides the yaml patterns with "no patterns".
+    assert_eq!(
+        changed_project_names(&["--changed-files-ignore-pattern="]),
+        BTreeSet::from([
+            "project-2-change-is-never-ignored".to_string(),
+            "project-3-ignored-by-pattern".to_string(),
+            "project-4-ignored-by-pattern".to_string(),
+            "project-5-ignored-by-pattern".to_string(),
+        ]),
     );
 
     drop(root);

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -640,32 +640,55 @@ fn recursive_run_filter_prod_follows_production_deps_only() {
     drop(root);
 }
 
-/// A `[<since>]` changed-packages selector is not supported by pacquet's
-/// filter engine yet, so a recursive `run` surfaces the
-/// `UnsupportedDiffSelector` error instead of swallowing it. This
-/// exercises the error-propagation (`?`) out of `select_recursive_projects`.
+/// A `[<since>]` changed-packages selector scopes a recursive `run` to
+/// the projects the git diff touches.
 #[test]
-fn recursive_run_diff_selector_is_unsupported() {
+fn recursive_run_diff_selector_selects_changed_projects() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    write_workspace(&workspace, &[("project-1", build_writes_marker("project-1"))]);
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", build_writes_marker("project-2")),
+        ],
+    );
+    let git = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&workspace)
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    };
+    git(&["init", "--initial-branch=main"]);
+    git(&["config", "user.email", "x@y.z"]);
+    git(&["config", "user.name", "xyz"]);
+    git(&["add", "."]);
+    git(&["commit", "-m", "base", "--no-gpg-sign"]);
+    fs::write(workspace.join("project-1").join("changed.js"), "").expect("write changed file");
+    git(&["add", "."]);
+    git(&["commit", "-m", "change project-1", "--no-gpg-sign"]);
 
-    let output = pacquet
+    pacquet
         .with_arg("-r")
         .with_arg("--filter")
-        .with_arg("[main]")
+        .with_arg("[HEAD~1]")
         .with_arg("run")
         .with_arg("build")
-        .output()
-        .expect("spawn pacquet");
-    assert!(!output.status.success(), "a [<since>] diff selector is unsupported and must fail");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+        .assert()
+        .success();
+
     assert!(
-        stderr.contains("Changed-package filter selectors"),
-        "stderr should explain the diff selector is unsupported, got: {stderr}",
+        workspace.join("project-1").join("ran.txt").exists(),
+        "the changed project-1 should run the build script",
     );
     assert!(
-        !workspace.join("project-1").join("ran.txt").exists(),
-        "run must reject the selector before invoking the build script, so no marker is written",
+        !workspace.join("project-2").join("ran.txt").exists(),
+        "the unchanged project-2 must stay outside the selection",
     );
 
     drop(root);

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -1276,3 +1276,86 @@ fn recursive_run_without_script_name_errors_with_script_name_is_required() {
 
     drop(root);
 }
+
+/// Port of upstream's `testPattern is respected by the test script`
+/// (`pnpm/test/monorepo/index.ts`): with `testPattern` in
+/// `pnpm-workspace.yaml`, a `...[<since>]` filter selects a project
+/// whose only changes match the pattern (project-2) without its
+/// dependents (project-1, project-3), while a source-changed project
+/// (project-4) is selected normally.
+#[test]
+fn test_pattern_from_workspace_yaml_is_respected_by_the_test_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let test_writes_marker = |name: &str, dependencies: Value| {
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "dependencies": dependencies,
+            "scripts": { "test": "touch tested.txt" },
+        })
+    };
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "project-1",
+                test_writes_marker(
+                    "project-1",
+                    json!({ "project-2": "workspace:*", "project-3": "workspace:*" }),
+                ),
+            ),
+            ("project-2", test_writes_marker("project-2", json!({}))),
+            ("project-3", test_writes_marker("project-3", json!({ "project-2": "workspace:*" }))),
+            ("project-4", test_writes_marker("project-4", json!({}))),
+        ],
+    );
+
+    let git = |args: &[&str]| {
+        let output = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&workspace)
+            .output()
+            .expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    };
+    let remote = root.path().join("remote");
+    fs::create_dir_all(&remote).expect("create remote dir");
+    git(&["init", "--initial-branch=main"]);
+    git(&["config", "user.email", "x@y.z"]);
+    git(&["config", "user.name", "xyz"]);
+    git(&["init", "--bare", &remote.to_string_lossy()]);
+    git(&["add", "."]);
+    git(&["commit", "-m", "init", "--no-gpg-sign"]);
+    git(&["remote", "add", "origin", &remote.to_string_lossy()]);
+    git(&["push", "-u", "origin", "main"]);
+
+    fs::write(workspace.join("project-2").join("file.js"), "").expect("write changed file");
+    fs::write(workspace.join("project-4").join("different-pattern.js"), "")
+        .expect("write changed file");
+    let workspace_yaml = "packages:\n  - project-1\n  - project-2\n  - project-3\n  - project-4\ntestPattern:\n  - '*/file.js'\n";
+    fs::write(workspace.join("pnpm-workspace.yaml"), workspace_yaml)
+        .expect("write pnpm-workspace.yaml");
+    git(&["add", "."]);
+    git(&["commit", "-m", "changes", "--no-gpg-sign"]);
+
+    pacquet.with_arg("--filter").with_arg("...[origin/main]").with_arg("test").assert().success();
+
+    for name in ["project-2", "project-4"] {
+        assert!(
+            workspace.join(name).join("tested.txt").exists(),
+            "{name} changed, so its test script should run",
+        );
+    }
+    for name in ["project-1", "project-3"] {
+        assert!(
+            !workspace.join(name).join("tested.txt").exists(),
+            "{name} depends on project-2 whose only change matches testPattern, so it must not run",
+        );
+    }
+
+    drop(root);
+}

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -185,6 +185,8 @@ impl WorkspaceSettings {
         json_field!(child_concurrency, "CHILD_CONCURRENCY");
         json_field!(workspace_concurrency, "WORKSPACE_CONCURRENCY");
         json_field!(git_shallow_hosts, "GIT_SHALLOW_HOSTS");
+        json_field!(test_pattern, "TEST_PATTERN");
+        json_field!(changed_files_ignore_pattern, "CHANGED_FILES_IGNORE_PATTERN");
         json_field!(supported_architectures, "SUPPORTED_ARCHITECTURES");
         json_field!(ignored_optional_dependencies, "IGNORED_OPTIONAL_DEPENDENCIES");
         json_field!(overrides, "OVERRIDES");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1199,6 +1199,20 @@ pub struct Config {
     /// dependency walk runs. A CLI-only array.
     pub filter_prod: Vec<String>,
 
+    /// `testPattern` from `pnpm-workspace.yaml` /
+    /// `PNPM_CONFIG_TEST_PATTERN`, overridable by the `--test-pattern`
+    /// CLI flag. Glob patterns naming test files: when a `[<since>]`
+    /// changed-packages filter selects a project whose changed files
+    /// all match, the project is selected without its dependents.
+    pub test_pattern: Vec<String>,
+
+    /// `changedFilesIgnorePattern` from `pnpm-workspace.yaml` /
+    /// `PNPM_CONFIG_CHANGED_FILES_IGNORE_PATTERN`, overridable by the
+    /// `--changed-files-ignore-pattern` CLI flag. Glob patterns of
+    /// changed files a `[<since>]` changed-packages filter ignores
+    /// when mapping the git diff to changed projects.
+    pub changed_files_ignore_pattern: Vec<String>,
+
     /// Git host names where pacquet should clone via `git init` +
     /// `git remote add` + `git fetch --depth 1 origin <commit>` instead
     /// of a full `git clone`. Saves bandwidth and disk when the remote

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -306,6 +306,14 @@ pub struct WorkspaceSettings {
     /// than merging.
     pub git_shallow_hosts: Option<Vec<String>>,
 
+    /// `testPattern` from `pnpm-workspace.yaml` — see
+    /// [`Config::test_pattern`].
+    pub test_pattern: Option<Vec<String>>,
+
+    /// `changedFilesIgnorePattern` from `pnpm-workspace.yaml` — see
+    /// [`Config::changed_files_ignore_pattern`].
+    pub changed_files_ignore_pattern: Option<Vec<String>>,
+
     /// `supportedArchitectures` from `pnpm-workspace.yaml`. Drives the
     /// optional-dependency platform check at install time: a
     /// `name: ['darwin'], cpu: ['arm64']` setting tells pacquet to
@@ -605,6 +613,8 @@ impl WorkspaceSettings {
         self.ignored_optional_dependencies = None;
         self.overrides = None;
         self.package_extensions = None;
+        self.test_pattern = None;
+        self.changed_files_ignore_pattern = None;
     }
 
     /// Walk up from `start_dir` looking for a readable `pnpm-workspace.yaml`.
@@ -736,6 +746,7 @@ impl WorkspaceSettings {
             network_concurrency, fetch_timeout, user_agent,
             enable_global_virtual_store,
             git_shallow_hosts,
+            test_pattern, changed_files_ignore_pattern,
             resolution_mode, catalog_mode, registry_supports_time_field,
             allowed_deprecated_versions, update_config, peer_dependency_rules,
             enable_pre_post_scripts, dlx_cache_max_age,

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -538,6 +538,46 @@ configDependencies:
     );
 }
 
+/// Port of upstream's `respects testPattern` / `respects
+/// changedFilesIgnorePattern` config tests: both settings come from
+/// `pnpm-workspace.yaml` and default to unset (pacquet: an empty list).
+#[test]
+fn parses_test_pattern_and_changed_files_ignore_pattern_from_yaml_and_applies() {
+    let yaml = r"
+testPattern:
+  - '*.spec.js'
+  - '*.spec.ts'
+changedFilesIgnorePattern:
+  - .github/**
+  - '**/README.md'
+";
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    let mut config = Config::new();
+    assert!(config.test_pattern.is_empty());
+    assert!(config.changed_files_ignore_pattern.is_empty());
+
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+
+    assert_eq!(config.test_pattern, ["*.spec.js", "*.spec.ts"]);
+    assert_eq!(config.changed_files_ignore_pattern, [".github/**", "**/README.md"]);
+}
+
+/// `testPattern` / `changedFilesIgnorePattern` cannot be set from the
+/// global `config.yaml` — pnpm lists both in its excluded keys.
+#[test]
+fn test_pattern_and_changed_files_ignore_pattern_cleared_as_workspace_only_fields() {
+    let yaml = r"
+testPattern:
+  - '*.spec.js'
+changedFilesIgnorePattern:
+  - '**/README.md'
+";
+    let mut settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    settings.clear_workspace_only_fields();
+    assert!(settings.test_pattern.is_none());
+    assert!(settings.changed_files_ignore_pattern.is_none());
+}
+
 /// `configDependencies` is workspace-only: it must not be honored from
 /// the global `config.yaml`, matching pnpm's `isConfigFileKey` filter.
 #[test]

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -113,6 +113,8 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         recursive: false,
         filter: Vec::new(),
         filter_prod: Vec::new(),
+        test_pattern: Vec::new(),
+        changed_files_ignore_pattern: Vec::new(),
         git_shallow_hosts: pacquet_config::default_git_shallow_hosts(),
         supported_architectures: None,
         ignored_optional_dependencies: None,

--- a/pnpm/crates/workspace-projects-filter/Cargo.toml
+++ b/pnpm/crates/workspace-projects-filter/Cargo.toml
@@ -18,9 +18,11 @@ derive_more = { workspace = true }
 indexmap    = { workspace = true }
 miette      = { workspace = true }
 pathdiff    = { workspace = true }
+wax         = { workspace = true }
 
 [dev-dependencies]
 pacquet-testing-utils = { workspace = true }
+tempfile              = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/workspace-projects-filter/src/filter.rs
+++ b/pnpm/crates/workspace-projects-filter/src/filter.rs
@@ -1,4 +1,5 @@
 use crate::{
+    get_changed_projects::{GetChangedProjectsOptions, get_changed_projects},
     glob,
     parse_project_selector::{ProjectSelector, parse_project_selector},
 };
@@ -33,11 +34,21 @@ pub struct FilteredProjects {
 }
 
 /// Options for [`filter_workspace_projects`].
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct FilterWorkspaceProjectsOptions {
     /// Match directory selectors with glob semantics (`{packages/*}`)
     /// rather than the default subdirectory check.
     pub use_glob_dir_filtering: bool,
+    /// Directory a `[<since>]` selector's git diff runs in when the
+    /// selector has no `{dir}` part — normally the workspace root.
+    pub workspace_dir: PathBuf,
+    /// `testPattern`: glob patterns naming test files. A `[<since>]`
+    /// selector selects a project whose changed files all match these
+    /// patterns without the project's dependents.
+    pub test_pattern: Vec<String>,
+    /// `changedFilesIgnorePattern`: glob patterns of changed files a
+    /// `[<since>]` selector ignores.
+    pub changed_files_ignore_pattern: Vec<String>,
 }
 
 /// Options for [`filter_projects`] / [`filter_projects_by_selector_objects`].
@@ -49,21 +60,34 @@ pub struct FilterProjectsOptions {
     /// [`create_projects_graph()`].
     pub link_workspace_packages: Option<bool>,
     pub use_glob_dir_filtering: bool,
+    /// See [`FilterWorkspaceProjectsOptions::workspace_dir`].
+    pub workspace_dir: PathBuf,
+    /// See [`FilterWorkspaceProjectsOptions::test_pattern`].
+    pub test_pattern: Vec<String>,
+    /// See [`FilterWorkspaceProjectsOptions::changed_files_ignore_pattern`].
+    pub changed_files_ignore_pattern: Vec<String>,
 }
 
 /// Error type of the filter functions.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum FilterError {
-    /// A `[<since>]` changed-packages selector was supplied. Resolving
-    /// it needs the git-diff project infrastructure pacquet has not
-    /// ported yet; the selector parses (so `parse_project_selector`
-    /// fills [`ProjectSelector::diff`]) but cannot be evaluated.
-    #[display(
-        "Changed-package filter selectors (`[<since>]`) are not supported yet: pacquet has not ported the git-diff project selection."
-    )]
-    #[diagnostic(code(pacquet_workspace_projects_filter::unsupported_diff_selector))]
-    UnsupportedDiffSelector,
+    /// The `git diff` behind a `[<since>]` changed-packages selector
+    /// failed — unknown revision, not a git repository, or git could
+    /// not be spawned. Carries git's stderr under pnpm's
+    /// `ERR_PNPM_FILTER_CHANGED` code.
+    #[display("Filtering by changed packages failed. {stderr}")]
+    #[diagnostic(code(ERR_PNPM_FILTER_CHANGED))]
+    FilterChanged {
+        #[error(not(source))]
+        stderr: String,
+    },
+
+    /// A `testPattern` / `changedFilesIgnorePattern` glob did not
+    /// compile.
+    #[display("Invalid pattern {pattern:?}: {message}")]
+    #[diagnostic(code(pacquet_workspace_projects_filter::invalid_pattern))]
+    InvalidPattern { pattern: String, message: String },
 
     /// A selector resolved to neither a name pattern, a directory, nor a
     /// diff. The message includes the offending selector so CLI input is
@@ -97,13 +121,19 @@ where
             unmatched_filters: Vec::new(),
         }
     } else {
-        filter_graph(projects_graph, *opts, &include_selectors)?
+        filter_graph(projects_graph, opts, &include_selectors)?
     };
-    let exclude = filter_graph(projects_graph, *opts, &exclude_selectors)?;
+    let exclude = filter_graph(projects_graph, opts, &exclude_selectors)?;
 
     let excluded: IndexSet<&PathBuf> = exclude.selected.iter().collect();
-    let selected_projects: Vec<PathBuf> =
-        include.selected.into_iter().filter(|dir| !excluded.contains(dir)).collect();
+    // Keep graph members only: a `[<since>]` selector can surface a
+    // changed directory that no workspace project contains (upstream
+    // drops those the same way, via its final `pick`).
+    let selected_projects: Vec<PathBuf> = include
+        .selected
+        .into_iter()
+        .filter(|dir| !excluded.contains(dir) && projects_graph.contains_key(dir))
+        .collect();
     let mut unmatched_filters = include.unmatched_filters;
     unmatched_filters.extend(exclude.unmatched_filters);
 
@@ -117,16 +147,13 @@ struct FilterGraphResult {
 
 fn filter_graph<Pkg>(
     projects_graph: &ProjectGraph<Pkg>,
-    opts: FilterWorkspaceProjectsOptions,
+    opts: &FilterWorkspaceProjectsOptions,
     selectors: &[&ProjectSelector],
 ) -> Result<FilterGraphResult, FilterError>
 where
     Pkg: BaseProject,
 {
-    let mut cherry_picked: Vec<PathBuf> = Vec::new();
-    let mut walked_dependencies: IndexSet<PathBuf> = IndexSet::new();
-    let mut walked_dependents: IndexSet<PathBuf> = IndexSet::new();
-    let mut walked_dependents_dependencies: IndexSet<PathBuf> = IndexSet::new();
+    let mut walk = WalkState::default();
     let mut unmatched_filters: Vec<String> = Vec::new();
 
     let forward = |id: &Path| projects_graph.get(id).map(|node| node.dependencies.clone());
@@ -137,14 +164,31 @@ where
     let reverse = |id: &Path| reversed_graph.as_ref().and_then(|graph| graph.get(id).cloned());
 
     for selector in selectors {
-        if selector.diff.is_some() {
-            return Err(FilterError::UnsupportedDiffSelector);
+        let mut entry_projects: Option<Vec<PathBuf>> = None;
+        if let Some(diff) = &selector.diff {
+            let changed = get_changed_projects(
+                projects_graph.keys().cloned().collect(),
+                diff,
+                &GetChangedProjectsOptions {
+                    workspace_dir: selector.parent_dir.as_deref().unwrap_or(&opts.workspace_dir),
+                    test_pattern: &opts.test_pattern,
+                    changed_files_ignore_pattern: &opts.changed_files_ignore_pattern,
+                },
+            )?;
+            entry_projects = Some(changed.changed_projects);
+            walk.select_entries(
+                WalkFlags { include_dependents: false, ..WalkFlags::of(selector) },
+                &changed.ignore_dependent_for_projects,
+                &forward,
+                &reverse,
+            );
+        } else if let Some(parent_dir) = selector.parent_dir.as_deref() {
+            entry_projects = Some(match_projects_by_path(
+                projects_graph,
+                parent_dir,
+                opts.use_glob_dir_filtering,
+            ));
         }
-
-        let mut entry_projects: Option<Vec<PathBuf>> =
-            selector.parent_dir.as_deref().map(|parent_dir| {
-                match_projects_by_path(projects_graph, parent_dir, opts.use_glob_dir_filtering)
-            });
 
         if let Some(name_pattern) = &selector.name_pattern {
             let candidates: Vec<(PathBuf, Option<String>)> = match &entry_projects {
@@ -180,31 +224,79 @@ where
             }
         }
 
-        let include_root = !selector.exclude_self;
-        if selector.include_dependencies {
-            pick_subgraph(&forward, &entry_projects, &mut walked_dependencies, include_root);
+        walk.select_entries(WalkFlags::of(selector), &entry_projects, &forward, &reverse);
+    }
+
+    Ok(FilterGraphResult { selected: walk.into_selected(), unmatched_filters })
+}
+
+/// The selector modifiers that drive [`WalkState::select_entries`]. A
+/// `[<since>]` selector selects its test-only-changed projects through
+/// a copy with `include_dependents` suppressed.
+#[derive(Clone, Copy)]
+struct WalkFlags {
+    include_dependencies: bool,
+    include_dependents: bool,
+    exclude_self: bool,
+}
+
+impl WalkFlags {
+    fn of(selector: &ProjectSelector) -> Self {
+        WalkFlags {
+            include_dependencies: selector.include_dependencies,
+            include_dependents: selector.include_dependents,
+            exclude_self: selector.exclude_self,
         }
-        if selector.include_dependents {
-            pick_subgraph(&reverse, &entry_projects, &mut walked_dependents, include_root);
+    }
+}
+
+/// Accumulates the projects the selectors of one [`filter_graph`] run
+/// pick, in the buckets whose union (dependencies, dependents,
+/// dependents' dependencies, then cherry-picks) fixes the selection
+/// order.
+#[derive(Default)]
+struct WalkState {
+    cherry_picked: Vec<PathBuf>,
+    walked_dependencies: IndexSet<PathBuf>,
+    walked_dependents: IndexSet<PathBuf>,
+    walked_dependents_dependencies: IndexSet<PathBuf>,
+}
+
+impl WalkState {
+    fn select_entries<Forward, Reverse>(
+        &mut self,
+        flags: WalkFlags,
+        entry_projects: &[PathBuf],
+        forward: &Forward,
+        reverse: &Reverse,
+    ) where
+        Forward: Fn(&Path) -> Option<Vec<PathBuf>>,
+        Reverse: Fn(&Path) -> Option<Vec<PathBuf>>,
+    {
+        let include_root = !flags.exclude_self;
+        if flags.include_dependencies {
+            pick_subgraph(forward, entry_projects, &mut self.walked_dependencies, include_root);
         }
-        if selector.include_dependencies && selector.include_dependents {
-            let dependents: Vec<PathBuf> = walked_dependents.iter().cloned().collect();
-            pick_subgraph(&forward, &dependents, &mut walked_dependents_dependencies, false);
+        if flags.include_dependents {
+            pick_subgraph(reverse, entry_projects, &mut self.walked_dependents, include_root);
         }
-        if !selector.include_dependencies && !selector.include_dependents {
-            cherry_picked.extend(entry_projects);
+        if flags.include_dependencies && flags.include_dependents {
+            let dependents: Vec<PathBuf> = self.walked_dependents.iter().cloned().collect();
+            pick_subgraph(forward, &dependents, &mut self.walked_dependents_dependencies, false);
+        }
+        if !flags.include_dependencies && !flags.include_dependents {
+            self.cherry_picked.extend(entry_projects.iter().cloned());
         }
     }
 
-    let mut walked: IndexSet<PathBuf> = IndexSet::new();
-    walked.extend(walked_dependencies);
-    walked.extend(walked_dependents);
-    walked.extend(walked_dependents_dependencies);
-    for project in cherry_picked {
-        walked.insert(project);
+    fn into_selected(self) -> Vec<PathBuf> {
+        let mut walked: IndexSet<PathBuf> = IndexSet::new();
+        walked.extend(self.walked_dependencies);
+        walked.extend(self.walked_dependents);
+        walked.extend(self.walked_dependents_dependencies);
+        walked.extend(self.cherry_picked);
+        walked.into_iter().collect()
     }
-
-    Ok(FilterGraphResult { selected: walked.into_iter().collect(), unmatched_filters })
 }
 
 /// Walk the subgraph reachable from `next_node_ids`.
@@ -324,8 +416,12 @@ where
 {
     let (prod_selectors, all_selectors): (Vec<ProjectSelector>, Vec<ProjectSelector>) =
         selectors.iter().cloned().partition(|selector| selector.follow_prod_deps_only);
-    let walk_opts =
-        FilterWorkspaceProjectsOptions { use_glob_dir_filtering: opts.use_glob_dir_filtering };
+    let walk_opts = FilterWorkspaceProjectsOptions {
+        use_glob_dir_filtering: opts.use_glob_dir_filtering,
+        workspace_dir: opts.workspace_dir.clone(),
+        test_pattern: opts.test_pattern.clone(),
+        changed_files_ignore_pattern: opts.changed_files_ignore_pattern.clone(),
+    };
 
     if all_selectors.is_empty() && prod_selectors.is_empty() {
         let result = create_projects_graph(

--- a/pnpm/crates/workspace-projects-filter/src/filter/tests.rs
+++ b/pnpm/crates/workspace-projects-filter/src/filter/tests.rs
@@ -623,10 +623,80 @@ mod changed_packages {
         )
         .unwrap_err();
 
+        dbg!(&error);
         assert!(matches!(error, FilterError::FilterChanged { .. }));
         assert_eq!(
             error.to_string(),
             "Filtering by changed packages failed. fatal: bad revision 'branch-does-no-exist'",
+        );
+    }
+
+    /// An option-like `<since>` must not be parsed as a git option:
+    /// without `--end-of-options`, `[--output=<path>]` would make
+    /// `git diff` write its output to an arbitrary file and exit 0.
+    #[test]
+    fn option_like_diff_ref_is_rejected_as_bad_revision() {
+        let workspace = TempDir::new().expect("create tempdir");
+        init_repo(workspace.path());
+        touch(&workspace.path().join("package-a").join("file.js"));
+        commit_all(workspace.path());
+        let graph = graph_of(&[&workspace.path().join("package-a")]);
+
+        let evil_output = workspace.path().join("evil.txt");
+        let error = filter_workspace_projects(
+            &graph,
+            &[diff_selector(&format!("--output={}", evil_output.to_string_lossy()))],
+            &FilterWorkspaceProjectsOptions {
+                workspace_dir: workspace.path().to_path_buf(),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+
+        dbg!(&error);
+        assert!(matches!(error, FilterError::FilterChanged { .. }));
+        assert!(
+            error.to_string().contains("bad revision"),
+            "git must treat the option-like ref as a revision, got: {error}",
+        );
+        assert!(!evil_output.exists(), "the ref must not be honored as a git option");
+    }
+
+    /// A worktree checked out *inside* another repository's tree still
+    /// resolves diff paths against the worktree root: the nearest
+    /// `.git` entry is the worktree's `.git` file, even though an
+    /// ancestor has a `.git` directory.
+    #[test]
+    fn select_changed_packages_under_git_worktree_nested_in_main_repo() {
+        let main_repo = TempDir::new().expect("create tempdir");
+        let main_repo_dir = main_repo.path();
+        init_repo(main_repo_dir);
+        touch(&main_repo_dir.join("package-a").join("file.js"));
+        touch(&main_repo_dir.join("package-b").join("file.js"));
+        commit_all(main_repo_dir);
+
+        let worktree_dir = main_repo_dir.join("worktrees").join("feature");
+        git(
+            main_repo_dir,
+            &["worktree", "add", "-b", "feature", &worktree_dir.to_string_lossy(), "main"],
+        );
+
+        let pkg_a_dir = worktree_dir.join("package-a");
+        touch(&pkg_a_dir.join("new-file.js"));
+        commit_all(&worktree_dir);
+
+        let graph = graph_of(&[&worktree_dir, &pkg_a_dir, &worktree_dir.join("package-b")]);
+
+        assert_eq!(
+            selected(
+                &graph,
+                &[diff_selector("HEAD~1")],
+                &FilterWorkspaceProjectsOptions {
+                    workspace_dir: worktree_dir,
+                    ..Default::default()
+                },
+            ),
+            [pkg_a_dir.to_string_lossy().into_owned()],
         );
     }
 }

--- a/pnpm/crates/workspace-projects-filter/src/filter/tests.rs
+++ b/pnpm/crates/workspace-projects-filter/src/filter/tests.rs
@@ -56,6 +56,33 @@ fn node(root: &str, name: &str, deps: &[&str]) -> (PathBuf, ProjectGraphNode<Tes
     )
 }
 
+fn node_at(root: &Path, name: &str, deps: &[&Path]) -> (PathBuf, ProjectGraphNode<TestPkg>) {
+    (
+        root.to_path_buf(),
+        ProjectGraphNode {
+            package: TestPkg {
+                root_dir: root.to_path_buf(),
+                name: Some(name.to_string()),
+                version: Some("1.0.0".to_string()),
+                deps: Vec::new(),
+                dev_deps: Vec::new(),
+            },
+            dependencies: deps.iter().map(|dep| dep.to_path_buf()).collect(),
+        },
+    )
+}
+
+fn filter_projects_options() -> FilterProjectsOptions {
+    FilterProjectsOptions {
+        prefix: PathBuf::from("/ws"),
+        link_workspace_packages: None,
+        use_glob_dir_filtering: false,
+        workspace_dir: PathBuf::from("/ws"),
+        test_pattern: Vec::new(),
+        changed_files_ignore_pattern: Vec::new(),
+    }
+}
+
 /// The shared project graph fixture used across the filter tests.
 fn projects_graph() -> ProjectGraph<TestPkg> {
     let mut graph: ProjectGraph<TestPkg> = IndexMap::new();
@@ -90,7 +117,7 @@ fn selected_with_glob(graph: &ProjectGraph<TestPkg>, selectors: &[ProjectSelecto
     filter_workspace_projects(
         graph,
         selectors,
-        &FilterWorkspaceProjectsOptions { use_glob_dir_filtering: true },
+        &FilterWorkspaceProjectsOptions { use_glob_dir_filtering: true, ..Default::default() },
     )
     .expect("filter should succeed")
     .selected_projects
@@ -378,16 +405,230 @@ fn is_subdir_contract() {
     assert!(!is_subdir(Path::new("/abs"), Path::new("/abs")));
 }
 
-#[test]
-fn diff_selector_is_unsupported() {
-    let graph = projects_graph();
-    let error = filter_workspace_projects(
-        &graph,
-        &[ProjectSelector { diff: Some("main".to_string()), ..Default::default() }],
-        &FilterWorkspaceProjectsOptions::default(),
-    )
-    .unwrap_err();
-    assert!(matches!(error, FilterError::UnsupportedDiffSelector));
+/// The `[<since>]` changed-packages selector tests, ported from
+/// upstream's "select changed packages" suite. Each builds a real git
+/// repository in a temp directory.
+mod changed_packages {
+    use super::{TestPkg, node_at};
+    use crate::{
+        filter::{FilterError, FilterWorkspaceProjectsOptions, filter_workspace_projects},
+        parse_project_selector::ProjectSelector,
+    };
+    use indexmap::IndexMap;
+    use pacquet_workspace_projects_graph::ProjectGraph;
+    use std::{fs, path::Path, process::Command};
+    use tempfile::TempDir;
+
+    fn git(cwd: &Path, args: &[&str]) {
+        let output = Command::new("git").args(args).current_dir(cwd).output().expect("spawn git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    fn init_repo(dir: &Path) {
+        git(dir, &["init", "--initial-branch=main"]);
+        git(dir, &["config", "user.email", "x@y.z"]);
+        git(dir, &["config", "user.name", "xyz"]);
+        git(dir, &["commit", "--allow-empty", "--allow-empty-message", "-m", "", "--no-gpg-sign"]);
+    }
+
+    fn commit_all(dir: &Path) {
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "--allow-empty-message", "-m", "", "--no-gpg-sign"]);
+    }
+
+    fn touch(path: &Path) {
+        fs::create_dir_all(path.parent().expect("file path has a parent"))
+            .expect("create parent dirs");
+        fs::write(path, "").expect("write file");
+    }
+
+    fn graph_of(dirs: &[&Path]) -> ProjectGraph<TestPkg> {
+        let mut graph: ProjectGraph<TestPkg> = IndexMap::new();
+        for (index, dir) in dirs.iter().enumerate() {
+            let (key, value) = node_at(dir, &format!("package-{index}"), &[]);
+            graph.insert(key, value);
+        }
+        graph
+    }
+
+    fn selected(
+        graph: &ProjectGraph<TestPkg>,
+        selectors: &[ProjectSelector],
+        opts: &FilterWorkspaceProjectsOptions,
+    ) -> Vec<String> {
+        filter_workspace_projects(graph, selectors, opts)
+            .expect("filter should succeed")
+            .selected_projects
+            .iter()
+            .map(|path| path.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn diff_selector(since: &str) -> ProjectSelector {
+        ProjectSelector { diff: Some(since.to_string()), ..Default::default() }
+    }
+
+    #[test]
+    fn select_changed_packages() {
+        let workspace = TempDir::new().expect("create tempdir");
+        let workspace_dir = workspace.path();
+        init_repo(workspace_dir);
+
+        let pkg_1_dir = workspace_dir.join("package-1");
+        touch(&pkg_1_dir.join("file1.js"));
+        let pkg_2_dir = workspace_dir.join("package-2");
+        touch(&pkg_2_dir.join("file2.js"));
+        let pkg_3_dir = workspace_dir.join("package-3");
+        fs::create_dir_all(&pkg_3_dir).expect("create package-3");
+        let pkg_kor_dir = workspace_dir.join("package-kor");
+        touch(&pkg_kor_dir.join("fileKor한글.js"));
+        commit_all(workspace_dir);
+
+        let pkg_20_dir = workspace_dir.join("package-20");
+
+        let mut graph: ProjectGraph<TestPkg> = IndexMap::new();
+        for (key, value) in [
+            node_at(workspace_dir, "root", &[]),
+            node_at(&pkg_1_dir, "package-1", &[]),
+            node_at(&pkg_2_dir, "package-2", &[]),
+            node_at(&pkg_3_dir, "package-3", &[&pkg_2_dir]),
+            node_at(&pkg_kor_dir, "package-kor", &[]),
+            node_at(&pkg_20_dir, "package-20", &[]),
+        ] {
+            graph.insert(key, value);
+        }
+
+        let opts = FilterWorkspaceProjectsOptions {
+            workspace_dir: workspace_dir.to_path_buf(),
+            ..Default::default()
+        };
+        let path_of = |dir: &Path| dir.to_string_lossy().into_owned();
+
+        assert_eq!(
+            selected(&graph, &[diff_selector("HEAD~1")], &opts),
+            [path_of(&pkg_1_dir), path_of(&pkg_2_dir), path_of(&pkg_kor_dir)],
+        );
+
+        assert_eq!(
+            selected(
+                &graph,
+                &[ProjectSelector {
+                    parent_dir: Some(pkg_2_dir.clone()),
+                    ..diff_selector("HEAD~1")
+                }],
+                &opts,
+            ),
+            [path_of(&pkg_2_dir)],
+        );
+
+        assert_eq!(
+            selected(
+                &graph,
+                &[ProjectSelector {
+                    name_pattern: Some("package-2*".to_string()),
+                    ..diff_selector("HEAD~1")
+                }],
+                &opts,
+            ),
+            [path_of(&pkg_2_dir)],
+        );
+
+        // `package-2`'s only change matches `testPattern`, so it is
+        // selected itself but its dependent `package-3` is not.
+        assert_eq!(
+            selected(
+                &graph,
+                &[ProjectSelector { include_dependents: true, ..diff_selector("HEAD~1") }],
+                &FilterWorkspaceProjectsOptions {
+                    test_pattern: vec!["*/file2.js".to_string()],
+                    ..opts.clone()
+                },
+            ),
+            [path_of(&pkg_1_dir), path_of(&pkg_kor_dir), path_of(&pkg_2_dir)],
+        );
+
+        // Changed files matching `changedFilesIgnorePattern` don't count
+        // as changes at all.
+        assert_eq!(
+            selected(
+                &graph,
+                &[diff_selector("HEAD~1")],
+                &FilterWorkspaceProjectsOptions {
+                    changed_files_ignore_pattern: vec!["*/file2.js".to_string()],
+                    ..opts
+                },
+            ),
+            [path_of(&pkg_1_dir), path_of(&pkg_kor_dir)],
+        );
+    }
+
+    #[test]
+    fn select_changed_packages_under_git_worktree() {
+        let main_repo = TempDir::new().expect("create tempdir");
+        let main_repo_dir = main_repo.path();
+        init_repo(main_repo_dir);
+        touch(&main_repo_dir.join("package-a").join("file.js"));
+        touch(&main_repo_dir.join("package-b").join("file.js"));
+        touch(&main_repo_dir.join("package-c").join("file.js"));
+        commit_all(main_repo_dir);
+
+        let worktree_parent = TempDir::new().expect("create tempdir");
+        let worktree_dir = worktree_parent.path().join("worktree");
+        git(
+            main_repo_dir,
+            &["worktree", "add", "-b", "worktree-branch", &worktree_dir.to_string_lossy(), "main"],
+        );
+
+        let pkg_a_dir = worktree_dir.join("package-a");
+        touch(&pkg_a_dir.join("new-file.js"));
+        commit_all(&worktree_dir);
+
+        let graph = graph_of(&[
+            &worktree_dir,
+            &pkg_a_dir,
+            &worktree_dir.join("package-b"),
+            &worktree_dir.join("package-c"),
+        ]);
+
+        assert_eq!(
+            selected(
+                &graph,
+                &[diff_selector("HEAD~1")],
+                &FilterWorkspaceProjectsOptions {
+                    workspace_dir: worktree_dir,
+                    ..Default::default()
+                },
+            ),
+            [pkg_a_dir.to_string_lossy().into_owned()],
+        );
+    }
+
+    #[test]
+    fn selection_fails_for_nonexistent_diff_branch() {
+        let workspace = TempDir::new().expect("create tempdir");
+        init_repo(workspace.path());
+        let graph = graph_of(&[&workspace.path().join("package-a")]);
+
+        let error = filter_workspace_projects(
+            &graph,
+            &[diff_selector("branch-does-no-exist")],
+            &FilterWorkspaceProjectsOptions {
+                workspace_dir: workspace.path().to_path_buf(),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, FilterError::FilterChanged { .. }));
+        assert_eq!(
+            error.to_string(),
+            "Filtering by changed packages failed. fatal: bad revision 'branch-does-no-exist'",
+        );
+    }
 }
 
 fn graph_project(root: &str, name: &str, deps: &[(&str, &str)]) -> TestPkg {
@@ -414,11 +655,7 @@ fn filter_projects_builds_graph_and_follows_dependencies() {
     let result = filter_projects(
         projects,
         &[WorkspaceFilter { filter: "a...".to_string(), follow_prod_deps_only: false }],
-        &FilterProjectsOptions {
-            prefix: PathBuf::from("/ws"),
-            link_workspace_packages: None,
-            use_glob_dir_filtering: false,
-        },
+        &filter_projects_options(),
     )
     .unwrap();
     let dirs: Vec<String> =
@@ -429,16 +666,7 @@ fn filter_projects_builds_graph_and_follows_dependencies() {
 #[test]
 fn filter_projects_empty_filter_selects_everything() {
     let projects = vec![graph_project("/ws/a", "a", &[]), graph_project("/ws/b", "b", &[])];
-    let result = filter_projects(
-        projects,
-        &[],
-        &FilterProjectsOptions {
-            prefix: PathBuf::from("/ws"),
-            link_workspace_packages: None,
-            use_glob_dir_filtering: false,
-        },
-    )
-    .unwrap();
+    let result = filter_projects(projects, &[], &filter_projects_options()).unwrap();
     let dirs: Vec<String> =
         result.selected_projects.iter().map(|path| path.to_string_lossy().into_owned()).collect();
     assert_eq!(dirs, ["/ws/a", "/ws/b"]);
@@ -458,11 +686,7 @@ fn filter_prod_follows_production_deps_only() {
             graph_project("/ws/b", "b", &[]),
         ]
     };
-    let opts = FilterProjectsOptions {
-        prefix: PathBuf::from("/ws"),
-        link_workspace_packages: None,
-        use_glob_dir_filtering: false,
-    };
+    let opts = filter_projects_options();
 
     let prod = filter_projects(
         make_projects(),
@@ -490,11 +714,7 @@ fn filter_projects_unions_prod_selection_before_all_selection() {
             WorkspaceFilter { filter: "b".to_string(), follow_prod_deps_only: true },
             WorkspaceFilter { filter: "a".to_string(), follow_prod_deps_only: false },
         ],
-        &FilterProjectsOptions {
-            prefix: PathBuf::from("/ws"),
-            link_workspace_packages: None,
-            use_glob_dir_filtering: false,
-        },
+        &filter_projects_options(),
     )
     .unwrap();
     assert_eq!(project_dirs(&result), ["/ws/b", "/ws/a"]);
@@ -514,42 +734,4 @@ fn path_selector_with_no_match_is_reported_unmatched() {
     .unwrap();
     assert!(result.selected_projects.is_empty());
     assert_eq!(result.unmatched_filters, ["/does-not-exist"]);
-}
-
-/// Filter cases that require the git-diff changed-packages selector
-/// (`[<since>]`). Pacquet parses the selector but has not ported git-diff
-/// project selection, so these are stubbed through
-/// [`pacquet_testing_utils::allow_known_failure`] until that lands. The
-/// selector-rejection path itself is covered by
-/// [`super::diff_selector_is_unsupported`].
-mod known_failures {
-    use pacquet_testing_utils::{
-        allow_known_failure,
-        known_failure::{KnownFailure, KnownResult},
-    };
-
-    fn git_diff_selection_unimplemented() -> KnownResult<()> {
-        Err(KnownFailure::new(
-            "Pacquet has not ported git-diff project selection, so `[<since>]` \
-             changed-package filter selectors cannot be evaluated. \
-             `parse_project_selector` fills the `diff` field, but \
-             `filter_workspace_projects` rejects it with \
-             `FilterError::UnsupportedDiffSelector`.",
-        ))
-    }
-
-    #[test]
-    fn select_changed_packages() {
-        allow_known_failure!(git_diff_selection_unimplemented());
-    }
-
-    #[test]
-    fn select_changed_packages_under_git_worktree() {
-        allow_known_failure!(git_diff_selection_unimplemented());
-    }
-
-    #[test]
-    fn selection_fails_for_nonexistent_diff_branch() {
-        allow_known_failure!(git_diff_selection_unimplemented());
-    }
 }

--- a/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
+++ b/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
@@ -92,13 +92,14 @@ fn get_changed_dirs_since_commit(
         .output()
         .map_err(|err| FilterError::FilterChanged { stderr: err.to_string() })?;
     if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(FilterError::FilterChanged {
-            stderr: String::from_utf8_lossy(&output.stderr).trim_end().to_string(),
+            stderr: strip_final_newline(&stderr).to_string(),
         });
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let diff = stdout.trim_end_matches('\n');
+    let diff = strip_final_newline(&stdout);
     if diff.is_empty() {
         return Ok(IndexMap::new());
     }
@@ -126,6 +127,14 @@ fn get_changed_dirs_since_commit(
         changed_dirs.insert(dir, change_type);
     }
     Ok(changed_dirs)
+}
+
+/// Strip one final `\n` (and a preceding `\r`, if any) — execa's
+/// `stripFinalNewline` behavior, which upstream's process output goes
+/// through before it is parsed or embedded in an error message.
+fn strip_final_newline(text: &str) -> &str {
+    let text = text.strip_suffix('\n').unwrap_or(text);
+    text.strip_suffix('\r').unwrap_or(text)
 }
 
 fn compile_globs(patterns: &[String]) -> Result<Vec<Glob<'_>>, FilterError> {

--- a/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
+++ b/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
@@ -1,0 +1,159 @@
+//! Resolve a `[<since>]` changed-packages selector to the workspace
+//! projects the git diff touches, upstream's `getChangedProjects`.
+
+use crate::filter::FilterError;
+use indexmap::IndexMap;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+use wax::{Glob, Program};
+
+/// Options for [`get_changed_projects`].
+pub(crate) struct GetChangedProjectsOptions<'a> {
+    /// Directory the `git diff` runs in and is path-restricted to: the
+    /// selector's `{dir}` part when present, else the workspace root.
+    pub workspace_dir: &'a Path,
+    pub test_pattern: &'a [String],
+    pub changed_files_ignore_pattern: &'a [String],
+}
+
+/// The two selection groups a `[<since>]` diff produces.
+pub(crate) struct ChangedProjects {
+    /// Projects with at least one changed file outside `test_pattern`;
+    /// selected with the selector's full dependency/dependent walk.
+    pub changed_projects: Vec<PathBuf>,
+    /// Projects whose changed files all match `test_pattern`; selected
+    /// themselves, but their dependents are not.
+    pub ignore_dependent_for_projects: Vec<PathBuf>,
+}
+
+/// Split `project_dirs` into the projects changed since `commit` and
+/// the projects whose only changes are test files. Both lists keep the
+/// `project_dirs` order. A changed file belongs to the nearest
+/// enclosing project directory; a project's change type is `source` as
+/// soon as any of its changed files is a source change.
+pub(crate) fn get_changed_projects(
+    project_dirs: Vec<PathBuf>,
+    commit: &str,
+    opts: &GetChangedProjectsOptions<'_>,
+) -> Result<ChangedProjects, FilterError> {
+    let repo_root = find_repo_root(opts.workspace_dir);
+    let changed_dirs = get_changed_dirs_since_commit(commit, opts)?;
+
+    let mut project_change_types: IndexMap<PathBuf, Option<ChangeType>> =
+        project_dirs.into_iter().map(|dir| (dir, None)).collect();
+    for (changed_dir, change_type) in changed_dirs {
+        let mut current = if changed_dir.as_os_str().is_empty() {
+            repo_root.clone()
+        } else {
+            repo_root.join(&changed_dir)
+        };
+        while !project_change_types.contains_key(&current) {
+            let Some(parent) = current.parent() else { break };
+            current = parent.to_path_buf();
+        }
+        let entry = project_change_types.entry(current).or_insert(None);
+        if *entry != Some(ChangeType::Source) {
+            *entry = Some(change_type);
+        }
+    }
+
+    let mut changed_projects: Vec<PathBuf> = Vec::new();
+    let mut ignore_dependent_for_projects: Vec<PathBuf> = Vec::new();
+    for (dir, change_type) in project_change_types {
+        match change_type {
+            Some(ChangeType::Source) => changed_projects.push(dir),
+            Some(ChangeType::Test) => ignore_dependent_for_projects.push(dir),
+            None => {}
+        }
+    }
+    Ok(ChangedProjects { changed_projects, ignore_dependent_for_projects })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChangeType {
+    Source,
+    Test,
+}
+
+/// Run `git diff --name-only <commit> -- <workspace_dir>` and bucket
+/// the changed files' directories (relative to the repository root) by
+/// change type. `source` is sticky: once a directory has a source
+/// change, later test changes don't downgrade it.
+fn get_changed_dirs_since_commit(
+    commit: &str,
+    opts: &GetChangedProjectsOptions<'_>,
+) -> Result<IndexMap<PathBuf, ChangeType>, FilterError> {
+    let output = Command::new("git")
+        .args(["diff", "--name-only", commit, "--"])
+        .arg(opts.workspace_dir)
+        .current_dir(opts.workspace_dir)
+        .output()
+        .map_err(|err| FilterError::FilterChanged { stderr: err.to_string() })?;
+    if !output.status.success() {
+        return Err(FilterError::FilterChanged {
+            stderr: String::from_utf8_lossy(&output.stderr).trim_end().to_string(),
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let diff = stdout.trim_end_matches('\n');
+    if diff.is_empty() {
+        return Ok(IndexMap::new());
+    }
+
+    let ignore_globs = compile_globs(opts.changed_files_ignore_pattern)?;
+    let test_globs = compile_globs(opts.test_pattern)?;
+
+    let mut changed_dirs: IndexMap<PathBuf, ChangeType> = IndexMap::new();
+    for line in diff.split('\n') {
+        // git wraps paths with non-ASCII characters in quotes.
+        let changed_file = line.strip_prefix('"').unwrap_or(line);
+        let changed_file = changed_file.strip_suffix('"').unwrap_or(changed_file);
+        if ignore_globs.iter().any(|glob| glob.is_match(changed_file)) {
+            continue;
+        }
+        let dir = Path::new(changed_file).parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+        if changed_dirs.get(&dir) == Some(&ChangeType::Source) {
+            continue;
+        }
+        let change_type = if test_globs.iter().any(|glob| glob.is_match(changed_file)) {
+            ChangeType::Test
+        } else {
+            ChangeType::Source
+        };
+        changed_dirs.insert(dir, change_type);
+    }
+    Ok(changed_dirs)
+}
+
+fn compile_globs(patterns: &[String]) -> Result<Vec<Glob<'_>>, FilterError> {
+    patterns
+        .iter()
+        .filter(|pattern| !pattern.is_empty())
+        .map(|pattern| {
+            Glob::new(pattern).map_err(|err| FilterError::InvalidPattern {
+                pattern: pattern.clone(),
+                message: err.to_string(),
+            })
+        })
+        .collect()
+}
+
+/// The directory git-diff paths are relative to: the parent of the
+/// nearest `.git` *directory* up from `workspace_dir` (regular repos),
+/// else the parent of the nearest `.git` *file* (worktrees), else the
+/// parent of `workspace_dir` itself.
+fn find_repo_root(workspace_dir: &Path) -> PathBuf {
+    let git_path = find_git_entry_up(workspace_dir, Path::is_dir)
+        .or_else(|| find_git_entry_up(workspace_dir, Path::is_file));
+    match git_path {
+        Some(git_path) => git_path.parent().expect("a `.git` path has a parent").to_path_buf(),
+        None => workspace_dir.parent().unwrap_or(workspace_dir).to_path_buf(),
+    }
+}
+
+fn find_git_entry_up(start: &Path, is_wanted_kind: impl Fn(&Path) -> bool) -> Option<PathBuf> {
+    start.ancestors().map(|dir| dir.join(".git")).find(|candidate| is_wanted_kind(candidate))
+}

--- a/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
+++ b/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
@@ -85,8 +85,11 @@ fn get_changed_dirs_since_commit(
     commit: &str,
     opts: &GetChangedProjectsOptions<'_>,
 ) -> Result<IndexMap<PathBuf, ChangeType>, FilterError> {
+    // `--end-of-options` keeps an option-like `<since>` (`--output=...`)
+    // from being parsed as a git option — git rejects it as a bad
+    // revision instead.
     let output = Command::new("git")
-        .args(["diff", "--name-only", commit, "--"])
+        .args(["diff", "--name-only", "--end-of-options", commit, "--"])
         .arg(opts.workspace_dir)
         .current_dir(opts.workspace_dir)
         .output()
@@ -151,18 +154,16 @@ fn compile_globs(patterns: &[String]) -> Result<Vec<Glob<'_>>, FilterError> {
 }
 
 /// The directory git-diff paths are relative to: the parent of the
-/// nearest `.git` *directory* up from `workspace_dir` (regular repos),
-/// else the parent of the nearest `.git` *file* (worktrees), else the
-/// parent of `workspace_dir` itself.
+/// nearest `.git` entry up from `workspace_dir` — a directory in
+/// regular repositories, a file in worktrees — else the parent of
+/// `workspace_dir` itself. The nearest entry of *either* kind wins, so
+/// a worktree checked out inside another repository's tree resolves to
+/// the worktree root, matching where git anchors its diff paths.
 fn find_repo_root(workspace_dir: &Path) -> PathBuf {
-    let git_path = find_git_entry_up(workspace_dir, Path::is_dir)
-        .or_else(|| find_git_entry_up(workspace_dir, Path::is_file));
+    let git_path =
+        workspace_dir.ancestors().map(|dir| dir.join(".git")).find(|candidate| candidate.exists());
     match git_path {
         Some(git_path) => git_path.parent().expect("a `.git` path has a parent").to_path_buf(),
         None => workspace_dir.parent().unwrap_or(workspace_dir).to_path_buf(),
     }
-}
-
-fn find_git_entry_up(start: &Path, is_wanted_kind: impl Fn(&Path) -> bool) -> Option<PathBuf> {
-    start.ancestors().map(|dir| dir.join(".git")).find(|candidate| is_wanted_kind(candidate))
 }

--- a/pnpm/crates/workspace-projects-filter/src/lib.rs
+++ b/pnpm/crates/workspace-projects-filter/src/lib.rs
@@ -10,11 +10,12 @@
 //!   the graph (via `pacquet-workspace-projects-graph`) and run the
 //!   filter, handling the `--filter-prod` production-only graph.
 //!
-//! Not yet ported: the `[<since>]` changed-packages selector, which
-//! needs git-diff project selection. It parses, but evaluating it
-//! returns [`FilterError::UnsupportedDiffSelector`].
+//! A `[<since>]` changed-packages selector selects the projects whose
+//! files changed since the given git ref (`git diff --name-only`),
+//! honoring `testPattern` / `changedFilesIgnorePattern`.
 
 mod filter;
+mod get_changed_projects;
 mod glob;
 mod parse_project_selector;
 mod path_util;

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -304,6 +304,9 @@ tests live in `filter::tests::changed_packages`:
 - [x] `TypeScript repo: workspace/projects-filter/test/index.ts:348` `select changed packages`. Ported as `changed_packages::select_changed_packages`.
 - [x] `TypeScript repo: workspace/projects-filter/test/index.ts:480` `select changed packages when operating under a git worktree`. Ported as `changed_packages::select_changed_packages_under_git_worktree`.
 - [x] `TypeScript repo: workspace/projects-filter/test/index.ts:553` `selection should fail when diffing to a branch that does not exist`. Ported as `changed_packages::selection_fails_for_nonexistent_diff_branch`.
+- [x] `TypeScript repo: pnpm/test/monorepo/index.ts:336` `testPattern is respected by the test script`. Ported as `run_recursive::test_pattern_from_workspace_yaml_is_respected_by_the_test_script`.
+- [x] `TypeScript repo: pnpm/test/monorepo/index.ts:404` `changedFilesIgnorePattern is respected`. Ported as `list::changed_files_ignore_pattern_is_respected`.
+- [x] `TypeScript repo: config/reader/test/index.ts:2686` `respects testPattern` and `config/reader/test/index.ts:2729` `respects changedFilesIgnorePattern`. Ported as `workspace_yaml::tests::parses_test_pattern_and_changed_files_ignore_pattern_from_yaml_and_applies` (plus the global-config exclusion in `test_pattern_and_changed_files_ignore_pattern_cleared_as_workspace_only_fields`); the upstream `.npmrc`-is-ignored case has no pacquet counterpart because pacquet reads no settings from `.npmrc`.
 
 `createProjectsGraph` has no upstream unit tests (it is exercised only
 through `filterProjectsFromDir`'s fixtures upstream); pacquet covers it

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -297,16 +297,13 @@ unfiltered, so the two `known_failures` hoist stubs below stay).
 - [x] `TypeScript repo: workspace/projects-filter/test/index.ts:591` `select by parentDir and exclude one package by pattern`.
 - [x] `TypeScript repo: workspace/projects-filter/test/index.ts:608` `select by parentDir with glob and exclude one package by pattern`.
 
-Changed-packages (`[<since>]`) selectors — stubbed in
-`filter::tests::known_failures` (the selector parses but
-`filter_workspace_projects` rejects it with
-`FilterError::UnsupportedDiffSelector`; the rejection path is covered by
-`filter::tests::diff_selector_is_unsupported`). These need git-diff
-project selection (`getChangedProjects`), not yet ported:
+Changed-packages (`[<since>]`) selectors — git-diff project selection
+(`getChangedProjects`) is ported as `get_changed_projects`, and the
+tests live in `filter::tests::changed_packages`:
 
-- [x] `TypeScript repo: workspace/projects-filter/test/index.ts:348` `select changed packages`. Stubbed (`git_diff_selection_unimplemented`).
-- [x] `TypeScript repo: workspace/projects-filter/test/index.ts:480` `select changed packages when operating under a git worktree`. Stubbed.
-- [x] `TypeScript repo: workspace/projects-filter/test/index.ts:553` `selection should fail when diffing to a branch that does not exist`. Stubbed.
+- [x] `TypeScript repo: workspace/projects-filter/test/index.ts:348` `select changed packages`. Ported as `changed_packages::select_changed_packages`.
+- [x] `TypeScript repo: workspace/projects-filter/test/index.ts:480` `select changed packages when operating under a git worktree`. Ported as `changed_packages::select_changed_packages_under_git_worktree`.
+- [x] `TypeScript repo: workspace/projects-filter/test/index.ts:553` `selection should fail when diffing to a branch that does not exist`. Ported as `changed_packages::selection_fails_for_nonexistent_diff_branch`.
 
 `createProjectsGraph` has no upstream unit tests (it is exercised only
 through `filterProjectsFromDir`'s fixtures upstream); pacquet covers it

--- a/pnpm11/workspace/projects-filter/src/getChangedProjects.ts
+++ b/pnpm11/workspace/projects-filter/src/getChangedProjects.ts
@@ -20,9 +20,11 @@ export async function getChangedProjects (
   opts: { workspaceDir: string, testPattern?: string[], changedFilesIgnorePattern?: string[] }
 ): Promise<[ProjectRootDir[], ProjectRootDir[]]> {
 
-  // .git is a directory in regular repos, but a file in worktrees
-  const gitPath = find.dir('.git', { cwd: opts.workspaceDir }) ??
-                  find.file('.git', { cwd: opts.workspaceDir })
+  // .git is a directory in regular repos, but a file in worktrees. The
+  // nearest entry of either kind wins, so a worktree checked out inside
+  // another repository's tree resolves to the worktree root, matching
+  // where git anchors its diff paths.
+  const gitPath = find.up('.git', { cwd: opts.workspaceDir })
 
   const repoRoot = path.resolve(gitPath ?? opts.workspaceDir, '..')
 
@@ -65,6 +67,9 @@ async function getChangedDirsSinceCommit (commit: string, workingDir: string, te
       await execa('git', [
         'diff',
         '--name-only',
+        // Keeps an option-like `<since>` (`--output=...`) from being
+        // parsed as a git option — git rejects it as a bad revision.
+        '--end-of-options',
         commit,
         '--',
         workingDir,

--- a/pnpm11/workspace/projects-filter/test/index.ts
+++ b/pnpm11/workspace/projects-filter/test/index.ts
@@ -591,6 +591,108 @@ test('select changed packages when operating under a git worktree', async () => 
   expect(Object.keys(selectedProjectsGraph)).toStrictEqual([worktreePkgADir])
 })
 
+test('select changed packages when operating under a git worktree nested inside the main repository', async () => {
+  if (isCI && isWindows()) {
+    return
+  }
+
+  const mainRepoDir = temporaryDirectory()
+  await execa('git', ['init', '--initial-branch=main'], { cwd: mainRepoDir })
+  await execa('git', ['config', 'user.email', 'x@y.z'], { cwd: mainRepoDir })
+  await execa('git', ['config', 'user.name', 'xyz'], { cwd: mainRepoDir })
+
+  const mainPkgADir = path.join(mainRepoDir, 'package-a')
+  const mainPkgBDir = path.join(mainRepoDir, 'package-b')
+  await mkdir(mainPkgADir)
+  await mkdir(mainPkgBDir)
+  await touch(path.join(mainPkgADir, 'file.js'))
+  await touch(path.join(mainPkgBDir, 'file.js'))
+  await execa('git', ['add', '.'], { cwd: mainRepoDir })
+  await execa('git', ['commit', '--allow-empty-message', '-m', '', '--no-gpg-sign'], { cwd: mainRepoDir })
+
+  // The worktree lives inside the main repository's tree, so an
+  // ancestor of the worktree has a `.git` directory while the worktree
+  // itself has a `.git` file. The nearest entry must win: git anchors
+  // its diff paths at the worktree root.
+  const worktreeDir = path.join(mainRepoDir, 'worktrees', 'feature')
+  await execa('git', ['worktree', 'add', '-b', 'feature', worktreeDir, 'main'], { cwd: mainRepoDir })
+
+  const worktreePkgADir = path.join(worktreeDir, 'package-a') as ProjectRootDir
+  const worktreePkgBDir = path.join(worktreeDir, 'package-b') as ProjectRootDir
+
+  await touch(path.join(worktreePkgADir, 'new-file.js'))
+  await execa('git', ['add', '.'], { cwd: worktreeDir })
+  await execa('git', ['commit', '--allow-empty-message', '-m', '', '--no-gpg-sign'], { cwd: worktreeDir })
+
+  const projectsGraph: ProjectGraph<BaseProject> = {
+    [worktreeDir as ProjectRootDir]: {
+      dependencies: [],
+      package: {
+        rootDir: worktreeDir as ProjectRootDir,
+        manifest: { name: 'root', version: '0.0.0' },
+      },
+    },
+    [worktreePkgADir]: {
+      dependencies: [],
+      package: {
+        rootDir: worktreePkgADir,
+        manifest: { name: 'package-a', version: '0.0.0' },
+      },
+    },
+    [worktreePkgBDir]: {
+      dependencies: [],
+      package: {
+        rootDir: worktreePkgBDir,
+        manifest: { name: 'package-b', version: '0.0.0' },
+      },
+    },
+  }
+
+  const { selectedProjectsGraph } = await filterWorkspaceProjects(projectsGraph, [{
+    diff: 'HEAD~1',
+  }], { workspaceDir: worktreeDir })
+
+  expect(Object.keys(selectedProjectsGraph)).toStrictEqual([worktreePkgADir])
+})
+
+test('an option-like diff ref is rejected as a bad revision instead of being parsed as a git option', async () => {
+  if (isCI && isWindows()) {
+    return
+  }
+
+  const workspaceDir = temporaryDirectory() as ProjectRootDir
+  await execa('git', ['init', '--initial-branch=main'], { cwd: workspaceDir })
+  await execa('git', ['config', 'user.email', 'x@y.z'], { cwd: workspaceDir })
+  await execa('git', ['config', 'user.name', 'xyz'], { cwd: workspaceDir })
+  const pkgADir = path.join(workspaceDir, 'package-a') as ProjectRootDir
+  await mkdir(pkgADir)
+  await touch(path.join(pkgADir, 'file.js'))
+  await execa('git', ['add', '.'], { cwd: workspaceDir })
+  await execa('git', ['commit', '--allow-empty-message', '-m', '', '--no-gpg-sign'], { cwd: workspaceDir })
+
+  const projectsGraph: ProjectGraph<BaseProject> = {
+    [pkgADir]: {
+      dependencies: [],
+      package: {
+        rootDir: pkgADir,
+        manifest: { name: 'package-a', version: '0.0.0' },
+      },
+    },
+  }
+
+  const evilOutputFile = path.join(workspaceDir, 'evil.txt')
+  let err!: PnpmError
+  try {
+    await filterWorkspaceProjects(projectsGraph, [{ diff: `--output=${evilOutputFile}` }], { workspaceDir })
+  } catch (_err: any) { // eslint-disable-line
+    err = _err
+  }
+  expect(err).toBeDefined()
+  expect(err.code).toBe('ERR_PNPM_FILTER_CHANGED')
+  expect(err.message).toContain('bad revision')
+  expect(fs.existsSync(evilOutputFile)).toBe(false)
+})
+
 test('selection should fail when diffing to a branch that does not exist', async () => {
   let err!: PnpmError
   try {


### PR DESCRIPTION
## Summary

Ports git-diff project selection (`getChangedProjects`) from `@pnpm/workspace.projects-filter` to pacquet, so a `--filter "...[<since>]"` selector selects the workspace projects whose files changed since the given git ref instead of failing with `pacquet_workspace_projects_filter::unsupported_diff_selector`.

This fixes the `ci:test-branch` CI job, which currently fails on every PR because `.github/scripts/run-ts-tests-chunk.mjs` discovers affected packages with `pn --filter=...[origin/main] -r list --depth=-1 --json` and the pacquet-based `@pnpm/exe` rejects the selector (example failure: https://github.com/pnpm/pnpm/actions/runs/29056291664/job/86252459055).

What the port covers, mirroring the TypeScript implementation:

- `git diff --name-only <since> -- <workspace_dir>` runs in the selector's `{dir}` part when present, else the workspace root; diff paths are resolved against the parent of the nearest `.git` directory, falling back to the nearest `.git` file (git worktrees).
- Each changed file maps to its nearest enclosing workspace project. Files matching `changedFilesIgnorePattern` are ignored; projects whose changes all match `testPattern` are selected without their dependents. Patterns are matched with `wax`, the glob crate pacquet already uses where upstream uses micromatch/fast-glob.
- A failing git diff surfaces git's stderr under pnpm's `ERR_PNPM_FILTER_CHANGED` error code with the same message text.
- The `testPattern` / `changedFilesIgnorePattern` settings are read from `pnpm-workspace.yaml` and `PNPM_CONFIG_*` env vars, overridable by the new global `--test-pattern` / `--changed-files-ignore-pattern` flags, and excluded from the global `config.yaml` — matching the TypeScript config surface.

The feature itself already exists in the TypeScript CLI; this PR closes the parity gap on the pacquet side. Review of the port surfaced two bugs present in **both** stacks, which are fixed here in both (per the repo's parity rule):

- **git argument injection**: `--filter "[--output=<path>]"` made `git diff` write its output to an arbitrary file and exit 0. Both stacks now pass `--end-of-options`, so git rejects option-like refs as bad revisions under `ERR_PNPM_FILTER_CHANGED`.
- **worktrees nested inside another repository's tree**: the repo root was resolved by preferring a `.git` *directory* anywhere up the tree over the worktree's `.git` *file*, anchoring diff paths at the wrong root. Both stacks now use the nearest `.git` entry of either kind (TypeScript: `find.up`).

Verification against the failing job:

- The exact failing invocation `pn --filter=...[origin/main] -r list --depth=-1 --json` now succeeds at this repository's root (a git worktree, so the `.git`-file path is exercised).
- `node .github/scripts/run-ts-tests-chunk.mjs --script ci:test-branch --chunk 1 --chunks 10 --dry-run` with the patched binary on PATH as `pn` completes and selects test tasks from the changed packages (it previously exited 1 at the list step).
- Parity check: the TypeScript CLI (freshly bundled `pnpm11/pnpm/dist/pnpm.mjs`) and the patched pacquet binary select the byte-identical project set for `...[origin/main]` on this repo — also when `--test-pattern` or `--changed-files-ignore-pattern` is added.
- All upstream tests around this feature are ported, and each was confirmed to fail when the implementation is deliberately broken:
  - the three `workspace/projects-filter` unit tests, from their `known_failures` stubs into `filter::tests::changed_packages` (basic selection including quoted non-ASCII paths, git-worktree layout, and the nonexistent-ref error);
  - the two `pnpm/test/monorepo` e2e tests: `testPattern is respected by the test script` (dependents of a test-only-changed project stay unselected on a recursive `test` run) and `changedFilesIgnorePattern is respected` (yaml-configured ignore patterns including brace alternation, plus the empty `--changed-files-ignore-pattern=` CLI override disabling them);
  - the two `config/reader` tests (`respects testPattern` / `respects changedFilesIgnorePattern`) as workspace-yaml config tests, plus their exclusion from the global `config.yaml`. The upstream `.npmrc`-is-ignored case has no pacquet counterpart because pacquet reads no settings from `.npmrc`, and the `parse-cli-args` single-value `--test-pattern` case is enforced by clap's declared arity.

## Squash Commit Body

```text
Port git-diff project selection from @pnpm/workspace.projects-filter to
pacquet, so a --filter "...[origin/main]" selector selects the workspace
projects whose files changed since the given git ref instead of failing
with unsupported_diff_selector. This unblocks the ci:test-branch job,
whose "pn --filter=...[origin/main] -r list --depth=-1 --json" discovery
step fails on every PR with the pacquet-based pnpm exe.

The port mirrors upstream getChangedProjects:

- "git diff --name-only <since> -- <workspace_dir>" runs in the
  selector's {dir} (else the workspace root); the repository root the
  diff paths are relative to is the parent of the nearest .git
  directory, falling back to the nearest .git file (worktrees).
- Each changed file maps to the nearest enclosing workspace project.
  Files matching changedFilesIgnorePattern are ignored entirely;
  projects whose changes all match testPattern are selected without
  their dependents. Both pattern sets are matched with wax, the glob
  crate pacquet already uses where upstream uses micromatch/fast-glob.
- A failing git diff surfaces git's stderr under pnpm's
  ERR_PNPM_FILTER_CHANGED error code.

FilterWorkspaceProjectsOptions / FilterProjectsOptions gain
workspace_dir, test_pattern, and changed_files_ignore_pattern, threaded
from Config by the recursive commands and deploy. The testPattern /
changedFilesIgnorePattern settings are read from pnpm-workspace.yaml
and PNPM_CONFIG_* env vars, overridable by the global --test-pattern /
--changed-files-ignore-pattern flags, and excluded from the global
config.yaml - all matching the TypeScript CLI.

All upstream tests around the feature are ported: the three
projects-filter unit tests (from their known_failures stubs into
filter::tests::changed_packages), the two monorepo e2e tests
(testPattern respected by the test script; changedFilesIgnorePattern
respected incl. the empty CLI override), and the config-reader tests
for both settings. The recursive run/exec integration tests now assert
the selector scopes execution to the changed project. Verified against the
TypeScript CLI on this repository: both stacks select the identical
project set for ...[origin/main], with and without the two pattern
flags.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recursive commands now support changed-project selectors based on Git revisions.
  - Added `--test-pattern` and `--changed-files-ignore-pattern` options for controlling project selection.
  - Changed-file ignore patterns can now be configured or overridden from the command line.
- **Bug Fixes**
  - Improved changed-project detection in Git worktrees and nested repositories.
  - Prevented option-like revision values from being misinterpreted as Git options.
  - Updated filtering behavior so only relevant changed projects are selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
