### PR TITLE
fix(ci): stage the Rust release binary outside the repo root before archiving

### DIFF
--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -166,9 +166,14 @@ jobs:
 
       - name: Archive Binary
         if: runner.os != 'Windows'
+        # The binary is staged in a scratch directory because the repo root
+        # already has a `pnpm/` directory (the Rust sub-project) — renaming the
+        # binary to `pnpm` in place would move it *into* that directory and tar
+        # up the whole source tree instead.
         run: |
-          mv target/${{ matrix.target }}/release/pacquet pnpm
-          tar czf pnpm-${{ matrix.code-target }}.tar.gz pnpm
+          mkdir stage
+          mv target/${{ matrix.target }}/release/pacquet stage/pnpm
+          tar czf pnpm-${{ matrix.code-target }}.tar.gz -C stage pnpm
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1


### PR DESCRIPTION
## Summary

The [Release pnpm (Rust) run](https://github.com/pnpm/pnpm/actions/runs/29113833296) failed in the Publish job with `EISDIR: illegal operation on a directory, copyfile '.../pnpm-darwin-x64'`.

Root cause: the build job's non-Windows "Archive Binary" step renamed the built binary to `pnpm` at the repo root before tarring it. Since pnpm/pnpm#12913 renamed the `pacquet/` directory to `pnpm/`, that `mv` moved the binary *into* the existing `pnpm/` source directory (as `pnpm/pacquet`), and `tar czf ... pnpm` archived the entire Rust source tree instead of the binary. The publish job then extracted a directory where it expected a binary, and `generate-packages.mjs` crashed. The Windows legs were unaffected because they rename to `pnpm.exe`, which doesn't collide.

This stages the binary in a scratch directory and tars from there. The archive layout is unchanged (a plain `pnpm` binary at the root), so the publish job, the GitHub release assets, and get.pnpm.io's install scripts all keep working as before. Verified locally that the new commands produce a tarball containing only `pnpm` and that the publish job's extract step yields a regular file. The pnpr release workflow doesn't have this bug — it renames its binary to `pnpr-<target>`, which doesn't collide with the `pnpr/` directory.

## Squash Commit Body

```text
The Release pnpm (Rust) workflow renamed the built binary to `pnpm` at the
repo root before tarring it. Since the pacquet/ directory was renamed to
pnpm/ (pnpm/pnpm#12913), that `mv` moved the binary *into* the existing
`pnpm/` source directory instead, so the non-Windows archives contained the
whole Rust source tree. The publish job then extracted a directory where it
expected a binary and failed with EISDIR in generate-packages.mjs
(https://github.com/pnpm/pnpm/actions/runs/29113833296).

Stage the binary in a scratch directory and tar from there, keeping the
archive layout (a plain `pnpm` binary at the root) unchanged.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. *(CI-only change to the Rust release workflow; nothing to port.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaging of non-Windows binary archives to ensure consistent archive contents and layout across platforms.
  * Preserved compatibility with subsequent release steps while avoiding changes to files in the repository root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->