### PR TITLE
chore: trust pnpm publishes and update pnpm to v12.0.0-alpha.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
     "shx": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@12.0.0-alpha.5",
+  "packageManager": "pnpm@12.0.0-alpha.6",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "12.0.0-alpha.5",
+      "version": "12.0.0-alpha.6",
       "onFail": "download"
     },
     "runtime": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,115 +7,115 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 12.0.0-alpha.5
-        version: 12.0.0-alpha.5
+        specifier: 12.0.0-alpha.6
+        version: 12.0.0-alpha.6
       pnpm:
-        specifier: 12.0.0-alpha.5
-        version: 12.0.0-alpha.5
+        specifier: 12.0.0-alpha.6
+        version: 12.0.0-alpha.6
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.5':
-    resolution: {integrity: sha512-QN9HtkwFX/eFAdTEX3IL1LmTVT26HScKELIFfll4SkEAryvU4SbBvfxQLHkYHfZsmQJDOII3XooL7ollaYVo8g==}
+  '@pnpm/exe.darwin-arm64@12.0.0-alpha.6':
+    resolution: {integrity: sha512-SQMx3DAFAw0PrMtBjCi8L3qwi88vrz13R3dtQOfK1sOUMKVToBXM1WW2cPjs43YhKPg2VdCTNmxDBYFBkPGTRw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.5':
-    resolution: {integrity: sha512-NIYrmQ0OCNVlEAw/0XwNsj6h/X6ap+unKt1DYacbDwrFzy8nzGFmW2gdKvDNMGTz1r1FMthczL9edOvON7vOsg==}
+  '@pnpm/exe.darwin-x64@12.0.0-alpha.6':
+    resolution: {integrity: sha512-Yh1zpBitpkwMbbsRpaJxZ3tc08FBj6e3vP5l+hriHm4XpR3XYaHG4rEOzQFlE841xQRUzd6cOYCsqwq9V3UChQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.5':
-    resolution: {integrity: sha512-buaqBJrMRyXM7l5fWUigqZFr2ROszWeqC/pYJSv4Cbvkrulo8I2dOy9DcDtNGd7JSJ1pO3kxtbvH+dWEHFdXmg==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.6':
+    resolution: {integrity: sha512-1UHEc6HYQD3UHyfGZGs7osWrhXmnO/oNddYXW5NtFX+kEsaZ8yKHwLIIJG8YLgwTbJJ/ocir0SD8LHe4cXfuRw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.5':
-    resolution: {integrity: sha512-+Oxphugo/xkKMP/sHRCMT1NjsGHlUAO+7p1ymKVMkVfoDGJkrS7yTBfFD2IocNFmhf2OBGMD9VyQkCGadgrytw==}
+  '@pnpm/exe.linux-arm64@12.0.0-alpha.6':
+    resolution: {integrity: sha512-ebG2lNpK2unnly388jMsVQJ+NYCRmcH21HJv/AudnaOz/vH6pfBmObf/OAPuouLYXhUPS258x2EN9TqbN6fAjQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.5':
-    resolution: {integrity: sha512-9p74kQ1yEAv5bZwKRm1s1i7a6ZtN/KRtT/dKMvI+QyEVDPQSxWRa6UnE/VMVB6mL3I0lHcuvfazawtrA9v9DfA==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.6':
+    resolution: {integrity: sha512-Dfwo2P9Zjty+oMZZxdUHJNHGAuf8fyHteoVI5Iv0f0WQMBvTgXuKK+s77aoCKdPRYQ9i7LA2BXOaR9ZTrCGzJQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-alpha.5':
-    resolution: {integrity: sha512-ncLkuuyvhr/xDcX0Gsf0anMKvbVHF37D/1ZI1MtCp8SF2IV07pIWs+b2udx3TMkiP8h3oIXt2yxFzGivzUUL9g==}
+  '@pnpm/exe.linux-x64@12.0.0-alpha.6':
+    resolution: {integrity: sha512-gH2PhliwVV+Xn73CnlS/7ClElVcdwb5AWSdz19yMpWchoAGAxhkGwCXkB2dXRcDaZDu6/SEd6XnhwIl0cqpboA==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.5':
-    resolution: {integrity: sha512-nb74Yg7ZZkW8JSrjSnB7kyLrny3RBjTokO+tOXtwIC+Nvwrvmjfh+a38g3wmDN5D9GibyRN/4V9nfErGS3Z03w==}
+  '@pnpm/exe.win32-arm64@12.0.0-alpha.6':
+    resolution: {integrity: sha512-i/+jLjI7Fp/YfGuZ0FoOTIk/lsf7VMedEjT82o38aQYXf82rGRyMybBQ0yyevF4UY9VfcOGYa/kXYpZ9iy7e8w==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-alpha.5':
-    resolution: {integrity: sha512-neCf7jeYyOgz00X5/VUGqf2kaE4Aqmu7A4m0P7O1YnKVm/NXFAWO9OBCZY02h4/CedPG8TZd6w15DfTpoeBfVw==}
+  '@pnpm/exe.win32-x64@12.0.0-alpha.6':
+    resolution: {integrity: sha512-/qkjA9E2Rna5DoQMVYpPFrY4t+b0CuwNmOrxSLV/+B7WNCZ1150F7/eq4zFlrn7bpz1dD8af1Iyh5ACTaykJiw==}
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0-alpha.5':
-    resolution: {integrity: sha512-bcehN56GYQ1Pd1GwVceO+RFjrTzhQvWOW3pMY+R+iKJfvuNfsiRTo9UrG7Yaq143Sc/rCVNZr7kez13UR65iLQ==}
+  '@pnpm/exe@12.0.0-alpha.6':
+    resolution: {integrity: sha512-atAAsxM0rv7IdQ6xRvKY6YzbXvdh9iglmf1aCc5GdgusK/axv99Lqm1XuqZryzI2sgAxBYJ8htM0ApzEwTAEsw==}
     engines: {node: '>=18.*'}
     hasBin: true
 
-  pnpm@12.0.0-alpha.5:
-    resolution: {integrity: sha512-VcP3t3bz4DA8UOYeVcA3BbIWcd0dLYjslfKVXk1N0wRhLh2sG9aO6yOJTT3Mm14tRL+htu35PXUKMJepprBJ1w==}
+  pnpm@12.0.0-alpha.6:
+    resolution: {integrity: sha512-HrjVDehJOyiQx3+BOBC8xebl900ehjja29Kz7a8fAqa1d0yYNDMvqyFoKMj0PWsOLvTIUdcu383EmoXlDyOWjA==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.5':
+  '@pnpm/exe.darwin-arm64@12.0.0-alpha.6':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.5':
+  '@pnpm/exe.darwin-x64@12.0.0-alpha.6':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.5':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.6':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.5':
+  '@pnpm/exe.linux-arm64@12.0.0-alpha.6':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.5':
+  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.6':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-alpha.5':
+  '@pnpm/exe.linux-x64@12.0.0-alpha.6':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.5':
+  '@pnpm/exe.win32-arm64@12.0.0-alpha.6':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-alpha.5':
+  '@pnpm/exe.win32-x64@12.0.0-alpha.6':
     optional: true
 
-  '@pnpm/exe@12.0.0-alpha.5':
+  '@pnpm/exe@12.0.0-alpha.6':
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.5
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.5
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.5
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.5
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.5
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.5
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.5
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.5
+      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.6
+      '@pnpm/exe.darwin-x64': 12.0.0-alpha.6
+      '@pnpm/exe.linux-arm64': 12.0.0-alpha.6
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.6
+      '@pnpm/exe.linux-x64': 12.0.0-alpha.6
+      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.6
+      '@pnpm/exe.win32-arm64': 12.0.0-alpha.6
+      '@pnpm/exe.win32-x64': 12.0.0-alpha.6
 
-  pnpm@12.0.0-alpha.5:
+  pnpm@12.0.0-alpha.6:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.5
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.5
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.5
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.5
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.5
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.5
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.5
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.5
+      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.6
+      '@pnpm/exe.darwin-x64': 12.0.0-alpha.6
+      '@pnpm/exe.linux-arm64': 12.0.0-alpha.6
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.6
+      '@pnpm/exe.linux-x64': 12.0.0-alpha.6
+      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.6
+      '@pnpm/exe.win32-arm64': 12.0.0-alpha.6
+      '@pnpm/exe.win32-x64': 12.0.0-alpha.6
 
 ---
 lockfileVersion: '9.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -506,6 +506,7 @@ trustPolicy: no-downgrade
 trustPolicyExclude:
   - '@pnpm/*'
   - '@yarnpkg/libzip@3.2.2'
+  - pnpm
   - rxjs@7.8.2
   - tinyexec@1.2.2
   - undici-types@6.21.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package manager version.
  * Adjusted workspace trust policy settings for improved package management compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->