### PR TITLE
feat(pacquet): port the stage command and add its -/stage endpoints to pnpr

### DIFF
--- a/.changeset/stage-list-page-cap.md
+++ b/.changeset/stage-list-page-cap.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+`pnpm stage list` now stops paginating after a fail-safe cap of 1000 pages, so a misbehaving registry cannot keep the command looping forever.

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ pacquet-hooks                             = { workspace = true }
 pacquet-lockfile                          = { workspace = true }
 pacquet-modules-yaml                      = { workspace = true }
 pacquet-network                           = { workspace = true }
+pacquet-network-web-auth                  = { workspace = true }
 pacquet-config                            = { workspace = true }
 pacquet-config-parse-overrides            = { workspace = true }
 pacquet-default-reporter                  = { workspace = true }
@@ -61,6 +62,7 @@ clap                 = { workspace = true }
 derive_more          = { workspace = true }
 dialoguer            = { workspace = true }
 dunce                = { workspace = true }
+flate2               = { workspace = true }
 futures-util         = { workspace = true }
 home                 = { workspace = true }
 indexmap             = { workspace = true }
@@ -76,6 +78,7 @@ rmp-serde            = { workspace = true }
 serde                = { workspace = true }
 serde_json           = { workspace = true }
 tabled               = { workspace = true }
+tar                  = { workspace = true }
 tempfile             = { workspace = true }
 tokio                = { workspace = true }
 tracing              = { workspace = true }
@@ -91,7 +94,6 @@ wax                  = { workspace = true }
 windows-sys = { workspace = true, features = ["Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 [dev-dependencies]
-pacquet-network-web-auth         = { workspace = true }
 pacquet-network-web-auth-testing = { workspace = true }
 pacquet-testing-utils            = { workspace = true }
 pnpr                             = { workspace = true }
@@ -99,12 +101,10 @@ pnpr                             = { workspace = true }
 assert_cmd        = { workspace = true }
 command-extra     = { workspace = true }
 dialoguer         = { workspace = true }
-flate2            = { workspace = true }
 insta             = { workspace = true }
 mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
 serde-saphyr      = { workspace = true }
-tar               = { workspace = true }
 text-block-macros = { workspace = true }
 walkdir           = { workspace = true }
 

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -55,6 +55,7 @@ pub mod search;
 pub mod self_update;
 pub mod set_script;
 pub mod setup;
+pub mod stage;
 pub mod stop;
 pub mod store;
 pub mod supported_architectures;

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -51,6 +51,7 @@ use super::{
     self_update::SelfUpdateArgs,
     set_script::SetScriptArgs,
     setup::SetupArgs,
+    stage::StageArgs,
     stop::StopArgs,
     store::StoreCommand,
     unlink::UnlinkArgs,
@@ -287,6 +288,9 @@ pub enum CliCommand {
     Pack(PackArgs),
     /// Publish a package to the registry
     Publish(PublishArgs),
+    /// Stage packages for publishing, deferring proof-of-presence (2FA) to a
+    /// later point in time.
+    Stage(StageArgs),
     /// Removes packages from `node_modules` and from the project's `package.json`.
     // Unlike npm, pnpm does not treat "r" as an alias of "remove" to avoid
     // confusion with "run" and "recursive".

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -233,7 +233,7 @@ impl CliArgs {
     }
 
     fn validate_report_summary_global_option(&self) -> Result<(), clap::Error> {
-        if matches!(self.command, CliCommand::Publish(_)) {
+        if matches!(self.command, CliCommand::Publish(_) | CliCommand::Stage(_)) {
             return Ok(());
         }
         self.validate_run_scoped_global_option("--report-summary")

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -308,6 +308,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Rebuild(args) => dispatch_install::rebuild(ctx, args),
         CliCommand::Pack(args) => dispatch_query::pack(ctx, &args),
         CliCommand::Publish(args) => dispatch_query::publish(ctx, args),
+        CliCommand::Stage(args) => dispatch_query::stage(ctx, args),
         CliCommand::Remove(args) => dispatch_install::remove(ctx, args),
         CliCommand::Patch(args) => dispatch_install::patch(ctx, args),
         CliCommand::PatchCommit(args) => dispatch_install::patch_commit(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -29,6 +29,7 @@ use super::{
     search::SearchArgs,
     self_update::SelfUpdateArgs,
     setup::SetupArgs,
+    stage::StageArgs,
     store::StoreCommand,
     why::WhyArgs,
     with::WithArgs,
@@ -224,13 +225,48 @@ pub(super) fn publish<'a>(
     let config = (ctx.config)()?;
     let dir = ctx.dir;
     let recursive = ctx.recursive;
-    args.report_summary |= ctx.recursive_report_summary;
+    args.flags.report_summary |= ctx.recursive_report_summary;
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => {
             Box::pin(args.run::<DefaultReporter>(dir, config, recursive))
         }
         ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(dir, config, recursive)),
         ReporterType::Silent => Box::pin(args.run::<SilentReporter>(dir, config, recursive)),
+    })
+}
+
+/// `stage` shares `publish`'s dispatch shape: the values are read off `ctx`
+/// before the boxed future so it captures only owned/concrete values (see
+/// [`publish`]), and the subcommand's output is printed here, sanitized,
+/// mirroring pnpm's `handler` → CLI print split.
+pub(super) fn stage<'a>(ctx: &RunCtx<'a>, args: StageArgs) -> miette::Result<CommandFuture<'a>> {
+    let config = (ctx.config)()?;
+    let dir = ctx.dir;
+    let recursive = ctx.recursive;
+    async fn print_output<Reporter: pacquet_reporter::Reporter>(
+        args: StageArgs,
+        dir: &std::path::Path,
+        config: &Config,
+        recursive: bool,
+    ) -> miette::Result<()> {
+        if let Some(output) = args.run::<Reporter>(dir, config, recursive).await? {
+            let output = super::sanitize::sanitize(&output);
+            if !output.is_empty() {
+                println!("{output}");
+            }
+        }
+        Ok(())
+    }
+    Ok(match ctx.reporter {
+        ReporterType::Default | ReporterType::AppendOnly => {
+            Box::pin(print_output::<DefaultReporter>(args, dir, config, recursive))
+        }
+        ReporterType::Ndjson => {
+            Box::pin(print_output::<NdjsonReporter>(args, dir, config, recursive))
+        }
+        ReporterType::Silent => {
+            Box::pin(print_output::<SilentReporter>(args, dir, config, recursive))
+        }
     })
 }
 

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -239,10 +239,14 @@ pub(super) fn publish<'a>(
 /// before the boxed future so it captures only owned/concrete values (see
 /// [`publish`]), and the subcommand's output is printed here, sanitized,
 /// mirroring pnpm's `handler` → CLI print split.
-pub(super) fn stage<'a>(ctx: &RunCtx<'a>, args: StageArgs) -> miette::Result<CommandFuture<'a>> {
+pub(super) fn stage<'a>(
+    ctx: &RunCtx<'a>,
+    mut args: StageArgs,
+) -> miette::Result<CommandFuture<'a>> {
     let config = (ctx.config)()?;
     let dir = ctx.dir;
     let recursive = ctx.recursive;
+    args.flags.report_summary |= ctx.recursive_report_summary;
     async fn print_output<Reporter: pacquet_reporter::Reporter>(
         args: StageArgs,
         dir: &std::path::Path,

--- a/pnpm/crates/cli/src/cli_args/dist_tag.rs
+++ b/pnpm/crates/cli/src/cli_args/dist_tag.rs
@@ -1,13 +1,12 @@
 use super::sanitize;
 use clap::Args;
 use derive_more::{Display, Error};
-use futures_util::StreamExt as _;
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use node_semver::Version;
 use pacquet_config::Config;
 use pacquet_network::{
-    NetworkSettings, RetryOpts, ThrottledClient, encode_uri_component, redact_url_credentials,
-    retry_async, send_with_retry,
+    LimitedBody, NetworkSettings, RetryOpts, ThrottledClient, encode_uri_component,
+    read_limited_body, redact_url_credentials, retry_async, send_with_retry,
 };
 use pacquet_resolving_npm_resolver::pick_registry_for_package;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -428,7 +427,7 @@ async fn write_error_from_response(response: Response, action: String) -> miette
     })?;
     let web_otp_challenge =
         if body.truncated { None } else { parse_web_otp_challenge(&body.bytes) };
-    let body = body.into_display_string();
+    let body = body_display_string(&body);
     if status == StatusCode::UNAUTHORIZED {
         if let Some(challenge) = web_otp_challenge {
             return Err(DistTagError::WebOtpRequired {
@@ -501,45 +500,18 @@ where
     .into()
 }
 
-struct LimitedBody {
-    bytes: Vec<u8>,
-    truncated: bool,
-}
-
-impl LimitedBody {
-    fn into_display_string(self) -> String {
-        let body = String::from_utf8_lossy(&self.bytes);
-        let mut body = sanitize::sanitize(&body).into_owned();
-        if self.truncated {
-            if !body.is_empty() && !body.chars().next_back().is_some_and(char::is_whitespace) {
-                body.push(' ');
-            }
-            body.push_str("(response body truncated)");
+/// Render a capped response body for an error message: lossy UTF-8,
+/// sanitized, with a truncation note when the cap was hit.
+pub(super) fn body_display_string(body: &LimitedBody) -> String {
+    let text = String::from_utf8_lossy(&body.bytes);
+    let mut text = sanitize::sanitize(&text).into_owned();
+    if body.truncated {
+        if !text.is_empty() && !text.chars().next_back().is_some_and(char::is_whitespace) {
+            text.push(' ');
         }
-        body
+        text.push_str("(response body truncated)");
     }
-}
-
-async fn read_limited_body(
-    response: Response,
-    limit: usize,
-) -> Result<LimitedBody, reqwest::Error> {
-    let header_exceeds_limit =
-        response.content_length().is_some_and(|length| length > limit as u64);
-    let mut bytes = Vec::new();
-    let mut truncated = header_exceeds_limit;
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
-        let remaining = limit.saturating_sub(bytes.len());
-        if chunk.len() > remaining {
-            bytes.extend_from_slice(&chunk[..remaining]);
-            truncated = true;
-            break;
-        }
-        bytes.extend_from_slice(&chunk);
-    }
-    Ok(LimitedBody { bytes, truncated })
+    text
 }
 
 #[derive(Deserialize)]

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -37,6 +37,15 @@ pub struct PublishArgs {
     /// Tarball or directory to publish. Defaults to the current directory.
     pub package: Option<String>,
 
+    #[clap(flatten)]
+    pub flags: PublishFlags,
+}
+
+/// The flag half of [`PublishArgs`], split out so `pacquet stage publish`
+/// (which accepts every publish option) can reuse it alongside its own
+/// positional subcommand parameters.
+#[derive(Debug, Args)]
+pub struct PublishFlags {
     /// Do everything `publish` would do except uploading to the registry.
     #[clap(long)]
     pub dry_run: bool,
@@ -92,6 +101,25 @@ pub struct PublishArgs {
     pub report_summary: bool,
 }
 
+/// What one `publish` / `stage publish` invocation published: the single
+/// package summary, or the recursive path's per-package summaries (possibly
+/// empty). The two arms serialize differently under `--json` — an object vs.
+/// an array — so the split is kept rather than flattened to a `Vec`.
+pub(super) enum PublishedPackages {
+    Single(Box<PublishSummary>),
+    Recursive(Vec<PublishSummary>),
+}
+
+impl PublishedPackages {
+    /// The summaries in publish order, without the single/recursive split.
+    pub(super) fn summaries(&self) -> &[PublishSummary] {
+        match self {
+            PublishedPackages::Single(summary) => std::slice::from_ref(summary),
+            PublishedPackages::Recursive(published) => published,
+        }
+    }
+}
+
 impl PublishArgs {
     /// Publish the package at `dir` (or the given tarball/directory),
     /// returning nothing — output is printed here. Handles the single-package
@@ -102,7 +130,36 @@ impl PublishArgs {
         config: &Config,
         recursive: bool,
     ) -> miette::Result<()> {
-        if self.batch && !recursive {
+        let published =
+            self.publish_packages::<Reporter>(dir, config, recursive, /* stage */ false).await?;
+        // Mirror `pnpm publish --json`: serialize only when asked. The
+        // recursive path emits the array of per-package summaries (an empty
+        // array when nothing was published).
+        if self.flags.json {
+            match &published {
+                PublishedPackages::Single(summary) => {
+                    println!("{}", summary.pipe(serde_json::to_string_pretty).into_diagnostic()?);
+                }
+                PublishedPackages::Recursive(published) => {
+                    println!("{}", published.pipe(serde_json::to_string_pretty).into_diagnostic()?);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Run the whole publish pipeline — git checks, packing, lifecycle
+    /// scripts, the registry request — and return the summaries instead of
+    /// printing, so `publish` and `stage publish` can render them differently.
+    /// `stage` sends the upload to the registry's staging endpoint.
+    pub(super) async fn publish_packages<Reporter: self::Reporter>(
+        &self,
+        dir: &Path,
+        config: &Config,
+        recursive: bool,
+        stage: bool,
+    ) -> miette::Result<PublishedPackages> {
+        if self.flags.batch && !recursive {
             return Err(miette::miette!(
                 code = "ERR_PNPM_BATCH_PUBLISH_REQUIRES_RECURSIVE",
                 help = r#"Run "pnpm publish -r --batch" to publish all workspace packages in a single request."#,
@@ -112,22 +169,17 @@ impl PublishArgs {
 
         // Upstream gates on `opts.gitChecks !== false`, which folds together
         // the `git-checks` config setting and the `--no-git-checks` flag.
-        let publish_branch = self.publish_branch.as_deref();
-        let git_checks = config.git_checks && !self.no_git_checks;
+        let publish_branch = self.flags.publish_branch.as_deref();
+        let git_checks = config.git_checks && !self.flags.no_git_checks;
         run_git_checks::<Host>(dir, git_checks, publish_branch)?;
 
         if recursive {
-            let published = self.run_recursive::<Reporter>(dir, config).await?;
-            // Mirror `pnpm publish --json`: the recursive path emits the array of
-            // per-package summaries (an empty array when nothing was published).
-            if self.json {
-                println!("{}", published.pipe_ref(serde_json::to_string_pretty).into_diagnostic()?);
-            }
-            return Ok(());
+            let published = self.run_recursive::<Reporter>(dir, config, stage).await?;
+            return Ok(PublishedPackages::Recursive(published));
         }
 
-        let otp = resolve_otp_from_env::<Host>(self.otp.clone());
-        let opts = self.publish_options(config, otp);
+        let otp = resolve_otp_from_env::<Host>(self.flags.otp.clone());
+        let opts = self.publish_options(config, otp, stage);
         let http_client = build_registry_client(config)?;
         let network = PublishNetwork { client: &http_client, auth_headers: &config.auth_headers };
 
@@ -138,12 +190,7 @@ impl PublishArgs {
                 let project_dir = self.package.as_deref().map_or(dir, Path::new);
                 self.publish_directory::<Reporter>(project_dir, config, &opts, &network).await?
             };
-
-        // Mirror `pnpm publish --json`: serialize only when asked.
-        if self.json {
-            println!("{}", summary.pipe_ref(serde_json::to_string_pretty).into_diagnostic()?);
-        }
-        Ok(())
+        Ok(PublishedPackages::Single(Box::new(summary)))
     }
 
     /// Publish a pre-built tarball: extract its manifest and hand the bytes
@@ -240,7 +287,7 @@ impl PublishArgs {
     /// suppress packing and publish scripts, matching pnpm's single
     /// `opts.ignoreScripts`.
     fn should_ignore_scripts(&self, config: &Config) -> bool {
-        self.ignore_scripts || config.ignore_scripts
+        self.flags.ignore_scripts || config.ignore_scripts
     }
 
     /// Pack the project into `pack_destination` for publishing (never a dry
@@ -259,7 +306,7 @@ impl PublishArgs {
             embed_readme: false,
             pack_gzip_level: None,
             node_linker: config.node_linker,
-            skip_manifest_obfuscation: self.skip_manifest_obfuscation,
+            skip_manifest_obfuscation: self.flags.skip_manifest_obfuscation,
             user_agent: config.user_agent.clone(),
             extra_bin_paths: config.extra_bin_paths.clone(),
             extra_env: HashMap::new(),
@@ -274,17 +321,22 @@ impl PublishArgs {
     }
 
     /// Map the CLI flags and resolved [`Config`] onto the publish options.
-    fn publish_options(&self, config: &Config, otp: Option<String>) -> PublishPackedPkgOptions {
+    fn publish_options(
+        &self,
+        config: &Config,
+        otp: Option<String>,
+        stage: bool,
+    ) -> PublishPackedPkgOptions {
         PublishPackedPkgOptions {
             default_registry: config.registry.clone(),
             scoped_registries: config.registries.clone(),
-            access: self.access.as_deref().and_then(Access::parse),
-            tag: self.tag.clone().unwrap_or_else(|| "latest".to_owned()),
+            access: self.flags.access.as_deref().and_then(Access::parse),
+            tag: self.flags.tag.clone().unwrap_or_else(|| "latest".to_owned()),
             otp,
             // An absent `--provenance` leaves the decision to the OIDC flow.
-            provenance: self.provenance.then_some(true),
-            dry_run: self.dry_run,
-            stage: false,
+            provenance: self.flags.provenance.then_some(true),
+            dry_run: self.flags.dry_run,
+            stage,
             http: OidcHttpOptions {
                 fetch_retries: Some(config.fetch_retries),
                 fetch_retry_factor: Some(f64::from(config.fetch_retry_factor)),

--- a/pnpm/crates/cli/src/cli_args/publish/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/recursive.rs
@@ -41,8 +41,9 @@ impl PublishArgs {
         &self,
         dir: &Path,
         config: &Config,
+        stage: bool,
     ) -> miette::Result<Vec<PublishSummary>> {
-        if self.batch {
+        if self.flags.batch {
             return Err(miette::miette!(
                 help = "Publish without --batch; batched publishing is not yet ported to pacquet.",
                 "Batch publishing (--batch) is not yet supported by pacquet",
@@ -68,8 +69,8 @@ impl PublishArgs {
 
         let http_client = build_registry_client(config)?;
         let network = PublishNetwork { client: &http_client, auth_headers: &config.auth_headers };
-        let otp = resolve_otp_from_env::<Host>(self.otp.clone());
-        let opts = self.publish_options(config, otp);
+        let otp = resolve_otp_from_env::<Host>(self.flags.otp.clone());
+        let opts = self.publish_options(config, otp, stage);
         let retry_opts = retry_opts_from_config(config);
 
         // Filter the selected graph: keep only packages that have a name and
@@ -82,7 +83,7 @@ impl PublishArgs {
             let manifest = node.package.project.manifest.value();
             let (name, version) = publish_eligible(manifest)?;
             Some(async move {
-                let already = !self.force
+                let already = !self.flags.force
                     && is_already_published(
                         name,
                         version,
@@ -104,7 +105,7 @@ impl PublishArgs {
 
         if to_publish.is_empty() {
             emit_info::<Reporter>("There are no new packages that should be published", dir);
-            if self.report_summary {
+            if self.flags.report_summary {
                 write_publish_summary(workspace_root, &[])?;
             }
             return Ok(Vec::new());
@@ -130,7 +131,7 @@ impl PublishArgs {
             }
         }
 
-        if self.report_summary {
+        if self.flags.report_summary {
             write_publish_summary(workspace_root, &published)?;
         }
         Ok(published)

--- a/pnpm/crates/cli/src/cli_args/publish/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/tests.rs
@@ -1,4 +1,4 @@
-use super::{PublishArgs, run_publish_scripts};
+use super::{PublishArgs, PublishFlags, run_publish_scripts};
 use pacquet_config::Config;
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_publish::{Access, PublishNetwork};
@@ -9,8 +9,15 @@ use serde_json::json;
 /// A `PublishArgs` with every flag at its default; a test overrides only the
 /// field it exercises.
 fn publish_args() -> PublishArgs {
-    PublishArgs {
-        package: None,
+    PublishArgs { package: None, flags: publish_flags() }
+}
+
+fn publish_args_with(flags: PublishFlags) -> PublishArgs {
+    PublishArgs { package: None, flags }
+}
+
+fn publish_flags() -> PublishFlags {
+    PublishFlags {
         dry_run: false,
         json: false,
         tag: None,
@@ -33,14 +40,16 @@ fn should_ignore_scripts_ors_the_flag_with_the_config() {
     let config_on = Config { ignore_scripts: true, ..Default::default() };
     assert!(!publish_args().should_ignore_scripts(&config_off));
     assert!(
-        PublishArgs { ignore_scripts: true, ..publish_args() }.should_ignore_scripts(&config_off),
+        publish_args_with(PublishFlags { ignore_scripts: true, ..publish_flags() })
+            .should_ignore_scripts(&config_off),
     );
     assert!(publish_args().should_ignore_scripts(&config_on));
 }
 
 #[test]
 fn publish_options_defaults_the_tag_to_latest_and_carries_the_otp() {
-    let options = publish_args().publish_options(&Config::default(), Some("246810".to_owned()));
+    let options =
+        publish_args().publish_options(&Config::default(), Some("246810".to_owned()), false);
     assert_eq!(options.tag, "latest");
     assert_eq!(options.otp, Some("246810".to_owned()));
     assert_eq!(options.provenance, None);
@@ -51,14 +60,14 @@ fn publish_options_defaults_the_tag_to_latest_and_carries_the_otp() {
 
 #[test]
 fn publish_options_applies_tag_access_provenance_and_dry_run() {
-    let args = PublishArgs {
+    let args = publish_args_with(PublishFlags {
         tag: Some("next".to_owned()),
         access: Some("restricted".to_owned()),
         provenance: true,
         dry_run: true,
-        ..publish_args()
-    };
-    let options = args.publish_options(&Config::default(), None);
+        ..publish_flags()
+    });
+    let options = args.publish_options(&Config::default(), None, false);
     assert_eq!(options.tag, "next");
     assert_eq!(options.access, Some(Access::Restricted));
     assert_eq!(options.provenance, Some(true));
@@ -73,7 +82,7 @@ fn pack_for_publish_writes_a_tarball_and_returns_the_manifest() {
         .expect("write the manifest");
     let dest = tempfile::tempdir().expect("a destination dir");
 
-    let args = PublishArgs { ignore_scripts: true, ..publish_args() };
+    let args = publish_args_with(PublishFlags { ignore_scripts: true, ..publish_flags() });
     let result = args
         .pack_for_publish::<SilentReporter>(dir.path(), &Config::default(), dest.path())
         .expect("packing succeeds");
@@ -131,7 +140,7 @@ async fn publish_directory_errors_when_no_manifest_is_present() {
     let dir = tempfile::tempdir().expect("an empty project dir");
     let config = Config::default();
     let args = publish_args();
-    let opts = args.publish_options(&config, None);
+    let opts = args.publish_options(&config, None, false);
     let client = ThrottledClient::default();
     let auth_headers = AuthHeaders::default();
     let network = PublishNetwork { client: &client, auth_headers: &auth_headers };
@@ -151,7 +160,7 @@ async fn publish_directory_errors_when_no_manifest_is_present() {
 /// publish is rejected before any git check or network work.
 #[tokio::test]
 async fn run_rejects_batch_without_recursive() {
-    let args = PublishArgs { batch: true, ..publish_args() };
+    let args = publish_args_with(PublishFlags { batch: true, ..publish_flags() });
     let err = args
         .run::<SilentReporter>(std::path::Path::new("."), &Config::default(), false)
         .await

--- a/pnpm/crates/cli/src/cli_args/stage.rs
+++ b/pnpm/crates/cli/src/cli_args/stage.rs
@@ -1,0 +1,760 @@
+//! `pacquet stage` — stage packages for publishing, deferring
+//! proof-of-presence (2FA) approval to a later point in time.
+//!
+//! `stage publish` runs the regular publish pipeline (packing, lifecycle
+//! scripts, OIDC/OTP) against the registry's staging endpoint; the remaining
+//! subcommands — `list`, `view`, `approve`, `reject`, `download` — talk to
+//! the registry's `-/stage` API directly.
+
+mod summarize_tarball;
+
+use std::{collections::HashMap, path::Path, time::Duration};
+
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_network::{
+    RetryOpts, ThrottledClient, read_limited_body, redact_url_credentials, send_with_retry,
+};
+use pacquet_network_web_auth::{
+    Host as WebAuthHost, OtpChallenge, OtpError, OtpErrorBody, WebAuthFetchOptions,
+    WebAuthRetryOptions, WithOtpError, with_otp_handling,
+};
+use pacquet_publish::{Host, PublishSummary, resolve_otp_from_env};
+use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
+use pacquet_resolving_npm_resolver::pick_registry_for_package;
+use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{
+    dist_tag::body_display_string,
+    publish::{PublishArgs, PublishFlags},
+};
+use crate::cli_args::registry_client::build_registry_client;
+use summarize_tarball::{create_tarball_filename, summarize_tarball};
+
+/// The staged-list page size; matches pnpm's paginated `-/stage` reads.
+const PER_PAGE: usize = 100;
+const STAGE_BODY_LIMIT: usize = 1024 * 1024;
+const STAGE_ERROR_BODY_LIMIT: usize = 64 * 1024;
+const STAGE_SUBCOMMANDS: &str = "publish, list, view, approve, reject, download";
+
+#[derive(Debug, Args)]
+pub struct StageArgs {
+    /// Stage subcommand and arguments.
+    pub params: Vec<String>,
+
+    /// The base URL of the npm registry.
+    #[clap(long)]
+    pub registry: Option<String>,
+
+    #[clap(flatten)]
+    pub flags: PublishFlags,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum StageError {
+    #[display("Stage subcommand is required")]
+    #[diagnostic(code(ERR_PNPM_STAGE_SUBCOMMAND_REQUIRED), help("Use one of: {STAGE_SUBCOMMANDS}"))]
+    SubcommandRequired,
+
+    #[display(r#"Unknown stage subcommand "{subcommand}""#)]
+    #[diagnostic(code(ERR_PNPM_STAGE_UNKNOWN_SUBCOMMAND), help("Use one of: {STAGE_SUBCOMMANDS}"))]
+    UnknownSubcommand {
+        #[error(not(source))]
+        subcommand: String,
+    },
+
+    #[display(r#"Missing required <stage-id> for "pnpm stage {subcommand}""#)]
+    #[diagnostic(code(ERR_PNPM_STAGE_ID_REQUIRED))]
+    StageIdRequired {
+        #[error(not(source))]
+        subcommand: &'static str,
+    },
+
+    #[display("stage-id must be a valid UUID")]
+    #[diagnostic(code(ERR_PNPM_INVALID_STAGE_ID))]
+    InvalidStageId,
+
+    #[display("Invalid package spec: {spec}")]
+    #[diagnostic(code(ERR_PNPM_INVALID_PACKAGE_SPEC))]
+    InvalidPackageSpec {
+        #[error(not(source))]
+        spec: String,
+    },
+
+    #[display("Version specifiers are not supported for listing staged packages")]
+    #[diagnostic(code(ERR_PNPM_STAGE_VERSION_SPECIFIER_UNSUPPORTED))]
+    VersionSpecifierUnsupported,
+
+    #[display("Failed to {operation}: {reason}")]
+    #[diagnostic(code(ERR_PNPM_STAGE_REGISTRY_ERROR))]
+    RequestFailed {
+        #[error(not(source))]
+        operation: String,
+        #[error(not(source))]
+        reason: String,
+    },
+
+    #[display("Could not read package.json from tarball")]
+    #[diagnostic(code(ERR_PNPM_STAGE_TARBALL_MANIFEST_NOT_FOUND))]
+    TarballManifestNotFound,
+
+    #[display(r#"Invalid package name "{name}"."#)]
+    #[diagnostic(code(ERR_PNPM_INVALID_PACKAGE_NAME))]
+    InvalidPackageName {
+        #[error(not(source))]
+        name: String,
+    },
+
+    #[display(r#"Invalid package version "{version}"."#)]
+    #[diagnostic(code(ERR_PNPM_INVALID_PACKAGE_VERSION))]
+    InvalidPackageVersion {
+        #[error(not(source))]
+        version: String,
+    },
+
+    #[display(r#"Invalid tarball filename "{filename}"."#)]
+    #[diagnostic(code(ERR_PNPM_INVALID_TARBALL_FILENAME))]
+    InvalidTarballFilename {
+        #[error(not(source))]
+        filename: String,
+    },
+}
+
+/// A failed `-/stage` registry response
+/// (`ERR_PNPM_STAGE_REGISTRY_ERROR`), mirroring pnpm's `StageRegistryError`
+/// message shape.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("{message}")]
+#[diagnostic(code(ERR_PNPM_STAGE_REGISTRY_ERROR))]
+pub struct StageRegistryError {
+    #[error(not(source))]
+    message: String,
+}
+
+impl StageRegistryError {
+    fn new(action: &str, status: u16, status_text: &str, body: &str) -> Self {
+        let status_display = if status_text.is_empty() {
+            status.to_string()
+        } else {
+            format!("{status} {status_text}")
+        };
+        let trimmed = body.trim();
+        let message = if trimmed.is_empty() {
+            format!("Failed to {action} (status {status_display})")
+        } else {
+            format!("Failed to {action} (status {status_display}): {trimmed}")
+        };
+        StageRegistryError { message }
+    }
+}
+
+/// One page of the registry's `-/stage` listing.
+#[derive(Debug, Deserialize)]
+struct StageListResponse {
+    items: Vec<Value>,
+    total: usize,
+}
+
+impl StageArgs {
+    /// Dispatch to the requested stage subcommand and return the output to
+    /// print, if any.
+    pub async fn run<Reporter: self::Reporter>(
+        self,
+        dir: &Path,
+        config: &Config,
+        recursive: bool,
+    ) -> miette::Result<Option<String>> {
+        match self.params.first().map(String::as_str) {
+            Some("publish") => self.stage_publish::<Reporter>(dir, config, recursive).await,
+            Some("list") => self.stage_list(config).await,
+            Some("view") => self.stage_view(config).await,
+            Some("approve") => self.stage_approve::<Reporter>(config).await,
+            Some("reject") => self.stage_reject::<Reporter>(config).await,
+            Some("download") => self.stage_download(dir, config).await,
+            None => Err(StageError::SubcommandRequired.into()),
+            Some(other) => {
+                Err(StageError::UnknownSubcommand { subcommand: other.to_owned() }.into())
+            }
+        }
+    }
+
+    /// `stage publish` — the regular publish pipeline against the staging
+    /// endpoint, rendered as `+ <pkg> (staged with id <id>)` lines or a
+    /// name-keyed JSON object.
+    async fn stage_publish<Reporter: self::Reporter>(
+        self,
+        dir: &Path,
+        config: &Config,
+        recursive: bool,
+    ) -> miette::Result<Option<String>> {
+        let StageArgs { params, flags, .. } = self;
+        let json = flags.json;
+        let dry_run = flags.dry_run;
+        let publish = PublishArgs { package: params.get(1).cloned(), flags };
+        let published =
+            publish.publish_packages::<Reporter>(dir, config, recursive, /* stage */ true).await?;
+        let summaries = published.summaries();
+        if json {
+            let keyed = key_by_package_name(summaries);
+            return Ok(Some(json_pretty(&Value::Object(keyed))?));
+        }
+        if summaries.is_empty() {
+            return Ok(None);
+        }
+        let lines: Vec<String> = summaries
+            .iter()
+            .map(|summary| render_stage_publish_summary(summary, dry_run))
+            .collect();
+        Ok(Some(lines.join("\n")))
+    }
+
+    /// `stage list [<package-spec>]` — every staged version, paginated.
+    async fn stage_list(&self, config: &Config) -> miette::Result<Option<String>> {
+        let package_filter = parse_package_filter(self.params.get(1))?;
+        let context = self.stage_context(config, package_filter.as_deref())?;
+        let mut items: Vec<Value> = Vec::new();
+        let mut page: usize = 0;
+        loop {
+            let mut url = stage_endpoint_url(&context.registry, "-/stage")?;
+            url.query_pairs_mut()
+                .append_pair("page", &page.to_string())
+                .append_pair("perPage", &PER_PAGE.to_string());
+            if let Some(package) = &package_filter {
+                url.query_pairs_mut().append_pair("package", package);
+            }
+            let response: StageListResponse =
+                stage_json_request(&context, url.as_str(), "list staged packages").await?;
+            let page_len = response.items.len();
+            items.extend(response.items);
+            if items.len() >= response.total || page_len < PER_PAGE {
+                break;
+            }
+            page += 1;
+        }
+
+        if self.flags.json {
+            return Ok(Some(json_pretty(&Value::Array(items))?));
+        }
+        if items.is_empty() {
+            return Ok(Some(match package_filter {
+                Some(package) => format!(r#"No staged versions of package name "{package}"."#),
+                None => "No staged packages found.".to_owned(),
+            }));
+        }
+        let rendered: Vec<String> = items.iter().map(render_stage_item).collect();
+        Ok(Some(rendered.join("\n\n")))
+    }
+
+    /// `stage view <stage-id>` — one staged version's metadata.
+    async fn stage_view(&self, config: &Config) -> miette::Result<Option<String>> {
+        let stage_id = require_stage_id(&self.params, "view")?;
+        let context = self.stage_context(config, None)?;
+        let url = stage_endpoint_url(&context.registry, &format!("-/stage/{stage_id}"))?;
+        let item: Value =
+            stage_json_request(&context, url.as_str(), &format!("view staged package {stage_id}"))
+                .await?;
+        if self.flags.json {
+            return Ok(Some(json_pretty(&item)?));
+        }
+        Ok(Some(render_stage_item(&item)))
+    }
+
+    /// `stage approve <stage-id>` — publish the staged version, satisfying an
+    /// OTP / web-auth challenge if the registry raises one.
+    async fn stage_approve<Reporter: self::Reporter>(
+        &self,
+        config: &Config,
+    ) -> miette::Result<Option<String>> {
+        let stage_id = require_stage_id(&self.params, "approve")?;
+        let context = self.stage_context(config, None)?;
+        let url = stage_endpoint_url(&context.registry, &format!("-/stage/{stage_id}/approve"))?;
+        stage_request_with_otp::<Reporter>(
+            &context,
+            reqwest::Method::POST,
+            url.as_str(),
+            &format!("approve staged package {stage_id}"),
+        )
+        .await?;
+        Ok(Some(format!("Staged package {stage_id} approved and published successfully.")))
+    }
+
+    /// `stage reject <stage-id>` — permanently delete the staged version.
+    async fn stage_reject<Reporter: self::Reporter>(
+        &self,
+        config: &Config,
+    ) -> miette::Result<Option<String>> {
+        let stage_id = require_stage_id(&self.params, "reject")?;
+        let context = self.stage_context(config, None)?;
+        global_warn::<Reporter>(
+            "Rejecting will permanently delete this staged publish record and tarball from the \
+             registry.",
+        );
+        let url = stage_endpoint_url(&context.registry, &format!("-/stage/{stage_id}"))?;
+        stage_request_with_otp::<Reporter>(
+            &context,
+            reqwest::Method::DELETE,
+            url.as_str(),
+            &format!("reject staged package {stage_id}"),
+        )
+        .await?;
+        Ok(Some(format!("Staged package {stage_id} has been rejected.")))
+    }
+
+    /// `stage download <stage-id>` — fetch the staged tarball into `dir` and
+    /// print its summary.
+    async fn stage_download(&self, dir: &Path, config: &Config) -> miette::Result<Option<String>> {
+        let stage_id = require_stage_id(&self.params, "download")?;
+        let context = self.stage_context(config, None)?;
+        let url = stage_endpoint_url(&context.registry, &format!("-/stage/{stage_id}/tarball"))?;
+        let action = format!("download staged package {stage_id}");
+        let (_guard, response) = stage_send(&context, reqwest::Method::GET, url.as_str(), None)
+            .await
+            .map_err(|source| request_failed(&action, source))?;
+        if !response.status().is_success() {
+            return Err(registry_error_from_response(response, &action).await.into());
+        }
+        let tarball_data =
+            response.bytes().await.map_err(|source| request_failed(&action, source))?;
+
+        let mut summary = summarize_tarball(&tarball_data)?;
+        let filename = create_tarball_filename(&summary.name, &summary.version, Some(stage_id))?;
+        summary.filename.clone_from(&filename);
+        let output_path = dir.join(&filename);
+        // `create_tarball_filename` already rejects separators; this guards
+        // the write against any bare-basename assumption it might not cover.
+        if output_path.file_name().map(|name| name.to_string_lossy().into_owned())
+            != Some(filename.clone())
+            || output_path.parent() != Some(dir)
+        {
+            return Err(StageError::InvalidTarballFilename { filename }.into());
+        }
+        std::fs::write(&output_path, &tarball_data)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("write {}", output_path.display()))?;
+
+        if self.flags.json {
+            let mut keyed = serde_json::Map::new();
+            keyed.insert(
+                summary.name.clone(),
+                serde_json::to_value(&summary).expect("a publish summary serializes"),
+            );
+            return Ok(Some(json_pretty(&Value::Object(keyed))?));
+        }
+        Ok(Some(format!("{}\n{filename}", render_tarball_summary(&summary))))
+    }
+
+    /// Shared per-subcommand request context: the resolved registry, its auth
+    /// header (package-scoped when a package filter is given), the network
+    /// client, and the configured OTP.
+    fn stage_context(
+        &self,
+        config: &Config,
+        package_name: Option<&str>,
+    ) -> miette::Result<StageContext> {
+        let mut registries: HashMap<String, String> =
+            config.resolved_registries().into_iter().collect();
+        if let Some(registry) = &self.registry {
+            registries.insert("default".to_owned(), registry.clone());
+        }
+        let registry = match package_name {
+            Some(package) => pick_registry_for_package(&registries, package, None),
+            None => registries.get("default").cloned().unwrap_or_default(),
+        };
+        let registry = if registry.ends_with('/') { registry } else { format!("{registry}/") };
+        let auth_header = config.auth_headers.for_url_with_package(&registry, package_name);
+        Ok(StageContext {
+            registry,
+            auth_header,
+            http_client: build_registry_client(config)?,
+            retry_opts: RetryOpts {
+                retries: config.fetch_retries,
+                factor: config.fetch_retry_factor,
+                min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
+                max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
+            },
+            otp: resolve_otp_from_env::<Host>(self.flags.otp.clone()),
+            web_auth_fetch_options: WebAuthFetchOptions {
+                timeout: Some(config.fetch_timeout),
+                retry: Some(WebAuthRetryOptions {
+                    factor: Some(f64::from(config.fetch_retry_factor)),
+                    max_timeout: Some(config.fetch_retry_maxtimeout),
+                    min_timeout: Some(config.fetch_retry_mintimeout),
+                    randomize: None,
+                    retries: Some(config.fetch_retries),
+                }),
+            },
+        })
+    }
+}
+
+struct StageContext {
+    registry: String,
+    auth_header: Option<String>,
+    http_client: ThrottledClient,
+    retry_opts: RetryOpts,
+    otp: Option<String>,
+    web_auth_fetch_options: WebAuthFetchOptions,
+}
+
+/// An HTTP-level failure of a stage mutation, handed to
+/// [`with_otp_handling`]. Only the [`Otp`](Self::Otp) arm is a challenge it
+/// acts on; the rest propagate.
+#[derive(Debug, Display, Error, Diagnostic)]
+enum StageHttpError {
+    #[display("the registry requested a one-time password")]
+    Otp {
+        #[error(not(source))]
+        challenge: OtpChallenge,
+    },
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Registry(#[error(not(source))] StageRegistryError),
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Request(#[error(not(source))] Box<StageError>),
+}
+
+impl OtpError for StageHttpError {
+    fn as_otp_challenge(&self) -> Option<OtpChallenge> {
+        match self {
+            StageHttpError::Otp { challenge } => Some(challenge.clone()),
+            StageHttpError::Registry(_) | StageHttpError::Request(_) => None,
+        }
+    }
+}
+
+/// Send one stage mutation (approve / reject) with OTP / web-auth handling:
+/// the first attempt carries any configured `--otp`; a 401 OTP challenge
+/// drives the interactive flow and retries with the obtained password.
+async fn stage_request_with_otp<Reporter: self::Reporter>(
+    context: &StageContext,
+    method: reqwest::Method,
+    url: &str,
+    action: &str,
+) -> miette::Result<()> {
+    with_otp_handling::<WebAuthHost, Reporter, (), StageHttpError, _, _>(
+        context.web_auth_fetch_options.clone(),
+        // A plain `FnMut` returning an `async move` block (not an
+        // `AsyncFnMut`) so the produced future carries an ordinary `Send`
+        // obligation — see `with_otp_handling`'s `Operation` bound.
+        move |challenge_otp: Option<String>| {
+            // The web-auth-provided OTP (a fresh challenge) takes precedence
+            // over any statically configured one.
+            let effective_otp = challenge_otp.or_else(|| context.otp.clone());
+            let method = method.clone();
+            async move {
+                stage_mutation(context, method, url, action, effective_otp.as_deref()).await
+            }
+        },
+    )
+    .await
+    .map_err(|error| match error {
+        // Unwrap the operation's own failure so the user sees the registry
+        // error once, not re-narrated through the OTP wrapper.
+        WithOtpError::Operation(StageHttpError::Registry(registry_error)) => {
+            miette::Report::new(registry_error)
+        }
+        WithOtpError::Operation(StageHttpError::Request(request_error)) => {
+            miette::Report::new(*request_error)
+        }
+        other => miette::Report::new(other),
+    })
+}
+
+/// Perform a single stage mutation request and classify the response.
+async fn stage_mutation(
+    context: &StageContext,
+    method: reqwest::Method,
+    url: &str,
+    action: &str,
+    otp: Option<&str>,
+) -> Result<(), StageHttpError> {
+    let (_guard, response) = stage_send(context, method, url, otp).await.map_err(|source| {
+        StageHttpError::Request(Box::new(request_failed_error(action, source)))
+    })?;
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let status_text = status.canonical_reason().unwrap_or_default().to_owned();
+    let www_authenticate = response
+        .headers()
+        .get(reqwest::header::WWW_AUTHENTICATE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let body = read_limited_body(response, STAGE_ERROR_BODY_LIMIT).await.map_err(|source| {
+        StageHttpError::Request(Box::new(request_failed_error(action, source)))
+    })?;
+    if status.as_u16() == 401
+        && let Some(challenge) = parse_stage_otp_challenge(www_authenticate.as_deref(), &body.bytes)
+    {
+        return Err(StageHttpError::Otp { challenge });
+    }
+    Err(StageHttpError::Registry(StageRegistryError::new(
+        action,
+        status.as_u16(),
+        &status_text,
+        &body_display_string(&body),
+    )))
+}
+
+/// GET a `-/stage` endpoint and parse its JSON body.
+async fn stage_json_request<Body: serde::de::DeserializeOwned>(
+    context: &StageContext,
+    url: &str,
+    action: &str,
+) -> miette::Result<Body> {
+    let (_guard, response) = stage_send(context, reqwest::Method::GET, url, None)
+        .await
+        .map_err(|source| request_failed(action, source))?;
+    if !response.status().is_success() {
+        return Err(registry_error_from_response(response, action).await.into());
+    }
+    let body = read_limited_body(response, STAGE_BODY_LIMIT)
+        .await
+        .map_err(|source| request_failed(action, source))?;
+    if body.truncated {
+        return Err(StageError::RequestFailed {
+            operation: action.to_owned(),
+            reason: format!("registry response exceeded {STAGE_BODY_LIMIT} bytes"),
+        }
+        .into());
+    }
+    serde_json::from_slice(&body.bytes).map_err(|source| request_failed(action, source))
+}
+
+/// Send one request to a `-/stage` endpoint with the stage headers
+/// (`npm-auth-type: web`, `npm-command: stage`, auth, optional OTP),
+/// retrying transient failures.
+async fn stage_send<'client>(
+    context: &'client StageContext,
+    method: reqwest::Method,
+    url: &str,
+    otp: Option<&str>,
+) -> Result<(pacquet_network::ThrottledClientGuard<'client>, reqwest::Response), reqwest::Error> {
+    send_with_retry(&context.http_client, url, context.retry_opts, |client| {
+        let mut builder = client
+            .request(method.clone(), url)
+            .header("npm-auth-type", "web")
+            .header("npm-command", "stage");
+        if let Some(auth_header) = &context.auth_header {
+            builder = builder.header("authorization", auth_header);
+        }
+        if let Some(otp) = otp {
+            builder = builder.header("npm-otp", otp);
+        }
+        builder
+    })
+    .await
+}
+
+/// Map a failed (non-2xx) stage response to a [`StageRegistryError`].
+async fn registry_error_from_response(
+    response: reqwest::Response,
+    action: &str,
+) -> StageRegistryError {
+    let status = response.status();
+    let status_text = status.canonical_reason().unwrap_or_default().to_owned();
+    let body = match read_limited_body(response, STAGE_ERROR_BODY_LIMIT).await {
+        Ok(body) => body_display_string(&body),
+        Err(_) => String::new(),
+    };
+    StageRegistryError::new(action, status.as_u16(), &status_text, &body)
+}
+
+/// Identify a 401 stage response as an OTP / web-auth challenge: a JSON body
+/// carrying `authUrl` + `doneUrl` (the browser-based flow), or a
+/// `www-authenticate` header mentioning `otp` (classic TOTP).
+fn parse_stage_otp_challenge(www_authenticate: Option<&str>, body: &[u8]) -> Option<OtpChallenge> {
+    let parsed: Option<Value> = serde_json::from_slice(body).ok();
+    let read =
+        |field: &str| parsed.as_ref().and_then(|json| json.get(field)?.as_str().map(str::to_owned));
+    let auth_url = read("authUrl");
+    let done_url = read("doneUrl");
+    let has_web_auth_urls = auth_url.is_some() && done_url.is_some();
+    let header_mentions_otp =
+        www_authenticate.is_some_and(|value| value.to_lowercase().contains("otp"));
+    if !has_web_auth_urls && !header_mentions_otp {
+        return None;
+    }
+    Some(OtpChallenge { body: Some(OtpErrorBody { auth_url, done_url }) })
+}
+
+fn request_failed(action: &str, source: impl std::fmt::Display) -> miette::Report {
+    request_failed_error(action, source).into()
+}
+
+fn request_failed_error(action: &str, source: impl std::fmt::Display) -> StageError {
+    StageError::RequestFailed {
+        operation: action.to_owned(),
+        reason: redact_url_credentials(&source.to_string()),
+    }
+}
+
+/// Resolve a `-/stage` path against the registry base URL.
+fn stage_endpoint_url(registry: &str, path: &str) -> miette::Result<reqwest::Url> {
+    reqwest::Url::parse(registry)
+        .and_then(|url| url.join(path))
+        .map_err(|source| request_failed("build the registry staging URL", source))
+}
+
+/// The `<stage-id>` argument of `view` / `approve` / `reject` / `download`,
+/// validated as a UUID.
+fn require_stage_id<'params>(
+    params: &'params [String],
+    subcommand: &'static str,
+) -> Result<&'params str, StageError> {
+    let stage_id = params.get(1).map(String::as_str).unwrap_or_default();
+    if stage_id.is_empty() {
+        return Err(StageError::StageIdRequired { subcommand });
+    }
+    if !is_uuid(stage_id) {
+        return Err(StageError::InvalidStageId);
+    }
+    Ok(stage_id)
+}
+
+/// Whether `value` is a hyphenated UUID (`8-4-4-4-12` hex digits).
+fn is_uuid(value: &str) -> bool {
+    value.len() == 36
+        && value.char_indices().all(|(index, char)| match index {
+            8 | 13 | 18 | 23 => char == '-',
+            _ => char.is_ascii_hexdigit(),
+        })
+}
+
+/// The `list` package filter: a bare package name; a version specifier other
+/// than `*` is rejected.
+fn parse_package_filter(raw_spec: Option<&String>) -> Result<Option<String>, StageError> {
+    let Some(raw_spec) = raw_spec.filter(|spec| !spec.is_empty()) else {
+        return Ok(None);
+    };
+    let parsed = parse_wanted_dependency(raw_spec);
+    let Some(name) = parsed.alias else {
+        return Err(StageError::InvalidPackageSpec { spec: raw_spec.clone() });
+    };
+    match parsed.bare_specifier.as_deref() {
+        None | Some("" | "*") => Ok(Some(name)),
+        Some(_) => Err(StageError::VersionSpecifierUnsupported),
+    }
+}
+
+/// The `--json` map `stage publish` and `stage download` print: summaries
+/// keyed by package name.
+fn key_by_package_name(summaries: &[PublishSummary]) -> serde_json::Map<String, Value> {
+    let mut keyed = serde_json::Map::new();
+    for summary in summaries {
+        let key = if summary.name.is_empty() { summary.id.clone() } else { summary.name.clone() };
+        if key.is_empty() {
+            continue;
+        }
+        keyed.insert(key, serde_json::to_value(summary).expect("a publish summary serializes"));
+    }
+    keyed
+}
+
+/// One `+ <pkg> (staged...)` line of the non-JSON `stage publish` output.
+fn render_stage_publish_summary(summary: &PublishSummary, dry_run: bool) -> String {
+    if dry_run {
+        return format!("+ {} (would stage)", summary.id);
+    }
+    match &summary.stage_id {
+        Some(stage_id) => format!("+ {} (staged with id {stage_id})", summary.id),
+        None => format!("+ {} (staged)", summary.id),
+    }
+}
+
+/// Render one staged item as `key: value` lines: the known fields in a fixed
+/// order, then any extra fields the registry returned, `null`s skipped.
+fn render_stage_item(item: &Value) -> String {
+    let Some(object) = item.as_object() else {
+        return render_value(item);
+    };
+    let mut lines: Vec<String> = Vec::new();
+    let mut push = |key: &str, value: Option<&Value>| {
+        if let Some(value) = value.filter(|value| !value.is_null()) {
+            lines.push(format!("{key}: {}", render_value(value)));
+        }
+    };
+    push("id", object.get("id"));
+    push("package name", object.get("packageName"));
+    push("version", object.get("version"));
+    push("tag", object.get("tag"));
+    push("date staged", object.get("createdAt"));
+    let staged_by = match object.get("actorType").and_then(Value::as_str).filter(|t| !t.is_empty())
+    {
+        Some(actor_type) => {
+            let actor = object
+                .get("actor")
+                .filter(|value| !value.is_null())
+                .map(render_value)
+                .unwrap_or_default();
+            Some(Value::String(format!("{actor} ({actor_type})")))
+        }
+        None => object.get("actor").cloned(),
+    };
+    push("staged by", staged_by.as_ref());
+    push("shasum", object.get("shasum"));
+    const KNOWN_KEYS: [&str; 8] =
+        ["id", "packageName", "version", "tag", "createdAt", "actor", "actorType", "shasum"];
+    for (key, value) in object {
+        if !KNOWN_KEYS.contains(&key.as_str()) {
+            push(key, Some(value));
+        }
+    }
+    lines.join("\n")
+}
+
+/// A value on a `key: value` line: strings raw, scalars via their JSON text,
+/// objects and arrays as compact JSON.
+fn render_value(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Bool(boolean) => boolean.to_string(),
+        Value::Number(number) => number.to_string(),
+        other => serde_json::to_string(other).expect("a JSON value serializes"),
+    }
+}
+
+/// The non-JSON `stage download` report: the tarball's contents and details,
+/// in pnpm's `renderTarballSummary` shape.
+fn render_tarball_summary(summary: &PublishSummary) -> String {
+    let files: Vec<&str> = summary.files.iter().map(|file| file.path.as_str()).collect();
+    format!(
+        "package: {name}@{version}\nTarball Contents\n{contents}\nTarball Details\nname: \
+         {name}\nversion: {version}\nfilename: {filename}\npackage size: {size}\nunpacked size: \
+         {unpacked_size}\nshasum: {shasum}\nintegrity: {integrity}\ntotal files: {entry_count}",
+        name = summary.name,
+        version = summary.version,
+        contents = files.join("\n"),
+        filename = summary.filename,
+        size = summary.size,
+        unpacked_size = summary.unpacked_size,
+        shasum = summary.shasum,
+        integrity = summary.integrity,
+        entry_count = summary.entry_count,
+    )
+}
+
+fn global_warn<Reporter: self::Reporter>(message: &str) {
+    Reporter::emit(&LogEvent::Global(GlobalLog {
+        level: LogLevel::Warn,
+        message: message.to_owned(),
+    }));
+}
+
+/// `JSON.stringify(value, null, 2)` — the two-space-indented JSON the
+/// `--json` outputs print.
+fn json_pretty(value: &Value) -> miette::Result<String> {
+    serde_json::to_string_pretty(value).into_diagnostic()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/stage.rs
+++ b/pnpm/crates/cli/src/cli_args/stage.rs
@@ -126,8 +126,8 @@ pub enum StageError {
 }
 
 /// A failed `-/stage` registry response
-/// (`ERR_PNPM_STAGE_REGISTRY_ERROR`), mirroring pnpm's `StageRegistryError`
-/// message shape.
+/// (`ERR_PNPM_STAGE_REGISTRY_ERROR`), with the same message shape as the
+/// TypeScript CLI's stage registry error.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[display("{message}")]
 #[diagnostic(code(ERR_PNPM_STAGE_REGISTRY_ERROR))]
@@ -688,7 +688,10 @@ fn render_stage_item(item: &Value) -> String {
     push("version", object.get("version"));
     push("tag", object.get("tag"));
     push("date staged", object.get("createdAt"));
-    let staged_by = match object.get("actorType").and_then(Value::as_str).filter(|t| !t.is_empty())
+    let staged_by = match object
+        .get("actorType")
+        .and_then(Value::as_str)
+        .filter(|actor_type| !actor_type.is_empty())
     {
         Some(actor_type) => {
             let actor = object

--- a/pnpm/crates/cli/src/cli_args/stage.rs
+++ b/pnpm/crates/cli/src/cli_args/stage.rs
@@ -37,8 +37,15 @@ use summarize_tarball::{create_tarball_filename, summarize_tarball};
 
 /// The staged-list page size; matches pnpm's paginated `-/stage` reads.
 const PER_PAGE: usize = 100;
+/// Fail-safe bound on the staged-list pagination loop, so a registry that
+/// keeps answering full pages with an inflated `total` cannot drive it
+/// forever.
+const STAGE_LIST_MAX_PAGES: usize = 1000;
 const STAGE_BODY_LIMIT: usize = 1024 * 1024;
 const STAGE_ERROR_BODY_LIMIT: usize = 64 * 1024;
+/// Cap on a staged tarball download; a registry response is
+/// attacker-controlled input and must not exhaust memory.
+const STAGE_TARBALL_BODY_LIMIT: usize = 512 * 1024 * 1024;
 const STAGE_SUBCOMMANDS: &str = "publish, list, view, approve, reject, download";
 
 #[derive(Debug, Args)]
@@ -235,6 +242,9 @@ impl StageArgs {
                 break;
             }
             page += 1;
+            if page >= STAGE_LIST_MAX_PAGES {
+                break;
+            }
         }
 
         if self.flags.json {
@@ -318,8 +328,17 @@ impl StageArgs {
         if !response.status().is_success() {
             return Err(registry_error_from_response(response, &action).await.into());
         }
-        let tarball_data =
-            response.bytes().await.map_err(|source| request_failed(&action, source))?;
+        let tarball_data = read_limited_body(response, STAGE_TARBALL_BODY_LIMIT)
+            .await
+            .map_err(|source| request_failed(&action, source))?;
+        if tarball_data.truncated {
+            return Err(StageError::RequestFailed {
+                operation: action,
+                reason: format!("registry response exceeded {STAGE_TARBALL_BODY_LIMIT} bytes"),
+            }
+            .into());
+        }
+        let tarball_data = tarball_data.bytes;
 
         let mut summary = summarize_tarball(&tarball_data)?;
         let filename = create_tarball_filename(&summary.name, &summary.version, Some(stage_id))?;

--- a/pnpm/crates/cli/src/cli_args/stage/summarize_tarball.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/summarize_tarball.rs
@@ -136,7 +136,7 @@ fn maybe_gunzip(data: &[u8]) -> Result<Vec<u8>, StageError> {
             Err(StageError::RequestFailed {
                 operation: "read the staged tarball".to_owned(),
                 reason: format!(
-                    "tarball exceeded {MAX_DECOMPRESSED_TARBALL_BYTES} bytes when decompressed"
+                    "tarball exceeded {MAX_DECOMPRESSED_TARBALL_BYTES} bytes when decompressed",
                 ),
             })
         }

--- a/pnpm/crates/cli/src/cli_args/stage/summarize_tarball.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/summarize_tarball.rs
@@ -1,0 +1,137 @@
+//! Summarize a packed tarball's bytes into the [`PublishSummary`] shape that
+//! `pnpm publish --json` emits — used by `pnpm stage download` to describe a
+//! staged tarball without re-packing it.
+
+use std::{collections::BTreeSet, io::Read};
+
+use flate2::read::GzDecoder;
+use miette::{Context, IntoDiagnostic};
+use pacquet_pack::sort_paths_en_locale;
+use pacquet_publish::{PackedPkgInfo, PublishSummary, create_publish_summary};
+use pacquet_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
+use serde_json::Value;
+
+use super::StageError;
+
+/// Parse a packed (gzipped or plain) tarball and return its
+/// [`PublishSummary`]. The tarball must contain a parseable
+/// `package/package.json` with a name and version.
+pub(super) fn summarize_tarball(tarball_data: &[u8]) -> miette::Result<PublishSummary> {
+    let tar_bytes = maybe_gunzip(tarball_data);
+    let mut archive = tar::Archive::new(tar_bytes.as_slice());
+    let mut files: Vec<String> = Vec::new();
+    let mut bundled: BTreeSet<String> = BTreeSet::new();
+    let mut manifest: Option<Value> = None;
+    let mut unpacked_size: u64 = 0;
+
+    let entries =
+        archive.entries().into_diagnostic().wrap_err("read the staged tarball's entries")?;
+    for entry in entries {
+        let mut entry = entry.into_diagnostic().wrap_err("read a staged tarball entry")?;
+        let path = String::from_utf8_lossy(&entry.path_bytes()).into_owned();
+        if entry.header().entry_type().is_file() {
+            unpacked_size += entry.header().size().unwrap_or(0);
+            files.push(path.strip_prefix("package/").unwrap_or(&path).to_owned());
+            if let Some(name) = bundled_dependency_name(&path) {
+                bundled.insert(name);
+            }
+        }
+        if path == "package/package.json" {
+            let mut text = String::new();
+            entry
+                .read_to_string(&mut text)
+                .into_diagnostic()
+                .wrap_err("read package/package.json from the staged tarball")?;
+            manifest =
+                Some(serde_json::from_str(&text).map_err(|_| StageError::TarballManifestNotFound)?);
+        }
+    }
+
+    let manifest = manifest.ok_or(StageError::TarballManifestNotFound)?;
+    let name = manifest_string(&manifest, "name");
+    let version = manifest_string(&manifest, "version");
+    if name.is_empty() || version.is_empty() {
+        return Err(StageError::TarballManifestNotFound.into());
+    }
+
+    sort_paths_en_locale(&mut files);
+    let filename = create_tarball_filename(&name, &version, None)?;
+    let mut summary = create_publish_summary(
+        &PackedPkgInfo {
+            published_manifest: &manifest,
+            tarball_path: &filename,
+            contents: &files,
+            unpacked_size,
+        },
+        tarball_data,
+    );
+    // A registry-packed tarball's manifest carries an `_id`; prefer it over
+    // the derived `name@version`, matching pnpm's `summarizeTarball`.
+    if let Some(id) = manifest.get("_id").and_then(Value::as_str) {
+        id.clone_into(&mut summary.id);
+    }
+    if !bundled.is_empty() {
+        summary.bundled = bundled.into_iter().collect();
+    }
+    Ok(summary)
+}
+
+/// The safe tarball basename `<normalized-name>-<version>[-<suffix>].tgz`,
+/// after validating that the name and version cannot smuggle path segments.
+pub(super) fn create_tarball_filename(
+    name: &str,
+    version: &str,
+    suffix: Option<&str>,
+) -> Result<String, StageError> {
+    if !is_valid_old_npm_package_name(name) {
+        return Err(StageError::InvalidPackageName { name: name.to_owned() });
+    }
+    if version.parse::<node_semver::Version>().is_err() {
+        return Err(StageError::InvalidPackageVersion { version: version.to_owned() });
+    }
+    let suffix = suffix.map(|suffix| format!("-{suffix}")).unwrap_or_default();
+    let filename = format!("{}-{version}{suffix}.tgz", normalize_package_name(name));
+    // The name/version validation above should already exclude separators;
+    // reject outright if a validated component still smuggled one in.
+    if filename.contains(['/', '\\', ':']) {
+        return Err(StageError::InvalidTarballFilename { filename });
+    }
+    Ok(filename)
+}
+
+/// `@scope/name` → `scope-name`: drop the first `@`, turn the first `/` into
+/// a `-`, exactly like pnpm's `normalizePackageName`.
+fn normalize_package_name(name: &str) -> String {
+    name.replacen('@', "", 1).replacen('/', "-", 1)
+}
+
+/// The bundled-dependency name of a `package/node_modules/...` tarball entry:
+/// the first path segment (or two for a scoped package) after
+/// `node_modules/`.
+fn bundled_dependency_name(path: &str) -> Option<String> {
+    let rest = path.strip_prefix("package/node_modules/")?;
+    let mut segments = rest.split('/');
+    let first = segments.next().filter(|segment| !segment.is_empty())?;
+    if let Some(scope) = first.strip_prefix('@') {
+        if scope.is_empty() {
+            return None;
+        }
+        let second = segments.next().filter(|segment| !segment.is_empty())?;
+        return Some(format!("{first}/{second}"));
+    }
+    Some(first.to_owned())
+}
+
+/// Gunzip `data`, falling back to the raw bytes when it is not gzipped.
+fn maybe_gunzip(data: &[u8]) -> Vec<u8> {
+    let mut decoder = GzDecoder::new(data);
+    let mut decompressed = Vec::new();
+    match decoder.read_to_end(&mut decompressed) {
+        Ok(_) => decompressed,
+        Err(_) => data.to_vec(),
+    }
+}
+
+fn manifest_string(manifest: &Value, key: &str) -> String {
+    manifest.get(key).and_then(Value::as_str).unwrap_or_default().to_owned()
+}

--- a/pnpm/crates/cli/src/cli_args/stage/summarize_tarball.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/summarize_tarball.rs
@@ -17,7 +17,7 @@ use super::StageError;
 /// [`PublishSummary`]. The tarball must contain a parseable
 /// `package/package.json` with a name and version.
 pub(super) fn summarize_tarball(tarball_data: &[u8]) -> miette::Result<PublishSummary> {
-    let tar_bytes = maybe_gunzip(tarball_data);
+    let tar_bytes = maybe_gunzip(tarball_data)?;
     let mut archive = tar::Archive::new(tar_bytes.as_slice());
     let mut files: Vec<String> = Vec::new();
     let mut bundled: BTreeSet<String> = BTreeSet::new();
@@ -122,13 +122,26 @@ fn bundled_dependency_name(path: &str) -> Option<String> {
     Some(first.to_owned())
 }
 
+/// Cap on the decompressed tarball; the bytes come from the registry, so a
+/// gzip bomb must not inflate past this into memory.
+const MAX_DECOMPRESSED_TARBALL_BYTES: u64 = 512 * 1024 * 1024;
+
 /// Gunzip `data`, falling back to the raw bytes when it is not gzipped.
-fn maybe_gunzip(data: &[u8]) -> Vec<u8> {
-    let mut decoder = GzDecoder::new(data);
+/// Decompression past [`MAX_DECOMPRESSED_TARBALL_BYTES`] is an error.
+fn maybe_gunzip(data: &[u8]) -> Result<Vec<u8>, StageError> {
+    let mut decoder = GzDecoder::new(data).take(MAX_DECOMPRESSED_TARBALL_BYTES + 1);
     let mut decompressed = Vec::new();
     match decoder.read_to_end(&mut decompressed) {
-        Ok(_) => decompressed,
-        Err(_) => data.to_vec(),
+        Ok(_) if decompressed.len() as u64 > MAX_DECOMPRESSED_TARBALL_BYTES => {
+            Err(StageError::RequestFailed {
+                operation: "read the staged tarball".to_owned(),
+                reason: format!(
+                    "tarball exceeded {MAX_DECOMPRESSED_TARBALL_BYTES} bytes when decompressed"
+                ),
+            })
+        }
+        Ok(_) => Ok(decompressed),
+        Err(_) => Ok(data.to_vec()),
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/stage/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/stage/tests.rs
@@ -1,0 +1,240 @@
+use flate2::{Compression, write::GzEncoder};
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use super::{
+    StageError, is_uuid, parse_package_filter, render_stage_item, render_stage_publish_summary,
+    render_tarball_summary, require_stage_id,
+    summarize_tarball::{create_tarball_filename, summarize_tarball},
+};
+
+const STAGE_ID: &str = "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f";
+
+fn params(values: &[&str]) -> Vec<String> {
+    values.iter().map(|value| (*value).to_owned()).collect()
+}
+
+#[test]
+fn is_uuid_accepts_hyphenated_uuids_only() {
+    assert!(is_uuid(STAGE_ID));
+    assert!(is_uuid("F8E7A45B-7A5F-4F31-8E6D-9DD1C6EF38C0"));
+    assert!(!is_uuid("not-a-uuid"));
+    assert!(!is_uuid("1de6f3db2ed94d72b3dd8f0e2b474a2f"));
+    assert!(!is_uuid("1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2g"));
+    assert!(!is_uuid(""));
+}
+
+#[test]
+fn require_stage_id_validates_presence_and_shape() {
+    let with_id = params(&["view", STAGE_ID]);
+    let id = require_stage_id(&with_id, "view").expect("a valid stage id");
+    assert_eq!(id, STAGE_ID);
+
+    let missing = require_stage_id(&params(&["view"]), "view").expect_err("no id given");
+    assert!(matches!(missing, StageError::StageIdRequired { subcommand: "view" }));
+
+    let empty = require_stage_id(&params(&["view", ""]), "view").expect_err("an empty id");
+    assert!(matches!(empty, StageError::StageIdRequired { .. }));
+
+    let invalid = require_stage_id(&params(&["view", "abc"]), "view").expect_err("not a UUID");
+    assert!(matches!(invalid, StageError::InvalidStageId));
+}
+
+#[test]
+fn parse_package_filter_accepts_bare_names_and_star() {
+    assert_eq!(parse_package_filter(None).expect("no filter"), None);
+    assert_eq!(
+        parse_package_filter(Some(&"@scope/example-package".to_owned())).expect("a scoped name"),
+        Some("@scope/example-package".to_owned()),
+    );
+    assert_eq!(
+        parse_package_filter(Some(&"pkg@*".to_owned())).expect("a star specifier"),
+        Some("pkg".to_owned()),
+    );
+}
+
+#[test]
+fn parse_package_filter_rejects_version_specifiers() {
+    let err = parse_package_filter(Some(&"pkg@1.0.0".to_owned()))
+        .expect_err("a version specifier is not supported");
+    assert!(matches!(err, StageError::VersionSpecifierUnsupported));
+}
+
+#[test]
+fn render_stage_publish_summary_covers_the_three_outcomes() {
+    let mut summary = sample_summary("pkg", "1.0.0");
+    assert_eq!(render_stage_publish_summary(&summary, true), "+ pkg@1.0.0 (would stage)");
+    assert_eq!(render_stage_publish_summary(&summary, false), "+ pkg@1.0.0 (staged)");
+    summary.stage_id = Some(STAGE_ID.to_owned());
+    assert_eq!(
+        render_stage_publish_summary(&summary, false),
+        format!("+ pkg@1.0.0 (staged with id {STAGE_ID})"),
+    );
+}
+
+#[test]
+fn render_stage_item_orders_known_fields_and_appends_the_rest() {
+    let item = json!({
+        "extra": {"nested": true},
+        "id": STAGE_ID,
+        "packageName": "@scope/example-package",
+        "version": "1.2.3",
+        "tag": "latest",
+        "createdAt": "2026-03-16T09:00:00.000Z",
+        "actor": "user",
+        "actorType": "user",
+        "shasum": "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+        "skipped": null,
+    });
+    let rendered = render_stage_item(&item);
+    assert_eq!(
+        rendered,
+        format!(
+            "id: {STAGE_ID}\npackage name: @scope/example-package\nversion: 1.2.3\ntag: \
+             latest\ndate staged: 2026-03-16T09:00:00.000Z\nstaged by: user (user)\nshasum: \
+             4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19\nextra: {{\"nested\":true}}",
+        ),
+    );
+}
+
+#[test]
+fn render_stage_item_renders_a_bare_actor_without_a_type() {
+    let rendered = render_stage_item(&json!({ "actor": "user" }));
+    assert_eq!(rendered, "staged by: user");
+}
+
+#[test]
+fn create_tarball_filename_normalizes_scoped_names_and_appends_the_suffix() {
+    assert_eq!(
+        create_tarball_filename("@scope/pkg", "1.0.0", Some(STAGE_ID)).expect("a safe filename"),
+        format!("scope-pkg-1.0.0-{STAGE_ID}.tgz"),
+    );
+    assert_eq!(
+        create_tarball_filename("pkg", "1.0.0", None).expect("a safe filename"),
+        "pkg-1.0.0.tgz",
+    );
+}
+
+#[test]
+fn create_tarball_filename_rejects_traversal_through_name_and_version() {
+    let bad_name = create_tarball_filename("@scope/../../outside", "1.0.0", None)
+        .expect_err("a traversal name");
+    assert!(matches!(bad_name, StageError::InvalidPackageName { .. }));
+
+    let bad_version = create_tarball_filename("@scope/pkg", "1.0.0/../../outside", None)
+        .expect_err("a traversal version");
+    assert!(matches!(bad_version, StageError::InvalidPackageVersion { .. }));
+}
+
+#[test]
+fn summarize_tarball_reads_the_manifest_files_and_digests() {
+    let tarball = gzipped_tarball(&[
+        ("package/package.json", r#"{"name":"@scope/pkg","version":"1.0.0"}"#),
+        ("package/lib/index.js", "module.exports = 1"),
+        ("package/README.md", "hi"),
+    ]);
+
+    let summary = summarize_tarball(&tarball).expect("a well-formed tarball");
+
+    assert_eq!(summary.name, "@scope/pkg");
+    assert_eq!(summary.version, "1.0.0");
+    assert_eq!(summary.id, "@scope/pkg@1.0.0");
+    assert_eq!(summary.filename, "scope-pkg-1.0.0.tgz");
+    assert_eq!(summary.entry_count, 3);
+    assert_eq!(summary.size, tarball.len() as u64);
+    let paths: Vec<&str> = summary.files.iter().map(|file| file.path.as_str()).collect();
+    assert_eq!(paths, ["lib/index.js", "package.json", "README.md"]);
+    assert!(summary.integrity.starts_with("sha512-"), "integrity: {}", summary.integrity);
+    assert_eq!(summary.shasum.len(), 40);
+    assert!(summary.bundled.is_empty());
+}
+
+#[test]
+fn summarize_tarball_accepts_a_plain_uncompressed_tarball() {
+    let tarball = plain_tarball(&[("package/package.json", r#"{"name":"pkg","version":"2.0.0"}"#)]);
+    let summary = summarize_tarball(&tarball).expect("a plain tarball");
+    assert_eq!(summary.name, "pkg");
+    assert_eq!(summary.version, "2.0.0");
+}
+
+#[test]
+fn summarize_tarball_collects_bundled_dependencies_from_node_modules() {
+    let tarball = gzipped_tarball(&[
+        ("package/package.json", r#"{"name":"pkg","version":"1.0.0"}"#),
+        ("package/node_modules/dep/index.js", ""),
+        ("package/node_modules/@scope/other/index.js", ""),
+    ]);
+    let summary = summarize_tarball(&tarball).expect("a tarball with bundled deps");
+    assert_eq!(summary.bundled, ["@scope/other", "dep"]);
+}
+
+#[test]
+fn summarize_tarball_requires_a_manifest_with_name_and_version() {
+    let missing = summarize_tarball(&gzipped_tarball(&[("package/index.js", "")]))
+        .expect_err("no manifest at all");
+    assert_eq!(
+        missing.code().map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_STAGE_TARBALL_MANIFEST_NOT_FOUND"),
+    );
+
+    let nameless =
+        summarize_tarball(&gzipped_tarball(&[("package/package.json", r#"{"version":"1.0.0"}"#)]))
+            .expect_err("a manifest without a name");
+    assert_eq!(
+        nameless.code().map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_STAGE_TARBALL_MANIFEST_NOT_FOUND"),
+    );
+}
+
+#[test]
+fn render_tarball_summary_matches_the_pnpm_layout() {
+    let mut summary = sample_summary("pkg", "1.0.0");
+    summary.files = vec![
+        pacquet_publish::PublishSummaryFile { path: "index.js".to_owned() },
+        pacquet_publish::PublishSummaryFile { path: "package.json".to_owned() },
+    ];
+    summary.entry_count = 2;
+    let rendered = render_tarball_summary(&summary);
+    assert_eq!(
+        rendered,
+        "package: pkg@1.0.0\nTarball Contents\nindex.js\npackage.json\nTarball Details\nname: \
+         pkg\nversion: 1.0.0\nfilename: pkg-1.0.0.tgz\npackage size: 128\nunpacked size: \
+         256\nshasum: abc\nintegrity: sha512-xyz\ntotal files: 2",
+    );
+}
+
+fn sample_summary(name: &str, version: &str) -> pacquet_publish::PublishSummary {
+    pacquet_publish::PublishSummary {
+        id: format!("{name}@{version}"),
+        name: name.to_owned(),
+        version: version.to_owned(),
+        size: 128,
+        unpacked_size: 256,
+        shasum: "abc".to_owned(),
+        integrity: "sha512-xyz".to_owned(),
+        filename: format!("{name}-{version}.tgz"),
+        files: Vec::new(),
+        entry_count: 0,
+        bundled: Vec::new(),
+        stage_id: None,
+    }
+}
+
+fn plain_tarball(entries: &[(&str, &str)]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (path, contents) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, path, contents.as_bytes()).expect("append tar entry");
+    }
+    builder.into_inner().expect("finish the tar archive")
+}
+
+fn gzipped_tarball(entries: &[(&str, &str)]) -> Vec<u8> {
+    let tar = plain_tarball(entries);
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    std::io::Write::write_all(&mut encoder, &tar).expect("gzip the tarball");
+    encoder.finish().expect("finish the gzip stream")
+}

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -470,6 +470,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Rebuild(_) => "rebuild",
         CliCommand::Pack(_) => "pack",
         CliCommand::Publish(_) => "publish",
+        CliCommand::Stage(_) => "stage",
         CliCommand::Remove(_) => "remove",
         CliCommand::Patch(_) => "patch",
         CliCommand::PatchCommit(_) => "patch-commit",

--- a/pnpm/crates/cli/src/state.rs
+++ b/pnpm/crates/cli/src/state.rs
@@ -112,6 +112,16 @@ fn load_or_create_manifest(manifest_path: PathBuf) -> Result<PackageManifest, In
         {
             return Ok(manifest);
         }
+        // A workspace root defined by `pnpm-workspace.yaml` alone is legal
+        // without a root manifest, and pnpm never scaffolds one there. A
+        // scaffolded root `package.json` would turn the root into a project —
+        // with the init template's failing `test` script — that recursive
+        // selection (e.g. a `[<since>]` filter picking up a root-level change)
+        // would then run. Use the scaffold in memory without persisting it.
+        if project_dir.join("pnpm-workspace.yaml").exists() {
+            let value = PackageManifest::init_value_for(&manifest_path);
+            return Ok(PackageManifest::from_value(manifest_path, value));
+        }
     }
     manifest_path.pipe(PackageManifest::create_if_needed).map_err(InitStateError::Manifest)
 }

--- a/pnpm/crates/cli/tests/stage.rs
+++ b/pnpm/crates/cli/tests/stage.rs
@@ -457,12 +457,8 @@ fn add_user(registry: &str) -> String {
         "roles": [],
     });
     block_on(async {
-        let response = http_client()
-            .put(&url)
-            .json(&body)
-            .send()
-            .await
-            .expect("send the adduser request");
+        let response =
+            http_client().put(&url).json(&body).send().await.expect("send the adduser request");
         assert_eq!(response.status().as_u16(), 201, "adduser must succeed");
         let payload: Value = response.json().await.expect("parse the adduser response");
         payload["token"].as_str().expect("token in the adduser response").to_owned()

--- a/pnpm/crates/cli/tests/stage.rs
+++ b/pnpm/crates/cli/tests/stage.rs
@@ -1,0 +1,543 @@
+//! `pacquet stage` integration tests: drive the real binary against a
+//! `mockito` registry, mirroring pnpm's `releasing/commands/test/stage.test.ts`
+//! scenarios that don't need an interactive terminal.
+//!
+//! CI env is cleared on every spawn so the binary's OIDC id-token probe stays
+//! offline and deterministic (outside a supported CI it resolves to "no token"
+//! without a network request).
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use mockito::Matcher;
+use serde_json::{Value, json};
+use std::{
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const STAGE_ID: &str = "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f";
+
+fn pacquet(workspace: &Path) -> Command {
+    Command::cargo_bin("pacquet")
+        .expect("find the pacquet binary")
+        .with_current_dir(workspace)
+        .without_env("GITHUB_ACTIONS")
+        .without_env("GITLAB_CI")
+        .without_env("NPM_ID_TOKEN")
+        .without_env("NPM_CONFIG_OTP")
+        .without_env("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+        .without_env("ACTIONS_ID_TOKEN_REQUEST_URL")
+}
+
+fn stage(workspace: &Path, args: &[&str]) -> std::process::Output {
+    pacquet(workspace).with_arg("stage").with_args(args).output().expect("spawn pacquet stage")
+}
+
+fn write_project(dir: &Path, registry: &str, manifest: &Value) {
+    fs::write(dir.join(".npmrc"), format!("registry={registry}\n")).expect("write .npmrc");
+    fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
+}
+
+fn write_registry_config(dir: &Path, registry: &str) {
+    fs::write(dir.join(".npmrc"), format!("registry={registry}\n")).expect("write .npmrc");
+}
+
+fn assert_success(output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "stage must succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn assert_failure_with_code(output: &std::process::Output, code: &str) {
+    assert!(!output.status.success(), "stage must fail with {code}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(code), "stderr must carry {code}; stderr: {stderr}");
+}
+
+#[test]
+fn publish_posts_to_the_staging_endpoint_and_returns_keyed_json_with_stage_id() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_project(
+        dir.path(),
+        &registry,
+        &json!({ "name": "@scope/stage-publish-json", "version": "1.0.0" }),
+    );
+    let mock = server
+        .mock("POST", "/-/stage/package/@scope%2fstage-publish-json")
+        .match_header("npm-command", "stage")
+        .with_status(201)
+        .with_body(format!(r#"{{"stageId":"{STAGE_ID}"}}"#))
+        .expect(1)
+        .create();
+
+    let output = stage(dir.path(), &["publish", "--json", "--no-git-checks", "--reporter=silent"]);
+
+    mock.assert();
+    assert_success(&output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let keyed: Value = serde_json::from_str(&stdout).expect("keyed JSON output");
+    let summary = &keyed["@scope/stage-publish-json"];
+    assert_eq!(summary["name"], "@scope/stage-publish-json");
+    assert_eq!(summary["version"], "1.0.0");
+    assert_eq!(summary["stageId"], STAGE_ID);
+}
+
+#[test]
+fn publish_prints_the_staged_line_with_the_stage_id() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_project(
+        dir.path(),
+        &registry,
+        &json!({ "name": "stage-publish-line", "version": "1.0.0" }),
+    );
+    server
+        .mock("POST", "/-/stage/package/stage-publish-line")
+        .with_status(201)
+        .with_body(format!(r#"{{"stageId":"{STAGE_ID}"}}"#))
+        .create();
+
+    let output = stage(dir.path(), &["publish", "--no-git-checks", "--reporter=silent"]);
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        format!("+ stage-publish-line@1.0.0 (staged with id {STAGE_ID})\n"),
+    );
+}
+
+#[test]
+fn publish_dry_run_reports_that_the_package_would_be_staged() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_project(
+        dir.path(),
+        &registry,
+        &json!({ "name": "@scope/stage-publish-dry-run", "version": "1.0.0" }),
+    );
+    let mock = server.mock("POST", Matcher::Any).expect(0).create();
+
+    let output =
+        stage(dir.path(), &["publish", "--dry-run", "--no-git-checks", "--reporter=silent"]);
+
+    mock.assert();
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "+ @scope/stage-publish-dry-run@1.0.0 (would stage)\n",
+    );
+}
+
+fn staged_item() -> Value {
+    json!({
+        "id": STAGE_ID,
+        "packageName": "@scope/example-package",
+        "version": "1.2.3",
+        "tag": "latest",
+        "createdAt": "2026-03-16T09:00:00.000Z",
+        "actor": "user",
+        "actorType": "user",
+        "shasum": "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+    })
+}
+
+#[test]
+fn list_and_view_fetch_staged_package_metadata() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let item = staged_item();
+    let list_mock = server
+        .mock("GET", "/-/stage")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "0".into()),
+            Matcher::UrlEncoded("perPage".into(), "100".into()),
+        ]))
+        .with_body(json!({ "items": [item], "page": 0, "perPage": 100, "total": 1 }).to_string())
+        .expect(1)
+        .create();
+    let view_mock = server
+        .mock("GET", format!("/-/stage/{STAGE_ID}").as_str())
+        .with_body(item.to_string())
+        .expect(1)
+        .create();
+
+    let list_output = stage(dir.path(), &["list", "--json", "--reporter=silent"]);
+    list_mock.assert();
+    assert_success(&list_output);
+    let listed: Value = serde_json::from_str(&String::from_utf8_lossy(&list_output.stdout))
+        .expect("list JSON output");
+    assert_eq!(listed, json!([staged_item()]));
+
+    let view_output = stage(dir.path(), &["view", STAGE_ID]);
+    view_mock.assert();
+    assert_success(&view_output);
+    let stdout = String::from_utf8_lossy(&view_output.stdout);
+    assert!(stdout.contains("package name: @scope/example-package"), "stdout: {stdout}");
+    assert!(stdout.contains("staged by: user (user)"), "stdout: {stdout}");
+}
+
+#[test]
+fn list_passes_the_package_filter_and_reports_an_empty_result() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let mock = server
+        .mock("GET", "/-/stage")
+        .match_query(Matcher::AllOf(vec![
+            Matcher::UrlEncoded("page".into(), "0".into()),
+            Matcher::UrlEncoded("perPage".into(), "100".into()),
+            Matcher::UrlEncoded("package".into(), "@scope/example-package".into()),
+        ]))
+        .with_body(json!({ "items": [], "page": 0, "perPage": 100, "total": 0 }).to_string())
+        .expect(1)
+        .create();
+
+    let output = stage(dir.path(), &["list", "@scope/example-package"]);
+
+    mock.assert();
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "No staged versions of package name \"@scope/example-package\".\n",
+    );
+}
+
+#[test]
+fn list_paginates_until_the_total_is_reached() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let full_page: Vec<Value> = (0..100).map(|_| staged_item()).collect();
+    let first = server
+        .mock("GET", "/-/stage")
+        .match_query(Matcher::UrlEncoded("page".into(), "0".into()))
+        .with_body(json!({ "items": full_page, "total": 101 }).to_string())
+        .expect(1)
+        .create();
+    let second = server
+        .mock("GET", "/-/stage")
+        .match_query(Matcher::UrlEncoded("page".into(), "1".into()))
+        .with_body(json!({ "items": [staged_item()], "total": 101 }).to_string())
+        .expect(1)
+        .create();
+
+    let output = stage(dir.path(), &["list", "--json", "--reporter=silent"]);
+
+    first.assert();
+    second.assert();
+    assert_success(&output);
+    let listed: Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("list JSON output");
+    assert_eq!(listed.as_array().map(Vec::len), Some(101));
+}
+
+#[test]
+fn list_uses_package_scoped_auth_for_package_filters() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let host = registry.strip_prefix("http://").unwrap_or(&registry);
+    let auth_file = dir.path().join("auth-npmrc");
+    fs::write(
+        &auth_file,
+        format!("//{host}:_authToken=default-token\n//{host}:@scope:_authToken=scoped-token\n"),
+    )
+    .expect("write auth .npmrc");
+    let mock = server
+        .mock("GET", "/-/stage")
+        .match_query(Matcher::Any)
+        .match_header("authorization", "Bearer scoped-token")
+        .with_body(json!({ "items": [], "page": 0, "perPage": 100, "total": 0 }).to_string())
+        .expect(1)
+        .create();
+
+    let output = pacquet(dir.path())
+        .with_arg("--npmrc-auth-file")
+        .with_arg(&auth_file)
+        .with_arg("stage")
+        .with_args(["list", "@scope/example-package"])
+        .output()
+        .expect("spawn pacquet stage");
+
+    mock.assert();
+    assert_success(&output);
+}
+
+#[test]
+fn list_rejects_version_specifiers() {
+    let dir = tempfile::tempdir().expect("workspace");
+    write_registry_config(dir.path(), "http://localhost:4873/");
+
+    let output = stage(dir.path(), &["list", "pkg@1.0.0"]);
+
+    assert_failure_with_code(&output, "ERR_PNPM_STAGE_VERSION_SPECIFIER_UNSUPPORTED");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Version specifiers are not supported for listing staged packages"),
+        "stderr: {stderr}",
+    );
+}
+
+#[test]
+fn approve_and_reject_send_the_configured_otp_and_stage_headers() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let approve_mock = server
+        .mock("POST", format!("/-/stage/{STAGE_ID}/approve").as_str())
+        .match_header("npm-auth-type", "web")
+        .match_header("npm-command", "stage")
+        .match_header("npm-otp", "123456")
+        .with_status(201)
+        .with_body(r#"{"ok":true}"#)
+        .expect(1)
+        .create();
+    let reject_mock = server
+        .mock("DELETE", format!("/-/stage/{STAGE_ID}").as_str())
+        .match_header("npm-auth-type", "web")
+        .match_header("npm-command", "stage")
+        .match_header("npm-otp", "123456")
+        .with_status(204)
+        .expect(1)
+        .create();
+
+    let approve = stage(dir.path(), &["approve", STAGE_ID, "--otp", "123456"]);
+    approve_mock.assert();
+    assert_success(&approve);
+    assert_eq!(
+        String::from_utf8_lossy(&approve.stdout),
+        format!("Staged package {STAGE_ID} approved and published successfully.\n"),
+    );
+
+    let reject = stage(dir.path(), &["reject", STAGE_ID, "--otp", "123456"]);
+    reject_mock.assert();
+    assert_success(&reject);
+    let stdout = String::from_utf8_lossy(&reject.stdout);
+    assert!(
+        stdout.contains(&format!("Staged package {STAGE_ID} has been rejected.")),
+        "stdout: {stdout}",
+    );
+}
+
+#[test]
+fn approve_maps_a_web_auth_challenge_to_the_non_interactive_error() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    server
+        .mock("POST", format!("/-/stage/{STAGE_ID}/approve").as_str())
+        .with_status(401)
+        .with_body(
+            json!({
+                "authUrl": "https://www.npmjs.com/auth/cli/test-auth-id",
+                "doneUrl": "https://registry.example.com/-/v1/done?authId=test-auth-id",
+            })
+            .to_string(),
+        )
+        .create();
+
+    // The spawned binary has no TTY, so the web-auth challenge cannot be
+    // driven interactively.
+    let output = stage(dir.path(), &["approve", STAGE_ID]);
+
+    assert_failure_with_code(&output, "ERR_PNPM_OTP_NON_INTERACTIVE");
+}
+
+#[test]
+fn approve_surfaces_a_plain_401_as_a_stage_registry_error() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    server
+        .mock("POST", format!("/-/stage/{STAGE_ID}/approve").as_str())
+        .with_status(401)
+        .with_header("www-authenticate", r#"Basic realm="example""#)
+        .with_body(r#"{"error":"unauthorized"}"#)
+        .create();
+
+    let output = stage(dir.path(), &["approve", STAGE_ID]);
+
+    assert_failure_with_code(&output, "ERR_PNPM_STAGE_REGISTRY_ERROR");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&format!("Failed to approve staged package {STAGE_ID}")),
+        "stderr: {stderr}",
+    );
+    // miette wraps long lines, so the status clause is asserted separately.
+    assert!(stderr.contains("(status 401 Unauthorized)"), "stderr: {stderr}");
+}
+
+#[test]
+fn download_writes_the_staged_tarball_and_prints_keyed_json() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let tarball = gzipped_tarball(&[(
+        "package/package.json",
+        r#"{"name":"@scope/stage-download-json","version":"1.0.0"}"#,
+    )]);
+    server
+        .mock("GET", format!("/-/stage/{STAGE_ID}/tarball").as_str())
+        .with_header("content-type", "application/octet-stream")
+        .with_body(&tarball)
+        .create();
+
+    let output = stage(dir.path(), &["download", STAGE_ID, "--json", "--reporter=silent"]);
+
+    assert_success(&output);
+    let keyed: Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("keyed JSON output");
+    let expected_filename = format!("scope-stage-download-json-1.0.0-{STAGE_ID}.tgz");
+    let summary = &keyed["@scope/stage-download-json"];
+    assert_eq!(summary["name"], "@scope/stage-download-json");
+    assert_eq!(summary["version"], "1.0.0");
+    assert_eq!(summary["filename"], Value::String(expected_filename.clone()));
+    let written = fs::read(dir.path().join(&expected_filename)).expect("the tarball is written");
+    assert_eq!(written, tarball);
+}
+
+#[test]
+fn download_rejects_traversal_through_the_tarball_manifest_version() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let outside_base = "stage-download-outside-version";
+    let tarball = gzipped_tarball(&[(
+        "package/package.json",
+        &json!({
+            "name": "@scope/stage-download-version",
+            "version": format!("1.0.0/../../{outside_base}"),
+        })
+        .to_string(),
+    )]);
+    let (registry, _server, download_dir) = download_registry(dir.path(), &tarball);
+    let outside_path = outside_tarball_path(&download_dir, &format!("{outside_base}-{STAGE_ID}"));
+
+    let output = stage(&download_dir, &["download", STAGE_ID]);
+
+    assert_failure_with_code(&output, "ERR_PNPM_INVALID_PACKAGE_VERSION");
+    assert!(!outside_path.exists(), "nothing may be written outside the download dir");
+    assert_download_dir_untouched(&download_dir);
+    drop(registry);
+}
+
+#[test]
+fn download_rejects_traversal_through_the_tarball_manifest_name() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let outside_base = "stage-download-outside-name";
+    let tarball = gzipped_tarball(&[(
+        "package/package.json",
+        &json!({
+            "name": format!("@scope/../../{outside_base}"),
+            "version": "1.0.0",
+        })
+        .to_string(),
+    )]);
+    let (registry, _server, download_dir) = download_registry(dir.path(), &tarball);
+    let outside_path =
+        outside_tarball_path(&download_dir, &format!("{outside_base}-1.0.0-{STAGE_ID}"));
+
+    let output = stage(&download_dir, &["download", STAGE_ID]);
+
+    assert_failure_with_code(&output, "ERR_PNPM_INVALID_PACKAGE_NAME");
+    assert!(!outside_path.exists(), "nothing may be written outside the download dir");
+    assert_download_dir_untouched(&download_dir);
+    drop(registry);
+}
+
+#[test]
+fn a_missing_subcommand_is_rejected_with_the_stage_error_code() {
+    let dir = tempfile::tempdir().expect("workspace");
+    write_registry_config(dir.path(), "http://localhost:4873/");
+
+    let output = stage(dir.path(), &[]);
+
+    assert_failure_with_code(&output, "ERR_PNPM_STAGE_SUBCOMMAND_REQUIRED");
+}
+
+#[test]
+fn an_unknown_subcommand_is_rejected_with_the_stage_error_code() {
+    let dir = tempfile::tempdir().expect("workspace");
+    write_registry_config(dir.path(), "http://localhost:4873/");
+
+    let output = stage(dir.path(), &["frobnicate"]);
+
+    assert_failure_with_code(&output, "ERR_PNPM_STAGE_UNKNOWN_SUBCOMMAND");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(r#"Unknown stage subcommand "frobnicate""#), "stderr: {stderr}");
+}
+
+#[test]
+fn view_requires_a_uuid_stage_id() {
+    let dir = tempfile::tempdir().expect("workspace");
+    write_registry_config(dir.path(), "http://localhost:4873/");
+
+    let missing = stage(dir.path(), &["view"]);
+    assert_failure_with_code(&missing, "ERR_PNPM_STAGE_ID_REQUIRED");
+
+    let invalid = stage(dir.path(), &["view", "not-a-uuid"]);
+    assert_failure_with_code(&invalid, "ERR_PNPM_INVALID_STAGE_ID");
+}
+
+/// A registry that serves `tarball` for the staged download, plus a fresh
+/// download workspace pointing at it.
+fn download_registry(
+    root: &Path,
+    tarball: &[u8],
+) -> (mockito::Mock, mockito::ServerGuard, PathBuf) {
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let mock = server
+        .mock("GET", format!("/-/stage/{STAGE_ID}/tarball").as_str())
+        .with_header("content-type", "application/octet-stream")
+        .with_body(tarball)
+        .create();
+    let download_dir = root.join("download");
+    fs::create_dir_all(&download_dir).expect("create the download dir");
+    write_registry_config(&download_dir, &registry);
+    (mock, server, download_dir)
+}
+
+fn outside_tarball_path(download_dir: &Path, basename: &str) -> PathBuf {
+    download_dir.parent().expect("the download dir has a parent").join(format!("{basename}.tgz"))
+}
+
+/// After a rejected download the workspace must hold only its `.npmrc`.
+fn assert_download_dir_untouched(download_dir: &Path) {
+    let entries: Vec<String> = fs::read_dir(download_dir)
+        .expect("read the download dir")
+        .flatten()
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(entries, [".npmrc"], "no tarball may be written on a rejected download");
+}
+
+fn gzipped_tarball(entries: &[(&str, &str)]) -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (path, contents) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, path, contents.as_bytes()).expect("append tar entry");
+    }
+    let tar = builder.into_inner().expect("finish the tar archive");
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&tar).expect("gzip the tarball");
+    encoder.finish().expect("finish the gzip stream")
+}

--- a/pnpm/crates/cli/tests/stage.rs
+++ b/pnpm/crates/cli/tests/stage.rs
@@ -1,6 +1,9 @@
-//! `pacquet stage` integration tests: drive the real binary against a
-//! `mockito` registry, mirroring pnpm's `releasing/commands/test/stage.test.ts`
-//! scenarios that don't need an interactive terminal.
+//! `pacquet stage` integration tests: drive the real binary end-to-end
+//! against a hosted in-process pnpr for the staging lifecycle, and against a
+//! `mockito` registry only for the faults a well-behaved registry cannot
+//! produce (OTP challenges, hostile tarball manifests, a misbehaving
+//! pagination `total`, exact header/no-upload assertions). Mirrors pnpm's
+//! `releasing/commands/test/stage.test.ts`.
 //!
 //! CI env is cleared on every spawn so the binary's OIDC id-token probe stays
 //! offline and deterministic (outside a supported CI it resolves to "no token"
@@ -59,61 +62,6 @@ fn assert_failure_with_code(output: &std::process::Output, code: &str) {
 }
 
 #[test]
-fn publish_posts_to_the_staging_endpoint_and_returns_keyed_json_with_stage_id() {
-    let dir = tempfile::tempdir().expect("workspace");
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-    write_project(
-        dir.path(),
-        &registry,
-        &json!({ "name": "@scope/stage-publish-json", "version": "1.0.0" }),
-    );
-    let mock = server
-        .mock("POST", "/-/stage/package/@scope%2fstage-publish-json")
-        .match_header("npm-command", "stage")
-        .with_status(201)
-        .with_body(format!(r#"{{"stageId":"{STAGE_ID}"}}"#))
-        .expect(1)
-        .create();
-
-    let output = stage(dir.path(), &["publish", "--json", "--no-git-checks", "--reporter=silent"]);
-
-    mock.assert();
-    assert_success(&output);
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let keyed: Value = serde_json::from_str(&stdout).expect("keyed JSON output");
-    let summary = &keyed["@scope/stage-publish-json"];
-    assert_eq!(summary["name"], "@scope/stage-publish-json");
-    assert_eq!(summary["version"], "1.0.0");
-    assert_eq!(summary["stageId"], STAGE_ID);
-}
-
-#[test]
-fn publish_prints_the_staged_line_with_the_stage_id() {
-    let dir = tempfile::tempdir().expect("workspace");
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-    write_project(
-        dir.path(),
-        &registry,
-        &json!({ "name": "stage-publish-line", "version": "1.0.0" }),
-    );
-    server
-        .mock("POST", "/-/stage/package/stage-publish-line")
-        .with_status(201)
-        .with_body(format!(r#"{{"stageId":"{STAGE_ID}"}}"#))
-        .create();
-
-    let output = stage(dir.path(), &["publish", "--no-git-checks", "--reporter=silent"]);
-
-    assert_success(&output);
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        format!("+ stage-publish-line@1.0.0 (staged with id {STAGE_ID})\n"),
-    );
-}
-
-#[test]
 fn publish_dry_run_reports_that_the_package_would_be_staged() {
     let dir = tempfile::tempdir().expect("workspace");
     let mut server = mockito::Server::new();
@@ -147,100 +95,6 @@ fn staged_item() -> Value {
         "actorType": "user",
         "shasum": "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
     })
-}
-
-#[test]
-fn list_and_view_fetch_staged_package_metadata() {
-    let dir = tempfile::tempdir().expect("workspace");
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-    write_registry_config(dir.path(), &registry);
-    let item = staged_item();
-    let list_mock = server
-        .mock("GET", "/-/stage")
-        .match_query(Matcher::AllOf(vec![
-            Matcher::UrlEncoded("page".into(), "0".into()),
-            Matcher::UrlEncoded("perPage".into(), "100".into()),
-        ]))
-        .with_body(json!({ "items": [item], "page": 0, "perPage": 100, "total": 1 }).to_string())
-        .expect(1)
-        .create();
-    let view_mock = server
-        .mock("GET", format!("/-/stage/{STAGE_ID}").as_str())
-        .with_body(item.to_string())
-        .expect(1)
-        .create();
-
-    let list_output = stage(dir.path(), &["list", "--json", "--reporter=silent"]);
-    list_mock.assert();
-    assert_success(&list_output);
-    let listed: Value = serde_json::from_str(&String::from_utf8_lossy(&list_output.stdout))
-        .expect("list JSON output");
-    assert_eq!(listed, json!([staged_item()]));
-
-    let view_output = stage(dir.path(), &["view", STAGE_ID]);
-    view_mock.assert();
-    assert_success(&view_output);
-    let stdout = String::from_utf8_lossy(&view_output.stdout);
-    assert!(stdout.contains("package name: @scope/example-package"), "stdout: {stdout}");
-    assert!(stdout.contains("staged by: user (user)"), "stdout: {stdout}");
-}
-
-#[test]
-fn list_passes_the_package_filter_and_reports_an_empty_result() {
-    let dir = tempfile::tempdir().expect("workspace");
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-    write_registry_config(dir.path(), &registry);
-    let mock = server
-        .mock("GET", "/-/stage")
-        .match_query(Matcher::AllOf(vec![
-            Matcher::UrlEncoded("page".into(), "0".into()),
-            Matcher::UrlEncoded("perPage".into(), "100".into()),
-            Matcher::UrlEncoded("package".into(), "@scope/example-package".into()),
-        ]))
-        .with_body(json!({ "items": [], "page": 0, "perPage": 100, "total": 0 }).to_string())
-        .expect(1)
-        .create();
-
-    let output = stage(dir.path(), &["list", "@scope/example-package"]);
-
-    mock.assert();
-    assert_success(&output);
-    assert_eq!(
-        String::from_utf8_lossy(&output.stdout),
-        "No staged versions of package name \"@scope/example-package\".\n",
-    );
-}
-
-#[test]
-fn list_paginates_until_the_total_is_reached() {
-    let dir = tempfile::tempdir().expect("workspace");
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-    write_registry_config(dir.path(), &registry);
-    let full_page: Vec<Value> = (0..100).map(|_| staged_item()).collect();
-    let first = server
-        .mock("GET", "/-/stage")
-        .match_query(Matcher::UrlEncoded("page".into(), "0".into()))
-        .with_body(json!({ "items": full_page, "total": 101 }).to_string())
-        .expect(1)
-        .create();
-    let second = server
-        .mock("GET", "/-/stage")
-        .match_query(Matcher::UrlEncoded("page".into(), "1".into()))
-        .with_body(json!({ "items": [staged_item()], "total": 101 }).to_string())
-        .expect(1)
-        .create();
-
-    let output = stage(dir.path(), &["list", "--json", "--reporter=silent"]);
-
-    first.assert();
-    second.assert();
-    assert_success(&output);
-    let listed: Value =
-        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("list JSON output");
-    assert_eq!(listed.as_array().map(Vec::len), Some(101));
 }
 
 /// A registry that keeps answering full pages with an inflated `total` must
@@ -410,36 +264,6 @@ fn approve_surfaces_a_plain_401_as_a_stage_registry_error() {
 }
 
 #[test]
-fn download_writes_the_staged_tarball_and_prints_keyed_json() {
-    let dir = tempfile::tempdir().expect("workspace");
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-    write_registry_config(dir.path(), &registry);
-    let tarball = gzipped_tarball(&[(
-        "package/package.json",
-        r#"{"name":"@scope/stage-download-json","version":"1.0.0"}"#,
-    )]);
-    server
-        .mock("GET", format!("/-/stage/{STAGE_ID}/tarball").as_str())
-        .with_header("content-type", "application/octet-stream")
-        .with_body(&tarball)
-        .create();
-
-    let output = stage(dir.path(), &["download", STAGE_ID, "--json", "--reporter=silent"]);
-
-    assert_success(&output);
-    let keyed: Value =
-        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("keyed JSON output");
-    let expected_filename = format!("scope-stage-download-json-1.0.0-{STAGE_ID}.tgz");
-    let summary = &keyed["@scope/stage-download-json"];
-    assert_eq!(summary["name"], "@scope/stage-download-json");
-    assert_eq!(summary["version"], "1.0.0");
-    assert_eq!(summary["filename"], Value::String(expected_filename.clone()));
-    let written = fs::read(dir.path().join(&expected_filename)).expect("the tarball is written");
-    assert_eq!(written, tarball);
-}
-
-#[test]
 fn download_rejects_traversal_through_the_tarball_manifest_version() {
     let dir = tempfile::tempdir().expect("workspace");
     let outside_base = "stage-download-outside-version";
@@ -566,4 +390,278 @@ fn gzipped_tarball(entries: &[(&str, &str)]) -> Vec<u8> {
     let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
     encoder.write_all(&tar).expect("gzip the tarball");
     encoder.finish().expect("finish the gzip stream")
+}
+
+// --------------------------------------------------------------------
+// End-to-end lifecycle against a hosted in-process pnpr. The shared
+// `pacquet_testing_utils` registry runs in proxy mode and rejects
+// publishes, so these tests serve their own static-mode instance.
+// --------------------------------------------------------------------
+
+/// A hosted pnpr on an ephemeral localhost port, backed by a fresh
+/// storage tempdir (returned so it outlives the test).
+fn spawn_hosted_registry() -> (String, tempfile::TempDir) {
+    let storage = tempfile::tempdir().expect("registry storage");
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .expect("bind the stage e2e registry to an unused localhost port");
+    listener.set_nonblocking(true).expect("set the registry listener to nonblocking");
+    let listen = listener.local_addr().expect("read the registry listener address");
+    let url = format!("http://{listen}/");
+    let mut config = pnpr::Config::static_serve(listen, storage.path().to_path_buf());
+    config.public_url = url.trim_end_matches('/').to_string();
+    config.auth.htpasswd.max_users = pnpr::MaxUsers::Unlimited;
+    std::thread::Builder::new()
+        .name("stage-e2e-registry".to_string())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("create the registry runtime");
+            runtime.block_on(async move {
+                let listener = tokio::net::TcpListener::from_std(listener)
+                    .expect("create the registry tokio listener");
+                pnpr::serve_listener(config, listener).await.expect("serve the stage e2e registry");
+            });
+        })
+        .expect("spawn the registry thread");
+    (url, storage)
+}
+
+/// Run one async request against the e2e registry from this synchronous test.
+fn block_on<Output>(future: impl std::future::Future<Output = Output>) -> Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create the request runtime")
+        .block_on(future)
+}
+
+/// Register a user against the e2e registry and return their bearer token.
+fn add_user(registry: &str) -> String {
+    let url = format!("{registry}-/user/org.couchdb.user:alice");
+    let body = json!({
+        "_id": "org.couchdb.user:alice",
+        "name": "alice",
+        "password": "secret",
+        "email": "alice@example.com",
+        "type": "user",
+        "roles": [],
+    });
+    block_on(async {
+        let response = reqwest::Client::new()
+            .put(&url)
+            .json(&body)
+            .send()
+            .await
+            .expect("send the adduser request");
+        assert_eq!(response.status().as_u16(), 201, "adduser must succeed");
+        let payload: Value = response.json().await.expect("parse the adduser response");
+        payload["token"].as_str().expect("token in the adduser response").to_owned()
+    })
+}
+
+/// The HTTP status of a plain packument read, bypassing the CLI.
+fn packument_status(registry: &str, token: &str, name: &str) -> u16 {
+    let url = format!("{registry}{name}");
+    block_on(async {
+        reqwest::Client::new()
+            .get(&url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .expect("send the packument request")
+            .status()
+            .as_u16()
+    })
+}
+
+/// A workspace whose `.npmrc` points at the e2e registry, plus an auth file
+/// carrying the registered user's token.
+fn e2e_workspace(dir: &Path, registry: &str, token: &str, manifest: &Value) -> PathBuf {
+    write_project(dir, registry, manifest);
+    let host = registry.strip_prefix("http://").unwrap_or(registry);
+    let auth_file = dir.join("auth-npmrc");
+    fs::write(&auth_file, format!("//{host}:_authToken={token}\n")).expect("write auth .npmrc");
+    auth_file
+}
+
+fn stage_with_auth(workspace: &Path, auth_file: &Path, args: &[&str]) -> std::process::Output {
+    pacquet(workspace)
+        .with_arg("--npmrc-auth-file")
+        .with_arg(auth_file)
+        .with_arg("stage")
+        .with_args(args)
+        .output()
+        .expect("spawn pacquet stage")
+}
+
+/// The whole staged-publishing happy path against a real registry: stage a
+/// scoped package, observe it held back, inspect and download it, approve
+/// it, and see it become installable with the staged record gone.
+#[test]
+fn stage_lifecycle_against_pnpr_publishes_only_on_approval() {
+    let (registry, _storage) = spawn_hosted_registry();
+    let token = add_user(&registry);
+    let dir = tempfile::tempdir().expect("workspace");
+    let auth_file = e2e_workspace(
+        dir.path(),
+        &registry,
+        &token,
+        &json!({ "name": "@stage-e2e/lifecycle", "version": "1.0.0" }),
+    );
+
+    let publish = stage_with_auth(
+        dir.path(),
+        &auth_file,
+        &["publish", "--json", "--no-git-checks", "--reporter=silent"],
+    );
+    assert_success(&publish);
+    let keyed: Value =
+        serde_json::from_str(&String::from_utf8_lossy(&publish.stdout)).expect("keyed JSON output");
+    let summary = &keyed["@stage-e2e/lifecycle"];
+    assert_eq!(summary["version"], "1.0.0");
+    let stage_id = summary["stageId"].as_str().expect("a stage id").to_owned();
+
+    // Held back: not installable until approved.
+    assert_eq!(packument_status(&registry, &token, "@stage-e2e/lifecycle"), 404);
+
+    let list = stage_with_auth(dir.path(), &auth_file, &["list", "--json", "--reporter=silent"]);
+    assert_success(&list);
+    let listed: Value =
+        serde_json::from_str(&String::from_utf8_lossy(&list.stdout)).expect("list JSON output");
+    assert_eq!(listed[0]["id"], Value::String(stage_id.clone()));
+    assert_eq!(listed[0]["packageName"], "@stage-e2e/lifecycle");
+    assert_eq!(listed[0]["tag"], "latest");
+    assert_eq!(listed[0]["actor"], "alice");
+
+    let view = stage_with_auth(dir.path(), &auth_file, &["view", &stage_id]);
+    assert_success(&view);
+    let stdout = String::from_utf8_lossy(&view.stdout);
+    assert!(stdout.contains("package name: @stage-e2e/lifecycle"), "stdout: {stdout}");
+    assert!(stdout.contains("staged by: alice (user)"), "stdout: {stdout}");
+
+    let download = stage_with_auth(
+        dir.path(),
+        &auth_file,
+        &["download", &stage_id, "--json", "--reporter=silent"],
+    );
+    assert_success(&download);
+    let downloaded: Value = serde_json::from_str(&String::from_utf8_lossy(&download.stdout))
+        .expect("download JSON output");
+    let expected_filename = format!("stage-e2e-lifecycle-1.0.0-{stage_id}.tgz");
+    assert_eq!(
+        downloaded["@stage-e2e/lifecycle"]["filename"],
+        Value::String(expected_filename.clone()),
+    );
+    assert!(dir.path().join(&expected_filename).exists(), "the tarball must be written");
+
+    let approve = stage_with_auth(dir.path(), &auth_file, &["approve", &stage_id]);
+    assert_success(&approve);
+    assert_eq!(
+        String::from_utf8_lossy(&approve.stdout),
+        format!("Staged package {stage_id} approved and published successfully.\n"),
+    );
+
+    assert_eq!(packument_status(&registry, &token, "@stage-e2e/lifecycle"), 200);
+    let list = stage_with_auth(dir.path(), &auth_file, &["list"]);
+    assert_success(&list);
+    assert_eq!(
+        String::from_utf8_lossy(&list.stdout),
+        "No staged packages found.\n",
+        "an approved stage leaves no record behind",
+    );
+}
+
+/// Rejecting a staged publish deletes it without ever publishing, and the
+/// non-JSON `stage publish` output carries the stage id to act on.
+#[test]
+fn stage_reject_against_pnpr_deletes_the_staged_publish() {
+    let (registry, _storage) = spawn_hosted_registry();
+    let token = add_user(&registry);
+    let dir = tempfile::tempdir().expect("workspace");
+    let auth_file = e2e_workspace(
+        dir.path(),
+        &registry,
+        &token,
+        &json!({ "name": "stage-e2e-rejected", "version": "1.0.0" }),
+    );
+
+    let publish = stage_with_auth(
+        dir.path(),
+        &auth_file,
+        &["publish", "--no-git-checks", "--reporter=silent"],
+    );
+    assert_success(&publish);
+    let stdout = String::from_utf8_lossy(&publish.stdout);
+    let stage_id = stdout
+        .trim()
+        .strip_prefix("+ stage-e2e-rejected@1.0.0 (staged with id ")
+        .and_then(|rest| rest.strip_suffix(')'))
+        .unwrap_or_else(|| panic!("staged line must carry the id; stdout: {stdout}"))
+        .to_owned();
+
+    let reject = stage_with_auth(dir.path(), &auth_file, &["reject", &stage_id]);
+    assert_success(&reject);
+    let stdout = String::from_utf8_lossy(&reject.stdout);
+    assert!(
+        stdout.contains(&format!("Staged package {stage_id} has been rejected.")),
+        "stdout: {stdout}",
+    );
+
+    assert_eq!(packument_status(&registry, &token, "stage-e2e-rejected"), 404);
+    let view = stage_with_auth(dir.path(), &auth_file, &["view", &stage_id]);
+    assert_failure_with_code(&view, "ERR_PNPM_STAGE_REGISTRY_ERROR");
+    let list = stage_with_auth(dir.path(), &auth_file, &["list", "stage-e2e-rejected"]);
+    assert_success(&list);
+    assert_eq!(
+        String::from_utf8_lossy(&list.stdout),
+        "No staged versions of package name \"stage-e2e-rejected\".\n",
+    );
+}
+
+/// The client's pagination loop crosses page boundaries against the real
+/// registry: 101 staged records arrive in one 100-item page plus one more.
+#[test]
+fn stage_list_paginates_against_pnpr() {
+    let (registry, _storage) = spawn_hosted_registry();
+    let token = add_user(&registry);
+    let dir = tempfile::tempdir().expect("workspace");
+    let auth_file = e2e_workspace(
+        dir.path(),
+        &registry,
+        &token,
+        &json!({ "name": "stage-e2e-paginated", "version": "1.0.0" }),
+    );
+
+    // Seed 101 staged records directly over HTTP; the client under test is
+    // the list loop, not the publisher.
+    block_on(async {
+        let client = reqwest::Client::new();
+        for index in 0..101 {
+            let name = format!("stage-e2e-paginated-{index:03}");
+            let doc = json!({
+                "_id": name,
+                "name": name,
+                "dist-tags": { "latest": "1.0.0" },
+                "versions": { "1.0.0": { "name": name, "version": "1.0.0" } },
+                "_attachments": {
+                    format!("{name}-1.0.0.tgz"): { "data": "dGFyYmFsbA==", "length": 7 }
+                },
+            });
+            let response = client
+                .post(format!("{registry}-/stage/package/{name}"))
+                .bearer_auth(&token)
+                .json(&doc)
+                .send()
+                .await
+                .expect("send the stage request");
+            assert_eq!(response.status().as_u16(), 201, "staging {name} must succeed");
+        }
+    });
+
+    let list = stage_with_auth(dir.path(), &auth_file, &["list", "--json", "--reporter=silent"]);
+    assert_success(&list);
+    let listed: Value =
+        serde_json::from_str(&String::from_utf8_lossy(&list.stdout)).expect("list JSON output");
+    assert_eq!(listed.as_array().map(Vec::len), Some(101));
 }

--- a/pnpm/crates/cli/tests/stage.rs
+++ b/pnpm/crates/cli/tests/stage.rs
@@ -436,6 +436,15 @@ fn block_on<Output>(future: impl std::future::Future<Output = Output>) -> Output
         .block_on(future)
 }
 
+/// An HTTP client whose requests time out instead of hanging the test run
+/// if the hosted registry stops responding.
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_mins(1))
+        .build()
+        .expect("build the test HTTP client")
+}
+
 /// Register a user against the e2e registry and return their bearer token.
 fn add_user(registry: &str) -> String {
     let url = format!("{registry}-/user/org.couchdb.user:alice");
@@ -448,7 +457,7 @@ fn add_user(registry: &str) -> String {
         "roles": [],
     });
     block_on(async {
-        let response = reqwest::Client::new()
+        let response = http_client()
             .put(&url)
             .json(&body)
             .send()
@@ -464,7 +473,7 @@ fn add_user(registry: &str) -> String {
 fn packument_status(registry: &str, token: &str, name: &str) -> u16 {
     let url = format!("{registry}{name}");
     block_on(async {
-        reqwest::Client::new()
+        http_client()
             .get(&url)
             .bearer_auth(token)
             .send()
@@ -636,7 +645,7 @@ fn stage_list_paginates_against_pnpr() {
     // Seed 101 staged records directly over HTTP; the client under test is
     // the list loop, not the publisher.
     block_on(async {
-        let client = reqwest::Client::new();
+        let client = http_client();
         for index in 0..101 {
             let name = format!("stage-e2e-paginated-{index:03}");
             let doc = json!({

--- a/pnpm/crates/cli/tests/stage.rs
+++ b/pnpm/crates/cli/tests/stage.rs
@@ -243,6 +243,32 @@ fn list_paginates_until_the_total_is_reached() {
     assert_eq!(listed.as_array().map(Vec::len), Some(101));
 }
 
+/// A registry that keeps answering full pages with an inflated `total` must
+/// not drive the pagination loop forever: it stops at the fail-safe cap of
+/// 1000 pages.
+#[test]
+fn list_stops_paginating_at_the_fail_safe_page_cap() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_registry_config(dir.path(), &registry);
+    let full_page: Vec<Value> = (0..100).map(|_| staged_item()).collect();
+    let mock = server
+        .mock("GET", "/-/stage")
+        .match_query(Matcher::Any)
+        .with_body(json!({ "items": full_page, "total": 10_000_000 }).to_string())
+        .expect(1000)
+        .create();
+
+    let output = stage(dir.path(), &["list", "--json", "--reporter=silent"]);
+
+    mock.assert();
+    assert_success(&output);
+    let listed: Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("list JSON output");
+    assert_eq!(listed.as_array().map(Vec::len), Some(100_000));
+}
+
 #[test]
 fn list_uses_package_scoped_auth_for_package_filters() {
     let dir = tempfile::tempdir().expect("workspace");

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -234,3 +234,39 @@ fn shared_workspace_dep_link_is_relative_to_each_importer() {
 
     drop((root, mock_instance));
 }
+
+/// A workspace root defined by `pnpm-workspace.yaml` alone is legal without a
+/// root `package.json`, and installing must not scaffold one — pnpm never
+/// does, and a scaffolded root manifest (with the init template's failing
+/// `test` script) would become a selectable project for recursive commands.
+#[test]
+fn install_does_not_scaffold_a_root_manifest_in_a_workspace() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - project\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    let project_dir = workspace.join("project");
+    fs::create_dir_all(&project_dir).expect("create project dir");
+    fs::write(
+        project_dir.join("package.json"),
+        serde_json::json!({ "name": "project", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write project package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    assert!(
+        !workspace.join("package.json").exists(),
+        "installing a workspace without a root manifest must not scaffold one",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod limited_body;
 mod priority_semaphore;
 mod proxy;
 mod retry;
@@ -10,6 +11,7 @@ pub use auth::{
     AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, MetadataCacheScope, UpstreamRouteHook,
     base64_encode, nerf_dart, redact_and_sanitize, redact_url_credentials,
 };
+pub use limited_body::{LimitedBody, read_limited_body};
 pub use url_encoding::{encode_package_name, encode_uri_component};
 
 mod url_encoding;

--- a/pnpm/crates/network/src/limited_body.rs
+++ b/pnpm/crates/network/src/limited_body.rs
@@ -1,0 +1,33 @@
+use reqwest::Response;
+
+/// A response body read through [`read_limited_body`]: at most the requested
+/// number of bytes, with `truncated` recording whether the wire body was
+/// longer.
+pub struct LimitedBody {
+    pub bytes: Vec<u8>,
+    pub truncated: bool,
+}
+
+/// Read a response body, capping it at `limit` bytes. A registry response
+/// that a command buffers whole (an error body, a metadata object) must not
+/// let a hostile or broken server exhaust memory, so reading stops — and the
+/// body is marked truncated — once the cap is reached.
+pub async fn read_limited_body(
+    mut response: Response,
+    limit: usize,
+) -> Result<LimitedBody, reqwest::Error> {
+    let header_exceeds_limit =
+        response.content_length().is_some_and(|length| length > limit as u64);
+    let mut bytes = Vec::new();
+    let mut truncated = header_exceeds_limit;
+    while let Some(chunk) = response.chunk().await? {
+        let remaining = limit.saturating_sub(bytes.len());
+        if chunk.len() > remaining {
+            bytes.extend_from_slice(&chunk[..remaining]);
+            truncated = true;
+            break;
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(LimitedBody { bytes, truncated })
+}

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -673,8 +673,8 @@ fn packed_contents(files_map: &indexmap::IndexMap<String, PathBuf>) -> Vec<Strin
 }
 
 /// Sort path strings the way pnpm's `localeCompare(b, 'en')` orders a
-/// tarball's file listing: case-insensitively, with
-/// [`case_precedence_tiebreak`] deciding ties.
+/// tarball's file listing: case-insensitively, with lowercase given
+/// precedence over uppercase on case-only ties.
 pub fn sort_paths_en_locale(paths: &mut Vec<String>) {
     // Decorate each path with its lowercase form once, rather than
     // recomputing `to_lowercase` for both sides on every comparison.

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -657,7 +657,7 @@ fn unpacked_size<Sys: FsFileLen>(
 /// stripped from the rest.
 fn packed_contents(files_map: &indexmap::IndexMap<String, PathBuf>) -> Vec<String> {
     let mut seen = HashSet::new();
-    let contents: Vec<String> = files_map
+    let mut contents: Vec<String> = files_map
         .keys()
         .map(|name| {
             if is_manifest_entry(name) {
@@ -668,17 +668,25 @@ fn packed_contents(files_map: &indexmap::IndexMap<String, PathBuf>) -> Vec<Strin
         })
         .filter(|item| seen.insert(item.clone()))
         .collect();
+    sort_paths_en_locale(&mut contents);
+    contents
+}
+
+/// Sort path strings the way pnpm's `localeCompare(b, 'en')` orders a
+/// tarball's file listing: case-insensitively, with
+/// [`case_precedence_tiebreak`] deciding ties.
+pub fn sort_paths_en_locale(paths: &mut Vec<String>) {
     // Decorate each path with its lowercase form once, rather than
     // recomputing `to_lowercase` for both sides on every comparison.
     let mut decorated: Vec<(String, String)> =
-        contents.into_iter().map(|item| (item.to_lowercase(), item)).collect();
+        std::mem::take(paths).into_iter().map(|item| (item.to_lowercase(), item)).collect();
     decorated.sort_by(|(left_lower, left), (right_lower, right)| {
         left_lower.cmp(right_lower).then_with(|| case_precedence_tiebreak(left, right))
     });
-    decorated.into_iter().map(|(_, item)| item).collect()
+    *paths = decorated.into_iter().map(|(_, item)| item).collect();
 }
 
-/// Tie-breaker for [`packed_contents`]' `localeCompare(b, 'en')`
+/// Tie-breaker for [`sort_paths_en_locale`]'s `localeCompare(b, 'en')`
 /// approximation: once two ASCII path strings compare equal
 /// case-insensitively, give a lowercase character precedence over its
 /// uppercase counterpart. Full ICU collation is not a workspace

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -86,15 +86,22 @@ impl PackageManifest {
     }
 
     fn write_to_file(path: &Path) -> Result<(Value, String), PackageManifestError> {
+        let manifest = PackageManifest::init_value_for(path);
+        let contents = serde_json::to_string_pretty(&manifest)?;
+        fs::write(path, &contents)?; // TODO: forbid overwriting existing files
+        Ok((manifest, contents))
+    }
+
+    /// The scaffold manifest `pnpm init` (and [`Self::create_if_needed`])
+    /// produces for `path`, named after the containing directory.
+    #[must_use]
+    pub fn init_value_for(path: &Path) -> Value {
         let name = path
             .parent()
             .and_then(|folder| folder.file_name())
             .and_then(|file_name| file_name.to_str())
             .unwrap_or("");
-        let manifest = PackageManifest::create_init_package_json(name);
-        let contents = serde_json::to_string_pretty(&manifest)?;
-        fs::write(path, &contents)?; // TODO: forbid overwriting existing files
-        Ok((manifest, contents))
+        PackageManifest::create_init_package_json(name)
     }
 
     /// Write `contents` to `path` atomically: a sibling temp file is written

--- a/pnpm/crates/publish/src/publish_packed_pkg.rs
+++ b/pnpm/crates/publish/src/publish_packed_pkg.rs
@@ -139,7 +139,13 @@ where
     let body =
         bytes::Bytes::from(serde_json::to_vec(&document).expect("serialize publish document"));
 
-    let put_url = join_registry(&registry, &escaped_package_name(&name))?;
+    // A staged publish goes to the registry's staging endpoint (a `POST` in
+    // `put_publish`); a regular publish PUTs the package document directly.
+    let put_url = if is_stage {
+        join_registry(&registry, &format!("-/stage/package/{}", escaped_package_name(&name)))?
+    } else {
+        join_registry(&registry, &escaped_package_name(&name))?
+    };
     let authorization = resolved
         .auth_token_override
         .as_ref()
@@ -286,8 +292,10 @@ async fn put_publish(
     is_stage: bool,
 ) -> Result<PublishResponse, PublishHttpError> {
     let guard = client.acquire_for_url(put_url).await;
-    let mut request = guard
-        .put(put_url)
+    // A staged publish POSTs to `-/stage/package/:pkg` (libnpmpublish's stage
+    // route); a regular publish PUTs to `/:pkg`.
+    let builder = if is_stage { guard.post(put_url) } else { guard.put(put_url) };
+    let mut request = builder
         .header("content-type", "application/json")
         .header("npm-auth-type", "web")
         .header("npm-command", npm_command)

--- a/pnpm/crates/publish/src/publish_packed_pkg/tests.rs
+++ b/pnpm/crates/publish/src/publish_packed_pkg/tests.rs
@@ -224,19 +224,27 @@ async fn put_publish_maps_a_one_time_pass_body_to_a_web_auth_challenge() {
 #[tokio::test]
 async fn put_publish_extracts_a_stage_id_only_for_a_staged_publish() {
     let mut server = mockito::Server::new_async().await;
+    // A staged publish POSTs; a regular publish PUTs the same path.
+    server
+        .mock("POST", "/pkg")
+        .with_status(200)
+        .with_body(r#"{"stageId":"stage-1"}"#)
+        .expect(1)
+        .create_async()
+        .await;
     server
         .mock("PUT", "/pkg")
         .with_status(200)
         .with_body(r#"{"stageId":"stage-1"}"#)
-        .expect(2)
+        .expect(1)
         .create_async()
         .await;
     let client = ThrottledClient::default();
     let url = format!("{}/pkg", server.url());
 
-    let staged = put_publish(&client, &url, None, "publish", body(), None, true)
+    let staged = put_publish(&client, &url, None, "stage", body(), None, true)
         .await
-        .expect("the PUT completes");
+        .expect("the POST completes");
     assert_eq!(staged.stage_id.as_deref(), Some("stage-1"));
 
     // Without `is_stage` the same body must not yield a stage id.

--- a/pnpm11/releasing/commands/src/stage/list.ts
+++ b/pnpm11/releasing/commands/src/stage/list.ts
@@ -7,6 +7,9 @@ import { stageJsonRequest } from './request.js'
 import type { StageItem, StageListResponse, StageOptions } from './types.js'
 
 const PER_PAGE = 100
+// Fail-safe bound on the pagination loop, so a registry that keeps answering
+// full pages with an inflated `total` cannot drive it forever.
+const MAX_PAGES = 1000
 
 export async function stageList (opts: StageOptions, params: string[]): Promise<string> {
   const packageFilter = parsePackageFilter(params[0])
@@ -26,6 +29,7 @@ export async function stageList (opts: StageOptions, params: string[]): Promise<
     items.push(...res.items)
     if (items.length >= res.total || res.items.length < PER_PAGE) break
     page++
+    if (page >= MAX_PAGES) break
   }
 
   if (opts.json) return JSON.stringify(items, null, 2)

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -5,10 +5,18 @@ import path from 'node:path'
 import { describe, expect, test } from '@jest/globals'
 import { prepare } from '@pnpm/prepare'
 import { pack, stage } from '@pnpm/releasing.commands'
+import { REGISTRY_URL } from '@pnpm/testing.command-defaults'
+import { getRegistryMockToken, REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import tar from 'tar-stream'
 import { temporaryDirectory } from 'tempy'
 
 import { DEFAULT_OPTS } from './publish/utils/index.js'
+
+const CONFIG_BY_URI = {
+  [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
+    '@': { authToken: getRegistryMockToken() },
+  },
+}
 
 const STAGE_ID = '1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f'
 
@@ -27,89 +35,117 @@ interface RegistryResponse {
 
 type RegistryHandler = (request: RegistryRequest) => Promise<RegistryResponse> | RegistryResponse
 
-describe('stage command', () => {
-  test('stage publish posts to the staging endpoint and returns keyed JSON with stageId', async () => {
-    const pkgName = '@scope/stage-publish-json'
-    const stageId = 'f8e7a45b-7a5f-4f31-8e6d-9dd1c6ef38c0'
+describe('stage command against the registry mock', () => {
+  // These tests run the staging lifecycle end-to-end against the pnpr
+  // instance the with-registry jest preset boots; the ad-hoc mock registry
+  // below is kept only for faults a well-behaved registry cannot produce.
+
+  test('stage publish holds the package back until it is approved', async () => {
+    const pkgName = '@pnpmtest/stage-e2e-lifecycle'
     prepare({ name: pkgName, version: '1.0.0' })
-
-    const registry = await createRegistry(async (request) => {
-      if (request.method === 'POST' && decodeURIComponent(request.url.pathname) === `/-/stage/package/${pkgName}`) {
-        return { status: 201, body: { stageId } }
-      }
-      return { status: 404, body: { error: 'not found' } }
-    })
-    try {
-      const result = await stage.handler({
-        ...stageOpts(registry.url),
-        argv: { original: ['stage', 'publish', '--json'] },
-        dir: process.cwd(),
-        json: true,
-      }, ['publish'])
-
-      expect(typeof result).toBe('object')
-      const output = JSON.parse((result as { output: string }).output)
-      expect(output[pkgName]).toMatchObject({
-        name: pkgName,
-        version: '1.0.0',
-        stageId,
-      })
-      expect(registry.requests.some((request) => request.method === 'POST' && decodeURIComponent(request.url.pathname) === `/-/stage/package/${pkgName}`)).toBe(true)
-    } finally {
-      await registry.close()
+    const opts = {
+      ...stageOpts(REGISTRY_URL),
+      configByUri: CONFIG_BY_URI,
     }
+
+    const publishResult = await stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'publish', '--json'] },
+      dir: process.cwd(),
+      json: true,
+    }, ['publish'])
+    const published = JSON.parse((publishResult as { output: string }).output)
+    expect(published[pkgName]).toMatchObject({ name: pkgName, version: '1.0.0' })
+    const stageId = published[pkgName].stageId as string
+    expect(typeof stageId).toBe('string')
+
+    // Held back: the package is not installable before approval.
+    expect((await fetchPackument(pkgName)).status).toBe(404)
+
+    const listResult = await stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'list', '--json'] },
+      json: true,
+    }, ['list', pkgName])
+    const listed = JSON.parse(listResult as string)
+    expect(listed).toHaveLength(1)
+    expect(listed[0]).toMatchObject({
+      id: stageId,
+      packageName: pkgName,
+      version: '1.0.0',
+      tag: 'latest',
+      actor: REGISTRY_MOCK_CREDENTIALS.username,
+      actorType: 'user',
+    })
+
+    const viewResult = await stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'view'] },
+    }, ['view', stageId])
+    expect(viewResult).toContain(`package name: ${pkgName}`)
+    expect(viewResult).toContain(`staged by: ${REGISTRY_MOCK_CREDENTIALS.username} (user)`)
+
+    const downloadDir = temporaryDirectory()
+    const downloadResult = await stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'download', '--json'] },
+      dir: downloadDir,
+      json: true,
+    }, ['download', stageId])
+    const downloaded = JSON.parse(downloadResult as string)
+    const expectedFilename = `pnpmtest-stage-e2e-lifecycle-1.0.0-${stageId}.tgz`
+    expect(downloaded[pkgName]).toMatchObject({ name: pkgName, version: '1.0.0', filename: expectedFilename })
+    expect(fs.existsSync(path.join(downloadDir, expectedFilename))).toBe(true)
+
+    await expect(stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'approve'] },
+    }, ['approve', stageId]))
+      .resolves.toBe(`Staged package ${stageId} approved and published successfully.`)
+
+    const packument = await fetchPackument(pkgName)
+    expect(packument.status).toBe(200)
+    expect((await packument.json() as { versions: Record<string, unknown> }).versions['1.0.0']).toBeTruthy()
+    await expect(stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'list'] },
+    }, ['list', pkgName]))
+      .resolves.toBe(`No staged versions of package name "${pkgName}".`)
   })
 
-  test('stage list and view fetch staged package metadata', async () => {
-    const item = {
-      id: STAGE_ID,
-      packageName: '@scope/example-package',
-      version: '1.2.3',
-      tag: 'latest',
-      createdAt: '2026-03-16T09:00:00.000Z',
-      actor: 'user',
-      actorType: 'user',
-      shasum: '4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19',
+  test('stage reject deletes the staged publish without publishing it', async () => {
+    const pkgName = '@pnpmtest/stage-e2e-rejected'
+    prepare({ name: pkgName, version: '1.0.0' })
+    const opts = {
+      ...stageOpts(REGISTRY_URL),
+      configByUri: CONFIG_BY_URI,
     }
-    const registry = await createRegistry((request) => {
-      if (request.method === 'GET' && request.url.pathname === '/-/stage') {
-        expect(request.url.searchParams.get('page')).toBe('0')
-        expect(request.url.searchParams.get('perPage')).toBe('100')
-        const packageFilter = request.url.searchParams.get('package')
-        if (packageFilter != null) {
-          expect(packageFilter).toBe('@scope/example-package')
-        }
-        return { body: { items: [item], page: 0, perPage: 100, total: 1 } }
-      }
-      if (request.method === 'GET' && request.url.pathname === `/-/stage/${STAGE_ID}`) {
-        return { body: item }
-      }
-      return { status: 404, body: { error: 'not found' } }
-    })
-    try {
-      const listResult = await stage.handler({
-        ...stageOpts(registry.url),
-        argv: { original: ['stage', 'list', '--json'] },
-        json: true,
-      }, ['list'])
-      expect(JSON.parse(listResult as string)).toStrictEqual([item])
 
-      const filteredListResult = await stage.handler({
-        ...stageOpts(registry.url),
-        argv: { original: ['stage', 'list', '--json'] },
-        json: true,
-      }, ['list', '@scope/example-package'])
-      expect(JSON.parse(filteredListResult as string)).toStrictEqual([item])
+    const publishResult = await stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'publish'] },
+      dir: process.cwd(),
+    }, ['publish'])
+    const output = (publishResult as { output: string }).output
+    const stageId = /\(staged with id ([0-9a-f-]{36})\)/.exec(output)?.[1]
+    if (!stageId) throw new Error(`staged line must carry the id: ${output}`)
 
-      const viewResult = await stage.handler({
-        ...stageOpts(registry.url),
-        argv: { original: ['stage', 'view'] },
-      }, ['view', STAGE_ID])
-      expect(viewResult).toContain('package name: @scope/example-package')
-      expect(viewResult).toContain('staged by: user (user)')
-    } finally {
-      await registry.close()
-    }
+    await expect(stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'reject'] },
+    }, ['reject', stageId]))
+      .resolves.toBe(`Staged package ${stageId} has been rejected.`)
+
+    expect((await fetchPackument(pkgName)).status).toBe(404)
+    await expect(stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'view'] },
+    }, ['view', stageId])).rejects.toMatchObject({ code: 'ERR_PNPM_STAGE_REGISTRY_ERROR' })
+    await expect(stage.handler({
+      ...opts,
+      argv: { original: ['stage', 'list'] },
+    }, ['list', pkgName]))
+      .resolves.toBe(`No staged versions of package name "${pkgName}".`)
   })
 
   test('stage list stops paginating at the fail-safe page cap', async () => {
@@ -278,49 +314,6 @@ describe('stage command', () => {
     }
   })
 
-  test('stage download --json is keyed by package name and writes the staged tarball', async () => {
-    const pkgName = '@scope/stage-download-json'
-    prepare({ name: pkgName, version: '1.0.0' })
-    const packDir = temporaryDirectory()
-    const packResult = await pack.api({
-      ...DEFAULT_OPTS,
-      argv: { original: ['pack'] },
-      dir: process.cwd(),
-      packDestination: packDir,
-    })
-    const tarballData = fs.readFileSync(packResult.tarballPath)
-
-    const registry = await createRegistry((request) => {
-      if (request.method === 'GET' && request.url.pathname === `/-/stage/${STAGE_ID}/tarball`) {
-        return {
-          body: tarballData,
-          headers: { 'content-type': 'application/octet-stream' },
-        }
-      }
-      return { status: 404, body: { error: 'not found' } }
-    })
-    const downloadDir = temporaryDirectory()
-    try {
-      const result = await stage.handler({
-        ...stageOpts(registry.url),
-        argv: { original: ['stage', 'download', '--json'] },
-        dir: downloadDir,
-        json: true,
-      }, ['download', STAGE_ID])
-
-      const output = JSON.parse(result as string)
-      expect(output[pkgName]).toMatchObject({
-        name: pkgName,
-        version: '1.0.0',
-        filename: `scope-stage-download-json-1.0.0-${STAGE_ID}.tgz`,
-      })
-      expect(output.undefined).toBeUndefined()
-      expect(fs.existsSync(path.join(downloadDir, `scope-stage-download-json-1.0.0-${STAGE_ID}.tgz`))).toBe(true)
-    } finally {
-      await registry.close()
-    }
-  })
-
   test('stage download rejects traversal through tarball manifest version', async () => {
     const outsideBase = `stage-download-outside-version-${process.pid}-${Date.now()}`
     const tarballData = await createPackageTarball({
@@ -414,6 +407,12 @@ describe('stage command', () => {
     }
   })
 })
+
+async function fetchPackument (pkgName: string): Promise<Response> {
+  return fetch(`${REGISTRY_URL}/${pkgName.replace('/', '%2f')}`, {
+    headers: { authorization: `Bearer ${getRegistryMockToken()}` },
+  })
+}
 
 function stageOpts (registry: string): Parameters<typeof stage.handler>[0] {
   return {

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import { describe, expect, test } from '@jest/globals'
 import { prepare } from '@pnpm/prepare'
-import { pack, stage } from '@pnpm/releasing.commands'
+import { stage } from '@pnpm/releasing.commands'
 import { REGISTRY_URL } from '@pnpm/testing.command-defaults'
 import { getRegistryMockToken, REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import tar from 'tar-stream'

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -12,12 +12,6 @@ import { temporaryDirectory } from 'tempy'
 
 import { DEFAULT_OPTS } from './publish/utils/index.js'
 
-const CONFIG_BY_URI = {
-  [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
-    '@': { authToken: getRegistryMockToken() },
-  },
-}
-
 const STAGE_ID = '1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f'
 
 interface RegistryRequest {
@@ -45,7 +39,7 @@ describe('stage command against the registry mock', () => {
     prepare({ name: pkgName, version: '1.0.0' })
     const opts = {
       ...stageOpts(REGISTRY_URL),
-      configByUri: CONFIG_BY_URI,
+      configByUri: configByUri(),
     }
 
     const publishResult = await stage.handler({
@@ -118,7 +112,7 @@ describe('stage command against the registry mock', () => {
     prepare({ name: pkgName, version: '1.0.0' })
     const opts = {
       ...stageOpts(REGISTRY_URL),
-      configByUri: CONFIG_BY_URI,
+      configByUri: configByUri(),
     }
 
     const publishResult = await stage.handler({
@@ -408,8 +402,16 @@ describe('stage command against the registry mock', () => {
   })
 })
 
+function configByUri (): Record<string, Record<string, { authToken: string }>> {
+  return {
+    [`//localhost:${REGISTRY_MOCK_PORT}/`]: {
+      '@': { authToken: getRegistryMockToken() },
+    },
+  }
+}
+
 async function fetchPackument (pkgName: string): Promise<Response> {
-  return fetch(`${REGISTRY_URL}/${pkgName.replace('/', '%2f')}`, {
+  return fetch(`${REGISTRY_URL}/${pkgName.replaceAll('/', '%2F')}`, {
     headers: { authorization: `Bearer ${getRegistryMockToken()}` },
   })
 }

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -112,6 +112,23 @@ describe('stage command', () => {
     }
   })
 
+  test('stage list stops paginating at the fail-safe page cap', async () => {
+    const fullPage = Array.from({ length: 100 }, () => ({ packageName: 'pkg', version: '1.0.0' }))
+    const registry = await createRegistry(() => ({ body: { items: fullPage, total: 10_000_000 } }))
+    try {
+      const result = await stage.handler({
+        ...stageOpts(registry.url),
+        argv: { original: ['stage', 'list', '--json'] },
+        json: true,
+      }, ['list'])
+
+      expect(registry.requests).toHaveLength(1000)
+      expect(JSON.parse(result as string)).toHaveLength(100_000)
+    } finally {
+      await registry.close()
+    }
+  }, 60_000)
+
   test('stage list rejects version specifiers', async () => {
     await expect(stage.handler(stageOpts('http://localhost:4873/'), ['list', 'pkg@1.0.0']))
       .rejects.toThrow('Version specifiers are not supported for listing staged packages')

--- a/pnpr/crates/pnpr/src/s3.rs
+++ b/pnpr/crates/pnpr/src/s3.rs
@@ -13,7 +13,11 @@
 //! resolver `SQLite` stores stay on local disk regardless —
 //! only the hosted store is pluggable.
 
-use crate::{error::Result, package_name::PackageName};
+use crate::{
+    error::Result,
+    package_name::PackageName,
+    storage::{STAGED_DIR, staged_id_of_meta_object},
+};
 use axum::body::Body;
 use futures_util::StreamExt;
 use object_store::{
@@ -266,6 +270,50 @@ impl S3Store {
 
     fn tarball_key(&self, name: &PackageName, filename: &str) -> ObjectPath {
         ObjectPath::from(format!("{}{}/{filename}", self.prefix, name.as_str()))
+    }
+
+    // Staged-publish records (see `storage::Storage`'s staged section for
+    // the layout contract shared with the fs backend).
+
+    pub async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
+        match self.store.get(&self.staged_key(object)).await {
+            Ok(result) => Ok(Some(result.bytes().await?.to_vec())),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
+        self.store.put(&self.staged_key(object), PutPayload::from(bytes.to_vec())).await?;
+        Ok(())
+    }
+
+    pub async fn remove_staged(&self, object: &str) -> Result<bool> {
+        match self.store.delete(&self.staged_key(object)).await {
+            Ok(()) => Ok(true),
+            Err(object_store::Error::NotFound { .. }) => Ok(false),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub async fn list_staged_ids(&self) -> Result<Vec<String>> {
+        let scope = ObjectPath::from(format!("{}{STAGED_DIR}", self.prefix));
+        let mut listing = self.store.list(Some(&scope));
+        let mut ids = Vec::new();
+        while let Some(meta) = listing.next().await {
+            let meta = meta?;
+            let Some(object) = meta.location.as_ref().rsplit('/').next() else {
+                continue;
+            };
+            if let Some(id) = staged_id_of_meta_object(object) {
+                ids.push(id.to_string());
+            }
+        }
+        Ok(ids)
+    }
+
+    fn staged_key(&self, object: &str) -> ObjectPath {
+        ObjectPath::from(format!("{}{STAGED_DIR}/{object}", self.prefix))
     }
 }
 

--- a/pnpr/crates/pnpr/src/search.rs
+++ b/pnpr/crates/pnpr/src/search.rs
@@ -156,7 +156,10 @@ fn build_search_package(name: &str, packument: &Value) -> Option<Value> {
     Some(Value::Object(pkg))
 }
 
-fn percent_decode(input: &str) -> String {
+/// Decode a percent-encoded query value. ASCII-oriented: multi-byte UTF-8
+/// sequences decode byte-by-byte, which is lossless for the ASCII values
+/// (package names, numbers) the query parsers here feed it.
+pub(crate) fn percent_decode(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     let mut bytes = input.bytes();
     while let Some(byte) = bytes.next() {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -363,6 +363,24 @@ fn router_with_auth_and_osv(
             // documents. Not part of the standard npm registry API —
             // `pnpm publish --batch` opts into it explicitly.
             .route("/-/pnpm/v1/publish", put(serve_batch_publish))
+            // Staged (two-phase) publishing — the `pnpm stage` surface.
+            // Static `-`/`stage` segments take priority over the generic
+            // segment-count routes below, so these never shadow package
+            // reads. Each route has a `/~<name>/`-prefixed twin so a client
+            // whose registry URL is a registry endpoint can stage through it.
+            .route("/-/stage", get(staged::list_staged))
+            .route("/-/stage/package/{name}", post(staged::post_staged_publish))
+            .route("/-/stage/{id}", get(staged::get_staged).delete(staged::reject_staged))
+            .route("/-/stage/{id}/approve", post(staged::approve_staged))
+            .route("/-/stage/{id}/tarball", get(staged::get_staged_tarball))
+            .route("/{prefix}/-/stage", get(staged::list_staged_prefixed))
+            .route("/{prefix}/-/stage/package/{name}", post(staged::post_staged_publish_prefixed))
+            .route(
+                "/{prefix}/-/stage/{id}",
+                get(staged::get_staged_prefixed).delete(staged::reject_staged_prefixed),
+            )
+            .route("/{prefix}/-/stage/{id}/approve", post(staged::approve_staged_prefixed))
+            .route("/{prefix}/-/stage/{id}/tarball", get(staged::get_staged_tarball_prefixed))
             .route("/{name}", get(get_packument_unscoped).put(put_one_segment))
             .route("/{first}/{second}", get(get_two_segments).put(put_two_segments))
             .route(
@@ -2339,6 +2357,8 @@ fn token_timestamp_millis(seconds: u64) -> i64 {
     let max_seconds = i64::MAX as u64 / MILLIS_PER_SECOND;
     (seconds.min(max_seconds) * MILLIS_PER_SECOND) as i64
 }
+
+mod staged;
 
 #[cfg(test)]
 mod tests;

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -329,8 +329,8 @@ async fn serve_staged_publish(
 }
 
 /// `GET /-/stage?page=&perPage=&package=` — the staged records visible to
-/// the caller through this registry address, newest-first-insensitive
-/// (sorted by staging time, then id, for stable pagination).
+/// the caller through this registry address, sorted oldest-first by staging
+/// time (then id) so pagination stays stable as new records arrive.
 async fn serve_staged_list(
     state: &AppState,
     identity: &Identity,

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -429,7 +429,7 @@ async fn serve_staged_approve(
         Ok(Some(body)) => body,
         Ok(None) => {
             return error_response(&RegistryError::Io(std::io::Error::other(format!(
-                "staged publish {stage_id} has no stored body"
+                "staged publish {stage_id} has no stored body",
             ))));
         }
         Err(err) => return error_response(&err),
@@ -593,17 +593,4 @@ fn generate_stage_id() -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::generate_stage_id;
-
-    #[test]
-    fn generate_stage_id_produces_hyphenated_v4_uuids() {
-        let id = generate_stage_id();
-        assert_eq!(id.len(), 36);
-        let dash_positions: Vec<usize> =
-            id.char_indices().filter(|(_, char)| *char == '-').map(|(index, _)| index).collect();
-        assert_eq!(dash_positions, [8, 13, 18, 23]);
-        assert_eq!(id.as_bytes()[14], b'4', "version nibble must be 4: {id}");
-        assert_ne!(generate_stage_id(), id, "two ids must not collide");
-    }
-}
+mod tests;

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -1,0 +1,609 @@
+//! The `-/stage` endpoints: staged (two-phase) publishing.
+//!
+//! `POST /-/stage/package/:pkg` accepts a regular publish document but holds
+//! it back instead of making it visible; the staged record is then listed
+//! (`GET /-/stage`), inspected (`GET /-/stage/:id`, `GET
+//! /-/stage/:id/tarball`), and finally approved (`POST /-/stage/:id/approve`
+//! — which replays the held document through the regular publish flow) or
+//! rejected (`DELETE /-/stage/:id` — which deletes it). This is the server
+//! half of `pnpm stage`.
+//!
+//! Every operation is gated by the same `publish` rule as a direct publish
+//! of the package, resolved through the registry prefix the stage was
+//! addressed with. Stage ids are random UUIDs, so the id itself is an
+//! unguessable capability; denials answer loudly (401/403) like the publish
+//! endpoint rather than masking.
+
+use axum::{
+    body::Body,
+    extract::{OriginalUri, Path, State},
+    http::{StatusCode, header},
+    response::Response,
+};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use super::{
+    Action, AppState, AuthedCaller, Identity, RegistrySource, authorize, commit_publishes,
+    error_response, is_tilde_prefix, json_response, not_found, private_no_cache,
+    resolve_write_target, stage_publish, validate_publish_doc,
+};
+use crate::{
+    error::RegistryError,
+    package_name::PackageName,
+    publish::{extract_attachments, now_iso},
+    search::percent_decode,
+};
+
+/// One staged publish's metadata, stored next to the held publish body and
+/// served by the list/view endpoints (without the `registry` field, which is
+/// routing state rather than metadata).
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StagedRecord {
+    id: String,
+    package_name: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    tag: Option<String>,
+    created_at: String,
+    actor: String,
+    actor_type: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    shasum: Option<String>,
+    /// The `/~<name>/` registry prefix the stage was addressed through;
+    /// `None` for the path-less base. A staged record is only visible
+    /// through the same address it was created with.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    registry: Option<String>,
+}
+
+impl StagedRecord {
+    /// The list/view representation: the record without its routing state.
+    fn metadata(&self) -> Value {
+        let mut value = serde_json::to_value(self).expect("a staged record serializes");
+        if let Some(object) = value.as_object_mut() {
+            object.remove("registry");
+        }
+        value
+    }
+}
+
+const DEFAULT_PER_PAGE: usize = 100;
+const MAX_PER_PAGE: usize = 100;
+
+#[derive(Debug)]
+struct StagedListQuery {
+    page: usize,
+    per_page: usize,
+    package: Option<String>,
+}
+
+/// Parse the list endpoint's `page` / `perPage` / `package` query
+/// parameters, ignoring anything unrecognized or unparsable.
+fn parse_staged_list_query(query: &str) -> StagedListQuery {
+    let mut parsed = StagedListQuery { page: 0, per_page: DEFAULT_PER_PAGE, package: None };
+    for pair in query.split('&') {
+        let Some((key, value)) = pair.split_once('=') else {
+            continue;
+        };
+        let decoded = percent_decode(value);
+        match key {
+            "page" => {
+                if let Ok(page) = decoded.parse() {
+                    parsed.page = page;
+                }
+            }
+            "perPage" => {
+                if let Ok(per_page) = decoded.parse() {
+                    parsed.per_page = per_page;
+                }
+            }
+            "package" if !decoded.is_empty() => parsed.package = Some(decoded),
+            _ => {}
+        }
+    }
+    parsed
+}
+
+// ---------------------------------------------------------------------
+// Route handlers — the path-less form and its `/~<name>/`-prefixed twin.
+// ---------------------------------------------------------------------
+
+pub(super) async fn post_staged_publish(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path(name): Path<String>,
+    body: axum::body::Bytes,
+) -> Response {
+    serve_staged_publish(&state, &identity, None, &name, &body).await
+}
+
+pub(super) async fn post_staged_publish_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((prefix, name)): Path<(String, String)>,
+    body: axum::body::Bytes,
+) -> Response {
+    match tilde_registry(&prefix) {
+        Some(registry) => {
+            serve_staged_publish(&state, &identity, Some(registry), &name, &body).await
+        }
+        None => not_found(),
+    }
+}
+
+pub(super) async fn list_staged(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    OriginalUri(uri): OriginalUri,
+) -> Response {
+    let query = parse_staged_list_query(uri.query().unwrap_or(""));
+    private_no_cache(serve_staged_list(&state, &identity, None, &query).await)
+}
+
+pub(super) async fn list_staged_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    OriginalUri(uri): OriginalUri,
+    Path(prefix): Path<String>,
+) -> Response {
+    match tilde_registry(&prefix) {
+        Some(registry) => {
+            let query = parse_staged_list_query(uri.query().unwrap_or(""));
+            private_no_cache(serve_staged_list(&state, &identity, Some(registry), &query).await)
+        }
+        None => not_found(),
+    }
+}
+
+pub(super) async fn get_staged(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path(stage_id): Path<String>,
+) -> Response {
+    private_no_cache(serve_staged_view(&state, &identity, None, &stage_id).await)
+}
+
+pub(super) async fn get_staged_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((prefix, stage_id)): Path<(String, String)>,
+) -> Response {
+    match tilde_registry(&prefix) {
+        Some(registry) => {
+            private_no_cache(serve_staged_view(&state, &identity, Some(registry), &stage_id).await)
+        }
+        None => not_found(),
+    }
+}
+
+pub(super) async fn reject_staged(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path(stage_id): Path<String>,
+) -> Response {
+    serve_staged_reject(&state, &identity, None, &stage_id).await
+}
+
+pub(super) async fn reject_staged_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((prefix, stage_id)): Path<(String, String)>,
+) -> Response {
+    match tilde_registry(&prefix) {
+        Some(registry) => serve_staged_reject(&state, &identity, Some(registry), &stage_id).await,
+        None => not_found(),
+    }
+}
+
+pub(super) async fn approve_staged(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path(stage_id): Path<String>,
+) -> Response {
+    serve_staged_approve(&state, &identity, None, &stage_id).await
+}
+
+pub(super) async fn approve_staged_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((prefix, stage_id)): Path<(String, String)>,
+) -> Response {
+    match tilde_registry(&prefix) {
+        Some(registry) => serve_staged_approve(&state, &identity, Some(registry), &stage_id).await,
+        None => not_found(),
+    }
+}
+
+pub(super) async fn get_staged_tarball(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path(stage_id): Path<String>,
+) -> Response {
+    private_no_cache(serve_staged_tarball(&state, &identity, None, &stage_id).await)
+}
+
+pub(super) async fn get_staged_tarball_prefixed(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((prefix, stage_id)): Path<(String, String)>,
+) -> Response {
+    match tilde_registry(&prefix) {
+        Some(registry) => private_no_cache(
+            serve_staged_tarball(&state, &identity, Some(registry), &stage_id).await,
+        ),
+        None => not_found(),
+    }
+}
+
+/// The registry a `/~<name>/`-prefixed staged route addresses, or `None`
+/// when the first segment isn't a tilde prefix (the route pattern also
+/// matches plain segments; those name no staged surface).
+fn tilde_registry(prefix: &str) -> Option<&str> {
+    is_tilde_prefix(prefix).then(|| &prefix[1..])
+}
+
+// ---------------------------------------------------------------------
+// The handlers proper.
+// ---------------------------------------------------------------------
+
+/// `POST /-/stage/package/:pkg` — validate and authorize the publish
+/// document exactly like a direct publish, then hold it back under a fresh
+/// stage id instead of committing it.
+async fn serve_staged_publish(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    raw_name: &str,
+    body: &axum::body::Bytes,
+) -> Response {
+    let name = match PackageName::parse(raw_name) {
+        Ok(name) => name,
+        Err(err) => return error_response(&err),
+    };
+    let incoming: Value = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(err) => return error_response(&RegistryError::Json(err)),
+    };
+    let body_name = incoming.get("name").and_then(Value::as_str);
+    if body_name.is_some_and(|body_name| body_name != name.as_str()) {
+        return error_response(&RegistryError::BadRequest {
+            reason: format!(
+                "package in URL ({:?}) does not match body ({:?})",
+                name.as_str(),
+                body_name.unwrap_or(""),
+            ),
+        });
+    }
+
+    // The same routing + `publish`-rule + attachment validation a direct
+    // publish runs; conflicts with already-published versions are checked
+    // when the stage is approved, against the registry state at that time.
+    let (validated, _target) =
+        match validate_publish_doc(state, identity, registry, name, incoming).await {
+            Ok(validated) => validated,
+            Err(response) => return *response,
+        };
+
+    let (version, dist) = validated.prepared.first().map_or((None, Value::Null), |attachment| {
+        (Some(attachment.version.clone()), attachment.dist.clone())
+    });
+    let tag = validated.incoming.get("dist-tags").and_then(Value::as_object).and_then(|tags| {
+        match &version {
+            Some(version) => tags
+                .iter()
+                .find(|(_, tagged)| tagged.as_str() == Some(version))
+                .or_else(|| tags.iter().next())
+                .map(|(tag, _)| tag.clone()),
+            None => tags.keys().next().cloned(),
+        }
+    });
+    let (actor, actor_type) = actor_of(identity);
+    let stage_id = generate_stage_id();
+    let record = StagedRecord {
+        id: stage_id.clone(),
+        package_name: validated.name.as_str().to_string(),
+        version,
+        tag,
+        created_at: now_iso(),
+        actor,
+        actor_type,
+        shasum: dist.get("shasum").and_then(Value::as_str).map(str::to_string),
+        registry: registry.map(str::to_string),
+    };
+
+    // Body first, metadata last: a record whose metadata exists always has
+    // its body. On a metadata failure the body is cleaned up best-effort.
+    if let Err(err) = state.inner.storage.write_staged_body(&stage_id, body).await {
+        return error_response(&err);
+    }
+    let meta_bytes = serde_json::to_vec(&record).expect("a staged record serializes");
+    if let Err(err) = state.inner.storage.write_staged_meta(&stage_id, &meta_bytes).await {
+        let _ = state.inner.storage.remove_staged(&stage_id).await;
+        return error_response(&err);
+    }
+    json_response(StatusCode::CREATED, &json!({ "ok": true, "stageId": stage_id }))
+}
+
+/// `GET /-/stage?page=&perPage=&package=` — the staged records visible to
+/// the caller through this registry address, newest-first-insensitive
+/// (sorted by staging time, then id, for stable pagination).
+async fn serve_staged_list(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    query: &StagedListQuery,
+) -> Response {
+    let per_page = query.per_page.clamp(1, MAX_PER_PAGE);
+    let ids = match state.inner.storage.list_staged_ids().await {
+        Ok(ids) => ids,
+        Err(err) => return error_response(&err),
+    };
+    let mut records: Vec<StagedRecord> = Vec::new();
+    for stage_id in ids {
+        let Ok(Some(record)) = read_staged_record(state, &stage_id).await else {
+            continue;
+        };
+        if record.registry.as_deref() != registry {
+            continue;
+        }
+        if let Some(package) = &query.package
+            && &record.package_name != package
+        {
+            continue;
+        }
+        // The listing shows only what the caller could publish (and thus
+        // approve); records outside their rights are simply not theirs to see.
+        if authorize_staged(state, identity, &record).await.is_err() {
+            continue;
+        }
+        records.push(record);
+    }
+    records.sort_by(|left, right| {
+        left.created_at.cmp(&right.created_at).then_with(|| left.id.cmp(&right.id))
+    });
+
+    let total = records.len();
+    let items: Vec<Value> = records
+        .iter()
+        .skip(query.page.saturating_mul(per_page))
+        .take(per_page)
+        .map(StagedRecord::metadata)
+        .collect();
+    json_response(
+        StatusCode::OK,
+        &json!({ "items": items, "page": query.page, "perPage": per_page, "total": total }),
+    )
+}
+
+/// `GET /-/stage/:id` — one staged record's metadata.
+async fn serve_staged_view(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    stage_id: &str,
+) -> Response {
+    let record = match load_authorized_record(state, identity, registry, stage_id).await {
+        Ok(record) => record,
+        Err(response) => return *response,
+    };
+    json_response(StatusCode::OK, &record.metadata())
+}
+
+/// `DELETE /-/stage/:id` — reject a staged publish, deleting its record and
+/// held tarball.
+async fn serve_staged_reject(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    stage_id: &str,
+) -> Response {
+    if let Err(response) = load_authorized_record(state, identity, registry, stage_id).await {
+        return *response;
+    }
+    match state.inner.storage.remove_staged(stage_id).await {
+        Ok(_) => Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(Body::empty())
+            .expect("static-shape response always builds"),
+        Err(err) => error_response(&err),
+    }
+}
+
+/// `POST /-/stage/:id/approve` — publish the held document through the
+/// regular validate → stage → commit flow, then drop the staged record.
+async fn serve_staged_approve(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    stage_id: &str,
+) -> Response {
+    let record = match load_authorized_record(state, identity, registry, stage_id).await {
+        Ok(record) => record,
+        Err(response) => return *response,
+    };
+    let body = match state.inner.storage.read_staged_body(stage_id).await {
+        Ok(Some(body)) => body,
+        Ok(None) => {
+            return error_response(&RegistryError::Io(std::io::Error::other(format!(
+                "staged publish {stage_id} has no stored body"
+            ))));
+        }
+        Err(err) => return error_response(&err),
+    };
+    let incoming: Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(err) => return error_response(&RegistryError::Json(err)),
+    };
+    let name = match PackageName::parse(&record.package_name) {
+        Ok(name) => name,
+        Err(err) => return error_response(&err),
+    };
+    // Re-validate against the registry state of *now*: rules may have
+    // changed since staging, and the version may have been published in
+    // the meantime (which surfaces as the usual 409).
+    let (validated, target) =
+        match validate_publish_doc(state, identity, record.registry.as_deref(), name, incoming)
+            .await
+        {
+            Ok(validated) => validated,
+            Err(response) => return *response,
+        };
+
+    let _packument_guard = state.inner.package_locks.lock(validated.name.as_str()).await;
+    let staged = match stage_publish(state, validated, &now_iso(), Some(&target.org)).await {
+        Ok(staged) => staged,
+        Err(err) => return error_response(&err),
+    };
+    if let Err(err) = commit_publishes(state, vec![staged]).await {
+        return error_response(&err);
+    }
+    if let Err(err) = state.inner.storage.remove_staged(stage_id).await {
+        // The publish is already committed and visible; a failed record
+        // cleanup must not report the approval as failed.
+        tracing::warn!(error = %err, stage_id, "approved staged publish but its record cleanup failed");
+    }
+    json_response(StatusCode::CREATED, &json!({ "ok": true }))
+}
+
+/// `GET /-/stage/:id/tarball` — the held tarball's bytes, decoded from the
+/// stored publish document's attachment.
+async fn serve_staged_tarball(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    stage_id: &str,
+) -> Response {
+    if let Err(response) = load_authorized_record(state, identity, registry, stage_id).await {
+        return *response;
+    }
+    let body = match state.inner.storage.read_staged_body(stage_id).await {
+        Ok(Some(body)) => body,
+        Ok(None) => return not_found(),
+        Err(err) => return error_response(&err),
+    };
+    let mut incoming: Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(err) => return error_response(&RegistryError::Json(err)),
+    };
+    let attachments = match extract_attachments(&mut incoming) {
+        Ok(attachments) => attachments,
+        Err(err) => return error_response(&err),
+    };
+    let Some(attachment) = attachments.into_iter().next() else {
+        return not_found();
+    };
+    let bytes = match BASE64.decode(attachment.data.as_bytes()) {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            return error_response(&RegistryError::InvalidAttachment {
+                filename: attachment.filename,
+                reason: format!("invalid base64 data: {err}"),
+            });
+        }
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/octet-stream")
+        .header(header::CONTENT_LENGTH, bytes.len())
+        .body(Body::from(bytes))
+        .expect("static-shape response always builds")
+}
+
+// ---------------------------------------------------------------------
+// Shared plumbing.
+// ---------------------------------------------------------------------
+
+/// Load a staged record and check the caller may act on it: the record must
+/// exist, be addressed through the same registry prefix it was staged with,
+/// and the caller must hold the `publish` right on its package.
+async fn load_authorized_record(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    stage_id: &str,
+) -> Result<StagedRecord, Box<Response>> {
+    let record = match read_staged_record(state, stage_id).await {
+        Ok(Some(record)) => record,
+        Ok(None) => return Err(Box::new(not_found())),
+        Err(err) => return Err(Box::new(error_response(&err))),
+    };
+    if record.registry.as_deref() != registry {
+        return Err(Box::new(not_found()));
+    }
+    authorize_staged(state, identity, &record).await?;
+    Ok(record)
+}
+
+/// The `publish` authorization a staged record's package demands, resolved
+/// through the registry prefix the record was staged with.
+async fn authorize_staged(
+    state: &AppState,
+    identity: &Identity,
+    record: &StagedRecord,
+) -> Result<(), Box<Response>> {
+    let name =
+        PackageName::parse(&record.package_name).map_err(|err| Box::new(error_response(&err)))?;
+    let target = resolve_write_target(state, identity, record.registry.as_deref(), &name)?;
+    authorize(
+        state,
+        identity,
+        &RegistrySource::Hosted(target.source),
+        name.as_str(),
+        Action::Publish,
+    )
+    .map_err(|err| Box::new(error_response(&err)))
+}
+
+async fn read_staged_record(
+    state: &AppState,
+    stage_id: &str,
+) -> Result<Option<StagedRecord>, RegistryError> {
+    let Some(bytes) = state.inner.storage.read_staged_meta(stage_id).await? else {
+        return Ok(None);
+    };
+    serde_json::from_slice(&bytes).map(Some).map_err(RegistryError::Json)
+}
+
+fn actor_of(identity: &Identity) -> (String, String) {
+    match identity {
+        Identity::User { username, .. } => (username.clone(), "user".to_string()),
+        // Reachable only when the registry's publish rule allows anonymous
+        // writes; the record still needs an actor to display.
+        Identity::Anonymous => ("anonymous".to_string(), "user".to_string()),
+    }
+}
+
+/// A fresh random (version 4) UUID from the OS CSPRNG — the stage id
+/// clients quote back on view/approve/reject/download.
+fn generate_stage_id() -> String {
+    let mut bytes = [0u8; 16];
+    getrandom::fill(&mut bytes).expect("OS CSPRNG must be available");
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    let hex = bytes.iter().fold(String::with_capacity(32), |mut hex, byte| {
+        use std::fmt::Write;
+        write!(hex, "{byte:02x}").expect("writing to a String cannot fail");
+        hex
+    });
+    format!("{}-{}-{}-{}-{}", &hex[0..8], &hex[8..12], &hex[12..16], &hex[16..20], &hex[20..32])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_stage_id;
+
+    #[test]
+    fn generate_stage_id_produces_hyphenated_v4_uuids() {
+        let id = generate_stage_id();
+        assert_eq!(id.len(), 36);
+        let dash_positions: Vec<usize> =
+            id.char_indices().filter(|(_, char)| *char == '-').map(|(index, _)| index).collect();
+        assert_eq!(dash_positions, [8, 13, 18, 23]);
+        assert_eq!(id.as_bytes()[14], b'4', "version nibble must be 4: {id}");
+        assert_ne!(generate_stage_id(), id, "two ids must not collide");
+    }
+}

--- a/pnpr/crates/pnpr/src/server/staged/tests.rs
+++ b/pnpr/crates/pnpr/src/server/staged/tests.rs
@@ -1,0 +1,12 @@
+use super::generate_stage_id;
+
+#[test]
+fn generate_stage_id_produces_hyphenated_v4_uuids() {
+    let id = generate_stage_id();
+    assert_eq!(id.len(), 36);
+    let dash_positions: Vec<usize> =
+        id.char_indices().filter(|(_, char)| *char == '-').map(|(index, _)| index).collect();
+    assert_eq!(dash_positions, [8, 13, 18, 23]);
+    assert_eq!(id.as_bytes()[14], b'4', "version nibble must be 4: {id}");
+    assert_ne!(generate_stage_id(), id, "two ids must not collide");
+}

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -524,10 +524,15 @@ impl Storage {
 
     /// Remove a staged record — the metadata first, so a concurrent list
     /// never surfaces a record whose body is already gone. `Ok(false)` when
-    /// no metadata existed.
+    /// no metadata existed. A body-removal failure is logged rather than
+    /// propagated: once the metadata is gone the record is deleted for every
+    /// reader, and an error here would misreport that while leaving nothing
+    /// for a retry to find (bodies are only discovered through metadata).
     pub async fn remove_staged(&self, stage_id: &str) -> Result<bool> {
         let removed = self.hosted.remove_staged(&staged_meta_object(stage_id)?).await?;
-        self.hosted.remove_staged(&staged_body_object(stage_id)?).await?;
+        if let Err(err) = self.hosted.remove_staged(&staged_body_object(stage_id)?).await {
+            tracing::warn!(error = %err, stage_id, "staged body cleanup failed after removing its metadata");
+        }
         Ok(removed)
     }
 

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -275,6 +275,34 @@ impl HostedStore {
             HostedStore::S3(store) => HostedStore::S3(store.namespaced(segment)),
         }
     }
+
+    async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
+        match self {
+            HostedStore::Fs(store) => store.read_staged(object).await,
+            HostedStore::S3(store) => store.read_staged(object).await,
+        }
+    }
+
+    async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
+        match self {
+            HostedStore::Fs(store) => store.write_staged(object, bytes).await,
+            HostedStore::S3(store) => store.write_staged(object, bytes).await,
+        }
+    }
+
+    async fn remove_staged(&self, object: &str) -> Result<bool> {
+        match self {
+            HostedStore::Fs(store) => store.remove_staged(object).await,
+            HostedStore::S3(store) => store.remove_staged(object).await,
+        }
+    }
+
+    async fn list_staged_ids(&self) -> Result<Vec<String>> {
+        match self {
+            HostedStore::Fs(store) => store.list_staged_ids().await,
+            HostedStore::S3(store) => store.list_staged_ids().await,
+        }
+    }
 }
 
 impl Storage {
@@ -464,6 +492,77 @@ impl Storage {
             HostedStore::S3(_) => &self.cached.root,
         };
         crate::journal::PublishJournal::new(root.join(crate::journal::JOURNAL_DIR))
+    }
+
+    // --- Staged publishes (`-/stage`) -------------------------------------
+    //
+    // A staged publish is a publish document held back until it is approved
+    // (`POST /-/stage/:id/approve`) or rejected (`DELETE /-/stage/:id`). Each
+    // record is two objects in the hosted backend, keyed by the stage id:
+    // a small metadata JSON (listed and served as-is) and the full original
+    // publish body (replayed through the regular publish flow on approval).
+    // Records live under the reserved `.staged/` namespace of the *root*
+    // hosted store — never a per-org view — because the stage id is the only
+    // thing a later `view`/`approve`/`reject` request carries; the record's
+    // metadata remembers which registry the stage was addressed through.
+
+    pub async fn read_staged_meta(&self, stage_id: &str) -> Result<Option<Vec<u8>>> {
+        self.hosted.read_staged(&staged_meta_object(stage_id)?).await
+    }
+
+    pub async fn write_staged_meta(&self, stage_id: &str, bytes: &[u8]) -> Result<()> {
+        self.hosted.write_staged(&staged_meta_object(stage_id)?, bytes).await
+    }
+
+    pub async fn read_staged_body(&self, stage_id: &str) -> Result<Option<Vec<u8>>> {
+        self.hosted.read_staged(&staged_body_object(stage_id)?).await
+    }
+
+    pub async fn write_staged_body(&self, stage_id: &str, bytes: &[u8]) -> Result<()> {
+        self.hosted.write_staged(&staged_body_object(stage_id)?, bytes).await
+    }
+
+    /// Remove a staged record — the metadata first, so a concurrent list
+    /// never surfaces a record whose body is already gone. `Ok(false)` when
+    /// no metadata existed.
+    pub async fn remove_staged(&self, stage_id: &str) -> Result<bool> {
+        let removed = self.hosted.remove_staged(&staged_meta_object(stage_id)?).await?;
+        self.hosted.remove_staged(&staged_body_object(stage_id)?).await?;
+        Ok(removed)
+    }
+
+    /// Every staged record's id, in unspecified order (the listing endpoint
+    /// sorts by staging time).
+    pub async fn list_staged_ids(&self) -> Result<Vec<String>> {
+        self.hosted.list_staged_ids().await
+    }
+}
+
+/// Reserved directory (fs) / key segment (S3) holding staged publishes.
+/// The leading dot keeps it out of the package namespace: a package name
+/// can never start with `.`.
+pub(crate) const STAGED_DIR: &str = ".staged";
+const STAGED_META_SUFFIX: &str = ".json";
+const STAGED_BODY_SUFFIX: &str = ".body.json";
+
+fn staged_meta_object(stage_id: &str) -> Result<String> {
+    Ok(format!("{}{STAGED_META_SUFFIX}", validated_stage_id(stage_id)?))
+}
+
+fn staged_body_object(stage_id: &str) -> Result<String> {
+    Ok(format!("{}{STAGED_BODY_SUFFIX}", validated_stage_id(stage_id)?))
+}
+
+/// Reject any stage id that could smuggle a path segment before it reaches a
+/// filesystem path or object key. Handlers validate the UUID shape already;
+/// this is the storage layer's own guard.
+fn validated_stage_id(stage_id: &str) -> Result<&str> {
+    let valid = !stage_id.is_empty()
+        && stage_id.chars().all(|char| char.is_ascii_hexdigit() || char == '-');
+    if valid {
+        Ok(stage_id)
+    } else {
+        Err(RegistryError::BadRequest { reason: format!("invalid stage id {stage_id:?}") })
     }
 }
 
@@ -667,6 +766,51 @@ impl Store {
     fn tarball_path(&self, name: &PackageName, filename: &str) -> PathBuf {
         self.package_dir(name).join(filename)
     }
+
+    async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
+        match fs::read(self.root.join(STAGED_DIR).join(object)).await {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
+        write_atomic(&self.root.join(STAGED_DIR).join(object), bytes).await
+    }
+
+    async fn remove_staged(&self, object: &str) -> Result<bool> {
+        match fs::remove_file(self.root.join(STAGED_DIR).join(object)).await {
+            Ok(()) => Ok(true),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn list_staged_ids(&self) -> Result<Vec<String>> {
+        let mut entries = match fs::read_dir(self.root.join(STAGED_DIR)).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(err.into()),
+        };
+        let mut ids = Vec::new();
+        while let Some(entry) = entries.next_entry().await? {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if let Some(id) = staged_id_of_meta_object(&name) {
+                ids.push(id.to_string());
+            }
+        }
+        Ok(ids)
+    }
+}
+
+/// The stage id of a metadata object name, or `None` for anything else in
+/// the staged namespace (bodies, tmp files from interrupted writes).
+pub(crate) fn staged_id_of_meta_object(object: &str) -> Option<&str> {
+    if object.ends_with(STAGED_BODY_SUFFIX) {
+        return None;
+    }
+    object.strip_suffix(STAGED_META_SUFFIX)
 }
 
 async fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {

--- a/pnpr/crates/pnpr/tests/staged_publish.rs
+++ b/pnpr/crates/pnpr/tests/staged_publish.rs
@@ -1,0 +1,448 @@
+//! Integration tests for the `-/stage` endpoints — the server half of
+//! `pnpm stage`. Static-mode (no upstream) to keep the tests hermetic.
+
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use pnpr::{Config, MaxUsers, router};
+use serde_json::{Value, json};
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    path::PathBuf,
+};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+fn static_config(storage: PathBuf) -> Config {
+    let listen = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873));
+    let mut config = Config::static_serve(listen, storage);
+    config.public_url = "http://example.test".to_string();
+    config.auth.htpasswd.max_users = MaxUsers::Unlimited;
+    config
+}
+
+async fn body_bytes(body: Body) -> Vec<u8> {
+    to_bytes(body, usize::MAX).await.expect("read body").to_vec()
+}
+
+async fn body_json(body: Body) -> Value {
+    serde_json::from_slice(&body_bytes(body).await).expect("body parses as JSON")
+}
+
+fn request(method: &str, path: &str, body: Body, token: Option<&str>) -> Request<Body> {
+    let mut builder =
+        Request::builder().method(method).uri(path).header("content-type", "application/json");
+    if let Some(token) = token {
+        builder = builder.header("Authorization", format!("Bearer {token}"));
+    }
+    builder.body(body).unwrap()
+}
+
+fn json_request(method: &str, path: &str, body: &Value, token: Option<&str>) -> Request<Body> {
+    request(method, path, Body::from(serde_json::to_vec(body).unwrap()), token)
+}
+
+async fn add_user_and_get_token(app: axum::Router, username: &str, password: &str) -> String {
+    let path = format!("/-/user/org.couchdb.user:{username}");
+    let body = json!({
+        "_id": format!("org.couchdb.user:{username}"),
+        "name": username,
+        "password": password,
+        "email": "foo@bar.net",
+        "type": "user",
+        "roles": [],
+    });
+    let response = app.oneshot(json_request("PUT", &path, &body, None)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let payload = body_json(response.into_body()).await;
+    payload["token"].as_str().expect("token in response").to_string()
+}
+
+fn publish_doc(name: &str, version: &str, tarball: &[u8]) -> Value {
+    let basename = name.rsplit('/').next().unwrap_or(name);
+    let filename = format!("{basename}-{version}.tgz");
+    json!({
+        "_id": name,
+        "name": name,
+        "description": "test",
+        "dist-tags": { "latest": version },
+        "versions": {
+            version: {
+                "name": name,
+                "version": version,
+                "dist": {
+                    "tarball": format!("http://localhost:4873/{name}/-/{filename}"),
+                    "shasum": sha1_hex(tarball),
+                    "integrity": sri_sha512(tarball),
+                }
+            }
+        },
+        "_attachments": {
+            filename: {
+                "content_type": "application/octet-stream",
+                "data": BASE64.encode(tarball),
+                "length": tarball.len()
+            }
+        }
+    })
+}
+
+/// Stage `doc` and return the stage id the registry minted.
+async fn stage_package(app: axum::Router, name: &str, doc: &Value, token: &str) -> String {
+    let path = format!("/-/stage/package/{}", name.replace('/', "%2f"));
+    let response = app.oneshot(json_request("POST", &path, doc, Some(token))).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let payload = body_json(response.into_body()).await;
+    payload["stageId"].as_str().expect("stageId in response").to_string()
+}
+
+fn is_uuid(value: &str) -> bool {
+    value.len() == 36
+        && value.char_indices().all(|(index, char)| match index {
+            8 | 13 | 18 | 23 => char == '-',
+            _ => char.is_ascii_hexdigit(),
+        })
+}
+
+#[tokio::test]
+async fn staged_publish_is_held_back_until_approved() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+
+    let tarball = b"staged-tarball";
+    let doc = publish_doc("staged-pkg", "1.0.0", tarball);
+    let stage_id = stage_package(app.clone(), "staged-pkg", &doc, &token).await;
+    assert!(is_uuid(&stage_id), "stage id must be a UUID: {stage_id}");
+
+    // Held back: the package is not installable and nothing is on disk
+    // under its name.
+    let read = app
+        .clone()
+        .oneshot(request("GET", "/staged-pkg", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(read.status(), StatusCode::NOT_FOUND);
+    assert!(!storage.join("staged-pkg").exists(), "no package dir before approval");
+
+    // Listed, viewable, and its tarball downloadable.
+    let list = app
+        .clone()
+        .oneshot(request("GET", "/-/stage?page=0&perPage=100", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(list.status(), StatusCode::OK);
+    let listed = body_json(list.into_body()).await;
+    assert_eq!(listed["total"], 1);
+    assert_eq!(listed["items"][0]["id"], Value::String(stage_id.clone()));
+    assert_eq!(listed["items"][0]["packageName"], "staged-pkg");
+    assert_eq!(listed["items"][0]["version"], "1.0.0");
+    assert_eq!(listed["items"][0]["tag"], "latest");
+    assert_eq!(listed["items"][0]["actor"], "alice");
+    assert_eq!(listed["items"][0]["actorType"], "user");
+    assert_eq!(listed["items"][0]["shasum"], Value::String(sha1_hex(tarball)));
+    assert!(listed["items"][0].get("registry").is_none(), "routing state must not be served");
+
+    let view = app
+        .clone()
+        .oneshot(request("GET", &format!("/-/stage/{stage_id}"), Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(view.status(), StatusCode::OK);
+    let viewed = body_json(view.into_body()).await;
+    assert_eq!(viewed["packageName"], "staged-pkg");
+
+    let download = app
+        .clone()
+        .oneshot(request(
+            "GET",
+            &format!("/-/stage/{stage_id}/tarball"),
+            Body::empty(),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(download.status(), StatusCode::OK);
+    assert_eq!(body_bytes(download.into_body()).await, tarball);
+
+    // Approve: the package becomes installable and the record disappears.
+    let approve = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            &format!("/-/stage/{stage_id}/approve"),
+            Body::empty(),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::CREATED);
+
+    let read = app
+        .clone()
+        .oneshot(request("GET", "/staged-pkg", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(read.status(), StatusCode::OK);
+    let packument = body_json(read.into_body()).await;
+    assert_eq!(packument["versions"]["1.0.0"]["version"], "1.0.0");
+    let on_disk = std::fs::read(storage.join("staged-pkg/staged-pkg-1.0.0.tgz"))
+        .expect("tarball promoted on approval");
+    assert_eq!(on_disk, tarball);
+
+    let list =
+        app.clone().oneshot(request("GET", "/-/stage", Body::empty(), Some(&token))).await.unwrap();
+    let listed = body_json(list.into_body()).await;
+    assert_eq!(listed["total"], 0, "an approved stage leaves no record behind");
+    let view = app
+        .oneshot(request("GET", &format!("/-/stage/{stage_id}"), Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(view.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn rejecting_a_staged_publish_deletes_it_without_publishing() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+
+    let doc = publish_doc("rejected-pkg", "1.0.0", b"bytes");
+    let stage_id = stage_package(app.clone(), "rejected-pkg", &doc, &token).await;
+
+    let reject = app
+        .clone()
+        .oneshot(request("DELETE", &format!("/-/stage/{stage_id}"), Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(reject.status(), StatusCode::NO_CONTENT);
+
+    let view = app
+        .clone()
+        .oneshot(request("GET", &format!("/-/stage/{stage_id}"), Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(view.status(), StatusCode::NOT_FOUND);
+    let read =
+        app.oneshot(request("GET", "/rejected-pkg", Body::empty(), Some(&token))).await.unwrap();
+    assert_eq!(read.status(), StatusCode::NOT_FOUND);
+    assert!(!storage.join("rejected-pkg").exists(), "a rejected stage publishes nothing");
+}
+
+#[tokio::test]
+async fn staging_supports_scoped_packages() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let app = router(static_config(storage.clone()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+
+    let tarball = b"scoped-bytes";
+    let doc = publish_doc("@scope/staged", "2.0.0", tarball);
+    let stage_id = stage_package(app.clone(), "@scope/staged", &doc, &token).await;
+
+    let list = app
+        .clone()
+        .oneshot(request("GET", "/-/stage?package=%40scope%2Fstaged", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    let listed = body_json(list.into_body()).await;
+    assert_eq!(listed["total"], 1);
+    assert_eq!(listed["items"][0]["packageName"], "@scope/staged");
+
+    let approve = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            &format!("/-/stage/{stage_id}/approve"),
+            Body::empty(),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::CREATED);
+    let on_disk = std::fs::read(storage.join("@scope/staged/staged-2.0.0.tgz"))
+        .expect("scoped tarball promoted on approval");
+    assert_eq!(on_disk, tarball);
+}
+
+#[tokio::test]
+async fn the_package_filter_narrows_the_listing() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+
+    stage_package(app.clone(), "filter-a", &publish_doc("filter-a", "1.0.0", b"a"), &token).await;
+    stage_package(app.clone(), "filter-b", &publish_doc("filter-b", "1.0.0", b"b"), &token).await;
+
+    let list = app
+        .clone()
+        .oneshot(request("GET", "/-/stage?package=filter-a", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    let listed = body_json(list.into_body()).await;
+    assert_eq!(listed["total"], 1);
+    assert_eq!(listed["items"][0]["packageName"], "filter-a");
+
+    let all = app.oneshot(request("GET", "/-/stage", Body::empty(), Some(&token))).await.unwrap();
+    let listed = body_json(all.into_body()).await;
+    assert_eq!(listed["total"], 2);
+}
+
+#[tokio::test]
+async fn pagination_slices_the_listing() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+
+    for index in 0..3 {
+        let name = format!("paged-{index}");
+        stage_package(app.clone(), &name, &publish_doc(&name, "1.0.0", b"x"), &token).await;
+    }
+
+    let page = app
+        .clone()
+        .oneshot(request("GET", "/-/stage?page=0&perPage=2", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    let first = body_json(page.into_body()).await;
+    assert_eq!(first["total"], 3);
+    assert_eq!(first["perPage"], 2);
+    assert_eq!(first["items"].as_array().map(Vec::len), Some(2));
+
+    let page = app
+        .oneshot(request("GET", "/-/stage?page=1&perPage=2", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    let second = body_json(page.into_body()).await;
+    assert_eq!(second["page"], 1);
+    assert_eq!(second["items"].as_array().map(Vec::len), Some(1));
+}
+
+#[tokio::test]
+async fn staging_requires_the_publish_right() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+
+    let doc = publish_doc("anon-staged", "1.0.0", b"bytes");
+    let response = app
+        .oneshot(json_request("POST", "/-/stage/package/anon-staged", &doc, None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn approving_requires_the_publish_right() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+
+    let doc = publish_doc("guarded-pkg", "1.0.0", b"bytes");
+    let stage_id = stage_package(app.clone(), "guarded-pkg", &doc, &token).await;
+
+    let approve = app
+        .clone()
+        .oneshot(request("POST", &format!("/-/stage/{stage_id}/approve"), Body::empty(), None))
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::UNAUTHORIZED);
+    let reject = app
+        .clone()
+        .oneshot(request("DELETE", &format!("/-/stage/{stage_id}"), Body::empty(), None))
+        .await
+        .unwrap();
+    assert_eq!(reject.status(), StatusCode::UNAUTHORIZED);
+
+    // An anonymous listing shows nothing rather than leaking the record.
+    let list = app.oneshot(request("GET", "/-/stage", Body::empty(), None)).await.unwrap();
+    assert_eq!(list.status(), StatusCode::OK);
+    let listed = body_json(list.into_body()).await;
+    assert_eq!(listed["total"], 0);
+}
+
+#[tokio::test]
+async fn approving_a_version_published_in_the_meantime_conflicts() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+
+    let doc = publish_doc("conflicted-pkg", "1.0.0", b"staged-bytes");
+    let stage_id = stage_package(app.clone(), "conflicted-pkg", &doc, &token).await;
+
+    // The same version lands through a direct publish before approval.
+    let direct = publish_doc("conflicted-pkg", "1.0.0", b"direct-bytes");
+    let response = app
+        .clone()
+        .oneshot(json_request("PUT", "/conflicted-pkg", &direct, Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let approve = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            &format!("/-/stage/{stage_id}/approve"),
+            Body::empty(),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::CONFLICT);
+
+    // The record survives a failed approval; it can still be rejected.
+    let reject = app
+        .oneshot(request("DELETE", &format!("/-/stage/{stage_id}"), Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(reject.status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test]
+async fn a_bogus_stage_id_is_not_found_or_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+
+    let unknown = "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f";
+    let view = app
+        .clone()
+        .oneshot(request("GET", &format!("/-/stage/{unknown}"), Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(view.status(), StatusCode::NOT_FOUND);
+
+    // A path-traversal-shaped id is rejected before it can reach storage.
+    let hostile = app
+        .oneshot(request("GET", "/-/stage/%2e%2e%2fescape", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(hostile.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Compute the SRI `sha512-...` string the way npm clients send it
+/// in `dist.integrity`.
+fn sri_sha512(bytes: &[u8]) -> String {
+    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
+    opts.input(bytes);
+    opts.result().to_string()
+}
+
+/// Compute the 40-char hex SHA-1 the way npm clients send it in the
+/// legacy `dist.shasum` field.
+fn sha1_hex(bytes: &[u8]) -> String {
+    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha1);
+    opts.input(bytes);
+    let integrity = opts.result();
+    let digest_base64 = &integrity.hashes[0].digest;
+    let digest_bytes = BASE64.decode(digest_base64).unwrap();
+    digest_bytes.iter().fold(String::with_capacity(40), |mut acc, byte| {
+        use std::fmt::Write;
+        write!(acc, "{byte:02x}").unwrap();
+        acc
+    })
+}


### PR DESCRIPTION
## Summary

Ports `pnpm stage` to the Rust CLI and implements the registry side of staged publishing in pnpr, so the two stacks stay at feature parity and the Rust CLI has a real registry to stage against.

**Rust CLI (`pnpm/`):**
- All six subcommands with the TypeScript CLI's surface, error codes, endpoints, and output: `publish` (regular publish pipeline against the staging endpoint, `+ pkg@1.0.0 (staged with id …)` / `(would stage)` lines or a name-keyed `--json` map), `list` (paginated with package filter and package-scoped auth), `view`, `approve` / `reject` (full OTP / web-auth challenge handling, configured `--otp` on the first attempt), and `download` (tarball summary in the `publish --json` shape, with traversal-safe filenames).
- Fixes the staged-publish route in `pacquet-publish`: a staged upload now sends `POST /-/stage/package/:pkg` (libnpmpublish's stage route) instead of the regular packument `PUT`. This path was previously unreachable because the CLI hardcoded `stage: false`.

**pnpr:**
- `POST /-/stage/package/:pkg` validates and authorizes exactly like a direct publish, then holds the document under a fresh UUID; `GET /-/stage` (paginated, package filter, filtered to what the caller may publish), `GET /-/stage/:id`, `GET /-/stage/:id/tarball`, `POST /-/stage/:id/approve` (replays through the regular validate → stage → commit flow, so a version published in the meantime surfaces as the usual 409), `DELETE /-/stage/:id`. Each route has a `/~<registry>/`-prefixed twin, and a record is only visible through the address it was staged with. Records persist under a reserved `.staged/` namespace on both the fs and S3 backends.

**Also fixes a broken test on main** (a semantic conflict between two green-merged PRs, pnpm/pnpm#12910 and pnpm/pnpm#12914): `pacquet install` scaffolded a root `package.json` at a manifest-less workspace root, which the verify-deps-before-run install wrote to disk and a `[<since>]` filter then selected as a runnable project with the init template's failing `test` script. `State::init` now uses the scaffold in memory without persisting it when a `pnpm-workspace.yaml` sits next to the missing manifest, matching the TypeScript CLI (which never scaffolds).

The TypeScript side needed one change, prompted by review: `pnpm stage list` gained the same fail-safe pagination cap (1000 pages) as the Rust port, with a patch changeset. The Rust download path additionally caps the tarball body and its decompression at 512 MiB each — following the dist-tag precedent of hardening beyond the TypeScript implementation, which reads these unbounded. One deliberate micro-divergence: a 401 OTP challenge on the read-only stage GETs surfaces as `ERR_PNPM_STAGE_REGISTRY_ERROR` rather than TS's internal `SyntheticOtpError` leaking through; no registry challenges GETs in practice.

## Squash Commit Body

```text
Port `pnpm stage` (publish, list, view, approve, reject, download) to the
Rust CLI, mirroring the TypeScript command's flags, error codes, endpoints,
and output. `stage publish` reuses the publish pipeline (PublishArgs is
split into a reusable PublishFlags, and the pipeline returns summaries
instead of printing); approve/reject drive the shared OTP / web-auth flow;
download summarizes the tarball with the same traversal protections as
the TypeScript implementation. Also fixes the staged-publish route in
pacquet-publish to POST -/stage/package/:pkg (libnpmpublish's stage route)
instead of the regular packument PUT — previously unreachable because the
CLI hardcoded stage: false.

pnpr grows the server half: POST /-/stage/package/:pkg validates and
authorizes like a direct publish and holds the document under a UUID;
list/view/tarball inspect held records; approve replays the document
through the regular validate/stage/commit flow; reject deletes it. Records
persist under a reserved .staged/ namespace on the fs and S3 backends,
with stage-id validation ahead of any path or object key.

Shared plumbing: the capped response-body reader moves from the dist-tag
command into pacquet-network, and pacquet-pack exports its en-locale path
sort for the tarball summary.

Also fixes a broken test on main (semantic conflict between
pnpm/pnpm#12910 and pnpm/pnpm#12914): State::init no longer persists a
scaffolded root package.json when a pnpm-workspace.yaml sits next to the
missing manifest, so a verify-deps-before-run install can't turn the
workspace root into a selectable project with the init template's failing
test script.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port (the TypeScript stage command already exists; this PR is its
  Rust port, plus the pnpr server side).
- [x] Added a changeset (for the TypeScript-side `stage list` pagination cap).
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staged publishing via `pnpm stage` (`publish`, `list`, `view`, `approve`, `reject`, `download`) with both JSON and human-readable output, including staged tarball details.
  * Introduced server-side staging endpoints backed by filesystem and cloud storage.
* **Bug Fixes**
  * Prevented workspace root `package.json` scaffolding when only `pnpm-workspace.yaml` is present.
  * Added a fail-safe cap to stop `stage list` pagination after excessive pages.
  * Hardened error/body handling and made `stage download` filenames/paths safer against traversal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
