### PR TITLE
refactor(pacquet): ship the CLI under its final pnpm name

### DIFF
--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/rustup
 
-      - name: Build pacquet and the harness
+      - name: Build pnpm and the harness
         run: cargo build --release --bin pnpm --bin ecosystem-e2e
 
       - name: Build the pnpm CLI bundle

--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/rustup
 
       - name: Build pacquet and the harness
-        run: cargo build --release --bin pacquet --bin ecosystem-e2e
+        run: cargo build --release --bin pnpm --bin ecosystem-e2e
 
       - name: Build the pnpm CLI bundle
         run: |
@@ -54,7 +54,7 @@ jobs:
         with:
           name: ecosystem-e2e-build
           path: |
-            target/release/pacquet
+            target/release/pnpm
             target/release/ecosystem-e2e
             pnpm11/pnpm/dist
           retention-days: 1
@@ -90,7 +90,7 @@ jobs:
 
       - name: Restore executable bits
         # Artifacts don't preserve the executable bit.
-        run: chmod +x target/release/pacquet target/release/ecosystem-e2e
+        run: chmod +x target/release/pnpm target/release/ecosystem-e2e
 
       - name: Wrap the built pnpm bundle as an executable
         # The harness takes a single executable for --pnpm; the launcher is a
@@ -104,7 +104,7 @@ jobs:
         run: |
           ./target/release/ecosystem-e2e \
             --pnpm "$PWD/pnpm-built" \
-            --pacquet "$PWD/target/release/pacquet" \
+            --pacquet "$PWD/target/release/pnpm" \
             --binary both \
             --layout both \
             --stack ${{ matrix.stack }} \

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -197,6 +197,7 @@ jobs:
         with:
           key: integrated-benchmark-bin-${{ matrix.os }}-${{ steps.revs.outputs.main_sha }}-${{ hashFiles('rust-toolchain.toml') }}
           path: |
+            bench-work-env/pnpr@main/pacquet/target/release/pnpm
             bench-work-env/pnpr@main/pacquet/target/release/pacquet
             bench-work-env/pnpr@main/pacquet/target/release/pnpr
         timeout-minutes: 2
@@ -207,6 +208,7 @@ jobs:
         with:
           key: integrated-benchmark-bin-${{ matrix.os }}-${{ steps.revs.outputs.head_sha }}-${{ hashFiles('rust-toolchain.toml') }}
           path: |
+            bench-work-env/pnpr@HEAD/pacquet/target/release/pnpm
             bench-work-env/pnpr@HEAD/pacquet/target/release/pacquet
             bench-work-env/pnpr@HEAD/pacquet/target/release/pnpr
         timeout-minutes: 2

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -185,10 +185,11 @@ jobs:
         continue-on-error: true
 
       # Prebuilt revision binaries, keyed on the resolved commit. A
-      # `pnpr@<rev>` build also produces the `pacquet` client binary, and
-      # the orchestrator's `--reuse-prebuilt-binaries` copies it to the
-      # same-revision `pacquet@<rev>` target — so caching the two pnpr
-      # binaries covers all four targets. `main` is a near-certain hit on
+      # `pnpr@<rev>` build also produces the client binary (named `pnpm`,
+      # or `pacquet` in revisions that predate the bin rename — both paths
+      # are listed), and the orchestrator's `--reuse-prebuilt-binaries`
+      # copies it to the same-revision `pacquet@<rev>` target — so caching
+      # the pnpr binaries covers all four targets. `main` is a near-certain hit on
       # PRs (stable SHA), and a same-HEAD re-run hits HEAD too; a fresh HEAD
       # is the only thing that compiles. Restored into the paths the
       # orchestrator builds into, so it skips the clone + `cargo build`.

--- a/.github/workflows/pacquet-release-to-npm.yml
+++ b/.github/workflows/pacquet-release-to-npm.yml
@@ -108,18 +108,18 @@ jobs:
 
       - name: Inject version into pnpm/crates/config/src/defaults.rs
         # `pacquet --version` and the default User-Agent both read the
-        # PACQUET_VERSION constant. Patch it here so the binary built for the
+        # PNPM_VERSION constant. Patch it here so the binary built for the
         # matrix leg reports the version we're about to publish.
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
         run: |
           file=pnpm/crates/config/src/defaults.rs
-          perl -i -pe 's/(pub const PACQUET_VERSION: &str = )"[^"]*";/${1}"'"$VERSION"'";/' "$file"
-          grep -F "PACQUET_VERSION: &str = \"$VERSION\"" "$file"
+          perl -i -pe 's/(pub const PNPM_VERSION: &str = )"[^"]*";/${1}"'"$VERSION"'";/' "$file"
+          grep -F "PNPM_VERSION: &str = \"$VERSION\"" "$file"
 
       - name: Build with cross
-        run: cross build -p pacquet-cli --bin pacquet --release --target=${{ matrix.target }}
+        run: cross build -p pacquet-cli --bin pnpm --release --target=${{ matrix.target }}
 
       - name: Build NAPI addon with cross
         # musl targets enable `crt-static` by default, but a `cdylib` (the
@@ -161,7 +161,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: bash
         run: |
-          mv target/${{ matrix.target }}/release/pacquet.exe pnpm.exe
+          mv target/${{ matrix.target }}/release/pnpm.exe pnpm.exe
           7z a pnpm-${{ matrix.code-target }}.zip pnpm.exe
 
       - name: Archive Binary
@@ -172,7 +172,7 @@ jobs:
         # up the whole source tree instead.
         run: |
           mkdir stage
-          mv target/${{ matrix.target }}/release/pacquet stage/pnpm
+          mv target/${{ matrix.target }}/release/pnpm stage/pnpm
           tar czf pnpm-${{ matrix.code-target }}.tar.gz -C stage pnpm
 
       - name: Attest build provenance

--- a/justfile
+++ b/justfile
@@ -111,4 +111,4 @@ integrated-benchmark +args:
   cargo run --bin=integrated-benchmark -- {{args}}
 
 cli +args:
-  cargo run --bin pacquet -- {{args}}
+  cargo run --bin pnpm -- {{args}}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-pkgs-branch": "pn remove-temp-dir && pn --workspace-concurrency=1 --filter=...[origin/main] --no-sort --if-present .test",
     "compile-only": "tsgo --build pnpm11/workspace/workspace-manifest-reader pnpm11/workspace/projects-reader && pnx node@runtime:26.4.0 pnpm11/__utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
     "compile": "pn compile-only && pn update-manifests",
-    "build:pacquet": "cargo build --release --bin pacquet",
+    "build:pnpm": "cargo build --release --bin pnpm",
     "make-lcov": "shx mkdir -p coverage && lcov-result-merger 'pnpm11/**/coverage/lcov.info' 'coverage/lcov.info'",
     "update-manifests": "pn meta-updater && pn install",
     "meta-updater": "pn --filter=@pnpm-private/updater compile && pn exec meta-updater",

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [[bin]]
-name = "pacquet"
+name = "pnpm"
 path = "src/bin/main.rs"
 
 [dependencies]

--- a/pnpm/crates/cli/README.md
+++ b/pnpm/crates/cli/README.md
@@ -39,7 +39,7 @@
 | Done | Command                     | Notes |
 | ---- | --------------------------- | ----- |
 |      | --force                     |       |
-| ✅   | --offline                   | Frozen-install only: refuses network fetches; errors with `ERR_PACQUET_NO_OFFLINE_TARBALL` when a snapshot isn't cached. Stage 2 resolver will additionally gate metadata fetches. |
+| ✅   | --offline                   | Frozen-install only: refuses network fetches; errors with `ERR_PNPM_NO_OFFLINE_TARBALL` when a snapshot isn't cached. Stage 2 resolver will additionally gate metadata fetches. |
 | ✅   | --prefer-offline            | No-op on frozen-install (warm prefetch already prefers the local store). Reserved for Stage 2's resolver. |
 |      | --prod                      |       |
 | ✅   | --dev                       |       |

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -67,7 +67,7 @@ use std::path::PathBuf;
 #[derive(Debug, Parser)]
 #[clap(name = "pnpm")]
 #[clap(bin_name = "pnpm")]
-#[clap(version = pacquet_config::PACQUET_VERSION)]
+#[clap(version = pacquet_config::PNPM_VERSION)]
 #[clap(disable_version_flag = true)]
 #[clap(about = "Experimental package manager for node.js")]
 pub struct CliArgs {

--- a/pnpm/crates/cli/src/cli_args/completion.rs
+++ b/pnpm/crates/cli/src/cli_args/completion.rs
@@ -51,7 +51,7 @@ impl CompletionShell {
 #[derive(Debug, Display, Error, Diagnostic, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CompletionError {
-    #[display("`pacquet completion` requires a shell name")]
+    #[display("`pnpm completion` requires a shell name")]
     #[diagnostic(code(ERR_PNPM_MISSING_SHELL_NAME))]
     MissingShellName,
 
@@ -188,7 +188,7 @@ fn words_without_binary(words: &[String]) -> Vec<String> {
     if Path::new(first)
         .file_stem()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name == "pacquet")
+        .is_some_and(|name| name == "pnpm" || name == "pacquet")
     {
         rest.to_vec()
     } else {
@@ -328,17 +328,17 @@ fn option_has_separate_value(option: &str) -> bool {
     !option.contains('=')
 }
 
-const BASH_COMPLETION: &str = r#"###-begin-pacquet-completion-###
-_pacquet_completion() {
+const BASH_COMPLETION: &str = r#"###-begin-pnpm-completion-###
+_pnpm_completion() {
   local IFS=$'\n'
-  COMPREPLY=($(COMP_LINE="$COMP_LINE" COMP_POINT="$COMP_POINT" SHELL=bash pacquet completion-server -- "${COMP_WORDS[@]}"))
+  COMPREPLY=($(COMP_LINE="$COMP_LINE" COMP_POINT="$COMP_POINT" SHELL=bash pnpm completion-server -- "${COMP_WORDS[@]}"))
 }
-complete -F _pacquet_completion pacquet
-###-end-pacquet-completion-###
+complete -F _pnpm_completion pnpm
+###-end-pnpm-completion-###
 "#;
 
-const FISH_COMPLETION: &str = r#"###-begin-pacquet-completion-###
-function __pacquet_completion
+const FISH_COMPLETION: &str = r#"###-begin-pnpm-completion-###
+function __pnpm_completion
   set -lx SHELL fish
   set -lx COMP_LINE (commandline -cp)
   set -lx COMP_POINT (string length -- $COMP_LINE)
@@ -349,14 +349,14 @@ function __pacquet_completion
   else if test "$tokens[-1]" != "$current"
     set -a tokens "$current"
   end
-  pacquet completion-server -- $tokens
+  pnpm completion-server -- $tokens
 end
-complete -c pacquet -f -a "(__pacquet_completion)"
-###-end-pacquet-completion-###
+complete -c pnpm -f -a "(__pnpm_completion)"
+###-end-pnpm-completion-###
 "#;
 
-const PWSH_COMPLETION: &str = r#"###-begin-pacquet-completion-###
-Register-ArgumentCompleter -Native -CommandName pacquet -ScriptBlock {
+const PWSH_COMPLETION: &str = r#"###-begin-pnpm-completion-###
+Register-ArgumentCompleter -Native -CommandName pnpm -ScriptBlock {
   param($wordToComplete, $commandAst, $cursorPosition)
   $env:SHELL = "pwsh"
   $env:COMP_LINE = $commandAst.ToString()
@@ -365,20 +365,20 @@ Register-ArgumentCompleter -Native -CommandName pacquet -ScriptBlock {
   if ($elements.Count -eq 0 -or $elements[-1] -ne $wordToComplete) {
     $elements += $wordToComplete
   }
-  pacquet completion-server -- @elements
+  pnpm completion-server -- @elements
 }
-###-end-pacquet-completion-###
+###-end-pnpm-completion-###
 "#;
 
-const ZSH_COMPLETION: &str = r#"#compdef pacquet
-###-begin-pacquet-completion-###
-_pacquet_completion() {
+const ZSH_COMPLETION: &str = r#"#compdef pnpm
+###-begin-pnpm-completion-###
+_pnpm_completion() {
   local reply
-  reply=("${(@f)$(COMP_CWORD=$((CURRENT-1)) COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" SHELL=zsh pacquet completion-server -- "${words[@]}")}")
+  reply=("${(@f)$(COMP_CWORD=$((CURRENT-1)) COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" SHELL=zsh pnpm completion-server -- "${words[@]}")}")
   _describe 'values' reply
 }
-compdef _pacquet_completion pacquet
-###-end-pacquet-completion-###
+compdef _pnpm_completion pnpm
+###-end-pnpm-completion-###
 "#;
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/completion/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/completion/tests.rs
@@ -21,14 +21,14 @@ fn supported_shells_are_pnpm_compatible() {
 #[test]
 fn missing_shell_errors_like_pnpm() {
     let err = shell_from_args(None, &[]).expect_err("missing shell rejected");
-    assert_eq!(err.to_string(), "`pacquet completion` requires a shell name");
+    assert_eq!(err.to_string(), "`pnpm completion` requires a shell name");
     assert_eq!(diagnostic_code(&err), Some("ERR_PNPM_MISSING_SHELL_NAME".to_string()));
 }
 
 #[test]
 fn empty_shell_errors_like_pnpm() {
     let err = shell_from_args(Some(" \n"), &[]).expect_err("blank shell rejected");
-    assert_eq!(err.to_string(), "`pacquet completion` requires a shell name");
+    assert_eq!(err.to_string(), "`pnpm completion` requires a shell name");
     assert_eq!(diagnostic_code(&err), Some("ERR_PNPM_MISSING_SHELL_NAME".to_string()));
 }
 
@@ -68,14 +68,13 @@ fn generated_scripts_call_completion_server() {
         let mut output = Vec::new();
         super::generate_completion(shell, &mut output).expect("generate completion");
         let script = String::from_utf8(output).expect("script is utf8");
-        assert!(script.contains("pacquet completion-server"), "{script}");
+        assert!(script.contains("pnpm completion-server"), "{script}");
     }
 }
 
 #[test]
 fn completion_can_run_before_async_runtime_setup() {
-    let args =
-        CliArgs::parse_from(["pacquet", "completion-server", "--", "pacquet", "completion", ""]);
+    let args = CliArgs::parse_from(["pnpm", "completion-server", "--", "pnpm", "completion", ""]);
 
     assert!(args.run_completion_if_requested().expect("completion dispatch succeeds"));
 }

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -176,7 +176,7 @@ pub struct InstallArgs {
     /// Refuse network tarball / zip-archive fetches on a cache miss.
     /// When the warm prefetch and the `index.db` lookup both miss
     /// for a package, pacquet fails with
-    /// `ERR_PACQUET_NO_OFFLINE_TARBALL` rather than hitting the
+    /// `ERR_PNPM_NO_OFFLINE_TARBALL` rather than hitting the
     /// registry. The `--offline` flag also gates the metadata-fetch
     /// path (`ERR_PNPM_NO_OFFLINE_META`), which pacquet doesn't have
     /// on the frozen-install flow (the lockfile pins every

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -1047,8 +1047,8 @@ fn serialize_cyclonedx(opts: &CycloneDxOpts<'_>) -> String {
         "lifecycles": [{ "phase": phase }],
         "tools": { "components": [{
             "type": "application",
-            "name": "pacquet",
-            "version": pacquet_config::PACQUET_VERSION,
+            "name": "pnpm",
+            "version": pacquet_config::PNPM_VERSION,
         }] },
         "component": root_component,
     });
@@ -1210,7 +1210,7 @@ fn serialize_spdx(result: &SbomResult, compact: bool) -> String {
         "documentNamespace": doc_namespace,
         "creationInfo": {
             "created": timestamp,
-            "creators": ["Tool: pacquet"],
+            "creators": ["Tool: pnpm"],
         },
         "packages": spdx_packages,
         "relationships": spdx_relationships,

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -16,7 +16,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_cmd_shim::{Host as CmdShimHost, link_bins_of_packages_with_excludes};
-use pacquet_config::{Config, PACQUET_VERSION};
+use pacquet_config::{Config, PNPM_VERSION};
 use pacquet_fs::force_symlink_dir;
 use pacquet_global::{
     create_global_cache_key, find_global_package, get_hash_link, read_installed_packages,
@@ -159,7 +159,7 @@ async fn handler<Reporter: self::Reporter + 'static>(
             read_project_pinned_pnpm_version(lockfile_dir, pm.version.as_deref())
                 .filter(|version| version != &target_version)
         }
-        _ if PACQUET_VERSION != target_version => Some(PACQUET_VERSION.to_string()),
+        _ if PNPM_VERSION != target_version => Some(PNPM_VERSION.to_string()),
         _ => None,
     };
     if let Some(previous) = &previous_version
@@ -190,22 +190,22 @@ async fn handler<Reporter: self::Reporter + 'static>(
     // Global switch. Version equality with the running binary alone must
     // not skip the update: a removed global install can be recovered by
     // running a local pnpm of the same version (see pnpm/pnpm#12877).
-    if target_version == PACQUET_VERSION
+    if target_version == PNPM_VERSION
         && is_installed_globally(config.global_pkg_dir.as_deref(), &target_version)?
     {
         return Ok(Some(format!(
-            r#"The currently active pnpm v{PACQUET_VERSION} is already "{bare_specifier}" and doesn't need an update"#,
+            r#"The currently active pnpm v{PNPM_VERSION} is already "{bare_specifier}" and doesn't need an update"#,
         )));
     }
-    if is_implicit_latest && version_lt(&target_version, PACQUET_VERSION) {
+    if is_implicit_latest && version_lt(&target_version, PNPM_VERSION) {
         return Ok(Some(format!(
-            r#"The currently active pnpm v{PACQUET_VERSION} is newer than the "latest" version on the registry (v{target_version}). No update performed. Run "pnpm self-update latest" to downgrade."#,
+            r#"The currently active pnpm v{PNPM_VERSION} is newer than the "latest" version on the registry (v{target_version}). No update performed. Run "pnpm self-update latest" to downgrade."#,
         )));
     }
 
     info::<Reporter>(
         &prefix,
-        &format!("Switching pnpm from v{PACQUET_VERSION} to v{target_version}..."),
+        &format!("Switching pnpm from v{PNPM_VERSION} to v{target_version}..."),
     );
 
     let env_root = config.global_pkg_dir.clone().ok_or(SelfUpdateError::NoGlobalDir)?;

--- a/pnpm/crates/cli/src/cli_args/setup.rs
+++ b/pnpm/crates/cli/src/cli_args/setup.rs
@@ -9,7 +9,7 @@ mod path_extender;
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
-use pacquet_config::{Host, PACQUET_VERSION, default_pnpm_home_dir};
+use pacquet_config::{Host, PNPM_VERSION, default_pnpm_home_dir};
 use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use path_extender::{
     AddDirToEnvPathOpts, AddingPosition, ConfigFileChangeType, ConfigReport, PathExtenderReport,
@@ -94,7 +94,7 @@ fn install_cli_globally<Reporter: self::Reporter + 'static>(
     if created_pkg_json {
         let pkg = serde_json::json!({
             "name": "@pnpm/exe",
-            "version": PACQUET_VERSION,
+            "version": PNPM_VERSION,
             "bin": { "pnpm": exec_name, "pn": exec_name },
         });
         fs::write(&pkg_json_path, pkg.to_string())

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{config_deps, config_overrides::ConfigOverrides};
 use miette::{Context, IntoDiagnostic};
-use pacquet_config::{Config, Host, PACQUET_VERSION, PmOnFail};
+use pacquet_config::{Config, Host, PNPM_VERSION, PmOnFail};
 use pacquet_lockfile::{EnvLockfile, LockfileResolution, PackageKey, PackageMetadata, VersionPart};
 use pacquet_reporter::SilentReporter;
 use std::{
@@ -58,7 +58,7 @@ pub(crate) async fn execute_switch(
     let config = Config::leak(config);
     let (version, bin_dir) = match source {
         SwitchSource::LockedEnv { env, version } => {
-            if version == PACQUET_VERSION {
+            if version == PNPM_VERSION {
                 return Ok(false);
             }
             let bin_dir =
@@ -69,7 +69,7 @@ pub(crate) async fn execute_switch(
             let resolved = config_deps::resolve_pnpm_version(config, &spec)
                 .await?
                 .ok_or_else(|| miette::miette!(r#"Cannot resolve pnpm version for "{}""#, spec))?;
-            if resolved.version == PACQUET_VERSION {
+            if resolved.version == PNPM_VERSION {
                 return Ok(false);
             }
             let bin_dir = Box::pin(install_pnpm_to_store::<SilentReporter>(
@@ -115,7 +115,7 @@ fn switch_plan_from_input(
     let Some(target) = switch_target(&config, &root_dir)? else {
         return Ok(None);
     };
-    if version_satisfies(PACQUET_VERSION, &target.spec) {
+    if version_satisfies(PNPM_VERSION, &target.spec) {
         return Ok(None);
     }
     Ok(Some(SwitchPlan { config, target }))

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -33,7 +33,7 @@ pub fn main() -> miette::Result<()> {
     let argv = with_current::rewrite(argv)?;
     // The default reporter's `Done in ... using pacquet v<version>` footer needs
     // the version before the first event (including the fast path's).
-    pacquet_default_reporter::set_package_version(pacquet_config::PACQUET_VERSION);
+    pacquet_default_reporter::set_package_version(pacquet_config::PNPM_VERSION);
     // Parse through a command augmented with a `--no-<flag>` negation for
     // every boolean flag, so pnpm's forwarded negations (`--no-frozen-lockfile`,
     // etc.) parse the same way nopt accepts them upstream. See `boolean_negations`.
@@ -53,7 +53,7 @@ pub fn main() -> miette::Result<()> {
             )? {
                 return Ok(());
             }
-            println!("{}", pacquet_config::PACQUET_VERSION);
+            println!("{}", pacquet_config::PNPM_VERSION);
             return Ok(());
         }
         Err(err) => err.exit(),

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -181,7 +181,7 @@ fn add_lockfile_only_from_workspace_subdir_prints_manifest_summary() {
     )
     .expect("write packages/b/package.json");
 
-    let output = Command::cargo_bin("pacquet")
+    let output = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&workspace)
         .with_args([

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -182,7 +182,7 @@ fn add_lockfile_only_from_workspace_subdir_prints_manifest_summary() {
     .expect("write packages/b/package.json");
 
     let output = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&workspace)
         .with_args([
             "--dir",

--- a/pnpm/crates/cli/tests/approve_builds.rs
+++ b/pnpm/crates/cli/tests/approve_builds.rs
@@ -33,7 +33,7 @@ fn disable_strict_dep_builds(workspace: &Path) {
 /// A fresh `pacquet` command rooted at `workspace` (each `assert_cmd`
 /// `Command` is single-use, so sequential steps build their own).
 fn pacquet(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// Set up a workspace that depends on `@pnpm.e2e/install-script-example`

--- a/pnpm/crates/cli/tests/approve_builds.rs
+++ b/pnpm/crates/cli/tests/approve_builds.rs
@@ -33,7 +33,7 @@ fn disable_strict_dep_builds(workspace: &Path) {
 /// A fresh `pacquet` command rooted at `workspace` (each `assert_cmd`
 /// `Command` is single-use, so sequential steps build their own).
 fn pacquet(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// Set up a workspace that depends on `@pnpm.e2e/install-script-example`

--- a/pnpm/crates/cli/tests/audit.rs
+++ b/pnpm/crates/cli/tests/audit.rs
@@ -815,7 +815,7 @@ fn audit_ignore_unfixable_ignores_advisories_without_a_fix() {
 /// multi-step tests (install, then audit) that can't reuse the one-shot
 /// command from [`CommandTempCwd`].
 fn pacquet_cmd(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_args(args)

--- a/pnpm/crates/cli/tests/audit.rs
+++ b/pnpm/crates/cli/tests/audit.rs
@@ -816,7 +816,7 @@ fn audit_ignore_unfixable_ignores_advisories_without_a_fix() {
 /// command from [`CommandTempCwd`].
 fn pacquet_cmd(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_args(args)
 }

--- a/pnpm/crates/cli/tests/bin.rs
+++ b/pnpm/crates/cli/tests/bin.rs
@@ -133,7 +133,7 @@ fn bin_matches_pnpm_from_a_workspace_subdir() {
     fs::write(member.join("package.json"), r#"{ "name": "foo", "version": "1.0.0" }"#)
         .expect("write member package.json");
 
-    let pacquet_out = Command::cargo_bin("pacquet")
+    let pacquet_out = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&member)
         .with_args(["bin"])

--- a/pnpm/crates/cli/tests/bin.rs
+++ b/pnpm/crates/cli/tests/bin.rs
@@ -134,7 +134,7 @@ fn bin_matches_pnpm_from_a_workspace_subdir() {
         .expect("write member package.json");
 
     let pacquet_out = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&member)
         .with_args(["bin"])
         .output()

--- a/pnpm/crates/cli/tests/bugs.rs
+++ b/pnpm/crates/cli/tests/bugs.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn empty_auth_file(root: &Path) -> PathBuf {

--- a/pnpm/crates/cli/tests/bugs.rs
+++ b/pnpm/crates/cli/tests/bugs.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn empty_auth_file(root: &Path) -> PathBuf {

--- a/pnpm/crates/cli/tests/cat_index.rs
+++ b/pnpm/crates/cli/tests/cat_index.rs
@@ -11,7 +11,7 @@ fn should_cat_index_of_installed_package() {
     let pacquet = pacquet;
     pacquet.with_args(["add", "@pnpm.e2e/hello-world-js-bin-parent"]).assert().success();
 
-    let mut pacquet2 = std::process::Command::cargo_bin("pacquet").unwrap();
+    let mut pacquet2 = std::process::Command::cargo_bin("pnpm").unwrap();
     pacquet2.current_dir(&workspace);
     let output = pacquet2
         .with_args(["cat-index", "@pnpm.e2e/hello-world-js-bin-parent"])
@@ -37,7 +37,7 @@ fn should_cat_index_of_npm_alias() {
     let alias_spec = "my-alias@npm:@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0";
     pacquet.with_args(["add", alias_spec]).assert().success();
 
-    let mut pacquet2 = std::process::Command::cargo_bin("pacquet").unwrap();
+    let mut pacquet2 = std::process::Command::cargo_bin("pnpm").unwrap();
     pacquet2.current_dir(&workspace);
     let output =
         pacquet2.with_args(["cat-index", alias_spec]).output().expect("run pacquet cat-index");
@@ -86,7 +86,7 @@ fn should_cat_index_with_dir_pointing_to_workspace_project() {
     pacquet.with_args(["install"]).assert().success();
 
     let project_dir_arg = project_dir.to_string_lossy().into_owned();
-    let mut pacquet2 = Command::cargo_bin("pacquet").unwrap();
+    let mut pacquet2 = Command::cargo_bin("pnpm").unwrap();
     pacquet2.current_dir(&workspace);
     let output = pacquet2
         .with_args(["--dir", project_dir_arg.as_str(), "cat-index", dependency])

--- a/pnpm/crates/cli/tests/catalog.rs
+++ b/pnpm/crates/cli/tests/catalog.rs
@@ -19,7 +19,7 @@ fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_args(args)
 }

--- a/pnpm/crates/cli/tests/catalog.rs
+++ b/pnpm/crates/cli/tests/catalog.rs
@@ -18,7 +18,7 @@ fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
 }
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_args(args)

--- a/pnpm/crates/cli/tests/completion.rs
+++ b/pnpm/crates/cli/tests/completion.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use tempfile::TempDir;
 
 fn pacquet() -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary")
+    Command::cargo_bin("pnpm").expect("find the pacquet binary")
 }
 
 fn stdout(output: std::process::Output) -> String {
@@ -19,10 +19,10 @@ fn stderr(output: std::process::Output) -> String {
 #[test]
 fn completion_scripts_are_lightweight_shims_for_pnpm_supported_shells() {
     let cases = [
-        ("bash", "_pacquet_completion"),
-        ("fish", "complete -c pacquet"),
-        ("pwsh", "Register-ArgumentCompleter -Native -CommandName pacquet"),
-        ("zsh", "#compdef pacquet"),
+        ("bash", "_pnpm_completion"),
+        ("fish", "complete -c pnpm"),
+        ("pwsh", "Register-ArgumentCompleter -Native -CommandName pnpm"),
+        ("zsh", "#compdef pnpm"),
     ];
 
     for (shell, marker) in cases {
@@ -31,7 +31,7 @@ fn completion_scripts_are_lightweight_shims_for_pnpm_supported_shells() {
         let script = stdout(output);
         assert!(script.contains(marker), "{shell} script should contain {marker:?}: {script}");
         assert!(
-            script.contains("pacquet completion-server"),
+            script.contains("pnpm completion-server"),
             "{shell} script should call completion-server: {script}",
         );
         assert!(script.lines().count() < 80, "{shell} script should be lightweight: {script}");
@@ -71,9 +71,9 @@ fn completion_scripts_preserve_current_token_for_fish_and_pwsh() {
 #[test]
 fn completion_server_lists_top_level_commands() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", ""])
+        .args(["completion-server", "--", "pnpm", ""])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert!(reply.lines().any(|line| line == "install"), "{reply}");
@@ -84,9 +84,9 @@ fn completion_server_lists_top_level_commands() {
 #[test]
 fn completion_server_lists_options_for_current_command() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "install", "--"])
+        .args(["completion-server", "--", "pnpm", "install", "--"])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert!(reply.lines().any(|line| line == "--filter"), "{reply}");
@@ -97,9 +97,9 @@ fn completion_server_lists_options_for_current_command() {
 #[test]
 fn completion_server_lists_option_values() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "--reporter", ""])
+        .args(["completion-server", "--", "pnpm", "--reporter", ""])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert!(reply.lines().any(|line| line == "default"), "{reply}");
@@ -111,9 +111,9 @@ fn completion_server_lists_option_values() {
 #[test]
 fn completion_server_lists_option_values_only_after_option_name() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "--reporter", "default", ""])
+        .args(["completion-server", "--", "pnpm", "--reporter", "default", ""])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert!(reply.lines().any(|line| line == "install"), "{reply}");
@@ -123,9 +123,9 @@ fn completion_server_lists_option_values_only_after_option_name() {
 #[test]
 fn completion_server_does_not_treat_option_values_as_commands() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "--filter", "install", ""])
+        .args(["completion-server", "--", "pnpm", "--filter", "install", ""])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert!(reply.lines().any(|line| line == "add"), "{reply}");
@@ -135,9 +135,9 @@ fn completion_server_does_not_treat_option_values_as_commands() {
 #[test]
 fn completion_server_stops_after_double_dash_separator() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "--", "--rep"])
+        .args(["completion-server", "--", "pnpm", "--", "--rep"])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert_eq!(reply, "");
@@ -146,9 +146,9 @@ fn completion_server_stops_after_double_dash_separator() {
 #[test]
 fn completion_server_lists_nested_subcommands() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "store", ""])
+        .args(["completion-server", "--", "pnpm", "store", ""])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert!(reply.lines().any(|line| line == "prune"), "{reply}");
@@ -158,9 +158,9 @@ fn completion_server_lists_nested_subcommands() {
 #[test]
 fn completion_server_filters_command_prefixes() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "inst"])
+        .args(["completion-server", "--", "pnpm", "inst"])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert_eq!(reply.lines().collect::<Vec<_>>(), ["install"]);
@@ -169,9 +169,9 @@ fn completion_server_filters_command_prefixes() {
 #[test]
 fn completion_server_filters_option_prefixes() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "--rep"])
+        .args(["completion-server", "--", "pnpm", "--rep"])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert_eq!(reply.lines().collect::<Vec<_>>(), ["--reporter"]);
@@ -180,9 +180,9 @@ fn completion_server_filters_option_prefixes() {
 #[test]
 fn completion_server_filters_option_value_prefixes() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "--reporter", "a"])
+        .args(["completion-server", "--", "pnpm", "--reporter", "a"])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert_eq!(reply.lines().collect::<Vec<_>>(), ["append-only"]);
@@ -191,9 +191,9 @@ fn completion_server_filters_option_value_prefixes() {
 #[test]
 fn completion_server_completes_equals_option_values() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "--reporter=de"])
+        .args(["completion-server", "--", "pnpm", "--reporter=de"])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert_eq!(reply.lines().collect::<Vec<_>>(), ["--reporter=default"]);
@@ -202,9 +202,9 @@ fn completion_server_completes_equals_option_values() {
 #[test]
 fn completion_server_lists_completion_shells() {
     let output = pacquet()
-        .args(["completion-server", "--", "pacquet", "completion", ""])
+        .args(["completion-server", "--", "pnpm", "completion", ""])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert_eq!(reply.lines().collect::<Vec<_>>(), ["bash", "fish", "pwsh", "zsh"]);
@@ -217,9 +217,9 @@ fn completion_server_does_not_require_a_project_or_existing_dir_argument() {
     let output = pacquet()
         .args(["--dir"])
         .arg(&missing_dir)
-        .args(["completion-server", "--", "pacquet", "completion", ""])
+        .args(["completion-server", "--", "pnpm", "completion", ""])
         .output()
-        .expect("run pacquet completion-server");
+        .expect("run pnpm completion-server");
     let reply = stdout(output);
 
     assert_eq!(reply.lines().collect::<Vec<_>>(), ["bash", "fish", "pwsh", "zsh"]);
@@ -229,7 +229,7 @@ fn completion_server_does_not_require_a_project_or_existing_dir_argument() {
 fn completion_missing_shell_errors_like_pnpm() {
     let output = pacquet().arg("completion").output().expect("run pacquet completion");
     let err = stderr(output);
-    assert!(err.contains("`pacquet completion` requires a shell name"), "{err}");
+    assert!(err.contains("`pnpm completion` requires a shell name"), "{err}");
 }
 
 #[test]
@@ -261,5 +261,5 @@ fn completion_does_not_require_a_project_or_existing_dir_argument() {
         .output()
         .expect("run pacquet completion");
     let script = stdout(output);
-    assert!(script.contains("#compdef pacquet"), "{script}");
+    assert!(script.contains("#compdef pnpm"), "{script}");
 }

--- a/pnpm/crates/cli/tests/completion.rs
+++ b/pnpm/crates/cli/tests/completion.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use tempfile::TempDir;
 
 fn pacquet() -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary")
+    Command::cargo_bin("pnpm").expect("find the pnpm binary")
 }
 
 fn stdout(output: std::process::Output) -> String {

--- a/pnpm/crates/cli/tests/config_dependencies.rs
+++ b/pnpm/crates/cli/tests/config_dependencies.rs
@@ -8,7 +8,7 @@ use pacquet_testing_utils::fs::is_symlink_or_junction;
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// `pacquet install` resolves the `configDependencies` declared in

--- a/pnpm/crates/cli/tests/config_dependencies.rs
+++ b/pnpm/crates/cli/tests/config_dependencies.rs
@@ -8,7 +8,7 @@ use pacquet_testing_utils::fs::is_symlink_or_junction;
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// `pacquet install` resolves the `configDependencies` declared in

--- a/pnpm/crates/cli/tests/custom_fetchers.rs
+++ b/pnpm/crates/cli/tests/custom_fetchers.rs
@@ -10,7 +10,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn write_manifest(workspace: &Path) {

--- a/pnpm/crates/cli/tests/custom_fetchers.rs
+++ b/pnpm/crates/cli/tests/custom_fetchers.rs
@@ -10,7 +10,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn write_manifest(workspace: &Path) {

--- a/pnpm/crates/cli/tests/custom_resolvers.rs
+++ b/pnpm/crates/cli/tests/custom_resolvers.rs
@@ -10,7 +10,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn write_manifest(workspace: &Path) {

--- a/pnpm/crates/cli/tests/custom_resolvers.rs
+++ b/pnpm/crates/cli/tests/custom_resolvers.rs
@@ -10,7 +10,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn write_manifest(workspace: &Path) {

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -57,7 +57,7 @@ fn dedupe_check_does_not_materialize_nor_write_lockfile() {
 
     // Recreate a pacquet command for the --check invocation
     let pacquet_check =
-        Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(&workspace);
+        Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(&workspace);
 
     let lockfile_path = workspace.join("pnpm-lock.yaml");
     assert!(lockfile_path.exists(), "dedupe must create pnpm-lock.yaml");

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -56,9 +56,8 @@ fn dedupe_check_does_not_materialize_nor_write_lockfile() {
     pacquet.with_arg("dedupe").assert().success();
 
     // Recreate a pacquet command for the --check invocation
-    let pacquet_check = Command::cargo_bin("pacquet")
-        .expect("find the pacquet binary")
-        .with_current_dir(&workspace);
+    let pacquet_check =
+        Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(&workspace);
 
     let lockfile_path = workspace.join("pnpm-lock.yaml");
     assert!(lockfile_path.exists(), "dedupe must create pnpm-lock.yaml");

--- a/pnpm/crates/cli/tests/dedupe_direct_deps.rs
+++ b/pnpm/crates/cli/tests/dedupe_direct_deps.rs
@@ -352,7 +352,7 @@ fn fs_remove_dir_all(path: &Path) {
 /// drive a second invocation in the same workspace because
 /// [`assert_cmd::Command::assert`] consumes the wrapped command.
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// Partial dedupe: a sibling with one shared dep and one unique

--- a/pnpm/crates/cli/tests/dedupe_direct_deps.rs
+++ b/pnpm/crates/cli/tests/dedupe_direct_deps.rs
@@ -352,7 +352,7 @@ fn fs_remove_dir_all(path: &Path) {
 /// drive a second invocation in the same workspace because
 /// [`assert_cmd::Command::assert`] consumes the wrapped command.
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// Partial dedupe: a sibling with one shared dep and one unique

--- a/pnpm/crates/cli/tests/dedupe_injected_deps.rs
+++ b/pnpm/crates/cli/tests/dedupe_injected_deps.rs
@@ -163,7 +163,7 @@ fn injected_workspace_dep_with_children_stays_link_after_remove() {
 
     // Removing an unrelated root dependency re-resolves the whole
     // workspace; the injected-with-children dedupe must hold across it.
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&workspace)
         .with_arg("remove")
@@ -263,7 +263,7 @@ fn injected_peer_suffixed_workspace_dep_stays_file_after_remove() {
 
     // Removing an unrelated root dependency re-resolves the whole
     // workspace; the peer-suffixed file: entry must survive intact.
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&workspace)
         .with_arg("remove")

--- a/pnpm/crates/cli/tests/dedupe_injected_deps.rs
+++ b/pnpm/crates/cli/tests/dedupe_injected_deps.rs
@@ -164,7 +164,7 @@ fn injected_workspace_dep_with_children_stays_link_after_remove() {
     // Removing an unrelated root dependency re-resolves the whole
     // workspace; the injected-with-children dedupe must hold across it.
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&workspace)
         .with_arg("remove")
         .with_arg("@pnpm.e2e/bar")
@@ -264,7 +264,7 @@ fn injected_peer_suffixed_workspace_dep_stays_file_after_remove() {
     // Removing an unrelated root dependency re-resolves the whole
     // workspace; the peer-suffixed file: entry must survive intact.
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&workspace)
         .with_arg("remove")
         .with_arg("@pnpm.e2e/bar")

--- a/pnpm/crates/cli/tests/deploy.rs
+++ b/pnpm/crates/cli/tests/deploy.rs
@@ -244,7 +244,7 @@ fn legacy_deploy_installs_selected_project() {
 }
 
 fn pacquet_cmd(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn write_workspace(workspace: &Path, inject_workspace_packages: bool) {

--- a/pnpm/crates/cli/tests/deploy.rs
+++ b/pnpm/crates/cli/tests/deploy.rs
@@ -244,7 +244,7 @@ fn legacy_deploy_installs_selected_project() {
 }
 
 fn pacquet_cmd(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn write_workspace(workspace: &Path, inject_workspace_packages: bool) {

--- a/pnpm/crates/cli/tests/dist_tag.rs
+++ b/pnpm/crates/cli/tests/dist_tag.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn nerf(registry: &str) -> String {

--- a/pnpm/crates/cli/tests/dist_tag.rs
+++ b/pnpm/crates/cli/tests/dist_tag.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn nerf(registry: &str) -> String {

--- a/pnpm/crates/cli/tests/docs.rs
+++ b/pnpm/crates/cli/tests/docs.rs
@@ -13,7 +13,7 @@ use pacquet_testing_utils::bin::CommandTempCwd;
 use std::process::Command;
 
 fn pacquet(workspace: &std::path::Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/docs.rs
+++ b/pnpm/crates/cli/tests/docs.rs
@@ -13,7 +13,7 @@ use pacquet_testing_utils::bin::CommandTempCwd;
 use std::process::Command;
 
 fn pacquet(workspace: &std::path::Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/dry_run.rs
+++ b/pnpm/crates/cli/tests/dry_run.rs
@@ -12,7 +12,7 @@ use std::{fs, path::Path, process::Command};
 
 /// A fresh `pacquet` command rooted at `workspace`.
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// On a fresh project (no lockfile), `--dry-run` reports the dependencies a

--- a/pnpm/crates/cli/tests/dry_run.rs
+++ b/pnpm/crates/cli/tests/dry_run.rs
@@ -12,7 +12,7 @@ use std::{fs, path::Path, process::Command};
 
 /// A fresh `pacquet` command rooted at `workspace`.
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// On a fresh project (no lockfile), `--dry-run` reports the dependencies a

--- a/pnpm/crates/cli/tests/fetch.rs
+++ b/pnpm/crates/cli/tests/fetch.rs
@@ -4,7 +4,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// Direct dependency from each group, so a test can assert which groups

--- a/pnpm/crates/cli/tests/fetch.rs
+++ b/pnpm/crates/cli/tests/fetch.rs
@@ -4,7 +4,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// Direct dependency from each group, so a test can assert which groups

--- a/pnpm/crates/cli/tests/find_hash.rs
+++ b/pnpm/crates/cli/tests/find_hash.rs
@@ -37,7 +37,7 @@ fn find_hash_works() {
     let (valid_hash, expected_name, expected_version) = find_hash_fixture(&store_index);
 
     // 2. Run find-hash with the valid hash
-    let mut pacquet2 = std::process::Command::cargo_bin("pacquet").unwrap();
+    let mut pacquet2 = std::process::Command::cargo_bin("pnpm").unwrap();
     pacquet2.current_dir(&workspace);
     let output = pacquet2.arg("find-hash").arg(&valid_hash).assert().success();
     let stdout = String::from_utf8_lossy(&output.get_output().stdout);
@@ -60,7 +60,7 @@ fn should_fail_on_missing_hash() {
     pacquet.arg("add").arg("is-odd@3.0.1").assert().success();
     // Use a valid-length hex string that no file matches. Create a fresh
     // command so the args from `add` don't carry over.
-    let mut pacquet2 = std::process::Command::cargo_bin("pacquet").unwrap();
+    let mut pacquet2 = std::process::Command::cargo_bin("pnpm").unwrap();
     pacquet2.current_dir(&workspace);
     let output = pacquet2.arg("find-hash").arg("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").assert().failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
@@ -105,7 +105,7 @@ fn find_hash_works_with_base64() {
         .collect::<Vec<u8>>();
     let base64_hash = format!("sha512-{}", BASE64.encode(&bytes));
 
-    let mut pacquet2 = std::process::Command::cargo_bin("pacquet").unwrap();
+    let mut pacquet2 = std::process::Command::cargo_bin("pnpm").unwrap();
     pacquet2.current_dir(&workspace);
     let output = pacquet2.arg("find-hash").arg(&base64_hash).assert().success();
     let stdout = String::from_utf8_lossy(&output.get_output().stdout);

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -45,7 +45,7 @@ fn global_command(workspace: &Path, pnpm_home: &Path) -> Command {
     let existing_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{existing_path}", global_bin.display());
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_env("PNPM_HOME", pnpm_home)
         .with_env("PATH", path)
@@ -300,7 +300,7 @@ fn global_list_empty() {
     let pnpm_home = root.path().join("pnpm-home");
 
     let output = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&workspace)
         .with_env("PNPM_HOME", &pnpm_home)
         .with_arg("list")
@@ -326,7 +326,7 @@ fn global_add_pnpm_is_rejected() {
     fs::create_dir_all(pnpm_home.join("bin")).expect("create global bin dir");
 
     let output = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&workspace)
         .with_env("PNPM_HOME", &pnpm_home)
         .with_arg("add")

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -44,7 +44,7 @@ fn global_command(workspace: &Path, pnpm_home: &Path) -> Command {
     let global_bin = pnpm_home.join("bin");
     let existing_path = std::env::var("PATH").unwrap_or_default();
     let path = format!("{}:{existing_path}", global_bin.display());
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_env("PNPM_HOME", pnpm_home)
@@ -299,7 +299,7 @@ fn global_list_empty() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     let pnpm_home = root.path().join("pnpm-home");
 
-    let output = Command::cargo_bin("pacquet")
+    let output = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&workspace)
         .with_env("PNPM_HOME", &pnpm_home)
@@ -325,7 +325,7 @@ fn global_add_pnpm_is_rejected() {
     let pnpm_home = root.path().join("pnpm-home");
     fs::create_dir_all(pnpm_home.join("bin")).expect("create global bin dir");
 
-    let output = Command::cargo_bin("pacquet")
+    let output = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&workspace)
         .with_env("PNPM_HOME", &pnpm_home)

--- a/pnpm/crates/cli/tests/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/hoisted_node_linker.rs
@@ -64,7 +64,7 @@ fn is_real_dir(workspace: &Path, relative: &str) -> bool {
 /// `pnpm-workspace.yaml`, so a command that merely runs in `workspace`
 /// inherits it without extra env.
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// `rm -rf` that tolerates an already-absent path.

--- a/pnpm/crates/cli/tests/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/hoisted_node_linker.rs
@@ -64,7 +64,7 @@ fn is_real_dir(workspace: &Path, relative: &str) -> bool {
 /// `pnpm-workspace.yaml`, so a command that merely runs in `workspace`
 /// inherits it without extra env.
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// `rm -rf` that tolerates an already-absent path.

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -102,7 +102,7 @@ fn frozen_install_honors_the_store_dir_cli_option() {
     fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
 
     std::process::Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&workspace)
         .with_args(["install", "--frozen-lockfile", "--store-dir=frozen-store"])
         .assert()
@@ -928,7 +928,7 @@ fn install_regenerates_lockfile_from_node_modules_when_wanted_is_missing() {
 
     eprintln!("Re-running install with --reporter=ndjson...");
     let pacquet_rerun =
-        Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(&workspace);
+        Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(&workspace);
     let output = pacquet_rerun
         .with_args(["--reporter=ndjson", "install"])
         .output()
@@ -990,7 +990,7 @@ fn frozen_install_short_circuits_when_node_modules_is_up_to_date() {
 
     eprintln!("Re-running with --frozen-lockfile + --reporter=ndjson...");
     let pacquet_rerun =
-        Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(&workspace);
+        Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(&workspace);
     let output = pacquet_rerun
         .with_args(["--reporter=ndjson", "install", "--frozen-lockfile"])
         .output()
@@ -1340,7 +1340,7 @@ fn install_with_peer_alias_deps(dependencies: serde_json::Value) -> String {
 /// binary more than once (the builder is consumed on `assert()`).
 fn new_pacquet_command(workspace: &std::path::Path) -> std::process::Command {
     std::process::Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
 }
 

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -101,7 +101,7 @@ fn frozen_install_honors_the_store_dir_cli_option() {
     pacquet.with_arg("install").assert().success();
     fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
 
-    std::process::Command::cargo_bin("pacquet")
+    std::process::Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&workspace)
         .with_args(["install", "--frozen-lockfile", "--store-dir=frozen-store"])
@@ -927,9 +927,8 @@ fn install_regenerates_lockfile_from_node_modules_when_wanted_is_missing() {
         .expect("remove .pnpm-workspace-state-v1.json");
 
     eprintln!("Re-running install with --reporter=ndjson...");
-    let pacquet_rerun = Command::cargo_bin("pacquet")
-        .expect("find the pacquet binary")
-        .with_current_dir(&workspace);
+    let pacquet_rerun =
+        Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(&workspace);
     let output = pacquet_rerun
         .with_args(["--reporter=ndjson", "install"])
         .output()
@@ -990,9 +989,8 @@ fn frozen_install_short_circuits_when_node_modules_is_up_to_date() {
     pacquet.with_arg("install").assert().success();
 
     eprintln!("Re-running with --frozen-lockfile + --reporter=ndjson...");
-    let pacquet_rerun = Command::cargo_bin("pacquet")
-        .expect("find the pacquet binary")
-        .with_current_dir(&workspace);
+    let pacquet_rerun =
+        Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(&workspace);
     let output = pacquet_rerun
         .with_args(["--reporter=ndjson", "install", "--frozen-lockfile"])
         .output()
@@ -1341,7 +1339,7 @@ fn install_with_peer_alias_deps(dependencies: serde_json::Value) -> String {
 /// A fresh `pacquet` command rooted at `workspace`, for tests that run the
 /// binary more than once (the builder is consumed on `assert()`).
 fn new_pacquet_command(workspace: &std::path::Path) -> std::process::Command {
-    std::process::Command::cargo_bin("pacquet")
+    std::process::Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
 }

--- a/pnpm/crates/cli/tests/lifecycle_scripts.rs
+++ b/pnpm/crates/cli/tests/lifecycle_scripts.rs
@@ -847,7 +847,7 @@ mod project_scripts {
         assert!(workspace.join("pnpm-lock.yaml").exists(), "first install should write a lockfile");
         fs::remove_file(workspace.join("order.txt")).expect("clear order.txt between installs");
 
-        Command::cargo_bin("pacquet")
+        Command::cargo_bin("pnpm")
             .expect("find the pacquet binary")
             .with_current_dir(&workspace)
             .with_arg("install")

--- a/pnpm/crates/cli/tests/lifecycle_scripts.rs
+++ b/pnpm/crates/cli/tests/lifecycle_scripts.rs
@@ -848,7 +848,7 @@ mod project_scripts {
         fs::remove_file(workspace.join("order.txt")).expect("clear order.txt between installs");
 
         Command::cargo_bin("pnpm")
-            .expect("find the pacquet binary")
+            .expect("find the pnpm binary")
             .with_current_dir(&workspace)
             .with_arg("install")
             .with_arg("--frozen-lockfile")

--- a/pnpm/crates/cli/tests/list.rs
+++ b/pnpm/crates/cli/tests/list.rs
@@ -170,9 +170,8 @@ fn changed_files_ignore_pattern_is_respected() {
     );
 
     let changed_project_names = |extra_args: &[&str]| {
-        let pacquet = Command::cargo_bin("pnpm")
-            .expect("find the pacquet binary")
-            .with_current_dir(&workspace);
+        let pacquet =
+            Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(&workspace);
         recursive_project_names(pacquet, &[&["--filter", "[origin/main]"], extra_args].concat())
     };
 

--- a/pnpm/crates/cli/tests/list.rs
+++ b/pnpm/crates/cli/tests/list.rs
@@ -170,7 +170,7 @@ fn changed_files_ignore_pattern_is_respected() {
     );
 
     let changed_project_names = |extra_args: &[&str]| {
-        let pacquet = Command::cargo_bin("pacquet")
+        let pacquet = Command::cargo_bin("pnpm")
             .expect("find the pacquet binary")
             .with_current_dir(&workspace);
         recursive_project_names(pacquet, &[&["--filter", "[origin/main]"], extra_args].concat())

--- a/pnpm/crates/cli/tests/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/lockfile_only.rs
@@ -18,7 +18,7 @@ use std::{fs, path::Path, process::Command};
 /// isn't `Clone` and each invocation consumes the builder, so tests that
 /// run pacquet more than once rebuild it here.
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// Content-addressable tarball blobs under the store (`v11/files/...`).

--- a/pnpm/crates/cli/tests/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/lockfile_only.rs
@@ -18,7 +18,7 @@ use std::{fs, path::Path, process::Command};
 /// isn't `Clone` and each invocation consumes the builder, so tests that
 /// run pacquet more than once rebuild it here.
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// Content-addressable tarball blobs under the store (`v11/files/...`).

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -13,7 +13,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, net::TcpListener, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// A `registry=` URL on a localhost port with nothing listening, so any

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -13,7 +13,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, net::TcpListener, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// A `registry=` URL on a localhost port with nothing listening, so any

--- a/pnpm/crates/cli/tests/outdated.rs
+++ b/pnpm/crates/cli/tests/outdated.rs
@@ -16,7 +16,7 @@ fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_args(args)
 }

--- a/pnpm/crates/cli/tests/outdated.rs
+++ b/pnpm/crates/cli/tests/outdated.rs
@@ -15,7 +15,7 @@ fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
 }
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_args(args)

--- a/pnpm/crates/cli/tests/patch.rs
+++ b/pnpm/crates/cli/tests/patch.rs
@@ -128,7 +128,7 @@ fn setup_patch_remove_project(
 }
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_args(args)

--- a/pnpm/crates/cli/tests/patch.rs
+++ b/pnpm/crates/cli/tests/patch.rs
@@ -129,7 +129,7 @@ fn setup_patch_remove_project(
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_args(args)
 }

--- a/pnpm/crates/cli/tests/ping.rs
+++ b/pnpm/crates/cli/tests/ping.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// An empty user-level `.npmrc`, returned for `--npmrc-auth-file`, so the

--- a/pnpm/crates/cli/tests/ping.rs
+++ b/pnpm/crates/cli/tests/ping.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// An empty user-level `.npmrc`, returned for `--npmrc-auth-file`, so the

--- a/pnpm/crates/cli/tests/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/pnpr_install.rs
@@ -92,7 +92,7 @@ fn wait_until_ready(addr: SocketAddr) {
 }
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/pnpr_install.rs
@@ -92,7 +92,7 @@ fn wait_until_ready(addr: SocketAddr) {
 }
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/pnpx_alias.rs
+++ b/pnpm/crates/cli/tests/pnpx_alias.rs
@@ -9,7 +9,7 @@ use tempfile::TempDir;
 
 #[test]
 fn launched_as_pnpx_injects_the_dlx_subcommand() {
-    let pacquet = env!("CARGO_BIN_EXE_pacquet");
+    let pacquet = env!("CARGO_BIN_EXE_pnpm");
 
     let dir = TempDir::new().expect("create temp dir");
     let pnpx = dir.path().join("pnpx");

--- a/pnpm/crates/cli/tests/prefix.rs
+++ b/pnpm/crates/cli/tests/prefix.rs
@@ -37,7 +37,7 @@ fn prefix_walks_up_to_find_package_json() {
     let member = workspace.join("sub/dir/deep");
     fs::create_dir_all(&member).expect("create member dir");
 
-    let pacquet_out = Command::cargo_bin("pacquet")
+    let pacquet_out = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&member)
         .with_args(["prefix"])
@@ -60,7 +60,7 @@ fn prefix_walks_up_from_node_modules() {
     let nm_dir = workspace.join("node_modules/some-pkg");
     fs::create_dir_all(&nm_dir).expect("create node_modules/some-pkg dir");
 
-    let pacquet_out = Command::cargo_bin("pacquet")
+    let pacquet_out = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&nm_dir)
         .with_args(["prefix"])
@@ -102,7 +102,7 @@ fn prefix_resolves_from_a_workspace_subdir() {
     let sub_member = member.join("src/utils");
     fs::create_dir_all(&sub_member).expect("create sub_member dir");
 
-    let pacquet_out = Command::cargo_bin("pacquet")
+    let pacquet_out = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&sub_member)
         .with_args(["prefix"])

--- a/pnpm/crates/cli/tests/prefix.rs
+++ b/pnpm/crates/cli/tests/prefix.rs
@@ -38,7 +38,7 @@ fn prefix_walks_up_to_find_package_json() {
     fs::create_dir_all(&member).expect("create member dir");
 
     let pacquet_out = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&member)
         .with_args(["prefix"])
         .output()
@@ -61,7 +61,7 @@ fn prefix_walks_up_from_node_modules() {
     fs::create_dir_all(&nm_dir).expect("create node_modules/some-pkg dir");
 
     let pacquet_out = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&nm_dir)
         .with_args(["prefix"])
         .output()
@@ -103,7 +103,7 @@ fn prefix_resolves_from_a_workspace_subdir() {
     fs::create_dir_all(&sub_member).expect("create sub_member dir");
 
     let pacquet_out = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&sub_member)
         .with_args(["prefix"])
         .output()

--- a/pnpm/crates/cli/tests/publish.rs
+++ b/pnpm/crates/cli/tests/publish.rs
@@ -16,7 +16,7 @@ use serde_json::{Value, json};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .without_env("GITHUB_ACTIONS")

--- a/pnpm/crates/cli/tests/publish.rs
+++ b/pnpm/crates/cli/tests/publish.rs
@@ -17,7 +17,7 @@ use std::{fs, path::Path, process::Command};
 
 fn pacquet(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .without_env("GITHUB_ACTIONS")
         .without_env("GITLAB_CI")

--- a/pnpm/crates/cli/tests/remove.rs
+++ b/pnpm/crates/cli/tests/remove.rs
@@ -5,7 +5,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn manifest_has(workspace: &Path, group: DependencyGroup, name: &str) -> bool {

--- a/pnpm/crates/cli/tests/remove.rs
+++ b/pnpm/crates/cli/tests/remove.rs
@@ -5,7 +5,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn manifest_has(workspace: &Path, group: DependencyGroup, name: &str) -> bool {

--- a/pnpm/crates/cli/tests/repo.rs
+++ b/pnpm/crates/cli/tests/repo.rs
@@ -12,7 +12,7 @@ use pacquet_testing_utils::bin::CommandTempCwd;
 use std::{fs, process::Command};
 
 fn pacquet(workspace: &std::path::Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/repo.rs
+++ b/pnpm/crates/cli/tests/repo.rs
@@ -12,7 +12,7 @@ use pacquet_testing_utils::bin::CommandTempCwd;
 use std::{fs, process::Command};
 
 fn pacquet(workspace: &std::path::Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/root.rs
+++ b/pnpm/crates/cli/tests/root.rs
@@ -93,7 +93,7 @@ fn root_matches_pnpm_from_a_workspace_subdir() {
         .expect("write member package.json");
 
     let pacquet_out = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&member)
         .with_args(["root"])
         .output()

--- a/pnpm/crates/cli/tests/root.rs
+++ b/pnpm/crates/cli/tests/root.rs
@@ -92,7 +92,7 @@ fn root_matches_pnpm_from_a_workspace_subdir() {
     fs::write(member.join("package.json"), r#"{ "name": "foo", "version": "1.0.0" }"#)
         .expect("write member package.json");
 
-    let pacquet_out = Command::cargo_bin("pacquet")
+    let pacquet_out = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&member)
         .with_args(["root"])

--- a/pnpm/crates/cli/tests/run.rs
+++ b/pnpm/crates/cli/tests/run.rs
@@ -355,7 +355,7 @@ fn run_finds_workspace_root_bin_on_path() {
     .to_string();
     fs::write(project.join("package.json"), manifest).expect("write package.json");
 
-    std::process::Command::cargo_bin("pacquet")
+    std::process::Command::cargo_bin("pnpm")
         .expect("find pacquet binary")
         .with_current_dir(&project)
         .with_arg("run")
@@ -626,7 +626,7 @@ fn run_start_fallback_uses_dir_for_server_js_probe() {
 
     let existing_path = std::env::var("PATH").unwrap_or_default();
     let new_path = format!("{}:{}", shim_dir.display(), existing_path);
-    std::process::Command::cargo_bin("pacquet")
+    std::process::Command::cargo_bin("pnpm")
         .expect("find pacquet binary")
         .with_current_dir(&workspace)
         .with_env("PATH", new_path)

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -228,7 +228,7 @@ fn recursive_lifecycle_aliases_use_recursive_run_options() {
         [("test", "test-ran.txt"), ("start", "start-ran.txt"), ("stop", "stop-ran.txt")]
     {
         let _ = fs::remove_file(workspace.join("pnpm-exec-summary.json"));
-        std::process::Command::cargo_bin("pacquet")
+        std::process::Command::cargo_bin("pnpm")
             .expect("find pacquet binary")
             .with_current_dir(&workspace)
             .with_arg("-r")

--- a/pnpm/crates/cli/tests/sbom.rs
+++ b/pnpm/crates/cli/tests/sbom.rs
@@ -40,7 +40,7 @@ fn copy_dir_recursive(src: &Path, dest: &Path) {
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_args(args)
 }

--- a/pnpm/crates/cli/tests/sbom.rs
+++ b/pnpm/crates/cli/tests/sbom.rs
@@ -39,7 +39,7 @@ fn copy_dir_recursive(src: &Path, dest: &Path) {
 }
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_args(args)
@@ -192,7 +192,7 @@ fn sbom_has_tools() {
     let tmp = copy_fixture("simple-sbom");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &[]);
     let tools = parsed["metadata"]["tools"]["components"].as_array().expect("tools");
-    assert!(tools.iter().any(|tool| tool["name"] == "pacquet"));
+    assert!(tools.iter().any(|tool| tool["name"] == "pnpm"));
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn sbom_spdx_creation_info() {
     let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
     assert!(parsed["creationInfo"]["created"].is_string());
     let creators = parsed["creationInfo"]["creators"].as_array().expect("creators");
-    assert!(creators.iter().any(|creator| creator.as_str().unwrap().contains("pacquet")));
+    assert!(creators.iter().any(|creator| creator.as_str().unwrap().contains("pnpm")));
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/search.rs
+++ b/pnpm/crates/cli/tests/search.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn empty_auth_file(root: &Path) -> PathBuf {

--- a/pnpm/crates/cli/tests/search.rs
+++ b/pnpm/crates/cli/tests/search.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn empty_auth_file(root: &Path) -> PathBuf {

--- a/pnpm/crates/cli/tests/set_script.rs
+++ b/pnpm/crates/cli/tests/set_script.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn write_manifest(workspace: &Path, value: &Value) {

--- a/pnpm/crates/cli/tests/set_script.rs
+++ b/pnpm/crates/cli/tests/set_script.rs
@@ -6,7 +6,7 @@ use serde_json::{Value, json};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn write_manifest(workspace: &Path, value: &Value) {

--- a/pnpm/crates/cli/tests/side_effects_cache.rs
+++ b/pnpm/crates/cli/tests/side_effects_cache.rs
@@ -77,7 +77,7 @@ fn side_effects_materialized_on_warm_frozen_reinstall() {
 /// command — no extra `CommandTempCwd` / registry.
 fn run_frozen_install(workspace: &Path) {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_args(["install", "--frozen-lockfile"])
         .assert()

--- a/pnpm/crates/cli/tests/side_effects_cache.rs
+++ b/pnpm/crates/cli/tests/side_effects_cache.rs
@@ -76,7 +76,7 @@ fn side_effects_materialized_on_warm_frozen_reinstall() {
 /// singleton kept alive by the caller, so this only needs its own
 /// command — no extra `CommandTempCwd` / registry.
 fn run_frozen_install(workspace: &Path) {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_args(["install", "--frozen-lockfile"])

--- a/pnpm/crates/cli/tests/stage.rs
+++ b/pnpm/crates/cli/tests/stage.rs
@@ -23,8 +23,8 @@ use std::{
 const STAGE_ID: &str = "1de6f3db-2ed9-4d72-b3dd-8f0e2b474a2f";
 
 fn pacquet(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet")
-        .expect("find the pacquet binary")
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .without_env("GITHUB_ACTIONS")
         .without_env("GITLAB_CI")

--- a/pnpm/crates/cli/tests/stale_pin_dedupe.rs
+++ b/pnpm/crates/cli/tests/stale_pin_dedupe.rs
@@ -9,7 +9,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn write_manifest(path: &Path, dep_of_version: &str) {

--- a/pnpm/crates/cli/tests/stale_pin_dedupe.rs
+++ b/pnpm/crates/cli/tests/stale_pin_dedupe.rs
@@ -9,7 +9,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn write_manifest(path: &Path, dep_of_version: &str) {

--- a/pnpm/crates/cli/tests/store.rs
+++ b/pnpm/crates/cli/tests/store.rs
@@ -65,7 +65,7 @@ fn store_path_resolves_global_and_dotted_overrides_from_workspace_root() {
         ("--config.store-dir=dotted-store", "dotted-store"),
     ] {
         let output = Command::cargo_bin("pnpm")
-            .expect("find the pacquet binary")
+            .expect("find the pnpm binary")
             .with_current_dir(root.path())
             .arg("--dir")
             .arg(&package_dir)
@@ -112,7 +112,7 @@ fn store_path_expands_a_quoted_home_override() {
 fn empty_store_dir_override_restores_the_platform_default() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     let default_output = Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(&workspace)
         .args(["store", "path"])
         .output()
@@ -127,7 +127,7 @@ fn empty_store_dir_override_restores_the_platform_default() {
         .expect("write configured store directory");
     for store_arg in ["--store-dir=", "--config.store-dir="] {
         let output = Command::cargo_bin("pnpm")
-            .expect("find the pacquet binary")
+            .expect("find the pnpm binary")
             .with_current_dir(&workspace)
             .args(["store", "path", store_arg])
             .output()

--- a/pnpm/crates/cli/tests/store.rs
+++ b/pnpm/crates/cli/tests/store.rs
@@ -64,7 +64,7 @@ fn store_path_resolves_global_and_dotted_overrides_from_workspace_root() {
         ("--store-dir=global-store", "global-store"),
         ("--config.store-dir=dotted-store", "dotted-store"),
     ] {
-        let output = Command::cargo_bin("pacquet")
+        let output = Command::cargo_bin("pnpm")
             .expect("find the pacquet binary")
             .with_current_dir(root.path())
             .arg("--dir")
@@ -111,7 +111,7 @@ fn store_path_expands_a_quoted_home_override() {
 #[test]
 fn empty_store_dir_override_restores_the_platform_default() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let default_output = Command::cargo_bin("pacquet")
+    let default_output = Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(&workspace)
         .args(["store", "path"])
@@ -126,7 +126,7 @@ fn empty_store_dir_override_restores_the_platform_default() {
     fs::write(workspace.join("pnpm-workspace.yaml"), "storeDir: yaml-store\n")
         .expect("write configured store directory");
     for store_arg in ["--store-dir=", "--config.store-dir="] {
-        let output = Command::cargo_bin("pacquet")
+        let output = Command::cargo_bin("pnpm")
             .expect("find the pacquet binary")
             .with_current_dir(&workspace)
             .args(["store", "path", store_arg])

--- a/pnpm/crates/cli/tests/tarball_url_dependency.rs
+++ b/pnpm/crates/cli/tests/tarball_url_dependency.rs
@@ -41,7 +41,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command, thread::sleep, time::Duration};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// The `integrity:` recorded for a `packages:` entry keyed by

--- a/pnpm/crates/cli/tests/tarball_url_dependency.rs
+++ b/pnpm/crates/cli/tests/tarball_url_dependency.rs
@@ -41,7 +41,7 @@ use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path, process::Command, thread::sleep, time::Duration};
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// The `integrity:` recorded for a `packages:` entry keyed by

--- a/pnpm/crates/cli/tests/unlink.rs
+++ b/pnpm/crates/cli/tests/unlink.rs
@@ -205,7 +205,7 @@ fn unlink_restores_registry_package_in_lockfile() {
         "the link override should make node_modules/{PKG} a symlink before unlink",
     );
 
-    let mut unlink = std::process::Command::cargo_bin("pacquet").expect("locate pacquet binary");
+    let mut unlink = std::process::Command::cargo_bin("pnpm").expect("locate pacquet binary");
     unlink.current_dir(&workspace);
     unlink.with_args(["unlink", PKG]).assert().success();
 

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -24,7 +24,7 @@ fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
 /// `assert_cmd` `Command` is single-shot, so each install/update step
 /// needs its own.
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_args(args)

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -25,7 +25,7 @@ fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
 /// needs its own.
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_args(args)
 }

--- a/pnpm/crates/cli/tests/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/verify_deps_before_run.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_in(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 fn write_manifest(workspace: &Path, marker: &Path) {

--- a/pnpm/crates/cli/tests/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/verify_deps_before_run.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_in(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 fn write_manifest(workspace: &Path, marker: &Path) {

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -12,7 +12,7 @@ fn version_flag_prints_the_bare_version() {
     assert!(output.status.success(), "pacquet --version should succeed");
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        format!("{}\n", pacquet_config::PACQUET_VERSION),
+        format!("{}\n", pacquet_config::PNPM_VERSION),
     );
 
     drop(root);
@@ -27,7 +27,7 @@ fn short_version_flag_prints_the_bare_version() {
     assert!(output.status.success(), "pacquet -v should succeed");
     assert_eq!(
         String::from_utf8_lossy(&output.stdout),
-        format!("{}\n", pacquet_config::PACQUET_VERSION),
+        format!("{}\n", pacquet_config::PNPM_VERSION),
     );
 
     drop(root);

--- a/pnpm/crates/cli/tests/whoami.rs
+++ b/pnpm/crates/cli/tests/whoami.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
 /// The nerf-darted `.npmrc` auth-key prefix (`//host:port/path/`) for a

--- a/pnpm/crates/cli/tests/whoami.rs
+++ b/pnpm/crates/cli/tests/whoami.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 fn pacquet_at(workspace: &Path) -> Command {
-    Command::cargo_bin("pacquet").expect("find the pacquet binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm").expect("find the pacquet binary").with_current_dir(workspace)
 }
 
 /// The nerf-darted `.npmrc` auth-key prefix (`//host:port/path/`) for a

--- a/pnpm/crates/cli/tests/why.rs
+++ b/pnpm/crates/cli/tests/why.rs
@@ -14,7 +14,7 @@ fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
 }
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
-    Command::cargo_bin("pacquet")
+    Command::cargo_bin("pnpm")
         .expect("find the pacquet binary")
         .with_current_dir(workspace)
         .with_args(args)

--- a/pnpm/crates/cli/tests/why.rs
+++ b/pnpm/crates/cli/tests/why.rs
@@ -15,7 +15,7 @@ fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
 
 fn pacquet(workspace: &Path, args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Command {
     Command::cargo_bin("pnpm")
-        .expect("find the pacquet binary")
+        .expect("find the pnpm binary")
         .with_current_dir(workspace)
         .with_args(args)
 }

--- a/pnpm/crates/cli/tests/with.rs
+++ b/pnpm/crates/cli/tests/with.rs
@@ -211,7 +211,7 @@ fn assert_success(output: &Output) {
 }
 
 fn assert_current_version(output: &Output) {
-    assert_eq!(stdout(output).trim(), pacquet_config::PACQUET_VERSION);
+    assert_eq!(stdout(output).trim(), pacquet_config::PNPM_VERSION);
 }
 
 fn assert_semver_like(value: &str) {

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -251,7 +251,7 @@ pub fn default_fetch_retry_maxtimeout() -> u64 {
 /// can't drift apart. The release workflow patches this constant to the
 /// version being published; the committed value tracks the current
 /// pre-release line.
-pub const PACQUET_VERSION: &str = "12.0.0-alpha.0";
+pub const PNPM_VERSION: &str = "12.0.0-alpha.0";
 
 pub fn default_fetch_timeout() -> u64 {
     pacquet_network::DEFAULT_FETCH_TIMEOUT_MS
@@ -265,7 +265,7 @@ pub fn default_fetch_timeout() -> u64 {
 /// [`pacquet_detect_libc::host_platform`] / [`pacquet_detect_libc::host_arch`].
 pub fn default_user_agent() -> String {
     format!(
-        "pnpm/{PACQUET_VERSION} npm/? node/? {} {}",
+        "pnpm/{PNPM_VERSION} npm/? node/? {} {}",
         pacquet_detect_libc::host_platform(),
         pacquet_detect_libc::host_arch(),
     )

--- a/pnpm/crates/config/src/defaults/tests.rs
+++ b/pnpm/crates/config/src/defaults/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    PACQUET_VERSION, default_cache_dir, default_child_concurrency,
+    PNPM_VERSION, default_cache_dir, default_child_concurrency,
     default_child_concurrency_with_parallelism, default_config_dir, default_fetch_timeout,
     default_store_dir, default_unsafe_perm, default_user_agent, default_workspace_concurrency,
     is_unsafe_perm_posix, resolve_child_concurrency, resolve_child_concurrency_with_parallelism,
@@ -360,7 +360,7 @@ fn fetch_timeout_default_matches_pnpm() {
 #[test]
 fn user_agent_default_matches_pnpm_format() {
     let ua = default_user_agent();
-    let prefix = format!("pnpm/{PACQUET_VERSION} npm/? node/? ");
+    let prefix = format!("pnpm/{PNPM_VERSION} npm/? node/? ");
     assert!(ua.starts_with(&prefix), "user-agent {ua:?} must start with {prefix:?}");
     let tail: Vec<&str> = ua[prefix.len()..].split(' ').collect();
     assert_eq!(tail.len(), 2, "expected `<platform> <arch>` tail, got {ua:?}");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -35,7 +35,7 @@ use std::{
 };
 
 pub use crate::defaults::{
-    GLOBAL_LAYOUT_VERSION, PACQUET_VERSION, available_parallelism, default_config_dir,
+    GLOBAL_LAYOUT_VERSION, PNPM_VERSION, available_parallelism, default_config_dir,
     default_git_shallow_hosts, default_peers_suffix_max_length, default_pnpm_home_dir,
     default_unsafe_perm, default_virtual_store_dir_max_length, default_workspace_concurrency,
     is_unsafe_perm_posix, resolve_child_concurrency,
@@ -762,7 +762,7 @@ pub struct Config {
     /// metadata-fetch path yet (no resolver until Stage 2), so the same
     /// flag instead gates pacquet's tarball-fetch fall-through: when both
     /// the warm prefetch and the `SQLite` `index.db` lookup miss, the
-    /// tarball fetcher fails fast with `ERR_PACQUET_NO_OFFLINE_TARBALL`
+    /// tarball fetcher fails fast with `ERR_PNPM_NO_OFFLINE_TARBALL`
     /// rather than hitting the registry. The frozen-lockfile install
     /// path needs no metadata, so the surface area collapses to
     /// "every snapshot must already be in the local store".

--- a/pnpm/crates/napi/src/lib.rs
+++ b/pnpm/crates/napi/src/lib.rs
@@ -45,7 +45,7 @@ pub use specifier::{ParsedBareSpecifier, parse_bare_specifier};
 #[napi(js_name = "engineVersion")]
 #[must_use]
 pub fn engine_version() -> &'static str {
-    pacquet_config::PACQUET_VERSION
+    pacquet_config::PNPM_VERSION
 }
 
 /// No-op stubs for the napi runtime symbols the `#[napi]` trampolines

--- a/pnpm/crates/napi/src/pack.rs
+++ b/pnpm/crates/napi/src/pack.rs
@@ -11,7 +11,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use napi_derive::napi;
 use pacquet_catalogs_types::Catalogs;
-use pacquet_config::{NodeLinker, PACQUET_VERSION};
+use pacquet_config::{NodeLinker, PNPM_VERSION};
 
 use crate::{
     error::to_napi_error,
@@ -65,7 +65,7 @@ pub async fn pack(options: PackOptions, on_log: Option<LogSink>) -> napi::Result
         pack_gzip_level: options.pack_gzip_level,
         node_linker: NodeLinker::default(),
         skip_manifest_obfuscation: false,
-        user_agent: format!("pnpm/{PACQUET_VERSION} napi"),
+        user_agent: format!("pnpm/{PNPM_VERSION} napi"),
         extra_bin_paths: options
             .extra_bin_paths
             .unwrap_or_default()

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -53,7 +53,7 @@ pub enum BuildModulesError {
     /// rather than a panic so the install path can return cleanly.
     #[display("Failed to build the per-install rayon thread pool: {source}")]
     #[diagnostic(
-        code(ERR_PACQUET_BUILD_THREAD_POOL),
+        code(ERR_PNPM_BUILD_THREAD_POOL),
         help(
             "Lower childConcurrency in pnpm-workspace.yaml, or raise the process's RLIMIT_NPROC."
         )

--- a/pnpm/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/pnpm/crates/package-manager/src/hoisted_dep_graph.rs
@@ -271,7 +271,7 @@ pub enum HoistedDepGraphError {
     /// already validated — but the conversion is fallible at the
     /// type level, so a typed error is the honest surface.
     #[display("Unparsable snapshot reference {reference:?} on hoisted node")]
-    #[diagnostic(code(ERR_PACQUET_HOISTED_GRAPH_BAD_REFERENCE))]
+    #[diagnostic(code(ERR_PNPM_HOISTED_GRAPH_BAD_REFERENCE))]
     BadReference {
         reference: String,
         #[error(source)]

--- a/pnpm/crates/package-manager/src/link_hoisted_modules.rs
+++ b/pnpm/crates/package-manager/src/link_hoisted_modules.rs
@@ -85,7 +85,7 @@ pub enum LinkHoistedModulesError {
     /// Indicates a bug in the caller (pre-fetch incomplete) — the
     /// linker can't conjure files it wasn't given.
     #[display("Missing CAS paths for required package {pkg_id_with_patch_hash:?} at {dir:?}")]
-    #[diagnostic(code(ERR_PACQUET_LINK_HOISTED_MISSING_CAS))]
+    #[diagnostic(code(ERR_PNPM_LINK_HOISTED_MISSING_CAS))]
     MissingCasPaths { pkg_id_with_patch_hash: PkgIdWithPatchHash, dir: PathBuf },
 
     /// A hierarchy entry referenced a directory that has no
@@ -95,7 +95,7 @@ pub enum LinkHoistedModulesError {
     /// surfacing the inconsistency fails the install fast rather
     /// than producing a partial layout.
     #[display("Hierarchy references {dir:?} but no matching graph node exists")]
-    #[diagnostic(code(ERR_PACQUET_LINK_HOISTED_MISSING_GRAPH_NODE))]
+    #[diagnostic(code(ERR_PNPM_LINK_HOISTED_MISSING_GRAPH_NODE))]
     MissingGraphNode { dir: PathBuf },
 
     #[diagnostic(transparent)]

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -238,8 +238,8 @@ pub enum TarballError {
     /// facing message; the underlying [`std::io::Error`] is
     /// exposed as `source` for miette / `Error::source` walkers.
     /// Kept separate from [`TarballError::ReadTarballEntries`] so
-    /// the retry-classification path emits `ERR_PACQUET_ZIP`
-    /// rather than the tar-specific `ERR_PACQUET_TARBALL_TAR`.
+    /// the retry-classification path emits `ERR_PNPM_ZIP`
+    /// rather than the tar-specific `ERR_PNPM_TARBALL_TAR`.
     #[from(ignore)]
     #[display("Failed to read zip entry {entry_path:?} from {url}: {source}")]
     #[diagnostic(code(pacquet_tarball::read_zip_entry))]
@@ -258,7 +258,7 @@ pub enum TarballError {
     /// clear "the snapshot isn't cached" error rather than letting
     /// the underlying network refusal propagate.
     ///
-    /// `ERR_PACQUET_NO_OFFLINE_TARBALL` is a pacquet-specific code;
+    /// `ERR_PNPM_NO_OFFLINE_TARBALL` is a pacquet-specific code;
     /// the message shape follows pnpm's `ERR_PNPM_NO_OFFLINE_META`
     /// — "Failed to resolve `<pkg>` in package mirror `<dir>`".
     #[from(ignore)]
@@ -266,7 +266,7 @@ pub enum TarballError {
         "Failed to fetch tarball for {package_id} from {url} in offline mode: snapshot not present in local store"
     )]
     #[diagnostic(
-        code(ERR_PACQUET_NO_OFFLINE_TARBALL),
+        code(ERR_PNPM_NO_OFFLINE_TARBALL),
         help(
             "Drop `--offline` (or `offline=true` in pnpm-workspace.yaml) or run an online install first to populate the store."
         )
@@ -1527,7 +1527,7 @@ pub struct DownloadTarballToStore<'a> {
 ///
 /// Today pacquet populates `http_status_code` for the
 /// [`TarballError::HttpStatus`] variant and a curated
-/// `ERR_PACQUET_*` constant in `code` for every other variant —
+/// `ERR_PNPM_*` constant in `code` for every other variant —
 /// the mapping is hand-maintained per match arm rather than
 /// reflectively derived, so renaming a [`TarballError`] variant
 /// won't silently change the emitted `code`. `errno` and `status`
@@ -1546,37 +1546,37 @@ fn tarball_error_to_request_retry(err: &TarballError) -> RequestRetryError {
             out.http_status_code = Some(http.status.to_string());
         }
         TarballError::FetchTarball(_) => {
-            out.code = Some("ERR_PACQUET_FETCH".to_string());
+            out.code = Some("ERR_PNPM_FETCH".to_string());
         }
         TarballError::Checksum(_) => {
-            out.code = Some("ERR_PACQUET_TARBALL_INTEGRITY".to_string());
+            out.code = Some("ERR_PNPM_TARBALL_INTEGRITY".to_string());
         }
         TarballError::DecodeGzip(_) => {
-            out.code = Some("ERR_PACQUET_TARBALL_GZIP".to_string());
+            out.code = Some("ERR_PNPM_TARBALL_GZIP".to_string());
         }
         TarballError::ReadTarballEntries(_) => {
-            out.code = Some("ERR_PACQUET_TARBALL_TAR".to_string());
+            out.code = Some("ERR_PNPM_TARBALL_TAR".to_string());
         }
         TarballError::ReadLocalTarball { .. } => {
-            out.code = Some("ERR_PACQUET_TARBALL_FILE".to_string());
+            out.code = Some("ERR_PNPM_TARBALL_FILE".to_string());
         }
         TarballError::WriteCasFile(_) | TarballError::WriteStoreIndex(_) => {
-            out.code = Some("ERR_PACQUET_TARBALL_STORE".to_string());
+            out.code = Some("ERR_PNPM_TARBALL_STORE".to_string());
         }
         TarballError::TaskJoin(_) => {
-            out.code = Some("ERR_PACQUET_TASK_JOIN".to_string());
+            out.code = Some("ERR_PNPM_TASK_JOIN".to_string());
         }
         TarballError::TarballTooLarge { .. } => {
-            out.code = Some("ERR_PACQUET_TARBALL_TOO_LARGE".to_string());
+            out.code = Some("ERR_PNPM_TARBALL_TOO_LARGE".to_string());
         }
         TarballError::SiblingFetchFailed { .. } => {
-            out.code = Some("ERR_PACQUET_SIBLING_FETCH".to_string());
+            out.code = Some("ERR_PNPM_SIBLING_FETCH".to_string());
         }
         TarballError::PathTraversal { .. } => {
-            out.code = Some("ERR_PACQUET_PATH_TRAVERSAL".to_string());
+            out.code = Some("ERR_PNPM_PATH_TRAVERSAL".to_string());
         }
         TarballError::ReadZipArchive { .. } | TarballError::ReadZipEntries { .. } => {
-            out.code = Some("ERR_PACQUET_ZIP".to_string());
+            out.code = Some("ERR_PNPM_ZIP".to_string());
         }
         TarballError::NoOfflineTarball { .. } => {
             // The retry classifier sees this only if the offline gate
@@ -1586,7 +1586,7 @@ fn tarball_error_to_request_retry(err: &TarballError) -> RequestRetryError {
             // exhaustiveness; the `code` field is set so a future
             // surface that does run this error through the retry
             // logger renders the right code.
-            out.code = Some("ERR_PACQUET_NO_OFFLINE_TARBALL".to_string());
+            out.code = Some("ERR_PNPM_NO_OFFLINE_TARBALL".to_string());
         }
     }
     out

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -2945,7 +2945,7 @@ async fn offline_mode_skips_network_on_cache_miss() {
     .expect_err("offline + cache miss must error before reaching the network");
 
     // Variant shape + diagnostic code together. The `code` check
-    // pins the user-facing surface — `ERR_PACQUET_NO_OFFLINE_TARBALL`
+    // pins the user-facing surface — `ERR_PNPM_NO_OFFLINE_TARBALL`
     // is part of the CLI contract, like pnpm's
     // `ERR_PNPM_NO_OFFLINE_META`.
     let TarballError::NoOfflineTarball { package_id, url: errored_url } = &err else {
@@ -2955,7 +2955,7 @@ async fn offline_mode_skips_network_on_cache_miss() {
     assert_eq!(errored_url, &url);
     let code = err.code().map(|c| c.to_string()).unwrap_or_default();
     assert_eq!(
-        code, "ERR_PACQUET_NO_OFFLINE_TARBALL",
+        code, "ERR_PNPM_NO_OFFLINE_TARBALL",
         "diagnostic code is part of the user-facing surface; must stay stable",
     );
 

--- a/pnpm/crates/testing-utils/src/bin.rs
+++ b/pnpm/crates/testing-utils/src/bin.rs
@@ -28,9 +28,8 @@ impl CommandTempCwd<()> {
         let root = tempdir().expect("create temporary directory");
         let workspace = root.path().join("workspace");
         fs::create_dir(&workspace).expect("create temporary workspace for the commands");
-        let pacquet = Command::cargo_bin("pnpm")
-            .expect("find the pacquet binary")
-            .with_current_dir(&workspace);
+        let pacquet =
+            Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(&workspace);
         let pnpm = Command::new("pnpm").with_current_dir(&workspace);
         CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info: () }
     }

--- a/pnpm/crates/testing-utils/src/bin.rs
+++ b/pnpm/crates/testing-utils/src/bin.rs
@@ -28,7 +28,7 @@ impl CommandTempCwd<()> {
         let root = tempdir().expect("create temporary directory");
         let workspace = root.path().join("workspace");
         fs::create_dir(&workspace).expect("create temporary workspace for the commands");
-        let pacquet = Command::cargo_bin("pacquet")
+        let pacquet = Command::cargo_bin("pnpm")
             .expect("find the pacquet binary")
             .with_current_dir(&workspace);
         let pnpm = Command::new("pnpm").with_current_dir(&workspace);

--- a/pnpm/tasks/ecosystem-e2e/README.md
+++ b/pnpm/tasks/ecosystem-e2e/README.md
@@ -44,7 +44,7 @@ Each cell runs four stages, stopping at the first failure:
 From the repo root:
 
 ```sh
-# Whole grid, every stack (pacquet must be built: cargo build --release --bin pnpm)
+# Whole grid, every stack (pnpm must be built: cargo build --release --bin pnpm)
 cargo run -p pacquet-ecosystem-e2e -- --pacquet ./target/release/pnpm
 
 # Just pnpm, one stack, both layouts

--- a/pnpm/tasks/ecosystem-e2e/README.md
+++ b/pnpm/tasks/ecosystem-e2e/README.md
@@ -44,8 +44,8 @@ Each cell runs four stages, stopping at the first failure:
 From the repo root:
 
 ```sh
-# Whole grid, every stack (pacquet must be built: cargo build --release --bin pacquet)
-cargo run -p pacquet-ecosystem-e2e -- --pacquet ./target/release/pacquet
+# Whole grid, every stack (pacquet must be built: cargo build --release --bin pnpm)
+cargo run -p pacquet-ecosystem-e2e -- --pacquet ./target/release/pnpm
 
 # Just pnpm, one stack, both layouts
 cargo run -p pacquet-ecosystem-e2e -- --binary pnpm --stack vite-react

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -216,7 +216,15 @@ impl WorkEnv {
             // time and reached via the `PNPM_CONFIG_PNPR_SERVER` env var
             // that `install.bash` sources from `.pnpr-env`.
             BenchId::PacquetRevision(_) | BenchId::PnprRevision(_) => {
-                "./pacquet/target/release/pacquet".to_string()
+                // The client bin is `pnpm` from the v12 rename onward and
+                // `pacquet` before it; resolve whichever this revision's
+                // build produced at script runtime, the same way the pnpm
+                // branch below resolves its bundle path.
+                let candidates =
+                    ["./pacquet/target/release/pnpm", "./pacquet/target/release/pacquet"].join(" ");
+                format!(
+                    r#""$(for f in {candidates}; do if [ -f "$f" ]; then echo "$f"; break; fi; done)""#,
+                )
             }
             BenchId::PnpmRevision(_) => {
                 // Take the first bundle that exists: `pnpm.mjs` over
@@ -278,15 +286,52 @@ impl WorkEnv {
         }
     }
 
-    /// Output binary a `pacquet@<rev>` target runs.
+    /// Output binary a `pacquet@<rev>` target runs. The bin is named
+    /// `pnpm` from the v12 rename onward and `pacquet` before it, so
+    /// prefer whichever exists (new name when neither does yet).
     fn pacquet_binary(&self, revision: &str) -> PathBuf {
-        self.pacquet_source_dir(revision).join("target").join("release").join("pacquet")
+        WorkEnv::client_binary_in(&self.pacquet_source_dir(revision))
     }
 
-    /// The `pacquet` client binary a `pnpr@<rev>` build produces (the pnpr
-    /// target builds `--bin=pacquet --bin=pnpr`).
+    /// The client binary a `pnpr@<rev>` build produces (the pnpr
+    /// target builds the client and `pnpr` bins together).
     fn pnpr_pacquet_binary(&self, revision: &str) -> PathBuf {
-        self.pnpr_source_dir(revision).join("target").join("release").join("pacquet")
+        WorkEnv::client_binary_in(&self.pnpr_source_dir(revision))
+    }
+
+    /// `<source_dir>/target/release/<client bin>` under either bin name:
+    /// the existing one wins so prebuilt caches and pre-rename revisions
+    /// keep working; the post-rename `pnpm` name is the default.
+    fn client_binary_in(source_dir: &Path) -> PathBuf {
+        let release = source_dir.join("target").join("release");
+        let pnpm = release.join("pnpm");
+        if pnpm.is_file() {
+            return pnpm;
+        }
+        let pacquet = release.join("pacquet");
+        if pacquet.is_file() { pacquet } else { pnpm }
+    }
+
+    /// CLI bin name this revision's checkout declares: `pnpm` from the
+    /// v12 rename onward, `pacquet` before it. Read from the clone's CLI
+    /// crate manifest (under either directory layout) so old and new
+    /// revisions both build with the right `--bin` flag.
+    fn cli_bin_name(revision_repo: &Path) -> &'static str {
+        for dir in ["pnpm", "pacquet"] {
+            let manifest = revision_repo.join(dir).join("crates").join("cli").join("Cargo.toml");
+            if let Ok(content) = fs::read_to_string(&manifest) {
+                // Whitespace-tolerant match: taplo pads `name` keys for
+                // alignment in some tables.
+                let has_pnpm_bin = content.lines().any(|line| {
+                    let mut parts = line.split_whitespace();
+                    parts.next() == Some("name")
+                        && parts.next() == Some("=")
+                        && parts.next() == Some(r#""pnpm""#)
+                });
+                return if has_pnpm_bin { "pnpm" } else { "pacquet" };
+            }
+        }
+        "pnpm"
     }
 
     /// The `pnpr` server binary a `pnpr@<rev>` build produces.
@@ -364,11 +409,12 @@ impl WorkEnv {
         sync_bench_repo(repository, &revision_repo, &commit);
 
         eprintln!("Building {revision:?}...");
+        let bin = WorkEnv::cli_bin_name(&revision_repo);
         Command::new("cargo")
             .current_dir(&revision_repo)
             .arg("build")
             .arg("--release")
-            .arg("--bin=pacquet")
+            .arg(format!("--bin={bin}"))
             .pipe(executor("cargo build"));
     }
 
@@ -396,12 +442,13 @@ impl WorkEnv {
 
         sync_bench_repo(repository, &revision_repo, &commit);
 
-        eprintln!("Building {revision:?} (pacquet + pnpr)...");
+        eprintln!("Building {revision:?} (client + pnpr)...");
+        let bin = WorkEnv::cli_bin_name(&revision_repo);
         Command::new("cargo")
             .current_dir(&revision_repo)
             .arg("build")
             .arg("--release")
-            .arg("--bin=pacquet")
+            .arg(format!("--bin={bin}"))
             .arg("--bin=pnpr")
             .pipe(executor("cargo build"));
     }
@@ -1900,7 +1947,7 @@ fn may_create_lockfile(dst_dir: &Path, scenario: BenchmarkScenario, src_dir: Opt
 }
 
 /// Write `install.bash` that invokes `command` (the resolved binary,
-/// e.g. `./pacquet/target/release/pacquet` or `node .../pnpm.mjs`)
+/// e.g. `./pacquet/target/release/pnpm` or `node .../pnpm.mjs`)
 /// with the scenario's install arguments.
 ///
 /// When `needs_pnpr_env` is set, the script sources `.pnpr-env` (written

--- a/pnpm/tasks/integrated-benchmark/src/work_env.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env.rs
@@ -216,10 +216,11 @@ impl WorkEnv {
             // time and reached via the `PNPM_CONFIG_PNPR_SERVER` env var
             // that `install.bash` sources from `.pnpr-env`.
             BenchId::PacquetRevision(_) | BenchId::PnprRevision(_) => {
-                // The client bin is `pnpm` from the v12 rename onward and
-                // `pacquet` before it; resolve whichever this revision's
-                // build produced at script runtime, the same way the pnpm
-                // branch below resolves its bundle path.
+                // Revisions disagree on the client bin name (`pnpm` on
+                // current checkouts, `pacquet` on older ones); resolve
+                // whichever this revision's build produced at script
+                // runtime, the same way the pnpm branch below resolves
+                // its bundle path.
                 let candidates =
                     ["./pacquet/target/release/pnpm", "./pacquet/target/release/pacquet"].join(" ");
                 format!(
@@ -286,9 +287,9 @@ impl WorkEnv {
         }
     }
 
-    /// Output binary a `pacquet@<rev>` target runs. The bin is named
-    /// `pnpm` from the v12 rename onward and `pacquet` before it, so
-    /// prefer whichever exists (new name when neither does yet).
+    /// Output binary a `pacquet@<rev>` target runs. Revisions disagree
+    /// on the client bin name, so prefer whichever exists (`pnpm` when
+    /// neither does yet).
     fn pacquet_binary(&self, revision: &str) -> PathBuf {
         WorkEnv::client_binary_in(&self.pacquet_source_dir(revision))
     }
@@ -300,8 +301,9 @@ impl WorkEnv {
     }
 
     /// `<source_dir>/target/release/<client bin>` under either bin name:
-    /// the existing one wins so prebuilt caches and pre-rename revisions
-    /// keep working; the post-rename `pnpm` name is the default.
+    /// the existing one wins so prebuilt caches and older revisions keep
+    /// working; `pnpm` is the default. The build fns delete the sibling
+    /// name after every build, so at most one candidate exists.
     fn client_binary_in(source_dir: &Path) -> PathBuf {
         let release = source_dir.join("target").join("release");
         let pnpm = release.join("pnpm");
@@ -312,10 +314,12 @@ impl WorkEnv {
         if pacquet.is_file() { pacquet } else { pnpm }
     }
 
-    /// CLI bin name this revision's checkout declares: `pnpm` from the
-    /// v12 rename onward, `pacquet` before it. Read from the clone's CLI
-    /// crate manifest (under either directory layout) so old and new
-    /// revisions both build with the right `--bin` flag.
+    /// CLI bin name the revision's checkout declares — `pnpm` on current
+    /// revisions, `pacquet` on older ones. Read from the clone's CLI
+    /// crate manifest (under either directory layout) so any revision
+    /// builds with the right `--bin` flag. The probe is a line scan, not
+    /// a TOML parse: the workspace has no TOML-parser dependency, and
+    /// pulling one in for a single boolean probe isn't worth it.
     fn cli_bin_name(revision_repo: &Path) -> &'static str {
         for dir in ["pnpm", "pacquet"] {
             let manifest = revision_repo.join(dir).join("crates").join("cli").join("Cargo.toml");
@@ -337,6 +341,16 @@ impl WorkEnv {
     /// The `pnpr` server binary a `pnpr@<rev>` build produces.
     fn pnpr_server_binary(&self, revision: &str) -> PathBuf {
         self.pnpr_source_dir(revision).join("target").join("release").join("pnpr")
+    }
+
+    /// Delete the client binary under the name `built_bin` does NOT use.
+    /// A bench dir is keyed by the revision *label* (e.g. `pnpr@main`),
+    /// so a moving label can leave the other name's binary from an
+    /// earlier run in `target/release`; without this cleanup,
+    /// existence-based resolution could pick that stale executable.
+    fn remove_sibling_client_binary(source_dir: &Path, built_bin: &str) {
+        let sibling = if built_bin == "pnpm" { "pacquet" } else { "pnpm" };
+        let _ = fs::remove_file(source_dir.join("target").join("release").join(sibling));
     }
 
     pub fn build(&self) {
@@ -381,10 +395,17 @@ impl WorkEnv {
                 eprintln!(
                     "Revision: {revision:?} (pacquet) — reusing the binary from the pnpr@{revision} build",
                 );
+                // Name the copy after the source so the copied binary keeps
+                // the bin name its revision declares.
+                let bin_name = from_pnpr.file_name().expect("client binary path has a file name");
+                let dest =
+                    self.pacquet_source_dir(revision).join("target").join("release").join(bin_name);
                 if let Some(parent) = dest.parent() {
                     fs::create_dir_all(parent).expect("create pacquet target/release dir");
                 }
-                fs::copy(&from_pnpr, &dest).expect("copy pacquet binary from the pnpr build");
+                fs::copy(&from_pnpr, &dest).expect("copy the client binary from the pnpr build");
+                let built = bin_name.to_str().expect("client bin name is UTF-8");
+                WorkEnv::remove_sibling_client_binary(&self.pacquet_source_dir(revision), built);
                 return;
             }
         }
@@ -416,6 +437,7 @@ impl WorkEnv {
             .arg("--release")
             .arg(format!("--bin={bin}"))
             .pipe(executor("cargo build"));
+        WorkEnv::remove_sibling_client_binary(&revision_repo, bin);
     }
 
     /// Build a pnpr target: both the `pacquet` client and the `pnpr`
@@ -451,6 +473,7 @@ impl WorkEnv {
             .arg(format!("--bin={bin}"))
             .arg("--bin=pnpr")
             .pipe(executor("cargo build"));
+        WorkEnv::remove_sibling_client_binary(&revision_repo, bin);
     }
 
     fn build_pnpm(&self, revision: &str) {

--- a/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
+++ b/pnpm/tasks/integrated-benchmark/src/work_env/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    BenchId, BenchmarkScenario, HyperfineCommand, PhaseEvent, collect_pnpr_direct_ratios,
+    BenchId, BenchmarkScenario, HyperfineCommand, PhaseEvent, WorkEnv, collect_pnpr_direct_ratios,
     create_install_script, non_trivial_cold_batch, pnpr_auth_config_key,
     pnpr_benchmark_config_yaml, read_phase_events, render_diagnostics_markdown,
     requires_fresh_pnpr_cold_batch_metrics, summarize_phase_events,
@@ -283,4 +283,58 @@ fn diagnostics_markdown_omits_baseline_note_after_pnpr_main_is_instrumented() {
     );
 
     assert!(!markdown.contains("tarball URL rewrite"));
+}
+
+#[test]
+fn cli_bin_name_reads_the_declared_bin_from_either_layout() {
+    let root = std::env::temp_dir()
+        .join(format!("pacquet-integrated-benchmark-cli-bin-name-{}", std::process::id()));
+
+    // Current layout, `pnpm` bin, with taplo-style key padding.
+    let current = root.join("current");
+    let manifest_dir = current.join("pnpm").join("crates").join("cli");
+    fs::create_dir_all(&manifest_dir).expect("create current-layout manifest dir");
+    fs::write(
+        manifest_dir.join("Cargo.toml"),
+        "[package]\nname       = \"pacquet-cli\"\n\n[[bin]]\nname = \"pnpm\"\n",
+    )
+    .expect("write current-layout manifest");
+    assert_eq!(WorkEnv::cli_bin_name(&current), "pnpm");
+
+    // Old layout, `pacquet` bin.
+    let old = root.join("old");
+    let manifest_dir = old.join("pacquet").join("crates").join("cli");
+    fs::create_dir_all(&manifest_dir).expect("create old-layout manifest dir");
+    fs::write(
+        manifest_dir.join("Cargo.toml"),
+        "[package]\nname = \"pacquet-cli\"\n\n[[bin]]\nname = \"pacquet\"\n",
+    )
+    .expect("write old-layout manifest");
+    assert_eq!(WorkEnv::cli_bin_name(&old), "pacquet");
+
+    // No manifest at all: default to the current name.
+    assert_eq!(WorkEnv::cli_bin_name(&root.join("missing")), "pnpm");
+
+    let _ = fs::remove_dir_all(&root);
+}
+
+#[test]
+fn client_binary_in_prefers_the_existing_binary() {
+    let root = std::env::temp_dir()
+        .join(format!("pacquet-integrated-benchmark-client-binary-{}", std::process::id()));
+    let release = root.join("target").join("release");
+    fs::create_dir_all(&release).expect("create release dir");
+
+    // Nothing built yet: default to the `pnpm` path.
+    assert_eq!(WorkEnv::client_binary_in(&root), release.join("pnpm"));
+
+    // Only the old name exists (an older revision's build).
+    fs::write(release.join("pacquet"), "old").expect("write pacquet binary");
+    assert_eq!(WorkEnv::client_binary_in(&root), release.join("pacquet"));
+
+    // Both exist: the current name wins.
+    fs::write(release.join("pnpm"), "new").expect("write pnpm binary");
+    assert_eq!(WorkEnv::client_binary_in(&root), release.join("pnpm"));
+
+    let _ = fs::remove_dir_all(&root);
 }


### PR DESCRIPTION
## What

Stage 2a of retiring the pacquet codename — the user-facing surfaces, kept separate from the internal crate renames (stage 2b):

- **Cargo bin `pacquet` → `pnpm`.** Every build now outputs the binary under its shipped name; the release workflow's archive steps no longer rename, so the released artifact is byte-for-byte what cargo produced. Build invocations stay `-p pacquet-cli --bin pnpm` until stage 2b renames the crates.
- **Error codes `ERR_PACQUET_*` → `ERR_PNPM_*`.** The port already emits 302 codes as `ERR_PNPM_*`; these were the 16 port-original stragglers (`ERR_PACQUET_NO_OFFLINE_TARBALL`, `ERR_PACQUET_PATH_TRAVERSAL`, …) that users would otherwise see, script against, and document before v12 stabilizes. `PACQUET_VERSION` rides along as `PNPM_VERSION`.
- **Shell completions register for `pnpm`.** They were broken for v12 — the scripts registered completion for a command named `pacquet`, but v12 installs the binary as `pnpm`. All four shells' scripts now register and invoke `pnpm`; the completion-server still accepts `pacquet` as the completed command's argv[0], so completion scripts installed by earlier alphas keep working until the user re-runs setup.
- **SBOM tool identity is `pnpm`** (CycloneDX tool component + SPDX `Tool:` creator), matching v11's output.

## Benchmark harness

The integrated-benchmark builds and runs arbitrary revisions, which now disagree on the bin name. Rather than breaking either side:

- `cli_bin_name()` reads the revision clone's CLI crate manifest (whitespace-tolerant, under either directory layout) to pick the right `--bin=` flag — this also covers the window of revisions between the directory rename (#12913) and this PR.
- The install command resolves the produced binary at script runtime by existence, the same trick the pnpm target already uses for its `pnpm.mjs`/`pnpm.cjs` bundle.
- The prebuilt-binary helpers prefer whichever name exists, and the CI binary-cache paths list both names, so old cache entries stay restorable.

## Deliberately unchanged

`pnpm11`'s `@pacquet/<platform>-<arch>` package references and its `PACQUET_VERSION = '0.11.7'` test constants (those name the old published npm packages, which still exist under those names), the `.pacquet` virtual-store dir, the harness clone dir, crate names, and prose.

## Verification

- `cargo check --workspace --all-targets` passes.
- All 77 tests in the touched suites pass (`completion`, `sbom`, `version`, `pnpx_alias`), including the completion integration tests that spawn the renamed binary.
- `cargo fmt --check` and typos (CI's pinned version) clean; all workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI build and distributed archives are now `pnpm`, with updated dev commands and release artifacts.
  * Shell completions are consistently branded as `pnpm` and generate `pnpm completion-server` wiring.
* **Bug Fixes**
  * Version output/user-agent reporting now aligns with `pnpm`.
  * Diagnostics and retry-related error codes are updated to `ERR_PNPM_*`.
* **Documentation**
  * Updated E2E and integrated-benchmark guides to reference `pnpm` build outputs.
  * SBOM metadata now identifies the tool as `pnpm`.
* **Chores**
  * Updated CI E2E/benchmark workflows and test suites to run the `pnpm` binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->