### PR TITLE
fix(pacquet): serialize same-name injected importer deps as plain file: refs

### DIFF
--- a/pnpm/crates/cli/tests/inject_workspace_packages.rs
+++ b/pnpm/crates/cli/tests/inject_workspace_packages.rs
@@ -127,8 +127,10 @@ fn inject_workspace_packages_writes_file_resolutions_and_lockfile_setting() {
     // The `file:` paths are rendered relative to the *lockfile root*
     // (the workspace dir), not relative to each consumer project. So
     // `project-2`'s recorded dep on project-1 reads
-    // `project-1@file:project-1(...)` even though project-2 lives a
-    // directory away.
+    // `file:project-1(...)` even though project-2 lives a directory
+    // away. The ref is the plain `file:` form — the `<name>@<ref>`
+    // alias form is reserved for renamed deps, and here the alias
+    // equals the package name.
     let parsed: pacquet_lockfile::Lockfile = serde_saphyr::from_str(&lockfile)
         .map_err(|err| {
             format!(
@@ -159,7 +161,7 @@ fn inject_workspace_packages_writes_file_resolutions_and_lockfile_setting() {
 
     let p2_dep_on_p1 = importer_version("project-2", "project-1");
     assert!(
-        p2_dep_on_p1.starts_with("project-1@file:project-1"),
+        p2_dep_on_p1.starts_with("file:project-1"),
         "project-2 importer must record project-1 as `file:project-1(...)` (inject on), not `link:`; \
          got version={p2_dep_on_p1:?}",
     );
@@ -171,7 +173,7 @@ fn inject_workspace_packages_writes_file_resolutions_and_lockfile_setting() {
 
     let p3_dep_on_p2 = importer_version("project-3", "project-2");
     assert!(
-        p3_dep_on_p2.starts_with("project-2@file:project-2"),
+        p3_dep_on_p2.starts_with("file:project-2"),
         "project-3 importer must record project-2 as `file:project-2(...)` (inject on), not `link:`; \
          got version={p3_dep_on_p2:?}",
     );
@@ -307,7 +309,7 @@ fn dependencies_meta_injected_per_dep_overrides_global_off() {
         .unwrap_or_else(|| panic!("missing project-1 in project-2 deps:\n{lockfile}"));
     let version = spec.version.to_string();
     assert!(
-        version.starts_with("project-1@file:project-1"),
+        version.starts_with("file:project-1"),
         "per-dep `dependenciesMeta.project-1.injected = true` must produce a `file:` resolution \
          even with the global `injectWorkspacePackages` off; got version={version:?}",
     );

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -363,15 +363,15 @@ fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDe
     let parsed = dep_path_str
         .parse::<PkgNameVerPeer>()
         .expect("dep paths produced by the resolver always parse as PkgNameVerPeer");
-    // An injected workspace dep's dep path is `<name>@file:<path>(peers)`
-    // — with `real_name` unset (directory resolutions learn their name
-    // from the manifest), the peered shape misses the bare `file:` strip
-    // above and would fall through to the `<name>@<ref>` alias form.
-    // pnpm v11 reserves that form for *renamed* deps and writes the
-    // plain `file:<path>(peers)` ref when the alias equals the package
-    // name; the aliased form double-prefixes every consumer that
-    // composes `alias@version` into a snapshot key (v11 readers, Bit's
-    // graph converter).
+    // An injected workspace dep reaches this point as its full peered
+    // dep path, `<name>@file:<path>(peers)` — the bare `file:` strip
+    // above only matches peerless dep paths, and `real_name` is unset
+    // for directory resolutions (they learn their name from the
+    // manifest). pnpm v11 reserves the `<name>@<ref>` alias form for
+    // *renamed* deps and writes the plain `file:<path>(peers)` ref when
+    // the alias equals the package name; a self-aliased ref would
+    // double-prefix every consumer that composes `alias@version` into a
+    // snapshot key (v11 readers, Bit's graph converter).
     if parsed.name.to_string() == alias && matches!(parsed.suffix.version(), VersionPart::File(_)) {
         let suffix = parsed.suffix.to_string();
         let payload = suffix

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -15,7 +15,7 @@ use pacquet_lockfile::{
     CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileSettings,
     LockfileVersion, PackageKey, PackageMetadata, PeerDependencyMeta, PkgName, PkgNameVerPeer,
     PkgVerPeer, ProjectSnapshot, ResolvedCatalogEntry, ResolvedDependencyMap,
-    ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
+    ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, VersionPart,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_deps_resolver::{DepPath, DependenciesGraph, DependenciesGraphNode};
@@ -360,10 +360,26 @@ fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDe
             return ImporterDepVersion::Regular(parsed);
         }
     }
-    dep_path_str
+    let parsed = dep_path_str
         .parse::<PkgNameVerPeer>()
-        .map(ImporterDepVersion::Alias)
-        .expect("dep paths produced by the resolver always parse as PkgNameVerPeer")
+        .expect("dep paths produced by the resolver always parse as PkgNameVerPeer");
+    // An injected workspace dep's dep path is `<name>@file:<path>(peers)`
+    // — with `real_name` unset (directory resolutions learn their name
+    // from the manifest), the peered shape misses the bare `file:` strip
+    // above and would fall through to the `<name>@<ref>` alias form.
+    // pnpm v11 reserves that form for *renamed* deps and writes the
+    // plain `file:<path>(peers)` ref when the alias equals the package
+    // name; the aliased form double-prefixes every consumer that
+    // composes `alias@version` into a snapshot key (v11 readers, Bit's
+    // graph converter).
+    if parsed.name.to_string() == alias && matches!(parsed.suffix.version(), VersionPart::File(_)) {
+        let suffix = parsed.suffix.to_string();
+        let payload = suffix
+            .strip_prefix("file:")
+            .expect("a File version part always displays with the file: scheme");
+        return ImporterDepVersion::File(payload.to_string());
+    }
+    ImporterDepVersion::Alias(parsed)
 }
 
 /// `Some(real_name)` when the resolver produced a structured name; `None`

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1505,3 +1505,58 @@ fn workspace_link_direct_dep_kept_when_exclude_links_from_lockfile_true() {
         other => panic!("expected Link(..), got {other:?}"),
     }
 }
+
+/// An injected workspace dep whose alias equals its package name must
+/// serialize as the plain `file:<path>(peers)` ref, matching pnpm v11 —
+/// the `<name>@<ref>` alias form is reserved for renamed deps. The
+/// peered dep path misses the bare `file:` strip and, with `name_ver`
+/// unset (directory resolutions learn their name from the manifest),
+/// used to fall through to the self-aliased form, which double-prefixes
+/// consumers composing `alias@version` into a snapshot key.
+#[test]
+fn same_name_injected_dep_serializes_as_plain_file_ref() {
+    use pacquet_lockfile::ImporterDepVersion;
+
+    let node = DependenciesGraphNode {
+        dep_path: DepPath::from("@scope/comp1@file:comp1(react@16.0.0)".to_string()),
+        resolved_package_id: "file:comp1".to_string(),
+        resolve_result: std::sync::Arc::new(ResolveResult {
+            id: "file:comp1".into(),
+            // Directory resolutions carry no structured name.
+            name_ver: None,
+            latest: None,
+            published_at: None,
+            manifest: Some(std::sync::Arc::new(
+                serde_json::json!({ "name": "@scope/comp1", "version": "1.0.0" }),
+            )),
+            resolution: pacquet_lockfile::DirectoryResolution { directory: "comp1".to_string() }
+                .into(),
+            resolved_via: "local-filesystem".to_string(),
+            normalized_bare_specifier: None,
+            alias: Some("@scope/comp1".to_string()),
+            policy_violation: None,
+        }),
+        children: BTreeMap::new(),
+        optional_children: HashSet::new(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::new(),
+        resolved_peer_names: HashSet::new(),
+        depth: 0,
+        installable: true,
+        is_pure: false,
+        optional: false,
+    };
+
+    let version = super::importer_dep_version("@scope/comp1", &node);
+    assert_eq!(
+        version,
+        ImporterDepVersion::File("comp1(react@16.0.0)".to_string()),
+        "same-name injected deps must use the plain file: ref",
+    );
+    // A genuinely renamed alias keeps the alias form.
+    let renamed = super::importer_dep_version("renamed", &node);
+    assert!(
+        matches!(renamed, ImporterDepVersion::Alias(_)),
+        "renamed aliases must keep the <name>@<ref> form: {renamed:?}",
+    );
+}

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1508,11 +1508,9 @@ fn workspace_link_direct_dep_kept_when_exclude_links_from_lockfile_true() {
 
 /// An injected workspace dep whose alias equals its package name must
 /// serialize as the plain `file:<path>(peers)` ref, matching pnpm v11 —
-/// the `<name>@<ref>` alias form is reserved for renamed deps. The
-/// peered dep path misses the bare `file:` strip and, with `name_ver`
-/// unset (directory resolutions learn their name from the manifest),
-/// used to fall through to the self-aliased form, which double-prefixes
-/// consumers composing `alias@version` into a snapshot key.
+/// the `<name>@<ref>` alias form is reserved for renamed deps, and
+/// consumers compose `alias@version` into a snapshot key, so a
+/// self-aliased ref would double-prefix that key.
 #[test]
 fn same_name_injected_dep_serializes_as_plain_file_ref() {
     use pacquet_lockfile::ImporterDepVersion;


### PR DESCRIPTION
An injected workspace dep's dep path is `<name>@file:<path>(peers)`. With `real_name` unset (directory resolutions learn their name from the fetched manifest), the peered shape missed the bare `file:` strip in `importer_dep_version` and fell through to the `<name>@<ref>` alias form. pnpm v11 reserves that form for *renamed* deps and writes the plain `file:<path>(peers)` ref when the alias equals the package name.

The self-aliased form double-prefixes every consumer that composes `alias@version` into a snapshot key — Bit's lockfile-to-graph converter crashed on it (`Cannot read properties of undefined`), which is the remaining `BIT_FEATURES=deps-graph` e2e failure cluster on teambit/bit#10293 after `@pnpm/napi` 12.0.0-alpha.6.

- Renamed (npm-alias) deps keep the `<name>@<ref>` form; a unit test pins both shapes.
- Verified against Bit's `deps-graph` e2e with a locally built binding: the `bit tag` crash is gone and the suite proceeds. (Its later assertions then reach pacquet's missing lockfile-resolution-reuse — the pre-existing gap tracked in `plans/LOCKFILE_RESOLUTION_REUSE.md` — which is unrelated to this serialization fix.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockfile generation for injected workspace dependencies: when the dependency alias matches the package name, lockfile entries now use a plain `file:<pkg>` reference instead of an alias-prefixed form.
  * Preserved the previous alias-based lockfile behavior when the alias differs from the package name.

* **Tests**
  * Added unit test coverage for both the matching-alias and differing-alias scenarios.
  * Updated end-to-end assertions to reflect the new expected lockfile output for injected workspace dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->