### PR TITLE
fix(cli): stop pacquet bugs tests from opening the developer's browser

### DIFF
--- a/pnpm/crates/cli/src/cli_args/bugs.rs
+++ b/pnpm/crates/cli/src/cli_args/bugs.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic};
 use pacquet_config::Config;
+use pacquet_network_web_auth::OpenUrl;
 use pacquet_package_manifest::safe_read_package_json_from_dir;
 use pacquet_registry::{PackageTag, PackageVersion};
 use serde_json::Value;
@@ -38,10 +39,10 @@ pub struct BugsArgs {
 }
 
 impl BugsArgs {
-    pub async fn run(&self, config: &Config, dir: &Path) -> miette::Result<()> {
+    pub async fn run<Sys: OpenUrl>(&self, config: &Config, dir: &Path) -> miette::Result<()> {
         if self.packages.is_empty() {
             let url = get_bugs_url_from_current_project(dir)?;
-            open_url(&url);
+            open_url::<Sys>(&url);
         } else {
             let http_client = build_registry_client(config)
                 .wrap_err("build the network client for registry requests")?;
@@ -75,7 +76,7 @@ impl BugsArgs {
                 futures_util::future::join_all(futures).await;
             for res in results {
                 let url = res?;
-                open_url(&url);
+                open_url::<Sys>(&url);
             }
         }
         Ok(())
@@ -299,12 +300,12 @@ fn normalize_registry_url(url: &str) -> String {
     if url.ends_with('/') { url.to_owned() } else { format!("{url}/") }
 }
 
-fn open_url(url: &str) {
+fn open_url<Sys: OpenUrl>(url: &str) {
     let sanitized = crate::cli_args::sanitize::sanitize(url);
     let redacted = pacquet_network::redact_url_credentials(&sanitized);
     println!("{redacted}");
 
-    // Clear username/password before passing to open_url_in_browser:
+    // Clear username/password before passing to the browser:
     let clean_url_for_browser = if let Ok(mut parsed) = Url::parse(url) {
         if !parsed.username().is_empty() || parsed.password().is_some() {
             let _ = parsed.set_username("");
@@ -319,62 +320,9 @@ fn open_url(url: &str) {
 
     let clean_url_for_browser = crate::cli_args::sanitize::sanitize(&clean_url_for_browser);
 
-    let result = open_url_in_browser(&clean_url_for_browser);
-    if let Err(err) = result {
+    if let Err(err) = Sys::open_url(&clean_url_for_browser) {
         tracing::debug!(target: "pacquet_cli", %err, "could not open browser");
     }
-}
-
-#[cfg(target_os = "linux")]
-fn open_url_in_browser(url: &str) -> std::io::Result<()> {
-    std::process::Command::new("xdg-open")
-        .arg(url)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()?;
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn open_url_in_browser(url: &str) -> std::io::Result<()> {
-    std::process::Command::new("open")
-        .arg(url)
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()?;
-    Ok(())
-}
-
-#[cfg(target_os = "windows")]
-fn open_url_in_browser(url: &str) -> std::io::Result<()> {
-    use std::ffi::OsStr;
-    use std::os::windows::ffi::OsStrExt;
-
-    let url_wide: Vec<u16> = OsStr::new(url).encode_wide().chain(std::iter::once(0)).collect();
-
-    // ShellExecuteW invokes the default handler for the URL protocol
-    // without shell metacharacter injection. The function takes a
-    // fully-qualified path (or registered protocol) so it does not
-    // depend on the executable search path or the SystemRoot env var,
-    // avoiding the hijack vector that rundll32.exe is subject to.
-    let result = unsafe {
-        windows_sys::Win32::UI::Shell::ShellExecuteW(
-            std::ptr::null_mut(), // hwnd
-            std::ptr::null(),     // lpOperation (null => "open")
-            url_wide.as_ptr(),    // lpFile
-            std::ptr::null(),     // lpParameters
-            std::ptr::null(),     // lpDirectory
-            windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL,
-        )
-    };
-    if (result as isize) > 32 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-fn open_url_in_browser(_url: &str) -> std::io::Result<()> {
-    Ok(())
 }
 
 fn parse_package_spec(spec: &str) -> (&str, Option<&str>) {

--- a/pnpm/crates/cli/src/cli_args/bugs/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/bugs/tests.rs
@@ -316,8 +316,10 @@ impl OpenUrl for RecordingBrowser {
     }
 }
 
+/// Drain the recorded URLs so state cannot leak between tests that
+/// libtest runs on the same thread (e.g. `--test-threads=1`).
 fn opened_urls() -> Vec<String> {
-    OPENED_URLS.with(|urls| urls.borrow().clone())
+    OPENED_URLS.with(RefCell::take)
 }
 
 async fn run_bugs_in_project(manifest: &str) -> miette::Result<()> {

--- a/pnpm/crates/cli/src/cli_args/bugs/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/bugs/tests.rs
@@ -329,9 +329,11 @@ async fn run_bugs_in_project(manifest: &str) -> miette::Result<()> {
 
 #[tokio::test]
 async fn run_opens_bugs_url_from_local_manifest_bugs_object() {
-    run_bugs_in_project(r#"{"name":"test-pkg","bugs":{"url":"https://github.com/test/pkg/issues"}}"#)
-        .await
-        .expect("bugs must succeed");
+    run_bugs_in_project(
+        r#"{"name":"test-pkg","bugs":{"url":"https://github.com/test/pkg/issues"}}"#,
+    )
+    .await
+    .expect("bugs must succeed");
     assert_eq!(opened_urls(), ["https://github.com/test/pkg/issues"]);
 }
 
@@ -370,15 +372,14 @@ fn version_response(name: &str, extra_fields: serde_json::Value) -> String {
         },
     });
     let fields = version.as_object_mut().expect("version response is an object");
-    let extra = extra_fields.as_object().expect("extra fields are an object");
-    fields.extend(extra.clone());
+    let serde_json::Value::Object(extra) = extra_fields else {
+        panic!("extra fields must be an object");
+    };
+    fields.extend(extra);
     version.to_string()
 }
 
-async fn run_bugs_against_registry(
-    registry: String,
-    package: &str,
-) -> miette::Result<()> {
+async fn run_bugs_against_registry(registry: String, package: &str) -> miette::Result<()> {
     let config = Config { registry, ..Config::default() };
     let args = BugsArgs { registry: None, packages: vec![package.to_owned()] };
     args.run::<RecordingBrowser>(&config, Path::new(".")).await

--- a/pnpm/crates/cli/src/cli_args/bugs/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/bugs/tests.rs
@@ -1,7 +1,11 @@
+use std::{cell::RefCell, fs, io, path::Path};
+
+use pacquet_config::Config;
+use pacquet_network_web_auth::OpenUrl;
 use serde_json::json;
 
 use super::{
-    is_http_url, parse_package_spec, pick_bugs_url, repository_to_issues_url,
+    BugsArgs, is_http_url, parse_package_spec, pick_bugs_url, repository_to_issues_url,
     try_hosted_git_shorthand,
 };
 
@@ -294,4 +298,148 @@ fn repo_url_strips_scp_fragment_and_query() {
         repository_to_issues_url("git@github.com:owner/repo.git#main"),
         Some("https://github.com/owner/repo/issues".to_string()),
     );
+}
+
+thread_local! {
+    static OPENED_URLS: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+}
+
+/// [`OpenUrl`] fake standing in for the user's browser; mirrors the mocked
+/// `open` module in the TypeScript tests
+/// (`pnpm11/deps/inspection/commands/test/bugs.ts`).
+struct RecordingBrowser;
+
+impl OpenUrl for RecordingBrowser {
+    fn open_url(url: &str) -> io::Result<()> {
+        OPENED_URLS.with(|urls| urls.borrow_mut().push(url.to_owned()));
+        Ok(())
+    }
+}
+
+fn opened_urls() -> Vec<String> {
+    OPENED_URLS.with(|urls| urls.borrow().clone())
+}
+
+async fn run_bugs_in_project(manifest: &str) -> miette::Result<()> {
+    let dir = tempfile::tempdir().expect("create temp project dir");
+    fs::write(dir.path().join("package.json"), manifest).expect("write package.json");
+    let args = BugsArgs { registry: None, packages: Vec::new() };
+    args.run::<RecordingBrowser>(&Config::default(), dir.path()).await
+}
+
+#[tokio::test]
+async fn run_opens_bugs_url_from_local_manifest_bugs_object() {
+    run_bugs_in_project(r#"{"name":"test-pkg","bugs":{"url":"https://github.com/test/pkg/issues"}}"#)
+        .await
+        .expect("bugs must succeed");
+    assert_eq!(opened_urls(), ["https://github.com/test/pkg/issues"]);
+}
+
+#[tokio::test]
+async fn run_opens_bugs_url_from_local_manifest_bugs_string() {
+    run_bugs_in_project(r#"{"name":"test-pkg","bugs":"https://github.com/test/pkg/issues"}"#)
+        .await
+        .expect("bugs must succeed");
+    assert_eq!(opened_urls(), ["https://github.com/test/pkg/issues"]);
+}
+
+#[tokio::test]
+async fn run_opens_repository_issues_url_when_bugs_is_missing() {
+    run_bugs_in_project(r#"{"name":"test-pkg","repository":"https://github.com/test/pkg"}"#)
+        .await
+        .expect("bugs must succeed");
+    assert_eq!(opened_urls(), ["https://github.com/test/pkg/issues"]);
+}
+
+#[tokio::test]
+async fn run_normalizes_git_plus_https_repository_url_with_dot_git() {
+    run_bugs_in_project(
+        r#"{"name":"test-pkg","repository":{"url":"git+https://github.com/test/pkg.git"}}"#,
+    )
+    .await
+    .expect("bugs must succeed");
+    assert_eq!(opened_urls(), ["https://github.com/test/pkg/issues"]);
+}
+
+fn version_response(name: &str, extra_fields: serde_json::Value) -> String {
+    let mut version = json!({
+        "name": name,
+        "version": "1.0.0",
+        "dist": {
+            "tarball": "https://example.com/pkg.tgz",
+        },
+    });
+    let fields = version.as_object_mut().expect("version response is an object");
+    let extra = extra_fields.as_object().expect("extra fields are an object");
+    fields.extend(extra.clone());
+    version.to_string()
+}
+
+async fn run_bugs_against_registry(
+    registry: String,
+    package: &str,
+) -> miette::Result<()> {
+    let config = Config { registry, ..Config::default() };
+    let args = BugsArgs { registry: None, packages: vec![package.to_owned()] };
+    args.run::<RecordingBrowser>(&config, Path::new(".")).await
+}
+
+#[tokio::test]
+async fn run_opens_bugs_url_of_registry_package() {
+    let mut server = mockito::Server::new_async().await;
+    let body = version_response(
+        "is-negative",
+        json!({ "bugs": { "url": "https://github.com/kevva/is-negative/issues" } }),
+    );
+    let mock = server
+        .mock("GET", "/is-negative/latest")
+        .with_status(200)
+        .with_body(&body)
+        .create_async()
+        .await;
+
+    run_bugs_against_registry(server.url(), "is-negative").await.expect("bugs must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(opened_urls(), ["https://github.com/kevva/is-negative/issues"]);
+}
+
+#[tokio::test]
+async fn run_opens_repository_issues_url_of_registry_package() {
+    let mut server = mockito::Server::new_async().await;
+    let body = version_response(
+        "test-pkg",
+        json!({ "repository": { "url": "git+https://github.com/test/pkg.git" } }),
+    );
+    let mock = server
+        .mock("GET", "/test-pkg/latest")
+        .with_status(200)
+        .with_body(&body)
+        .create_async()
+        .await;
+
+    run_bugs_against_registry(server.url(), "test-pkg").await.expect("bugs must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(opened_urls(), ["https://github.com/test/pkg/issues"]);
+}
+
+#[tokio::test]
+async fn run_encodes_scoped_package_name_in_registry_request() {
+    let mut server = mockito::Server::new_async().await;
+    let body = version_response(
+        "@scope/pkg",
+        json!({ "bugs": { "url": "https://github.com/scope/pkg/issues" } }),
+    );
+    let mock = server
+        .mock("GET", "/@scope%2Fpkg/latest")
+        .with_status(200)
+        .with_body(&body)
+        .create_async()
+        .await;
+
+    run_bugs_against_registry(server.url(), "@scope/pkg").await.expect("bugs must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(opened_urls(), ["https://github.com/scope/pkg/issues"]);
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -467,7 +467,7 @@ pub(super) fn ignored_builds<'a>(
 pub(super) fn bugs<'a>(ctx: &RunCtx<'a>, args: BugsArgs) -> miette::Result<CommandFuture<'a>> {
     let cfg: &Config = (ctx.config)()?;
     let dir = ctx.dir;
-    Ok(Box::pin(async move { args.run(cfg, dir).await }))
+    Ok(Box::pin(async move { args.run::<pacquet_network_web_auth::Host>(cfg, dir).await }))
 }
 
 pub(super) fn find_hash<'a>(

--- a/pnpm/crates/cli/tests/bugs.rs
+++ b/pnpm/crates/cli/tests/bugs.rs
@@ -1,3 +1,12 @@
+//! `pacquet bugs` / `pacquet issues` — open the bug tracker URL of a package
+//! in the browser.
+//!
+//! Covers the error paths that never reach the browser: no `package.json`,
+//! no derivable bugs URL, and a registry package without one. The
+//! URL-opening happy paths are covered by the unit tests in
+//! `src/cli_args/bugs/tests.rs` through the `OpenUrl` seam — running them
+//! against the real binary would launch the developer's browser.
+
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;
@@ -24,112 +33,6 @@ fn run_bugs(workspace: &Path, auth_file: &Path, args: &[&str]) -> std::process::
         command = command.with_arg(arg);
     }
     command.output().expect("spawn pacquet bugs")
-}
-
-fn version_response(name: &str, extra_fields: &serde_json::Value) -> String {
-    let mut version = serde_json::json!({
-        "name": name,
-        "version": "1.0.0",
-        "dist": {
-            "tarball": "https://example.com/pkg.tgz",
-        },
-    });
-    if let Some(obj) = version.as_object_mut()
-        && let Some(extra) = extra_fields.as_object()
-    {
-        for (k, v) in extra {
-            obj.insert(k.clone(), v.clone());
-        }
-    }
-    version.to_string()
-}
-
-#[test]
-fn prints_bugs_url_from_local_manifest_bugs_object() {
-    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let auth_file = empty_auth_file(root.path());
-    fs::write(
-        workspace.join("package.json"),
-        r#"{"name":"test-pkg","bugs":{"url":"https://github.com/test/pkg/issues"}}"#,
-    )
-    .expect("write package.json");
-
-    let output = run_bugs(&workspace, &auth_file, &[]);
-
-    assert!(
-        output.status.success(),
-        "bugs must succeed (stderr: {})",
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout.trim(), "https://github.com/test/pkg/issues");
-    drop(root);
-}
-
-#[test]
-fn prints_bugs_url_from_local_manifest_bugs_string() {
-    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let auth_file = empty_auth_file(root.path());
-    fs::write(
-        workspace.join("package.json"),
-        r#"{"name":"test-pkg","bugs":"https://github.com/test/pkg/issues"}"#,
-    )
-    .expect("write package.json");
-
-    let output = run_bugs(&workspace, &auth_file, &[]);
-
-    assert!(
-        output.status.success(),
-        "bugs must succeed (stderr: {})",
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout.trim(), "https://github.com/test/pkg/issues");
-    drop(root);
-}
-
-#[test]
-fn prints_repository_issues_url_when_bugs_is_missing() {
-    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let auth_file = empty_auth_file(root.path());
-    fs::write(
-        workspace.join("package.json"),
-        r#"{"name":"test-pkg","repository":"https://github.com/test/pkg"}"#,
-    )
-    .expect("write package.json");
-
-    let output = run_bugs(&workspace, &auth_file, &[]);
-
-    assert!(
-        output.status.success(),
-        "bugs must succeed (stderr: {})",
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout.trim(), "https://github.com/test/pkg/issues");
-    drop(root);
-}
-
-#[test]
-fn normalizes_git_plus_https_repository_url_with_dot_git() {
-    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let auth_file = empty_auth_file(root.path());
-    fs::write(
-        workspace.join("package.json"),
-        r#"{"name":"test-pkg","repository":{"url":"git+https://github.com/test/pkg.git"}}"#,
-    )
-    .expect("write package.json");
-
-    let output = run_bugs(&workspace, &auth_file, &[]);
-
-    assert!(
-        output.status.success(),
-        "bugs must succeed (stderr: {})",
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout.trim(), "https://github.com/test/pkg/issues");
-    drop(root);
 }
 
 #[test]
@@ -175,74 +78,19 @@ fn fails_when_no_package_json_exists() {
 }
 
 #[test]
-fn looks_up_package_on_registry_by_name() {
-    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-
-    let body = version_response(
-        "is-negative",
-        &serde_json::json!({
-            "bugs": { "url": "https://github.com/kevva/is-negative/issues" },
-        }),
-    );
-    let mock = server.mock("GET", "/is-negative/latest").with_status(200).with_body(&body).create();
-
-    fs::write(workspace.join(".npmrc"), format!("registry={registry}\n"))
-        .expect("write project .npmrc");
-    let auth_file = empty_auth_file(root.path());
-
-    let output = run_bugs(&workspace, &auth_file, &["is-negative"]);
-
-    mock.assert();
-    assert!(
-        output.status.success(),
-        "bugs must succeed (stderr: {})",
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout.trim(), "https://github.com/kevva/is-negative/issues");
-    drop((root, server));
-}
-
-#[test]
-fn prints_repository_issues_url_from_registry_package() {
-    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-
-    let body = version_response(
-        "test-pkg",
-        &serde_json::json!({
-            "repository": { "url": "git+https://github.com/test/pkg.git" },
-        }),
-    );
-    let mock = server.mock("GET", "/test-pkg/latest").with_status(200).with_body(&body).create();
-
-    fs::write(workspace.join(".npmrc"), format!("registry={registry}\n"))
-        .expect("write project .npmrc");
-    let auth_file = empty_auth_file(root.path());
-
-    let output = run_bugs(&workspace, &auth_file, &["test-pkg"]);
-
-    mock.assert();
-    assert!(
-        output.status.success(),
-        "bugs must succeed (stderr: {})",
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout.trim(), "https://github.com/test/pkg/issues");
-    drop((root, server));
-}
-
-#[test]
 fn fails_when_registry_package_has_no_bugs_url() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     let mut server = mockito::Server::new();
     let registry = format!("{}/", server.url());
 
-    let body = version_response("no-bugs-pkg", &serde_json::json!({}));
+    let body = serde_json::json!({
+        "name": "no-bugs-pkg",
+        "version": "1.0.0",
+        "dist": {
+            "tarball": "https://example.com/pkg.tgz",
+        },
+    })
+    .to_string();
     let mock = server.mock("GET", "/no-bugs-pkg/latest").with_status(200).with_body(&body).create();
 
     fs::write(workspace.join(".npmrc"), format!("registry={registry}\n"))
@@ -262,37 +110,5 @@ fn fails_when_registry_package_has_no_bugs_url() {
         stderr.contains("ERR_PNPM_NO_BUGS_URL"),
         "stderr must contain ERR_PNPM_NO_BUGS_URL; got:\n{stderr}",
     );
-    drop((root, server));
-}
-
-#[test]
-fn encodes_scoped_package_name_in_registry_request() {
-    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let mut server = mockito::Server::new();
-    let registry = format!("{}/", server.url());
-
-    let body = version_response(
-        "@scope/pkg",
-        &serde_json::json!({
-            "bugs": { "url": "https://github.com/scope/pkg/issues" },
-        }),
-    );
-    let mock =
-        server.mock("GET", "/@scope%2Fpkg/latest").with_status(200).with_body(&body).create();
-
-    fs::write(workspace.join(".npmrc"), format!("registry={registry}\n"))
-        .expect("write project .npmrc");
-    let auth_file = empty_auth_file(root.path());
-
-    let output = run_bugs(&workspace, &auth_file, &["@scope/pkg"]);
-
-    mock.assert();
-    assert!(
-        output.status.success(),
-        "bugs must succeed for a scoped package (stderr: {})",
-        String::from_utf8_lossy(&output.stderr),
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(stdout.trim(), "https://github.com/scope/pkg/issues");
     drop((root, server));
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Running the pacquet test suite opened `https://github.com/test/pkg/issues` (and two other URLs) in the developer's browser — up to five tabs per run. The `pacquet bugs` happy-path integration tests spawned the real binary, whose `open_url` launched `xdg-open` unconditionally, with failures downgraded to a debug log so the tests stayed green while the browser filled up.

This PR routes the browser launch through the existing `OpenUrl` dependency-injection seam and moves the happy-path coverage to unit tests that record the opened URL instead of launching a browser:

- `BugsArgs::run` and `open_url` are now generic over `Sys: OpenUrl`, reusing the capability trait and `Host` provider from `pacquet-network-web-auth` (promoted from dev-dependency to dependency; it was already in the production build graph via `pacquet-auth-commands`). The dispatch site turbofishes `Host`.
- The hand-rolled per-OS launcher in `bugs.rs` (`xdg-open` / `open` / `ShellExecuteW`, including the `unsafe` Windows block) is deleted; production now launches via `open::that_detached`, the same path the web-auth login flow already uses.
- The seven browser-opening happy-path tests moved from `pnpm/crates/cli/tests/bugs.rs` into `bugs/tests.rs` unit tests driving `run` through a thread-local `RecordingBrowser` fake — mirroring the mocked `open` module in the TypeScript tests (`pnpm11/deps/inspection/commands/test/bugs.ts`), so the two stacks keep matching scenario coverage. The integration file keeps only the error paths, which never reach the browser, matching the convention `docs.rs` and `repo.rs` already follow.

Verification:

- A canary `xdg-open` shim on `PATH` recorded zero invocations across the whole bugs test set (previously five per run), while the same shim confirmed the real binary still opens the URL and prints it.
- A mutation test (passing a wrong URL to `Sys::open_url`) made all seven new unit tests fail, so they catch regressions.
- `cargo nextest` for the bugs tests, clippy with `--deny warnings`, `cargo fmt`, taplo, typos, and rustdoc are all clean.

No TypeScript changes: there is no user-visible behavior change, and the TS tests already mock `open`. No changeset: Rust-only change. Follow-up candidate (not in this PR, to keep it focused): `docs.rs` and `repo.rs` still carry their own duplicated per-OS launcher code and could migrate to the same seam.

Note for reviewers: the full `pacquet-cli` suite currently has one unrelated failure on `main` (`run_recursive::test_pattern_from_workspace_yaml_is_respected_by_the_test_script`), a semantic conflict between pnpm/pnpm#12914 and pnpm/pnpm#12910 that pacquet CI never ran on combined (the subsequent pushes to `main` were path-filtered). It fails identically without this PR and will be addressed separately.

## Squash Commit Body

```text
The bugs happy-path integration tests spawned the real binary, whose
open_url launched xdg-open unconditionally, so every test run opened
https://github.com/test/pkg/issues (and friends) in the developer's
browser. Failures were downgraded to a debug log, so the tests stayed
green while doing it.

Thread the existing pacquet_network_web_auth::OpenUrl capability
through BugsArgs::run, replacing the hand-rolled per-OS launcher
(xdg-open / open / ShellExecuteW, including the unsafe Windows block)
with the shared Host provider, which launches via open::that_detached —
the same path the web-auth login flow already uses in production.
pacquet-network-web-auth moves from dev-dependency to dependency of
pacquet-cli; it was already in the production build graph via
pacquet-auth-commands.

Port the happy-path coverage to unit tests driving run through a
recording OpenUrl fake — mirroring the mocked open module in the
TypeScript tests — and keep only the error paths, which never reach
the browser, as binary-level integration tests. This matches the
convention the docs and repo test files already follow, which
deliberately deferred their browser-opening paths.

Verified with a canary xdg-open shim on PATH: zero launches across the
test suite, while the real binary still opens the URL; a mutation test
(wrong URL passed to Sys::open_url) fails all seven new unit tests.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the `bugs`/`issues` commands to open the correct URL consistently across environments.
  * Improved fallback behavior to derive issue links from available package/repository data.

* **Bug Fixes**
  * More reliable bugs URL detection from `bugs` and `repository` metadata, including registry responses.
  * Better handling of `git+https://.../.git` URLs and scoped package names.

* **Tests**
  * Expanded async test coverage for URL resolution, registry request behavior (including encoding), and controlled browser-opening verification.
  * Clarified that these tests focus on error-path scenarios that do not open a browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->