### PR TITLE
fix(resolver): break peer dep-path await cycles that span resolution passes

### DIFF
--- a/.changeset/peer-await-cycle-deadlock.md
+++ b/.changeset/peer-await-cycle-deadlock.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed a deadlock in peer dependency resolution: `pnpm install` hung forever when a peer dependency cycle spanned a project's own dependencies and auto-installed peer providers, for example when installing `electron-builder@26.15.3` [#12921](https://github.com/pnpm/pnpm/issues/12921).

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1401,6 +1401,145 @@ fn pruned_hoisted_providers_with_mutual_peers_resolve() {
     );
 }
 
+/// Mirror of the TS test "an own direct dependency and a pruned hoisted peer
+/// provider that peer-depend on each other are resolved together"
+/// (`deps-resolver/test/resolvePeers.ts`) — the shape behind
+/// <https://github.com/pnpm/pnpm/issues/12921>, where the peer cycle spans an
+/// own direct dependency and a pruned provider. Both sides of the cycle must
+/// collapse to `name@version` suffixes.
+#[test]
+fn own_direct_dep_and_pruned_provider_with_mutual_peers_resolve() {
+    let plugin = NodeId::leaf("plugin@1.0.0");
+    let main = NodeId::next();
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "main".to_string(),
+                node_id: main.clone(),
+                id: "main@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "plugin".to_string(),
+                node_id: plugin.clone(),
+                id: "plugin@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("main@1.0.0".to_string(), package("main", "1.0.0", &[("plugin", "^1.0.0")], false)),
+            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("main", "^1.0.0")], true)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (main, tree_node("main@1.0.0", BTreeMap::new(), 0)),
+            (plugin.clone(), tree_node("plugin@1.0.0", BTreeMap::new(), 1)),
+        ]),
+        all_peer_dep_names: HashSet::from(["main".to_string(), "plugin".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(
+        &mut tree,
+        ResolvePeersOptions {
+            hoisted_peer_provider_node_ids: HashSet::from([plugin]),
+            ..ResolvePeersOptions::default()
+        },
+    );
+
+    assert_eq!(
+        result.direct_dependencies_by_alias.get("main"),
+        Some(&DepPath::from("main@1.0.0(plugin@1.0.0)")),
+        "graph keys: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert_eq!(
+        result.direct_dependencies_by_alias.get("plugin"),
+        Some(&DepPath::from("plugin@1.0.0(main@1.0.0)")),
+        "graph keys: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+}
+
+/// Mirror of the TS test "a peer cycle between an own direct dependency and a
+/// hoisted peer provider resolved at its tree position does not deadlock":
+/// the provider is walked at its true position inside host's subtree, so the
+/// peer cycle spans two traversal levels instead of two root-level passes.
+#[test]
+fn peer_cycle_between_own_dep_and_provider_at_tree_position_resolves() {
+    let host = NodeId::next();
+    let main = NodeId::next();
+    let plugin = NodeId::next();
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "host".to_string(),
+                node_id: host.clone(),
+                id: "host@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "main".to_string(),
+                node_id: main.clone(),
+                id: "main@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "plugin".to_string(),
+                node_id: plugin.clone(),
+                id: "plugin@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("host@1.0.0".to_string(), package("host", "1.0.0", &[], false)),
+            ("main@1.0.0".to_string(), package("main", "1.0.0", &[("plugin", "^1.0.0")], false)),
+            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("main", "^1.0.0")], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (
+                host,
+                tree_node(
+                    "host@1.0.0",
+                    BTreeMap::from([("plugin".to_string(), plugin.clone())]),
+                    0,
+                ),
+            ),
+            (main, tree_node("main@1.0.0", BTreeMap::new(), 0)),
+            (plugin.clone(), tree_node("plugin@1.0.0", BTreeMap::new(), 1)),
+        ]),
+        all_peer_dep_names: HashSet::from(["main".to_string(), "plugin".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(
+        &mut tree,
+        ResolvePeersOptions {
+            hoisted_peer_provider_node_ids: HashSet::from([plugin]),
+            ..ResolvePeersOptions::default()
+        },
+    );
+
+    assert_eq!(
+        result.direct_dependencies_by_alias.get("host"),
+        Some(&DepPath::from("host@1.0.0(main@1.0.0)")),
+        "graph keys: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert_eq!(
+        result.direct_dependencies_by_alias.get("main"),
+        Some(&DepPath::from("main@1.0.0(plugin@1.0.0)")),
+        "graph keys: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+    assert_eq!(
+        result.direct_dependencies_by_alias.get("plugin"),
+        Some(&DepPath::from("plugin@1.0.0(main@1.0.0)")),
+        "graph keys: {:#?}",
+        result.graph.keys().collect::<Vec<_>>(),
+    );
+}
+
 fn tree_node(pkg_id: &str, children: BTreeMap<String, NodeId>, depth: i32) -> DependenciesTreeNode {
     DependenciesTreeNode {
         resolved_package_id: pkg_id.to_string(),

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -109,6 +109,9 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
   const depGraph: GenericDependenciesGraph<T> = {}
   const pathsByNodeId = new Map<NodeId, DepPath>()
   const pathsByNodeIdPromises = new Map<NodeId, DeferredPromise<DepPath>>()
+  const awaitedPeerNodeIdsByNodeId = new Map<NodeId, Set<NodeId>>()
+  const peersCacheOwnerByNodeId = new Map<NodeId, NodeId>()
+  const cycleBrokenNodeIds = new Set<NodeId>()
   const depPathsByPkgId = new Map<PkgIdWithPatchHash, Set<DepPath>>()
   const nodeIdsByPreviousDepPath = opts.resolvedPeerProviderPaths == null
     ? new Map<DepPath, NodeId>()
@@ -173,6 +176,9 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       parentDepPathsChain: [],
       pathsByNodeId,
       pathsByNodeIdPromises,
+      awaitedPeerNodeIdsByNodeId,
+      peersCacheOwnerByNodeId,
+      cycleBrokenNodeIds,
       depPathsByPkgId,
       nodeIdsByPreviousDepPath,
       resolvedPeerProviderPaths: opts.resolvedPeerProviderPaths,
@@ -199,6 +205,9 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     // its cycle analysis only sees the children of one call, and providers
     // frequently peer-depend on each other, so resolving them one by one
     // would leave their dep path calculations awaiting each other forever.
+    // A peer cycle that spans this call and the traversal above is still
+    // invisible here; breakDepPathAwaitCycles resolves those before the
+    // finishing promises are awaited.
     const prunedProviderChildren: Record<string, NodeId> = {}
     for (const [alias, nodeId] of Object.entries(hoistedProviderChildren)) {
       if (parentPkgsOfNode.has(nodeId)) continue
@@ -218,6 +227,14 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       }
     }
   }
+  breakDepPathAwaitCycles({
+    awaitedPeerNodeIdsByNodeId,
+    peersCacheOwnerByNodeId,
+    cycleBrokenNodeIds,
+    pathsByNodeId,
+    pathsByNodeIdPromises,
+    dependenciesTree: opts.dependenciesTree,
+  })
   await Promise.all(finishingList)
 
   const depGraphWithResolvedChildren = resolveChildren(depGraph)
@@ -265,6 +282,70 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     dependenciesByProjectId,
     peerDependencyIssuesByProjects,
     pathsByNodeId,
+  }
+}
+
+// Cycle analysis inside resolvePeersOfChildren only sees the children of a
+// single call, but a dep path calculation may await a node resolved in a
+// different call or at a different tree level (a hoisted peer provider and
+// a consumer that peer-depend on each other, https://github.com/pnpm/pnpm/issues/12921).
+// Such an await cycle never settles on its own, so before the finishing
+// promises are awaited, walk the recorded await edges and resolve every
+// dep path promise on a cycle to the peer's `name@version` — the same
+// collapse in-call cycle detection applies (see calculateDepPath).
+// A node that hit the peers cache awaits its dep path from the node that
+// created the cache entry, so it borrows that owner's await edges.
+function breakDepPathAwaitCycles<T extends PartialResolvedPackage> (
+  opts: {
+    awaitedPeerNodeIdsByNodeId: Map<NodeId, Set<NodeId>>
+    peersCacheOwnerByNodeId: Map<NodeId, NodeId>
+    cycleBrokenNodeIds: Set<NodeId>
+    pathsByNodeId: Map<NodeId, DepPath>
+    pathsByNodeIdPromises: Map<NodeId, DeferredPromise<DepPath>>
+    dependenciesTree: DependenciesTree<T>
+  }
+): void {
+  const isSettled = (nodeId: NodeId): boolean =>
+    opts.pathsByNodeId.has(nodeId) || opts.cycleBrokenNodeIds.has(nodeId)
+  const keysByNodeId = new Map<NodeId, string>()
+  const nodeIdsByKey = new Map<string, NodeId>()
+  function keyOf (nodeId: NodeId): string {
+    let key = keysByNodeId.get(nodeId)
+    if (key == null) {
+      key = String(keysByNodeId.size)
+      keysByNodeId.set(nodeId, key)
+      nodeIdsByKey.set(key, nodeId)
+    }
+    return key
+  }
+  const graphEntries: Array<[string, string[]]> = []
+  const awaitingNodeIds = new Set([
+    ...opts.awaitedPeerNodeIdsByNodeId.keys(),
+    ...opts.peersCacheOwnerByNodeId.keys(),
+  ])
+  for (const nodeId of awaitingNodeIds) {
+    if (isSettled(nodeId)) continue
+    const cacheOwnerNodeId = opts.peersCacheOwnerByNodeId.get(nodeId)
+    const awaitedNodeIds = opts.awaitedPeerNodeIdsByNodeId.get(nodeId) ??
+      (cacheOwnerNodeId == null ? undefined : opts.awaitedPeerNodeIdsByNodeId.get(cacheOwnerNodeId))
+    if (awaitedNodeIds == null) continue
+    const liveTargets: string[] = []
+    for (const awaitedNodeId of awaitedNodeIds) {
+      if (!isSettled(awaitedNodeId)) {
+        liveTargets.push(keyOf(awaitedNodeId))
+      }
+    }
+    if (liveTargets.length > 0) {
+      graphEntries.push([keyOf(nodeId), liveTargets])
+    }
+  }
+  if (graphEntries.length === 0) return
+  const { cycles } = analyzeGraph(graphEntries as unknown as Graph) as unknown as { cycles: string[][] }
+  for (const key of new Set(cycles.flat())) {
+    const nodeId = nodeIdsByKey.get(key)!
+    const { name, version } = opts.dependenciesTree.get(nodeId)!.resolvedPackage
+    opts.cycleBrokenNodeIds.add(nodeId)
+    opts.pathsByNodeIdPromises.get(nodeId)?.resolve(`${name}@${version}` as DepPath)
   }
 }
 
@@ -413,6 +494,9 @@ interface PeersCacheItem {
   depPath: DeferredPromise<DepPath>
   resolvedPeers: Map<string, NodeId>
   missingPeers: MissingPeers
+  // The node whose resolution created this entry and will resolve depPath.
+  // See breakDepPathAwaitCycles.
+  ownerNodeId: NodeId
 }
 
 type PeersCache = Map<PkgIdWithPatchHash, PeersCacheItem[]>
@@ -425,6 +509,13 @@ interface PeersResolution {
 interface ResolvePeersContext {
   pathsByNodeId: Map<NodeId, DepPath>
   pathsByNodeIdPromises: Map<NodeId, DeferredPromise<DepPath>>
+  // The await edges between dep path calculations, consumed by
+  // breakDepPathAwaitCycles: which pathsByNodeIdPromises entries each node's
+  // calculateDepPath awaits, which node each peers-cache hit awaits, and
+  // which promises were already resolved to `name@version` by cycle breaking.
+  awaitedPeerNodeIdsByNodeId: Map<NodeId, Set<NodeId>>
+  peersCacheOwnerByNodeId: Map<NodeId, NodeId>
+  cycleBrokenNodeIds: Set<NodeId>
   depPathsByPkgId?: Map<PkgIdWithPatchHash, Set<DepPath>>
   nodeIdsByPreviousDepPath: Map<DepPath, NodeId>
   resolvedPeerProviderPaths?: Map<NodeId, DepPath>
@@ -580,6 +671,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
         wantedRange,
       })
     }
+    ctx.peersCacheOwnerByNodeId.set(nodeId, hit.ownerNodeId)
     return {
       missingPeers: hit.missingPeers,
       finishing: (async () => {
@@ -649,6 +741,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       missingPeers: allMissingPeers,
       depPath: pDefer(),
       resolvedPeers: allResolvedPeers,
+      ownerNodeId: nodeId,
     }
     if (ctx.peersCache.has(resolvedPackage.pkgIdWithPatchHash)) {
       ctx.peersCache.get(resolvedPackage.pkgIdWithPatchHash)!.push(cache)
@@ -713,6 +806,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
           if (cyclicPeerAliases.has(pendingPeer.alias)) {
             const { name, version } = ctx.dependenciesTree.get(pendingPeer.nodeId)?.resolvedPackage as T
             const id = `${name}@${version}`
+            ctx.cycleBrokenNodeIds.add(pendingPeer.nodeId)
             ctx.pathsByNodeIdPromises.get(pendingPeer.nodeId)?.resolve(id as DepPath)
             return id
           }
@@ -722,6 +816,12 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
               return { name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version }
             }
           }
+          let awaitedPeerNodeIds = ctx.awaitedPeerNodeIdsByNodeId.get(nodeId)
+          if (awaitedPeerNodeIds == null) {
+            awaitedPeerNodeIds = new Set()
+            ctx.awaitedPeerNodeIdsByNodeId.set(nodeId, awaitedPeerNodeIds)
+          }
+          awaitedPeerNodeIds.add(pendingPeer.nodeId)
           return ctx.pathsByNodeIdPromises.get(pendingPeer.nodeId)!.promise
         })
       ),

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -1861,3 +1861,150 @@ test('a pruned hoisted peer provider is resolved by the root-context fallback', 
   expect(dependenciesByProjectId['.'].get('prov')).toBe('prov@1.0.0')
   expect(Object.keys(dependenciesGraph)).toContain('consumer@1.0.0(prov@1.0.0)')
 })
+
+test('an own direct dependency and a pruned hoisted peer provider that peer-depend on each other are resolved together', async () => {
+  // Regression test for https://github.com/pnpm/pnpm/issues/12921: the peer
+  // cycle spans two resolvePeersOfChildren calls (the own direct children and
+  // the pruned-provider fallback), so neither call's cycle analysis sees it —
+  // the dep path calculations awaited each other forever.
+  const mainPkg = {
+    name: 'main',
+    pkgIdWithPatchHash: 'main@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {
+      plugin: { version: '^1.0.0' },
+    },
+    id: '' as PkgResolutionId,
+  }
+  const pluginPkg = {
+    name: 'plugin',
+    pkgIdWithPatchHash: 'plugin@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {
+      main: { version: '^1.0.0' },
+    },
+    id: '' as PkgResolutionId,
+  }
+  const { dependenciesGraph, dependenciesByProjectId } = await resolvePeers({
+    allPeerDepNames: new Set(['main', 'plugin']),
+    projects: [
+      {
+        directNodeIdsByAlias: new Map([
+          ['main', '>main@1.0.0>' as NodeId],
+          ['plugin', '>plugin@1.0.0>' as NodeId],
+        ]),
+        hoistedPeerProviderNodeIds: new Set(['>plugin@1.0.0>' as NodeId]),
+        topParents: [],
+        rootDir: '' as ProjectRootDir,
+        id: '.',
+      },
+    ],
+    resolvedImporters: {},
+    dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>main@1.0.0>' as NodeId, {
+        children: {},
+        installable: true,
+        resolvedPackage: mainPkg,
+        depth: 0,
+      }],
+      ['>plugin@1.0.0>' as NodeId, {
+        children: {},
+        installable: true,
+        resolvedPackage: pluginPkg,
+        depth: 1,
+      }],
+    ]),
+    virtualStoreDir: '',
+    lockfileDir: '',
+    virtualStoreDirMaxLength: 120,
+    peersSuffixMaxLength: 1000,
+    workspaceProjectIds: new Set(),
+  })
+  expect(Object.keys(dependenciesGraph).sort()).toStrictEqual([
+    'main@1.0.0(plugin@1.0.0)',
+    'plugin@1.0.0(main@1.0.0)',
+  ])
+  expect(dependenciesByProjectId['.'].get('main')).toBe('main@1.0.0(plugin@1.0.0)')
+  expect(dependenciesByProjectId['.'].get('plugin')).toBe('plugin@1.0.0(main@1.0.0)')
+})
+
+test('a peer cycle between an own direct dependency and a hoisted peer provider resolved at its tree position does not deadlock', async () => {
+  // Same await cycle as in https://github.com/pnpm/pnpm/issues/12921, but the
+  // provider is visited at its true tree position (inside host's subtree), so
+  // the cycle spans two traversal levels instead of two root-level calls.
+  const hostPkg = {
+    name: 'host',
+    pkgIdWithPatchHash: 'host@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {} as PeerDependencies,
+    id: '' as PkgResolutionId,
+  }
+  const mainPkg = {
+    name: 'main',
+    pkgIdWithPatchHash: 'main@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {
+      plugin: { version: '^1.0.0' },
+    },
+    id: '' as PkgResolutionId,
+  }
+  const pluginPkg = {
+    name: 'plugin',
+    pkgIdWithPatchHash: 'plugin@1.0.0' as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies: {
+      main: { version: '^1.0.0' },
+    },
+    id: '' as PkgResolutionId,
+  }
+  const { dependenciesGraph, dependenciesByProjectId } = await resolvePeers({
+    allPeerDepNames: new Set(['main', 'plugin']),
+    projects: [
+      {
+        directNodeIdsByAlias: new Map([
+          ['host', '>host@1.0.0>' as NodeId],
+          ['main', '>main@1.0.0>' as NodeId],
+          ['plugin', '>host@1.0.0>plugin@1.0.0>' as NodeId],
+        ]),
+        hoistedPeerProviderNodeIds: new Set(['>host@1.0.0>plugin@1.0.0>' as NodeId]),
+        topParents: [],
+        rootDir: '' as ProjectRootDir,
+        id: '.',
+      },
+    ],
+    resolvedImporters: {},
+    dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      ['>host@1.0.0>' as NodeId, {
+        children: { plugin: '>host@1.0.0>plugin@1.0.0>' as NodeId },
+        installable: true,
+        resolvedPackage: hostPkg,
+        depth: 0,
+      }],
+      ['>main@1.0.0>' as NodeId, {
+        children: {},
+        installable: true,
+        resolvedPackage: mainPkg,
+        depth: 0,
+      }],
+      ['>host@1.0.0>plugin@1.0.0>' as NodeId, {
+        children: {},
+        installable: true,
+        resolvedPackage: pluginPkg,
+        depth: 1,
+      }],
+    ]),
+    virtualStoreDir: '',
+    lockfileDir: '',
+    virtualStoreDirMaxLength: 120,
+    peersSuffixMaxLength: 1000,
+    workspaceProjectIds: new Set(),
+  })
+  expect(Object.keys(dependenciesGraph).sort()).toStrictEqual([
+    'host@1.0.0(main@1.0.0)',
+    'main@1.0.0(plugin@1.0.0)',
+    'plugin@1.0.0(main@1.0.0)',
+  ])
+  expect(dependenciesByProjectId['.'].get('host')).toBe('host@1.0.0(main@1.0.0)')
+  expect(dependenciesByProjectId['.'].get('main')).toBe('main@1.0.0(plugin@1.0.0)')
+  expect(dependenciesByProjectId['.'].get('plugin')).toBe('plugin@1.0.0(main@1.0.0)')
+})


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#12921 — `pnpm install` deadlocked on 11.11.0 (e.g. with `electron-builder@26.15.3`) after pnpm/pnpm#12847 split the root peer-resolution pass into two `resolvePeersOfChildren` calls. Cycle detection only sees the children of a single call, so a peer cycle spanning a project's own dependencies and hoisted peer providers (or a provider resolved at its true tree position) was invisible, and the dep-path deferreds awaited each other forever.

The fix records the actual await edges between dep-path calculations — including waits that go through a `peersCache` hit, which borrow the cache owner's edges — and, after the traversal and before the finishing promises are awaited, breaks any remaining await cycle by resolving each member's dep-path promise to `name@version`, the same collapse in-call cycle detection applies. Installs that resolved before are untouched: the breaker only fires on await graphs that could never settle on their own.

pacquet's synchronous walker already performs global cycle detection and needs no code change; mirrored Rust tests pin the same dep paths for both scenarios. Verified end-to-end: the `electron-builder@26.15.3` repro from the issue now installs in ~6s with the fixed bundle, and the TypeScript CLI and pacquet produce byte-identical lockfiles for it.

## Squash Commit Body

```text
The dep path of a package with peer dependencies is computed after the
dep paths of its peers, and peer cycles are broken by collapsing the
suffix to name@version. That cycle detection only sees the children of
a single resolvePeersOfChildren call, and since hoisted peer providers
stopped being walked in the root context (commit fecfe8334b), a peer
cycle between a project's own dependency and a hoisted provider - or a
provider resolved at its true tree position - spans two calls, so the
dep path calculations awaited each other's promise forever and
pnpm install hung, e.g. with electron-builder@26.15.3.

Record which dep path promise each calculation awaits (borrowing the
cache owner's edges for peers-cache hits) and, after the traversal,
resolve every promise on a remaining await cycle to name@version - the
same collapse in-call cycle detection applies. Installs that resolved
before are untouched: the breaker only fires on await graphs that could
never settle.

pacquet's synchronous walker already detects these cycles globally and
needs no code change; mirrored tests in both stacks pin the same dep
paths, and the electron-builder repro now produces byte-identical
lockfiles across the two implementations.

Fixes https://github.com/pnpm/pnpm/issues/12921
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (pacquet needs no code change — its global cycle detection already handles
  these shapes; mirrored tests added to prove parity.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (No documentation impact.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a case where `pnpm install` could hang indefinitely due to circular peer-dependency resolution.
  * Improved peer dependency cycle handling, including scenarios involving direct dependencies and auto-installed provider packages.
* **Tests**
  * Added regression tests covering peer cycles across multiple traversal levels and pruned hoisted providers.
* **Chores**
  * Updated the dependency resolver and pnpm with a patch-level release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->