### PR TITLE
fix(deps-resolver): preserve linked transitive dependencies

### DIFF
--- a/.changeset/steady-lockfile-children.md
+++ b/.changeset/steady-lockfile-children.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed `pnpm update` removing transitive lockfile entries when `dedupePeerDependents` is disabled and the selected package is absent [pnpm/pnpm#12456](https://github.com/pnpm/pnpm/issues/12456).

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -58,6 +58,23 @@ fn set_ignore_dependencies(workspace: &Path, names: &[&str]) {
     fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
 }
 
+/// Append `dedupePeerDependents: false` to the `pnpm-workspace.yaml` the
+/// harness already wrote — the setting under which pnpm/pnpm#12456
+/// reproduces on the TypeScript stack.
+fn disable_dedupe_peer_dependents(workspace: &Path) {
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    assert!(
+        !yaml.contains("dedupePeerDependents:"),
+        "pnpm-workspace.yaml already has a `dedupePeerDependents:` key — update this helper",
+    );
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("dedupePeerDependents: false\n");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+}
+
 fn dep_spec(workspace: &Path, name: &str) -> Option<String> {
     let manifest = PackageManifest::from_path(workspace.join("package.json")).unwrap();
     manifest
@@ -782,6 +799,47 @@ fn update_strict_catalog_range_mismatch_errors() {
     assert!(
         stderr.contains("ERR_PNPM_CATALOG_VERSION_MISMATCH"),
         "stderr did not carry the error code: {stderr}",
+    );
+
+    drop((root, anchor));
+}
+
+/// Updating one dependency must not drop the transitive snapshots of an
+/// unrelated, non-targeted dependency when `dedupePeerDependents` is
+/// disabled. Parity guard for pnpm/pnpm#12456: on the TypeScript stack
+/// the already-linked resolver shortcut fired below the update-depth
+/// boundary, so a partial update made a reused parent snapshot appear
+/// childless. pacquet reuses the whole subtree of a non-targeted package
+/// from the lockfile ([`UpdateReuseScope::Except`]), so the transitive
+/// edge survives — this test locks that in.
+///
+/// The TypeScript regression updates a package absent from the manifest;
+/// pacquet rejects that with `NO_PACKAGE_IN_DEPENDENCIES`, so the update
+/// here targets `foo`, already pinned at its latest so the update is a
+/// no-op. The reused parent is `pkg-with-1-dep`, whose transitive
+/// `dep-of-pkg-with-1-dep` must remain in the lockfile.
+#[test]
+fn update_preserves_unrelated_transitives_without_peer_dedupe() {
+    let (root, workspace, anchor) = setup();
+    disable_dedupe_peer_dependents(&workspace);
+
+    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0", "{FOO}": "100.1.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let lockfile_before =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile_before.contains(DEP),
+        "the parent's transitive dependency should be in the lockfile after install:\n{lockfile_before}",
+    );
+
+    pacquet(&workspace, ["update", FOO]).assert().success();
+
+    let lockfile_after =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert_eq!(
+        lockfile_after, lockfile_before,
+        "a no-op update of an unrelated package must leave the lockfile — and the reused parent's transitive edges — untouched",
     );
 
     drop((root, anchor));

--- a/pnpm11/installing/deps-installer/test/install/update.ts
+++ b/pnpm11/installing/deps-installer/test/install/update.ts
@@ -101,6 +101,23 @@ test('update does not install the package if it is not present in package.json',
   project.hasNot('is-positive')
 })
 
+test('update of an absent package preserves transitive dependencies when peer deduplication is disabled', async () => {
+  const project = prepareEmpty()
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage({}, [
+    '@pnpm.e2e/pkg-with-1-dep@100.0.0',
+  ], testDefaults({ dedupePeerDependents: false }))
+  const lockfileBeforeUpdate = project.readLockfile()
+
+  await addDependenciesToPackage(manifest, ['is-negative'], testDefaults({
+    allowNew: false,
+    dedupePeerDependents: false,
+    update: true,
+  }))
+
+  expect(project.readLockfile()).toStrictEqual(lockfileBeforeUpdate)
+})
+
 test('update dependency when external lockfile directory is used', async () => {
   prepareEmpty()
 

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -1816,7 +1816,11 @@ async function resolveDependency (
     )
   )
 
-  if (!options.update && !options.proceed && (currentPkg.resolution != null) && depIsLinked) {
+  if (
+    !options.update && !options.proceed &&
+    options.currentDepth === Math.max(0, options.updateDepth) &&
+    (currentPkg.resolution != null) && depIsLinked
+  ) {
     return null
   }
 


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#12456. With `dedupePeerDependents: false`, updating a package that is absent from the project could remove existing transitive snapshots from the lockfile. The linked-dependency shortcut returned before those nested dependencies were reconstructed.

The shortcut now applies only at the configured update-depth boundary. A regression test asserts that the existing lockfile remains unchanged. The equivalent Rust CLI path already preserves the lockfile, so no Rust change is needed.

## Squash Commit Body

```text
Only reuse the already-linked shortcut at the update-depth boundary. Below that boundary, resolution still needs to reconstruct transitive edges from the existing lockfile; returning early there makes the parent snapshot appear childless during a partial update.

Closes pnpm/pnpm#12456.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `pnpm update` could remove transitive lockfile entries when peer dependency deduplication was disabled and the selected package was not present.
  * Updates now preserve the existing lockfile/transitive dependency state in these scenarios.
* **Tests**
  * Added coverage to ensure lockfiles remain unchanged when updating without adding missing dependencies and with peer deduplication turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->