### PR TITLE
fix(pacquet): accept sibling-slot native binaries for the unscoped pnpm wrapper

### DIFF
--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -10,7 +10,7 @@ use crate::{State, cli_args::add::add_package};
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::{Config, PackageManagerBootstrap};
 use pacquet_global::{clean_orphaned_install_dirs, create_install_dir, find_global_package};
-use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
+use pacquet_graph_hasher::{format_global_virtual_store_path, host_arch, host_libc, host_platform};
 use pacquet_package_is_installable::SupportedArchitectures;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
@@ -373,26 +373,23 @@ fn native_source_trust_root(install_real_dir: &Path, wrapper_pkg_name: &str) -> 
         .unwrap_or_else(|| install_real_dir.to_path_buf())
 }
 
+// Recognizes a slot by re-deriving its `links`-relative path with
+// [`format_global_virtual_store_path`] — the same formatter that laid the
+// slot out — so this walk can't drift from the layout (e.g. the `@`
+// placeholder scope segment unscoped packages sit under).
 fn global_virtual_store_root_from_slot(slot_dir: &Path, package_name: &str) -> Option<PathBuf> {
-    let mut cursor = slot_dir.parent()?;
-    let version = cursor.file_name()?.to_str()?;
+    let hash = slot_dir.file_name()?.to_str()?;
+    let version = slot_dir.parent()?.file_name()?.to_str()?;
     node_semver::Version::parse(version).ok()?;
 
-    cursor = cursor.parent()?;
-    let mut package_segments = package_name.split('/').rev();
-    let name = package_segments.next()?;
-    if cursor.file_name()?.to_str()? != name {
-        return None;
-    }
-    for segment in package_segments {
-        cursor = cursor.parent()?;
+    let mut cursor = slot_dir;
+    for segment in format_global_virtual_store_path(package_name, version, hash).split('/').rev() {
         if cursor.file_name()?.to_str()? != segment {
             return None;
         }
+        cursor = cursor.parent()?;
     }
-
-    let root = cursor.parent()?;
-    (root.file_name()?.to_str()? == "links").then(|| root.to_path_buf())
+    (cursor.file_name()?.to_str()? == "links").then(|| cursor.to_path_buf())
 }
 
 fn validate_native_binary_source(src: &Path, source_root: &Path) -> miette::Result<PathBuf> {

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -101,6 +101,114 @@ fn links_the_host_platform_binary_into_scoped_exe_wrapper() {
     assert_eq!(fs::read(&dest).expect("read linked binary"), b"#!/bin/sh\necho pnpm\n");
 }
 
+/// Lay out the wrapper slot of a fake global-virtual-store engine install
+/// (`links/<scope-or-@>/<name>/<version>/<hash>`) and return the slot
+/// directory. The platform package is left to each test: the real installer
+/// materializes it as a symlink to a sibling slot, which is exactly the
+/// resolution under test.
+#[cfg(unix)]
+fn fake_gvs_wrapper_slot(
+    links_dir: &std::path::Path,
+    wrapper_pkg_name: &str,
+) -> std::path::PathBuf {
+    let slot = match wrapper_pkg_name.split_once('/') {
+        Some((scope, name)) => links_dir.join(scope).join(name),
+        None => links_dir.join("@").join(wrapper_pkg_name),
+    }
+    .join("12.0.0-alpha.7")
+    .join("cafe0123");
+    fs::create_dir_all(package_dir(&slot, wrapper_pkg_name)).expect("create wrapper dir");
+    fs::create_dir_all(slot.join("node_modules").join("@pnpm")).expect("create scope dir");
+    slot
+}
+
+/// Materialize the native platform package in its own sibling slot under
+/// `links` and return the package directory the wrapper's platform symlink
+/// should point at.
+#[cfg(unix)]
+fn fake_gvs_native_slot(links_dir: &std::path::Path) -> std::path::PathBuf {
+    let platform_dir = exe_platform_pkg_dir_name_next(host_platform(), host_arch(), host_libc());
+    let native_pkg_dir = links_dir
+        .join("@pnpm")
+        .join(&platform_dir)
+        .join("12.0.0-alpha.7")
+        .join("beef4567")
+        .join("node_modules")
+        .join("@pnpm")
+        .join(&platform_dir);
+    fs::create_dir_all(&native_pkg_dir).expect("create native package dir");
+    fs::write(native_pkg_dir.join("pnpm"), b"#!/bin/sh\necho pnpm\n").expect("write native binary");
+    native_pkg_dir
+}
+
+/// `packageManager` delegation installs the engine into the global virtual
+/// store, where the unscoped `pnpm` wrapper sits under the `@` placeholder
+/// scope and its platform package legitimately resolves into a sibling slot
+/// — the trust root must widen to `links` instead of the wrapper's own slot.
+#[cfg(unix)]
+#[test]
+fn links_native_binary_from_a_sibling_global_virtual_store_slot() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let links_dir = temp.path().join("links");
+    let slot = fake_gvs_wrapper_slot(&links_dir, "pnpm");
+    let native_pkg_dir = fake_gvs_native_slot(&links_dir);
+    let platform_dir = exe_platform_pkg_dir_name_next(host_platform(), host_arch(), host_libc());
+    std::os::unix::fs::symlink(
+        &native_pkg_dir,
+        slot.join("node_modules").join("@pnpm").join(platform_dir),
+    )
+    .expect("symlink platform package to the sibling slot");
+
+    link_exe_platform_binary(&slot, "pnpm").expect("linking should succeed");
+
+    let dest = package_dir(&slot, "pnpm").join("pnpm");
+    assert!(dest.exists(), "the native binary is linked into the wrapper");
+    assert_eq!(fs::read(&dest).expect("read linked binary"), b"#!/bin/sh\necho pnpm\n");
+}
+
+#[cfg(unix)]
+#[test]
+fn links_native_binary_from_a_sibling_slot_into_the_scoped_wrapper() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let links_dir = temp.path().join("links");
+    let slot = fake_gvs_wrapper_slot(&links_dir, PNPM_EXE_PACKAGE_NAME);
+    let native_pkg_dir = fake_gvs_native_slot(&links_dir);
+    let platform_dir = exe_platform_pkg_dir_name_next(host_platform(), host_arch(), host_libc());
+    std::os::unix::fs::symlink(
+        &native_pkg_dir,
+        slot.join("node_modules").join("@pnpm").join(platform_dir),
+    )
+    .expect("symlink platform package to the sibling slot");
+
+    link_exe_platform_binary(&slot, PNPM_EXE_PACKAGE_NAME).expect("linking should succeed");
+
+    assert!(package_dir(&slot, PNPM_EXE_PACKAGE_NAME).join("pnpm").exists());
+}
+
+/// A platform-package symlink that leaves `links` entirely must still be
+/// rejected even when the wrapper sits in a global-virtual-store slot.
+#[cfg(unix)]
+#[test]
+fn rejects_native_binary_that_escapes_the_global_virtual_store() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let outside = tempfile::tempdir().expect("outside tempdir");
+    let links_dir = temp.path().join("links");
+    let slot = fake_gvs_wrapper_slot(&links_dir, "pnpm");
+    let platform_dir = exe_platform_pkg_dir_name_next(host_platform(), host_arch(), host_libc());
+    let outside_pkg_dir = outside.path().join(&platform_dir);
+    fs::create_dir_all(&outside_pkg_dir).expect("create outside package dir");
+    fs::write(outside_pkg_dir.join("pnpm"), b"outside").expect("write outside binary");
+    std::os::unix::fs::symlink(
+        &outside_pkg_dir,
+        slot.join("node_modules").join("@pnpm").join(platform_dir),
+    )
+    .expect("symlink platform package outside the store");
+
+    let err = link_exe_platform_binary(&slot, "pnpm").expect_err("escaped native source rejected");
+    assert!(err.to_string().contains("resolves outside"), "unexpected error: {err:?}");
+    assert!(!package_dir(&slot, "pnpm").join("pnpm").exists());
+}
+
 #[cfg(unix)]
 #[test]
 fn rejects_wrapper_symlink_that_escapes_the_install_dir() {


### PR DESCRIPTION
## Summary

Fixes the `packageManager` delegation failure that broke the [Update Lockfile run 29134436655](https://github.com/pnpm/pnpm/actions/runs/29134436655/job/86495886559): any delegation from an installed v12 binary to a *different* v12 version aborted with `the native pnpm binary at … resolves outside …`.

The global virtual store lays engine slots out as `links/<scope>/<name>/<version>/<hash>`, with a literal `@` placeholder as the scope segment of unscoped packages (see `format_global_virtual_store_path`). `global_virtual_store_root_from_slot` walked the slot path upward without knowing about that placeholder, so for the unscoped `pnpm` wrapper it landed on `@` where it expected `links` and returned `None`; `native_source_trust_root` then fell back to the wrapper's own slot as the trust root. Since the wrapper's `@pnpm/exe.<target>` platform package is a symlink into a *sibling* slot under `links`, `validate_native_binary_source` rejected a perfectly healthy install. Scoped wrappers (`@pnpm/exe`) happened to walk correctly, which is why only the unscoped `pnpm` wrapper — i.e. exactly the v12 delegation path — was affected.

The fix re-derives the slot's `links`-relative path with `format_global_virtual_store_path` — the same formatter that laid the slot out — so the reader and writer of the layout can't drift again. The symlink-escape guard is unchanged: a platform package resolving outside `links` is still rejected (covered by a new test).

Note for maintainers: released alpha.6/alpha.7 binaries still carry the bug and the *old* binary performs the delegation, so CI jobs remain broken until the `packageManager` pin and the installed setup version match again (and permanently once a fixed release is the installed binary).

## Squash Commit Body

```text
The global virtual store lays slots out as
links/<scope>/<name>/<version>/<hash>, with a literal @ placeholder as the
scope segment of unscoped packages (see format_global_virtual_store_path).
global_virtual_store_root_from_slot walked the slot path upward without
that placeholder, so for the unscoped pnpm wrapper it landed on @ where it
expected links, gave up, and native_source_trust_root fell back to the
wrapper's own slot. The wrapper's @pnpm/exe.<target> platform package is a
symlink to a sibling slot under links, so linking the native binary then
failed with "the native pnpm binary ... resolves outside ...". This is
exactly the packageManager-delegation path: any delegation to a different
v12 version aborted, which broke the Update Lockfile workflow after its
updater bumped the pin mid-job.

Derive the slot's links-relative path with format_global_virtual_store_path
- the formatter that laid the slot out - instead of a hand-rolled walk, so
the reader and writer of the layout cannot drift again. Scoped wrappers
resolved to the links root before and still do, and a platform-package
symlink escaping links entirely is still rejected.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only: the trust-root containment check is pacquet-only hardening; the TypeScript `linkExePlatformBinary` has no such check, so there is nothing to mirror.)*
- [x] Added or updated tests. *(Regression test verified to fail against the previous walk; plus a scoped-wrapper test and a symlink-escape test guarding the security check.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-update handling for native platform binaries installed through the global virtual store.
  * Native binaries now link correctly for both standard and scoped package installations.
  * Added safeguards to prevent linking binaries from invalid locations outside the supported package store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->