### PR TITLE
fix(cli): support catalogs in deploy

### DIFF
--- a/.changeset/deploy-catalog-snapshots.md
+++ b/.changeset/deploy-catalog-snapshots.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/releasing.commands": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 `pnpm deploy` now supports workspaces that use catalogs.

--- a/.changeset/deploy-catalog-snapshots.md
+++ b/.changeset/deploy-catalog-snapshots.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+`pnpm deploy` now supports workspaces that use catalogs.

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -859,6 +859,9 @@ fn create_deploy_files(
     }
 
     let mut deploy_lockfile = lockfile.clone();
+    // The deployed manifest contains concrete dependency versions, so catalog
+    // snapshots would refer to configuration that is not copied to the target.
+    deploy_lockfile.catalogs = None;
     deploy_lockfile.patched_dependencies = None;
     deploy_lockfile.overrides = None;
     deploy_lockfile.package_extensions_checksum = None;

--- a/pnpm/crates/cli/tests/deploy.rs
+++ b/pnpm/crates/cli/tests/deploy.rs
@@ -56,6 +56,36 @@ fn deploy_from_shared_lockfile_installs_selected_project() {
 }
 
 #[test]
+fn deploy_from_shared_lockfile_supports_catalog_dependencies() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml = fs::read_to_string(&workspace_yaml_path).unwrap();
+    workspace_yaml.push_str("catalog:\n  '@pnpm.e2e/foo': 100.0.0\n");
+    fs::write(workspace_yaml_path, workspace_yaml).unwrap();
+    let manifest_path = workspace.join("packages/app/package.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    manifest["dependencies"]["@pnpm.e2e/foo"] = serde_json::Value::String("catalog:".to_string());
+    fs::write(manifest_path, manifest.to_string()).unwrap();
+
+    pacquet.with_arg("install").assert().success();
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--prod", "deploy"])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("deploy");
+    assert!(deploy_dir.join("node_modules/@pnpm.e2e/foo").exists());
+    let lockfile = fs::read_to_string(deploy_dir.join("pnpm-lock.yaml")).unwrap();
+    assert!(!lockfile.contains("catalogs:"), "unexpected catalog snapshot:\n{lockfile}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn deploy_refuses_non_empty_target_without_force() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -127,6 +127,8 @@ export function createDeployFiles ({
   const result: DeployFiles = {
     lockfile: {
       ...lockfile,
+      // The deployed manifest contains concrete versions, and catalogs are not copied to the target.
+      catalogs: undefined,
       patchedDependencies: undefined,
       overrides: undefined, // the effects of the overrides should already be part of the package snapshots
       packageExtensionsChecksum: undefined, // the effects of the package extensions should already be part of the package snapshots

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -561,6 +561,13 @@ test('deploy with dedupePeerDependents=true ignores the value of dedupePeerDepen
 test('deploy works when workspace packages use catalog protocol', async () => {
   preparePackages([
     {
+      location: '.',
+      package: {
+        name: 'root',
+        private: true,
+      },
+    },
+    {
       name: 'project-1',
       dependencies: {
         'project-2': 'workspace:*',
@@ -584,15 +591,29 @@ test('deploy works when workspace packages use catalog protocol', async () => {
   ])
 
   const { allProjects, selectedProjectsGraph } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [{ namePattern: 'project-1' }])
+  const catalogs = {
+    default: {
+      'is-positive': '1.0.0',
+    },
+  }
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    allProjects,
+    catalogs,
+    dir: process.cwd(),
+    dev: true,
+    production: true,
+    lockfileOnly: true,
+    sharedWorkspaceLockfile: true,
+    lockfileDir: process.cwd(),
+    workspaceDir: process.cwd(),
+  })
 
   await deploy.handler({
     ...DEFAULT_OPTS,
     allProjects,
-    catalogs: {
-      default: {
-        'is-positive': '1.0.0',
-      },
-    },
+    catalogs,
     dir: process.cwd(),
     dev: false,
     production: true,
@@ -604,7 +625,8 @@ test('deploy works when workspace packages use catalog protocol', async () => {
   }, ['deploy'])
 
   // Make sure the is-positive cataloged dependency was actually installed.
-  expect(fs.existsSync('deploy/node_modules/.pnpm/project-3@file+project-3/node_modules/is-positive')).toBeTruthy()
+  expect(fs.existsSync('deploy/node_modules/is-positive')).toBeTruthy()
+  expect(assertProject(path.resolve('deploy')).readLockfile()).not.toHaveProperty('catalogs')
 })
 
 test('deploy does not preserve the inject workspace packages settings in the lockfile', async () => {


### PR DESCRIPTION
Summary:
- omit catalog snapshots from generated deploy lockfiles
- add an end-to-end catalog deploy regression test
- add a pnpm patch changeset

Testing:
- cargo fmt --check
- cargo test -p pacquet-cli --test deploy deploy_from_shared_lockfile_supports_catalog_dependencies
- verified the regression test fails with the production fix removed

Full just ready is currently blocked on upstream main because sysinfo 0.39.3 requires Rust 1.95 while rust-toolchain.toml pins Rust 1.93.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm deploy` now supports workspaces that use catalog-based dependency specifiers.
* **Bug Fixes**
  * Deployment lockfiles no longer include catalog snapshot data; catalog dependencies are represented as resolved concrete versions.
* **Tests**
  * Added a new CLI integration test and updated an existing regression test to verify deploy output and confirm the generated lockfile omits any `catalogs` snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->