### PR TITLE
fix(resolver): stop hoisted peers from ignoring the declared peer range

### DIFF
--- a/.changeset/peer-hoist-respect-range.md
+++ b/.changeset/peer-hoist-respect-range.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed peer dependency auto-install picking a version the peer range rejects. In a workspace with several projects, a package declaring a peer dependency with a semver range (for example `^1.0.0`) could get the highest version found anywhere in the workspace (for example a `2.0.0` resolved for another project) instead of a version that satisfies the range. Peers are now deduplicated onto the highest preferred version that satisfies the declared range, and when none does, the range is resolved from the registry.

--- a/.changeset/peer-hoist-respect-range.md
+++ b/.changeset/peer-hoist-respect-range.md
@@ -4,3 +4,5 @@
 ---
 
 Fixed peer dependency auto-install picking a version the peer range rejects. In a workspace with several projects, a package declaring a peer dependency with a semver range (for example `^1.0.0`) could get the highest version found anywhere in the workspace (for example a `2.0.0` resolved for another project) instead of a version that satisfies the range. Peers are now deduplicated onto the highest preferred version that satisfies the declared range, and when none does, the range is resolved from the registry.
+
+Also fixed re-resolving with an existing lockfile hoisting a different peer version than a fresh install of the same manifest: root dependencies reused from the lockfile were invisible to peer hoisting, so a peer that a root dependency provides could be bound to another version.

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -737,6 +737,61 @@ fn peer_dependency_prefers_non_aliased_provider_over_alias() {
     );
 }
 
+/// Adding a dependent to a manifest whose aliased peer providers are
+/// already in the lockfile must bind the peer the same way a fresh
+/// install of the full manifest does.
+#[test]
+fn peer_dependency_binds_the_same_when_added_to_an_existing_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("autoInstallPeers: false\n");
+    workspace_yaml.push_str("strictPeerDependencies: false\n");
+    workspace_yaml.push_str("peersSuffixMaxLength: 1000\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": {
+            "peer-c3": "npm:@pnpm.e2e/peer-c@1.0.0",
+            "peer-c2": "npm:@pnpm.e2e/peer-c@1.0.1",
+            "peer-c1": "npm:@pnpm.e2e/peer-c@2.0.0",
+        } })
+        .to_string(),
+    )
+    .expect("write package.json");
+    pacquet.with_arg("install").assert().success();
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": {
+            "peer-c3": "npm:@pnpm.e2e/peer-c@1.0.0",
+            "peer-c2": "npm:@pnpm.e2e/peer-c@1.0.1",
+            "peer-c1": "npm:@pnpm.e2e/peer-c@2.0.0",
+            "@pnpm.e2e/abc": "1.0.0",
+        } })
+        .to_string(),
+    )
+    .expect("rewrite package.json");
+    new_pacquet_command(&workspace).with_arg("install").assert().success();
+
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)"),
+        "re-resolving with a lockfile must bind the same provider as a fresh install; lockfile:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn peer_dependency_prefers_highest_aliased_subdependency_version() {
     let lockfile = install_with_peer_alias_deps(serde_json::json!({

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -84,14 +84,26 @@ pub fn hoist_peers(
                     _ => non_versions.push(spec.as_str()),
                 }
             }
-            let is_exact_version = range.parse::<Version>().is_ok();
+            // Dedupe onto a preferred version only when it actually satisfies
+            // the wanted peer range. Picking the highest preferred version
+            // regardless of the range lets a version resolved for one importer
+            // be auto-installed as another importer's peer even though nothing
+            // in that importer's closure accepts it, silently producing a peer
+            // graph that mixes incompatible majors. Ranges that are not semver
+            // (workspace:, npm: aliases, dist-tags) cannot be checked, so they
+            // keep the dedupe-to-highest behavior.
+            let is_semver_range = range.parse::<Range>().is_ok();
             let satisfying_version =
-                if is_exact_version { max_satisfying(&versions, range) } else { None };
+                if is_semver_range { max_satisfying(&versions, range) } else { None };
             if let Some(satisfying) = satisfying_version {
                 let mut parts: Vec<&str> = vec![satisfying];
                 parts.extend(non_versions.iter().copied());
                 dependencies.insert(peer_name.clone(), parts.join(" || "));
-            } else if is_exact_version && opts.auto_install_peers {
+            } else if is_semver_range && !versions.is_empty() && opts.auto_install_peers {
+                // Preferred versions exist but none satisfies the wanted
+                // range. Use the range directly so it resolves from the
+                // registry rather than installing a version the peer
+                // explicitly rejects.
                 dependencies.insert(peer_name.clone(), range.clone());
             } else {
                 let mut parts: Vec<String> = Vec::new();

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -99,12 +99,15 @@ pub fn hoist_peers(
                 let mut parts: Vec<&str> = vec![satisfying];
                 parts.extend(non_versions.iter().copied());
                 dependencies.insert(peer_name.clone(), parts.join(" || "));
-            } else if is_semver_range && !versions.is_empty() && opts.auto_install_peers {
+            } else if is_semver_range && !versions.is_empty() {
                 // Preferred versions exist but none satisfies the wanted
                 // range. Use the range directly so it resolves from the
                 // registry rather than installing a version the peer
-                // explicitly rejects.
-                dependencies.insert(peer_name.clone(), range.clone());
+                // explicitly rejects. Without auto-install-peers, hoist
+                // nothing and leave the peer missing.
+                if opts.auto_install_peers {
+                    dependencies.insert(peer_name.clone(), range.clone());
+                }
             } else {
                 let mut parts: Vec<String> = Vec::new();
                 if let Some(highest) = max_satisfying_any(&versions) {

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
@@ -71,7 +71,7 @@ fn falls_back_to_range_when_no_preferred_version_satisfies_it() {
 }
 
 #[test]
-fn picks_highest_preferred_version_for_deduplication_when_range_is_not_exact() {
+fn picks_highest_preferred_version_satisfying_range_for_deduplication() {
     let preferred = preferred(&[(
         "foo",
         &[
@@ -82,16 +82,57 @@ fn picks_highest_preferred_version_for_deduplication_when_range_is_not_exact() {
     )]);
     let result = hoist_peers(&opts(true, &preferred), &[missing("foo", "^2.0.0")]);
     let mut expected = BTreeMap::new();
-    expected.insert("foo".to_string(), "3.0.0".to_string());
+    expected.insert("foo".to_string(), "2.1.0".to_string());
     assert_eq!(result, expected);
 }
 
 #[test]
-fn reuses_higher_preferred_version_when_range_is_not_exact() {
+fn does_not_reuse_preferred_version_that_the_peer_range_rejects() {
     let preferred = preferred(&[("foo", &[("2.0.0", plain(VersionSelectorType::Version))])]);
     let result = hoist_peers(&opts(true, &preferred), &[missing("foo", "1")]);
     let mut expected = BTreeMap::new();
-    expected.insert("foo".to_string(), "2.0.0".to_string());
+    expected.insert("foo".to_string(), "1".to_string());
+    assert_eq!(result, expected);
+}
+
+/// A peer declared as `^1.0.0` must not be handed a foreign `2.x`
+/// contributed by another importer when a satisfying `1.x` exists.
+#[test]
+fn prefers_preferred_version_satisfying_non_exact_range() {
+    let preferred = preferred(&[(
+        "foo",
+        &[
+            ("1.0.0", plain(VersionSelectorType::Version)),
+            ("2.0.0", plain(VersionSelectorType::Version)),
+        ],
+    )]);
+    let result = hoist_peers(&opts(true, &preferred), &[missing("foo", "^1.0.0")]);
+    let mut expected = BTreeMap::new();
+    expected.insert("foo".to_string(), "1.0.0".to_string());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn does_not_treat_prerelease_of_next_major_as_satisfying_caret_range() {
+    let preferred = preferred(&[(
+        "foo",
+        &[
+            ("1.0.0", plain(VersionSelectorType::Version)),
+            ("2.0.0-beta.1", plain(VersionSelectorType::Version)),
+        ],
+    )]);
+    let result = hoist_peers(&opts(true, &preferred), &[missing("foo", "^1.0.0")]);
+    let mut expected = BTreeMap::new();
+    expected.insert("foo".to_string(), "1.0.0".to_string());
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn falls_back_to_range_when_no_preferred_version_satisfies_non_exact_range() {
+    let preferred = preferred(&[("foo", &[("2.0.0", plain(VersionSelectorType::Version))])]);
+    let result = hoist_peers(&opts(true, &preferred), &[missing("foo", "^1.0.0")]);
+    let mut expected = BTreeMap::new();
+    expected.insert("foo".to_string(), "^1.0.0".to_string());
     assert_eq!(result, expected);
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
@@ -136,6 +136,13 @@ fn falls_back_to_range_when_no_preferred_version_satisfies_non_exact_range() {
     assert_eq!(result, expected);
 }
 
+#[test]
+fn hoists_nothing_when_no_preferred_version_satisfies_range_without_auto_install() {
+    let preferred = preferred(&[("foo", &[("2.0.0", plain(VersionSelectorType::Version))])]);
+    let result = hoist_peers(&opts(false, &preferred), &[missing("foo", "^1.0.0")]);
+    assert_eq!(result, BTreeMap::new());
+}
+
 /// Regression for <https://github.com/pnpm/pnpm/pull/11049>.
 #[test]
 fn returns_valid_specifier_when_given_only_range_preferred_version_selectors() {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -889,13 +889,19 @@ impl Walker<'_> {
         let mut child_parent_refs = parent_parent_refs.clone();
         let mut new_parent_refs = ParentRefs::new();
         for (alias, child_node_id) in &children_map {
-            if !self.tree.all_peer_dep_names.contains(alias) {
-                continue;
-            }
             let Some(child_tree) = self.tree.dependencies_tree.get(child_node_id) else { continue };
             let Some(child_pkg) = self.tree.packages.get(&child_tree.resolved_package_id) else {
                 continue;
             };
+            // Match by the install alias and by the real package name, so
+            // an npm-alias child (`peer-c1@npm:@pnpm.e2e/peer-c@2.0.0`) can
+            // provide the peer declared under its real name.
+            let (child_real_name, _) = pkg_name_version(&child_pkg.result);
+            if !self.tree.all_peer_dep_names.contains(alias)
+                && !self.tree.all_peer_dep_names.contains(&child_real_name)
+            {
+                continue;
+            }
             insert_parent_ref(
                 &mut new_parent_refs,
                 alias,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -747,6 +747,18 @@ impl Walker<'_> {
         self.build_importer_parents_from(&self.tree.direct)
     }
 
+    /// Whether a dependency installed under `alias` can provide a peer:
+    /// its alias or its real package name (the two differ for npm-alias
+    /// deps like `peer-c1@npm:@pnpm.e2e/peer-c@2.0.0`) is declared as a
+    /// peer somewhere in the tree.
+    fn is_peer_relevant(&self, alias: &str, pkg: &ResolvedPackage) -> bool {
+        if self.tree.all_peer_dep_names.contains(alias) {
+            return true;
+        }
+        let (real_name, _) = pkg_name_version(&pkg.result);
+        self.tree.all_peer_dep_names.contains(&real_name)
+    }
+
     /// Same as [`Self::build_importer_parents`] but seeds from an
     /// externally-supplied direct-deps slice — used by the multi-importer
     /// [`fn@resolve_peers_workspace`] where each importer's `direct`
@@ -760,10 +772,7 @@ impl Walker<'_> {
             let Some(pkg) = self.tree.packages.get(&tree_node.resolved_package_id) else {
                 continue;
             };
-            let (real_name, _) = pkg_name_version(&pkg.result);
-            if !self.tree.all_peer_dep_names.contains(&direct.alias)
-                && !self.tree.all_peer_dep_names.contains(&real_name)
-            {
+            if !self.is_peer_relevant(&direct.alias, pkg) {
                 continue;
             }
             let parent_node_id = remap_link_node_id(&self.opts, &direct.alias, &pkg.result)
@@ -893,13 +902,7 @@ impl Walker<'_> {
             let Some(child_pkg) = self.tree.packages.get(&child_tree.resolved_package_id) else {
                 continue;
             };
-            // Match by the install alias and by the real package name, so
-            // an npm-alias child (`peer-c1@npm:@pnpm.e2e/peer-c@2.0.0`) can
-            // provide the peer declared under its real name.
-            let (child_real_name, _) = pkg_name_version(&child_pkg.result);
-            if !self.tree.all_peer_dep_names.contains(alias)
-                && !self.tree.all_peer_dep_names.contains(&child_real_name)
-            {
+            if !self.is_peer_relevant(alias, child_pkg) {
                 continue;
             }
             insert_parent_ref(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -461,7 +461,7 @@ fn own_peer_is_resolved_from_aliased_sibling_real_name() {
     );
     assert_eq!(
         result.graph[&dep_path].children.get("peer-c"),
-        Some(&DepPath::from("peer-c@2.0.0"))
+        Some(&DepPath::from("peer-c@2.0.0")),
     );
     assert!(!result.peer_dependency_issues.missing.contains_key("peer-c"));
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -142,7 +142,7 @@ fn own_peer_is_resolved_from_peer_relevant_child() {
 }
 
 #[test]
-fn non_peer_alias_child_does_not_resolve_by_real_package_name() {
+fn alias_child_resolves_peer_by_real_package_name() {
     let provider = NodeId::leaf("peer@1.0.0");
     let plugin = NodeId::next();
     let consumer = NodeId::next();
@@ -176,16 +176,16 @@ fn non_peer_alias_child_does_not_resolve_by_real_package_name() {
     let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
 
     assert!(
-        result.graph.contains_key(&DepPath::from("plugin@1.0.0")),
-        "plugin should not resolve peer by provider's real package name: {:#?}",
+        result.graph.contains_key(&DepPath::from("plugin@1.0.0(peer@1.0.0)")),
+        "alias `not-peer` should satisfy peer `peer` by its real package name: {:#?}",
         result.graph.keys().collect::<Vec<_>>(),
     );
     assert!(
-        !result.graph.contains_key(&DepPath::from("plugin@1.0.0(peer@1.0.0)")),
-        "non-peer alias `not-peer` must not satisfy peer `peer`: {:#?}",
+        !result.graph.contains_key(&DepPath::from("plugin@1.0.0")),
+        "plugin must not stay peer-less when a sibling provides the peer: {:#?}",
         result.graph.keys().collect::<Vec<_>>(),
     );
-    assert!(result.peer_dependency_issues.missing.contains_key("peer"));
+    assert!(!result.peer_dependency_issues.missing.contains_key("peer"));
 }
 
 #[test]
@@ -412,7 +412,7 @@ fn missing_names_by_pkg_records_only_children_context_missing_peers() {
 }
 
 #[test]
-fn own_peer_is_not_resolved_from_aliased_child_real_name() {
+fn own_peer_is_resolved_from_aliased_sibling_real_name() {
     let peer_c = NodeId::leaf("peer-c@2.0.0");
     let consumer = NodeId::next();
     let parent = NodeId::next();
@@ -452,15 +452,18 @@ fn own_peer_is_not_resolved_from_aliased_child_real_name() {
     };
 
     let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
-    let dep_path = DepPath::from("consumer@1.0.0");
+    let dep_path = DepPath::from("consumer@1.0.0(peer-c@2.0.0)");
 
     assert!(
         result.graph.contains_key(&dep_path),
-        "consumer should not resolve peer-c from a child installed as peer-c1: {:#?}",
+        "consumer should resolve peer-c from the sibling installed as peer-c1: {:#?}",
         result.graph.keys().collect::<Vec<_>>(),
     );
-    assert!(!result.graph[&dep_path].children.contains_key("peer-c"));
-    assert!(result.peer_dependency_issues.missing.contains_key("peer-c"));
+    assert_eq!(
+        result.graph[&dep_path].children.get("peer-c"),
+        Some(&DepPath::from("peer-c@2.0.0"))
+    );
+    assert!(!result.peer_dependency_issues.missing.contains_key("peer-c"));
 }
 
 #[test]

--- a/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
+++ b/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
@@ -623,9 +623,15 @@ test('auto install hoisted peer dependency', async () => {
   const project = prepareEmpty()
   await addDependenciesToPackage({}, ['@pnpm.e2e/has-peer-c-in-deps@1.0.0', '@pnpm.e2e/abc'], testDefaults({ autoInstallPeers: true }))
   const lockfile = project.readLockfile()
+  // @pnpm.e2e/abc declares @pnpm.e2e/peer-c@^1.0.0, so the peer-c@2.0.0
+  // brought in by @pnpm.e2e/has-peer-c-in-deps must not be reused for it.
   expect(Object.keys(lockfile.snapshots).filter((depPath) => depPath.startsWith('@pnpm.e2e/peer-c@'))).toStrictEqual([
+    '@pnpm.e2e/peer-c@1.0.0',
     '@pnpm.e2e/peer-c@2.0.0',
   ])
+  const abcSnapshots = Object.keys(lockfile.snapshots).filter((depPath) => depPath.startsWith('@pnpm.e2e/abc@'))
+  expect(abcSnapshots).toHaveLength(1)
+  expect(abcSnapshots[0]).toContain('@pnpm.e2e/peer-c@1.0.0')
 })
 
 test('auto install peer of optional peer', async () => {

--- a/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
@@ -1575,7 +1575,7 @@ test('resolve peer dependency using the alias that differs from the real name of
   expect(lockfile.snapshots['@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-a@1.0.0)']?.dependencies['@pnpm.e2e/peer-b']).toBe('@pnpm.e2e/peer-a@1.0.0')
 })
 
-test('when there are several aliased dependencies of the same package, pick the one with the highest version that satisfies the peer range to resolve peers', async () => {
+test('when there are several aliased dependencies of the same package, pick the one with the highest version to resolve peers', async () => {
   prepareEmpty()
 
   const opts = testDefaults({ autoInstallPeers: false, strictPeerDependencies: false })
@@ -1586,11 +1586,8 @@ test('when there are several aliased dependencies of the same package, pick the 
   ], opts)
   await addDependenciesToPackage(manifest, ['@pnpm.e2e/abc@1.0.0'], opts)
 
-  // Re-resolving with the aliases already in the lockfile hoists a
-  // real-named peer-c for abc; the hoist picks the highest version
-  // satisfying abc's peer range (^1.0.0), so peer-c@2.0.0 is not used.
   const lockfile = readYamlFileSync<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
-  expect(lockfile.snapshots['@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@1.0.1)']).toBeTruthy()
+  expect(lockfile.snapshots['@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)']).toBeTruthy()
 })
 
 test('when there is an aliases dependency and a non-aliased one, prefer the non-aliased dependency to resolve peers', async () => {

--- a/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
@@ -1575,7 +1575,7 @@ test('resolve peer dependency using the alias that differs from the real name of
   expect(lockfile.snapshots['@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-a@1.0.0)']?.dependencies['@pnpm.e2e/peer-b']).toBe('@pnpm.e2e/peer-a@1.0.0')
 })
 
-test('when there are several aliased dependencies of the same package, pick the one with the highest version to resolve peers', async () => {
+test('when there are several aliased dependencies of the same package, pick the one with the highest version that satisfies the peer range to resolve peers', async () => {
   prepareEmpty()
 
   const opts = testDefaults({ autoInstallPeers: false, strictPeerDependencies: false })
@@ -1586,8 +1586,11 @@ test('when there are several aliased dependencies of the same package, pick the 
   ], opts)
   await addDependenciesToPackage(manifest, ['@pnpm.e2e/abc@1.0.0'], opts)
 
+  // Re-resolving with the aliases already in the lockfile hoists a
+  // real-named peer-c for abc; the hoist picks the highest version
+  // satisfying abc's peer range (^1.0.0), so peer-c@2.0.0 is not used.
   const lockfile = readYamlFileSync<any>(path.resolve(WANTED_LOCKFILE)) // eslint-disable-line
-  expect(lockfile.snapshots['@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@2.0.0)']).toBeTruthy()
+  expect(lockfile.snapshots['@pnpm.e2e/abc@1.0.0(@pnpm.e2e/peer-c@1.0.1)']).toBeTruthy()
 })
 
 test('when there is an aliases dependency and a non-aliased one, prefer the non-aliased dependency to resolve peers', async () => {

--- a/pnpm11/installing/deps-resolver/src/hoistPeers.ts
+++ b/pnpm11/installing/deps-resolver/src/hoistPeers.ts
@@ -2,13 +2,18 @@ import type { PreferredVersions } from '@pnpm/resolving.resolver-base'
 import { lexCompare } from '@pnpm/util.lex-comparator'
 import semver from 'semver'
 
-import type { PkgAddressOrLink } from './resolveDependencies.js'
+/** One workspace-root dependency that a missing peer can be satisfied with. */
+export interface HoistableRootDep {
+  alias: string
+  pkgName: string
+  normalizedBareSpecifier?: string
+}
 
 export function hoistPeers (
   opts: {
     autoInstallPeers: boolean
     allPreferredVersions?: PreferredVersions
-    workspaceRootDeps: PkgAddressOrLink[]
+    workspaceRootDeps: HoistableRootDep[]
   },
   missingRequiredPeers: Array<[string, { range: string }]>
 ): Record<string, string> {
@@ -20,7 +25,7 @@ export function hoistPeers (
       continue
     }
     const rootDep = opts.workspaceRootDeps
-      .filter((rootDep) => rootDep.pkg.name === peerName)
+      .filter((rootDep) => rootDep.pkgName === peerName)
       .sort((rootDep1, rootDep2) => lexCompare(rootDep1.alias, rootDep2.alias))[0]
     if (rootDep?.normalizedBareSpecifier) {
       dependencies[peerName] = rootDep.normalizedBareSpecifier

--- a/pnpm11/installing/deps-resolver/src/hoistPeers.ts
+++ b/pnpm11/installing/deps-resolver/src/hoistPeers.ts
@@ -37,20 +37,23 @@ export function hoistPeers (
           nonVersions.push(spec)
         }
       }
-      // When the range is an exact version (e.g. pinned by an override like "4.3.0"),
-      // try to find a preferred version that satisfies it. This prevents a stale
-      // higher version from the lockfile being picked over the overridden version.
-      // For regular semver ranges (e.g. "^1.0.0"), use the highest preferred
-      // version for deduplication.
-      const isExactVersion = semver.valid(range) != null
-      const satisfyingVersion = isExactVersion
+      // Dedupe onto a preferred version only when it actually satisfies the
+      // wanted peer range. Picking the highest preferred version regardless of
+      // the range lets a version resolved for one importer be auto-installed as
+      // another importer's peer even though nothing in that importer's closure
+      // accepts it, silently producing a peer graph that mixes incompatible
+      // majors. Ranges that are not semver (workspace:, npm: aliases, dist-tags)
+      // cannot be checked, so they keep the dedupe-to-highest behavior.
+      const isSemverRange = semver.validRange(range, { includePrerelease: true }) != null
+      const satisfyingVersion = isSemverRange
         ? semver.maxSatisfying(versions, range, { includePrerelease: true })
         : null
       if (satisfyingVersion) {
         dependencies[peerName] = [satisfyingVersion, ...nonVersions].join(' || ')
-      } else if (isExactVersion && opts.autoInstallPeers) {
-        // No preferred version satisfies the exact override version.
-        // Use the range directly so pnpm resolves it from the registry.
+      } else if (isSemverRange && versions.length > 0 && opts.autoInstallPeers) {
+        // Preferred versions exist but none satisfies the wanted range.
+        // Use the range directly so pnpm resolves it from the registry rather
+        // than installing a version the peer explicitly rejects.
         dependencies[peerName] = range
       } else {
         dependencies[peerName] = [semver.maxSatisfying(versions, '*', { includePrerelease: true }), ...nonVersions]

--- a/pnpm11/installing/deps-resolver/src/hoistPeers.ts
+++ b/pnpm11/installing/deps-resolver/src/hoistPeers.ts
@@ -55,11 +55,14 @@ export function hoistPeers (
         : null
       if (satisfyingVersion) {
         dependencies[peerName] = [satisfyingVersion, ...nonVersions].join(' || ')
-      } else if (isSemverRange && versions.length > 0 && opts.autoInstallPeers) {
+      } else if (isSemverRange && versions.length > 0) {
         // Preferred versions exist but none satisfies the wanted range.
         // Use the range directly so pnpm resolves it from the registry rather
-        // than installing a version the peer explicitly rejects.
-        dependencies[peerName] = range
+        // than installing a version the peer explicitly rejects. Without
+        // autoInstallPeers, hoist nothing and leave the peer missing.
+        if (opts.autoInstallPeers) {
+          dependencies[peerName] = range
+        }
       } else {
         dependencies[peerName] = [semver.maxSatisfying(versions, '*', { includePrerelease: true }), ...nonVersions]
           .filter(spec => spec != null)

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -61,7 +61,7 @@ import semver from 'semver'
 
 import { getExactSinglePreferredVersions } from './getExactSinglePreferredVersions.js'
 import { getNonDevWantedDependencies, type WantedDependency } from './getNonDevWantedDependencies.js'
-import { getHoistableOptionalPeers, hoistPeers } from './hoistPeers.js'
+import { getHoistableOptionalPeers, type HoistableRootDep, hoistPeers } from './hoistPeers.js'
 import { safeIntersect } from './mergePeers.js'
 import { nextNodeId, type NodeId } from './nextNodeId.js'
 import { parentIdsContainSequence } from './parentIdsContainSequence.js'
@@ -401,10 +401,35 @@ export async function resolveRootDependencies (
       time,
     }
   }
-  let workspaceRootDeps!: PkgAddressOrLink[]
+  let workspaceRootDeps!: HoistableRootDep[]
   if (ctx.resolvePeersFromWorkspaceRoot) {
     const rootImporterIndex = importers.findIndex(({ options }) => options.parentIds[0] === '.')
-    workspaceRootDeps = pkgAddressesByImportersWithoutPeers[rootImporterIndex]?.pkgAddresses ?? []
+    const rootPkgAddresses = pkgAddressesByImportersWithoutPeers[rootImporterIndex]?.pkgAddresses ?? []
+    // A root dependency reused from the lockfile skips full resolution, so its
+    // address (if any) carries no normalizedBareSpecifier. It still provides
+    // its package to missing peers; without falling back to the wanted
+    // specifier, re-resolving with a lockfile would hoist a different version
+    // than a fresh install of the same manifest.
+    const wantedSpecifierByAlias = new Map<string, string>()
+    for (const wantedDep of importers[rootImporterIndex]?.wantedDependencies ?? []) {
+      if (wantedDep.alias && wantedDep.bareSpecifier) {
+        wantedSpecifierByAlias.set(wantedDep.alias, wantedDep.bareSpecifier)
+      }
+    }
+    workspaceRootDeps = rootPkgAddresses.map((pkgAddress) => ({
+      alias: pkgAddress.alias,
+      pkgName: pkgAddress.pkg.name,
+      normalizedBareSpecifier: pkgAddress.normalizedBareSpecifier ?? wantedSpecifierByAlias.get(pkgAddress.alias),
+    }))
+    const coveredAliases = new Set(workspaceRootDeps.map(({ alias }) => alias))
+    for (const [alias, bareSpecifier] of wantedSpecifierByAlias) {
+      if (coveredAliases.has(alias)) continue
+      workspaceRootDeps.push({
+        alias,
+        pkgName: unwrapPackageName(alias, bareSpecifier).pkgName,
+        normalizedBareSpecifier: bareSpecifier,
+      })
+    }
   } else {
     workspaceRootDeps = []
   }

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -401,35 +401,13 @@ export async function resolveRootDependencies (
       time,
     }
   }
-  let workspaceRootDeps!: HoistableRootDep[]
+  let workspaceRootDeps: HoistableRootDep[]
   if (ctx.resolvePeersFromWorkspaceRoot) {
     const rootImporterIndex = importers.findIndex(({ options }) => options.parentIds[0] === '.')
-    const rootPkgAddresses = pkgAddressesByImportersWithoutPeers[rootImporterIndex]?.pkgAddresses ?? []
-    // A root dependency reused from the lockfile skips full resolution, so its
-    // address (if any) carries no normalizedBareSpecifier. It still provides
-    // its package to missing peers; without falling back to the wanted
-    // specifier, re-resolving with a lockfile would hoist a different version
-    // than a fresh install of the same manifest.
-    const wantedSpecifierByAlias = new Map<string, string>()
-    for (const wantedDep of importers[rootImporterIndex]?.wantedDependencies ?? []) {
-      if (wantedDep.alias && wantedDep.bareSpecifier) {
-        wantedSpecifierByAlias.set(wantedDep.alias, wantedDep.bareSpecifier)
-      }
-    }
-    workspaceRootDeps = rootPkgAddresses.map((pkgAddress) => ({
-      alias: pkgAddress.alias,
-      pkgName: pkgAddress.pkg.name,
-      normalizedBareSpecifier: pkgAddress.normalizedBareSpecifier ?? wantedSpecifierByAlias.get(pkgAddress.alias),
-    }))
-    const coveredAliases = new Set(workspaceRootDeps.map(({ alias }) => alias))
-    for (const [alias, bareSpecifier] of wantedSpecifierByAlias) {
-      if (coveredAliases.has(alias)) continue
-      workspaceRootDeps.push({
-        alias,
-        pkgName: unwrapPackageName(alias, bareSpecifier).pkgName,
-        normalizedBareSpecifier: bareSpecifier,
-      })
-    }
+    workspaceRootDeps = getHoistableRootDeps(
+      importers[rootImporterIndex],
+      pkgAddressesByImportersWithoutPeers[rootImporterIndex]?.pkgAddresses ?? []
+    )
   } else {
     workspaceRootDeps = []
   }
@@ -523,6 +501,41 @@ export async function resolveRootDependencies (
     pkgAddressesByImporters: pkgAddressesByImportersWithoutPeers.map(({ pkgAddresses }) => pkgAddresses),
     time,
   }
+}
+
+/**
+ * Lists the workspace-root dependencies that `hoistPeers` may satisfy a
+ * missing peer with. A root dependency reused from the lockfile skips full
+ * resolution, so it has no address (or an address without a
+ * normalizedBareSpecifier); its wanted specifier is used instead, so that
+ * re-resolving with a lockfile hoists the same version as a fresh install of
+ * the same manifest.
+ */
+function getHoistableRootDeps (
+  rootImporter: ImporterToResolve | undefined,
+  rootPkgAddresses: PkgAddressOrLink[]
+): HoistableRootDep[] {
+  const wantedSpecifierByAlias = new Map<string, string>()
+  for (const wantedDep of rootImporter?.wantedDependencies ?? []) {
+    if (wantedDep.alias && wantedDep.bareSpecifier) {
+      wantedSpecifierByAlias.set(wantedDep.alias, wantedDep.bareSpecifier)
+    }
+  }
+  const rootDeps: HoistableRootDep[] = rootPkgAddresses.map((pkgAddress) => ({
+    alias: pkgAddress.alias,
+    pkgName: pkgAddress.pkg.name,
+    normalizedBareSpecifier: pkgAddress.normalizedBareSpecifier ?? wantedSpecifierByAlias.get(pkgAddress.alias),
+  }))
+  const coveredAliases = new Set(rootDeps.map(({ alias }) => alias))
+  for (const [alias, bareSpecifier] of wantedSpecifierByAlias) {
+    if (coveredAliases.has(alias)) continue
+    rootDeps.push({
+      alias,
+      pkgName: unwrapPackageName(alias, bareSpecifier).pkgName,
+      normalizedBareSpecifier: bareSpecifier,
+    })
+  }
+  return rootDeps
 }
 
 interface ResolvedDependenciesResult {

--- a/pnpm11/installing/deps-resolver/test/hoistPeers.test.ts
+++ b/pnpm11/installing/deps-resolver/test/hoistPeers.test.ts
@@ -49,9 +49,7 @@ test('hoistPeers falls back to range when no preferred version satisfies it', ()
   })
 })
 
-test('hoistPeers picks highest preferred version for deduplication when range is not exact', () => {
-  // For non-exact ranges (like ^2.0.0), hoistPeers picks the highest preferred
-  // version overall (for deduplication), not just the highest satisfying the range.
+test('hoistPeers picks the highest preferred version that satisfies a range for deduplication', () => {
   expect(hoistPeers({
     autoInstallPeers: true,
     allPreferredVersions: {
@@ -63,14 +61,11 @@ test('hoistPeers picks highest preferred version for deduplication when range is
     },
     workspaceRootDeps: [],
   }, [['foo', { range: '^2.0.0' }]])).toStrictEqual({
-    foo: '3.0.0',
+    foo: '2.1.0',
   })
 })
 
-test('hoistPeers reuses higher preferred version when range is not exact', () => {
-  // When the peer dep range is a semver range (not an exact version),
-  // prefer reusing a higher existing version for deduplication even if
-  // it doesn't satisfy the range.
+test('hoistPeers does not reuse a preferred version that the peer range rejects', () => {
   expect(hoistPeers({
     autoInstallPeers: true,
     allPreferredVersions: {
@@ -80,7 +75,54 @@ test('hoistPeers reuses higher preferred version when range is not exact', () =>
     },
     workspaceRootDeps: [],
   }, [['foo', { range: '1' }]])).toStrictEqual({
-    foo: '2.0.0',
+    foo: '1',
+  })
+})
+
+test('hoistPeers prefers the preferred version that satisfies a non-exact range', () => {
+  // In a multi-importer workspace, allPreferredVersions aggregates versions
+  // from every importer. A peer declared as ^1.0.0 must not be handed a
+  // foreign 2.x contributed by another importer when a satisfying 1.x exists.
+  expect(hoistPeers({
+    autoInstallPeers: true,
+    allPreferredVersions: {
+      foo: {
+        '1.0.0': 'version',
+        '2.0.0': 'version',
+      },
+    },
+    workspaceRootDeps: [],
+  }, [['foo', { range: '^1.0.0' }]])).toStrictEqual({
+    foo: '1.0.0',
+  })
+})
+
+test('hoistPeers does not treat a prerelease of the next major as satisfying a caret range', () => {
+  expect(hoistPeers({
+    autoInstallPeers: true,
+    allPreferredVersions: {
+      foo: {
+        '1.0.0': 'version',
+        '2.0.0-beta.1': 'version',
+      },
+    },
+    workspaceRootDeps: [],
+  }, [['foo', { range: '^1.0.0' }]])).toStrictEqual({
+    foo: '1.0.0',
+  })
+})
+
+test('hoistPeers falls back to the range when no preferred version satisfies a non-exact range', () => {
+  expect(hoistPeers({
+    autoInstallPeers: true,
+    allPreferredVersions: {
+      foo: {
+        '2.0.0': 'version',
+      },
+    },
+    workspaceRootDeps: [],
+  }, [['foo', { range: '^1.0.0' }]])).toStrictEqual({
+    foo: '^1.0.0',
   })
 })
 

--- a/pnpm11/installing/deps-resolver/test/hoistPeers.test.ts
+++ b/pnpm11/installing/deps-resolver/test/hoistPeers.test.ts
@@ -126,6 +126,18 @@ test('hoistPeers falls back to the range when no preferred version satisfies a n
   })
 })
 
+test('hoistPeers hoists nothing when no preferred version satisfies the range and peers are not auto-installed', () => {
+  expect(hoistPeers({
+    autoInstallPeers: false,
+    allPreferredVersions: {
+      foo: {
+        '2.0.0': 'version',
+      },
+    },
+    workspaceRootDeps: [],
+  }, [['foo', { range: '^1.0.0' }]])).toStrictEqual({})
+})
+
 // Regression test for https://github.com/pnpm/pnpm/pull/11049
 test('hoistPeers returns valid specifier when given only range preferred version selectors', () => {
   expect(hoistPeers({


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#12847 and pnpm/pnpm#12921. Continues the same cleanup as pnpm/pnpm#12927: pnpm/pnpm#12847 was our fix, and this addresses the remaining correctness gap it did not close. The change is independent of pnpm/pnpm#12927 (verified: the two touch disjoint product code, and the reproduction measures the same 46 poisoned snapshots with or without it), so it targets `main` directly and can land before or after the deadlock fix.

First, an apology: pnpm/pnpm#12847's two-pass split hung `pnpm install` for every `electron-builder@26.15.3` user until pnpm/pnpm#12927. We are sorry for the disruption that caused.

### What was still broken after pnpm/pnpm#12847

`hoistPeers` only checked preferred versions against the wanted peer range when the range was an **exact version**. For an ordinary semver range (`^1.0.0`), it deduplicated onto `semver.maxSatisfying(versions, '*')` — the highest preferred version overall, with the declared range never consulted.

In a multi-importer workspace, `allPreferredVersions` aggregates versions contributed by every importer. So importer A depending on `foo@2.0.0` put `2.0.0` into the candidate set, and a package deep inside importer B's self-contained `1.x` closure — declaring `peerDependencies: { foo: "^1.0.0" }` — was handed `2.0.0`, because it is numerically highest and `'*'` matches anything. pnpm then only warned about the violation, so the incoherent peer graph shipped silently and failed at runtime. This happens upstream of `resolvePeers`, so pnpm/pnpm#12847 (single-importer case, fixed) and pnpm/pnpm#12927 (deadlock, orthogonal) do not reach it.

Measured on a minimal 4-file reproduction (two importers, `autoInstallPeers: true`): **46 poisoned snapshots on pnpm 11.11.0 → 0 with this change**, on both the TypeScript CLI and the Rust port.

### The fix

- `hoistPeers` / `hoist_peers` now validate the wanted range with `semver.validRange` (not just `semver.valid`) and dedupe onto the **highest preferred version that satisfies the range**. When preferred versions exist but none satisfies, the range itself is resolved from the registry instead of installing a version the peer explicitly rejects. Non-semver specifiers (`workspace:`, `npm:` aliases, dist-tags) cannot be range-checked and keep the dedupe-to-highest behavior.
- Fixing this exposed a Rust-port divergence the old behavior had masked: `resolve_peers` indexed a node's children into `ParentRefs` only by install alias, so an npm-alias child could never provide a peer under its real package name below the importer level. Descent-time children are now indexed by both alias and real name, matching `resolvePeers.ts`.

### Why we believe this matches pnpm's intended behavior

- Auto-installing peers exists to *satisfy* declared peer ranges; a version the range explicitly rejects can never satisfy it. Deduplication is an optimization and should not override an explicit constraint from a manifest.
- The exact-version branch added earlier already embodies this principle (pick a satisfying version, else resolve the range from the registry); this extends the same rule to ordinary ranges instead of leaving them on a `'*'` match.
- Peers that the user's own tree genuinely provides still resolve as before (warn on mismatch, never error) — this only changes versions **pnpm itself introduces** via hoisting/auto-install.
- It is a behavior change for lockfiles that relied on dedupe-to-highest (a few existing tests asserted the old outcome and were updated in both stacks). With pnpm 12 about to release, this seems like the right time to land it.

### Follow-up: re-resolve consistency (second commit)

Investigating the two-pass behavior surfaced a second, related defect in the TypeScript CLI. On a fresh install, a missing peer that a workspace-root dependency provides is hoisted to that root dependency's own specifier. On a re-resolve with an existing lockfile, root dependencies reused from the lockfile skip full resolution and were invisible to that branch, so the hoist could pick a different version than a fresh install of the same manifest — the lockfile depended on *how* you arrived at it. The old `'*'`-dedupe made the two flows coincidentally identical, which is why this was never visible before. The hoist's root-dep table now falls back to the importer's wanted specifiers, its entry type is narrowed to the exact fields the hoist reads (the same shape as the Rust port's `WorkspaceRootDep`), and both stacks carry a regression test pinning the shared expectation: adding a dependent to an existing lockfile binds the same peer provider as a fresh install. The Rust port already behaved correctly in both flows (its peers dry-run sees providers regardless of lockfile reuse) and needed no product change.

## Squash Commit Body

```text
When deduplicating a missing peer onto the workspace's preferred
versions, hoistPeers matched candidates against '*' unless the wanted
range was an exact version. In a multi-importer workspace,
allPreferredVersions aggregates versions from every importer, so a peer
declared as ^1.0.0 inside one importer's closure could be auto-installed
as a 2.x resolved for another importer, silently producing a peer graph
that mixes incompatible majors. This survived pnpm/pnpm#12847 (which
fixed the single-importer case in resolvePeers) and is independent of
the pnpm/pnpm#12921 deadlock fix: the wrong version is chosen upstream
of peer resolution, during peer hoisting.

Both stacks now dedupe onto the highest preferred version that
satisfies the wanted range and fall back to resolving the range from
the registry when no candidate satisfies it. Non-semver specifiers
(workspace:, npm: aliases, dist-tags) keep the dedupe-to-highest
behavior.

Fixing this exposed a pacquet-only divergence the old behavior masked:
resolve_peers indexed a node's children into ParentRefs only by their
install alias, so an npm-alias child could never provide a peer under
its real package name below the importer level, and the binding fell
through to the importer-level hoisted entry. Descent-time children are
now indexed by both alias and real name, matching resolvePeers.ts.

Measured on the multi-importer reproduction: 46 poisoned snapshots on
pnpm 11.11.0, 0 with this change, in both the TypeScript CLI and
pacquet.

Additionally, hoistPeers now binds the same peer on a re-resolve with
an existing lockfile as on a fresh install of the same manifest: root
dependencies reused from the lockfile skip full resolution and were
invisible to the workspace-root branch of the hoist, so the picked
version depended on whether a lockfile was present. The root-dep table
falls back to the importer's wanted specifiers, and its entry type is
narrowed to HoistableRootDep — the fields hoistPeers reads, matching
the Rust port's WorkspaceRootDep.

Related to pnpm/pnpm#12847 and pnpm/pnpm#12921.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Peer dependencies now deduplicate and resolve to the highest version that satisfies the declared semver range, including non-exact caret ranges.
  * Auto-installed peer selection now respects semver-checkable peer ranges and falls back safely when no compatible preferred version exists.
  * Peer hoisting stays consistent across fresh installs vs existing lockfile installs.
  * Improved peer matching for aliased installations using the provider’s real package name, with fixes for prerelease and unsupported-range edge cases.
* **Tests**
  * Added regression coverage and updated expectations for peer hoisting, deduplication behavior, alias handling, and lockfile consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->