### PR TITLE
fix(network): respect macOS scoped DNS

### DIFF
--- a/.changeset/calm-cats-resolve.md
+++ b/.changeset/calm-cats-resolve.md
@@ -1,5 +1,5 @@
 ---
-"pnpm": patch
+"pacquet": patch
 ---
 
 Use macOS native DNS resolution with bounded concurrency so installs respect scoped and VPN-provided resolvers.

--- a/.changeset/calm-cats-resolve.md
+++ b/.changeset/calm-cats-resolve.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Use macOS native DNS resolution with bounded concurrency so installs respect scoped and VPN-provided resolvers.

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -21,6 +21,10 @@ pub use tls::{PerRegistryTls, RegistryTls, TlsConfig, TlsError};
 
 use priority_semaphore::{Permit, PrioritySemaphore};
 use proxy::{NoProxyMatcher, parse_proxy_url, strip_userinfo};
+#[cfg(target_os = "macos")]
+use reqwest::dns::Addrs;
+#[cfg(any(target_os = "macos", test))]
+use reqwest::dns::{Name, Resolve, Resolving};
 use reqwest::{
     Certificate, Client, Identity, Proxy,
     header::{HeaderMap, HeaderValue, USER_AGENT},
@@ -287,20 +291,11 @@ impl ThrottledClient {
     /// [`DEFAULT_FETCH_TIMEOUT_MS`] (60s), the `fetchTimeout` setting's
     /// default.
     ///
-    /// `hickory_dns(true)` swaps reqwest's default resolver
-    /// (tokio's `lookup_host`, which calls the platform's blocking
-    /// `getaddrinfo` from a `spawn_blocking` thread) for the
-    /// pure-Rust async resolver. The default resolver is correct
-    /// but on macOS it routes every lookup through `mDNSResponder`,
-    /// which spuriously returns `EAI_NONAME` ("nodename nor servname
-    /// provided") for valid hostnames when many concurrent lookups
-    /// pile up — e.g. the [`default_network_concurrency`] simultaneous
-    /// tarball connections this client opens. pnpm doesn't hit it
-    /// because Node's `dns.lookup`
-    /// runs on libuv's 4-thread pool, naturally throttling concurrent
-    /// `getaddrinfo` calls. `hickory-dns` queries DNS over UDP / TCP
-    /// directly, bypassing `mDNSResponder` and the `EAI_NONAME` flake
-    /// entirely.
+    /// DNS resolution is platform-specific. macOS uses its native
+    /// `getaddrinfo` resolver because Hickory misses scoped resolver
+    /// routing used by VPNs. A four-request cap matches Node's libuv DNS
+    /// pool and prevents concurrent calls from overwhelming
+    /// `mDNSResponder`. Other platforms keep Hickory's async resolver.
     #[must_use]
     pub fn new_for_installs() -> Self {
         Self::for_installs(
@@ -572,12 +567,69 @@ fn allowlist_redirect_policy(guard: RedirectGuard) -> reqwest::redirect::Policy 
     })
 }
 
+#[cfg(any(target_os = "macos", test))]
+struct CappedDnsResolver<Inner> {
+    inner: Arc<Inner>,
+    permits: Arc<Semaphore>,
+}
+
+#[cfg(target_os = "macos")]
+struct NativeDnsResolver;
+
+#[cfg(target_os = "macos")]
+impl Resolve for NativeDnsResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_owned();
+        Box::pin(async move {
+            tokio::net::lookup_host((host, 0))
+                .await
+                .map(|addrs| Box::new(addrs) as Addrs)
+                .map_err(|error| Box::new(error) as Box<dyn std::error::Error + Send + Sync>)
+        })
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl<Inner> CappedDnsResolver<Inner> {
+    fn new(inner: Inner, concurrency: NonZeroUsize) -> Self {
+        Self { inner: Arc::new(inner), permits: Arc::new(Semaphore::new(concurrency.get())) }
+    }
+}
+
+#[cfg(any(target_os = "macos", test))]
+impl<Inner> Resolve for CappedDnsResolver<Inner>
+where
+    Inner: Resolve + 'static,
+{
+    fn resolve(&self, name: Name) -> Resolving {
+        let inner = Arc::clone(&self.inner);
+        let permits = Arc::clone(&self.permits);
+        Box::pin(async move {
+            let _permit =
+                permits.acquire_owned().await.expect("DNS concurrency semaphore is never closed");
+            inner.resolve(name).await
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn configure_dns(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    const DNS_CONCURRENCY: NonZeroUsize = NonZeroUsize::new(4).expect("four is non-zero");
+
+    builder.dns_resolver(CappedDnsResolver::new(NativeDnsResolver, DNS_CONCURRENCY))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn configure_dns(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
+    builder.hickory_dns(true)
+}
+
 fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder {
     let user_agent = HeaderValue::from_str(&settings.user_agent)
         .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_USER_AGENT));
     let mut default_headers = HeaderMap::with_capacity(1);
     default_headers.insert(USER_AGENT, user_agent);
-    Client::builder()
+    let builder = Client::builder()
         .http1_only()
         // Request gzip and transparently decompress it. Packuments are the
         // largest payloads pulled during resolution and registries serve
@@ -589,8 +641,8 @@ fn default_client_builder(settings: &NetworkSettings) -> reqwest::ClientBuilder 
         .default_headers(default_headers)
         .connect_timeout(settings.fetch_timeout)
         .timeout(settings.fetch_timeout)
-        .pool_idle_timeout(Duration::from_secs(4))
-        .hickory_dns(true)
+        .pool_idle_timeout(Duration::from_secs(4));
+    configure_dns(builder)
 }
 
 /// Load the PEM bundle named by `NODE_EXTRA_CA_CERTS` as extra trust

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -12,12 +12,89 @@
 //! absolute-form URI and a decoded `Proxy-Authorization` header.
 
 use super::{
-    ForInstallsError, NetworkSettings, NoProxyMatcher, NoProxySetting, PerRegistryTls, ProxyConfig,
-    ProxyError, ThrottledClient, TlsConfig, origin_of, parse_proxy_url,
+    CappedDnsResolver, ForInstallsError, NetworkSettings, NoProxyMatcher, NoProxySetting,
+    PerRegistryTls, ProxyConfig, ProxyError, ThrottledClient, TlsConfig, origin_of,
+    parse_proxy_url,
 };
 use crate::proxy::{percent_decode_str, strip_userinfo};
 use pacquet_testing_utils::env_guard::EnvGuard;
-use reqwest::Url;
+use reqwest::{
+    Url,
+    dns::{Addrs, Name, Resolve, Resolving},
+};
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+use tokio::sync::Semaphore;
+
+struct RecordingResolver {
+    active: Arc<AtomicUsize>,
+    gate: Arc<Semaphore>,
+    maximum_active: Arc<AtomicUsize>,
+}
+
+impl Resolve for RecordingResolver {
+    fn resolve(&self, _name: Name) -> Resolving {
+        let active = Arc::clone(&self.active);
+        let gate = Arc::clone(&self.gate);
+        let maximum_active = Arc::clone(&self.maximum_active);
+        Box::pin(async move {
+            let active_count = active.fetch_add(1, Ordering::SeqCst) + 1;
+            maximum_active.fetch_max(active_count, Ordering::SeqCst);
+            let _gate_permit =
+                gate.acquire_owned().await.expect("test gate semaphore is never closed");
+            active.fetch_sub(1, Ordering::SeqCst);
+            Ok(Box::new(std::iter::empty()) as Addrs)
+        })
+    }
+}
+
+#[tokio::test]
+async fn capped_dns_resolver_limits_concurrency() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let gate = Arc::new(Semaphore::new(0));
+    let maximum_active = Arc::new(AtomicUsize::new(0));
+    let resolver = Arc::new(CappedDnsResolver::new(
+        RecordingResolver {
+            active: Arc::clone(&active),
+            gate: Arc::clone(&gate),
+            maximum_active: Arc::clone(&maximum_active),
+        },
+        NonZeroUsize::new(4).expect("four is non-zero"),
+    ));
+    let tasks = (0..8)
+        .map(|_| {
+            let resolver = Arc::clone(&resolver);
+            tokio::spawn(async move {
+                let _addresses = resolver
+                    .resolve("registry.npmjs.org".parse().expect("valid DNS name"))
+                    .await
+                    .expect("recording resolver succeeds");
+            })
+        })
+        .collect::<Vec<_>>();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while active.load(Ordering::SeqCst) < 4 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("four resolutions should start");
+    assert_eq!(maximum_active.load(Ordering::SeqCst), 4);
+
+    gate.add_permits(8);
+    for task in tasks {
+        task.await.expect("resolution task succeeds");
+    }
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+    assert_eq!(maximum_active.load(Ordering::SeqCst), 4);
+}
 
 fn list(entries: &[&str]) -> NoProxySetting {
     NoProxySetting::List(entries.iter().map(|s| (*s).to_string()).collect())


### PR DESCRIPTION
## Problem

pnpm v12 hard-enables Hickory DNS for install requests. On macOS, Hickory reads the global DNS state but does not honor the full scoped/supplemental resolver graph used by VPNs such as Tailscale. In that setup, public registry names can be sent to a supplemental resolver with its search suffix and repeatedly fail.

## Fix

- use macOS native `getaddrinfo` resolution through `tokio::net::lookup_host`
- cap native lookups at four concurrent requests, matching Node/libuv behavior and retaining protection against `mDNSResponder` overload
- keep Hickory on non-macOS platforms
- cover the concurrency cap with a deterministic resolver test

This also avoids a registry-specific trailing-dot workaround, so tarball, custom-registry, and other HTTP hosts use the same correct macOS resolver routing. Hickory per-domain macOS resolver support is tracked in https://github.com/hickory-dns/hickory-dns/issues/2251.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p pacquet-network` (102 passed)
- `cargo clippy -p pacquet-network --tests --no-deps`
- fresh CLI install from `https://registry.npmjs.org/` on the affected Tailscale Mac (2 packages downloaded, 271 ms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS resolution during installs on macOS by switching to native DNS behavior to respect scoped and VPN-provided resolvers.
  * Added a bounded concurrency limit for DNS lookups (max 4 simultaneous resolutions) to improve reliability and avoid resource exhaustion.
  * Kept existing DNS behavior on non-macOS platforms.
* **Tests**
  * Added coverage to verify the DNS resolver enforces the concurrency cap and completes all lookups correctly.
* **Chores**
  * Released as a patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->