### PR TITLE
fix(deploy): prune unreachable package graph

### DIFF
--- a/.changeset/tidy-deploy-graphs.md
+++ b/.changeset/tidy-deploy-graphs.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/releasing.commands": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 Limit modern deploy lockfiles and localized virtual stores to dependencies reachable from the selected dependency groups.

--- a/.changeset/tidy-deploy-graphs.md
+++ b/.changeset/tidy-deploy-graphs.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Limit modern deploy lockfiles and localized virtual stores to dependencies reachable from the selected dependency groups.

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -27,7 +27,7 @@ use pacquet_workspace_projects_filter::{FilterProjectsOptions, WorkspaceFilter, 
 use pacquet_workspace_projects_graph::{BaseProject, GraphProject};
 use serde_json::{Map, Value, json};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet, VecDeque},
     fs,
     io::{self, Write},
     path::{Path, PathBuf},
@@ -283,6 +283,8 @@ impl DeployArgs {
         };
 
         let project_id = importer_id_from_root_dir(workspace_dir, &selected.project.root_dir);
+        let dependency_groups =
+            self.install_args.dependency_options.dependency_groups().collect::<Vec<_>>();
         let deploy_files = create_deploy_files(
             &lockfile,
             selected,
@@ -290,6 +292,7 @@ impl DeployArgs {
             workspace_dir,
             deploy_dir,
             config,
+            &dependency_groups,
         )?;
         write_deploy_files(deploy_dir, &deploy_files)?;
         // Boxed for the same large-future reason as the legacy path above.
@@ -762,6 +765,7 @@ fn create_deploy_files(
     lockfile_dir: &Path,
     deploy_dir: &Path,
     config: &Config,
+    dependency_groups: &[DependencyGroup],
 ) -> miette::Result<DeployFiles> {
     let input_snapshot = lockfile
         .importers
@@ -870,6 +874,7 @@ fn create_deploy_files(
         HashMap::from([(Lockfile::ROOT_IMPORTER_KEY.to_string(), target_snapshot.clone())]);
     deploy_lockfile.packages = (!packages.is_empty()).then_some(packages);
     deploy_lockfile.snapshots = (!snapshots.is_empty()).then_some(snapshots);
+    prune_deploy_lockfile_graph(&mut deploy_lockfile, dependency_groups);
 
     let mut manifest = selected.project.manifest.value().clone();
     set_manifest_dependencies(&mut manifest, "dependencies", target_snapshot.dependencies.as_ref());
@@ -923,6 +928,77 @@ fn create_deploy_files(
             .then_some(Value::Object(workspace_manifest)),
         workspace_config,
     })
+}
+
+/// Keep only the dependency graph that the deploy install will materialize.
+///
+/// The deploy importer and package manifest intentionally retain every direct
+/// dependency group so the generated frozen lockfile still satisfies the
+/// generated manifest. Only the package graph is mode-specific: for example,
+/// `deploy --prod` excludes dev-only and unrelated workspace snapshots from
+/// both the lockfile and the localized virtual store.
+fn prune_deploy_lockfile_graph(lockfile: &mut Lockfile, dependency_groups: &[DependencyGroup]) {
+    let Some(snapshots) = lockfile.snapshots.as_ref() else { return };
+    let Some(importer) = lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY) else { return };
+
+    let include_prod = dependency_groups.contains(&DependencyGroup::Prod);
+    let include_dev = dependency_groups.contains(&DependencyGroup::Dev);
+    let include_optional = dependency_groups.contains(&DependencyGroup::Optional);
+    let mut queue = VecDeque::new();
+
+    {
+        let mut enqueue_importer_map = |dependencies: Option<&ResolvedDependencyMap>| {
+            for (alias, dependency) in dependencies.into_iter().flatten() {
+                let Some(key) = dependency.version.resolved_key(alias) else { continue };
+                if snapshots.contains_key(&key) {
+                    queue.push_back(key);
+                }
+            }
+        };
+        if include_prod {
+            enqueue_importer_map(importer.dependencies.as_ref());
+        }
+        if include_dev {
+            enqueue_importer_map(importer.dev_dependencies.as_ref());
+        }
+        if include_optional {
+            enqueue_importer_map(importer.optional_dependencies.as_ref());
+        }
+    }
+
+    let mut reachable = HashSet::new();
+    while let Some(key) = queue.pop_front() {
+        if !reachable.insert(key.clone()) {
+            continue;
+        }
+        let Some(snapshot) = snapshots.get(&key) else { continue };
+        for dependencies in
+            snapshot.dependencies.as_ref().into_iter().chain(
+                include_optional.then_some(snapshot.optional_dependencies.as_ref()).flatten(),
+            )
+        {
+            for (alias, dependency) in dependencies {
+                let Some(child) = dependency.resolve(alias) else { continue };
+                if snapshots.contains_key(&child) {
+                    queue.push_back(child);
+                }
+            }
+        }
+    }
+
+    let reachable_metadata = reachable.iter().map(PackageKey::without_peer).collect::<HashSet<_>>();
+    if let Some(snapshots) = lockfile.snapshots.as_mut() {
+        snapshots.retain(|key, _| reachable.contains(key));
+        if snapshots.is_empty() {
+            lockfile.snapshots = None;
+        }
+    }
+    if let Some(packages) = lockfile.packages.as_mut() {
+        packages.retain(|key, _| reachable_metadata.contains(key));
+        if packages.is_empty() {
+            lockfile.packages = None;
+        }
+    }
 }
 
 fn fill_target_dependency_map(

--- a/pnpm/crates/cli/tests/deploy.rs
+++ b/pnpm/crates/cli/tests/deploy.rs
@@ -461,8 +461,10 @@ fn deploy_graph_keys(deploy_dir: &Path) -> Vec<String> {
 
 fn virtual_store_entries(deploy_dir: &Path) -> Vec<String> {
     fs::read_dir(deploy_dir.join("node_modules/.pnpm"))
-        .unwrap()
-        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .expect("read the deploy virtual store")
+        .map(|entry| {
+            entry.expect("read a virtual store entry").file_name().to_string_lossy().into_owned()
+        })
         .collect()
 }
 

--- a/pnpm/crates/cli/tests/deploy.rs
+++ b/pnpm/crates/cli/tests/deploy.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_lockfile::Lockfile;
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::is_symlink_or_junction,
@@ -11,7 +12,7 @@ fn deploy_from_shared_lockfile_installs_selected_project() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
-    write_workspace(&workspace, true);
+    write_reachability_workspace(&workspace);
 
     pacquet.with_arg("install").assert().success();
     pacquet_cmd(&workspace)
@@ -50,6 +51,127 @@ fn deploy_from_shared_lockfile_installs_selected_project() {
     assert!(
         !deploy_dir.join("node_modules/dev-only").exists(),
         "dev-only workspace dependency should not be linked with --prod",
+    );
+
+    let graph_keys = deploy_graph_keys(&deploy_dir);
+    assert!(
+        graph_keys.iter().any(|key| key.contains("@pnpm.e2e/pkg-with-1-dep@100.0.0")),
+        "production dependency should remain in the deploy lock graph: {graph_keys:#?}",
+    );
+    assert!(
+        graph_keys.iter().any(|key| key.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@")),
+        "transitive production dependency should remain in the deploy lock graph: {graph_keys:#?}",
+    );
+    for excluded in
+        ["dev-only@file:", "@pnpm.e2e/bar@100.0.0", "unused@file:", "@pnpm.e2e/qar@100.0.0"]
+    {
+        assert!(
+            !graph_keys.iter().any(|key| key.contains(excluded)),
+            "production deploy lock graph should exclude {excluded}: {graph_keys:#?}",
+        );
+    }
+
+    let virtual_store_entries = virtual_store_entries(&deploy_dir);
+    assert!(
+        virtual_store_entries
+            .iter()
+            .any(|entry| entry.contains("@pnpm.e2e+dep-of-pkg-with-1-dep@")),
+        "transitive production dependency should be materialized: {virtual_store_entries:#?}",
+    );
+    for excluded in
+        ["dev-only@file+", "@pnpm.e2e+bar@100.0.0", "unused@file+", "@pnpm.e2e+qar@100.0.0"]
+    {
+        assert!(
+            !virtual_store_entries.iter().any(|entry| entry.contains(excluded)),
+            "production deploy virtual store should exclude {excluded}: {virtual_store_entries:#?}",
+        );
+    }
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn production_deploy_does_not_require_dev_only_workspace_sources() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+
+    pacquet.with_arg("install").assert().success();
+    fs::remove_dir_all(workspace.join("packages/dev-only")).unwrap();
+
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--prod", "deploy"])
+        .assert()
+        .success();
+    assert!(workspace.join("deploy/node_modules/lib").exists());
+    assert!(!workspace.join("deploy/node_modules/dev-only").exists());
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn shared_lockfile_deploy_honors_no_optional_in_graph_and_virtual_store() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+    write_project(
+        &workspace,
+        "app",
+        &serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "dependencies": { "lib": "workspace:*" },
+            "devDependencies": { "dev-only": "workspace:*" },
+            "optionalDependencies": { "optional-only": "workspace:*" },
+        }),
+    );
+    write_project(
+        &workspace,
+        "optional-only",
+        &serde_json::json!({
+            "name": "optional-only",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "dependencies": { "@pnpm.e2e/qar": "100.0.0" },
+        }),
+    );
+
+    pacquet.with_arg("install").assert().success();
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--prod", "deploy-with-optional"])
+        .assert()
+        .success();
+    let with_optional = workspace.join("deploy-with-optional");
+    assert!(with_optional.join("node_modules/optional-only").exists());
+    assert!(
+        deploy_graph_keys(&with_optional).iter().any(|key| key.contains("@pnpm.e2e/qar@100.0.0")),
+    );
+
+    pacquet_cmd(&workspace)
+        .with_args([
+            "--filter",
+            "app",
+            "deploy",
+            "--prod",
+            "--no-optional",
+            "deploy-without-optional",
+        ])
+        .assert()
+        .success();
+    let without_optional = workspace.join("deploy-without-optional");
+    assert!(!without_optional.join("node_modules/optional-only").exists());
+    assert!(
+        !deploy_graph_keys(&without_optional)
+            .iter()
+            .any(|key| key.contains("optional-only@file:") || key.contains("@pnpm.e2e/qar@")),
+    );
+    assert!(
+        !virtual_store_entries(&without_optional)
+            .iter()
+            .any(|entry| entry.contains("optional-only@file+") || entry.contains("@pnpm.e2e+qar@")),
     );
 
     drop((root, mock_instance));
@@ -326,6 +448,24 @@ fn pacquet_cmd(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
+fn deploy_graph_keys(deploy_dir: &Path) -> Vec<String> {
+    let deploy_lockfile = Lockfile::load_wanted_from_dir(deploy_dir).unwrap().unwrap();
+    deploy_lockfile
+        .packages
+        .iter()
+        .flatten()
+        .map(|(key, _)| key.to_string())
+        .chain(deploy_lockfile.snapshots.iter().flatten().map(|(key, _)| key.to_string()))
+        .collect()
+}
+
+fn virtual_store_entries(deploy_dir: &Path) -> Vec<String> {
+    fs::read_dir(deploy_dir.join("node_modules/.pnpm"))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+        .collect()
+}
+
 fn write_workspace(workspace: &Path, inject_workspace_packages: bool) {
     let mut workspace_yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).unwrap();
     workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
@@ -369,6 +509,40 @@ fn write_workspace(workspace: &Path, inject_workspace_packages: bool) {
             "name": "dev-only",
             "version": "1.0.0",
             "files": ["index.js"],
+        }),
+    );
+}
+
+fn write_reachability_workspace(workspace: &Path) {
+    write_workspace(workspace, true);
+    write_project(
+        workspace,
+        "lib",
+        &serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" },
+        }),
+    );
+    write_project(
+        workspace,
+        "dev-only",
+        &serde_json::json!({
+            "name": "dev-only",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "dependencies": { "@pnpm.e2e/bar": "100.0.0" },
+        }),
+    );
+    write_project(
+        workspace,
+        "unused",
+        &serde_json::json!({
+            "name": "unused",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "dependencies": { "@pnpm.e2e/qar": "100.0.0" },
         }),
     );
 }

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -205,6 +205,7 @@ function filterDeployPackageSnapshots (
     reachable.add(depPath)
 
     const snapshot = packages[depPath]
+    if (snapshot == null) continue
     enqueue(snapshot.dependencies)
     if (include.optionalDependencies) enqueue(snapshot.optionalDependencies)
   }

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -26,6 +26,7 @@ const DEPENDENCIES_FIELD = ['dependencies', 'devDependencies', 'optionalDependen
 export interface CreateDeployFilesOptions {
   allProjects: Array<Pick<Project, 'manifest' | 'rootDirRealPath'>>
   deployDir: string
+  include: { [dependenciesField in DependenciesField]: boolean }
   lockfile: LockfileObject
   lockfileDir: string
   patchedDependencies?: PnpmSettings['patchedDependencies']
@@ -49,6 +50,7 @@ export interface DeployFiles {
 export function createDeployFiles ({
   allProjects,
   deployDir,
+  include,
   lockfile,
   lockfileDir,
   patchedDependencies,
@@ -124,6 +126,12 @@ export function createDeployFiles ({
     }
   }
 
+  const deployPackageSnapshots = filterDeployPackageSnapshots(
+    targetSnapshot,
+    targetPackageSnapshots,
+    include
+  )
+
   const result: DeployFiles = {
     lockfile: {
       ...lockfile,
@@ -138,7 +146,7 @@ export function createDeployFiles ({
       importers: {
         ['.' as ProjectId]: targetSnapshot,
       },
-      packages: targetPackageSnapshots,
+      packages: deployPackageSnapshots,
     },
     manifest: {
       ...selectedProjectManifest,
@@ -170,6 +178,40 @@ export function createDeployFiles ({
   }
 
   return result
+}
+
+function filterDeployPackageSnapshots (
+  importer: ProjectSnapshot,
+  packages: PackageSnapshots,
+  include: CreateDeployFilesOptions['include']
+): PackageSnapshots {
+  const queue: DepPath[] = []
+  const enqueue = (dependencies: ResolvedDependencies | undefined) => {
+    for (const [alias, reference] of Object.entries(dependencies ?? {})) {
+      const depPath = dp.refToRelative(reference, alias)
+      if (depPath != null && packages[depPath] != null) queue.push(depPath)
+    }
+  }
+
+  if (include.dependencies) enqueue(importer.dependencies)
+  if (include.devDependencies) enqueue(importer.devDependencies)
+  if (include.optionalDependencies) enqueue(importer.optionalDependencies)
+
+  const reachable = new Set<DepPath>()
+  let head = 0
+  while (head < queue.length) {
+    const depPath = queue[head++]!
+    if (reachable.has(depPath)) continue
+    reachable.add(depPath)
+
+    const snapshot = packages[depPath]
+    enqueue(snapshot.dependencies)
+    if (include.optionalDependencies) enqueue(snapshot.optionalDependencies)
+  }
+
+  return Object.fromEntries(
+    Array.from(reachable, (depPath) => [depPath, packages[depPath]])
+  ) as PackageSnapshots
 }
 
 interface ConvertOptions {

--- a/pnpm11/releasing/commands/src/deploy/deploy.ts
+++ b/pnpm11/releasing/commands/src/deploy/deploy.ts
@@ -378,6 +378,11 @@ async function deployFromSharedLockfile (
   const deployFiles = createDeployFiles({
     allProjects,
     deployDir,
+    include: {
+      dependencies: opts.production !== false,
+      devDependencies: opts.dev !== false,
+      optionalDependencies: opts.optional !== false,
+    },
     lockfile,
     lockfileDir,
     patchedDependencies: opts.patchedDependencies,

--- a/pnpm11/releasing/commands/test/deploy/deploy.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/deploy.test.ts
@@ -620,6 +620,19 @@ test('deploy does not preserve the inject workspace packages settings in the loc
     {
       name: 'project',
       version: '1.0.0',
+      dependencies: {
+        'is-positive': '1.0.0',
+      },
+      devDependencies: {
+        'is-negative': '1.0.0',
+      },
+    },
+    {
+      name: 'unused',
+      version: '1.0.0',
+      dependencies: {
+        'is-odd': '1.0.0',
+      },
     },
   ])
 
@@ -651,6 +664,12 @@ test('deploy does not preserve the inject workspace packages settings in the loc
   }, ['dist'])
 
   const project = assertProject(path.resolve('dist'))
+  project.has('is-positive')
+  project.hasNot('is-negative')
   const lockfile = project.readLockfile()
+  const packageKeys = Object.keys(lockfile.packages)
+  expect(packageKeys.some((key) => key.startsWith('is-positive@'))).toBeTruthy()
+  expect(packageKeys.some((key) => key.startsWith('is-negative@'))).toBeFalsy()
+  expect(packageKeys.some((key) => key.startsWith('is-odd@'))).toBeFalsy()
   expect(lockfile.settings).not.toHaveProperty('injectWorkspacePackages')
 })


### PR DESCRIPTION
Fixes #12933.

## Problem

The Rust modern deploy path converts every workspace importer and every package/snapshot into the dedicated deploy lockfile. `--prod` removes top-level dev links, but `CreateVirtualStore` still materializes that entire graph into the localized `.pnpm` directory. Unrelated workspaces and dev-only tools therefore make production deploys much larger.

The TypeScript implementation already filters the graph before physical linking, but its emitted deploy lockfile is also broader than the selected dependency groups.

## Fix

- derive the exact dependency groups once for Rust deploy
- walk the converted deploy graph from importer `.` and keep only reachable snapshots/package metadata
- include required transitive edges and gate optional edges on `--no-optional`
- apply the equivalent graph filtering to TypeScript deploy lockfile generation
- preserve importer maps and the generated package manifest so frozen freshness validation still succeeds

## Large-monorepo measurement

With a warm store and `deploy --prod`:

- before: 4,576,976,896 bytes and 3,795 virtual-store directories
- after: 1,292,177,408 bytes and 1,826 virtual-store directories
- fixed Rust deploy: 16.39s and 210,681,856-byte max RSS
- TypeScript pnpm 11.11 baseline: 28.08s and 1,895,956,480-byte max RSS

The fixed output contains no Storybook, Playwright, Expo, or TypeScript 7 snapshots for the selected production service.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p pacquet-cli --test deploy` (9 passed)
- TypeScript build and ESLint for changed deploy files
- TypeScript deploy suite (13 passed)
- integration coverage for prod/dev/unrelated workspaces, transitive prod dependencies, deleted dev-workspace sources, and optional/no-optional output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment lockfiles and virtual stores are now pruned to include only packages reachable from the selected dependency groups.
  - Shared-lockfile deployments honor production/development/optional selections, excluding unused, development-only, and optional-only packages when omitted.
  - Deploys succeed even if excluded development sources are removed, without linking them into the output.
  - Workspace package contents in deploy lockfiles now keep runtime dependencies while excluding dev-only/unused ones.
- **Tests**
  - Expanded deploy coverage to validate reachability pruning, virtual-store materialization, and `--no-optional` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->