### PR TITLE
feat(napi): pass the resolved directory to the readPackage hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4829,6 +4829,7 @@ name = "pacquet-resolving-deps-resolver"
 version = "0.0.1"
 dependencies = [
  "async-recursion",
+ "async-trait",
  "chrono",
  "derive_more",
  "futures-util",

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -415,7 +415,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     let mut current = input.clone();
     for pnpmfile in &pnpmfiles {
         let hooks = finder::load_pnpmfile_at(pnpmfile.clone());
-        let ctx = HookContext { log: hook_logger::<Reporter>(pnpmfile, &prefix) };
+        let ctx = HookContext { log: hook_logger::<Reporter>(pnpmfile, &prefix), dir: None };
         current = hooks
             .update_config(current, ctx)
             .await

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -31,6 +31,16 @@ pub enum HookError {
 /// Context provided to pnpmfile hooks.
 pub struct HookContext {
     pub log: Arc<dyn Fn(String) + Send + Sync>,
+    /// Lockfile-root-relative directory of the resolution, set when the
+    /// manifest being transformed was resolved from a local directory (an
+    /// injected workspace project or a `file:` dependency). A host-supplied
+    /// `readPackage` callback uses it to recognize a workspace project's
+    /// dependency instance and substitute the project's raw manifest —
+    /// pnpm's TS engine reaches the same effect by keeping raw project
+    /// manifests and applying its hook chain contextually. Only the
+    /// node-API bridge forwards it to JS; the `.pnpmfile.cjs` contract
+    /// (`readPackage(pkg, context)`) has no directory, matching pnpm.
+    pub dir: Option<String>,
 }
 
 /// Logger for preResolution hook (info/warn methods).

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -35,11 +35,10 @@ pub struct HookContext {
     /// manifest being transformed was resolved from a local directory (an
     /// injected workspace project or a `file:` dependency). A host-supplied
     /// `readPackage` callback uses it to recognize a workspace project's
-    /// dependency instance and substitute the project's raw manifest —
-    /// pnpm's TS engine reaches the same effect by keeping raw project
-    /// manifests and applying its hook chain contextually. Only the
-    /// node-API bridge forwards it to JS; the `.pnpmfile.cjs` contract
-    /// (`readPackage(pkg, context)`) has no directory, matching pnpm.
+    /// dependency instance and substitute the project's raw manifest.
+    /// Only the node-API bridge forwards it to JS; the `.pnpmfile.cjs`
+    /// contract (`readPackage(pkg, context)`) has no directory, matching
+    /// pnpm.
     pub dir: Option<String>,
 }
 

--- a/pnpm/crates/hooks/tests/node_hooks.rs
+++ b/pnpm/crates/hooks/tests/node_hooks.rs
@@ -88,7 +88,10 @@ function readPackage(pkg) {
     });
 
     let result = hooks
-        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None })
+        .read_package(
+            manifest.clone(),
+            pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None },
+        )
         .await;
 
     let updated = result.expect("readPackage should succeed");
@@ -121,7 +124,10 @@ function readPackage(pkg) {
     });
 
     let result = hooks
-        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None })
+        .read_package(
+            manifest.clone(),
+            pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None },
+        )
         .await;
 
     let updated = result.expect("readPackage should succeed");
@@ -154,7 +160,9 @@ function filterLog(log) {
     });
 
     assert!(
-        hooks.filter_log(debug_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None }).await,
+        hooks
+            .filter_log(debug_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None })
+            .await,
     );
 
     let warn_log = serde_json::json!({
@@ -163,7 +171,9 @@ function filterLog(log) {
     });
 
     assert!(
-        !hooks.filter_log(warn_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None }).await,
+        !hooks
+            .filter_log(warn_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None })
+            .await,
     );
 }
 
@@ -198,7 +208,10 @@ function readPackage(pkg) {
     });
 
     let result = hooks
-        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None })
+        .read_package(
+            manifest.clone(),
+            pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None },
+        )
         .await;
 
     let updated = result.unwrap_or_else(|err| {

--- a/pnpm/crates/hooks/tests/node_hooks.rs
+++ b/pnpm/crates/hooks/tests/node_hooks.rs
@@ -88,7 +88,7 @@ function readPackage(pkg) {
     });
 
     let result = hooks
-        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
+        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None })
         .await;
 
     let updated = result.expect("readPackage should succeed");
@@ -121,7 +121,7 @@ function readPackage(pkg) {
     });
 
     let result = hooks
-        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
+        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None })
         .await;
 
     let updated = result.expect("readPackage should succeed");
@@ -154,7 +154,7 @@ function filterLog(log) {
     });
 
     assert!(
-        hooks.filter_log(debug_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}) }).await,
+        hooks.filter_log(debug_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None }).await,
     );
 
     let warn_log = serde_json::json!({
@@ -163,7 +163,7 @@ function filterLog(log) {
     });
 
     assert!(
-        !hooks.filter_log(warn_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}) }).await,
+        !hooks.filter_log(warn_log, pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None }).await,
     );
 }
 
@@ -198,7 +198,7 @@ function readPackage(pkg) {
     });
 
     let result = hooks
-        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}) })
+        .read_package(manifest.clone(), pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None })
         .await;
 
     let updated = result.unwrap_or_else(|err| {
@@ -312,7 +312,7 @@ async fn read_package_err(source: &str) -> String {
     hooks
         .read_package(
             serde_json::json!({ "name": "foo", "version": "1.0.0" }),
-            pacquet_hooks::HookContext { log: Arc::new(|_| {}) },
+            pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None },
         )
         .await
         .expect_err("readPackage should fail")
@@ -374,7 +374,7 @@ async fn read_package_normalizes_missing_dependency_fields() {
     let updated = hooks
         .read_package(
             serde_json::json!({ "name": "x", "version": "1.0.0" }),
-            pacquet_hooks::HookContext { log: Arc::new(|_| {}) },
+            pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None },
         )
         .await
         .expect("readPackage should succeed after normalization");
@@ -417,7 +417,7 @@ async fn worker_multiplexes_concurrent_read_package_calls() {
             let updated = hooks
                 .read_package(
                     serde_json::json!({ "name": name, "version": "1.0.0" }),
-                    pacquet_hooks::HookContext { log: Arc::new(|_| {}) },
+                    pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None },
                 )
                 .await
                 .expect("readPackage should succeed");
@@ -449,6 +449,7 @@ async fn worker_forwards_read_package_context_log() {
             serde_json::json!({ "name": "foo", "version": "1.0.0" }),
             pacquet_hooks::HookContext {
                 log: Arc::new(move |message| sink.lock().unwrap().push(message)),
+                dir: None,
             },
         )
         .await
@@ -458,7 +459,7 @@ async fn worker_forwards_read_package_context_log() {
 }
 
 fn noop_context() -> pacquet_hooks::HookContext {
-    pacquet_hooks::HookContext { log: Arc::new(|_| {}) }
+    pacquet_hooks::HookContext { log: Arc::new(|_| {}), dir: None }
 }
 
 #[test]

--- a/pnpm/crates/napi/src/hooks.rs
+++ b/pnpm/crates/napi/src/hooks.rs
@@ -7,6 +7,13 @@
 //! host-supplied JS callback: `read_package` forwards each manifest to the
 //! callback over a [`ThreadsafeFunction`] and awaits the transformed result.
 //!
+//! The callback receives `(manifest, resolvedDir?)` — `resolvedDir` is the
+//! lockfile-root-relative directory when the manifest came from a directory
+//! resolution (an injected workspace project or a `file:` dependency), so the
+//! host can substitute a workspace project's raw manifest for its dependency
+//! instances. The `.pnpmfile.cjs` bridge does not receive it, matching pnpm's
+//! pnpmfile contract.
+//!
 //! The callback must be **synchronous** (return the manifest, not a promise) —
 //! [`ThreadsafeFunction::call_async`] resolves the JS return value directly and
 //! does not await a returned promise. Bit's composed `readPackage` hook is
@@ -19,17 +26,25 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use napi::{Status, threadsafe_function::ThreadsafeFunction};
+use napi::{Status, bindgen_prelude::FnArgs, threadsafe_function::ThreadsafeFunction};
 use pacquet_hooks::{
     HookContext, HookError, PnpmfileHooks, PreResolutionHookContext, PreResolutionHookLogger,
     ReadPackageResult,
 };
 use serde_json::Value;
 
-/// A synchronous JS `(manifest) => manifest` callback. `CalleeHandled = false`
-/// (no leading error arg); the JS return value is deserialized back to a
+/// A synchronous JS `(manifest, resolvedDir?) => manifest` callback.
+/// `CalleeHandled = false` (no leading error arg); the [`FnArgs`] wrapper
+/// spreads the tuple into two JS arguments (a bare tuple would serialize into
+/// a single JSON array) and the JS return value is deserialized back to a
 /// manifest.
-pub type HookSink = ThreadsafeFunction<Value, Value, Value, Status, false>;
+pub type HookSink = ThreadsafeFunction<
+    FnArgs<(Value, Option<String>)>,
+    Value,
+    FnArgs<(Value, Option<String>)>,
+    Status,
+    false,
+>;
 
 /// [`PnpmfileHooks`] implementation that runs `readPackage` through a JS
 /// callback.
@@ -48,9 +63,9 @@ impl PnpmfileHooks for JsReadPackageHook {
     async fn read_package(
         &self,
         pkg: Value,
-        _ctx: HookContext,
+        ctx: HookContext,
     ) -> Result<ReadPackageResult, HookError> {
-        match self.read_package.call_async(pkg).await {
+        match self.read_package.call_async(FnArgs::from((pkg, ctx.dir))).await {
             Ok(transformed) => Ok(Arc::new(transformed)),
             Err(error) => Err(HookError::Execution {
                 pnpmfile: "<napi readPackage>".to_string(),

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -2244,7 +2244,7 @@ async fn save_wanted_lockfile(
 
     let value = serde_json::to_value(built_lockfile)
         .map_err(InstallWithFreshLockfileError::AfterAllResolvedSerialize)?;
-    let ctx = pacquet_hooks::HookContext { log: log.unwrap_or_else(|| Arc::new(|_| {})) };
+    let ctx = pacquet_hooks::HookContext { log: log.unwrap_or_else(|| Arc::new(|_| {})), dir: None };
     let result = hook
         .after_all_resolved(value, ctx)
         .await

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -2244,7 +2244,8 @@ async fn save_wanted_lockfile(
 
     let value = serde_json::to_value(built_lockfile)
         .map_err(InstallWithFreshLockfileError::AfterAllResolvedSerialize)?;
-    let ctx = pacquet_hooks::HookContext { log: log.unwrap_or_else(|| Arc::new(|_| {})), dir: None };
+    let ctx =
+        pacquet_hooks::HookContext { log: log.unwrap_or_else(|| Arc::new(|_| {})), dir: None };
     let result = hook
         .after_all_resolved(value, ctx)
         .await

--- a/pnpm/crates/resolving-deps-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-deps-resolver/Cargo.toml
@@ -35,6 +35,7 @@ serde_json                             = { workspace = true }
 tokio                                  = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
+async-trait       = { workspace = true }
 node-semver       = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile          = { workspace = true }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1891,7 +1891,16 @@ where
         && let Some(manifest) = result_inner.manifest.take()
     {
         let log = ctx.workspace.read_package_log.clone().unwrap_or_else(|| Arc::new(|_| {}));
-        let hook_ctx = pacquet_hooks::HookContext { log };
+        // Directory resolutions carry their lockfile-root-relative dir so the
+        // hook can tell a workspace project's dependency instance apart from a
+        // registry manifest — see `HookContext::dir`.
+        let dir = match &result_inner.resolution {
+            pacquet_lockfile::LockfileResolution::Directory(directory_resolution) => {
+                Some(directory_resolution.directory.clone())
+            }
+            _ => None,
+        };
+        let hook_ctx = pacquet_hooks::HookContext { log, dir };
 
         let updated = pnpmfile_hook
             .read_package((*manifest).clone(), hook_ctx)

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -3077,10 +3077,13 @@ mod cycle_edges {
     }
 }
 
+/// The `(name, dir)` pairs recorded by [`RecordingHooks`].
+type RecordedReadPackageCalls = std::sync::Arc<Mutex<Vec<(String, Option<String>)>>>;
+
 /// [`pacquet_hooks::PnpmfileHooks`] stub that records the `(name, dir)` pair
 /// of every `read_package` call and returns the manifest unchanged.
 struct RecordingHooks {
-    calls: std::sync::Arc<Mutex<Vec<(String, Option<String>)>>>,
+    calls: RecordedReadPackageCalls,
 }
 
 #[async_trait::async_trait]
@@ -3110,19 +3113,13 @@ impl pacquet_hooks::PnpmfileHooks for RecordingHooks {
     ) {
     }
 
-    async fn filter_log(
-        &self,
-        _log: serde_json::Value,
-        _ctx: pacquet_hooks::HookContext,
-    ) -> bool {
+    async fn filter_log(&self, _log: serde_json::Value, _ctx: pacquet_hooks::HookContext) -> bool {
         true
     }
 }
 
-/// The `readPackage` hook context carries the lockfile-root-relative directory
-/// for directory resolutions (injected workspace projects, `file:` deps) and
-/// no directory for registry resolutions — the signal a host uses to
-/// substitute a workspace project's raw manifest for its dependency instances.
+/// A host needs the directory to tell a workspace project's dependency
+/// instance apart from registry packages and substitute its raw manifest.
 #[tokio::test]
 async fn read_package_hook_receives_the_directory_of_directory_resolutions() {
     use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
@@ -3139,7 +3136,11 @@ async fn read_package_hook_receives_the_directory_of_directory_resolutions() {
     table.insert(("injected".to_string(), "file:packages/injected".to_string()), injected);
     table.insert(
         ("regular".to_string(), "^2.0.0".to_string()),
-        fake_result("regular", "2.1.0", serde_json::json!({ "name": "regular", "version": "2.1.0" })),
+        fake_result(
+            "regular",
+            "2.1.0",
+            serde_json::json!({ "name": "regular", "version": "2.1.0" }),
+        ),
     );
     let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
     let (_tmp, manifest) = fake_manifest(serde_json::json!({

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -3076,3 +3076,102 @@ mod cycle_edges {
         );
     }
 }
+
+/// [`pacquet_hooks::PnpmfileHooks`] stub that records the `(name, dir)` pair
+/// of every `read_package` call and returns the manifest unchanged.
+struct RecordingHooks {
+    calls: std::sync::Arc<Mutex<Vec<(String, Option<String>)>>>,
+}
+
+#[async_trait::async_trait]
+impl pacquet_hooks::PnpmfileHooks for RecordingHooks {
+    async fn read_package(
+        &self,
+        pkg: serde_json::Value,
+        ctx: pacquet_hooks::HookContext,
+    ) -> Result<pacquet_hooks::ReadPackageResult, pacquet_hooks::HookError> {
+        let name = pkg.get("name").and_then(|name| name.as_str()).unwrap_or_default().to_string();
+        self.calls.lock().unwrap().push((name, ctx.dir));
+        Ok(std::sync::Arc::new(pkg))
+    }
+
+    async fn after_all_resolved(
+        &self,
+        lockfile: serde_json::Value,
+        _ctx: pacquet_hooks::HookContext,
+    ) -> Result<serde_json::Value, pacquet_hooks::HookError> {
+        Ok(lockfile)
+    }
+
+    async fn pre_resolution(
+        &self,
+        _ctx: pacquet_hooks::PreResolutionHookContext,
+        _logger: pacquet_hooks::PreResolutionHookLogger,
+    ) {
+    }
+
+    async fn filter_log(
+        &self,
+        _log: serde_json::Value,
+        _ctx: pacquet_hooks::HookContext,
+    ) -> bool {
+        true
+    }
+}
+
+/// The `readPackage` hook context carries the lockfile-root-relative directory
+/// for directory resolutions (injected workspace projects, `file:` deps) and
+/// no directory for registry resolutions — the signal a host uses to
+/// substitute a workspace project's raw manifest for its dependency instances.
+#[tokio::test]
+async fn read_package_hook_receives_the_directory_of_directory_resolutions() {
+    use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
+
+    let mut injected = fake_result(
+        "injected",
+        "1.0.0",
+        serde_json::json!({ "name": "injected", "version": "1.0.0" }),
+    );
+    injected.resolution = LockfileResolution::Directory(DirectoryResolution {
+        directory: "packages/injected".to_string(),
+    });
+    let mut table = HashMap::new();
+    table.insert(("injected".to_string(), "file:packages/injected".to_string()), injected);
+    table.insert(
+        ("regular".to_string(), "^2.0.0".to_string()),
+        fake_result("regular", "2.1.0", serde_json::json!({ "name": "regular", "version": "2.1.0" })),
+    );
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({
+        "injected": "file:packages/injected",
+        "regular": "^2.0.0",
+    }));
+    let calls = std::sync::Arc::new(Mutex::new(Vec::new()));
+    let hooks = RecordingHooks { calls: std::sync::Arc::clone(&calls) };
+
+    resolve_dependency_tree(
+        &resolver,
+        &manifest,
+        [DependencyGroup::Prod],
+        ResolveDependencyTreeOptions {
+            base_opts: ResolveOptions::default(),
+            patched_dependencies: None,
+            manifest_hook: None,
+            pnpmfile_hook: Some(std::sync::Arc::new(hooks)),
+            read_package_log: None,
+            auto_install_peers: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut calls = calls.lock().unwrap().clone();
+    calls.sort();
+    assert_eq!(
+        calls,
+        vec![
+            ("injected".to_string(), Some("packages/injected".to_string())),
+            ("regular".to_string(), None),
+        ],
+    );
+}

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -59,8 +59,16 @@ export interface NetworkConfig {
   userAgent?: string
 }
 
-/** A synchronous `readPackage` hook applied to resolved dependency manifests. */
-export type ReadPackageHook = (manifest: PackageManifest) => PackageManifest
+/**
+ * A synchronous `readPackage` hook applied to resolved dependency manifests.
+ *
+ * `resolvedDir` is set when the manifest came from a directory resolution (an
+ * injected workspace project or a `file:` dependency); it is the directory
+ * recorded in the lockfile, relative to the lockfile root. Hosts use it to
+ * recognize a workspace project's dependency instance and substitute the
+ * project's raw manifest.
+ */
+export type ReadPackageHook = (manifest: PackageManifest, resolvedDir?: string) => PackageManifest
 
 /**
  * Receives engine log events. The event stream is wire-compatible with
@@ -190,9 +198,9 @@ export interface InstallResult {
 
 /**
  * @param onLog receives wire-compatible pnpm log events.
- * @param readPackageHook a **synchronous** `(manifest) => manifest` transform
- *   applied to every resolved dependency manifest during resolution (the
- *   `readPackage` hook). Must return the manifest object, not a promise.
+ * @param readPackageHook a **synchronous** `(manifest, resolvedDir?) => manifest`
+ *   transform applied to every resolved dependency manifest during resolution
+ *   (the `readPackage` hook). Must return the manifest object, not a promise.
  */
 export function install(
   options: InstallOptions,


### PR DESCRIPTION
When the engine resolves a workspace project as an injected `file:` dependency, it feeds the host's `readPackage` callback that project's manifest as supplied in `projects`. A host that pre-transforms its importer manifests (Bit strips workspace-sibling deps there because it wires those links itself) has no way to recognize the call and restore the raw manifest — so the injected instance silently loses dependencies, and Bit's component graph loses its component edges (the `BIT_FEATURES=deps-graph` "should replace pending version in direct dependency" e2e cluster on teambit/bit#10293).

pnpm's TS engine never had this problem: it keeps raw project manifests and applies the host hook chain contextually — with the project dir for the importer view, without it for dependency manifests.

This PR gives the node-API host the same discrimination:

- `HookContext` carries the lockfile-root-relative directory of a directory resolution (injected workspace projects and `file:` deps); other resolutions pass none.
- The napi bridge forwards it as the JS callback's second argument: `(manifest, resolvedDir?) => manifest`. `FnArgs` is required for the two-argument spread — a bare tuple serializes into a single JSON array argument.
- The `.pnpmfile.cjs` bridge deliberately does not expose it, matching pnpm's pnpmfile `readPackage(pkg, context)` contract.

A unit test pins the contract (directory resolution → `Some(dir)`, registry → `None`).

Verified end-to-end against Bit with a locally built binding plus the matching lynx change (teambit/bit@9c45e72be): the deps-graph e2e file goes from 7 failing to 3 failing, and the remaining three are the pre-existing lockfile-resolution-reuse gap (`plans/LOCKFILE_RESOLUTION_REUSE.md`), unrelated to manifests. Full pacquet suite: 5157/5157 pass.

---
Written by an agent (Claude Code, claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `readPackage` hooks can now receive an optional `resolvedDir` value for directory/file-based dependency resolutions.
  * Updated public type definitions and JSDoc to reflect the new `(manifest, resolvedDir?) => manifest` hook signature.
* **Bug Fixes**
  * Ensured the directory context is propagated consistently to `readPackage` for directory resolutions, while leaving it unset for registry-based resolutions.
* **Tests**
  * Added regression coverage verifying `resolvedDir` is provided for directory dependencies and omitted for registry dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->