### PR TITLE
chore(release): 11.12.0

### DIFF
--- a/.changeset/changed-packages-filter-hardening.md
+++ b/.changeset/changed-packages-filter-hardening.md
@@ -1,6 +1,0 @@
----
-"@pnpm/workspace.projects-filter": patch
-"pnpm": patch
----
-
-The changed-packages filter (`--filter "...[<since>]"`) no longer allows an option-like `<since>` value (such as `--output=<path>`) to be interpreted as a git option — git now rejects it as a bad revision. The repository root is also resolved to the nearest `.git` entry, so the filter works in a git worktree checked out inside another repository's tree.

--- a/.changeset/custom-fetcher-delegation.md
+++ b/.changeset/custom-fetcher-delegation.md
@@ -1,7 +1,0 @@
----
-"@pnpm/hooks.types": minor
-"@pnpm/fetching.pick-fetcher": minor
-"pnpm": minor
----
-
-Custom fetchers exported from a pnpmfile can now delegate by returning a `{ delegate: <resolution> }` envelope: pnpm rewrites the package's resolution to the delegated shape and runs the built-in fetcher on it. This is the portable delegation form that also works in pacquet, where `cafs` and `fetchers` cannot be passed to the hook. Related to [pnpm/pnpm#11685](https://github.com/pnpm/pnpm/issues/11685).

--- a/.changeset/outdated-skip-local-links.md
+++ b/.changeset/outdated-skip-local-links.md
@@ -1,6 +1,0 @@
----
-"@pnpm/deps.inspection.outdated": patch
-"pnpm": patch
----
-
-`pnpm outdated` no longer checks the registry for dependencies that are resolved from local `link:`, `file:`, or `workspace:` references in the lockfile [#12827](https://github.com/pnpm/pnpm/issues/12827).

--- a/.changeset/peer-await-cycle-deadlock.md
+++ b/.changeset/peer-await-cycle-deadlock.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"pnpm": patch
----
-
-Fixed a deadlock in peer dependency resolution: `pnpm install` hung forever when a peer dependency cycle spanned a project's own dependencies and auto-installed peer providers, for example when installing `electron-builder@26.15.3` [#12921](https://github.com/pnpm/pnpm/issues/12921).

--- a/.changeset/peer-hoist-respect-range.md
+++ b/.changeset/peer-hoist-respect-range.md
@@ -1,8 +1,0 @@
----
-"@pnpm/installing.deps-resolver": patch
-"pnpm": patch
----
-
-Fixed peer dependency auto-install picking a version the peer range rejects. In a workspace with several projects, a package declaring a peer dependency with a semver range (for example `^1.0.0`) could get the highest version found anywhere in the workspace (for example a `2.0.0` resolved for another project) instead of a version that satisfies the range. Peers are now deduplicated onto the highest preferred version that satisfies the declared range, and when none does, the range is resolved from the registry.
-
-Also fixed re-resolving with an existing lockfile hoisting a different peer version than a fresh install of the same manifest: root dependencies reused from the lockfile were invisible to peer hoisting, so a peer that a root dependency provides could be bound to another version.

--- a/.changeset/self-update-active-version.md
+++ b/.changeset/self-update-active-version.md
@@ -1,6 +1,0 @@
----
-"@pnpm/engine.pm.commands": patch
-"pnpm": patch
----
-
-`pnpm self-update <version>` now installs the requested pnpm version when it matches the currently running version but is missing from the global self-update directory.

--- a/.changeset/stage-list-page-cap.md
+++ b/.changeset/stage-list-page-cap.md
@@ -1,6 +1,0 @@
----
-"@pnpm/releasing.commands": patch
-"pnpm": patch
----
-
-`pnpm stage list` now stops paginating after a fail-safe cap of 1000 pages, so a misbehaving registry cannot keep the command looping forever.

--- a/.changeset/violet-pianos-brush.md
+++ b/.changeset/violet-pianos-brush.md
@@ -1,6 +1,0 @@
----
-"@pnpm/deps.status": patch
-"pnpm": patch
----
-
-`verify-deps-before-run` no longer spawns a `pnpm install` when pnpm is executed in a directory that has no `package.json`. A mistyped command run outside a project (for example `pnpm witch 10 login`) used to crash with a confusing error from the spawned install; now it fails with the regular "no package.json found" error.

--- a/.meta-updater/CHANGELOG.md
+++ b/.meta-updater/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm-private/updater
 
+## 1100.0.24
+
+### Patch Changes
+
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.23
 
 ### Patch Changes

--- a/.meta-updater/package.json
+++ b/.meta-updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm-private/updater",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pnpm11/auth/commands/CHANGELOG.md
+++ b/pnpm11/auth/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/auth.commands
 
+## 1100.2.9
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.2.8
 
 ### Patch Changes

--- a/pnpm11/auth/commands/package.json
+++ b/pnpm11/auth/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/auth.commands",
-  "version": "1100.2.8",
+  "version": "1100.2.9",
   "description": "Commands for authentication with npm registries",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/after-install/CHANGELOG.md
+++ b/pnpm11/building/after-install/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/building.after-install
 
+## 1102.0.5
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/config.reader@1101.11.2
+- @pnpm/store.connection-manager@1100.3.5
+- @pnpm/deps.graph-hasher@1100.2.9
+- @pnpm/installing.context@1100.0.23
+
 ## 1102.0.4
 
 ### Patch Changes

--- a/pnpm11/building/after-install/package.json
+++ b/pnpm11/building/after-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.after-install",
-  "version": "1102.0.4",
+  "version": "1102.0.5",
   "description": "Rebuild packages that are already installed by running their lifecycle scripts",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/commands/CHANGELOG.md
+++ b/pnpm11/building/commands/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/building.commands
 
+## 1100.1.10
+
+### Patch Changes
+
+- @pnpm/installing.commands@1100.10.4
+- @pnpm/config.reader@1101.11.2
+- @pnpm/store.connection-manager@1100.3.5
+- @pnpm/building.after-install@1102.0.5
+
 ## 1100.1.9
 
 ### Patch Changes

--- a/pnpm11/building/commands/package.json
+++ b/pnpm11/building/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.commands",
-  "version": "1100.1.9",
+  "version": "1100.1.10",
   "description": "Commands for rebuilding and managing dependency builds",
   "keywords": [
     "pnpm",

--- a/pnpm11/building/during-install/CHANGELOG.md
+++ b/pnpm11/building/during-install/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/building.during-install
 
+## 1102.0.5
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+- @pnpm/deps.graph-hasher@1100.2.9
+
 ## 1102.0.4
 
 ### Patch Changes

--- a/pnpm11/building/during-install/package.json
+++ b/pnpm11/building/during-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/building.during-install",
-  "version": "1102.0.4",
+  "version": "1102.0.5",
   "description": "Build packages in node_modules",
   "keywords": [
     "pnpm",

--- a/pnpm11/cache/api/CHANGELOG.md
+++ b/pnpm11/cache/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/cache.api
 
+## 1100.0.27
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.0.26
 
 ### Patch Changes

--- a/pnpm11/cache/api/package.json
+++ b/pnpm11/cache/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cache.api",
-  "version": "1100.0.26",
+  "version": "1100.0.27",
   "description": "API for controlling the cache",
   "keywords": [
     "pnpm",

--- a/pnpm11/cache/commands/CHANGELOG.md
+++ b/pnpm11/cache/commands/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/cache.commands
 
+## 1100.0.28
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+- @pnpm/cache.api@1100.0.27
+
 ## 1100.0.27
 
 ### Patch Changes

--- a/pnpm11/cache/commands/package.json
+++ b/pnpm11/cache/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cache.commands",
-  "version": "1100.0.27",
+  "version": "1100.0.28",
   "description": "Commands for controlling the cache",
   "keywords": [
     "pnpm",

--- a/pnpm11/cli/commands/CHANGELOG.md
+++ b/pnpm11/cli/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/cli.commands
 
+## 1100.0.26
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.0.25
 
 ### Patch Changes

--- a/pnpm11/cli/commands/package.json
+++ b/pnpm11/cli/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cli.commands",
-  "version": "1100.0.25",
+  "version": "1100.0.26",
   "description": "Commands for pnpm CLI",
   "keywords": [
     "pnpm",

--- a/pnpm11/cli/default-reporter/CHANGELOG.md
+++ b/pnpm11/cli/default-reporter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/default-reporter
 
+## 1100.3.6
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.3.5
 
 ### Patch Changes

--- a/pnpm11/cli/default-reporter/package.json
+++ b/pnpm11/cli/default-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/cli.default-reporter",
-  "version": "1100.3.5",
+  "version": "1100.3.6",
   "description": "The default reporter of pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/commands/CHANGELOG.md
+++ b/pnpm11/config/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/plugin-commands-config
 
+## 1100.0.27
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.0.26
 
 ### Patch Changes

--- a/pnpm11/config/commands/package.json
+++ b/pnpm11/config/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.commands",
-  "version": "1100.0.26",
+  "version": "1100.0.27",
   "description": "Commands for reading and writing settings to/from config files",
   "keywords": [
     "pnpm",

--- a/pnpm11/config/reader/CHANGELOG.md
+++ b/pnpm11/config/reader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/config
 
+## 1101.11.2
+
+### Patch Changes
+
+- @pnpm/hooks.pnpmfile@1100.0.18
+
 ## 1101.11.1
 
 ### Patch Changes

--- a/pnpm11/config/reader/package.json
+++ b/pnpm11/config/reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/config.reader",
-  "version": "1101.11.1",
+  "version": "1101.11.2",
   "description": "Gets configuration options for pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/audit/CHANGELOG.md
+++ b/pnpm11/deps/compliance/audit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/audit
 
+## 1101.0.21
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1101.0.20
 
 ### Patch Changes

--- a/pnpm11/deps/compliance/audit/package.json
+++ b/pnpm11/deps/compliance/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.audit",
-  "version": "1101.0.20",
+  "version": "1101.0.21",
   "description": "Audit a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/commands/CHANGELOG.md
+++ b/pnpm11/deps/compliance/commands/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pnpm/deps.compliance.commands
 
+## 1101.5.3
+
+### Patch Changes
+
+- @pnpm/installing.commands@1100.10.4
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/config.reader@1101.11.2
+- @pnpm/deps.compliance.audit@1101.0.21
+- @pnpm/deps.compliance.license-scanner@1100.0.24
+- @pnpm/deps.compliance.sbom@1100.3.2
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1101.5.2
 
 ### Patch Changes

--- a/pnpm11/deps/compliance/commands/package.json
+++ b/pnpm11/deps/compliance/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.commands",
-  "version": "1101.5.2",
+  "version": "1101.5.3",
   "description": "pnpm commands for audit, licenses, and sbom",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/license-scanner/CHANGELOG.md
+++ b/pnpm11/deps/compliance/license-scanner/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/license-scanner
 
+## 1100.0.24
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.23
 
 ### Patch Changes

--- a/pnpm11/deps/compliance/license-scanner/package.json
+++ b/pnpm11/deps/compliance/license-scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.license-scanner",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "description": "Check for licenses packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/compliance/sbom/CHANGELOG.md
+++ b/pnpm11/deps/compliance/sbom/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/deps.compliance.sbom
 
+## 1100.3.2
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+
 ## 1100.3.1
 
 ### Patch Changes

--- a/pnpm11/deps/compliance/sbom/package.json
+++ b/pnpm11/deps/compliance/sbom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.compliance.sbom",
-  "version": "1100.3.1",
+  "version": "1100.3.2",
   "description": "Generate SBOM from pnpm lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/graph-builder/CHANGELOG.md
+++ b/pnpm11/deps/graph-builder/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/deps.graph-builder
 
+## 1100.0.21
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+  - @pnpm/lockfile.utils@1100.1.2
+  - @pnpm/deps.graph-hasher@1100.2.9
+  - @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.20
 
 ### Patch Changes

--- a/pnpm11/deps/graph-builder/package.json
+++ b/pnpm11/deps/graph-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.graph-builder",
-  "version": "1100.0.20",
+  "version": "1100.0.21",
   "description": "A package for building a dependency graph from a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/graph-hasher/CHANGELOG.md
+++ b/pnpm11/deps/graph-hasher/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/calc-dep-state
 
+## 1100.2.9
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+
 ## 1100.2.8
 
 ### Patch Changes

--- a/pnpm11/deps/graph-hasher/package.json
+++ b/pnpm11/deps/graph-hasher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.graph-hasher",
-  "version": "1100.2.8",
+  "version": "1100.2.9",
   "description": "Calculates the state of a dependency",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/commands/CHANGELOG.md
+++ b/pnpm11/deps/inspection/commands/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @pnpm/deps.inspection.commands
 
+## 1100.5.2
+
+### Patch Changes
+
+- Updated dependencies [43711ce]
+  - @pnpm/deps.inspection.outdated@1100.1.13
+  - @pnpm/resolving.default-resolver@1100.3.13
+  - @pnpm/config.reader@1101.11.2
+  - @pnpm/global.commands@1100.0.33
+  - @pnpm/lockfile.fs@1100.1.10
+  - @pnpm/deps.inspection.list@1100.0.23
+  - @pnpm/deps.inspection.peers-checker@1100.0.19
+
 ## 1100.5.1
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/commands/package.json
+++ b/pnpm11/deps/inspection/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.commands",
-  "version": "1100.5.1",
+  "version": "1100.5.2",
   "description": "The list, ll, why, and outdated commands of pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/list/CHANGELOG.md
+++ b/pnpm11/deps/inspection/list/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/list
 
+## 1100.0.23
+
+### Patch Changes
+
+- @pnpm/deps.inspection.tree-builder@1100.0.20
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.22
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/list/package.json
+++ b/pnpm11/deps/inspection/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.list",
-  "version": "1100.0.22",
+  "version": "1100.0.23",
   "description": "List installed packages in a symlinked `node_modules`",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/outdated/CHANGELOG.md
+++ b/pnpm11/deps/inspection/outdated/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/outdated
 
+## 1100.1.13
+
+### Patch Changes
+
+- 43711ce: `pnpm outdated` no longer checks the registry for dependencies that are resolved from local `link:`, `file:`, or `workspace:` references in the lockfile [#12827](https://github.com/pnpm/pnpm/issues/12827).
+  - @pnpm/installing.client@1100.2.13
+  - @pnpm/lockfile.utils@1100.1.2
+  - @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.1.12
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/outdated/package.json
+++ b/pnpm11/deps/inspection/outdated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.outdated",
-  "version": "1100.1.12",
+  "version": "1100.1.13",
   "description": "Check for outdated packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/peers-checker/CHANGELOG.md
+++ b/pnpm11/deps/inspection/peers-checker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/deps.inspection.peers-checker
 
+## 1100.0.19
+
+### Patch Changes
+
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.18
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/peers-checker/package.json
+++ b/pnpm11/deps/inspection/peers-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.peers-checker",
-  "version": "1100.0.18",
+  "version": "1100.0.19",
   "description": "Check for unmet and missing peer dependency issues from the lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/inspection/tree-builder/CHANGELOG.md
+++ b/pnpm11/deps/inspection/tree-builder/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/reviewing.dependencies-hierarchy
 
+## 1100.0.20
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.19
 
 ### Patch Changes

--- a/pnpm11/deps/inspection/tree-builder/package.json
+++ b/pnpm11/deps/inspection/tree-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.inspection.tree-builder",
-  "version": "1100.0.19",
+  "version": "1100.0.20",
   "description": "Creates a dependencies hierarchy for a symlinked `node_modules`",
   "keywords": [
     "pnpm",

--- a/pnpm11/deps/status/CHANGELOG.md
+++ b/pnpm11/deps/status/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pnpm/deps.status
 
+## 1100.1.6
+
+### Patch Changes
+
+- eee7c9a: `verify-deps-before-run` no longer spawns a `pnpm install` when pnpm is executed in a directory that has no `package.json`. A mistyped command run outside a project (for example `pnpm witch 10 login`) used to crash with a confusing error from the spawned install; now it fails with the regular "no package.json found" error.
+  - @pnpm/config.reader@1101.11.2
+  - @pnpm/lockfile.fs@1100.1.10
+  - @pnpm/lockfile.verification@1100.0.23
+  - @pnpm/installing.context@1100.0.23
+  - @pnpm/workspace.state@1100.0.27
+  - @pnpm/lockfile.settings-checker@1100.1.2
+
 ## 1100.1.5
 
 ### Patch Changes

--- a/pnpm11/deps/status/package.json
+++ b/pnpm11/deps/status/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/deps.status",
-  "version": "1100.1.5",
+  "version": "1100.1.6",
   "description": "Check dependencies status",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/pm/commands/CHANGELOG.md
+++ b/pnpm11/engine/pm/commands/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @pnpm/engine.pm.commands
 
+## 1101.2.2
+
+### Patch Changes
+
+- a38adda: `pnpm self-update <version>` now installs the requested pnpm version when it matches the currently running version but is missing from the global self-update directory.
+  - @pnpm/installing.client@1100.2.13
+  - @pnpm/store.controller@1102.0.4
+  - @pnpm/installing.env-installer@1102.0.5
+  - @pnpm/installing.deps-restorer@1102.1.4
+  - @pnpm/config.reader@1101.11.2
+  - @pnpm/store.connection-manager@1100.3.5
+  - @pnpm/global.commands@1100.0.33
+  - @pnpm/deps.graph-hasher@1100.2.9
+  - @pnpm/lockfile.fs@1100.1.10
+
 ## 1101.2.1
 
 ### Patch Changes

--- a/pnpm11/engine/pm/commands/package.json
+++ b/pnpm11/engine/pm/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.pm.commands",
-  "version": "1101.2.1",
+  "version": "1101.2.2",
   "description": "pnpm commands for self-updating and setting up pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/commands/CHANGELOG.md
+++ b/pnpm11/engine/runtime/commands/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/engine.runtime.commands
 
+## 1100.1.10
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+- @pnpm/engine.runtime.node-resolver@1101.1.12
+
 ## 1100.1.9
 
 ### Patch Changes

--- a/pnpm11/engine/runtime/commands/package.json
+++ b/pnpm11/engine/runtime/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.commands",
-  "version": "1100.1.9",
+  "version": "1100.1.10",
   "description": "pnpm commands for managing runtimes",
   "keywords": [
     "pnpm",

--- a/pnpm11/engine/runtime/node-resolver/CHANGELOG.md
+++ b/pnpm11/engine/runtime/node-resolver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/node.resolver
 
+## 1101.1.12
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1101.1.11
 
 ### Patch Changes

--- a/pnpm11/engine/runtime/node-resolver/package.json
+++ b/pnpm11/engine/runtime/node-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/engine.runtime.node-resolver",
-  "version": "1101.1.11",
+  "version": "1101.1.12",
   "description": "Resolves a Node.js version specifier to an exact Node.js version",
   "keywords": [
     "pnpm",

--- a/pnpm11/exec/commands/CHANGELOG.md
+++ b/pnpm11/exec/commands/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pnpm/plugin-commands-script-runners
 
+## 1100.3.4
+
+### Patch Changes
+
+- Updated dependencies [eee7c9a]
+  - @pnpm/deps.status@1100.1.6
+  - @pnpm/building.commands@1100.1.10
+  - @pnpm/installing.commands@1100.10.4
+  - @pnpm/installing.client@1100.2.13
+  - @pnpm/config.reader@1101.11.2
+  - @pnpm/engine.runtime.commands@1100.1.10
+
 ## 1100.3.3
 
 ### Patch Changes

--- a/pnpm11/exec/commands/package.json
+++ b/pnpm11/exec/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exec.commands",
-  "version": "1100.3.3",
+  "version": "1100.3.4",
   "description": "Commands for running scripts",
   "keywords": [
     "pnpm",

--- a/pnpm11/fetching/pick-fetcher/CHANGELOG.md
+++ b/pnpm11/fetching/pick-fetcher/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @pnpm/pick-fetcher
 
+## 1100.1.0
+
+### Minor Changes
+
+- a897ef7: Custom fetchers exported from a pnpmfile can now delegate by returning a `{ delegate: <resolution> }` envelope: pnpm rewrites the package's resolution to the delegated shape and runs the built-in fetcher on it. This is the portable delegation form that also works in pacquet, where `cafs` and `fetchers` cannot be passed to the hook. Related to [pnpm/pnpm#11685](https://github.com/pnpm/pnpm/issues/11685).
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+
 ## 1100.0.14
 
 ### Patch Changes

--- a/pnpm11/fetching/pick-fetcher/package.json
+++ b/pnpm11/fetching/pick-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/fetching.pick-fetcher",
-  "version": "1100.0.14",
+  "version": "1100.1.0",
   "description": "Pick a package fetcher by type",
   "keywords": [
     "pnpm",

--- a/pnpm11/global/commands/CHANGELOG.md
+++ b/pnpm11/global/commands/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/global.commands
 
+## 1100.0.33
+
+### Patch Changes
+
+- @pnpm/installing.deps-installer@1102.2.2
+- @pnpm/config.reader@1101.11.2
+- @pnpm/store.connection-manager@1100.3.5
+- @pnpm/deps.inspection.list@1100.0.23
+
 ## 1100.0.32
 
 ### Patch Changes

--- a/pnpm11/global/commands/package.json
+++ b/pnpm11/global/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/global.commands",
-  "version": "1100.0.32",
+  "version": "1100.0.33",
   "description": "Global package command handlers for pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/hooks/pnpmfile/CHANGELOG.md
+++ b/pnpm11/hooks/pnpmfile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/pnpmfile
 
+## 1100.0.18
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+
 ## 1100.0.17
 
 ### Patch Changes

--- a/pnpm11/hooks/pnpmfile/package.json
+++ b/pnpm11/hooks/pnpmfile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/hooks.pnpmfile",
-  "version": "1100.0.17",
+  "version": "1100.0.18",
   "description": "Reading a .pnpmfile.cjs",
   "keywords": [
     "pnpm",

--- a/pnpm11/hooks/types/CHANGELOG.md
+++ b/pnpm11/hooks/types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/hooks.types
 
+## 1100.2.0
+
+### Minor Changes
+
+- a897ef7: Custom fetchers exported from a pnpmfile can now delegate by returning a `{ delegate: <resolution> }` envelope: pnpm rewrites the package's resolution to the delegated shape and runs the built-in fetcher on it. This is the portable delegation form that also works in pacquet, where `cafs` and `fetchers` cannot be passed to the hook. Related to [pnpm/pnpm#11685](https://github.com/pnpm/pnpm/issues/11685).
+
 ## 1100.1.1
 
 ### Patch Changes

--- a/pnpm11/hooks/types/package.json
+++ b/pnpm11/hooks/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/hooks.types",
-  "version": "1100.1.1",
+  "version": "1100.2.0",
   "description": "Types for hooks",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/client/CHANGELOG.md
+++ b/pnpm11/installing/client/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @pnpm/client
 
+## 1100.2.13
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+  - @pnpm/resolving.default-resolver@1100.3.13
+  - @pnpm/engine.runtime.node-resolver@1101.1.12
+
 ## 1100.2.12
 
 ### Patch Changes

--- a/pnpm11/installing/client/package.json
+++ b/pnpm11/installing/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.client",
-  "version": "1100.2.12",
+  "version": "1100.2.13",
   "description": "Creates the package resolve and fetch functions",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/commands/CHANGELOG.md
+++ b/pnpm11/installing/commands/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @pnpm/plugin-commands-installation
 
+## 1100.10.4
+
+### Patch Changes
+
+- Updated dependencies [2b02764]
+- Updated dependencies [43711ce]
+- Updated dependencies [eee7c9a]
+  - @pnpm/workspace.projects-filter@1100.0.26
+  - @pnpm/deps.inspection.outdated@1100.1.13
+  - @pnpm/deps.status@1100.1.6
+  - @pnpm/hooks.pnpmfile@1100.0.18
+  - @pnpm/installing.deps-installer@1102.2.2
+  - @pnpm/store.controller@1102.0.4
+  - @pnpm/installing.env-installer@1102.0.5
+  - @pnpm/config.reader@1101.11.2
+  - @pnpm/store.connection-manager@1100.3.5
+  - @pnpm/global.commands@1100.0.33
+  - @pnpm/building.after-install@1102.0.5
+  - @pnpm/lockfile.fs@1100.1.10
+  - @pnpm/installing.context@1100.0.23
+  - @pnpm/workspace.state@1100.0.27
+
 ## 1100.10.3
 
 ### Patch Changes

--- a/pnpm11/installing/commands/package.json
+++ b/pnpm11/installing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.commands",
-  "version": "1100.10.3",
+  "version": "1100.10.4",
   "description": "Commands for installation",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/context/CHANGELOG.md
+++ b/pnpm11/installing/context/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/get-context
 
+## 1100.0.23
+
+### Patch Changes
+
+- @pnpm/store.controller@1102.0.4
+- @pnpm/lockfile.fs@1100.1.10
+- @pnpm/installing.read-projects-context@1100.0.20
+
 ## 1100.0.22
 
 ### Patch Changes

--- a/pnpm11/installing/context/package.json
+++ b/pnpm11/installing/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.context",
-  "version": "1100.0.22",
+  "version": "1100.0.23",
   "description": "Gets context information about a project",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-installer/CHANGELOG.md
+++ b/pnpm11/installing/deps-installer/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @pnpm/core
 
+## 1102.2.2
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+- Updated dependencies [3c6718b]
+- Updated dependencies [252f15e]
+  - @pnpm/hooks.types@1100.2.0
+  - @pnpm/installing.deps-resolver@1100.2.8
+  - @pnpm/installing.package-requester@1102.1.2
+  - @pnpm/lockfile.utils@1100.1.2
+  - @pnpm/installing.deps-restorer@1102.1.4
+  - @pnpm/building.after-install@1102.0.5
+  - @pnpm/deps.graph-hasher@1100.2.9
+  - @pnpm/installing.linking.modules-cleaner@1100.1.11
+  - @pnpm/lockfile.filtering@1100.1.10
+  - @pnpm/lockfile.fs@1100.1.10
+  - @pnpm/lockfile.preferred-versions@1100.0.19
+  - @pnpm/lockfile.to-pnp@1100.1.4
+  - @pnpm/lockfile.verification@1100.0.23
+  - @pnpm/installing.context@1100.0.23
+  - @pnpm/building.during-install@1102.0.5
+  - @pnpm/pnpr.client@1.3.2
+  - @pnpm/lockfile.settings-checker@1100.1.2
+
 ## 1102.2.1
 
 ### Patch Changes

--- a/pnpm11/installing/deps-installer/package.json
+++ b/pnpm11/installing/deps-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-installer",
-  "version": "1102.2.1",
+  "version": "1102.2.2",
   "description": "Fast, disk space efficient installation engine",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-resolver/CHANGELOG.md
+++ b/pnpm11/installing/deps-resolver/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @pnpm/resolve-dependencies
 
+## 1100.2.8
+
+### Patch Changes
+
+- 3c6718b: Fixed a deadlock in peer dependency resolution: `pnpm install` hung forever when a peer dependency cycle spanned a project's own dependencies and auto-installed peer providers, for example when installing `electron-builder@26.15.3` [#12921](https://github.com/pnpm/pnpm/issues/12921).
+- 252f15e: Fixed peer dependency auto-install picking a version the peer range rejects. In a workspace with several projects, a package declaring a peer dependency with a semver range (for example `^1.0.0`) could get the highest version found anywhere in the workspace (for example a `2.0.0` resolved for another project) instead of a version that satisfies the range. Peers are now deduplicated onto the highest preferred version that satisfies the declared range, and when none does, the range is resolved from the registry.
+
+  Also fixed re-resolving with an existing lockfile hoisting a different peer version than a fresh install of the same manifest: root dependencies reused from the lockfile were invisible to peer hoisting, so a peer that a root dependency provides could be bound to another version.
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+  - @pnpm/fetching.pick-fetcher@1100.1.0
+  - @pnpm/lockfile.utils@1100.1.2
+  - @pnpm/deps.graph-hasher@1100.2.9
+  - @pnpm/lockfile.preferred-versions@1100.0.19
+
 ## 1100.2.7
 
 ### Patch Changes

--- a/pnpm11/installing/deps-resolver/package.json
+++ b/pnpm11/installing/deps-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-resolver",
-  "version": "1100.2.7",
+  "version": "1100.2.8",
   "description": "Resolves dependency graph of a package",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/deps-restorer/CHANGELOG.md
+++ b/pnpm11/installing/deps-restorer/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @pnpm/headless
 
+## 1102.1.4
+
+### Patch Changes
+
+- @pnpm/deps.graph-builder@1100.0.21
+- @pnpm/installing.package-requester@1102.1.2
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/deps.graph-hasher@1100.2.9
+- @pnpm/installing.linking.modules-cleaner@1100.1.11
+- @pnpm/installing.linking.real-hoist@1100.1.6
+- @pnpm/lockfile.filtering@1100.1.10
+- @pnpm/lockfile.fs@1100.1.10
+- @pnpm/lockfile.to-pnp@1100.1.4
+- @pnpm/building.during-install@1102.0.5
+
 ## 1102.1.3
 
 ### Patch Changes

--- a/pnpm11/installing/deps-restorer/package.json
+++ b/pnpm11/installing/deps-restorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.deps-restorer",
-  "version": "1102.1.3",
+  "version": "1102.1.4",
   "description": "Fast installation using only pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/env-installer/CHANGELOG.md
+++ b/pnpm11/installing/env-installer/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @pnpm/config.deps-installer
 
+## 1102.0.5
+
+### Patch Changes
+
+- Updated dependencies [3c6718b]
+- Updated dependencies [252f15e]
+  - @pnpm/installing.deps-resolver@1100.2.8
+  - @pnpm/lockfile.utils@1100.1.2
+  - @pnpm/store.controller@1102.0.4
+  - @pnpm/deps.graph-hasher@1100.2.9
+  - @pnpm/lockfile.fs@1100.1.10
+
 ## 1102.0.4
 
 ### Patch Changes

--- a/pnpm11/installing/env-installer/package.json
+++ b/pnpm11/installing/env-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.env-installer",
-  "version": "1102.0.4",
+  "version": "1102.0.5",
   "description": "Installer for configurational dependencies",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/linking/modules-cleaner/CHANGELOG.md
+++ b/pnpm11/installing/linking/modules-cleaner/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/modules-cleaner
 
+## 1100.1.11
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/lockfile.filtering@1100.1.10
+
 ## 1100.1.10
 
 ### Patch Changes

--- a/pnpm11/installing/linking/modules-cleaner/package.json
+++ b/pnpm11/installing/linking/modules-cleaner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.linking.modules-cleaner",
-  "version": "1100.1.10",
+  "version": "1100.1.11",
   "description": "Exports util functions to clean up node_modules",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/linking/real-hoist/CHANGELOG.md
+++ b/pnpm11/installing/linking/real-hoist/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/real-hoist
 
+## 1100.1.6
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+
 ## 1100.1.5
 
 ### Patch Changes

--- a/pnpm11/installing/linking/real-hoist/package.json
+++ b/pnpm11/installing/linking/real-hoist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.linking.real-hoist",
-  "version": "1100.1.5",
+  "version": "1100.1.6",
   "description": "Hoists dependencies in a node_modules created by pnpm",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/package-requester/CHANGELOG.md
+++ b/pnpm11/installing/package-requester/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/package-requester
 
+## 1102.1.2
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+  - @pnpm/fetching.pick-fetcher@1100.1.0
+
 ## 1102.1.1
 
 ### Patch Changes

--- a/pnpm11/installing/package-requester/package.json
+++ b/pnpm11/installing/package-requester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.package-requester",
-  "version": "1102.1.1",
+  "version": "1102.1.2",
   "description": "Concurrent downloader of npm-compatible packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/installing/read-projects-context/CHANGELOG.md
+++ b/pnpm11/installing/read-projects-context/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/read-projects-context
 
+## 1100.0.20
+
+### Patch Changes
+
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.19
 
 ### Patch Changes

--- a/pnpm11/installing/read-projects-context/package.json
+++ b/pnpm11/installing/read-projects-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/installing.read-projects-context",
-  "version": "1100.0.19",
+  "version": "1100.0.20",
   "description": "Reads the current state of projects from modules manifest",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/filtering/CHANGELOG.md
+++ b/pnpm11/lockfile/filtering/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/filter-lockfile
 
+## 1100.1.10
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+
 ## 1100.1.9
 
 ### Patch Changes

--- a/pnpm11/lockfile/filtering/package.json
+++ b/pnpm11/lockfile/filtering/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.filtering",
-  "version": "1100.1.9",
+  "version": "1100.1.10",
   "description": "Filters a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/fs/CHANGELOG.md
+++ b/pnpm11/lockfile/fs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/lockfile-file
 
+## 1100.1.10
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+
 ## 1100.1.9
 
 ### Patch Changes

--- a/pnpm11/lockfile/fs/package.json
+++ b/pnpm11/lockfile/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.fs",
-  "version": "1100.1.9",
+  "version": "1100.1.10",
   "description": "Read/write pnpm-lock.yaml files",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/make-dedicated-lockfile/CHANGELOG.md
+++ b/pnpm11/lockfile/make-dedicated-lockfile/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/make-dedicated-lockfile
 
+## 1100.0.24
+
+### Patch Changes
+
+- @pnpm/releasing.exportable-manifest@1100.1.9
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.23
 
 ### Patch Changes

--- a/pnpm11/lockfile/make-dedicated-lockfile/package.json
+++ b/pnpm11/lockfile/make-dedicated-lockfile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.make-dedicated-lockfile",
-  "version": "1100.0.23",
+  "version": "1100.0.24",
   "description": "Creates a dedicated lockfile for a subset of workspace projects",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/preferred-versions/CHANGELOG.md
+++ b/pnpm11/lockfile/preferred-versions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/lockfile.preferred-versions
 
+## 1100.0.19
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+
 ## 1100.0.18
 
 ### Patch Changes

--- a/pnpm11/lockfile/preferred-versions/package.json
+++ b/pnpm11/lockfile/preferred-versions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.preferred-versions",
-  "version": "1100.0.18",
+  "version": "1100.0.19",
   "description": "Get preferred version from lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/settings-checker/CHANGELOG.md
+++ b/pnpm11/lockfile/settings-checker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/lockfile.settings-checker
 
+## 1100.1.2
+
+### Patch Changes
+
+- @pnpm/lockfile.verification@1100.0.23
+
 ## 1100.1.1
 
 ### Patch Changes

--- a/pnpm11/lockfile/settings-checker/package.json
+++ b/pnpm11/lockfile/settings-checker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.settings-checker",
-  "version": "1100.1.1",
+  "version": "1100.1.2",
   "description": "Utilities to check if lockfile settings are out-of-date",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/to-pnp/CHANGELOG.md
+++ b/pnpm11/lockfile/to-pnp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/lockfile-to-pnp
 
+## 1100.1.4
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.1.3
 
 ### Patch Changes

--- a/pnpm11/lockfile/to-pnp/package.json
+++ b/pnpm11/lockfile/to-pnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.to-pnp",
-  "version": "1100.1.3",
+  "version": "1100.1.4",
   "description": "Creates a Plug'n'Play file from a pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/utils/CHANGELOG.md
+++ b/pnpm11/lockfile/utils/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/lockfile-utils
 
+## 1100.1.2
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+
 ## 1100.1.1
 
 ### Patch Changes

--- a/pnpm11/lockfile/utils/package.json
+++ b/pnpm11/lockfile/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.utils",
-  "version": "1100.1.1",
+  "version": "1100.1.2",
   "description": "Utils for dealing with pnpm-lock.yaml",
   "keywords": [
     "pnpm",

--- a/pnpm11/lockfile/verification/CHANGELOG.md
+++ b/pnpm11/lockfile/verification/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/lockfile.verification
 
+## 1100.0.23
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/installing.context@1100.0.23
+
 ## 1100.0.22
 
 ### Patch Changes

--- a/pnpm11/lockfile/verification/package.json
+++ b/pnpm11/lockfile/verification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/lockfile.verification",
-  "version": "1100.0.22",
+  "version": "1100.0.23",
   "description": "Checks a lockfile",
   "keywords": [
     "pnpm",

--- a/pnpm11/modules-mounter/daemon/CHANGELOG.md
+++ b/pnpm11/modules-mounter/daemon/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/mount-modules
 
+## 1100.0.27
+
+### Patch Changes
+
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/config.reader@1101.11.2
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.0.26
 
 ### Patch Changes

--- a/pnpm11/modules-mounter/daemon/package.json
+++ b/pnpm11/modules-mounter/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/modules-mounter.daemon",
-  "version": "1100.0.26",
+  "version": "1100.0.27",
   "description": "Mounts a node_modules directory with FUSE",
   "keywords": [
     "pnpm",

--- a/pnpm11/patching/commands/CHANGELOG.md
+++ b/pnpm11/patching/commands/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/plugin-commands-patching
 
+## 1100.1.10
+
+### Patch Changes
+
+- @pnpm/installing.commands@1100.10.4
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/config.reader@1101.11.2
+- @pnpm/store.connection-manager@1100.3.5
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1100.1.9
 
 ### Patch Changes

--- a/pnpm11/patching/commands/package.json
+++ b/pnpm11/patching/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/patching.commands",
-  "version": "1100.1.9",
+  "version": "1100.1.10",
   "description": "Commands for creating patches",
   "keywords": [
     "pnpm",

--- a/pnpm11/pkg-manifest/commands/CHANGELOG.md
+++ b/pnpm11/pkg-manifest/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/pkg-manifest.commands
 
+## 1100.1.11
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.1.10
 
 ### Patch Changes

--- a/pnpm11/pkg-manifest/commands/package.json
+++ b/pnpm11/pkg-manifest/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/pkg-manifest.commands",
-  "version": "1100.1.10",
+  "version": "1100.1.11",
   "description": "Commands for managing package.json",
   "keywords": [
     "pnpm",

--- a/pnpm11/pnpm/CHANGELOG.md
+++ b/pnpm11/pnpm/CHANGELOG.md
@@ -1,5 +1,24 @@
 # pnpm
 
+## 11.12.0
+
+### Minor Changes
+
+- a897ef7: Custom fetchers exported from a pnpmfile can now delegate by returning a `{ delegate: <resolution> }` envelope: pnpm rewrites the package's resolution to the delegated shape and runs the built-in fetcher on it. This is the portable delegation form that also works in pacquet, where `cafs` and `fetchers` cannot be passed to the hook. Related to [pnpm/pnpm#11685](https://github.com/pnpm/pnpm/issues/11685).
+
+### Patch Changes
+
+- 2b02764: The changed-packages filter (`--filter "...[<since>]"`) no longer allows an option-like `<since>` value (such as `--output=<path>`) to be interpreted as a git option — git now rejects it as a bad revision. The repository root is also resolved to the nearest `.git` entry, so the filter works in a git worktree checked out inside another repository's tree.
+- 43711ce: `pnpm outdated` no longer checks the registry for dependencies that are resolved from local `link:`, `file:`, or `workspace:` references in the lockfile [#12827](https://github.com/pnpm/pnpm/issues/12827).
+- 3c6718b: Fixed a deadlock in peer dependency resolution: `pnpm install` hung forever when a peer dependency cycle spanned a project's own dependencies and auto-installed peer providers, for example when installing `electron-builder@26.15.3` [#12921](https://github.com/pnpm/pnpm/issues/12921).
+- 252f15e: Fixed peer dependency auto-install picking a version the peer range rejects. In a workspace with several projects, a package declaring a peer dependency with a semver range (for example `^1.0.0`) could get the highest version found anywhere in the workspace (for example a `2.0.0` resolved for another project) instead of a version that satisfies the range. Peers are now deduplicated onto the highest preferred version that satisfies the declared range, and when none does, the range is resolved from the registry.
+
+  Also fixed re-resolving with an existing lockfile hoisting a different peer version than a fresh install of the same manifest: root dependencies reused from the lockfile were invisible to peer hoisting, so a peer that a root dependency provides could be bound to another version.
+
+- a38adda: `pnpm self-update <version>` now installs the requested pnpm version when it matches the currently running version but is missing from the global self-update directory.
+- 6a85968: `pnpm stage list` now stops paginating after a fail-safe cap of 1000 pages, so a misbehaving registry cannot keep the command looping forever.
+- eee7c9a: `verify-deps-before-run` no longer spawns a `pnpm install` when pnpm is executed in a directory that has no `package.json`. A mistyped command run outside a project (for example `pnpm witch 10 login`) used to crash with a confusing error from the spawned install; now it fails with the regular "no package.json found" error.
+
 ## 11.11.0
 
 ### Minor Changes

--- a/pnpm11/pnpm/artifacts/darwin-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/macos-arm64",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/exe/package.json
+++ b/pnpm11/pnpm/artifacts/exe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/exe",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/pnpm11/pnpm/artifacts/linux-arm64-musl/package.json
+++ b/pnpm11/pnpm/artifacts/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-arm64",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-arm64",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-x64-musl/package.json
+++ b/pnpm11/pnpm/artifacts/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linuxstatic-x64",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/linux-x64/package.json
+++ b/pnpm11/pnpm/artifacts/linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/linux-x64",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/win32-arm64/package.json
+++ b/pnpm11/pnpm/artifacts/win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-arm64",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/artifacts/win32-x64/package.json
+++ b/pnpm11/pnpm/artifacts/win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/win-x64",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "keywords": [
     "pnpm",
     "pnpm11",

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pnpm",
-  "version": "11.11.0",
+  "version": "11.12.0",
   "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",

--- a/pnpm11/registry-access/commands/CHANGELOG.md
+++ b/pnpm11/registry-access/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/registry-access.commands
 
+## 1100.4.1
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.4.0
 
 ### Minor Changes

--- a/pnpm11/registry-access/commands/package.json
+++ b/pnpm11/registry-access/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/registry-access.commands",
-  "version": "1100.4.0",
+  "version": "1100.4.1",
   "description": "Commands for managing packages on the registry",
   "keywords": [
     "pnpm",

--- a/pnpm11/releasing/commands/CHANGELOG.md
+++ b/pnpm11/releasing/commands/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @pnpm/releasing.commands
 
+## 1100.5.5
+
+### Patch Changes
+
+- 6a85968: `pnpm stage list` now stops paginating after a fail-safe cap of 1000 pages, so a misbehaving registry cannot keep the command looping forever.
+  - @pnpm/installing.commands@1100.10.4
+  - @pnpm/installing.client@1100.2.13
+  - @pnpm/config.reader@1101.11.2
+  - @pnpm/releasing.exportable-manifest@1100.1.9
+  - @pnpm/lockfile.fs@1100.1.10
+  - @pnpm/engine.runtime.commands@1100.1.10
+  - @pnpm/engine.runtime.node-resolver@1101.1.12
+
 ## 1100.5.4
 
 ### Patch Changes

--- a/pnpm11/releasing/commands/package.json
+++ b/pnpm11/releasing/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/releasing.commands",
-  "version": "1100.5.4",
+  "version": "1100.5.5",
   "description": "Commands for deploy, pack, and publish",
   "keywords": [
     "pnpm",

--- a/pnpm11/resolving/default-resolver/CHANGELOG.md
+++ b/pnpm11/resolving/default-resolver/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/default-resolver
 
+## 1100.3.13
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+  - @pnpm/engine.runtime.node-resolver@1101.1.12
+
 ## 1100.3.12
 
 ### Patch Changes

--- a/pnpm11/resolving/default-resolver/package.json
+++ b/pnpm11/resolving/default-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/resolving.default-resolver",
-  "version": "1100.3.12",
+  "version": "1100.3.13",
   "description": "pnpm's default package resolver",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/commands/CHANGELOG.md
+++ b/pnpm11/store/commands/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @pnpm/store.commands
 
+## 1100.0.31
+
+### Patch Changes
+
+- @pnpm/installing.client@1100.2.13
+- @pnpm/lockfile.utils@1100.1.2
+- @pnpm/config.reader@1101.11.2
+- @pnpm/store.connection-manager@1100.3.5
+- @pnpm/installing.context@1100.0.23
+
 ## 1100.0.30
 
 ### Patch Changes

--- a/pnpm11/store/commands/package.json
+++ b/pnpm11/store/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.commands",
-  "version": "1100.0.30",
+  "version": "1100.0.31",
   "description": "Commands for controlling and inspecting the store",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/connection-manager/CHANGELOG.md
+++ b/pnpm11/store/connection-manager/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/store-connection-manager
 
+## 1100.3.5
+
+### Patch Changes
+
+- @pnpm/installing.client@1100.2.13
+- @pnpm/store.controller@1102.0.4
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.3.4
 
 ### Patch Changes

--- a/pnpm11/store/connection-manager/package.json
+++ b/pnpm11/store/connection-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.connection-manager",
-  "version": "1100.3.4",
+  "version": "1100.3.5",
   "description": "Create a pnpm store controller",
   "keywords": [
     "pnpm",

--- a/pnpm11/store/controller/CHANGELOG.md
+++ b/pnpm11/store/controller/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @pnpm/package-store
 
+## 1102.0.4
+
+### Patch Changes
+
+- Updated dependencies [a897ef7]
+  - @pnpm/hooks.types@1100.2.0
+  - @pnpm/installing.package-requester@1102.1.2
+
 ## 1102.0.3
 
 ### Patch Changes

--- a/pnpm11/store/controller/package.json
+++ b/pnpm11/store/controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/store.controller",
-  "version": "1102.0.3",
+  "version": "1102.0.4",
   "description": "A storage for packages",
   "keywords": [
     "pnpm",

--- a/pnpm11/testing/temp-store/CHANGELOG.md
+++ b/pnpm11/testing/temp-store/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pnpm/testing.temp-store
 
+## 1100.1.14
+
+### Patch Changes
+
+- @pnpm/installing.client@1100.2.13
+- @pnpm/store.controller@1102.0.4
+
 ## 1100.1.13
 
 ### Patch Changes

--- a/pnpm11/testing/temp-store/package.json
+++ b/pnpm11/testing/temp-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/testing.temp-store",
-  "version": "1100.1.13",
+  "version": "1100.1.14",
   "description": "A temporary store for testing purposes",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/commands/CHANGELOG.md
+++ b/pnpm11/workspace/commands/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/plugin-commands-init
 
+## 1100.1.25
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.1.24
 
 ### Patch Changes

--- a/pnpm11/workspace/commands/package.json
+++ b/pnpm11/workspace/commands/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.commands",
-  "version": "1100.1.24",
+  "version": "1100.1.25",
   "description": "Create a package.json file",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/projects-filter/CHANGELOG.md
+++ b/pnpm11/workspace/projects-filter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/filter-workspace-packages
 
+## 1100.0.26
+
+### Patch Changes
+
+- 2b02764: The changed-packages filter (`--filter "...[<since>]"`) no longer allows an option-like `<since>` value (such as `--output=<path>`) to be interpreted as a git option — git now rejects it as a bad revision. The repository root is also resolved to the nearest `.git` entry, so the filter works in a git worktree checked out inside another repository's tree.
+
 ## 1100.0.25
 
 ### Patch Changes

--- a/pnpm11/workspace/projects-filter/package.json
+++ b/pnpm11/workspace/projects-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.projects-filter",
-  "version": "1100.0.25",
+  "version": "1100.0.26",
   "description": "Filters packages in a workspace",
   "keywords": [
     "pnpm",

--- a/pnpm11/workspace/state/CHANGELOG.md
+++ b/pnpm11/workspace/state/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/workspace.state
 
+## 1100.0.27
+
+### Patch Changes
+
+- @pnpm/config.reader@1101.11.2
+
 ## 1100.0.26
 
 ### Patch Changes

--- a/pnpm11/workspace/state/package.json
+++ b/pnpm11/workspace/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/workspace.state",
-  "version": "1100.0.26",
+  "version": "1100.0.27",
   "description": "Track the list of actual paths of workspace packages in a cache",
   "keywords": [
     "pnpm",

--- a/pnpr/client/CHANGELOG.md
+++ b/pnpr/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pnpm/agent.client
 
+## 1.3.2
+
+### Patch Changes
+
+- @pnpm/lockfile.fs@1100.1.10
+
 ## 1.3.1
 
 ### Patch Changes

--- a/pnpr/client/package.json
+++ b/pnpr/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pnpm/pnpr.client",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Client for the pnpr server — resolves a project server-side and receives the resolved lockfile",
   "keywords": [
     "pnpm",


### PR DESCRIPTION
Automated release PR created by the create-release-pr workflow.

Releasing `main` as pnpm v11.12.0. Merging this PR consumes the pending changesets and records them in the `.changeset-released` ledger under `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Metadata**
  - Updated package and platform artifact versions across the pnpm distribution.
  - Refreshed the client package version and supporting package release metadata.

- **Documentation**
  - Removed several pending changeset entries covering installation, dependency resolution, outdated checks, self-update behavior, staging safeguards, and workspace filtering.
  - The removed entries will no longer appear as part of the generated release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->