### PR TITLE
ci: disable git hooks in the release-pr and update-lockfile workflows

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -22,6 +22,13 @@ jobs:
   create-release-pr:
     if: github.repository == 'pnpm/pnpm' # Only run on the main repository, not forks
     runs-on: ubuntu-latest
+    env:
+      # The husky hooks are a developer safety net; CI has its own gates. Without
+      # this, `pnpm install` wires the hooks and the pre-push hook runs the full
+      # TS compile/lint plus the Rust clippy/doc sweep during "Commit and push"
+      # (the shallow clone and URL remote make its change detection always
+      # conclude that Rust sources changed).
+      HUSKY: 0
     steps:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -19,6 +19,12 @@ jobs:
   update-lockfile:
     if: github.repository == 'pnpm/pnpm' # Only run on the main repository, not forks
     runs-on: ubuntu-latest
+    env:
+      # The husky hooks are a developer safety net; CI has its own gates. Without
+      # this, the full install wires the hooks and the pre-push hook runs the TS
+      # compile/lint (and, when the remote branch doesn't exist yet, the Rust
+      # clippy/doc sweep) during "Commit and push".
+      HUSKY: 0
     steps:
     - name: Checkout Commit
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Both workflows that commit and push (`create-release-pr.yml` and `update-lockfile.yml`) run a full `pnpm install`, which executes the root `prepare: husky` script and wires the git hooks on the runner. Their "Commit and push" steps then trigger the husky `pre-push` hook, which always runs the TS `compile-only` + lint pass and, when its change detection concludes Rust sources changed, the full `cargo clippy`/`cargo doc` workspace sweep from `pnpm/scripts/pre-push-rust.sh`.

That detection can never say "unchanged" when the remote branch is new: the push remote is a raw URL (so `--not --remotes=$remote` matches no remote-tracking refs) and the clone is shallow (so the graft commit lists the whole tree, including `pnpm/` and `pnpr/`). That is why the Create Release PR run https://github.com/pnpm/pnpm/actions/runs/29147527261 spent most of its time building Rust. The daily update-lockfile run pays the compile+lint cost every day and hits the Rust sweep whenever `chore/update-lockfile` doesn't already exist on the remote.

The hooks are a developer safety net; the PRs these workflows open go through the normal CI gates. This PR sets `HUSKY: 0` at the job level in both workflows so no hooks are installed and no git hook runs for any git operation on the runner.

## Squash Commit Body

```text
The "Commit and push" steps of create-release-pr.yml and
update-lockfile.yml ran the husky pre-push hook on the runner: the TS
compile/lint pass plus, when the hook's change detection concluded Rust
sources changed, the full cargo clippy/doc sweep from
pnpm/scripts/pre-push-rust.sh. The detection can never conclude
"unchanged" when the remote branch is new, for two independent reasons:
the push remote is a raw URL, so `--not --remotes=$remote` matches no
remote-tracking refs and every reachable commit counts as being pushed;
and the checkout is shallow, so the graft commit lists the entire tree,
including pnpm/ and pnpr/ paths.

Set HUSKY=0 at the job level in both workflows so `pnpm install` never
installs the hooks on the runner. The hooks are a developer safety net;
the PRs these workflows open go through the normal CI gates.
```

## Checklist

- [x] Added or updated tests. *(Not applicable — CI workflow change only, no runtime code.)*
- [x] Updated the documentation if needed. *(Not applicable.)*

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated release pull request creation by disabling local Git hook checks during workflow execution, preventing full pre-push verification runs during the “Commit and push” phase.
  * Applied the same optimization to the lockfile update workflow to keep the commit/push step faster and lighter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->