### PR TITLE
fix(pacquet): parse peer suffixes after patch hashes

### DIFF
--- a/pnpm/crates/resolving-deps-resolver/src/dedupe_peer_dependents.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dedupe_peer_dependents.rs
@@ -280,8 +280,7 @@ fn dep_path_peer_names(dep_path: &DepPath) -> HashSet<String> {
 fn collect_peer_names(raw: &str, names: &mut HashSet<String>) {
     let suffix = index_of_dep_path_suffix(raw);
     let Some(peers_index) = suffix.peers_index else { return };
-    let peers_end = suffix.patch_hash_index.unwrap_or(raw.len());
-    let Some(segments) = split_peer_suffix_segments(&raw[peers_index..peers_end]) else {
+    let Some(segments) = split_peer_suffix_segments(&raw[peers_index..]) else {
         return;
     };
     for segment in segments {

--- a/pnpm/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
@@ -1,4 +1,4 @@
-use super::{DirectByImporter, dedupe_peer_dependents, deduplicate_dep_paths};
+use super::{DirectByImporter, dedupe_peer_dependents, deduplicate_dep_paths, dep_path_peer_names};
 use crate::dependencies_graph::{DependenciesGraph, DependenciesGraphNode};
 use pacquet_deps_path::DepPath;
 use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
@@ -10,6 +10,26 @@ use std::{
 
 fn dp(raw: &str) -> DepPath {
     DepPath::from(raw.to_string())
+}
+
+#[test]
+fn collects_peer_names_after_patch_hash() {
+    let dep_path = dp(concat!(
+        "@medusajs/workflows-sdk@2.13.3",
+        "(patch_hash=248195172cff27c28650c005b6aa0aa3b2f2976f9739544b360b81668f2d8b59)",
+        "(@types/node@20.19.17)",
+        "(better-sqlite3@12.8.0)",
+        "(express@4.21.2)",
+    ));
+
+    assert_eq!(
+        dep_path_peer_names(&dep_path),
+        HashSet::from([
+            "@types/node".to_string(),
+            "better-sqlite3".to_string(),
+            "express".to_string(),
+        ]),
+    );
 }
 
 fn make_node(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -2450,8 +2450,7 @@ fn dep_path_with_allowed_peer_segments(
     let raw = dep_path.as_str();
     let suffix = index_of_dep_path_suffix(raw);
     let peers_index = suffix.peers_index?;
-    let peers_end = suffix.patch_hash_index.unwrap_or(raw.len());
-    let segments = split_peer_suffix_segments(&raw[peers_index..peers_end])?;
+    let segments = split_peer_suffix_segments(&raw[peers_index..])?;
     let mut kept = Vec::new();
     for segment in &segments {
         let name = peer_segment_name(segment)?;
@@ -2468,9 +2467,6 @@ fn dep_path_with_allowed_peer_segments(
         out.push_str(segment);
         out.push(')');
     }
-    if peers_end < raw.len() {
-        out.push_str(&raw[peers_end..]);
-    }
     Some(DepPath::from(out))
 }
 
@@ -2486,8 +2482,7 @@ fn peer_segment_names(dep_path: &DepPath) -> Option<Vec<String>> {
     let raw = dep_path.as_str();
     let suffix = index_of_dep_path_suffix(raw);
     let peers_index = suffix.peers_index?;
-    let peers_end = suffix.patch_hash_index.unwrap_or(raw.len());
-    let segments = split_peer_suffix_segments(&raw[peers_index..peers_end])?;
+    let segments = split_peer_suffix_segments(&raw[peers_index..])?;
     segments.iter().map(|segment| peer_segment_name(segment).map(str::to_string)).collect()
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    ImporterPeerInput, NodeRecord, ResolvePeersOptions, Walker, resolve_peers,
+    ImporterPeerInput, NodeRecord, ResolvePeersOptions, Walker,
+    dep_path_with_allowed_peer_segments, peer_segment_names, resolve_peers,
     resolve_peers_workspace, satisfies_with_prereleases,
 };
 use crate::{
@@ -17,6 +18,34 @@ use std::{
     str::FromStr,
     sync::Arc,
 };
+
+const PATCHED_WORKFLOWS_SDK: &str = concat!(
+    "@medusajs/workflows-sdk@2.13.3",
+    "(patch_hash=248195172cff27c28650c005b6aa0aa3b2f2976f9739544b360b81668f2d8b59)",
+    "(@types/node@20.19.17)",
+    "(better-sqlite3@12.8.0)",
+    "(express@4.21.2)",
+);
+
+#[test]
+fn parses_peer_suffix_after_patch_hash() {
+    let dep_path = DepPath::from(PATCHED_WORKFLOWS_SDK);
+    assert_eq!(
+        peer_segment_names(&dep_path),
+        Some(vec!["@types/node".to_string(), "better-sqlite3".to_string(), "express".to_string(),]),
+    );
+
+    let allowed = HashSet::from(["@types/node".to_string(), "express".to_string()]);
+    assert_eq!(
+        dep_path_with_allowed_peer_segments(&dep_path, &allowed),
+        Some(DepPath::from(concat!(
+            "@medusajs/workflows-sdk@2.13.3",
+            "(patch_hash=248195172cff27c28650c005b6aa0aa3b2f2976f9739544b360b81668f2d8b59)",
+            "(@types/node@20.19.17)",
+            "(express@4.21.2)",
+        ))),
+    );
+}
 
 #[test]
 fn satisfies_handles_basic_ranges() {


### PR DESCRIPTION
## Summary

Canonical patched dep paths place the patch hash before their peer suffix:

```text
package@version(patch_hash=...)(peer@version)
```

Three Rust resolver consumers used `patch_hash_index` as the end of the peer slice. For a patched package with peers, that makes the slice begin after it ends and panics. This PR parses peer segments from `peers_index` through the end, matching pnpm 11, while preserving the patch hash through the existing prefix.

The regressions use the real dep-path shape that exposed the panic and cover both peer filtering and peer-name collection. This is a resolver bug, not corrupt lockfile data and not specific to legacy deploy.

## Squash Commit Body

```text
Parse peer suffix segments from peers_index through the end of canonical dep paths, where patch_hash precedes peers. This prevents invalid Rust slices and preserves patch hashes while filtering or deduplicating patched packages with peer dependencies.
```

## Verification

- Exact pre-fix panic reproduced independently in `resolve_peers` and `dedupe_peer_dependents`
- Focused regressions: 2/2 passed
- Resolver suite: 175/175 passed on Rust 1.93.1 and pinned Rust 1.95
- Pinned-toolchain Clippy with warnings denied: passed
- Typos, formatting, full workspace check, and `git diff --check`: passed
- Full `just ready` reached nextest test-binary linking, then the local run stopped on disk exhaustion; no source/test failure was observed

## Checklist

- [x] No TypeScript change is needed; pnpm 11 already parses from `peersIndex` through the end.
- [x] No changeset is included because this is a pacquet-only PR.
- [x] Added regression coverage.
- [x] No documentation change is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency resolution for packages with peer dependency suffixes following patch-hash information.
  * Correctly identifies peer dependency names in these scenarios.
  * Preserves accurate dependency paths when filtering allowed peer segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->