### PR TITLE
fix(pacquet): resolve versionless workspace packages

### DIFF
--- a/.changeset/pacquet-versionless-workspace-packages.md
+++ b/.changeset/pacquet-versionless-workspace-packages.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `workspace:` dependencies failing to resolve when they point at a named workspace package whose `package.json` has no `version` (or a `null` version). Such packages are now indexed as version `0.0.0`, matching the TypeScript CLI, so specs like `workspace:*` and `workspace:0.0.0` resolve instead of failing with a misleading "no package named" error.

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -235,6 +235,127 @@ fn shared_workspace_dep_link_is_relative_to_each_importer() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn workspace_specs_resolve_a_versionless_private_package() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    // Keep the injected resolution observable instead of deduping the empty
+    // package back to a link.
+    workspace_yaml.push_str(
+        "packages:\n  - 'packages/*'\ninjectWorkspacePackages: true\ndedupeInjectedDeps: false\n",
+    );
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::create_dir_all(workspace.join("packages/sa")).expect("mkdir packages/sa");
+    fs::write(
+        workspace.join("packages/sa/package.json"),
+        serde_json::json!({ "name": "sa", "private": true }).to_string(),
+    )
+    .expect("write packages/sa/package.json");
+
+    fs::create_dir_all(workspace.join("packages/web")).expect("mkdir packages/web");
+    fs::write(
+        workspace.join("packages/web/package.json"),
+        serde_json::json!({
+            "name": "web",
+            "private": true,
+            "dependencies": { "sa": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/web/package.json");
+
+    fs::create_dir_all(workspace.join("packages/exact")).expect("mkdir packages/exact");
+    fs::write(
+        workspace.join("packages/exact/package.json"),
+        serde_json::json!({
+            "name": "exact",
+            "private": true,
+            "dependencies": { "sa": "workspace:0.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/exact/package.json");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let parsed: pacquet_lockfile::Lockfile = serde_saphyr::from_str(&lockfile)
+        .unwrap_or_else(|err| panic!("re-parse pnpm-lock.yaml: {err}\n{lockfile}"));
+    let sa_name: pacquet_lockfile::PkgName = "sa".parse().expect("parse package name");
+    let resolved = |importer_id: &str| {
+        parsed
+            .importers
+            .get(importer_id)
+            .and_then(|importer| importer.dependencies.as_ref())
+            .and_then(|dependencies| dependencies.get(&sa_name))
+            .unwrap_or_else(|| panic!("missing sa in {importer_id}:\n{lockfile}"))
+            .version
+            .to_string()
+    };
+    assert_eq!(resolved("packages/web"), "file:packages/sa");
+    assert_eq!(resolved("packages/exact"), "file:packages/sa");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn workspace_specs_do_not_resolve_a_non_string_version_as_zero() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::create_dir_all(workspace.join("packages/bad")).expect("mkdir packages/bad");
+    fs::write(
+        workspace.join("packages/bad/package.json"),
+        serde_json::json!({ "name": "bad", "version": 42, "private": true }).to_string(),
+    )
+    .expect("write packages/bad/package.json");
+
+    fs::create_dir_all(workspace.join("packages/consumer")).expect("mkdir packages/consumer");
+    fs::write(
+        workspace.join("packages/consumer/package.json"),
+        serde_json::json!({
+            "name": "consumer",
+            "private": true,
+            "dependencies": { "bad": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/consumer/package.json");
+
+    let output = pacquet
+        .with_args(["install", "--lockfile-only"])
+        .output()
+        .expect("run install with malformed workspace version");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "malformed workspace version unexpectedly resolved");
+    assert!(
+        stderr.contains("no package named \"bad\" is present in the workspace"),
+        "unexpected error for malformed workspace version:\n{stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// A workspace root defined by `pnpm-workspace.yaml` alone is legal without a
 /// root `package.json`, and installing must not scaffold one — pnpm never
 /// does, and a scaffolded root manifest (with the init template's failing

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -348,8 +348,12 @@ fn workspace_specs_do_not_resolve_a_non_string_version_as_zero() {
         .expect("run install with malformed workspace version");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!output.status.success(), "malformed workspace version unexpectedly resolved");
+    // miette wraps error output at terminal width (where the wrap point depends
+    // on the temp dir path length), so flatten the decorated lines before
+    // matching the message text.
+    let stderr_flat = stderr.replace('│', " ").split_whitespace().collect::<Vec<_>>().join(" ");
     assert!(
-        stderr.contains("no package named \"bad\" is present in the workspace"),
+        stderr_flat.contains(r#"no package named "bad" is present in the workspace"#),
         "unexpected error for malformed workspace version:\n{stderr}",
     );
 

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2495,9 +2495,8 @@ fn configured_or_discovered_workspace_dir(
 ///
 /// The map is a name/version index of per-project `WorkspacePackage`
 /// entries (`{ rootDir, manifest }`) consumed by the resolver.
-/// Projects whose manifest lacks a name or version are silently
-/// skipped; the manifest reader emits a separate warning that pacquet
-/// doesn't carry through here.
+/// Projects whose manifest lacks a name are skipped. A missing or null
+/// version is indexed as `0.0.0`; malformed non-string versions are skipped.
 fn build_workspace_packages_map(
     projects: Option<&[pacquet_workspace::Project]>,
 ) -> Option<pacquet_resolving_resolver_base::WorkspacePackages> {
@@ -2505,9 +2504,15 @@ fn build_workspace_packages_map(
     let mut map: pacquet_resolving_resolver_base::WorkspacePackages =
         std::collections::BTreeMap::new();
     for project in projects {
-        let name = manifest_string_field(&project.manifest, "name");
-        let version = manifest_string_field(&project.manifest, "version");
-        let (Some(name), Some(version)) = (name, version) else { continue };
+        let Some(name) = manifest_string_field(&project.manifest, "name") else { continue };
+        let version = match project.manifest.value().get("version") {
+            None => "0.0.0".to_string(),
+            Some(value) if value.is_null() => "0.0.0".to_string(),
+            Some(value) => {
+                let Some(version) = value.as_str() else { continue };
+                version.to_string()
+            }
+        };
         map.entry(name).or_default().insert(
             version,
             pacquet_resolving_resolver_base::WorkspacePackage {


### PR DESCRIPTION
## Summary

pnpm 12's Rust workspace map currently drops every named workspace project whose `package.json` has no `version`. A dependency such as `sa: workspace:*` then fails with a misleading "no package named sa" error.

pnpm 11 intentionally treats a named, versionless workspace package as version `0.0.0` (see #2648 and #2678). This PR restores that behavior in the Rust implementation and covers both `workspace:*` and `workspace:0.0.0` while `injectWorkspacePackages` is enabled. Malformed non-string versions remain excluded instead of being coerced to `0.0.0`.

## Squash Commit Body

```text
Index named workspace projects without a version under 0.0.0 instead of dropping them from the workspace package map. This restores pnpm 11 behavior for private/versionless workspace packages and allows workspace:* and workspace:0.0.0 dependencies to resolve in injected workspaces.

Related to #2648 and #2678.
```

## Verification

- Regression reproduced with published `pnpm@12.0.0-alpha.7`
- Focused positive CLI E2E fails before the fix and passed afterward
- Added a source-reviewed negative E2E proving a malformed non-string version is not treated as `0.0.0`
- Targeted E2E: passed
- Targeted Clippy with warnings denied on the pinned Rust 1.95 toolchain: passed
- Formatting, typos, and `git diff --check`: passed
- pnpm 11.11 and the fixed Rust implementation produce matching injected lockfile shapes
- A post-review cold rebuild stopped on local disk exhaustion before the two E2Es ran; CI will rerun them from scratch

## Checklist

- [x] No TypeScript change is needed; the pnpm 11 engine already uses `0.0.0` for versionless workspace packages.
- [x] No changeset is included because this is a pacquet-only PR.
- [x] Added regression coverage.
- [x] No documentation change is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace packages missing a version, or explicitly set to `null`, are now recognized during installation.
  - Workspace dependency specs for private packages now resolve reliably when versions are omitted.
  - If a workspace package has a malformed (non-string) version, installation fails safely with a clear error message instead of proceeding with incorrect resolution.

- **Tests**
  - Added integration coverage for workspace dependency resolution and for failing on invalid version declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->