### PR TITLE
feat(pacquet): honor extraBinPaths and extraEnv from the updateConfig hook

### DIFF
--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -18,7 +18,7 @@ use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use serde_json::{Value, json};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     ffi::OsString,
     fs,
     path::{Path, PathBuf},
@@ -173,6 +173,7 @@ impl DlxArgs {
         let cache_key =
             create_cache_key(&pkgs, &registries, &allow_build, effective_architectures.as_ref());
         let extra_bin_paths = config.extra_bin_paths.clone();
+        let extra_env = config.extra_env.clone();
 
         let dlx_command_cache_dir = cache_dir.join("dlx").join(&cache_key);
         fs::create_dir_all(&dlx_command_cache_dir).map_err(|source| DlxError::Cache {
@@ -223,7 +224,7 @@ impl DlxArgs {
         // The dlx bin runs in the process working directory
         // (`cwd: process.cwd()`), independent of `--dir`.
         let run_cwd = std::env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
-        run_bin(&bin_name, args, &run_cwd, bins_dir, &extra_bin_paths, shell_mode)
+        run_bin(&bin_name, args, &run_cwd, bins_dir, &extra_bin_paths, &extra_env, shell_mode)
     }
 }
 
@@ -338,6 +339,7 @@ fn run_bin(
     cwd: &Path,
     bins_dir: PathBuf,
     extra_bin_paths: &[PathBuf],
+    extra_env: &HashMap<String, String>,
     shell_mode: bool,
 ) -> miette::Result<()> {
     let mut prepend = Vec::with_capacity(1 + extra_bin_paths.len());
@@ -367,6 +369,10 @@ fn run_bin(
     };
 
     cmd.current_dir(cwd);
+    // `updateConfig`-provided env, applied first so pnpm's own keys win
+    // on conflict (matching `exec`'s spawn and TS `makeEnv`). Empty
+    // unless the dlx install populated it.
+    cmd.envs(extra_env);
     cmd.env_remove("PATH");
     cmd.env_remove("Path");
     cmd.env("PATH", &path);

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -370,8 +370,10 @@ fn run_bin(
 
     cmd.current_dir(cwd);
     // `updateConfig`-provided env, applied first so pnpm's own keys win
-    // on conflict (matching `exec`'s spawn and TS `makeEnv`). Empty
-    // unless the dlx install populated it.
+    // on conflict (matching `exec`'s spawn and TS `makeEnv`). dlx does
+    // not run the `updateConfig` hook, so this is currently always
+    // empty; wired for uniformity with the other spawn sites and so it
+    // works if that changes.
     cmd.envs(extra_env);
     cmd.env_remove("PATH");
     cmd.env_remove("Path");

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -167,6 +167,11 @@ pub(super) fn spawn_in_dir(
     };
 
     cmd.current_dir(dir);
+    // `updateConfig`-provided env, applied first so pnpm's own keys
+    // below (PATH, user-agent, NODE_OPTIONS) win on conflict — matching
+    // TS `makeEnv`, which spreads `...extraEnv` into the base. Empty
+    // unless an install-family command populated it.
+    cmd.envs(&config.extra_env);
     // Drop any inherited PATH-like key before re-inserting our own, so
     // a Windows `Path`/`PATH` pair can't collapse to an unspecified
     // winner at spawn time (matching the lifecycle spawn in

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -25,7 +25,6 @@ use pacquet_pack::{
 use pacquet_reporter::Reporter;
 use pacquet_workspace::read_workspace_manifest;
 use std::{
-    collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -239,7 +238,7 @@ impl PackArgs {
             skip_manifest_obfuscation: self.skip_manifest_obfuscation,
             user_agent: config.user_agent.clone(),
             extra_bin_paths: config.extra_bin_paths.clone(),
-            extra_env: HashMap::new(),
+            extra_env: config.extra_env.clone(),
             workspace_dir: config.workspace_dir.clone(),
             dry_run: self.dry_run,
             out,

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -312,7 +312,7 @@ impl PublishArgs {
             skip_manifest_obfuscation: self.flags.skip_manifest_obfuscation,
             user_agent: config.user_agent.clone(),
             extra_bin_paths: config.extra_bin_paths.clone(),
-            extra_env: HashMap::new(),
+            extra_env: config.extra_env.clone(),
             workspace_dir: config.workspace_dir.clone(),
             dry_run: false,
             out: None,

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -380,7 +380,7 @@ fn run_publish_scripts<Reporter: self::Reporter>(
         root_modules_dir: &root_modules_dir,
         init_cwd: dir,
         extra_bin_paths: &config.extra_bin_paths,
-        extra_env: &HashMap::new(),
+        extra_env: &config.extra_env,
         node_execpath: None,
         npm_execpath: None,
         node_gyp_path: None,

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -155,7 +155,7 @@ impl RunArgs {
             .into());
         }
 
-        let mut extra_env = HashMap::new();
+        let mut extra_env = config.extra_env.clone();
         if let Some(node_options) = &config.node_options {
             extra_env.insert("NODE_OPTIONS".to_string(), node_options.clone());
         }

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -119,7 +119,7 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
     // `script_shell`, and the user-agent. Compute the bits that don't
     // vary per project once; the per-project `RunContext` reuses them.
     let init_cwd = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
-    let mut extra_env: HashMap<String, String> = HashMap::new();
+    let mut extra_env: HashMap<String, String> = config.extra_env.clone();
     if let Some(node_options) = &config.node_options {
         extra_env.insert("NODE_OPTIONS".to_string(), node_options.clone());
     }

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -431,6 +431,20 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
             "catalogs".to_string(),
             serde_json::to_value(&yaml_catalogs).into_diagnostic()?,
         );
+        // Seed the live `extraBinPaths` / `extraEnv` so a hook can read
+        // and extend them (PnpmBuild's `updateConfig` appends its bin
+        // dir and sets `npm_config_nodedir`). Neither is a
+        // `WorkspaceSettings` key, so like `storeDir`/`catalogs` they are
+        // injected here and re-read from the delta below rather than
+        // going through `apply_to`.
+        object.insert(
+            "extraBinPaths".to_string(),
+            serde_json::to_value(&config.extra_bin_paths).into_diagnostic()?,
+        );
+        object.insert(
+            "extraEnv".to_string(),
+            serde_json::to_value(&config.extra_env).into_diagnostic()?,
+        );
     }
 
     let prefix = root_dir.to_string_lossy().into_owned();
@@ -475,10 +489,31 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     let changed_virtual_store_dir = delta.get("virtualStoreDir").cloned();
     let changed_global_virtual_store_dir = delta.get("globalVirtualStoreDir").cloned();
     let virtual_store_dir_cleared = changed_virtual_store_dir.as_ref().is_some_and(Value::is_null);
+    // `extraBinPaths` / `extraEnv` aren't `WorkspaceSettings` fields, so
+    // `from_value(delta)` below ignores them. Pull the hook's values out
+    // first and assign them directly.
+    let changed_extra_bin_paths = delta
+        .get("extraBinPaths")
+        .map(|value| serde_json::from_value::<Vec<PathBuf>>(value.clone()))
+        .transpose()
+        .into_diagnostic()
+        .wrap_err("the updateConfig hook produced an invalid extraBinPaths value")?;
+    let changed_extra_env = delta
+        .get("extraEnv")
+        .map(|value| serde_json::from_value::<HashMap<String, String>>(value.clone()))
+        .transpose()
+        .into_diagnostic()
+        .wrap_err("the updateConfig hook produced an invalid extraEnv value")?;
     let delta_settings: WorkspaceSettings = serde_json::from_value(delta)
         .into_diagnostic()
         .wrap_err("deserialize the updateConfig hook result")?;
     delta_settings.apply_to(config, &base_dir);
+    if let Some(extra_bin_paths) = changed_extra_bin_paths {
+        config.extra_bin_paths = extra_bin_paths;
+    }
+    if let Some(extra_env) = changed_extra_env {
+        config.extra_env = extra_env;
+    }
     if virtual_store_dir_cleared {
         config.virtual_store_dir = base_dir.join("node_modules/.pnpm");
     }

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -48,6 +48,52 @@ async fn update_config_null_clears_global_virtual_store_dir() {
     assert!(!config.explicit_settings.contains_key("globalVirtualStoreDir"));
 }
 
+#[tokio::test]
+async fn update_config_can_extend_extra_bin_paths() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    // A workspace manifest makes `current` seed `extra_bin_paths` with the
+    // workspace root's `node_modules/.bin`; the hook appends to that.
+    fs::write(root.path().join("pnpm-workspace.yaml"), "\n").expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.extraBinPaths = [...config.extraBinPaths, '/opt/pnpm-build/bin']; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    let seeded = config.extra_bin_paths.clone();
+    assert_eq!(seeded, vec![root.path().join("node_modules").join(".bin")]);
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    let mut expected = seeded;
+    expected.push(Path::new("/opt/pnpm-build/bin").to_path_buf());
+    assert_eq!(config.extra_bin_paths, expected);
+}
+
+#[tokio::test]
+async fn update_config_can_set_extra_env() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "\n").expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.extraEnv = { ...config.extraEnv, npm_config_nodedir: '/brazil/node' }; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    assert!(config.extra_env.is_empty());
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(
+        config.extra_env.get("npm_config_nodedir").map(String::as_str),
+        Some("/brazil/node"),
+    );
+}
+
 /// `Accept` header the resolver sends for full metadata
 /// (`ACCEPT_FULL_DOC`); only the full packument carries the per-version
 /// `time` map and trust evidence the no-downgrade check reads.

--- a/pnpm/crates/cli/tests/lifecycle_scripts.rs
+++ b/pnpm/crates/cli/tests/lifecycle_scripts.rs
@@ -951,8 +951,7 @@ mod project_scripts {
     /// An `updateConfig` pnpmfile hook that sets `extraEnv` exports those
     /// variables into the project's lifecycle-script environment. Mirrors
     /// the TypeScript CLI, where `config.extraEnv` is forwarded to
-    /// lifecycle scripts; here the `PnpmBuild` use case
-    /// (`npm_config_nodedir`) stands in.
+    /// lifecycle scripts.
     #[test]
     fn update_config_extra_env_reaches_lifecycle_scripts() {
         let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -980,6 +979,45 @@ mod project_scripts {
         let value =
             fs::read_to_string(workspace.join("extra-env.txt")).expect("read extra-env.txt");
         assert_eq!(value.trim(), "from-hook");
+
+        drop((root, mock_instance));
+    }
+
+    /// A hook `extraEnv` that tries to override a reserved pnpm stamp
+    /// (`INIT_CWD`) must NOT win: pnpm's own value is authoritative,
+    /// matching TS `runLifecycleHook`. The script writes `INIT_CWD`,
+    /// which must be the lockfile dir, not the hook's bogus value.
+    #[test]
+    fn update_config_extra_env_cannot_override_reserved_stamps() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        let package_json = serde_json::json!({
+            "name": "project-reserved-stamp",
+            "version": "1.0.0",
+            "scripts": {
+                "postinstall":
+                    r#"node -e "require('fs').writeFileSync('init-cwd.txt', process.env.INIT_CWD || '')""#,
+            },
+        });
+        fs::write(workspace.join("package.json"), package_json.to_string())
+            .expect("write package.json");
+        fs::write(
+            workspace.join(".pnpmfile.cjs"),
+            "module.exports = { hooks: { updateConfig (config) { config.extraEnv = { ...config.extraEnv, INIT_CWD: '/bogus-from-hook' }; return config } } }",
+        )
+        .expect("write pnpmfile");
+
+        pacquet.with_arg("install").assert().success();
+
+        let init_cwd =
+            fs::read_to_string(workspace.join("init-cwd.txt")).expect("read init-cwd.txt");
+        assert_ne!(init_cwd.trim(), "/bogus-from-hook", "hook extraEnv must not override INIT_CWD");
+        let canonical_workspace = fs::canonicalize(&workspace).expect("canonicalize workspace dir");
+        let canonical_init_cwd =
+            fs::canonicalize(init_cwd.trim()).expect("canonicalize INIT_CWD value");
+        assert_eq!(canonical_init_cwd, canonical_workspace);
 
         drop((root, mock_instance));
     }

--- a/pnpm/crates/cli/tests/lifecycle_scripts.rs
+++ b/pnpm/crates/cli/tests/lifecycle_scripts.rs
@@ -948,6 +948,42 @@ mod project_scripts {
         drop((root, mock_instance));
     }
 
+    /// An `updateConfig` pnpmfile hook that sets `extraEnv` exports those
+    /// variables into the project's lifecycle-script environment. Mirrors
+    /// the TypeScript CLI, where `config.extraEnv` is forwarded to
+    /// lifecycle scripts; here the `PnpmBuild` use case
+    /// (`npm_config_nodedir`) stands in.
+    #[test]
+    fn update_config_extra_env_reaches_lifecycle_scripts() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        let package_json = serde_json::json!({
+            "name": "project-reads-extra-env",
+            "version": "1.0.0",
+            "scripts": {
+                "postinstall":
+                    r#"node -e "require('fs').writeFileSync('extra-env.txt', process.env.PNPM_BUILD_MARKER || '')""#,
+            },
+        });
+        fs::write(workspace.join("package.json"), package_json.to_string())
+            .expect("write package.json");
+        fs::write(
+            workspace.join(".pnpmfile.cjs"),
+            "module.exports = { hooks: { updateConfig (config) { config.extraEnv = { ...config.extraEnv, PNPM_BUILD_MARKER: 'from-hook' }; return config } } }",
+        )
+        .expect("write pnpmfile");
+
+        pacquet.with_arg("install").assert().success();
+
+        let value =
+            fs::read_to_string(workspace.join("extra-env.txt")).expect("read extra-env.txt");
+        assert_eq!(value.trim(), "from-hook");
+
+        drop((root, mock_instance));
+    }
+
     /// `pacquet add <pkg>` is a partial install, so the project's own
     /// lifecycle scripts must not run: `postinstall`/`prepare` are not
     /// executed after a named install.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1232,12 +1232,15 @@ pub struct Config {
     /// member's scripts.
     pub extra_bin_paths: Vec<PathBuf>,
 
-    /// `extraEnv`: extra environment variables exported to lifecycle
-    /// scripts and `pnpm exec`/`pnpm run` child processes. Empty by
+    /// `extraEnv`: extra environment variables exported to the lifecycle
+    /// scripts and spawned child processes of a command. Empty by
     /// default. Not a `pnpm-workspace.yaml` key — the only way to
     /// populate it is an `updateConfig` pnpmfile hook that returns an
     /// `extraEnv` object, wired up in `pacquet_cli`'s
-    /// `run_update_config_hooks`.
+    /// `run_update_config_hooks`. That hook runs only for the
+    /// install-family commands (install, deploy, dedupe, prune), so this
+    /// is non-empty only under those; other commands' spawn sites read it
+    /// too, but see an empty map until the hook broadens.
     pub extra_env: HashMap<String, String>,
 
     /// `unsafePerm` from `pnpm-workspace.yaml`. When `false`,

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1232,6 +1232,14 @@ pub struct Config {
     /// member's scripts.
     pub extra_bin_paths: Vec<PathBuf>,
 
+    /// `extraEnv`: extra environment variables exported to lifecycle
+    /// scripts and `pnpm exec`/`pnpm run` child processes. Empty by
+    /// default. Not a `pnpm-workspace.yaml` key — the only way to
+    /// populate it is an `updateConfig` pnpmfile hook that returns an
+    /// `extraEnv` object, wired up in `pacquet_cli`'s
+    /// `run_update_config_hooks`.
+    pub extra_env: HashMap<String, String>,
+
     /// `unsafePerm` from `pnpm-workspace.yaml`. When `false`,
     /// lifecycle scripts run under a TMPDIR isolated to
     /// `node_modules/.tmp` and uid/gid drops to a non-root user.

--- a/pnpm/crates/executor/src/make_env.rs
+++ b/pnpm/crates/executor/src/make_env.rs
@@ -13,9 +13,11 @@ pub const VERIFY_DEPS_BEFORE_RUN_ENV: &str = "pnpm_config_verify_deps_before_run
 
 /// Inputs needed to build the env for a single lifecycle hook spawn:
 /// the package context, the per-call stamps the hook runner adds, and
-/// the caller-supplied `extra_env` (the user's `updateConfig`
-/// `extraEnv`), which pnpm's reserved stamps override — see
-/// [`build_env`].
+/// the caller-supplied `extra_env`. `extra_env` carries the user's
+/// `updateConfig` `extraEnv` plus any pnpm-controlled keys the caller
+/// merges in first (e.g. `NODE_OPTIONS` from `nodeOptions`); the
+/// reserved per-call stamps below override all of it regardless of
+/// origin — see [`build_env`].
 pub struct EnvOptions<'a> {
     pub stage: &'a str,
     pub script: &'a str,
@@ -94,13 +96,14 @@ pub fn build_env(
         env.insert("npm_execpath".into(), p.to_string_lossy().into_owned());
     }
 
-    // 4. `extra_env` (which now carries the user's `updateConfig`
-    //    `extraEnv`) is applied BEFORE the reserved per-call stamps
+    // 4. `extra_env` (the user's `updateConfig` `extraEnv` plus any
+    //    pnpm-controlled keys the caller merged in, such as
+    //    `NODE_OPTIONS`) is applied BEFORE the reserved per-call stamps
     //    below, so pnpm's own stamps win on conflict. This mirrors TS
     //    `runLifecycleHook`, which spreads `{ ...extraEnv, INIT_CWD,
     //    PNPM_SCRIPT_SRC_DIR, npm_config_user_agent }` — the reserved
-    //    keys overwrite anything `extraEnv` set. A user `extraEnv`
-    //    entry for a non-reserved key still takes effect.
+    //    keys overwrite anything `extra_env` set. A non-reserved key
+    //    still takes effect.
     for (k, v) in opts.extra_env {
         env.insert(k.clone(), v.clone());
     }

--- a/pnpm/crates/executor/src/make_env.rs
+++ b/pnpm/crates/executor/src/make_env.rs
@@ -96,6 +96,13 @@ pub fn build_env(
         env.insert("npm_execpath".into(), p.to_string_lossy().into_owned());
     }
 
+    // `npm_config_node_gyp` is a default pnpm supplies, not a reserved
+    // stamp: TS `npm-lifecycle` sets it before spreading `extraEnv`, so a
+    // user `extraEnv` overrides it. Stamp it before `extra_env` to match.
+    if let Some(p) = opts.node_gyp_path {
+        env.insert("npm_config_node_gyp".into(), p.to_string_lossy().into_owned());
+    }
+
     // 4. `extra_env` (the user's `updateConfig` `extraEnv` plus any
     //    pnpm-controlled keys the caller merged in, such as
     //    `NODE_OPTIONS`) is applied BEFORE the reserved per-call stamps
@@ -111,9 +118,6 @@ pub fn build_env(
     env.insert("INIT_CWD".into(), opts.init_cwd.to_string_lossy().into_owned());
     env.insert("PNPM_SCRIPT_SRC_DIR".into(), opts.script_src_dir.to_string_lossy().into_owned());
 
-    if let Some(p) = opts.node_gyp_path {
-        env.insert("npm_config_node_gyp".into(), p.to_string_lossy().into_owned());
-    }
     if let Some(ua) = opts.user_agent {
         env.insert("npm_config_user_agent".into(), ua.to_string());
     }

--- a/pnpm/crates/executor/src/make_env.rs
+++ b/pnpm/crates/executor/src/make_env.rs
@@ -13,7 +13,9 @@ pub const VERIFY_DEPS_BEFORE_RUN_ENV: &str = "pnpm_config_verify_deps_before_run
 
 /// Inputs needed to build the env for a single lifecycle hook spawn:
 /// the package context, the per-call stamps the hook runner adds, and
-/// the caller-supplied `extra_env` overrides.
+/// the caller-supplied `extra_env` (the user's `updateConfig`
+/// `extraEnv`), which pnpm's reserved stamps override — see
+/// [`build_env`].
 pub struct EnvOptions<'a> {
     pub stage: &'a str,
     pub script: &'a str,
@@ -40,9 +42,11 @@ pub struct EnvBuild {
 /// process env to inherit from.
 ///
 /// Two layers of work: the base env build (parent-env filter,
-/// `npm_package_*` recursion, multi-line escaping) and the per-call
-/// stamping that follows it, then the caller-supplied `extra_env`
-/// overrides applied last.
+/// `npm_package_*` recursion, multi-line escaping), then the
+/// caller-supplied `extra_env`, then the reserved per-call stamps
+/// (`INIT_CWD`, `PNPM_SCRIPT_SRC_DIR`, `npm_config_user_agent`, the
+/// verify-deps guard, `npm_lifecycle_script`) applied last so they win
+/// over anything `extra_env` set — matching TS `runLifecycleHook`.
 ///
 /// `parent_env` is taken by value so the production caller can pass
 /// `env::vars().collect()` and tests can pass a controlled fixture
@@ -90,6 +94,17 @@ pub fn build_env(
         env.insert("npm_execpath".into(), p.to_string_lossy().into_owned());
     }
 
+    // 4. `extra_env` (which now carries the user's `updateConfig`
+    //    `extraEnv`) is applied BEFORE the reserved per-call stamps
+    //    below, so pnpm's own stamps win on conflict. This mirrors TS
+    //    `runLifecycleHook`, which spreads `{ ...extraEnv, INIT_CWD,
+    //    PNPM_SCRIPT_SRC_DIR, npm_config_user_agent }` — the reserved
+    //    keys overwrite anything `extraEnv` set. A user `extraEnv`
+    //    entry for a non-reserved key still takes effect.
+    for (k, v) in opts.extra_env {
+        env.insert(k.clone(), v.clone());
+    }
+
     env.insert("INIT_CWD".into(), opts.init_cwd.to_string_lossy().into_owned());
     env.insert("PNPM_SCRIPT_SRC_DIR".into(), opts.script_src_dir.to_string_lossy().into_owned());
 
@@ -101,14 +116,9 @@ pub fn build_env(
     }
 
     // Breaks the recursion a spawned install's lifecycle scripts would
-    // otherwise enter (pnpm stamps the same value via `config.extraEnv`).
+    // otherwise enter. Stamped after `extra_env` so a user `extraEnv`
+    // can't disable the guard (pnpm keeps this key authoritative).
     env.insert(VERIFY_DEPS_BEFORE_RUN_ENV.into(), "false".into());
-
-    // 4. `extra_env` is applied last among the base env writes, so it
-    //    overrides anything stamped above.
-    for (k, v) in opts.extra_env {
-        env.insert(k.clone(), v.clone());
-    }
 
     // 5. TMPDIR under <wd>/node_modules/.tmp when !unsafe_perm.
     //    The caller creates the dir; we only record the path and pass
@@ -121,8 +131,8 @@ pub fn build_env(
         Some(dir)
     };
 
-    // 6. `npm_lifecycle_script` is set after the `extra_env` overwrite,
-    //    so the caller can never clobber it.
+    // 6. `npm_lifecycle_script` is set after `extra_env`, so the
+    //    caller can never clobber it.
     env.insert("npm_lifecycle_script".into(), opts.script.to_string());
 
     EnvBuild { env, tmpdir }

--- a/pnpm/crates/executor/src/make_env/tests.rs
+++ b/pnpm/crates/executor/src/make_env/tests.rs
@@ -176,16 +176,23 @@ fn make_env_tmpdir_gating_mirrors_unsafe_perm() {
 
 /// pnpm's reserved per-call stamps override a user `extraEnv` that
 /// tries to set the same key (matching TS `runLifecycleHook`, which
-/// spreads `extraEnv` before its own `INIT_CWD` / user-agent / etc.),
-/// while a non-reserved `extraEnv` key still takes effect.
+/// spreads `extraEnv` before its own `INIT_CWD` / user-agent / etc.).
+/// The non-reserved keys pnpm generates before `extra_env`
+/// (`npm_lifecycle_event`, `npm_config_node_gyp`, `npm_package_*`) stay
+/// overridable, matching TS `npm-lifecycle`, which applies `extraEnv`
+/// after those. A brand-new key also applies.
 #[test]
 fn reserved_stamps_win_over_extra_env_but_custom_keys_apply() {
     let pkg_root = Path::new("/tmp/w");
+    let node_gyp = Path::new("/pnpm/node-gyp");
     let mut extra = HashMap::new();
     extra.insert("INIT_CWD".into(), "/overridden".into());
     extra.insert("npm_config_user_agent".into(), "evil".into());
     extra.insert(VERIFY_DEPS_BEFORE_RUN_ENV.into(), "true".into());
     extra.insert("npm_lifecycle_script".into(), "FAKE".into());
+    extra.insert("npm_lifecycle_event".into(), "from-hook".into());
+    extra.insert("npm_config_node_gyp".into(), "/from-hook/node-gyp".into());
+    extra.insert("npm_package_name".into(), "from-hook".into());
     extra.insert("CUSTOM".into(), "hello".into());
 
     let opts = EnvOptions {
@@ -196,7 +203,7 @@ fn reserved_stamps_win_over_extra_env_but_custom_keys_apply() {
         script_src_dir: pkg_root,
         node_execpath: None,
         npm_execpath: None,
-        node_gyp_path: None,
+        node_gyp_path: Some(node_gyp),
         user_agent: Some("pnpm"),
         unsafe_perm: true,
         extra_env: &extra,
@@ -209,7 +216,15 @@ fn reserved_stamps_win_over_extra_env_but_custom_keys_apply() {
     assert_eq!(built.env.get("npm_config_user_agent").map(String::as_str), Some("pnpm"));
     assert_eq!(built.env.get(VERIFY_DEPS_BEFORE_RUN_ENV).map(String::as_str), Some("false"));
     assert_eq!(built.env.get("npm_lifecycle_script").map(String::as_str), Some("REAL"));
-    // A non-reserved key from `extraEnv` still applies.
+    // Non-reserved stamps pnpm generates before `extra_env` stay
+    // overridable, matching TS.
+    assert_eq!(built.env.get("npm_lifecycle_event").map(String::as_str), Some("from-hook"));
+    assert_eq!(
+        built.env.get("npm_config_node_gyp").map(String::as_str),
+        Some("/from-hook/node-gyp"),
+    );
+    assert_eq!(built.env.get("npm_package_name").map(String::as_str), Some("from-hook"));
+    // A brand-new key from `extraEnv` also applies.
     assert_eq!(built.env.get("CUSTOM").map(String::as_str), Some("hello"));
 }
 

--- a/pnpm/crates/executor/src/make_env/tests.rs
+++ b/pnpm/crates/executor/src/make_env/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    EnvOptions, build_env, escape_newlines, is_stamping_key, sanitize_env_key, stamp_package,
+    EnvOptions, VERIFY_DEPS_BEFORE_RUN_ENV, build_env, escape_newlines, is_stamping_key,
+    sanitize_env_key, stamp_package,
 };
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -173,11 +174,17 @@ fn make_env_tmpdir_gating_mirrors_unsafe_perm() {
     assert_eq!(built.env.get("TMPDIR"), Some(&expected_tmpdir.to_string_lossy().into_owned()));
 }
 
+/// pnpm's reserved per-call stamps override a user `extraEnv` that
+/// tries to set the same key (matching TS `runLifecycleHook`, which
+/// spreads `extraEnv` before its own `INIT_CWD` / user-agent / etc.),
+/// while a non-reserved `extraEnv` key still takes effect.
 #[test]
-fn extra_env_overrides_writes_except_lifecycle_script() {
+fn reserved_stamps_win_over_extra_env_but_custom_keys_apply() {
     let pkg_root = Path::new("/tmp/w");
     let mut extra = HashMap::new();
     extra.insert("INIT_CWD".into(), "/overridden".into());
+    extra.insert("npm_config_user_agent".into(), "evil".into());
+    extra.insert(VERIFY_DEPS_BEFORE_RUN_ENV.into(), "true".into());
     extra.insert("npm_lifecycle_script".into(), "FAKE".into());
     extra.insert("CUSTOM".into(), "hello".into());
 
@@ -190,15 +197,19 @@ fn extra_env_overrides_writes_except_lifecycle_script() {
         node_execpath: None,
         npm_execpath: None,
         node_gyp_path: None,
-        user_agent: None,
+        user_agent: Some("pnpm"),
         unsafe_perm: true,
         extra_env: &extra,
     };
 
     let built = build_env(&opts, &json!({"name":"w","version":"0"}), HashMap::new());
 
-    assert_eq!(built.env.get("INIT_CWD").map(String::as_str), Some("/overridden"));
+    // Reserved pnpm keys win over the user's `extraEnv`.
+    assert_eq!(built.env.get("INIT_CWD").map(String::as_str), Some("/original"));
+    assert_eq!(built.env.get("npm_config_user_agent").map(String::as_str), Some("pnpm"));
+    assert_eq!(built.env.get(VERIFY_DEPS_BEFORE_RUN_ENV).map(String::as_str), Some("false"));
     assert_eq!(built.env.get("npm_lifecycle_script").map(String::as_str), Some("REAL"));
+    // A non-reserved key from `extraEnv` still applies.
     assert_eq!(built.env.get("CUSTOM").map(String::as_str), Some("hello"));
 }
 

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2231,7 +2231,7 @@ fn run_projects_lifecycle_scripts<Reporter: self::Reporter>(
         pacquet_config::ScriptsPrependNodePath::Never => ExecScriptsPrependNodePath::Never,
         pacquet_config::ScriptsPrependNodePath::WarnOnly => ExecScriptsPrependNodePath::WarnOnly,
     };
-    let mut extra_env = std::collections::HashMap::new();
+    let mut extra_env = config.extra_env.clone();
     if let Some(node_options) = &config.node_options {
         extra_env.insert("NODE_OPTIONS".to_string(), node_options.clone());
     }

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2251,7 +2251,7 @@ fn run_projects_lifecycle_scripts<Reporter: self::Reporter>(
             pkg_root: project_dir,
             root_modules_dir: &root_modules_dir,
             init_cwd: workspace_root,
-            extra_bin_paths: &[],
+            extra_bin_paths: &config.extra_bin_paths,
             extra_env: &extra_env,
             node_execpath: None,
             npm_execpath: None,

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1302,7 +1302,7 @@ where
             None => engine_name,
         };
 
-        let mut build_extra_env = HashMap::new();
+        let mut build_extra_env = config.extra_env.clone();
         if let Some(node_options) = &config.node_options {
             build_extra_env.insert("NODE_OPTIONS".to_string(), node_options.clone());
         }

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -109,6 +109,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         script_shell: None,
         node_options: None,
         extra_bin_paths: Default::default(),
+        extra_env: Default::default(),
         unsafe_perm: true,
         child_concurrency: 1,
         workspace_concurrency: 1,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1969,7 +1969,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .map_err(InstallWithFreshLockfileError::WritePackageMap)?;
         }
 
-        let mut build_extra_env = HashMap::new();
+        let mut build_extra_env = config.extra_env.clone();
         if let Some(node_options) = &config.node_options {
             build_extra_env.insert("NODE_OPTIONS".to_string(), node_options.clone());
         }


### PR DESCRIPTION
## Summary

The TypeScript pnpm CLI passes the entire `Config` object through the
`updateConfig` pnpmfile hook and adopts the returned object wholesale, so a hook
can read and extend `extraBinPaths` / `extraEnv`. Pacquet only round-tripped
`WorkspaceSettings` through the hook, silently dropping both fields — a hook that
set them was a no-op.

This brings pacquet to parity:

- Adds `extra_env` to `Config` (`extra_bin_paths` already existed).
- Seeds the `updateConfig` hook input with the live `extraBinPaths` / `extraEnv`
  so a hook can append to them, then reads the hook's values back from the delta
  and assigns them to `Config`. Neither is a `pnpm-workspace.yaml` key, so they
  are special-cased like `storeDir` / `catalogs` rather than going through
  `WorkspaceSettings::apply_to`.
- Seeds `config.extra_env` into every child-process spawn site — the
  install-family lifecycle scripts (install, fresh/frozen lockfile installs),
  `run`, recursive `run`, `pack`, `publish`, `exec`, and the `dlx` bin. The
  lifecycle env builder (`make_env.rs`) applies `extra_env` *before* pnpm's
  reserved per-call stamps (`INIT_CWD`, `PNPM_SCRIPT_SRC_DIR`,
  `npm_config_user_agent`, the verify-deps guard), so pnpm's keys win on
  conflict while non-reserved `extraEnv` keys still apply — matching TS
  `runLifecycleHook`. The `exec`/`dlx` spawns apply it the same way.
- Forwards `config.extra_bin_paths` to project (root) lifecycle scripts,
  matching TS `install/index.ts`.

Note on scope: `config.extra_env` is populated only by the `updateConfig` hook,
which today runs only for the install-family commands (install, deploy, dedupe,
prune). So it is non-empty only under those; the seedings at the other spawn
sites read an empty map until the hook broadens, but are wired uniformly so
behavior stays consistent when it does.

`npmPath` is intentionally not implemented: it is a type-only field on the
TypeScript `Config` that is never read as a value, and `publish` is native on
both stacks, so pacquet ignoring it already matches TypeScript behavior.

## Squash Commit Body

```text
feat(pacquet): honor extraBinPaths and extraEnv from the updateConfig hook

The TypeScript pnpm CLI passes the whole Config object through the
updateConfig pnpmfile hook and adopts the returned object wholesale, so
a hook can read and extend extraBinPaths / extraEnv. Pacquet only
round-tripped WorkspaceSettings through the hook, silently dropping both
fields.

Bring pacquet to parity:

- Add extra_env to Config (extra_bin_paths already existed).
- In run_update_config_hooks, seed the hook input with the live
  extraBinPaths / extraEnv (so a hook can append to them), then read the
  hook's values back from the delta and assign them to Config. Neither is
  a pnpm-workspace.yaml key, so they are special-cased like storeDir /
  catalogs rather than going through WorkspaceSettings::apply_to.
- Seed config.extra_env into every child-process spawn site: the
  install-family lifecycle scripts, run, recursive run, pack, publish,
  exec, and the dlx bin. Populated only by the hook, which today runs
  only for the install-family commands, so it is empty at the other
  sites until the hook broadens; wiring them uniformly keeps behavior
  consistent.
- Apply extra_env before pnpm's reserved per-call stamps in make_env, so
  a hook's extraEnv can't override INIT_CWD, PNPM_SCRIPT_SRC_DIR,
  npm_config_user_agent, or the verify-deps guard (matching TS
  runLifecycleHook); non-reserved keys still apply. The exec/dlx spawns
  layer pnpm's keys on top the same way.
- Forward config.extra_bin_paths to project lifecycle scripts, matching
  TS install/index.ts.

npmPath is intentionally not implemented: it is a type-only field on the
TypeScript Config that is never read as a value, and publish is native
on both stacks, so pacquet ignoring it already matches TypeScript
behavior.

This is a pacquet-only parity fix; the TypeScript CLI already has this
behavior, so no changeset is warranted.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *Pacquet-only parity fix: the TypeScript CLI already honors these fields
  because it passes the whole `Config` through `updateConfig`.*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. *Not applicable — no published-package behavior changes; the
  TypeScript CLI already had this behavior.*
- [x] Added or updated tests. *Two unit tests in `config_deps/tests.rs` and one
  end-to-end lifecycle-script test in `lifecycle_scripts.rs`.*
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `updateConfig` hooks can now provide additional environment variables and binary paths.
  * Hook-provided environment variables are available to lifecycle scripts and spawned commands across supported operations.
  * Custom environment variables are preserved during installs, runs, packing, publishing, and execution.

* **Bug Fixes**
  * Reserved package-manager environment values now reliably take precedence over custom values.
  * Added coverage ensuring lifecycle scripts receive configured values without overriding protected settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->