### PR TITLE
fix(pacquet): close CLI gaps that broke the pnpm release workflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3914,6 +3914,7 @@ dependencies = [
  "p256",
  "pacquet-auth-commands",
  "pacquet-catalogs-config",
+ "pacquet-catalogs-types",
  "pacquet-cmd-shim",
  "pacquet-config",
  "pacquet-config-parse-overrides",

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/bin/main.rs"
 [dependencies]
 pacquet-auth-commands                     = { workspace = true }
 pacquet-catalogs-config                   = { workspace = true }
+pacquet-catalogs-types                    = { workspace = true }
 pacquet-cmd-shim                          = { workspace = true }
 pacquet-crypto-hash                       = { workspace = true }
 pacquet-detect-libc                       = { workspace = true }

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -66,7 +66,7 @@ pub mod whoami;
 pub mod why;
 pub mod with;
 
-mod cli_command;
+pub(crate) mod cli_command;
 mod dispatch;
 mod dispatch_install;
 mod dispatch_query;
@@ -78,8 +78,6 @@ pub(crate) mod switch_cli_version;
 mod verify_deps;
 
 pub(crate) use cli_command::CliArgs;
-#[cfg(test)]
-pub(crate) use cli_command::CliCommand;
 
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -78,6 +78,8 @@ pub(crate) mod switch_cli_version;
 mod verify_deps;
 
 pub(crate) use cli_command::CliArgs;
+#[cfg(test)]
+pub(crate) use cli_command::CliCommand;
 
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -313,6 +313,10 @@ impl DeployArgs {
             .map_or(base_config.node_linker, NodeLinkerArg::into_config);
         let mut deploy_config = create_deploy_install_config(base_config, deploy_dir, node_linker);
         deploy_config.prefer_frozen_lockfile = frozen_lockfile;
+        // pnpm's deploy forwards `--force` into the install, where it
+        // bypasses the installability check so optional dependencies of
+        // every platform are materialized (see `Config::force`).
+        deploy_config.force = self.force;
 
         match mode {
             DeployInstallMode::Legacy => {}

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -14,16 +14,39 @@ use crate::cli_args::recursive::{
     AutoExcludeRoot, discover_workspace_projects, select_recursive_projects, sort_filtered_projects,
 };
 use clap::Args;
-use miette::Context;
+use miette::{Context, IntoDiagnostic};
+use pacquet_catalogs_config::get_catalogs_from_workspace_manifest;
+use pacquet_catalogs_types::Catalogs;
 use pacquet_config::Config;
 use pacquet_pack::{
     Host, PackError, PackOptions, PackResultJson, api, format_pack_output, to_pack_result_json,
 };
 use pacquet_reporter::Reporter;
+use pacquet_workspace::read_workspace_manifest;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
 };
+
+/// The catalogs `catalog:` specifiers resolve against when packing a
+/// package for `pack` / `publish`: the hook-injected set when an
+/// `updateConfig` pnpmfile provided one ([`Config::catalogs`] is `Some`),
+/// otherwise the `catalog:` / `catalogs:` tables of the workspace
+/// manifest — the same fallback the install performs.
+pub(crate) fn pack_catalogs(config: &Config) -> miette::Result<Catalogs> {
+    if let Some(catalogs) = &config.catalogs {
+        return Ok(catalogs.clone());
+    }
+    let Some(workspace_dir) = config.workspace_dir.as_deref() else {
+        return Ok(Catalogs::default());
+    };
+    let workspace_manifest = read_workspace_manifest(workspace_dir)
+        .into_diagnostic()
+        .wrap_err("read the workspace manifest for catalogs")?;
+    get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+        .into_diagnostic()
+        .wrap_err("read the workspace catalogs")
+}
 
 /// `pacquet pack` arguments. The `-r` / `--recursive` and `--filter`
 /// selectors are global flags on [`crate::CliArgs`]; `--recursive` is
@@ -79,6 +102,7 @@ impl PackArgs {
             let options = self.pack_options(
                 dir.to_path_buf(),
                 config,
+                pack_catalogs(config)?,
                 self.out.clone(),
                 self.pack_destination.clone(),
             );
@@ -123,6 +147,7 @@ impl PackArgs {
         // to the CLI dir), so every tarball lands in one place regardless
         // of each project's own root.
         let (out, pack_destination) = self.resolve_recursive_destination(dir);
+        let catalogs = pack_catalogs(config)?;
 
         let mut packed: Vec<PackResultJson> = Vec::new();
         for chunk in &chunks {
@@ -143,6 +168,7 @@ impl PackArgs {
                 let options = self.pack_options(
                     project.root_dir.clone(),
                     config,
+                    catalogs.clone(),
                     out.clone(),
                     pack_destination.clone(),
                 );
@@ -181,12 +207,13 @@ impl PackArgs {
         &self,
         dir: PathBuf,
         config: &Config,
+        catalogs: Catalogs,
         out: Option<String>,
         pack_destination: Option<String>,
     ) -> PackOptions {
         PackOptions {
             dir,
-            catalogs: config.catalogs.clone().unwrap_or_default(),
+            catalogs,
             ignore_scripts: config.ignore_scripts,
             unsafe_perm: config.unsafe_perm,
             embed_readme: false,

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -300,7 +300,7 @@ impl PublishArgs {
     ) -> miette::Result<PackResult> {
         let options = PackOptions {
             dir: dir.to_path_buf(),
-            catalogs: config.catalogs.clone().unwrap_or_default(),
+            catalogs: crate::cli_args::pack::pack_catalogs(config)?,
             ignore_scripts: self.should_ignore_scripts(config),
             unsafe_perm: config.unsafe_perm,
             embed_readme: false,

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -1,6 +1,8 @@
 use crate::cli_args::CliArgs;
 use clap::CommandFactory;
-use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, VerifyDepsBeforeRun};
+use pacquet_config::{
+    Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker, VerifyDepsBeforeRun,
+};
 use pacquet_fs::lexical_normalize;
 use pacquet_store_dir::StoreDir;
 use std::{
@@ -81,6 +83,8 @@ pub struct ConfigOverrides {
     registries: BTreeMap<String, String>,
     deploy_all_files: Option<bool>,
     force_legacy_deploy: Option<bool>,
+    inject_workspace_packages: Option<bool>,
+    node_linker: Option<NodeLinker>,
     shared_workspace_lockfile: Option<bool>,
     verify_deps_before_run: Option<VerifyDepsBeforeRun>,
 }
@@ -127,6 +131,15 @@ impl ConfigOverrides {
             self.force_legacy_deploy = parse_bool(value);
             return;
         }
+        if key == "inject-workspace-packages" {
+            self.inject_workspace_packages = parse_bool(value);
+            return;
+        }
+        if key == "node-linker" {
+            self.node_linker =
+                serde_json::from_value(serde_json::Value::String(value.to_string())).ok();
+            return;
+        }
         if key == "shared-workspace-lockfile" {
             self.shared_workspace_lockfile = parse_bool(value);
             return;
@@ -162,6 +175,12 @@ impl ConfigOverrides {
         }
         if let Some(value) = self.force_legacy_deploy {
             config.force_legacy_deploy = value;
+        }
+        if let Some(value) = self.inject_workspace_packages {
+            config.inject_workspace_packages = value;
+        }
+        if let Some(value) = self.node_linker {
+            config.node_linker = value;
         }
         if let Some(value) = self.shared_workspace_lockfile {
             config.shared_workspace_lockfile = value;

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -1,5 +1,5 @@
 use super::{ConfigOverrides, apply_store_dir_override};
-use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe};
+use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker};
 use pacquet_store_dir::STORE_VERSION;
 use pretty_assertions::assert_eq;
 use std::{ffi::OsString, path::PathBuf};
@@ -78,6 +78,24 @@ fn unknown_keys_are_dropped_silently() {
     let mut config = Config::default();
     overrides.apply(&mut config);
     assert_eq!(config.registry, default_registry, "no known key set ⇒ registry untouched");
+}
+
+#[test]
+fn extract_applies_inject_workspace_packages_and_node_linker_overrides() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "--config.inject-workspace-packages=true",
+        "--config.node-linker=hoisted",
+        "deploy",
+        "target",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "deploy", "target"]));
+    let mut config = Config::default();
+    assert!(!config.inject_workspace_packages);
+    assert_eq!(config.node_linker, NodeLinker::Isolated);
+    overrides.apply(&mut config);
+    assert!(config.inject_workspace_packages);
+    assert_eq!(config.node_linker, NodeLinker::Hoisted);
 }
 
 #[test]

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -1,0 +1,173 @@
+//! Position-independent placement of subcommand options.
+//!
+//! pnpm parses argv with `nopt`, which merges the universal option table
+//! with the invoked command's table and accepts any option anywhere on
+//! the command line: `pnpm --ignore-scripts --prod deploy <dir>` and
+//! `pnpm deploy --ignore-scripts --prod <dir>` are the same invocation
+//! (pnpm's release tooling relies on this — `bundle-deps.ts` passes
+//! install flags ahead of `deploy`). Clap instead scopes options to the
+//! level they are declared on, so an option owned by a subcommand aborts
+//! the parse with "unexpected argument" when it appears before the
+//! subcommand.
+//!
+//! [`relocate_pre_subcommand_flags`] closes the gap in argv space:
+//! option tokens that appear before the subcommand and are not part of
+//! the top-level grammar move to directly after the subcommand token
+//! (relative order preserved), so clap parses them with the subcommand's
+//! grammar exactly as if they had been written there. Whether a moved
+//! option consumes the following token as its value is decided from the
+//! union of every subcommand's arg table; on an arity conflict between
+//! subcommands the option is treated as boolean so a subcommand name is
+//! never swallowed as a value. Tokens move only when the first
+//! positional token names a real subcommand — external commands
+//! (`pnpm <script>`) keep their argv untouched, as does everything after
+//! a `--` terminator.
+
+use clap::{Arg, ArgAction, Command};
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::OsString,
+};
+
+/// Move pre-subcommand option tokens that belong to a subcommand's
+/// grammar to directly after the subcommand token. See the module docs.
+///
+/// `cmd` must be the same [`Command`] the returned argv is parsed with
+/// (including the [`crate::boolean_negations`] augmentation), so the
+/// hidden `--no-<flag>` negations relocate like their positive forms.
+pub fn relocate_pre_subcommand_flags(cmd: &Command, argv: Vec<OsString>) -> Vec<OsString> {
+    let top_level = ArgTable::top_level(cmd);
+    let subcommand_union = ArgTable::subcommand_union(cmd);
+
+    let mut moved_indexes: HashSet<usize> = HashSet::new();
+    let mut index = 1;
+    let subcommand_index = loop {
+        let Some(token) = argv.get(index).and_then(|token| token.to_str()) else {
+            return argv;
+        };
+        if token == "--" {
+            return argv;
+        }
+        if let Some(rest) = token.strip_prefix("--") {
+            let (name, has_inline_value) =
+                rest.split_once('=').map_or((rest, false), |(name, _)| (name, true));
+            if let Some(consumes_value) = top_level.long_consumes_value(name) {
+                index += token_width(consumes_value, has_inline_value);
+            } else {
+                let consumes_value = subcommand_union.long_consumes_value(name).unwrap_or(false);
+                let width = token_width(consumes_value, has_inline_value);
+                for offset in 0..width.min(argv.len() - index) {
+                    moved_indexes.insert(index + offset);
+                }
+                index += width;
+            }
+        } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
+            let short = rest.chars().next().expect("checked non-empty");
+            // A multi-character short token (`-Cdir`, combined bools) has
+            // its value / siblings attached, so it never consumes the
+            // next token regardless of the short's arity.
+            let is_bare_short = rest.chars().count() == 1;
+            if let Some(consumes_value) = top_level.short_consumes_value(short) {
+                index += token_width(consumes_value && is_bare_short, false);
+            } else {
+                let consumes_value = subcommand_union.short_consumes_value(short).unwrap_or(false);
+                let width = token_width(consumes_value && is_bare_short, false);
+                for offset in 0..width.min(argv.len() - index) {
+                    moved_indexes.insert(index + offset);
+                }
+                index += width;
+            }
+        } else {
+            break index;
+        }
+    };
+
+    if moved_indexes.is_empty() || cmd.find_subcommand(&argv[subcommand_index]).is_none() {
+        return argv;
+    }
+
+    let mut result: Vec<OsString> = Vec::with_capacity(argv.len());
+    let mut moved: Vec<OsString> = Vec::with_capacity(moved_indexes.len());
+    for (token_index, token) in argv.into_iter().enumerate() {
+        if moved_indexes.contains(&token_index) {
+            moved.push(token);
+        } else {
+            result.push(token);
+            if token_index == subcommand_index {
+                result.append(&mut moved);
+            }
+        }
+    }
+    result
+}
+
+/// The number of argv tokens an option occupies: itself, plus its value
+/// when the value is a separate token rather than `--flag=value` inline.
+fn token_width(consumes_value: bool, has_inline_value: bool) -> usize {
+    if consumes_value && !has_inline_value { 2 } else { 1 }
+}
+
+/// Option-name lookup table: long / short spelling → whether the option
+/// consumes the next argv token as its value.
+#[derive(Debug, Default)]
+struct ArgTable {
+    longs: HashMap<String, bool>,
+    shorts: HashMap<char, bool>,
+}
+
+impl ArgTable {
+    /// The top-level grammar: everything already valid before the
+    /// subcommand, which therefore stays in place. Clap only adds the
+    /// automatic `--help` / `-h` at build time, so they are seeded
+    /// manually.
+    fn top_level(cmd: &Command) -> Self {
+        let mut table = Self::default();
+        table.longs.insert("help".to_string(), false);
+        table.shorts.insert('h', false);
+        table.absorb(cmd.get_arguments());
+        table
+    }
+
+    /// The union of every subcommand's args, used only to decide how
+    /// many tokens a to-be-moved option occupies.
+    fn subcommand_union(cmd: &Command) -> Self {
+        let mut table = Self::default();
+        table.absorb(cmd.get_subcommands().flat_map(Command::get_arguments));
+        table
+    }
+
+    fn absorb<'a, Args: IntoIterator<Item = &'a Arg>>(&mut self, args: Args) {
+        for arg in args {
+            let consumes_value = matches!(arg.get_action(), ArgAction::Set | ArgAction::Append);
+            for long in
+                arg.get_long().into_iter().chain(arg.get_all_aliases().into_iter().flatten())
+            {
+                merge_arity(self.longs.entry(long.to_string()), consumes_value);
+            }
+            for short in
+                arg.get_short().into_iter().chain(arg.get_all_short_aliases().into_iter().flatten())
+            {
+                merge_arity(self.shorts.entry(short), consumes_value);
+            }
+        }
+    }
+
+    fn long_consumes_value(&self, name: &str) -> Option<bool> {
+        self.longs.get(name).copied()
+    }
+
+    fn short_consumes_value(&self, short: char) -> Option<bool> {
+        self.shorts.get(&short).copied()
+    }
+}
+
+/// On an arity conflict across subcommands, prefer "does not consume a
+/// value": misparsing a value as a flag fails loudly in clap, while
+/// consuming a subcommand name as a value would silently derail the
+/// whole parse.
+fn merge_arity<Key>(entry: std::collections::hash_map::Entry<'_, Key, bool>, consumes_value: bool) {
+    entry.and_modify(|existing| *existing = *existing && consumes_value).or_insert(consumes_value);
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/flag_relocation/tests.rs
+++ b/pnpm/crates/cli/src/flag_relocation/tests.rs
@@ -1,0 +1,118 @@
+use super::relocate_pre_subcommand_flags;
+use crate::{boolean_negations::with_boolean_negations, cli_args::CliArgs};
+use clap::{CommandFactory, FromArgMatches};
+use pretty_assertions::assert_eq;
+use std::ffi::OsString;
+
+fn relocate(tokens: &[&str]) -> Vec<String> {
+    let cmd = with_boolean_negations(CliArgs::command());
+    relocate_pre_subcommand_flags(&cmd, tokens.iter().map(OsString::from).collect())
+        .into_iter()
+        .map(|token| token.into_string().expect("test tokens are UTF-8"))
+        .collect()
+}
+
+fn parse(tokens: &[&str]) -> CliArgs {
+    let cmd = with_boolean_negations(CliArgs::command());
+    let argv = relocate_pre_subcommand_flags(&cmd, tokens.iter().map(OsString::from).collect());
+    cmd.try_get_matches_from(argv)
+        .and_then(|matches| CliArgs::from_arg_matches(&matches))
+        .expect("parses after relocation")
+}
+
+#[test]
+fn subcommand_flags_before_the_subcommand_move_after_it() {
+    // The exact shape pnpm's `bundle-deps.ts` forwards to `pnpm deploy`
+    // during a release (`--config.*` tokens already extracted).
+    assert_eq!(
+        relocate(&[
+            "pnpm",
+            "--ignore-scripts",
+            "--force",
+            "--filter=pnpm",
+            "--prod",
+            "deploy",
+            "temp-deploy",
+        ]),
+        ["pnpm", "--filter=pnpm", "deploy", "--ignore-scripts", "--force", "--prod", "temp-deploy",],
+        "subcommand flags move after `deploy` in order; the global --filter stays put",
+    );
+}
+
+#[test]
+fn relocated_deploy_invocation_parses_with_the_flags_applied() {
+    let args = parse(&[
+        "pnpm",
+        "--ignore-scripts",
+        "--force",
+        "--filter=pnpm",
+        "--prod",
+        "deploy",
+        "temp-deploy",
+    ]);
+    assert_eq!(args.filter, ["pnpm"]);
+    let crate::cli_args::CliCommand::Deploy(deploy) = args.command else {
+        panic!("expected deploy");
+    };
+    assert!(deploy.force);
+    assert!(deploy.install_args.ignore_scripts);
+    assert_eq!(deploy.target_dirs, [std::path::PathBuf::from("temp-deploy")]);
+}
+
+#[test]
+fn top_level_options_stay_in_place() {
+    let argv = ["pnpm", "-C", "project", "--reporter", "ndjson", "install"];
+    assert_eq!(relocate(&argv), argv, "every token is top-level grammar already");
+}
+
+#[test]
+fn value_consuming_subcommand_option_moves_with_its_value() {
+    assert_eq!(
+        relocate(&["pnpm", "--tag", "next-11", "publish"]),
+        ["pnpm", "publish", "--tag", "next-11"],
+    );
+}
+
+#[test]
+fn inline_value_moves_as_one_token() {
+    assert_eq!(
+        relocate(&["pnpm", "--node-linker=hoisted", "install"]),
+        ["pnpm", "install", "--node-linker=hoisted"],
+    );
+}
+
+#[test]
+fn boolean_negations_move_like_their_positive_forms() {
+    assert_eq!(
+        relocate(&["pnpm", "--no-frozen-lockfile", "install"]),
+        ["pnpm", "install", "--no-frozen-lockfile"],
+    );
+}
+
+#[test]
+fn short_subcommand_flag_moves() {
+    assert_eq!(relocate(&["pnpm", "-P", "install"]), ["pnpm", "install", "-P"]);
+}
+
+#[test]
+fn subcommand_alias_is_recognized() {
+    assert_eq!(relocate(&["pnpm", "--prod", "i"]), ["pnpm", "i", "--prod"]);
+}
+
+#[test]
+fn external_command_argv_is_untouched() {
+    let argv = ["pnpm", "--ignore-scripts", "some-script"];
+    assert_eq!(relocate(&argv), argv, "not a subcommand → script argv must not be reshaped");
+}
+
+#[test]
+fn double_dash_terminator_stops_relocation() {
+    let argv = ["pnpm", "--ignore-scripts", "--", "install"];
+    assert_eq!(relocate(&argv), argv);
+}
+
+#[test]
+fn argv_without_subcommand_flags_is_untouched() {
+    let argv = ["pnpm", "install", "--frozen-lockfile"];
+    assert_eq!(relocate(&argv), argv);
+}

--- a/pnpm/crates/cli/src/flag_relocation/tests.rs
+++ b/pnpm/crates/cli/src/flag_relocation/tests.rs
@@ -51,7 +51,7 @@ fn relocated_deploy_invocation_parses_with_the_flags_applied() {
         "temp-deploy",
     ]);
     assert_eq!(args.filter, ["pnpm"]);
-    let crate::cli_args::CliCommand::Deploy(deploy) = args.command else {
+    let crate::cli_args::cli_command::CliCommand::Deploy(deploy) = args.command else {
         panic!("expected deploy");
     };
     assert!(deploy.force);

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -2,6 +2,7 @@ mod boolean_negations;
 mod cli_args;
 mod config_deps;
 mod config_overrides;
+mod flag_relocation;
 mod job_control;
 mod state;
 mod with_current;
@@ -10,6 +11,7 @@ use boolean_negations::with_boolean_negations;
 use clap::{CommandFactory, FromArgMatches};
 use cli_args::CliArgs;
 use config_overrides::ConfigOverrides;
+use flag_relocation::relocate_pre_subcommand_flags;
 use miette::set_panic_hook;
 use pacquet_diagnostics::enable_tracing_by_env;
 use state::State;
@@ -37,7 +39,12 @@ pub fn main() -> miette::Result<()> {
     // Parse through a command augmented with a `--no-<flag>` negation for
     // every boolean flag, so pnpm's forwarded negations (`--no-frozen-lockfile`,
     // etc.) parse the same way nopt accepts them upstream. See `boolean_negations`.
-    let mut args = match with_boolean_negations(CliArgs::command())
+    let command = with_boolean_negations(CliArgs::command());
+    // pnpm's option parser is position-independent; move subcommand
+    // options written before the subcommand to after it so clap agrees.
+    // See `flag_relocation`.
+    let argv = relocate_pre_subcommand_flags(&command, argv);
+    let mut args = match command
         .try_get_matches_from(argv.clone())
         .and_then(|matches| CliArgs::from_arg_matches(&matches))
     {

--- a/pnpm/crates/cli/tests/deploy.rs
+++ b/pnpm/crates/cli/tests/deploy.rs
@@ -222,6 +222,85 @@ fn deploy_rejects_linked_target_parent() {
     drop((root, mock_instance));
 }
 
+/// The invocation pnpm's release tooling (`bundle-deps.ts`) forwards: every
+/// option ahead of the `deploy` subcommand, `--config.*` overrides for
+/// settings the workspace yaml doesn't enable, and `--force` so optional
+/// dependencies of every platform are materialized into the deploy dir.
+#[test]
+fn release_style_deploy_accepts_pre_subcommand_flags_and_forces_foreign_platform_optionals() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+    write_project(
+        &workspace,
+        "app",
+        &serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "files": ["index.js"],
+            "dependencies": { "lib": "workspace:*" },
+            "devDependencies": { "dev-only": "workspace:*" },
+            "optionalDependencies": { "@pnpm.e2e/not-compatible-with-any-os": "1.0.0" },
+        }),
+    );
+
+    pacquet.with_arg("install").assert().success();
+
+    let incompatible = "node_modules/@pnpm.e2e/not-compatible-with-any-os";
+    pacquet_cmd(&workspace)
+        .with_args([
+            "--config.inject-workspace-packages=true",
+            "--config.node-linker=hoisted",
+            "--ignore-scripts",
+            "--filter=app",
+            "--prod",
+            "deploy",
+            "plain-deploy",
+        ])
+        .assert()
+        .success();
+    assert!(
+        !workspace.join("plain-deploy").join(incompatible).exists(),
+        "without --force the platform-incompatible optional dependency stays skipped",
+    );
+    assert!(
+        !workspace.join("plain-deploy/node_modules/dev-only").exists(),
+        "the hoisted deploy install must not materialize dev dependencies with --prod",
+    );
+
+    pacquet_cmd(&workspace)
+        .with_args([
+            "--config.inject-workspace-packages=true",
+            "--config.node-linker=hoisted",
+            "--ignore-scripts",
+            "--force",
+            "--filter=app",
+            "--prod",
+            "deploy",
+            "release-deploy",
+        ])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("release-deploy");
+    assert!(deploy_dir.join("index.js").exists());
+    assert!(
+        deploy_dir.join(incompatible).exists(),
+        "--force must install optional dependencies regardless of platform",
+    );
+    assert!(
+        !deploy_dir.join("node_modules/dev-only").exists(),
+        "dev-only workspace dependency should not be linked with --prod",
+    );
+    assert!(
+        deploy_dir.join("node_modules/.modules.yaml").exists(),
+        "the hoisted deploy install should write the modules state file",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn legacy_deploy_installs_selected_project() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/pack_recursive.rs
+++ b/pnpm/crates/cli/tests/pack_recursive.rs
@@ -135,3 +135,67 @@ fn recursive_pack_includes_workspace_root() {
 
     drop(root);
 }
+
+/// `catalog:` specifiers resolve against the workspace manifest's
+/// `catalog:` table even when no pnpmfile hook injected catalogs into
+/// the config (`Config::catalogs` stays `None` on that path). This is
+/// the shape pnpm's own release drives: `pn --filter=<pkg> publish`
+/// packs workspace packages whose dependencies use `catalog:`.
+#[test]
+fn recursive_pack_resolves_catalog_specifiers_from_the_workspace_manifest() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1"]);
+    let mut workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml");
+    workspace_yaml.push_str("catalog:\n  lodash: 4.17.21\n");
+    fs::write(workspace.join("pnpm-workspace.yaml"), workspace_yaml)
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("project-1/package.json"),
+        json!({
+            "name": "project-1",
+            "version": "1.0.0",
+            "dependencies": { "lodash": "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let out = workspace.join("tarballs");
+    fs::create_dir_all(&out).expect("create out dir");
+
+    pacquet
+        .with_arg("--filter")
+        .with_arg("project-1")
+        .with_arg("pack")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+
+    let tarball = out.join("project-1-1.0.0.tgz");
+    let manifest = read_manifest_from_tarball(&tarball);
+    assert_eq!(
+        manifest["dependencies"]["lodash"], "4.17.21",
+        "the packed manifest must carry the catalog-resolved version",
+    );
+
+    drop(root);
+}
+
+/// Extract `package/package.json` from a packed tarball.
+fn read_manifest_from_tarball(tarball: &Path) -> serde_json::Value {
+    use std::io::Read as _;
+
+    let bytes = fs::read(tarball).expect("read tarball");
+    let decoder = flate2::read::GzDecoder::new(bytes.as_slice());
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries().expect("iterate tarball entries") {
+        let mut entry = entry.expect("read tarball entry");
+        if entry.path().expect("entry path") == Path::new("package/package.json") {
+            let mut contents = String::new();
+            entry.read_to_string(&mut contents).expect("read manifest");
+            return serde_json::from_str(&contents).expect("parse manifest");
+        }
+    }
+    panic!("package/package.json not found in {}", tarball.display());
+}

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -995,11 +995,26 @@ pub struct Config {
     ///
     /// pnpm rejects `frozenStore` combined with `force` (force re-imports
     /// packages into the store, which a read-only store cannot accept).
-    /// pacquet has no `force` flow yet, so there is no conflict to guard;
-    /// the guard ports alongside `force`.
+    /// The guard lives in the install pipeline's entry
+    /// (`ERR_PNPM_CONFIG_CONFLICT_FROZEN_STORE_WITH_FORCE`); see
+    /// [`Config::force`].
     ///
     /// The `frozenStore` / `--frozen-store` setting (default `false`).
     pub frozen_store: bool,
+
+    /// pnpm's `--force`. Install every package the lockfile names, even
+    /// ones whose `cpu` / `os` / `libc` / `engines` don't match the host
+    /// — the per-snapshot installability check is bypassed entirely, so
+    /// optional dependencies for foreign platforms are materialized
+    /// instead of skipped, mirroring pnpm's `!opts.force &&
+    /// packageIsInstallable(...)` gate in its dep-graph builders.
+    ///
+    /// CLI-only (merged from `pnpm deploy --force` at the dispatch, like
+    /// `ignoreScripts`); not a `pnpm-workspace.yaml` / `.npmrc` setting.
+    /// pnpm's `--force` additionally re-imports packages from the store;
+    /// pacquet's store import is content-addressed and self-healing, so
+    /// only the installability bypass is modeled here.
+    pub force: bool,
 
     /// Whether to consult the side-effects cache
     /// (`PackageFilesIndex.sideEffects`) when importing a package

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -478,6 +478,16 @@ pub enum InstallError {
     #[display("Cannot generate a pnpm-lock.yaml because lockfile is set to false")]
     #[diagnostic(code(ERR_PNPM_CONFIG_CONFLICT_LOCKFILE_ONLY_WITH_NO_LOCKFILE))]
     ConfigConflictLockfileOnlyWithNoLockfile,
+
+    /// `--force` was requested together with `frozenStore`. Force
+    /// re-imports packages into the store, which `frozenStore` opens
+    /// read-only, so the combination cannot proceed. Mirrors pnpm's
+    /// `ERR_PNPM_CONFIG_CONFLICT_FROZEN_STORE_WITH_FORCE`.
+    #[display(
+        "Cannot use force together with frozenStore: --force re-imports packages into the store, which is opened read-only when frozenStore is enabled"
+    )]
+    #[diagnostic(code(ERR_PNPM_CONFIG_CONFLICT_FROZEN_STORE_WITH_FORCE))]
+    ConfigConflictFrozenStoreWithForce,
 }
 
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
@@ -566,6 +576,10 @@ where
         // Fail fast rather than run a resolve that writes nothing.
         if lockfile_only && !config.lockfile {
             return Err(InstallError::ConfigConflictLockfileOnlyWithNoLockfile);
+        }
+
+        if config.frozen_store && config.force {
+            return Err(InstallError::ConfigConflictFrozenStoreWithForce);
         }
 
         // Resolve the effective `preferFrozenLockfile` for the

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -640,12 +640,17 @@ where
         // When constraints DO exist, the host is needed before
         // extraction (so `CreateVirtualStore` can suppress slots for
         // skipped snapshots), and the spawn cost is unavoidable.
-        let needs_installability_check = match (snapshots, packages) {
-            (Some(snaps), Some(pkgs)) if !snaps.is_empty() => {
-                any_installability_constraint(snaps, pkgs)
-            }
-            _ => false,
-        };
+        // `--force` bypasses the check outright: every snapshot in the
+        // lockfile is materialized regardless of platform / engine
+        // constraints, mirroring pnpm's `!opts.force &&
+        // packageIsInstallable(...)` gate.
+        let needs_installability_check = !config.force
+            && match (snapshots, packages) {
+                (Some(snaps), Some(pkgs)) if !snaps.is_empty() => {
+                    any_installability_constraint(snaps, pkgs)
+                }
+                _ => false,
+            };
 
         // Seed the skip set from the previous install's
         // `.modules.yaml.skipped`. Each entry there is a depPath
@@ -658,7 +663,11 @@ where
         // A read error (corrupt yaml, permissions) is degraded to
         // an empty seed — `.modules.yaml` is a cache artifact, not
         // an authoritative source. Missing file → empty seed.
-        let seed = if let Some(skipped) = seed_skipped {
+        let seed = if config.force {
+            // `--force` installs previously-skipped snapshots too, so the
+            // recorded skip set must not survive into this install.
+            SkippedSnapshots::new()
+        } else if let Some(skipped) = seed_skipped {
             SkippedSnapshots::from_strings(&skipped)
         } else {
             match read_modules_manifest::<Host>(&config.modules_dir) {
@@ -1552,6 +1561,25 @@ pub(crate) fn run_hoisted_linker<Reporter: self::Reporter>(
         requester,
     } = inputs;
 
+    // The hoist tree seeds from every importer dep map, so groups the
+    // user excluded (`--prod`, `--dev`, `--no-optional`) must be cleared
+    // from the lockfile before the walk — otherwise their whole subgraph
+    // materializes as real directories. Mirrors pnpm, which hands its
+    // hoisted walker an include-filtered lockfile.
+    let included = IncludedDependencies {
+        dependencies: dependency_groups.contains(&DependencyGroup::Prod),
+        dev_dependencies: dependency_groups.contains(&DependencyGroup::Dev),
+        optional_dependencies: dependency_groups.contains(&DependencyGroup::Optional),
+    };
+    let filtered_lockfile;
+    let lockfile =
+        if included.dependencies && included.dev_dependencies && included.optional_dependencies {
+            lockfile
+        } else {
+            filtered_lockfile = exclude_importer_groups(lockfile, included);
+            &filtered_lockfile
+        };
+
     // Walker installability inputs come straight from the optional
     // `host_node` the caller built for the `compute_skipped_snapshots`
     // pass. When `host_node` is `None` no per-snapshot constraint
@@ -1563,7 +1591,7 @@ pub(crate) fn run_hoisted_linker<Reporter: self::Reporter>(
         lockfile_dir: walker_lockfile_dir.to_path_buf(),
         auto_install_peers: config.auto_install_peers,
         skipped: walker_skipped.clone(),
-        force: false,
+        force: config.force,
         // Matches the `engineStrict` policy `compute_skipped_snapshots`
         // used upthread (both read `config.engine_strict`): an engine
         // mismatch on a required package is a hard error under strict,
@@ -1673,6 +1701,26 @@ pub(crate) fn run_hoisted_linker<Reporter: self::Reporter>(
         hoisted_locations: walker_result.hoisted_locations,
         hoisted_pkg_root_by_key: Some(pkg_root_by_key),
     })
+}
+
+/// Clone the lockfile with every importer's excluded dep groups
+/// cleared, so seeds for the hoist tree come only from the included
+/// groups. Snapshots that thereby become unreachable are simply never
+/// visited by the hoister, so the snapshot/package maps stay as-is.
+fn exclude_importer_groups(lockfile: &Lockfile, included: IncludedDependencies) -> Lockfile {
+    let mut filtered = lockfile.clone();
+    for importer in filtered.importers.values_mut() {
+        if !included.dependencies {
+            importer.dependencies = None;
+        }
+        if !included.dev_dependencies {
+            importer.dev_dependencies = None;
+        }
+        if !included.optional_dependencies {
+            importer.optional_dependencies = None;
+        }
+    }
+    filtered
 }
 
 /// Pre-computed hoist plan threaded across the install pipeline so

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -82,6 +82,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         block_exotic_subdeps: false,
         verify_store_integrity: true,
         frozen_store: false,
+        force: false,
         side_effects_cache: true,
         side_effects_cache_readonly: false,
         fetch_retries: 2,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1455,13 +1455,17 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             elapsed_ms = phase_start.elapsed().as_millis() as u64,
             "phase complete",
         );
-        let needs_optional_installability_check =
-            built_lockfile.packages.as_ref().is_some_and(|packages| {
+        // `--force` bypasses the installability checks outright (see
+        // `Config::force`): no skip set is computed and the hoisted
+        // walker emits every dep, so no host detection is needed either.
+        let needs_optional_installability_check = !config.force
+            && built_lockfile.packages.as_ref().is_some_and(|packages| {
                 built_lockfile.snapshots.as_ref().is_some_and(|snapshots| {
                     crate::any_optional_installability_constraint(snapshots, packages)
                 })
             });
-        let needs_hoisted_installability_host = is_hoisted
+        let needs_hoisted_installability_host = !config.force
+            && is_hoisted
             && built_lockfile.packages.as_ref().is_some_and(|packages| {
                 built_lockfile.snapshots.as_ref().is_some_and(|snapshots| {
                     crate::any_installability_constraint(snapshots, packages)


### PR DESCRIPTION
## Summary

The v11.12.0 release run failed while publishing `@pnpm/exe`: `bundle-deps.ts` invokes `pnpm --config.inject-workspace-packages=true --config.node-linker=hoisted --ignore-scripts --force --filter=pnpm --prod deploy <dir>`, and the Rust pnpm rejected `--ignore-scripts` with clap's "unexpected argument" (failed run: https://github.com/pnpm/pnpm/actions/runs/29147964284/job/86572027599).

Fixing that parse error and then driving every step of `release.yml` locally against a freshly built pacquet binary surfaced five gaps in total, all closed here:

1. **Options before the subcommand were rejected.** pnpm's nopt parser is position-independent; clap scopes options to the level that declares them. A new `flag_relocation` argv pass moves pre-subcommand option tokens (that aren't top-level grammar) to directly after the subcommand, so `pnpm --ignore-scripts --prod deploy dir` parses exactly like `pnpm deploy --ignore-scripts --prod dir`. External commands (`pnpm <script>`) and everything after `--` are left untouched.
2. **`--config.inject-workspace-packages` and `--config.node-linker` were dropped.** `ConfigOverrides` now applies both keys, so the shared-lockfile deploy no longer dies with `ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE` and the deploy install honors the hoisted linker.
3. **`deploy --force` didn't force foreign-platform optionals.** pnpm's `--force` bypasses the installability check so optional dependencies of *every* platform are materialized (that's how all `@reflink/reflink-*` variants end up in the published `dist/node_modules`). Added `Config::force`, threaded it through both frozen and fresh install paths and the hoisted walker, wired it from `deploy --force`, and ported the `ERR_PNPM_CONFIG_CONFLICT_FROZEN_STORE_WITH_FORCE` guard.
4. **The hoisted linker materialized dev dependencies under `--prod`.** The hoist tree seeded from every importer dep map regardless of the included dependency groups, so the `--prod` deploy shipped 588 packages in `dist/node_modules` instead of 22. Excluded dep groups are now cleared from the lockfile before the hoist walk, mirroring pnpm's include-filtered lockfile.
5. **`pack`/`publish` couldn't resolve `catalog:` specifiers.** They read `Config::catalogs`, which is only populated by an `updateConfig` pnpmfile hook, so publishing `@pnpm/exe` (whose deps use `catalog:`) failed with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC`. They now fall back to the workspace manifest's `catalog:`/`catalogs:` tables, like the install does.

### Local verification

With script shims putting the locally built binary on `PATH` as `pnpm`/`pn`/`pnx`, every step of `release.yml` now completes:

- `pn --filter=@pnpm/exe run build-artifacts` — full compile, `pnx node@runtime:24.6.0 bundle.ts`, `bundle-deps.ts` deploy (the step that broke CI), and `pack-app` (darwin-arm64 signing needs `ldid`/macOS, so the darwin target was skipped locally; CI runs on macOS).
- `pn config set/delete "//registry.npmjs.org/:_authToken"`.
- All three publish steps with `--dry-run` (`@pnpm/exe`, 70 internal workspace packages via `--filter=!pnpm --filter=!@pnpm/exe`, and `pnpm` itself including its `prepublishOnly` re-deploy).
- `pn copy-artifacts` (all 7 platform archives + source maps) and `pn make-release-description`.
- `dist/node_modules` now contains the expected 22 packages (node-gyp, v8-compile-cache, `@reflink/*` incl. all platform variants, and their transitive deps) instead of 588.

No TypeScript-side changes are needed: each item replicates behavior the TS CLI already has.

## Squash Commit Body

```text
The v11.12.0 release workflow failed because bundle-deps.ts invokes

  pnpm --config.inject-workspace-packages=true --config.node-linker=hoisted \
       --ignore-scripts --force --filter=pnpm --prod deploy <dir>

and pacquet's clap-based CLI rejected --ignore-scripts ahead of the
subcommand. Running the whole release.yml sequence locally against a
fresh build surfaced five gaps, all fixed here:

- Accept options anywhere on the command line. nopt parses
  position-independently, so pnpm accepts a command's options before
  the command name. The new flag_relocation pass moves pre-subcommand
  option tokens that aren't top-level grammar to directly after the
  subcommand before clap parses argv. Widths for value-consuming
  options come from the union of the subcommand arg tables; arity
  conflicts degrade to "no value" so a subcommand name can never be
  swallowed. External commands and post-`--` tokens are untouched.

- Honor --config.inject-workspace-packages and --config.node-linker
  in ConfigOverrides; both were silently dropped, so the shared-lockfile
  deploy failed with ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE.

- Give deploy --force pnpm's install semantics. Config::force now
  bypasses the installability check on the frozen and fresh install
  paths and in the hoisted walker (and clears the skipped-snapshot
  seed), so optional deps of every platform are materialized — that is
  how all @reflink/reflink-* variants reach the published
  dist/node_modules. The ERR_PNPM_CONFIG_CONFLICT_FROZEN_STORE_WITH_FORCE
  guard is ported alongside, as the frozen_store docs promised.

- Exclude dev dependencies from the hoisted linker under --prod. The
  hoist tree seeded from every importer dep map regardless of the
  included dependency groups, so the --prod deploy shipped 588 packages
  in dist/node_modules instead of 22. run_hoisted_linker now clears
  excluded importer dep groups from the lockfile before the walk,
  mirroring pnpm's include-filtered lockfile.

- Resolve catalog: specifiers in pack/publish from the workspace
  manifest when no updateConfig hook injected Config::catalogs;
  publishing @pnpm/exe failed with
  ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC.

Verified locally by driving every release.yml step with the built
binary: build-artifacts (including the bundle-deps deploy that broke
CI), the three publish steps under --dry-run, config set/delete,
copy-artifacts, and make-release-description.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: every item replicates behavior the TypeScript CLI already has.)
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786390534&installation_id=145934176&pr_number=12944&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12944&signature=3a48c3c71d96ab5274640e913e11ce21f2dc9a40fbb5372dfd912975e0ac92d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for relocating subcommand flags placed before the command name.
  * Added `--config.inject-workspace-packages` and `--config.node-linker` overrides.
  * Improved catalog resolution when packing workspace projects.
  * Added force-install behavior for deploys, including foreign-platform optional dependencies.

* **Bug Fixes**
  * Added validation for incompatible `--force` and frozen-store settings.
  * Improved dependency filtering during hoisted installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->