### PR TITLE
test: skip registry-resolving version tests until the release is published

### DIFF
--- a/pnpm11/pnpm/test/configurationalDependencies.test.ts
+++ b/pnpm11/pnpm/test/configurationalDependencies.test.ts
@@ -10,7 +10,7 @@ import { readYamlFileSync } from 'read-yaml-file'
 import { writeJsonFileSync } from 'write-json-file'
 import { writeYamlFileSync } from 'write-yaml-file'
 
-import { execPnpm, execPnpmSync, pnpmBinLocation } from './utils/index.js'
+import { execPnpm, execPnpmSync, isCurrentVersionPublished, pnpmBinLocation } from './utils/index.js'
 
 test('patch from configuration dependency is applied', async () => {
   prepare()
@@ -150,10 +150,12 @@ test('package manager from the packageManager field is not saved into the lockfi
 })
 
 // These tests resolve the running pnpm version's integrity from registry-mock,
-// which proxies pnpm to npmjs. They fail between a release commit and the
-// matching npm publish ("No matching version found for pnpm@<version>"), and
-// pass again once the version lands on npmjs.
-describe('release-brittle: may fail until current version is published to npm', () => {
+// which proxies pnpm to npmjs, so they can only pass once the running version
+// is published. They are skipped in the window between a release commit and
+// the matching npm publish.
+const describeOnPublishedVersion = isCurrentVersionPublished() ? describe : describe.skip
+
+describeOnPublishedVersion('requires the running pnpm version to be published to npm', () => {
   test('packageManagerDependencies is refreshed when pnpm is invoked via corepack (#11397)', async () => {
     const pnpmVersion = JSON.parse(fs.readFileSync(path.join(path.dirname(pnpmBinLocation), '..', 'package.json'), 'utf8')).version as string
     prepare({

--- a/pnpm11/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm11/pnpm/test/packageManagerCheck.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from '@jest/globals'
 import { prepare, prepareEmpty } from '@pnpm/prepare'
 import { writeYamlFileSync } from 'write-yaml-file'
 
-import { execPnpmSync } from './utils/index.js'
+import { execPnpmSync, isCurrentVersionPublished } from './utils/index.js'
 
 test('install should fail if the used pnpm version does not satisfy the pnpm version specified in engines', async () => {
   prepare({
@@ -738,10 +738,12 @@ test.each([
 })
 
 // These tests resolve the running pnpm version's integrity from registry-mock,
-// which proxies pnpm to npmjs. They fail between a release commit and the
-// matching npm publish ("No matching version found for pnpm@<version>"), and
-// pass again once the version lands on npmjs.
-describe('release-brittle: may fail until current version is published to npm', () => {
+// which proxies pnpm to npmjs, so they can only pass once the running version
+// is published. They are skipped in the window between a release commit and
+// the matching npm publish.
+const describeOnPublishedVersion = isCurrentVersionPublished() ? describe : describe.skip
+
+describeOnPublishedVersion('requires the running pnpm version to be published to npm', () => {
   test('pnpm --version exits promptly when devEngines.packageManager matches the running pnpm', async () => {
     // Regression test: main.ts's `--version` short-circuit returned before
     // the command-handler `finally` that calls finishWorkers(), and

--- a/pnpm11/pnpm/test/utils/index.ts
+++ b/pnpm11/pnpm/test/utils/index.ts
@@ -11,6 +11,7 @@ import {
   spawnPnpx,
   waitForPnpmExit,
 } from './execPnpm.js'
+import { isCurrentVersionPublished } from './isCurrentVersionPublished.js'
 import { pathToLocalPkg } from './localPkg.js'
 import testDefaults from './testDefaults.js'
 
@@ -21,6 +22,7 @@ export {
   execPnpmSync,
   execPnpx,
   execPnpxSync,
+  isCurrentVersionPublished,
   pathToLocalPkg,
   pnpmBinLocation,
   pnpxBinLocation,

--- a/pnpm11/pnpm/test/utils/isCurrentVersionPublished.ts
+++ b/pnpm11/pnpm/test/utils/isCurrentVersionPublished.ts
@@ -1,0 +1,35 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { pnpmBinLocation } from './execPnpm.js'
+
+/**
+ * Tells whether the pnpm version under test is already published to npmjs as
+ * both the `pnpm` and `@pnpm/exe` packages. Tests that resolve the running
+ * version through the registry can only pass once the release is published,
+ * so they must be skipped in the window between a release commit landing on
+ * main and the matching npm publish. Also returns `false` when npmjs cannot
+ * be reached, since such tests would fail on the registry request anyway.
+ * Emits a warning when it returns `false`, so skips are visible in the logs.
+ */
+export function isCurrentVersionPublished (): boolean {
+  const manifestPath = path.join(path.dirname(pnpmBinLocation), '..', 'package.json')
+  const { version } = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as { version: string }
+  const urls = ['pnpm', '@pnpm/exe'].map(name => `https://registry.npmjs.org/${name}/${version}`)
+  const { status } = spawnSync(process.execPath, ['-e', ALL_URLS_OK_SCRIPT, ...urls], { timeout: 60_000 })
+  if (status === 0) return true
+  console.warn(`Version ${version} of pnpm and/or @pnpm/exe is not available on registry.npmjs.org yet. Tests that resolve the running version from the registry will be skipped.`)
+  return false
+}
+
+// process.argv[0] is the node binary when running via `node -e`, so the URLs
+// start at index 1.
+const ALL_URLS_OK_SCRIPT = `
+Promise.all(process.argv.slice(1).map((url) => fetch(url).then((response) => response.ok)))
+  .then((allOk) => {
+    process.exitCode = allOk.every(Boolean) ? 0 : 1
+  }, () => {
+    process.exitCode = 1
+  })
+`


### PR DESCRIPTION
## Summary

CI on main is red on every release commit (e.g. [this run](https://github.com/pnpm/pnpm/actions/runs/29147949595) on `chore(release): 11.12.0`): the three tests in the "release-brittle" describe blocks of `pnpm11/pnpm/test/packageManagerCheck.test.ts` and `pnpm11/pnpm/test/configurationalDependencies.test.ts` resolve the *running* pnpm version through registry-mock (which proxies `pnpm` and `@pnpm/exe` to npmjs), so between the release commit landing and the matching npm publish they fail with `No matching version found for pnpm@<version>` / `@pnpm/exe@<version>`.

This PR makes those tests skip themselves during that window instead of failing CI. A new test util, `isCurrentVersionPublished()`, synchronously checks registry.npmjs.org for the running version of both `pnpm` and `@pnpm/exe`; the describe blocks are gated with the existing `cond ? describe : describe.skip` idiom. When skipping, a warning is printed so the skip is visible in CI logs. If npmjs is unreachable the tests are also skipped, since they would fail on the registry request anyway.

Verified locally (with 11.12.0 still unpublished, i.e. inside the brittle window): both test files pass with exactly the 3 release-brittle tests skipped — `Tests: 3 skipped, 54 passed, 57 total`.

## Squash Commit Body

```text
The tests grouped under the release-brittle describe blocks in
packageManagerCheck.test.ts and configurationalDependencies.test.ts
resolve the running pnpm version through registry-mock, which proxies
pnpm and `@pnpm/exe` to npmjs. In the window between a release commit
landing on main and the matching npm publish, that version does not
exist upstream yet, so every CI run on main fails with "No matching
version found for pnpm@<version>".

Gate those describe blocks on a synchronous check against
registry.npmjs.org for the running version of both packages. While the
version is unpublished (or npmjs is unreachable, in which case the
tests would fail on the registry request anyway), the tests are skipped
and a warning is printed so the skip is visible in CI logs.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. *(TS-only test-infrastructure change; no user-visible behavior, nothing to port.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. *(Not needed — test-only change, no published package affected.)*
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786391414&installation_id=145934176&pr_number=12945&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12945&signature=101717fec871e42e9599ba9d771cd7310ca280df28a2d7aa05c2cc9fcfe122d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Release-sensitive integrity and configuration tests now run only when the corresponding pnpm version is available in the npm registry.
  * Tests are automatically skipped during the short period between publishing a release and its registry availability.
  * Added checks to verify that required pnpm packages for the current version are published before running these tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->