### PR TITLE
fix(pacquet): pin saved node runtime version and preserve package.json formatting

### DIFF
--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
@@ -138,23 +138,11 @@ impl NodeResolver {
         // resolve re-fetches the asset list. Add the fast path once the
         // seam carries it.
 
-        if self.offline {
-            return Err(Box::new(NodeResolverError::Offline) as ResolveError);
-        }
-
-        let parsed = parse_node_specifier(version_spec).map_err(|err| {
-            Box::new(NodeResolverError::InvalidReleaseChannel(err)) as ResolveError
-        })?;
-        let mirror = get_node_mirror(Some(&self.node_download_mirrors), &parsed.release_channel);
-        let version =
-            resolve_node_version(&self.http_client, &parsed.version_specifier, Some(&mirror))
-                .await
-                .map_err(|err| Box::new(NodeResolverError::FetchReleaseIndex(err)) as ResolveError)?
-                .ok_or_else(|| {
-                    Box::new(NodeResolverError::VersionNotFound { spec: version_spec.to_string() })
-                        as ResolveError
-                })?;
-        let variants = self.read_node_assets(&mirror, &version, &parsed.release_channel).await?;
+        let PickedNodeVersion { version, mirror, release_channel } = self
+            .pick_node_version(version_spec)
+            .await
+            .map_err(|err| Box::new(err) as ResolveError)?;
+        let variants = self.read_node_assets(&mirror, &version, &release_channel).await?;
         let range = normalize_node_runtime_version_specifier(
             version_spec,
             &version,
@@ -178,6 +166,45 @@ impl NodeResolver {
             alias: wanted_dependency.alias.clone(),
             policy_violation: None,
         }))
+    }
+
+    /// Parse a `runtime:` version spec, pick the mirror for its release
+    /// channel, and resolve the spec to a concrete version.
+    async fn pick_node_version(
+        &self,
+        version_spec: &str,
+    ) -> Result<PickedNodeVersion, NodeResolverError> {
+        if self.offline {
+            return Err(NodeResolverError::Offline);
+        }
+        let parsed =
+            parse_node_specifier(version_spec).map_err(NodeResolverError::InvalidReleaseChannel)?;
+        let mirror = get_node_mirror(Some(&self.node_download_mirrors), &parsed.release_channel);
+        let version =
+            resolve_node_version(&self.http_client, &parsed.version_specifier, Some(&mirror))
+                .await
+                .map_err(NodeResolverError::FetchReleaseIndex)?
+                .ok_or_else(|| NodeResolverError::VersionNotFound {
+                    spec: version_spec.to_string(),
+                })?;
+        Ok(PickedNodeVersion { version, mirror, release_channel: parsed.release_channel })
+    }
+
+    /// The specifier an `add node@runtime:<spec>` request saves to the
+    /// manifest: `runtime:` plus the picked version, pinned exactly unless
+    /// the previous specifier (or the requested spec) carries a `^`/`~`
+    /// operator. This is the same normalization [`Resolver::resolve`]
+    /// reports through `normalized_bare_specifier`, computed without
+    /// fetching the platform asset list.
+    pub async fn resolve_save_specifier(
+        &self,
+        version_spec: &str,
+        prev_specifier: Option<&str>,
+    ) -> Result<String, NodeResolverError> {
+        let picked = self.pick_node_version(version_spec).await?;
+        let range =
+            normalize_node_runtime_version_specifier(version_spec, &picked.version, prev_specifier);
+        Ok(format!("{BARE_SPEC_PREFIX}{range}"))
     }
 
     async fn resolve_latest_impl(
@@ -252,6 +279,14 @@ impl NodeResolver {
         }
         Ok(assets)
     }
+}
+
+/// A concrete Node.js version picked for a `runtime:` version spec, plus
+/// the mirror and release channel it was picked from.
+struct PickedNodeVersion {
+    version: String,
+    mirror: String,
+    release_channel: String,
 }
 
 /// Strip `runtime:` from a `(alias, bareSpecifier)` pair when both

--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver/tests.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver/tests.rs
@@ -115,6 +115,68 @@ fn normalized_runtime_spec_preserves_version_prefix() {
     assert_eq!(normalize_node_runtime_version_specifier("^22", "22.0.0-rc.0", None), "22.0.0-rc.0");
 }
 
+/// `add node@runtime:<spec>` saves the picked version, not the requested
+/// range — `runtime:26` must reach the manifest as `runtime:26.5.0`.
+#[tokio::test]
+async fn resolve_save_specifier_pins_the_picked_version() {
+    let mut server = mockito::Server::new_async().await;
+    let index = server
+        .mock("GET", "/download/release/index.json")
+        .with_status(200)
+        .with_body(
+            r#"[
+                {"version": "v26.5.0", "lts": false},
+                {"version": "v26.4.0", "lts": false},
+                {"version": "v24.13.0", "lts": "Krypton"}
+            ]"#,
+        )
+        .expect_at_least(1)
+        .create_async()
+        .await;
+    let mut resolver = resolver();
+    resolver
+        .node_download_mirrors
+        .insert("release".to_string(), format!("{}/download/release/", server.url()));
+
+    let cases = [
+        ("26", None, "runtime:26.5.0"),
+        ("^26", None, "runtime:^26.5.0"),
+        ("26", Some("runtime:~26.4.0"), "runtime:~26.5.0"),
+        ("", None, "runtime:26.5.0"),
+        ("lts", None, "runtime:24.13.0"),
+    ];
+    for (version_spec, prev_specifier, expected) in cases {
+        assert_eq!(
+            resolver.resolve_save_specifier(version_spec, prev_specifier).await.unwrap(),
+            expected,
+            "version_spec={version_spec:?}, prev_specifier={prev_specifier:?}",
+        );
+    }
+    index.assert_async().await;
+}
+
+#[tokio::test]
+async fn resolve_save_specifier_errors_when_no_version_satisfies() {
+    let mut server = mockito::Server::new_async().await;
+    let _index = server
+        .mock("GET", "/download/release/index.json")
+        .with_status(200)
+        .with_body(r#"[{"version": "v26.5.0", "lts": false}]"#)
+        .create_async()
+        .await;
+    let mut resolver = resolver();
+    resolver
+        .node_download_mirrors
+        .insert("release".to_string(), format!("{}/download/release/", server.url()));
+
+    let err = resolver.resolve_save_specifier("99", None).await.unwrap_err();
+    let code: &dyn miette::Diagnostic = &err;
+    assert_eq!(
+        code.code().map(|code| code.to_string()).as_deref(),
+        Some("NODEJS_VERSION_NOT_FOUND"),
+    );
+}
+
 #[tokio::test]
 async fn release_asset_reader_requires_signature_when_requested() {
     let mut server = mockito::Server::new_async().await;

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -10,6 +10,7 @@ use pacquet_catalogs_config::{
 };
 use pacquet_catalogs_types::Catalogs;
 use pacquet_config::Config;
+use pacquet_engine_runtime_node_resolver::{NodeResolver, NodeResolverError};
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests;
 use pacquet_network::ThrottledClient;
@@ -111,6 +112,11 @@ pub enum AddError {
     #[diagnostic(transparent)]
     ResolveSpec(#[error(source)] Box<PickPackageError>),
 
+    /// Resolving a `node@runtime:<spec>` selector against the Node.js
+    /// release index (to pin the manifest to the picked version) failed.
+    #[diagnostic(transparent)]
+    ResolveRuntimeSpec(#[error(source)] NodeResolverError),
+
     /// `minimumReleaseAgeExclude` contained an invalid rule.
     #[diagnostic(transparent)]
     MinimumReleaseAgeExclude(#[error(source)] pacquet_config::version_policy::VersionPolicyError),
@@ -176,45 +182,59 @@ where
         //   pins — `pnpm add foo@^7` records `^7.8.4`, not
         //   `^7`. Specifiers that aren't a plain registry range/tag/version
         //   for this package (protocols, `npm:` aliases) stay verbatim;
+        // - an explicit `node@runtime:<spec>` is likewise pinned to the
+        //   picked Node.js version, so the `devEngines.runtime` entry the
+        //   saved dependency folds into records e.g. `26.5.0`, not the
+        //   requested `26`;
         // - a re-add with no version keeps the dependency's current
         //   specifier verbatim (a `catalog:` reference, a range, or an
         //   exact pin) — `pnpm add <existing>` without a
         //   version leaves the declared range untouched;
         // - a brand-new dependency fetches and pins the `latest` range.
-        let bare_specifier = match (explicit_spec, prev_specifier.as_deref()) {
-            (Some(spec), prev) => resolve_explicit_registry_spec(
-                package_name,
-                spec,
-                prev,
-                config,
-                http_client,
-                pinned_version,
-                lockfile_only,
-                lockfile,
-                manifest,
-            )
-            .await?
-            .unwrap_or_else(|| normalized_save_specifier(spec)),
-            (None, Some(prev)) => prev.to_string(),
-            (None, None) => {
-                let registries: std::collections::HashMap<String, String> =
-                    config.resolved_registries().into_iter().collect();
-                let registry = pick_registry_for_package(&registries, package_name, None);
-                let latest = PackageVersion::fetch_from_registry(
-                    package_name,
-                    PackageTag::Latest,
-                    http_client,
-                    &registry,
-                    &config.auth_headers,
-                )
-                .await
-                .map_err(|error| AddError::ResolveLatest {
-                    name: package_name.to_string(),
-                    error,
-                })?;
-                latest.serialize(pinned_version)
-            }
-        };
+        let bare_specifier =
+            if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
+                let mut node_resolver = NodeResolver::new(std::sync::Arc::clone(&http_client_arc));
+                node_resolver.offline = config.offline;
+                node_resolver
+                    .resolve_save_specifier(version_spec, prev_specifier.as_deref())
+                    .await
+                    .map_err(AddError::ResolveRuntimeSpec)?
+            } else {
+                match (explicit_spec, prev_specifier.as_deref()) {
+                    (Some(spec), prev) => resolve_explicit_registry_spec(
+                        package_name,
+                        spec,
+                        prev,
+                        config,
+                        http_client,
+                        pinned_version,
+                        lockfile_only,
+                        lockfile,
+                        manifest,
+                    )
+                    .await?
+                    .unwrap_or_else(|| normalized_save_specifier(spec)),
+                    (None, Some(prev)) => prev.to_string(),
+                    (None, None) => {
+                        let registries: std::collections::HashMap<String, String> =
+                            config.resolved_registries().into_iter().collect();
+                        let registry = pick_registry_for_package(&registries, package_name, None);
+                        let latest = PackageVersion::fetch_from_registry(
+                            package_name,
+                            PackageTag::Latest,
+                            http_client,
+                            &registry,
+                            &config.auth_headers,
+                        )
+                        .await
+                        .map_err(|error| AddError::ResolveLatest {
+                            name: package_name.to_string(),
+                            error,
+                        })?;
+                        latest.serialize(pinned_version)
+                    }
+                }
+            };
 
         let mut updated_catalogs = Catalogs::new();
         let dep = CatalogModeDep {
@@ -483,6 +503,20 @@ fn normalized_save_specifier(spec: &str) -> String {
         Some(hosted) if hosted.auth.is_none() => hosted.shortcut(HostedOpts::default()),
         _ => spec.to_string(),
     }
+}
+
+/// The `<spec>` half of an explicit `node@runtime:<spec>` request, when that
+/// is what's being added. Only the node resolver pins the saved specifier to
+/// the picked version; deno and bun normalize to the requested spec, so they
+/// stay on the verbatim save path.
+fn node_runtime_version_spec<'a>(
+    package_name: &str,
+    explicit_spec: Option<&'a str>,
+) -> Option<&'a str> {
+    if package_name != "node" {
+        return None;
+    }
+    explicit_spec?.strip_prefix("runtime:")
 }
 
 #[cfg(test)]

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -1,4 +1,4 @@
-use super::{Add, normalized_save_specifier};
+use super::{Add, node_runtime_version_spec, normalized_save_specifier};
 use crate::ResolvedPackages;
 use pacquet_config::Config;
 use pacquet_network::ThrottledClient;
@@ -158,4 +158,16 @@ fn normalizes_hosted_git_specifiers_to_shortcut_form() {
     assert_eq!(normalized_save_specifier("npm:bar@^1"), "npm:bar@^1");
     assert_eq!(normalized_save_specifier("file:../bar"), "file:../bar");
     assert_eq!(normalized_save_specifier("workspace:*"), "workspace:*");
+}
+
+#[test]
+fn node_runtime_version_spec_matches_only_explicit_node_runtime_requests() {
+    assert_eq!(node_runtime_version_spec("node", Some("runtime:26")), Some("26"));
+    assert_eq!(node_runtime_version_spec("node", Some("runtime:")), Some(""));
+    // A registry-range `node` request is owned by the npm resolver.
+    assert_eq!(node_runtime_version_spec("node", Some("^26")), None);
+    assert_eq!(node_runtime_version_spec("node", None), None);
+    // Deno and bun echo the requested spec back, so they save verbatim.
+    assert_eq!(node_runtime_version_spec("deno", Some("runtime:2")), None);
+    assert_eq!(node_runtime_version_spec("bun", Some("runtime:latest")), None);
 }

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -106,11 +106,11 @@ impl PackageManifest {
         })
     }
 
-    fn write_to_file(path: &Path) -> Result<(Value, String), PackageManifestError> {
+    fn write_to_file(path: &Path) -> Result<String, PackageManifestError> {
         let manifest = PackageManifest::init_value_for(path);
-        let contents = serde_json::to_string_pretty(&manifest)?;
+        let contents = serialize_with_indent(&manifest, DEFAULT_INDENT)?;
         fs::write(path, format!("{contents}\n"))?; // TODO: forbid overwriting existing files
-        Ok((manifest, contents))
+        Ok(contents)
     }
 
     /// The scaffold manifest `pnpm init` (and [`Self::create_if_needed`])
@@ -167,7 +167,7 @@ impl PackageManifest {
         if path.exists() {
             return Err(PackageManifestError::AlreadyExist);
         }
-        let (_, contents) = PackageManifest::write_to_file(path)?;
+        let contents = PackageManifest::write_to_file(path)?;
         println!("Wrote to {path}\n\n{contents}", path = path.display());
         Ok(())
     }
@@ -181,17 +181,13 @@ impl PackageManifest {
     }
 
     pub fn create_if_needed(path: PathBuf) -> Result<PackageManifest, PackageManifestError> {
-        if path.exists() {
-            return PackageManifest::read_from_file(path);
+        if !path.exists() {
+            PackageManifest::write_to_file(&path)?;
         }
-        let (value, _) = PackageManifest::write_to_file(&path)?;
-        Ok(PackageManifest {
-            path,
-            on_disk: Some(value.clone()),
-            value,
-            insert_final_newline: true,
-            indent: DEFAULT_INDENT.to_string(),
-        })
+        // Read the scaffold back rather than assembling the manifest by
+        // hand, so its formatting and no-op-save baseline are derived from
+        // the file the same way as for a pre-existing manifest.
+        PackageManifest::read_from_file(path)
     }
 
     /// Build a manifest from an in-memory JSON value paired with the path it
@@ -545,11 +541,18 @@ fn detect_indent(contents: &str) -> &str {
 }
 
 /// Serialize with the manifest's own indentation unit; an empty unit
-/// produces a compact single-line document.
+/// produces a compact single-line document. At most the first 10
+/// characters of the unit are used — the cap `JSON.stringify` applies to
+/// its `space` argument, which pnpm writes manifests through — so a
+/// pathologically indented source file can't amplify the output.
 fn serialize_with_indent(value: &Value, indent: &str) -> Result<String, serde_json::Error> {
     if indent.is_empty() {
         return serde_json::to_string(value);
     }
+    let indent = match indent.char_indices().nth(10) {
+        Some((cap, _)) => &indent[..cap],
+        None => indent,
+    };
     let mut out = Vec::new();
     let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
     let mut serializer = serde_json::Serializer::with_formatter(&mut out, formatter);

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -62,11 +62,32 @@ pub enum BundleDependencies {
     List(Vec<String>),
 }
 
+/// Indentation for manifests with no source file to detect it from
+/// (freshly scaffolded or in-memory).
+const DEFAULT_INDENT: &str = "  ";
+
 /// Content of the `package.json` files and its path.
+///
+/// Carries the source file's formatting (indentation unit, final-newline
+/// state) and its parsed value across the read/save round-trip, so
+/// [`Self::save`] preserves the file's style and skips the write entirely
+/// when nothing changed — the same contract as pnpm's project-manifest
+/// reader/writer pair.
 #[derive(Clone)]
 pub struct PackageManifest {
     path: PathBuf,
     value: Value, // TODO: convert this into a proper struct + an array of keys order
+    /// Whether a save ends the file with a newline. New and in-memory
+    /// manifests get one.
+    insert_final_newline: bool,
+    /// One indentation level. Empty for a single-line source document,
+    /// which then round-trips back to its compact form.
+    indent: String,
+    /// The manifest as the file currently encodes it (`devEngines` folded,
+    /// dependency fields normalized), used to skip a save that wouldn't
+    /// change the file. `None` when there is no file baseline (in-memory
+    /// manifests), so the first save always writes.
+    on_disk: Option<Value>,
 }
 
 impl PackageManifest {
@@ -88,7 +109,7 @@ impl PackageManifest {
     fn write_to_file(path: &Path) -> Result<(Value, String), PackageManifestError> {
         let manifest = PackageManifest::init_value_for(path);
         let contents = serde_json::to_string_pretty(&manifest)?;
-        fs::write(path, &contents)?; // TODO: forbid overwriting existing files
+        fs::write(path, format!("{contents}\n"))?; // TODO: forbid overwriting existing files
         Ok((manifest, contents))
     }
 
@@ -126,12 +147,20 @@ impl PackageManifest {
         Ok(())
     }
 
-    fn read_from_file(path: &Path) -> Result<Value, PackageManifestError> {
-        let contents = fs::read_to_string(path)?;
+    fn read_from_file(path: PathBuf) -> Result<PackageManifest, PackageManifestError> {
+        let contents = fs::read_to_string(&path)?;
         let mut value: Value = serde_json::from_str(&contents)?;
+        let mut on_disk = value.clone();
+        normalize_dependency_fields(&mut on_disk);
         convert_engines_runtime_to_dependencies(&mut value, "devEngines", "devDependencies");
         convert_engines_runtime_to_dependencies(&mut value, "engines", "dependencies");
-        Ok(value)
+        Ok(PackageManifest {
+            path,
+            value,
+            insert_final_newline: contents.ends_with('\n'),
+            indent: detect_indent(&contents).to_string(),
+            on_disk: Some(on_disk),
+        })
     }
 
     pub fn init(path: &Path) -> Result<(), PackageManifestError> {
@@ -148,18 +177,21 @@ impl PackageManifest {
             return Err(PackageManifestError::NoImporterManifestFound(path.display().to_string()));
         }
 
-        let value = PackageManifest::read_from_file(&path)?;
-        Ok(PackageManifest { path, value })
+        PackageManifest::read_from_file(path)
     }
 
     pub fn create_if_needed(path: PathBuf) -> Result<PackageManifest, PackageManifestError> {
-        let value = if path.exists() {
-            PackageManifest::read_from_file(&path)?
-        } else {
-            PackageManifest::write_to_file(&path).map(|(value, _)| value)?
-        };
-
-        Ok(PackageManifest { path, value })
+        if path.exists() {
+            return PackageManifest::read_from_file(path);
+        }
+        let (value, _) = PackageManifest::write_to_file(&path)?;
+        Ok(PackageManifest {
+            path,
+            on_disk: Some(value.clone()),
+            value,
+            insert_final_newline: true,
+            indent: DEFAULT_INDENT.to_string(),
+        })
     }
 
     /// Build a manifest from an in-memory JSON value paired with the path it
@@ -182,7 +214,13 @@ impl PackageManifest {
         }
         convert_engines_runtime_to_dependencies(&mut value, "devEngines", "devDependencies");
         convert_engines_runtime_to_dependencies(&mut value, "engines", "dependencies");
-        PackageManifest { path, value }
+        PackageManifest {
+            path,
+            value,
+            insert_final_newline: true,
+            indent: DEFAULT_INDENT.to_string(),
+            on_disk: None,
+        }
     }
 
     #[must_use]
@@ -206,16 +244,30 @@ impl PackageManifest {
         &mut self.value
     }
 
-    pub fn save_and_get_written_value(&self) -> Result<Value, PackageManifestError> {
+    /// Persist the manifest in its on-disk shape (`devEngines` folded back,
+    /// dependency fields normalized) and return that shape.
+    ///
+    /// The write preserves the source file's indentation and final-newline
+    /// state, and is skipped entirely when the file already encodes the
+    /// same manifest — so a no-op save never churns formatting or mtime.
+    pub fn save_and_get_written_value(&mut self) -> Result<Value, PackageManifestError> {
         let mut value = self.value.clone();
         convert_dependencies_to_engines_runtime(&mut value, "devDependencies", "devEngines")?;
         convert_dependencies_to_engines_runtime(&mut value, "dependencies", "engines")?;
-        let contents = serde_json::to_string_pretty(&value)?;
+        normalize_dependency_fields(&mut value);
+        if self.on_disk.as_ref() == Some(&value) {
+            return Ok(value);
+        }
+        let mut contents = serialize_with_indent(&value, &self.indent)?;
+        if self.insert_final_newline {
+            contents.push('\n');
+        }
         Self::write_atomic(&self.path, &contents)?;
+        self.on_disk = Some(value.clone());
         Ok(value)
     }
 
-    pub fn save(&self) -> Result<(), PackageManifestError> {
+    pub fn save(&mut self) -> Result<(), PackageManifestError> {
         self.save_and_get_written_value()?;
         Ok(())
     }
@@ -457,6 +509,52 @@ pub fn convert_engines_runtime_to_dependencies(
     for (name, spec) in to_insert {
         deps_obj.insert(name.to_string(), Value::String(spec));
     }
+}
+
+/// pnpm's on-write manifest normalization: within each dependency field,
+/// sort the entries by name, and drop the field entirely when it holds no
+/// entries.
+fn normalize_dependency_fields(manifest: &mut Value) {
+    let Some(manifest) = manifest.as_object_mut() else { return };
+    for field in ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"] {
+        let is_empty_object = match manifest.get_mut(field) {
+            Some(Value::Object(deps)) => {
+                deps.sort_keys();
+                deps.is_empty()
+            }
+            _ => continue,
+        };
+        if is_empty_object {
+            manifest.remove(field);
+        }
+    }
+}
+
+/// The indentation unit of a JSON document: the leading whitespace of its
+/// first indented line. Empty for a single-line (or unindented) document,
+/// which then round-trips back to its compact form.
+fn detect_indent(contents: &str) -> &str {
+    contents
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim_start_matches([' ', '\t']);
+            (!trimmed.is_empty() && trimmed.len() < line.len())
+                .then(|| &line[..line.len() - trimmed.len()])
+        })
+        .unwrap_or("")
+}
+
+/// Serialize with the manifest's own indentation unit; an empty unit
+/// produces a compact single-line document.
+fn serialize_with_indent(value: &Value, indent: &str) -> Result<String, serde_json::Error> {
+    if indent.is_empty() {
+        return serde_json::to_string(value);
+    }
+    let mut out = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(indent.as_bytes());
+    let mut serializer = serde_json::Serializer::with_formatter(&mut out, formatter);
+    value.serialize(&mut serializer)?;
+    Ok(String::from_utf8(out).expect("serde_json emits UTF-8"))
 }
 
 /// Fold `runtime:<version>` dependency entries back into

--- a/pnpm/crates/package-manifest/src/tests.rs
+++ b/pnpm/crates/package-manifest/src/tests.rs
@@ -878,7 +878,7 @@ fn save_preserves_the_source_indentation() {
 
     let cases = [
         ("tabs.json", "{\n\t\"name\": \"foo\"\n}\n", "\t\"name\""),
-        ("wide.json", "{\n    \"name\": \"foo\"\n}\n", "    \"name\""),
+        ("wide.json", "{\n    \"name\": \"foo\"\n}\n", r#"    "name""#),
     ];
     for (file_name, source, expected_fragment) in cases {
         let path = dir.path().join(file_name);
@@ -893,7 +893,7 @@ fn save_preserves_the_source_indentation() {
     }
 
     let single_line = dir.path().join("single-line.json");
-    std::fs::write(&single_line, "{\"name\":\"foo\"}").unwrap();
+    std::fs::write(&single_line, r#"{"name":"foo"}"#).unwrap();
     let mut manifest = PackageManifest::from_path(single_line.clone()).unwrap();
     manifest.add_dependency("fastify", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();

--- a/pnpm/crates/package-manifest/src/tests.rs
+++ b/pnpm/crates/package-manifest/src/tests.rs
@@ -25,7 +25,8 @@ fn save_leaves_the_original_intact_when_the_write_cannot_complete() {
     let original = r#"{"name":"intact","version":"1.0.0"}"#;
     std::fs::write(&path, original).unwrap();
 
-    let manifest = PackageManifest::from_path(path.clone()).unwrap();
+    let mut manifest = PackageManifest::from_path(path.clone()).unwrap();
+    manifest.add_dependency("fastify", "1.0.0", DependencyGroup::Prod).unwrap();
 
     // Make the directory read-only so a sibling temp file cannot be created.
     // An atomic temp-file-then-rename write fails up front and leaves the
@@ -50,7 +51,8 @@ fn save_preserves_the_existing_package_json_permissions() {
     std::fs::write(&path, r#"{"name":"perm","version":"1.0.0"}"#).unwrap();
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
 
-    let manifest = PackageManifest::from_path(path.clone()).unwrap();
+    let mut manifest = PackageManifest::from_path(path.clone()).unwrap();
+    manifest.add_dependency("fastify", "1.0.0", DependencyGroup::Prod).unwrap();
     manifest.save().unwrap();
 
     // The atomic temp-file-then-rename must keep the original mode, not leave
@@ -494,8 +496,8 @@ fn save_converts_runtime_dependencies_before_writing() {
             },
         })),
     );
-    assert_eq!(saved.get("devDependencies"), Some(&json!({})));
-    assert_eq!(saved.get("dependencies"), Some(&json!({})));
+    assert_eq!(saved.get("devDependencies"), None);
+    assert_eq!(saved.get("dependencies"), None);
 }
 
 #[test]
@@ -520,7 +522,10 @@ fn save_and_get_written_value_returns_saved_manifest() {
             },
         })),
     );
-    assert_eq!(saved.get("devDependencies"), Some(&json!({})));
+    // The reification-only `devDependencies` ends up empty after the fold
+    // and is dropped from the written file, while the in-memory manifest
+    // keeps the reified entry.
+    assert_eq!(saved.get("devDependencies"), None);
     assert_eq!(manifest.value().get("devDependencies"), Some(&json!({ "node": "runtime:22" })));
 }
 
@@ -547,7 +552,7 @@ fn save_prunes_removed_reified_runtime_entry() {
     let saved: serde_json::Value =
         serde_json::from_str(&read_to_string(path).unwrap()).expect("parse saved manifest");
     assert_eq!(saved.get("devEngines"), Some(&json!({})));
-    assert_eq!(saved.get("devDependencies"), Some(&json!({})));
+    assert_eq!(saved.get("devDependencies"), None);
 }
 
 #[test]
@@ -591,7 +596,7 @@ fn save_prunes_only_removed_reified_runtime_entry_from_array() {
             ],
         })),
     );
-    assert_eq!(saved.get("devDependencies"), Some(&json!({})));
+    assert_eq!(saved.get("devDependencies"), None);
 }
 
 #[test]
@@ -608,7 +613,7 @@ fn failed_save_preserves_existing_file_contents() {
     .unwrap();
     std::fs::write(&path, &raw).unwrap();
 
-    let manifest = PackageManifest::from_path(path.clone()).unwrap();
+    let mut manifest = PackageManifest::from_path(path.clone()).unwrap();
     assert!(matches!(manifest.save(), Err(PackageManifestError::InvalidAttribute(_))));
     assert_eq!(read_to_string(path).unwrap(), raw);
 }
@@ -829,4 +834,115 @@ fn from_value_coerces_non_object_input_to_an_empty_object() {
             .add_dependency("is-odd", "3.0.1", DependencyGroup::Prod)
             .expect("adding a dependency to a normalized manifest must not fail");
     }
+}
+
+/// A save round-trips the source file's final-newline state: a file that
+/// ends with a newline keeps it, a file that doesn't stays without one.
+#[test]
+fn save_preserves_the_final_newline_state_of_the_source_file() {
+    let dir = tempdir().unwrap();
+
+    let with_newline = dir.path().join("with-newline.json");
+    std::fs::write(&with_newline, "{\n  \"name\": \"foo\"\n}\n").unwrap();
+    let mut manifest = PackageManifest::from_path(with_newline.clone()).unwrap();
+    manifest.add_dependency("fastify", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+    assert!(read_to_string(with_newline).unwrap().ends_with('\n'));
+
+    let without_newline = dir.path().join("without-newline.json");
+    std::fs::write(&without_newline, "{\n  \"name\": \"foo\"\n}").unwrap();
+    let mut manifest = PackageManifest::from_path(without_newline.clone()).unwrap();
+    manifest.add_dependency("fastify", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+    assert!(!read_to_string(without_newline).unwrap().ends_with('\n'));
+}
+
+/// A manifest scaffolded for a project with no `package.json` ends with a
+/// newline, both as created and after a save.
+#[test]
+fn new_manifests_end_with_a_final_newline() {
+    let dir = tempdir().unwrap();
+    let tmp = dir.path().join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(tmp.clone()).unwrap();
+    assert!(read_to_string(&tmp).unwrap().ends_with('\n'));
+    manifest.save().unwrap();
+    assert!(read_to_string(&tmp).unwrap().ends_with('\n'));
+}
+
+/// A save re-serializes with the source file's own indentation unit: tabs
+/// stay tabs, wider space units stay wide, and a single-line document
+/// stays compact.
+#[test]
+fn save_preserves_the_source_indentation() {
+    let dir = tempdir().unwrap();
+
+    let cases = [
+        ("tabs.json", "{\n\t\"name\": \"foo\"\n}\n", "\t\"name\""),
+        ("wide.json", "{\n    \"name\": \"foo\"\n}\n", "    \"name\""),
+    ];
+    for (file_name, source, expected_fragment) in cases {
+        let path = dir.path().join(file_name);
+        std::fs::write(&path, source).unwrap();
+        let mut manifest = PackageManifest::from_path(path.clone()).unwrap();
+        manifest.add_dependency("fastify", "1.0.0", DependencyGroup::Prod).unwrap();
+        manifest.save().unwrap();
+        let saved = read_to_string(&path).unwrap();
+        eprintln!("{file_name} SAVED:\n{saved}");
+        assert!(saved.contains(expected_fragment));
+        assert!(saved.contains("fastify"));
+    }
+
+    let single_line = dir.path().join("single-line.json");
+    std::fs::write(&single_line, "{\"name\":\"foo\"}").unwrap();
+    let mut manifest = PackageManifest::from_path(single_line.clone()).unwrap();
+    manifest.add_dependency("fastify", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+    assert_eq!(
+        read_to_string(&single_line).unwrap(),
+        r#"{"name":"foo","dependencies":{"fastify":"1.0.0"}}"#,
+    );
+}
+
+/// A write sorts each dependency field by name and drops a dependency
+/// field that ended up empty, like pnpm's on-write manifest normalization.
+#[test]
+fn save_sorts_dependency_fields_and_drops_empty_ones() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("package.json");
+    std::fs::write(
+        &path,
+        "{\n  \"name\": \"foo\",\n  \"dependencies\": {\n    \"zebra\": \"1.0.0\"\n  },\n  \"devDependencies\": {}\n}\n",
+    )
+    .unwrap();
+    let mut manifest = PackageManifest::from_path(path.clone()).unwrap();
+    manifest.add_dependency("aardvark", "2.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let saved = read_to_string(&path).unwrap();
+    eprintln!("SAVED:\n{saved}");
+    let aardvark = saved.find("aardvark").unwrap();
+    let zebra = saved.find("zebra").unwrap();
+    assert!(aardvark < zebra);
+    assert!(!saved.contains("devDependencies"));
+}
+
+/// A save that wouldn't change the manifest leaves the file byte-for-byte
+/// untouched — even a file in non-canonical form (unsorted dependencies)
+/// is only normalized when a real change triggers a write.
+#[test]
+fn noop_save_does_not_rewrite_the_file() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("package.json");
+    let original = "{\n  \"name\": \"foo\",\n  \"dependencies\": {\n    \"zebra\": \"1.0.0\",\n    \"aardvark\": \"2.0.0\"\n  }\n}";
+    std::fs::write(&path, original).unwrap();
+
+    let mut manifest = PackageManifest::from_path(path.clone()).unwrap();
+    manifest.save().unwrap();
+    assert_eq!(read_to_string(&path).unwrap(), original);
+
+    // Re-adding an already-declared dependency at its existing version is
+    // also a no-op.
+    manifest.add_dependency("zebra", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+    assert_eq!(read_to_string(&path).unwrap(), original);
 }

--- a/pnpm/crates/package-manifest/src/tests.rs
+++ b/pnpm/crates/package-manifest/src/tests.rs
@@ -903,6 +903,24 @@ fn save_preserves_the_source_indentation() {
     );
 }
 
+/// The preserved indentation unit is capped at 10 characters on write,
+/// like `JSON.stringify`'s `space` argument.
+#[test]
+fn save_caps_the_indentation_unit_at_ten_characters() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("package.json");
+    let twelve_spaces = " ".repeat(12);
+    std::fs::write(&path, format!("{{\n{twelve_spaces}\"name\": \"foo\"\n}}\n")).unwrap();
+    let mut manifest = PackageManifest::from_path(path.clone()).unwrap();
+    manifest.add_dependency("fastify", "1.0.0", DependencyGroup::Prod).unwrap();
+    manifest.save().unwrap();
+
+    let saved = read_to_string(&path).unwrap();
+    eprintln!("SAVED:\n{saved}");
+    assert!(saved.contains(&format!("\n{}\"name\"", " ".repeat(10))));
+    assert!(!saved.contains(&format!("\n{twelve_spaces}\"name\"")));
+}
+
 /// A write sorts each dependency field by name and drops a dependency
 /// field that ended up empty, like pnpm's on-write manifest normalization.
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

The daily update-lockfile PR (related to pnpm/pnpm#12802) regressed after the workflow switched to the Rust pnpm: `pnpm runtime set node 26` wrote `devEngines.runtime.version: "26"` instead of the resolved `26.5.0`, and package.json lost its trailing newline. Both were pacquet-only divergences from the TypeScript CLI's manifest-write behavior.

This PR closes them, plus the remaining manifest-formatting parity gaps:

- **Pin the saved `node@runtime:` specifier to the picked version.** The TypeScript CLI rewrites the manifest after resolution with the node resolver's normalized specifier; pacquet decides the saved specifier before the install, so that normalization never ran and the requested range was written verbatim. The node resolver now exposes `resolve_save_specifier` (the shared parse/mirror/pick-version path, without the platform asset fetch), and `Add::run` calls it for explicit `node@runtime:` requests. A `^`/`~` operator on the previous specifier (or the request) is preserved, exactly like the resolver's `normalized_bare_specifier`.  Deno and bun are unchanged: both stacks save the requested spec for them.
- **Preserve package.json formatting on save.** `PackageManifest` now records the source file's final-newline state and indentation unit at read and reuses both on save (a single-line document round-trips back to compact form); new manifests get two-space indentation and a final newline. The indentation unit is capped at 10 characters on write — the same cap `JSON.stringify` applies to its `space` argument, which the TypeScript writer serializes through — so a pathologically indented source file can't amplify the output.
- **Normalize dependency fields on write**, ported from the TypeScript project-manifest writer: entries are sorted by name and a field with no entries is dropped, so a reification-only `"devDependencies": {}` never lands on disk.
- **Skip no-op saves.** The parsed on-disk value is kept as a baseline; a save whose folded, normalized value matches it doesn't touch the file, so a no-op `pnpm add` no longer churns formatting or mtime. This turns `PackageManifest::save` into a `&mut self` method. A freshly scaffolded manifest reads its baseline back from the file it just wrote, so scaffolds and pre-existing manifests share one code path.

Verified end to end with the built binary: `runtime set node 26` on a tab-indented project writes `"version": "26.5.0"` keeping tabs and the final newline, leaves no empty `devDependencies`, and a second run leaves the file untouched.

## Squash Commit Body

```text
The update-lockfile workflow runs `pnpm runtime set node 26` and expects
the exact resolved version in devEngines.runtime.version. The TypeScript
CLI rewrites the manifest after resolution with the node resolver's
normalized specifier; pacquet decides the saved specifier before the
install runs, so the requested range was written verbatim ("26" instead
of "26.5.0") even though the lockfile resolved 26.5.0 correctly.

Expose the normalization as NodeResolver::resolve_save_specifier — the
shared parse/mirror/pick-version path without the platform asset fetch —
and call it from Add::run for explicit node@runtime: requests, mirroring
how registry specs are already pinned up front. Deno and bun stay on the
verbatim save path; both stacks normalize those to the requested spec.

Also close the remaining manifest-write parity gaps with the TypeScript
project-manifest reader/writer, which surfaced in the same automated PR:

- Preserve the source file's final-newline state and indentation unit
  across the read/save round-trip; a single-line document round-trips
  back to its compact form, and new manifests get two-space indentation
  plus a final newline. The indentation unit is capped at 10 characters
  on write, the cap JSON.stringify applies to its space argument, which
  the TypeScript writer serializes through.
- Normalize dependency fields on write: sort entries by name and drop a
  field that holds no entries, so a reification-only devDependencies: {}
  never lands on disk.
- Skip the write entirely when the file already encodes the same
  manifest, so a no-op save never churns formatting or mtime. This turns
  PackageManifest::save into a &mut self method (it tracks the on-disk
  baseline). A freshly scaffolded manifest reads its baseline back from
  the file it just wrote, so scaffolds and pre-existing manifests share
  one serialization path.

Related to pnpm/pnpm#12802.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (The
  TypeScript CLI already behaves this way; this PR brings the Rust port to
  parity, so no TypeScript changes are needed.)
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing Node.js via `node@runtime:<version>` specifications.
  * Runtime selectors are resolved and pinned to the exact available Node.js version, ensuring consistent `package.json` updates.
  * Added clear failures when the requested runtime version (or range) can’t be satisfied.

* **Bug Fixes**
  * Package manifest saves now preserve existing indentation and final-newline style, keep compact formatting where applicable, and omit empty dependency sections.
  * Prevents unnecessary rewrites by skipping saves when the resulting manifest would be unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->