### PR TITLE
fix: restore cached build artifacts with separate workspace lockfiles

### DIFF
--- a/.changeset/fix-separate-lockfile-side-effects.md
+++ b/.changeset/fix-separate-lockfile-side-effects.md
@@ -1,4 +1,5 @@
 ---
+"@pnpm/deps.graph-hasher": patch
 "@pnpm/installing.commands": patch
 "@pnpm/installing.deps-installer": patch
 "@pnpm/installing.deps-restorer": patch

--- a/.changeset/fix-separate-lockfile-side-effects.md
+++ b/.changeset/fix-separate-lockfile-side-effects.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.commands": patch
+"@pnpm/installing.deps-installer": patch
+"@pnpm/installing.deps-restorer": patch
+"pnpm": patch
+---
+
+Restore cached build artifacts when reinstalling a workspace that uses separate lockfiles [#12942](https://github.com/pnpm/pnpm/issues/12942).

--- a/pnpm11/deps/graph-hasher/src/index.ts
+++ b/pnpm11/deps/graph-hasher/src/index.ts
@@ -124,6 +124,24 @@ export function calcDepState<T extends string> (
   return result
 }
 
+/**
+ * Decide whether a package's side-effects-cache key must include the
+ * dependency-graph hash, i.e. whether the package is (or will be) built.
+ *
+ * `deferDependencyBuilds` covers separate-lockfile installs, where each
+ * project install passes `ignoreScripts: true` because the actual build
+ * happens in a later workspace-wide rebuild pass. Those packages are still
+ * built, so their cache key must match the hashed key the rebuild writes —
+ * unlike an explicit `--ignore-scripts` run, where nothing is ever built.
+ */
+export function shouldIncludeDepGraphHash (opts: {
+  ignoreScripts: boolean
+  deferDependencyBuilds: boolean
+  requiresBuild: boolean
+}): boolean {
+  return (!opts.ignoreScripts || opts.deferDependencyBuilds) && opts.requiresBuild
+}
+
 function calcDepGraphHash<T extends string> (
   depsGraph: DepsGraph<T>,
   cache: DepsStateCache,

--- a/pnpm11/installing/commands/src/recursive.ts
+++ b/pnpm11/installing/commands/src/recursive.ts
@@ -465,6 +465,7 @@ export async function recursive (
             bin: path.join(rootDir, 'node_modules', '.bin'),
             dir: rootDir,
             hooks,
+            deferDependencyBuilds: !opts.lockfileOnly && !opts.ignoreScripts,
             ignoreScripts: true,
             pinnedVersion: getPinnedVersion({
               saveExact: typeof localConfig.saveExact === 'boolean' ? localConfig.saveExact : opts.saveExact,

--- a/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -118,6 +118,8 @@ export interface StrictInstallOptions {
   includeDirect: IncludedDependencies
   ignoreCurrentSpecifiers: boolean
   ignoreScripts: boolean
+  /** Dependency builds are postponed until the workspace-wide rebuild pass. */
+  deferDependencyBuilds: boolean
   childConcurrency: number
   userAgent: string
   unsafePerm: boolean
@@ -314,6 +316,7 @@ const defaults = (opts: InstallOptions): StrictInstallOptions => {
     hooks: {},
     ignoreCurrentSpecifiers: false,
     ignoreScripts: false,
+    deferDependencyBuilds: false,
     include: {
       dependencies: true,
       devDependencies: true,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1723,6 +1723,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         dedupeDirectDeps: opts.dedupeDirectDeps,
         dependenciesByProjectId,
         depsStateCache,
+        deferDependencyBuilds: opts.deferDependencyBuilds,
         disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
         enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
         extraNodePaths: ctx.extraNodePaths,

--- a/pnpm11/installing/deps-installer/src/install/link.ts
+++ b/pnpm11/installing/deps-installer/src/install/link.ts
@@ -49,6 +49,7 @@ export interface LinkPackagesOptions {
   currentLockfile: LockfileObject
   dedupeDirectDeps: boolean
   dependenciesByProjectId: Record<string, Map<string, DepPath>>
+  deferDependencyBuilds: boolean
   disableRelinkLocalDirDeps?: boolean
   force: boolean
   depsStateCache: DepsStateCache
@@ -157,6 +158,7 @@ export async function linkPackages (projects: ImporterToUpdate[], depGraph: Depe
     depGraph,
     {
       allowBuild: opts.allowBuild,
+      deferDependencyBuilds: opts.deferDependencyBuilds,
       disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
       enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
       force: opts.force,
@@ -329,6 +331,7 @@ function resolvePath (where: string, spec: string): string {
 
 interface LinkNewPackagesOptions {
   allowBuild?: AllowBuild
+  deferDependencyBuilds: boolean
   depsStateCache: DepsStateCache
   disableRelinkLocalDirDeps?: boolean
   enableGlobalVirtualStore: boolean
@@ -448,6 +451,7 @@ async function linkNewPackages (
       allowBuild: opts.allowBuild,
       depGraph,
       depsStateCache: opts.depsStateCache,
+      deferDependencyBuilds: opts.deferDependencyBuilds,
       disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
       enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
       force: opts.force,
@@ -505,6 +509,7 @@ async function linkAllPkgs (
     allowBuild?: AllowBuild
     depGraph: DependenciesGraph
     depsStateCache: DepsStateCache
+    deferDependencyBuilds: boolean
     disableRelinkLocalDirDeps?: boolean
     enableGlobalVirtualStore: boolean
     force: boolean
@@ -528,7 +533,7 @@ async function linkAllPkgs (
       if (opts.sideEffectsCacheRead && files.sideEffectsMaps && !isEmpty(files.sideEffectsMaps)) {
         if (opts.allowBuild?.(depNode.depPath) === true) {
           sideEffectsCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.depPath, {
-            includeDepGraphHash: !opts.ignoreScripts && depNode.requiresBuild, // true when is built
+            includeDepGraphHash: (!opts.ignoreScripts || opts.deferDependencyBuilds) && depNode.requiresBuild,
             patchFileHash: depNode.patch?.hash,
             supportedArchitectures: opts.supportedArchitectures,
             nodeVersion,

--- a/pnpm11/installing/deps-installer/src/install/link.ts
+++ b/pnpm11/installing/deps-installer/src/install/link.ts
@@ -6,7 +6,7 @@ import {
   stageLogger,
   statsLogger,
 } from '@pnpm/core-loggers'
-import { calcDepState, type DepsStateCache, findRuntimeNodeVersion } from '@pnpm/deps.graph-hasher'
+import { calcDepState, type DepsStateCache, findRuntimeNodeVersion, shouldIncludeDepGraphHash } from '@pnpm/deps.graph-hasher'
 import { readModulesDir } from '@pnpm/fs.read-modules-dir'
 import { symlinkDependency } from '@pnpm/fs.symlink-dependency'
 import {
@@ -533,7 +533,11 @@ async function linkAllPkgs (
       if (opts.sideEffectsCacheRead && files.sideEffectsMaps && !isEmpty(files.sideEffectsMaps)) {
         if (opts.allowBuild?.(depNode.depPath) === true) {
           sideEffectsCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.depPath, {
-            includeDepGraphHash: (!opts.ignoreScripts || opts.deferDependencyBuilds) && depNode.requiresBuild,
+            includeDepGraphHash: shouldIncludeDepGraphHash({
+              ignoreScripts: opts.ignoreScripts,
+              deferDependencyBuilds: opts.deferDependencyBuilds,
+              requiresBuild: depNode.requiresBuild,
+            }),
             patchFileHash: depNode.patch?.hash,
             supportedArchitectures: opts.supportedArchitectures,
             nodeVersion,

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -127,6 +127,7 @@ export interface HeadlessOptions {
   hoistingLimits?: HoistingLimits
   externalDependencies?: Set<string>
   ignoreScripts: boolean
+  deferDependencyBuilds?: boolean
   ignorePackageManifest?: boolean
   /**
    * When true, skip fetching local dependencies (file: protocol pointing to directories).
@@ -423,6 +424,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
     if (!skipPostImportLinking) {
       await linkHoistedModules(opts.storeController, graph, prevGraph, hierarchy, {
         allowBuild,
+        deferDependencyBuilds: opts.deferDependencyBuilds === true,
         depsStateCache,
         disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
         force: opts.force,
@@ -460,6 +462,7 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
           }),
         linkAllPkgs(opts.storeController, depNodes, {
           allowBuild,
+          deferDependencyBuilds: opts.deferDependencyBuilds === true,
           force: opts.force,
           disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
           depGraph: graph,
@@ -954,6 +957,7 @@ async function linkAllPkgs (
     allowBuild?: AllowBuild
     depGraph: DependenciesGraph
     depsStateCache: DepsStateCache
+    deferDependencyBuilds: boolean
     disableRelinkLocalDirDeps?: boolean
     enableGlobalVirtualStore?: boolean
     force: boolean
@@ -996,7 +1000,7 @@ async function linkAllPkgs (
       if (opts.sideEffectsCacheRead && filesResponse.sideEffectsMaps && !isEmpty(filesResponse.sideEffectsMaps)) {
         if (opts.allowBuild?.(depNode.depPath) === true) {
           sideEffectsCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.dir, {
-            includeDepGraphHash: !opts.ignoreScripts && depNode.requiresBuild, // true when is built
+            includeDepGraphHash: (!opts.ignoreScripts || opts.deferDependencyBuilds) && depNode.requiresBuild,
             patchFileHash: depNode.patch?.hash,
             supportedArchitectures: opts.supportedArchitectures,
             nodeVersion,

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -22,7 +22,7 @@ import {
   lockfileToDepGraph,
   type LockfileToDepGraphOptions,
 } from '@pnpm/deps.graph-builder'
-import { calcDepState, type DepsStateCache, findRuntimeNodeVersion } from '@pnpm/deps.graph-hasher'
+import { calcDepState, type DepsStateCache, findRuntimeNodeVersion, shouldIncludeDepGraphHash } from '@pnpm/deps.graph-hasher'
 import * as dp from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
 import {
@@ -1000,7 +1000,11 @@ async function linkAllPkgs (
       if (opts.sideEffectsCacheRead && filesResponse.sideEffectsMaps && !isEmpty(filesResponse.sideEffectsMaps)) {
         if (opts.allowBuild?.(depNode.depPath) === true) {
           sideEffectsCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.dir, {
-            includeDepGraphHash: (!opts.ignoreScripts || opts.deferDependencyBuilds) && depNode.requiresBuild,
+            includeDepGraphHash: shouldIncludeDepGraphHash({
+              ignoreScripts: opts.ignoreScripts,
+              deferDependencyBuilds: opts.deferDependencyBuilds,
+              requiresBuild: depNode.requiresBuild,
+            }),
             patchFileHash: depNode.patch?.hash,
             supportedArchitectures: opts.supportedArchitectures,
             nodeVersion,

--- a/pnpm11/installing/deps-restorer/src/linkHoistedModules.ts
+++ b/pnpm11/installing/deps-restorer/src/linkHoistedModules.ts
@@ -10,7 +10,7 @@ import type {
   DependenciesGraph,
   DepHierarchy,
 } from '@pnpm/deps.graph-builder'
-import { calcDepState, type DepsStateCache, findRuntimeNodeVersion } from '@pnpm/deps.graph-hasher'
+import { calcDepState, type DepsStateCache, findRuntimeNodeVersion, shouldIncludeDepGraphHash } from '@pnpm/deps.graph-hasher'
 import { logger } from '@pnpm/logger'
 import type {
   PackageFilesResponse,
@@ -139,7 +139,11 @@ async function linkAllPkgsInOrder (
         if (opts.sideEffectsCacheRead && filesResponse.sideEffectsMaps && !isEmpty(filesResponse.sideEffectsMaps)) {
           if (opts.allowBuild?.(depNode.depPath) === true) {
             sideEffectsCacheKey = calcDepState(graph, opts.depsStateCache, dir, {
-              includeDepGraphHash: (!opts.ignoreScripts || opts.deferDependencyBuilds) && depNode.requiresBuild,
+              includeDepGraphHash: shouldIncludeDepGraphHash({
+                ignoreScripts: opts.ignoreScripts,
+                deferDependencyBuilds: opts.deferDependencyBuilds,
+                requiresBuild: depNode.requiresBuild,
+              }),
               patchFileHash: depNode.patch?.hash,
               supportedArchitectures: opts.supportedArchitectures,
               nodeVersion: opts.nodeVersion,

--- a/pnpm11/installing/deps-restorer/src/linkHoistedModules.ts
+++ b/pnpm11/installing/deps-restorer/src/linkHoistedModules.ts
@@ -30,6 +30,7 @@ export async function linkHoistedModules (
   hierarchy: DepHierarchy,
   opts: {
     allowBuild?: AllowBuild
+    deferDependencyBuilds: boolean
     depsStateCache: DepsStateCache
     disableRelinkLocalDirDeps?: boolean
     force: boolean
@@ -101,6 +102,7 @@ async function linkAllPkgsInOrder (
   parentDir: string,
   opts: {
     allowBuild?: AllowBuild
+    deferDependencyBuilds: boolean
     depsStateCache: DepsStateCache
     disableRelinkLocalDirDeps?: boolean
     force: boolean
@@ -137,7 +139,7 @@ async function linkAllPkgsInOrder (
         if (opts.sideEffectsCacheRead && filesResponse.sideEffectsMaps && !isEmpty(filesResponse.sideEffectsMaps)) {
           if (opts.allowBuild?.(depNode.depPath) === true) {
             sideEffectsCacheKey = calcDepState(graph, opts.depsStateCache, dir, {
-              includeDepGraphHash: !opts.ignoreScripts && depNode.requiresBuild, // true when is built
+              includeDepGraphHash: (!opts.ignoreScripts || opts.deferDependencyBuilds) && depNode.requiresBuild,
               patchFileHash: depNode.patch?.hash,
               supportedArchitectures: opts.supportedArchitectures,
               nodeVersion: opts.nodeVersion,

--- a/pnpm11/pnpm/test/monorepo/index.ts
+++ b/pnpm11/pnpm/test/monorepo/index.ts
@@ -1354,6 +1354,12 @@ test('built dependencies are restored from a populated store when the workspace 
   await execPnpm(['install', '--frozen-lockfile'])
 
   expect(fs.existsSync(buildArtifact)).toBe(true)
+
+  rimrafSync('node_modules')
+  rimrafSync('project-1/node_modules')
+  await execPnpm(['install', '--ignore-scripts', '--frozen-lockfile'])
+
+  expect(fs.existsSync(buildArtifact)).toBe(false)
 })
 
 test("linking the package's bin to another workspace package in a monorepo", async () => {

--- a/pnpm11/pnpm/test/monorepo/index.ts
+++ b/pnpm11/pnpm/test/monorepo/index.ts
@@ -1314,6 +1314,48 @@ test('dependencies of workspace projects are built during headless installation'
   }
 })
 
+test('built dependencies are restored from a populated store when the workspace has separate lockfiles', async () => {
+  preparePackages([
+    {
+      location: '.',
+      package: {},
+    },
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      dependencies: {
+        '@pnpm.e2e/pre-and-postinstall-scripts-example': '1.0.0',
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['**', '!store/**'],
+    sharedWorkspaceLockfile: false,
+    allowBuilds: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example': true,
+    },
+    packageExtensions: {
+      '@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0': {
+        dependencies: {
+          'is-positive': '1.0.0',
+        },
+      },
+    },
+  })
+
+  const buildArtifact = 'project-1/node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js'
+
+  await execPnpm(['install'])
+  expect(fs.existsSync(buildArtifact)).toBe(true)
+
+  rimrafSync('node_modules')
+  rimrafSync('project-1/node_modules')
+  await execPnpm(['install', '--frozen-lockfile'])
+
+  expect(fs.existsSync(buildArtifact)).toBe(true)
+})
+
 test("linking the package's bin to another workspace package in a monorepo", async () => {
   const projects = preparePackages([
     {


### PR DESCRIPTION
## Summary

- preserve dependency-graph side-effects cache keys while workspace builds are deferred
- restore cached build artifacts on fresh installs with `sharedWorkspaceLockfile: false`
- keep explicit `--ignore-scripts` behavior unchanged

## Why

Separate-lockfile installs defer dependency scripts during each project install. The importer therefore calculated an unhashed cache key, while the later rebuild found the hashed cache entry and skipped rebuilding. The package was left without its generated artifacts.

Pacquet uses a different build path: it does not defer workspace scripts through `ignore_scripts`, and its side-effects cache key includes the dependency graph whenever scripts run. A recursive pacquet cold/warm/`--ignore-scripts` smoke passes, so no Rust source change is needed.

Closes #12942.

## Validation

- repository pre-push checks - TypeScript typecheck, bundle, lint, spellcheck, and metadata validation passed
- TypeScript populated-store CLI smoke - cold and warm artifacts present; `--ignore-scripts` left the artifact absent
- pacquet recursive populated-store CLI smoke - cold and warm artifacts present; `--ignore-scripts` left the artifact absent
- `git diff --check` - passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reinstalls in workspaces that use separate lockfiles so cached build artifacts are restored correctly.
  * Refined dependency build scheduling and side-effects cache behavior to correctly handle deferred builds and scenarios where install scripts are ignored.
* **Tests**
  * Added an integration test covering separate-lockfile monorepos, confirming artifacts persist across `--frozen-lockfile` reinstalls and are removed when reinstalling with scripts ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->