### PR TITLE
fix: `pnpm publish --otp` and `pnpm publish --batch --otp` to send the configured OTP to the registry

### DIFF
--- a/.changeset/preserve-publish-otp.md
+++ b/.changeset/preserve-publish-otp.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm publish --otp` and `pnpm publish --batch --otp` to send the configured OTP to the registry.

--- a/pnpm/crates/publish/src/publish_packed_pkg/tests.rs
+++ b/pnpm/crates/publish/src/publish_packed_pkg/tests.rs
@@ -333,6 +333,43 @@ async fn publish_with_otp_handling_returns_the_response_when_no_otp_is_required(
     mock.assert_async().await;
 }
 
+/// A statically configured OTP (`pnpm publish --otp`) must ride the first PUT,
+/// not just a post-challenge retry. `publish_with_otp_handling` invokes its
+/// operation with no challenge OTP first, so the configured one has to fall
+/// through; regressing that would make `--otp` a no-op until the registry
+/// challenges. The single `expect(1)` mock matches `npm-otp` on the first
+/// request and returns 200, so a dropped OTP or an extra challenge round-trip
+/// fails the assertion.
+#[tokio::test]
+async fn publish_with_otp_handling_sends_a_configured_otp_on_the_first_attempt() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("PUT", "/pkg")
+        .match_header("npm-otp", "123456")
+        .with_status(200)
+        .with_body("")
+        .expect(1)
+        .create_async()
+        .await;
+    let client = ThrottledClient::default();
+    let url = format!("{}/pkg", server.url());
+
+    let response = publish_with_otp_handling::<WebAuthHost, SilentReporter>(
+        &client,
+        &url,
+        None,
+        "publish",
+        body(),
+        Some("123456"),
+        false,
+        unused_fetch_options(),
+    )
+    .await
+    .expect("the publish succeeds with the configured OTP");
+    assert!(response.ok);
+    mock.assert_async().await;
+}
+
 /// The classic OTP flow, driven end-to-end through the publish HTTP layer:
 /// prompt for an OTP on the challenge and retry. The first PUT
 /// (no `npm-otp`) gets a 401 OTP challenge, the fake host prompts and returns

--- a/pnpm11/releasing/commands/src/publish/batchPublish.ts
+++ b/pnpm11/releasing/commands/src/publish/batchPublish.ts
@@ -162,7 +162,7 @@ async function multiPublishToRegistry (registry: string, group: PackedPkg[], opt
       operation: async (otp) => npmFetch(BATCH_PUBLISH_ENDPOINT, {
         ...publishOptions,
         access: publishOptions.access ?? undefined,
-        otp,
+        otp: otp ?? publishOptions.otp,
         method: 'PUT',
         body,
         ignoreBody: true,

--- a/pnpm11/releasing/commands/src/publish/otp.ts
+++ b/pnpm11/releasing/commands/src/publish/otp.ts
@@ -73,10 +73,10 @@ export async function publishWithOtpHandling ({
   return withOtpHandling({
     context,
     fetchOptions,
-    // When otp is undefined (first attempt), { ...publishOptions, otp } adds
+    // When otp is undefined (it can be on first attempt), { ...publishOptions, otp } adds
     // otp: undefined to the options. This is safe because libnpmpublish treats
     // undefined the same as absent (unlike HTTP headers, where undefined gets
     // coerced to the string "undefined").
-    operation: otp => publish(manifest, tarballData, { ...publishOptions, otp }),
+    operation: otp => publish(manifest, tarballData, { ...publishOptions, otp: otp ?? publishOptions.otp }),
   })
 }

--- a/pnpm11/releasing/commands/src/publish/otp.ts
+++ b/pnpm11/releasing/commands/src/publish/otp.ts
@@ -73,10 +73,13 @@ export async function publishWithOtpHandling ({
   return withOtpHandling({
     context,
     fetchOptions,
-    // When otp is undefined (it can be on first attempt), { ...publishOptions, otp } adds
-    // otp: undefined to the options. This is safe because libnpmpublish treats
-    // undefined the same as absent (unlike HTTP headers, where undefined gets
-    // coerced to the string "undefined").
+    // withOtpHandling first calls this with no otp, then retries with the otp
+    // it obtained from an OTP challenge. On the first attempt we fall back to
+    // the configured --otp (publishOptions.otp) so it is actually sent; a retry
+    // otp takes precedence over it. When both are undefined, passing
+    // otp: undefined is safe because libnpmpublish treats undefined the same as
+    // absent (unlike HTTP headers, where undefined gets coerced to the string
+    // "undefined").
     operation: otp => publish(manifest, tarballData, { ...publishOptions, otp: otp ?? publishOptions.otp }),
   })
 }

--- a/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
+++ b/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
@@ -13,6 +13,7 @@ import { checkPkgExists, DEFAULT_OPTS } from './utils/index.js'
 interface ReceivedRequest {
   method: string
   url: string
+  headers: http.IncomingHttpHeaders
   body: unknown
 }
 
@@ -41,6 +42,7 @@ async function createRegistryStub (): Promise<RegistryStub> {
       received.push({
         method: req.method!,
         url: req.url!,
+        headers: req.headers,
         body: rawBody.length > 0 ? JSON.parse(rawBody.toString()) : undefined,
       })
       if (req.method === 'PUT' && req.url === '/-/pnpm/v1/publish') {
@@ -148,6 +150,25 @@ test('batch publish sends all packages in a single batch publish request', async
   expect(dist.integrity).toBe(`sha512-${createHash('sha512').update(tarballData).digest('base64')}`)
   expect(dist.shasum).toBe(createHash('sha1').update(tarballData).digest('hex'))
   expect(dist.tarball).toBe(`${registry.url}@pnpmtest/batch-pkg-1/-/@pnpmtest/batch-pkg-1-1.0.0.tgz`)
+})
+
+test('batch publish sends configured OTP on the first publish request', async () => {
+  preparePackages([
+    {
+      name: 'batch-otp',
+      version: '1.0.0',
+    },
+  ])
+
+  await publish.handler({
+    ...batchPublishOpts(),
+    ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+    otp: '123456',
+  }, [])
+
+  const publishRequests = registry.received.filter(({ url }) => url === '/-/pnpm/v1/publish')
+  expect(publishRequests).toHaveLength(1)
+  expect(publishRequests[0].headers['npm-otp']).toBe('123456')
 })
 
 test('batch publish with --dry-run sends no request but reports the packages', async () => {

--- a/pnpm11/releasing/commands/test/publish/otp.test.ts
+++ b/pnpm11/releasing/commands/test/publish/otp.test.ts
@@ -61,6 +61,26 @@ describe('publishWithOtpHandling', () => {
     expect(result).toBe(response)
   })
 
+  it('preserves OTP from publish options on the first publish attempt', async () => {
+    let callCount = 0
+    const context = createMockContext({
+      publish: async (_m, _t, opts) => {
+        callCount++
+        expect(opts.otp).toBe('123456')
+        return createOkResponse()
+      },
+    })
+    const result = await publishWithOtpHandling({
+      context,
+      manifest,
+      publishOptions: { otp: '123456' } as typeof publishOptions,
+      tarballData,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(callCount).toBe(1)
+  })
+
   it('throws non-OTP errors as-is', async () => {
     const error = new Error('network error')
     const context = createMockContext({


### PR DESCRIPTION
## Summary

I found this when testing if Changesets correctly handle pnpm 11.

## Squash Commit Body

```text
Fixed `pnpm publish --otp` and `pnpm publish --batch --otp` to send the configured OTP to the registry. It was accidentally overridden by the `undefined` coming from the first `operation` call in `withOtpHandling`
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786485653&installation_id=145934176&pr_number=12957&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12957&signature=402b261ac398730d1c6e21aee5c79f36ac33df58ddc59c9c0e7af7c286b5b094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm publish --otp` and `pnpm publish --batch --otp` to send the configured OTP on the first registry request.
  * Ensured OTP handling no longer passes `otp: undefined` during initial attempts when an OTP is already available.
* **Tests**
  * Added coverage to verify the `npm-otp` header is correctly included for batch publishing and that OTP is forwarded unchanged for OTP handling.
* **Release**
  * Included patch releases for the publishing commands and pnpm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->