### PR TITLE
feat(release): give pnpr its own tag namespace for independent releases

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -170,7 +170,7 @@ jobs:
             --title "chore(release): ${VERSION}" \
             --body "Automated release PR created by the create-release-pr workflow.
 
-        Releasing \`${TARGET}\`: ${VERSION}. Merging this PR consumes the pending changesets and records them in the committed \`.changeset/ledger.yaml\`. After merging, push the version tag of a released product to run the release workflow." \
+        Releasing \`${TARGET}\`: ${VERSION}. Merging this PR consumes the pending changesets and records them in the committed \`.changeset/ledger.yaml\`. After merging, push the version tag of a released product to run the release workflow: \`v<version>\` for the pnpm CLI (TypeScript or Rust), \`pnpr-v<version>\` for pnpr." \
             --base "$TARGET" \
             --head "$BRANCH"
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,20 @@ name: Release
 # `plan` job, which asks the npm registry which committed versions are not
 # published yet, and only those products' jobs run. Tagging e.g. a v12
 # prerelease therefore skips the TypeScript jobs whose version is already on
-# npm, and vice versa.
+# npm, and vice versa. pnpm releases on `v<version>` tags; pnpr, a separate
+# product on its own 0.x line, on `pnpr-v<version>` tags — but since the tag is
+# only a trigger, the `plan` job still decides what actually publishes.
 on:
   push:
     tags:
+      # pnpm (the TypeScript and Rust CLIs) releases on `v<version>` tags; pnpr,
+      # a separate product on its own 0.x line, releases on `pnpr-v<version>`
+      # tags so it doesn't share pnpm's version-tag namespace. The tag is only a
+      # trigger — the `plan` job decides which products actually publish from
+      # their committed versions, so either pattern can drive any product's
+      # release; the convention keeps the tag readable.
       - "v*.*.*"
+      - "pnpr-v*"
   # Manual trigger for rerunning a tag release. Dispatching this workflow from a
   # branch fails before publishing because release artifacts are only built on
   # version tags.
@@ -26,8 +35,9 @@ jobs:
         run: |
           case "${GITHUB_REF}" in
             refs/tags/v*.*.*) ;;
+            refs/tags/pnpr-v*) ;;
             *)
-              echo "::error::The release workflow must run from a version tag like v11.9.0. Current ref: ${GITHUB_REF}"
+              echo "::error::The release workflow must run from a version tag (v<version> for pnpm, pnpr-v<version> for pnpr). Current ref: ${GITHUB_REF}"
               exit 1
               ;;
           esac
@@ -193,11 +203,16 @@ jobs:
       - name: Release
         # `gh release create` could replace this, but the release pipeline is
         # sensitive and softprops/action-gh-release is widely battle-tested.
+        # Pin the release to the committed TypeScript version rather than the
+        # triggering tag: a pnpr-v<version> trigger (or a Rust-only tag) must
+        # not retag this release.
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
           draft: true
           files: dist/*
           body_path: RELEASE.md
+          tag_name: v${{ needs.plan.outputs.ts_version }}
+          target_commitish: ${{ github.sha }}
 
   build-rust:
     needs: plan
@@ -571,6 +586,8 @@ jobs:
     permissions:
       # Required for npm trusted publishing and provenance attestations via OIDC.
       id-token: write
+      # Required for softprops/action-gh-release to create the GitHub release.
+      contents: write
     needs:
       - plan
       - build-pnpr
@@ -620,6 +637,24 @@ jobs:
           for package in pnpr/npm/pnpr-* pnpr/npm/pnpr; do
             pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
           done
+
+      - name: Release
+        # pnpr releases in its own `pnpr-v<version>` tag namespace, separate from
+        # pnpm's `v<version>` tags. Draft so a maintainer publishes it
+        # deliberately; `make_latest: false` keeps a pnpr prerelease off the
+        # repository's "Latest" badge (which tracks the stable pnpm CLI).
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
+        with:
+          draft: true
+          prerelease: ${{ contains(needs.plan.outputs.pnpr_version, '-') }}
+          make_latest: false
+          tag_name: pnpr-v${{ needs.plan.outputs.pnpr_version }}
+          target_commitish: ${{ github.sha }}
+          name: pnpr ${{ needs.plan.outputs.pnpr_version }}
+          files: |
+            *.zip
+            *.tar.gz
+            *.sha256
 
   docker-pnpr:
     name: Publish the pnpr Docker image


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Follow-up to pnpm/pnpm#12949. Lets pnpr be released independently on its own tag namespace.

After the unified release flow landed, the workflow triggered only on `v<version>` tags — pnpm's version-tag namespace — so a pnpr-only release would have to push a `v0.x` tag that reads like a pnpm 0.x release. Worse, the TypeScript CLI's GitHub release used the **triggering tag** directly (no explicit `tag_name`), so that stray `v0.x` tag would have become the TypeScript release's tag if the TS version happened to be unpublished.

This PR:

1. **Triggers `release.yml` on `pnpr-v<version>` tags** in addition to `v*.*.*`, and accepts both in `validate-release-ref`. pnpm (the TypeScript and Rust CLIs) keeps `v<version>`; pnpr, a separate product on its own 0.x line, gets `pnpr-v<version>`.
2. **Pins the TypeScript release to its committed version** with an explicit `tag_name: v${{ needs.plan.outputs.ts_version }}` (and `target_commitish: ${{ github.sha }}`), matching what the Rust release job already does — so no job depends on the raw trigger tag.
3. **`publish-pnpr` now creates its own draft GitHub release** at `pnpr-v<version>` (with the platform archives), for parity with the pnpm and Rust CLI releases. It's `draft` + `make_latest: false` so a pnpr prerelease never steals the repo's "Latest" badge from the stable pnpm CLI.

The tag stays purely a **trigger** — the `plan` job still decides which products actually publish from their committed versions — so pushing `pnpr-v0.1.0-alpha.1` after a pnpr-only bump releases just pnpr (npm packages + Docker image), while the pnpm CLI tags stay on `v*`.

## Squash Commit Body

```text
The release workflow triggered only on `v<version>` tags — pnpm's
version-tag namespace — and the TypeScript CLI's GitHub release used the
triggering tag directly. pnpr is a separate product on its own 0.x line,
so it had no way to be released without pushing a `v0.x` tag into pnpm's
namespace, which would also have retagged the TypeScript release had it
been unpublished.

Trigger the workflow on `pnpr-v<version>` tags in addition to
`v<version>`, accept both in validate-release-ref, and pin the TypeScript
release to its committed version with an explicit tag_name so no job
depends on the raw trigger tag. publish-pnpr now creates its own draft
GitHub release at `pnpr-v<version>`. The tag stays only a trigger — the
plan job still decides what publishes from the committed versions — so
pushing `pnpr-v0.1.0-alpha.1` releases just pnpr.
```

## Checklist

- [x] Updated the documentation if needed (the workflow header comment and the release-PR body now document the `v<version>` / `pnpr-v<version>` tag convention).

<!-- No changeset: this changes only the GitHub Actions release workflow, not
any published package. No CLI code changed, so there is nothing to port between
the TypeScript and Rust stacks, and no tests to add. -->

---
Written by an agent (Claude Code, claude-opus-4-8[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786526231&installation_id=145934176&pr_number=12963&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12963&signature=1228e8819b2565208259956108d0053203e522c6c2efbdd4163b580312c25771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing pnpr releases from `pnpr-v<version>` tags.
  * pnpr releases now create GitHub release drafts with the published package artifacts attached.

* **Bug Fixes**
  * Prevented pnpr or Rust release triggers from incorrectly retagging TypeScript releases.
  * Updated release permissions and tag validation for reliable publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->