### PR TITLE
fix: keep bundled dependency fields out of the published pnpm manifest

### DIFF
--- a/.changeset/pacquet-before-packing-hook.md
+++ b/.changeset/pacquet-before-packing-hook.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm pack` and `pnpm publish` now apply the `beforePacking` pnpmfile hook to the manifest before a package is packed, matching the TypeScript CLI.

--- a/.changeset/pnpm-publish-strip-bundled-deps.md
+++ b/.changeset/pnpm-publish-strip-bundled-deps.md
@@ -2,4 +2,4 @@
 "pnpm": patch
 ---
 
-Fix the published `pnpm` package declaring `dependencies` and `devDependencies` that shouldn't be installed by consumers. Because the CLI bundles its runtime dependencies into `dist/node_modules`, the published manifest is now stripped of dependency fields during packing, so `npm install` of the tarball no longer tries to resolve internal-only packages such as `@pnpm/test-ipc-server`. Closes pnpm/pnpm#12955.
+The published `pnpm` package no longer declares `dependencies` or `devDependencies`. Because the CLI bundles its runtime dependencies into `dist/node_modules`, those fields are dropped when packing, so `npm install` of the tarball no longer tries to resolve internal-only packages such as `@pnpm/test-ipc-server`. Closes pnpm/pnpm#12955.

--- a/.changeset/pnpm-publish-strip-bundled-deps.md
+++ b/.changeset/pnpm-publish-strip-bundled-deps.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fix the published `pnpm` package declaring `dependencies` and `devDependencies` that shouldn't be installed by consumers. Because the CLI bundles its runtime dependencies into `dist/node_modules`, the published manifest is now stripped of dependency fields during packing, so `npm install` of the tarball no longer tries to resolve internal-only packages such as `@pnpm/test-ipc-server`. Closes pnpm/pnpm#12955.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4578,6 +4578,7 @@ dependencies = [
  "pacquet-executor",
  "pacquet-exportable-manifest",
  "pacquet-fs-packlist",
+ "pacquet-hooks",
  "pacquet-package-manifest",
  "pacquet-reporter",
  "pacquet-resolving-parse-wanted-dependency",
@@ -4586,6 +4587,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -315,7 +315,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Ping(args) => dispatch_query::ping(ctx, args),
         CliCommand::Search(args) => dispatch_query::search(ctx, args),
         CliCommand::Rebuild(args) => dispatch_install::rebuild(ctx, args),
-        CliCommand::Pack(args) => dispatch_query::pack(ctx, &args),
+        CliCommand::Pack(args) => dispatch_query::pack(ctx, args),
         CliCommand::Publish(args) => dispatch_query::publish(ctx, args),
         CliCommand::Stage(args) => dispatch_query::stage(ctx, args),
         CliCommand::Remove(args) => dispatch_install::remove(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -231,24 +231,26 @@ pub(super) fn ping<'a>(ctx: &RunCtx<'a>, args: PingArgs) -> miette::Result<Comma
 // `pack` prints the tarball summary (or JSON) its handler returns; the
 // reporter type only affects the lifecycle-script output, so it's threaded
 // into `run` and the result printed here, mirroring pnpm's `handler` → CLI
-// print split. The handler is synchronous, so this resolves to a ready future
-// once the output is printed.
-pub(super) fn pack<'a>(ctx: &RunCtx<'a>, args: &PackArgs) -> miette::Result<CommandFuture<'a>> {
-    let output = match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            args.run::<DefaultReporter>(ctx.dir, (ctx.config)()?, ctx.recursive)?
+// print split. `run` is async (it may invoke `beforePacking` pnpmfile
+// hooks), so the work is deferred into the returned future.
+pub(super) fn pack<'a>(ctx: &RunCtx<'a>, args: PackArgs) -> miette::Result<CommandFuture<'a>> {
+    let config = (ctx.config)()?;
+    let dir = ctx.dir;
+    let recursive = ctx.recursive;
+    let reporter = ctx.reporter;
+    Ok(Box::pin(async move {
+        let output = match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                args.run::<DefaultReporter>(dir, config, recursive).await?
+            }
+            ReporterType::Ndjson => args.run::<NdjsonReporter>(dir, config, recursive).await?,
+            ReporterType::Silent => args.run::<SilentReporter>(dir, config, recursive).await?,
+        };
+        if !output.is_empty() {
+            println!("{output}");
         }
-        ReporterType::Ndjson => {
-            args.run::<NdjsonReporter>(ctx.dir, (ctx.config)()?, ctx.recursive)?
-        }
-        ReporterType::Silent => {
-            args.run::<SilentReporter>(ctx.dir, (ctx.config)()?, ctx.recursive)?
-        }
-    };
-    if !output.is_empty() {
-        println!("{output}");
-    }
-    Ok(Box::pin(std::future::ready(Ok(()))))
+        Ok(())
+    }))
 }
 
 /// `publish` packs the project, runs its prepublish/publish lifecycle scripts,

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -90,14 +90,14 @@ pub struct PackArgs {
 impl PackArgs {
     /// Pack the project at `dir` (or the `--filter`-selected workspace
     /// projects when `recursive`), returning the text/JSON the CLI prints.
-    pub fn run<Reporter: self::Reporter>(
+    pub async fn run<Reporter: self::Reporter>(
         &self,
         dir: &Path,
         config: &Config,
         recursive: bool,
     ) -> miette::Result<String> {
         if recursive {
-            self.run_recursive::<Reporter>(dir, config)
+            self.run_recursive::<Reporter>(dir, config).await
         } else {
             let options = self.pack_options(
                 dir.to_path_buf(),
@@ -107,6 +107,7 @@ impl PackArgs {
                 self.pack_destination.clone(),
             );
             let result = api::<Reporter, Host>(&options)
+                .await
                 .map_err(miette::Report::new)
                 .wrap_err("pack the package")?;
             Ok(format_pack_output(&[to_pack_result_json(&result)], self.json, false))
@@ -115,7 +116,7 @@ impl PackArgs {
 
     /// Pack each `--filter`-selected workspace project that declares both
     /// a name and a version, in topological order.
-    fn run_recursive<Reporter: self::Reporter>(
+    async fn run_recursive<Reporter: self::Reporter>(
         &self,
         dir: &Path,
         config: &Config,
@@ -173,6 +174,7 @@ impl PackArgs {
                     pack_destination.clone(),
                 );
                 let result = api::<Reporter, Host>(&options)
+                    .await
                     .map_err(miette::Report::new)
                     .wrap_err_with(|| format!("pack {}", project.root_dir.display()))?;
                 packed.push(to_pack_result_json(&result));
@@ -211,6 +213,8 @@ impl PackArgs {
         out: Option<String>,
         pack_destination: Option<String>,
     ) -> PackOptions {
+        let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(&dir);
+        let pnpmfiles = crate::config_deps::resolve_pnpmfile_paths(config, pnpmfile_root);
         PackOptions {
             dir,
             catalogs,
@@ -227,6 +231,7 @@ impl PackArgs {
             dry_run: self.dry_run,
             out,
             pack_destination,
+            pnpmfiles,
         }
     }
 }

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -18,6 +18,7 @@ use miette::{Context, IntoDiagnostic};
 use pacquet_catalogs_config::get_catalogs_from_workspace_manifest;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_config::Config;
+use pacquet_hooks::PnpmfileHooks;
 use pacquet_pack::{
     Host, PackError, PackOptions, PackResultJson, api, format_pack_output, to_pack_result_json,
 };
@@ -26,6 +27,7 @@ use pacquet_workspace::read_workspace_manifest;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 /// The catalogs `catalog:` specifiers resolve against when packing a
@@ -99,12 +101,14 @@ impl PackArgs {
         if recursive {
             self.run_recursive::<Reporter>(dir, config).await
         } else {
+            let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(dir);
             let options = self.pack_options(
                 dir.to_path_buf(),
                 config,
                 pack_catalogs(config)?,
                 self.out.clone(),
                 self.pack_destination.clone(),
+                crate::config_deps::load_before_packing_hooks(config, pnpmfile_root),
             );
             let result = api::<Reporter, Host>(&options)
                 .await
@@ -149,6 +153,11 @@ impl PackArgs {
         // of each project's own root.
         let (out, pack_destination) = self.resolve_recursive_destination(dir);
         let catalogs = pack_catalogs(config)?;
+        // Load the pnpmfiles once for the whole workspace (they live at the
+        // workspace root); cloning the Arcs into each project shares one
+        // worker per pnpmfile instead of re-spawning it per packed project.
+        let before_packing_hooks =
+            crate::config_deps::load_before_packing_hooks(config, workspace_root);
 
         let mut packed: Vec<PackResultJson> = Vec::new();
         for chunk in &chunks {
@@ -172,6 +181,7 @@ impl PackArgs {
                     catalogs.clone(),
                     out.clone(),
                     pack_destination.clone(),
+                    before_packing_hooks.clone(),
                 );
                 let result = api::<Reporter, Host>(&options)
                     .await
@@ -205,6 +215,10 @@ impl PackArgs {
     }
 
     /// Map `self` plus the resolved `config` onto a [`PackOptions`].
+    ///
+    /// `before_packing_hooks` is loaded once by the caller and cloned in
+    /// (like `catalogs`) so a recursive pack shares one worker per
+    /// pnpmfile across every project.
     fn pack_options(
         &self,
         dir: PathBuf,
@@ -212,9 +226,8 @@ impl PackArgs {
         catalogs: Catalogs,
         out: Option<String>,
         pack_destination: Option<String>,
+        before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
     ) -> PackOptions {
-        let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(&dir);
-        let pnpmfiles = crate::config_deps::resolve_pnpmfile_paths(config, pnpmfile_root);
         PackOptions {
             dir,
             catalogs,
@@ -231,7 +244,7 @@ impl PackArgs {
             dry_run: self.dry_run,
             out,
             pack_destination,
-            pnpmfiles,
+            before_packing_hooks,
         }
     }
 }

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -299,7 +299,8 @@ impl PublishArgs {
         pack_destination: &Path,
     ) -> miette::Result<PackResult> {
         let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(dir);
-        let pnpmfiles = crate::config_deps::resolve_pnpmfile_paths(config, pnpmfile_root);
+        let before_packing_hooks =
+            crate::config_deps::load_before_packing_hooks(config, pnpmfile_root);
         let options = PackOptions {
             dir: dir.to_path_buf(),
             catalogs: crate::cli_args::pack::pack_catalogs(config)?,
@@ -316,7 +317,7 @@ impl PublishArgs {
             dry_run: false,
             out: None,
             pack_destination: Some(pack_destination.to_string_lossy().into_owned()),
-            pnpmfiles,
+            before_packing_hooks,
         };
         pack_api::<Reporter, PackHost>(&options)
             .await

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -252,7 +252,7 @@ impl PublishArgs {
 
         let pack_destination = tempfile::tempdir().into_diagnostic().wrap_err("create temp dir")?;
         let pack_result =
-            self.pack_for_publish::<Reporter>(project_dir, config, pack_destination.path())?;
+            self.pack_for_publish::<Reporter>(project_dir, config, pack_destination.path()).await?;
         let tarball_data = std::fs::read(&pack_result.tarball_path)
             .into_diagnostic()
             .wrap_err("read packed tarball")?;
@@ -292,12 +292,14 @@ impl PublishArgs {
 
     /// Pack the project into `pack_destination` for publishing (never a dry
     /// run; the publish itself honors `--dry-run`).
-    fn pack_for_publish<Reporter: self::Reporter>(
+    async fn pack_for_publish<Reporter: self::Reporter>(
         &self,
         dir: &Path,
         config: &Config,
         pack_destination: &Path,
     ) -> miette::Result<PackResult> {
+        let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(dir);
+        let pnpmfiles = crate::config_deps::resolve_pnpmfile_paths(config, pnpmfile_root);
         let options = PackOptions {
             dir: dir.to_path_buf(),
             catalogs: crate::cli_args::pack::pack_catalogs(config)?,
@@ -314,8 +316,10 @@ impl PublishArgs {
             dry_run: false,
             out: None,
             pack_destination: Some(pack_destination.to_string_lossy().into_owned()),
+            pnpmfiles,
         };
         pack_api::<Reporter, PackHost>(&options)
+            .await
             .map_err(miette::Report::new)
             .wrap_err("pack the package")
     }

--- a/pnpm/crates/cli/src/cli_args/publish/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/tests.rs
@@ -75,8 +75,8 @@ fn publish_options_applies_tag_access_provenance_and_dry_run() {
     assert_eq!(options.otp, None);
 }
 
-#[test]
-fn pack_for_publish_writes_a_tarball_and_returns_the_manifest() {
+#[tokio::test]
+async fn pack_for_publish_writes_a_tarball_and_returns_the_manifest() {
     let dir = tempfile::tempdir().expect("a source dir");
     std::fs::write(dir.path().join("package.json"), r#"{"name":"pkg","version":"1.0.0"}"#)
         .expect("write the manifest");
@@ -85,6 +85,7 @@ fn pack_for_publish_writes_a_tarball_and_returns_the_manifest() {
     let args = publish_args_with(PublishFlags { ignore_scripts: true, ..publish_flags() });
     let result = args
         .pack_for_publish::<SilentReporter>(dir.path(), &Config::default(), dest.path())
+        .await
         .expect("packing succeeds");
 
     assert_eq!(result.published_manifest["name"], "pkg");

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -15,7 +15,7 @@ use pacquet_env_installer::{
     ConfigDepsInstallOptions, resolve_and_install_config_deps, resolve_package_manager_integrities,
 };
 use pacquet_graph_hasher::{detect_node_version, host_arch, host_libc, host_platform};
-use pacquet_hooks::{HookContext, LogFn, finder};
+use pacquet_hooks::{HookContext, LogFn, PnpmfileHooks, finder};
 use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient};
 use pacquet_reporter::{HookLog, LogEvent, LogLevel, Reporter};
 use pacquet_resolving_npm_resolver::{
@@ -385,6 +385,16 @@ pub fn resolve_pnpmfile_paths(config: &Config, root_dir: &Path) -> Vec<PathBuf> 
         pnpmfiles.push(root_pnpmfile);
     }
     pnpmfiles
+}
+
+/// Load the pnpmfiles that contribute a `beforePacking` hook for
+/// `root_dir` (see [`resolve_pnpmfile_paths`]), returning one shareable
+/// hook handle per pnpmfile. A recursive pack loads them once and clones
+/// the `Arc`s into each project so a pnpmfile's Node worker is spawned
+/// once, not once per packed project.
+#[must_use]
+pub fn load_before_packing_hooks(config: &Config, root_dir: &Path) -> Vec<Arc<dyn PnpmfileHooks>> {
+    resolve_pnpmfile_paths(config, root_dir).into_iter().map(finder::load_pnpmfile_at).collect()
 }
 
 pub async fn run_update_config_hooks<Reporter: self::Reporter>(

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -365,10 +365,14 @@ impl EnvInstallerContext {
 /// outside `WorkspaceSettings` — are seeded into the hook input and, when
 /// a hook changes them, captured into [`Config::catalogs`] for the install
 /// to use.
-pub async fn run_update_config_hooks<Reporter: self::Reporter>(
-    config: &mut Config,
-    root_dir: &Path,
-) -> Result<()> {
+/// The pnpmfile paths that contribute hooks for `root_dir`, in
+/// application order: config-dependency plugin pnpmfiles (lexical
+/// order) first, then the workspace-root `.pnpmfile.{cjs,mjs}`. Shared
+/// by the `updateConfig` install hook and the `beforePacking`
+/// pack/publish hook so both apply the same pnpmfile set, matching
+/// pnpm's single loaded hooks object.
+#[must_use]
+pub fn resolve_pnpmfile_paths(config: &Config, root_dir: &Path) -> Vec<PathBuf> {
     let config_modules_dir = root_dir.join("node_modules").join(".pnpm-config");
     let mut pnpmfiles: Vec<PathBuf> = match config.config_dependencies.as_ref() {
         Some(deps) => finder::calc_pnpmfile_paths_of_plugin_deps(
@@ -380,6 +384,14 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     if let Some(root_pnpmfile) = finder::find_pnpmfile(root_dir) {
         pnpmfiles.push(root_pnpmfile);
     }
+    pnpmfiles
+}
+
+pub async fn run_update_config_hooks<Reporter: self::Reporter>(
+    config: &mut Config,
+    root_dir: &Path,
+) -> Result<()> {
+    let pnpmfiles = resolve_pnpmfile_paths(config, root_dir);
     if pnpmfiles.is_empty() {
         return Ok(());
     }

--- a/pnpm/crates/cli/tests/pack.rs
+++ b/pnpm/crates/cli/tests/pack.rs
@@ -1,0 +1,136 @@
+//! Single-project `pack` integration tests, focused on the
+//! `beforePacking` pnpmfile hook: the published manifest a package is
+//! packed with must reflect what the hook returns, exactly as pnpm's
+//! `pnpm pack` / `pnpm publish` apply it. This is the mechanism the pnpm
+//! CLI's own release relies on to strip its bundled dependency fields
+//! from the published manifest (pnpm/pnpm#12955).
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use serde_json::json;
+use std::{fs, path::Path};
+
+/// A `beforePacking` hook that deletes `devDependencies` and stamps a
+/// marker rewrites the manifest packed into the tarball.
+#[test]
+fn before_packing_hook_rewrites_the_packed_manifest() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "devDependencies": { "internal-only": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r"module.exports = {
+  hooks: {
+    beforePacking (manifest) {
+      delete manifest.devDependencies
+      manifest.packedByHook = true
+      return manifest
+    },
+  },
+}
+",
+    )
+    .expect("write .pnpmfile.cjs");
+    let out = workspace.join("tarballs");
+    fs::create_dir_all(&out).expect("create out dir");
+
+    pacquet
+        .with_arg("pack")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+
+    let manifest = read_manifest_from_tarball(&out.join("pkg-1.0.0.tgz"));
+    assert_eq!(manifest["packedByHook"], json!(true), "the hook's added field must be packed");
+    assert!(
+        manifest.get("devDependencies").is_none(),
+        "the field the hook deleted must not be in the packed manifest",
+    );
+
+    drop(root);
+}
+
+/// The workspace-root `.pnpmfile.cjs` applies to a `--filter`-selected
+/// sub-package, the exact shape pnpm's `release.yml` drives with
+/// `pn publish --filter=<pkg>`: the pnpmfile lives at the repo root while
+/// the packed project is a nested workspace package.
+#[test]
+fn workspace_root_before_packing_hook_applies_to_a_filtered_package() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r"module.exports = {
+  hooks: {
+    beforePacking (manifest) {
+      if (manifest.name === 'pkg') {
+        delete manifest.dependencies
+      }
+      return manifest
+    },
+  },
+}
+",
+    )
+    .expect("write .pnpmfile.cjs");
+    let pkg_dir = workspace.join("packages/pkg");
+    fs::create_dir_all(&pkg_dir).expect("create package dir");
+    fs::write(
+        pkg_dir.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "dependencies": { "left-pad": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let out = workspace.join("tarballs");
+    fs::create_dir_all(&out).expect("create out dir");
+
+    pacquet
+        .with_arg("--filter")
+        .with_arg("pkg")
+        .with_arg("pack")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+
+    let manifest = read_manifest_from_tarball(&out.join("pkg-1.0.0.tgz"));
+    assert!(
+        manifest.get("dependencies").is_none(),
+        "the workspace-root pnpmfile's beforePacking hook must strip the sub-package's dependencies",
+    );
+
+    drop(root);
+}
+
+/// Extract `package/package.json` from a packed tarball.
+fn read_manifest_from_tarball(tarball: &Path) -> serde_json::Value {
+    use std::io::Read as _;
+
+    let bytes = fs::read(tarball).expect("read tarball");
+    let decoder = flate2::read::GzDecoder::new(bytes.as_slice());
+    let mut archive = tar::Archive::new(decoder);
+    for entry in archive.entries().expect("iterate tarball entries") {
+        let mut entry = entry.expect("read tarball entry");
+        if entry.path().expect("entry path") == Path::new("package/package.json") {
+            let mut contents = String::new();
+            entry.read_to_string(&mut contents).expect("read manifest");
+            return serde_json::from_str(&contents).expect("parse manifest");
+        }
+    }
+    panic!("package/package.json not found in {}", tarball.display());
+}

--- a/pnpm/crates/cli/tests/pack.rs
+++ b/pnpm/crates/cli/tests/pack.rs
@@ -117,6 +117,59 @@ fn workspace_root_before_packing_hook_applies_to_a_filtered_package() {
     drop(root);
 }
 
+/// A recursive pack applies the workspace-root `beforePacking` hook to
+/// every packed project. The hooks are loaded once and shared across
+/// projects, so this also exercises the shared-worker path.
+#[test]
+fn recursive_pack_applies_before_packing_hook_to_every_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r"module.exports = {
+  hooks: {
+    beforePacking (manifest) {
+      manifest.packedByHook = true
+      return manifest
+    },
+  },
+}
+",
+    )
+    .expect("write .pnpmfile.cjs");
+    for name in ["project-1", "project-2"] {
+        let dir = workspace.join("packages").join(name);
+        fs::create_dir_all(&dir).expect("create package dir");
+        fs::write(
+            dir.join("package.json"),
+            json!({ "name": name, "version": "1.0.0" }).to_string(),
+        )
+        .expect("write package.json");
+    }
+    let out = workspace.join("tarballs");
+    fs::create_dir_all(&out).expect("create out dir");
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("pack")
+        .with_arg("--pack-destination")
+        .with_arg(out.to_str().expect("utf8 out dir"))
+        .assert()
+        .success();
+
+    for name in ["project-1", "project-2"] {
+        let manifest = read_manifest_from_tarball(&out.join(format!("{name}-1.0.0.tgz")));
+        assert_eq!(
+            manifest["packedByHook"],
+            json!(true),
+            "the workspace-root beforePacking hook must run for {name}",
+        );
+    }
+
+    drop(root);
+}
+
 /// Extract `package/package.json` from a packed tarball.
 fn read_manifest_from_tarball(tarball: &Path) -> serde_json::Value {
     use std::io::Read as _;

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -99,6 +99,27 @@ pub trait PnpmfileHooks: Send + Sync {
         Ok(config)
     }
 
+    /// `beforePacking` hook: transforms a project's published manifest
+    /// before it is packed. Publish and pack run it once per project,
+    /// after the exportable manifest is built and before the file list
+    /// is computed, so a hook may still change `files`, `bin`, or the
+    /// dependency fields.
+    ///
+    /// Called with `(manifest, dir, context)`, mirroring pnpm's cooked
+    /// `beforePacking(pkg, dir, context)` signature. Returns the
+    /// (possibly modified) manifest; a hook that returns nothing — and
+    /// the default no-op — leaves `manifest` unchanged. A throwing hook
+    /// yields a [`HookError`] and aborts packing.
+    async fn before_packing(
+        &self,
+        manifest: Value,
+        dir: &std::path::Path,
+        ctx: HookContext,
+    ) -> Result<Value, HookError> {
+        let _ = (dir, ctx);
+        Ok(manifest)
+    }
+
     /// `preResolution` hook: side-effect hook called before resolution (e.g., logging, validation).
     async fn pre_resolution(&self, ctx: PreResolutionHookContext, logger: PreResolutionHookLogger);
 

--- a/pnpm/crates/hooks/src/node_runtime.rs
+++ b/pnpm/crates/hooks/src/node_runtime.rs
@@ -287,6 +287,15 @@ impl crate::PnpmfileHooks for NodeJsHooks {
         Ok(if result.is_null() { config } else { result })
     }
 
+    async fn before_packing(
+        &self,
+        manifest: Value,
+        dir: &std::path::Path,
+        ctx: crate::HookContext,
+    ) -> Result<Value, HookError> {
+        self.worker().await?.call_before_packing(manifest, &dir.to_string_lossy(), ctx.log).await
+    }
+
     async fn pre_resolution(
         &self,
         ctx: crate::PreResolutionHookContext,

--- a/pnpm/crates/hooks/src/worker.rs
+++ b/pnpm/crates/hooks/src/worker.rs
@@ -154,6 +154,24 @@ impl NodeWorker {
         self.request(hook, serde_json::json!({ "hook": hook, "payload": payload }), log).await
     }
 
+    /// Call the `beforePacking` hook with `(manifest, dir, context)`.
+    /// Returns the hook's result, or `manifest` unchanged when the
+    /// pnpmfile exports no `beforePacking` (mirroring pnpm's
+    /// `await hook(pkg, dir) ?? publishManifest`).
+    pub async fn call_before_packing(
+        &self,
+        manifest: Value,
+        dir: &str,
+        log: LogFn,
+    ) -> Result<Value, HookError> {
+        self.request(
+            "beforePacking",
+            serde_json::json!({ "hook": "beforePacking", "payload": manifest, "dir": dir }),
+            log,
+        )
+        .await
+    }
+
     /// Whether the loaded pnpmfile exports a `hooks` object. Mirrors
     /// pnpm's `entry.hooks != null` gate for `pnpmfileChecksum`.
     pub async fn has_hooks(&self) -> bool {
@@ -371,6 +389,10 @@ async function handle(line) {{
         }}
       }}
       send({{ ok: newPkg }});
+    }} else if (req.hook === 'beforePacking') {{
+      if (typeof fn !== 'function') {{ send({{ ok: req.payload }}); return; }}
+      const newPkg = await fn(req.payload, req.dir, context);
+      send({{ ok: newPkg == null ? req.payload : newPkg }});
     }} else if (req.hook === 'filterLog') {{
       const res = (typeof fn === 'function') ? await fn(req.payload, context) : true;
       send({{ ok: res }});

--- a/pnpm/crates/napi/src/pack.rs
+++ b/pnpm/crates/napi/src/pack.rs
@@ -77,10 +77,16 @@ pub async fn pack(options: PackOptions, on_log: Option<LogSink>) -> napi::Result
         dry_run: options.dry_run.unwrap_or(false),
         pack_destination: options.pack_destination,
         out: options.out,
+        // Bit drives its own `readPackage` hook through the napi bridge and
+        // loads no `beforePacking` pnpmfiles, so the hook loop is a no-op.
+        pnpmfiles: Vec::new(),
     };
 
     let result = tokio::task::spawn_blocking(move || {
-        pacquet_pack::api::<NodeBridgeReporter, pacquet_pack::Host>(&pack_opts)
+        // `api` is async; drive it to completion on the blocking thread so the
+        // synchronous tarball write still runs off the async worker threads.
+        tokio::runtime::Handle::current()
+            .block_on(pacquet_pack::api::<NodeBridgeReporter, pacquet_pack::Host>(&pack_opts))
     })
     .await;
 

--- a/pnpm/crates/napi/src/pack.rs
+++ b/pnpm/crates/napi/src/pack.rs
@@ -79,12 +79,12 @@ pub async fn pack(options: PackOptions, on_log: Option<LogSink>) -> napi::Result
         out: options.out,
         // Bit drives its own `readPackage` hook through the napi bridge and
         // loads no `beforePacking` pnpmfiles, so the hook loop is a no-op.
-        pnpmfiles: Vec::new(),
+        before_packing_hooks: Vec::new(),
     };
 
     let result = tokio::task::spawn_blocking(move || {
-        // `api` is async; drive it to completion on the blocking thread so the
-        // synchronous tarball write still runs off the async worker threads.
+        // `api` is async; drive it to completion on this blocking-pool thread so
+        // the blocking tarball write does not tie up an async worker thread.
         tokio::runtime::Handle::current()
             .block_on(pacquet_pack::api::<NodeBridgeReporter, pacquet_pack::Host>(&pack_opts))
     })

--- a/pnpm/crates/pack/Cargo.toml
+++ b/pnpm/crates/pack/Cargo.toml
@@ -17,6 +17,7 @@ pacquet-config                            = { workspace = true }
 pacquet-executor                          = { workspace = true }
 pacquet-exportable-manifest               = { workspace = true }
 pacquet-fs-packlist                       = { workspace = true }
+pacquet-hooks                             = { workspace = true }
 pacquet-package-manifest                  = { workspace = true }
 pacquet-reporter                          = { workspace = true }
 pacquet-resolving-parse-wanted-dependency = { workspace = true }
@@ -33,6 +34,7 @@ tempfile    = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio    = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -36,8 +36,9 @@ use pacquet_exportable_manifest::{
     CreateExportableManifestError, CreateExportableManifestOptions, create_exportable_manifest,
 };
 use pacquet_fs_packlist::{PacklistError, packlist};
+use pacquet_hooks::{HookContext, LogFn, finder};
 use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
-use pacquet_reporter::Reporter;
+use pacquet_reporter::{HookLog, LogEvent, LogLevel, Reporter};
 use pacquet_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
 use serde_json::Value;
 use std::{
@@ -45,6 +46,7 @@ use std::{
     collections::{HashMap, HashSet},
     io,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 pub use capabilities::{FsAtomicWrite, FsCreateDirAll, FsFileLen, FsReadFile, Host};
@@ -86,6 +88,11 @@ pub struct PackOptions {
     /// Workspace root, used to inject a root `LICENSE` into a
     /// sub-package tarball that lacks one.
     pub workspace_dir: Option<PathBuf>,
+    /// Pnpmfile paths whose `beforePacking` hook runs against the
+    /// published manifest before the file list is computed, in
+    /// application order (config-dependency plugin pnpmfiles first, then
+    /// the workspace-root pnpmfile). Empty when none are configured.
+    pub pnpmfiles: Vec<PathBuf>,
     /// Do everything except writing the tarball to disk.
     pub dry_run: bool,
     /// Directory to write the tarball into.
@@ -179,6 +186,10 @@ pub enum PackError {
     #[diagnostic(transparent)]
     Lifecycle(#[error(source)] LifecycleScriptError),
 
+    #[display("The \"beforePacking\" hook from {pnpmfile} failed: {message}")]
+    #[diagnostic(code(pacquet_pack::before_packing))]
+    BeforePacking { pnpmfile: String, message: String },
+
     #[display("Failed to read {path}: {source}")]
     #[diagnostic(code(pacquet_pack::read_file))]
     ReadFile {
@@ -209,7 +220,7 @@ pub enum PackError {
 /// `R` threads the reporter through the lifecycle-script emits; `Sys`
 /// is the filesystem seam for the tarball write phase
 /// ([`capabilities::Host`] in production).
-pub fn api<Reporter, Sys>(opts: &PackOptions) -> Result<PackResult, PackError>
+pub async fn api<Reporter, Sys>(opts: &PackOptions) -> Result<PackResult, PackError>
 where
     Reporter: self::Reporter,
     Sys: FsReadFile + FsFileLen + FsCreateDirAll + FsAtomicWrite,
@@ -267,6 +278,15 @@ where
         },
     )
     .map_err(PackError::CreateManifest)?;
+
+    // Run `beforePacking` hooks against the built manifest, before the
+    // file list is computed, so a hook that rewrites `files` / `bin` /
+    // dependency fields is honored. pnpm runs it inside
+    // `createExportableManifest`; pacquet applies it here because
+    // `create_exportable_manifest` is a pure, synchronous transform.
+    publish_manifest =
+        apply_before_packing::<Reporter>(&opts.dir, &dir, publish_manifest, &opts.pnpmfiles)
+            .await?;
 
     // Strip semver build metadata (the `+<build>` segment) so the
     // tarball name, the packed manifest, and any registry metadata all
@@ -328,6 +348,48 @@ where
     let tarball_path = packed_tarball_path(&opts.dir, &dir, &dest_dir, &tarball_name);
 
     Ok(PackResult { published_manifest: publish_manifest, contents, tarball_path, unpacked_size })
+}
+
+/// Chain every configured pnpmfile's `beforePacking` hook over the
+/// published `manifest`, in order. `project_dir` is the packed project's
+/// root (used as the log prefix); `publish_dir` is the directory passed
+/// to the hook (the project's publish directory, honoring
+/// `publishConfig.directory`), matching pnpm's `hook(manifest, dir)`.
+async fn apply_before_packing<Reporter: self::Reporter>(
+    project_dir: &Path,
+    publish_dir: &Path,
+    mut manifest: Value,
+    pnpmfiles: &[PathBuf],
+) -> Result<Value, PackError> {
+    let prefix = project_dir.to_string_lossy();
+    for pnpmfile in pnpmfiles {
+        let hooks = finder::load_pnpmfile_at(pnpmfile.clone());
+        let ctx =
+            HookContext { log: before_packing_logger::<Reporter>(pnpmfile, &prefix), dir: None };
+        manifest = hooks.before_packing(manifest, publish_dir, ctx).await.map_err(|err| {
+            PackError::BeforePacking {
+                pnpmfile: pnpmfile.display().to_string(),
+                message: err.to_string(),
+            }
+        })?;
+    }
+    Ok(manifest)
+}
+
+/// A `context.log(...)` sink forwarding each `beforePacking` log line to
+/// the `pnpm:hook` channel, tagged with the pnpmfile it came from.
+fn before_packing_logger<Reporter: self::Reporter>(pnpmfile: &Path, prefix: &str) -> LogFn {
+    let from = pnpmfile.to_string_lossy().into_owned();
+    let prefix = prefix.to_owned();
+    Arc::new(move |message| {
+        Reporter::emit(&LogEvent::Hook(HookLog {
+            level: LogLevel::Debug,
+            from: from.clone(),
+            hook: "beforePacking".to_string(),
+            prefix: prefix.clone(),
+            message,
+        }));
+    })
 }
 
 /// Project a [`PackResult`] into its JSON shape.

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -36,7 +36,7 @@ use pacquet_exportable_manifest::{
     CreateExportableManifestError, CreateExportableManifestOptions, create_exportable_manifest,
 };
 use pacquet_fs_packlist::{PacklistError, packlist};
-use pacquet_hooks::{HookContext, LogFn, finder};
+use pacquet_hooks::{HookContext, LogFn, PnpmfileHooks};
 use pacquet_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
 use pacquet_reporter::{HookLog, LogEvent, LogLevel, Reporter};
 use pacquet_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
@@ -88,11 +88,15 @@ pub struct PackOptions {
     /// Workspace root, used to inject a root `LICENSE` into a
     /// sub-package tarball that lacks one.
     pub workspace_dir: Option<PathBuf>,
-    /// Pnpmfile paths whose `beforePacking` hook runs against the
+    /// Loaded pnpmfiles whose `beforePacking` hook runs against the
     /// published manifest before the file list is computed, in
     /// application order (config-dependency plugin pnpmfiles first, then
     /// the workspace-root pnpmfile). Empty when none are configured.
-    pub pnpmfiles: Vec<PathBuf>,
+    ///
+    /// Holding the loaded hooks (rather than paths) lets a recursive pack
+    /// share one worker per pnpmfile across every packed project instead
+    /// of re-spawning it per project.
+    pub before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
     /// Do everything except writing the tarball to disk.
     pub dry_run: bool,
     /// Directory to write the tarball into.
@@ -284,9 +288,13 @@ where
     // dependency fields is honored. pnpm runs it inside
     // `createExportableManifest`; pacquet applies it here because
     // `create_exportable_manifest` is a pure, synchronous transform.
-    publish_manifest =
-        apply_before_packing::<Reporter>(&opts.dir, &dir, publish_manifest, &opts.pnpmfiles)
-            .await?;
+    publish_manifest = apply_before_packing::<Reporter>(
+        &opts.dir,
+        &dir,
+        publish_manifest,
+        &opts.before_packing_hooks,
+    )
+    .await?;
 
     // Strip semver build metadata (the `+<build>` segment) so the
     // tarball name, the packed manifest, and any registry metadata all
@@ -359,14 +367,14 @@ async fn apply_before_packing<Reporter: self::Reporter>(
     project_dir: &Path,
     publish_dir: &Path,
     mut manifest: Value,
-    pnpmfiles: &[PathBuf],
+    hooks: &[Arc<dyn PnpmfileHooks>],
 ) -> Result<Value, PackError> {
     let prefix = project_dir.to_string_lossy();
-    for pnpmfile in pnpmfiles {
-        let hooks = finder::load_pnpmfile_at(pnpmfile.clone());
+    for hook in hooks {
+        let pnpmfile = hook.source_path().unwrap_or_else(|| Path::new("<pnpmfile>"));
         let ctx =
             HookContext { log: before_packing_logger::<Reporter>(pnpmfile, &prefix), dir: None };
-        manifest = hooks.before_packing(manifest, publish_dir, ctx).await.map_err(|err| {
+        manifest = hook.before_packing(manifest, publish_dir, ctx).await.map_err(|err| {
             PackError::BeforePacking {
                 pnpmfile: pnpmfile.display().to_string(),
                 message: err.to_string(),

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -38,7 +38,7 @@ fn fixture(manifest: &Value) -> (TempDir, PackOptions) {
         dry_run: false,
         pack_destination: None,
         out: None,
-        pnpmfiles: Vec::new(),
+        before_packing_hooks: Vec::new(),
     };
     (dir, opts)
 }
@@ -316,7 +316,7 @@ fn workspace_license_is_injected_into_a_sub_package() {
         dry_run: false,
         pack_destination: None,
         out: None,
-        pnpmfiles: Vec::new(),
+        before_packing_hooks: Vec::new(),
     };
 
     let result = api::<SilentReporter, Host>(&opts).unwrap();
@@ -360,7 +360,7 @@ fn symlinked_workspace_license_is_not_injected() {
         dry_run: false,
         pack_destination: None,
         out: None,
-        pnpmfiles: Vec::new(),
+        before_packing_hooks: Vec::new(),
     };
 
     let result = api::<SilentReporter, Host>(&opts).unwrap();

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -1,6 +1,4 @@
-use super::{
-    Host, PackError, PackOptions, PackResult, api, format_pack_output, to_pack_result_json,
-};
+use super::{Host, PackError, PackOptions, PackResult, format_pack_output, to_pack_result_json};
 use crate::capabilities::{FsAtomicWrite, FsCreateDirAll, FsFileLen, FsReadFile};
 use flate2::read::GzDecoder;
 use pacquet_config::NodeLinker;
@@ -40,8 +38,25 @@ fn fixture(manifest: &Value) -> (TempDir, PackOptions) {
         dry_run: false,
         pack_destination: None,
         out: None,
+        pnpmfiles: Vec::new(),
     };
     (dir, opts)
+}
+
+/// Block on the async [`super::api`] so the synchronous `#[test]`
+/// functions can drive it. These fixtures configure no pnpmfiles, so
+/// the `beforePacking` loop is a no-op and a bare current-thread runtime
+/// is enough.
+fn api<Reporter, Sys>(opts: &PackOptions) -> Result<PackResult, PackError>
+where
+    Reporter: pacquet_reporter::Reporter,
+    Sys: FsReadFile + FsFileLen + FsCreateDirAll + FsAtomicWrite,
+{
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(super::api::<Reporter, Sys>(opts))
 }
 
 fn touch(dir: &Path, rel: &str, contents: &str) {
@@ -301,6 +316,7 @@ fn workspace_license_is_injected_into_a_sub_package() {
         dry_run: false,
         pack_destination: None,
         out: None,
+        pnpmfiles: Vec::new(),
     };
 
     let result = api::<SilentReporter, Host>(&opts).unwrap();
@@ -344,6 +360,7 @@ fn symlinked_workspace_license_is_not_injected() {
         dry_run: false,
         pack_destination: None,
         out: None,
+        pnpmfiles: Vec::new(),
     };
 
     let result = api::<SilentReporter, Host>(&opts).unwrap();

--- a/pnpm11/pnpm/bundle-deps.ts
+++ b/pnpm11/pnpm/bundle-deps.ts
@@ -55,6 +55,7 @@ import { execSync } from 'node:child_process'
 
 const WORKSPACE_DIR = path.join(import.meta.dirname, '..', '..')
 const DEPLOY_DIR = path.join(import.meta.dirname, 'temp-deploy')
+const MANIFEST_PATH = path.join(import.meta.dirname, 'package.json')
 
 const NODE_MODULES_TEMP_DIR = path.join(DEPLOY_DIR, 'node_modules')
 const NODE_MODULES_DEST_DIR = path.join(import.meta.dirname, 'dist/node_modules')
@@ -109,4 +110,23 @@ function createDistNodeModules () {
   fs.rmSync(DEPLOY_DIR, { recursive: true })
 }
 
+// The bundled dist/node_modules created above already contains every runtime
+// dependency, so the published manifest must not declare dependencies or
+// devDependencies — otherwise pnpm would install them a second time (and the
+// internal-only devDependencies, e.g. @pnpm/test-ipc-server, aren't even
+// published, so the install would fail).
+//
+// The workspace .pnpmfile.cjs beforePacking hook already drops these fields when
+// packing. This on-disk strip is a temporary workaround for pnpm/pnpm#12955: the
+// pnpm v12 alpha that currently runs the release does not yet honor beforePacking,
+// so it published 11.12.0 with the fields intact. Remove this once the release
+// runs a pnpm that applies the hook.
+function stripBundledDependenciesFromManifest () {
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'))
+  delete manifest.dependencies
+  delete manifest.devDependencies
+  fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, undefined, 2)}\n`)
+}
+
 createDistNodeModules()
+stripBundledDependenciesFromManifest()

--- a/pnpm11/pnpm/bundle-deps.ts
+++ b/pnpm11/pnpm/bundle-deps.ts
@@ -110,6 +110,8 @@ function createDistNodeModules () {
   fs.rmSync(DEPLOY_DIR, { recursive: true })
 }
 
+createDistNodeModules()
+
 // The bundled dist/node_modules created above already contains every runtime
 // dependency, so the published manifest must not declare dependencies or
 // devDependencies — otherwise pnpm would install them a second time (and the
@@ -121,12 +123,7 @@ function createDistNodeModules () {
 // pnpm v12 alpha that currently runs the release does not yet honor beforePacking,
 // so it published 11.12.0 with the fields intact. Remove this once the release
 // runs a pnpm that applies the hook.
-function stripBundledDependenciesFromManifest () {
-  const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'))
-  delete manifest.dependencies
-  delete manifest.devDependencies
-  fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, undefined, 2)}\n`)
-}
-
-createDistNodeModules()
-stripBundledDependenciesFromManifest()
+const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'))
+delete manifest.dependencies
+delete manifest.devDependencies
+fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, undefined, 2)}\n`)


### PR DESCRIPTION
## Summary

The published `pnpm@11.12.0` broke `npm install --omit=dev --omit=optional` on its own tarball: the manifest declared `dependencies` **and** a large `devDependencies` list of internal-only packages (e.g. `@pnpm/test-ipc-server@1100.0.0`) that aren't on the public registry, so the install 404s. `11.11.0` published with neither field.

Root cause: the `pnpm` package bundles its runtime deps into `dist/node_modules`, so its manifest is meant to be dep-less — the workspace `.pnpmfile.cjs` `beforePacking` hook strips `dependencies`/`devDependencies` when packing. The `11.12.0` release ran a **pnpm 12 alpha (pacquet)** that does not yet honor `beforePacking`, so the fields leaked into the published manifest.

This fixes the pnpm 12 gap and adds a stopgap for it:

1. **Rust (pacquet)** — pacquet now honors `beforePacking` pnpmfile hooks during pack/publish. Once the release runs a pnpm that includes this, the hook drops the fields as intended.
2. **TypeScript (temporary workaround)** — until the release runs such a pnpm, `bundle-deps.ts` (the CLI's `prepublishOnly`) strips `dependencies`/`devDependencies` from the on-disk manifest after building the bundle. `pack` re-reads the manifest after `prepublishOnly`, so the fields never reach the tarball. This on-disk strip can be removed once the release publishes with a `beforePacking`-aware pnpm.

Closes pnpm/pnpm#12955.

> A sibling symptom in the issue comments — empty `@pnpm/macos-arm64` tarballs missing the native binary — is a separate pacquet pack/build bug from the same bad release and is **not** addressed here.

## Squash Commit Body

```text
The published pnpm package bundles its runtime dependencies into
dist/node_modules, so its manifest must not declare dependencies or
devDependencies — otherwise pnpm installs them a second time, and the
internal-only devDependencies (e.g. @pnpm/test-ipc-server) aren't
published, so the install 404s. pnpm 11.11.0 published with neither field.

The workspace .pnpmfile.cjs beforePacking hook drops these fields when
packing, but the release for 11.12.0 ran a pnpm 12 alpha (pacquet) that
does not yet honor beforePacking, so the fields leaked into the published
manifest and broke installs.

This fixes the pnpm 12 gap and adds a stopgap for it:

1. pacquet now honors beforePacking pnpmfile hooks during pack/publish,
   so once the release runs a pnpm that includes this, the hook drops the
   fields as intended:
   - PnpmfileHooks::before_packing (trait default no-op) plus a worker JS
     branch and NodeJsHooks impl, called as beforePacking(pkg, dir, ctx)
     with pnpm's `?? manifest` fallback.
   - pack::api is now async; it loads the workspace-root and
     config-dependency pnpmfiles (via a resolve_pnpmfile_paths helper
     shared with the updateConfig hook) and applies beforePacking to the
     published manifest before the file list is computed. The async change
     ripples through pack::run, dispatch_query::pack, publish, and napi.

2. As a temporary workaround until the release runs such a pnpm,
   bundle-deps.ts (the CLI's prepublishOnly) strips dependencies and
   devDependencies from the on-disk manifest after building the bundle.
   pack re-reads the manifest after prepublishOnly, so the fields never
   reach the tarball regardless of the beforePacking gap.

Integration tests drive the real binary through pnpm pack with a
.pnpmfile.cjs beforePacking hook, including the release shape a
workspace-root pnpmfile applied to a --filter-selected sub-package.

Closes pnpm/pnpm#12955.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port. (Rust: `beforePacking` bridge — the actual fix; TS: `bundle-deps.ts` stopgap until the release runs a `beforePacking`-aware pnpm.)
- [x] Added changesets. This is a parity change, so the two stacks get separate changesets (different release notes): `"pnpm": patch` for the published-manifest dependency strip, and `"pacquet": patch` for pacquet applying the `beforePacking` hook (`@pnpm/napi` bumps with pacquet via its fixed group).
- [x] Added or updated tests. (Rust `pnpm/crates/cli/tests/pack.rs` end-to-end `beforePacking` tests; updated pack/publish unit tests for the async `pack::api`.)
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8[1m]).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm pack` and `pnpm publish` now apply `beforePacking` hooks to package manifests before creating archives, including workspace-level hooks.
* **Bug Fixes**
  * Pack and publish output now correctly reflects manifest changes made by `beforePacking` hooks.
  * Published tarballs no longer include `dependencies`/`devDependencies` that could cause installs to pull internal-only packages.
* **Error Handling**
  * Packing now reports clear failures when a `beforePacking` hook fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->