### PR TITLE
fix(pacquet): honor --no-optional for transitive optional dependencies

### DIFF
--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -14,6 +14,7 @@ use pipe_trait::Pipe;
 use std::{
     fs::{self, OpenOptions},
     io::Write,
+    process::Command,
 };
 
 #[test]
@@ -84,6 +85,33 @@ fn no_optional_excludes_transitive_optional_dependencies() {
     assert!(
         !virtual_store.join("is-positive@1.0.0").exists(),
         "--no-optional must not materialize the transitive optional dependency",
+    );
+
+    // The exclusion is transient: the optional stays in the lockfile and is
+    // not persisted to `.modules.yaml.skipped`, so a later install without
+    // `--no-optional` restores it.
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("is-positive@1.0.0"),
+        "the excluded optional must remain in the lockfile:\n{lockfile}",
+    );
+    let modules_yaml = fs::read_to_string(workspace.join("node_modules/.modules.yaml"))
+        .expect("read .modules.yaml");
+    assert!(
+        !modules_yaml.contains("is-positive"),
+        "a `--no-optional` exclusion must not be recorded in .modules.yaml.skipped:\n{modules_yaml}",
+    );
+
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["install"])
+        .assert()
+        .success();
+    assert!(
+        virtual_store.join("is-positive@1.0.0").exists(),
+        "a normal install must restore the previously excluded optional dependency",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -54,6 +54,42 @@ fn should_install_dependencies() {
 }
 
 #[test]
+fn no_optional_excludes_transitive_optional_dependencies() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    // `@pnpm.e2e/pkg-with-good-optional` is a prod dependency whose own
+    // `optionalDependencies` pull in `is-positive`. `--no-optional` must
+    // exclude that transitive optional, not just the root's own optionals.
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-good-optional": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write to package.json");
+
+    pacquet.with_args(["install", "--no-optional"]).assert().success();
+
+    let virtual_store = workspace.join("node_modules/.pnpm");
+    assert!(
+        virtual_store.join("@pnpm.e2e+pkg-with-good-optional@1.0.0").exists(),
+        "the prod dependency must be installed",
+    );
+    assert!(
+        !virtual_store.join("is-positive@1.0.0").exists(),
+        "--no-optional must not materialize the transitive optional dependency",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn store_dir_cli_option_overrides_config_and_resolves_from_dir() {
     let CommandTempCwd { mut pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1444,6 +1444,7 @@ where
                 supported_architectures: supported_architectures.as_ref(),
                 lockfile_only: resolve_only,
                 dry_run,
+                is_full_install,
                 update_seed_policy,
                 auth_override,
                 resolution_observer,

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -214,6 +214,134 @@ async fn should_install_dependencies() {
     drop((dir, mock_instance));
 }
 
+/// `Install` with `UpdateSeedPolicy::DropAll` is the update path
+/// programmatic callers reach through napi `install({ update: true })`,
+/// separate from the `update` subcommand's `Update` type — so it needs
+/// its own coverage that `DropAll` drops the lockfile pin rather than
+/// reusing it.
+#[tokio::test]
+async fn install_with_drop_all_seed_policy_bumps_dependency_within_range() {
+    let mock_instance = TestRegistry::start();
+
+    let dir = tempdir().unwrap();
+    let store_dir = dir.path().join("pacquet-store");
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pacquet");
+    fs::create_dir_all(&project_root).unwrap();
+
+    let manifest_path = project_root.join("package.json");
+    let mut manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    // Pin 100.0.0 exactly so the first install writes that version, even
+    // though 100.1.0 exists and satisfies the widened range used below.
+    manifest
+        .add_dependency("@pnpm.e2e/dep-of-pkg-with-1-dep", "100.0.0", DependencyGroup::Prod)
+        .unwrap();
+    manifest.save().unwrap();
+
+    let mut config = Config::new();
+    config.lockfile = true;
+    config.store_dir = store_dir.into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = virtual_store_dir.clone();
+    config.registry = mock_instance.url();
+    let config = config.leak();
+
+    let lockfile_path = project_root.join("pnpm-lock.yaml");
+
+    // Pass 1: a plain install pins 100.0.0.
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        emit_initial_manifest: true,
+        lockfile: MaybeLazyLockfile::Loaded(None),
+        lockfile_path: Some(&lockfile_path),
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        dry_run: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        peer_issues_sink: None,
+        catalogs_override: None,
+        disable_optimistic_repeat_install: false,
+        pnpmfile_hook_override: None,
+        workspace_projects_override: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("first install should succeed");
+    assert!(
+        virtual_store_dir.join("@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0").exists(),
+        "the pinned install should materialize 100.0.0",
+    );
+
+    // Widen the range and reload the lockfile (which now pins 100.0.0).
+    manifest
+        .add_dependency("@pnpm.e2e/dep-of-pkg-with-1-dep", "^100.0.0", DependencyGroup::Prod)
+        .unwrap();
+    manifest.save().unwrap();
+    let lockfile = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("read the written current lockfile")
+        .expect("a lockfile should have been written");
+
+    // Pass 2: install with `DropAll` (the `update: true` seed policy) must
+    // drop the 100.0.0 pin and re-resolve to the highest in-range 100.1.0.
+    Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        emit_initial_manifest: true,
+        lockfile: MaybeLazyLockfile::Loaded(Some(&lockfile)),
+        lockfile_path: Some(&lockfile_path),
+        dependency_groups: [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional],
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: Some(false),
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        is_full_install: true,
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        dry_run: false,
+        resolved_packages: &Default::default(),
+        update_seed_policy: crate::UpdateSeedPolicy::DropAll,
+        auth_override: None,
+        resolution_observer: None,
+        peer_issues_sink: None,
+        catalogs_override: None,
+        disable_optimistic_repeat_install: false,
+        pnpmfile_hook_override: None,
+        workspace_projects_override: None,
+    }
+    .run::<SilentReporter>()
+    .await
+    .expect("update install should succeed");
+    assert!(
+        virtual_store_dir.join("@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0").exists(),
+        "install with DropAll should bump the dependency to the highest in-range version",
+    );
+
+    drop((dir, mock_instance));
+}
+
 /// A first install (no prior `.modules.yaml`, so the prune throttle
 /// always fires) sweeps a surplus `.pacquet` directory the wanted
 /// lockfile doesn't reference, while keeping the slot it does. Drives

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1591,6 +1591,24 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             SkippedSnapshots::new()
         };
 
+        // `--no-optional` excludes the Optional group. `dependency_groups`
+        // already drops the root importer's own optional direct deps, but a
+        // transitive optional (an `optionalDependencies` entry of a resolved
+        // package) is still in the graph and would be materialized. Exclude
+        // every optional-only snapshot the same way the frozen-lockfile path
+        // does — via the transient `optional_excluded` skip set, which keeps
+        // it out of materialization and `.modules.yaml.skipped` yet leaves it
+        // in the lockfile, so a later install without the flag restores it.
+        if !dependency_groups.contains(&DependencyGroup::Optional)
+            && let Some(snapshots) = built_lockfile.snapshots.as_ref()
+        {
+            for (key, snapshot) in snapshots {
+                if snapshot.optional {
+                    skipped.add_optional_excluded(key.clone());
+                }
+            }
+        }
+
         // Materialise the virtual store via the same phased
         // warm/cold-batch pipeline the frozen-lockfile path uses. The
         // phased pipeline in `CreateVirtualStore` runs a single

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -168,6 +168,13 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     /// the caller diffs the returned [`InstallWithFreshLockfileResult::wanted_lockfile`]
     /// against the existing one and reports the changes.
     pub dry_run: bool,
+    /// A full workspace install versus a partial one (`pacquet add` and the
+    /// package installs built on it — `dlx`, global add, the engine install).
+    /// See [`crate::Install::is_full_install`]. Gates the `--no-optional`
+    /// exclusion: a partial add's `dependency_groups` names the manifest
+    /// group to save into, not a `--no-optional` intent, so it must not
+    /// drop the added package's transitive optionals.
+    pub is_full_install: bool,
     /// Which lockfile pins to withhold from the preferred-versions seed
     /// so the affected names re-resolve to the highest version
     /// satisfying their manifest range. Drives `pacquet update`'s
@@ -505,6 +512,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             supported_architectures,
             lockfile_only,
             dry_run,
+            is_full_install,
             update_seed_policy,
             auth_override,
             resolution_observer,
@@ -1599,7 +1607,14 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // does — via the transient `optional_excluded` skip set, which keeps
         // it out of materialization and `.modules.yaml.skipped` yet leaves it
         // in the lockfile, so a later install without the flag restores it.
-        if !dependency_groups.contains(&DependencyGroup::Optional)
+        //
+        // Gated on `is_full_install`: for a partial `add` (and the package
+        // installs built on it — `dlx`, global add, the engine install)
+        // `dependency_groups` names the manifest group to save into, not a
+        // `--no-optional` intent, so those must keep their transitive
+        // optionals (e.g. `@pnpm/exe`'s platform binary).
+        if is_full_install
+            && !dependency_groups.contains(&DependencyGroup::Optional)
             && let Some(snapshots) = built_lockfile.snapshots.as_ref()
         {
             for (key, snapshot) in snapshots {


### PR DESCRIPTION
## What

A fresh install with `--no-optional` (`includeOptionalDeps: false`) only dropped the **root importer's** own `optionalDependencies`. A **transitive** optional — an `optionalDependencies` entry of a resolved package — stayed in the graph and was materialized into `node_modules`. So `install <pkg> --no-optional` still linked `<pkg>`'s optional deps.

## Why

The `dependency_groups` filter excludes the Optional group when building the root importer's direct-dep set, but `extract_children` in the deps resolver descends into every resolved package's `optionalDependencies` unconditionally. The frozen-lockfile path already compensates for this (it adds every `optional` snapshot to the transient `optional_excluded` skip set when Optional isn't requested); the fresh-resolve path did not.

## Fix

In `install_with_fresh_lockfile.rs`, after resolution, mirror the frozen path: when `Optional` is not in the requested `dependency_groups`, add every `built_lockfile` snapshot with `optional == true` to `skipped.add_optional_excluded(key)`. Those snapshots:

- are excluded from materialization (through the same gate installability skips use),
- stay out of `.modules.yaml.skipped`, so a later install without `--no-optional` brings them back,
- remain in the lockfile.

The fresh path already re-derives `snapshot.optional` (optional-only-reachable) in `dependencies_graph_to_lockfile.rs`, so the flag is available.

## Tests

- New CLI integration test `no_optional_excludes_transitive_optional_dependencies` — installs `@pnpm.e2e/pkg-with-good-optional` (whose `optionalDependencies` pull in `is-positive`) with `--no-optional` and asserts the transitive optional is not materialized while the prod dep is. Verified it **fails without the fix** and passes with it.
- Also adds a package-manager regression test `install_with_drop_all_seed_policy_bumps_dependency_within_range` guarding an adjacent path: `Install` with `UpdateSeedPolicy::DropAll` (what napi `install({ update: true })` uses) must re-resolve within range and drop the lockfile pin. It passes on unchanged engine code — included to lock down the contract that programmatic `install --update` consumers depend on.

`cargo fmt` + `clippy -D warnings` clean; all install/prune integration tests and the 693 package-manager unit tests pass.

## Context

Found while bringing Bit up on the Rust engine (`bit install --no-optional` leaked optional deps). No behavior change for installs that don't pass `--no-optional` / a restricted dependency-group set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786530440&installation_id=145934176&pr_number=12965&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12965&signature=1d25d3df2d1dd1553f1b8baedd9f52deadfd474986a6c9e38f7488612b840eb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm install --no-optional` so optional-only snapshots are not materialized while their entries remain in the lockfile for future optional-enabled installs.
  * With seed-policy **DropAll**, installs now correctly pick the highest version within the compatible range after widening dependency ranges.
* **Tests**
  * Added end-to-end coverage that verifies transitive optional dependencies are absent from `node_modules` after `--no-optional`, then restored by a subsequent standard install.
  * Added integration coverage for the **DropAll** update behavior during `install({ update: true })`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->