### PR TITLE
feat(pacquet): report extraneous packages in pnpm list

### DIFF
--- a/.changeset/pacquet-list-unsaved-deps.md
+++ b/.changeset/pacquet-list-unsaved-deps.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm list --json` and `pnpm list --parseable` now report extraneous packages — packages present in `node_modules` but absent from the lockfile — under `unsavedDependencies`, matching the TypeScript CLI.

--- a/pnpm/crates/cli/src/cli_args/list.rs
+++ b/pnpm/crates/cli/src/cli_args/list.rs
@@ -1,5 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
+    ffi::OsStr,
+    io,
     path::{Path, PathBuf},
 };
 
@@ -7,6 +9,7 @@ use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use owo_colors::{OwoColorize, Stream};
 use pacquet_config::Config;
+use pacquet_fs::lexical_normalize;
 use pacquet_global::{ListReportAs, list_global_packages};
 pub(crate) use pacquet_lockfile::PkgNameVerPeer;
 use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, SnapshotEntry};
@@ -219,6 +222,21 @@ impl ListArgs {
             }
         }
 
+        // Only the `--json`/`--parseable` renderers surface extraneous
+        // packages (the tree view omits them), so the `node_modules` scan
+        // is skipped for the default tree output. It is also suppressed
+        // when searching by name and for `--depth -1` (project-only
+        // output) — the same gates the TypeScript CLI applies before it
+        // scans `node_modules`.
+        let unsaved = if (self.json || self.parseable)
+            && self.packages.is_empty()
+            && self.depth != RecursionLimit::ProjectsOnly
+        {
+            read_unsaved_dependencies(importer, dir, config)?
+        } else {
+            Vec::new()
+        };
+
         let root = LocalTreeRoot {
             name: root_name,
             version: root_version,
@@ -227,6 +245,7 @@ impl ListArgs {
             dependencies: tree.dependencies,
             dev_dependencies: tree.dev_dependencies,
             optional_dependencies: tree.optional_dependencies,
+            unsaved,
         };
 
         Ok(LocalRootResult::Root(root))
@@ -292,6 +311,11 @@ pub(crate) struct LocalTreeRoot {
     pub(crate) dependencies: Vec<DepNode>,
     pub(crate) dev_dependencies: Vec<DepNode>,
     pub(crate) optional_dependencies: Vec<DepNode>,
+    /// Packages present in the importer's `node_modules` but absent from
+    /// its lockfile entry (npm calls these "extraneous"). Surfaced by
+    /// `--json` and `--parseable` only; the tree view omits them, matching
+    /// the TypeScript CLI, which hardcodes `showExtraneous: false`.
+    pub(crate) unsaved: Vec<DepNode>,
 }
 
 fn project_only_root(project: &pacquet_workspace::Project) -> LocalTreeRoot {
@@ -304,6 +328,7 @@ fn project_only_root(project: &pacquet_workspace::Project) -> LocalTreeRoot {
         dependencies: Vec::new(),
         dev_dependencies: Vec::new(),
         optional_dependencies: Vec::new(),
+        unsaved: Vec::new(),
     }
 }
 
@@ -588,6 +613,148 @@ pub(crate) fn read_root_manifest(
     Ok((name, version, private))
 }
 
+/// Scan `project_dir`'s `node_modules` for packages that are installed on
+/// disk but not recorded in `importer` (npm's "extraneous" dependencies),
+/// building a leaf [`DepNode`] for each. Mirrors the unsaved-dependency
+/// handling of the TypeScript CLI's `buildDependenciesTree`.
+fn read_unsaved_dependencies(
+    importer: &ProjectSnapshot,
+    project_dir: &Path,
+    config: &Config,
+) -> miette::Result<Vec<DepNode>> {
+    // Same per-importer modules-dir suffix the linker uses: the final
+    // component of `modules_dir` (default `node_modules`) under the
+    // project root.
+    let modules_dir_name =
+        config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+    let modules_dir = project_dir.join(modules_dir_name);
+
+    let saved = saved_direct_dep_names(importer);
+    let mut unsaved: Vec<DepNode> = read_modules_dir_names(&modules_dir)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to read {}", modules_dir.display()))?
+        .into_iter()
+        .filter(|name| !saved.contains(name))
+        .map(|name| build_unsaved_node(&name, &modules_dir, project_dir))
+        .collect();
+    sort_deps(&mut unsaved);
+    Ok(unsaved)
+}
+
+/// The alias keys of an importer's `dependencies`, `devDependencies`, and
+/// `optionalDependencies` — the directory names a saved dependency owns
+/// under `node_modules`. Always spans all three groups regardless of
+/// `--prod`/`--dev`/`--optional`, matching the TypeScript CLI's
+/// `getAllDirectDependencies`.
+fn saved_direct_dep_names(importer: &ProjectSnapshot) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let groups =
+        [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies];
+    for group in groups.into_iter().flatten() {
+        for name in group.keys() {
+            names.insert(name.to_string());
+        }
+    }
+    names
+}
+
+/// The package directory names directly under `modules_dir`, following
+/// the same enumeration rules as the TypeScript CLI's `readModulesDir`. A
+/// missing `modules_dir` is not an error; any other read failure is.
+fn read_modules_dir_names(modules_dir: &Path) -> io::Result<Vec<String>> {
+    let mut names = Vec::new();
+    collect_module_names(modules_dir, None, &mut names)?;
+    Ok(names)
+}
+
+fn collect_module_names(
+    modules_dir: &Path,
+    scope: Option<&str>,
+    names: &mut Vec<String>,
+) -> io::Result<()> {
+    let parent_dir = match scope {
+        Some(scope) => modules_dir.join(scope),
+        None => modules_dir.to_path_buf(),
+    };
+    let entries = match std::fs::read_dir(&parent_dir) {
+        Ok(entries) => entries,
+        // A missing directory is "no packages"; every other error is
+        // surfaced, matching `readModulesDir`, which only swallows ENOENT.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        if entry.file_type().is_ok_and(|file_type| file_type.is_file()) {
+            continue;
+        }
+        if scope.is_none() && name.starts_with('@') {
+            collect_module_names(modules_dir, Some(name), names)?;
+            continue;
+        }
+        match scope {
+            Some(scope) => names.push(format!("{scope}/{name}")),
+            None => names.push(name.to_string()),
+        }
+    }
+    Ok(())
+}
+
+/// Build the leaf [`DepNode`] for one extraneous package, taking its
+/// version and path from the symlink target for a `link:` dependency or
+/// from `package.json` for a regular directory.
+fn build_unsaved_node(name: &str, modules_dir: &Path, project_dir: &Path) -> DepNode {
+    let entry_path = modules_dir.join(name);
+    let (path, version) = if let Some(target) = resolve_link_target(&entry_path) {
+        let relative = pathdiff::diff_paths(&target, project_dir).unwrap_or_else(|| target.clone());
+        let version = format!("link:{}", relative.display().to_string().replace('\\', "/"));
+        (target.to_string_lossy().into_owned(), version)
+    } else {
+        let version = read_package_version(&entry_path).unwrap_or_else(|| "undefined".to_string());
+        (entry_path.to_string_lossy().into_owned(), version)
+    };
+    DepNode {
+        alias: name.to_string(),
+        name: name.to_string(),
+        version,
+        path,
+        is_peer: false,
+        is_dev: false,
+        is_optional: false,
+        dependencies: Vec::new(),
+    }
+}
+
+/// Resolve a symlink to the absolute path of its immediate target,
+/// lexically (without requiring the target to exist), matching the
+/// TypeScript CLI's `resolveLinkTarget`. `None` when `link` is not a
+/// symlink.
+fn resolve_link_target(link: &Path) -> Option<PathBuf> {
+    let target = std::fs::read_link(link).ok()?;
+    let joined = if target.is_absolute() {
+        target
+    } else {
+        match link.parent() {
+            Some(parent) => parent.join(target),
+            None => target,
+        }
+    };
+    Some(lexical_normalize(&joined))
+}
+
+fn read_package_version(pkg_dir: &Path) -> Option<String> {
+    let bytes = std::fs::read(pkg_dir.join("package.json")).ok()?;
+    let manifest: Value = serde_json::from_slice(&bytes).ok()?;
+    manifest.get("version").and_then(Value::as_str).map(str::to_string)
+}
+
 const LEGEND: &str = "Legend: production dependency, optional only, dev only\n\n";
 
 struct TreeNode {
@@ -807,6 +974,14 @@ fn local_root_to_json(root: &LocalTreeRoot) -> Value {
         root_obj.insert("optionalDependencies".to_string(), Value::Object(opt_map));
     }
 
+    if !root.unsaved.is_empty() {
+        let mut unsaved_map = Map::new();
+        for dep in &root.unsaved {
+            unsaved_map.insert(dep.alias.clone(), dep_to_json(dep));
+        }
+        root_obj.insert("unsavedDependencies".to_string(), Value::Object(unsaved_map));
+    }
+
     Value::Object(root_obj)
 }
 
@@ -859,6 +1034,9 @@ pub(crate) fn render_local_parseable(root: &LocalTreeRoot, long: bool) -> String
         flatten_parseable(dep, &mut lines, &mut seen, long);
     }
     for dep in &root.optional_dependencies {
+        flatten_parseable(dep, &mut lines, &mut seen, long);
+    }
+    for dep in &root.unsaved {
         flatten_parseable(dep, &mut lines, &mut seen, long);
     }
 

--- a/pnpm/crates/cli/src/cli_args/list/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/list/tests.rs
@@ -1,9 +1,15 @@
+use std::{collections::HashMap, fs};
+
+use pacquet_config::Config;
+use pacquet_lockfile::{ImporterDepVersion, ProjectSnapshot, ResolvedDependencySpec};
 use pretty_assertions::assert_eq;
 use serde_json::Value;
+use tempfile::TempDir;
 
 use super::{
-    DepNode, LocalTreeRoot, PkgNameVerPeer, dep_to_json, get_peer_set, glob_match, matches_params,
-    name_at_version, print_label, read_root_manifest, render_local_json, render_local_parseable,
+    DepNode, LocalTreeRoot, PkgNameVerPeer, build_unsaved_node, dep_to_json, get_peer_set,
+    glob_match, matches_params, name_at_version, print_label, read_modules_dir_names,
+    read_root_manifest, read_unsaved_dependencies, render_local_json, render_local_parseable,
     render_local_tree, sort_deps,
 };
 
@@ -165,6 +171,7 @@ fn render_local_tree_shows_root_with_name() {
         dependencies: vec![],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_tree(&root, false);
     assert!(output.contains("my-pkg"));
@@ -180,6 +187,7 @@ fn render_local_tree_shows_private() {
         dependencies: vec![],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_tree(&root, false);
     assert!(output.contains("PRIVATE"));
@@ -204,6 +212,7 @@ fn render_local_tree_with_deps() {
         }],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_tree(&root, false);
     assert!(output.contains("foo"));
@@ -220,6 +229,7 @@ fn render_local_tree_empty_returns_root_line() {
         dependencies: vec![],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_tree(&root, false);
     assert!(output.contains("lone"));
@@ -236,6 +246,7 @@ fn render_local_tree_sanitizes_root_name_without_deps() {
         dependencies: vec![],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_tree(&root, false);
     assert!(!output.contains('\u{1b}'));
@@ -261,6 +272,7 @@ fn render_local_json_basic() {
         }],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_json(&root);
     assert!(output.contains("pkg"));
@@ -281,6 +293,7 @@ fn render_local_json_private() {
         dependencies: vec![],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_json(&root);
     let parsed: Value = serde_json::from_str(&output).expect("valid json");
@@ -306,6 +319,7 @@ fn render_local_parseable_flat() {
         }],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_parseable(&root, false);
     let lines: Vec<&str> = output.lines().collect();
@@ -332,6 +346,7 @@ fn render_local_parseable_long() {
         }],
         dev_dependencies: vec![],
         optional_dependencies: vec![],
+        unsaved: vec![],
     };
     let output = render_local_parseable(&root, true);
     assert!(output.contains(":test@3.0.0"));
@@ -428,4 +443,143 @@ fn print_label_alias_with_version_containing_at() {
     let label = print_label(&dep, &|text| text.to_string());
     assert!(label.starts_with("aliased"));
     assert!(label.contains("npm:@scope/pkg@1.0.0"));
+}
+
+fn write_package(modules_dir: &std::path::Path, name: &str, version: &str) {
+    let pkg = modules_dir.join(name);
+    fs::create_dir_all(&pkg).expect("create package dir");
+    fs::write(pkg.join("package.json"), format!(r#"{{"name":"{name}","version":"{version}"}}"#))
+        .expect("write package.json");
+}
+
+#[test]
+fn read_modules_dir_names_skips_dot_entries_and_files_and_descends_scopes() {
+    let dir = TempDir::new().expect("temp dir");
+    let modules = dir.path().join("node_modules");
+    fs::create_dir_all(modules.join("foo")).expect("create foo");
+    fs::create_dir_all(modules.join(".pnpm")).expect("create .pnpm");
+    fs::create_dir_all(modules.join(".bin")).expect("create .bin");
+    fs::create_dir_all(modules.join("@scope").join("bar")).expect("create @scope/bar");
+    fs::write(modules.join("a-file"), "x").expect("write file");
+
+    let mut names = read_modules_dir_names(&modules).expect("read node_modules");
+    names.sort();
+    assert_eq!(names, vec!["@scope/bar".to_string(), "foo".to_string()]);
+}
+
+#[test]
+fn read_modules_dir_names_of_missing_dir_is_empty() {
+    let dir = TempDir::new().expect("temp dir");
+    assert!(read_modules_dir_names(&dir.path().join("node_modules")).expect("read").is_empty());
+}
+
+#[test]
+fn build_unsaved_node_reads_regular_package_version() {
+    let project = TempDir::new().expect("temp dir");
+    let modules = project.path().join("node_modules");
+    write_package(&modules, "foo", "1.2.3");
+
+    let node = build_unsaved_node("foo", &modules, project.path());
+    assert_eq!(node.alias, "foo");
+    assert_eq!(node.name, "foo");
+    assert_eq!(node.version, "1.2.3");
+    assert_eq!(node.path, modules.join("foo").to_string_lossy());
+    assert!(!node.is_peer && !node.is_dev && !node.is_optional);
+    assert!(node.dependencies.is_empty());
+}
+
+#[test]
+fn build_unsaved_node_without_version_is_undefined() {
+    let project = TempDir::new().expect("temp dir");
+    let modules = project.path().join("node_modules");
+    fs::create_dir_all(modules.join("foo")).expect("create foo");
+
+    let node = build_unsaved_node("foo", &modules, project.path());
+    assert_eq!(node.version, "undefined");
+}
+
+#[cfg(unix)]
+#[test]
+fn build_unsaved_node_symlink_gets_relative_link_version() {
+    let root = TempDir::new().expect("temp dir");
+    let project = root.path().join("project");
+    let sibling = root.path().join("sibling");
+    let modules = project.join("node_modules");
+    fs::create_dir_all(&modules).expect("create node_modules");
+    fs::create_dir_all(&sibling).expect("create sibling");
+    // A relative symlink, as the linker writes for workspace/link: deps.
+    std::os::unix::fs::symlink("../../sibling", modules.join("sibling")).expect("create symlink");
+
+    let node = build_unsaved_node("sibling", &modules, &project);
+    assert_eq!(node.version, "link:../sibling");
+    assert_eq!(node.path, sibling.to_string_lossy());
+}
+
+#[test]
+fn read_unsaved_dependencies_excludes_saved_and_lists_extraneous() {
+    let project = TempDir::new().expect("temp dir");
+    let modules = project.path().join("node_modules");
+    write_package(&modules, "saved-dep", "1.0.0");
+    write_package(&modules, "extraneous", "9.9.9");
+    fs::create_dir_all(modules.join(".pnpm")).expect("create .pnpm");
+
+    let mut deps: HashMap<_, _> = HashMap::new();
+    deps.insert(
+        "saved-dep".parse().expect("parse pkg name"),
+        ResolvedDependencySpec {
+            specifier: "1.0.0".into(),
+            version: ImporterDepVersion::Link("ignored".into()),
+        },
+    );
+    let importer = ProjectSnapshot { dependencies: Some(deps), ..Default::default() };
+
+    let unsaved = read_unsaved_dependencies(&importer, project.path(), &Config::default())
+        .expect("scan node_modules");
+    assert_eq!(unsaved.len(), 1);
+    assert_eq!(unsaved[0].name, "extraneous");
+    assert_eq!(unsaved[0].version, "9.9.9");
+}
+
+fn root_with_one_unsaved() -> LocalTreeRoot {
+    LocalTreeRoot {
+        name: Some("pkg".into()),
+        version: Some("1.0.0".into()),
+        private: Some(false),
+        path: "/p".into(),
+        dependencies: vec![],
+        dev_dependencies: vec![],
+        optional_dependencies: vec![],
+        unsaved: vec![DepNode {
+            alias: "foo".into(),
+            name: "foo".into(),
+            version: "1.0.0".into(),
+            path: "/p/node_modules/foo".into(),
+            is_peer: false,
+            is_dev: false,
+            is_optional: false,
+            dependencies: vec![],
+        }],
+    }
+}
+
+#[test]
+fn render_local_json_includes_unsaved_dependencies() {
+    let parsed: Value =
+        serde_json::from_str(&render_local_json(&root_with_one_unsaved())).expect("valid json");
+    let unsaved = &parsed[0]["unsavedDependencies"]["foo"];
+    assert_eq!(unsaved["from"], "foo");
+    assert_eq!(unsaved["version"], "1.0.0");
+    assert_eq!(unsaved["path"], "/p/node_modules/foo");
+}
+
+#[test]
+fn render_local_parseable_includes_unsaved_dependency_path() {
+    let output = render_local_parseable(&root_with_one_unsaved(), false);
+    assert!(output.lines().any(|line| line == "/p/node_modules/foo"), "output was:\n{output}");
+}
+
+#[test]
+fn render_local_tree_omits_unsaved_dependencies() {
+    let output = render_local_tree(&root_with_one_unsaved(), false);
+    assert!(!output.contains("foo"), "tree must not show extraneous deps:\n{output}");
 }

--- a/pnpm/crates/cli/tests/list.rs
+++ b/pnpm/crates/cli/tests/list.rs
@@ -193,3 +193,118 @@ fn changed_files_ignore_pattern_is_respected() {
 
     drop(root);
 }
+
+/// Scaffold a project whose lockfile records exactly one dependency
+/// (`saved-dep`), with both that dependency and an unrecorded
+/// `extraneous` package materialized in `node_modules`.
+fn write_project_with_extraneous_dep(workspace: &Path) {
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "with-extraneous",
+            "version": "1.0.0",
+            "dependencies": { "saved-dep": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    fs::write(
+        workspace.join("pnpm-lock.yaml"),
+        "\
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      saved-dep:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+
+  saved-dep@1.0.0:
+    resolution: {integrity: sha512-lOLfrmtpmkreuw+9G/zcKnfJGnOPqBvvZqYOaklGJHfyEcEmuItDJee2bDIA9hRK8j0MiYbU5yHEMh0GKG/Ig==}
+
+snapshots:
+
+  saved-dep@1.0.0: {}
+",
+    )
+    .expect("write pnpm-lock.yaml");
+
+    let modules = workspace.join("node_modules");
+    for (name, version) in [("saved-dep", "1.0.0"), ("extraneous", "9.9.9")] {
+        let pkg = modules.join(name);
+        fs::create_dir_all(&pkg).expect("create package dir");
+        fs::write(
+            pkg.join("package.json"),
+            json!({ "name": name, "version": version }).to_string(),
+        )
+        .expect("write package.json");
+    }
+}
+
+/// A package present in `node_modules` but absent from the lockfile
+/// (npm's "extraneous") is reported under `unsavedDependencies` by
+/// `list --json`, while a saved dependency is not. Mirrors the
+/// TypeScript CLI's unsaved-dependency handling.
+#[test]
+fn list_json_reports_extraneous_packages_as_unsaved() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_project_with_extraneous_dep(&workspace);
+
+    let output = pacquet.with_arg("list").with_arg("--json").output().expect("spawn pacquet list");
+    assert!(
+        output.status.success(),
+        "list should succeed:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let roots: Vec<Value> = serde_json::from_slice(&output.stdout).expect("parse list JSON");
+    let unsaved = &roots[0]["unsavedDependencies"];
+    assert_eq!(unsaved["extraneous"]["from"], "extraneous");
+    assert_eq!(unsaved["extraneous"]["version"], "9.9.9");
+    assert!(
+        unsaved.get("saved-dep").is_none(),
+        "a saved dependency must not be reported as unsaved:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    drop(root);
+}
+
+/// Extraneous packages are suppressed when a package-name argument
+/// narrows the listing (the search path). Ports the TypeScript
+/// tree-builder's "unsaved dependencies are listed and filtered".
+#[test]
+fn list_json_with_package_arg_omits_unsaved_dependencies() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_project_with_extraneous_dep(&workspace);
+
+    let output = pacquet
+        .with_arg("list")
+        .with_arg("saved-dep")
+        .with_arg("--json")
+        .output()
+        .expect("spawn pacquet list");
+    assert!(
+        output.status.success(),
+        "list should succeed:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let roots: Vec<Value> = serde_json::from_slice(&output.stdout).expect("parse list JSON");
+    assert!(
+        roots[0].get("unsavedDependencies").is_none(),
+        "a package-name filter must suppress extraneous deps:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

`pnpm list --json` and `pnpm list --parseable` now report **extraneous** packages in pacquet — packages present in an importer's `node_modules` but absent from the lockfile — under an `unsavedDependencies` object, matching the TypeScript CLI.

pacquet builds the list tree entirely from the lockfile, so extraneous packages (an npm-installed package later removed from `package.json`, or an unrecorded local link) were never surfaced. This closes that parity gap. The gap was spotted while reviewing pnpm/pnpm#12866 (the TypeScript-side EMFILE fix for reading these same unsaved dependencies).

Behavior matches the TypeScript CLI exactly:

- The **default tree view still omits** extraneous packages — the TypeScript CLI hardcodes `showExtraneous: false`, and only its `--json` and `--parseable` renderers surface them. pacquet does the same: the tree renderer is untouched; only the JSON and parseable renderers gain the new group.
- A symlinked entry (a workspace / `link:` dependency the manifest no longer records) reports `version: "link:<relative-to-project>"` and its resolved path; a regular directory reports its `package.json` version (or the literal `undefined` when missing/unreadable) and its on-disk path — the shape `buildDependenciesTree` produces.
- The `node_modules` scan follows the same rules as the TypeScript `readModulesDir`: skip files and dot-prefixed entries (`.pnpm`, `.bin`), descend one level into `@scope` directories.
- Detection is skipped when searching by package name and for `--depth -1` (project-only output) — the same two gates the TypeScript CLI applies before it scans `node_modules`.
- The "saved" set spans all three importer dependency groups regardless of `--prod`/`--dev`/`--optional`, matching `getAllDirectDependencies`.

No new dependencies: reuses `pacquet_fs::lexical_normalize` (matching `resolve-link-target`'s lexical resolution) and `pathdiff`, both already in the crate.

Known limitation: `std::fs::read_link` does not resolve Windows junctions (which the linker uses there), so an unsaved *workspace-link* package on Windows would report its `package.json` version rather than `link:<target>` — a rare, non-breaking edge case; the symlink unit test is unix-gated.

## Squash Commit Body

```text
feat(pacquet): report extraneous packages in pnpm list

`pnpm list --json` and `pnpm list --parseable` now report packages that
are present in an importer's `node_modules` but absent from the lockfile
(npm's "extraneous" dependencies) under `unsavedDependencies`, matching
the TypeScript CLI.

pacquet built the list tree entirely from the lockfile, so extraneous
packages were never surfaced. The tree is still lockfile-only; the scan
of `node_modules` runs only for the `--json` and `--parseable` renderers,
mirroring the TypeScript CLI, which hardcodes `showExtraneous: false` for
the default tree view. Extraneous detection is skipped when searching by
package name and for `--depth -1` (project-only output) — the same two
gates the TypeScript CLI applies before scanning `node_modules`.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(The TypeScript CLI already ships this behavior; this PR brings the Rust `pnpm/` port to parity.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786534649&installation_id=145934176&pr_number=12967&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12967&signature=4d44c8221ee037670db17798ee346cc885650f1362426ec79cf9a82aeec91aec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `pnpm list --json` now reports packages installed in `node_modules` but missing from the lockfile under `unsavedDependencies`.
  * `pnpm list --parseable` now includes these unsaved packages in its output.
* **Bug Fixes**
  * Package listings now more accurately distinguish lockfile dependencies from additional installed packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->