### PR TITLE
fix(publish): send README to the registry as metadata

### DIFF
--- a/.changeset/pnpr-hoist-readme.md
+++ b/.changeset/pnpr-hoist-readme.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+On publish, the README of the `latest` version is now hoisted to the packument's top-level `readme` (and `readmeFilename`) field, matching npm and verdaccio. Publish clients only send the readme inside the version manifest, so without this a package published to pnpr exposed no top-level readme for full-packument consumers and registry UIs to render.

--- a/.changeset/publish-readme-metadata.md
+++ b/.changeset/publish-readme-metadata.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/releasing.exportable-manifest": patch
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm publish` again sends the package's README to the registry as metadata, so registries can render it on the package page. The readme is always included in the published metadata (matching the npm CLI), while the `embed-readme` setting continues to control only whether the readme is written into the `package.json` inside the tarball. This restores the behavior that was lost when publishing became fully native. Closes pnpm/pnpm#12966.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,6 +4256,7 @@ name = "pacquet-exportable-manifest"
 version = "0.0.1"
 dependencies = [
  "derive_more",
+ "libc",
  "miette 7.6.0",
  "pacquet-catalogs-resolver",
  "pacquet-catalogs-types",

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -21,7 +21,7 @@ use pacquet_executor::{RunPostinstallHooks, ScriptsPrependNodePath, run_lifecycl
 use pacquet_pack::{Host as PackHost, PackOptions, PackResult, api as pack_api};
 use pacquet_publish::{
     Access, Host, OidcHttpOptions, PackedPkg, PublishNetwork, PublishPackedPkgOptions,
-    PublishSummary, extract_manifest_from_packed, is_tarball_path, publish_packed_pkg,
+    PublishSummary, extract_publish_manifest_from_packed, is_tarball_path, publish_packed_pkg,
     resolve_otp_from_env, run_git_checks,
 };
 use pacquet_reporter::Reporter;
@@ -201,7 +201,7 @@ impl PublishArgs {
         opts: &PublishPackedPkgOptions,
         network: &PublishNetwork<'_>,
     ) -> miette::Result<PublishSummary> {
-        let manifest = extract_manifest_from_packed(tarball_path)?;
+        let manifest = extract_publish_manifest_from_packed(tarball_path)?;
         let tarball_data = std::fs::read(tarball_path)
             .into_diagnostic()
             .wrap_err_with(|| format!("read tarball {tarball_path}"))?;

--- a/pnpm/crates/cli/tests/publish.rs
+++ b/pnpm/crates/cli/tests/publish.rs
@@ -82,6 +82,33 @@ fn publish_puts_the_package_document_with_dist_tag_and_attachment() {
 }
 
 #[test]
+fn publish_sends_the_readme_to_the_registry_as_metadata() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_project(
+        dir.path(),
+        &registry,
+        &json!({ "name": "test-publish-readme", "version": "1.0.0" }),
+    );
+    fs::write(dir.path().join("README.md"), "# Hello").expect("write README");
+
+    // The readme rides the version metadata even though `embed-readme` defaults to false.
+    let mock = server
+        .mock("PUT", "/test-publish-readme")
+        .match_body(Matcher::PartialJsonString(
+            r##"{"versions":{"1.0.0":{"readme":"# Hello"}}}"##.to_owned(),
+        ))
+        .with_status(200)
+        .with_body(r#"{"ok":true}"#)
+        .expect(1)
+        .create();
+
+    assert_success(&publish(dir.path(), &[]));
+    mock.assert();
+}
+
+#[test]
 fn dry_run_uploads_nothing() {
     let dir = tempfile::tempdir().expect("workspace");
     let mut server = mockito::Server::new();

--- a/pnpm/crates/exportable-manifest/Cargo.toml
+++ b/pnpm/crates/exportable-manifest/Cargo.toml
@@ -20,6 +20,10 @@ derive_more = { workspace = true }
 miette      = { workspace = true }
 serde_json  = { workspace = true }
 
+# `O_NOFOLLOW` for the symlink-safe README read (see `read_readme_file`).
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/pnpm/crates/exportable-manifest/src/create.rs
+++ b/pnpm/crates/exportable-manifest/src/create.rs
@@ -303,10 +303,32 @@ pub fn read_readme_file(dir: &Path) -> io::Result<Option<String>> {
             continue;
         }
         if entry.file_name().to_string_lossy().eq_ignore_ascii_case("readme.md") {
-            return fs::read_to_string(entry.path()).map(Some);
+            return read_regular_file(&entry.path());
         }
     }
     Ok(None)
+}
+
+/// Read a file, refusing to follow a symlink at the final path component so a
+/// symlink swapped in after the `read_dir` type check (a TOCTOU race) can't
+/// redirect the read outside the project and leak its target into the published
+/// manifest. A symlink (`ELOOP`) yields `Ok(None)`, matching the `is_file`
+/// intent. Windows lacks `O_NOFOLLOW` (and gates symlink creation behind a
+/// privilege), so it falls back to a plain read.
+#[cfg(unix)]
+fn read_regular_file(path: &Path) -> io::Result<Option<String>> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let file = match fs::OpenOptions::new().read(true).custom_flags(libc::O_NOFOLLOW).open(path) {
+        Ok(file) => file,
+        Err(err) if err.raw_os_error() == Some(libc::ELOOP) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    io::read_to_string(file).map(Some)
+}
+
+#[cfg(not(unix))]
+fn read_regular_file(path: &Path) -> io::Result<Option<String>> {
+    fs::read_to_string(path).map(Some)
 }
 
 /// Clone `map` without the entries named in `keys`, preserving the

--- a/pnpm/crates/exportable-manifest/src/create.rs
+++ b/pnpm/crates/exportable-manifest/src/create.rs
@@ -296,7 +296,7 @@ fn override_publish_config(publish: &mut Map<String, Value>) {
 /// Read a root `README.md` (case-insensitive) for embedding. Only a
 /// regular file is embedded — a symlink is skipped so it can't leak
 /// the contents of a target outside the project.
-fn read_readme_file(dir: &Path) -> io::Result<Option<String>> {
+pub fn read_readme_file(dir: &Path) -> io::Result<Option<String>> {
     for entry in fs::read_dir(dir)? {
         let entry = entry?;
         if !entry.file_type()?.is_file() {

--- a/pnpm/crates/exportable-manifest/src/create/tests.rs
+++ b/pnpm/crates/exportable-manifest/src/create/tests.rs
@@ -231,6 +231,26 @@ fn readme_is_not_embedded_without_opt_in() {
     assert!(out.get("readme").is_none());
 }
 
+#[cfg(unix)]
+#[test]
+fn readme_symlink_is_not_embedded() {
+    // A symlinked README could point outside the project; it must be skipped so its
+    // target's contents can't be leaked into the published manifest.
+    let dir = tempdir().unwrap();
+    let secret = tempdir().unwrap();
+    fs::write(secret.path().join("secret"), "TOP SECRET").unwrap();
+    std::os::unix::fs::symlink(secret.path().join("secret"), dir.path().join("README.md")).unwrap();
+    let catalogs = empty_catalogs();
+    let opts = CreateExportableManifestOptions {
+        catalogs: &catalogs,
+        modules_dir: None,
+        skip_manifest_obfuscation: false,
+        embed_readme: true,
+    };
+    let out = build(dir.path(), &json!({ "name": "foo", "version": "1.0.0" }), &opts);
+    assert!(out.get("readme").is_none());
+}
+
 #[test]
 fn missing_name_surfaces_transform_error() {
     let dir = tempdir().unwrap();

--- a/pnpm/crates/exportable-manifest/src/lib.rs
+++ b/pnpm/crates/exportable-manifest/src/lib.rs
@@ -21,6 +21,7 @@ mod tests;
 
 pub use create::{
     CreateExportableManifestError, CreateExportableManifestOptions, create_exportable_manifest,
+    read_readme_file,
 };
 pub use replace::{
     CannotResolveWorkspaceProtocolError, ReplaceWorkspaceProtocolError, replace_workspace_protocol,

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -34,6 +34,7 @@ use pacquet_executor::{
 };
 use pacquet_exportable_manifest::{
     CreateExportableManifestError, CreateExportableManifestOptions, create_exportable_manifest,
+    read_readme_file,
 };
 use pacquet_fs_packlist::{PacklistError, PacklistOptions, packlist_with_options};
 use pacquet_hooks::{HookContext, LogFn, PnpmfileHooks};
@@ -374,7 +375,27 @@ where
 
     let tarball_path = packed_tarball_path(&opts.dir, &dir, &dest_dir, &tarball_name);
 
-    Ok(PackResult { published_manifest: publish_manifest, contents, tarball_path, unpacked_size })
+    let published_manifest = with_registry_readme(publish_manifest, &dir)?;
+    Ok(PackResult { published_manifest, contents, tarball_path, unpacked_size })
+}
+
+/// The readme is always reported as part of the published manifest, matching the npm CLI, so a
+/// registry can render it on the package page. `embed_readme` only controls whether the readme is
+/// additionally written into the `package.json` inside the tarball (via
+/// [`create_exportable_manifest`]), which is why it is filled in on the returned manifest here
+/// rather than in the packed one.
+fn with_registry_readme(mut manifest: Value, dir: &Path) -> Result<Value, PackError> {
+    if manifest.get("readme").is_some_and(|readme| !readme.is_null()) {
+        return Ok(manifest);
+    }
+    let readme = read_readme_file(dir)
+        .map_err(|source| PackError::ReadFile { path: dir.display().to_string(), source })?;
+    if let Some(readme) = readme
+        && let Some(object) = manifest.as_object_mut()
+    {
+        object.insert("readme".to_string(), Value::String(readme));
+    }
+    Ok(manifest)
 }
 
 /// Chain every configured pnpmfile's `beforePacking` hook over the

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -200,6 +200,34 @@ fn manifest_entry_is_the_published_manifest_not_the_on_disk_one() {
 }
 
 #[test]
+fn readme_is_reported_for_the_registry_but_kept_out_of_the_tarball_manifest() {
+    let (dir, opts) = fixture(&json!({ "name": "foo", "version": "1.0.0" }));
+    touch(dir.path(), "README.md", "# Hello\n");
+    // `embed_readme` defaults to `false` in the fixture.
+
+    let result = api::<SilentReporter, Host>(&opts).unwrap();
+
+    // The manifest reported for publishing carries the readme, matching the npm CLI...
+    assert_eq!(result.published_manifest["readme"], json!("# Hello\n"));
+
+    // ...but the package.json packed into the tarball stays clean.
+    let tarball = dir.path().join("foo-1.0.0.tgz");
+    let file = std::fs::File::open(&tarball).unwrap();
+    let mut archive = tar::Archive::new(GzDecoder::new(file));
+    let mut packed_manifest = None;
+    for entry in archive.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        if entry.path().unwrap().to_string_lossy() == "package/package.json" {
+            let mut buf = String::new();
+            io::Read::read_to_string(&mut entry, &mut buf).unwrap();
+            packed_manifest = Some(serde_json::from_str::<Value>(&buf).unwrap());
+        }
+    }
+    let packed = packed_manifest.expect("tarball carries package/package.json");
+    assert!(packed.get("readme").is_none(), "readme must not be embedded in the tarball manifest");
+}
+
+#[test]
 fn dry_run_reports_without_writing_a_tarball() {
     let (dir, mut opts) = fixture(&json!({ "name": "foo", "version": "1.0.0" }));
     touch(dir.path(), "index.js", "x\n");

--- a/pnpm/crates/publish/src/extract_manifest_from_packed.rs
+++ b/pnpm/crates/publish/src/extract_manifest_from_packed.rs
@@ -47,6 +47,62 @@ pub fn extract_manifest_from_packed(tarball_path: &str) -> Result<Value, Extract
     }))
 }
 
+/// Read the publish manifest from a pre-built tarball, filling in its `readme`
+/// from the tarball's root README when the manifest doesn't already declare
+/// one. This mirrors the npm CLI, which reads the readme out of the tarball (via
+/// pacote's `fullReadJson`) so the registry gets it as metadata even though it
+/// isn't stored in the packed `package.json`.
+pub fn extract_publish_manifest_from_packed(
+    tarball_path: &str,
+) -> Result<Value, ExtractManifestError> {
+    let read_err = |source: std::io::Error| ExtractManifestError::Read {
+        tarball_path: tarball_path.to_owned(),
+        source,
+    };
+    let file = File::open(tarball_path).map_err(read_err)?;
+    let mut archive = tar::Archive::new(GzDecoder::new(file));
+    let entries = archive.entries().map_err(read_err)?;
+
+    let mut manifest_text: Option<String> = None;
+    let mut readme: Option<String> = None;
+    for entry in entries {
+        let mut entry = entry.map_err(read_err)?;
+        let normalized = normalize_entry_path(&entry.path().map_err(read_err)?);
+        let target = if normalized == "package/package.json" {
+            &mut manifest_text
+        } else if is_root_readme(&normalized) {
+            &mut readme
+        } else {
+            continue;
+        };
+        let mut text = String::new();
+        entry.read_to_string(&mut text).map_err(read_err)?;
+        *target = Some(text);
+    }
+
+    let manifest_text = manifest_text.ok_or_else(|| {
+        ExtractManifestError::MissingManifest(PublishArchiveMissingManifestError {
+            tarball_path: tarball_path.to_owned(),
+        })
+    })?;
+    let mut manifest: Value = serde_json::from_str(&manifest_text).map_err(|source| {
+        ExtractManifestError::Parse { tarball_path: tarball_path.to_owned(), source }
+    })?;
+    if let Some(readme) = readme
+        && manifest.get("readme").is_none_or(Value::is_null)
+        && let Some(object) = manifest.as_object_mut()
+    {
+        object.insert("readme".to_string(), Value::String(readme));
+    }
+    Ok(manifest)
+}
+
+/// Whether a normalized tar entry path names the package's root README,
+/// matching pnpm's `/^package\/readme\.md$/i`.
+fn is_root_readme(normalized: &str) -> bool {
+    normalized.strip_prefix("package/").is_some_and(|name| name.eq_ignore_ascii_case("readme.md"))
+}
+
 /// Normalize a tar entry path to forward slashes and collapse `.` / `..`
 /// segments (so e.g. `package/./package.json` still matches).
 ///

--- a/pnpm/crates/publish/src/extract_manifest_from_packed/tests.rs
+++ b/pnpm/crates/publish/src/extract_manifest_from_packed/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    ExtractManifestError, extract_manifest_from_packed, is_tarball_path, normalize_entry_path,
+    ExtractManifestError, extract_manifest_from_packed, extract_publish_manifest_from_packed,
+    is_tarball_path, normalize_entry_path,
 };
 use flate2::{Compression, write::GzEncoder};
 use pretty_assertions::assert_eq;
@@ -74,4 +75,41 @@ fn errors_when_manifest_missing() {
     let path = write_tarball(&dir, &[("package/index.js", "x")]);
     let err = extract_manifest_from_packed(&path).unwrap_err();
     assert!(matches!(err, ExtractManifestError::MissingManifest(_)));
+}
+
+#[test]
+fn publish_manifest_fills_readme_from_the_tarball_readme() {
+    let dir = TempDir::new().unwrap();
+    let path = write_tarball(
+        &dir,
+        &[
+            ("package/package.json", r#"{"name":"foo","version":"1.0.0"}"#),
+            ("package/README.md", "# Hello"),
+        ],
+    );
+    let manifest = extract_publish_manifest_from_packed(&path).unwrap();
+    assert_eq!(manifest["readme"], "# Hello");
+}
+
+#[test]
+fn publish_manifest_keeps_a_readme_already_in_the_manifest() {
+    let dir = TempDir::new().unwrap();
+    let path = write_tarball(
+        &dir,
+        &[
+            ("package/package.json", r#"{"name":"foo","version":"1.0.0","readme":"embedded"}"#),
+            ("package/README.md", "# Hello"),
+        ],
+    );
+    let manifest = extract_publish_manifest_from_packed(&path).unwrap();
+    assert_eq!(manifest["readme"], "embedded");
+}
+
+#[test]
+fn publish_manifest_leaves_readme_unset_without_a_tarball_readme() {
+    let dir = TempDir::new().unwrap();
+    let path =
+        write_tarball(&dir, &[("package/package.json", r#"{"name":"foo","version":"1.0.0"}"#)]);
+    let manifest = extract_publish_manifest_from_packed(&path).unwrap();
+    assert!(manifest.get("readme").is_none());
 }

--- a/pnpm/crates/publish/src/lib.rs
+++ b/pnpm/crates/publish/src/lib.rs
@@ -24,7 +24,7 @@ pub use display_error::display_error;
 pub use execute_token_helper::execute_token_helper;
 pub use extract_manifest_from_packed::{
     ExtractManifestError, PublishArchiveMissingManifestError, extract_manifest_from_packed,
-    is_tarball_path,
+    extract_publish_manifest_from_packed, is_tarball_path,
 };
 pub use failed_to_publish_error::FailedToPublishError;
 pub use git_checks::{

--- a/pnpm11/releasing/commands/src/publish/extractManifestFromPacked.ts
+++ b/pnpm11/releasing/commands/src/publish/extractManifestFromPacked.ts
@@ -15,7 +15,7 @@ export const isTarballPath = (path: string): path is TarballPath =>
   TARBALL_SUFFIXES.some(suffix => path.endsWith(suffix))
 
 export async function extractManifestFromPacked<Output = ExportedManifest> (tarballPath: TarballPath): Promise<Output> {
-  const { manifest } = await extractEntriesFromPacked(tarballPath)
+  const { manifest } = await extractEntriesFromPacked(tarballPath, false)
   return JSON.parse(manifest)
 }
 
@@ -26,7 +26,7 @@ export async function extractManifestFromPacked<Output = ExportedManifest> (tarb
  * metadata even though it isn't stored in the packed `package.json`.
  */
 export async function extractPublishManifestFromPacked (tarballPath: TarballPath): Promise<ExportedManifest> {
-  const { manifest, readme } = await extractEntriesFromPacked(tarballPath)
+  const { manifest, readme } = await extractEntriesFromPacked(tarballPath, true)
   const parsed = JSON.parse(manifest) as ExportedManifest
   if (parsed.readme == null && readme != null) {
     parsed.readme = readme
@@ -39,7 +39,13 @@ interface PackedEntries {
   readme?: string
 }
 
-async function extractEntriesFromPacked (tarballPath: TarballPath): Promise<PackedEntries> {
+/**
+ * Scan the tarball for `package/package.json` and, when `wantReadme` is set, the root
+ * `README.md`. The manifest-only path (`wantReadme` false) resolves as soon as the manifest
+ * entry is read and stops decompressing the rest of the archive; the publish path scans on
+ * because a README can appear after the manifest.
+ */
+async function extractEntriesFromPacked (tarballPath: TarballPath, wantReadme: boolean): Promise<PackedEntries> {
   const extract = tar.extract()
   const gunzip = createGunzip()
   const tarballStream = fs.createReadStream(tarballPath)
@@ -56,21 +62,33 @@ async function extractEntriesFromPacked (tarballPath: TarballPath): Promise<Pack
   }
 
   const promise = new Promise<PackedEntries>((resolve, reject) => {
+    let settled = false
+    let manifest: string | undefined
+    let readme: string | undefined
+
     function handleError (error: unknown): void {
       cleanup()
       reject(error)
     }
 
+    function settle (): void {
+      if (settled) return
+      settled = true
+      cleanup()
+      if (manifest == null) {
+        reject(new PublishArchiveMissingManifestError(tarballPath))
+        return
+      }
+      resolve({ manifest, readme })
+    }
+
     tarballStream.once('error', handleError)
     gunzip.once('error', handleError)
-
-    let manifest: string | undefined
-    let readme: string | undefined
 
     extract.on('entry', (header, stream, next) => {
       const normalizedPath = path.normalize(header.name).replaceAll('\\', '/')
       const isManifest = normalizedPath === 'package/package.json'
-      const isReadme = /^package\/readme\.md$/i.test(normalizedPath)
+      const isReadme = wantReadme && /^package\/readme\.md$/i.test(normalizedPath)
 
       if (!isManifest && !isReadme) {
         stream.once('end', next)
@@ -90,22 +108,19 @@ async function extractEntriesFromPacked (tarballPath: TarballPath): Promise<Pack
         } else {
           readme = text
         }
+        // Stop early once every wanted entry has been captured, so the manifest-only
+        // path doesn't stream and decompress the remainder of the tarball.
+        if (manifest != null && (!wantReadme || readme != null)) {
+          settle()
+          return
+        }
         next()
       })
 
       stream.once('error', handleError)
     })
 
-    extract.once('finish', () => {
-      cleanup()
-
-      if (manifest == null) {
-        reject(new PublishArchiveMissingManifestError(tarballPath))
-        return
-      }
-      resolve({ manifest, readme })
-    })
-
+    extract.once('finish', settle)
     extract.once('error', handleError)
   })
 

--- a/pnpm11/releasing/commands/src/publish/extractManifestFromPacked.ts
+++ b/pnpm11/releasing/commands/src/publish/extractManifestFromPacked.ts
@@ -15,6 +15,31 @@ export const isTarballPath = (path: string): path is TarballPath =>
   TARBALL_SUFFIXES.some(suffix => path.endsWith(suffix))
 
 export async function extractManifestFromPacked<Output = ExportedManifest> (tarballPath: TarballPath): Promise<Output> {
+  const { manifest } = await extractEntriesFromPacked(tarballPath)
+  return JSON.parse(manifest)
+}
+
+/**
+ * Read the publish manifest from a pre-built tarball, filling in its `readme` from the tarball's
+ * root README file when the manifest doesn't already declare one. This mirrors the npm CLI, which
+ * reads the readme out of the tarball (via pacote's `fullReadJson`) so the registry gets it as
+ * metadata even though it isn't stored in the packed `package.json`.
+ */
+export async function extractPublishManifestFromPacked (tarballPath: TarballPath): Promise<ExportedManifest> {
+  const { manifest, readme } = await extractEntriesFromPacked(tarballPath)
+  const parsed = JSON.parse(manifest) as ExportedManifest
+  if (parsed.readme == null && readme != null) {
+    parsed.readme = readme
+  }
+  return parsed
+}
+
+interface PackedEntries {
+  manifest: string
+  readme?: string
+}
+
+async function extractEntriesFromPacked (tarballPath: TarballPath): Promise<PackedEntries> {
   const extract = tar.extract()
   const gunzip = createGunzip()
   const tarballStream = fs.createReadStream(tarballPath)
@@ -30,7 +55,7 @@ export async function extractManifestFromPacked<Output = ExportedManifest> (tarb
     tarballStream.destroy()
   }
 
-  const promise = new Promise<string>((resolve, reject) => {
+  const promise = new Promise<PackedEntries>((resolve, reject) => {
     function handleError (error: unknown): void {
       cleanup()
       reject(error)
@@ -39,18 +64,19 @@ export async function extractManifestFromPacked<Output = ExportedManifest> (tarb
     tarballStream.once('error', handleError)
     gunzip.once('error', handleError)
 
-    let manifestFound = false
+    let manifest: string | undefined
+    let readme: string | undefined
 
     extract.on('entry', (header, stream, next) => {
       const normalizedPath = path.normalize(header.name).replaceAll('\\', '/')
+      const isManifest = normalizedPath === 'package/package.json'
+      const isReadme = /^package\/readme\.md$/i.test(normalizedPath)
 
-      if (normalizedPath !== 'package/package.json') {
+      if (!isManifest && !isReadme) {
         stream.once('end', next)
         stream.resume()
         return
       }
-
-      manifestFound = true
 
       const chunks: Buffer[] = []
       stream.on('data', (chunk: Buffer) => {
@@ -58,13 +84,13 @@ export async function extractManifestFromPacked<Output = ExportedManifest> (tarb
       })
 
       stream.once('end', () => {
-        try {
-          const text = Buffer.concat(chunks).toString()
-          cleanup()
-          resolve(text)
-        } catch (error) {
-          handleError(error)
+        const text = Buffer.concat(chunks).toString()
+        if (isManifest) {
+          manifest = text
+        } else {
+          readme = text
         }
+        next()
       })
 
       stream.once('error', handleError)
@@ -73,9 +99,11 @@ export async function extractManifestFromPacked<Output = ExportedManifest> (tarb
     extract.once('finish', () => {
       cleanup()
 
-      if (!manifestFound) {
+      if (manifest == null) {
         reject(new PublishArchiveMissingManifestError(tarballPath))
+        return
       }
+      resolve({ manifest, readme })
     })
 
     extract.once('error', handleError)
@@ -83,7 +111,7 @@ export async function extractManifestFromPacked<Output = ExportedManifest> (tarb
 
   tarballStream.pipe(gunzip).pipe(extract)
 
-  return JSON.parse(await promise)
+  return promise
 }
 
 export class PublishArchiveMissingManifestError extends PnpmError {

--- a/pnpm11/releasing/commands/src/publish/pack.ts
+++ b/pnpm11/releasing/commands/src/publish/pack.ts
@@ -11,7 +11,7 @@ import { PnpmError } from '@pnpm/error'
 import { packlist } from '@pnpm/fs.packlist'
 import type { Hooks } from '@pnpm/hooks.pnpmfile'
 import { logger } from '@pnpm/logger'
-import { createExportableManifest, type ExportedManifest } from '@pnpm/releasing.exportable-manifest'
+import { createExportableManifest, type ExportedManifest, readReadmeFile } from '@pnpm/releasing.exportable-manifest'
 import { changelogStorage, readPendingChangelog, renderChangelog } from '@pnpm/releasing.versioning'
 import type { DependencyManifest, Project, ProjectManifest, ProjectRootDir, ProjectsGraph } from '@pnpm/types'
 import { sortFilteredProjects } from '@pnpm/workspace.projects-sorter'
@@ -375,11 +375,25 @@ export async function api (opts: PackOptions): Promise<PackResult> {
     packedTarballPath = path.relative(opts.dir, path.join(dir, tarballName))
   }
   return {
-    publishedManifest: publishManifest,
+    publishedManifest: await withRegistryReadme(publishManifest, dir),
     contents: packedContents,
     tarballPath: packedTarballPath,
     unpackedSize,
   }
+}
+
+/**
+ * The readme is always sent to the registry as package metadata, matching the npm CLI, so that
+ * registries can render it on the package page. The `embed-readme` setting only controls whether
+ * the readme is additionally written into the `package.json` inside the tarball (via
+ * `createExportableManifest`), which is why it is added to the returned manifest here rather than
+ * to the packed one.
+ */
+async function withRegistryReadme (manifest: ExportedManifest, projectDir: string): Promise<ExportedManifest> {
+  if (manifest.readme != null) return manifest
+  const readme = await readReadmeFile(projectDir)
+  if (readme == null) return manifest
+  return { ...manifest, readme }
 }
 
 export interface PackResult {

--- a/pnpm11/releasing/commands/src/publish/publish.ts
+++ b/pnpm11/releasing/commands/src/publish/publish.ts
@@ -15,7 +15,7 @@ import { realpathMissing } from 'realpath-missing'
 import { renderHelp } from 'render-help'
 import { temporaryDirectory } from 'tempy'
 
-import { extractManifestFromPacked, isTarballPath } from './extractManifestFromPacked.js'
+import { extractPublishManifestFromPacked, isTarballPath } from './extractManifestFromPacked.js'
 import { optionsWithOtpEnv } from './otpEnv.js'
 import * as pack from './pack.js'
 import { publishPackedPkg, type PublishSummary } from './publishPackedPkg.js'
@@ -238,7 +238,7 @@ export async function publish (
 
   if (dirInParams != null && isTarballPath(dirInParams)) {
     const tarballPath = dirInParams
-    const publishedManifest = await extractManifestFromPacked(tarballPath)
+    const publishedManifest = await extractPublishManifestFromPacked(tarballPath)
     // Publishing a pre-built tarball bypasses `pack.api()`, so we don't have the file listing
     // or unpacked size — those summary fields are reported as empty/zero.
     const publishSummary = await publishPackedPkg({

--- a/pnpm11/releasing/commands/test/publish/extractManifestFromPacked.test.ts
+++ b/pnpm11/releasing/commands/test/publish/extractManifestFromPacked.test.ts
@@ -8,6 +8,7 @@ import tar from 'tar-stream'
 
 import {
   extractManifestFromPacked,
+  extractPublishManifestFromPacked,
   isTarballPath,
   PublishArchiveMissingManifestError,
   type TarballPath,
@@ -97,6 +98,50 @@ describe('extractManifestFromPacked', () => {
       code: 'ERR_PNPM_PUBLISH_ARCHIVE_MISSING_MANIFEST',
       tarballPath,
     })
+  })
+})
+
+describe('extractPublishManifestFromPacked', () => {
+  test('fills the manifest readme from the tarball README when the manifest lacks one', async () => {
+    prepareEmpty()
+
+    const tarballPath: TarballPath = 'my-package.tgz'
+
+    await createTarball(tarballPath, {
+      'package/package.json': { name: 'hello-world', version: '0.0.0' },
+      'package/README.md': '# Hello',
+    })
+
+    expect(await extractPublishManifestFromPacked(tarballPath)).toStrictEqual({
+      name: 'hello-world',
+      version: '0.0.0',
+      readme: '# Hello',
+    })
+  })
+
+  test('keeps a readme already declared in the manifest', async () => {
+    prepareEmpty()
+
+    const tarballPath: TarballPath = 'my-package.tgz'
+
+    await createTarball(tarballPath, {
+      'package/package.json': { name: 'hello-world', version: '0.0.0', readme: 'embedded' },
+      'package/README.md': '# Hello',
+    })
+
+    expect((await extractPublishManifestFromPacked(tarballPath)).readme).toBe('embedded')
+  })
+
+  test('leaves readme unset when the tarball has no README', async () => {
+    prepareEmpty()
+
+    const tarballPath: TarballPath = 'my-package.tgz'
+
+    await createTarball(tarballPath, {
+      'package/package.json': { name: 'hello-world', version: '0.0.0' },
+    })
+
+    expect((await extractPublishManifestFromPacked(tarballPath)).readme).toBeUndefined()
   })
 })
 

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -572,6 +572,27 @@ test('pack: should not embed readme', async () => {
   expect(pkg.readme).toBeFalsy()
 })
 
+test('pack: readme is sent to the registry as metadata even when not embedded in the tarball', async () => {
+  tempDir()
+
+  const packResult = await pack.api({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: path.join(import.meta.dirname, '../../fixtures/readme'),
+    extraBinPaths: [],
+    packDestination: process.cwd(),
+    embedReadme: false,
+  })
+
+  // The manifest reported for publishing carries the readme, matching the npm CLI...
+  expect(packResult.publishedManifest.readme).toContain('# README')
+
+  // ...but the package.json packed into the tarball stays clean.
+  await tar.x({ file: 'readme-0.0.0.tgz' })
+  const { default: pkg } = await import(path.resolve('package/package.json'))
+  expect(pkg.readme).toBeFalsy()
+})
+
 test('pack: remove publishConfig', async () => {
   prepare({
     name: 'remove-publish-config',

--- a/pnpm11/releasing/commands/test/publish/publishReadme.test.ts
+++ b/pnpm11/releasing/commands/test/publish/publishReadme.test.ts
@@ -1,0 +1,116 @@
+import { once } from 'node:events'
+import fs from 'node:fs'
+import http from 'node:http'
+import path from 'node:path'
+
+import { afterEach, beforeEach, expect, test } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+import { publish } from '@pnpm/releasing.commands'
+
+interface CapturedRequest {
+  method: string
+  url: string
+  body: string
+}
+
+let server: http.Server
+let captured: CapturedRequest[]
+let registry: string
+
+beforeEach(async () => {
+  captured = []
+  server = http.createServer((req, res) => {
+    let body = ''
+    req.on('data', (chunk) => {
+      body += chunk
+    })
+    req.on('end', () => {
+      captured.push({ method: req.method!, url: req.url!, body })
+      res.writeHead(201, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, success: true }))
+    })
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const { port } = server.address() as import('node:net').AddressInfo
+  registry = `http://127.0.0.1:${port}/`
+})
+
+afterEach(async () => {
+  server.close()
+  await once(server, 'close')
+})
+
+async function runPublish (dir: string, embedReadme: boolean, params: string[] = []): Promise<void> {
+  await publish.publish({
+    dir,
+    argv: { original: [] },
+    gitChecks: false,
+    ignoreScripts: true,
+    embedReadme,
+    skipManifestObfuscation: false,
+    catalogs: {},
+    registries: { default: registry },
+    configByUri: { [registry]: { '@//': { authToken: 'test' } } },
+    tag: 'latest',
+    userAgent: 'test',
+    fetchRetries: 0,
+    fetchRetryFactor: 1,
+    fetchRetryMintimeout: 0,
+    fetchRetryMaxtimeout: 1,
+    fetchTimeout: 10000,
+  } as unknown as Parameters<typeof publish.publish>[0], params)
+}
+
+function publishedVersionManifest (): Record<string, unknown> {
+  const put = captured.find((request) => request.method === 'PUT')
+  expect(put).toBeDefined()
+  const document = JSON.parse(put!.body)
+  const version = Object.keys(document.versions)[0]
+  return document.versions[version]
+}
+
+test('publish sends the readme to the registry as metadata (embed-readme off)', async () => {
+  prepare({ name: 'publish-readme-off', version: '1.0.0' })
+  fs.writeFileSync('README.md', '# Hello\n')
+
+  await runPublish(process.cwd(), false)
+
+  expect(publishedVersionManifest().readme).toBe('# Hello\n')
+})
+
+test('publish embeds the readme in the version manifest when embed-readme is on', async () => {
+  prepare({ name: 'publish-readme-on', version: '1.0.0' })
+  fs.writeFileSync('README.md', '# Hello\n')
+
+  await runPublish(process.cwd(), true)
+
+  expect(publishedVersionManifest().readme).toBe('# Hello\n')
+})
+
+test('publish omits readme metadata when the package has no README', async () => {
+  prepare({ name: 'publish-readme-none', version: '1.0.0' })
+  fs.rmSync('README.md', { force: true })
+
+  await runPublish(process.cwd(), false)
+
+  expect(publishedVersionManifest().readme).toBeUndefined()
+})
+
+test('publish reads the readme from a pre-built tarball', async () => {
+  prepare({ name: 'publish-readme-tarball', version: '1.0.0' })
+  fs.writeFileSync('README.md', '# From tarball\n')
+
+  const { pack } = await import('@pnpm/releasing.commands')
+  const packResult = await pack.api({
+    dir: process.cwd(),
+    argv: { original: [] },
+    embedReadme: false,
+    catalogs: {},
+    ignoreScripts: true,
+  } as unknown as Parameters<typeof pack.api>[0])
+
+  await runPublish(process.cwd(), false, [path.resolve(packResult.tarballPath)])
+
+  expect(publishedVersionManifest().readme).toBe('# From tarball\n')
+})

--- a/pnpm11/releasing/commands/test/publish/publishReadme.test.ts
+++ b/pnpm11/releasing/commands/test/publish/publishReadme.test.ts
@@ -41,35 +41,6 @@ afterEach(async () => {
   await once(server, 'close')
 })
 
-async function runPublish (dir: string, embedReadme: boolean, params: string[] = []): Promise<void> {
-  await publish.publish({
-    dir,
-    argv: { original: [] },
-    gitChecks: false,
-    ignoreScripts: true,
-    embedReadme,
-    skipManifestObfuscation: false,
-    catalogs: {},
-    registries: { default: registry },
-    configByUri: { [registry]: { '@//': { authToken: 'test' } } },
-    tag: 'latest',
-    userAgent: 'test',
-    fetchRetries: 0,
-    fetchRetryFactor: 1,
-    fetchRetryMintimeout: 0,
-    fetchRetryMaxtimeout: 1,
-    fetchTimeout: 10000,
-  } as unknown as Parameters<typeof publish.publish>[0], params)
-}
-
-function publishedVersionManifest (): Record<string, unknown> {
-  const put = captured.find((request) => request.method === 'PUT')
-  expect(put).toBeDefined()
-  const document = JSON.parse(put!.body)
-  const version = Object.keys(document.versions)[0]
-  return document.versions[version]
-}
-
 test('publish sends the readme to the registry as metadata (embed-readme off)', async () => {
   prepare({ name: 'publish-readme-off', version: '1.0.0' })
   fs.writeFileSync('README.md', '# Hello\n')
@@ -114,3 +85,32 @@ test('publish reads the readme from a pre-built tarball', async () => {
 
   expect(publishedVersionManifest().readme).toBe('# From tarball\n')
 })
+
+async function runPublish (dir: string, embedReadme: boolean, params: string[] = []): Promise<void> {
+  await publish.publish({
+    dir,
+    argv: { original: [] },
+    gitChecks: false,
+    ignoreScripts: true,
+    embedReadme,
+    skipManifestObfuscation: false,
+    catalogs: {},
+    registries: { default: registry },
+    configByUri: { [registry]: { '@//': { authToken: 'test' } } },
+    tag: 'latest',
+    userAgent: 'test',
+    fetchRetries: 0,
+    fetchRetryFactor: 1,
+    fetchRetryMintimeout: 0,
+    fetchRetryMaxtimeout: 1,
+    fetchTimeout: 10000,
+  } as unknown as Parameters<typeof publish.publish>[0], params)
+}
+
+function publishedVersionManifest (): Record<string, unknown> {
+  const put = captured.find((request) => request.method === 'PUT')
+  expect(put).toBeDefined()
+  const document = JSON.parse(put!.body)
+  const version = Object.keys(document.versions)[0]
+  return document.versions[version]
+}

--- a/pnpm11/releasing/exportable-manifest/src/index.ts
+++ b/pnpm11/releasing/exportable-manifest/src/index.ts
@@ -33,15 +33,6 @@ export interface MakePublishManifestOptions {
   embedReadme?: boolean
 }
 
-export async function readReadmeFile (projectDir: string): Promise<string | undefined> {
-  const entries = await fs.promises.readdir(projectDir, { withFileTypes: true })
-  // Only embed a regular README.md file. A symlink could point outside the
-  // project and leak its target's contents into the published manifest.
-  const readmeEntry = entries.find((entry) => entry.isFile() && /^readme\.md$/i.test(entry.name))
-  if (readmeEntry == null) return undefined
-  return fs.promises.readFile(path.join(projectDir, readmeEntry.name), 'utf8')
-}
-
 export async function createExportableManifest (
   dir: string,
   originalManifest: ProjectManifest,
@@ -95,6 +86,15 @@ export async function createExportableManifest (
   }
 
   return transform(publishManifest)
+}
+
+export async function readReadmeFile (projectDir: string): Promise<string | undefined> {
+  const entries = await fs.promises.readdir(projectDir, { withFileTypes: true })
+  // Only embed a regular README.md file. A symlink could point outside the
+  // project and leak its target's contents into the published manifest.
+  const readmeEntry = entries.find((entry) => entry.isFile() && /^readme\.md$/i.test(entry.name))
+  if (readmeEntry == null) return undefined
+  return fs.promises.readFile(path.join(projectDir, readmeEntry.name), 'utf8')
 }
 
 export type PublishDependencyConverter = (

--- a/pnpm11/releasing/exportable-manifest/src/index.ts
+++ b/pnpm11/releasing/exportable-manifest/src/index.ts
@@ -33,7 +33,7 @@ export interface MakePublishManifestOptions {
   embedReadme?: boolean
 }
 
-async function readReadmeFile (projectDir: string): Promise<string | undefined> {
+export async function readReadmeFile (projectDir: string): Promise<string | undefined> {
   const entries = await fs.promises.readdir(projectDir, { withFileTypes: true })
   // Only embed a regular README.md file. A symlink could point outside the
   // project and leak its target's contents into the published manifest.

--- a/pnpm11/releasing/exportable-manifest/src/index.ts
+++ b/pnpm11/releasing/exportable-manifest/src/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { type CatalogResolver, resolveFromCatalog } from '@pnpm/catalogs.resolver'
 import type { Catalogs } from '@pnpm/catalogs.types'
@@ -88,13 +89,29 @@ export async function createExportableManifest (
   return transform(publishManifest)
 }
 
+// `O_NOFOLLOW` makes the open itself refuse a symlink at the final path component, closing the
+// TOCTOU window between the `readdir` type check and the read: a symlink swapped in for README.md
+// after the check can't redirect the read outside the project and leak its target into the
+// published manifest. Windows lacks the flag (and requires privileges to create symlinks), so it
+// falls back to a plain read.
+const README_READ_FLAGS = fs.constants.O_RDONLY | (process.platform === 'win32' ? 0 : fs.constants.O_NOFOLLOW)
+
 export async function readReadmeFile (projectDir: string): Promise<string | undefined> {
   const entries = await fs.promises.readdir(projectDir, { withFileTypes: true })
-  // Only embed a regular README.md file. A symlink could point outside the
-  // project and leak its target's contents into the published manifest.
+  // Only embed a regular README.md file — a symlink is skipped (see README_READ_FLAGS).
   const readmeEntry = entries.find((entry) => entry.isFile() && /^readme\.md$/i.test(entry.name))
   if (readmeEntry == null) return undefined
-  return fs.promises.readFile(path.join(projectDir, readmeEntry.name), 'utf8')
+  let handle: fs.promises.FileHandle | undefined
+  try {
+    handle = await fs.promises.open(path.join(projectDir, readmeEntry.name), README_READ_FLAGS)
+    return await handle.readFile('utf8')
+  } catch (err: unknown) {
+    // ELOOP: the entry is a symlink after all (a concurrent swap) — skip it, as the isFile() check intended.
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ELOOP') return undefined
+    throw err
+  } finally {
+    await handle?.close()
+  }
 }
 
 export type PublishDependencyConverter = (

--- a/pnpr/crates/pnpr/src/publish.rs
+++ b/pnpr/crates/pnpr/src/publish.rs
@@ -314,7 +314,13 @@ fn hoist_readme_from_latest(out: &mut Map<String, Value>) {
         .map(|version| {
             ["readme", "readmeFilename"]
                 .into_iter()
-                .filter_map(|key| version.get(key).cloned().map(|value| (key.to_owned(), value)))
+                .filter_map(|key| {
+                    version
+                        .get(key)
+                        .filter(|value| !value.is_null())
+                        .cloned()
+                        .map(|value| (key.to_owned(), value))
+                })
                 .collect()
         })
         .unwrap_or_default();

--- a/pnpr/crates/pnpr/src/publish.rs
+++ b/pnpr/crates/pnpr/src/publish.rs
@@ -275,6 +275,8 @@ pub fn merge_manifest(
         }
     }
 
+    hoist_readme_from_latest(&mut out);
+
     // Sort `versions` by semver-ish key order so the on-disk file is
     // stable across runs. Use a BTreeMap to take advantage of
     // serde_json's `preserve_order` feature — without sorting, two
@@ -286,6 +288,39 @@ pub fn merge_manifest(
     }
 
     Value::Object(out)
+}
+
+/// Copy the `readme` / `readmeFilename` of the `dist-tags.latest` version up to
+/// the packument top level, where full-packument consumers and registry UIs
+/// read it. Publish clients (`libnpmpublish`, pacquet) only send the readme
+/// inside `versions[<version>]`, so without this a published package would
+/// expose no top-level readme — this hoist matches npm and verdaccio.
+///
+/// A top-level value already present (e.g. from an earlier publish or the
+/// upstream packument) is left in place when the latest version carries no
+/// readme, so a metadata-only re-publish never blanks it.
+fn hoist_readme_from_latest(out: &mut Map<String, Value>) {
+    let Some(latest) = out
+        .get("dist-tags")
+        .and_then(|tags| tags.get("latest"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+    else {
+        return;
+    };
+    let hoisted: Vec<(String, Value)> = out
+        .get("versions")
+        .and_then(|versions| versions.get(&latest))
+        .map(|version| {
+            ["readme", "readmeFilename"]
+                .into_iter()
+                .filter_map(|key| version.get(key).cloned().map(|value| (key.to_owned(), value)))
+                .collect()
+        })
+        .unwrap_or_default();
+    for (key, value) in hoisted {
+        out.insert(key, value);
+    }
 }
 
 fn merge_objects(existing: Option<&Value>, incoming: &Value) -> Value {

--- a/pnpr/crates/pnpr/src/publish/tests.rs
+++ b/pnpr/crates/pnpr/src/publish/tests.rs
@@ -307,16 +307,18 @@ fn merge_does_not_hoist_a_null_readme_over_an_existing_top_level_one() {
     let existing = json!({
         "name": "foo",
         "readme": "# Foo",
+        "readmeFilename": "README.md",
         "versions": { "1.0.0": { "version": "1.0.0" } },
         "dist-tags": { "latest": "1.0.0" }
     });
     let incoming = json!({
         "name": "foo",
-        "versions": { "1.1.0": { "version": "1.1.0", "readme": null } },
+        "versions": { "1.1.0": { "version": "1.1.0", "readme": null, "readmeFilename": null } },
         "dist-tags": { "latest": "1.1.0" }
     });
     let merged = merge_manifest(Some(&existing), &incoming, Some(&existing), "now");
     assert_eq!(merged["readme"], "# Foo");
+    assert_eq!(merged["readmeFilename"], "README.md");
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/publish/tests.rs
+++ b/pnpr/crates/pnpr/src/publish/tests.rs
@@ -266,6 +266,41 @@ fn merge_takes_incoming_for_an_upstream_only_version() {
 }
 
 #[test]
+fn merge_hoists_readme_from_the_latest_version_to_the_top_level() {
+    // Publish clients send the readme only inside the version manifest; the
+    // packument's top-level `readme` is what full-packument consumers render.
+    let incoming = json!({
+        "name": "foo",
+        "versions": {
+            "1.0.0": { "version": "1.0.0", "readme": "# Foo", "readmeFilename": "README.md" }
+        },
+        "dist-tags": { "latest": "1.0.0" }
+    });
+    let merged = merge_manifest(None, &incoming, None, "now");
+    assert_eq!(merged["readme"], "# Foo");
+    assert_eq!(merged["readmeFilename"], "README.md");
+}
+
+#[test]
+fn merge_keeps_the_top_level_readme_when_the_latest_version_has_none() {
+    // A metadata-only re-publish of a version without a readme must not blank
+    // the packument's existing top-level readme.
+    let existing = json!({
+        "name": "foo",
+        "readme": "# Foo",
+        "versions": { "1.0.0": { "version": "1.0.0" } },
+        "dist-tags": { "latest": "1.0.0" }
+    });
+    let incoming = json!({
+        "name": "foo",
+        "versions": { "1.0.0": { "version": "1.0.0" } },
+        "dist-tags": { "latest": "1.0.0" }
+    });
+    let merged = merge_manifest(Some(&existing), &incoming, Some(&existing), "now");
+    assert_eq!(merged["readme"], "# Foo");
+}
+
+#[test]
 fn now_iso_has_expected_shape() {
     let now = now_iso();
     let bytes = now.as_bytes();

--- a/pnpr/crates/pnpr/src/publish/tests.rs
+++ b/pnpr/crates/pnpr/src/publish/tests.rs
@@ -301,6 +301,25 @@ fn merge_keeps_the_top_level_readme_when_the_latest_version_has_none() {
 }
 
 #[test]
+fn merge_does_not_hoist_a_null_readme_over_an_existing_top_level_one() {
+    // Attacker-controlled metadata could set `"readme": null` on the version;
+    // hoisting it would blank the packument's existing top-level readme.
+    let existing = json!({
+        "name": "foo",
+        "readme": "# Foo",
+        "versions": { "1.0.0": { "version": "1.0.0" } },
+        "dist-tags": { "latest": "1.0.0" }
+    });
+    let incoming = json!({
+        "name": "foo",
+        "versions": { "1.1.0": { "version": "1.1.0", "readme": null } },
+        "dist-tags": { "latest": "1.1.0" }
+    });
+    let merged = merge_manifest(Some(&existing), &incoming, Some(&existing), "now");
+    assert_eq!(merged["readme"], "# Foo");
+}
+
+#[test]
 fn now_iso_has_expected_shape() {
     let now = now_iso();
     let bytes = now.as_bytes();


### PR DESCRIPTION
## Summary

`pnpm publish` stopped including the package's README in the metadata it sends to the registry, so registries (e.g. Forgejo/Codeberg) no longer render it on the package page. This is a regression between v10 and v11. Closes pnpm/pnpm#12966.

**Root cause:** Until v11, pnpm delegated the actual upload to `npm publish <tarball>`, and npm reads the README out of the tarball (pacote's `fullReadJson`) into the version metadata regardless of pnpm's `embed-readme` setting. When publishing became fully native (through `libnpmpublish` with pnpm's own `publishedManifest`), the README only reached the registry when `embed-readme` was `true` — but that setting defaults to `false` (deliberately, so the tarball's `package.json` stays clean). So published packages silently lost their README metadata.

**Fix — decouple the two concerns:** the README is now always attached to the manifest reported for publishing (matching the npm CLI), while `embed-readme` continues to control only whether it is written into the `package.json` inside the tarball. For a pre-built tarball passed to `pnpm publish <tarball>`, the README is read back out of the tarball, mirroring npm's `fullReadJson`. This covers single, recursive, batch, and stage publishing. Applied to both stacks: TypeScript (`@pnpm/releasing.commands`, `@pnpm/releasing.exportable-manifest`) and Rust pacquet (`pacquet-pack`, `pacquet-publish`; `stage` delegates to publish).

**pnpr (registry server):** publish clients send the readme only inside `versions[<version>].readme`; the packument's top-level `readme` — what full-packument consumers and registry UIs render — is populated server-side by npm/verdaccio. pnpr kept the per-version readme but never set the top-level field, so a package published to pnpr exposed no top-level readme (the same class of bug, one layer down). It now hoists the `readme`/`readmeFilename` of the `dist-tags.latest` version onto the packument root during the publish merge, leaving an existing top-level value untouched when the latest version has none.

**Verification:** end-to-end against a capturing HTTP server — with the default `embed-readme=false`, `versions[<version>].readme` now carries the README body (previously `undefined`), while the `package.json` packed into the tarball stays clean. Added a TS end-to-end publish test (mock HTTP registry) mirroring the pacquet integration test, plus unit tests for the pack/extract/merge paths on both stacks.

## Squash Commit Body

```text
`pnpm publish` again includes the package's README in the metadata sent to
the registry, matching the npm CLI, so registries can render it on the
package page.

Until v11 the actual upload was delegated to `npm publish <tarball>`, and
npm reads the README out of the tarball (pacote's fullReadJson) into the
version metadata regardless of pnpm's embed-readme setting. Once publishing
became fully native and went through libnpmpublish with pnpm's own
publishedManifest, the README only reached the registry when embed-readme
was true — but that setting defaults to false (deliberately, so the tarball's
package.json stays clean). The result was that published packages silently
lost their README metadata.

Decouple the two concerns: the README is now always attached to the manifest
reported for publishing, while embed-readme continues to control only whether
it is written into the package.json inside the tarball. For a pre-built
tarball passed to `pnpm publish <tarball>`, the README is read back out of the
tarball, mirroring npm's fullReadJson. Applied to both the TypeScript CLI and
the Rust pacquet stack (pack + publish; stage delegates to publish).

pnpr additionally hoists the latest version's readme to the packument's
top-level readme/readmeFilename on publish, matching npm and verdaccio, so a
package published to pnpm's own registry exposes a top-level readme.

Closes pnpm/pnpm#12966.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishing now ensures the package README is included as registry version metadata for package page display.
  * When publishing from pre-built tarballs, the packaged README is carried into the published version metadata when missing.
  * Registry packument output now hoists `latest`’s `readme`/`readmeFilename` to the top level.

* **Bug Fixes**
  * Republishing preserves existing packument README metadata and no longer overwrites it with `null`/missing values.
  * README handling is now symlink-safe, preventing unintended README inclusion.

* **Tests**
  * Added integration and Jest coverage for registry metadata, tarball extraction, and packument hoisting/republish scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->