### PR TITLE
ci: run TS and Rust test jobs on Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     name: TS CI / Build pnpr
     uses: ./.github/workflows/build-pnpr.yml
     with:
-      os: ubuntu-latest
+      os: blacksmith-8vcpu-ubuntu-2404
 
   build-pnpr-windows:
     needs: changes
@@ -118,7 +118,7 @@ jobs:
     name: TS CI / Build pnpr
     uses: ./.github/workflows/build-pnpr.yml
     with:
-      os: windows-latest
+      os: blacksmith-8vcpu-windows-2025
 
   test-smoke:
     name: TS CI / Test / ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     with:
       node: '24.0.0'
       node_major: '24'
-      platform: ubuntu-latest
+      platform: blacksmith-8vcpu-ubuntu-2404
       garnet: true
     secrets:
       GARNET_API_TOKEN: ${{ secrets.GARNET_API_TOKEN }}
@@ -141,13 +141,13 @@ jobs:
         include:
           - node: '22.13.0'
             node_major: '22'
-            platform: ubuntu-latest
+            platform: blacksmith-8vcpu-ubuntu-2404
             platform_label: ubuntu
             test_chunk: '1'
             test_chunk_total: '1'
           - node: '26.5.0'
             node_major: '26'
-            platform: ubuntu-latest
+            platform: blacksmith-8vcpu-ubuntu-2404
             platform_label: ubuntu
             test_chunk: '1'
             test_chunk_total: '1'
@@ -171,19 +171,19 @@ jobs:
         include:
           - node: '22.13.0'
             node_major: '22'
-            platform: windows-latest
+            platform: blacksmith-8vcpu-windows-2022
             platform_label: windows 1/3
             test_chunk: '1'
             test_chunk_total: '3'
           - node: '22.13.0'
             node_major: '22'
-            platform: windows-latest
+            platform: blacksmith-8vcpu-windows-2022
             platform_label: windows 2/3
             test_chunk: '2'
             test_chunk_total: '3'
           - node: '22.13.0'
             node_major: '22'
-            platform: windows-latest
+            platform: blacksmith-8vcpu-windows-2022
             platform_label: windows 3/3
             test_chunk: '3'
             test_chunk_total: '3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,19 +171,19 @@ jobs:
         include:
           - node: '22.13.0'
             node_major: '22'
-            platform: blacksmith-8vcpu-windows-2022
+            platform: blacksmith-8vcpu-windows-2025
             platform_label: windows 1/3
             test_chunk: '1'
             test_chunk_total: '3'
           - node: '22.13.0'
             node_major: '22'
-            platform: blacksmith-8vcpu-windows-2022
+            platform: blacksmith-8vcpu-windows-2025
             platform_label: windows 2/3
             test_chunk: '2'
             test_chunk_total: '3'
           - node: '22.13.0'
             node_major: '22'
-            platform: blacksmith-8vcpu-windows-2022
+            platform: blacksmith-8vcpu-windows-2025
             platform_label: windows 3/3
             test_chunk: '3'
             test_chunk_total: '3'

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -90,7 +90,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: blacksmith-8vcpu-windows-2022
+          - os: blacksmith-8vcpu-windows-2025
             os_label: windows
           - os: blacksmith-8vcpu-ubuntu-2404
             os_label: ubuntu

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -90,10 +90,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
+          - os: blacksmith-8vcpu-windows-2022
             os_label: windows
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             os_label: ubuntu
+          # Blacksmith offers no macOS runners, so this leg stays on the
+          # GitHub-hosted image.
           - os: macos-latest
             os_label: macos
     runs-on: ${{ matrix.os }}
@@ -177,10 +179,10 @@ jobs:
 
       - name: Stage Bencher test durations
         env:
-          TESTBED_OS: ${{ matrix.os }}
+          TESTBED_OS: ${{ matrix.os_label }}
         shell: bash
         run: |
-          os="${TESTBED_OS%-latest}"
+          os="$TESTBED_OS"
           artifact_dir=.bench/artifact/rust
           mkdir -p "$artifact_dir"
           cp .bench/pacquet-tests-all.json "$artifact_dir/pacquet-tests-all.json"
@@ -205,7 +207,7 @@ jobs:
       - name: Upload Bencher test duration artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ci-performance-rust-${{ matrix.os }}
+          name: ci-performance-rust-${{ matrix.os_label }}
           path: .bench/artifact/rust/
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,15 +232,18 @@ jobs:
           benchmark="${BENCHMARK}.chunk${TEST_CHUNK}"
           cli_benchmark="${cli_benchmark}.chunk${TEST_CHUNK}"
         fi
-        platform_slug=${PLATFORM%-latest}
-        node_major=${NODE_VERSION%%.*}
-        case "$platform_slug" in
-          ubuntu|windows) ;;
+        # Map both GitHub-hosted (`ubuntu-latest`) and Blacksmith
+        # (`blacksmith-8vcpu-ubuntu-2404`) labels to the bare OS slug the
+        # Bencher testbed name requires.
+        case "$PLATFORM" in
+          *ubuntu*) platform_slug=ubuntu ;;
+          *windows*) platform_slug=windows ;;
           *)
-            echo "::error::Unsupported platform '$platform_slug' for pnpm benchmarks; expected ubuntu or windows"
+            echo "::error::Unsupported platform '$PLATFORM' for pnpm benchmarks; expected an ubuntu or windows runner"
             exit 1
             ;;
         esac
+        node_major=${NODE_VERSION%%.*}
         case "$node_major" in
           22|24|26) ;;
           *)

--- a/pnpm/crates/cli/tests/stale_pin_dedupe.rs
+++ b/pnpm/crates/cli/tests/stale_pin_dedupe.rs
@@ -6,10 +6,31 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::{fs, path::Path, process::Command};
+use std::{fs, path::Path, process::Command, time::Duration};
 
 fn pacquet_at(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+/// Push `manifest_path`'s mtime to well after `lockfile_path`'s so the
+/// second install reads the manifest as a genuine later edit rather than
+/// an unchanged repeat. pnpm and pacquet both gate their incremental
+/// install fast path on a manifest being newer than the previous
+/// install; on a filesystem whose mtime granularity is coarser than the
+/// sub-second gap between these two back-to-back installs (some CI
+/// runners), both writes land in the same tick and the edit is otherwise
+/// skipped.
+fn mark_manifest_edited_after_install(manifest_path: &Path, lockfile_path: &Path) {
+    let lock_mtime = fs::metadata(lockfile_path)
+        .expect("stat pnpm-lock.yaml")
+        .modified()
+        .expect("read pnpm-lock.yaml mtime");
+    fs::File::options()
+        .write(true)
+        .open(manifest_path)
+        .expect("open package.json to bump its mtime")
+        .set_modified(lock_mtime + Duration::from_secs(10))
+        .expect("set package.json mtime");
 }
 
 fn write_manifest(path: &Path, dep_of_version: &str) {
@@ -56,6 +77,7 @@ fn refreshes_stale_transitive_pin_to_higher_direct_dep_version() {
     // transitive `^100.0.0`, so both edges must land on 100.1.0 and the
     // stale 100.0.0 must be pruned.
     write_manifest(&manifest_path, "100.1.0");
+    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
@@ -88,6 +110,7 @@ fn refreshes_stale_transitive_pin_for_caret_range_direct_dep() {
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     write_manifest(&manifest_path, "^100.1.0");
+    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
@@ -134,6 +157,7 @@ fn does_not_refresh_an_aliased_transitive_dependency() {
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     write("100.1.0");
+    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");


### PR DESCRIPTION
## Summary

Moves the unit and e2e **test** jobs of both CI workflows onto Blacksmith runners. The lint/detect/ancillary jobs already ran on Blacksmith (`blacksmith-4vcpu-ubuntu-2404`); only the test jobs were still on GitHub-hosted runners.

- **TS CI** (`ci.yml`): `test-smoke` and the `test` / `test-windows` matrices now pass `blacksmith-8vcpu-ubuntu-2404` / `blacksmith-8vcpu-windows-2022` into the reusable `test.yml`.
- **Rust CI** (`pacquet-ci.yml`): the `test` matrix ubuntu/windows legs move to the same Blacksmith labels. The macOS leg stays on `macos-latest` — Blacksmith offers no macOS runners.

The Bencher upload workflow validates testbed names against strict `ubuntu|windows|macos` regexes, and both test workflows derived that slug by stripping `-latest` from the runner label — which no longer works for Blacksmith labels. Fixed by mapping `*ubuntu*`/`*windows*` labels to the bare slug in `test.yml`, and deriving the slug (and artifact name) from `matrix.os_label` in the Rust test job.

### Bundled test fix: `stale_pin_dedupe` coarse-mtime robustness

Migrating the Rust `test` job to Blacksmith surfaced a deterministic failure in the three `stale_pin_dedupe` tests. Each runs two back-to-back installs, rewriting `package.json` between them, and asserts the second install re-resolves the bumped version. pnpm and pacquet both gate their incremental-install fast path (`optimistic_repeat_install`) on a manifest's mtime being newer than the previous install. The two installs run a few hundred ms apart, so on Blacksmith's coarse-granularity (≥1s) filesystem the rewritten manifest lands in the **same mtime tick** as the first install — the edit isn't seen as newer, re-resolution is skipped, and the lockfile keeps the stale version.

This is not a pacquet-vs-pnpm divergence (the fast path behaves the same in both stacks; forcing the second manifest's mtime equal to the lockfile's reproduces it locally regardless of baseline). The fix pushes the rewritten manifest's mtime past the lockfile's so the install reads a genuine later edit. It's bundled here rather than in a separate PR because the failure **only reproduces on Blacksmith**, so it can only be validated in this PR's CI.

> [!NOTE]
> Requires Blacksmith Windows runners to be enabled for the org — otherwise the Windows legs will sit queued. macOS is untouched.

## Squash Commit Body

```text
Move the unit and e2e test jobs that were still on GitHub-hosted runners
onto Blacksmith 8vcpu runners, matching the Blacksmith runners the
lint/detect/ancillary jobs already use.

- TS CI (ci.yml): test-smoke and the test/test-windows matrices now pass
  blacksmith-8vcpu-ubuntu-2404 / blacksmith-8vcpu-windows-2022 into the
  reusable test.yml.
- Rust CI (pacquet-ci.yml): the test matrix ubuntu/windows legs move to the
  same Blacksmith labels. The macOS leg stays on macos-latest because
  Blacksmith offers no macOS runners.

The Bencher upload workflow validates testbed names against strict
ubuntu/windows/macos regexes, and both test workflows derived that slug by
stripping "-latest" from the runner label, which no longer works for
Blacksmith labels. test.yml now maps *ubuntu*/*windows* labels to the bare
slug, and the Rust test job derives the slug (and its artifact name) from
matrix.os_label instead.

Also harden the three stale_pin_dedupe tests, which run two back-to-back
installs and fail on Blacksmith's coarse-granularity (>=1s) mtime
filesystem: the incremental-install fast path (shared with pnpm) treats
the same-tick manifest rewrite as unchanged and skips re-resolution. Push
the rewritten manifest's mtime past the lockfile's so the second install
reads a genuine later edit.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. _(CI config touches both stacks; the test fix is Rust-only test robustness — production fast path unchanged and already matches pnpm.)_
- [x] Added a changeset if this PR changes any published package. _(N/A — CI + test-only, no published package affected.)_
- [x] Added or updated tests. _(Hardens the three stale_pin_dedupe tests.)_
- [x] Updated the documentation if needed. _(N/A.)_

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI Improvements**
  - Updated TypeScript CI to run Ubuntu smoke and sharded tests on dedicated Blacksmith Ubuntu runners, using a single Ubuntu chunk.
  - Updated TypeScript Windows CI to use dedicated Blacksmith Windows runners for sharded execution while preserving the 3-shard structure.
  - Switched Pacquet/Bencher test duration staging to derive OS labels directly from the run matrix.
  - Improved the reusable test workflow’s OS matching logic for duration staging and error messaging.
- **Tests**
  - Strengthened pnpm stale pin refresh coverage by adjusting manifest modification times to avoid timestamp granularity flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->