### PR TITLE
test(deploy): pass the required include option in createDeployFiles test

### DIFF
--- a/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
@@ -53,6 +53,11 @@ test('createDeployFiles keeps local tarball package names when rewriting file UR
       },
     }],
     deployDir,
+    include: {
+      dependencies: true,
+      devDependencies: true,
+      optionalDependencies: true,
+    },
     lockfile,
     lockfileDir,
     selectedProjectManifest: {


### PR DESCRIPTION
## Summary

`main` currently fails `pnpm run compile-only` with `TS2741: Property 'include' is missing` in `createDeployFiles.test.ts`.

This is a logical merge conflict between two independently-green PRs:
- `#12864` added the `createDeployFiles({...})` call site in this test (without an `include` field).
- `#12935` made `include` a **required** option on `CreateDeployFilesOptions` and updated the production call site, but not this test.

Combined on `main`, the whole TypeScript build no longer type-checks.

The fix passes `include` with every dependency field enabled, matching the default the production deploy command (`deploy.ts`) uses when no `--prod`/`--dev`/`--no-optional` flags are set — so the test keeps exercising the same behavior it did before `include` existed.

Verified locally: `@pnpm/releasing.commands` compiles cleanly and `createDeployFiles.test.ts` passes (1/1).

## Squash Commit Body

```text
The createDeployFiles test predates the required `include` option that was
added to CreateDeployFilesOptions when the deploy graph-pruning logic
landed. The test's call site was never updated, so `pnpm run compile-only`
fails on main with TS2741 (Property 'include' is missing).

This is a logical merge conflict: the test's call site and the newly
required option arrived in separate PRs that were each green against an
older base. Pass `include` with every dependency field enabled, matching
the default the production deploy command uses when no --prod/--dev/--no-
optional flags are set, so the test keeps exercising the same behavior.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. _(TS test-only fix; the Rust side of the pruning feature already landed with #12935.)_
- [x] Added a changeset if this PR changes any published package. _(N/A — test-only, no published package behavior change.)_
- [x] Added or updated tests. _(Fixes the existing test's call site.)_
- [x] Updated the documentation if needed. _(N/A.)_

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786543504&installation_id=145934176&pr_number=12970&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12970&signature=2a49fc96d3fe400a05cbfd9b8a35c64bbd5c2d7940eb06f4d87328caec93d044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded deployment file generation test coverage to include dependency, development dependency, and optional dependency metadata.
  * Continued validating that local tarball package names remain intact when file URLs are rewritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->