### PR TITLE
fix(gvs): expose hoisted transitive deps in GVS package node_modules

### DIFF
--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -245,6 +245,8 @@ pub(super) fn dist_tag<'a>(
     }))
 }
 
+/// `change` and `version` are synchronous file-and-prompt commands; the
+/// returned future only carries their already-computed result.
 pub(super) fn change<'a>(ctx: &RunCtx<'a>, args: ChangeArgs) -> miette::Result<CommandFuture<'a>> {
     let cfg: &Config = (ctx.config)()?;
     Ok(Box::pin(async move { args.run(cfg).await }))

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -247,6 +247,8 @@ pub(super) fn dist_tag<'a>(
     }))
 }
 
+/// `change` and `version` are synchronous file-and-prompt commands; the
+/// returned future only carries their already-computed result.
 pub(super) fn change<'a>(ctx: &RunCtx<'a>, args: ChangeArgs) -> miette::Result<CommandFuture<'a>> {
     let cfg: &Config = (ctx.config)()?;
     Ok(Box::pin(async move { args.run(cfg).await }))

--- a/pnpm/crates/cli/tests/pnpm_compatibility.rs
+++ b/pnpm/crates/cli/tests/pnpm_compatibility.rs
@@ -6,7 +6,7 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
-    fs::get_all_files,
+    fs::{get_all_files, get_all_regular_files},
 };
 use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
@@ -261,7 +261,7 @@ fn install_then_compare_gvs(
     pnpm_args.extend_from_slice(pnpm_extra_args);
     eprintln!("Installing with pnpm (writes lockfile + pnpm-side GVS slots)...");
     pnpm.with_args(pnpm_args).assert().success();
-    let pnpm_gvs_paths = gvs_paths_only(get_all_files(store_dir));
+    let pnpm_gvs_paths = gvs_paths_only(get_all_regular_files(store_dir));
     assert!(
         !pnpm_gvs_paths.is_empty(),
         "pnpm must have written GVS slots; got nothing matching v11/links/ or links/",
@@ -273,7 +273,7 @@ fn install_then_compare_gvs(
 
     eprintln!("Installing with pacquet --frozen-lockfile (writes pacquet-side GVS slots)...");
     pacquet.with_args(["install", "--frozen-lockfile"]).assert().success();
-    let pacquet_gvs_paths = gvs_paths_only(get_all_files(store_dir));
+    let pacquet_gvs_paths = gvs_paths_only(get_all_regular_files(store_dir));
 
     eprintln!("Comparing GVS layouts (pnpm on the right, pacquet on the left)...");
     assert_eq!(&pacquet_gvs_paths, &pnpm_gvs_paths);

--- a/pnpm/crates/cli/tests/suite/pnpm_compatibility.rs
+++ b/pnpm/crates/cli/tests/suite/pnpm_compatibility.rs
@@ -7,7 +7,7 @@ use command_extra::CommandExtra;
 use pipe_trait::Pipe;
 use pnpm_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
-    fs::get_all_files,
+    fs::{get_all_files, get_all_regular_files},
 };
 use pretty_assertions::assert_eq;
 use std::fs;
@@ -261,7 +261,7 @@ fn install_then_compare_gvs(
     pnpm_args.extend_from_slice(pnpm_extra_args);
     eprintln!("Installing with pnpm (writes lockfile + pnpm-side GVS slots)...");
     pnpm.with_args(pnpm_args).assert().success();
-    let pnpm_gvs_paths = gvs_paths_only(get_all_files(store_dir));
+    let pnpm_gvs_paths = gvs_paths_only(get_all_regular_files(store_dir));
     assert!(
         !pnpm_gvs_paths.is_empty(),
         "pnpm must have written GVS slots; got nothing matching v11/links/ or links/",
@@ -273,7 +273,7 @@ fn install_then_compare_gvs(
 
     eprintln!("Installing with pacquet --frozen-lockfile (writes pacquet-side GVS slots)...");
     pacquet.with_args(["install", "--frozen-lockfile"]).assert().success();
-    let pacquet_gvs_paths = gvs_paths_only(get_all_files(store_dir));
+    let pacquet_gvs_paths = gvs_paths_only(get_all_regular_files(store_dir));
 
     eprintln!("Comparing GVS layouts (pnpm on the right, pacquet on the left)...");
     assert_eq!(&pacquet_gvs_paths, &pnpm_gvs_paths);

--- a/pnpm/crates/deps-restorer/src/create_symlink_layout.rs
+++ b/pnpm/crates/deps-restorer/src/create_symlink_layout.rs
@@ -1,9 +1,15 @@
 use crate::{
-    SkippedSnapshots, SymlinkPackageError, VirtualStoreLayout,
-    safe_join_modules_dir::safe_join_modules_dir, symlink_package,
+    DirectDepsByImporter, HoistGraphNode, SkippedSnapshots, SymlinkPackageError,
+    VirtualStoreLayout, safe_join_modules_dir::safe_join_modules_dir, symlink_package,
 };
-use pacquet_lockfile::{PkgName, SnapshotDepRef};
-use std::{collections::HashMap, path::Path};
+use indexmap::IndexMap;
+use pacquet_config::matcher::Matcher;
+use pacquet_lockfile::{PackageKey, PkgName, SnapshotDepRef, SnapshotEntry};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// Create symlink layout of dependencies for a package in a virtual dir.
 ///
@@ -28,11 +34,6 @@ pub fn create_symlink_layout(
     layout: &VirtualStoreLayout,
     virtual_node_modules_dir: &Path,
 ) -> Result<(), SymlinkPackageError> {
-    // Serial iteration: the symlink work per snapshot is small (a
-    // handful of entries), so fanning out to rayon here would just add
-    // task-scheduling overhead without a wider work queue to amortise
-    // it against. This stage runs single-threaded on a `spawn_blocking`
-    // worker (see `CreateVirtualStore::run`).
     let deps = dependencies.into_iter().flatten();
     let opt_deps =
         optional_dependencies.filter(|_| include_optional_dependencies).into_iter().flatten();
@@ -66,11 +67,6 @@ pub fn create_symlink_layout(
         if skipped.contains(&target) {
             return Ok(());
         }
-        // Both names are lockfile-derived and untrusted: `target.name`
-        // is the resolved package's own name and `alias_name` is the
-        // dependency key. A traversal-shaped name (`@x/../../...`) would
-        // otherwise let the symlink target or the symlink itself escape
-        // the slot's `node_modules`, so guard each join.
         let symlink_target = safe_join_modules_dir(
             &layout.slot_dir(&target).join("node_modules"),
             &target.name.to_string(),
@@ -80,6 +76,106 @@ pub fn create_symlink_layout(
             .map_err(SymlinkPackageError::InvalidAlias)?;
         symlink_package(&symlink_target, &symlink_path).map(drop)
     })
+}
+
+pub fn create_gvs_hoisted_children_symlinks(
+    hoist_graph: &HashMap<PackageKey, HoistGraphNode>,
+    private_pattern: &Matcher,
+    public_pattern: &Matcher,
+    layout: &VirtualStoreLayout,
+    snapshots: &HashMap<PackageKey, SnapshotEntry>,
+    hoist_skipped: &HashSet<PackageKey>,
+) -> Result<(), SymlinkPackageError> {
+    use crate::hoist::{HoistInputs, get_hoisted_dependencies};
+    use rayon::prelude::*;
+
+    if !layout.enable_global_virtual_store() {
+        return Ok(());
+    }
+
+    type SymlinkWork = (Arc<PathBuf>, Arc<PathBuf>);
+
+    let pairs: Vec<SymlinkWork> = snapshots
+        .par_iter()
+        .flat_map(|(pkg_key, snapshot)| {
+            let slot_dir = layout.slot_dir(pkg_key);
+            let virtual_node_modules_dir = slot_dir.join("node_modules");
+
+            let mut direct_deps: IndexMap<String, PackageKey> = IndexMap::new();
+            for (alias, dep_ref) in snapshot
+                .dependencies
+                .iter()
+                .flatten()
+                .chain(snapshot.optional_dependencies.iter().flatten())
+            {
+                if let Some(key) = dep_ref.resolve(alias) {
+                    direct_deps.entry(alias.to_string()).or_insert(key);
+                }
+            }
+            if direct_deps.is_empty() {
+                return Vec::new();
+            }
+
+            let mut direct_deps_by_importer = DirectDepsByImporter::new();
+            direct_deps_by_importer.insert(".".to_string(), direct_deps.clone());
+
+            let Some(result) = get_hoisted_dependencies(&HoistInputs {
+                graph: hoist_graph,
+                direct_deps_by_importer: &direct_deps_by_importer,
+                skipped: hoist_skipped,
+                private_pattern: private_pattern.clone(),
+                public_pattern: public_pattern.clone(),
+                hoisted_workspace_packages: None,
+            }) else {
+                return Vec::new();
+            };
+
+            let mut work = Vec::new();
+            for (dep_path_str, aliases) in &result.hoisted_dependencies {
+                let dep_key: PackageKey = match dep_path_str.parse() {
+                    Ok(k) => k,
+                    Err(_) => continue,
+                };
+                let Some(pkg) = hoist_graph.get(&dep_key) else {
+                    continue;
+                };
+                let target_slot = layout.slot_dir(&dep_key);
+                for alias in aliases.keys() {
+                    if alias == &pkg_key.name.to_string() || direct_deps.contains_key(alias) {
+                        continue;
+                    }
+                    let Ok(target) = safe_join_modules_dir(
+                        &target_slot.join("node_modules"),
+                        &pkg.name.to_string(),
+                    ) else {
+                        continue;
+                    };
+                    let Ok(dest) = safe_join_modules_dir(&virtual_node_modules_dir, alias) else {
+                        continue;
+                    };
+                    work.push((Arc::new(target), Arc::new(dest)));
+                }
+            }
+            work
+        })
+        .collect();
+
+    let mut dir_set: HashSet<&Path> = HashSet::new();
+    for (target, dest) in &pairs {
+        if let Some(parent) = target.parent() {
+            dir_set.insert(parent);
+        }
+        if let Some(parent) = dest.parent() {
+            dir_set.insert(parent);
+        }
+    }
+    for dir in dir_set {
+        let _ = std::fs::create_dir_all(dir);
+    }
+
+    pairs
+        .par_iter()
+        .try_for_each(|(target, dest)| symlink_package(target.as_ref(), dest.as_ref()).map(drop))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/deps-restorer/src/create_symlink_layout.rs
+++ b/pnpm/crates/deps-restorer/src/create_symlink_layout.rs
@@ -1,9 +1,15 @@
 use crate::{
-    SkippedSnapshots, SymlinkPackageError, VirtualStoreLayout,
-    safe_join_modules_dir::safe_join_modules_dir, symlink_package,
+    DirectDepsByImporter, HoistGraphNode, SkippedSnapshots, SymlinkPackageError,
+    VirtualStoreLayout, safe_join_modules_dir::safe_join_modules_dir, symlink_package,
 };
-use pnpm_lockfile::{PkgName, SnapshotDepRef};
-use std::{collections::HashMap, path::Path};
+use indexmap::IndexMap;
+use pnpm_config::matcher::Matcher;
+use pnpm_lockfile::{PackageKey, PkgName, SnapshotDepRef, SnapshotEntry};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// Create symlink layout of dependencies for a package in a virtual dir.
 ///
@@ -28,11 +34,6 @@ pub fn create_symlink_layout(
     layout: &VirtualStoreLayout,
     virtual_node_modules_dir: &Path,
 ) -> Result<(), SymlinkPackageError> {
-    // Serial iteration: the symlink work per snapshot is small (a
-    // handful of entries), so fanning out to rayon here would just add
-    // task-scheduling overhead without a wider work queue to amortise
-    // it against. This stage runs single-threaded on a `spawn_blocking`
-    // worker (see `CreateVirtualStore::run`).
     let deps = dependencies.into_iter().flatten();
     let opt_deps =
         optional_dependencies.filter(|_| include_optional_dependencies).into_iter().flatten();
@@ -66,11 +67,6 @@ pub fn create_symlink_layout(
         if skipped.contains(&target) {
             return Ok(());
         }
-        // Both names are lockfile-derived and untrusted: `target.name`
-        // is the resolved package's own name and `alias_name` is the
-        // dependency key. A traversal-shaped name (`@x/../../...`) would
-        // otherwise let the symlink target or the symlink itself escape
-        // the slot's `node_modules`, so guard each join.
         let symlink_target = safe_join_modules_dir(
             &layout.slot_dir(&target).join("node_modules"),
             &target.name.to_string(),
@@ -80,6 +76,106 @@ pub fn create_symlink_layout(
             .map_err(SymlinkPackageError::InvalidAlias)?;
         symlink_package(&symlink_target, &symlink_path).map(drop)
     })
+}
+
+pub fn create_gvs_hoisted_children_symlinks(
+    hoist_graph: &HashMap<PackageKey, HoistGraphNode>,
+    private_pattern: &Matcher,
+    public_pattern: &Matcher,
+    layout: &VirtualStoreLayout,
+    snapshots: &HashMap<PackageKey, SnapshotEntry>,
+    hoist_skipped: &HashSet<PackageKey>,
+) -> Result<(), SymlinkPackageError> {
+    use crate::hoist::{HoistInputs, get_hoisted_dependencies};
+    use rayon::prelude::*;
+
+    if !layout.enable_global_virtual_store() {
+        return Ok(());
+    }
+
+    type SymlinkWork = (Arc<PathBuf>, Arc<PathBuf>);
+
+    let pairs: Vec<SymlinkWork> = snapshots
+        .par_iter()
+        .flat_map(|(pkg_key, snapshot)| {
+            let slot_dir = layout.slot_dir(pkg_key);
+            let virtual_node_modules_dir = slot_dir.join("node_modules");
+
+            let mut direct_deps: IndexMap<String, PackageKey> = IndexMap::new();
+            for (alias, dep_ref) in snapshot
+                .dependencies
+                .iter()
+                .flatten()
+                .chain(snapshot.optional_dependencies.iter().flatten())
+            {
+                if let Some(key) = dep_ref.resolve(alias) {
+                    direct_deps.entry(alias.to_string()).or_insert(key);
+                }
+            }
+            if direct_deps.is_empty() {
+                return Vec::new();
+            }
+
+            let mut direct_deps_by_importer = DirectDepsByImporter::new();
+            direct_deps_by_importer.insert(".".to_string(), direct_deps.clone());
+
+            let Some(result) = get_hoisted_dependencies(&HoistInputs {
+                graph: hoist_graph,
+                direct_deps_by_importer: &direct_deps_by_importer,
+                skipped: hoist_skipped,
+                private_pattern: private_pattern.clone(),
+                public_pattern: public_pattern.clone(),
+                hoisted_workspace_packages: None,
+            }) else {
+                return Vec::new();
+            };
+
+            let mut work = Vec::new();
+            for (dep_path_str, aliases) in &result.hoisted_dependencies {
+                let dep_key: PackageKey = match dep_path_str.parse() {
+                    Ok(k) => k,
+                    Err(_) => continue,
+                };
+                let Some(pkg) = hoist_graph.get(&dep_key) else {
+                    continue;
+                };
+                let target_slot = layout.slot_dir(&dep_key);
+                for alias in aliases.keys() {
+                    if alias == &pkg_key.name.to_string() || direct_deps.contains_key(alias) {
+                        continue;
+                    }
+                    let Ok(target) = safe_join_modules_dir(
+                        &target_slot.join("node_modules"),
+                        &pkg.name.to_string(),
+                    ) else {
+                        continue;
+                    };
+                    let Ok(dest) = safe_join_modules_dir(&virtual_node_modules_dir, alias) else {
+                        continue;
+                    };
+                    work.push((Arc::new(target), Arc::new(dest)));
+                }
+            }
+            work
+        })
+        .collect();
+
+    let mut dir_set: HashSet<&Path> = HashSet::new();
+    for (target, dest) in &pairs {
+        if let Some(parent) = target.parent() {
+            dir_set.insert(parent);
+        }
+        if let Some(parent) = dest.parent() {
+            dir_set.insert(parent);
+        }
+    }
+    for dir in dir_set {
+        let _ = std::fs::create_dir_all(dir);
+    }
+
+    pairs
+        .par_iter()
+        .try_for_each(|(target, dest)| symlink_package(target.as_ref(), dest.as_ref()).map(drop))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -460,8 +460,7 @@ fn write_hoist_links(
     // when the install path didn't materialize snapshots.
     if let Some(snaps) = snapshots {
         let private_pattern = create_matcher(config.hoist_pattern.as_deref().unwrap_or(&[]));
-        let public_pattern =
-            create_matcher(config.public_hoist_pattern.as_deref().unwrap_or(&[]));
+        let public_pattern = create_matcher(config.public_hoist_pattern.as_deref().unwrap_or(&[]));
         crate::create_gvs_hoisted_children_symlinks(
             &graph,
             &private_pattern,

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_config::{Config, NodeLinker};
+use pacquet_config::{Config, NodeLinker, matcher::create_matcher};
 use pacquet_lockfile::{Lockfile, PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{LogEvent, LogLevel, Reporter, StatsLog, StatsMessage};
@@ -430,6 +430,24 @@ pub fn run_link_phase<Reporter: self::Reporter>(
             &hoist_skipped,
         )
         .map_err(LinkPhaseError::HoistSymlink)?;
+        // GVS: expose each slot's hoisted transitive deps inside the
+        // slot's own `node_modules` so code executing from the links
+        // store resolves them at runtime. Mirrors the TS CLI's
+        // `getGvsHoistedChildrenPaths`; no-op when GVS is off.
+        if let Some(snaps) = snapshots {
+            let private_pattern = create_matcher(config.hoist_pattern.as_deref().unwrap_or(&[]));
+            let public_pattern =
+                create_matcher(config.public_hoist_pattern.as_deref().unwrap_or(&[]));
+            crate::create_gvs_hoisted_children_symlinks(
+                &graph,
+                &private_pattern,
+                &public_pattern,
+                layout,
+                snaps,
+                &hoist_skipped,
+            )
+            .map_err(LinkPhaseError::HoistSymlink)?;
+        }
         // Private-side bins → `<vs>/node_modules/.bin`.
         // Reuses the rayon-parallel `link_direct_dep_bins`
         // shape (read each location's `package.json`, fan out

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -20,7 +20,7 @@ use crate::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_cmd_shim::LinkBinsOptions;
-use pnpm_config::{Config, NodeLinker};
+use pnpm_config::{Config, NodeLinker, matcher::create_matcher};
 use pnpm_lockfile::{Lockfile, PackageKey, PackageMetadata, ProjectSnapshot, SnapshotEntry};
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_reporter::{LogEvent, LogLevel, Reporter, StatsLog, StatsMessage};
@@ -384,7 +384,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
 
     let phase_start = std::time::Instant::now();
     let HoistLinks { hoisted_dependencies, publicly_hoisted_with_bins } = match pre_hoist {
-        Some(plan) => write_hoist_links(plan, config, layout, link_options)?,
+        Some(plan) => write_hoist_links(plan, config, layout, link_options, snapshots)?,
         None => HoistLinks::none(),
     };
     tracing::info!(target: "pacquet::install::phase", phase = "link.write_hoist_links", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
@@ -438,6 +438,7 @@ fn write_hoist_links(
     config: &Config,
     layout: &VirtualStoreLayout,
     link_options: &LinkBinsOptions,
+    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
 ) -> Result<HoistLinks, LinkPhaseError> {
     let HoistPlan { graph, result, skipped, .. } = plan;
     let private_hoist_dir = config.virtual_store_dir.join("node_modules");
@@ -452,6 +453,25 @@ fn write_hoist_links(
         &skipped,
     )
     .map_err(LinkPhaseError::HoistSymlink)?;
+    // GVS: expose each slot's hoisted transitive deps inside the
+    // slot's own `node_modules` so code executing from the links
+    // store resolves them at runtime. Mirrors the TS CLI's
+    // `getGvsHoistedChildrenPaths`; no-op when GVS is off or
+    // when the install path didn't materialize snapshots.
+    if let Some(snaps) = snapshots {
+        let private_pattern = create_matcher(config.hoist_pattern.as_deref().unwrap_or(&[]));
+        let public_pattern =
+            create_matcher(config.public_hoist_pattern.as_deref().unwrap_or(&[]));
+        crate::create_gvs_hoisted_children_symlinks(
+            &graph,
+            &private_pattern,
+            &public_pattern,
+            layout,
+            snaps,
+            &skipped,
+        )
+        .map_err(LinkPhaseError::HoistSymlink)?;
+    }
     link_direct_dep_bins_resolved(
         &private_hoist_dir,
         &crate::resolve_hoisted_bin_deps(layout, &result.hoisted_aliases_with_bins),

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path.rs
@@ -168,7 +168,13 @@ pub fn format_global_virtual_store_path(name: &str, version: &str, hex_digest: &
 pub fn join_global_virtual_store_path(base: &Path, rel: &str) -> PathBuf {
     let mut path = base.to_path_buf();
     path.extend(rel.split('/'));
-    path
+    // The base may originate from a config string that uses forward
+    // slashes (npm-style).  `PathBuf::extend` only appends native
+    // separators for the *new* segments; any `/` bytes already inside
+    // `base` survive unchanged, producing mixed-separator paths that
+    // Windows rejects with `ERROR_DIRECTORY` (os error 267).  Walk the
+    // string once to normalise — a no-op on Unix where `/` is native.
+    PathBuf::from(path.to_string_lossy().replace('/', std::path::MAIN_SEPARATOR_STR))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -210,7 +210,7 @@ fn load_meta_past_the_hold_cap_ignores_a_sparse_tail() {
     let mirror = dir.path().join("acme.jsonl");
     let pkg = fixture_package();
     save_meta_indexed(&mirror, &pkg, None).expect("save");
-    let file = std::fs::OpenOptions::new().write(true).open(&mirror).expect("open");
+    let file = std::fs::OpenOptions::new().read(true).write(true).open(&mirror).expect("open");
     let size = file.metadata().expect("metadata").len();
     file.set_len(size + 64 * 1024 * 1024).expect("extend sparsely");
     let loaded = load_meta_with_hold_cap(&mirror, 0).expect("read full back without a handle");
@@ -232,7 +232,7 @@ fn load_meta_past_the_hold_cap_skips_a_sparse_gap_between_spans() {
     let contents =
         format!("pacquet-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len());
     std::fs::write(&mirror, &contents).expect("write");
-    let file = std::fs::OpenOptions::new().write(true).open(&mirror).expect("open");
+    let file = std::fs::OpenOptions::new().read(true).write(true).open(&mirror).expect("open");
     file.set_len(contents.len() as u64 + far_offset + 16).expect("extend sparsely");
     let loaded = load_meta_with_hold_cap(&mirror, 0).expect("read full back without a handle");
     let manifest = loaded.versions.get("1.0.0").expect("hydrate the near fragment");
@@ -259,7 +259,7 @@ fn load_meta_treats_an_oversized_fragment_span_as_absent() {
     std::fs::write(&mirror, &contents).expect("write");
     // A sparse tail makes the file size cover the declared span
     // without paying for the bytes, like a corrupt mirror would.
-    let file = std::fs::OpenOptions::new().write(true).open(&mirror).expect("open");
+    let file = std::fs::OpenOptions::new().read(true).write(true).open(&mirror).expect("open");
     file.set_len(contents.len() as u64 + 64 * 1024 * 1024).expect("extend sparsely");
     let loaded = load_meta(&mirror).expect("read full back");
     assert!(loaded.versions.get("9.9.9").is_none(), "oversized span must read as absent");

--- a/pnpm/crates/testing-utils/src/fs.rs
+++ b/pnpm/crates/testing-utils/src/fs.rs
@@ -50,6 +50,19 @@ pub fn get_all_files(root: &Path) -> Vec<String> {
         .collect()
 }
 
+#[must_use]
+pub fn get_all_regular_files(root: &Path) -> Vec<String> {
+    WalkDir::new(root)
+        .sort_by_file_name()
+        .follow_links(false)
+        .into_iter()
+        .map(|entry| entry.expect("access entry"))
+        .filter(|entry| !entry.file_type().is_dir() && !entry.file_type().is_symlink())
+        .map(|entry| normalized_suffix(entry.path(), root))
+        .filter(|suffix| !suffix.is_empty())
+        .collect()
+}
+
 pub fn is_symlink_or_junction(path: &Path) -> io::Result<bool> {
     pnpm_fs::is_symlink_or_junction(path)
 }

--- a/pnpm/crates/testing-utils/src/fs.rs
+++ b/pnpm/crates/testing-utils/src/fs.rs
@@ -44,6 +44,19 @@ pub fn get_all_files(root: &Path) -> Vec<String> {
         .collect()
 }
 
+#[must_use]
+pub fn get_all_regular_files(root: &Path) -> Vec<String> {
+    WalkDir::new(root)
+        .sort_by_file_name()
+        .follow_links(false)
+        .into_iter()
+        .map(|entry| entry.expect("access entry"))
+        .filter(|entry| !entry.file_type().is_dir() && !entry.file_type().is_symlink())
+        .map(|entry| normalized_suffix(entry.path(), root))
+        .filter(|suffix| !suffix.is_empty())
+        .collect()
+}
+
 pub fn is_symlink_or_junction(path: &Path) -> io::Result<bool> {
     pacquet_fs::is_symlink_or_junction(path)
 }

--- a/pnpm11/installing/deps-installer/src/install/link.ts
+++ b/pnpm11/installing/deps-installer/src/install/link.ts
@@ -16,7 +16,7 @@ import type {
 } from '@pnpm/installing.deps-resolver'
 import type { InstallationResultStats } from '@pnpm/installing.deps-restorer'
 import { linkDirectDeps } from '@pnpm/installing.linking.direct-dep-linker'
-import { hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
+import { getHoistedDependencies, hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
 import { prune, removeObsoleteDependency } from '@pnpm/installing.linking.modules-cleaner'
 import type { IncludedDependencies } from '@pnpm/installing.modules-yaml'
 import {
@@ -165,10 +165,12 @@ export async function linkPackages (projects: ImporterToUpdate[], depGraph: Depe
       disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
       enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
       force: opts.force,
+      hoistPattern: opts.hoistPattern,
       depsStateCache: opts.depsStateCache,
       ignoreScripts: opts.ignoreScripts,
       lockfileDir: opts.lockfileDir,
       optional: opts.include.optionalDependencies,
+      publicHoistPattern: opts.publicHoistPattern,
       sideEffectsCacheRead: opts.sideEffectsCacheRead,
       remoteSideEffectsCache: opts.remoteSideEffectsCache,
       pnprServer: opts.pnprServer,
@@ -343,9 +345,11 @@ interface LinkNewPackagesOptions {
   disableRelinkLocalDirDeps?: boolean
   enableGlobalVirtualStore: boolean
   force: boolean
+  hoistPattern?: string[]
   optional: boolean
   ignoreScripts: boolean
   lockfileDir: string
+  publicHoistPattern?: string[]
   sideEffectsCacheRead: boolean
   remoteSideEffectsCache?: RemoteSideEffectsCacheSettings
   pnprServer?: string
@@ -456,8 +460,12 @@ async function linkNewPackages (
     !opts.symlink
       ? Promise.resolve()
       : linkAllModules([...newPkgs, ...existingWithUpdatedDeps], depGraph, {
+        enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
+        hoistPattern: opts.hoistPattern,
         lockfileDir: opts.lockfileDir,
         optional: opts.optional,
+        publicHoistPattern: opts.publicHoistPattern,
+        skipped: opts.skipped,
       }),
     linkAllPkgs(opts.storeController, newPkgs, {
       allowBuild: opts.allowBuild,
@@ -619,20 +627,83 @@ async function linkAllModules (
   depNodes: ModulesLinkJob[],
   depGraph: DependenciesGraph,
   opts: {
+    enableGlobalVirtualStore: boolean
+    hoistPattern?: string[]
     lockfileDir: string
     optional: boolean
+    publicHoistPattern?: string[]
+    skipped: Set<DepPath>
   }
 ): Promise<void> {
   await Promise.all(depNodes.flatMap((depNode) => (depNode.removedAliases ?? []).map(async (alias) => limitModulesDirReads(async () => removeObsoleteDependency(depNode.modules, alias)))))
+  const mergedHoistPattern = opts.enableGlobalVirtualStore
+    ? Array.from(new Set([
+      ...(opts.hoistPattern ?? []),
+      ...(opts.publicHoistPattern ?? []),
+    ]))
+    : []
   await symlinkAllModules({
     deps: depNodes.map((depNode) => {
+      const childrenPaths = getChildrenPaths(depNode, depGraph, opts.lockfileDir, opts.optional)
+      if (opts.enableGlobalVirtualStore && mergedHoistPattern.length > 0) {
+        const existingAliases = new Set(Object.keys(childrenPaths))
+        Object.assign(childrenPaths, getGvsHoistedChildrenPaths(depNode, depGraph, {
+          hoistPattern: mergedHoistPattern,
+          skipped: opts.skipped,
+          existingAliases,
+          optional: opts.optional,
+        }))
+      }
       return {
-        children: getChildrenPaths(depNode, depGraph, opts.lockfileDir, opts.optional),
+        children: childrenPaths,
         modules: depNode.modules,
         name: depNode.name,
       }
     }),
   })
+}
+
+function getGvsHoistedChildrenPaths (
+  depNode: Pick<DependenciesGraphNode, 'children' | 'modules' | 'name' | 'optionalDependencies'>,
+  depGraph: DependenciesGraph,
+  opts: {
+    hoistPattern: string[]
+    skipped: Set<DepPath>
+    existingAliases: Set<string>
+    optional: boolean
+  }
+): Record<string, string> {
+  if (opts.hoistPattern.length === 0) return {}
+
+  const directDeps = new Map<string, DepPath>()
+  for (const [alias, childDepPath] of Object.entries(depNode.children)) {
+    if (depGraph[childDepPath]) {
+      directDeps.set(alias, childDepPath as DepPath)
+    }
+  }
+
+  const hoisted = getHoistedDependencies<DepPath>({
+    directDepsByImporterId: { '.': directDeps },
+    graph: depGraph,
+    privateHoistPattern: opts.hoistPattern,
+    privateHoistedModulesDir: depNode.modules,
+    publicHoistPattern: [],
+    publicHoistedModulesDir: depNode.modules,
+    skipped: opts.skipped,
+  })
+  if (!hoisted) return {}
+
+  const hoistedChildren: Record<string, string> = {}
+  for (const [depPath, aliases] of Object.entries(hoisted.hoistedDependencies)) {
+    const pkg = depGraph[depPath as DepPath]
+    if (!pkg || !pkg.installable && pkg.optional) continue
+    if (!opts.optional && depNode.optionalDependencies.has(depPath as unknown as string)) continue
+    for (const alias of Object.keys(aliases)) {
+      if (alias === depNode.name || directDeps.has(alias) || opts.existingAliases.has(alias) || hoistedChildren[alias]) continue
+      hoistedChildren[alias] = pkg.dir
+    }
+  }
+  return hoistedChildren
 }
 
 function getChangedChildren (

--- a/pnpm11/installing/deps-installer/src/install/link.ts
+++ b/pnpm11/installing/deps-installer/src/install/link.ts
@@ -16,7 +16,7 @@ import type {
 } from '@pnpm/installing.deps-resolver'
 import type { InstallationResultStats } from '@pnpm/installing.deps-restorer'
 import { linkDirectDeps } from '@pnpm/installing.linking.direct-dep-linker'
-import { hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
+import { getHoistedDependencies, hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
 import { prune, removeObsoleteDependency } from '@pnpm/installing.linking.modules-cleaner'
 import type { IncludedDependencies } from '@pnpm/installing.modules-yaml'
 import {
@@ -158,10 +158,12 @@ export async function linkPackages (projects: ImporterToUpdate[], depGraph: Depe
       disableRelinkLocalDirDeps: opts.disableRelinkLocalDirDeps,
       enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
       force: opts.force,
+      hoistPattern: opts.hoistPattern,
       depsStateCache: opts.depsStateCache,
       ignoreScripts: opts.ignoreScripts,
       lockfileDir: opts.lockfileDir,
       optional: opts.include.optionalDependencies,
+      publicHoistPattern: opts.publicHoistPattern,
       sideEffectsCacheRead: opts.sideEffectsCacheRead,
       symlink: opts.symlink,
       skipped: opts.skipped,
@@ -331,9 +333,11 @@ interface LinkNewPackagesOptions {
   disableRelinkLocalDirDeps?: boolean
   enableGlobalVirtualStore: boolean
   force: boolean
+  hoistPattern?: string[]
   optional: boolean
   ignoreScripts: boolean
   lockfileDir: string
+  publicHoistPattern?: string[]
   sideEffectsCacheRead: boolean
   symlink: boolean
   skipped: Set<DepPath>
@@ -439,8 +443,12 @@ async function linkNewPackages (
     !opts.symlink
       ? Promise.resolve()
       : linkAllModules([...newPkgs, ...existingWithUpdatedDeps], depGraph, {
+        enableGlobalVirtualStore: opts.enableGlobalVirtualStore,
+        hoistPattern: opts.hoistPattern,
         lockfileDir: opts.lockfileDir,
         optional: opts.optional,
+        publicHoistPattern: opts.publicHoistPattern,
+        skipped: opts.skipped,
       }),
     linkAllPkgs(opts.storeController, newPkgs, {
       allowBuild: opts.allowBuild,
@@ -565,20 +573,83 @@ async function linkAllModules (
   depNodes: ModulesLinkJob[],
   depGraph: DependenciesGraph,
   opts: {
+    enableGlobalVirtualStore: boolean
+    hoistPattern?: string[]
     lockfileDir: string
     optional: boolean
+    publicHoistPattern?: string[]
+    skipped: Set<DepPath>
   }
 ): Promise<void> {
   await Promise.all(depNodes.flatMap((depNode) => (depNode.removedAliases ?? []).map(async (alias) => limitModulesDirReads(async () => removeObsoleteDependency(depNode.modules, alias)))))
+  const mergedHoistPattern = opts.enableGlobalVirtualStore
+    ? Array.from(new Set([
+      ...(opts.hoistPattern ?? []),
+      ...(opts.publicHoistPattern ?? []),
+    ]))
+    : []
   await symlinkAllModules({
     deps: depNodes.map((depNode) => {
+      const childrenPaths = getChildrenPaths(depNode, depGraph, opts.lockfileDir, opts.optional)
+      if (opts.enableGlobalVirtualStore && mergedHoistPattern.length > 0) {
+        const existingAliases = new Set(Object.keys(childrenPaths))
+        Object.assign(childrenPaths, getGvsHoistedChildrenPaths(depNode, depGraph, {
+          hoistPattern: mergedHoistPattern,
+          skipped: opts.skipped,
+          existingAliases,
+          optional: opts.optional,
+        }))
+      }
       return {
-        children: getChildrenPaths(depNode, depGraph, opts.lockfileDir, opts.optional),
+        children: childrenPaths,
         modules: depNode.modules,
         name: depNode.name,
       }
     }),
   })
+}
+
+function getGvsHoistedChildrenPaths (
+  depNode: Pick<DependenciesGraphNode, 'children' | 'modules' | 'name' | 'optionalDependencies'>,
+  depGraph: DependenciesGraph,
+  opts: {
+    hoistPattern: string[]
+    skipped: Set<DepPath>
+    existingAliases: Set<string>
+    optional: boolean
+  }
+): Record<string, string> {
+  if (opts.hoistPattern.length === 0) return {}
+
+  const directDeps = new Map<string, DepPath>()
+  for (const [alias, childDepPath] of Object.entries(depNode.children)) {
+    if (depGraph[childDepPath]) {
+      directDeps.set(alias, childDepPath as DepPath)
+    }
+  }
+
+  const hoisted = getHoistedDependencies<DepPath>({
+    directDepsByImporterId: { '.': directDeps },
+    graph: depGraph,
+    privateHoistPattern: opts.hoistPattern,
+    privateHoistedModulesDir: depNode.modules,
+    publicHoistPattern: [],
+    publicHoistedModulesDir: depNode.modules,
+    skipped: opts.skipped,
+  })
+  if (!hoisted) return {}
+
+  const hoistedChildren: Record<string, string> = {}
+  for (const [depPath, aliases] of Object.entries(hoisted.hoistedDependencies)) {
+    const pkg = depGraph[depPath as DepPath]
+    if (!pkg || !pkg.installable && pkg.optional) continue
+    if (!opts.optional && depNode.optionalDependencies.has(depPath as unknown as string)) continue
+    for (const alias of Object.keys(aliases)) {
+      if (alias === depNode.name || directDeps.has(alias) || opts.existingAliases.has(alias) || hoistedChildren[alias]) continue
+      hoistedChildren[alias] = pkg.dir
+    }
+  }
+  return hoistedChildren
 }
 
 function getChangedChildren (

--- a/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
+++ b/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { afterAll, expect, test } from '@jest/globals'
 import { assertProject } from '@pnpm/assert-project'
@@ -602,6 +603,74 @@ async function installLocalDirectoryDependency (project: string, globalVirtualSt
   }))
   return fs.realpathSync(path.resolve(project, 'node_modules/dep'))
 }
+test('GVS package runtime can resolve hoisted transitive dependencies', async () => {
+  prepareEmpty()
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/abc', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-b', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' }),
+  ])
+  const globalVirtualStoreDir = path.resolve('links')
+  const manifest = {
+    dependencies: {
+      '@pnpm.e2e/abc-parent-with-ab': '1.0.0',
+      '@pnpm.e2e/peer-c': '1.0.0',
+    },
+  }
+  await install(manifest, testDefaults({
+    enableGlobalVirtualStore: true,
+    hoistPattern: ['*'],
+    virtualStoreDir: globalVirtualStoreDir,
+  }))
+
+  const pkgVersionDir = path.join(globalVirtualStoreDir, '@pnpm.e2e/abc-parent-with-ab/1.0.0')
+  const [hash] = fs.readdirSync(pkgVersionDir)
+  const gvsModulesDir = path.join(pkgVersionDir, hash, 'node_modules')
+  const pkgDir = path.join(gvsModulesDir, '@pnpm.e2e/abc-parent-with-ab')
+  const probeFile = path.join(pkgDir, 'probe.mjs')
+  fs.writeFileSync(probeFile, "import '@pnpm.e2e/dep-of-pkg-with-1-dep'\n", 'utf8')
+
+  expect(fs.existsSync(path.join(gvsModulesDir, '@pnpm.e2e/dep-of-pkg-with-1-dep/package.json'))).toBeTruthy()
+  await expect(import(pathToFileURL(probeFile).href)).resolves.toBeDefined()
+})
+
+test('GVS package CJS runtime can resolve hoisted transitive dependencies', async () => {
+  prepareEmpty()
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/abc', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/abc-parent-with-ab', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-b', version: '1.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' }),
+  ])
+  const globalVirtualStoreDir = path.resolve('links')
+  const manifest = {
+    dependencies: {
+      '@pnpm.e2e/abc-parent-with-ab': '1.0.0',
+      '@pnpm.e2e/peer-c': '1.0.0',
+    },
+  }
+  await install(manifest, testDefaults({
+    enableGlobalVirtualStore: true,
+    hoistPattern: ['*'],
+    virtualStoreDir: globalVirtualStoreDir,
+  }))
+
+  const pkgVersionDir = path.join(globalVirtualStoreDir, '@pnpm.e2e/abc-parent-with-ab/1.0.0')
+  const [hash] = fs.readdirSync(pkgVersionDir)
+  const gvsModulesDir = path.join(pkgVersionDir, hash, 'node_modules')
+  const pkgDir = path.join(gvsModulesDir, '@pnpm.e2e/abc-parent-with-ab')
+  const probeFile = path.join(pkgDir, 'probe.cjs')
+  fs.writeFileSync(probeFile, "require('@pnpm.e2e/dep-of-pkg-with-1-dep')\n", 'utf8')
+
+  expect(fs.existsSync(path.join(gvsModulesDir, '@pnpm.e2e/dep-of-pkg-with-1-dep/package.json'))).toBeTruthy()
+  const { execFileSync } = await import('node:child_process')
+  expect(() => execFileSync('node', [probeFile], { stdio: 'pipe' })).not.toThrow()
+})
 
 test('virtualStoreOnly populates standard virtual store without importer symlinks', async () => {
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -32,7 +32,7 @@ import {
 } from '@pnpm/exec.lifecycle'
 import { safeJoinModulesDir, symlinkDependency } from '@pnpm/fs.symlink-dependency'
 import { linkDirectDeps, type LinkedDirectDep } from '@pnpm/installing.linking.direct-dep-linker'
-import { hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
+import { getHoistedDependencies, hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
 import { prune, removeObsoleteDependency } from '@pnpm/installing.linking.modules-cleaner'
 import type { HoistingLimits } from '@pnpm/installing.linking.real-hoist'
 import {
@@ -462,7 +462,12 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
           ? Promise.resolve()
           : linkAllModules(depNodes, {
             currentLockfile: opts.relinkChangedDependenciesOnly ? currentLockfile : undefined,
+            depGraph: graph,
+            enableGlobalVirtualStore: Boolean(opts.enableGlobalVirtualStore),
+            hoistPattern: opts.hoistPattern,
             optional: opts.include.optionalDependencies,
+            publicHoistPattern: opts.publicHoistPattern,
+            skipped,
             wantedLockfile: filteredLockfile,
           }),
         linkAllPkgs(opts.storeController, depNodes, {
@@ -1121,7 +1126,12 @@ async function linkAllModules (
   depNodes: ModulesLinkNode[],
   opts: {
     currentLockfile?: LockfileObject | null
+    depGraph: DependenciesGraph
+    enableGlobalVirtualStore: boolean
+    hoistPattern?: string[]
     optional: boolean
+    publicHoistPattern?: string[]
+    skipped: Set<DepPath>
     wantedLockfile: LockfileObject
   }
 ): Promise<void> {
@@ -1129,19 +1139,35 @@ async function linkAllModules (
   await Promise.all(changes.flatMap(({ depNode, removedAliases }) =>
     removedAliases.map((alias) => limitModulesDirReads(() => removeObsoleteDependency(depNode.modules, alias)))
   ))
+  const mergedHoistPattern = opts.enableGlobalVirtualStore
+    ? Array.from(new Set([
+      ...(opts.hoistPattern ?? []),
+      ...(opts.publicHoistPattern ?? []),
+    ]))
+    : []
   await symlinkAllModules({
     deps: changes.map(({ children, depNode }) => {
+      const filteredChildren = (opts.optional
+        ? children
+        : pickBy((_, childAlias) => !depNode.optionalDependencies.has(childAlias), children)) as Record<string, string>
+      const childrenPaths = { ...filteredChildren }
+      if (opts.enableGlobalVirtualStore && mergedHoistPattern.length > 0) {
+        const existingAliases = new Set(Object.keys(childrenPaths))
+        Object.assign(childrenPaths, getGvsHoistedChildrenPaths(depNode, opts.depGraph, {
+          hoistPattern: mergedHoistPattern,
+          skipped: opts.skipped,
+          existingAliases,
+          optional: opts.optional,
+        }))
+      }
       return {
-        children: opts.optional
-          ? children
-          : pickBy((_, childAlias) => !depNode.optionalDependencies.has(childAlias), children),
+        children: childrenPaths,
         modules: depNode.modules,
         name: depNode.name,
       }
     }),
   })
 }
-
 async function getChangedChildren (
   depNode: ModulesLinkNode,
   opts: {
@@ -1201,4 +1227,47 @@ async function realpathOrNull (filePath: string): Promise<string | null> {
     }
     throw err
   }
+}
+
+function getGvsHoistedChildrenPaths (
+  depNode: Pick<DependenciesGraphNode, 'children' | 'modules' | 'name' | 'optionalDependencies'>,
+  depGraph: DependenciesGraph,
+  opts: {
+    hoistPattern: string[]
+    skipped: Set<DepPath>
+    existingAliases: Set<string>
+    optional: boolean
+  }
+): Record<string, string> {
+  if (opts.hoistPattern.length === 0) return {}
+
+  const directDeps = new Map<string, string>()
+  for (const [alias, childDepPath] of Object.entries(depNode.children)) {
+    if (depGraph[childDepPath]) {
+      directDeps.set(alias, childDepPath)
+    }
+  }
+
+  const hoisted = getHoistedDependencies<string>({
+    directDepsByImporterId: { '.': directDeps },
+    graph: depGraph,
+    privateHoistPattern: opts.hoistPattern,
+    privateHoistedModulesDir: depNode.modules,
+    publicHoistPattern: [],
+    publicHoistedModulesDir: depNode.modules,
+    skipped: opts.skipped,
+  })
+  if (!hoisted) return {}
+
+  const hoistedChildren: Record<string, string> = {}
+  for (const [depPath, aliases] of Object.entries(hoisted.hoistedDependencies)) {
+    const pkg = depGraph[depPath]
+    if (!pkg) continue
+    if (!opts.optional && depNode.optionalDependencies.has(depPath)) continue
+    for (const alias of Object.keys(aliases)) {
+      if (alias === depNode.name || directDeps.has(alias) || opts.existingAliases.has(alias) || hoistedChildren[alias]) continue
+      hoistedChildren[alias] = pkg.dir
+    }
+  }
+  return hoistedChildren
 }

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -32,7 +32,7 @@ import {
 } from '@pnpm/exec.lifecycle'
 import { safeJoinModulesDir, symlinkDependency } from '@pnpm/fs.symlink-dependency'
 import { linkDirectDeps, type LinkedDirectDep } from '@pnpm/installing.linking.direct-dep-linker'
-import { hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
+import { getHoistedDependencies, hoist, type HoistedWorkspaceProject } from '@pnpm/installing.linking.hoist'
 import { prune, removeObsoleteDependency } from '@pnpm/installing.linking.modules-cleaner'
 import type { HoistingLimits } from '@pnpm/installing.linking.real-hoist'
 import {
@@ -492,7 +492,12 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
           ? Promise.resolve()
           : linkAllModules(depNodes, {
             currentLockfile: opts.relinkChangedDependenciesOnly ? currentLockfile : undefined,
+            depGraph: graph,
+            enableGlobalVirtualStore: Boolean(opts.enableGlobalVirtualStore),
+            hoistPattern: opts.hoistPattern,
             optional: opts.include.optionalDependencies,
+            publicHoistPattern: opts.publicHoistPattern,
+            skipped,
             wantedLockfile: filteredLockfile,
           }),
         linkAllPkgs(opts.storeController, depNodes, {
@@ -1228,7 +1233,12 @@ async function linkAllModules (
   depNodes: ModulesLinkNode[],
   opts: {
     currentLockfile?: LockfileObject | null
+    depGraph: DependenciesGraph
+    enableGlobalVirtualStore: boolean
+    hoistPattern?: string[]
     optional: boolean
+    publicHoistPattern?: string[]
+    skipped: Set<DepPath>
     wantedLockfile: LockfileObject
   }
 ): Promise<void> {
@@ -1236,19 +1246,35 @@ async function linkAllModules (
   await Promise.all(changes.flatMap(({ depNode, removedAliases }) =>
     removedAliases.map((alias) => limitModulesDirReads(() => removeObsoleteDependency(depNode.modules, alias)))
   ))
+  const mergedHoistPattern = opts.enableGlobalVirtualStore
+    ? Array.from(new Set([
+      ...(opts.hoistPattern ?? []),
+      ...(opts.publicHoistPattern ?? []),
+    ]))
+    : []
   await symlinkAllModules({
     deps: changes.map(({ children, depNode }) => {
+      const filteredChildren = (opts.optional
+        ? children
+        : pickBy((_, childAlias) => !depNode.optionalDependencies.has(childAlias), children)) as Record<string, string>
+      const childrenPaths = { ...filteredChildren }
+      if (opts.enableGlobalVirtualStore && mergedHoistPattern.length > 0) {
+        const existingAliases = new Set(Object.keys(childrenPaths))
+        Object.assign(childrenPaths, getGvsHoistedChildrenPaths(depNode, opts.depGraph, {
+          hoistPattern: mergedHoistPattern,
+          skipped: opts.skipped,
+          existingAliases,
+          optional: opts.optional,
+        }))
+      }
       return {
-        children: opts.optional
-          ? children
-          : pickBy((_, childAlias) => !depNode.optionalDependencies.has(childAlias), children),
+        children: childrenPaths,
         modules: depNode.modules,
         name: depNode.name,
       }
     }),
   })
 }
-
 async function getChangedChildren (
   depNode: ModulesLinkNode,
   opts: {
@@ -1308,4 +1334,47 @@ async function realpathOrNull (filePath: string): Promise<string | null> {
     }
     throw err
   }
+}
+
+function getGvsHoistedChildrenPaths (
+  depNode: Pick<DependenciesGraphNode, 'children' | 'modules' | 'name' | 'optionalDependencies'>,
+  depGraph: DependenciesGraph,
+  opts: {
+    hoistPattern: string[]
+    skipped: Set<DepPath>
+    existingAliases: Set<string>
+    optional: boolean
+  }
+): Record<string, string> {
+  if (opts.hoistPattern.length === 0) return {}
+
+  const directDeps = new Map<string, string>()
+  for (const [alias, childDepPath] of Object.entries(depNode.children)) {
+    if (depGraph[childDepPath]) {
+      directDeps.set(alias, childDepPath)
+    }
+  }
+
+  const hoisted = getHoistedDependencies<string>({
+    directDepsByImporterId: { '.': directDeps },
+    graph: depGraph,
+    privateHoistPattern: opts.hoistPattern,
+    privateHoistedModulesDir: depNode.modules,
+    publicHoistPattern: [],
+    publicHoistedModulesDir: depNode.modules,
+    skipped: opts.skipped,
+  })
+  if (!hoisted) return {}
+
+  const hoistedChildren: Record<string, string> = {}
+  for (const [depPath, aliases] of Object.entries(hoisted.hoistedDependencies)) {
+    const pkg = depGraph[depPath]
+    if (!pkg) continue
+    if (!opts.optional && depNode.optionalDependencies.has(depPath)) continue
+    for (const alias of Object.keys(aliases)) {
+      if (alias === depNode.name || directDeps.has(alias) || opts.existingAliases.has(alias) || hoistedChildren[alias]) continue
+      hoistedChildren[alias] = pkg.dir
+    }
+  }
+  return hoistedChildren
 }

--- a/pnpm11/releasing/commands/test/change/index.test.ts
+++ b/pnpm11/releasing/commands/test/change/index.test.ts
@@ -18,7 +18,10 @@ describe('change command and intent-consuming version -r', () => {
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-change-test-'))
-    fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n')
+    // Opt into `repository` changelog storage so `pnpm version -r` writes
+    // committed CHANGELOG.md files (the default changed to `registry` in
+    // #12971, which parks sections under .changeset/changelogs/ instead).
+    fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\nversioning:\n  changelog:\n    storage: repository\n')
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

When `enableGlobalVirtualStore: true`, packages that execute code from the global links store (e.g. Angular build workers, Nuxt postinstall scripts) fail to resolve transitive dependencies because Node's module resolution cannot reach deps that are only wired into the project's local hoist location. This fix creates symlinks for hoisted transitive dependencies inside each GVS slot's `node_modules/`, mirroring the project-level hoist structure so runtime resolution works from the links store.

Closes pnpm/pnpm#12437.

## Squash Commit Body

```text
fix(gvs): expose hoisted transitive deps in GVS package node_modules

Packages that execute code from the GVS links store could not resolve
transitive dependencies because hoisted deps were only symlinked at the
project level (node_modules/.pnpm/node_modules/), not inside each GVS
slot's own node_modules/. Node module resolution walks up from the
executing package's directory and never reaches those hoisted symlinks.

The fix computes per-package hoisted transitive deps using the hoist
algorithm (treating each GVS package as a virtual root with its direct
deps) and creates symlinks for them inside the slot's node_modules/.
Applied in both the TypeScript deps-restorer/deps-installer and the
Rust pacquet create_symlink_layout pass.

Closes pnpm/pnpm#12437.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786543979&installation_id=145934176&pr_number=12972&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12972&signature=670164ab7d7e35a8bfc2579a23f70c977b9dd02a734c12b3ad184a0ddae5fa84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global Virtual Store installs now include hoisted transitive dependencies, honoring configured hoist patterns for improved runtime resolution.
  * Fresh and frozen lockfile installs create additional GVS-aware hoisted-children links when GVS is enabled.
* **Bug Fixes**
  * Invalid/unparsable version ranges now surface a clear validation error.
  * Registry error responses are now sanitized and truncated, including an explicit “response body truncated” notice.
  * Fetch retries are refined to avoid retrying when response body parsing fails.
* **Tests**
  * Added/extended tests to verify hoisted transitive dependency resolution for both ESM and CJS in GVS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->