### PR TITLE
test(cli): make stale-pin-dedupe robust on coarse-mtime filesystems

### DIFF
--- a/pnpm/crates/cli/tests/stale_pin_dedupe.rs
+++ b/pnpm/crates/cli/tests/stale_pin_dedupe.rs
@@ -6,10 +6,31 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::{fs, path::Path, process::Command};
+use std::{fs, path::Path, process::Command, time::Duration};
 
 fn pacquet_at(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+/// Push `manifest_path`'s mtime to well after `lockfile_path`'s so the
+/// second install reads the manifest as a genuine later edit rather than
+/// an unchanged repeat. pnpm and pacquet both gate their incremental
+/// install fast path on a manifest being newer than the previous
+/// install; on a filesystem whose mtime granularity is coarser than the
+/// sub-second gap between these two back-to-back installs (some CI
+/// runners), both writes land in the same tick and the edit is otherwise
+/// skipped.
+fn mark_manifest_edited_after_install(manifest_path: &Path, lockfile_path: &Path) {
+    let lock_mtime = fs::metadata(lockfile_path)
+        .expect("stat pnpm-lock.yaml")
+        .modified()
+        .expect("read pnpm-lock.yaml mtime");
+    fs::File::options()
+        .write(true)
+        .open(manifest_path)
+        .expect("open package.json to bump its mtime")
+        .set_modified(lock_mtime + Duration::from_secs(10))
+        .expect("set package.json mtime");
 }
 
 fn write_manifest(path: &Path, dep_of_version: &str) {
@@ -56,6 +77,7 @@ fn refreshes_stale_transitive_pin_to_higher_direct_dep_version() {
     // transitive `^100.0.0`, so both edges must land on 100.1.0 and the
     // stale 100.0.0 must be pruned.
     write_manifest(&manifest_path, "100.1.0");
+    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
@@ -88,6 +110,7 @@ fn refreshes_stale_transitive_pin_for_caret_range_direct_dep() {
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     write_manifest(&manifest_path, "^100.1.0");
+    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
@@ -134,6 +157,7 @@ fn does_not_refresh_an_aliased_transitive_dependency() {
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     write("100.1.0");
+    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");


### PR DESCRIPTION
## Summary

The three `stale_pin_dedupe` tests each run two back-to-back `pnpm install`s, rewriting `package.json` between them, and assert the second install re-resolves the bumped dependency version. They pass on ext4-backed runners and local dev but fail **deterministically** on CI runners whose filesystem has second-granularity mtimes.

Root cause: pnpm and pacquet both gate their incremental-install fast path (`optimistic_repeat_install`) on a manifest's mtime being newer than the previous install. The two installs run a few hundred milliseconds apart, so on a filesystem whose mtime granularity is coarser than that gap, the rewritten manifest lands in the **same mtime tick** as the first install — the edit isn't seen as newer, re-resolution is skipped, and the lockfile keeps the stale version. The failing lockfile dump shows the tell: the importer's `specifier` itself never updated.

This is **not** a pacquet-vs-pnpm divergence. The mtime fast path behaves the same in both stacks, and forcing the second manifest's mtime *equal* to the lockfile's reproduces the failure locally regardless of which baseline (wall-clock `now_millis()` or the lockfile mtime) the gate uses — I verified both. Switching baselines does not change the coarse-filesystem outcome.

The fix models the intended scenario explicitly: after the second rewrite, push the manifest's mtime well past the lockfile's so the second install reads it as a genuine later edit — exactly what a user editing `package.json` at a later time produces. The assertions still exercise the real stale-pin-refresh behavior (I confirmed the reproduction fails, and the `+10s` bump passes, locally).

Verified: `cargo nextest run -p pacquet-cli --test stale_pin_dedupe` — 3 passed; `cargo fmt --check` and `cargo clippy --tests` clean.

## Squash Commit Body

```text
The three stale_pin_dedupe tests run two back-to-back installs, rewriting
package.json between them, and assert the second install re-resolves the
bumped version. pnpm and pacquet both gate their incremental-install fast
path (optimistic_repeat_install) on a manifest's mtime being newer than
the previous install. The two installs run a few hundred milliseconds
apart, so on a filesystem whose mtime granularity is coarser than that
gap the rewritten manifest lands in the same mtime tick as the first
install, the edit is not seen as newer, re-resolution is skipped, and the
lockfile keeps the stale version.

This surfaced on CI runners whose filesystem has second-granularity
mtimes: the tests pass on ext4-backed runners and local dev but fail
deterministically there. It is not a pacquet-vs-pnpm divergence, and
forcing the second manifest's mtime equal to the lockfile's reproduces it
locally regardless of which baseline the gate uses.

Push the rewritten manifest's mtime well past the lockfile's so the
second install reads it as a genuine later edit. The assertions still
exercise the real stale-pin-refresh behavior.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. _(Test-only robustness fix; the production fast path is unchanged and already matches pnpm — no TS change needed.)_
- [x] Added a changeset if this PR changes any published package. _(N/A — test-only, no published behavior change.)_
- [x] Added or updated tests. _(Hardens the three existing tests.)_
- [x] Updated the documentation if needed. _(N/A.)_

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786545319&installation_id=145934176&pr_number=12973&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12973&signature=e24c37774d6fdaac6c03a00756725fc0f0071fcde66ea3756cfaf1395f1895ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for incremental installs when the project manifest is newer than the lockfile.
  * Preserved validation that stale transitive pins refresh correctly while aliased transitive dependencies remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->