### PR TITLE
fix: honor same-second edits on whole-second-mtime filesystems

### DIFF
--- a/.changeset/repeat-install-coarse-mtime.md
+++ b/.changeset/repeat-install-coarse-mtime.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.status": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed the dependency status check wrongly reporting "up to date" when a `package.json`, `.pnpmfile.cjs`, or patch file was edited in the same second as the previous install, on filesystems that record mtimes at whole-second resolution (for example ext4 with 128-byte inodes). The optimistic repeat-install fast path and `verify-deps-before-run` compared mtimes strictly, so a same-second edit whose mtime rounded down looked unchanged and re-resolution was skipped. Such a file's whole second is now treated as possibly-modified, falling through to the content check; behavior on sub-second filesystems is unchanged.

--- a/cspell.json
+++ b/cspell.json
@@ -151,6 +151,7 @@
     "idempotency",
     "imagetools",
     "imurmurhash",
+    "inodes",
     "invalidformat",
     "ionicons",
     "isexe",

--- a/pnpm/crates/cli/tests/stale_pin_dedupe.rs
+++ b/pnpm/crates/cli/tests/stale_pin_dedupe.rs
@@ -6,31 +6,10 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::{fs, path::Path, process::Command, time::Duration};
+use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
-}
-
-/// Push `manifest_path`'s mtime to well after `lockfile_path`'s so the
-/// second install reads the manifest as a genuine later edit rather than
-/// an unchanged repeat. pnpm and pacquet both gate their incremental
-/// install fast path on a manifest being newer than the previous
-/// install; on a filesystem whose mtime granularity is coarser than the
-/// sub-second gap between these two back-to-back installs (some CI
-/// runners), both writes land in the same tick and the edit is otherwise
-/// skipped.
-fn mark_manifest_edited_after_install(manifest_path: &Path, lockfile_path: &Path) {
-    let lock_mtime = fs::metadata(lockfile_path)
-        .expect("stat pnpm-lock.yaml")
-        .modified()
-        .expect("read pnpm-lock.yaml mtime");
-    fs::File::options()
-        .write(true)
-        .open(manifest_path)
-        .expect("open package.json to bump its mtime")
-        .set_modified(lock_mtime + Duration::from_secs(10))
-        .expect("set package.json mtime");
 }
 
 fn write_manifest(path: &Path, dep_of_version: &str) {
@@ -77,7 +56,6 @@ fn refreshes_stale_transitive_pin_to_higher_direct_dep_version() {
     // transitive `^100.0.0`, so both edges must land on 100.1.0 and the
     // stale 100.0.0 must be pruned.
     write_manifest(&manifest_path, "100.1.0");
-    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
@@ -110,7 +88,6 @@ fn refreshes_stale_transitive_pin_for_caret_range_direct_dep() {
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     write_manifest(&manifest_path, "^100.1.0");
-    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
@@ -157,7 +134,6 @@ fn does_not_refresh_an_aliased_transitive_dependency() {
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     write("100.1.0");
-    mark_manifest_edited_after_install(&manifest_path, &lockfile_path);
     pacquet_at(&workspace).with_arg("install").assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -236,7 +236,7 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
     };
     let modified: Vec<&ManifestStat<'_>> = manifest_stats
         .iter()
-        .filter(|stat| stat.mtime_ms > state.last_validated_timestamp)
+        .filter(|stat| modified_at_or_after(stat.mtime, state.last_validated_timestamp))
         .collect();
 
     // A lockfile-only change — `git checkout`/stash-restore of just
@@ -488,7 +488,7 @@ fn regenerate_wanted_lockfile_if_missing(
 struct ManifestStat<'a> {
     root_dir: &'a Path,
     manifest: &'a PackageManifest,
-    mtime_ms: i64,
+    mtime: FileMtime,
 }
 
 /// The modified-manifests branch: the lockfile-equality assertion plus
@@ -519,8 +519,8 @@ fn modified_manifests_match_lockfile(
     let mut loaded_current: Option<Lockfile> = None;
     let mut wanted_is_current = false;
     let lockfile = lockfile.get().map_err(|_| "the wanted lockfile cannot be read or parsed")?;
-    let (wanted, wanted_mtime_ms): (&Lockfile, i64) = if let Some(wanted) = lockfile {
-        let Some(mtime) = mtime_ms(&workspace_root.join(Lockfile::FILE_NAME)) else {
+    let (wanted, wanted_mtime): (&Lockfile, FileMtime) = if let Some(wanted) = lockfile {
+        let Some(mtime) = file_mtime(&workspace_root.join(Lockfile::FILE_NAME)) else {
             return Err(
                 "a manifest is newer than the last validation and pnpm-lock.yaml cannot be stat'd",
             );
@@ -528,7 +528,7 @@ fn modified_manifests_match_lockfile(
         (wanted, mtime)
     } else {
         let current_path = config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
-        let Some(mtime) = mtime_ms(&current_path) else {
+        let Some(mtime) = file_mtime(&current_path) else {
             return Err("a manifest is newer than the last validation and no lockfile is loaded");
         };
         let current = Lockfile::load_current_from_virtual_store_dir(&config.virtual_store_dir)
@@ -550,7 +550,7 @@ fn modified_manifests_match_lockfile(
     } else if is_workspace_install {
         // Workspace branch: a wanted lockfile newer than the last
         // validation must equal what the previous install materialized.
-        if wanted_mtime_ms > state.last_validated_timestamp {
+        if modified_at_or_after(wanted_mtime, state.last_validated_timestamp) {
             assert_wanted_lockfile_equals_current(wanted, config)?;
         }
         modified
@@ -560,12 +560,12 @@ fn modified_manifests_match_lockfile(
         let current_mtime_ms =
             mtime_ms(&config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME));
         if let Some(current_mtime_ms) = current_mtime_ms
-            && wanted_mtime_ms > current_mtime_ms
+            && modified_at_or_after(wanted_mtime, current_mtime_ms)
         {
             assert_wanted_lockfile_equals_current(wanted, config)?;
         }
         let root = modified.first().expect("modified-manifests branch requires a modified project");
-        if root.mtime_ms > wanted_mtime_ms {
+        if modified_at_or_after(root.mtime, wanted_mtime.ms) {
             modified
         } else if current_mtime_ms.is_some() {
             // "The manifest file is not newer than the lockfile.
@@ -841,14 +841,51 @@ fn semver_satisfies_loosely(version: &str, range: &str) -> bool {
     range.satisfies(&version)
 }
 
-/// Millisecond mtime of `path`, `None` when it can't be stat'd.
-/// Converts wall-clock to ms-since-epoch the same way
-/// `pacquet_workspace_state::now_millis` does on the write side, so
-/// comparisons against `lastValidatedTimestamp` are apples-to-apples.
-fn mtime_ms(path: &Path) -> Option<i64> {
+/// A file's mtime reduced to the two facts the repeat-install fast path
+/// compares: milliseconds since the epoch, and whether the filesystem
+/// recorded it at whole-second resolution.
+#[derive(Clone, Copy)]
+struct FileMtime {
+    /// Milliseconds since the epoch, matching the `now_millis` the write
+    /// side stamps into `lastValidatedTimestamp` so the two are
+    /// apples-to-apples.
+    ms: i64,
+    /// The filesystem stored no sub-second component, so the real
+    /// modification time lies anywhere in `[ms, ms + 1000)`. True on
+    /// second-granularity filesystems (ext4 with 128-byte inodes, HFS+,
+    /// some CI runner disks); false wherever mtimes keep sub-second
+    /// precision (ext4 256-byte inodes, APFS, NTFS, xfs, and so on).
+    whole_second: bool,
+}
+
+/// [`FileMtime`] of `path`, `None` when it can't be stat'd.
+fn file_mtime(path: &Path) -> Option<FileMtime> {
     let modified = fs::metadata(path).and_then(|metadata| metadata.modified()).ok()?;
     let elapsed = modified.duration_since(SystemTime::UNIX_EPOCH).ok()?;
-    Some(i64::try_from(elapsed.as_millis()).unwrap_or(i64::MAX))
+    Some(FileMtime {
+        ms: i64::try_from(elapsed.as_millis()).unwrap_or(i64::MAX),
+        whole_second: elapsed.subsec_nanos() == 0,
+    })
+}
+
+/// Millisecond mtime of `path`, `None` when it can't be stat'd.
+fn mtime_ms(path: &Path) -> Option<i64> {
+    file_mtime(path).map(|mtime| mtime.ms)
+}
+
+/// Whether a file with mtime `subject` may have been modified at or after
+/// `reference_ms`. On a filesystem that keeps sub-second mtimes the
+/// comparison is exact (`ms > reference`); on one that rounds mtimes down
+/// to whole seconds the file could have been touched anywhere within its
+/// second, so the whole second counts as possibly-after
+/// (`ms + 1000 > reference`). A manifest, lockfile, patch, or pnpmfile
+/// edited in the same second as the previous install would otherwise
+/// look unchanged there and wrongly keep the fast path. Erring toward
+/// "modified" only runs the authoritative content check — it never skips
+/// a needed install — and it is a no-op on sub-second filesystems, so the
+/// common case is unaffected.
+fn modified_at_or_after(subject: FileMtime, reference_ms: i64) -> bool {
+    if subject.whole_second { subject.ms + 1_000 > reference_ms } else { subject.ms > reference_ms }
 }
 
 /// Whether `<workspace_root>/pnpm-lock.yaml` has an mtime newer than the
@@ -857,8 +894,8 @@ fn mtime_ms(path: &Path) -> Option<i64> {
 /// missing lockfile reports `false` here — it is handled by the
 /// existence and stand-in gates, not treated as a modification.
 fn wanted_lockfile_modified(workspace_root: &Path, last_validated_timestamp: i64) -> bool {
-    mtime_ms(&workspace_root.join(Lockfile::FILE_NAME))
-        .is_some_and(|mtime| mtime > last_validated_timestamp)
+    file_mtime(&workspace_root.join(Lockfile::FILE_NAME))
+        .is_some_and(|mtime| modified_at_or_after(mtime, last_validated_timestamp))
 }
 
 fn current_lockfile_unusable_with_non_empty_wanted(
@@ -1292,14 +1329,7 @@ fn patches_modified_since(workspace_root: &Path, config: &Config, cutoff_ms: i64
         } else {
             workspace_root.join(candidate)
         };
-        let Ok(modified) = fs::metadata(&path).and_then(|metadata| metadata.modified()) else {
-            return false;
-        };
-        let Ok(elapsed) = modified.duration_since(SystemTime::UNIX_EPOCH) else {
-            return false;
-        };
-        let modified_ms = i64::try_from(elapsed.as_millis()).unwrap_or(i64::MAX);
-        modified_ms > cutoff_ms
+        file_mtime(&path).is_some_and(|mtime| modified_at_or_after(mtime, cutoff_ms))
     })
 }
 
@@ -1331,14 +1361,11 @@ fn pnpmfiles_drift(workspace_root: &Path, previous: &[String], cutoff_ms: i64) -
         return Some("The list of pnpmfiles changed.".to_string());
     }
     current.iter().find_map(|path| {
-        let Ok(modified) = fs::metadata(path).and_then(|metadata| metadata.modified()) else {
+        let Some(mtime) = file_mtime(Path::new(path)) else {
             return Some(format!(r#"pnpmfile at "{path}" was removed"#));
         };
-        let Ok(elapsed) = modified.duration_since(SystemTime::UNIX_EPOCH) else {
-            return Some(format!(r#"pnpmfile at "{path}" was modified"#));
-        };
-        let modified_ms = i64::try_from(elapsed.as_millis()).unwrap_or(i64::MAX);
-        (modified_ms > cutoff_ms).then(|| format!(r#"pnpmfile at "{path}" was modified"#))
+        modified_at_or_after(mtime, cutoff_ms)
+            .then(|| format!(r#"pnpmfile at "{path}" was modified"#))
     })
 }
 
@@ -1350,10 +1377,10 @@ fn stat_manifests<'a>(
     project_manifests
         .iter()
         .map(|(root_dir, manifest)| {
-            mtime_ms(manifest.path()).map(|mtime_ms| ManifestStat {
+            file_mtime(manifest.path()).map(|mtime| ManifestStat {
                 root_dir: root_dir.as_path(),
                 manifest,
-                mtime_ms,
+                mtime,
             })
         })
         .collect()
@@ -1453,7 +1480,7 @@ pub fn check_deps_status_before_run(
     };
     let modified: Vec<&ManifestStat<'_>> = manifest_stats
         .iter()
-        .filter(|stat| stat.mtime_ms > state.last_validated_timestamp)
+        .filter(|stat| modified_at_or_after(stat.mtime, state.last_validated_timestamp))
         .collect();
     let lockfile_modified =
         wanted_lockfile_modified(workspace_root, state.last_validated_timestamp);

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    Decision, OptimisticRepeatInstallCheck, check_optimistic_repeat_install, current_settings,
-    current_settings_with_catalogs,
+    Decision, FileMtime, OptimisticRepeatInstallCheck, check_optimistic_repeat_install,
+    current_settings, current_settings_with_catalogs, modified_at_or_after,
 };
 use indexmap::IndexMap;
 use pacquet_catalogs_types::Catalogs;
@@ -2223,4 +2223,26 @@ fn does_not_regenerate_wanted_lockfile_when_lockfile_writing_disabled() {
     );
     assert_eq!(decision, Decision::UpToDate);
     assert!(!dir.path().join(Lockfile::FILE_NAME).exists(), "lockfile: false must skip the write");
+}
+
+/// A sub-second mtime is compared exactly; a whole-second mtime (as a
+/// second-granularity filesystem records) counts its entire second as
+/// possibly-after the reference, so a change made in the same second as
+/// the last install is not missed.
+#[test]
+fn modified_at_or_after_tolerates_whole_second_mtimes() {
+    let second = 1_700_000_000_000; // a whole second, in ms
+
+    let coarse = FileMtime { ms: second, whole_second: true };
+    // The reference falls inside the mtime's second: possibly modified.
+    assert!(modified_at_or_after(coarse, second));
+    assert!(modified_at_or_after(coarse, second + 999));
+    // The reference is in a later second: the whole second is before it.
+    assert!(!modified_at_or_after(coarse, second + 1_000));
+
+    let fine = FileMtime { ms: second, whole_second: false };
+    // Sub-second mtimes are exact: equal is not "after".
+    assert!(!modified_at_or_after(fine, second));
+    assert!(!modified_at_or_after(fine, second + 1));
+    assert!(modified_at_or_after(fine, second - 1));
 }

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -356,7 +356,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
 
     const modifiedProjects = allManifestStats.filter(
       ({ manifestStats }) =>
-        manifestStats.mtime.valueOf() > workspaceState.lastValidatedTimestamp
+        modifiedAtOrAfter(manifestStats, workspaceState.lastValidatedTimestamp)
     )
 
     if ((modifiedProjects.length === 0) && !lockfilesModified) {
@@ -414,7 +414,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
           useGitBranchLockfile: opts.useGitBranchLockfile,
           mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
         })
-        if (wantedLockfileStats.mtime.valueOf() > workspaceState.lastValidatedTimestamp) {
+        if (modifiedAtOrAfter(wantedLockfileStats, workspaceState.lastValidatedTimestamp)) {
           const currentLockfile = await readCurrentLockfile(path.join(workspaceDir, 'node_modules/.pnpm'), { ignoreIncompatible: false })
           const wantedLockfile = (await wantedLockfilePromise) ?? throwLockfileNotFound(workspaceDir)
           assertLockfilesEqual(currentLockfile, wantedLockfile, workspaceDir)
@@ -434,7 +434,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
         const wantedLockfileStats = await safeStat(path.join(wantedLockfileDir, wantedLockfileName))
 
         if (!wantedLockfileStats) return throwLockfileNotFound(wantedLockfileDir)
-        if (wantedLockfileStats.mtime.valueOf() > workspaceState.lastValidatedTimestamp) {
+        if (modifiedAtOrAfter(wantedLockfileStats, workspaceState.lastValidatedTimestamp)) {
           const currentLockfile = await readCurrentLockfile(path.join(wantedLockfileDir, 'node_modules/.pnpm'), { ignoreIncompatible: false })
           const wantedLockfile = (await wantedLockfilePromise) ?? throwLockfileNotFound(wantedLockfileDir)
           assertLockfilesEqual(currentLockfile, wantedLockfile, wantedLockfileDir)
@@ -560,7 +560,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
       return { upToDate: false, issue, workspaceState }
     }
 
-    if (!wantedLockfileIsMissing && currentLockfileStats && wantedLockfileStats.mtime.valueOf() > currentLockfileStats.mtime.valueOf()) {
+    if (!wantedLockfileIsMissing && currentLockfileStats && modifiedAtOrAfter(wantedLockfileStats, currentLockfileStats.mtime.valueOf())) {
       const currentLockfile = await currentLockfilePromise
       const wantedLockfile = (await wantedLockfilePromise) ?? throwLockfileNotFound(rootProjectManifestDir)
       assertLockfilesEqual(currentLockfile, wantedLockfile, rootProjectManifestDir)
@@ -571,7 +571,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
       throw new Error(`Cannot find one of ${MANIFEST_BASE_NAMES.join(', ')} in ${rootProjectManifestDir}`)
     }
 
-    if (manifestStats.mtime.valueOf() > effectiveWantedLockfileStats.mtime.valueOf()) {
+    if (modifiedAtOrAfter(manifestStats, effectiveWantedLockfileStats.mtime.valueOf())) {
       logger.debug({ msg: 'The manifest is newer than the lockfile. Continuing check.' })
       try {
         await assertWantedLockfileUpToDate({
@@ -890,15 +890,15 @@ function scanWantedLockfiles (lockfileDirs: string[], lastValidatedTimestamp: nu
       : [opts.wantedLockfileName]
     let foundInDir = false
     for (const lockfileName of lockfileNames) {
-      let mtime: number
+      let stats: fs.Stats
       try {
-        mtime = fs.statSync(path.join(lockfileDir, lockfileName)).mtime.valueOf()
+        stats = fs.statSync(path.join(lockfileDir, lockfileName))
       } catch (err: unknown) {
         if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') continue
         throw err
       }
       foundInDir = true
-      if (mtime <= lastValidatedTimestamp) continue
+      if (!modifiedAtOrAfter(stats, lastValidatedTimestamp)) continue
       anyModified = true
       if (wantedLockfileHasMergeConflictsSync(lockfileDir, lockfileName)) {
         conflictedDir = lockfileDir
@@ -939,7 +939,7 @@ async function patchesOrHooksAreModified (opts: {
     }))
     if (allPatchStats.some(
       (patch) =>
-        patch && patch.mtime.valueOf() > opts.lastValidatedTimestamp
+        patch && modifiedAtOrAfter(patch, opts.lastValidatedTimestamp)
     )) {
       return 'Patches were modified'
     }
@@ -952,9 +952,30 @@ async function patchesOrHooksAreModified (opts: {
     if (pnpmfileStats == null) {
       return `pnpmfile at "${pnpmfilePath}" was removed`
     }
-    if (pnpmfileStats.mtime.valueOf() > opts.lastValidatedTimestamp) {
+    if (modifiedAtOrAfter(pnpmfileStats, opts.lastValidatedTimestamp)) {
       return `pnpmfile at "${pnpmfilePath}" was modified`
     }
   }
   return undefined
+}
+
+// Whether a file with these `stats` may have been modified at or after
+// `referenceMs`. On a filesystem that keeps sub-second mtimes the
+// comparison is exact; on one that rounds mtimes down to whole seconds
+// (ext4 with 128-byte inodes, HFS+, some CI runner disks) the file could
+// have been touched anywhere within its second, so the whole second
+// counts as possibly-after. Without this a manifest, lockfile, patch, or
+// pnpmfile edited in the same second as the previous install looks
+// unchanged and the deps-status fast path wrongly reports up to date.
+// Erring toward "modified" only runs the authoritative content check; it
+// never skips a needed install, and it is a no-op on sub-second
+// filesystems, so the common case is unaffected.
+//
+// `mtimeMs` keeps the sub-millisecond fraction, so a whole-second mtime
+// has no remainder modulo 1000; `mtime.valueOf()` is truncated to whole
+// milliseconds and would misread a sub-millisecond mtime as whole-second.
+function modifiedAtOrAfter (stats: fs.Stats, referenceMs: number): boolean {
+  const wholeSecond = stats.mtimeMs % 1000 === 0
+  const mtimeMs = stats.mtime.valueOf()
+  return wholeSecond ? mtimeMs + 1000 > referenceMs : mtimeMs > referenceMs
 }

--- a/pnpm11/deps/status/test/checkDepsStatus.test.ts
+++ b/pnpm11/deps/status/test/checkDepsStatus.test.ts
@@ -385,6 +385,60 @@ describe('checkDepsStatus - pnpmfile modification', () => {
     expect(result.issue).toBe('pnpmfile at "modifiedPnpmfile.js" was modified')
   })
 
+  it('detects a pnpmfile edited in the same second on a whole-second-mtime filesystem', async () => {
+    // The pnpmfile was edited in the same second as the last install, but
+    // on a filesystem that records mtimes at whole-second resolution its
+    // mtime rounds down below `lastValidatedTimestamp` and a strict `>`
+    // would miss it. The whole second must count as possibly-modified.
+    const lastValidatedTimestamp = 1_700_000_000_500 // 500 ms into its second
+    const sameSecondWholeMtime = 1_700_000_000_000 // the whole second, before the timestamp
+    const mockWorkspaceState: WorkspaceState = {
+      lastValidatedTimestamp,
+      pnpmfiles: ['pnpmfile.js'],
+      settings: {
+        excludeLinksFromLockfile: false,
+        linkWorkspacePackages: true,
+        preferWorkspacePackages: true,
+      },
+      projects: {},
+      filteredInstall: false,
+    }
+
+    jest.mocked(loadWorkspaceState).mockReturnValue(mockWorkspaceState)
+    jest.mocked(fsUtils.safeStatSync).mockImplementation((filePath: string) => {
+      if (filePath === 'pnpmfile.js') {
+        return {
+          mtime: new Date(sameSecondWholeMtime),
+          mtimeMs: sameSecondWholeMtime,
+        } as Stats
+      }
+      return undefined
+    })
+    jest.mocked(fsUtils.safeStat).mockImplementation(async () => {
+      return {
+        mtime: new Date(sameSecondWholeMtime),
+        mtimeMs: sameSecondWholeMtime,
+      } as Stats
+    })
+    jest.mocked(statManifestFileUtils.statManifestFile).mockImplementation(async () => {
+      return undefined
+    })
+    const returnEmptyLockfile = async () => ({} as LockfileObject)
+    jest.mocked(lockfileFs.readCurrentLockfile).mockImplementation(returnEmptyLockfile)
+    jest.mocked(lockfileFs.readWantedLockfile).mockImplementation(returnEmptyLockfile)
+
+    const opts: CheckDepsStatusOptions = {
+      rootProjectManifest: {},
+      rootProjectManifestDir: '/project',
+      pnpmfile: mockWorkspaceState.pnpmfiles,
+      ...mockWorkspaceState.settings,
+    }
+    const result = await checkDepsStatus(opts)
+
+    expect(result.upToDate).toBe(false)
+    expect(result.issue).toBe('pnpmfile at "pnpmfile.js" was modified')
+  })
+
   it('returns upToDate: false when a patch was modified and manifests were not modified', async () => {
     const lastValidatedTimestamp = Date.now() - 10_000
     const beforeLastValidation = lastValidatedTimestamp - 10_000


### PR DESCRIPTION
## Summary

The optimistic repeat-install fast path (and `verify-deps-before-run`) decides whether a `package.json`, `.pnpmfile.cjs`, or patch file changed since the last install by comparing its mtime against the last-validated timestamp with a strict `>`. On a filesystem that records mtimes at **whole-second resolution** (ext4 with 128-byte inodes, HFS+, some CI runner disks), a file edited in the *same second* as the previous install gets an mtime that rounds **down** below the timestamp — so the edit looks unchanged, the fast path short-circuits, and re-resolution is skipped. The second install becomes a no-op and keeps the stale result.

This is a real, if narrow, correctness bug: a human editing a manifest and reinstalling is always >1s later, so it only bites automated same-second reinstalls on a coarse-mtime filesystem. It surfaced as deterministic pacquet integration-test failures (`stale_pin_dedupe`, `custom_resolvers`) once the Rust CI test job moved to a runner whose disk has second-granularity mtimes.

### The fix

Detect a whole-second mtime (no sub-second component) and treat its whole second as *possibly-after* the reference — `mtime + 1000 > reference` instead of `mtime > reference` — so the comparison falls through to the authoritative content check instead of trusting the rounded-down mtime. Erring toward "modified" only ever runs the (cheap) content check; it never skips a needed install.

**Key property: a complete no-op on sub-second filesystems.** On ext4/APFS/NTFS/xfs the mtime carries a fractional part, so the branch stays strict and behavior/perf are unchanged — the existing `checkDepsStatus` and `optimistic_repeat_install` unit suites pass without modification. (An earlier fixed-tolerance attempt was rejected precisely because it regressed the common path; this variant keys off each file's own sub-second component, so it doesn't.)

Landed in **both stacks**:
- pacquet — `pnpm/crates/package-manager/src/optimistic_repeat_install.rs` (new `FileMtime` carrying a `whole_second` flag + `modified_at_or_after`).
- pnpm — `pnpm11/deps/status/src/checkDepsStatus.ts` (`modifiedAtOrAfter`, using `mtimeMs` to detect the whole second).

Each side gets a regression test that forces a whole-second mtime so the coarse-filesystem path is exercised on any filesystem (both verified to fail without the fix). I also removed the temporary per-test mtime bumps added in pnpm/pnpm#12969 so `stale_pin_dedupe` genuinely validates this fix.

## Squash Commit Body

```text
The optimistic repeat-install fast path and verify-deps-before-run decide
whether a package.json, .pnpmfile.cjs, or patch file changed since the
last install by comparing its mtime against the last-validated timestamp
with a strict `>`. On a filesystem that records mtimes at whole-second
resolution (ext4 with 128-byte inodes, HFS+, some CI runner disks) a file
edited in the same second as the install gets an mtime that rounds down
below the timestamp, so the edit looks unchanged, the fast path
short-circuits, and re-resolution is skipped.

Detect a whole-second mtime (no sub-second component) and treat its whole
second as possibly-after the reference, falling through to the content
check instead of trusting the rounded-down mtime. On sub-second
filesystems the mtime carries a fractional part, so the comparison stays
exact and the common case is unaffected.

Landed in both stacks: pacquet's optimistic_repeat_install and pnpm's
checkDepsStatus, each with a regression test that forces a whole-second
mtime.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. _(`@pnpm/deps.status`, `pnpm`, `pacquet` — patch.)_
- [x] Added or updated tests. _(Regression test on each stack; removed the #12969 per-test workaround.)_
- [x] Updated the documentation if needed. _(N/A — internal behavior fix.)_

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786550898&installation_id=145934176&pr_number=12975&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12975&signature=329f5ae58f7b02e44c1c54dc6b606fe297e2a703358d2f3de21d6b048f00e3d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency freshness checks on filesystems with whole-second timestamp resolution.
  * Changes to manifests, lockfiles, patches, or configuration files made within the same second as an installation are now detected reliably.
  * Prevented repeat installs and pre-run checks from incorrectly treating dependencies as up to date.
  * Added coverage for detecting recently edited configuration files and stale dependency state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->