### PR TITLE
fix: create global virtual store symlinks with native path separators on Windows

### DIFF
--- a/.changeset/gvs-windows-separators.md
+++ b/.changeset/gvs-windows-separators.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed installs failing on Windows when the global virtual store is enabled. The `<store>/links/<scope>/<name>/<version>/<hash>` slot path is formatted with `/` separators (it doubles as a cross-platform canonical id), and those forward slashes were reaching `CreateSymbolicLinkW`, which rejects forward-slash paths with `ERROR_DIRECTORY` (os error 267). The slot path is now expanded into native path components before any filesystem call.

--- a/pnpm/crates/env-installer/src/install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/install_config_deps.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use pacquet_graph_hasher::{
     calc_global_virtual_store_path_with_subdeps, calc_leaf_global_virtual_store_path,
+    join_global_virtual_store_path,
 };
 use pacquet_lockfile::{EnvLockfile, LockfileResolution, npm_tarball_url};
 use pacquet_package_is_installable::{
@@ -73,7 +74,9 @@ pub async fn install_config_deps<Reporter: self::Reporter>(
             &dep.version,
             &subdep_ids,
         );
-        let leaf_node_modules = global_virtual_store_dir.join(&rel_path).join("node_modules");
+        let leaf_node_modules =
+            join_global_virtual_store_path(&global_virtual_store_dir, &rel_path)
+                .join("node_modules");
         let pkg_dir_in_gvs = leaf_node_modules.join(name);
 
         let parent_symlink_already_correct = existing.iter().any(|entry| entry == name)
@@ -246,8 +249,9 @@ async fn install_optional_subdeps<Reporter: self::Reporter>(
         let subdep_full_id = full_pkg_id(&subdep.name, &subdep.version, &subdep.integrity);
         let subdep_rel =
             calc_leaf_global_virtual_store_path(&subdep_full_id, &subdep.name, &subdep.version);
-        let subdep_dir =
-            global_virtual_store_dir.join(&subdep_rel).join("node_modules").join(&subdep.name);
+        let subdep_dir = join_global_virtual_store_path(global_virtual_store_dir, &subdep_rel)
+            .join("node_modules")
+            .join(&subdep.name);
         if !subdep_dir.join("package.json").exists() {
             started.report::<Reporter>();
             materialize::<Reporter>(

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path.rs
@@ -19,7 +19,10 @@ use crate::{
     hash_object, hash_object_without_sorting,
 };
 use serde_json::{Value, json};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    path::{Path, PathBuf},
+};
 
 /// Compute the hex digest that uniquely identifies one snapshot's
 /// position in the global virtual store.
@@ -139,6 +142,26 @@ pub fn calc_global_virtual_store_path_with_subdeps(
 pub fn format_global_virtual_store_path(name: &str, version: &str, hex_digest: &str) -> String {
     let prefix = if name.starts_with('@') { "" } else { "@/" };
     format!("{prefix}{name}/{version}/{hex_digest}")
+}
+
+/// Join `base` with a [`format_global_virtual_store_path`]-shaped
+/// relative path, expanding each `/`-separated segment into a native
+/// path component.
+///
+/// The GVS relative path is always formatted with `/` because it
+/// doubles as a cross-platform canonical id (it feeds hashing and
+/// lockfile comparison). Passing that string straight to
+/// [`Path::join`] keeps the `/` bytes on Windows, and the directory
+/// symlink/junction syscall that later consumes the slot path then
+/// rejects the forward-slash path with `ERROR_DIRECTORY`
+/// (`os error 267`). Splitting on `/` and pushing each segment yields
+/// a path built from the platform-native separator on every OS (and
+/// is a no-op transformation on Unix, where `/` is already native).
+#[must_use]
+pub fn join_global_virtual_store_path(base: &Path, rel: &str) -> PathBuf {
+    let mut path = base.to_path_buf();
+    path.extend(rel.split('/'));
+    path
 }
 
 #[cfg(test)]

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
@@ -1,9 +1,13 @@
 use super::{
     calc_global_virtual_store_path_with_subdeps, calc_graph_node_hash,
     calc_leaf_global_virtual_store_path, format_global_virtual_store_path,
+    join_global_virtual_store_path,
 };
 use crate::dep_state::DepsGraphNode;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    path::{MAIN_SEPARATOR, Path},
+};
 
 #[test]
 fn format_prefixes_unscoped_with_at_slash() {
@@ -14,6 +18,26 @@ fn format_prefixes_unscoped_with_at_slash() {
     assert_eq!(
         format_global_virtual_store_path("@scope/foo", "1.2.3", "deadbeef"),
         "@scope/foo/1.2.3/deadbeef",
+    );
+}
+
+/// Guards the native-separator contract of
+/// [`join_global_virtual_store_path`]: the tail it appends to `base`
+/// must contain no `/` (which is what breaks the slot path on Windows).
+#[test]
+fn join_expands_suffix_into_native_components() {
+    let rel = format_global_virtual_store_path("foo", "1.2.3", "deadbeef");
+    let joined = join_global_virtual_store_path(Path::new("base"), &rel);
+
+    // The four suffix segments plus `base` become five components.
+    assert_eq!(joined.components().count(), 5, "{joined:?}");
+
+    // The portion appended after `base` must carry no `/` on any OS —
+    // on Windows that would otherwise survive into the symlink syscall.
+    let tail = joined.strip_prefix("base").unwrap();
+    assert!(
+        !tail.to_string_lossy().contains('/') || MAIN_SEPARATOR == '/',
+        "tail {tail:?} still contains a forward slash",
     );
 }
 

--- a/pnpm/crates/graph-hasher/src/lib.rs
+++ b/pnpm/crates/graph-hasher/src/lib.rs
@@ -23,6 +23,7 @@ pub use engine_name::{
 pub use global_virtual_store_path::{
     calc_global_virtual_store_path_with_subdeps, calc_graph_node_hash,
     calc_leaf_global_virtual_store_path, format_global_virtual_store_path,
+    join_global_virtual_store_path,
 };
 pub use object_hasher::{
     hash_object, hash_object_nullable_with_prefix, hash_object_with_encoding,

--- a/pnpm/crates/package-manager/src/virtual_store_layout.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout.rs
@@ -25,7 +25,7 @@ use pacquet_config::Config;
 use pacquet_deps_path::get_pkg_id_with_patch_hash;
 use pacquet_graph_hasher::{
     DepsGraphNode, DepsStateCache, calc_graph_node_hash, engine_name,
-    format_global_virtual_store_path,
+    format_global_virtual_store_path, join_global_virtual_store_path,
 };
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgName, PkgVerPeer,
@@ -273,7 +273,10 @@ impl VirtualStoreLayout {
                 .unwrap_or_else(|| key.to_virtual_store_name(self.virtual_store_dir_max_length)),
             None => key.to_virtual_store_name(self.virtual_store_dir_max_length),
         };
-        self.package_store_dir.join(suffix)
+        // The flat non-GVS `to_virtual_store_name` fallback carries no
+        // `/`, so it too can route through the GVS join (which then just
+        // pushes it as a single component).
+        join_global_virtual_store_path(&self.package_store_dir, &suffix)
     }
 }
 


### PR DESCRIPTION
## Problem

`pnpm install` (pacquet engine) aborts on **Windows** whenever the global virtual store is enabled — which broke `Rust CI / Test / windows` on `main` and every PR:

```
Failed to create symlink at "...\store\v11\links\@/arraybuffer.prototype.slice/1.0.4/<hash>\node_modules\es-abstract"
  ╰─▶ The directory name is invalid. (os error 267)
```

Note the separators in that path: native `\` up to `…\links`, then **forward slashes** for the rest.

## Root cause

The global-virtual-store slot suffix is produced by `format_global_virtual_store_path` as `@/<name>/<version>/<hash>`, which always uses `/` because it doubles as a cross-platform canonical id (it feeds hashing and lockfile comparison). It was joined onto the store dir with a plain `PathBuf::join`, which **preserves `/` on Windows**. Those forward slashes then reached `CreateSymbolicLinkW`, and Windows' reparse-point APIs reject forward-slash paths with `ERROR_DIRECTORY` (os error 267). The junction fallback only kicks in on `PermissionDenied`, so a 267 propagated straight up.

Unix is unaffected because `/` is already the native separator — which is why only Windows broke.

## Fix

Add a `join_global_virtual_store_path(base, rel)` helper that expands the `/`-separated suffix into native path components, and route the slot-path join sites through it:

- `VirtualStoreLayout::slot_dir` — the choke point every symlink target/link path flows through
- the two config-deps installer joins in `install_config_deps.rs`

No-op on Unix; produces `\` paths on Windows. Covered by a new unit test in `graph-hasher`; existing `slot_dir`/env-installer tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786551226&installation_id=145934176&pr_number=12976&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12976&signature=29a244e10131a942af605cdc4328d0335c6a6b1739396796c25238458cc4708b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows installation failures when the global virtual store is enabled by ensuring filesystem paths use native separators during symlink operations.
  - Improved cross-platform path handling for node_modules layout and related symlink targets when global virtual store paths are derived.
- **Tests**
  - Added unit coverage to confirm global virtual store path joining expands slash-formatted suffixes into native path components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->