### PR TITLE
test: fix change/version integration tests broken by registry-storage changelog default

### DIFF
--- a/pnpm/crates/cli/tests/change.rs
+++ b/pnpm/crates/cli/tests/change.rs
@@ -11,8 +11,16 @@ use pacquet_testing_utils::bin::CommandTempCwd;
 use std::{fs, path::Path, process::Command};
 
 fn write_workspace(workspace: &Path) {
-    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
-        .expect("write pnpm-workspace.yaml");
+    // These tests assert committed CHANGELOG.md files, which predate the
+    // `registry`-storage default (where a release's section is parked under
+    // `.changeset/changelogs/` and composed at publish time instead). Opt back
+    // into `repository` storage so `pnpm version -r` writes the changelogs
+    // inline, the way the assertions below expect.
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nversioning:\n  changelog:\n    storage: repository\n",
+    )
+    .expect("write pnpm-workspace.yaml");
     fs::write(workspace.join("package.json"), "{\"name\": \"e2e-root\", \"private\": true}\n")
         .expect("write root package.json");
 }


### PR DESCRIPTION
## Problem

`Rust CI / Test / ubuntu` is red on `main` — two tests in `pnpm/crates/cli/tests/change.rs` panic:

```
change_records_an_intent_and_version_applies_the_release_plan ... FAILED
lanes_are_entered_released_and_graduated ... FAILED
  panicked at change.rs:89 / :156: read changelog: No such file or directory
```

Both fail at `fs::read_to_string(packages/<pkg>/CHANGELOG.md).expect("read changelog")` — the file no longer exists after `pnpm version -r`.

## Cause

#12971 (*compose changelogs at publish time (registry storage)*) made `changelog.storage: registry` the **default**: `pnpm version -r` no longer commits a `CHANGELOG.md`, it parks each release's section under `.changeset/changelogs/` for publish-time composition. These integration tests (added in #12953) still assert committed `CHANGELOG.md` files, so they broke when #12971 landed. #12971 updated the *versioning* unit tests (adding a `repository()` settings helper with the note *"the existing changelog assertions predate the registry-storage default, so they opt back into committed CHANGELOG.md files"*) but the CLI integration tests were missed.

## Fix

Give the integration tests the same treatment: their workspace opts into `versioning.changelog.storage: repository`, so `pnpm version -r` writes the changelogs inline the way the assertions expect. This also matches the TypeScript reference test (`releasing/commands/test/change/index.test.ts`), which asserts committed `CHANGELOG.md` with default opts.

Test-only change; no changeset. Verified locally — all 7 tests in `change.rs` pass (the run also confirms `pnpm lane`'s workspace-yaml edits preserve the sibling `changelog.storage` key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786552263&installation_id=145934176&pr_number=12977&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12977&signature=c89ad75b4eec31bc8e59e8b1fc77063462d75df5e21df7829c2468d11f1ea1cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test workspace configuration to align changelog storage behavior with recursive versioning.
  * Ensured tests correctly validate committed `CHANGELOG.md` contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->