### PR TITLE
test: fix process-cleanup fixtures aborting on implicit install in CI

### DIFF
--- a/pnpm11/__fixtures__/exec-error-exit/pnpm-workspace.yaml
+++ b/pnpm11/__fixtures__/exec-error-exit/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
+# This fixture exercises process-tree cleanup when a recursive exec fails, not
+# dependency verification. `prepareFixtures` pre-installs it with the default
+# store, so the implicit install that `verifyDepsBeforeRun: install` would spawn
+# aborts on a store-mismatch modules purge in the non-TTY test subprocess. The
+# projects have no dependencies, so skip the check entirely.
+verifyDepsBeforeRun: false
+
 packages:
   - project-a
   - project-b

--- a/pnpm11/__fixtures__/multiple-scripts-error-exit/pnpm-workspace.yaml
+++ b/pnpm11/__fixtures__/multiple-scripts-error-exit/pnpm-workspace.yaml
@@ -1,1 +1,6 @@
-{}
+# This fixture exercises child-process cleanup when `pnpm run` exits, not
+# dependency verification. `prepareFixtures` pre-installs it with the default
+# store, so the implicit install that `verifyDepsBeforeRun: install` would spawn
+# aborts on a store-mismatch modules purge in the non-TTY test subprocess. This
+# package has no dependencies, so skip the check entirely.
+verifyDepsBeforeRun: false


### PR DESCRIPTION
## Summary

The `errorHandler` process-cleanup e2e tests are failing on `main` (e.g. on the new Blacksmith Windows runners) with:

```
[ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
```

instead of the expected `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`.

**Root cause.** These tests (`should clean up the process trees of running commands when a recursive exec fails` and `should clean up child processes when process exited`) run `pnpm exec` / `pnpm run` directly inside the shared `exec-error-exit` and `multiple-scripts-error-exit` fixtures. `prepareFixtures` pre-installs every fixture from the outer `__fixtures__` workspace using the default store, so each fixture's committed `node_modules/.modules.yaml` records that store. At test time the CLI runs with `store_dir=../store`, and the default `verifyDepsBeforeRun: install` makes `pnpm exec`/`pnpm run` spawn an implicit `pnpm install`. That install's `checkCompatibility` throws `UnexpectedStoreError` on the store mismatch and tries to purge the modules directory. Because the fixture was installed at the outer level, no workspace-state file exists at the fixture level, so `checkDepsStatus` reports "out of sync" and the install always runs. In the non-TTY test subprocess — which also never inherits `CI` (`createEnv` only forwards `PATH`/`COLORTERM`/`APPDATA`) — the purge aborts with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` before the scripts ever run.

**Fix.** These fixtures test process-tree cleanup, not dependency verification, and have no dependencies. Setting `verifyDepsBeforeRun: false` in each fixture's `pnpm-workspace.yaml` skips the implicit install entirely, so the exec runs the scripts and fails with the expected `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`.

Verified locally by reproducing the exact failure (identical `runDepsStatusCheck` → `runPnpmCli` → install → `getFinalError` stack trace) against the built bundle with a store-mismatched pre-install and no workspace-state file, then confirming the fix produces `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`.

## Squash Commit Body

```text
The errorHandler process-cleanup tests run `pnpm exec`/`pnpm run` directly
inside the shared exec-error-exit and multiple-scripts-error-exit fixtures.
prepareFixtures pre-installs every fixture with the default store, so the
committed node_modules/.modules.yaml records that store. At test time the CLI
runs with store_dir=../store, and the default verifyDepsBeforeRun: install
spawns an implicit `pnpm install` whose checkCompatibility throws
UnexpectedStoreError on the store mismatch and tries to purge the modules
directory. In the non-TTY test subprocess (which also never inherits CI), that
purge aborts with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY before the scripts
ever run, so the expected ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL is never produced.

These fixtures test process-tree cleanup, not dependency verification, and have
no dependencies, so set verifyDepsBeforeRun: false to skip the implicit install.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. <!-- TypeScript-only test-fixture change; no Rust or user-visible surface affected. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note. <!-- Not applicable: test-scaffolding only, no published package changes. -->
- [x] Added or updated tests. <!-- Fixes existing tests' scaffolding. -->
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786552375&installation_id=145934176&pr_number=12978&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12978&signature=553d3cc18cb6f02f71db605281106cfa3c5b91c53eac04ed97e213ea7821b0d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->