### PR TITLE
test: stabilize lockfile-verify cache content-change test on coarse-mtime runners

### DIFF
--- a/pnpm11/installing/deps-installer/test/install/verifyLockfileResolutionsCache.ts
+++ b/pnpm11/installing/deps-installer/test/install/verifyLockfileResolutionsCache.ts
@@ -118,8 +118,16 @@ describe('tryLockfileVerificationCache', () => {
     recordVerification(cacheDir, { lockfilePath, verifiers: [mraVerifier(60)], hashLockfile: hashLockfileFor('content-a') })
 
     // Same byte length, different content — hash check is what rejects.
+    // Write the replacement to a sibling and rename it in so it gets a
+    // fresh inode. Rewriting in place can reuse the freed inode, and on
+    // filesystems with coarse mtime granularity (some CI runners) both
+    // writes land in the same mtime tick — which would let the stat
+    // shortcut spuriously match on (size, mtime, inode) and skip the hash
+    // check this test exercises.
+    const sibling = path.join(tmpDir, 'pnpm-lock-2.yaml')
+    await fs.promises.writeFile(sibling, 'bbbbbbbbbbbb')
     await fs.promises.rm(lockfilePath)
-    await fs.promises.writeFile(lockfilePath, 'bbbbbbbbbbbb')
+    await fs.promises.rename(sibling, lockfilePath)
 
     const result = tryLockfileVerificationCache(cacheDir, {
       lockfilePath,


### PR DESCRIPTION
## Summary

The `@pnpm/installing.deps-installer` unit test `tryLockfileVerificationCache › miss when content changed even if size happens to match` is failing on `main` (e.g. https://github.com/pnpm/pnpm/actions/runs/29266927820/job/86875592857) with `Expected: false, Received: true`.

**Root cause.** `tryLockfileVerificationCache` has a stat fast path that trusts the cached content hash when a lockfile's `(size, mtimeNs, inode)` still match the recorded values, skipping the hash entirely. The test rewrote the lockfile in place (`rm` + `writeFile`) with the same 12-byte length, expecting the stat shortcut to bail so the content-hash check would reject the changed content.

On CI runners with coarse (≥1s) filesystem mtime granularity, both writes land in the same mtime tick, and the freed inode gets reused, so all three stat fields match. The stat shortcut then fires and returns a hit *before* the hash check runs — so the test observed `hit: true` instead of `false`. This is test fragility, not an implementation bug: a stat fast path inherently can't distinguish a same-size/same-mtime/same-inode content swap, and a real lockfile edit changes both size and mtime.

**Fix.** Write the replacement to a sibling file and rename it in — the same technique the sibling `hash-fallback` test already uses. Two files that coexist must have distinct inodes, so the renamed replacement is guaranteed a different inode from the original regardless of mtime granularity. The stat shortcut always bails and the content hash is what rejects the change, which is exactly what the test means to exercise.

Verified locally: the full suite passes (19/19), and a standalone check confirms sibling+rename always yields a distinct inode while preserving the byte size.

## Squash Commit Body

```text
tryLockfileVerificationCache has a stat fast path that trusts the cached hash
when a lockfile's (size, mtimeNs, inode) still match the recorded values,
skipping the content hash. The "miss when content changed even if size happens
to match" test rewrote the lockfile in place (rm + writeFile) with identical
byte length, expecting the stat shortcut to bail so the hash check rejects the
new content.

On CI runners with coarse (>=1s) filesystem mtime granularity, both writes land
in the same mtime tick, and the freed inode gets reused, so all three stat
fields match. The stat shortcut then fires and returns a hit before the hash
check runs, so the test saw hit: true instead of false.

Write the replacement to a sibling file and rename it in, as the sibling test
already does. Two files that coexist must have distinct inodes, so the renamed
replacement is guaranteed a different inode regardless of mtime granularity.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. <!-- TypeScript-only unit-test change; no runtime or user-visible surface affected. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note. <!-- Not applicable: test-only change, no published package behavior changes. -->
- [x] Added or updated tests. <!-- Stabilizes an existing unit test. -->
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786553922&installation_id=145934176&pr_number=12980&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12980&signature=261fe65b6857618ba776a84b8f5893533d93bdcc0a1043b00bfd5c98171d91d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for cache invalidation when lockfile content changes without changing its size.
  * Strengthened verification that modified lockfiles are correctly detected rather than incorrectly treated as unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->