### PR TITLE
fix(pacquet): base repeat-install freshness on filesystem mtime at nanosecond precision

### DIFF
--- a/.changeset/repeat-install-clock-skew.md
+++ b/.changeset/repeat-install-clock-skew.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed the incremental install fast path wrongly reporting "already up to date" — skipping re-resolution — when a `package.json`, `.pnpmfile.cjs`, or patch file was edited immediately after an install. The freshness check compared file modification times against a wall-clock timestamp, which broke in two ways: on a machine whose wall clock and filesystem clock disagree (seen on some CI runners) the timestamp could sit ahead of a later edit's mtime, and a fast install could write its lockfile in the same millisecond as the subsequent edit. The check now records the baseline from filesystem mtimes and compares at nanosecond precision.

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2569,7 +2569,24 @@ pub(crate) fn build_workspace_state(
     project_manifests: &[(std::path::PathBuf, &PackageManifest)],
 ) -> WorkspaceState {
     WorkspaceState {
-        last_validated_timestamp: now_millis(),
+        // Record the freshness baseline from the lockfile this install
+        // just wrote, not the wall clock. The repeat-install fast path
+        // compares this timestamp against file mtimes, so the two must be
+        // on the same clock: on a runner whose wall clock runs ahead of
+        // the filesystem's mtime clock (observed ~2 ms on some CI
+        // microVMs), a `now_millis()` baseline can sit above the mtime of
+        // a manifest/pnpmfile edited moments later, hiding the edit and
+        // wrongly keeping the fast path. The lockfile's own mtime shares
+        // the filesystem clock with every file the check compares, so no
+        // skew is possible. Mirrors pnpm's `checkDepsStatus`, whose
+        // single-project path keys off the wanted lockfile's mtime. Fall
+        // back to the wall clock only when no lockfile was written.
+        last_validated_timestamp: crate::optimistic_repeat_install::validation_baseline_ms(
+            workspace_root,
+            config,
+            project_manifests,
+        )
+        .unwrap_or_else(now_millis),
         projects: build_projects_map(project_manifests),
         pnpmfiles: crate::optimistic_repeat_install::current_pnpmfiles(workspace_root),
         // Pacquet has no `--filter` yet (issue <https://github.com/pnpm/pacquet/issues/299> stage 2). Hard-code

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -951,17 +951,28 @@ pub(crate) fn validation_baseline_ms(
 /// millisecond, so millisecond precision still catches it.
 fn wanted_lockfile_modified(workspace_root: &Path, last_validated_timestamp: i64) -> bool {
     file_mtime(&workspace_root.join(Lockfile::FILE_NAME))
-        .is_some_and(|mtime| lockfile_mtime_after(mtime.ms, last_validated_timestamp))
+        .is_some_and(|mtime| lockfile_modified_since(mtime, last_validated_timestamp))
 }
 
-/// Whether a lockfile with mtime `subject_ms` post-dates `reference_ms`,
-/// at whole-millisecond precision. Unlike the nanosecond
-/// [`modified_at_or_after`] used for manifests/patches/pnpmfiles: the
-/// baseline is the lockfile's own mtime truncated to milliseconds, so a
-/// nanosecond comparison would flag the unchanged lockfile against its own
-/// truncated value every repeat install. See [`wanted_lockfile_modified`].
-fn lockfile_mtime_after(subject_ms: i64, reference_ms: i64) -> bool {
-    subject_ms > reference_ms
+/// Whether the lockfile's `subject` mtime post-dates `reference_ms`.
+///
+/// On a sub-second filesystem this is a whole-*millisecond* comparison,
+/// unlike the nanosecond [`modified_at_or_after`] used for
+/// manifests/patches/pnpmfiles: the baseline is the lockfile's own mtime
+/// truncated to milliseconds, so a nanosecond comparison would flag the
+/// unchanged lockfile against its own truncated value on every repeat
+/// install. An external lockfile edit lands in a later millisecond and is
+/// still caught. On a whole-second-mtime filesystem the whole second is
+/// treated as possibly-after (as [`modified_at_or_after`] does), because
+/// there a same-second external edit is indistinguishable from the
+/// install's own lockfile write by mtime alone, so it must fall through to
+/// the authoritative content check. See [`wanted_lockfile_modified`].
+fn lockfile_modified_since(subject: FileMtime, reference_ms: i64) -> bool {
+    if subject.whole_second {
+        subject.ms.saturating_add(1_000) > reference_ms
+    } else {
+        subject.ms > reference_ms
+    }
 }
 
 fn current_lockfile_unusable_with_non_empty_wanted(

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -888,6 +888,35 @@ fn modified_at_or_after(subject: FileMtime, reference_ms: i64) -> bool {
     if subject.whole_second { subject.ms + 1_000 > reference_ms } else { subject.ms > reference_ms }
 }
 
+/// The freshness baseline recorded in the workspace state: the latest
+/// mtime among the lockfile this install wrote (the wanted
+/// `pnpm-lock.yaml`, or the current `<virtual_store_dir>/lock.yaml` when
+/// the wanted one is absent) and the project manifests it validated.
+///
+/// A filesystem mtime, not the wall clock, so the baseline shares a clock
+/// with every file the repeat-install check later compares against it: a
+/// wall-vs-mtime clock skew (observed ~2 ms on some CI microVMs, where the
+/// wall clock ran ahead of the filesystem's mtime clock) would otherwise
+/// let a `now()` baseline sit above the mtime of a manifest/pnpmfile
+/// edited moments after the install, hiding the edit and wrongly keeping
+/// the fast path. Taking the max over the manifests too means a content
+/// check that passed on an already-edited manifest still blesses it, so
+/// the next run can take the pure-mtime fast path. `None` when nothing can
+/// be stat'd.
+pub(crate) fn validation_baseline_ms(
+    workspace_root: &Path,
+    config: &Config,
+    project_manifests: &[(PathBuf, &PackageManifest)],
+) -> Option<i64> {
+    let lockfile = mtime_ms(&workspace_root.join(Lockfile::FILE_NAME))
+        .or_else(|| mtime_ms(&config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME)));
+    project_manifests
+        .iter()
+        .filter_map(|(_, manifest)| mtime_ms(manifest.path()))
+        .chain(lockfile)
+        .max()
+}
+
 /// Whether `<workspace_root>/pnpm-lock.yaml` has an mtime newer than the
 /// last validation. A lockfile-only change leaves every manifest
 /// untouched but must still defeat the manifest-mtime fast path. A

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -940,9 +940,28 @@ pub(crate) fn validation_baseline_ms(
 /// untouched but must still defeat the manifest-mtime fast path. A
 /// missing lockfile reports `false` here — it is handled by the
 /// existence and stand-in gates, not treated as a modification.
+///
+/// Compared at whole-millisecond precision, unlike the manifest / patch /
+/// pnpmfile checks: `lastValidatedTimestamp` is itself a lockfile mtime
+/// truncated to milliseconds (see
+/// [`crate::install::build_workspace_state`]), so a nanosecond comparison
+/// would flag the *unchanged* lockfile against its own truncated value on
+/// every repeat install and force a content check each time. An external
+/// lockfile edit (git checkout, manual rewrite) lands in a later
+/// millisecond, so millisecond precision still catches it.
 fn wanted_lockfile_modified(workspace_root: &Path, last_validated_timestamp: i64) -> bool {
     file_mtime(&workspace_root.join(Lockfile::FILE_NAME))
-        .is_some_and(|mtime| modified_at_or_after(mtime, last_validated_timestamp))
+        .is_some_and(|mtime| lockfile_mtime_after(mtime.ms, last_validated_timestamp))
+}
+
+/// Whether a lockfile with mtime `subject_ms` post-dates `reference_ms`,
+/// at whole-millisecond precision. Unlike the nanosecond
+/// [`modified_at_or_after`] used for manifests/patches/pnpmfiles: the
+/// baseline is the lockfile's own mtime truncated to milliseconds, so a
+/// nanosecond comparison would flag the unchanged lockfile against its own
+/// truncated value every repeat install. See [`wanted_lockfile_modified`].
+fn lockfile_mtime_after(subject_ms: i64, reference_ms: i64) -> bool {
+    subject_ms > reference_ms
 }
 
 fn current_lockfile_unusable_with_non_empty_wanted(

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -841,17 +841,30 @@ fn semver_satisfies_loosely(version: &str, range: &str) -> bool {
     range.satisfies(&version)
 }
 
-/// A file's mtime reduced to the two facts the repeat-install fast path
-/// compares: milliseconds since the epoch, and whether the filesystem
-/// recorded it at whole-second resolution.
+const NANOS_PER_MILLI: i64 = 1_000_000;
+const NANOS_PER_SEC: i64 = 1_000_000_000;
+
+/// A file's mtime, kept at full nanosecond precision. The recorded
+/// `lastValidatedTimestamp` is only millisecond-precise (it is a
+/// filesystem mtime truncated to ms — see
+/// [`crate::install::build_workspace_state`]), but the comparison against
+/// it must not be: pacquet installs are fast enough that a lockfile
+/// written by one install and a manifest edited moments later can share
+/// the same millisecond, so a millisecond-granular comparison would miss
+/// the edit and wrongly keep the fast path. Comparing the file's
+/// nanosecond mtime against the truncated (rounded-down) reference
+/// distinguishes them.
 #[derive(Clone, Copy)]
 struct FileMtime {
-    /// Milliseconds since the epoch, matching the `now_millis` the write
-    /// side stamps into `lastValidatedTimestamp` so the two are
-    /// apples-to-apples.
+    /// Milliseconds since the epoch. Used where the value is *recorded* as
+    /// the reference (the state stores `lastValidatedTimestamp` in ms, and
+    /// pnpm's `checkDepsStatus` compares in ms).
     ms: i64,
+    /// Nanoseconds since the epoch. Used as the *subject* of a comparison,
+    /// where sub-millisecond precision matters.
+    ns: i64,
     /// The filesystem stored no sub-second component, so the real
-    /// modification time lies anywhere in `[ms, ms + 1000)`. True on
+    /// modification time lies anywhere in `[ns, ns + 1s)`. True on
     /// second-granularity filesystems (ext4 with 128-byte inodes, HFS+,
     /// some CI runner disks); false wherever mtimes keep sub-second
     /// precision (ext4 256-byte inodes, APFS, NTFS, xfs, and so on).
@@ -864,6 +877,7 @@ fn file_mtime(path: &Path) -> Option<FileMtime> {
     let elapsed = modified.duration_since(SystemTime::UNIX_EPOCH).ok()?;
     Some(FileMtime {
         ms: i64::try_from(elapsed.as_millis()).unwrap_or(i64::MAX),
+        ns: i64::try_from(elapsed.as_nanos()).unwrap_or(i64::MAX),
         whole_second: elapsed.subsec_nanos() == 0,
     })
 }
@@ -874,18 +888,22 @@ fn mtime_ms(path: &Path) -> Option<i64> {
 }
 
 /// Whether a file with mtime `subject` may have been modified at or after
-/// `reference_ms`. On a filesystem that keeps sub-second mtimes the
-/// comparison is exact (`ms > reference`); on one that rounds mtimes down
-/// to whole seconds the file could have been touched anywhere within its
-/// second, so the whole second counts as possibly-after
-/// (`ms + 1000 > reference`). A manifest, lockfile, patch, or pnpmfile
-/// edited in the same second as the previous install would otherwise
-/// look unchanged there and wrongly keep the fast path. Erring toward
+/// `reference_ms`. The reference is millisecond-precise (a filesystem
+/// mtime truncated toward zero); the subject is compared at nanosecond
+/// precision, so a file whose whole-millisecond mtime equals the
+/// reference's but which was really written later in that millisecond is
+/// still seen as modified. On a filesystem that rounds mtimes down to
+/// whole seconds the file could have been touched anywhere within its
+/// second, so the whole second counts as possibly-after. Erring toward
 /// "modified" only runs the authoritative content check — it never skips
-/// a needed install — and it is a no-op on sub-second filesystems, so the
-/// common case is unaffected.
+/// a needed install.
 fn modified_at_or_after(subject: FileMtime, reference_ms: i64) -> bool {
-    if subject.whole_second { subject.ms + 1_000 > reference_ms } else { subject.ms > reference_ms }
+    let reference_ns = reference_ms.saturating_mul(NANOS_PER_MILLI);
+    if subject.whole_second {
+        subject.ns.saturating_add(NANOS_PER_SEC) > reference_ns
+    } else {
+        subject.ns > reference_ns
+    }
 }
 
 /// The freshness baseline recorded in the workspace state: the latest

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     Decision, FileMtime, OptimisticRepeatInstallCheck, check_optimistic_repeat_install,
-    current_settings, current_settings_with_catalogs, lockfile_mtime_after, modified_at_or_after,
+    current_settings, current_settings_with_catalogs, lockfile_modified_since,
+    modified_at_or_after,
 };
 use indexmap::IndexMap;
 use pacquet_catalogs_types::Catalogs;
@@ -2253,20 +2254,34 @@ fn modified_at_or_after_compares_at_nanosecond_precision() {
     assert!(modified_at_or_after(later_in_same_ms, ms));
 }
 
-/// The lockfile freshness check uses whole-millisecond precision so the
-/// unchanged lockfile is never flagged against its own millisecond-
-/// truncated baseline (which the nanosecond manifest comparison would),
-/// while an external edit a millisecond later is still caught.
+/// On a sub-second filesystem the lockfile freshness check uses
+/// whole-millisecond precision so the unchanged lockfile is never flagged
+/// against its own millisecond-truncated baseline (which the nanosecond
+/// manifest comparison would), while an external edit a millisecond later
+/// is still caught. On a whole-second-mtime filesystem the whole second is
+/// possibly-after, so a same-second external edit falls through to the
+/// content check.
 #[test]
 fn lockfile_check_does_not_self_flag_its_own_baseline() {
     let ms = 1_700_000_000_000_i64;
     let subsecond_ns = ms * 1_000_000 + 500_000; // .5 ms into its millisecond
+    let fine = FileMtime { ms, ns: subsecond_ns, whole_second: false };
 
     // A manifest with this mtime would (correctly) be flagged via
     // nanoseconds against a baseline equal to its own truncated ms:
-    assert!(modified_at_or_after(FileMtime { ms, ns: subsecond_ns, whole_second: false }, ms));
+    assert!(modified_at_or_after(fine, ms));
     // The lockfile must NOT self-flag against that same baseline:
-    assert!(!lockfile_mtime_after(ms, ms));
+    assert!(!lockfile_modified_since(fine, ms));
     // An external edit a whole millisecond later is still caught:
-    assert!(lockfile_mtime_after(ms + 1, ms));
+    assert!(lockfile_modified_since(
+        FileMtime { ms: ms + 1, ns: subsecond_ns, whole_second: false },
+        ms
+    ));
+
+    // Whole-second (coarse) filesystem: the whole second is possibly-after
+    // its own baseline, so a same-second external edit is not missed.
+    let coarse = FileMtime { ms, ns: ms * 1_000_000, whole_second: true };
+    assert!(lockfile_modified_since(coarse, ms));
+    // A whole second entirely before the baseline is not flagged.
+    assert!(!lockfile_modified_since(coarse, ms + 1_000));
 }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -2225,24 +2225,30 @@ fn does_not_regenerate_wanted_lockfile_when_lockfile_writing_disabled() {
     assert!(!dir.path().join(Lockfile::FILE_NAME).exists(), "lockfile: false must skip the write");
 }
 
-/// A sub-second mtime is compared exactly; a whole-second mtime (as a
-/// second-granularity filesystem records) counts its entire second as
-/// possibly-after the reference, so a change made in the same second as
-/// the last install is not missed.
+/// The subject is compared at nanosecond precision against the
+/// millisecond-precise reference, and a whole-second mtime counts its
+/// entire second as possibly-after.
 #[test]
-fn modified_at_or_after_tolerates_whole_second_mtimes() {
-    let second = 1_700_000_000_000; // a whole second, in ms
+fn modified_at_or_after_compares_at_nanosecond_precision() {
+    let ms = 1_700_000_000_000_i64; // a whole millisecond, in ms
+    let ns = ms * 1_000_000; // the same instant, in ns
 
-    let coarse = FileMtime { ms: second, whole_second: true };
-    // The reference falls inside the mtime's second: possibly modified.
-    assert!(modified_at_or_after(coarse, second));
-    assert!(modified_at_or_after(coarse, second + 999));
+    // Whole-second (coarse filesystem) mtime: the whole second is possibly-after.
+    let coarse = FileMtime { ms, ns, whole_second: true };
+    assert!(modified_at_or_after(coarse, ms));
+    assert!(modified_at_or_after(coarse, ms + 999));
     // The reference is in a later second: the whole second is before it.
-    assert!(!modified_at_or_after(coarse, second + 1_000));
+    assert!(!modified_at_or_after(coarse, ms + 1_000));
 
-    let fine = FileMtime { ms: second, whole_second: false };
-    // Sub-second mtimes are exact: equal is not "after".
-    assert!(!modified_at_or_after(fine, second));
-    assert!(!modified_at_or_after(fine, second + 1));
-    assert!(modified_at_or_after(fine, second - 1));
+    // Sub-second mtime exactly on the millisecond boundary: equal is not after.
+    let on_boundary = FileMtime { ms, ns, whole_second: false };
+    assert!(!modified_at_or_after(on_boundary, ms));
+    assert!(!modified_at_or_after(on_boundary, ms + 1));
+    assert!(modified_at_or_after(on_boundary, ms - 1));
+
+    // Same millisecond as the reference, half a millisecond later: the
+    // millisecond values tie, but the nanosecond mtime does not, so the
+    // edit is still seen (the same-millisecond flake this guards against).
+    let later_in_same_ms = FileMtime { ms, ns: ns + 500_000, whole_second: false };
+    assert!(modified_at_or_after(later_in_same_ms, ms));
 }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     Decision, FileMtime, OptimisticRepeatInstallCheck, check_optimistic_repeat_install,
-    current_settings, current_settings_with_catalogs, modified_at_or_after,
+    current_settings, current_settings_with_catalogs, lockfile_mtime_after, modified_at_or_after,
 };
 use indexmap::IndexMap;
 use pacquet_catalogs_types::Catalogs;
@@ -2251,4 +2251,22 @@ fn modified_at_or_after_compares_at_nanosecond_precision() {
     // edit is still seen (the same-millisecond flake this guards against).
     let later_in_same_ms = FileMtime { ms, ns: ns + 500_000, whole_second: false };
     assert!(modified_at_or_after(later_in_same_ms, ms));
+}
+
+/// The lockfile freshness check uses whole-millisecond precision so the
+/// unchanged lockfile is never flagged against its own millisecond-
+/// truncated baseline (which the nanosecond manifest comparison would),
+/// while an external edit a millisecond later is still caught.
+#[test]
+fn lockfile_check_does_not_self_flag_its_own_baseline() {
+    let ms = 1_700_000_000_000_i64;
+    let subsecond_ns = ms * 1_000_000 + 500_000; // .5 ms into its millisecond
+
+    // A manifest with this mtime would (correctly) be flagged via
+    // nanoseconds against a baseline equal to its own truncated ms:
+    assert!(modified_at_or_after(FileMtime { ms, ns: subsecond_ns, whole_second: false }, ms));
+    // The lockfile must NOT self-flag against that same baseline:
+    assert!(!lockfile_mtime_after(ms, ms));
+    // An external edit a whole millisecond later is still caught:
+    assert!(lockfile_mtime_after(ms + 1, ms));
 }


### PR DESCRIPTION
## Summary

The optimistic repeat-install fast path (and `verify-deps-before-run`) records `lastValidatedTimestamp` and later compares it against manifest / `.pnpmfile.cjs` / patch mtimes to decide whether anything changed. Pacquet compared a **wall-clock** timestamp against **filesystem** mtimes, which fails in two independent ways — both surfaced as flaky pacquet-CLI test failures once the Rust test job moved onto Blacksmith's Linux runners:

1. **Wall-vs-filesystem clock skew.** `lastValidatedTimestamp` came from `now_millis()` (wall clock). On Blacksmith's Linux microVM the wall clock runs **~2–3 ms ahead** of the filesystem's mtime clock (measured), so a file edited a couple ms after an install gets an mtime *below* the baseline and the strict `mtime > baseline` comparison misses the edit.
2. **Same-millisecond collision.** Pacquet installs are fast enough that the lockfile one install writes and a manifest edited immediately after can land in the **same millisecond**; the comparison truncated both to whole ms, so `manifest.ms == lockfile.ms` read as "unchanged".

### Fix (two commits, pacquet-only)

- **Base the freshness timestamp on filesystem mtimes** — the max of the lockfile this install wrote and the manifests it validated — instead of the wall clock, so the baseline and the mtimes it's compared against share one clock (no skew). The max preserves the content-check-pass optimization (an already-edited but validated manifest is still blessed). This mirrors pnpm's `checkDepsStatus`, whose single-project path already keys off the lockfile mtime; pacquet had diverged.
- **Compare at nanosecond precision.** The recorded timestamp stays millisecond-precise (a rounded-down mtime, kept ms for cross-stack parity), but the subject is compared in nanoseconds, so a file whose whole-ms mtime ties the baseline but was written later in that ms is still seen as modified.

### Verification

- **On the actual skewed Blacksmith Linux runner** (probe confirmed 2–3 ms skew still present): the previously-flaky tests ran **40/40 green**, and the full pacquet suite (5380 tests) passed. The skew fix alone left a 2/40 residual — the same-ms flake — which the nanosecond fix closes.
- **Deterministic local proof:** a forced same-millisecond / higher-nanosecond edit passes only with the nanosecond comparison and fails with the millisecond one.
- 709 unit tests + the CLI integration suites pass locally; fmt / clippy / doc / dylint clean.

Note: this is the actual root cause of the Blacksmith pacquet flakiness. An earlier fix (pnpm/pnpm#12975) addressed whole-second mtime *granularity*, which Blacksmith doesn't have — it's harmless (and still helps genuinely coarse filesystems) but was a misdiagnosis; happy to revert it separately if you'd prefer.

## Squash Commit Body

```text
Pacquet's repeat-install fast path recorded lastValidatedTimestamp from
the wall clock but compared it against filesystem mtimes. On a runner
whose wall clock runs ahead of the filesystem's mtime clock (~2-3 ms on
Blacksmith Linux), a file edited just after an install got an mtime below
the baseline and the edit was missed; and because installs are fast, the
lockfile and a same-instant edit could share a millisecond, which the
ms-truncated comparison also missed.

Record the baseline from filesystem mtimes (max of the lockfile and the
validated manifests) so it shares a clock with the files it is compared
against, and compare the subject at nanosecond precision against the
rounded-down millisecond reference. Mirrors pnpm's checkDepsStatus, which
already keys single-project freshness off the lockfile mtime.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. _(Pacquet-only: it aligns pacquet with pnpm's existing single-project behavior; no TS change needed.)_
- [x] Added a changeset. _(`pacquet`, patch.)_
- [x] Added or updated tests. _(Nanosecond-precision unit test; the CLI integration tests are the regression coverage — verified 40/40 on the skewed runner.)_
- [x] Updated the documentation if needed. _(N/A.)_

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786555898&installation_id=145934176&pr_number=12981&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12981&signature=5ed8e3ce21c913053907e72c220108c50cf318f8d0a0b894d4d2e6b235bf78cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optimistic repeat-install “already up to date” detection after quick edits to project manifests, patch files, or lockfile-related inputs.
  * Improved freshness checks by using higher-precision file modification timestamps, ensuring changes within the same millisecond are detected.
  * Updated lockfile freshness evaluation to avoid incorrect re-resolution skips and reduce timestamp-resolution mismatches.
* **Tests**
  * Added and updated regression tests for nanosecond-precision behavior and lockfile baseline edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Update (review round)

CodeRabbit and Qodo both flagged a real regression in the first cut: the nanosecond comparison made the **unchanged lockfile self-flag** against its own millisecond-truncated baseline, forcing a content check on every repeat install. Fixed in `82b4c352dd` — the lockfile freshness check now compares at whole-millisecond precision (the unchanged lockfile ties its baseline; an external edit lands in a later ms and is still caught), while manifests/patches/pnpmfiles keep nanosecond precision (needed for same-ms edits, and can't self-flag because they compare against a *different* file). Added `lockfile_check_does_not_self_flag_its_own_baseline`. Re-verified **40/40 green** on the skewed Blacksmith Linux runner.

Known residual (documented for reviewers): after a **workspace** content-check pass on a manifest edited with unchanged deps, that manifest becomes the stored baseline and self-flags on later runs — a content check repeats until a real re-resolve. This matches pnpm's *single-project* behavior; pnpm's *workspace* path avoids it via a wall-clock refresh. Fully closing it needs a larger workspace-state change (it collides with the workspace unit tests and pnpm's ms state-format), so it's left as follow-up. The common fully-unchanged repeat install is fast again.
