### PR TITLE
fix: handle cross-realm missing pnpmfile errors

### DIFF
--- a/.changeset/calm-loaders-probe.md
+++ b/.changeset/calm-loaders-probe.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/hooks.pnpmfile": patch
+"pnpm": patch
+---
+
+Fixed pnpm failing to start under asynchronous Node.js module loaders when no `.pnpmfile.mjs` exists [pnpm/pnpm#11701](https://github.com/pnpm/pnpm/issues/11701).

--- a/.changeset/default-pnpmfile-mjs.md
+++ b/.changeset/default-pnpmfile-mjs.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/hooks.pnpmfile": patch
+"pnpm": patch
+---
+
+Avoid importing a missing default `.pnpmfile.mjs` when probing for pnpmfile hooks [pnpm/pnpm#11701](https://github.com/pnpm/pnpm/issues/11701).

--- a/.changeset/default-pnpmfile-mjs.md
+++ b/.changeset/default-pnpmfile-mjs.md
@@ -1,6 +1,0 @@
----
-"@pnpm/hooks.pnpmfile": patch
-"pnpm": patch
----
-
-Avoid importing a missing default `.pnpmfile.mjs` when probing for pnpmfile hooks [pnpm/pnpm#11701](https://github.com/pnpm/pnpm/issues/11701).

--- a/pnpm11/hooks/pnpmfile/src/requirePnpmfile.ts
+++ b/pnpm11/hooks/pnpmfile/src/requirePnpmfile.ts
@@ -45,9 +45,6 @@ export interface Pnpmfile {
 
 export async function requirePnpmfile (pnpmFilePath: string, prefix: string): Promise<{ pnpmfileModule: Pnpmfile | undefined } | undefined> {
   try {
-    if (pnpmFilePath.endsWith('.mjs') && !pnpmFileExistsSync(pnpmFilePath)) {
-      return undefined
-    }
     let pnpmfile: Pnpmfile
     // Check if it's an ESM module (ends with .mjs)
     if (pnpmFilePath.endsWith('.mjs')) {

--- a/pnpm11/hooks/pnpmfile/src/requirePnpmfile.ts
+++ b/pnpm11/hooks/pnpmfile/src/requirePnpmfile.ts
@@ -94,16 +94,19 @@ export async function requirePnpmfile (pnpmFilePath: string, prefix: string): Pr
       console.error(err)
       process.exit(1)
     }
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      'code' in err &&
+      (err.code === 'MODULE_NOT_FOUND' || err.code === 'ERR_MODULE_NOT_FOUND') &&
+      !pnpmFileExistsSync(pnpmFilePath)
+    ) {
+      return undefined
+    }
     if (!util.types.isNativeError(err)) {
       throw new PnpmFileFailError(pnpmFilePath, toError(err))
     }
-    if (
-      !('code' in err && (err.code === 'MODULE_NOT_FOUND' || err.code === 'ERR_MODULE_NOT_FOUND')) ||
-      pnpmFileExistsSync(pnpmFilePath)
-    ) {
-      throw new PnpmFileFailError(pnpmFilePath, err)
-    }
-    return undefined
+    throw new PnpmFileFailError(pnpmFilePath, err)
   }
 }
 

--- a/pnpm11/hooks/pnpmfile/src/requirePnpmfile.ts
+++ b/pnpm11/hooks/pnpmfile/src/requirePnpmfile.ts
@@ -45,6 +45,9 @@ export interface Pnpmfile {
 
 export async function requirePnpmfile (pnpmFilePath: string, prefix: string): Promise<{ pnpmfileModule: Pnpmfile | undefined } | undefined> {
   try {
+    if (pnpmFilePath.endsWith('.mjs') && !pnpmFileExistsSync(pnpmFilePath)) {
+      return undefined
+    }
     let pnpmfile: Pnpmfile
     // Check if it's an ESM module (ends with .mjs)
     if (pnpmFilePath.endsWith('.mjs')) {

--- a/pnpm11/hooks/pnpmfile/src/requirePnpmfile.ts
+++ b/pnpm11/hooks/pnpmfile/src/requirePnpmfile.ts
@@ -94,20 +94,21 @@ export async function requirePnpmfile (pnpmFilePath: string, prefix: string): Pr
       console.error(err)
       process.exit(1)
     }
-    if (
-      typeof err === 'object' &&
-      err !== null &&
-      'code' in err &&
-      (err.code === 'MODULE_NOT_FOUND' || err.code === 'ERR_MODULE_NOT_FOUND') &&
-      !pnpmFileExistsSync(pnpmFilePath)
-    ) {
+    if (isModuleNotFoundError(err) && !pnpmFileExistsSync(pnpmFilePath)) {
       return undefined
     }
-    if (!util.types.isNativeError(err)) {
-      throw new PnpmFileFailError(pnpmFilePath, toError(err))
-    }
-    throw new PnpmFileFailError(pnpmFilePath, err)
+    throw new PnpmFileFailError(pnpmFilePath, toError(err))
   }
+}
+
+/**
+ * Errors are matched by shape, not by class, because asynchronous module customization
+ * hooks forward them from their own realm, where `util.types.isNativeError()` returns false.
+ * See https://github.com/pnpm/pnpm/issues/11701
+ */
+function isModuleNotFoundError (err: unknown): boolean {
+  return typeof err === 'object' && err !== null && 'code' in err &&
+    (err.code === 'MODULE_NOT_FOUND' || err.code === 'ERR_MODULE_NOT_FOUND')
 }
 
 function pnpmFileExistsSync (pnpmFilePath: string): boolean {
@@ -118,7 +119,7 @@ function pnpmFileExistsSync (pnpmFilePath: string): boolean {
 }
 
 function toError (err: unknown): Error {
-  if (err instanceof Error) return err
+  if (util.types.isNativeError(err) || err instanceof Error) return err
   try {
     return new Error(String(err), { cause: err })
   } catch {

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/load-missing-default-pnpmfile.mjs
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/load-missing-default-pnpmfile.mjs
@@ -1,0 +1,3 @@
+import { requireHooks } from '@pnpm/hooks.pnpmfile'
+
+await requireHooks(import.meta.dirname, { tryLoadDefaultPnpmfile: true })

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/load-missing-default-pnpmfile.mjs
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/load-missing-default-pnpmfile.mjs
@@ -1,3 +1,11 @@
+import assert from 'node:assert/strict'
+
 import { requireHooks } from '@pnpm/hooks.pnpmfile'
 
-await requireHooks(import.meta.dirname, { tryLoadDefaultPnpmfile: true })
+import { PROBE_SPECIFIER } from './loader.mjs'
+
+// Fail loudly rather than passing vacuously if the loader stops being registered.
+await assert.rejects(import(PROBE_SPECIFIER), /the asynchronous loader is registered/)
+
+const { resolvedPnpmfilePaths } = await requireHooks(import.meta.dirname, { tryLoadDefaultPnpmfile: true })
+assert.deepEqual(resolvedPnpmfilePaths, [])

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/loader.mjs
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/loader.mjs
@@ -1,0 +1,3 @@
+export function resolve (specifier, context, nextResolve) {
+  return nextResolve(specifier, context)
+}

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/loader.mjs
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/loader.mjs
@@ -1,3 +1,8 @@
+export const PROBE_SPECIFIER = 'pnpm-async-loader-probe:'
+
 export function resolve (specifier, context, nextResolve) {
+  if (specifier === PROBE_SPECIFIER) {
+    throw new Error('the asynchronous loader is registered')
+  }
   return nextResolve(specifier, context)
 }

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/register-loader.mjs
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/async-loader/register-loader.mjs
@@ -1,0 +1,3 @@
+import { register } from 'node:module'
+
+register('./loader.mjs', import.meta.url)

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/default-cjs-only/.pnpmfile.cjs
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/default-cjs-only/.pnpmfile.cjs
@@ -1,0 +1,1 @@
+module.exports = { hooks: {} }

--- a/pnpm11/hooks/pnpmfile/test/__fixtures__/missing-import/.pnpmfile.mjs
+++ b/pnpm11/hooks/pnpmfile/test/__fixtures__/missing-import/.pnpmfile.mjs
@@ -1,0 +1,1 @@
+import './does-not-exist.mjs'

--- a/pnpm11/hooks/pnpmfile/test/index.ts
+++ b/pnpm11/hooks/pnpmfile/test/index.ts
@@ -1,4 +1,6 @@
+import { execFileSync } from 'node:child_process'
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 
 import { expect, test } from '@jest/globals'
 import type { Log } from '@pnpm/core-loggers'
@@ -99,9 +101,28 @@ test('.pnpmfile.mjs takes priority over .pnpmfile.cjs when both exist', async ()
   expect(pkg._fromCjs).toBeUndefined()
 })
 
+test('falls back to .pnpmfile.cjs when .pnpmfile.mjs does not exist', async () => {
+  const fixtureDir = path.join(import.meta.dirname, '__fixtures__/default-cjs-only')
+  const { hooks, resolvedPnpmfilePaths } = await requireHooks(fixtureDir, { tryLoadDefaultPnpmfile: true })
+
+  expect(hooks.readPackage).toHaveLength(0)
+  expect(resolvedPnpmfilePaths).toStrictEqual([path.join(fixtureDir, '.pnpmfile.cjs')])
+})
+
 test('calculatePnpmfileChecksum is undefined when pnpmfile does not exist', async () => {
   const { hooks } = await requireHooks(import.meta.dirname, {})
   expect(hooks.calculatePnpmfileChecksum).toBeUndefined()
+})
+
+test('ignores a missing default pnpmfile when asynchronous module hooks are registered', () => {
+  const fixtureDir = path.join(import.meta.dirname, '__fixtures__/async-loader')
+  const registerLoader = pathToFileURL(path.join(fixtureDir, 'register-loader.mjs')).href
+  execFileSync(process.execPath, [path.join(fixtureDir, 'load-missing-default-pnpmfile.mjs')], {
+    env: {
+      ...process.env,
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --disable-warning=DEP0205 --import=${registerLoader}`.trim(),
+    },
+  })
 })
 
 test('calculatePnpmfileChecksum resolves to hash string for existing pnpmfile', async () => {
@@ -127,8 +148,19 @@ test('requirePnpmfile wraps non-native-Error throws instead of crashing', async 
   await expect(requirePnpmfile(pnpmfilePath, import.meta.dirname)).rejects.toThrow('this is a string error, not a native Error')
 })
 
-test('requireHooks throw an error if one of the specified pnpmfiles does not exist', async () => {
-  await expect(requireHooks(import.meta.dirname, { pnpmfiles: ['does-not-exist.cjs'] })).rejects.toThrow('is not found')
+test('requirePnpmfile reports missing imports from an existing ESM pnpmfile', async () => {
+  const pnpmfilePath = path.join(import.meta.dirname, '__fixtures__/missing-import/.pnpmfile.mjs')
+  await expect(requirePnpmfile(pnpmfilePath, import.meta.dirname)).rejects.toMatchObject({
+    code: 'ERR_PNPM_PNPMFILE_FAIL',
+    message: expect.stringContaining('Error during pnpmfile execution'),
+  })
+})
+
+test.each(['cjs', 'mjs'])('requireHooks throws an error if a specified %s pnpmfile does not exist', async (extension) => {
+  await expect(requireHooks(import.meta.dirname, { pnpmfiles: [`does-not-exist.${extension}`] })).rejects.toMatchObject({
+    code: 'ERR_PNPM_PNPMFILE_NOT_FOUND',
+    message: expect.stringContaining('is not found'),
+  })
 })
 
 test('requireHooks throws an error if there are two finders with the same name', async () => {

--- a/pnpm11/hooks/pnpmfile/test/index.ts
+++ b/pnpm11/hooks/pnpmfile/test/index.ts
@@ -1,9 +1,6 @@
-import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
-import util from 'node:util'
 
-import { expect, jest, test } from '@jest/globals'
+import { expect, test } from '@jest/globals'
 import type { Log } from '@pnpm/core-loggers'
 import { BadReadPackageHookError, type HookContext, requireHooks } from '@pnpm/hooks.pnpmfile'
 import { fixtures } from '@pnpm/test-fixtures'
@@ -102,37 +99,6 @@ test('.pnpmfile.mjs takes priority over .pnpmfile.cjs when both exist', async ()
   expect(pkg._fromCjs).toBeUndefined()
 })
 
-test('falling back to .pnpmfile.cjs without classifying a missing default .pnpmfile.mjs import error', async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-pnpmfile-'))
-  const cjsPath = path.join(dir, '.pnpmfile.cjs')
-  fs.writeFileSync(cjsPath, 'module.exports = { hooks: {} }\n')
-  const isNativeErrorSpy = jest.spyOn(util.types, 'isNativeError').mockReturnValue(false)
-
-  try {
-    const { hooks, resolvedPnpmfilePaths } = await requireHooks(dir, { tryLoadDefaultPnpmfile: true })
-
-    expect(hooks.readPackage?.length).toBe(0)
-    expect(resolvedPnpmfilePaths).toStrictEqual([cjsPath])
-    expect(isNativeErrorSpy).not.toHaveBeenCalled()
-  } finally {
-    isNativeErrorSpy.mockRestore()
-    fs.rmSync(dir, { recursive: true })
-  }
-})
-
-test('skipping missing default pnpmfiles', async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-pnpmfile-'))
-
-  try {
-    const { hooks, resolvedPnpmfilePaths } = await requireHooks(dir, { tryLoadDefaultPnpmfile: true })
-
-    expect(hooks.readPackage?.length).toBe(0)
-    expect(resolvedPnpmfilePaths).toStrictEqual([])
-  } finally {
-    fs.rmSync(dir, { recursive: true })
-  }
-})
-
 test('calculatePnpmfileChecksum is undefined when pnpmfile does not exist', async () => {
   const { hooks } = await requireHooks(import.meta.dirname, {})
   expect(hooks.calculatePnpmfileChecksum).toBeUndefined()
@@ -161,26 +127,8 @@ test('requirePnpmfile wraps non-native-Error throws instead of crashing', async 
   await expect(requirePnpmfile(pnpmfilePath, import.meta.dirname)).rejects.toThrow('this is a string error, not a native Error')
 })
 
-test('requirePnpmfile reports missing imports from an existing ESM pnpmfile', async () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-pnpmfile-'))
-  const pnpmfilePath = path.join(dir, '.pnpmfile.mjs')
-  fs.writeFileSync(pnpmfilePath, "import './missing.mjs'\n")
-
-  try {
-    await expect(requirePnpmfile(pnpmfilePath, dir)).rejects.toMatchObject({
-      code: 'ERR_PNPM_PNPMFILE_FAIL',
-      message: expect.stringContaining('Error during pnpmfile execution'),
-    })
-  } finally {
-    fs.rmSync(dir, { recursive: true })
-  }
-})
-
-test.each(['cjs', 'mjs'])('requireHooks throws an error if a specified %s pnpmfile does not exist', async (extension) => {
-  await expect(requireHooks(import.meta.dirname, { pnpmfiles: [`does-not-exist.${extension}`] })).rejects.toMatchObject({
-    code: 'ERR_PNPM_PNPMFILE_NOT_FOUND',
-    message: expect.stringContaining('is not found'),
-  })
+test('requireHooks throw an error if one of the specified pnpmfiles does not exist', async () => {
+  await expect(requireHooks(import.meta.dirname, { pnpmfiles: ['does-not-exist.cjs'] })).rejects.toThrow('is not found')
 })
 
 test('requireHooks throws an error if there are two finders with the same name', async () => {

--- a/pnpm11/hooks/pnpmfile/test/index.ts
+++ b/pnpm11/hooks/pnpmfile/test/index.ts
@@ -1,6 +1,9 @@
+import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
+import util from 'node:util'
 
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import type { Log } from '@pnpm/core-loggers'
 import { BadReadPackageHookError, type HookContext, requireHooks } from '@pnpm/hooks.pnpmfile'
 import { fixtures } from '@pnpm/test-fixtures'
@@ -99,6 +102,37 @@ test('.pnpmfile.mjs takes priority over .pnpmfile.cjs when both exist', async ()
   expect(pkg._fromCjs).toBeUndefined()
 })
 
+test('falling back to .pnpmfile.cjs without classifying a missing default .pnpmfile.mjs import error', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-pnpmfile-'))
+  const cjsPath = path.join(dir, '.pnpmfile.cjs')
+  fs.writeFileSync(cjsPath, 'module.exports = { hooks: {} }\n')
+  const isNativeErrorSpy = jest.spyOn(util.types, 'isNativeError').mockReturnValue(false)
+
+  try {
+    const { hooks, resolvedPnpmfilePaths } = await requireHooks(dir, { tryLoadDefaultPnpmfile: true })
+
+    expect(hooks.readPackage?.length).toBe(0)
+    expect(resolvedPnpmfilePaths).toStrictEqual([cjsPath])
+    expect(isNativeErrorSpy).not.toHaveBeenCalled()
+  } finally {
+    isNativeErrorSpy.mockRestore()
+    fs.rmSync(dir, { recursive: true })
+  }
+})
+
+test('skipping missing default pnpmfiles', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-pnpmfile-'))
+
+  try {
+    const { hooks, resolvedPnpmfilePaths } = await requireHooks(dir, { tryLoadDefaultPnpmfile: true })
+
+    expect(hooks.readPackage?.length).toBe(0)
+    expect(resolvedPnpmfilePaths).toStrictEqual([])
+  } finally {
+    fs.rmSync(dir, { recursive: true })
+  }
+})
+
 test('calculatePnpmfileChecksum is undefined when pnpmfile does not exist', async () => {
   const { hooks } = await requireHooks(import.meta.dirname, {})
   expect(hooks.calculatePnpmfileChecksum).toBeUndefined()
@@ -127,8 +161,26 @@ test('requirePnpmfile wraps non-native-Error throws instead of crashing', async 
   await expect(requirePnpmfile(pnpmfilePath, import.meta.dirname)).rejects.toThrow('this is a string error, not a native Error')
 })
 
-test('requireHooks throw an error if one of the specified pnpmfiles does not exist', async () => {
-  await expect(requireHooks(import.meta.dirname, { pnpmfiles: ['does-not-exist.cjs'] })).rejects.toThrow('is not found')
+test('requirePnpmfile reports missing imports from an existing ESM pnpmfile', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-pnpmfile-'))
+  const pnpmfilePath = path.join(dir, '.pnpmfile.mjs')
+  fs.writeFileSync(pnpmfilePath, "import './missing.mjs'\n")
+
+  try {
+    await expect(requirePnpmfile(pnpmfilePath, dir)).rejects.toMatchObject({
+      code: 'ERR_PNPM_PNPMFILE_FAIL',
+      message: expect.stringContaining('Error during pnpmfile execution'),
+    })
+  } finally {
+    fs.rmSync(dir, { recursive: true })
+  }
+})
+
+test.each(['cjs', 'mjs'])('requireHooks throws an error if a specified %s pnpmfile does not exist', async (extension) => {
+  await expect(requireHooks(import.meta.dirname, { pnpmfiles: [`does-not-exist.${extension}`] })).rejects.toMatchObject({
+    code: 'ERR_PNPM_PNPMFILE_NOT_FOUND',
+    message: expect.stringContaining('is not found'),
+  })
 })
 
 test('requireHooks throws an error if there are two finders with the same name', async () => {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->
<!-- cspell:words Qodo -->

## Summary

Fixes pnpm/pnpm#11701.

### Root cause

TypeScript tooling can set `NODE_OPTIONS=--import .../tsx/dist/loader.mjs` and forward `process.env` to child commands. A pnpm process launched in that environment inherits an asynchronous Node.js module loader even though pnpm itself was not started through the TypeScript tooling directly.

When pnpm probes the optional default `.pnpmfile.mjs`, `requirePnpmfile()` attempts a dynamic import and catches `ERR_MODULE_NOT_FOUND` if the file is absent. Asynchronous module customization hooks run in a separate loader thread and realm, so the error object crossing back to pnpm is not recognized by `util.types.isNativeError()` in the main realm. The existing catch block checks `isNativeError()` before checking the error code and target path, which wraps the optional missing-file result as `ERR_PNPM_PNPMFILE_FAIL`.

The replacement fix identifies the established missing-module condition structurally—`MODULE_NOT_FOUND` or `ERR_MODULE_NOT_FOUND` plus an absent target pnpmfile—before applying native-error classification. All other errors continue through the existing wrapper. This is preferable to checking the filesystem before `import()`: it preserves custom-loader resolution behavior, avoids changing the loader contract based on a pre-import filesystem snapshot, and still distinguishes a missing pnpmfile from a missing import inside an existing pnpmfile.

The Rust implementation already checks candidate pnpmfiles with `Path::is_file()` before loading them and does not use Node.js module loaders, so no pacquet change is needed for parity.

### Minimal reproduction

Create a directory without `.pnpmfile.mjs` or `.pnpmfile.cjs` containing these files:

`package.json`:

```json
{
  "name": "pnpm-async-loader-repro",
  "private": true,
  "packageManager": "pnpm@11.13.0"
}
```

`loader.mjs`:

```js
export function resolve (specifier, context, nextResolve) {
  return nextResolve(specifier, context)
}
```

`register-loader.mjs`:

```js
import { register } from 'node:module'

register('./loader.mjs', import.meta.url)
```

Then run:

```sh
NODE_OPTIONS='--import ./register-loader.mjs' pnpm install
```

On an affected pnpm version, the absent optional `.pnpmfile.mjs` is reported as `ERR_PNPM_PNPMFILE_FAIL`. With this change, pnpm continues without hooks.

### Tests

The three useful behavioral cases from the original change remain, with the synthetic `isNativeError()` mock replaced by the actual cross-realm reproduction:

- a missing `.pnpmfile.mjs` falls back to `.pnpmfile.cjs`;
- missing default pnpmfiles are ignored under a real asynchronous module loader;
- a missing import from an existing `.pnpmfile.mjs` remains `ERR_PNPM_PNPMFILE_FAIL`.

The existing explicit-path test now covers both missing `.cjs` and `.mjs` files and preserves `ERR_PNPM_PNPMFILE_NOT_FOUND`.

Validation:

- `pn --filter @pnpm/hooks.pnpmfile test`:

```text
Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total
Snapshots:   0 total
Time:        0.291 s, estimated 1 s
Ran all test suites.
```

- `pn --filter pnpm run compile` completed successfully. Its only diagnostics were the repository's seven existing skipped-test warnings: `✖ 7 problems (0 errors, 7 warnings)`.
- The rebuilt CLI completed the reproduction under the asynchronous loader:

```text
Already up to date
Done in 253ms using pnpm v11.12.0
```

- Targeted spelling and diff checks passed:

```text
CSpell: Files checked: 8, Issues found: 0 in 0 files.
```

## Squash Commit Body

```text
Asynchronous Node.js module loaders return dynamic import failures from their
loader realm. After ERR_MODULE_NOT_FOUND crosses threads,
util.types.isNativeError() can return false, causing an absent optional
.pnpmfile.mjs to be wrapped as PNPMFILE_FAIL.

Recognize the missing-module code and absent target before classifying native
errors. Preserve failures for existing pnpmfiles and explicitly configured
paths, and cover the behavior with a real asynchronous loader.

Fixes pnpm/pnpm#11701
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing pnpmfile configurations so the app starts correctly with asynchronous Node.js module loaders.
  * Added clearer errors when a specified pnpmfile cannot be found, while allowing fallback to an available alternate file.
  * Better distinguishes between missing modules and other failures to avoid unnecessary startup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->