### PR TITLE
test: opt version -r changelog test into repository storage

### DIFF
--- a/pnpm11/releasing/commands/test/change/index.test.ts
+++ b/pnpm11/releasing/commands/test/change/index.test.ts
@@ -69,7 +69,12 @@ describe('change command and intent-consuming version -r', () => {
   it('bare version -r applies the release plan and cleans up the intent', async () => {
     const lib = addPkg({ name: 'lib', version: '1.0.0' })
     const cli = addPkg({ name: 'cli', version: '2.0.0', dependencies: { lib: 'workspace:*' } })
-    const opts = baseOpts([lib, cli])
+    // Assert the committed-CHANGELOG flow: `repository` storage writes
+    // CHANGELOG.md and deletes the consumed intent at version time. The default
+    // `registry` storage instead parks the section and defers intent GC until
+    // the registry confirms publication — covered in the versioning package's
+    // lifecycle tests.
+    const opts = { ...baseOpts([lib, cli]), versioning: { changelog: { storage: 'repository' } } }
 
     await change.handler({ ...opts, bump: 'major', summary: 'Breaking change.' } as any, ['lib']) // eslint-disable-line @typescript-eslint/no-explicit-any
 


### PR DESCRIPTION
## Summary

The `@pnpm/releasing.commands` test `change command and intent-consuming version -r › bare version -r applies the release plan and cleans up the intent` is failing on `main` with:

```
ENOENT: no such file or directory, open '/tmp/pnpm-change-test-XXXXXX/packages/lib/CHANGELOG.md'
```

**Root cause.** That test asserts the committed-CHANGELOG flow — it reads `lib/CHANGELOG.md`, expects it to contain the release note, and expects the consumed intent to be deleted at version time. PR #12971 (compose changelogs at publish time) made `changelog.storage: registry` the **default**: `pnpm version -r` no longer commits `CHANGELOG.md`; it parks the section under `.changeset/changelogs/` and defers intent garbage-collection until the registry confirms publication (via `verifyPublished`). The test provides no registry, so under the new default the changelog file is never written (ENOENT) and the intent is never collected. #12971 added storage-mode coverage in the versioning package's lifecycle tests but didn't update this pre-existing command-level test.

**Fix.** Opt this test into `versioning.changelog.storage: 'repository'` so it keeps exercising the committed-changelog + intent-cleanup path it was written for — the same opt-in the versioning `lifecycle.ts` tests use for their committed-changelog assertions. Registry-storage behavior (parked section, deferred GC) is already covered by those lifecycle tests.

Verified locally: the full `test/change/index.test.ts` suite passes (13/13) after the change.

## Squash Commit Body

```text
The "bare version -r applies the release plan and cleans up the intent" test
asserts the committed-CHANGELOG flow: it reads lib/CHANGELOG.md and expects the
consumed intent to be deleted at version time. Since composing changelogs at
publish time (registry storage) became the default, `pnpm version -r` no longer
commits CHANGELOG.md — it parks the section under .changeset/changelogs/ and
defers intent GC until the registry confirms publication. With no verifyPublished
registry in the test, the changelog file is never written (ENOENT) and the
intent is never collected, so the test failed.

Opt the test into versioning.changelog.storage: repository so it keeps
exercising the committed-changelog + intent-cleanup path, matching the pattern
the versioning package's lifecycle tests already use.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. <!-- TypeScript-only test change; the Rust versioning port has its own changelog-storage tests. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note. <!-- Not applicable: test-only change, no published package behavior changes. -->
- [x] Added or updated tests. <!-- Repairs an existing test stranded by the registry-storage default. -->
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786560674&installation_id=145934176&pr_number=12984&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12984&signature=c819d5506bb0bcc7349f41daae354e42fb6a79486bb1104952369ae68957a1a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated release command test coverage for repository-based changelog storage.
  - Verified that applying a release plan with the bare version option also cleans up the associated intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->