### PR TITLE
fix: approve git-hosted tarball builds by repository url

### DIFF
--- a/.changeset/allow-git-tarball-builds-by-repo-url.md
+++ b/.changeset/allow-git-tarball-builds-by-repo-url.md
@@ -1,0 +1,13 @@
+---
+"@pnpm/building.policy": patch
+"pnpm": patch
+---
+
+`allowBuilds` entries can now approve git-hosted packages that pnpm downloads as a tarball, such as `github:` dependencies (which are fetched from `codeload.github.com` rather than cloned), by their repository URL without the resolved commit hash. This matches the hashless `git+` matching already supported for cloned git dependencies. For example:
+
+```yaml
+allowBuilds:
+  "foo@git+https://github.com/org/foo.git": true
+```
+
+This approves the package whether pnpm clones it or downloads a tarball, so the entry no longer has to be updated every time the pinned commit changes. GitLab and Bitbucket tarball downloads are matched the same way. Approving or denying a specific resolved commit by its full tarball dep path continues to work.

--- a/.changeset/allow-git-tarball-builds-by-repo-url.md
+++ b/.changeset/allow-git-tarball-builds-by-repo-url.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/building.policy": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 `allowBuilds` entries can now approve git-hosted packages that pnpm downloads as a tarball, such as `github:` dependencies (which are fetched from `codeload.github.com` rather than cloned), by their repository URL without the resolved commit hash. This matches the hashless `git+` matching already supported for cloned git dependencies. For example:

--- a/cspell.json
+++ b/cspell.json
@@ -142,6 +142,7 @@
     "hardlinking",
     "hardlinks",
     "hashbang",
+    "hashless",
     "highmaps",
     "hikljmi",
     "hoistable",

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -20,6 +20,7 @@ use pacquet_reporter::{
 };
 use rayon::prelude::*;
 use std::{
+    borrow::Cow,
     collections::{BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::Mutex,
@@ -217,6 +218,7 @@ impl AllowBuildPolicy {
             return Some(false);
         }
         let git_repo_key = git_repo_allow_build_key_from_dep_path(&normalized_dep_path);
+        let git_repo_key = git_repo_key.as_deref();
         if let Some(git_repo_key) = git_repo_key
             && self.disallowed_git_repos.contains(git_repo_key)
         {
@@ -300,18 +302,71 @@ fn is_git_repo_allow_build_key(spec: &str) -> bool {
     !spec.contains('#') && is_git_repo_dep_path(spec)
 }
 
-fn git_repo_allow_build_key_from_dep_path(dep_path: &str) -> Option<&str> {
-    if !is_git_repo_dep_path(dep_path) {
-        return None;
+fn git_repo_allow_build_key_from_dep_path(dep_path: &str) -> Option<Cow<'_, str>> {
+    if is_git_repo_dep_path(dep_path) {
+        return Some(match dep_path.find('#') {
+            Some(ref_start) => Cow::Borrowed(&dep_path[..ref_start]),
+            None => Cow::Borrowed(dep_path),
+        });
     }
-    Some(match dep_path.find('#') {
-        Some(ref_start) => &dep_path[..ref_start],
-        None => dep_path,
-    })
+    // Packages installed from a git host as a downloaded tarball (e.g. the
+    // `github:` shortcut, which pnpm fetches from codeload.github.com rather
+    // than cloning) have a depPath built from the tarball URL, not a `git+`
+    // clone URL, so the check above misses them. Normalize the tarball URL back
+    // to the same `git+https://<host>/<repo>.git` repo key that a clone of the
+    // same repository would produce, so a single hashless `allowBuilds` entry
+    // approves the package however pnpm happened to fetch it.
+    git_hosted_tarball_repo_key(dep_path).map(Cow::Owned)
 }
 
 fn is_git_repo_dep_path(dep_path: &str) -> bool {
     dep_path.starts_with("git+") || dep_path.contains("@git+")
+}
+
+/// Rebuilds the `<name>@git+https://<host>/<repo>.git` repo key for a git-host
+/// tarball depPath (mirrors the TypeScript `gitHostedTarballRepoKey`).
+fn git_hosted_tarball_repo_key(dep_path: &str) -> Option<String> {
+    let (name, version) = parse_dep_path_name_version(dep_path)?;
+    let repo_url = git_hosted_tarball_repo_url(version)?;
+    Some(format!("{name}@{repo_url}"))
+}
+
+/// The committish-free repository URL for a git host that pnpm downloads as a
+/// tarball instead of cloning. The patterns mirror the tarball templates in
+/// `@pnpm/git-resolver` (from hosted-git-info, except GitLab's override). Each
+/// known host is anchored so a look-alike download host (e.g.
+/// `codeload.github.com.example.com`) cannot be rewritten into an unrelated key.
+fn git_hosted_tarball_repo_url(tarball_url: &str) -> Option<String> {
+    // GitHub: `https://codeload.github.com/<owner>/<repo>/tar.gz/<committish>`
+    if let Some(rest) = tarball_url.strip_prefix("https://codeload.github.com/") {
+        let (owner, rest) = rest.split_once('/')?;
+        let (repo, _) = rest.split_once("/tar.gz/")?;
+        if owner.is_empty() || repo.is_empty() {
+            return None;
+        }
+        return Some(format!("git+https://github.com/{owner}/{repo}.git"));
+    }
+    // Bitbucket: `https://bitbucket.org/<owner>/<repo>/get/<committish>.tar.gz`
+    if let Some(rest) = tarball_url.strip_prefix("https://bitbucket.org/") {
+        let (owner, rest) = rest.split_once('/')?;
+        let (repo, _) = rest.split_once("/get/")?;
+        if owner.is_empty() || repo.is_empty() {
+            return None;
+        }
+        return Some(format!("git+https://bitbucket.org/{owner}/{repo}.git"));
+    }
+    // GitLab (incl. self-hosted): the project path may contain nested groups,
+    // so match up to the `/-/archive/<ref>/` marker.
+    // `https://<host>/<group...>/<repo>/-/archive/<ref>/<repo>-<ref>.tar.gz`
+    if let Some(rest) = tarball_url.strip_prefix("https://") {
+        let (host, rest) = rest.split_once('/')?;
+        let (project, _) = rest.split_once("/-/archive/")?;
+        if host.is_empty() || project.is_empty() {
+            return None;
+        }
+        return Some(format!("git+https://{host}/{project}.git"));
+    }
+    None
 }
 
 fn is_dep_path_allow_build_key(spec: &str) -> bool {

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -341,7 +341,11 @@ fn git_hosted_tarball_repo_url(tarball_url: &str) -> Option<String> {
     if let Some(rest) = tarball_url.strip_prefix("https://codeload.github.com/") {
         let (owner, rest) = rest.split_once('/')?;
         let (repo, _) = rest.split_once("/tar.gz/")?;
-        if owner.is_empty() || repo.is_empty() {
+        // `owner` and `repo` are each a single path segment, matching the
+        // `[^/]+` anchors in the TypeScript matcher so both stacks normalize
+        // identically. `owner` cannot contain a slash (it is the first
+        // `split_once('/')` half), but `repo` can, so reject that here.
+        if owner.is_empty() || repo.is_empty() || repo.contains('/') {
             return None;
         }
         return Some(format!("git+https://github.com/{owner}/{repo}.git"));
@@ -350,7 +354,8 @@ fn git_hosted_tarball_repo_url(tarball_url: &str) -> Option<String> {
     if let Some(rest) = tarball_url.strip_prefix("https://bitbucket.org/") {
         let (owner, rest) = rest.split_once('/')?;
         let (repo, _) = rest.split_once("/get/")?;
-        if owner.is_empty() || repo.is_empty() {
+        // Single-segment `repo`, as in the GitHub branch above.
+        if owner.is_empty() || repo.is_empty() || repo.contains('/') {
             return None;
         }
         return Some(format!("git+https://bitbucket.org/{owner}/{repo}.git"));

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -364,12 +364,25 @@ fn git_hosted_tarball_repo_url(tarball_url: &str) -> Option<String> {
     // so match up to the `/-/archive/<ref>/` marker.
     // `https://<host>/<group...>/<repo>/-/archive/<ref>/<repo>-<ref>.tar.gz`
     if let Some(rest) = tarball_url.strip_prefix("https://") {
-        let (host, rest) = rest.split_once('/')?;
-        let (project, _) = rest.split_once("/-/archive/")?;
-        if host.is_empty() || project.is_empty() {
+        let (host, path) = rest.split_once('/')?;
+        if host.is_empty() {
             return None;
         }
-        return Some(format!("git+https://{host}/{project}.git"));
+        // Take the shortest non-empty project whose marker is followed by a
+        // non-empty `<ref>/` segment, mirroring the lazy `(.+?)` project
+        // capture and the `[^/]+/` ref anchor of the TypeScript matcher.
+        const ARCHIVE_MARKER: &str = "/-/archive/";
+        for (marker_index, _) in path.match_indices(ARCHIVE_MARKER) {
+            let project = &path[..marker_index];
+            let after_marker = &path[marker_index + ARCHIVE_MARKER.len()..];
+            let Some((git_ref, _)) = after_marker.split_once('/') else {
+                continue;
+            };
+            if project.is_empty() || git_ref.is_empty() {
+                continue;
+            }
+            return Some(format!("git+https://{host}/{project}.git"));
+        }
     }
     None
 }

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -213,6 +213,20 @@ fn explicit_allow_by_git_hosted_tarball_repo_url() {
     // key allowlisted, the multi-segment URL stays unapproved.
     assert_eq!(policy.check("qux@https://codeload.github.com/org/extra/qux/tar.gz/abc123"), None);
     assert_eq!(policy.check("quux@https://bitbucket.org/org/extra/quux/get/abc123.tar.gz"), None);
+    // A URL on a claimed download host that does not match that host's tarball
+    // pattern is rejected outright — it must not fall through to the generic
+    // GitLab matcher and produce the host's trusted repo key.
+    assert_eq!(
+        policy.check("bar@https://bitbucket.org/org/bar/-/archive/abc123/bar-abc123.tar.gz"),
+        None,
+    );
+    assert_eq!(
+        policy.check("foo@https://codeload.github.com/org/foo/-/archive/abc123/foo-abc123.tar.gz"),
+        None,
+    );
+    // A GitLab archive URL without a `<ref>/` segment after the marker is not
+    // normalized.
+    assert_eq!(policy.check("baz@https://gitlab.com/group/subgroup/baz/-/archive/abc123"), None);
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -173,6 +173,9 @@ fn explicit_allow_by_git_hosted_tarball_repo_url() {
             ("bar@git+https://bitbucket.org/org/bar.git", true),
             ("baz@git+https://gitlab.com/group/subgroup/baz.git", true),
             ("evil@git+https://github.com/org/evil.git", false),
+            // Slash-bearing keys the buggy multi-segment parse would have produced.
+            ("qux@git+https://github.com/org/extra/qux.git", true),
+            ("quux@git+https://bitbucket.org/org/extra/quux.git", true),
         ],
         false,
     );
@@ -203,6 +206,13 @@ fn explicit_allow_by_git_hosted_tarball_repo_url() {
         policy.check("evil@https://codeload.github.com/org/evil/tar.gz/abc123"),
         Some(false),
     );
+
+    // A tarball URL with an extra path segment is not a valid codeload/get URL
+    // (a repo is exactly `owner/repo`) and must not be normalized, matching the
+    // `[^/]+` repo anchor in the TypeScript matcher. Even with the slash-bearing
+    // key allowlisted, the multi-segment URL stays unapproved.
+    assert_eq!(policy.check("qux@https://codeload.github.com/org/extra/qux/tar.gz/abc123"), None);
+    assert_eq!(policy.check("quux@https://bitbucket.org/org/extra/quux/get/abc123.tar.gz"), None);
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -166,6 +166,46 @@ fn explicit_allow_by_git_repo_allows_untrusted_package_identity() {
 }
 
 #[test]
+fn explicit_allow_by_git_hosted_tarball_repo_url() {
+    let policy = policy_from_specs(
+        [
+            ("foo@git+https://github.com/org/foo.git", true),
+            ("bar@git+https://bitbucket.org/org/bar.git", true),
+            ("baz@git+https://gitlab.com/group/subgroup/baz.git", true),
+            ("evil@git+https://github.com/org/evil.git", false),
+        ],
+        false,
+    );
+
+    // A GitHub `github:` dependency is downloaded from codeload.github.com, yet
+    // the same key a clone of the repo would use approves it — no commit hash.
+    assert_eq!(policy.check("foo@https://codeload.github.com/org/foo/tar.gz/abc123"), Some(true));
+    assert_eq!(
+        policy.check("foo@https://codeload.github.com/org/foo/tar.gz/def456(react@19.0.0)"),
+        Some(true),
+    );
+    // Bitbucket and GitLab (with nested groups) tarball downloads too.
+    assert_eq!(policy.check("bar@https://bitbucket.org/org/bar/get/abc123.tar.gz"), Some(true));
+    assert_eq!(
+        policy
+            .check("baz@https://gitlab.com/group/subgroup/baz/-/archive/abc123/baz-abc123.tar.gz"),
+        Some(true),
+    );
+    // A different repository under the same package name is not approved.
+    assert_eq!(policy.check("foo@https://codeload.github.com/attacker/foo/tar.gz/abc123"), None);
+    // A look-alike download host must not be rewritten into the trusted key.
+    assert_eq!(
+        policy.check("foo@https://codeload.github.com.attacker.net/org/foo/tar.gz/abc123"),
+        None,
+    );
+    // Denial by hashless repository key works as well.
+    assert_eq!(
+        policy.check("evil@https://codeload.github.com/org/evil/tar.gz/abc123"),
+        Some(false),
+    );
+}
+
+#[test]
 fn explicit_allow_by_tarball_dep_path_allows_untrusted_package_identity() {
     let policy = policy_from_specs([("foo@https://example.com/foo.tgz", true)], false);
 

--- a/pnpm11/building/policy/src/index.ts
+++ b/pnpm11/building/policy/src/index.ts
@@ -122,13 +122,60 @@ function isGitRepoAllowBuildKey (pkg: string): boolean {
 }
 
 function getGitRepoAllowBuildKeyFromDepPath (depPath: string): string | undefined {
-  if (!isGitRepoDepPath(depPath)) return undefined
-  const refStart = depPath.indexOf('#')
-  return refStart === -1 ? depPath : depPath.slice(0, refStart)
+  if (isGitRepoDepPath(depPath)) {
+    const refStart = depPath.indexOf('#')
+    return refStart === -1 ? depPath : depPath.slice(0, refStart)
+  }
+  // Packages installed from a git host as a downloaded tarball (e.g. the
+  // `github:` shortcut, which pnpm fetches from codeload.github.com rather
+  // than cloning) have a depPath built from the tarball URL, not a `git+`
+  // clone URL, so the check above misses them. Normalize the tarball URL back
+  // to the same `git+https://<host>/<repo>.git` repo key that a clone of the
+  // same repository would produce, so a single hashless `allowBuilds` entry
+  // approves the package however pnpm happened to fetch it.
+  return gitHostedTarballRepoKey(depPath)
 }
 
 function isGitRepoDepPath (depPath: string): boolean {
   return depPath.startsWith('git+') || depPath.includes('@git+')
+}
+
+// Reconstructs the committish-free repository URL from the download URL of a
+// git host that pnpm fetches as a tarball instead of cloning. The patterns
+// mirror the tarball templates in @pnpm/git-resolver (which come from
+// hosted-git-info, except GitLab's, which that package overrides). The host of
+// each known template is anchored so a look-alike download host (e.g.
+// `codeload.github.com.example.com`) cannot be rewritten into an unrelated
+// repo key.
+const GIT_HOSTED_TARBALL_REPO_URL_MATCHERS: Array<(tarballUrl: string) => string | undefined> = [
+  // GitHub: https://codeload.github.com/<owner>/<repo>/tar.gz/<committish>
+  makeTarballRepoUrlMatcher(/^https:\/\/codeload\.github\.com\/([^/]+)\/([^/]+)\/tar\.gz\//, (m) => `github.com/${m[1]}/${m[2]}`),
+  // Bitbucket: https://bitbucket.org/<owner>/<repo>/get/<committish>.tar.gz
+  makeTarballRepoUrlMatcher(/^https:\/\/bitbucket\.org\/([^/]+)\/([^/]+)\/get\//, (m) => `bitbucket.org/${m[1]}/${m[2]}`),
+  // GitLab (incl. self-hosted): https://<host>/<group…>/<repo>/-/archive/<ref>/…
+  // The project path may contain nested groups, so match up to the
+  // `/-/archive/<ref>/` marker rather than a fixed number of path segments.
+  makeTarballRepoUrlMatcher(/^https:\/\/([^/]+)\/(.+?)\/-\/archive\/[^/]+\//, (m) => `${m[1]}/${m[2]}`),
+]
+
+function makeTarballRepoUrlMatcher (
+  re: RegExp,
+  toRepoPath: (m: RegExpExecArray) => string
+): (tarballUrl: string) => string | undefined {
+  return (tarballUrl) => {
+    const match = re.exec(tarballUrl)
+    return match == null ? undefined : `git+https://${toRepoPath(match)}.git`
+  }
+}
+
+function gitHostedTarballRepoKey (pkgIdWithPatchHash: string): string | undefined {
+  const { name, nonSemverVersion } = dp.parse(pkgIdWithPatchHash)
+  if (name == null || nonSemverVersion == null) return undefined
+  for (const match of GIT_HOSTED_TARBALL_REPO_URL_MATCHERS) {
+    const repoUrl = match(nonSemverVersion)
+    if (repoUrl != null) return `${name}@${repoUrl}`
+  }
+  return undefined
 }
 
 function isDepPathAllowBuildKey (pkg: string): boolean {

--- a/pnpm11/building/policy/src/index.ts
+++ b/pnpm11/building/policy/src/index.ts
@@ -140,42 +140,40 @@ function isGitRepoDepPath (depPath: string): boolean {
   return depPath.startsWith('git+') || depPath.includes('@git+')
 }
 
+function gitHostedTarballRepoKey (pkgIdWithPatchHash: string): string | undefined {
+  const { name, nonSemverVersion } = dp.parse(pkgIdWithPatchHash)
+  if (name == null || nonSemverVersion == null) return undefined
+  const repoUrl = gitHostedTarballRepoUrl(nonSemverVersion)
+  return repoUrl == null ? undefined : `${name}@${repoUrl}`
+}
+
 // Reconstructs the committish-free repository URL from the download URL of a
 // git host that pnpm fetches as a tarball instead of cloning. The patterns
 // mirror the tarball templates in @pnpm/git-resolver (which come from
 // hosted-git-info, except GitLab's, which that package overrides). The host of
 // each known template is anchored so a look-alike download host (e.g.
 // `codeload.github.com.example.com`) cannot be rewritten into an unrelated
-// repo key.
-const GIT_HOSTED_TARBALL_REPO_URL_MATCHERS: Array<(tarballUrl: string) => string | undefined> = [
+// repo key, and each known download host claims its URLs exclusively: a URL on
+// codeload.github.com or bitbucket.org that does not match that host's tarball
+// pattern is rejected rather than falling through to the generic GitLab
+// pattern, so a malformed URL on a known host cannot be rewritten into that
+// host's trusted repo key either.
+function gitHostedTarballRepoUrl (tarballUrl: string): string | undefined {
   // GitHub: https://codeload.github.com/<owner>/<repo>/tar.gz/<committish>
-  makeTarballRepoUrlMatcher(/^https:\/\/codeload\.github\.com\/([^/]+)\/([^/]+)\/tar\.gz\//, (m) => `github.com/${m[1]}/${m[2]}`),
+  if (tarballUrl.startsWith('https://codeload.github.com/')) {
+    const match = /^https:\/\/codeload\.github\.com\/([^/]+)\/([^/]+)\/tar\.gz\//.exec(tarballUrl)
+    return match == null ? undefined : `git+https://github.com/${match[1]}/${match[2]}.git`
+  }
   // Bitbucket: https://bitbucket.org/<owner>/<repo>/get/<committish>.tar.gz
-  makeTarballRepoUrlMatcher(/^https:\/\/bitbucket\.org\/([^/]+)\/([^/]+)\/get\//, (m) => `bitbucket.org/${m[1]}/${m[2]}`),
+  if (tarballUrl.startsWith('https://bitbucket.org/')) {
+    const match = /^https:\/\/bitbucket\.org\/([^/]+)\/([^/]+)\/get\//.exec(tarballUrl)
+    return match == null ? undefined : `git+https://bitbucket.org/${match[1]}/${match[2]}.git`
+  }
   // GitLab (incl. self-hosted): https://<host>/<group…>/<repo>/-/archive/<ref>/…
   // The project path may contain nested groups, so match up to the
   // `/-/archive/<ref>/` marker rather than a fixed number of path segments.
-  makeTarballRepoUrlMatcher(/^https:\/\/([^/]+)\/(.+?)\/-\/archive\/[^/]+\//, (m) => `${m[1]}/${m[2]}`),
-]
-
-function makeTarballRepoUrlMatcher (
-  re: RegExp,
-  toRepoPath: (m: RegExpExecArray) => string
-): (tarballUrl: string) => string | undefined {
-  return (tarballUrl) => {
-    const match = re.exec(tarballUrl)
-    return match == null ? undefined : `git+https://${toRepoPath(match)}.git`
-  }
-}
-
-function gitHostedTarballRepoKey (pkgIdWithPatchHash: string): string | undefined {
-  const { name, nonSemverVersion } = dp.parse(pkgIdWithPatchHash)
-  if (name == null || nonSemverVersion == null) return undefined
-  for (const match of GIT_HOSTED_TARBALL_REPO_URL_MATCHERS) {
-    const repoUrl = match(nonSemverVersion)
-    if (repoUrl != null) return `${name}@${repoUrl}`
-  }
-  return undefined
+  const match = /^https:\/\/([^/]+)\/(.+?)\/-\/archive\/[^/]+\//.exec(tarballUrl)
+  return match == null ? undefined : `git+https://${match[1]}/${match[2]}.git`
 }
 
 function isDepPathAllowBuildKey (pkg: string): boolean {

--- a/pnpm11/building/policy/test/index.ts
+++ b/pnpm11/building/policy/test/index.ts
@@ -127,6 +127,8 @@ it('should allow git-hosted tarball builds by hashless repository key', () => {
       'bar@git+https://bitbucket.org/org/bar.git': true,
       'baz@git+https://gitlab.com/group/subgroup/baz.git': true,
       'evil@git+https://github.com/org/evil.git': false,
+      'qux@git+https://github.com/org/extra/qux.git': true,
+      'quux@git+https://bitbucket.org/org/extra/quux.git': true,
     },
   })
   // A GitHub `github:` dependency is downloaded from codeload.github.com, yet
@@ -142,6 +144,11 @@ it('should allow git-hosted tarball builds by hashless repository key', () => {
   expect(allowBuild!(depPath('foo@https://codeload.github.com.attacker.net/org/foo/tar.gz/abc123'))).toBeUndefined()
   // Denial by hashless repository key works as well.
   expect(allowBuild!(depPath('evil@https://codeload.github.com/org/evil/tar.gz/abc123'))).toBe(false)
+  // A tarball URL with an extra path segment is not a valid codeload/get URL (a repo is exactly
+  // `owner/repo`); the `[^/]+` repo anchor rejects it, so the multi-segment URL stays unapproved
+  // even with the slash-bearing key allowlisted. This keeps parity with the Rust matcher.
+  expect(allowBuild!(depPath('qux@https://codeload.github.com/org/extra/qux/tar.gz/abc123'))).toBeUndefined()
+  expect(allowBuild!(depPath('quux@https://bitbucket.org/org/extra/quux/get/abc123.tar.gz'))).toBeUndefined()
 })
 
 it('should allow untrusted package identity by source-only depPath', () => {

--- a/pnpm11/building/policy/test/index.ts
+++ b/pnpm11/building/policy/test/index.ts
@@ -120,6 +120,30 @@ it('should allow git-hosted depPaths by repository key', () => {
   expect(allowBuild!(depPath('bar@git+ssh://git@example.com/org/bar.git#abc123'))).toBe(false)
 })
 
+it('should allow git-hosted tarball builds by hashless repository key', () => {
+  const allowBuild = createAllowBuildFunction({
+    allowBuilds: {
+      'foo@git+https://github.com/org/foo.git': true,
+      'bar@git+https://bitbucket.org/org/bar.git': true,
+      'baz@git+https://gitlab.com/group/subgroup/baz.git': true,
+      'evil@git+https://github.com/org/evil.git': false,
+    },
+  })
+  // A GitHub `github:` dependency is downloaded from codeload.github.com, yet
+  // the same key a clone of the repo would use approves it, with no commit hash.
+  expect(allowBuild!(depPath('foo@https://codeload.github.com/org/foo/tar.gz/abc123'))).toBe(true)
+  expect(allowBuild!(depPath('foo@https://codeload.github.com/org/foo/tar.gz/def456(react@19.0.0)'))).toBe(true)
+  // Bitbucket and GitLab (with nested groups) tarball downloads too.
+  expect(allowBuild!(depPath('bar@https://bitbucket.org/org/bar/get/abc123.tar.gz'))).toBe(true)
+  expect(allowBuild!(depPath('baz@https://gitlab.com/group/subgroup/baz/-/archive/abc123/baz-abc123.tar.gz'))).toBe(true)
+  // A different repository under the same package name is not approved.
+  expect(allowBuild!(depPath('foo@https://codeload.github.com/attacker/foo/tar.gz/abc123'))).toBeUndefined()
+  // A look-alike download host must not be rewritten into the trusted key.
+  expect(allowBuild!(depPath('foo@https://codeload.github.com.attacker.net/org/foo/tar.gz/abc123'))).toBeUndefined()
+  // Denial by hashless repository key works as well.
+  expect(allowBuild!(depPath('evil@https://codeload.github.com/org/evil/tar.gz/abc123'))).toBe(false)
+})
+
 it('should allow untrusted package identity by source-only depPath', () => {
   const allowBuild = createAllowBuildFunction({
     allowBuilds: { 'github.com/org/foo/abc123': true },

--- a/pnpm11/building/policy/test/index.ts
+++ b/pnpm11/building/policy/test/index.ts
@@ -149,6 +149,13 @@ it('should allow git-hosted tarball builds by hashless repository key', () => {
   // even with the slash-bearing key allowlisted. This keeps parity with the Rust matcher.
   expect(allowBuild!(depPath('qux@https://codeload.github.com/org/extra/qux/tar.gz/abc123'))).toBeUndefined()
   expect(allowBuild!(depPath('quux@https://bitbucket.org/org/extra/quux/get/abc123.tar.gz'))).toBeUndefined()
+  // A URL on a claimed download host that does not match that host's tarball pattern is rejected
+  // outright — it must not fall through to the generic GitLab matcher and produce the host's
+  // trusted repo key.
+  expect(allowBuild!(depPath('bar@https://bitbucket.org/org/bar/-/archive/abc123/bar-abc123.tar.gz'))).toBeUndefined()
+  expect(allowBuild!(depPath('foo@https://codeload.github.com/org/foo/-/archive/abc123/foo-abc123.tar.gz'))).toBeUndefined()
+  // A GitLab archive URL without a `<ref>/` segment after the marker is not normalized.
+  expect(allowBuild!(depPath('baz@https://gitlab.com/group/subgroup/baz/-/archive/abc123'))).toBeUndefined()
 })
 
 it('should allow untrusted package identity by source-only depPath', () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/pnpm/pnpm/issues/13429

pnpm 11.11 (pnpm/pnpm#12856) let an `allowBuilds` entry approve a git dependency's build scripts by its repository URL without the resolved commit hash, but only for dependencies pnpm clones, whose dep path looks like `name@git+https://host/org/repo.git#<commit>`. 

The common `github:` case isn't cloned, pnpm downloads it as a tarball from codeload.github.com, giving a dep path of the form `name@https://codeload.github.com/org/repo/tar.gz/<commit>`. That form has neither the `git+` prefix nor the `#` separator the hashless matcher keys on, so the entry was ignored and the build stayed unapproved unless it pinned the exact commit hash.

This PR normalizes a git-hosted tarball dep path back to the canonical `name@git+https://host/org/repo.git` key that a clone of the same repository produces, so one hashless entry approves the package whether pnpm clones it or downloads a tarball. 

GitHub (codeload), GitLab archive, and Bitbucket download URLs are covered. The host is part of each derived key, and the GitHub and Bitbucket download hosts are matched against a literal value (GitLab's is captured generically to allow self-hosted instances), so a look-alike host cannot be rewritten into an unrelated repository key. Approving or denying a specific resolved commit by its full tarball dep path continues to work.

The change is mirrored in both stacks, `@pnpm/building.policy` and `pacquet-package-manager`, with unit tests on each side.

Manually validated against this minimal reproduction: https://github.com/n3dst4/pnpm-allowbuilds-repro

**Validation:**

- `pnpm --filter @pnpm/building.policy test` — TS policy suite, 17/17 pass, including the new `should allow git-hosted tarball builds by hashless repository key`
- `pnpm exec eslint pnpm11/building/policy/src/index.ts pnpm11/building/policy/test/index.ts` — clean
- `cargo test -p pacquet-package-manager --lib build_modules` — 58 pass, including the new `explicit_allow_by_git_hosted_tarball_repo_url`
- `cargo fmt -p pacquet-package-manager -- --check` — clean
- `cargo clippy -p pacquet-package-manager --all-targets --locked -- -D warnings` — clean
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps -p pacquet-package-manager --all-features` — clean
- `typos pnpm11/building/policy pnpm/crates/package-manager/src/build_modules.rs pnpm/crates/package-manager/src/build_modules/tests.rs .changeset/allow-git-tarball-builds-by-repo-url.md` — clean
- End-to-end policy check: fed the exact codeload dep path and hashless `allowBuilds` key from the minimal repro through the compiled `createAllowBuildFunction`, which returns `true` (stock pnpm returns `undefined` for the same input, so the build is ignored)
- Bug reproduction: stock pnpm 11.12 on the minimal repro fails with `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` and never runs the build, confirming the gap this PR closes

<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->



## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

````text
Normalizes git-hosted tarball dep paths back to the canonical
`name@git+https://host/org/repo.git` key that a clone of the same repository produces, so one
hashless entry approves the package whether pnpm clones it or downloads a tarball. GitHub
(codeload), GitLab archive, and Bitbucket download URLs are covered. The host is part of each
derived key, and the GitHub and Bitbucket download hosts are matched against a literal value
(GitLab's is captured generically to allow self-hosted instances), so a look-alike host cannot
be rewritten into an unrelated repository key. Approving or denying a specific resolved commit
by its full tarball dep path continues to work.
````

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786562861&installation_id=145934176&pr_number=12985&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12985&signature=cfc7298e858eb8d73c7858db34e3a0840eb859aeb8bdf494befe4cc61e959d7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build approvals now support Git-hosted dependencies fetched as tarballs (GitHub, GitLab, Bitbucket) using repository-URL–based allow keys, including “hashless” entries.
* **Bug Fixes**
  * Improved canonical matching so tarball origins are evaluated consistently with existing `git+...` allow lists.
  * Added validation to prevent approvals for look-alike hosts, mismatched repositories, and tarball URLs with unexpected extra path segments.
* **Tests**
  * Added coverage for hashless tarball allow/deny behavior across common hosting patterns.
* **Chores**
  * Updated spell-check terms for “hashless.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->