### PR TITLE
fix(release): sync Rust product versions via the meta-updater

### DIFF
--- a/.meta-updater/src/index.ts
+++ b/.meta-updater/src/index.ts
@@ -60,6 +60,13 @@ export default async (workspaceDir: string) => { // eslint-disable-line
   const workspaceManifest = await readWorkspaceManifest(workspaceDir)!
   const pnpmManifest = loadJsonFileSync<ProjectManifest>(path.join(workspaceDir, 'pnpm11/pnpm/package.json'))
   const pnpmVersion = pnpmManifest!.version!
+  // The Rust products embed the versions their release builds report and
+  // verify. `pnpm version -r` bumps only the npm wrapper manifests, so those
+  // are the source of truth; the Rust-source handlers below mirror them, and
+  // `meta-updater --test` (run in pre-push and CI) fails a missed sync before
+  // it can reach the release workflow.
+  const rustCliVersion = loadJsonFileSync<ProjectManifest>(path.join(workspaceDir, 'pnpm/npm/pnpm/package.json'))!.version!
+  const pnprVersion = loadJsonFileSync<ProjectManifest>(path.join(workspaceDir, 'pnpr/npm/pnpr/package.json'))!.version!
   const pnpmMajorNumber = pnpmVersion.split('.')[0]
   const pnpmMajorKeyword = `pnpm${pnpmMajorNumber}`
   const nextTag = `next-${pnpmMajorNumber}`
@@ -72,7 +79,7 @@ export default async (workspaceDir: string) => { // eslint-disable-line
   const workspacePackageNames = new Set(workspacePackages.map(pkg => pkg.manifest.name).filter(Boolean))
   const nodeRuntimeVersion = readNodeRuntimeVersion(workspaceDir)
   return createUpdateOptions({
-    formats: { '.yml': yamlTextFormat },
+    formats: { '.yml': textFormat, '.rs': textFormat, '.toml': textFormat, '.lock': textFormat },
     files: {
       'package.json': (manifest: ProjectManifest & { keywords?: string[] } | null, { dir }: { dir: string }) => {
         if (!manifest) {
@@ -194,6 +201,14 @@ export default async (workspaceDir: string) => { // eslint-disable-line
       '.github/workflows/ci.yml': (content: string | null) => syncNodeVersionInWorkflow(content, nodeRuntimeVersion),
       '.github/workflows/release.yml': (content: string | null) => syncNodeVersionInWorkflow(content, nodeRuntimeVersion),
       '.github/workflows/benchmark.yml': (content: string | null) => syncNodeVersionInWorkflow(content, nodeRuntimeVersion),
+      // Mirror the bumped npm wrapper versions into the Rust sources their
+      // release builds report and verify (see rustCliVersion / pnprVersion).
+      'pnpm/crates/config/src/defaults.rs': (content: string | null) =>
+        replaceRustVersion(content, /(pub const PNPM_VERSION: &str = )"[^"]*"/, `$1"${rustCliVersion}"`),
+      'pnpr/crates/pnpr/Cargo.toml': (content: string | null) =>
+        replaceRustVersion(content, /^(version\s*=\s*)"[^"]*"/m, `$1"${pnprVersion}"`),
+      'Cargo.lock': (content: string | null) =>
+        replaceRustVersion(content, /(\[\[package\]\]\nname = "pnpr"\nversion = )"[^"]*"/, `$1"${pnprVersion}"`),
     },
   })
 }
@@ -339,7 +354,20 @@ function syncNodeVersionInWorkflow (content: string | null, version: string | un
   return content.replace(new RegExp(`\\b${major}\\.\\d+\\.\\d+\\b`, 'g'), version)
 }
 
-const yamlTextFormat = createFormat<string>({
+// Rewrites a version literal in a Rust source file to match the npm wrapper.
+// `meta-updater` passes `null` for the packages that don't have the file (only
+// the workspace root does), which are left untouched; a present file that has
+// lost the expected pattern is a hard error so a renamed constant can't
+// silently stop being synced.
+function replaceRustVersion (content: string | null, pattern: RegExp, replacement: string): string | null {
+  if (content == null) return content
+  if (!pattern.test(content)) {
+    throw new Error(`Pattern ${pattern} not found`)
+  }
+  return content.replace(pattern, replacement)
+}
+
+const textFormat = createFormat<string>({
   read: ({ resolvedPath }) => fs.readFileSync(resolvedPath, 'utf8'),
   update: (actual, updater, options) => updater(actual, options),
   equal: (expected, actual) => expected === actual,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5463,7 +5463,7 @@ dependencies = [
 
 [[package]]
 name = "pnpr"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "async-trait",
  "axum 0.8.9",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "monorepo-root",
   "private": true,
   "scripts": {
-    "bump": "node pnpm11/__utils__/scripts/src/bump.ts && pn update-manifests",
+    "bump": "node pnpm11/__utils__/scripts/src/bump.ts",
     "prepare": "husky",
     "pretest": "pn compile-only && pn prepare-fixtures",
     "prepare-fixtures": "pn --dir=pnpm11/__fixtures__ prepareFixtures",

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -251,7 +251,7 @@ pub fn default_fetch_retry_maxtimeout() -> u64 {
 /// can't drift apart. `pnpm bump` keeps this constant in sync with the
 /// version of the npm wrapper package (`pnpm/npm/pnpm/package.json`);
 /// the release workflow verifies the two match before building.
-pub const PNPM_VERSION: &str = "12.0.0-alpha.9";
+pub const PNPM_VERSION: &str = "12.0.0-alpha.10";
 
 pub fn default_fetch_timeout() -> u64 {
     pacquet_network::DEFAULT_FETCH_TIMEOUT_MS

--- a/pnpm11/__utils__/scripts/src/bump.ts
+++ b/pnpm11/__utils__/scripts/src/bump.ts
@@ -1,5 +1,5 @@
-// Applies the pending release plan and mirrors the bumped Rust wrapper
-// versions into the Rust sources the release builds from.
+// Applies the pending release plan, then runs the meta-updater to mirror the
+// bumped Rust wrapper versions into the Rust sources the release builds from.
 //
 // `pnpm version -r` (native workspace release management) consumes the pending
 // `.changeset/*.md` intents: it bumps versions across the workspace, writes
@@ -7,9 +7,10 @@
 // ledger.yaml`. The ledger keeps cherry-picks and merge-backs between release
 // branches safe, and the Rust products' `alpha` release lanes (configured under
 // `versioning` in pnpm-workspace.yaml) advance their `X.Y.Z-alpha.N` prerelease
-// lines. The one job left to this script is `syncRustVersions`: the Rust
-// sources embed the versions their release builds report, so the bumped npm
-// wrapper versions have to be copied into them.
+// lines. `pnpm version -r` bumps only the npm wrapper manifests, so the
+// meta-updater then copies those versions into the Rust sources that embed
+// them (see the Rust-source handlers in `.meta-updater/src/index.ts`);
+// `meta-updater --test` in pre-push and CI enforces the same sync.
 
 import { execSync } from 'node:child_process'
 import fs from 'node:fs'
@@ -23,52 +24,7 @@ function main (): void {
   // The release PR branch is dirty here (refreshed trust roots, synthesized
   // changesets), so skip the clean-tree check.
   execSync('pnpm version -r --no-git-checks', { cwd: repoRoot, stdio: 'inherit' })
-  syncRustVersions(repoRoot)
-}
-
-// The npm wrapper manifests of the Rust products, versioned by the release
-// plan; their versions are mirrored into Rust sources by syncRustVersions.
-export const RUST_CLI_WRAPPER_MANIFEST = 'pnpm/npm/pnpm/package.json'
-export const PNPR_WRAPPER_MANIFEST = 'pnpr/npm/pnpr/package.json'
-
-// The Rust sources embed the versions their release builds report; the npm
-// wrapper manifests bumped by `pnpm version -r` are the source of truth. The
-// release workflow verifies the copies match, so a missed sync fails the
-// release instead of shipping a binary with a stale --version.
-export function syncRustVersions (repoRoot: string): void {
-  const pnpmVersion = readManifestVersion(path.join(repoRoot, RUST_CLI_WRAPPER_MANIFEST))
-  replaceInFile(
-    path.join(repoRoot, 'pnpm/crates/config/src/defaults.rs'),
-    /(pub const PNPM_VERSION: &str = )"[^"]*"/,
-    `$1"${pnpmVersion}"`
-  )
-  const pnprVersion = readManifestVersion(path.join(repoRoot, PNPR_WRAPPER_MANIFEST))
-  replaceInFile(
-    path.join(repoRoot, 'pnpr/crates/pnpr/Cargo.toml'),
-    /^(version\s*=\s*)"[^"]*"/m,
-    `$1"${pnprVersion}"`
-  )
-  replaceInFile(
-    path.join(repoRoot, 'Cargo.lock'),
-    /(\[\[package\]\]\nname = "pnpr"\nversion = )"[^"]*"/,
-    `$1"${pnprVersion}"`
-  )
-}
-
-function readManifestVersion (absManifestPath: string): string {
-  const manifest = JSON.parse(fs.readFileSync(absManifestPath, 'utf8'))
-  if (typeof manifest.version !== 'string') {
-    throw new Error(`No version field in ${absManifestPath}`)
-  }
-  return manifest.version
-}
-
-function replaceInFile (file: string, pattern: RegExp, replacement: string): void {
-  const content = fs.readFileSync(file, 'utf8')
-  if (!pattern.test(content)) {
-    throw new Error(`Pattern ${pattern} not found in ${file}`)
-  }
-  fs.writeFileSync(file, content.replace(pattern, replacement))
+  execSync('pnpm update-manifests', { cwd: repoRoot, stdio: 'inherit' })
 }
 
 export function findRepoRoot (startDir: string): string {

--- a/pnpm11/__utils__/scripts/test/bump.ts
+++ b/pnpm11/__utils__/scripts/test/bump.ts
@@ -4,10 +4,7 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
 
-import {
-  findRepoRoot,
-  syncRustVersions,
-} from '../src/bump.js'
+import { findRepoRoot } from '../src/bump.js'
 
 describe('findRepoRoot', () => {
   let dir: string
@@ -25,53 +22,5 @@ describe('findRepoRoot', () => {
 
   test('throws when no .changeset directory exists above', () => {
     expect(() => findRepoRoot(dir)).toThrow(/No \.changeset directory/)
-  })
-})
-
-function writeManifest (repoRoot: string, manifestPath: string, manifest: object): void {
-  const abs = path.join(repoRoot, manifestPath)
-  fs.mkdirSync(path.dirname(abs), { recursive: true })
-  fs.writeFileSync(abs, `${JSON.stringify(manifest, null, 2)}\n`)
-}
-
-describe('syncRustVersions', () => {
-  let dir: string
-  beforeEach(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bump-sync-'))
-    writeManifest(dir, 'pnpm/npm/pnpm/package.json', { name: 'pnpm', version: '12.0.0-alpha.9' })
-    writeManifest(dir, 'pnpr/npm/pnpr/package.json', { name: '@pnpm/pnpr', version: '0.2.0' })
-    fs.mkdirSync(path.join(dir, 'pnpm/crates/config/src'), { recursive: true })
-    fs.writeFileSync(
-      path.join(dir, 'pnpm/crates/config/src/defaults.rs'),
-      'pub const PNPM_VERSION: &str = "12.0.0-alpha.8";\n'
-    )
-    fs.mkdirSync(path.join(dir, 'pnpr/crates/pnpr'), { recursive: true })
-    fs.writeFileSync(
-      path.join(dir, 'pnpr/crates/pnpr/Cargo.toml'),
-      '[package]\nname              = "pnpr"\nversion           = "0.1.0"\n'
-    )
-    fs.writeFileSync(
-      path.join(dir, 'Cargo.lock'),
-      '[[package]]\nname = "pnpr"\nversion = "0.1.0"\ndependencies = [\n "clap",\n]\n\n[[package]]\nname = "other"\nversion = "0.1.0"\n'
-    )
-  })
-  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }))
-
-  test('copies the wrapper versions into the Rust sources', () => {
-    syncRustVersions(dir)
-
-    expect(fs.readFileSync(path.join(dir, 'pnpm/crates/config/src/defaults.rs'), 'utf8'))
-      .toContain('pub const PNPM_VERSION: &str = "12.0.0-alpha.9";')
-    expect(fs.readFileSync(path.join(dir, 'pnpr/crates/pnpr/Cargo.toml'), 'utf8'))
-      .toContain('version           = "0.2.0"')
-    const lock = fs.readFileSync(path.join(dir, 'Cargo.lock'), 'utf8')
-    expect(lock).toContain('name = "pnpr"\nversion = "0.2.0"')
-    // Only the pnpr package entry is touched, not other packages at the same version.
-    expect(lock).toContain('name = "other"\nversion = "0.1.0"')
-  })
-
-  test('throws when an expected version site is missing', () => {
-    fs.writeFileSync(path.join(dir, 'pnpm/crates/config/src/defaults.rs'), '// gone\n')
-    expect(() => syncRustVersions(dir)).toThrow(/not found in .*defaults\.rs/)
   })
 })

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name              = "pnpr"
 description       = "pnpm-compatible npm registry server"
-version           = "0.1.0-alpha.1"
+version           = "0.1.0-alpha.2"
 authors           = ["pnpm contributors"]
 edition.workspace = true
 license-file      = "../../LICENSE.md"


### PR DESCRIPTION
## Summary

The v12 release jobs failed at **Package pnpm (Rust) → Verify the committed version** ([failed run](https://github.com/pnpm/pnpm/actions/runs/29285040537/job/86935497256)): the npm wrappers had been bumped (`pacquet` → `12.0.0-alpha.10`, `pnpr` → `0.1.0-alpha.2`) but the Rust sources that embed and verify those versions were still at the previous ones.

Root cause: `pnpm version -r` bumps only the npm wrapper manifests. The Rust sources (`PNPM_VERSION` in `pnpm/crates/config/src/defaults.rs`, the crate version in `pnpr/crates/pnpr/Cargo.toml`, and its `Cargo.lock` entry) were mirrored by a separate `syncRustVersions` step in `bump.ts`. Running `pnpm version -r` without the full bump flow bumped the wrappers but skipped that step, and **nothing caught the drift** until the release workflow's verify step failed.

This moves the sync into the meta-updater, so it is:
- **written** by `pnpm update-manifests` (via new Rust-source file handlers keyed on the three files), and
- **validated** by `meta-updater --test`, which runs in **pre-push and CI** — a missed sync now fails locally instead of at release time.

`bump.ts` drops the now-redundant `syncRustVersions` and runs `pnpm update-manifests` after `pnpm version -r`; the root `bump` script no longer needs its own trailing `update-manifests`.

Regenerating brings the Rust sources up to the already-bumped wrapper versions (`alpha.10` / `alpha.2`), which unblocks the release. I verified `meta-updater --test` passes when in sync and **fails with a clear diff** when `PNPM_VERSION` is deliberately mismatched.

## Squash Commit Body

```text
The Rust CLI and pnpr embed the versions their release builds report and
verify (PNPM_VERSION in pnpm/crates/config/src/defaults.rs, the crate
version in pnpr/crates/pnpr/Cargo.toml, and its Cargo.lock entry). These
were mirrored from the npm wrappers by syncRustVersions in bump.ts — a step
separate from the meta-updater, so running `pnpm version -r` without the
full bump flow bumped the wrappers (pacquet 12.0.0-alpha.10, pnpr
0.1.0-alpha.2) while the Rust sources stayed behind. The release workflow's
"Verify the committed version" step then failed, and nothing caught the
drift before the tag.

Move the sync into the meta-updater as Rust-source file handlers, so it is
written by `pnpm update-manifests` and validated by `meta-updater --test`
in pre-push and CI — a missed sync now fails locally instead of at release
time. bump.ts drops the redundant syncRustVersions and runs
`pnpm update-manifests` after `pnpm version -r`; the root `bump` script no
longer needs its own trailing update-manifests.

Regenerating brings the Rust sources up to the already-bumped wrapper
versions (alpha.10 / alpha.2), unblocking the release.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Release tooling that operates on both stacks; no port needed. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. <!-- Not needed: the version bumps this syncs are already covered
  by existing changesets; this only makes the Rust sources match them. -->
- [x] Added or updated tests. <!-- bump.ts test trimmed to the remaining
  exports; the sync is now covered by `meta-updater --test` in pre-push/CI. -->
- [x] Updated the documentation if needed. <!-- N/A -->

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786569633&installation_id=145934176&pr_number=12988&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12988&signature=26eee5924ded34b94fbedf93a9acf5d2330748384c56728f8278c4cccedf59e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization of package and Rust wrapper version information across release artifacts.
  * Expanded formatting support for YAML, Rust, TOML, and lock files.

* **Bug Fixes**
  * Improved version update validation to detect missing or unexpected version entries.

* **Chores**
  * Updated PNPM to `12.0.0-alpha.10`.
  * Updated PNPR to `0.1.0-alpha.2`.
  * Streamlined the release bump workflow and refreshed related test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->