### PR TITLE
fix(fs): rewrite symlink paths to native separators on Windows

### DIFF
--- a/.changeset/pacquet-scoped-symlink-windows-separators.md
+++ b/.changeset/pacquet-scoped-symlink-windows-separators.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed installs failing on Windows when a scoped dependency (`@scope/name`) had to be symlinked. Its `node_modules/@scope/name` link path was built by joining the whole alias as one segment, which left a `/` in the otherwise `\`-separated path; that forward slash reached `CreateSymbolicLinkW`, which rejects forward-slash paths with `ERROR_DIRECTORY` (os error 267). Paths are now rewritten to native separators before every filesystem call in the symlink writer.

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -33,34 +33,25 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
     }
 }
 
-/// Rewrite `path` so every directory separator is the platform-native
-/// one.
+/// Rewrite every `/` in `path` to the native `\` on Windows.
 ///
-/// [`Path::join`] appends each segment verbatim, so an alias that is
-/// itself a `/`-bearing string — a scoped package like `@scope/name`,
-/// joined into `node_modules` as one segment — leaves a forward slash
-/// in an otherwise `\`-separated Windows path. That slash survives into
-/// `CreateSymbolicLinkW`, which rejects forward-slash paths (the long
-/// store paths reach it in verbatim `\\?\` form, where `/` is a literal
-/// filename byte rather than a separator) with `ERROR_DIRECTORY`
-/// (os error 267). Every `/` is rewritten to `\`.
+/// A scoped alias like `@scope/name` is joined into a path as a single
+/// segment, and [`Path::join`] appends it verbatim, leaving a forward
+/// slash that `CreateSymbolicLinkW` rejects with `ERROR_DIRECTORY`
+/// (os error 267) — the long store paths reach it in verbatim `\\?\`
+/// form, where `/` is a literal byte rather than a separator.
 ///
-/// Borrows unless a rewrite is actually needed. A no-op on Unix, where
-/// `/` is already native.
+/// Borrows unless a rewrite is needed; a no-op on Unix.
 #[cfg(windows)]
 fn to_native_separators(path: &Path) -> Cow<'_, Path> {
-    // WTF-8 keeps ASCII bytes verbatim, so a literal `/` (0x2F) shows up
-    // here iff the path really carries a forward slash — cheaper than
-    // allocating a `String` to scan.
+    // In WTF-8 a 0x2F byte appears iff the path holds a literal `/`, so
+    // scanning bytes is a correct, allocation-free check.
     if !path.as_os_str().as_encoded_bytes().contains(&b'/') {
         return Cow::Borrowed(path);
     }
-    // A plain `/`→`\` string replacement rather than rebuilding from
-    // `Path::components`, because in a verbatim `\\?\` path `components`
-    // treats `/` as a literal filename byte, not a separator, and would
-    // leave it in place. Package paths are always valid Unicode, so
-    // `to_str` succeeds; a path that somehow isn't UTF-8 carries no
-    // separator-intended `/` and is returned untouched.
+    // A string replace, not `Path::components`: in a verbatim `\\?\`
+    // path `components` treats `/` as a literal byte and leaves it in
+    // place. Package paths are valid Unicode, so `to_str` succeeds.
     match path.to_str() {
         Some(s) => Cow::Owned(PathBuf::from(s.replace('/', "\\"))),
         None => Cow::Borrowed(path),
@@ -198,11 +189,8 @@ pub struct ForceSymlinkOutcome {
 /// the `AlreadyExists` and the rename, the initial `AlreadyExists`
 /// error is surfaced rather than the rename's `NotFound`.
 pub fn force_symlink_dir(target: &Path, link: &Path) -> io::Result<ForceSymlinkOutcome> {
-    // Normalize separators once, up front, so every filesystem operation
-    // the retry loop performs on `link` (read_link, remove_dir, rename,
-    // create_dir_all) — not just the symlink syscall — sees a native
-    // path. See [`to_native_separators`] for why a stray `/` is fatal on
-    // Windows.
+    // Normalize up front so every retry-loop fs op on `link` — not just
+    // the symlink syscall — sees a native path. See [`to_native_separators`].
     let target = to_native_separators(target);
     let link = to_native_separators(link);
     force_symlink_inner(&target, &link, false)

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -43,8 +43,7 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
 /// `CreateSymbolicLinkW`, which rejects forward-slash paths (the long
 /// store paths reach it in verbatim `\\?\` form, where `/` is a literal
 /// filename byte rather than a separator) with `ERROR_DIRECTORY`
-/// (os error 267). Collecting the path's components re-emits each one
-/// behind [`std::path::MAIN_SEPARATOR`].
+/// (os error 267). Every `/` is rewritten to `\`.
 ///
 /// Borrows unless a rewrite is actually needed. A no-op on Unix, where
 /// `/` is already native.
@@ -53,10 +52,18 @@ fn to_native_separators(path: &Path) -> Cow<'_, Path> {
     // WTF-8 keeps ASCII bytes verbatim, so a literal `/` (0x2F) shows up
     // here iff the path really carries a forward slash — cheaper than
     // allocating a `String` to scan.
-    if path.as_os_str().as_encoded_bytes().contains(&b'/') {
-        Cow::Owned(path.components().collect())
-    } else {
-        Cow::Borrowed(path)
+    if !path.as_os_str().as_encoded_bytes().contains(&b'/') {
+        return Cow::Borrowed(path);
+    }
+    // A plain `/`→`\` string replacement rather than rebuilding from
+    // `Path::components`, because in a verbatim `\\?\` path `components`
+    // treats `/` as a literal filename byte, not a separator, and would
+    // leave it in place. Package paths are always valid Unicode, so
+    // `to_str` succeeds; a path that somehow isn't UTF-8 carries no
+    // separator-intended `/` and is returned untouched.
+    match path.to_str() {
+        Some(s) => Cow::Owned(PathBuf::from(s.replace('/', "\\"))),
+        None => Cow::Borrowed(path),
     }
 }
 

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fs, io,
     path::{Path, PathBuf},
 };
@@ -26,8 +27,42 @@ pub fn symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
     }
     #[cfg(windows)]
     {
-        windows::create(original, link)
+        let original = to_native_separators(original);
+        let link = to_native_separators(link);
+        windows::create(&original, &link)
     }
+}
+
+/// Rewrite `path` so every directory separator is the platform-native
+/// one.
+///
+/// [`Path::join`] appends each segment verbatim, so an alias that is
+/// itself a `/`-bearing string — a scoped package like `@scope/name`,
+/// joined into `node_modules` as one segment — leaves a forward slash
+/// in an otherwise `\`-separated Windows path. That slash survives into
+/// `CreateSymbolicLinkW`, which rejects forward-slash paths (the long
+/// store paths reach it in verbatim `\\?\` form, where `/` is a literal
+/// filename byte rather than a separator) with `ERROR_DIRECTORY`
+/// (os error 267). Collecting the path's components re-emits each one
+/// behind [`std::path::MAIN_SEPARATOR`].
+///
+/// Borrows unless a rewrite is actually needed. A no-op on Unix, where
+/// `/` is already native.
+#[cfg(windows)]
+fn to_native_separators(path: &Path) -> Cow<'_, Path> {
+    // WTF-8 keeps ASCII bytes verbatim, so a literal `/` (0x2F) shows up
+    // here iff the path really carries a forward slash — cheaper than
+    // allocating a `String` to scan.
+    if path.as_os_str().as_encoded_bytes().contains(&b'/') {
+        Cow::Owned(path.components().collect())
+    } else {
+        Cow::Borrowed(path)
+    }
+}
+
+#[cfg(not(windows))]
+fn to_native_separators(path: &Path) -> Cow<'_, Path> {
+    Cow::Borrowed(path)
 }
 
 /// Compute the symlink contents for a true symlink: the path from the
@@ -156,7 +191,14 @@ pub struct ForceSymlinkOutcome {
 /// the `AlreadyExists` and the rename, the initial `AlreadyExists`
 /// error is surfaced rather than the rename's `NotFound`.
 pub fn force_symlink_dir(target: &Path, link: &Path) -> io::Result<ForceSymlinkOutcome> {
-    force_symlink_inner(target, link, false)
+    // Normalize separators once, up front, so every filesystem operation
+    // the retry loop performs on `link` (read_link, remove_dir, rename,
+    // create_dir_all) — not just the symlink syscall — sees a native
+    // path. See [`to_native_separators`] for why a stray `/` is fatal on
+    // Windows.
+    let target = to_native_separators(target);
+    let link = to_native_separators(link);
+    force_symlink_inner(&target, &link, false)
 }
 
 fn force_symlink_inner(

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -8,6 +8,8 @@
 use super::relative_target_for;
 #[cfg(unix)]
 use super::symlink_dir;
+#[cfg(windows)]
+use super::to_native_separators;
 use super::{ForceSymlinkOutcome, force_symlink_dir, read_symlink_dir};
 use std::fs;
 #[cfg(windows)]
@@ -131,6 +133,42 @@ fn windows_cross_drive_symlink_target_falls_back_to_absolute() {
     assert_eq!(relative_target_for(target, link), target);
 }
 
+/// Regression for the Windows CI failure where a scoped dependency's
+/// `node_modules/@scope/name` symlink path — built by joining the
+/// `@scope/name` alias as a single segment — kept its forward slash and
+/// was rejected by `CreateSymbolicLinkW` with `ERROR_DIRECTORY`
+/// (os error 267). The writer must rewrite it to a native `\` path
+/// before the syscall.
+#[cfg(windows)]
+#[test]
+fn windows_scoped_alias_path_gets_native_separators() {
+    let mixed = Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules").join("@scope/name");
+    assert!(
+        mixed.as_os_str().to_string_lossy().contains('/'),
+        "the join must leave a forward slash for the rewrite to remove: {mixed:?}",
+    );
+
+    let native = to_native_separators(&mixed);
+    assert!(
+        !native.as_os_str().to_string_lossy().contains('/'),
+        "no forward slash may survive into the symlink syscall: {native:?}",
+    );
+    assert_eq!(
+        native.as_ref(),
+        Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope\name"),
+    );
+}
+
+/// A path that already uses native separators must be returned
+/// unchanged (and borrowed, not reallocated).
+#[cfg(windows)]
+#[test]
+fn windows_native_path_is_borrowed_unchanged() {
+    let native = Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\dep");
+    assert!(matches!(to_native_separators(native), std::borrow::Cow::Borrowed(_)));
+    assert_eq!(to_native_separators(native).as_ref(), native);
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_same_drive_symlink_target_stays_relative() {
@@ -147,6 +185,26 @@ fn windows_verbatim_and_plain_disk_resolve_to_same_root() {
     let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
 
     assert!(relative_target_for(target, link).is_relative());
+}
+
+/// A scoped dependency's link path is built by joining the whole
+/// `@scope/name` alias as one segment. `force_symlink_dir` must create
+/// the intervening `@scope` directory and the link regardless of the
+/// separator the join left behind.
+#[test]
+fn force_symlink_dir_links_a_scoped_alias() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("store").join("node_modules").join("@scope").join("name");
+    let modules = root.path().join("app").join("node_modules");
+    let link = modules.join("@scope/name");
+    fs::create_dir_all(&target).expect("create target dir");
+
+    let outcome = force_symlink_dir(&target, &link).expect("force_symlink_dir succeeds");
+    assert!(!outcome.reused);
+
+    let resolved_link = fs::canonicalize(&link).expect("canonicalize the scoped symlink");
+    let resolved_target = fs::canonicalize(&target).expect("canonicalize target");
+    assert_eq!(resolved_link, resolved_target);
 }
 
 #[test]

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -159,6 +159,25 @@ fn windows_scoped_alias_path_gets_native_separators() {
     );
 }
 
+/// Even a verbatim `\\?\` path — where `Path::components` would treat
+/// `/` as a literal filename byte rather than a separator — must have
+/// its forward slashes rewritten. The rewrite runs before the stdlib's
+/// own verbatim conversion, so it must not rely on component parsing.
+#[cfg(windows)]
+#[test]
+fn windows_verbatim_path_forward_slashes_are_rewritten() {
+    let verbatim = Path::new(r"\\?\C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope/name");
+    let native = to_native_separators(verbatim);
+    assert!(
+        !native.as_os_str().to_string_lossy().contains('/'),
+        "no forward slash may survive into the symlink syscall: {native:?}",
+    );
+    assert_eq!(
+        native.as_ref(),
+        Path::new(r"\\?\C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope\name"),
+    );
+}
+
 /// A path that already uses native separators must be returned
 /// unchanged (and borrowed, not reallocated).
 #[cfg(windows)]

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -133,12 +133,6 @@ fn windows_cross_drive_symlink_target_falls_back_to_absolute() {
     assert_eq!(relative_target_for(target, link), target);
 }
 
-/// Regression for the Windows CI failure where a scoped dependency's
-/// `node_modules/@scope/name` symlink path — built by joining the
-/// `@scope/name` alias as a single segment — kept its forward slash and
-/// was rejected by `CreateSymbolicLinkW` with `ERROR_DIRECTORY`
-/// (os error 267). The writer must rewrite it to a native `\` path
-/// before the syscall.
 #[cfg(windows)]
 #[test]
 fn windows_scoped_alias_path_gets_native_separators() {
@@ -159,10 +153,8 @@ fn windows_scoped_alias_path_gets_native_separators() {
     );
 }
 
-/// Even a verbatim `\\?\` path — where `Path::components` would treat
-/// `/` as a literal filename byte rather than a separator — must have
-/// its forward slashes rewritten. The rewrite runs before the stdlib's
-/// own verbatim conversion, so it must not rely on component parsing.
+/// The verbatim `\\?\` form is the case a `Path::components` rewrite
+/// would miss, since it treats `/` there as a literal byte.
 #[cfg(windows)]
 #[test]
 fn windows_verbatim_path_forward_slashes_are_rewritten() {
@@ -178,8 +170,6 @@ fn windows_verbatim_path_forward_slashes_are_rewritten() {
     );
 }
 
-/// A path that already uses native separators must be returned
-/// unchanged (and borrowed, not reallocated).
 #[cfg(windows)]
 #[test]
 fn windows_native_path_is_borrowed_unchanged() {
@@ -206,10 +196,6 @@ fn windows_verbatim_and_plain_disk_resolve_to_same_root() {
     assert!(relative_target_for(target, link).is_relative());
 }
 
-/// A scoped dependency's link path is built by joining the whole
-/// `@scope/name` alias as one segment. `force_symlink_dir` must create
-/// the intervening `@scope` directory and the link regardless of the
-/// separator the join left behind.
 #[test]
 fn force_symlink_dir_links_a_scoped_alias() {
     let root = tempdir().expect("create temp dir");


### PR DESCRIPTION
## Summary

`pnpm install` (pacquet) aborts on Windows when a **scoped** dependency has to be symlinked into a `node_modules`. The `node_modules/@scope/name` link path is built by joining the whole `@scope/name` alias as a single segment, and Rust's `Path::join` appends segments verbatim (unlike Node's `path.join`, which normalizes separators). The `/` inside the alias therefore survives into an otherwise `\`-separated Windows path and reaches `CreateSymbolicLinkW`, which rejects forward-slash paths — the long store paths reach it in verbatim `\\?\` form, where `/` is a literal filename byte rather than a separator — with `ERROR_DIRECTORY` (os error 267).

This is the same failure class as the global-virtual-store slot-path fix in pnpm/pnpm#12976, which normalized the slot suffix at its construction sites. #12976 covered the slot directories, but the leaf alias join was still verbatim, so scoped packages continued to fail.

Rather than chase every join site, this rewrites paths to native separators at the symlink writer's own choke points:

- `symlink_dir` — covers the hoisted linker, which calls it directly.
- `force_symlink_dir`'s entry — so its `read_link` / `remove_dir` / `rename` / `create_dir_all` retry steps all operate on a native path too, not just the final symlink syscall.

The rewrite only allocates when a `/` is actually present in the path and is a no-op on Unix, where `/` is already native.

The TypeScript CLI is unaffected: Node's `path.join` already normalizes separators on Windows, so there is no counterpart change to make.

> Note: this PR does not by itself turn the currently-red Windows Rust CI job green. That job fails in its `setup-pnpm` bootstrap step, which uses the published `pnpm` alpha (`v12.0.0-alpha.9`) to install workspace deps; that alpha predates #12976, so cold-cache runners still hit os error 267 there. Landing this fix and cutting a new alpha (so `setup-pnpm` bootstraps with a build that carries both #12976 and this change) is what clears the job.

Related to pnpm/pnpm#12976.

## Squash Commit Body

```text
A scoped dependency's node_modules/@scope/name link path is built by
joining the whole @scope/name alias as one segment. Rust's Path::join
appends segments verbatim (unlike Node's path.join, which normalizes),
so the / inside the alias survived into an otherwise \-separated Windows
path and reached CreateSymbolicLinkW, which rejects forward-slash paths
— the long store paths reach it in verbatim \\?\ form where / is a
literal filename byte — with ERROR_DIRECTORY (os error 267), aborting
the install.

This is the same failure class as the global-virtual-store slot-path fix
in pnpm/pnpm#12976, which normalized the slot suffix at its construction
sites. Rather than chase every join site, rewrite paths to native
separators at the symlink writer's own choke points: symlink_dir
(covering the hoisted linker's direct calls) and force_symlink_dir's
entry (so its read_link / remove_dir / rename / create_dir_all retry
steps all see a native path too). The rewrite only allocates when a /
is actually present and is a no-op on Unix.

The TypeScript CLI is unaffected: Node's path.join already normalizes
separators on Windows, so no counterpart change is needed.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only; the TypeScript CLI is not affected — Node's `path.join` normalizes separators on Windows.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786574650&installation_id=145934176&pr_number=12991&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12991&signature=445502603a1f59e6ad38965a98f02a22ca7c4d1ce3ecc52b906a44806f418d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows install failures when creating symlinks for scoped dependencies.
  * Improved Windows symlink/junction creation by converting forward-slash paths to native path separators.
  * Enhanced correctness for scoped dependency symlink resolution, including handling of special Windows path formats.
* **Tests**
  * Added Windows regression coverage for separator rewriting and scoped symlink resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->