### PR TITLE
fix(self-update): store the resolved pnpm pin as the packageManagerDependencies specifier

### DIFF
--- a/.changeset/pacquet-self-update-pin-specifier.md
+++ b/.changeset/pacquet-self-update-pin-specifier.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fix `pnpm self-update <dist-tag>` recording the dist-tag (e.g. `next-12`) as the `packageManagerDependencies` specifier in `pnpm-lock.yaml`. It now records the resolved `devEngines.packageManager` pin, matching the manifest, so a later `--frozen-lockfile` install no longer fails with "the lockfile is not up to date".

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -176,15 +176,8 @@ async fn handler<Reporter: self::Reporter + 'static>(
     if let Some(pm) = &wanted
         && pm.name == "pnpm"
     {
-        return Box::pin(update_project_pin(
-            config,
-            dir,
-            pm,
-            &target_version,
-            bare_specifier,
-            is_implicit_latest,
-        ))
-        .await;
+        return Box::pin(update_project_pin(config, dir, pm, &target_version, is_implicit_latest))
+            .await;
     }
 
     // Global switch. Version equality with the running binary alone must
@@ -214,7 +207,7 @@ async fn handler<Reporter: self::Reporter + 'static>(
     Box::pin(config_deps::sync_package_manager_dependencies(
         config,
         &env_root,
-        bare_specifier,
+        &target_version,
         &target_version,
         false,
     ))
@@ -254,7 +247,6 @@ async fn update_project_pin(
     dir: &Path,
     pm: &super::package_manager::WantedPackageManager,
     target_version: &str,
-    bare_specifier: &str,
     is_implicit_latest: bool,
 ) -> miette::Result<Option<String>> {
     if pm.version.as_deref() == Some(target_version) {
@@ -296,19 +288,24 @@ async fn update_project_pin(
             .is_some_and(|(name, version)| name == "pnpm" && version.is_some());
 
         let mut changed = false;
+        // The specifier recorded in packageManagerDependencies must match the
+        // devEngines pin a later install reads back (see
+        // `package_manager::package_manager_to_sync`), not the CLI dist-tag —
+        // otherwise a subsequent `--frozen-lockfile` install treats the
+        // lockfile as outdated. Default to the resolved version for the case
+        // where there is no readable pnpm entry to update.
+        let mut pin_specifier = target_version.to_string();
         if let Some(entry) = dev_engines_pnpm_entry_mut(manifest.value_mut()) {
             let current = entry.get("version").and_then(Value::as_str).map(ToString::to_string);
-            let updated = if legacy_pins_pnpm {
-                target_version.to_string()
-            } else {
-                update_version_constraint(current.as_deref(), target_version)
-            };
+            let updated =
+                package_manager_pin_specifier(legacy_pins_pnpm, current.as_deref(), target_version);
             if current.as_deref() != Some(updated.as_str())
                 && let Some(object) = entry.as_object_mut()
             {
-                object.insert("version".to_string(), Value::String(updated));
+                object.insert("version".to_string(), Value::String(updated.clone()));
                 changed = true;
             }
+            pin_specifier = updated;
         }
         if legacy_pins_pnpm {
             let new_legacy = format!("pnpm@{target_version}");
@@ -327,7 +324,7 @@ async fn update_project_pin(
             Box::pin(config_deps::sync_package_manager_dependencies(
                 config,
                 &root_dir,
-                bare_specifier,
+                &pin_specifier,
                 target_version,
                 false,
             ))
@@ -369,6 +366,26 @@ fn pm_for_persist(
         version: pm.version.clone(),
         from_dev_engines: true,
         on_fail: pm.on_fail.clone(),
+    }
+}
+
+/// The specifier to record in `packageManagerDependencies` after
+/// `self-update` rewrites the `devEngines.packageManager` pin. It must equal
+/// the constraint a later install reads back from the manifest (see
+/// [`super::package_manager::package_manager_to_sync`]) — the updated
+/// devEngines constraint, never the CLI dist-tag or range passed to
+/// `self-update` — so a subsequent `--frozen-lockfile` install does not
+/// reject the lockfile as outdated. A legacy `packageManager` pin is always
+/// exact, so it takes the resolved version directly.
+fn package_manager_pin_specifier(
+    legacy_pins_pnpm: bool,
+    current_dev_engine_version: Option<&str>,
+    target_version: &str,
+) -> String {
+    if legacy_pins_pnpm {
+        target_version.to_string()
+    } else {
+        update_version_constraint(current_dev_engine_version, target_version)
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -288,12 +288,8 @@ async fn update_project_pin(
             .is_some_and(|(name, version)| name == "pnpm" && version.is_some());
 
         let mut changed = false;
-        // The specifier recorded in packageManagerDependencies must match the
-        // devEngines pin a later install reads back (see
-        // `package_manager::package_manager_to_sync`), not the CLI dist-tag —
-        // otherwise a subsequent `--frozen-lockfile` install treats the
-        // lockfile as outdated. Default to the resolved version for the case
-        // where there is no readable pnpm entry to update.
+        // Falls back to the resolved version when devEngines has no pnpm entry
+        // to update; `package_manager_pin_specifier` supplies it otherwise.
         let mut pin_specifier = target_version.to_string();
         if let Some(entry) = dev_engines_pnpm_entry_mut(manifest.value_mut()) {
             let current = entry.get("version").and_then(Value::as_str);

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -296,10 +296,9 @@ async fn update_project_pin(
         // where there is no readable pnpm entry to update.
         let mut pin_specifier = target_version.to_string();
         if let Some(entry) = dev_engines_pnpm_entry_mut(manifest.value_mut()) {
-            let current = entry.get("version").and_then(Value::as_str).map(ToString::to_string);
-            let updated =
-                package_manager_pin_specifier(legacy_pins_pnpm, current.as_deref(), target_version);
-            if current.as_deref() != Some(updated.as_str())
+            let current = entry.get("version").and_then(Value::as_str);
+            let updated = package_manager_pin_specifier(legacy_pins_pnpm, current, target_version);
+            if current != Some(updated.as_str())
                 && let Some(object) = entry.as_object_mut()
             {
                 object.insert("version".to_string(), Value::String(updated.clone()));

--- a/pnpm/crates/cli/src/cli_args/self_update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/tests.rs
@@ -1,4 +1,7 @@
-use super::{install_pnpm, is_installed_globally, update_version_constraint, version_lt};
+use super::{
+    install_pnpm, is_installed_globally, package_manager_pin_specifier, update_version_constraint,
+    version_lt,
+};
 use std::{fs, path::Path};
 
 #[test]
@@ -33,6 +36,26 @@ fn seed_global_engine(global_dir: &Path, package_name: &str, version: &str) {
     .unwrap();
     pacquet_fs::force_symlink_dir(&install_dir, &global_dir.join(format!("hash-{version}")))
         .unwrap();
+}
+
+#[test]
+fn pin_specifier_records_the_resolved_pin_not_the_cli_dist_tag() {
+    // Regression: `self-update next-12` resolves to an exact prerelease and
+    // rewrites the exact devEngines pin to it, so the packageManagerDependencies
+    // specifier must be that resolved version — not the `next-12` dist-tag the
+    // user typed. Recording the dist-tag desyncs the lockfile from the manifest
+    // pin and breaks the next `--frozen-lockfile` install.
+    assert_eq!(
+        package_manager_pin_specifier(false, Some("12.0.0-alpha.9"), "12.0.0-alpha.10"),
+        "12.0.0-alpha.10",
+    );
+    // A range pin is preserved (the lockfile pins the exact version), so the
+    // specifier is the range a later install reads back from the manifest.
+    assert_eq!(package_manager_pin_specifier(false, Some("^12.0.0"), "12.1.0"), "^12.0.0");
+    // A legacy `packageManager` pin is always exact.
+    assert_eq!(package_manager_pin_specifier(true, Some("^12.0.0"), "12.1.0"), "12.1.0");
+    // No prior constraint → the resolved version.
+    assert_eq!(package_manager_pin_specifier(false, None, "12.1.0"), "12.1.0");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/self_update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/tests.rs
@@ -40,11 +40,9 @@ fn seed_global_engine(global_dir: &Path, package_name: &str, version: &str) {
 
 #[test]
 fn pin_specifier_records_the_resolved_pin_not_the_cli_dist_tag() {
-    // Regression: `self-update next-12` resolves to an exact prerelease and
-    // rewrites the exact devEngines pin to it, so the packageManagerDependencies
-    // specifier must be that resolved version — not the `next-12` dist-tag the
-    // user typed. Recording the dist-tag desyncs the lockfile from the manifest
-    // pin and breaks the next `--frozen-lockfile` install.
+    // Guards the `self-update next-12` regression: recording the dist-tag
+    // instead of the resolved pin desyncs the lockfile from the manifest and
+    // breaks the next `--frozen-lockfile` install.
     assert_eq!(
         package_manager_pin_specifier(false, Some("12.0.0-alpha.9"), "12.0.0-alpha.10"),
         "12.0.0-alpha.10",


### PR DESCRIPTION
## Summary

`pnpm self-update <dist-tag>` (e.g. `next-12`) resolved the tag to an exact version and wrote that exact version into `devEngines.packageManager.version`, but recorded the **raw dist-tag** as the `packageManagerDependencies` specifier in `pnpm-lock.yaml`. The lockfile specifier then no longer matched the manifest pin.

Because pacquet validates the `packageManagerDependencies` specifier under `--frozen-lockfile` (it derives the expected specifier from the manifest via `package_manager_to_sync`), the mismatch made a later frozen install fail with `FrozenLockfileOutdated` ("the lockfile is not up to date"). This is how the daily update-lockfile job produced an invalid lockfile in pnpm/pnpm#12989, which had to be hot-fixed by hand in pnpm/pnpm#12990.

The TypeScript CLI is **unaffected** — its `self-update` derives the specifier from the resolved version, so this is a pacquet-only correctness bug and a parity divergence.

Both self-update call sites now record the resolved pin instead of the CLI argument:
- **project-pin path** stores the updated `devEngines` constraint (the value a later install reads back), via a new `package_manager_pin_specifier` helper — exact for exact/legacy pins, preserved range for range pins;
- **global-switch path** stores the resolved version.

Related to pnpm/pnpm#12989, pnpm/pnpm#12990.

## Squash Commit Body

```text
`pnpm self-update <dist-tag>` resolved the tag to an exact version and wrote it
into devEngines.packageManager.version, but recorded the raw dist-tag as the
packageManagerDependencies specifier in pnpm-lock.yaml. pacquet validates that
specifier against the manifest under --frozen-lockfile, so the mismatch made a
later frozen install fail with FrozenLockfileOutdated (the cause of the invalid
lockfile in pnpm/pnpm#12989, hot-fixed in pnpm/pnpm#12990).

Both self-update call sites now record the resolved pin: the project-pin path
stores the updated devEngines constraint (the value a later install reads back)
via a new package_manager_pin_specifier helper, and the global-switch path
stores the resolved version. The TypeScript CLI already derived the specifier
from the resolved version and is unaffected.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. <!-- pacquet-only bug; the TypeScript CLI is already correct. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm self-update <dist-tag>` to record the correct resolved package manager version (or pin range style) into `packageManagerDependencies`, preventing `pnpm-lock.yaml` drift and avoiding `--frozen-lockfile` failures.
  * Improved consistency between the updated project pin and what future installs accept, including prerelease and legacy `packageManager` pin scenarios.
* **Tests**
  * Added regression coverage for prerelease resolved versions, preserved range pins, legacy exact-version behavior, and behavior when no prior constraint exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->