### PR TITLE
fix(tarball): bound gzip size hints

### DIFF
--- a/.changeset/bound-pacquet-gzip-hints.md
+++ b/.changeset/bound-pacquet-gzip-hints.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Limit registry-provided gzip preallocation hints to 64 MiB so oversized `dist.unpackedSize` values cannot trigger excessive eager allocation.

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -35,6 +35,12 @@ use zune_inflate::{DeflateDecoder, DeflateOptions, errors::InflateDecodeErrors};
 /// attacker-controlled, and post-download work runs concurrently (see
 /// [`post_download_semaphore`]), so whatever one task reserves up front
 /// is multiplied across every task in flight.
+///
+/// An oversized figure is clamped to the ceiling rather than dropped.
+/// Both consumers grow their buffer on demand, so clamping still decodes
+/// a genuinely larger archive in full while keeping the reservation the
+/// hint exists for — dropping it instead would leave a large package
+/// growing from the decoder's 37 KB default in 4 KiB steps.
 const MAX_UNTRUSTED_PREALLOC_BYTES: usize = 64 * 1024 * 1024;
 
 /// Cap on concurrent post-download tarball work (SHA-512 of the whole
@@ -462,15 +468,12 @@ fn read_local_tarball_error(
     }
 }
 
-/// Keep a `dist.unpackedSize` hint only while it stays within
-/// [`MAX_UNTRUSTED_PREALLOC_BYTES`]. An oversized hint is dropped rather
-/// than clamped to the ceiling: zune-inflate turns the hint into an
-/// infallible zero-filled `vec![0; hint]`, so clamping would let every
-/// package that overstates its size pin the whole ceiling up front.
-/// Dropping the hint costs only buffer growth: the decoder resizes as
-/// it goes, so a genuinely larger archive still decompresses.
+/// Clamp a `dist.unpackedSize` hint to [`MAX_UNTRUSTED_PREALLOC_BYTES`].
+/// zune-inflate turns the hint into an infallible zero-filled
+/// `vec![0; hint]` that aborts the process when the allocation fails, so
+/// the registry's figure must never reach it unbounded.
 fn bounded_gzip_size_hint(unpacked_size: Option<usize>) -> Option<usize> {
-    unpacked_size.filter(|&size| size <= MAX_UNTRUSTED_PREALLOC_BYTES)
+    unpacked_size.map(|size| size.min(MAX_UNTRUSTED_PREALLOC_BYTES))
 }
 
 #[instrument(skip(gz_data), fields(gz_data_len = gz_data.len()))]
@@ -1029,10 +1032,6 @@ fn extract_zip_entries(
             continue;
         }
 
-        // Clamped here rather than dropped as in `bounded_gzip_size_hint`:
-        // the `try_reserve` below surfaces a refused reservation as an
-        // error instead of aborting, so a capped hint stays useful for a
-        // large legitimate entry.
         let prealloc_hint = entry.size().min(MAX_UNTRUSTED_PREALLOC_BYTES as u64) as usize;
         let mut buffer = Vec::new();
         buffer.try_reserve(prealloc_hint).map_err(|err| TarballError::ReadZipEntries {

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -29,6 +29,8 @@ use tokio::sync::{Notify, RwLock, Semaphore};
 use tracing::instrument;
 use zune_inflate::{DeflateDecoder, DeflateOptions, errors::InflateDecodeErrors};
 
+const MAX_UNTRUSTED_PREALLOC_BYTES: usize = 64 * 1024 * 1024;
+
 /// Cap on concurrent post-download tarball work (SHA-512 of the whole
 /// tarball + gzip inflate + per-file SHA-512 + CAFS writes). The body is
 /// CPU-bound with some blocking FS I/O, and putting it on
@@ -454,11 +456,15 @@ fn read_local_tarball_error(
     }
 }
 
+fn bounded_gzip_size_hint(unpacked_size: Option<usize>) -> Option<usize> {
+    unpacked_size.filter(|&size| size <= MAX_UNTRUSTED_PREALLOC_BYTES)
+}
+
 #[instrument(skip(gz_data), fields(gz_data_len = gz_data.len()))]
 fn decompress_gzip(gz_data: &[u8], unpacked_size: Option<usize>) -> Result<Vec<u8>, TarballError> {
     let mut options = DeflateOptions::default().set_confirm_checksum(false);
 
-    if let Some(size) = unpacked_size {
+    if let Some(size) = bounded_gzip_size_hint(unpacked_size) {
         options = options.set_size_hint(size);
     }
 
@@ -1015,8 +1021,7 @@ fn extract_zip_entries(
         // hint at 64 MiB so a maliciously huge `uncompressed_size`
         // in the central directory can't crash the process before
         // `read_to_end` has a chance to surface the real error.
-        const MAX_ENTRY_PREALLOC_BYTES: u64 = 64 * 1024 * 1024;
-        let prealloc_hint = entry.size().min(MAX_ENTRY_PREALLOC_BYTES) as usize;
+        let prealloc_hint = entry.size().min(MAX_UNTRUSTED_PREALLOC_BYTES as u64) as usize;
         let mut buffer = Vec::new();
         buffer.try_reserve(prealloc_hint).map_err(|err| TarballError::ReadZipEntries {
             url: package_url.to_string(),

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -36,11 +36,9 @@ use zune_inflate::{DeflateDecoder, DeflateOptions, errors::InflateDecodeErrors};
 /// [`post_download_semaphore`]), so whatever one task reserves up front
 /// is multiplied across every task in flight.
 ///
-/// An oversized figure is clamped to the ceiling rather than dropped.
-/// Both consumers grow their buffer on demand, so clamping still decodes
-/// a genuinely larger archive in full while keeping the reservation the
-/// hint exists for — dropping it instead would leave a large package
-/// growing from the decoder's 37 KB default in 4 KiB steps.
+/// Bounds the eager reservation only, never the output: both consumers
+/// grow their buffer on demand, so an archive larger than the ceiling
+/// still decodes in full.
 const MAX_UNTRUSTED_PREALLOC_BYTES: usize = 64 * 1024 * 1024;
 
 /// Cap on concurrent post-download tarball work (SHA-512 of the whole
@@ -468,10 +466,9 @@ fn read_local_tarball_error(
     }
 }
 
-/// Clamp a `dist.unpackedSize` hint to [`MAX_UNTRUSTED_PREALLOC_BYTES`].
-/// zune-inflate turns the hint into an infallible zero-filled
-/// `vec![0; hint]` that aborts the process when the allocation fails, so
-/// the registry's figure must never reach it unbounded.
+/// Bound a registry-supplied `dist.unpackedSize` before it reaches
+/// zune-inflate, which reserves the hint as an infallible zero-filled
+/// `vec![0; hint]` and aborts the process if that allocation fails.
 fn bounded_gzip_size_hint(unpacked_size: Option<usize>) -> Option<usize> {
     unpacked_size.map(|size| size.min(MAX_UNTRUSTED_PREALLOC_BYTES))
 }

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -29,6 +29,12 @@ use tokio::sync::{Notify, RwLock, Semaphore};
 use tracing::instrument;
 use zune_inflate::{DeflateDecoder, DeflateOptions, errors::InflateDecodeErrors};
 
+/// Ceiling on a single eager buffer reservation sized from untrusted
+/// archive metadata — `dist.unpackedSize` in registry metadata and an
+/// entry's `uncompressed_size` in a zip central directory. Both are
+/// attacker-controlled, and post-download work runs concurrently (see
+/// [`post_download_semaphore`]), so whatever one task reserves up front
+/// is multiplied across every task in flight.
 const MAX_UNTRUSTED_PREALLOC_BYTES: usize = 64 * 1024 * 1024;
 
 /// Cap on concurrent post-download tarball work (SHA-512 of the whole
@@ -456,6 +462,13 @@ fn read_local_tarball_error(
     }
 }
 
+/// Keep a `dist.unpackedSize` hint only while it stays within
+/// [`MAX_UNTRUSTED_PREALLOC_BYTES`]. An oversized hint is dropped rather
+/// than clamped to the ceiling: zune-inflate turns the hint into an
+/// infallible zero-filled `vec![0; hint]`, so clamping would let every
+/// package that overstates its size pin the whole ceiling up front.
+/// Dropping the hint costs only buffer growth: the decoder resizes as
+/// it goes, so a genuinely larger archive still decompresses.
 fn bounded_gzip_size_hint(unpacked_size: Option<usize>) -> Option<usize> {
     unpacked_size.filter(|&size| size <= MAX_UNTRUSTED_PREALLOC_BYTES)
 }
@@ -1016,11 +1029,10 @@ fn extract_zip_entries(
             continue;
         }
 
-        // Same allocation-safety shape as
-        // [`extract_tarball_entries`]: clamp the pre-allocation
-        // hint at 64 MiB so a maliciously huge `uncompressed_size`
-        // in the central directory can't crash the process before
-        // `read_to_end` has a chance to surface the real error.
+        // Clamped here rather than dropped as in `bounded_gzip_size_hint`:
+        // the `try_reserve` below surfaces a refused reservation as an
+        // error instead of aborting, so a capped hint stays useful for a
+        // large legitimate entry.
         let prealloc_hint = entry.size().min(MAX_UNTRUSTED_PREALLOC_BYTES as u64) as usize;
         let mut buffer = Vec::new();
         buffer.try_reserve(prealloc_hint).map_err(|err| TarballError::ReadZipEntries {

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -44,11 +44,10 @@ fn gzip_size_hint_enforces_untrusted_preallocation_limit() {
     assert_eq!(bounded_gzip_size_hint(Some(usize::MAX)), Some(MAX_UNTRUSTED_PREALLOC_BYTES));
 }
 
-/// `decompress_gzip` must route `dist.unpackedSize` through
-/// [`bounded_gzip_size_hint`] instead of handing it to zune-inflate,
-/// which reserves it as an infallible zero-filled `vec![0; hint]` —
-/// a failed reservation aborts the process and takes the install with
-/// it. A registry that overstates the size still decodes correctly.
+/// Covers the wiring rather than the bound itself: nothing in
+/// [`bounded_gzip_size_hint`]'s own test catches `decompress_gzip`
+/// handing the raw hint to zune-inflate, which aborts the process
+/// instead of failing.
 #[test]
 fn decompress_gzip_bounds_oversized_unpacked_size() {
     let payload = b"decompressed tar payload";

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -37,8 +37,11 @@ fn gzip_size_hint_enforces_untrusted_preallocation_limit() {
         bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES)),
         Some(MAX_UNTRUSTED_PREALLOC_BYTES),
     );
-    assert_eq!(bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES + 1)), None);
-    assert_eq!(bounded_gzip_size_hint(Some(usize::MAX)), None);
+    assert_eq!(
+        bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES + 1)),
+        Some(MAX_UNTRUSTED_PREALLOC_BYTES),
+    );
+    assert_eq!(bounded_gzip_size_hint(Some(usize::MAX)), Some(MAX_UNTRUSTED_PREALLOC_BYTES));
 }
 
 /// `decompress_gzip` must route `dist.unpackedSize` through
@@ -47,7 +50,7 @@ fn gzip_size_hint_enforces_untrusted_preallocation_limit() {
 /// a failed reservation aborts the process and takes the install with
 /// it. A registry that overstates the size still decodes correctly.
 #[test]
-fn decompress_gzip_ignores_oversized_unpacked_size() {
+fn decompress_gzip_bounds_oversized_unpacked_size() {
     let payload = b"decompressed tar payload";
     let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
     std::io::Write::write_all(&mut encoder, payload).expect("gzip payload");

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -37,7 +37,7 @@ fn gzip_size_hint_enforces_untrusted_preallocation_limit() {
         bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES)),
         Some(MAX_UNTRUSTED_PREALLOC_BYTES),
     );
-    assert_eq!(bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES + 1)), None,);
+    assert_eq!(bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES + 1)), None);
     assert_eq!(bounded_gzip_size_hint(Some(usize::MAX)), None);
 }
 

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1,10 +1,11 @@
 use super::{
-    DownloadTarballToStore, FetchTarballForResolution, HttpStatusError, MemCache, NetworkError,
-    PrefetchedCasPaths, RetryOpts, SharedReportedProgressKeys, TarballError, VerifyChecksumError,
-    allocate_local_tarball_buffer, allocate_tarball_buffer, apply_append_manifest,
-    download_priority, extract_tarball_entries, extract_zip_entries, fetch_and_extract_with_retry,
-    is_transient_error, local_file_tarball_path, normalize_bundled_manifest, open_local_tarball,
-    prefetch_cas_paths, read_local_tarball_buffer,
+    DownloadTarballToStore, FetchTarballForResolution, HttpStatusError,
+    MAX_UNTRUSTED_PREALLOC_BYTES, MemCache, NetworkError, PrefetchedCasPaths, RetryOpts,
+    SharedReportedProgressKeys, TarballError, VerifyChecksumError, allocate_local_tarball_buffer,
+    allocate_tarball_buffer, apply_append_manifest, bounded_gzip_size_hint, download_priority,
+    extract_tarball_entries, extract_zip_entries, fetch_and_extract_with_retry, is_transient_error,
+    local_file_tarball_path, normalize_bundled_manifest, open_local_tarball, prefetch_cas_paths,
+    read_local_tarball_buffer,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient, UNPRIORITIZED};
 use pacquet_reporter::SilentReporter;
@@ -26,6 +27,18 @@ use tempfile::{TempDir, tempdir};
 
 fn integrity(integrity_str: &str) -> Integrity {
     integrity_str.parse().expect("parse integrity string")
+}
+
+#[test]
+fn gzip_size_hint_enforces_untrusted_preallocation_limit() {
+    assert_eq!(bounded_gzip_size_hint(None), None);
+    assert_eq!(bounded_gzip_size_hint(Some(1)), Some(1));
+    assert_eq!(
+        bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES)),
+        Some(MAX_UNTRUSTED_PREALLOC_BYTES),
+    );
+    assert_eq!(bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES + 1)), None,);
+    assert_eq!(bounded_gzip_size_hint(Some(usize::MAX)), None);
 }
 
 /// Absent `Content-Length` (chunked transfer) returns an empty

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -2,10 +2,10 @@ use super::{
     DownloadTarballToStore, FetchTarballForResolution, HttpStatusError,
     MAX_UNTRUSTED_PREALLOC_BYTES, MemCache, NetworkError, PrefetchedCasPaths, RetryOpts,
     SharedReportedProgressKeys, TarballError, VerifyChecksumError, allocate_local_tarball_buffer,
-    allocate_tarball_buffer, apply_append_manifest, bounded_gzip_size_hint, download_priority,
-    extract_tarball_entries, extract_zip_entries, fetch_and_extract_with_retry, is_transient_error,
-    local_file_tarball_path, normalize_bundled_manifest, open_local_tarball, prefetch_cas_paths,
-    read_local_tarball_buffer,
+    allocate_tarball_buffer, apply_append_manifest, bounded_gzip_size_hint, decompress_gzip,
+    download_priority, extract_tarball_entries, extract_zip_entries, fetch_and_extract_with_retry,
+    is_transient_error, local_file_tarball_path, normalize_bundled_manifest, open_local_tarball,
+    prefetch_cas_paths, read_local_tarball_buffer,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient, UNPRIORITIZED};
 use pacquet_reporter::SilentReporter;
@@ -39,6 +39,23 @@ fn gzip_size_hint_enforces_untrusted_preallocation_limit() {
     );
     assert_eq!(bounded_gzip_size_hint(Some(MAX_UNTRUSTED_PREALLOC_BYTES + 1)), None);
     assert_eq!(bounded_gzip_size_hint(Some(usize::MAX)), None);
+}
+
+/// `decompress_gzip` must route `dist.unpackedSize` through
+/// [`bounded_gzip_size_hint`] instead of handing it to zune-inflate,
+/// which reserves it as an infallible zero-filled `vec![0; hint]` —
+/// a failed reservation aborts the process and takes the install with
+/// it. A registry that overstates the size still decodes correctly.
+#[test]
+fn decompress_gzip_ignores_oversized_unpacked_size() {
+    let payload = b"decompressed tar payload";
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    std::io::Write::write_all(&mut encoder, payload).expect("gzip payload");
+    let gz_data = encoder.finish().expect("finish gzip");
+
+    let decompressed = decompress_gzip(&gz_data, Some(usize::MAX)).expect("decompress gzip");
+
+    assert_eq!(decompressed, payload);
 }
 
 /// Absent `Content-Length` (chunked transfer) returns an empty


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Registry metadata can supply an arbitrary `dist.unpackedSize`, and pacquet passed that value directly to zune-inflate as an eager output-buffer allocation hint. zune-inflate reserves the hint as an infallible zero-filled `vec![0; hint]`, so an arbitrary registry figure aborts the process rather than failing gracefully — multiplied across concurrent post-download tasks.

- Clamp gzip hints to the tarball module's existing 64 MiB untrusted-preallocation ceiling, now shared with the ZIP entry reservation that already bounded against the same figure.
- Bound the eager reservation only, never the output: zune-inflate grows its buffer on demand, so an archive larger than the ceiling still decodes in full.
- Cover the boundary scalars, plus the wiring that routes the registry figure through the bound.

The TypeScript CLI does not use `dist.unpackedSize` as a decompressor allocation hint, so no TypeScript-side change is needed.

### Why clamp rather than omit

Omitting an oversized hint also bounds the allocation, but discards the pre-sizing for honest large packages, which then grow from zune-inflate's 37 KB default in 4 KiB steps. Decompressing an 80 MiB package (release, best-of-3):

| hint strategy | time |
| --- | --- |
| omitted | 72.3 ms |
| unbounded (pre-fix) | 17.7 ms |
| clamped to 64 MiB | 11.4 ms |

Clamping is safe from a memory-consumption perspective: `vec![0; 64 MiB]` is lazily backed, so pages the decoder never writes never become resident. With 20 concurrent tiny packages each claiming `usize::MAX` (matching `post_download_semaphore`'s `num_cpus * 2`), every buffer held alive at once:

```
20 lying pkgs (usize::MAX hint) held: RSS +0.7 MiB (eager would be +1280 MiB)
```

Clamping therefore keeps the change to the smallest correct one — behavior differs from the pre-fix code only for figures above the ceiling — and matches the sibling ZIP entry reservation, which has always clamped against this same bound.

Verified with:

- `cargo test --locked -p pacquet-tarball --lib` (74 passed)
- An 80 MiB archive round-tripped through `decompress_gzip` with a truthful over-ceiling hint, length and content asserted
- `cargo fmt --all --check`
- `cargo clippy --locked -p pacquet-tarball --all-targets -- --deny warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --locked -p pacquet-tarball --no-deps`
- `typos pnpm/crates/tarball .changeset/bound-pacquet-gzip-hints.md`
- The repository pre-push hook, including TypeScript compile/lint, workspace Rust clippy/rustdoc, and Rust spell checking

## Squash Commit Body

```text
Registry-provided dist.unpackedSize was forwarded unbounded to zune-inflate as an eager output-buffer allocation hint. zune-inflate reserves it as an infallible zero-filled `vec![0; hint]`, so an arbitrary registry figure could abort the process instead of failing gracefully, multiplied across concurrent post-download tasks.

Clamp the hint to the tarball module's existing 64 MiB untrusted-preallocation ceiling, now shared with the zip entry reservation that already bounded against the same figure. The ceiling bounds the eager reservation only, never the output: zune-inflate grows its buffer on demand, so an archive larger than the ceiling still decodes in full.

Clamping preserves the pre-sizing the hint exists for. Omitting an oversized hint instead would leave an honest large package growing from the decoder's small default, measured ~6x slower on an 80 MiB archive. A clamped reservation is lazily backed, so a package that overstates its size holds address space rather than resident memory: 20 concurrent tiny packages each claiming usize::MAX hold +0.7 MiB RSS.

Add boundary coverage for absent, ordinary, exact-limit, over-limit, and maximum-size hints, plus a test that decompress_gzip routes the registry figure through the bound rather than forwarding it raw.
```
## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).
Description and squash body revised by an agent (Claude Code, claude-opus-4-8) after the clamp change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786605758&installation_id=145934176&pr_number=12993&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12993&signature=7dc5b3d86c929956c8588b110dc88563c34e66286d6c2a49104b200ee91d6dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capped registry-provided gzip preallocation hints to 64 MiB to prevent excessive eager memory allocation.
  * Clamped ZIP extraction preallocation so oversized or untrusted advertised entry sizes can’t drive large upfront reservations.
* **Tests**
  * Added unit tests covering gzip hint bounding and ensuring decompression works when given oversized unpacked-size hints.
* **Release**
  * Prepared a patch release for the pacquet package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
