### PR TITLE
fix(package-manager): enforce engines on fresh installs

### DIFF
--- a/.changeset/pacquet-fresh-engine-strict.md
+++ b/.changeset/pacquet-fresh-engine-strict.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed fresh isolated installs to enforce incompatible required dependency engines when `engineStrict` is enabled.

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -135,7 +135,7 @@ fn fresh_isolated_install_rejects_required_incompatible_engine_in_strict_mode() 
         "stderr must identify the incompatible lockfile package ID; got:\n{stderr}",
     );
     assert!(
-        stderr.contains("wanted: {\"node\":\">=999.0.0\"}"),
+        stderr.contains(r#"wanted: {"node":">=999.0.0"}"#),
         "stderr must report the required Node.js version; got:\n{stderr}",
     );
 
@@ -186,7 +186,7 @@ fn frozen_isolated_install_rejects_required_incompatible_engine_in_strict_mode()
         "stderr must identify the incompatible lockfile package ID; got:\n{stderr}",
     );
     assert!(
-        stderr.contains("wanted: {\"node\":\">=999.0.0\"}"),
+        stderr.contains(r#"wanted: {"node":">=999.0.0"}"#),
         "stderr must report the required Node.js version; got:\n{stderr}",
     );
 

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -12,8 +12,10 @@ use pacquet_testing_utils::{
 #[cfg(unix)]
 use pipe_trait::Pipe;
 use std::{
+    fmt::Write as _,
     fs::{self, OpenOptions},
     io::Write,
+    path::Path,
     process::Command,
 };
 
@@ -112,6 +114,80 @@ fn no_optional_excludes_transitive_optional_dependencies() {
     assert!(
         virtual_store.join("is-positive@1.0.0").exists(),
         "a normal install must restore the previously excluded optional dependency",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn fresh_isolated_install_rejects_required_incompatible_engine_in_strict_mode() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_required_incompatible_engine_fixture(&workspace, true);
+
+    let assert = pacquet.with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    eprintln!("STDERR:\n{stderr}\n");
+    assert!(
+        stderr.contains("Unsupported engine for incompatible-engine@file:incompatible-engine"),
+        "stderr must identify the incompatible lockfile package ID; got:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("wanted: {\"node\":\">=999.0.0\"}"),
+        "stderr must report the required Node.js version; got:\n{stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn fresh_isolated_install_allows_required_incompatible_engine_without_strict_mode() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_required_incompatible_engine_fixture(&workspace, false);
+
+    pacquet.with_arg("install").assert().success();
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn frozen_isolated_install_rejects_required_incompatible_engine_in_strict_mode() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_required_incompatible_engine_fixture(&workspace, false);
+    pacquet.with_arg("install").assert().success();
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    let strict_workspace_yaml = workspace_yaml.replace("engineStrict: false", "engineStrict: true");
+    assert_ne!(
+        strict_workspace_yaml, workspace_yaml,
+        "fixture must contain the non-strict setting before the frozen install",
+    );
+    fs::write(&workspace_yaml_path, strict_workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    let assert = new_pacquet_command(&workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    eprintln!("STDERR:\n{stderr}\n");
+    assert!(
+        stderr.contains("Unsupported engine for incompatible-engine@file:incompatible-engine"),
+        "stderr must identify the incompatible lockfile package ID; got:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("wanted: {\"node\":\">=999.0.0\"}"),
+        "stderr must report the required Node.js version; got:\n{stderr}",
     );
 
     drop((root, mock_instance));
@@ -1453,6 +1529,44 @@ fn install_with_peer_alias_deps(dependencies: serde_json::Value) -> String {
 
     drop((root, mock_instance));
     lockfile
+}
+
+fn write_required_incompatible_engine_fixture(workspace: &Path, engine_strict: bool) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "incompatible-engine": "file:./incompatible-engine",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let dependency_dir = workspace.join("incompatible-engine");
+    fs::create_dir(&dependency_dir).expect("create incompatible-engine directory");
+    fs::write(
+        dependency_dir.join("package.json"),
+        serde_json::json!({
+            "name": "incompatible-engine",
+            "version": "1.0.0",
+            "engines": {
+                "node": ">=999.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write incompatible-engine package.json");
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("nodeVersion: 20.0.0\n");
+    writeln!(workspace_yaml, "engineStrict: {engine_strict}").expect("append engineStrict setting");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
 }
 
 /// A fresh `pacquet` command rooted at `workspace`, for tests that run the

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1512,22 +1512,13 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // `--force` bypasses the installability checks outright (see
         // `Config::force`): no skip set is computed and the hoisted
         // walker emits every dep, so no host detection is needed either.
-        let needs_optional_installability_check = !config.force
-            && built_lockfile.packages.as_ref().is_some_and(|packages| {
-                built_lockfile.snapshots.as_ref().is_some_and(|snapshots| {
-                    crate::any_optional_installability_constraint(snapshots, packages)
-                })
-            });
-        let needs_hoisted_installability_host = !config.force
-            && is_hoisted
+        let needs_installability_check = !config.force
             && built_lockfile.packages.as_ref().is_some_and(|packages| {
                 built_lockfile.snapshots.as_ref().is_some_and(|snapshots| {
                     crate::any_installability_constraint(snapshots, packages)
                 })
             });
-        let needs_installability_host =
-            needs_optional_installability_check || needs_hoisted_installability_host;
-        let installability_host = if needs_installability_host {
+        let installability_host = if needs_installability_check {
             let engine_strict = config.engine_strict;
             let mut host = match config.node_version.clone() {
                 // An explicit `nodeVersion` needs no `node --version` probe, so
@@ -1623,7 +1614,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             );
         }
 
-        let mut skipped = if needs_optional_installability_check {
+        let mut skipped = if needs_installability_check {
             match (
                 built_lockfile.snapshots.as_ref(),
                 built_lockfile.packages.as_ref(),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

> [!IMPORTANT]
> This branch must incorporate pnpm/pnpm#13066 before this PR can merge. The intended sequence is to merge pnpm/pnpm#13066 into `main`, then rebase or update this branch onto the latest `main` so the zizmor security check runs with the shared fix.

Fresh isolated pacquet installs only constructed an installability host when optional dependencies needed platform checks. As a result, a required dependency with an incompatible `engines.node` range was installed successfully even when `engineStrict` was enabled.

- Gate fresh-install host construction on any package installability constraint, not only optional constraints.
- Reuse that same gate when computing skipped snapshots while preserving `--force` and constraint-free fast paths.
- Add local, deterministic coverage for fresh strict, fresh non-strict, and frozen strict installs.

The TypeScript CLI already rejects this case, so this is a pacquet parity fix and needs no TypeScript-side change.

Verified with:

- `cargo test --locked -p pacquet-cli --test install required_incompatible_engine` (3 passed)
- `cargo test --locked -p pacquet-cli --test install` (36 passed, 1 ignored)
- `cargo test --locked -p pacquet-package-manager` (717 passed)
- `cargo check --locked -p pacquet-package-manager -p pacquet-cli --all-targets`
- `cargo clippy --locked -p pacquet-package-manager -p pacquet-cli --all-targets -- --deny warnings`
- The repository pre-push hook, including TypeScript compile/lint, workspace Rust clippy/rustdoc, and Rust spell checking

## Squash Commit Body

```text
Fresh isolated installs constructed an installability host only when optional dependencies carried platform or engine constraints. Required dependencies therefore skipped strict engine validation, allowing an incompatible engines.node range to install successfully under engineStrict.

Use one installability gate for any constrained package and reuse it when computing skipped snapshots. Keep host detection disabled for --force and constraint-free graphs, while preserving the existing configured nodeVersion, supported architecture, and optional-dependency behavior.

Add deterministic local-dependency regressions covering fresh strict rejection, fresh non-strict acceptance, and frozen strict rejection.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786606946&installation_id=145934176&pr_number=12994&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12994&signature=212513d98f9ad1e430ef6c79434c41da18ba906c956c398f53b3704c49b8a555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fresh and frozen isolated installs now correctly enforce incompatible required Node.js engine versions when strict engine checking is enabled.
  * Non-strict installs continue to succeed despite incompatible dependency engine requirements.
  * Improved installability checks for fresh lockfile installations.

* **Tests**
  * Added regression coverage for strict and non-strict isolated installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->