### PR TITLE
fix(add): support multiple package selectors

### DIFF
--- a/.changeset/pacquet-add-multiple-packages.md
+++ b/.changeset/pacquet-add-multiple-packages.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pacquet add` to accept and install multiple package selectors in one operation.

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -123,6 +123,13 @@ impl AddArgs {
         );
     }
 
+    /// The `--config` selectors parsed into the `name → specifier` pairs to
+    /// record, or `None` when `--config` was not passed.
+    ///
+    /// Callers must run this *before* [`State::init`]: that scaffolds a
+    /// `package.json` on disk, so rejecting an invalid selector afterwards
+    /// would leave a half-created project behind. A version-less selector
+    /// resolves the `latest` tag, matching the default `add` behavior.
     pub(super) fn parse_config_dependencies(
         &self,
     ) -> miette::Result<Option<BTreeMap<String, String>>> {
@@ -144,7 +151,9 @@ impl AddArgs {
         Ok(Some(added))
     }
 
-    /// Execute the subcommand.
+    /// Execute the subcommand. `config_dependencies` is
+    /// [`Self::parse_config_dependencies`]'s output, so it is `Some` exactly
+    /// when `--config` was passed.
     pub async fn run<Reporter: self::Reporter + 'static>(
         self,
         state: State,
@@ -152,11 +161,9 @@ impl AddArgs {
     ) -> miette::Result<()> {
         // `--config` routes to the configurational-dependency path
         // instead of the regular `package.json` add: resolve + install
-        // into `.pnpm-config`, then record the clean specifier in
+        // into `.pnpm-config`, then record the clean specifiers in
         // `pnpm-workspace.yaml`.
-        if self.config {
-            let added = config_dependencies
-                .expect("config dependency selectors are parsed before state initialization");
+        if let Some(added) = config_dependencies {
             // configDependencies are workspace-level: write to the
             // workspace root's `pnpm-workspace.yaml` / env lockfile /
             // `.pnpm-config`, not the current package's. Fall back to the
@@ -245,7 +252,10 @@ impl AddArgs {
 
 /// Add a single package to `state`'s manifest and install it.
 ///
-/// Compatibility adapter for single-package callers such as `pacquet dlx`.
+/// Shared by `pacquet dlx`, `pacquet runtime`, and the self-updater. dlx
+/// points `state` at a cache directory (via a [`Config`] whose `modules_dir`
+/// is anchored there) and saves to `dependencies` so the package's bin lands
+/// in `<cacheDir>/node_modules/.bin`.
 pub(crate) async fn add_package<Reporter, ListDependencyGroups, DependencyGroupList>(
     state: State,
     package_name: &str,

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -13,7 +13,10 @@ use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 #[derive(Debug, Args)]
 pub struct AddDependencyOptions {
@@ -67,8 +70,9 @@ impl AddDependencyOptions {
 
 #[derive(Debug, Args)]
 pub struct AddArgs {
-    /// Name of the package
-    pub package_name: String, // TODO: 1. support version range, 2. multiple arguments, 3. name this `packages`
+    /// Names of the packages to add.
+    #[clap(required = true)]
+    pub package_names: Vec<String>,
     /// --save-prod, --save-dev, --save-optional, --save-peer
     #[clap(flatten)]
     pub dependency_options: AddDependencyOptions,
@@ -119,23 +123,40 @@ impl AddArgs {
         );
     }
 
+    pub(super) fn parse_config_dependencies(
+        &self,
+    ) -> miette::Result<Option<BTreeMap<String, String>>> {
+        if !self.config {
+            return Ok(None);
+        }
+
+        let mut added = BTreeMap::new();
+        for package_name in &self.package_names {
+            let parsed = parse_wanted_dependency(package_name);
+            let Some(name) = parsed.alias else {
+                return Err(miette::miette!(
+                    "'{package_name}' is not a valid package name for a configuration dependency",
+                ));
+            };
+            let specifier = parsed.bare_specifier.unwrap_or_else(|| "latest".to_string());
+            added.insert(name, specifier);
+        }
+        Ok(Some(added))
+    }
+
     /// Execute the subcommand.
-    pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        state: State,
+        config_dependencies: Option<BTreeMap<String, String>>,
+    ) -> miette::Result<()> {
         // `--config` routes to the configurational-dependency path
         // instead of the regular `package.json` add: resolve + install
         // into `.pnpm-config`, then record the clean specifier in
         // `pnpm-workspace.yaml`.
         if self.config {
-            let parsed = parse_wanted_dependency(&self.package_name);
-            let Some(name) = parsed.alias else {
-                return Err(miette::miette!(
-                    "'{}' is not a valid package name for a configuration dependency",
-                    self.package_name,
-                ));
-            };
-            // No version given → resolve the `latest` tag, matching the
-            // default `add` behavior.
-            let specifier = parsed.bare_specifier.unwrap_or_else(|| "latest".to_string());
+            let added = config_dependencies
+                .expect("config dependency selectors are parsed before state initialization");
             // configDependencies are workspace-level: write to the
             // workspace root's `pnpm-workspace.yaml` / env lockfile /
             // `.pnpm-config`, not the current package's. Fall back to the
@@ -143,11 +164,10 @@ impl AddArgs {
             let root_dir = state.config.workspace_dir.clone().unwrap_or_else(|| {
                 state.manifest.path().parent().map_or_else(|| PathBuf::from("."), Path::to_path_buf)
             });
-            return config_deps::add_config_dependency::<Reporter>(
+            return config_deps::add_config_dependencies::<Reporter>(
                 state.config,
                 &root_dir,
-                &name,
-                &specifier,
+                &added,
             )
             .await;
         }
@@ -176,9 +196,9 @@ impl AddArgs {
         let pinned_version =
             PinnedVersion::from_save_options(self.save_exact, self.save_prefix.as_deref());
 
-        add_package::<Reporter, _, _>(
+        add_packages::<Reporter, _, _>(
             state,
-            &self.package_name,
+            &self.package_names,
             pinned_version,
             save_catalog_name,
             self.lockfile_only,
@@ -214,7 +234,7 @@ impl AddArgs {
             PinnedVersion::from_save_options(self.save_exact, self.save_prefix.as_deref());
         Box::pin(crate::cli_args::global::handle_global_add::<Reporter>(
             config,
-            &[self.package_name],
+            &self.package_names,
             pinned_version,
             supported_architectures,
             dir,
@@ -225,13 +245,38 @@ impl AddArgs {
 
 /// Add a single package to `state`'s manifest and install it.
 ///
-/// Shared by `pacquet add` and `pacquet dlx`. dlx points `state` at a
-/// cache directory (via a [`Config`] whose
-/// `modules_dir` is anchored there) and saves to `dependencies` so the
-/// package's bin lands in `<cacheDir>/node_modules/.bin`.
+/// Compatibility adapter for single-package callers such as `pacquet dlx`.
 pub(crate) async fn add_package<Reporter, ListDependencyGroups, DependencyGroupList>(
-    mut state: State,
+    state: State,
     package_name: &str,
+    pinned_version: PinnedVersion,
+    save_catalog_name: Option<String>,
+    lockfile_only: bool,
+    supported_architectures: Option<pacquet_package_is_installable::SupportedArchitectures>,
+    list_dependency_groups: ListDependencyGroups,
+) -> miette::Result<()>
+where
+    Reporter: self::Reporter + 'static,
+    ListDependencyGroups: Fn() -> DependencyGroupList,
+    DependencyGroupList: IntoIterator<Item = DependencyGroup>,
+{
+    let package_names = [package_name.to_string()];
+    Box::pin(add_packages::<Reporter, _, _>(
+        state,
+        &package_names,
+        pinned_version,
+        save_catalog_name,
+        lockfile_only,
+        supported_architectures,
+        list_dependency_groups,
+    ))
+    .await
+}
+
+/// Add packages to `state`'s manifest and install them in one operation.
+pub(crate) async fn add_packages<Reporter, ListDependencyGroups, DependencyGroupList>(
+    mut state: State,
+    package_names: &[String],
     pinned_version: PinnedVersion,
     save_catalog_name: Option<String>,
     lockfile_only: bool,
@@ -260,7 +305,7 @@ where
         lockfile,
         lockfile_path: lockfile_path.as_deref(),
         list_dependency_groups,
-        package_name,
+        package_names,
         pinned_version,
         save_catalog_name,
         resolved_packages,

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -44,16 +44,21 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
             ReporterType::Silent => Box::pin(args.run_global::<SilentReporter>(config, dir)),
         });
     }
+    let config_dependencies = args.parse_config_dependencies()?;
     let config = (ctx.config)()?;
     args.apply_cli_config(config);
     let command_state = State::init(ctx.manifest_path.to_path_buf(), config, false)
         .wrap_err("initialize the state")?;
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>(command_state))
+            Box::pin(args.run::<DefaultReporter>(command_state, config_dependencies))
         }
-        ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
-        ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
+        ReporterType::Ndjson => {
+            Box::pin(args.run::<NdjsonReporter>(command_state, config_dependencies))
+        }
+        ReporterType::Silent => {
+            Box::pin(args.run::<SilentReporter>(command_state, config_dependencies))
+        }
     })
 }
 

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -9,7 +9,7 @@
 use crate::{
     State,
     cli_args::{
-        add::add_package, approve_builds::ApproveBuildsArgs,
+        add::add_packages, approve_builds::ApproveBuildsArgs,
         ignored_builds::get_automatically_ignored_builds, rebuild::run_rebuild,
     },
 };
@@ -353,21 +353,22 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
     let config: &'static Config = Config::leak(cfg);
 
     let manifest_path = install_dir.join("package.json");
-    for selector in selectors {
-        let selector = infer_local_package_alias(selector)?;
-        let state = State::init(manifest_path.clone(), config, false)
-            .wrap_err("initialize the global install state")?;
-        add_package::<Reporter, _, _>(
-            state,
-            &selector,
-            pinned_version,
-            None,
-            false,
-            config.supported_architectures.clone(),
-            || std::iter::once(DependencyGroup::Prod),
-        )
-        .await?;
-    }
+    let selectors = selectors
+        .iter()
+        .map(|selector| infer_local_package_alias(selector))
+        .collect::<miette::Result<Vec<_>>>()?;
+    let state = State::init(manifest_path, config, false)
+        .wrap_err("initialize the global install state")?;
+    add_packages::<Reporter, _, _>(
+        state,
+        &selectors,
+        pinned_version,
+        None,
+        false,
+        config.supported_architectures.clone(),
+        || std::iter::once(DependencyGroup::Prod),
+    )
+    .await?;
 
     prompt_approve_global_builds::<Reporter>(config, &install_dir, global_pkg_dir).await?;
     Ok((install_dir, config))

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -27,7 +27,7 @@ use pacquet_store_dir::StoreDir;
 use pacquet_workspace_state::ConfigDependency;
 use serde_json::Value;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -177,30 +177,34 @@ pub async fn resolve_pnpm_version(
     }))
 }
 
-/// Add a single config dependency: resolve + install it (merged with any
-/// already-declared config deps), then write the clean specifier into
+/// Add config dependencies: resolve + install them (merged with any
+/// already-declared config deps), then write the clean specifiers into
 /// `pnpm-workspace.yaml`'s `configDependencies` block. Backs
 /// `pacquet add --config`.
-pub async fn add_config_dependency<Reporter: self::Reporter>(
+pub async fn add_config_dependencies<Reporter: self::Reporter>(
     config: &Config,
     root_dir: &Path,
-    name: &str,
-    specifier: &str,
+    added: &BTreeMap<String, String>,
 ) -> Result<()> {
     let mut config_dependencies = config.config_dependencies.clone().unwrap_or_default();
-    config_dependencies
-        .insert(name.to_string(), ConfigDependency::VersionWithIntegrity(specifier.to_string()));
+    for (name, specifier) in added {
+        config_dependencies
+            .insert(name.clone(), ConfigDependency::VersionWithIntegrity(specifier.clone()));
+    }
 
     resolve_and_install::<Reporter>(config, &config_dependencies, root_dir, false).await?;
 
-    pacquet_workspace_manifest_writer::set_config_dependency(root_dir, name, specifier)
-        .into_diagnostic()
-        .wrap_err("recording the config dependency in pnpm-workspace.yaml")
+    pacquet_workspace_manifest_writer::set_config_dependencies(
+        root_dir,
+        added.iter().map(|(name, specifier)| (name.as_str(), specifier.as_str())),
+    )
+    .into_diagnostic()
+    .wrap_err("recording the config dependencies in pnpm-workspace.yaml")
 }
 
 /// Build the resolver + install options from `config` and resolve +
 /// install `config_dependencies`. Shared by [`install_config_deps`] and
-/// [`add_config_dependency`].
+/// [`add_config_dependencies`].
 async fn resolve_and_install<Reporter: self::Reporter>(
     config: &Config,
     config_dependencies: &std::collections::BTreeMap<String, ConfigDependency>,

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -1,5 +1,6 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_lockfile::{Lockfile, PkgName};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
@@ -109,6 +110,49 @@ fn should_add_to_package_json() {
             .any(|(k, _)| k == "@pnpm.e2e/hello-world-js-bin"),
     );
     drop((root, anchor)); // cleanup
+}
+
+#[test]
+fn add_accepts_multiple_local_package_selectors() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let fixtures_dir = workspace.join("fixtures");
+    for package_name in ["local-a", "local-b"] {
+        let package_dir = fixtures_dir.join(package_name);
+        std::fs::create_dir_all(&package_dir).expect("create local package directory");
+        std::fs::write(
+            package_dir.join("package.json"),
+            serde_json::json!({ "name": package_name, "version": "1.0.0" }).to_string(),
+        )
+        .expect("write local package manifest");
+    }
+
+    pacquet
+        .with_args(["add", "local-a@file:./fixtures/local-a", "local-b@file:./fixtures/local-b"])
+        .assert()
+        .success();
+
+    assert_eq!(prod_spec(&workspace, "local-a"), "file:./fixtures/local-a");
+    assert_eq!(prod_spec(&workspace, "local-b"), "file:./fixtures/local-b");
+
+    let lockfile_text =
+        std::fs::read_to_string(workspace.join(Lockfile::FILE_NAME)).expect("read pnpm-lock.yaml");
+    let lockfile: Lockfile = serde_saphyr::from_str(&lockfile_text)
+        .unwrap_or_else(|error| panic!("parse pnpm-lock.yaml: {error}\n{lockfile_text}"));
+    let dependencies = lockfile
+        .importers
+        .get(Lockfile::ROOT_IMPORTER_KEY)
+        .and_then(|importer| importer.dependencies.as_ref())
+        .expect("root importer dependencies");
+    for package_name in ["local-a", "local-b"] {
+        let parsed_name: PkgName = package_name.parse().expect("parse local package name");
+        assert!(dependencies.contains_key(&parsed_name), "lockfile contains {package_name}");
+        assert!(
+            workspace.join("node_modules").join(package_name).join("package.json").exists(),
+            "{package_name} is installed",
+        );
+    }
+
+    drop(root); // cleanup
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/config_dependencies.rs
+++ b/pnpm/crates/cli/tests/config_dependencies.rs
@@ -2,9 +2,12 @@ pub mod _utils;
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_config::WorkspaceSettings;
+use pacquet_lockfile::EnvLockfile;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 #[cfg(unix)]
 use pacquet_testing_utils::fs::is_symlink_or_junction;
+use pacquet_workspace_state::ConfigDependency;
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
@@ -143,6 +146,78 @@ fn add_config_writes_workspace_yaml_and_installs() {
     );
 
     drop((root, mock_instance));
+}
+
+#[test]
+fn add_config_accepts_multiple_package_selectors_in_one_operation() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(workspace.join("package.json"), serde_json::json!({}).to_string())
+        .expect("write package.json");
+
+    pacquet_at(&workspace)
+        .with_args(["add", "--config", "@pnpm.e2e/foo@100.0.0", "@pnpm.e2e/bar@100.0.0"])
+        .assert()
+        .success();
+
+    let (_, settings) = WorkspaceSettings::find_and_load(&workspace)
+        .expect("read pnpm-workspace.yaml")
+        .expect("workspace manifest exists");
+    let config_dependencies = settings.config_dependencies.expect("configDependencies map");
+    assert_eq!(config_dependencies.len(), 2);
+    for package_name in ["@pnpm.e2e/foo", "@pnpm.e2e/bar"] {
+        assert_eq!(
+            config_dependencies.get(package_name),
+            Some(&ConfigDependency::VersionWithIntegrity("100.0.0".to_string())),
+        );
+    }
+
+    let env_lockfile =
+        EnvLockfile::read(&workspace).expect("read env lockfile").expect("env lockfile exists");
+    let root_importer = &env_lockfile.importers[EnvLockfile::ROOT_IMPORTER_KEY];
+    for package_name in ["@pnpm.e2e/foo", "@pnpm.e2e/bar"] {
+        let dependency = &root_importer.config_dependencies[package_name];
+        assert_eq!(dependency.specifier, "100.0.0");
+        assert_eq!(dependency.version, "100.0.0");
+
+        let installed =
+            workspace.join("node_modules/.pnpm-config").join(package_name).join("package.json");
+        assert!(installed.exists(), "config dependency installed at {}", installed.display());
+    }
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn add_config_validates_all_selectors_before_writing_files() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    for path in [
+        workspace.join("package.json"),
+        workspace.join("pnpm-lock.yaml"),
+        workspace.join("pnpm-workspace.yaml"),
+        workspace.join("node_modules"),
+    ] {
+        assert!(!path.exists(), "precondition: {} does not exist", path.display());
+    }
+
+    pacquet
+        .with_args(["add", "--config", "valid-package@1.0.0", "file:../missing"])
+        .assert()
+        .failure();
+
+    for path in [
+        workspace.join("package.json"),
+        workspace.join("pnpm-lock.yaml"),
+        workspace.join("pnpm-workspace.yaml"),
+        workspace.join("node_modules"),
+    ] {
+        assert!(!path.exists(), "invalid selector must not create {}", path.display());
+    }
+
+    drop(root);
 }
 
 /// An `updateConfig` hook can inject a `catalogs` entry that the install

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -40,8 +40,9 @@ where
     pub manifest: &'a mut PackageManifest,
     pub lockfile: Option<&'a Lockfile>,
     pub lockfile_path: Option<&'a std::path::Path>,
-    pub list_dependency_groups: ListDependencyGroups, // must be a function because it is called multiple times
-    pub package_name: &'a str, // may carry a `@<version>` suffix; TODO: multiple arguments, name this `packages`
+    pub list_dependency_groups: ListDependencyGroups,
+    /// Package selectors, each of which may carry an `@<version>` suffix.
+    pub package_names: &'a [String],
     /// How the freshly-resolved version is pinned into the manifest range,
     /// derived from `--save-exact` / `--save-prefix`. See
     /// [`PinnedVersion::from_save_options`].
@@ -137,15 +138,13 @@ where
             lockfile,
             lockfile_path,
             list_dependency_groups,
-            package_name,
+            package_names,
             pinned_version,
             save_catalog_name,
             resolved_packages,
             supported_architectures,
             lockfile_only,
         } = self;
-
-        let (package_name, explicit_spec) = split_name_spec(package_name);
 
         // Read the workspace catalogs so `catalogMode` / `--save-catalog`
         // can reconcile the added version against them, the same read a
@@ -164,111 +163,48 @@ where
             .map_err(AddError::InvalidCatalogsConfiguration)?;
         let prefix =
             workspace_dir_opt.as_deref().unwrap_or(&manifest_dir).to_string_lossy().into_owned();
-
-        // The dependency's current specifier *in the group(s) this add
-        // targets*, so a re-add keeps the existing range / `catalog:`
-        // reference of the bucket being written. Scanning only the target
-        // groups (rather than every group) avoids preserving a different
-        // group's specifier when the same package exists in more than one
-        // bucket with different specs.
-        let prev_specifier = manifest
-            .dependencies(list_dependency_groups())
-            .find(|(name, _)| *name == package_name)
-            .map(|(_, spec)| spec.to_string());
-
-        // The bare specifier to reconcile against the catalogs:
-        // - an explicit `@<version>` is resolved to a concrete version and
-        //   recorded with the range operator it (or the existing entry)
-        //   pins — `pnpm add foo@^7` records `^7.8.4`, not
-        //   `^7`. Specifiers that aren't a plain registry range/tag/version
-        //   for this package (protocols, `npm:` aliases) stay verbatim;
-        // - an explicit `node@runtime:<spec>` is likewise pinned to the
-        //   picked Node.js version, so the `devEngines.runtime` entry the
-        //   saved dependency folds into records e.g. `26.5.0`, not the
-        //   requested `26`;
-        // - a re-add with no version keeps the dependency's current
-        //   specifier verbatim (a `catalog:` reference, a range, or an
-        //   exact pin) — `pnpm add <existing>` without a
-        //   version leaves the declared range untouched;
-        // - a brand-new dependency fetches and pins the `latest` range.
-        let bare_specifier =
-            if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
-                let mut node_resolver = NodeResolver::new(std::sync::Arc::clone(&http_client_arc));
-                node_resolver.offline = config.offline;
-                node_resolver
-                    .resolve_save_specifier(version_spec, prev_specifier.as_deref())
-                    .await
-                    .map_err(AddError::ResolveRuntimeSpec)?
-            } else {
-                match (explicit_spec, prev_specifier.as_deref()) {
-                    (Some(spec), prev) => resolve_explicit_registry_spec(
-                        package_name,
-                        spec,
-                        prev,
-                        config,
-                        http_client,
-                        pinned_version,
-                        lockfile_only,
-                        lockfile,
-                        manifest,
-                    )
-                    .await?
-                    .unwrap_or_else(|| normalized_save_specifier(spec)),
-                    (None, Some(prev)) => prev.to_string(),
-                    (None, None) => {
-                        let registries: std::collections::HashMap<String, String> =
-                            config.resolved_registries().into_iter().collect();
-                        let registry = pick_registry_for_package(&registries, package_name, None);
-                        let latest = PackageVersion::fetch_from_registry(
-                            package_name,
-                            PackageTag::Latest,
-                            http_client,
-                            &registry,
-                            &config.auth_headers,
-                        )
-                        .await
-                        .map_err(|error| AddError::ResolveLatest {
-                            name: package_name.to_string(),
-                            error,
-                        })?;
-                        latest.serialize(pinned_version)
-                    }
-                }
-            };
-
-        let mut updated_catalogs = Catalogs::new();
-        let dep = CatalogModeDep {
-            alias: package_name,
-            bare_specifier: &bare_specifier,
-            prev_specifier: prev_specifier.as_deref(),
-        };
-        let manifest_specifier = match decide_catalog::<Reporter>(
-            config.catalog_mode,
-            save_catalog_name.as_deref(),
-            &catalogs,
-            &dep,
-            &prefix,
-        )
-        .map_err(AddError::CatalogVersionMismatch)?
-        {
-            CatalogDecision::KeepDirect => bare_specifier,
-            CatalogDecision::Catalog { manifest_specifier, updated_entry } => {
-                if let Some(entry) = updated_entry {
-                    updated_catalogs
-                        .entry(entry.catalog_name)
-                        .or_default()
-                        .insert(package_name.to_string(), entry.specifier);
-                }
-                manifest_specifier
-            }
-        };
+        let dependency_groups: Vec<DependencyGroup> =
+            list_dependency_groups().into_iter().collect();
+        let mut resolved_dependencies = Vec::with_capacity(package_names.len());
+        for package_name in package_names {
+            resolved_dependencies.push(
+                resolve_added_dependency::<Reporter>(
+                    package_name,
+                    config,
+                    manifest,
+                    lockfile,
+                    http_client,
+                    &http_client_arc,
+                    pinned_version,
+                    save_catalog_name.as_deref(),
+                    &catalogs,
+                    &prefix,
+                    lockfile_only,
+                    &dependency_groups,
+                )
+                .await?,
+            );
+        }
 
         emit_initial_package_manifest::<Reporter>(manifest);
 
-        for dependency_group in list_dependency_groups() {
-            manifest
-                .add_dependency(package_name, &manifest_specifier, dependency_group)
-                .map_err(AddError::AddDependencyToManifest)?;
+        for dependency in &resolved_dependencies {
+            for dependency_group in &dependency_groups {
+                manifest
+                    .add_dependency(
+                        &dependency.package_name,
+                        &dependency.manifest_specifier,
+                        *dependency_group,
+                    )
+                    .map_err(AddError::AddDependencyToManifest)?;
+            }
+        }
+
+        let mut updated_catalogs = Catalogs::new();
+        for dependency in resolved_dependencies {
+            for (catalog_name, entries) in dependency.updated_catalogs {
+                updated_catalogs.entry(catalog_name).or_default().extend(entries);
+            }
         }
 
         // Write the new catalog entry to `pnpm-workspace.yaml` before the
@@ -289,7 +225,7 @@ where
             emit_initial_manifest: false,
             lockfile: MaybeLazyLockfile::Loaded(lockfile),
             lockfile_path,
-            dependency_groups: list_dependency_groups(),
+            dependency_groups,
             frozen_lockfile: false,
             // `pacquet add` mutates the manifest, so the lockfile is
             // necessarily stale by the time the install dispatch
@@ -351,6 +287,137 @@ where
 
         Ok(())
     }
+}
+
+struct ResolvedAddedDependency {
+    package_name: String,
+    manifest_specifier: String,
+    updated_catalogs: Catalogs,
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "resolving an add selector requires the shared resolution inputs"
+)]
+async fn resolve_added_dependency<Reporter: self::Reporter>(
+    package_selector: &str,
+    config: &Config,
+    manifest: &PackageManifest,
+    lockfile: Option<&Lockfile>,
+    http_client: &ThrottledClient,
+    http_client_arc: &std::sync::Arc<ThrottledClient>,
+    pinned_version: PinnedVersion,
+    save_catalog_name: Option<&str>,
+    catalogs: &Catalogs,
+    prefix: &str,
+    lockfile_only: bool,
+    dependency_groups: &[DependencyGroup],
+) -> Result<ResolvedAddedDependency, AddError> {
+    let (package_name, explicit_spec) = split_name_spec(package_selector);
+
+    // The dependency's current specifier *in the group(s) this add
+    // targets*, so a re-add keeps the existing range / `catalog:`
+    // reference of the bucket being written. Scanning only the target
+    // groups (rather than every group) avoids preserving a different
+    // group's specifier when the same package exists in more than one
+    // bucket with different specs.
+    let prev_specifier = manifest
+        .dependencies(dependency_groups.iter().copied())
+        .find(|(name, _)| *name == package_name)
+        .map(|(_, spec)| spec.to_string());
+
+    // The bare specifier to reconcile against the catalogs:
+    // - an explicit `@<version>` is resolved to a concrete version and
+    //   recorded with the range operator it (or the existing entry)
+    //   pins — `pnpm add foo@^7` records `^7.8.4`, not
+    //   `^7`. Specifiers that aren't a plain registry range/tag/version
+    //   for this package (protocols, `npm:` aliases) stay verbatim;
+    // - an explicit `node@runtime:<spec>` is likewise pinned to the
+    //   picked Node.js version, so the `devEngines.runtime` entry the
+    //   saved dependency folds into records e.g. `26.5.0`, not the
+    //   requested `26`;
+    // - a re-add with no version keeps the dependency's current
+    //   specifier verbatim (a `catalog:` reference, a range, or an
+    //   exact pin) — `pnpm add <existing>` without a
+    //   version leaves the declared range untouched;
+    // - a brand-new dependency fetches and pins the `latest` range.
+    let bare_specifier =
+        if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
+            let mut node_resolver = NodeResolver::new(std::sync::Arc::clone(http_client_arc));
+            node_resolver.offline = config.offline;
+            node_resolver
+                .resolve_save_specifier(version_spec, prev_specifier.as_deref())
+                .await
+                .map_err(AddError::ResolveRuntimeSpec)?
+        } else {
+            match (explicit_spec, prev_specifier.as_deref()) {
+                (Some(spec), prev) => resolve_explicit_registry_spec(
+                    package_name,
+                    spec,
+                    prev,
+                    config,
+                    http_client,
+                    pinned_version,
+                    lockfile_only,
+                    lockfile,
+                    manifest,
+                )
+                .await?
+                .unwrap_or_else(|| normalized_save_specifier(spec)),
+                (None, Some(prev)) => prev.to_string(),
+                (None, None) => {
+                    let registries: std::collections::HashMap<String, String> =
+                        config.resolved_registries().into_iter().collect();
+                    let registry = pick_registry_for_package(&registries, package_name, None);
+                    let latest = PackageVersion::fetch_from_registry(
+                        package_name,
+                        PackageTag::Latest,
+                        http_client,
+                        &registry,
+                        &config.auth_headers,
+                    )
+                    .await
+                    .map_err(|error| AddError::ResolveLatest {
+                        name: package_name.to_string(),
+                        error,
+                    })?;
+                    latest.serialize(pinned_version)
+                }
+            }
+        };
+
+    let mut updated_catalogs = Catalogs::new();
+    let dep = CatalogModeDep {
+        alias: package_name,
+        bare_specifier: &bare_specifier,
+        prev_specifier: prev_specifier.as_deref(),
+    };
+    let manifest_specifier = match decide_catalog::<Reporter>(
+        config.catalog_mode,
+        save_catalog_name,
+        catalogs,
+        &dep,
+        prefix,
+    )
+    .map_err(AddError::CatalogVersionMismatch)?
+    {
+        CatalogDecision::KeepDirect => bare_specifier,
+        CatalogDecision::Catalog { manifest_specifier, updated_entry } => {
+            if let Some(entry) = updated_entry {
+                updated_catalogs
+                    .entry(entry.catalog_name)
+                    .or_default()
+                    .insert(package_name.to_string(), entry.specifier);
+            }
+            manifest_specifier
+        }
+    };
+
+    Ok(ResolvedAddedDependency {
+        package_name: package_name.to_string(),
+        manifest_specifier,
+        updated_catalogs,
+    })
 }
 
 /// Resolve an explicit `add <name>@<spec>` registry specifier to the

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -64,6 +64,7 @@ async fn add_routes_scoped_packages_to_configured_scoped_registry() {
 
     let http_client = ThrottledClient::default();
     let resolved_packages = ResolvedPackages::default();
+    let package_names = ["@private/foo".to_string()];
     Add {
         tarball_mem_cache: Arc::default(),
         resolved_packages: &resolved_packages,
@@ -74,7 +75,7 @@ async fn add_routes_scoped_packages_to_configured_scoped_registry() {
         lockfile: None,
         lockfile_path: None,
         list_dependency_groups: || [DependencyGroup::Prod],
-        package_name: "@private/foo",
+        package_names: &package_names,
         pinned_version: PinnedVersion::Patch,
         save_catalog_name: None,
         supported_architectures: None,

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -131,22 +131,12 @@ pub fn update_workspace_manifest(
     write_or_remove_manifest(&path, manifest)
 }
 
-/// Write a `name → specifier` entry into `dir`'s `pnpm-workspace.yaml`
+/// Write `name → specifier` entries into `dir`'s `pnpm-workspace.yaml`
 /// `configDependencies:` block (creating the file/block if absent),
-/// preserving the rest of the document's formatting. Used by
-/// `pnpm add --config`; the resolved integrity is recorded separately in
-/// the env lockfile, so only the clean specifier is written here.
-pub fn set_config_dependency(
-    dir: &Path,
-    name: &str,
-    specifier: &str,
-) -> Result<(), UpdateWorkspaceManifestError> {
-    set_config_dependencies(dir, [(name, specifier)])
-}
-
-/// Write `name → specifier` entries into `dir`'s
-/// `pnpm-workspace.yaml` `configDependencies:` block, reading, parsing,
-/// and writing the manifest at most once.
+/// preserving the rest of the document's formatting and reading, parsing,
+/// and writing the file at most once. Used by `pnpm add --config`; the
+/// resolved integrity is recorded separately in the env lockfile, so only
+/// the clean specifier is written here.
 pub fn set_config_dependencies<'a>(
     dir: &Path,
     entries: impl IntoIterator<Item = (&'a str, &'a str)>,

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -141,6 +141,16 @@ pub fn set_config_dependency(
     name: &str,
     specifier: &str,
 ) -> Result<(), UpdateWorkspaceManifestError> {
+    set_config_dependencies(dir, [(name, specifier)])
+}
+
+/// Write `name → specifier` entries into `dir`'s
+/// `pnpm-workspace.yaml` `configDependencies:` block, reading, parsing,
+/// and writing the manifest at most once.
+pub fn set_config_dependencies<'a>(
+    dir: &Path,
+    entries: impl IntoIterator<Item = (&'a str, &'a str)>,
+) -> Result<(), UpdateWorkspaceManifestError> {
     let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
 
     let original = match fs::read_to_string(&path) {
@@ -152,8 +162,11 @@ pub fn set_config_dependency(
     let mut manifest = Manifest::parse(original.as_deref())
         .map_err(|source| UpdateWorkspaceManifestError::Parse { path: path.clone(), source })?;
 
-    let changed = edit::add_config_dependency(&mut manifest, name, specifier)
-        .map_err(|source| UpdateWorkspaceManifestError::Edit { path: path.clone(), source })?;
+    let mut changed = false;
+    for (name, specifier) in entries {
+        changed |= edit::add_config_dependency(&mut manifest, name, specifier)
+            .map_err(|source| UpdateWorkspaceManifestError::Edit { path: path.clone(), source })?;
+    }
     if !changed {
         return Ok(());
     }

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -221,6 +221,30 @@ fn config_dependency_added_to_existing_block() {
 }
 
 #[test]
+fn config_dependencies_batch_updates_all_entries_in_one_manifest() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+    fs::write(&path, "# preserved comment\nconfigDependencies:\n  existing-package: 0.1.0\n")
+        .expect("seed manifest");
+
+    crate::set_config_dependencies(
+        dir.path(),
+        [("@pnpm.e2e/foo", "1.0.0"), ("@pnpm.e2e/bar", "2.0.0")],
+    )
+    .expect("batch update succeeds");
+
+    let out = fs::read_to_string(path).expect("read updated manifest");
+    for expected in [
+        "# preserved comment",
+        "existing-package: 0.1.0",
+        "'@pnpm.e2e/foo': 1.0.0",
+        "'@pnpm.e2e/bar': 2.0.0",
+    ] {
+        assert!(out.contains(expected), "manifest contains {expected:?}");
+    }
+}
+
+#[test]
 fn config_dependency_upserts_existing_entry() {
     let original = "configDependencies:\n  '@pnpm.e2e/foo': 1.0.0\n";
     let out = run_config_dep(Some(original), "@pnpm.e2e/foo", "2.0.0");

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -195,15 +195,15 @@ fn preserves_comment_when_inserting_before_commented_entry() {
     );
 }
 
-/// Run `set_config_dependency` against `original` (when `Some`) and return
-/// the resulting file contents.
+/// Run `set_config_dependencies` with a single entry against `original`
+/// (when `Some`) and return the resulting file contents.
 fn run_config_dep(original: Option<&str>, name: &str, specifier: &str) -> String {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
     if let Some(text) = original {
         fs::write(&path, text).expect("seed manifest");
     }
-    crate::set_config_dependency(dir.path(), name, specifier).expect("update succeeds");
+    crate::set_config_dependencies(dir.path(), [(name, specifier)]).expect("update succeeds");
     fs::read_to_string(&path).expect("file written")
 }
 
@@ -234,14 +234,10 @@ fn config_dependencies_batch_updates_all_entries_in_one_manifest() {
     .expect("batch update succeeds");
 
     let out = fs::read_to_string(path).expect("read updated manifest");
-    for expected in [
-        "# preserved comment",
-        "existing-package: 0.1.0",
-        "'@pnpm.e2e/foo': 1.0.0",
-        "'@pnpm.e2e/bar': 2.0.0",
-    ] {
-        assert!(out.contains(expected), "manifest contains {expected:?}");
-    }
+    assert_eq!(
+        out,
+        "# preserved comment\nconfigDependencies:\n  '@pnpm.e2e/bar': 2.0.0\n  '@pnpm.e2e/foo': 1.0.0\n  existing-package: 0.1.0\n",
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Pacquet's `add` command now accepts every package selector supplied in one invocation for regular, global, and configuration-dependency installs.

The command validates the complete selector list before initializing installation state, batches manifest updates, and performs one install/save operation. The workspace manifest writer now also supports applying multiple configuration-dependency updates atomically.

The TypeScript CLI already supports multiple package selectors, so this change brings the Rust CLI to parity. No TypeScript changes are required.

## Squash Commit Body

```text
Pacquet collected trailing add arguments but only forwarded the first package selector. Carry the full selector list through regular, global, and configuration-dependency dispatch paths.

Parse and validate all configuration-dependency selectors before initializing installation state so an invalid later selector cannot leave partial filesystem changes. Batch dependency and workspace-manifest updates and persist each result once per command.

Add integration and unit coverage for multi-selector regular adds, configuration-dependency adds, validation atomicity, and batched workspace-manifest writes.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786607793&installation_id=145934176&pr_number=12995&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12995&signature=e38e545e53aefa736dc7062340cc7ecf885a169f528e66bd727659d3f9722396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pacquet add` now accepts multiple package selectors in a single command and installs them together.
  * Global installs (`-g`) support batched additions for all selected packages.
  * `pacquet add --config` can record multiple config dependencies in one run, updating the workspace manifest and related lockfile artifacts.
* **Bug Fixes**
  * Invalid package selectors now fail safely without creating partial files, lockfiles, workspace manifests, or node_modules installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
