### PR TITLE
fix(exe): correct package source links

### DIFF
--- a/.changeset/exe-repository-links.md
+++ b/.changeset/exe-repository-links.md
@@ -1,6 +1,5 @@
 ---
 "@pnpm/exe": patch
-"pnpm": patch
 ---
 
 Correct the `@pnpm/exe` repository and homepage metadata so npm links to its current source directory.

--- a/.changeset/exe-repository-links.md
+++ b/.changeset/exe-repository-links.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exe": patch
+"pnpm": patch
+---
+
+Correct the `@pnpm/exe` repository and homepage metadata so npm links to its current source directory.

--- a/pnpm11/pnpm/artifacts/exe/package.json
+++ b/pnpm11/pnpm/artifacts/exe/package.json
@@ -9,8 +9,8 @@
   ],
   "license": "MIT",
   "funding": "https://opencollective.com/pnpm",
-  "repository": "https://github.com/pnpm/pnpm/tree/main/pnpm/artifacts/exe",
-  "homepage": "https://github.com/pnpm/pnpm/tree/main/pnpm/artifacts/exe#readme",
+  "repository": "https://github.com/pnpm/pnpm/tree/main/pnpm11/pnpm/artifacts/exe",
+  "homepage": "https://github.com/pnpm/pnpm/tree/main/pnpm11/pnpm/artifacts/exe#readme",
   "bugs": {
     "url": "https://github.com/pnpm/pnpm/issues"
   },


### PR DESCRIPTION
## Summary

The `repository` and `homepage` fields published by `@pnpm/exe` still pointed
to the removed `pnpm/artifacts/exe` path, so both npm package links returned a
404. Point them at the current `pnpm11/pnpm/artifacts/exe` directory.

Closes pnpm/pnpm#12843.

Validation:

- `pnpm exec meta-updater --test`
- `pnpm --filter @pnpm/exe test` (7 passed, 4 platform-specific skips)
- `pnpm change status`
- Pre-push TypeScript build, lint, meta-updater, and cspell checks

The pre-push Rust and TOML checks were not run locally because this change only
touches JSON package metadata and a Markdown changeset, and the pinned Rust
1.95 auxiliary toolchain is not installed in this environment.

## Squash Commit Body

```text
The `@pnpm/exe` package metadata still pointed to the pre-reorganization
pnpm/artifacts/exe directory, so its repository and homepage links returned
404.

Point both fields at pnpm11/pnpm/artifacts/exe.

Closes pnpm/pnpm#12843.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. No Rust
  counterpart is needed because this only corrects TypeScript package metadata.
- [x] Added a patch changeset for `@pnpm/exe`, the only package affected by this metadata correction.

---
Written by an agent (OpenAI Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786611248&installation_id=145934176&pr_number=12996&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12996&signature=f034826c874b8b49d6f9e5ee940cacc376941261b02cdf437b137a0b5a96c67a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected package repository and homepage links so they point to the current source location.
* **Chores**
  * Prepared patch releases for the affected packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
