### PR TITLE
fix(deps-resolver): drop reuse-only peer suffixes after propagation (alternative to #12830)

### DIFF
--- a/.changeset/peer-lockfile-drift-cleanup.md
+++ b/.changeset/peer-lockfile-drift-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+`pnpm install` no longer leaves peer dependency suffixes on unrelated packages when regenerating the lockfile after a manifest edit. The locked-peer-context reuse pass still resolves peers as before, but a following cleanup drops, per package, the peer suffixes a fresh resolution (and `pnpm dedupe`) would not have produced, so the deduplicated instances collapse during a plain `pnpm install`. This fixes lockfile drift where an unrelated `pnpm install` would add peer suffixes that `pnpm dedupe` would immediately remove.

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -301,6 +301,7 @@ export async function resolveDependencies (
     ? await resolvePeers({
       ...peerResolutionOpts,
       resolvedPeerProviderPaths: initiallyResolvedPeers.pathsByNodeId,
+      previousResolvedPeerNamesByNodeId: getResolvedPeerNamesByNodeId(initiallyResolvedPeers),
     })
     : initiallyResolvedPeers
 
@@ -618,4 +619,20 @@ function extendGraph (
     })
   }
   return graph
+}
+
+function getResolvedPeerNamesByNodeId (
+  resolved: {
+    dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<ResolvedPackage>
+    pathsByNodeId: Map<NodeId, DepPath>
+  }
+): Map<NodeId, Set<string>> {
+  const resolvedPeerNamesByNodeId = new Map<NodeId, Set<string>>()
+  for (const [nodeId, depPath] of resolved.pathsByNodeId.entries()) {
+    const node = resolved.dependenciesGraph[depPath]
+    if (node != null && node.resolvedPeerNames.size > 0) {
+      resolvedPeerNamesByNodeId.set(nodeId, node.resolvedPeerNames)
+    }
+  }
+  return resolvedPeerNamesByNodeId
 }

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -42,6 +42,10 @@ export interface BaseGenericDependenciesGraphNode {
   isBuilt?: boolean
   isPure: boolean
   resolvedPeerNames: Set<string>
+  // The node id of every resolved peer, keyed by peer name. Kept so the
+  // dedupePeerDependents cleanup can recompute this instance's depPath after
+  // dropping a peer that was only bound by the locked-context reuse pass.
+  resolvedPeerNodeIds?: Map<string, NodeId>
   requiresBuild?: boolean
 }
 
@@ -100,6 +104,11 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     peersSuffixMaxLength: number
     workspaceProjectIds: Set<string>
     resolvedPeerProviderPaths?: Map<NodeId, DepPath>
+    // The resolved peer names each node had in the first (fresh) peer-resolution
+    // pass, keyed by node id. Present only for the locked-context reuse pass, it
+    // lets the reuse pass drop a peer it bound laterally that a fresh resolution
+    // (and `pnpm dedupe`) would have left unresolved — see dropSpuriousReusePeers.
+    previousResolvedPeerNamesByNodeId?: Map<NodeId, Set<string>>
   }
 ): Promise<{
   dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<T>
@@ -278,11 +287,259 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       }
     }
   }
+  // Runs after dedupePeerDependents so that compatible instances the reuse pass
+  // duplicated (e.g. the same package resolved with and without a bubbled-up
+  // transitive peer) have already been merged. Only then does each reachable
+  // instance carry a consistent set of children, so dropping a peer the fresh
+  // pass never resolved collapses it onto its deduplicated form without leaving
+  // a conflicting sibling behind.
+  if (opts.previousResolvedPeerNamesByNodeId != null) {
+    dropSpuriousReusePeers({
+      depGraph: depGraphWithResolvedChildren,
+      pathsByNodeId,
+      depPathsByPkgId,
+      dependenciesByProjectId,
+      previousResolvedPeerNamesByNodeId: opts.previousResolvedPeerNamesByNodeId,
+      dependenciesTree: opts.dependenciesTree,
+      dedupePeers: opts.dedupePeers,
+      peersSuffixMaxLength: opts.peersSuffixMaxLength,
+    })
+  }
   return {
     dependenciesGraph: depGraphWithResolvedChildren,
     dependenciesByProjectId,
     peerDependencyIssuesByProjects,
     pathsByNodeId,
+  }
+}
+
+// The locked-context reuse pass keeps a peer bound to the provider recorded in
+// the lockfile so a writable install does not rewrite still-valid dependency
+// instances. It finds that provider through a global lookup, so it can bind a
+// transitive (non-own) peer laterally to a provider in an unrelated subtree —
+// one the first (fresh) pass, and therefore `pnpm dedupe`, left unresolved.
+// That extra binding adds a peer suffix to the consumer that a fresh resolution
+// never produces, which is the lockfile drift in
+// https://github.com/pnpm/pnpm/issues/12756.
+//
+// Rather than stop the reuse pass from propagating the peer (which would forgo
+// the deduplication that resolving a shared provider can enable), this cleanup
+// runs after propagation and drops, per node, only the non-own peers the fresh
+// pass did not resolve for it. Own peers and genuinely reused contexts (a peer
+// the fresh pass also resolved, even to a different provider) are kept, so the
+// context-preservation the reuse pass exists for is untouched. Recomputing the
+// affected depPaths lets the now-canonical instances collapse onto their
+// deduplicated peers — the same result `pnpm dedupe` reaches — during a plain
+// `pnpm install`.
+function dropSpuriousReusePeers<T extends PartialResolvedPackage> (
+  opts: {
+    depGraph: GenericDependenciesGraphWithResolvedChildren<T>
+    pathsByNodeId: Map<NodeId, DepPath>
+    depPathsByPkgId: Map<PkgIdWithPatchHash, Set<DepPath>>
+    dependenciesByProjectId: DependenciesByProjectId
+    previousResolvedPeerNamesByNodeId: Map<NodeId, Set<string>>
+    dependenciesTree: DependenciesTree<T>
+    dedupePeers?: boolean
+    peersSuffixMaxLength: number
+  }
+): void {
+  const { depGraph } = opts
+
+  // Only nodes reachable from an importer end up in the lockfile. The reuse pass
+  // can leave behind unreferenced intermediate instances (e.g. a superseded peer
+  // context); ignoring them keeps the cleanup from seeing a phantom collision
+  // with a node that will be pruned anyway.
+  const reachable = new Set<DepPath>()
+  const reachableStack: DepPath[] = []
+  for (const deps of Object.values(opts.dependenciesByProjectId)) {
+    for (const depPath of deps.values()) {
+      if (!reachable.has(depPath)) {
+        reachable.add(depPath)
+        reachableStack.push(depPath)
+      }
+    }
+  }
+  while (reachableStack.length > 0) {
+    const depPath = reachableStack.pop()!
+    const node = depGraph[depPath]
+    if (node == null) continue
+    for (const childDepPath of Object.values<DepPath>(node.children)) {
+      if (!reachable.has(childDepPath)) {
+        reachable.add(childDepPath)
+        reachableStack.push(childDepPath)
+      }
+    }
+  }
+
+  // Every tree node that resolves to each depPath. A peer is only spurious for a
+  // depPath when the fresh pass left it unresolved for *every* position the
+  // depPath represents — otherwise the depPath stands for a context where the
+  // peer is genuine and must be kept.
+  const nodeIdsByDepPath = new Map<DepPath, NodeId[]>()
+  for (const [nodeId, depPath] of opts.pathsByNodeId.entries()) {
+    let nodeIds = nodeIdsByDepPath.get(depPath)
+    if (nodeIds == null) {
+      nodeIds = []
+      nodeIdsByDepPath.set(depPath, nodeIds)
+    }
+    nodeIds.push(nodeId)
+  }
+
+  const spuriousPeersByDepPath = new Map<DepPath, Set<string>>()
+  for (const [depPath, node] of Object.entries(depGraph)) {
+    if (!reachable.has(depPath as DepPath)) continue
+    if (node.resolvedPeerNames.size === 0) continue
+    // Recomputing a depPath needs every resolved peer's node id. If any is
+    // missing the suffix cannot be rebuilt faithfully, so leave the node as-is.
+    if (node.resolvedPeerNodeIds == null || node.resolvedPeerNodeIds.size !== node.resolvedPeerNames.size) continue
+    const ownPeerNames = node.peerDependencies == null ? new Set<string>() : new Set(Object.keys(node.peerDependencies))
+    const nodeIds = nodeIdsByDepPath.get(depPath as DepPath) ?? []
+    let spurious: Set<string> | undefined
+    for (const peerName of node.resolvedPeerNames) {
+      if (ownPeerNames.has(peerName)) continue
+      const genuine = nodeIds.some((nodeId) => opts.previousResolvedPeerNamesByNodeId.get(nodeId)?.has(peerName))
+      if (genuine) continue
+      spurious ??= new Set<string>()
+      spurious.add(peerName)
+    }
+    if (spurious != null) spuriousPeersByDepPath.set(depPath as DepPath, spurious)
+  }
+
+  if (spuriousPeersByDepPath.size === 0) return
+
+  // Recompute each node's depPath with its spurious peers removed. A depPath is
+  // a function of the kept peers' identifiers, and a non-deduped peer's
+  // identifier is the provider's own (possibly recomputed) depPath, so this
+  // memoized recursion mirrors how depPaths were first built while resolving
+  // provider remaps. A depPath already in progress is on a peer cycle; return
+  // it unchanged, matching how the first pass breaks such cycles.
+  const finalDepPathCache = new Map<DepPath, DepPath>()
+  const inProgress = new Set<DepPath>()
+  const finalDepPath = (depPath: DepPath): DepPath => {
+    const cached = finalDepPathCache.get(depPath)
+    if (cached != null) return cached
+    const node = depGraph[depPath]
+    if (node == null || inProgress.has(depPath)) return depPath
+    // A node whose resolved peers cannot be fully recomputed (see above) keeps
+    // its depPath; recomputing from a partial set would drop real peers.
+    if (node.resolvedPeerNames.size > 0 && (node.resolvedPeerNodeIds == null || node.resolvedPeerNodeIds.size !== node.resolvedPeerNames.size)) {
+      return depPath
+    }
+    inProgress.add(depPath)
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const peerIds: PeerId[] = []
+    if (node.resolvedPeerNodeIds != null) {
+      for (const [peerName, peerNodeId] of node.resolvedPeerNodeIds.entries()) {
+        if (spurious?.has(peerName)) continue
+        if (typeof peerNodeId === 'string' && peerNodeId.startsWith('link:')) {
+          peerIds.push({ name: peerName, version: linkPathToPeerVersion(peerNodeId.slice(5)) })
+        } else if (opts.dedupePeers) {
+          const peerNode = opts.dependenciesTree.get(peerNodeId)
+          if (peerNode != null) {
+            peerIds.push({ name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version })
+          }
+        } else {
+          const providerDepPath = node.children[peerName]
+          peerIds.push(providerDepPath != null ? finalDepPath(providerDepPath) : (peerNodeId as unknown as DepPath))
+        }
+      }
+    }
+    const suffix = peerIds.length === 0 ? '' : createPeerDepGraphHash(peerIds, opts.peersSuffixMaxLength)
+    const newDepPath = `${node.pkgIdWithPatchHash}${suffix}` as DepPath
+    inProgress.delete(depPath)
+    finalDepPathCache.set(depPath, newDepPath)
+    return newDepPath
+  }
+
+  const remap = new Map<DepPath, DepPath>()
+  for (const depPath of Object.keys(depGraph) as DepPath[]) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = finalDepPath(depPath)
+    if (newDepPath !== depPath) remap.set(depPath, newDepPath)
+  }
+
+  if (remap.size === 0) return
+
+  const remapped = (depPath: DepPath): DepPath => remap.get(depPath) ?? depPath
+
+  // Safety net: a strip is only valid when the reachable nodes that collapse
+  // onto a recomputed depPath are identical afterwards. If two would collide on
+  // the same depPath with different children, a dropped peer was actually
+  // load-bearing, so skip the cleanup entirely and keep the reuse pass output
+  // rather than risk losing a distinct instance. In practice this never fires;
+  // a fresh resolution distinguishes such nodes through a peer that is then kept.
+  const childrenSignatureByDepPath = new Map<DepPath, string>()
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = remapped(depPath)
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const signature = Object.entries<DepPath>(node.children)
+      .filter(([alias]) => !spurious?.has(alias))
+      .map(([alias, childDepPath]) => `${alias}=${remapped(childDepPath)}`)
+      .sort()
+      .join('\n')
+    const existing = childrenSignatureByDepPath.get(newDepPath)
+    if (existing == null) {
+      childrenSignatureByDepPath.set(newDepPath, signature)
+    } else if (existing !== signature) {
+      return
+    }
+  }
+
+  // Rebuild the graph under the recomputed depPaths. Reachable nodes are written
+  // last so a remapped reachable instance wins over any unreferenced node that
+  // happens to occupy its recomputed depPath. Nodes that collapse onto the same
+  // depPath are identical after dropping their spurious peers; a dropped peer's
+  // child entry is removed (it is already in transitivePeerDependencies) and
+  // every surviving child is remapped.
+  const newDepGraph: GenericDependenciesGraphWithResolvedChildren<T> = {}
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (reachable.has(depPath)) continue
+    newDepGraph[depPath] = node
+  }
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = remapped(depPath)
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const children: Record<string, DepPath> = {}
+    for (const [alias, childDepPath] of Object.entries<DepPath>(node.children)) {
+      if (spurious?.has(alias)) continue
+      children[alias] = remapped(childDepPath)
+    }
+    let resolvedPeerNames = node.resolvedPeerNames
+    let resolvedPeerNodeIds = node.resolvedPeerNodeIds
+    if (spurious != null) {
+      resolvedPeerNames = new Set([...node.resolvedPeerNames].filter((peerName) => !spurious.has(peerName)))
+      if (resolvedPeerNodeIds != null) {
+        resolvedPeerNodeIds = new Map([...resolvedPeerNodeIds].filter(([peerName]) => !spurious.has(peerName)))
+      }
+    }
+    newDepGraph[newDepPath] = {
+      ...node,
+      depPath: newDepPath,
+      children,
+      resolvedPeerNames,
+      resolvedPeerNodeIds,
+    }
+  }
+
+  for (const depPath of Object.keys(depGraph) as DepPath[]) {
+    delete depGraph[depPath]
+  }
+  Object.assign(depGraph, newDepGraph)
+
+  for (const [nodeId, depPath] of opts.pathsByNodeId.entries()) {
+    opts.pathsByNodeId.set(nodeId, remapped(depPath))
+  }
+
+  for (const [pkgId, depPaths] of opts.depPathsByPkgId.entries()) {
+    opts.depPathsByPkgId.set(pkgId, new Set([...depPaths].map(remapped)))
+  }
+
+  for (const deps of Object.values(opts.dependenciesByProjectId)) {
+    for (const [alias, depPath] of deps.entries()) {
+      deps.set(alias, remapped(depPath))
+    }
   }
 }
 
@@ -850,6 +1107,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
         peerDependencies,
         transitivePeerDependencies,
         resolvedPeerNames: new Set(allResolvedPeers.keys()),
+        resolvedPeerNodeIds: new Map(allResolvedPeers),
       }
     }
   }

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -887,6 +887,19 @@ describe('locked peer provider preferences', () => {
     }
   }
 
+  function resolvedPeerNamesByNodeId (
+    result: Awaited<ReturnType<typeof resolvePeers>>
+  ): Map<NodeId, Set<string>> {
+    const byNodeId = new Map<NodeId, Set<string>>()
+    for (const [nodeId, depPath] of result.pathsByNodeId.entries()) {
+      const node = result.dependenciesGraph[depPath]
+      if (node != null && node.resolvedPeerNames.size > 0) {
+        byNodeId.set(nodeId, node.resolvedPeerNames)
+      }
+    }
+    return byNodeId
+  }
+
   test('prefers a compatible locked provider that remains reachable in the current graph', async () => {
     const resolutionOpts = options(createTree(), new Map([
       ['peer', currentPeerNodeId],
@@ -1111,6 +1124,111 @@ describe('locked peer provider preferences', () => {
 
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('drops a spuriously reused optional peer that the fresh pass left unresolved', async () => {
+    // Regression test for https://github.com/pnpm/pnpm/issues/12756. `dep` has an
+    // OPTIONAL peer whose only provider (peer@2.0.0) lives in an unrelated sibling
+    // subtree (under retainer), so a fresh resolution leaves it unbound. The
+    // locked-context reuse pass still binds it under `consumer`'s `dep` — that
+    // propagation is intentionally preserved so a shared provider can deduplicate
+    // — which bubbles `peer` up onto `consumer` (it is not `consumer`'s own peer).
+    // The dropSpuriousReusePeers cleanup then removes that bubbled-up suffix from
+    // `consumer` because the fresh pass did not resolve `peer` for it, keeping a
+    // writable install aligned with `pnpm dedupe`.
+    const depNodeId = '>wrapper/1.0.0>consumer/1.0.0>dep/1.0.0>' as NodeId
+    const depPkg = {
+      name: 'dep',
+      pkgIdWithPatchHash: 'dep/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {
+        peer: { version: '>=1', optional: true },
+      },
+      id: '' as PkgResolutionId,
+    }
+    const plainConsumerPkg = {
+      ...consumerPkg,
+      peerDependencies: {} as PeerDependencies,
+    }
+    const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [retainerNodeId, {
+        children: { peer: retainedPeerNodeId },
+        installable: true,
+        resolvedPackage: retainerPkg,
+        depth: 0,
+      }],
+      [retainedPeerNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer/2.0.0' as DepPath,
+        resolvedPackage: peer2Pkg,
+        depth: 1,
+      }],
+      [wrapperNodeId, {
+        children: { consumer: consumerNodeId },
+        installable: true,
+        resolvedPackage: wrapperPkg,
+        depth: 0,
+      }],
+      [consumerNodeId, {
+        children: { dep: depNodeId },
+        installable: true,
+        resolvedPackage: plainConsumerPkg,
+        depth: 1,
+      }],
+      [depNodeId, {
+        children: {},
+        installable: true,
+        lockedPeerContext: { peer: 'peer/2.0.0' as DepPath },
+        resolvedPackage: depPkg,
+        depth: 2,
+      }],
+    ])
+    const resolutionOpts = options(dependenciesTree, new Map([
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+
+    // Without the fresh-pass oracle the reuse pass still propagates the peer,
+    // bubbling the suffixed instance up onto consumer, which the cleanup removes.
+    const propagated = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+    expect(propagated.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
+
+    const cleaned = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+      previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+      dedupePeerDependents: true,
+    })
+    expect(cleaned.dependenciesGraph['consumer/1.0.0' as DepPath]).toBeTruthy()
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('keeps a genuine reused peer context that the fresh pass also resolved', async () => {
+    // The consumer's peer is REQUIRED and a provider (peer@1.0.0) is in scope, so
+    // the fresh pass resolves the peer and the reuse pass re-binds it to the
+    // locked peer@2.0.0. Because the fresh pass also resolved `peer`, the cleanup
+    // treats the context as genuine and keeps it — the context preservation the
+    // reuse pass exists for is not undone.
+    const resolutionOpts = options(createTree(), new Map([
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+    const cleaned = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+      previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+      dedupePeerDependents: true,
+    })
+
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
**Closed in favor of #13109**

## Summary

Alternative fix for **Fixes pnpm/pnpm#12756** — a writable `pnpm install` after a manifest edit re-propagates an **optional** transitive peer onto unrelated packages, producing lockfile churn that a follow-up `pnpm dedupe` immediately undoes (in a large monorepo, a single edit rewrote hundreds of lines; 134 unrelated packages gained a `(supports-color@5.5.0)` suffix).

This PR is an **alternative to pnpm/pnpm#12830**, opened to address a review concern on that approach. Only one of the two should land.

### The original approach and the concern it raised

pnpm/pnpm#12830 guards the locked-peer-context reuse pass (added in pnpm/pnpm#12083) so it does **not** resolve an optional peer whose provider is not visible in the resolving package's scope:

```ts
if (peerDependency.optional === true && parentPkgs[peerName] == null) continue
```

On review, @zkochan requested changes with this concern:

> I agree that the dependency graph should not be mutated in this case but I am not sure this solution is good. Resolving the optional peer dependency in this case would increase the chance of deduplication.

In other words: refusing to *resolve* the peer in the reuse pass short-circuits the deduplication that resolving a shared provider can enable (`dedupePeerDependents` runs during a normal `pnpm install`, not only under `pnpm dedupe`).

### This approach: propagate, then clean up

Instead of stopping the reuse pass from resolving the peer, this PR lets it **propagate exactly as before**, then reconciles the result:

1. After `dedupePeerDependents` has merged the compatible instances the reuse pass duplicated, a cleanup (`dropSpuriousReusePeers`) drops **per reachable node** only the **non-own** peers that the first (fresh) peer-resolution pass — and therefore `pnpm dedupe` — never resolved for it.
2. It recomputes the affected depPaths so the now-canonical instances collapse onto their deduplicated peers **during a plain `pnpm install`**.

Own peers and genuinely reused contexts (a peer the fresh pass also resolved, even to a different provider) are kept, so the context preservation of pnpm/pnpm#12083 is untouched. Because the peer is still resolved and shared instances are still merged, **deduplication is not short-circuited** — the exact concern above.

Key design points that make it robust on a real monorepo:

- **Runs after `dedupePeerDependents`.** The reuse pass can resolve a transitive peer inconsistently, yielding e.g. both `debug@4.4.3` and `debug@4.4.3(supports-color@5.5.0)` under different parents. Running the cleanup after the dedup pass means each reachable package already has one consistent set of children, so dropping a spurious parent suffix collapses cleanly instead of colliding with a not-yet-merged sibling.
- **Restricted to nodes reachable from importers.** The reuse pass leaves unreferenced intermediate instances behind; ignoring them (they are pruned anyway) avoids a phantom collision that would otherwise abort the cleanup.
- **Exact depPath recomputation.** Each node records its resolved peers' node ids so the suffix is rebuilt faithfully, including the version-only form used when `dedupePeers` is enabled.
- **Collision safety net.** If two reachable nodes would still collapse onto one depPath with different children, the cleanup is skipped entirely rather than risk losing a distinct instance.

## Squash Commit Body

```text
Alternative fix for the lockfile drift in pnpm/pnpm#12756, where a writable
`pnpm install` after a manifest edit re-propagates an optional transitive peer
onto unrelated packages — churn that a follow-up `pnpm dedupe` immediately undoes.

The first attempt (pnpm/pnpm#12830) guarded the locked-peer-context reuse pass so
it would not resolve an optional peer with no visible provider. Reviewers noted
that refusing to resolve the peer forgoes the deduplication that resolving a
shared provider can enable.

This instead lets the reuse pass propagate as before and, after
dedupePeerDependents has merged the compatible instances, drops from each
reachable node only the non-own peers the fresh pass never resolved — recomputing
the affected depPaths so the now-canonical instances collapse onto their
deduplicated peers during a plain `pnpm install`. Own peers and genuinely reused
contexts are kept, so the context preservation of pnpm/pnpm#12083 is untouched
and deduplication is not short-circuited.
```

## Validation

- Minimal repro (astegmaier/playground-pnpm-lockfile-drift-bug): `pnpm install` now produces a lockfile **byte-identical to `pnpm dedupe`**.
- Large private monorepo: a manifest edit that drove `install` to 205 `(supports-color@5.5.0)` positions now yields 66 — the same as `pnpm dedupe` — and `pnpm dedupe` followed by `pnpm install` is **byte-identical** (zero drift).
- New unit tests in `resolvePeers.ts`: one asserts the reuse pass still *propagates* the peer and the cleanup then *removes* the spurious suffix; another asserts a genuine reused context (a peer the fresh pass also resolved) is kept.
- The full `@pnpm/installing.deps-resolver` unit suite and the peer-dependency / `dedupePeers` / `preferLockedPeerContexts` (pnpm/pnpm#12083) e2e suites pass.

## Checklist

- [ ] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port. **Only the TypeScript side is done here.** pnpm/pnpm#12083 notes pacquet mirrors the reuse pass, so the equivalent cleanup still needs porting to pacquet before this lands.
- [x] Added a changeset.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (No user-facing docs change; behavior now matches `pnpm dedupe`.)

---
Written by an agent (GitHub Copilot CLI, claude-opus-4.8).
