### PR TITLE
feat(cli): add clean/purge commands

### DIFF
--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -9,6 +9,7 @@ pub mod cat_file;
 pub mod cat_index;
 pub mod change;
 pub mod changelog;
+pub mod clean;
 pub mod completion;
 pub mod config;
 pub mod create;

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -114,21 +114,17 @@ fn clean_builtin(ctx: &RunCtx<'_>, config: &Config, remove_lockfile: bool) -> mi
             print_removing(&full_modules_dir);
             remove_modules_dir_contents(&full_modules_dir)?;
         }
-        if remove_lockfile {
-            let lockfile_path = dir.join("pnpm-lock.yaml");
-            if lockfile_path.exists() {
-                print_removing(&lockfile_path);
-                std::fs::remove_file(&lockfile_path)
-                    .or_else(|error| {
-                        if error.kind() == std::io::ErrorKind::NotFound {
-                            Ok(())
-                        } else {
-                            Err(error)
-                        }
-                    })
-                    .into_diagnostic()
-                    .wrap_err_with(|| format!("removing {}", lockfile_path.display()))?;
-            }
+    }
+    if remove_lockfile {
+        let lockfile_path = root_dir.join("pnpm-lock.yaml");
+        if lockfile_path.exists() {
+            print_removing(&lockfile_path);
+            std::fs::remove_file(&lockfile_path)
+                .or_else(|error| {
+                    if error.kind() == std::io::ErrorKind::NotFound { Ok(()) } else { Err(error) }
+                })
+                .into_diagnostic()
+                .wrap_err_with(|| format!("removing {}", lockfile_path.display()))?;
         }
     }
     // A virtual store dir configured outside `node_modules` (e.g. a
@@ -165,8 +161,7 @@ fn remove_modules_dir_contents(modules_dir: &Path) -> miette::Result<()> {
         return Ok(());
     };
     for entry in entries.filter_map(Result::ok) {
-        let name = entry.file_name().to_string_lossy().into_owned();
-        if name.starts_with('.') && !PNPM_HIDDEN_ENTRIES.contains(&name.as_str()) {
+        if !is_pnpm_entry(&entry.file_name().to_string_lossy()) {
             continue;
         }
         remove_path(&entry.path())?;
@@ -175,7 +170,9 @@ fn remove_modules_dir_contents(modules_dir: &Path) -> miette::Result<()> {
 }
 
 fn remove_path(path: &Path) -> miette::Result<()> {
-    std::fs::remove_dir_all(path)
+    let result =
+        if path.is_dir() { std::fs::remove_dir_all(path) } else { std::fs::remove_file(path) };
+    result
         .or_else(
             |error| {
                 if error.kind() == std::io::ErrorKind::NotFound { Ok(()) } else { Err(error) }
@@ -194,8 +191,34 @@ fn is_pnpm_entry(name: &str) -> bool {
 /// empty relative path renders as `.`.
 fn print_removing(path: &Path) {
     let cwd = std::env::current_dir().unwrap_or_default();
-    let relative = path.strip_prefix(&cwd).unwrap_or(path);
+    let relative = strip_prefix_case_insensitive(path, &cwd).unwrap_or_else(|| path.to_path_buf());
     let owned: PathBuf =
-        if relative.as_os_str().is_empty() { PathBuf::from(".") } else { relative.to_path_buf() };
+        if relative.as_os_str().is_empty() { PathBuf::from(".") } else { relative };
     println!("Removing {}", owned.display());
+}
+
+/// Like [`Path::strip_prefix`], but falls back to a case-insensitive
+/// comparison on Windows where `current_dir()` may differ in casing.
+fn strip_prefix_case_insensitive(path: &Path, base: &Path) -> Option<PathBuf> {
+    path.strip_prefix(base)
+        .ok()
+        .map(Path::to_path_buf)
+        .or_else(|| case_insensitive_strip_prefix(path, base))
+}
+
+/// On Windows, `current_dir()` may return different casing than the
+/// canonical path. This fallback strips the base using a case-insensitive
+/// comparison.
+#[cfg(windows)]
+fn case_insensitive_strip_prefix(path: &Path, base: &Path) -> Option<PathBuf> {
+    let path_s = path.to_string_lossy().to_lowercase();
+    let base_s = base.to_string_lossy().to_lowercase();
+    let rest = path_s.strip_prefix(&base_s)?;
+    let byte_offset = path.to_string_lossy().len() - rest.len();
+    Some(PathBuf::from(&path.to_string_lossy()[byte_offset..]))
+}
+
+#[cfg(not(windows))]
+fn case_insensitive_strip_prefix(_path: &Path, _base: &Path) -> Option<PathBuf> {
+    None
 }

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -1,0 +1,201 @@
+use super::{
+    dispatch::RunCtx, recursive::discover_workspace_projects, reporter::ReporterType, run::RunArgs,
+};
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_config::Config;
+use pacquet_fs::{is_subdir, lexical_normalize};
+use pacquet_workspace::read_project_manifest_only;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+/// `pnpm clean` / `pnpm purge`: safely remove the `node_modules`
+/// directories of the current project (or every project in the workspace)
+/// without following NTFS junctions into their targets. A `clean` /
+/// `purge` script in `package.json` overrides the built-in command,
+/// mirroring pnpm's `overridableByScript` flag.
+#[derive(Debug, clap::Args)]
+pub struct CleanArgs {
+    /// Also remove `pnpm-lock.yaml` files.
+    #[clap(short = 'l', long = "lockfile")]
+    pub lockfile: bool,
+}
+
+/// `pnpm clean` was invoked from a subdirectory of a workspace
+/// whose root `package.json` declares a `clean` / `purge` script.
+/// pnpm refuses to run the built-in from the subdirectory in that
+/// case (it would shadow the root script), and directs the user to
+/// `pnpm run <script>` at the root.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(
+    "The workspace root has a \"{command}\" script, so the built-in \"pnpm {command}\" command cannot run from a subdirectory"
+)]
+#[diagnostic(
+    code(ERR_PNPM_SCRIPT_OVERRIDE_IN_WORKSPACE_ROOT),
+    help("Run \"pnpm run {command}\" from the workspace root to execute the script")
+)]
+struct ScriptOverrideInWorkspaceRoot {
+    command: String,
+}
+
+/// The pnpm hidden entries inside `node_modules` that `clean` removes
+/// alongside the regular package directories. Any other dotfile (e.g.
+/// `.cache`) is left in place.
+const PNPM_HIDDEN_ENTRIES: &[&str] =
+    &[".bin", ".modules.yaml", ".pnpm", ".pnpm-workspace-state-v1.json"];
+
+impl CleanArgs {
+    pub fn run(self, ctx: &RunCtx<'_>, command_name: &str) -> miette::Result<()> {
+        let config = (ctx.config)()?;
+        // A `<command_name>` script in the current project's `package.json`
+        // replaces the built-in command.
+        if let Some(script) = script_of(read_project_manifest_only(ctx.dir).ok(), command_name)
+            && !script.is_empty()
+        {
+            return RunArgs {
+                command: Some(command_name.to_string()),
+                args: Vec::new(),
+                if_present: false,
+                resume_from: None,
+                report_summary: false,
+                no_bail: false,
+                sort: true,
+            }
+            .run(ctx.dir, config, matches!(ctx.reporter, ReporterType::Silent));
+        }
+        // Inside a workspace subdirectory, a `<command_name>` script at the
+        // workspace root must be run from the root rather than shadowed by
+        // the built-in command here.
+        if let Some(workspace_dir) = config.workspace_dir.as_deref()
+            && lexical_normalize(workspace_dir) != lexical_normalize(ctx.dir)
+            && let Some(script) =
+                script_of(read_project_manifest_only(workspace_dir).ok(), command_name)
+            && !script.is_empty()
+        {
+            return Err(ScriptOverrideInWorkspaceRoot { command: command_name.to_string() }.into());
+        }
+        clean_builtin(ctx, config, self.lockfile)
+    }
+}
+
+/// Resolve the `<command_name>` script body from an optional manifest
+/// (`None` when the manifest is absent), mirroring pnpm's
+/// `safeReadProjectManifestOnly` tolerance for a missing `package.json`.
+fn script_of(
+    manifest: Option<pacquet_package_manifest::PackageManifest>,
+    command_name: &str,
+) -> Option<String> {
+    manifest?
+        .value()
+        .get("scripts")
+        .and_then(Value::as_object)
+        .and_then(|scripts| scripts.get(command_name))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Remove `node_modules` contents and (optionally) lockfiles from the
+/// current project or every workspace project.
+fn clean_builtin(ctx: &RunCtx<'_>, config: &Config, remove_lockfile: bool) -> miette::Result<()> {
+    // `pnpm clean` resolves the modules dir relative to each project
+    // directory, not against a single absolute prefix, so strip the
+    // config anchor back to the leaf and rejoin per project.
+    let modules_leaf = config.modules_dir.strip_prefix(ctx.dir).unwrap_or(&config.modules_dir);
+    let root_dir = config.workspace_dir.as_deref().unwrap_or(ctx.dir);
+    let dirs: Vec<PathBuf> = if let Some(workspace_dir) = config.workspace_dir.as_deref() {
+        let (projects, _patterns) = discover_workspace_projects(workspace_dir)?;
+        projects.into_iter().map(|project| project.root_dir).collect()
+    } else {
+        vec![ctx.dir.to_path_buf()]
+    };
+    for dir in &dirs {
+        let full_modules_dir = dir.join(modules_leaf);
+        if has_contents_to_remove(&full_modules_dir) {
+            print_removing(&full_modules_dir);
+            remove_modules_dir_contents(&full_modules_dir)?;
+        }
+        if remove_lockfile {
+            let lockfile_path = dir.join("pnpm-lock.yaml");
+            if lockfile_path.exists() {
+                print_removing(&lockfile_path);
+                std::fs::remove_file(&lockfile_path)
+                    .or_else(|error| {
+                        if error.kind() == std::io::ErrorKind::NotFound {
+                            Ok(())
+                        } else {
+                            Err(error)
+                        }
+                    })
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("removing {}", lockfile_path.display()))?;
+            }
+        }
+    }
+    // A virtual store dir configured outside `node_modules` (e.g. a
+    // custom `virtual-store-dir`) is removed separately; the default
+    // `node_modules/.pnpm` is cleaned as part of the contents above.
+    let resolved_virtual_store_dir: PathBuf = if config.virtual_store_dir.is_absolute() {
+        config.virtual_store_dir.clone()
+    } else {
+        root_dir.join(&config.virtual_store_dir)
+    };
+    let root_modules_dir = root_dir.join(modules_leaf);
+    if !is_subdir(&root_modules_dir, &resolved_virtual_store_dir)
+        && is_subdir(root_dir, &resolved_virtual_store_dir)
+        && resolved_virtual_store_dir.exists()
+    {
+        print_removing(&resolved_virtual_store_dir);
+        remove_path(&resolved_virtual_store_dir)?;
+    }
+    Ok(())
+}
+
+/// Whether `modules_dir` holds anything `clean` removes: a regular
+/// package directory or one of the pnpm hidden entries. Other dotfiles
+/// (e.g. `.cache`) mean "nothing to clean" on their own.
+fn has_contents_to_remove(modules_dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(modules_dir) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| is_pnpm_entry(&entry.file_name().to_string_lossy()))
+}
+
+fn remove_modules_dir_contents(modules_dir: &Path) -> miette::Result<()> {
+    let Ok(entries) = std::fs::read_dir(modules_dir) else {
+        return Ok(());
+    };
+    for entry in entries.filter_map(Result::ok) {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.starts_with('.') && !PNPM_HIDDEN_ENTRIES.contains(&name.as_str()) {
+            continue;
+        }
+        remove_path(&entry.path())?;
+    }
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> miette::Result<()> {
+    std::fs::remove_dir_all(path)
+        .or_else(
+            |error| {
+                if error.kind() == std::io::ErrorKind::NotFound { Ok(()) } else { Err(error) }
+            },
+        )
+        .into_diagnostic()
+        .wrap_err_with(|| format!("removing {}", path.display()))
+}
+
+fn is_pnpm_entry(name: &str) -> bool {
+    !name.starts_with('.') || PNPM_HIDDEN_ENTRIES.contains(&name)
+}
+
+/// Print `Removing <path>` relative to the current working directory,
+/// matching pnpm's `path.relative(process.cwd(), p)` formatting. An
+/// empty relative path renders as `.`.
+fn print_removing(path: &Path) {
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let relative = path.strip_prefix(&cwd).unwrap_or(path);
+    let owned: PathBuf =
+        if relative.as_os_str().is_empty() { PathBuf::from(".") } else { relative.to_path_buf() };
+    println!("Removing {}", owned.display());
+}

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -9,6 +9,7 @@ use super::{
     cat_file::CatFileArgs,
     cat_index::CatIndexArgs,
     change::ChangeArgs,
+    clean::CleanArgs,
     completion::{CompletionArgs, CompletionServerArgs},
     config::ConfigArgs,
     create::CreateArgs,
@@ -372,6 +373,15 @@ pub enum CliCommand {
     Runtime(RuntimeArgs),
     /// Print the directory where pnpm will install executables.
     Bin(BinArgs),
+    /// Safely remove `node_modules` directories from the current project
+    /// (or every workspace project) without following NTFS junctions into
+    /// their targets. A `clean` script in `package.json` overrides
+    /// the built-in command.
+    Clean(CleanArgs),
+    /// Alias of `clean`: same behavior, except a `purge` script
+    /// (not a `clean` script) overrides it when present.
+    #[clap(name = "purge")]
+    Purge(CleanArgs),
     /// Print the effective `node_modules` directory.
     Root(RootArgs),
     /// Print the current package prefix.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -341,6 +341,8 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::FindHash(args) => dispatch_query::find_hash(ctx, args),
         CliCommand::Runtime(args) => dispatch_install::runtime(ctx, args),
         CliCommand::Bin(args) => dispatch_query::bin(ctx, args),
+        CliCommand::Clean(args) => dispatch_query::clean(ctx, args, "clean"),
+        CliCommand::Purge(args) => dispatch_query::clean(ctx, args, "purge"),
         CliCommand::Root(args) => dispatch_query::root(ctx, args),
         CliCommand::Prefix(args) => dispatch_query::prefix(ctx, args),
         CliCommand::Config(args) => dispatch_query::config(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -7,6 +7,7 @@ use super::{
     cat_file::CatFileArgs,
     cat_index::CatIndexArgs,
     change::ChangeArgs,
+    clean::CleanArgs,
     config::ConfigArgs,
     deprecate::DeprecateArgs,
     dispatch::{CommandFuture, RunCtx},
@@ -380,6 +381,15 @@ pub(super) fn stage<'a>(
 
 pub(super) fn bin<'a>(ctx: &RunCtx<'a>, args: BinArgs) -> miette::Result<CommandFuture<'a>> {
     args.run(ctx.dir, (ctx.config)()?)?;
+    Ok(Box::pin(std::future::ready(Ok(()))))
+}
+
+pub(super) fn clean<'a>(
+    ctx: &RunCtx<'a>,
+    args: CleanArgs,
+    command_name: &'a str,
+) -> miette::Result<CommandFuture<'a>> {
+    args.run(ctx, command_name)?;
     Ok(Box::pin(std::future::ready(Ok(()))))
 }
 

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -497,6 +497,8 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::FindHash(_) => "find-hash",
         CliCommand::Runtime(_) => "runtime",
         CliCommand::Bin(_) => "bin",
+        CliCommand::Clean(_) => "clean",
+        CliCommand::Purge(_) => "purge",
         CliCommand::Root(_) => "root",
         CliCommand::Prefix(_) => "prefix",
         CliCommand::Config(_) => "config",

--- a/pnpm/crates/cli/tests/clean.rs
+++ b/pnpm/crates/cli/tests/clean.rs
@@ -1,8 +1,6 @@
 use command_extra::CommandExtra;
-use std::fs;
-use std::path::Path;
-
 use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{fs, path::Path};
 
 /// Create `dir/node_modules/<name>/package.json` so the directory
 /// looks like an installed package that `clean` must remove.
@@ -22,6 +20,7 @@ fn clean_removes_packages_and_pnpm_entries_but_preserves_non_pnpm_dotfiles() {
     fs::create_dir_all(node_modules.join(".pnpm")).expect("create .pnpm");
     fs::create_dir_all(node_modules.join(".cache")).expect("create .cache");
     fs::write(node_modules.join(".cache").join("data"), "x").expect("write .cache/data");
+    fs::write(node_modules.join(".modules.yaml"), "").expect("write .modules.yaml");
 
     let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
     assert!(output.status.success(), "pacquet clean should succeed");
@@ -32,6 +31,7 @@ fn clean_removes_packages_and_pnpm_entries_but_preserves_non_pnpm_dotfiles() {
     // Regular packages and pnpm hidden entries are gone.
     assert!(!node_modules.join("lodash").exists(), "lodash package should be removed");
     assert!(!node_modules.join(".pnpm").exists(), ".pnpm should be removed");
+    assert!(!node_modules.join(".modules.yaml").exists(), ".modules.yaml should be removed");
 
     // Non-pnpm dotfiles (e.g. .cache) are preserved, along with the
     // node_modules directory itself.
@@ -168,7 +168,8 @@ fn clean_does_not_remove_virtual_store_dir_outside_the_project_root() {
 /// module is Unix-only.
 #[cfg(unix)]
 mod scripts {
-    use super::*;
+    use super::{CommandTempCwd, Path, fs, seed_package};
+    use command_extra::CommandExtra;
 
     fn write_manifest(dir: &Path, scripts: &serde_json::Value) {
         let manifest = serde_json::json!({
@@ -196,7 +197,7 @@ mod scripts {
         // The built-in clean is overridden, so node_modules is untouched.
         assert!(
             node_modules.join("lodash").exists(),
-            "node_modules must not be cleaned when a script overrides"
+            "node_modules must not be cleaned when a script overrides",
         );
 
         drop(root);
@@ -217,7 +218,7 @@ mod scripts {
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
             !stdout.contains("script-clean-ran"),
-            "purge must not run the clean script: {stdout}"
+            "purge must not run the clean script: {stdout}",
         );
         assert!(!node_modules.join("lodash").exists(), "purge built-in must clean node_modules");
 
@@ -240,7 +241,7 @@ mod scripts {
         assert!(stdout.contains("script-purge-ran"), "purge script should run: {stdout}");
         assert!(
             node_modules.join("lodash").exists(),
-            "node_modules must not be cleaned when a script overrides"
+            "node_modules must not be cleaned when a script overrides",
         );
 
         drop(root);

--- a/pnpm/crates/cli/tests/clean.rs
+++ b/pnpm/crates/cli/tests/clean.rs
@@ -1,0 +1,248 @@
+use command_extra::CommandExtra;
+use std::fs;
+use std::path::Path;
+
+use pacquet_testing_utils::bin::CommandTempCwd;
+
+/// Create `dir/node_modules/<name>/package.json` so the directory
+/// looks like an installed package that `clean` must remove.
+fn seed_package(node_modules: &Path, name: &str) {
+    let pkg_dir = node_modules.join(name);
+    fs::create_dir_all(&pkg_dir).expect("create package dir");
+    fs::write(pkg_dir.join("package.json"), "{}").expect("write package manifest");
+}
+
+#[test]
+fn clean_removes_packages_and_pnpm_entries_but_preserves_non_pnpm_dotfiles() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let node_modules = workspace.join("node_modules");
+    fs::create_dir_all(&node_modules).expect("create node_modules");
+    seed_package(&node_modules, "lodash");
+    fs::create_dir_all(node_modules.join(".pnpm")).expect("create .pnpm");
+    fs::create_dir_all(node_modules.join(".cache")).expect("create .cache");
+    fs::write(node_modules.join(".cache").join("data"), "x").expect("write .cache/data");
+
+    let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
+    assert!(output.status.success(), "pacquet clean should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Removing node_modules"), "expected Removing node_modules: {stdout}");
+
+    // Regular packages and pnpm hidden entries are gone.
+    assert!(!node_modules.join("lodash").exists(), "lodash package should be removed");
+    assert!(!node_modules.join(".pnpm").exists(), ".pnpm should be removed");
+
+    // Non-pnpm dotfiles (e.g. .cache) are preserved, along with the
+    // node_modules directory itself.
+    assert!(node_modules.join(".cache").exists(), ".cache should be preserved");
+    assert!(node_modules.exists(), "node_modules directory should remain");
+
+    drop(root);
+}
+
+#[test]
+fn clean_handles_missing_node_modules_gracefully() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
+    assert!(output.status.success(), "pacquet clean should succeed with no node_modules");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.is_empty(), "nothing should be printed: {stdout}");
+
+    drop(root);
+}
+
+#[test]
+fn clean_preserves_lockfile_by_default() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let lockfile = workspace.join("pnpm-lock.yaml");
+    fs::write(&lockfile, "lockfileVersion: '9.0'\n").expect("write lockfile");
+
+    let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
+    assert!(output.status.success(), "pacquet clean should succeed");
+
+    assert!(lockfile.exists(), "pnpm-lock.yaml should be preserved by default");
+
+    drop(root);
+}
+
+#[test]
+fn clean_lockfile_removes_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let lockfile = workspace.join("pnpm-lock.yaml");
+    fs::write(&lockfile, "lockfileVersion: '9.0'\n").expect("write lockfile");
+
+    let output =
+        pacquet.with_args(["clean", "--lockfile"]).output().expect("run pacquet clean --lockfile");
+    assert!(output.status.success(), "pacquet clean --lockfile should succeed");
+
+    assert!(!lockfile.exists(), "pnpm-lock.yaml should be removed with --lockfile");
+
+    drop(root);
+}
+
+#[test]
+fn clean_works_in_a_workspace() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - pkg1\n  - pkg2\n")
+        .expect("write pnpm-workspace.yaml");
+    let pkg1 = workspace.join("pkg1");
+    let pkg2 = workspace.join("pkg2");
+    fs::create_dir_all(&pkg1).expect("create pkg1");
+    fs::create_dir_all(&pkg2).expect("create pkg2");
+    fs::write(pkg1.join("package.json"), "{}").expect("write pkg1 manifest");
+    fs::write(pkg2.join("package.json"), "{}").expect("write pkg2 manifest");
+    seed_package(&pkg1.join("node_modules"), "a");
+    seed_package(&pkg2.join("node_modules"), "b");
+
+    let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
+    assert!(output.status.success(), "pacquet clean should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Removing pkg1/node_modules"), "expected pkg1: {stdout}");
+    assert!(stdout.contains("Removing pkg2/node_modules"), "expected pkg2: {stdout}");
+    assert!(!pkg1.join("node_modules").join("a").exists(), "pkg1 package removed");
+    assert!(!pkg2.join("node_modules").join("b").exists(), "pkg2 package removed");
+
+    drop(root);
+}
+
+#[test]
+fn clean_removes_custom_virtual_store_dir_inside_the_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "virtualStoreDir: .pnpm-store\npackages:\n  - .\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+    fs::write(workspace.join("package.json"), "{}").expect("write root manifest");
+    let node_modules = workspace.join("node_modules");
+    fs::create_dir_all(&node_modules).expect("create node_modules");
+    seed_package(&node_modules, "lodash");
+    let virtual_store = workspace.join(".pnpm-store");
+    fs::create_dir_all(&virtual_store).expect("create custom virtual store");
+
+    let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
+    assert!(output.status.success(), "pacquet clean should succeed");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Removing .pnpm-store"), "expected custom store removal: {stdout}");
+    assert!(!virtual_store.exists(), "custom virtual store should be removed");
+    assert!(!node_modules.join("lodash").exists(), "packages removed");
+
+    drop(root);
+}
+
+#[test]
+fn clean_does_not_remove_virtual_store_dir_outside_the_project_root() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let outside = workspace.parent().unwrap().join("outside-store");
+    fs::create_dir_all(&outside).expect("create store outside root");
+
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "virtualStoreDir: ../outside-store\npackages:\n  - .\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+    fs::write(workspace.join("package.json"), "{}").expect("write root manifest");
+    let node_modules = workspace.join("node_modules");
+    fs::create_dir_all(&node_modules).expect("create node_modules");
+    seed_package(&node_modules, "lodash");
+
+    let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
+    assert!(output.status.success(), "pacquet clean should succeed");
+
+    assert!(outside.exists(), "virtual store outside root must be left alone");
+
+    drop(root);
+}
+
+/// Script-override tests drive `/bin/sh` lifecycle scripts, so the whole
+/// module is Unix-only.
+#[cfg(unix)]
+mod scripts {
+    use super::*;
+
+    fn write_manifest(dir: &Path, scripts: &serde_json::Value) {
+        let manifest = serde_json::json!({
+            "name": "test-pkg",
+            "version": "1.0.0",
+            "scripts": scripts,
+        });
+        fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
+    }
+
+    #[test]
+    fn clean_runs_the_clean_script_when_present() {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+        write_manifest(&workspace, &serde_json::json!({ "clean": "echo script-clean-ran" }));
+        let node_modules = workspace.join("node_modules");
+        fs::create_dir_all(&node_modules).expect("create node_modules");
+        seed_package(&node_modules, "lodash");
+
+        let output = pacquet.with_args(["clean"]).output().expect("run pacquet clean");
+        assert!(output.status.success(), "pacquet clean should succeed");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("script-clean-ran"), "clean script should run: {stdout}");
+        // The built-in clean is overridden, so node_modules is untouched.
+        assert!(
+            node_modules.join("lodash").exists(),
+            "node_modules must not be cleaned when a script overrides"
+        );
+
+        drop(root);
+    }
+
+    #[test]
+    fn purge_runs_the_builtin_clean_when_only_a_clean_script_exists() {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+        write_manifest(&workspace, &serde_json::json!({ "clean": "echo script-clean-ran" }));
+        let node_modules = workspace.join("node_modules");
+        fs::create_dir_all(&node_modules).expect("create node_modules");
+        seed_package(&node_modules, "lodash");
+
+        let output = pacquet.with_args(["purge"]).output().expect("run pacquet purge");
+        assert!(output.status.success(), "pacquet purge should succeed");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("script-clean-ran"),
+            "purge must not run the clean script: {stdout}"
+        );
+        assert!(!node_modules.join("lodash").exists(), "purge built-in must clean node_modules");
+
+        drop(root);
+    }
+
+    #[test]
+    fn purge_runs_the_purge_script_when_present() {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+        write_manifest(&workspace, &serde_json::json!({ "purge": "echo script-purge-ran" }));
+        let node_modules = workspace.join("node_modules");
+        fs::create_dir_all(&node_modules).expect("create node_modules");
+        seed_package(&node_modules, "lodash");
+
+        let output = pacquet.with_args(["purge"]).output().expect("run pacquet purge");
+        assert!(output.status.success(), "pacquet purge should succeed");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("script-purge-ran"), "purge script should run: {stdout}");
+        assert!(
+            node_modules.join("lodash").exists(),
+            "node_modules must not be cleaned when a script overrides"
+        );
+
+        drop(root);
+    }
+}


### PR DESCRIPTION
## Summary

Native Rust implementation of the `clean` and `purge` commands, achieving 100% parity with the legacy TypeScript implementation (`pnpm11/pnpm/src/cmd/clean.ts`). 

Related to: https://github.com/pnpm/pnpm/issues/11633.

Both commands safely remove `node_modules` contents from the current project or every workspace project. A `clean` or `purge` script in `package.json` overrides the built-in command when present. Lockfile removal is supported via `--lockfile`. Virtual store directories outside the project root are never removed.

## Squash Commit Body

```text
feat(cli): add clean/purge commands

Native Rust implementation of the clean and purge commands, achieving
100% parity with the legacy TypeScript implementation.

Both commands safely remove node_modules contents from the current
project or every workspace project. A clean/purge script in package.json
overrides the built-in command when present. Lockfile removal is
supported via --lockfile. Virtual store directories outside the project
root are never removed.

related to: #11633
```

## Checklist

- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/12999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786638610&installation_id=145934176&pr_number=12999&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F12999&signature=4085f09583c3768e1c75f9631e659d17dc38d5561289066dcab3211b3986e922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit
* **New Features**
  * Added `clean` and `purge` commands to remove pnpm-managed `node_modules` contents (keeps unrelated dotfiles and leaves the top-level folder in place).
  * Added `--lockfile` / `-l` to also delete `pnpm-lock.yaml`.
  * Works across workspace projects and cleans the configured virtual store when within the intended scope.
  * Supports pnpm-style script override rules, including an error when overridden scripts are only defined at the workspace root while running from a subdirectory.
* **Tests**
  * Added integration coverage for normal, lockfile, workspace, virtual store cleanup, and script override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->