### PR TITLE
feat(cli): implement native owner/owners command in Rust

### DIFF
--- a/.changeset/owner-ls-auth-errors.md
+++ b/.changeset/owner-ls-auth-errors.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/registry-access.commands": patch
+"pnpm": patch
+---
+
+`pnpm owner ls` now reports authentication and authorization failures (401/403) as dedicated errors that include the registry's response body, matching `pnpm owner add`/`rm`, instead of a generic `Failed to fetch owners` message.

--- a/.changeset/pacquet-owner.md
+++ b/.changeset/pacquet-owner.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added the `owner` command (aliased as `owners`) for managing package owners on the registry, with the `ls` (default), `add`, and `rm` subcommands and support for `--registry` and `--otp`.

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -32,6 +32,7 @@ pub mod list;
 pub mod login;
 pub mod logout;
 pub mod outdated;
+pub mod owner;
 pub mod pack;
 pub mod pack_app;
 

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -31,6 +31,7 @@ use super::{
     login::LoginArgs,
     logout::LogoutArgs,
     outdated::OutdatedArgs,
+    owner::OwnerArgs,
     pack::PackArgs,
     pack_app::PackAppArgs,
     patch::PatchArgs,
@@ -438,6 +439,9 @@ pub enum CliCommand {
     Login(LoginArgs),
     /// Manage organization teams and team memberships.
     Team(TeamArgs),
+    /// Manage package owners on the registry.
+    #[clap(visible_alias = "owners")]
+    Owner(OwnerArgs),
     /// Log out of an npm registry.
     Logout(LogoutArgs),
     /// Runs pnpm at a specific version (or the currently running one) for a

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -334,6 +334,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Stars(args) => dispatch_query::stars(ctx, args),
         CliCommand::DistTag(args) => dispatch_query::dist_tag(ctx, args),
         CliCommand::Team(args) => dispatch_query::team(ctx, args),
+        CliCommand::Owner(args) => dispatch_query::owner(ctx, args),
         CliCommand::Deprecate(args) => dispatch_query::deprecate(ctx, args),
         CliCommand::Undeprecate(args) => dispatch_query::undeprecate(ctx, args),
         CliCommand::Ping(args) => dispatch_query::ping(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -20,6 +20,7 @@ use super::{
     login::LoginArgs,
     logout::LogoutArgs,
     outdated::{OutdatedArgs, OutdatedOutcome},
+    owner::OwnerArgs,
     pack::PackArgs,
     pack_app::PackAppArgs,
     peers::{PeersArgs, PeersOutcome},
@@ -264,6 +265,20 @@ pub(super) fn undeprecate<'a>(
 }
 
 pub(super) fn team<'a>(ctx: &RunCtx<'a>, args: TeamArgs) -> miette::Result<CommandFuture<'a>> {
+    let cfg: &Config = (ctx.config)()?;
+    Ok(Box::pin(async move {
+        if let Some(output) = args.run(cfg).await? {
+            let output = super::sanitize::sanitize(&output);
+            if output.is_empty() {
+                return Ok(());
+            }
+            println!("{output}");
+        }
+        Ok(())
+    }))
+}
+
+pub(super) fn owner<'a>(ctx: &RunCtx<'a>, args: OwnerArgs) -> miette::Result<CommandFuture<'a>> {
     let cfg: &Config = (ctx.config)()?;
     Ok(Box::pin(async move {
         if let Some(output) = args.run(cfg).await? {

--- a/pnpm/crates/cli/src/cli_args/owner.rs
+++ b/pnpm/crates/cli/src/cli_args/owner.rs
@@ -50,6 +50,13 @@ pub enum OwnerError {
         package_name: String,
     },
 
+    #[display("Package not found in registry. {body}")]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_NOT_FOUND))]
+    WritePackageNotFound {
+        #[error(not(source))]
+        body: String,
+    },
+
     #[display("You must be logged in to {action} packages. {body}")]
     #[diagnostic(code(ERR_PNPM_UNAUTHORIZED))]
     Unauthorized {
@@ -163,12 +170,7 @@ async fn owner_ls(context: &OwnerContext<'_>, params: &[String]) -> miette::Resu
         return Err(OwnerError::PackageNotFound { package_name: package_name.clone() }.into());
     }
     if !response.status().is_success() {
-        return Err(write_error_from_response(
-            response,
-            "fetch owners of".to_string(),
-            package_name,
-        )
-        .await);
+        return Err(write_error_from_response(response, "fetch owners of".to_string()).await);
     }
 
     let body = read_limited_body(response, OWNER_BODY_LIMIT)
@@ -216,8 +218,7 @@ async fn owner_add(context: &OwnerContext<'_>, params: &[String]) -> miette::Res
     if response.status().is_success() {
         return Ok(format!("+{owner}: {package_name}"));
     }
-    Err(write_error_from_response(response, format!(r#"add owner "{owner}" to"#), package_name)
-        .await)
+    Err(write_error_from_response(response, format!(r#"add owner "{owner}" to"#)).await)
 }
 
 async fn owner_rm(context: &OwnerContext<'_>, params: &[String]) -> miette::Result<String> {
@@ -252,12 +253,7 @@ async fn owner_rm(context: &OwnerContext<'_>, params: &[String]) -> miette::Resu
     if response.status().is_success() {
         return Ok(format!("-{owner}: {package_name}"));
     }
-    Err(write_error_from_response(
-        response,
-        format!(r#"remove owner "{owner}" from"#),
-        package_name,
-    )
-    .await)
+    Err(write_error_from_response(response, format!(r#"remove owner "{owner}" from"#)).await)
 }
 
 fn build_http_client(config: &Config) -> miette::Result<ThrottledClient> {
@@ -286,11 +282,7 @@ where
     .into()
 }
 
-async fn write_error_from_response(
-    response: Response,
-    action: String,
-    package_name: &str,
-) -> miette::Report {
+async fn write_error_from_response(response: Response, action: String) -> miette::Report {
     let status = response.status();
     let status_text = status.canonical_reason().unwrap_or_default().to_string();
     let body = match read_limited_body(response, OWNER_ERROR_BODY_LIMIT).await {
@@ -301,9 +293,7 @@ async fn write_error_from_response(
     match status {
         reqwest::StatusCode::UNAUTHORIZED => OwnerError::Unauthorized { action, body }.into(),
         reqwest::StatusCode::FORBIDDEN => OwnerError::Forbidden { action, body }.into(),
-        reqwest::StatusCode::NOT_FOUND => {
-            OwnerError::PackageNotFound { package_name: package_name.to_string() }.into()
-        }
+        reqwest::StatusCode::NOT_FOUND => OwnerError::WritePackageNotFound { body }.into(),
         _ => OwnerError::RegistryWriteFailed { action, status: status.as_u16(), status_text, body }
             .into(),
     }

--- a/pnpm/crates/cli/src/cli_args/owner.rs
+++ b/pnpm/crates/cli/src/cli_args/owner.rs
@@ -68,7 +68,7 @@ pub enum OwnerError {
         body: String,
     },
 
-    #[display("Failed to {action}: {status} {status_text}. {body}")]
+    #[display("Failed to {action} package: {status} {status_text}. {body}")]
     #[diagnostic(code(ERR_PNPM_REGISTRY_ERROR))]
     RegistryWriteFailed {
         #[error(not(source))]
@@ -78,14 +78,6 @@ pub enum OwnerError {
         status_text: String,
         #[error(not(source))]
         body: String,
-    },
-
-    #[display("Failed to fetch owners: {status} {status_text}")]
-    #[diagnostic(code(ERR_PNPM_REGISTRY_ERROR))]
-    FetchOwnersFailed {
-        status: u16,
-        #[error(not(source))]
-        status_text: String,
     },
 
     #[display("Failed to {operation}: {reason}")]
@@ -113,21 +105,24 @@ struct OwnerEntry {
 }
 
 impl OwnerArgs {
-    pub async fn run(self, config: &Config) -> miette::Result<Option<String>> {
+    pub async fn run(&self, config: &Config) -> miette::Result<Option<String>> {
         let subcommand = self.params.first().map(String::as_str);
-        let context = Self::context(config, self.otp)?;
+        let context = self.context(config)?;
 
         match subcommand {
             Some("ls" | "list") => owner_ls(&context, &self.params[1..]).await.map(Some),
             Some("add") => owner_add(&context, &self.params[1..]).await.map(Some),
-            Some("rm" | "remove") => owner_rm(&context, &self.params[1..]).await.map(Some),
+            Some("rm") => owner_rm(&context, &self.params[1..]).await.map(Some),
             _ => owner_ls(&context, &self.params).await.map(Some),
         }
     }
 
-    fn context(config: &Config, otp: Option<String>) -> miette::Result<OwnerContext<'_>> {
-        let registries: HashMap<String, String> =
+    fn context<'a>(&'a self, config: &'a Config) -> miette::Result<OwnerContext<'a>> {
+        let mut registries: HashMap<String, String> =
             config.resolved_registries().into_iter().collect();
+        if let Some(registry) = &self.registry {
+            registries.insert("default".to_string(), normalize_registry_url(registry));
+        }
         Ok(OwnerContext {
             config,
             http_client: build_http_client(config)?,
@@ -138,7 +133,7 @@ impl OwnerArgs {
                 max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
             },
             registries,
-            otp,
+            otp: self.otp.clone(),
         })
     }
 }
@@ -168,12 +163,12 @@ async fn owner_ls(context: &OwnerContext<'_>, params: &[String]) -> miette::Resu
         return Err(OwnerError::PackageNotFound { package_name: package_name.clone() }.into());
     }
     if !response.status().is_success() {
-        let status = response.status();
-        return Err(OwnerError::FetchOwnersFailed {
-            status: status.as_u16(),
-            status_text: status.canonical_reason().unwrap_or_default().to_string(),
-        }
-        .into());
+        return Err(write_error_from_response(
+            response,
+            "fetch owners of".to_string(),
+            package_name,
+        )
+        .await);
     }
 
     let body = read_limited_body(response, OWNER_BODY_LIMIT)
@@ -312,6 +307,10 @@ async fn write_error_from_response(
         _ => OwnerError::RegistryWriteFailed { action, status: status.as_u16(), status_text, body }
             .into(),
     }
+}
+
+fn normalize_registry_url(registry_url: &str) -> String {
+    if registry_url.ends_with('/') { registry_url.to_string() } else { format!("{registry_url}/") }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/owner.rs
+++ b/pnpm/crates/cli/src/cli_args/owner.rs
@@ -1,0 +1,318 @@
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::{Diagnostic, IntoDiagnostic, WrapErr};
+use pacquet_config::Config;
+use pacquet_network::{
+    NetworkSettings, RetryOpts, ThrottledClient, encode_package_name, encode_uri_component,
+    read_limited_body, redact_url_credentials, send_with_retry,
+};
+use pacquet_resolving_npm_resolver::pick_registry_for_package;
+use reqwest::Response;
+use serde::Deserialize;
+use std::{collections::HashMap, time::Duration};
+
+const OWNER_BODY_LIMIT: usize = 1024 * 1024;
+const OWNER_ERROR_BODY_LIMIT: usize = 64 * 1024;
+
+#[derive(Debug, Args)]
+pub struct OwnerArgs {
+    /// The base URL of the npm registry.
+    #[clap(long)]
+    pub registry: Option<String>,
+
+    /// One-time password for registries that require two-factor authentication.
+    #[clap(long)]
+    pub otp: Option<String>,
+
+    /// Subcommand and arguments.
+    pub params: Vec<String>,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum OwnerError {
+    #[display("Package name is required")]
+    #[diagnostic(code(ERR_PNPM_OWNER_LS_PACKAGE_REQUIRED))]
+    LsPackageRequired,
+
+    #[display("Package name and owner are required (e.g., pnpm owner add pkg username)")]
+    #[diagnostic(code(ERR_PNPM_OWNER_ADD_ARGS_REQUIRED))]
+    AddArgsRequired,
+
+    #[display("Package name and owner are required (e.g., pnpm owner rm pkg username)")]
+    #[diagnostic(code(ERR_PNPM_OWNER_RM_ARGS_REQUIRED))]
+    RmArgsRequired,
+
+    #[display(r#"Package "{package_name}" not found in registry"#)]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_NOT_FOUND))]
+    PackageNotFound {
+        #[error(not(source))]
+        package_name: String,
+    },
+
+    #[display("You must be logged in to {action} packages. {body}")]
+    #[diagnostic(code(ERR_PNPM_UNAUTHORIZED))]
+    Unauthorized {
+        #[error(not(source))]
+        action: String,
+        #[error(not(source))]
+        body: String,
+    },
+
+    #[display("You do not have permission to {action} this package. {body}")]
+    #[diagnostic(code(ERR_PNPM_FORBIDDEN))]
+    Forbidden {
+        #[error(not(source))]
+        action: String,
+        #[error(not(source))]
+        body: String,
+    },
+
+    #[display("Failed to {action}: {status} {status_text}. {body}")]
+    #[diagnostic(code(ERR_PNPM_REGISTRY_ERROR))]
+    RegistryWriteFailed {
+        #[error(not(source))]
+        action: String,
+        status: u16,
+        #[error(not(source))]
+        status_text: String,
+        #[error(not(source))]
+        body: String,
+    },
+
+    #[display("Failed to fetch owners: {status} {status_text}")]
+    #[diagnostic(code(ERR_PNPM_REGISTRY_ERROR))]
+    FetchOwnersFailed {
+        status: u16,
+        #[error(not(source))]
+        status_text: String,
+    },
+
+    #[display("Failed to {operation}: {reason}")]
+    #[diagnostic(code(ERR_PNPM_REGISTRY_ERROR))]
+    RegistryOperationFailed {
+        #[error(not(source))]
+        operation: &'static str,
+        #[error(not(source))]
+        reason: String,
+    },
+}
+
+struct OwnerContext<'a> {
+    config: &'a Config,
+    http_client: ThrottledClient,
+    retry_opts: RetryOpts,
+    registries: HashMap<String, String>,
+    otp: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OwnerEntry {
+    username: String,
+    email: String,
+}
+
+impl OwnerArgs {
+    pub async fn run(self, config: &Config) -> miette::Result<Option<String>> {
+        let subcommand = self.params.first().map(String::as_str);
+        let context = Self::context(config, self.otp)?;
+
+        match subcommand {
+            Some("ls" | "list") => owner_ls(&context, &self.params[1..]).await.map(Some),
+            Some("add") => owner_add(&context, &self.params[1..]).await.map(Some),
+            Some("rm" | "remove") => owner_rm(&context, &self.params[1..]).await.map(Some),
+            _ => owner_ls(&context, &self.params).await.map(Some),
+        }
+    }
+
+    fn context(config: &Config, otp: Option<String>) -> miette::Result<OwnerContext<'_>> {
+        let registries: HashMap<String, String> =
+            config.resolved_registries().into_iter().collect();
+        Ok(OwnerContext {
+            config,
+            http_client: build_http_client(config)?,
+            retry_opts: RetryOpts {
+                retries: config.fetch_retries,
+                factor: config.fetch_retry_factor,
+                min_timeout: Duration::from_millis(config.fetch_retry_mintimeout),
+                max_timeout: Duration::from_millis(config.fetch_retry_maxtimeout),
+            },
+            registries,
+            otp,
+        })
+    }
+}
+
+async fn owner_ls(context: &OwnerContext<'_>, params: &[String]) -> miette::Result<String> {
+    let package_name = params.first().ok_or(OwnerError::LsPackageRequired)?;
+
+    let registry_url = pick_registry_for_package(&context.registries, package_name, None);
+    let auth_header =
+        context.config.auth_headers.for_url_with_package(&registry_url, Some(package_name));
+
+    let escaped = encode_package_name(package_name);
+    let url = format!("{registry_url}-/package/{escaped}/owners");
+
+    let (_guard, response) =
+        send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
+            let mut builder = client.get(&url);
+            if let Some(auth) = auth_header.as_deref() {
+                builder = builder.header("authorization", auth);
+            }
+            builder
+        })
+        .await
+        .map_err(|source| registry_operation_error("fetching owners", source))?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Err(OwnerError::PackageNotFound { package_name: package_name.clone() }.into());
+    }
+    if !response.status().is_success() {
+        let status = response.status();
+        return Err(OwnerError::FetchOwnersFailed {
+            status: status.as_u16(),
+            status_text: status.canonical_reason().unwrap_or_default().to_string(),
+        }
+        .into());
+    }
+
+    let body = read_limited_body(response, OWNER_BODY_LIMIT)
+        .await
+        .map_err(|source| registry_operation_error("reading owners response", source))?;
+    let owners: Vec<OwnerEntry> = serde_json::from_slice(&body.bytes)
+        .into_diagnostic()
+        .map_err(|source| registry_operation_error("parsing owners response", source))?;
+
+    let lines: Vec<String> =
+        owners.iter().map(|o| format!("{} <{}>", o.username, o.email)).collect();
+    Ok(lines.join("\n"))
+}
+
+async fn owner_add(context: &OwnerContext<'_>, params: &[String]) -> miette::Result<String> {
+    if params.len() < 2 {
+        return Err(OwnerError::AddArgsRequired.into());
+    }
+    let package_name = &params[0];
+    let owner = &params[1];
+
+    let registry_url = pick_registry_for_package(&context.registries, package_name, None);
+    let auth_header =
+        context.config.auth_headers.for_url_with_package(&registry_url, Some(package_name));
+
+    let escaped = encode_package_name(package_name);
+    let url = format!("{registry_url}-/package/{escaped}/owners");
+    let body = serde_json::json!({ "user": owner }).to_string();
+
+    let (_guard, response) =
+        send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
+            let mut builder =
+                client.put(&url).header("content-type", "application/json").body(body.clone());
+            if let Some(auth) = auth_header.as_deref() {
+                builder = builder.header("authorization", auth);
+            }
+            if let Some(otp) = &context.otp {
+                builder = builder.header("npm-otp", otp.as_str());
+            }
+            builder
+        })
+        .await
+        .map_err(|source| registry_operation_error("adding owner", source))?;
+
+    if response.status().is_success() {
+        return Ok(format!("+{owner}: {package_name}"));
+    }
+    Err(write_error_from_response(response, format!(r#"add owner "{owner}" to"#), package_name)
+        .await)
+}
+
+async fn owner_rm(context: &OwnerContext<'_>, params: &[String]) -> miette::Result<String> {
+    if params.len() < 2 {
+        return Err(OwnerError::RmArgsRequired.into());
+    }
+    let package_name = &params[0];
+    let owner = &params[1];
+
+    let registry_url = pick_registry_for_package(&context.registries, package_name, None);
+    let auth_header =
+        context.config.auth_headers.for_url_with_package(&registry_url, Some(package_name));
+
+    let escaped = encode_package_name(package_name);
+    let encoded_owner = encode_uri_component(owner);
+    let url = format!("{registry_url}-/package/{escaped}/owners/{encoded_owner}");
+
+    let (_guard, response) =
+        send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
+            let mut builder = client.delete(&url);
+            if let Some(auth) = auth_header.as_deref() {
+                builder = builder.header("authorization", auth);
+            }
+            if let Some(otp) = &context.otp {
+                builder = builder.header("npm-otp", otp.as_str());
+            }
+            builder
+        })
+        .await
+        .map_err(|source| registry_operation_error("removing owner", source))?;
+
+    if response.status().is_success() {
+        return Ok(format!("-{owner}: {package_name}"));
+    }
+    Err(write_error_from_response(
+        response,
+        format!(r#"remove owner "{owner}" from"#),
+        package_name,
+    )
+    .await)
+}
+
+fn build_http_client(config: &Config) -> miette::Result<ThrottledClient> {
+    ThrottledClient::for_installs(
+        &config.proxy,
+        &config.tls,
+        &config.tls_by_uri,
+        &NetworkSettings {
+            network_concurrency: config.network_concurrency,
+            fetch_timeout: Duration::from_millis(config.fetch_timeout),
+            user_agent: config.user_agent.clone(),
+        },
+    )
+    .into_diagnostic()
+    .wrap_err("create the network client for owner command")
+}
+
+fn registry_operation_error<ErrorType>(operation: &'static str, error: ErrorType) -> miette::Report
+where
+    ErrorType: std::fmt::Display,
+{
+    OwnerError::RegistryOperationFailed {
+        operation,
+        reason: redact_url_credentials(&error.to_string()),
+    }
+    .into()
+}
+
+async fn write_error_from_response(
+    response: Response,
+    action: String,
+    package_name: &str,
+) -> miette::Report {
+    let status = response.status();
+    let status_text = status.canonical_reason().unwrap_or_default().to_string();
+    let body = match read_limited_body(response, OWNER_ERROR_BODY_LIMIT).await {
+        Ok(body) => super::sanitize::body_display_string(&body),
+        Err(_) => String::new(),
+    };
+
+    match status {
+        reqwest::StatusCode::UNAUTHORIZED => OwnerError::Unauthorized { action, body }.into(),
+        reqwest::StatusCode::FORBIDDEN => OwnerError::Forbidden { action, body }.into(),
+        reqwest::StatusCode::NOT_FOUND => {
+            OwnerError::PackageNotFound { package_name: package_name.to_string() }.into()
+        }
+        _ => OwnerError::RegistryWriteFailed { action, status: status.as_u16(), status_text, body }
+            .into(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/owner.rs
+++ b/pnpm/crates/cli/src/cli_args/owner.rs
@@ -3,13 +3,13 @@ use derive_more::{Display, Error};
 use miette::{Diagnostic, IntoDiagnostic, WrapErr};
 use pacquet_config::Config;
 use pacquet_network::{
-    NetworkSettings, RetryOpts, ThrottledClient, encode_package_name, encode_uri_component,
-    read_limited_body, redact_url_credentials, send_with_retry,
+    NetworkSettings, RedirectGuard, RetryOpts, ThrottledClient, encode_package_name,
+    encode_uri_component, read_limited_body, redact_url_credentials, send_with_retry,
 };
 use pacquet_resolving_npm_resolver::pick_registry_for_package;
 use reqwest::Response;
 use serde::Deserialize;
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 const OWNER_BODY_LIMIT: usize = 1024 * 1024;
 const OWNER_ERROR_BODY_LIMIT: usize = 64 * 1024;
@@ -130,9 +130,32 @@ impl OwnerArgs {
         if let Some(registry) = &self.registry {
             registries.insert("default".to_string(), normalize_registry_url(registry));
         }
+        // When an OTP is in play, restrict redirects to the configured registry
+        // origins so a cross-host redirect cannot forward the `npm-otp` header to
+        // another host — reqwest only strips standard auth headers, not custom
+        // ones, on cross-host redirects. Mirrors the `team`/`access` guard.
+        let redirect_guard = self.otp.as_ref().map(|_| {
+            let origins: Vec<(String, String, Option<u16>)> = registries
+                .values()
+                .filter_map(|registry| {
+                    reqwest::Url::parse(registry).ok().and_then(|url| {
+                        url.host_str()
+                            .map(|host| (url.scheme().to_string(), host.to_string(), url.port()))
+                    })
+                })
+                .collect();
+            let guard: RedirectGuard = Arc::new(move |target: &reqwest::Url| -> bool {
+                origins.iter().any(|(scheme, host, port)| {
+                    target.scheme() == scheme
+                        && target.host_str() == Some(host.as_str())
+                        && target.port() == *port
+                })
+            });
+            guard
+        });
         Ok(OwnerContext {
             config,
-            http_client: build_http_client(config)?,
+            http_client: build_http_client(config, redirect_guard.as_ref())?,
             retry_opts: RetryOpts {
                 retries: config.fetch_retries,
                 factor: config.fetch_retry_factor,
@@ -256,8 +279,11 @@ async fn owner_rm(context: &OwnerContext<'_>, params: &[String]) -> miette::Resu
     Err(write_error_from_response(response, format!(r#"remove owner "{owner}" from"#)).await)
 }
 
-fn build_http_client(config: &Config) -> miette::Result<ThrottledClient> {
-    ThrottledClient::for_installs(
+fn build_http_client(
+    config: &Config,
+    redirect_guard: Option<&RedirectGuard>,
+) -> miette::Result<ThrottledClient> {
+    ThrottledClient::for_installs_with_guard(
         &config.proxy,
         &config.tls,
         &config.tls_by_uri,
@@ -266,6 +292,7 @@ fn build_http_client(config: &Config) -> miette::Result<ThrottledClient> {
             fetch_timeout: Duration::from_millis(config.fetch_timeout),
             user_agent: config.user_agent.clone(),
         },
+        redirect_guard,
     )
     .into_diagnostic()
     .wrap_err("create the network client for owner command")

--- a/pnpm/crates/cli/src/cli_args/owner/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/owner/tests.rs
@@ -1,9 +1,12 @@
-use super::{OwnerEntry, OwnerError};
+use pacquet_config::Config;
+use serde_json::json;
+
+use super::{OwnerArgs, OwnerError};
 
 #[test]
 fn owner_entry_deserializes() {
     let json = r#"{"username": "alice", "email": "alice@example.com"}"#;
-    let entry: OwnerEntry = serde_json::from_str(json).expect("should deserialize");
+    let entry: super::OwnerEntry = serde_json::from_str(json).expect("should deserialize");
     assert_eq!(entry.username, "alice");
     assert_eq!(entry.email, "alice@example.com");
 }
@@ -14,7 +17,7 @@ fn owner_entry_deserializes_array() {
         {"username": "alice", "email": "alice@example.com"},
         {"username": "bob", "email": "bob@example.com"}
     ]"#;
-    let entries: Vec<OwnerEntry> = serde_json::from_str(json).expect("should deserialize");
+    let entries: Vec<super::OwnerEntry> = serde_json::from_str(json).expect("should deserialize");
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].username, "alice");
     assert_eq!(entries[1].username, "bob");
@@ -57,4 +60,536 @@ fn error_forbidden_display() {
     };
     assert!(err.to_string().contains("permission"));
     assert!(err.to_string().contains("not allowed"));
+}
+
+#[test]
+fn error_registry_write_failed_includes_package() {
+    let err = OwnerError::RegistryWriteFailed {
+        action: r#"add owner "bob" to"#.to_string(),
+        status: 500,
+        status_text: "Internal Server Error".to_string(),
+        body: "something broke".to_string(),
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("package"),
+        "error message must include 'package' for parity with TypeScript: {msg}"
+    );
+    assert!(msg.contains("add owner \"bob\" to"));
+    assert!(msg.contains("500"));
+}
+
+fn config_with_registry(registry: &str) -> Config {
+    let url = if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") };
+    Config { registry: url, ..Config::default() }
+}
+
+fn config_with_registry_no_retries(registry: &str) -> Config {
+    let url = if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") };
+    Config { registry: url, fetch_retries: 0, ..Config::default() }
+}
+
+fn owner_args(subcommand: &str, params: &[&str]) -> OwnerArgs {
+    let mut all_params = vec![subcommand.to_string()];
+    all_params.extend(params.iter().map(ToString::to_string));
+    OwnerArgs { registry: None, otp: None, params: all_params }
+}
+
+fn owner_args_with_registry(registry: &str, subcommand: &str, params: &[&str]) -> OwnerArgs {
+    let mut all_params = vec![subcommand.to_string()];
+    all_params.extend(params.iter().map(ToString::to_string));
+    OwnerArgs { registry: Some(registry.to_string()), otp: None, params: all_params }
+}
+
+fn owner_args_with_otp(otp: &str, subcommand: &str, params: &[&str]) -> OwnerArgs {
+    let mut all_params = vec![subcommand.to_string()];
+    all_params.extend(params.iter().map(ToString::to_string));
+    OwnerArgs { registry: None, otp: Some(otp.to_string()), params: all_params }
+}
+
+// ── owner ls HTTP-flow tests ──────────────────────────────────────────
+
+#[tokio::test]
+async fn owner_ls_success() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/-/package/my-pkg/owners")
+        .with_status(200)
+        .with_body(
+            json!([
+                {"username": "alice", "email": "alice@example.com"},
+                {"username": "bob", "email": "bob@example.com"}
+            ])
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("ls", &["my-pkg"]);
+    let result = args.run(&config).await.expect("owner ls must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("alice <alice@example.com>\nbob <bob@example.com>"));
+}
+
+#[tokio::test]
+async fn owner_ls_404_returns_package_not_found() {
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("GET", "/-/package/unknown-pkg/owners").with_status(404).create_async().await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("ls", &["unknown-pkg"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("not found"), "expected PackageNotFound, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_ls_401_returns_unauthorized() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/-/package/private-pkg/owners")
+        .with_status(401)
+        .with_body("unauthorized access")
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("ls", &["private-pkg"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("logged in"), "expected Unauthorized error, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_ls_403_returns_forbidden() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/-/package/locked-pkg/owners")
+        .with_status(403)
+        .with_body("forbidden")
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("ls", &["locked-pkg"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("permission"), "expected Forbidden error, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_ls_500_returns_registry_error() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/-/package/broken-pkg/owners")
+        .with_status(500)
+        .with_body("internal error")
+        .create_async()
+        .await;
+
+    let config = config_with_registry_no_retries(&server.url());
+    let args = owner_args("ls", &["broken-pkg"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("500"), "expected status 500 in error, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_ls_scoped_package_encodes_correctly() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/-/package/@scope%2Fpkg/owners")
+        .with_status(200)
+        .with_body(json!([{"username": "alice", "email": "a@b.com"}]).to_string())
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("ls", &["@scope/pkg"]);
+    let result = args.run(&config).await.expect("owner ls must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("alice <a@b.com>"));
+}
+
+#[tokio::test]
+async fn owner_ls_list_alias() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/-/package/my-pkg/owners")
+        .with_status(200)
+        .with_body(json!([{"username": "carol", "email": "c@d.com"}]).to_string())
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("list", &["my-pkg"]);
+    let result = args.run(&config).await.expect("owner list must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("carol <c@d.com>"));
+}
+
+#[tokio::test]
+async fn owner_ls_no_params_returns_package_required() {
+    let config = config_with_registry("http://unused/");
+    let args = OwnerArgs { registry: None, otp: None, params: vec!["ls".to_string()] };
+    let err = args.run(&config).await.unwrap_err();
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("Package name is required"));
+}
+
+// ── owner add HTTP-flow tests ─────────────────────────────────────────
+
+#[tokio::test]
+async fn owner_add_success() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("PUT", "/-/package/my-pkg/owners")
+        .match_body(mockito::Matcher::Json(json!({"user": "alice"})))
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("add", &["my-pkg", "alice"]);
+    let result = args.run(&config).await.expect("owner add must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("+alice: my-pkg"));
+}
+
+#[tokio::test]
+async fn owner_add_401_returns_unauthorized() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("PUT", "/-/package/my-pkg/owners")
+        .with_status(401)
+        .with_body("token expired")
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("add", &["my-pkg", "alice"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("logged in"), "expected Unauthorized, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_add_403_returns_forbidden() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("PUT", "/-/package/my-pkg/owners")
+        .with_status(403)
+        .with_body("not allowed")
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("add", &["my-pkg", "alice"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("permission"), "expected Forbidden, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_add_404_returns_package_not_found() {
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("PUT", "/-/package/missing-pkg/owners").with_status(404).create_async().await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("add", &["missing-pkg", "alice"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("not found"), "expected PackageNotFound, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_add_500_returns_registry_error_with_body() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("PUT", "/-/package/my-pkg/owners")
+        .with_status(500)
+        .with_body("something went wrong")
+        .create_async()
+        .await;
+
+    let config = config_with_registry_no_retries(&server.url());
+    let args = owner_args("add", &["my-pkg", "alice"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("500"), "expected status code in error, got: {formatted}");
+    assert!(formatted.contains("package"), "expected 'package' in error message for TS parity");
+}
+
+#[tokio::test]
+async fn owner_add_sends_otp_header() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("PUT", "/-/package/my-pkg/owners")
+        .match_header("npm-otp", "123456")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args_with_otp("123456", "add", &["my-pkg", "alice"]);
+    let result = args.run(&config).await.expect("owner add with OTP must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("+alice: my-pkg"));
+}
+
+#[tokio::test]
+async fn owner_add_too_few_args() {
+    let config = config_with_registry("http://unused/");
+    let args = owner_args("add", &["my-pkg"]);
+    let err = args.run(&config).await.unwrap_err();
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("Package name and owner are required"));
+}
+
+// ── owner rm HTTP-flow tests ──────────────────────────────────────────
+
+#[tokio::test]
+async fn owner_rm_success() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/-/package/my-pkg/owners/alice")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("rm", &["my-pkg", "alice"]);
+    let result = args.run(&config).await.expect("owner rm must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("-alice: my-pkg"));
+}
+
+#[tokio::test]
+async fn owner_rm_401_returns_unauthorized() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/-/package/my-pkg/owners/alice")
+        .with_status(401)
+        .with_body("unauthorized")
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("rm", &["my-pkg", "alice"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("logged in"), "expected Unauthorized, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_rm_403_returns_forbidden() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/-/package/my-pkg/owners/alice")
+        .with_status(403)
+        .with_body("not allowed")
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("rm", &["my-pkg", "alice"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("permission"), "expected Forbidden, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_rm_404_returns_package_not_found() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/-/package/missing-pkg/owners/alice")
+        .with_status(404)
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("rm", &["missing-pkg", "alice"]);
+    let err = args.run(&config).await.unwrap_err();
+
+    mock.assert_async().await;
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("not found"), "expected PackageNotFound, got: {formatted}");
+}
+
+#[tokio::test]
+async fn owner_rm_sends_otp_header() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/-/package/my-pkg/owners/bob")
+        .match_header("npm-otp", "654321")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args_with_otp("654321", "rm", &["my-pkg", "bob"]);
+    let result = args.run(&config).await.expect("owner rm with OTP must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("-bob: my-pkg"));
+}
+
+#[tokio::test]
+async fn owner_rm_too_few_args() {
+    let config = config_with_registry("http://unused/");
+    let args = owner_args("rm", &["my-pkg"]);
+    let err = args.run(&config).await.unwrap_err();
+    let report: miette::Report = err;
+    let formatted = format!("{report:?}");
+    assert!(formatted.contains("Package name and owner are required"));
+}
+
+#[tokio::test]
+async fn owner_rm_encodes_owner_in_url() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("DELETE", "/-/package/my-pkg/owners/user%40example.com")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = owner_args("rm", &["my-pkg", "user@example.com"]);
+    let result = args.run(&config).await.expect("owner rm must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("-user@example.com: my-pkg"));
+}
+
+// ── default subcommand (no subcommand → ls) ──────────────────────────
+
+#[tokio::test]
+async fn owner_no_subcommand_defaults_to_ls() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/-/package/my-pkg/owners")
+        .with_status(200)
+        .with_body(json!([{"username": "dave", "email": "dave@example.com"}]).to_string())
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&server.url());
+    let args = OwnerArgs { registry: None, otp: None, params: vec!["my-pkg".to_string()] };
+    let result = args.run(&config).await.expect("default ls must succeed");
+
+    mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("dave <dave@example.com>"));
+}
+
+// ── --registry override ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn owner_ls_registry_override() {
+    let mut default_server = mockito::Server::new_async().await;
+    let _default_mock = default_server
+        .mock("GET", "/-/package/my-pkg/owners")
+        .with_status(200)
+        .with_body(json!([{"username": "wrong", "email": "wrong@example.com"}]).to_string())
+        .create_async()
+        .await;
+
+    let mut override_server = mockito::Server::new_async().await;
+    let override_mock = override_server
+        .mock("GET", "/-/package/my-pkg/owners")
+        .with_status(200)
+        .with_body(json!([{"username": "correct", "email": "correct@example.com"}]).to_string())
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&default_server.url());
+    let args = owner_args_with_registry(&override_server.url(), "ls", &["my-pkg"]);
+    let result = args.run(&config).await.expect("owner ls with registry override must succeed");
+
+    override_mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("correct <correct@example.com>"));
+}
+
+#[tokio::test]
+async fn owner_add_registry_override() {
+    let mut default_server = mockito::Server::new_async().await;
+    let _default_mock = default_server
+        .mock("PUT", "/-/package/my-pkg/owners")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let mut override_server = mockito::Server::new_async().await;
+    let override_mock = override_server
+        .mock("PUT", "/-/package/my-pkg/owners")
+        .match_body(mockito::Matcher::Json(json!({"user": "alice"})))
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let config = config_with_registry(&default_server.url());
+    let args = owner_args_with_registry(&override_server.url(), "add", &["my-pkg", "alice"]);
+    let result = args.run(&config).await.expect("owner add with registry override must succeed");
+
+    override_mock.assert_async().await;
+    assert_eq!(result.as_deref(), Some("+alice: my-pkg"));
+}
+
+// ── normalize_registry_url ───────────────────────────────────────────
+
+#[test]
+fn normalize_registry_url_adds_trailing_slash() {
+    assert_eq!(
+        super::normalize_registry_url("https://registry.example.com"),
+        "https://registry.example.com/",
+    );
+}
+
+#[test]
+fn normalize_registry_url_preserves_trailing_slash() {
+    assert_eq!(
+        super::normalize_registry_url("https://registry.example.com/"),
+        "https://registry.example.com/",
+    );
 }

--- a/pnpm/crates/cli/src/cli_args/owner/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/owner/tests.rs
@@ -130,6 +130,7 @@ async fn owner_ls_success() {
     let result = args.run(&config).await.expect("owner ls must succeed");
 
     mock.assert_async().await;
+    eprintln!("OWNERS:\n{}\n", result.as_deref().unwrap_or_default());
     assert_eq!(result.as_deref(), Some("alice <alice@example.com>\nbob <bob@example.com>"));
 }
 
@@ -149,6 +150,10 @@ async fn owner_ls_404_returns_package_not_found() {
     assert!(formatted.contains("not found"), "expected PackageNotFound, got: {formatted}");
 }
 
+// The `ls` fetch path shares the `add`/`rm` write path's status mapping (TS
+// `fetchOwners` delegates to `throwRegistryError`), so a 401/403 surfaces the
+// registry's response body as an Unauthorized/Forbidden error rather than a
+// bare status line.
 #[tokio::test]
 async fn owner_ls_401_returns_unauthorized() {
     let mut server = mockito::Server::new_async().await;
@@ -166,7 +171,12 @@ async fn owner_ls_401_returns_unauthorized() {
     mock.assert_async().await;
     let report: miette::Report = err;
     let formatted = format!("{report:?}");
-    assert!(formatted.contains("logged in"), "expected Unauthorized error, got: {formatted}");
+    // Assert single tokens: miette's Debug output word-wraps long lines, so a
+    // multi-word substring can straddle a line break.
+    assert!(
+        formatted.contains("logged in") && formatted.contains("unauthorized"),
+        "expected Unauthorized error with body, got: {formatted}",
+    );
 }
 
 #[tokio::test]
@@ -175,7 +185,7 @@ async fn owner_ls_403_returns_forbidden() {
     let mock = server
         .mock("GET", "/-/package/locked-pkg/owners")
         .with_status(403)
-        .with_body("forbidden")
+        .with_body("forbidden detail")
         .create_async()
         .await;
 
@@ -186,7 +196,10 @@ async fn owner_ls_403_returns_forbidden() {
     mock.assert_async().await;
     let report: miette::Report = err;
     let formatted = format!("{report:?}");
-    assert!(formatted.contains("permission"), "expected Forbidden error, got: {formatted}");
+    assert!(
+        formatted.contains("permission") && formatted.contains("forbidden"),
+        "expected Forbidden error with body, got: {formatted}",
+    );
 }
 
 #[tokio::test]
@@ -195,7 +208,7 @@ async fn owner_ls_500_returns_registry_error() {
     let mock = server
         .mock("GET", "/-/package/broken-pkg/owners")
         .with_status(500)
-        .with_body("internal error")
+        .with_body("teapot")
         .create_async()
         .await;
 
@@ -206,7 +219,12 @@ async fn owner_ls_500_returns_registry_error() {
     mock.assert_async().await;
     let report: miette::Report = err;
     let formatted = format!("{report:?}");
-    assert!(formatted.contains("500"), "expected status 500 in error, got: {formatted}");
+    assert!(
+        formatted.contains("fetch owners")
+            && formatted.contains("500")
+            && formatted.contains("teapot"),
+        "expected registry error with body, got: {formatted}",
+    );
 }
 
 #[tokio::test]
@@ -315,11 +333,18 @@ async fn owner_add_403_returns_forbidden() {
     assert!(formatted.contains("permission"), "expected Forbidden, got: {formatted}");
 }
 
+// The write path (add/rm) mirrors the TypeScript `throwRegistryError`, whose
+// 404 message is `Package not found in registry. {body}` — distinct from the
+// `ls` fetch path, which quotes the package name instead.
 #[tokio::test]
 async fn owner_add_404_returns_package_not_found() {
     let mut server = mockito::Server::new_async().await;
-    let mock =
-        server.mock("PUT", "/-/package/missing-pkg/owners").with_status(404).create_async().await;
+    let mock = server
+        .mock("PUT", "/-/package/missing-pkg/owners")
+        .with_status(404)
+        .with_body("no such package")
+        .create_async()
+        .await;
 
     let config = config_with_registry(&server.url());
     let args = owner_args("add", &["missing-pkg", "alice"]);
@@ -328,7 +353,11 @@ async fn owner_add_404_returns_package_not_found() {
     mock.assert_async().await;
     let report: miette::Report = err;
     let formatted = format!("{report:?}");
-    assert!(formatted.contains("not found"), "expected PackageNotFound, got: {formatted}");
+    assert!(
+        formatted.contains("Package not found in registry")
+            && formatted.contains("no such package"),
+        "expected write-path PackageNotFound with body, got: {formatted}",
+    );
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/src/cli_args/owner/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/owner/tests.rs
@@ -1,0 +1,60 @@
+use super::{OwnerEntry, OwnerError};
+
+#[test]
+fn owner_entry_deserializes() {
+    let json = r#"{"username": "alice", "email": "alice@example.com"}"#;
+    let entry: OwnerEntry = serde_json::from_str(json).expect("should deserialize");
+    assert_eq!(entry.username, "alice");
+    assert_eq!(entry.email, "alice@example.com");
+}
+
+#[test]
+fn owner_entry_deserializes_array() {
+    let json = r#"[
+        {"username": "alice", "email": "alice@example.com"},
+        {"username": "bob", "email": "bob@example.com"}
+    ]"#;
+    let entries: Vec<OwnerEntry> = serde_json::from_str(json).expect("should deserialize");
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].username, "alice");
+    assert_eq!(entries[1].username, "bob");
+}
+
+#[test]
+fn error_add_args_required_display() {
+    let err = OwnerError::AddArgsRequired;
+    assert!(err.to_string().contains("Package name and owner are required"));
+}
+
+#[test]
+fn error_rm_args_required_display() {
+    let err = OwnerError::RmArgsRequired;
+    assert!(err.to_string().contains("Package name and owner are required"));
+}
+
+#[test]
+fn error_package_not_found_display() {
+    let err = OwnerError::PackageNotFound { package_name: "my-pkg".to_string() };
+    assert!(err.to_string().contains("my-pkg"));
+    assert!(err.to_string().contains("not found"));
+}
+
+#[test]
+fn error_unauthorized_display() {
+    let err = OwnerError::Unauthorized {
+        action: "add owner to".to_string(),
+        body: "token expired".to_string(),
+    };
+    assert!(err.to_string().contains("logged in"));
+    assert!(err.to_string().contains("token expired"));
+}
+
+#[test]
+fn error_forbidden_display() {
+    let err = OwnerError::Forbidden {
+        action: "remove owner from".to_string(),
+        body: "not allowed".to_string(),
+    };
+    assert!(err.to_string().contains("permission"));
+    assert!(err.to_string().contains("not allowed"));
+}

--- a/pnpm/crates/cli/src/cli_args/owner/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/owner/tests.rs
@@ -73,9 +73,9 @@ fn error_registry_write_failed_includes_package() {
     let msg = err.to_string();
     assert!(
         msg.contains("package"),
-        "error message must include 'package' for parity with TypeScript: {msg}"
+        "error message must include 'package' for parity with TypeScript: {msg}",
     );
-    assert!(msg.contains("add owner \"bob\" to"));
+    assert!(msg.contains(r#"add owner "bob" to"#));
     assert!(msg.contains("500"));
 }
 

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -527,6 +527,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Completion(_) => "completion",
         CliCommand::CompletionServer(_) => "completion-server",
         CliCommand::Team(_) => "team",
+        CliCommand::Owner(_) => "owner",
     }
 }
 

--- a/pnpm11/registry-access/commands/src/owner.ts
+++ b/pnpm11/registry-access/commands/src/owner.ts
@@ -216,7 +216,7 @@ async function fetchOwners (
     if (response.status === 404) {
       throw new PnpmError('PACKAGE_NOT_FOUND', `Package "${packageName}" not found in registry`)
     }
-    throw new PnpmError('REGISTRY_ERROR', `Failed to fetch owners: ${response.status} ${response.statusText}`)
+    await throwRegistryError(response, 'fetch owners of')
   }
 
   return await response.json() as Owner[]

--- a/pnpm11/registry-access/commands/test/owner.ts
+++ b/pnpm11/registry-access/commands/test/owner.ts
@@ -83,6 +83,38 @@ describe('owner command', () => {
     }).rejects.toThrow('not found')
   })
 
+  it('owner ls: should throw on 401 (unauthorized)', async () => {
+    getMockAgent().get('https://registry.npmjs.org').intercept({
+      method: 'GET',
+      path: /^\/-\/package\/@pnpm%2[Ff]test\/owners$/,
+    }).reply(401, { error: 'Unauthorized' })
+
+    await expect(async () => {
+      await owner.handler({
+        cliOptions: {},
+        registries: {
+          default: REGISTRY_URL,
+        },
+      }, ['ls', '@pnpm/test'])
+    }).rejects.toThrow('logged in')
+  })
+
+  it('owner ls: should throw on 403 (forbidden)', async () => {
+    getMockAgent().get('https://registry.npmjs.org').intercept({
+      method: 'GET',
+      path: /^\/-\/package\/@pnpm%2[Ff]test\/owners$/,
+    }).reply(403, { error: 'Forbidden' })
+
+    await expect(async () => {
+      await owner.handler({
+        cliOptions: {},
+        registries: {
+          default: REGISTRY_URL,
+        },
+      }, ['ls', '@pnpm/test'])
+    }).rejects.toThrow('permission')
+  })
+
   it('owner add: should add an owner to a package', async () => {
     getMockAgent().get('https://registry.npmjs.org').intercept({
       method: 'PUT',


### PR DESCRIPTION
## Summary

Implement the `pnpm owner` (aliased as `pnpm owners`) command natively in Rust, matching the TypeScript implementation at `pnpm11/registry-access/commands/src/owner.ts`.

This command manages package ownership on the npm registry with three subcommands:
- `pnpm owner ls <package>` — list owners
- `pnpm owner add <package> <user>` — add an owner
- `pnpm owner rm <package> <user>` — remove an owner

The implementation follows the established patterns from the `team`, `access`, and `dist_tag` commands.

As a cross-stack parity improvement, `owner ls` now reports authentication/authorization failures (401/403) as dedicated errors that include the registry's response body — matching `owner add`/`rm` — instead of a generic `Failed to fetch owners` message. This is applied to both the Rust and the TypeScript (`@pnpm/registry-access.commands`) implementations so they stay behaviorally identical.

related to: #11633

## Squash Commit Body
```text
Native Rust implementation of the owner/owners CLI command.

Registry API endpoints used:
- GET  /-/package/{name}/owners           (list)
- PUT  /-/package/{name}/owners           (add)
- DELETE /-/package/{name}/owners/{user}  (remove)

Features matching TypeScript parity:
- Subcommands: ls, list, add, rm
- Default to ls when first arg is a package name
- --otp flag sends npm-otp header for add/rm
- Scoped package registry resolution via pick_registry_for_package
- Auth header resolution via nerf-dart URL matching
- Retry with exponential backoff
- Body size limits (1MB for reads, 64KB for error bodies)
- Error codes: ERR_PNPM_OWNER_LS_PACKAGE_REQUIRED, ERR_PNPM_OWNER_ADD_ARGS_REQUIRED, ERR_PNPM_OWNER_RM_ARGS_REQUIRED, ERR_PNPM_PACKAGE_NOT_FOUND, ERR_PNPM_UNAUTHORIZED, ERR_PNPM_FORBIDDEN, ERR_PNPM_REGISTRY_ERROR

related to: #11633
```
## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset if this PR changes any published package.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786642496&installation_id=145934176&pr_number=13000&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13000&signature=50f90934fd24bdc99d0dbe4c75dc0073b0631dcc7960c7d605dbb43a105cc0d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added an `owner` CLI command (with `owners` alias) to manage package registry owners: `ls`, `add`, and `rm`.
  - Supports `--registry` override, authentication, and optional `--otp`; defaults to `ls` when no subcommand is provided.
- **Bug Fixes**
  - Enhanced user-facing handling and formatting of registry errors (not found, unauthorized/forbidden, and request/response failures).
- **Tests**
  - Added comprehensive unit and async tests covering JSON parsing, URL encoding, OTP headers, error mappings, defaults, and registry override routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
