### PR TITLE
ci: auto-tag released versions when the release PR merges

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -177,7 +177,7 @@ jobs:
             --title "chore(release): ${VERSION}" \
             --body "Automated release PR created by the create-release-pr workflow.
 
-        Releasing \`${TARGET}\`: ${VERSION}. Merging this PR consumes the pending changesets and records them in the committed \`.changeset/ledger.yaml\`. After merging, push the version tag of a released product to run the release workflow." \
+        Releasing \`${TARGET}\`: ${VERSION}. Merging this PR consumes the pending changesets and records them in the committed \`.changeset/ledger.yaml\`, then auto-tags each released product (tag-release.yml) to run the release workflow." \
             --base "$TARGET" \
             --head "$BRANCH"
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ on:
     tags:
       # pnpm (TypeScript, v11.x) and pacquet (v12.x) share the `v<version>`
       # namespace that get.pnpm.io's install scripts fetch by. pnpr gets its own
-      # `pnpr-v<version>` namespace: pnpm's tag history includes v0.x/v1.x that
-      # pnpr's low version numbers would otherwise collide with.
+      # Changesets-style `pnpr@<version>` namespace: pnpm's tag history includes
+      # v0.x/v1.x that pnpr's low version numbers would otherwise collide with.
       - "v*.*.*"
-      - "pnpr-v*.*.*"
+      - "pnpr@*.*.*"
   # Manual trigger for rerunning a tag release. Dispatching this workflow from a
   # branch fails before publishing because release artifacts are only built on
   # version tags.
@@ -41,9 +41,9 @@ jobs:
         run: |
           case "${GITHUB_REF}" in
             refs/tags/v*.*.*) ;;
-            refs/tags/pnpr-v*.*.*) ;;
+            refs/tags/pnpr@*.*.*) ;;
             *)
-              echo "::error::The release workflow must run from a version tag like v11.9.0 or pnpr-v0.2.0. Current ref: ${GITHUB_REF}"
+              echo "::error::The release workflow must run from a version tag like v11.9.0 or pnpr@0.2.0. Current ref: ${GITHUB_REF}"
               exit 1
               ;;
           esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,12 @@ name: Release
 on:
   push:
     tags:
+      # pnpm (TypeScript, v11.x) and pacquet (v12.x) share the `v<version>`
+      # namespace that get.pnpm.io's install scripts fetch by. pnpr gets its own
+      # `pnpr-v<version>` namespace: pnpm's tag history includes v0.x/v1.x that
+      # pnpr's low version numbers would otherwise collide with.
       - "v*.*.*"
+      - "pnpr-v*.*.*"
   # Manual trigger for rerunning a tag release. Dispatching this workflow from a
   # branch fails before publishing because release artifacts are only built on
   # version tags.
@@ -36,8 +41,9 @@ jobs:
         run: |
           case "${GITHUB_REF}" in
             refs/tags/v*.*.*) ;;
+            refs/tags/pnpr-v*.*.*) ;;
             *)
-              echo "::error::The release workflow must run from a version tag like v11.9.0. Current ref: ${GITHUB_REF}"
+              echo "::error::The release workflow must run from a version tag like v11.9.0 or pnpr-v0.2.0. Current ref: ${GITHUB_REF}"
               exit 1
               ;;
           esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,16 @@ on:
   # version tags.
   workflow_dispatch:
 
+# A release PR that bumps several products auto-tags each one (tag-release.yml),
+# so several version tags can land together and start a run apiece. Serialize
+# them: the plan job gates every publish on what npm reports as unpublished, so
+# once the first run publishes a product the rest skip it — but only if they
+# don't run concurrently and all read "unpublished" at once. Never cancel a
+# run mid-publish.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   validate-release-ref:
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -62,8 +62,8 @@ jobs:
 
           to_push=()
           add_tag() {
-            local manifest="$1" tag
-            tag="v$(jq -r .version "$manifest")"
+            local manifest="$1" prefix="$2" tag
+            tag="${prefix}v$(jq -r .version "$manifest")"
             case "$seen" in
               *" $tag "*)
                 echo "$tag already exists; skipping"
@@ -75,9 +75,13 @@ jobs:
             seen="$seen$tag "
           }
 
-          add_tag pnpm11/pnpm/package.json
-          add_tag pnpm/npm/pnpm/package.json
-          add_tag pnpr/npm/pnpr/package.json
+          # pnpm (TypeScript, v11.x) and pacquet (v12.x) share the `v<version>`
+          # namespace get.pnpm.io fetches by. pnpr takes a `pnpr-` prefix so its
+          # low version numbers don't collide with pnpm's v0.x/v1.x tag history —
+          # release.yml triggers on `pnpr-v*.*.*` too.
+          add_tag pnpm11/pnpm/package.json ''
+          add_tag pnpm/npm/pnpm/package.json ''
+          add_tag pnpr/npm/pnpr/package.json 'pnpr-'
 
           if [ ${#to_push[@]} -eq 0 ]; then
             echo "No new version tags to push"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,82 @@
+name: Tag Release
+
+# When a release PR (opened by create-release-pr.yml) is merged, derive the
+# version tags from the committed manifests and push them. This replaces the
+# manual `git tag && git push` step: deriving each tag from the version already
+# committed on the merge commit makes it impossible to tag a name that doesn't
+# match what was published (a mismatch drafts a GitHub release for a tag that
+# doesn't exist and the release workflow fails).
+on:
+  pull_request:
+    types:
+      - closed
+
+# The checkout only needs read; the tags are pushed with a PAT (below) so the
+# push triggers release.yml — a tag pushed with the default GITHUB_TOKEN would
+# not, by GitHub's workflow-recursion guard.
+permissions:
+  contents: read
+
+jobs:
+  tag-release:
+    name: Push version tags for the merged release
+    # Only merged release PRs on the main repository. `create-release-pr.yml`
+    # always opens them from a `release-pr/<target>` head branch.
+    if: >-
+      github.repository == 'pnpm/pnpm' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release-pr/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the merge commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+
+      - name: Push version tags for released products
+        # The manifests read here are exactly the ones release.yml's plan job
+        # reads to decide what to publish, so each `v<version>` tag matches the
+        # version its product will publish. A tag that already exists (a product
+        # whose version didn't change this release) is skipped, so only the
+        # freshly bumped products get tagged — and release.yml still gates the
+        # actual publish on what npm reports as unpublished.
+        env:
+          GH_TOKEN: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -eu
+          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # Tags already on the remote, so a re-run or an unchanged product can
+          # never clobber or repush an existing version tag. `seen` is a
+          # space-padded set for the ` $tag ` membership test; it also collects
+          # the tags staged this run so a shared version can't be pushed twice.
+          seen=" $(git ls-remote --tags "$REMOTE" | awk '{ print $2 }' | sed 's#refs/tags/##' | tr '\n' ' ') "
+
+          to_push=()
+          add_tag() {
+            local manifest="$1" tag
+            tag="v$(jq -r .version "$manifest")"
+            case "$seen" in
+              *" $tag "*)
+                echo "$tag already exists; skipping"
+                return
+                ;;
+            esac
+            git tag "$tag" "$SHA"
+            to_push+=("$tag")
+            seen="$seen$tag "
+          }
+
+          add_tag pnpm11/pnpm/package.json
+          add_tag pnpm/npm/pnpm/package.json
+          add_tag pnpr/npm/pnpr/package.json
+
+          if [ ${#to_push[@]} -eq 0 ]; then
+            echo "No new version tags to push"
+            exit 0
+          fi
+
+          echo "Pushing: ${to_push[*]}"
+          git push "$REMOTE" "${to_push[@]}"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,11 +1,11 @@
 name: Tag Release
 
-# When a release PR (opened by create-release-pr.yml) is merged, derive the
-# version tags from the committed manifests and push them. This replaces the
-# manual `git tag && git push` step: deriving each tag from the version already
-# committed on the merge commit makes it impossible to tag a name that doesn't
-# match what was published (a mismatch drafts a GitHub release for a tag that
-# doesn't exist and the release workflow fails).
+# When a release PR (opened by create-release-pr.yml) is merged, derive each
+# product's version tag from the version committed on the merge commit and push
+# it. Deriving the tag from the committed version keeps the tag name in lockstep
+# with what release.yml publishes: a tag naming a version that isn't on the
+# merge commit would draft a GitHub release for a tag that doesn't exist, which
+# the release workflow rejects.
 on:
   pull_request:
     types:
@@ -20,12 +20,15 @@ permissions:
 jobs:
   tag-release:
     name: Push version tags for the merged release
-    # Only merged release PRs on the main repository. `create-release-pr.yml`
-    # always opens them from a `release-pr/<target>` head branch.
+    # Only merged release PRs on the main repository. Match create-release-pr.yml's
+    # exact contract — a same-repo head branch named `release-pr/<base>` — so a
+    # fork PR or an unrelated branch that merely starts with `release-pr/` can't
+    # reach the tag push.
     if: >-
       github.repository == 'pnpm/pnpm' &&
       github.event.pull_request.merged == true &&
-      startsWith(github.event.pull_request.head.ref, 'release-pr/')
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref == format('release-pr/{0}', github.event.pull_request.base.ref)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the merge commit
@@ -45,14 +48,17 @@ jobs:
           GH_TOKEN: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
           SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          set -eu
+          set -euo pipefail
           REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           # Tags already on the remote, so a re-run or an unchanged product can
           # never clobber or repush an existing version tag. `seen` is a
           # space-padded set for the ` $tag ` membership test; it also collects
           # the tags staged this run so a shared version can't be pushed twice.
-          seen=" $(git ls-remote --tags "$REMOTE" | awk '{ print $2 }' | sed 's#refs/tags/##' | tr '\n' ' ') "
+          # `--refs` drops the peeled `^{}` entries of annotated tags. pipefail
+          # (above) makes a failed ls-remote abort instead of yielding an empty
+          # set that would make every version look new.
+          seen=" $(git ls-remote --tags --refs "$REMOTE" | awk '{ print $2 }' | sed 's#refs/tags/##' | tr '\n' ' ') "
 
           to_push=()
           add_tag() {

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -63,7 +63,7 @@ jobs:
           to_push=()
           add_tag() {
             local manifest="$1" prefix="$2" tag
-            tag="${prefix}v$(jq -r .version "$manifest")"
+            tag="${prefix}$(jq -r .version "$manifest")"
             case "$seen" in
               *" $tag "*)
                 echo "$tag already exists; skipping"
@@ -76,12 +76,12 @@ jobs:
           }
 
           # pnpm (TypeScript, v11.x) and pacquet (v12.x) share the `v<version>`
-          # namespace get.pnpm.io fetches by. pnpr takes a `pnpr-` prefix so its
-          # low version numbers don't collide with pnpm's v0.x/v1.x tag history —
-          # release.yml triggers on `pnpr-v*.*.*` too.
-          add_tag pnpm11/pnpm/package.json ''
-          add_tag pnpm/npm/pnpm/package.json ''
-          add_tag pnpr/npm/pnpr/package.json 'pnpr-'
+          # namespace get.pnpm.io fetches by. pnpr uses the Changesets-style
+          # `pnpr@<version>` so its low version numbers don't collide with pnpm's
+          # v0.x/v1.x tag history — release.yml triggers on `pnpr@*.*.*` too.
+          add_tag pnpm11/pnpm/package.json 'v'
+          add_tag pnpm/npm/pnpm/package.json 'v'
+          add_tag pnpr/npm/pnpr/package.json 'pnpr@'
 
           if [ ${#to_push[@]} -eq 0 ]; then
             echo "No new version tags to push"


### PR DESCRIPTION
## Summary

Auto-tags released versions when a release PR is merged, so a release tag can never drift from the version it's supposed to release.

Today the version tag is pushed by hand after merging the release PR. If the tag name doesn't match the version committed on the merge commit, `release.yml`'s `plan` job (which reads the committed version, not the tag) publishes the committed version to npm but `github-release-rust` then drafts a GitHub release for `v<committed-version>` — a tag that doesn't exist as a git ref — and the create-release call fails with `403 Resource not accessible by integration`, even though the job has `contents: write`. That is exactly what happened on the [v12.0.0-alpha.11 release](https://github.com/pnpm/pnpm/actions/runs/29359965575/job/87186344448): the tag `v12.0.0-alpha.12` was pushed onto the commit that bumped the committed version to `12.0.0-alpha.11`.

This PR adds `.github/workflows/tag-release.yml`, which on a merged `release-pr/*` PR derives each product's tag from its committed manifest (the same manifests `plan` reads), skips versions already tagged on the remote, and pushes the new tags. Because the tag is derived from the committed version rather than typed, the off-by-one is impossible; because the tag exists as a real ref before `release.yml` runs, the draft-release step no longer 403s.

## Squash Commit Body

```text
The release tag was pushed by hand after merging a release PR, which let
the tag name drift from the version committed on the merge commit. When
they disagree, release.yml's plan job publishes the committed version but
github-release-rust drafts a GitHub release for `v<committed-version>` — a
tag that doesn't exist as a git ref — and the create-release call returns
403 "Resource not accessible by integration" even with contents: write.

Add tag-release.yml: on a merged `release-pr/*` PR it derives each
product's tag from the committed manifest (the same manifests plan reads),
skips versions already tagged on the remote, and pushes the new tags with
UPDATE_LOCKFILE_TOKEN so the push triggers release.yml (a tag pushed with
the default GITHUB_TOKEN would not). Deriving the tag from the committed
version makes the off-by-one impossible, and the tag exists as a real ref
before release.yml runs, so the draft-release step no longer 403s.

A release PR can bump several products at once, landing several tags and
starting a release run apiece; add a `release` concurrency group so they
serialize and plan's already-published gate makes the later runs no-ops.

Drop the now-obsolete "push the version tag after merging" line from the
release PR body.
```

## Checklist

- [x] The change is CI-only (release orchestration); it applies equally to the TypeScript CLI, the Rust `pnpm/` port, and pnpr — the workflow tags all three from their committed manifests.
- [x] No changeset: this changes only GitHub Actions workflows, not any published package.
- [ ] Added or updated tests.
- [x] Updated the documentation if needed (updated the release PR body text; no user-facing docs affected).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786652597&installation_id=145934176&pr_number=13004&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13004&signature=185051ed7ff0b36716c1fa602c7d4b90a826ea404ef10dbe2b28483f3e66aed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Improvements**
  - Merged release pull requests now automatically create and publish version tags to trigger the release workflow.
  - Release runs are serialized to prevent overlapping publishes and to avoid canceling an in-progress release.
  - Existing version tags are preserved: the process skips tags that already exist to prevent duplicate tagging or republishing.
  - Release tag validation now accepts both `v*.*.*` and `pnpr@*.*.*` formats.
- **Documentation**
  - Updated release pull request instructions to match the tag-based release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->