### PR TITLE
fix(fs-packlist): honor npm-packlist ignore-file priority when files field is set

### DIFF
--- a/.changeset/fix-packlist-ignore-priority.md
+++ b/.changeset/fix-packlist-ignore-priority.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm pack` and `pnpm publish` now honor npm-packlist's ignore-file priority: when `files` is set in package.json, `.gitignore` and `.npmignore` no longer exclude listed entries. Fixes the empty platform-package tarballs shipped in 11.12.0 and 11.13.0.

--- a/pnpm/crates/fs-packlist/src/lib.rs
+++ b/pnpm/crates/fs-packlist/src/lib.rs
@@ -7,10 +7,12 @@
 //!
 //! The algorithm has four passes:
 //!
-//! 1. **Honor `.npmignore` and `.gitignore`** while walking. The
-//!    `ignore::WalkBuilder` does per-directory inheritance: a
-//!    `.npmignore` in `lib/` applies to `lib/**` only, while the
-//!    package's root `.gitignore` applies to the whole tree.
+//! 1. **Walk with ignore-file filtering**, honoring npm-packlist's
+//!    three-tier priority at the package root: (a) `files` present
+//!    disables both `.gitignore` and `.npmignore`, leaving the
+//!    allowlist in pass 2 as the sole gate; (b) no `files` but a
+//!    root `.npmignore` exists disables `.gitignore`; (c) neither
+//!    present falls back to `.gitignore`.
 //! 2. **Apply the `files` field allowlist** on top of the walk's
 //!    output: when the manifest sets `files: ["dist/**"]`, drop
 //!    anything outside that set (except the always-included files
@@ -31,21 +33,14 @@
 //!    `node_modules/` be found and spliced in under its real path.
 //!    Port of [`npm-bundled`](https://github.com/npm/npm-bundled).
 //!
-//! Two intentional divergences from npm-packlist:
+//! One intentional divergence from npm-packlist:
 //!
-//! - The `ignore` crate combines `.npmignore` and `.gitignore` rules
-//!   when both files exist in the same directory; npm-packlist would
-//!   use only `.npmignore`. The combined-rules outcome is the same
-//!   for the common case (a `.npmignore` that's a strict superset of
-//!   `.gitignore`); the divergence shows up only when `.npmignore`
-//!   explicitly *includes* a path `.gitignore` excludes, which is a
-//!   rare configuration in the wild. Documented gap; revisit if a
-//!   real package surfaces it.
-//! - `.git/info/exclude` and global `~/.gitignore` are NOT honored —
-//!   only the in-tree `.gitignore` / `.npmignore` files. Callers pass
-//!   a clean tarball / git checkout or a project directory, not a
-//!   user's working tree, so the global-state ignores are wrong by
-//!   construction.
+//! - npm-packlist evaluates the `.npmignore`-supersedes-`.gitignore`
+//!   rule per-directory, but the `ignore` crate's `WalkBuilder`
+//!   toggles are process-global, so pacquet applies the three-tier
+//!   priority at the package root only. In tier 3, a subdirectory
+//!   that has both ignore files gets them combined rather than
+//!   `.npmignore` winning. This is rare in published packages.
 
 use derive_more::{Display, Error};
 use ignore::{WalkBuilder, gitignore::Gitignore};
@@ -308,30 +303,34 @@ fn collect_own_files(
 
     let mut out: BTreeSet<String> = BTreeSet::new();
 
-    // Pass 1: walk with `.gitignore` / `.npmignore` filtering.
+    // Pass 1: walk with ignore-file filtering.  The three-tier
+    // priority (see module doc) decides which ignore files apply.
+    //
     // `standard_filters(false)` turns off `ignore`'s opinionated
     // defaults (hidden-file skip, `.git`-dir skip, etc.) so we control
-    // every filter explicitly. `git_ignore(true)` /
-    // `add_custom_ignore_filename(".npmignore")` enable the two ignore
-    // file sources; `require_git(false)` makes `ignore` honor
-    // `.gitignore` even though a git-hosted snapshot's `.git/` has
-    // already been deleted by [`crate::GitFetcher`] before this point.
+    // every filter explicitly. `require_git(false)` makes `ignore`
+    // honor `.gitignore` even though a git-hosted snapshot's `.git/`
+    // has already been deleted by [`crate::GitFetcher`] before this
+    // point.
+    let has_root_npmignore = pkg_dir.join(".npmignore").is_file();
     let mut builder = WalkBuilder::new(pkg_dir);
     builder
         .current_dir(pkg_dir)
         .standard_filters(false)
         .hidden(false)
-        .git_ignore(true)
         .git_exclude(false)
         .git_global(false)
         .require_git(false)
-        // Don't search parent directories of `pkg_dir` for ignore
-        // files: the packlist must depend only on the contents of the
-        // package directory itself. Otherwise a `.gitignore` in the
-        // workspace root above a git-hosted snapshot's working copy
-        // would leak into the published file set.
-        .parents(false)
-        .add_custom_ignore_filename(".npmignore");
+        .parents(false);
+    if files_field.is_some() {
+        builder.git_ignore(false);
+    } else if has_root_npmignore {
+        builder.git_ignore(false);
+        builder.add_custom_ignore_filename(".npmignore");
+    } else {
+        builder.git_ignore(true);
+        builder.add_custom_ignore_filename(".npmignore");
+    }
     add_workspace_ignore_files(&mut builder, pkg_dir, workspace_dir)?;
 
     for entry in builder.build() {

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -871,3 +871,77 @@ fn main_resolving_through_a_symlinked_dir_is_not_force_included() {
         "main resolving outside the package via a symlinked dir must not be included: {out:?}",
     );
 }
+
+#[test]
+fn files_field_overrides_root_gitignore() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    fs::write(root.join("pnpm"), "binary-content").unwrap();
+    fs::write(root.join(".gitignore"), "pnpm\n").unwrap();
+
+    let manifest = json!({
+        "name": "@pnpm/linux-x64",
+        "version": "11.12.0",
+        "files": ["pnpm"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(
+        out.contains(&"pnpm".to_string()),
+        "`files: [\"pnpm\"]` must override `.gitignore` that excludes `pnpm`; received {out:?}",
+    );
+}
+
+#[test]
+fn npmignore_disables_gitignore_in_same_directory() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "index.js");
+    touch(root, "build/output.js");
+    touch(root, "test/foo.test.js");
+    fs::write(root.join(".gitignore"), "build/\n").unwrap();
+    fs::write(root.join(".npmignore"), "test/\n").unwrap();
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
+
+    assert!(
+        out.contains(&"build/output.js".to_string()),
+        "`.npmignore` must supersede `.gitignore`; `build/` should be included: {out:?}",
+    );
+    assert!(
+        !out.iter().any(|p| p.starts_with("test/")),
+        "`.npmignore` must exclude `test/`: {out:?}",
+    );
+}
+
+#[test]
+fn files_field_overrides_gitignore_with_npmignore_coexisting() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    fs::write(root.join("pnpm"), "binary-content").unwrap();
+    touch(root, "nodes/extra");
+    touch(root, "src/index.ts");
+    fs::write(root.join(".gitignore"), "pnpm\n").unwrap();
+    fs::write(root.join(".npmignore"), "nodes\n").unwrap();
+
+    let manifest = json!({
+        "name": "@pnpm/macos-arm64",
+        "version": "11.12.0",
+        "files": ["pnpm"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert!(
+        out.contains(&"pnpm".to_string()),
+        "`files` must override both `.gitignore` and `.npmignore`; received {out:?}",
+    );
+    assert!(
+        !out.contains(&"src/index.ts".to_string()),
+        "files not in the `files` allowlist must be excluded: {out:?}",
+    );
+}

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -889,7 +889,7 @@ fn files_field_overrides_root_gitignore() {
 
     assert!(
         out.contains(&"pnpm".to_string()),
-        "`files: [\"pnpm\"]` must override `.gitignore` that excludes `pnpm`; received {out:?}",
+        r#"`files: ["pnpm"]` must override `.gitignore` that excludes `pnpm`; received {out:?}"#,
     );
 }
 


### PR DESCRIPTION
## Summary

`collect_own_files` unconditionally enabled `.gitignore` and `.npmignore` via `WalkBuilder`, ignoring npm-packlist's three-tier priority. This caused platform packages (`@pnpm/linux-x64`, etc.) whose `package.json` lists `files: ["pnpm"]` alongside a `.gitignore` containing `pnpm` to produce empty tarballs in 11.12.0 and 11.13.0.

Apply the three-tier priority conditionally: (a) `files` present disables both ignore files, (b) root `.npmignore` present disables `.gitignore`, (c) neither falls back to `.gitignore`.

Rust-only; the TypeScript CLI delegates to the `npm-packlist` library which already handles this.

## Squash Commit Body

```text
collect_own_files unconditionally enabled .gitignore and .npmignore via
WalkBuilder, ignoring npm-packlist's three-tier priority: (a) files field
present disables both, (b) root .npmignore present disables .gitignore,
(c) neither falls back to .gitignore. This caused platform packages
whose package.json lists files: ["pnpm"] alongside a .gitignore
containing "pnpm" to produce empty tarballs (the binary was excluded
by the walker before the files allowlist could include it).

Apply the three-tier priority conditionally in collect_own_files. The
ignore crate's WalkBuilder toggles are global, so the priority is
applied at the package root only; subdirectory behavior is documented
as a known divergence.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. *(Rust-only; the TypeScript CLI delegates to `npm-packlist` which already handles this.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786653657&installation_id=145934176&pr_number=13005&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13005&signature=ea9a1fac33f4b3a96f0d9fce4382c2e599c6d872b5b225eda8ac5f56d6f85e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Package creation and publishing now correctly apply ignore-file precedence: when `package.json` includes `files`, it overrides `.gitignore` and `.npmignore`.
  - Ensures files intended for the npm package aren’t dropped, preventing empty or incomplete platform-package tarballs.
- **Tests**
  - Added unit tests covering `files` vs `.gitignore`, `.npmignore` overriding `.gitignore` in the same directory, and combined behavior when multiple ignore files exist.
- **Documentation**
  - Updated packaging ignore-file behavior documentation to reflect the corrected three-tier priority.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->