### PR TITLE
fix(cli): make pnpm setup install the native CLI globally

### DIFF
--- a/.changeset/native-setup-ignore-scripts.md
+++ b/.changeset/native-setup-ignore-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fix `pnpm setup` failing when the native CLI installs its downloaded executable globally.

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -1,4 +1,10 @@
-use crate::{State, cli_args::supported_architectures::SupportedArchitecturesArgs, config_deps};
+use crate::{
+    State,
+    cli_args::{
+        install::resolve_bool_override, supported_architectures::SupportedArchitecturesArgs,
+    },
+    config_deps,
+};
 use clap::Args;
 use miette::Context;
 use pacquet_config::Config;
@@ -96,9 +102,23 @@ pub struct AddArgs {
     /// Install the package globally, linking its bins into the global bin directory.
     #[clap(short = 'g', long)]
     pub global: bool,
+    /// Don't run lifecycle scripts of the added package or its dependencies.
+    #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
+    pub ignore_scripts: bool,
+    /// Force-enable lifecycle scripts for this invocation.
+    #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
+    pub no_ignore_scripts: bool,
 }
 
 impl AddArgs {
+    pub(crate) fn apply_cli_config(&self, config: &mut Config) {
+        config.ignore_scripts = resolve_bool_override(
+            self.ignore_scripts,
+            self.no_ignore_scripts,
+            config.ignore_scripts,
+        );
+    }
+
     /// Execute the subcommand.
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
         // `--config` routes to the configurational-dependency path

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -26,6 +26,7 @@ use super::{
     unlink::UnlinkArgs,
     update::UpdateArgs,
 };
+use crate::State;
 use miette::Context;
 use pacquet_default_reporter::DefaultReporter;
 use pacquet_reporter::{NdjsonReporter, SilentReporter};
@@ -33,6 +34,7 @@ use pacquet_reporter::{NdjsonReporter, SilentReporter};
 pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<CommandFuture<'a>> {
     if args.global {
         let config = (ctx.global_config)()?;
+        args.apply_cli_config(config);
         let dir = ctx.dir;
         return Ok(match ctx.reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
@@ -42,7 +44,10 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
             ReporterType::Silent => Box::pin(args.run_global::<SilentReporter>(config, dir)),
         });
     }
-    let command_state = (ctx.state)(false)?;
+    let config = (ctx.config)()?;
+    args.apply_cli_config(config);
+    let command_state = State::init(ctx.manifest_path.to_path_buf(), config, false)
+        .wrap_err("initialize the state")?;
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => {
             Box::pin(args.run::<DefaultReporter>(command_state))

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -587,20 +587,36 @@ fn resolve_local_param(param: &str, base_dir: &Path) -> String {
 }
 
 fn infer_local_package_alias(selector: &str) -> miette::Result<String> {
-    let Some(path) = selector.strip_prefix("file:").map(Path::new).filter(|path| path.is_dir())
-    else {
+    let Some(path) = selector.strip_prefix("file:").map(Path::new) else {
         return Ok(selector.to_string());
     };
+    let path_display = path.display().to_string();
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(selector.to_string());
+        }
+        Err(error) => {
+            return Err(error)
+                .into_diagnostic()
+                .wrap_err(format!("read local package metadata from {path_display}"));
+        }
+    };
+    if !metadata.is_dir() {
+        return Ok(selector.to_string());
+    }
     let manifest = safe_read_package_json_from_dir(path)
         .map_err(miette::Report::new)
-        .wrap_err_with(|| format!("read local package manifest from {}", path.display()))?
-        .ok_or_else(|| miette::miette!("No package.json was found in {}", path.display()))?;
+        .wrap_err_with(|| format!("read local package manifest from {path_display}"))?
+        .ok_or_else(|| miette::miette!("No package.json was found in {path_display}"))?;
     let name = manifest
         .get("name")
         .and_then(serde_json::Value::as_str)
         .filter(|name| !name.is_empty())
+        .or_else(|| path.file_name().and_then(|name| name.to_str()))
+        .filter(|name| !name.is_empty())
         .ok_or_else(|| {
-            miette::miette!("The local package at {} has no package name", path.display())
+            miette::miette!("The local package at {path_display} has no package name")
         })?;
     Ok(format!("{name}@{selector}"))
 }

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -577,13 +577,17 @@ fn refers_to_existing_local_path(param: &str, base_dir: &Path) -> bool {
     resolved.exists()
 }
 
+/// Mirror the TypeScript `resolveLocalParam`: rewrite only *dot-relative*
+/// `file:`/`link:` selectors against `base_dir`. Bare names, home-relative
+/// (`~/`), and absolute selectors pass through unchanged so the local
+/// resolver's own `~` expansion and registry fallbacks still apply.
 fn resolve_local_param(param: &str, base_dir: &Path) -> String {
     for prefix in ["file:", "link:"] {
         if let Some(rest) = param.strip_prefix(prefix) {
-            if Path::new(rest).is_absolute() || is_windows_drive_path(rest) {
-                return param.to_string();
+            if rest.starts_with('.') {
+                return format!("{prefix}{}", lexical_normalize(&base_dir.join(rest)).display());
             }
-            return format!("{prefix}{}", lexical_normalize(&base_dir.join(rest)).display());
+            return param.to_string();
         }
     }
     if param.starts_with('.') {

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -25,7 +25,7 @@ use pacquet_global::{
     scan_global_packages,
 };
 use pacquet_package_is_installable::SupportedArchitectures;
-use pacquet_package_manifest::DependencyGroup;
+use pacquet_package_manifest::{DependencyGroup, safe_read_package_json_from_dir};
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -348,11 +348,12 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
 
     let manifest_path = install_dir.join("package.json");
     for selector in selectors {
+        let selector = infer_local_package_alias(selector)?;
         let state = State::init(manifest_path.clone(), config, false)
             .wrap_err("initialize the global install state")?;
         add_package::<Reporter, _, _>(
             state,
-            selector,
+            &selector,
             pinned_version,
             None,
             false,
@@ -583,6 +584,25 @@ fn resolve_local_param(param: &str, base_dir: &Path) -> String {
         return lexical_normalize(&base_dir.join(param)).display().to_string();
     }
     param.to_string()
+}
+
+fn infer_local_package_alias(selector: &str) -> miette::Result<String> {
+    let Some(path) = selector.strip_prefix("file:").map(Path::new).filter(|path| path.is_dir())
+    else {
+        return Ok(selector.to_string());
+    };
+    let manifest = safe_read_package_json_from_dir(path)
+        .map_err(miette::Report::new)
+        .wrap_err_with(|| format!("read local package manifest from {}", path.display()))?
+        .ok_or_else(|| miette::miette!("No package.json was found in {}", path.display()))?;
+    let name = manifest
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            miette::miette!("The local package at {} has no package name", path.display())
+        })?;
+    Ok(format!("{name}@{selector}"))
 }
 
 fn is_windows_drive_path(param: &str) -> bool {

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -28,7 +28,9 @@ use pacquet_package_is_installable::SupportedArchitectures;
 use pacquet_package_manifest::{DependencyGroup, safe_read_package_json_from_dir};
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
-use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
+use pacquet_resolving_parse_wanted_dependency::{
+    is_valid_old_npm_package_name, parse_wanted_dependency,
+};
 use std::{
     collections::HashSet,
     fs,
@@ -56,6 +58,10 @@ pub enum GlobalError {
     #[display("Cannot remove '{param}': not found in global packages")]
     #[diagnostic(code(ERR_PNPM_GLOBAL_PKG_NOT_FOUND))]
     PkgNotFound { param: String },
+
+    #[display(r#"Invalid package name "{name}"."#)]
+    #[diagnostic(code(ERR_PNPM_INVALID_PACKAGE_NAME))]
+    InvalidPackageName { name: String },
 }
 
 /// Resolve the global packages and global bin directories, erroring with
@@ -574,10 +580,10 @@ fn refers_to_existing_local_path(param: &str, base_dir: &Path) -> bool {
 fn resolve_local_param(param: &str, base_dir: &Path) -> String {
     for prefix in ["file:", "link:"] {
         if let Some(rest) = param.strip_prefix(prefix) {
-            if rest.starts_with('.') {
-                return format!("{prefix}{}", lexical_normalize(&base_dir.join(rest)).display());
+            if Path::new(rest).is_absolute() || is_windows_drive_path(rest) {
+                return param.to_string();
             }
-            return param.to_string();
+            return format!("{prefix}{}", lexical_normalize(&base_dir.join(rest)).display());
         }
     }
     if param.starts_with('.') {
@@ -618,6 +624,9 @@ fn infer_local_package_alias(selector: &str) -> miette::Result<String> {
         .ok_or_else(|| {
             miette::miette!("The local package at {path_display} has no package name")
         })?;
+    if !is_valid_old_npm_package_name(name) {
+        return Err(GlobalError::InvalidPackageName { name: name.to_string() }.into());
+    }
     Ok(format!("{name}@{selector}"))
 }
 

--- a/pnpm/crates/cli/src/cli_args/global/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global/tests.rs
@@ -41,18 +41,26 @@ fn unnamed_local_package_uses_directory_name_as_alias() {
 }
 
 #[test]
-fn relative_file_selectors_resolve_from_the_configured_base_directory() {
+fn dot_relative_file_selectors_resolve_from_the_configured_base_directory() {
     let root = tempfile::tempdir().expect("create temp directory");
     let package_dir = create_local_package(root.path(), "local-package", "{}");
+    let resolved = resolve_local_param("file:.", package_dir.as_path());
 
-    for selector in ["file:.", "file:local-package"] {
-        let base_dir = if selector == "file:." { package_dir.as_path() } else { root.path() };
-        let resolved = resolve_local_param(selector, base_dir);
+    assert_eq!(
+        infer_local_package_alias(&resolved).expect("infer package alias"),
+        format!("local-package@{resolved}"),
+    );
+}
 
-        assert_eq!(
-            infer_local_package_alias(&resolved).expect("infer package alias"),
-            format!("local-package@{resolved}"),
-        );
+/// Parity with the TypeScript `resolveLocalParam`: non-dot `file:`/`link:`
+/// selectors are left untouched. Rewriting a bare name against `base_dir`
+/// would diverge from pnpm, and rewriting `file:~/…` would defeat the
+/// resolver's home-directory expansion.
+#[test]
+fn non_dot_local_selectors_are_passed_through_unchanged() {
+    let base_dir = Path::new("/base");
+    for selector in ["file:local-package", "file:~/pkg", "link:~/pkg", "link:pkg"] {
+        assert_eq!(resolve_local_param(selector, base_dir), selector);
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/global/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    is_windows_drive_path, replacement_aliases, should_replace_existing_package,
-    split_comma_separated,
+    infer_local_package_alias, is_windows_drive_path, replacement_aliases,
+    should_replace_existing_package, split_comma_separated,
 };
 use pacquet_global::GlobalPackageInfo;
 use std::path::{Path, PathBuf};
@@ -26,6 +26,21 @@ fn detects_windows_drive_paths() {
     assert!(is_windows_drive_path(r"C:\foo"));
     assert!(is_windows_drive_path("d:/bar"));
     assert!(!is_windows_drive_path("foo"));
+}
+
+#[test]
+fn unnamed_local_package_uses_directory_name_as_alias() {
+    let package_dir = tempfile::tempdir().expect("create local package");
+    std::fs::write(package_dir.path().join("package.json"), "{}")
+        .expect("write local package manifest");
+    let selector = format!("file:{}", package_dir.path().display());
+    let directory_name =
+        package_dir.path().file_name().and_then(|name| name.to_str()).expect("directory name");
+
+    assert_eq!(
+        infer_local_package_alias(&selector).expect("infer package alias"),
+        format!("{directory_name}@{selector}"),
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/global/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    infer_local_package_alias, is_windows_drive_path, replacement_aliases,
+    infer_local_package_alias, is_windows_drive_path, replacement_aliases, resolve_local_param,
     should_replace_existing_package, split_comma_separated,
 };
 use pacquet_global::GlobalPackageInfo;
@@ -30,17 +30,56 @@ fn detects_windows_drive_paths() {
 
 #[test]
 fn unnamed_local_package_uses_directory_name_as_alias() {
-    let package_dir = tempfile::tempdir().expect("create local package");
-    std::fs::write(package_dir.path().join("package.json"), "{}")
-        .expect("write local package manifest");
-    let selector = format!("file:{}", package_dir.path().display());
-    let directory_name =
-        package_dir.path().file_name().and_then(|name| name.to_str()).expect("directory name");
+    let root = tempfile::tempdir().expect("create temp directory");
+    let package_dir = create_local_package(root.path(), "local-package", "{}");
+    let selector = format!("file:{}", package_dir.display());
 
     assert_eq!(
         infer_local_package_alias(&selector).expect("infer package alias"),
-        format!("{directory_name}@{selector}"),
+        format!("local-package@{selector}"),
     );
+}
+
+#[test]
+fn relative_file_selectors_resolve_from_the_configured_base_directory() {
+    let root = tempfile::tempdir().expect("create temp directory");
+    let package_dir = create_local_package(root.path(), "local-package", "{}");
+
+    for selector in ["file:.", "file:local-package"] {
+        let base_dir = if selector == "file:." { package_dir.as_path() } else { root.path() };
+        let resolved = resolve_local_param(selector, base_dir);
+
+        assert_eq!(
+            infer_local_package_alias(&resolved).expect("infer package alias"),
+            format!("local-package@{resolved}"),
+        );
+    }
+}
+
+#[test]
+fn parent_file_selector_uses_parent_directory_name_as_alias() {
+    let root = tempfile::tempdir().expect("create temp directory");
+    let package_dir = create_local_package(root.path(), "local-package", "{}");
+    let child_dir = package_dir.join("child");
+    std::fs::create_dir(&child_dir).expect("create local package child");
+    let resolved = resolve_local_param("file:..", &child_dir);
+
+    assert_eq!(
+        infer_local_package_alias(&resolved).expect("infer package alias"),
+        format!("local-package@{resolved}"),
+    );
+}
+
+#[test]
+fn invalid_inferred_package_name_is_rejected() {
+    let root = tempfile::tempdir().expect("create temp directory");
+    let package_dir =
+        create_local_package(root.path(), "local-package", r#"{ "name": "Invalid Name" }"#);
+    let selector = format!("file:{}", package_dir.display());
+
+    let error = infer_local_package_alias(&selector).expect_err("reject invalid package name");
+
+    assert!(error.to_string().contains(r#"Invalid package name "Invalid Name"."#));
 }
 
 #[test]
@@ -95,4 +134,12 @@ fn global_package(aliases: &[&str]) -> GlobalPackageInfo {
             .map(|alias| ((*alias).to_string(), "1.0.0".to_string()))
             .collect(),
     }
+}
+
+fn create_local_package(root: &Path, directory_name: &str, manifest: &str) -> PathBuf {
+    let package_dir = root.join(directory_name);
+    std::fs::create_dir(&package_dir).expect("create local package");
+    std::fs::write(package_dir.join("package.json"), manifest)
+        .expect("write local package manifest");
+    package_dir
 }

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -145,6 +145,21 @@ fn global_add_accepts_ignore_scripts_for_local_directory() {
     )
     .expect("write local package manifest");
     fs::create_dir_all(pnpm_home.join("bin")).expect("create global bin dir");
+    // Pin a per-test store/cache so `add -g` cannot read from or write to the
+    // developer/CI machine's default global store. The global install anchors
+    // its config at the pnpm home, so seed the store/cache there (as
+    // `prepare_global_home` does).
+    let store_dir = root.path().join("pacquet-store");
+    let cache_dir = root.path().join("pacquet-cache");
+    fs::write(
+        pnpm_home.join("pnpm-workspace.yaml"),
+        format!(
+            "storeDir: {}\ncacheDir: {}\nenableGlobalVirtualStore: false\n",
+            store_dir.display(),
+            cache_dir.display(),
+        ),
+    )
+    .expect("seed the pnpm-home workspace yaml");
     let global_pkg_dir = pnpm_home.join("global").join("v11");
     fs::create_dir_all(&global_pkg_dir).expect("create global package dir");
     fs::write(global_pkg_dir.join("pnpm-workspace.yaml"), "dangerouslyAllowAllBuilds: true\n")

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -154,7 +154,7 @@ fn global_add_accepts_ignore_scripts_for_local_directory() {
     fs::write(
         pnpm_home.join("pnpm-workspace.yaml"),
         format!(
-            "storeDir: {}\ncacheDir: {}\nenableGlobalVirtualStore: false\n",
+            "storeDir: {}\ncacheDir: {}\nenableGlobalVirtualStore: false\nignoreScripts: false\n",
             store_dir.display(),
             cache_dir.display(),
         ),
@@ -166,6 +166,7 @@ fn global_add_accepts_ignore_scripts_for_local_directory() {
         .expect("allow package build scripts");
 
     global_command(&workspace, &pnpm_home)
+        .with_env("PNPM_CONFIG_IGNORE_SCRIPTS", "false")
         .with_arg("add")
         .with_arg("-g")
         .with_arg("--ignore-scripts")

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -135,8 +135,10 @@ fn global_add_accepts_ignore_scripts_for_local_directory() {
 
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     let pnpm_home = root.path().join("pnpm-home");
-    let package_dir =
-        tempfile::tempdir_in(env!("CARGO_MANIFEST_DIR")).expect("create local package");
+    // Keep the package on the checkout filesystem so macOS resolves it
+    // outside the symlinked `/var` temp root used for the global home.
+    let target_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../target");
+    let package_dir = tempfile::tempdir_in(target_dir).expect("create local package");
     fs::write(
         package_dir.path().join("package.json"),
         r#"{ "name": "@pnpm/exe", "version": "12.0.0", "scripts": { "install": "exit 1" } }"#,

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -125,6 +125,40 @@ fn global_add_list_remove_round_trip() {
     drop(root);
 }
 
+/// `pnpm setup` installs the standalone executable through this exact
+/// command shape. The local directory's package name must be inferred
+/// without treating the `file:` selector as a registry package.
+#[cfg(unix)]
+#[test]
+fn global_add_accepts_ignore_scripts_for_local_directory() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let pnpm_home = root.path().join("pnpm-home");
+    let package_dir =
+        tempfile::tempdir_in(env!("CARGO_MANIFEST_DIR")).expect("create local package");
+    fs::write(
+        package_dir.path().join("package.json"),
+        r#"{ "name": "@pnpm/exe", "version": "12.0.0", "scripts": { "install": "exit 1" } }"#,
+    )
+    .expect("write local package manifest");
+    fs::create_dir_all(pnpm_home.join("bin")).expect("create global bin dir");
+    let global_pkg_dir = pnpm_home.join("global").join("v11");
+    fs::create_dir_all(&global_pkg_dir).expect("create global package dir");
+    fs::write(global_pkg_dir.join("pnpm-workspace.yaml"), "dangerouslyAllowAllBuilds: true\n")
+        .expect("allow package build scripts");
+
+    global_command(&workspace, &pnpm_home)
+        .with_arg("add")
+        .with_arg("-g")
+        .with_arg("--ignore-scripts")
+        .with_arg(format!("file:{}", package_dir.path().display()))
+        .assert()
+        .success();
+
+    drop(root);
+}
+
 /// A build approved during a global install must persist to the stable
 /// global packages directory (where the next global install reads it back),
 /// not to the throwaway per-group install dir. Regression test: the group

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -635,7 +635,7 @@ fn fetch_directory_resolution(
     workspace_root: &Path,
     dir_resolution: &DirectoryResolution,
 ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
-    let directory = workspace_root.join(&dir_resolution.directory);
+    let directory = lexical_normalize(&workspace_root.join(&dir_resolution.directory));
     let output = pacquet_directory_fetcher::DirectoryFetcher {
         directory,
         include_only_package_files: false,


### PR DESCRIPTION
## Summary

Fix the native pnpm `setup` flow, which recursively runs:

```text
pnpm add -g --ignore-scripts file:<download-directory>
```

The Rust CLI rejected `--ignore-scripts` on `add`. Once accepted, the setup command also exposed two existing gaps in global local-directory installs: the package alias was not inferred from `package.json`, and unresolved `..` components could break directory fetching when the temporary and global directories crossed a symlinked filesystem root.

This restores the behavior already supported by the TypeScript CLI by:

- applying `--ignore-scripts` and `--no-ignore-scripts` to add configuration;
- inferring the alias for global `file:` directory selectors;
- normalizing the resolved directory path before fetching it;
- covering the exact setup command through the public CLI.

Related to https://github.com/pnpm/pnpm/issues/12955.

## Squash Commit Body

```text
The native setup command installs its downloaded executable by recursively
running `pnpm add -g --ignore-scripts file:<directory>`. The Rust add parser
did not expose the script flags, so setup failed before installation.

Apply the paired script override to both local and global add configuration.
For aliasless global `file:` directory selectors, read the local manifest and
use its package name before invoking the add pipeline. Normalize the directory
fetch path lexically so relative lockfile paths remain valid when temporary
directories cross symlinked filesystem roots, such as `/var` on macOS.

Add an integration test that exercises the exact setup command shape and uses
a failing install script to prove that `--ignore-scripts` reaches the install
configuration.

Related to https://github.com/pnpm/pnpm/issues/12955.
```

## Checklist

- [x] The TypeScript CLI already supports this setup command shape; this restores parity in the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) for `pacquet`.
- [x] Added or updated tests.

---
Written by an agent (GitHub Copilot CLI, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786656663&installation_id=145934176&pr_number=13006&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13006&signature=727e6672c61ba7e47e1ebc1538c80f02ce562a0a5ea105f8c186feef65fe2813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--ignore-scripts` and `--no-ignore-scripts` options to the `add` command.
  - Global installs/updates now derive stable aliases for local `file:` directories, including unnamed packages.

- **Bug Fixes**
  - Fixed global installs for local directory packages when lifecycle scripts are disabled.
  - Improved installation directory handling by normalizing injected paths.
  - Addressed an issue where `pnpm setup` could fail due to a globally installed native CLI executable.

- **Tests**
  - Added Unix-only regression coverage for `pnpm add -g --ignore-scripts` with local directories.
  - Added a unit test for unnamed local `file:` alias derivation.

- **Chores**
  - Updated CI dependency installation steps to run OS-specific commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->