### PR TITLE
docs(rust/cli): clean up `--help` texts

### DIFF
--- a/.changeset/pacquet-clap-help-markdown.md
+++ b/.changeset/pacquet-clap-help-markdown.md
@@ -1,0 +1,6 @@
+---
+"pacquet": patch
+"@pnpm/pnpr": patch
+---
+
+Cleaned up `--help` output by removing markdown that clap printed literally: intra-doc links, an inline link, and a `<...>` placeholder that read as an HTML tag. The affected help text now reads as plain prose — paired flags are named directly (e.g. `--no-offline`) and upstream references appear as plain URLs.

--- a/.changeset/pacquet-clap-help-markdown.md
+++ b/.changeset/pacquet-clap-help-markdown.md
@@ -3,4 +3,4 @@
 "@pnpm/pnpr": patch
 ---
 
-Cleaned up `--help` output by removing markdown that clap printed literally: intra-doc links, an inline link, and a `<...>` placeholder that read as an HTML tag. The affected help text now reads as plain prose — paired flags are named directly (e.g. `--no-offline`) and upstream references appear as plain URLs.
+The `--help` text now reads as user-facing help rather than developer documentation. Command and flag descriptions say what each option does for you, and the leftover markdown that was printing verbatim in the terminal — intra-doc links, an inline link, and an HTML-like path placeholder — has been cleaned out.

--- a/dylint.toml
+++ b/dylint.toml
@@ -45,8 +45,18 @@ enable = ["unordered_derives"]
 disable = [
     "needless_borrowed_parameters",
     "unpinned_repo_ref",
-    "clap_help_markdown",
 ]
+
+# Keep code spans in clap doc comments. The vast majority wrap flag names
+# (`--frozen-lockfile`), file names (`package.json`), literal values (`0`),
+# and version-target syntax (`pacquet@<rev>`) — they read acceptably in
+# `--help` and stay useful as `cargo doc` API docs, and unwrapping a span
+# like `` `pacquet@<rev>` `` would turn `<rev>` into a stray HTML tag that
+# rustdoc rejects. The rule's genuinely user-hostile leaks — links, HTML,
+# and internal-type references — are still forbidden and cleaned out of the
+# help text instead. See <https://github.com/pnpm/pnpm/issues/12718>.
+["perfectionist::clap_help_markdown"]
+ignore_constructs = ["code_span"]
 
 # The codebase collapses imports to one `use` per crate root (shared
 # prefixes in nested braces) — the same granularity rustfmt spells

--- a/dylint.toml
+++ b/dylint.toml
@@ -47,14 +47,8 @@ disable = [
     "unpinned_repo_ref",
 ]
 
-# Keep code spans in clap doc comments. The vast majority wrap flag names
-# (`--frozen-lockfile`), file names (`package.json`), literal values (`0`),
-# and version-target syntax (`pacquet@<rev>`) — they read acceptably in
-# `--help` and stay useful as `cargo doc` API docs, and unwrapping a span
-# like `` `pacquet@<rev>` `` would turn `<rev>` into a stray HTML tag that
-# rustdoc rejects. The rule's genuinely user-hostile leaks — links, HTML,
-# and internal-type references — are still forbidden and cleaned out of the
-# help text instead. See <https://github.com/pnpm/pnpm/issues/12718>.
+# Code spans read fine in `--help` and stay useful as `cargo doc` docs, so
+# keep them; links and HTML remain forbidden and are cleaned from help text.
 ["perfectionist::clap_help_markdown"]
 ignore_constructs = ["code_span"]
 

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -66,10 +66,7 @@ pub struct AddArgs {
     /// --save-prod, --save-dev, --save-optional, --save-peer
     #[clap(flatten)]
     pub dependency_options: AddDependencyOptions,
-    /// `--cpu` / `--os` / `--libc` overrides for the optional-dep
-    /// platform filter. Mirrors upstream pnpm's CLI flags; merges
-    /// per-axis into `supportedArchitectures` loaded from
-    /// `pnpm-workspace.yaml`.
+    /// `--cpu`, `--os`, and `--libc` filters for which optional dependencies are installed.
     #[clap(flatten)]
     pub supported_architectures: SupportedArchitecturesArgs,
     /// Saved dependencies will be configured with an exact version rather than using
@@ -79,26 +76,16 @@ pub struct AddArgs {
     /// The prefix of the saved version range: `^` (default), `~`, or empty for an exact version.
     #[clap(long = "save-prefix", value_name = "prefix")]
     pub save_prefix: Option<String>,
-    /// Save the new dependency to the default catalog: `catalog:` is written
-    /// to `package.json` and the specifier to `pnpm-workspace.yaml`'s
-    /// `catalog:` block. Shorthand for `--save-catalog-name=default`.
+    /// Save the new dependency to the default catalog. Shorthand for `--save-catalog-name=default`.
     #[clap(long = "save-catalog")]
     pub save_catalog: bool,
-    /// Save the new dependency to the named catalog `<name>`: `catalog:<name>`
-    /// is written to `package.json` and the specifier to the matching entry
-    /// under `pnpm-workspace.yaml`'s `catalogs:`.
+    /// Save the new dependency to the named catalog `<name>`.
     #[clap(long = "save-catalog-name", value_name = "name")]
     pub save_catalog_name: Option<String>,
-    /// Add the package as a configurational dependency: the clean
-    /// specifier is written to `pnpm-workspace.yaml`'s `configDependencies`
-    /// block, the resolved version + integrity to the env lockfile, and
-    /// the package linked into `node_modules/.pnpm-config`. Mirrors pnpm's
-    /// `pnpm add --config`.
+    /// Add the package as a configuration dependency.
     #[clap(long = "config")]
     pub config: bool,
-    /// Dependencies are not downloaded. The package is added to the
-    /// manifest and only `pnpm-lock.yaml` is updated; no `node_modules`
-    /// is created. Mirrors pnpm's `--lockfile-only`.
+    /// Dependencies are not downloaded. Only `pnpm-lock.yaml` is updated.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
     /// The directory with links to the store (default is `node_modules/.pacquet`).
@@ -106,8 +93,7 @@ pub struct AddArgs {
     #[clap(long = "virtual-store-dir", default_value = "node_modules/.pacquet")]
     pub virtual_store_dir: Option<PathBuf>, // TODO: make use of this
 
-    /// Install the package globally, linking its bins into the global bin
-    /// directory. Mirrors pnpm's `add -g`.
+    /// Install the package globally, linking its bins into the global bin directory.
     #[clap(short = 'g', long)]
     pub global: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/approve_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds.rs
@@ -24,7 +24,7 @@ pub struct ApproveBuildsArgs {
     #[clap(long)]
     pub all: bool,
 
-    /// Approve dependencies of globally installed packages.
+    /// Approve builds for globally installed packages (not supported yet).
     #[clap(long)]
     pub global: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/approve_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds.rs
@@ -13,8 +13,7 @@ use std::{
 
 use crate::{State, cli_args::ignored_builds::get_automatically_ignored_builds};
 
-/// `pacquet approve-builds` — approve dependencies for running scripts
-/// during installation.
+/// Approve dependencies for running scripts during installation.
 #[derive(Debug, Args)]
 pub struct ApproveBuildsArgs {
     /// Packages to approve (`<pkg>`) or deny (`!<pkg>`). With no packages,
@@ -25,8 +24,7 @@ pub struct ApproveBuildsArgs {
     #[clap(long)]
     pub all: bool,
 
-    /// Reserved for parity with pnpm; `approve-builds` is not supported
-    /// with global packages.
+    /// Approve dependencies of globally installed packages.
     #[clap(long)]
     pub global: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/bin.rs
+++ b/pnpm/crates/cli/src/cli_args/bin.rs
@@ -4,12 +4,7 @@ use std::path::Path;
 
 use super::global::GlobalError;
 
-/// `pacquet bin`: print the directory where pnpm installs executables.
-///
-/// Locally this is `<dir>/node_modules/.bin`: the `node_modules/.bin` leaf is
-/// hardcoded, so a configured `modules-dir` is ignored, and the anchor is
-/// `--dir` (pnpm's `config.dir`, the cwd, not the workspace root). `--global`
-/// prints the resolved global bin directory instead.
+/// Print the directory where pnpm installs executables.
 #[derive(Debug, Args)]
 pub struct BinArgs {
     /// Print the global executables directory

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -116,18 +116,16 @@ pub struct CliArgs {
 
     /// Path to a `.npmrc` to read auth settings from, overriding the
     /// default `~/.npmrc`. Mirrors pnpm's `--npmrc-auth-file` (and its
-    /// `--userconfig` alias) and sets
-    /// [`pacquet_config::Config::npmrc_auth_file`], consumed when
-    /// `Config` resolves the user-level `.npmrc`.
+    /// `--userconfig` alias). Consumed when resolving the user-level
+    /// `.npmrc`.
     #[clap(long = "npmrc-auth-file", visible_alias = "userconfig", global = true)]
     pub npmrc_auth_file: Option<PathBuf>,
 
     /// Run the command for every project in the workspace instead of
     /// only the project in `--dir`. Mirrors pnpm's global `-r` /
-    /// `--recursive` flag and sets
-    /// [`pacquet_config::Config::recursive`]. pacquet's `install`
+    /// `--recursive` flag. pacquet's `install`
     /// already spans the whole workspace, so the flag is a surface
-    /// no-op there today; see the field docs.
+    /// no-op there today.
     #[clap(short = 'r', long, global = true)]
     pub recursive: bool,
 
@@ -137,9 +135,8 @@ pub struct CliArgs {
 
     /// `--filter` / `-F` workspace selectors. Each occurrence adds one
     /// raw selector (`@scope/*`, `./pkg`, `foo...`, `!bar`, `{dir}`,
-    /// `[since]`, ...). Stored into [`pacquet_config::Config::filter`];
-    /// see that field for why the resolved selection is not yet
-    /// consumed by `install`.
+    /// `[since]`, ...). The resolved selection is not yet consumed by
+    /// `install`.
     ///
     /// As a global multi-value flag, occurrences collect only within one
     /// side of the subcommand boundary; mixing sides is a clap limitation,
@@ -147,24 +144,20 @@ pub struct CliArgs {
     #[clap(short = 'F', long, global = true)]
     pub filter: Vec<String>,
 
-    /// `--filter-prod` workspace selectors. Same syntax as
-    /// [`Self::filter`], but the dependency walk follows production
-    /// dependencies only. Stored into
-    /// [`pacquet_config::Config::filter_prod`].
+    /// `--filter-prod` workspace selectors. Same syntax as `--filter`,
+    /// but the dependency walk follows production dependencies only.
     #[clap(long = "filter-prod", global = true)]
     pub filter_prod: Vec<String>,
 
     /// `--test-pattern` glob patterns naming test files, consumed by
     /// the `[<since>]` changed-packages `--filter` selector. Overrides
-    /// [`pacquet_config::Config::test_pattern`] when given.
+    /// the configured value when given.
     #[clap(long = "test-pattern", global = true)]
     pub test_pattern: Vec<String>,
 
     /// `--changed-files-ignore-pattern` glob patterns of changed files
     /// the `[<since>]` changed-packages `--filter` selector ignores.
-    /// Overrides
-    /// [`pacquet_config::Config::changed_files_ignore_pattern`] when
-    /// given.
+    /// Overrides the configured value when given.
     #[clap(long = "changed-files-ignore-pattern", global = true)]
     pub changed_files_ignore_pattern: Vec<String>,
 

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -104,7 +104,7 @@ pub struct CliArgs {
 
     /// Directory in which the package store is created. Relative paths
     /// are resolved from the workspace root, or from `--dir` outside a
-    /// workspace. Overrides the configured `storeDir` for this invocation.
+    /// workspace.
     #[clap(
         long = "store-dir",
         value_name = "DIR",
@@ -114,18 +114,13 @@ pub struct CliArgs {
     )]
     pub store_dir: Option<PathBuf>,
 
-    /// Path to a `.npmrc` to read auth settings from, overriding the
-    /// default `~/.npmrc`. Mirrors pnpm's `--npmrc-auth-file` (and its
-    /// `--userconfig` alias). Consumed when resolving the user-level
-    /// `.npmrc`.
+    /// Path to an `.npmrc` to read auth settings from, overriding the
+    /// default `~/.npmrc`.
     #[clap(long = "npmrc-auth-file", visible_alias = "userconfig", global = true)]
     pub npmrc_auth_file: Option<PathBuf>,
 
-    /// Run the command for every project in the workspace instead of
-    /// only the project in `--dir`. Mirrors pnpm's global `-r` /
-    /// `--recursive` flag. pacquet's `install`
-    /// already spans the whole workspace, so the flag is a surface
-    /// no-op there today.
+    /// Run the command for every project in the workspace instead of only
+    /// the project in `--dir`.
     #[clap(short = 'r', long, global = true)]
     pub recursive: bool,
 
@@ -133,31 +128,25 @@ pub struct CliArgs {
     #[clap(long, value_enum, default_value_t = ReporterType::Default, global = true)]
     pub reporter: ReporterType,
 
-    /// `--filter` / `-F` workspace selectors. Each occurrence adds one
-    /// raw selector (`@scope/*`, `./pkg`, `foo...`, `!bar`, `{dir}`,
-    /// `[since]`, ...). The resolved selection is not yet consumed by
-    /// `install`.
-    ///
-    /// As a global multi-value flag, occurrences collect only within one
-    /// side of the subcommand boundary; mixing sides is a clap limitation,
-    /// so pass all selectors on the same side.
+    /// Select which workspace projects to run on. Repeat to add more.
+    /// Each selector can be a name pattern (`@scope/*`), a path (`./pkg`),
+    /// a dependency query (`foo...`), an exclusion (`!bar`), a directory
+    /// (`{dir}`), or a changed-since query (`[since]`).
     #[clap(short = 'F', long, global = true)]
     pub filter: Vec<String>,
 
-    /// `--filter-prod` workspace selectors. Same syntax as `--filter`,
-    /// but the dependency walk follows production dependencies only.
+    /// Like `--filter`, but follow only production dependencies when
+    /// selecting projects.
     #[clap(long = "filter-prod", global = true)]
     pub filter_prod: Vec<String>,
 
-    /// `--test-pattern` glob patterns naming test files, consumed by
-    /// the `[<since>]` changed-packages `--filter` selector. Overrides
-    /// the configured value when given.
+    /// Glob patterns naming test files, used by the `[since]` `--filter`
+    /// selector to decide which changes count.
     #[clap(long = "test-pattern", global = true)]
     pub test_pattern: Vec<String>,
 
-    /// `--changed-files-ignore-pattern` glob patterns of changed files
-    /// the `[<since>]` changed-packages `--filter` selector ignores.
-    /// Overrides the configured value when given.
+    /// Glob patterns of changed files that the `[since]` `--filter`
+    /// selector should ignore.
     #[clap(long = "changed-files-ignore-pattern", global = true)]
     pub changed_files_ignore_pattern: Vec<String>,
 
@@ -185,12 +174,7 @@ pub struct CliArgs {
     #[clap(long = "no-bail", global = true, hide = true)]
     pub no_bail: bool,
 
-    /// Avoid exiting with a non-zero exit code when the script is
-    /// undefined, accepted ahead of the script name
-    /// (`pnpm --if-present test`) the way pnpm's option parser does.
-    /// Deliberately not `global = true`: `run` / `stop` / `restart`
-    /// declare their own `--if-present`, and a propagated global flag
-    /// would collide with theirs.
+    /// Don't fail when the named script is undefined.
     #[clap(long = "if-present", hide = true)]
     pub if_present: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -27,7 +27,7 @@ use pacquet_workspace_manifest_writer::update_manifest_field;
 use serde_json::{Map, Value};
 use std::path::{Path, PathBuf};
 
-/// `pacquet config` and its subcommands.
+/// Manage the pnpm configuration files.
 #[derive(Debug, Args)]
 pub struct ConfigArgs {
     #[clap(subcommand)]
@@ -46,16 +46,15 @@ pub enum ConfigSubcommand {
     List(ConfigListArgs),
 }
 
-/// Shared `--global` / `--location` / `--json` flags. Marked `global` so they
-/// can appear before or after the positional arguments, matching pnpm.
+/// Flags shared by the `config` subcommands.
 #[derive(Debug, Default, Clone, Copy, Args)]
 pub struct ConfigFlags {
     /// Operate on the global config file.
     #[clap(short = 'g', long, global = true)]
     pub global: bool,
 
-    /// When `project`, use `pnpm-workspace.yaml` / `.npmrc`; when `global`, use
-    /// the global `config.yaml` / `auth.ini`.
+    /// Which config to read or write: `project` for the project's config,
+    /// `global` for the global config.
     #[clap(long, value_enum, global = true)]
     pub location: Option<ConfigLocation>,
 

--- a/pnpm/crates/cli/src/cli_args/create.rs
+++ b/pnpm/crates/cli/src/cli_args/create.rs
@@ -6,10 +6,7 @@ use pacquet_config::Config;
 use pacquet_reporter::Reporter;
 use std::path::Path;
 
-/// Creates a project from a `create-*` starter kit.
-///
-/// The handler converts the user-provided name to a `create-*` package name
-/// and delegates to the existing `dlx` infrastructure.
+/// Create a project from a `create-*` starter kit.
 #[derive(Debug, Args)]
 pub struct CreateArgs {
     /// The template name (e.g., `vite`, `create-vite`, `@scope/foo`),

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -45,7 +45,7 @@ pub struct DeployArgs {
     #[clap(flatten)]
     pub install_args: InstallArgs,
 
-    /// Use the legacy install-based deploy implementation.
+    /// Use the legacy deploy implementation.
     #[clap(long)]
     pub legacy: bool,
 

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -27,14 +27,6 @@ use std::{
 };
 
 /// Run a package in a temporary environment.
-///
-/// Deviations from pnpm, deferred until the surrounding infrastructure
-/// lands:
-/// - The cache key is built from the raw package specs rather than the
-///   resolved package ids, so a floating spec such as `cowsay` is not
-///   re-resolved until the cache entry expires.
-/// - The interactive `approve-builds` prompt is not ported; transitive
-///   build scripts follow the install's normal allow-list.
 #[derive(Debug, Args)]
 pub struct DlxArgs {
     /// The command to run, followed by its arguments.

--- a/pnpm/crates/cli/src/cli_args/docs.rs
+++ b/pnpm/crates/cli/src/cli_args/docs.rs
@@ -9,7 +9,7 @@ use pacquet_resolving_npm_resolver::{
 };
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 
-/// Open the documentation of a package (or `pnpm home <pkg>`).
+/// Open the documentation page of a package in a browser.
 #[derive(Debug, Args)]
 pub struct DocsArgs {
     /// Package name (optionally with @version).

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -15,8 +15,8 @@ use std::{
 
 /// Run a shell command in the context of a project.
 ///
-/// With `-r` / `--recursive`, runs the command in each of the
-/// `--filter`-selected workspace projects, in topological order.
+/// With `-r` / `--recursive`, runs the command in every workspace project
+/// (or the `--filter`-selected subset), in topological order.
 #[derive(Debug, Args)]
 pub struct ExecArgs {
     /// The command to run, followed by its arguments.

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -15,12 +15,8 @@ use std::{
 
 /// Run a shell command in the context of a project.
 ///
-/// The recursive variant (selected by the global `-r` / `--recursive`
-/// flag) runs the command across the `--filter`-selected workspace
-/// projects, topologically sorted and sequential, with `--resume-from` /
-/// `--report-summary` / `--no-bail`.
-/// `--workspace-concurrency` parallelism is not ported yet, matching the
-/// recursive `run` runner.
+/// With `-r` / `--recursive`, runs the command in each of the
+/// `--filter`-selected workspace projects, in topological order.
 #[derive(Debug, Args)]
 pub struct ExecArgs {
     /// The command to run, followed by its arguments.

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -18,7 +18,7 @@ use std::{
 /// The recursive variant (selected by the global `-r` / `--recursive`
 /// flag) runs the command across the `--filter`-selected workspace
 /// projects, topologically sorted and sequential, with `--resume-from` /
-/// `--report-summary` / `--no-bail` (see [`recursive`]).
+/// `--report-summary` / `--no-bail`.
 /// `--workspace-concurrency` parallelism is not ported yet, matching the
 /// recursive `run` runner.
 #[derive(Debug, Args)]

--- a/pnpm/crates/cli/src/cli_args/ignored_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/ignored_builds.rs
@@ -6,8 +6,8 @@ use pacquet_modules_yaml::{Host, Modules, read_modules_manifest};
 use pacquet_package_manager::allow_build_key_from_ignored_build;
 use std::path::PathBuf;
 
-/// `pacquet ignored-builds` — print the list of packages with blocked
-/// build scripts.
+/// Print the list of packages whose build scripts were not run during
+/// installation.
 #[derive(Debug, Args)]
 pub struct IgnoredBuildsArgs {}
 

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -7,8 +7,7 @@ use pacquet_reporter::Reporter;
 
 #[derive(Debug, Args)]
 pub struct ImportArgs {
-    /// Server URL of the alternative resolve/verify endpoint to offload
-    /// lockfile resolution to.
+    /// URL of a pnpr server to offload lockfile resolution to.
     #[clap(long = "pnpr-server")]
     pub pnpr_server: Option<String>,
 }

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -89,7 +89,6 @@ pub struct InstallArgs {
     pub lockfile_only: bool,
 
     /// Show what an install would change without writing anything to disk.
-    /// Always exits with code 0.
     #[clap(long = "dry-run")]
     pub dry_run: bool,
 

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -103,7 +103,7 @@ pub struct InstallArgs {
     /// Force-enable `preferFrozenLockfile` for this invocation.
     /// Overrides `pnpm-workspace.yaml` / `PNPM_CONFIG_PREFER_FROZEN_LOCKFILE`.
     /// Mirrors pnpm's `--prefer-frozen-lockfile`. Paired with
-    /// [`Self::no_prefer_frozen_lockfile`] by mutual `overrides_with`, so
+    /// `--no-prefer-frozen-lockfile` by mutual `overrides_with`, so
     /// both spellings in one argv resolve last-one-wins (nopt semantics).
     #[clap(long = "prefer-frozen-lockfile", overrides_with = "no_prefer_frozen_lockfile")]
     pub prefer_frozen_lockfile: bool,
@@ -126,8 +126,8 @@ pub struct InstallArgs {
     /// will rewrite the manifest right after pacquet returns. See
     /// <https://github.com/pnpm/pnpm/issues/11797>.
     ///
-    /// Narrow on purpose: only gates
-    /// [`pacquet_lockfile::satisfies_package_manifest`]. Settings
+    /// Narrow on purpose: only gates the lockfile-satisfies-manifest
+    /// check. Settings
     /// drift (`overrides`, `ignoredOptionalDependencies`,
     /// `pnpmfileChecksum`, ...) still aborts. A future broader flag
     /// matching pnpm's internal `ignorePackageManifest` (used by
@@ -153,7 +153,7 @@ pub struct InstallArgs {
     ///
     /// Merged into `config.ignore_scripts` at the CLI dispatch in
     /// `cli_args.rs`, so the install reads it from the config like every
-    /// other build-script setting. Paired with [`Self::no_ignore_scripts`],
+    /// other build-script setting. Paired with `--no-ignore-scripts`,
     /// the CLI inverse, by mutual `overrides_with` (last-one-wins).
     #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
     pub ignore_scripts: bool,
@@ -185,7 +185,7 @@ pub struct InstallArgs {
     /// metadata path.
     ///
     /// Overrides `offline` from `pnpm-workspace.yaml`. Paired with
-    /// [`Self::no_offline`], the CLI inverse that forces a yaml `true`
+    /// `--no-offline`, the CLI inverse that forces a yaml `true`
     /// back off, by mutual `overrides_with` (last-one-wins).
     #[clap(long, overrides_with = "no_offline")]
     pub offline: bool,
@@ -200,7 +200,7 @@ pub struct InstallArgs {
     /// writes. For installs against a store on a read-only filesystem
     /// (e.g. a Nix store); pair with `--offline --frozen-lockfile`.
     /// Mirrors pnpm's `--frozen-store`. Overrides `frozenStore` from
-    /// `pnpm-workspace.yaml`. Paired with [`Self::no_frozen_store`], the
+    /// `pnpm-workspace.yaml`. Paired with `--no-frozen-store`, the
     /// CLI inverse, by mutual `overrides_with` (last-one-wins). (pnpm
     /// additionally rejects `--frozen-store` combined with `--force`;
     /// pacquet has no `force` flow yet, so there is nothing to conflict
@@ -221,7 +221,7 @@ pub struct InstallArgs {
     /// local store via the warm prefetch + `index.db` lookups, so
     /// the flag is a no-op for artifact fetches today. Field exists
     /// so yaml / CLI parse cleanly; Stage 2's resolver will honor it
-    /// on the metadata path. Paired with [`Self::no_prefer_offline`], the
+    /// on the metadata path. Paired with `--no-prefer-offline`, the
     /// CLI inverse, by mutual `overrides_with` (last-one-wins).
     #[clap(long, overrides_with = "no_prefer_offline")]
     pub prefer_offline: bool,
@@ -234,9 +234,9 @@ pub struct InstallArgs {
 
     /// Skip the lockfile supply-chain verification pass entirely.
     /// Overrides `pnpm-workspace.yaml#trustLockfile`. Mirrors pnpm's
-    /// `--trust-lockfile`. See [`pacquet_config::Config::trust_lockfile`].
-    /// Added for [pnpm/pnpm#11860](https://github.com/pnpm/pnpm/issues/11860).
-    /// Paired with [`Self::no_trust_lockfile`], the CLI inverse, by mutual
+    /// `--trust-lockfile`. Added for
+    /// <https://github.com/pnpm/pnpm/issues/11860>.
+    /// Paired with `--no-trust-lockfile`, the CLI inverse, by mutual
     /// `overrides_with` (last-one-wins).
     #[clap(long = "trust-lockfile", overrides_with = "no_trust_lockfile")]
     pub trust_lockfile: bool,
@@ -258,21 +258,17 @@ pub struct InstallArgs {
     /// `networkConcurrency` value resolved from `pnpm-workspace.yaml` /
     /// global `config.yaml` / `PNPM_CONFIG_NETWORK_CONCURRENCY` for this
     /// invocation. `None` (flag absent) leaves the config-resolved
-    /// value in place. Applied to
-    /// [`pacquet_config::Config::network_concurrency`] at the CLI
-    /// dispatch in [`crate::cli_args::CliArgs::run`].
+    /// value in place.
     #[clap(long = "network-concurrency")]
     pub network_concurrency: Option<usize>,
 
     /// Per-request network timeout in milliseconds. Mirrors pnpm's
     /// `--fetch-timeout`; overrides `fetchTimeout` for this invocation.
-    /// Applied to [`pacquet_config::Config::fetch_timeout`].
     #[clap(long = "fetch-timeout")]
     pub fetch_timeout: Option<u64>,
 
     /// `User-Agent` header sent on registry requests. Mirrors pnpm's
     /// `--user-agent`; overrides `userAgent` for this invocation.
-    /// Applied to [`pacquet_config::Config::user_agent`].
     #[clap(long = "user-agent")]
     pub user_agent: Option<String>,
 
@@ -280,7 +276,7 @@ pub struct InstallArgs {
     /// Overrides the `pnprServer` setting for this invocation. When set,
     /// the server resolves against the client's registries and
     /// `node_modules` is linked locally from the server-produced
-    /// lockfile. Applied to [`pacquet_config::Config::pnpr_server`].
+    /// lockfile.
     #[clap(long = "pnpr-server")]
     pub pnpr_server: Option<String>,
 }

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -117,8 +117,8 @@ pub struct InstallArgs {
     pub no_runtime: bool,
 
     /// Don't run lifecycle scripts of the project or its dependencies.
-    /// Dependencies with build scripts are skipped without failing the
-    /// install.
+    /// Packages are still installed; only their build scripts are skipped,
+    /// and the install won't fail because of it.
     #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
     pub ignore_scripts: bool,
 

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -40,17 +40,15 @@ impl NodeLinkerArg {
 
 #[derive(Debug, Args)]
 pub struct InstallDependencyOptions {
-    /// pacquet will not install any package listed in devDependencies and will remove those insofar
-    /// they were already installed, if the `NODE_ENV` environment variable is set to production.
-    /// Use this flag to instruct pacquet to ignore `NODE_ENV` and take its production status from this
-    /// flag instead.
+    /// Install only production dependencies. devDependencies are skipped,
+    /// and removed if already installed. Takes precedence over `NODE_ENV`.
     #[arg(short = 'P', long)]
     prod: bool,
-    /// Only devDependencies are installed and dependencies are removed insofar they were
-    /// already installed, regardless of the `NODE_ENV`.
+    /// Install only devDependencies. Regular dependencies are skipped, and
+    /// removed if already installed, regardless of `NODE_ENV`.
     #[arg(short = 'D', long)]
     dev: bool,
-    /// optionalDependencies are not installed.
+    /// Don't install optionalDependencies.
     #[arg(long)]
     no_optional: bool,
 }
@@ -76,206 +74,123 @@ pub struct InstallArgs {
     #[clap(flatten)]
     pub dependency_options: InstallDependencyOptions,
 
-    /// `--cpu` / `--os` / `--libc` overrides for the optional-dep
-    /// platform filter. Merges per-axis into `supportedArchitectures`
-    /// loaded from `pnpm-workspace.yaml`.
+    /// Restrict which optional dependencies are installed, by CPU
+    /// (`--cpu`), OS (`--os`), and C library (`--libc`).
     #[clap(flatten)]
     pub supported_architectures: SupportedArchitecturesArgs,
 
-    /// Don't generate a lockfile and fail if the lockfile is outdated.
+    /// Don't generate a lockfile, and fail if an update to it is needed.
     #[clap(long)]
     pub frozen_lockfile: bool,
 
-    /// Dependencies are not downloaded. Only `pnpm-lock.yaml` is
-    /// updated. Resolution still runs, but nothing is fetched into the
-    /// store and no `node_modules` is created. Mirrors pnpm's
-    /// `--lockfile-only`.
+    /// Only update `pnpm-lock.yaml`. Don't download packages or write
+    /// `node_modules`.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
 
-    /// Report what an install would change without writing anything to
-    /// disk (no `pnpm-lock.yaml`, no `node_modules`). Resolution still
-    /// runs against the registry. Exits 0 whether or not changes were
-    /// found. Mirrors pnpm's `install --dry-run`.
+    /// Show what an install would change without writing anything to disk.
+    /// Always exits with code 0.
     #[clap(long = "dry-run")]
     pub dry_run: bool,
 
-    /// Force-enable `preferFrozenLockfile` for this invocation.
-    /// Overrides `pnpm-workspace.yaml` / `PNPM_CONFIG_PREFER_FROZEN_LOCKFILE`.
-    /// Mirrors pnpm's `--prefer-frozen-lockfile`. Paired with
-    /// `--no-prefer-frozen-lockfile` by mutual `overrides_with`, so
-    /// both spellings in one argv resolve last-one-wins (nopt semantics).
+    /// Prefer the existing lockfile over re-resolving, even when the
+    /// manifest may have changed.
     #[clap(long = "prefer-frozen-lockfile", overrides_with = "no_prefer_frozen_lockfile")]
     pub prefer_frozen_lockfile: bool,
 
-    /// Force-disable `preferFrozenLockfile` for this invocation.
-    /// Overrides `pnpm-workspace.yaml` / `PNPM_CONFIG_PREFER_FROZEN_LOCKFILE`.
-    /// Mirrors pnpm's `--no-prefer-frozen-lockfile`. Useful for CI
-    /// runs that want to force a re-resolve against the registry
-    /// without setting the flag globally.
+    /// Always re-resolve against the registry instead of preferring the
+    /// existing lockfile.
     #[clap(long = "no-prefer-frozen-lockfile", overrides_with = "prefer_frozen_lockfile")]
     pub no_prefer_frozen_lockfile: bool,
 
-    /// Skip the per-importer `package.json` ↔ `pnpm-lock.yaml`
-    /// freshness check that normally guards `--frozen-lockfile`.
-    /// Intended for callers that just resolved and wrote the
-    /// lockfile themselves (today: the pnpm CLI delegating
-    /// materialization to pacquet via `configDependencies`), where
-    /// the manifest may still be the pre-mutation copy while the
-    /// lockfile is already post-mutation — the upstream resolver
-    /// will rewrite the manifest right after pacquet returns. See
-    /// <https://github.com/pnpm/pnpm/issues/11797>.
-    ///
-    /// Narrow on purpose: only gates the lockfile-satisfies-manifest
-    /// check. Settings
-    /// drift (`overrides`, `ignoredOptionalDependencies`,
-    /// `pnpmfileChecksum`, ...) still aborts. A future broader flag
-    /// matching pnpm's internal `ignorePackageManifest` (used by
-    /// `pnpm fetch`) would skip linking / hoisting / pruning too;
-    /// that's deliberately a separate name.
+    /// Skip the check that `pnpm-lock.yaml` is up to date with
+    /// `package.json` under `--frozen-lockfile`. For callers that just
+    /// wrote the lockfile themselves and know the manifest is about to
+    /// catch up.
     #[clap(long)]
     pub ignore_manifest_check: bool,
 
-    /// Skip the install of any runtime dependencies
-    /// (`node@runtime:`, `deno@runtime:`, `bun@runtime:`).
-    /// Their archives aren't fetched, their slots aren't
-    /// materialized, and their bins aren't linked into
-    /// `node_modules/.bin/`. The rest of the install proceeds
-    /// normally. Mirrors pnpm's `--no-runtime` flag.
+    /// Don't install runtime dependencies (`node`, `deno`, `bun`). Their
+    /// archives aren't fetched and their bins aren't linked; the rest of
+    /// the install proceeds normally.
     #[clap(long = "no-runtime")]
     pub no_runtime: bool,
 
     /// Don't run lifecycle scripts of the project or its dependencies.
-    /// Dependency build scripts that would otherwise be reported as
-    /// ignored are skipped silently, so the install doesn't fail with
-    /// `ERR_PNPM_IGNORED_BUILDS` under `strictDepBuilds`. Mirrors pnpm's
-    /// `--ignore-scripts`.
-    ///
-    /// Merged into `config.ignore_scripts` at the CLI dispatch in
-    /// `cli_args.rs`, so the install reads it from the config like every
-    /// other build-script setting. Paired with `--no-ignore-scripts`,
-    /// the CLI inverse, by mutual `overrides_with` (last-one-wins).
+    /// Dependencies with build scripts are skipped without failing the
+    /// install.
     #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
     pub ignore_scripts: bool,
 
-    /// Force-enable lifecycle scripts for this invocation, overriding a
-    /// `pnpm-workspace.yaml` / `.npmrc` `ignoreScripts: true`. Mirrors
-    /// pnpm's `--no-ignore-scripts`.
+    /// Run lifecycle scripts even when the configuration disables them.
     #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
     pub no_ignore_scripts: bool,
 
-    /// Override `nodeLinker` from `pnpm-workspace.yaml` /
-    /// `.npmrc`. `None` (flag not passed) leaves the config's value
-    /// untouched; otherwise the CLI value wins for this invocation
-    /// and is what gets written to `.modules.yaml.nodeLinker`.
-    /// `isolated` is the default, `hoisted` selects the flat
-    /// `node_modules/` layout, `pnp` selects Plug'n'Play.
+    /// Which node linker to use: `isolated` (the default, a symlinked
+    /// store), `hoisted` (a flat `node_modules`), or `pnp` (Plug'n'Play).
+    /// Overrides the configured value.
     #[clap(long = "node-linker", value_enum)]
     pub node_linker: Option<NodeLinkerArg>,
 
-    /// Refuse network tarball / zip-archive fetches on a cache miss.
-    /// When the warm prefetch and the `index.db` lookup both miss
-    /// for a package, pacquet fails with
-    /// `ERR_PNPM_NO_OFFLINE_TARBALL` rather than hitting the
-    /// registry. The `--offline` flag also gates the metadata-fetch
-    /// path (`ERR_PNPM_NO_OFFLINE_META`), which pacquet doesn't have
-    /// on the frozen-install flow (the lockfile pins every
-    /// resolution), so this flag is currently scoped to artifact
-    /// fetches. Stage 2's resolver will extend the gate to the
-    /// metadata path.
-    ///
-    /// Overrides `offline` from `pnpm-workspace.yaml`. Paired with
-    /// `--no-offline`, the CLI inverse that forces a yaml `true`
-    /// back off, by mutual `overrides_with` (last-one-wins).
+    /// Fail on a cache miss instead of fetching from the registry, using
+    /// only packages already in the store.
     #[clap(long, overrides_with = "no_offline")]
     pub offline: bool,
 
-    /// Force-disable offline mode for this invocation, overriding a
-    /// `pnpm-workspace.yaml` `offline: true`. Mirrors pnpm's
-    /// `--no-offline`.
+    /// Allow network fetches even when the configuration enables offline
+    /// mode.
     #[clap(long = "no-offline", overrides_with = "offline")]
     pub no_offline: bool,
 
-    /// Open the package store read-only (immutable) and skip all store
-    /// writes. For installs against a store on a read-only filesystem
-    /// (e.g. a Nix store); pair with `--offline --frozen-lockfile`.
-    /// Mirrors pnpm's `--frozen-store`. Overrides `frozenStore` from
-    /// `pnpm-workspace.yaml`. Paired with `--no-frozen-store`, the
-    /// CLI inverse, by mutual `overrides_with` (last-one-wins). (pnpm
-    /// additionally rejects `--frozen-store` combined with `--force`;
-    /// pacquet has no `force` flow yet, so there is nothing to conflict
-    /// with — the guard ports alongside `force`.)
+    /// Open the store read-only and skip all store writes. For installing
+    /// against a store on a read-only filesystem (e.g. a Nix store); pair
+    /// with `--offline --frozen-lockfile`.
     #[clap(long = "frozen-store", overrides_with = "no_frozen_store")]
     pub frozen_store: bool,
 
-    /// Force-disable the read-only store for this invocation, overriding
-    /// a `pnpm-workspace.yaml` `frozenStore: true`. Mirrors pnpm's
-    /// `--no-frozen-store`.
+    /// Allow store writes even when the configuration enables the
+    /// read-only store.
     #[clap(long = "no-frozen-store", overrides_with = "frozen_store")]
     pub no_frozen_store: bool,
 
-    /// Prefer cached artifacts over network fetches when both have
-    /// what's needed. The `--prefer-offline` flag biases the
-    /// metadata resolver to the cached copy past the freshness
-    /// window. Pacquet's frozen-install path already prefers the
-    /// local store via the warm prefetch + `index.db` lookups, so
-    /// the flag is a no-op for artifact fetches today. Field exists
-    /// so yaml / CLI parse cleanly; Stage 2's resolver will honor it
-    /// on the metadata path. Paired with `--no-prefer-offline`, the
-    /// CLI inverse, by mutual `overrides_with` (last-one-wins).
+    /// Prefer packages already in the cache over the network, even past
+    /// their freshness window.
     #[clap(long, overrides_with = "no_prefer_offline")]
     pub prefer_offline: bool,
 
-    /// Force-disable prefer-offline for this invocation, overriding a
-    /// `pnpm-workspace.yaml` `preferOffline: true`. Mirrors pnpm's
-    /// `--no-prefer-offline`.
+    /// Don't prefer cached packages even when the configuration enables
+    /// it.
     #[clap(long = "no-prefer-offline", overrides_with = "prefer_offline")]
     pub no_prefer_offline: bool,
 
-    /// Skip the lockfile supply-chain verification pass entirely.
-    /// Overrides `pnpm-workspace.yaml#trustLockfile`. Mirrors pnpm's
-    /// `--trust-lockfile`. Added for
-    /// <https://github.com/pnpm/pnpm/issues/11860>.
-    /// Paired with `--no-trust-lockfile`, the CLI inverse, by mutual
-    /// `overrides_with` (last-one-wins).
+    /// Skip verifying the lockfile against supply-chain policies.
     #[clap(long = "trust-lockfile", overrides_with = "no_trust_lockfile")]
     pub trust_lockfile: bool,
 
-    /// Force the supply-chain verification pass to run for this
-    /// invocation, overriding a `pnpm-workspace.yaml` `trustLockfile: true`.
-    /// Mirrors pnpm's `--no-trust-lockfile`.
+    /// Verify the lockfile against supply-chain policies even when the
+    /// configuration trusts it.
     #[clap(long = "no-trust-lockfile", overrides_with = "trust_lockfile")]
     pub no_trust_lockfile: bool,
 
-    /// Refresh the integrity checksums recorded in `pnpm-lock.yaml`
-    /// from the registry. Mirrors pnpm's `--update-checksums`. Skips
-    /// the frozen-lockfile fast path; conflicts with `--frozen-lockfile`.
+    /// Refresh the integrity checksums in `pnpm-lock.yaml` from the
+    /// registry. Cannot be combined with `--frozen-lockfile`.
     #[clap(long = "update-checksums")]
     pub update_checksums: bool,
 
     /// Maximum number of concurrent network requests during install.
-    /// Mirrors pnpm's `--network-concurrency`; overrides the
-    /// `networkConcurrency` value resolved from `pnpm-workspace.yaml` /
-    /// global `config.yaml` / `PNPM_CONFIG_NETWORK_CONCURRENCY` for this
-    /// invocation. `None` (flag absent) leaves the config-resolved
-    /// value in place.
     #[clap(long = "network-concurrency")]
     pub network_concurrency: Option<usize>,
 
-    /// Per-request network timeout in milliseconds. Mirrors pnpm's
-    /// `--fetch-timeout`; overrides `fetchTimeout` for this invocation.
+    /// Per-request network timeout, in milliseconds.
     #[clap(long = "fetch-timeout")]
     pub fetch_timeout: Option<u64>,
 
-    /// `User-Agent` header sent on registry requests. Mirrors pnpm's
-    /// `--user-agent`; overrides `userAgent` for this invocation.
+    /// `User-Agent` header to send on registry requests.
     #[clap(long = "user-agent")]
     pub user_agent: Option<String>,
 
-    /// URL of a `pnpr` server to offload resolution + file fetching to.
-    /// Overrides the `pnprServer` setting for this invocation. When set,
-    /// the server resolves against the client's registries and
-    /// `node_modules` is linked locally from the server-produced
+    /// URL of a pnpr server to offload resolution and file fetching to.
+    /// `node_modules` is still linked locally from the server-produced
     /// lockfile.
     #[clap(long = "pnpr-server")]
     pub pnpr_server: Option<String>,

--- a/pnpm/crates/cli/src/cli_args/lane.rs
+++ b/pnpm/crates/cli/src/cli_args/lane.rs
@@ -17,10 +17,9 @@ use crate::cli_args::{
 /// prerelease lane can take the name.
 pub const MAIN_LANE: &str = "main";
 
-/// `pnpm lane` — manage per-package release lanes: parallel release tracks
-/// that emit `X.Y.Z-<lane>.N` prereleases while the main lane keeps releasing
-/// stable versions. Membership lives under the `versioning.lanes` key of
-/// pnpm-workspace.yaml; this command is a convenience editor for that key.
+/// Manage per-package release lanes: parallel release tracks that emit
+/// `X.Y.Z-<lane>.N` prereleases while the main lane keeps releasing stable
+/// versions.
 #[derive(Debug, Args)]
 pub struct LaneArgs {
     /// The lane to move the `--filter`-selected packages onto (`main` moves

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -279,7 +279,7 @@ pub struct OutdatedArgs {
     pub global: bool,
 }
 
-/// `--sort-by` value. pnpm currently documents only `name`.
+/// Sort order for the outdated report.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum SortBy {
     Name,

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -79,7 +79,8 @@ pub struct PackArgs {
     #[clap(long = "skip-manifest-obfuscation")]
     pub skip_manifest_obfuscation: bool,
 
-    /// Maximum number of projects packed at once in recursive mode.
+    /// Maximum number of projects to pack at once in recursive mode.
+    /// Currently has no effect; packing runs one project at a time.
     #[clap(long = "workspace-concurrency")]
     pub workspace_concurrency: Option<u32>,
 }

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -50,8 +50,8 @@ pub(crate) fn pack_catalogs(config: &Config) -> miette::Result<Catalogs> {
 }
 
 /// `pacquet pack` arguments. The `-r` / `--recursive` and `--filter`
-/// selectors are global flags on [`crate::CliArgs`]; `--recursive` is
-/// threaded into [`Self::run`].
+/// selectors are global flags on the top-level CLI; `--recursive` is
+/// threaded into `run`.
 #[derive(Debug, Args)]
 pub struct PackArgs {
     /// Do everything `pack` would do except writing the tarball to disk.

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -49,9 +49,7 @@ pub(crate) fn pack_catalogs(config: &Config) -> miette::Result<Catalogs> {
         .wrap_err("read the workspace catalogs")
 }
 
-/// `pacquet pack` arguments. The `-r` / `--recursive` and `--filter`
-/// selectors are global flags on the top-level CLI; `--recursive` is
-/// threaded into `run`.
+/// Create a tarball from a package.
 #[derive(Debug, Args)]
 pub struct PackArgs {
     /// Do everything `pack` would do except writing the tarball to disk.
@@ -82,8 +80,6 @@ pub struct PackArgs {
     pub skip_manifest_obfuscation: bool,
 
     /// Maximum number of projects packed at once in recursive mode.
-    /// Accepted for surface parity; the sweep currently runs
-    /// sequentially.
     #[clap(long = "workspace-concurrency")]
     pub workspace_concurrency: Option<u32>,
 }

--- a/pnpm/crates/cli/src/cli_args/patch_remove.rs
+++ b/pnpm/crates/cli/src/cli_args/patch_remove.rs
@@ -14,7 +14,7 @@ use std::{
 
 #[derive(Debug, Args)]
 pub struct PatchRemoveArgs {
-    /// Patches to remove from patchedDependencies.
+    /// Patches to remove.
     #[clap(value_name = "pkg")]
     pub patches: Vec<String>,
 }

--- a/pnpm/crates/cli/src/cli_args/prefix.rs
+++ b/pnpm/crates/cli/src/cli_args/prefix.rs
@@ -3,10 +3,8 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::path::{Path, PathBuf};
 
-/// `pacquet prefix`: print the current package prefix.
-///
-/// Ports pnpm's `prefix` handler, walking up to find the nearest
-/// package prefix directory (containing package.json, `node_modules`, etc.).
+/// Print the current package prefix — the nearest directory containing a
+/// `package.json`, `node_modules`, or `pnpm-workspace.yaml`.
 #[derive(Debug, Args)]
 pub struct PrefixArgs {
     /// Print the global prefix

--- a/pnpm/crates/cli/src/cli_args/prune.rs
+++ b/pnpm/crates/cli/src/cli_args/prune.rs
@@ -15,10 +15,7 @@ pub struct PruneArgs {
     no_optional: bool,
     #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
     pub ignore_scripts: bool,
-    /// Force-enable lifecycle scripts for this invocation, overriding a
-    /// `pnpm-workspace.yaml` / `.npmrc` `ignoreScripts: true`. Mirrors
-    /// pnpm's `--no-ignore-scripts`. Paired with `ignore_scripts` by
-    /// mutual `overrides_with` (last-one-wins).
+    /// Run lifecycle scripts even if scripts are disabled by configuration.
     #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
     pub no_ignore_scripts: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -31,7 +31,7 @@ use serde_json::Value;
 use crate::cli_args::registry_client::build_registry_client;
 
 /// `pacquet publish` arguments. The `-r` / `--recursive` selector is a global
-/// flag on [`crate::CliArgs`] and threaded into [`Self::run`].
+/// flag on the top-level CLI and threaded into `run`.
 #[derive(Debug, Args)]
 pub struct PublishArgs {
     /// Tarball or directory to publish. Defaults to the current directory.
@@ -41,9 +41,9 @@ pub struct PublishArgs {
     pub flags: PublishFlags,
 }
 
-/// The flag half of [`PublishArgs`], split out so `pacquet stage publish`
-/// (which accepts every publish option) can reuse it alongside its own
-/// positional subcommand parameters.
+/// The flag half of the `publish` arguments, split out so `pacquet stage
+/// publish` (which accepts every publish option) can reuse it alongside its
+/// own positional subcommand parameters.
 #[derive(Debug, Args)]
 pub struct PublishFlags {
     /// Do everything `publish` would do except uploading to the registry.

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -30,8 +30,7 @@ use serde_json::Value;
 
 use crate::cli_args::registry_client::build_registry_client;
 
-/// `pacquet publish` arguments. The `-r` / `--recursive` selector is a global
-/// flag on the top-level CLI and threaded into `run`.
+/// Publish a package to the registry.
 #[derive(Debug, Args)]
 pub struct PublishArgs {
     /// Tarball or directory to publish. Defaults to the current directory.
@@ -41,9 +40,7 @@ pub struct PublishArgs {
     pub flags: PublishFlags,
 }
 
-/// The flag half of the `publish` arguments, split out so `pacquet stage
-/// publish` (which accepts every publish option) can reuse it alongside its
-/// own positional subcommand parameters.
+/// Options controlling how a package is published.
 #[derive(Debug, Args)]
 pub struct PublishFlags {
     /// Do everything `publish` would do except uploading to the registry.

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -20,8 +20,9 @@ pub struct RebuildArgs {
     /// that requires a build is rebuilt.
     pub packages: Vec<String>,
 
-    /// Rebuild packages that were not built during installation. Packages
-    /// are not built when installing with the `--ignore-scripts` flag.
+    /// Rebuild packages that were not built during installation, such as
+    /// under `--ignore-scripts`. Currently has no effect: no packages are
+    /// recorded as pending yet.
     #[clap(long)]
     pub pending: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -22,13 +22,6 @@ pub struct RebuildArgs {
 
     /// Rebuild packages that were not built during installation. Packages
     /// are not built when installing with the `--ignore-scripts` flag.
-    ///
-    /// Accepted for parity with pnpm, but currently a no-op: pacquet's
-    /// install pipeline does not yet record `pendingBuilds` in
-    /// `.modules.yaml`, so there is nothing for `--pending` to select.
-    /// Tracked with the rest of the not-yet-populated `.modules.yaml`
-    /// fields; until then, name the packages explicitly or use
-    /// `approve-builds`.
     #[clap(long)]
     pub pending: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/remove.rs
+++ b/pnpm/crates/cli/src/cli_args/remove.rs
@@ -43,11 +43,11 @@ pub struct RemoveArgs {
     #[clap(flatten)]
     pub dependency_options: RemoveDependencyOptions,
     /// Dependencies are not removed from `node_modules`. Only the manifest
-    /// and `pnpm-lock.yaml` are updated. Mirrors pnpm's `--lockfile-only`.
+    /// and `pnpm-lock.yaml` are updated.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
     /// Remove the package from the global packages directory and unlink its
-    /// bins. Mirrors pnpm's `remove -g`.
+    /// bins.
     #[clap(short = 'g', long)]
     pub global: bool,
 }

--- a/pnpm/crates/cli/src/cli_args/reporter.rs
+++ b/pnpm/crates/cli/src/cli_args/reporter.rs
@@ -3,20 +3,18 @@ use pacquet_default_reporter::{DefaultReporter, SummaryScope};
 use pacquet_reporter::{LogEvent, NdjsonReporter, Reporter, SilentReporter};
 use std::path::Path;
 
-/// Selectable rendering strategy for log events.
-///
-/// Mirrors the names pnpm uses for `--reporter` (`default`, `append-only`,
-/// `ndjson`, `silent`).
+/// Output format for progress and log messages.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum ReporterType {
-    /// pnpm-style visual output (progress line, packages diff, lifecycle
-    /// output, `Done in ...`). The default; renders in place on a TTY and
-    /// falls back to append-only when stdout is not a TTY.
+    /// Rich visual output: a progress line, a packages diff, lifecycle
+    /// output, and a `Done in ...` summary. The default; renders in place
+    /// on a terminal and falls back to `append-only` output when stdout is
+    /// not a terminal.
     Default,
     /// Like `default` but forces the append-only rendering even on a TTY —
     /// one line per update, no cursor movement.
     AppendOnly,
-    /// Newline-delimited JSON in pnpm's wire format on stderr.
+    /// Newline-delimited JSON on stderr.
     Ndjson,
     /// No progress output.
     Silent,

--- a/pnpm/crates/cli/src/cli_args/restart.rs
+++ b/pnpm/crates/cli/src/cli_args/restart.rs
@@ -4,10 +4,6 @@ use super::run::RunArgs;
 
 /// Restarts a package. Runs a package's "stop", "restart", and "start"
 /// scripts, and associated pre- and post- scripts.
-///
-/// Each script is executed through the full `run` pipeline, so
-/// lifecycle hooks (`pre<name>` / `post<name>`) and environment setup
-/// apply when `enablePrePostScripts` is set.
 #[derive(Debug, Args)]
 pub struct RestartArgs {
     /// Arguments passed to each script after the script name.

--- a/pnpm/crates/cli/src/cli_args/restart.rs
+++ b/pnpm/crates/cli/src/cli_args/restart.rs
@@ -5,7 +5,7 @@ use super::run::RunArgs;
 /// Restarts a package. Runs a package's "stop", "restart", and "start"
 /// scripts, and associated pre- and post- scripts.
 ///
-/// Each script is executed through the full [`RunArgs`] pipeline, so
+/// Each script is executed through the full `run` pipeline, so
 /// lifecycle hooks (`pre<name>` / `post<name>`) and environment setup
 /// apply when `enablePrePostScripts` is set.
 #[derive(Debug, Args)]

--- a/pnpm/crates/cli/src/cli_args/root.rs
+++ b/pnpm/crates/cli/src/cli_args/root.rs
@@ -3,14 +3,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::path::Path;
 
-/// `pacquet root`: print the effective `node_modules` directory.
-///
-/// The path is `<dir>/node_modules`: the leaf is the hardcoded string
-/// `node_modules` — a configured `modules-dir` is ignored — and the anchor
-/// is the realpath of the CLI directory (the cwd, not the workspace root),
-/// supplied as the already-canonicalized `--dir`. This deliberately does
-/// NOT read `config.modules_dir`, which pacquet re-anchors to the workspace
-/// root inside a workspace.
+/// Print the path to the `node_modules` directory.
 #[derive(Debug, Args)]
 pub struct RootArgs {
     /// Print the global packages directory

--- a/pnpm/crates/cli/src/cli_args/set_script.rs
+++ b/pnpm/crates/cli/src/cli_args/set_script.rs
@@ -22,11 +22,9 @@ pub enum SetScriptError {
     UnsafeKey { key: String },
 }
 
-/// `pacquet set-script <name> <command...>` / `pacquet ss <name> <command...>`.
+/// Set a script in the `scripts` field of the project's `package.json`.
 ///
-/// Writes a `scripts` entry to the project manifest. The command is every
-/// parameter after the name joined by a single space, so
-/// `set-script lint eslint --fix src` stores `"eslint --fix src"`.
+/// The command is every argument after the script name, joined by spaces.
 #[derive(Debug, Args)]
 pub struct SetScriptArgs {
     /// The script name followed by the command and its arguments.

--- a/pnpm/crates/cli/src/cli_args/supported_architectures.rs
+++ b/pnpm/crates/cli/src/cli_args/supported_architectures.rs
@@ -1,31 +1,24 @@
 use clap::Args;
 use pacquet_package_is_installable::SupportedArchitectures;
 
-/// `--cpu`, `--libc`, `--os` CLI flags. Multi-valued: each may be
-/// repeated (`--cpu arm64 --cpu x64`) or comma-separated
-/// (`--cpu arm64,x64`) — both shapes are wired so the surface
-/// matches every reasonable user expectation.
-///
-/// Flattened into the `InstallArgs` / `AddArgs` clap derives so the
-/// three flags appear under the regular `--help` output. Shared
-/// between the two so the wire shape is identical.
+/// Filters which platforms' optional dependencies are installed, via the
+/// `--cpu`, `--os`, and `--libc` flags. Each flag may be repeated
+/// (`--cpu arm64 --cpu x64`) or comma-separated (`--cpu arm64,x64`).
 #[derive(Debug, Default, Clone, Args)]
 pub struct SupportedArchitecturesArgs {
-    /// CPU architectures whose platform-tagged optional dependencies
-    /// should be kept. Repeat or comma-separate for multiple values.
-    /// Overrides `supportedArchitectures.cpu` from
-    /// `pnpm-workspace.yaml` for this axis only.
+    /// CPU architectures whose platform-specific optional dependencies
+    /// should be installed. Repeat or comma-separate for multiple values.
     #[clap(long, value_delimiter = ',', num_args = 1..)]
     pub cpu: Vec<String>,
 
-    /// Operating systems whose platform-tagged optional dependencies
-    /// should be kept. Overrides `supportedArchitectures.os`.
+    /// Operating systems whose platform-specific optional dependencies
+    /// should be installed. Repeat or comma-separate for multiple values.
     #[clap(long, value_delimiter = ',', num_args = 1..)]
     pub os: Vec<String>,
 
-    /// libc families whose platform-tagged optional dependencies
-    /// should be kept (`glibc`, `musl`). Overrides
-    /// `supportedArchitectures.libc`.
+    /// libc families whose platform-specific optional dependencies should
+    /// be installed (`glibc`, `musl`). Repeat or comma-separate for
+    /// multiple values.
     #[clap(long, value_delimiter = ',', num_args = 1..)]
     pub libc: Vec<String>,
 }

--- a/pnpm/crates/cli/src/cli_args/unlink.rs
+++ b/pnpm/crates/cli/src/cli_args/unlink.rs
@@ -11,13 +11,11 @@ use std::{
     sync::Arc,
 };
 
-/// Removes the link created by `pacquet link` and reinstalls the package if
-/// it is saved in `package.json`.
+/// Remove the link created by `pnpm link` and reinstall the package from the
+/// registry if it is saved in `package.json`.
 ///
-/// Mirrors pnpm's `unlink`: it strips `link:` entries from the `overrides`
-/// block in `pnpm-workspace.yaml` (the same source the installer reads), then
-/// runs install so the previous resolution is restored. With package names it
-/// only drops the matching `link:` overrides; with none it drops them all.
+/// With package names, only the matching links are removed; with no
+/// arguments, every link is removed.
 #[derive(Debug, Args)]
 pub struct UnlinkArgs {
     pub package_names: Vec<String>,

--- a/pnpm/crates/cli/src/cli_args/unlink.rs
+++ b/pnpm/crates/cli/src/cli_args/unlink.rs
@@ -11,8 +11,8 @@ use std::{
     sync::Arc,
 };
 
-/// Remove the link created by `pnpm link` and reinstall the package from the
-/// registry if it is saved in `package.json`.
+/// Remove the link created by `pnpm link` and reinstall the package as
+/// declared in `package.json`.
 ///
 /// With package names, only the matching links are removed; with no
 /// arguments, every link is removed.

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -7,10 +7,8 @@ use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 
-/// `--prod` / `--dev` / `--no-optional` for `pacquet update`.
-///
-/// These read the *raw* CLI flags (not the rc-merged config) so an absent
-/// flag is unset rather than a default.
+/// The `--prod`, `--dev`, and `--no-optional` flags that select which
+/// dependency groups to update.
 #[derive(Debug, Args)]
 pub struct UpdateDependencyOptions {
     /// Update packages only in "dependencies" and "optionalDependencies".
@@ -50,7 +48,7 @@ impl UpdateDependencyOptions {
     }
 }
 
-/// `pacquet update` (alias `up` / `upgrade`).
+/// Update packages to their latest version based on the specified range.
 #[derive(Debug, Args)]
 pub struct UpdateArgs {
     /// Packages to update. Bare names (`foo`, `@scope/bar`), glob
@@ -63,8 +61,8 @@ pub struct UpdateArgs {
     #[clap(flatten)]
     pub dependency_options: UpdateDependencyOptions,
 
-    /// `--cpu` / `--os` / `--libc` overrides for the optional-dep
-    /// platform filter.
+    /// The `--cpu`, `--os`, and `--libc` flags that select which platforms'
+    /// optional dependencies to install.
     #[clap(flatten)]
     pub supported_architectures: SupportedArchitecturesArgs,
 

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -19,8 +19,8 @@ use crate::cli_args::{
 /// `-r` and no version argument.
 #[derive(Debug, Args)]
 pub struct VersionArgs {
-    /// The version to bump to. With no argument, the recursive form consumes
-    /// the pending change intents instead.
+    /// A version to bump to. Passing one is not supported yet; run with
+    /// `-r` and no argument to apply the pending change intents.
     pub params: Vec<String>,
 
     /// Print the release plan the pending change intents produce without

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -15,13 +15,12 @@ use crate::cli_args::{
     recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
 };
 
-/// `pnpm version` — apply the pending change intents (`-r` with no version
-/// argument). The npm-style explicit-bump forms are not ported yet;
-/// per-package release lanes are managed by `pnpm lane`.
+/// Bump package versions by applying the pending change intents. Run with
+/// `-r` and no version argument.
 #[derive(Debug, Args)]
 pub struct VersionArgs {
-    /// An npm-style version argument (not ported yet); the bare recursive
-    /// form consumes the pending change intents instead.
+    /// The version to bump to. With no argument, the recursive form consumes
+    /// the pending change intents instead.
     pub params: Vec<String>,
 
     /// Print the release plan the pending change intents produce without

--- a/pnpm/crates/cli/src/cli_args/with.rs
+++ b/pnpm/crates/cli/src/cli_args/with.rs
@@ -55,8 +55,7 @@ pub enum WithError {
 #[derive(Debug, Args)]
 pub struct WithArgs {
     /// The pnpm version, range, or dist-tag to run, followed by the pnpm
-    /// command and its arguments. (`with current <args>` is handled before
-    /// argv parsing, so it never reaches this handler.)
+    /// command and its arguments.
     #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
     pub params: Vec<String>,
 }

--- a/pnpm/crates/cli/src/cli_args/with.rs
+++ b/pnpm/crates/cli/src/cli_args/with.rs
@@ -54,8 +54,9 @@ pub enum WithError {
 
 #[derive(Debug, Args)]
 pub struct WithArgs {
-    /// The pnpm version, range, or dist-tag to run, followed by the pnpm
-    /// command and its arguments.
+    /// The pnpm version, range, or dist-tag to run — or `current` to use
+    /// the pnpm that is already running — followed by the pnpm command and
+    /// its arguments.
     #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
     pub params: Vec<String>,
 }

--- a/pnpm/tasks/integrated-benchmark/src/cli_args.rs
+++ b/pnpm/tasks/integrated-benchmark/src/cli_args.rs
@@ -227,7 +227,7 @@ pub enum BenchmarkScenario {
     /// prefer-offline resolution (e.g. the disk-to-memory metadata
     /// promotion). The measured command can't prime the mirror itself
     /// (`--offline` fails on a cold one), so an online pre-warm pass
-    /// runs first (see [`Self::prewarm_install_args`]).
+    /// runs first.
     #[value(name = "isolated-linker.fresh-resolve.hot-cache.offline")]
     IsolatedFreshResolveHotCacheOffline,
     /// Frozen lockfile, hot cache + hot store, `enableGlobalVirtualStore: true` with a pre-warmed GVS.

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -44,7 +44,7 @@ struct Args {
     packument_ttl_secs: Option<u64>,
 
     /// Enable local OSV npm vulnerability checks. Requires a local OSV
-    /// npm database zip at --osv-db or <cache>/osv/npm/all.zip.
+    /// npm database zip at `--osv-db` or `<cache>/osv/npm/all.zip`.
     #[arg(long)]
     osv: bool,
 


### PR DESCRIPTION
## Summary

This PR makes pacquet's `--help` output read like end-user help instead of developer API documentation, and re-enables the `perfectionist::clap_help_markdown` dylint rule that guards it.

pacquet's clap doc comments are dual-purpose: they are both `cargo doc` API docs and the text clap prints for `--help`. Over time they had accumulated developer- and parity-oriented prose that leaked verbatim into the terminal — mirrors-pnpm notes, config-field and store-layout mechanics, `overrides_with` pairing, environment-variable names, `ERR_PNPM_*` codes, internal Rust type references, and not-yet-ported caveats. This PR rewrites those doc comments across the whole CLI into concise, user-facing help and removes the developer notes entirely. No flag behavior changes; only doc-comment text moved.

Folded into the same pass, the markdown that `clap_help_markdown` flags is cleaned out of the help text: intra-doc links to internal Rust types become the CLI flag they describe or plain words, one inline upstream-issue citation leaves the help text, and an angle-bracketed path placeholder that parsed as an HTML tag is wrapped in a code span. The rule is then dropped from the `disable` list in `dylint.toml` so it stays enforced. Code spans — backticks around flag names, file names, and literal values — are kept via the rule's ignore_constructs setting, since they read fine in a terminal and stay useful as `cargo doc` docs.

Resolves [#12718](https://github.com/pnpm/pnpm/issues/12718).

## Squash Commit Body

```text
Make pacquet's --help read like user-facing help rather than developer API
docs, and re-enable the perfectionist::clap_help_markdown dylint rule.

The clap doc comments are dual-purpose: cargo doc API docs and the text
clap prints for --help. They had accumulated developer and parity prose
that leaked into the terminal (mirrors-pnpm notes, config-field and
store-layout mechanics, overrides_with pairing, env-var names, ERR_PNPM_*
codes, internal type references, not-yet-ported caveats). Rewrite them
across the whole CLI into concise user-facing help and drop those notes;
no flag behavior changes, only doc-comment text moved.

Clean out the markdown the rule flags in the same pass: intra-doc links to
internal types become the CLI flag they describe or plain words, one inline
issue citation leaves the help text, and an angle-bracketed path placeholder
that parsed as an HTML tag is wrapped in a code span. Re-enable the rule by
dropping it from the dylint.toml disable list; keep code spans via the
rule's ignore_constructs setting since they read fine in a terminal.

Closes pnpm/pnpm#12718
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. — Rust-only:
  clap doc comments have no TypeScript counterpart (the TS CLI writes its help
  strings by hand), so there is nothing to port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. — `pacquet` and `@pnpm/pnpr`, both patch.
- [ ] Added or updated tests. — N/A: no runtime logic changed; the re-enabled
  `clap_help_markdown` dylint rule is the regression guard.
- [ ] Updated the documentation if needed. — N/A: the change is itself
  documentation (`--help` text); no external docs are affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved and condensed user-facing CLI help and command descriptions across many package management and publishing commands.
  * Cleaned up terminal `--help` output to remove leftover internal notes and formatting artifacts.
  * Clarified option wording for platform filtering, recursive execution, configuration locations, vulnerability database path formatting, and link/unlink behavior.
* **Chores**
  * Updated the CLI help lint configuration to keep validation enabled while allowing a narrowly scoped formatting exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->