### PR TITLE
fix(fs): make concurrent Windows junction creation atomic

### DIFF
--- a/.changeset/windows-atomic-junctions.md
+++ b/.changeset/windows-atomic-junctions.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed concurrent package linking failures on Windows when directory symlinks fall back to junctions.

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -154,6 +154,16 @@ jobs:
           tool: just
 
       - name: Install dependencies
+        if: runner.os != 'Windows'
+        run: just install
+
+      # The released native CLI bootstraps this job before the branch is
+      # compiled. Disable its broken GVS path so the Windows suite can test
+      # the source fix in this PR.
+      - name: Install dependencies on Windows
+        if: runner.os == 'Windows'
+        env:
+          PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE: 'false'
         run: just install
 
       - name: Install cargo-nextest

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -153,10 +153,6 @@ jobs:
         with:
           tool: just
 
-      - name: Reproduce missing-parent junction failure
-        if: runner.os == 'Windows'
-        run: cargo test -p pacquet-fs windows_junction_creation_recovers_when_link_parent_is_missing
-
       - name: Install dependencies
         run: just install
 

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -153,10 +153,6 @@ jobs:
         with:
           tool: just
 
-      - name: Reproduce concurrent junction creation
-        if: runner.os == 'Windows'
-        run: cargo test -p pacquet-fs windows_concurrent_junction_creation_reuses_one_link
-
       - name: Install dependencies
         run: just install
 

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Install dependencies on Windows
         if: runner.os == 'Windows'
         env:
-          PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE: 'false'
+          pnpm_config_enable_global_virtual_store: 'false'
         run: just install
 
       - name: Install cargo-nextest

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -154,16 +154,6 @@ jobs:
           tool: just
 
       - name: Install dependencies
-        if: runner.os != 'Windows'
-        run: just install
-
-      # The released native CLI bootstraps this job before the branch is
-      # compiled. Disable its broken GVS path so the Windows suite can test
-      # the source fix in this PR.
-      - name: Install dependencies on Windows
-        if: runner.os == 'Windows'
-        env:
-          pnpm_config_enable_global_virtual_store: 'false'
         run: just install
 
       - name: Install cargo-nextest

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -153,6 +153,10 @@ jobs:
         with:
           tool: just
 
+      - name: Reproduce concurrent junction creation
+        if: runner.os == 'Windows'
+        run: cargo test -p pacquet-fs windows_concurrent_junction_creation_reuses_one_link
+
       - name: Install dependencies
         run: just install
 

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -153,6 +153,10 @@ jobs:
         with:
           tool: just
 
+      - name: Reproduce missing-parent junction failure
+        if: runner.os == 'Windows'
+        run: cargo test -p pacquet-fs windows_junction_creation_recovers_when_link_parent_is_missing
+
       - name: Install dependencies
         run: just install
 

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -455,14 +455,11 @@ mod windows {
             match fs::symlink_metadata(link) {
                 Ok(_) => {
                     if let Some(cleanup_error) = cleanup_error {
-                        return Err(io::Error::new(
-                            rename_error.kind(),
-                            format!(
-                                "failed to rename staged junction {staging:?} to {link:?}: \
-                                 {rename_error}; destination now exists, but cleanup failed: \
-                                 {cleanup_error}",
-                            ),
-                        ));
+                        return Err(io::Error::other(format!(
+                            "failed to rename staged junction {staging:?} to {link:?}: \
+                             {rename_error}; destination now exists, but cleanup failed: \
+                             {cleanup_error}",
+                        )));
                     }
                     return Err(io::Error::new(
                         io::ErrorKind::AlreadyExists,
@@ -474,26 +471,27 @@ mod windows {
                 }
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {}
                 Err(error) => {
-                    let cleanup_context = cleanup_error
-                        .map(|cleanup| format!("; staged-junction cleanup failed: {cleanup}"))
-                        .unwrap_or_default();
+                    if let Some(cleanup_error) = cleanup_error {
+                        return Err(io::Error::other(format!(
+                            "failed to inspect junction destination {link:?} after rename \
+                             failed: {rename_error}; inspection error: {error}; \
+                             staged-junction cleanup failed: {cleanup_error}",
+                        )));
+                    }
                     return Err(io::Error::new(
                         rename_error.kind(),
                         format!(
                             "failed to inspect junction destination {link:?} after rename \
-                             failed: {rename_error}; inspection error: {error}{cleanup_context}",
+                             failed: {rename_error}; inspection error: {error}",
                         ),
                     ));
                 }
             }
             if let Some(cleanup_error) = cleanup_error {
-                return Err(io::Error::new(
-                    rename_error.kind(),
-                    format!(
-                        "failed to rename staged junction {staging:?} to {link:?}: \
-                         {rename_error}; cleanup failed: {cleanup_error}",
-                    ),
-                ));
+                return Err(io::Error::other(format!(
+                    "failed to rename staged junction {staging:?} to {link:?}: \
+                     {rename_error}; cleanup failed: {cleanup_error}",
+                )));
             }
             return Err(rename_error);
         }

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -349,6 +349,11 @@ mod windows {
         }
     }
 
+    #[cfg(test)]
+    pub(super) fn force_junction_mode() {
+        MODE.store(USE_JUNCTION, Ordering::Relaxed);
+    }
+
     /// True symlinks on Windows take a relative target —
     /// `path.relative(dirname(dest), src)`, the same form used on Unix.
     /// Junctions take the absolute path with a trailing backslash, but

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -148,6 +148,9 @@ pub fn force_symlink_dir(target: &Path, link: &Path) -> io::Result<ForceSymlinkO
     // the symlink syscall — sees a native path. See [`to_native_separators`].
     let target = to_native_separators(target);
     let link = to_native_separators(link);
+    #[cfg(windows)]
+    return force_symlink_inner(&target, &link, false, windows::create);
+    #[cfg(not(windows))]
     force_symlink_inner(&target, &link, false, symlink_dir)
 }
 

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -327,9 +327,9 @@ fn rename_overwrite(src: &Path, dst: &Path) -> io::Result<()> {
 #[cfg(windows)]
 mod windows {
     use std::{
-        io,
-        path::Path,
-        sync::atomic::{AtomicU8, Ordering},
+        fs, io,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU8, AtomicU64, Ordering},
     };
 
     /// Cached choice of writer. `UNDECIDED` until the first successful
@@ -340,11 +340,12 @@ mod windows {
     const USE_SYMLINK: u8 = 1;
     const USE_JUNCTION: u8 = 2;
     static MODE: AtomicU8 = AtomicU8::new(UNDECIDED);
+    static JUNCTION_STAGING_ID: AtomicU64 = AtomicU64::new(0);
 
     pub fn create(original: &Path, link: &Path) -> io::Result<()> {
         match MODE.load(Ordering::Relaxed) {
             USE_SYMLINK => create_true_symlink(original, link),
-            USE_JUNCTION => junction::create(original, link),
+            USE_JUNCTION => create_junction(original, link),
             _ => probe_and_cache(original, link),
         }
     }
@@ -378,7 +379,7 @@ mod windows {
                 Ok(())
             }
             Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
-                let result = junction::create(original, link);
+                let result = create_junction(original, link);
                 if result.is_ok() {
                     MODE.store(USE_JUNCTION, Ordering::Relaxed);
                 }
@@ -386,6 +387,56 @@ mod windows {
             }
             Err(error) => Err(error),
         }
+    }
+
+    fn create_junction(original: &Path, link: &Path) -> io::Result<()> {
+        let staging = loop {
+            let candidate = junction_staging_path(link);
+            match junction::create(original, &candidate) {
+                Ok(()) => break candidate,
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        };
+
+        if let Err(rename_error) = fs::rename(&staging, link) {
+            fs::remove_dir(&staging).map_err(|cleanup_error| {
+                io::Error::new(
+                    cleanup_error.kind(),
+                    format!(
+                        "failed to clean up staged junction {staging:?} after rename to \
+                         {link:?} failed: {cleanup_error}"
+                    ),
+                )
+            })?;
+            match fs::symlink_metadata(link) {
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        format!("junction path already exists: {link:?}"),
+                    ));
+                }
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(io::Error::new(
+                        error.kind(),
+                        format!(
+                            "failed to inspect junction destination {link:?} after rename \
+                             failed: {error}"
+                        ),
+                    ));
+                }
+            }
+            return Err(rename_error);
+        }
+
+        Ok(())
+    }
+
+    fn junction_staging_path(link: &Path) -> PathBuf {
+        let id = JUNCTION_STAGING_ID.fetch_add(1, Ordering::Relaxed);
+        let name = format!(".pnpm-junction-{}-{id}", std::process::id());
+        link.with_file_name(name)
     }
 }
 

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -479,7 +479,7 @@ mod windows {
                         )));
                     }
                     return Err(io::Error::new(
-                        rename_error.kind(),
+                        error.kind(),
                         format!(
                             "failed to inspect junction destination {link:?} after rename \
                              failed: {rename_error}; inspection error: {error}",

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -349,7 +349,12 @@ mod windows {
 
     pub fn create(original: &Path, link: &Path) -> io::Result<()> {
         match MODE.load(Ordering::Relaxed) {
-            USE_SYMLINK => create_true_symlink(original, link),
+            USE_SYMLINK => match create_true_symlink(original, link) {
+                Err(error) if should_fallback_to_junction(&error) => {
+                    create_and_cache_junction(original, link)
+                }
+                result => result,
+            },
             USE_JUNCTION => create_junction(original, link),
             _ => probe_and_cache(original, link),
         }
@@ -378,15 +383,25 @@ mod windows {
                 MODE.store(USE_SYMLINK, Ordering::Relaxed);
                 Ok(())
             }
-            Err(error) if error.kind() == io::ErrorKind::PermissionDenied => {
-                let result = create_junction(original, link);
-                if result.is_ok() {
-                    MODE.store(USE_JUNCTION, Ordering::Relaxed);
-                }
-                result
+            Err(error) if should_fallback_to_junction(&error) => {
+                create_and_cache_junction(original, link)
             }
             Err(error) => Err(error),
         }
+    }
+
+    pub(super) fn should_fallback_to_junction(error: &io::Error) -> bool {
+        const ERROR_DIRECTORY: i32 = 267;
+        error.kind() == io::ErrorKind::PermissionDenied
+            || error.raw_os_error() == Some(ERROR_DIRECTORY)
+    }
+
+    fn create_and_cache_junction(original: &Path, link: &Path) -> io::Result<()> {
+        let result = create_junction(original, link);
+        if result.is_ok() {
+            MODE.store(USE_JUNCTION, Ordering::Relaxed);
+        }
+        result
     }
 
     pub(super) fn create_junction(original: &Path, link: &Path) -> io::Result<()> {
@@ -402,13 +417,18 @@ mod windows {
         let _commit_guard = JUNCTION_COMMIT_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         match fs::symlink_metadata(link) {
             Ok(_) => {
-                let cleanup_error = fs::remove_dir(&staging).err();
-                let cleanup_context = cleanup_error
-                    .map(|error| format!("; staged-junction cleanup failed: {error}"))
-                    .unwrap_or_default();
+                fs::remove_dir(&staging).map_err(|error| {
+                    io::Error::new(
+                        error.kind(),
+                        format!(
+                            "junction path already exists at {link:?}, but staged junction \
+                             cleanup failed at {staging:?}: {error}",
+                        ),
+                    )
+                })?;
                 return Err(io::Error::new(
                     io::ErrorKind::AlreadyExists,
-                    format!("junction path already exists: {link:?}{cleanup_context}"),
+                    format!("junction path already exists: {link:?}"),
                 ));
             }
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
@@ -431,14 +451,21 @@ mod windows {
             let cleanup_error = fs::remove_dir(&staging).err();
             match fs::symlink_metadata(link) {
                 Ok(_) => {
-                    let cleanup_context = cleanup_error
-                        .map(|error| format!("; staged-junction cleanup failed: {error}"))
-                        .unwrap_or_default();
+                    if let Some(cleanup_error) = cleanup_error {
+                        return Err(io::Error::new(
+                            rename_error.kind(),
+                            format!(
+                                "failed to rename staged junction {staging:?} to {link:?}: \
+                                 {rename_error}; destination now exists, but cleanup failed: \
+                                 {cleanup_error}",
+                            ),
+                        ));
+                    }
                     return Err(io::Error::new(
                         io::ErrorKind::AlreadyExists,
                         format!(
                             "junction path already exists after rename failed: {link:?}; \
-                             rename error: {rename_error}{cleanup_context}",
+                             rename error: {rename_error}",
                         ),
                     ));
                 }

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
-    fs, io,
+    error::Error,
+    fmt, fs, io,
     path::{Path, PathBuf},
 };
 
@@ -128,13 +129,25 @@ pub fn read_symlink_dir(link: &Path) -> io::Result<PathBuf> {
 /// `reused` is `true` when the symlink at `link` already pointed at
 /// the requested target, so no on-disk write was needed. `warning`
 /// carries the human-readable note emitted when an existing non-symlink
-/// occupant had to be moved out of the way to install the symlink —
-/// surface it to the user if your call site has a reporter.
+/// occupant had to be moved out of the way or a concurrent junction
+/// commit succeeded but left a staging path that could not be cleaned
+/// up — surface it to the user if your call site has a reporter.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ForceSymlinkOutcome {
     pub reused: bool,
     pub warning: Option<String>,
 }
+
+#[derive(Debug)]
+struct ConcurrentCleanupWarning(String);
+
+impl fmt::Display for ConcurrentCleanupWarning {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl Error for ConcurrentCleanupWarning {}
 
 /// Idempotent, overwrite-on-stale symlink creator with overwrite-on
 /// semantics: an existing occupant at `link` is moved aside.
@@ -164,6 +177,10 @@ fn force_symlink_inner(
         Ok(()) => return Ok(ForceSymlinkOutcome { reused: false, warning: None }),
         Err(error) => error,
     };
+    let reuse_warning = initial_err
+        .get_ref()
+        .and_then(|error| error.downcast_ref::<ConcurrentCleanupWarning>())
+        .map(|warning| warning.0.clone());
 
     match initial_err.kind() {
         io::ErrorKind::NotFound => {
@@ -189,7 +206,7 @@ fn force_symlink_inner(
 
     if let Ok(existing) = read_symlink_dir(link) {
         if existing_symlink_up_to_date(target, link, &existing) {
-            return Ok(ForceSymlinkOutcome { reused: true, warning: None });
+            return Ok(ForceSymlinkOutcome { reused: true, warning: reuse_warning });
         }
         // Stale link — unlink and retry. Ignore `NotFound` in
         // case a parallel installer beat us to the unlink.
@@ -422,11 +439,11 @@ mod windows {
             Ok(_) => {
                 fs::remove_dir(&staging).map_err(|error| {
                     io::Error::new(
-                        error.kind(),
-                        format!(
+                        io::ErrorKind::AlreadyExists,
+                        super::ConcurrentCleanupWarning(format!(
                             "junction path already exists at {link:?}, but staged junction \
                              cleanup failed at {staging:?}: {error}",
-                        ),
+                        )),
                     )
                 })?;
                 return Err(io::Error::new(
@@ -455,11 +472,14 @@ mod windows {
             match fs::symlink_metadata(link) {
                 Ok(_) => {
                     if let Some(cleanup_error) = cleanup_error {
-                        return Err(io::Error::other(format!(
-                            "failed to rename staged junction {staging:?} to {link:?}: \
-                             {rename_error}; destination now exists, but cleanup failed: \
-                             {cleanup_error}",
-                        )));
+                        return Err(io::Error::new(
+                            io::ErrorKind::AlreadyExists,
+                            super::ConcurrentCleanupWarning(format!(
+                                "failed to rename staged junction {staging:?} to {link:?}: \
+                                 {rename_error}; destination now exists, but cleanup failed: \
+                                 {cleanup_error}",
+                            )),
+                        ));
                     }
                     return Err(io::Error::new(
                         io::ErrorKind::AlreadyExists,

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -148,15 +148,16 @@ pub fn force_symlink_dir(target: &Path, link: &Path) -> io::Result<ForceSymlinkO
     // the symlink syscall — sees a native path. See [`to_native_separators`].
     let target = to_native_separators(target);
     let link = to_native_separators(link);
-    force_symlink_inner(&target, &link, false)
+    force_symlink_inner(&target, &link, false, symlink_dir)
 }
 
 fn force_symlink_inner(
     target: &Path,
     link: &Path,
     rename_tried: bool,
+    create_symlink: fn(&Path, &Path) -> io::Result<()>,
 ) -> io::Result<ForceSymlinkOutcome> {
-    let initial_err = match symlink_dir(target, link) {
+    let initial_err = match create_symlink(target, link) {
         Ok(()) => return Ok(ForceSymlinkOutcome { reused: false, warning: None }),
         Err(error) => error,
     };
@@ -177,7 +178,7 @@ fn force_symlink_inner(
                     )
                 })?;
             }
-            return force_symlink_inner(target, link, rename_tried);
+            return force_symlink_inner(target, link, rename_tried, create_symlink);
         }
         io::ErrorKind::AlreadyExists | io::ErrorKind::IsADirectory => {}
         _ => return Err(initial_err),
@@ -194,7 +195,7 @@ fn force_symlink_inner(
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(error) => return Err(error),
         }
-        force_symlink_inner(target, link, rename_tried)
+        force_symlink_inner(target, link, rename_tried, create_symlink)
     } else {
         // `link` is occupied by a regular file or directory.
         // Move it out of the way, then retry. On the second
@@ -225,7 +226,7 @@ fn force_symlink_inner(
                 sep = std::path::MAIN_SEPARATOR,
             )
         };
-        let mut outcome = force_symlink_inner(target, link, true)?;
+        let mut outcome = force_symlink_inner(target, link, true, create_symlink)?;
         outcome.warning = Some(warning);
         Ok(outcome)
     }
@@ -329,7 +330,10 @@ mod windows {
     use std::{
         fs, io,
         path::{Path, PathBuf},
-        sync::atomic::{AtomicU8, AtomicU64, Ordering},
+        sync::{
+            Mutex, PoisonError,
+            atomic::{AtomicU8, AtomicU64, Ordering},
+        },
     };
 
     /// Cached choice of writer. `UNDECIDED` until the first successful
@@ -341,6 +345,7 @@ mod windows {
     const USE_JUNCTION: u8 = 2;
     static MODE: AtomicU8 = AtomicU8::new(UNDECIDED);
     static JUNCTION_STAGING_ID: AtomicU64 = AtomicU64::new(0);
+    static JUNCTION_COMMIT_LOCK: Mutex<()> = Mutex::new(());
 
     pub fn create(original: &Path, link: &Path) -> io::Result<()> {
         match MODE.load(Ordering::Relaxed) {
@@ -348,11 +353,6 @@ mod windows {
             USE_JUNCTION => create_junction(original, link),
             _ => probe_and_cache(original, link),
         }
-    }
-
-    #[cfg(test)]
-    pub(super) fn force_junction_mode() {
-        MODE.store(USE_JUNCTION, Ordering::Relaxed);
     }
 
     /// True symlinks on Windows take a relative target —
@@ -389,7 +389,7 @@ mod windows {
         }
     }
 
-    fn create_junction(original: &Path, link: &Path) -> io::Result<()> {
+    pub(super) fn create_junction(original: &Path, link: &Path) -> io::Result<()> {
         let staging = loop {
             let candidate = junction_staging_path(link);
             match junction::create(original, &candidate) {
@@ -399,33 +399,71 @@ mod windows {
             }
         };
 
-        if let Err(rename_error) = fs::rename(&staging, link) {
-            fs::remove_dir(&staging).map_err(|cleanup_error| {
-                io::Error::new(
-                    cleanup_error.kind(),
+        let _commit_guard = JUNCTION_COMMIT_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        match fs::symlink_metadata(link) {
+            Ok(_) => {
+                let cleanup_error = fs::remove_dir(&staging).err();
+                let cleanup_context = cleanup_error
+                    .map(|error| format!("; staged-junction cleanup failed: {error}"))
+                    .unwrap_or_default();
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("junction path already exists: {link:?}{cleanup_context}"),
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                let cleanup_error = fs::remove_dir(&staging).err();
+                let cleanup_context = cleanup_error
+                    .map(|cleanup| format!("; staged-junction cleanup failed: {cleanup}"))
+                    .unwrap_or_default();
+                return Err(io::Error::new(
+                    error.kind(),
                     format!(
-                        "failed to clean up staged junction {staging:?} after rename to \
-                         {link:?} failed: {cleanup_error}"
+                        "failed to inspect junction destination {link:?}: \
+                         {error}{cleanup_context}",
                     ),
-                )
-            })?;
+                ));
+            }
+        }
+
+        if let Err(rename_error) = fs::rename(&staging, link) {
+            let cleanup_error = fs::remove_dir(&staging).err();
             match fs::symlink_metadata(link) {
                 Ok(_) => {
+                    let cleanup_context = cleanup_error
+                        .map(|error| format!("; staged-junction cleanup failed: {error}"))
+                        .unwrap_or_default();
                     return Err(io::Error::new(
                         io::ErrorKind::AlreadyExists,
-                        format!("junction path already exists: {link:?}"),
+                        format!(
+                            "junction path already exists after rename failed: {link:?}; \
+                             rename error: {rename_error}{cleanup_context}",
+                        ),
                     ));
                 }
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {}
                 Err(error) => {
+                    let cleanup_context = cleanup_error
+                        .map(|cleanup| format!("; staged-junction cleanup failed: {cleanup}"))
+                        .unwrap_or_default();
                     return Err(io::Error::new(
-                        error.kind(),
+                        rename_error.kind(),
                         format!(
                             "failed to inspect junction destination {link:?} after rename \
-                             failed: {error}"
+                             failed: {rename_error}; inspection error: {error}{cleanup_context}",
                         ),
                     ));
                 }
+            }
+            if let Some(cleanup_error) = cleanup_error {
+                return Err(io::Error::new(
+                    rename_error.kind(),
+                    format!(
+                        "failed to rename staged junction {staging:?} to {link:?}: \
+                         {rename_error}; cleanup failed: {cleanup_error}",
+                    ),
+                ));
             }
             return Err(rename_error);
         }

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -57,6 +57,28 @@ fn force_symlink_dir_returns_reused_when_already_pointing_at_target() {
 }
 
 #[test]
+fn force_symlink_inner_surfaces_concurrent_cleanup_warnings() {
+    fn create_then_warn(target: &std::path::Path, link: &std::path::Path) -> std::io::Result<()> {
+        super::symlink_dir(target, link)?;
+        Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            super::ConcurrentCleanupWarning("staged junction cleanup failed".into()),
+        ))
+    }
+
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("real");
+    let link = root.path().join("link");
+    fs::create_dir_all(&target).expect("create target");
+
+    let outcome = super::force_symlink_inner(&target, &link, false, create_then_warn)
+        .expect("completed link should be reused");
+
+    assert!(outcome.reused);
+    assert_eq!(outcome.warning.as_deref(), Some("staged junction cleanup failed"));
+}
+
+#[test]
 fn force_symlink_dir_retargets_a_stale_symlink() {
     let root = tempdir().expect("create temp dir");
     let stale_target = root.path().join("old-target");

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -15,9 +15,7 @@ use std::fs;
 #[cfg(not(windows))]
 use std::path::PathBuf;
 #[cfg(windows)]
-use std::sync::Barrier;
-#[cfg(windows)]
-use std::{io, path::Path};
+use std::{io, path::Path, sync::Barrier};
 use tempfile::tempdir;
 
 #[cfg(unix)]

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -13,7 +13,7 @@ use super::{ForceSymlinkOutcome, force_symlink_dir, read_symlink_dir};
 use super::{is_reparse_point, relative_target_for};
 use std::fs;
 #[cfg(windows)]
-use std::path::Path;
+use std::{io, path::Path};
 #[cfg(not(windows))]
 use std::path::PathBuf;
 #[cfg(windows)]
@@ -259,25 +259,6 @@ fn windows_concurrent_junction_creation_reuses_one_link() {
 
 #[cfg(windows)]
 #[test]
-fn windows_junction_creation_recovers_when_link_parent_is_missing() {
-    let root = tempdir().expect("create temp dir");
-    let target = root.path().join("target");
-    let link = root.path().join("deeply").join("nested").join("link");
-    fs::create_dir_all(&target).expect("create target");
-
-    let outcome =
-        super::force_symlink_inner(&target, &link, false, super::windows::create_junction)
-            .expect("junction creation must create missing link parents");
-
-    assert!(!outcome.reused);
-    assert_eq!(
-        fs::canonicalize(&link).expect("canonicalize junction"),
-        fs::canonicalize(&target).expect("canonicalize target"),
-    );
-}
-
-#[cfg(windows)]
-#[test]
 fn windows_same_drive_symlink_target_stays_relative() {
     let target = Path::new(r"C:\workspace\packages\pkg-a");
     let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
@@ -292,6 +273,13 @@ fn windows_verbatim_and_plain_disk_resolve_to_same_root() {
     let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
 
     assert!(relative_target_for(target, link).is_relative());
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_error_directory_falls_back_to_junctions() {
+    assert!(super::windows::should_fallback_to_junction(&io::Error::from_raw_os_error(267)));
+    assert!(!super::windows::should_fallback_to_junction(&io::Error::from_raw_os_error(123)));
 }
 
 #[test]

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -12,12 +12,12 @@ use super::{ForceSymlinkOutcome, force_symlink_dir, read_symlink_dir};
 #[cfg(windows)]
 use super::{is_reparse_point, relative_target_for};
 use std::fs;
-#[cfg(windows)]
-use std::{io, path::Path};
 #[cfg(not(windows))]
 use std::path::PathBuf;
 #[cfg(windows)]
 use std::sync::Barrier;
+#[cfg(windows)]
+use std::{io, path::Path};
 use tempfile::tempdir;
 
 #[cfg(unix)]

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -16,6 +16,8 @@ use std::fs;
 use std::path::Path;
 #[cfg(unix)]
 use std::path::PathBuf;
+#[cfg(windows)]
+use std::sync::{Arc, Barrier};
 use tempfile::tempdir;
 
 #[cfg(unix)]
@@ -211,6 +213,48 @@ fn windows_force_symlink_dir_repairs_dangling_junction_parent() {
     let resolved_link = fs::canonicalize(&link).expect("canonicalize the repaired symlink");
     let resolved_target = fs::canonicalize(&target).expect("canonicalize target");
     assert_eq!(resolved_link, resolved_target, "the link must resolve to the real target");
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_concurrent_junction_creation_reuses_one_link() {
+    super::windows::force_junction_mode();
+
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    fs::create_dir_all(&target).expect("create target");
+
+    for iteration in 0..10 {
+        let link = root.path().join(format!("link-{iteration}"));
+        let barrier = Arc::new(Barrier::new(32));
+        let outcomes = std::thread::scope(|scope| {
+            let handles: Vec<_> = (0..32)
+                .map(|_| {
+                    let barrier = Arc::clone(&barrier);
+                    let link = &link;
+                    let target = &target;
+                    scope.spawn(move || {
+                        barrier.wait();
+                        force_symlink_dir(target, link)
+                    })
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("junction worker panicked"))
+                .collect::<Vec<_>>()
+        });
+
+        let outcomes: Vec<_> = outcomes
+            .into_iter()
+            .map(|result| result.expect("concurrent junction creation must succeed"))
+            .collect();
+        assert_eq!(
+            outcomes.iter().filter(|outcome| !outcome.reused).count(),
+            1,
+            "one worker must create the junction and every other worker must reuse it",
+        );
+    }
 }
 
 #[cfg(windows)]

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -14,10 +14,10 @@ use super::{is_reparse_point, relative_target_for};
 use std::fs;
 #[cfg(windows)]
 use std::path::Path;
-#[cfg(unix)]
+#[cfg(not(windows))]
 use std::path::PathBuf;
 #[cfg(windows)]
-use std::sync::{Arc, Barrier};
+use std::sync::Barrier;
 use tempfile::tempdir;
 
 #[cfg(unix)]
@@ -218,24 +218,24 @@ fn windows_force_symlink_dir_repairs_dangling_junction_parent() {
 #[cfg(windows)]
 #[test]
 fn windows_concurrent_junction_creation_reuses_one_link() {
-    super::windows::force_junction_mode();
-
     let root = tempdir().expect("create temp dir");
     let target = root.path().join("target");
     fs::create_dir_all(&target).expect("create target");
 
     for iteration in 0..10 {
         let link = root.path().join(format!("link-{iteration}"));
-        let barrier = Arc::new(Barrier::new(32));
+        let barrier = Barrier::new(32);
         let outcomes = std::thread::scope(|scope| {
             let handles: Vec<_> = (0..32)
                 .map(|_| {
-                    let barrier = Arc::clone(&barrier);
-                    let link = &link;
-                    let target = &target;
-                    scope.spawn(move || {
+                    scope.spawn(|| {
                         barrier.wait();
-                        force_symlink_dir(target, link)
+                        super::force_symlink_inner(
+                            &target,
+                            &link,
+                            false,
+                            super::windows::create_junction,
+                        )
                     })
                 })
                 .collect();

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -259,6 +259,25 @@ fn windows_concurrent_junction_creation_reuses_one_link() {
 
 #[cfg(windows)]
 #[test]
+fn windows_junction_creation_recovers_when_link_parent_is_missing() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    let link = root.path().join("deeply").join("nested").join("link");
+    fs::create_dir_all(&target).expect("create target");
+
+    let outcome =
+        super::force_symlink_inner(&target, &link, false, super::windows::create_junction)
+            .expect("junction creation must create missing link parents");
+
+    assert!(!outcome.reused);
+    assert_eq!(
+        fs::canonicalize(&link).expect("canonicalize junction"),
+        fs::canonicalize(&target).expect("canonicalize target"),
+    );
+}
+
+#[cfg(windows)]
+#[test]
 fn windows_same_drive_symlink_target_stays_relative() {
     let target = Path::new(r"C:\workspace\packages\pkg-a");
     let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -12,10 +12,6 @@ use super::{ForceSymlinkOutcome, force_symlink_dir, read_symlink_dir};
 #[cfg(windows)]
 use super::{is_reparse_point, relative_target_for};
 use std::fs;
-#[cfg(not(windows))]
-use std::path::PathBuf;
-#[cfg(windows)]
-use std::{io, path::Path, sync::Barrier};
 use tempfile::tempdir;
 
 #[cfg(unix)]
@@ -32,7 +28,7 @@ fn unix_symlink_contents_are_relative_to_link_parent() {
     let contents = fs::read_link(&link).expect("read_link the symlink we just wrote");
     assert_eq!(
         contents,
-        PathBuf::from("..").join("packages").join("pkg-a"),
+        std::path::PathBuf::from("..").join("packages").join("pkg-a"),
         "symlink contents must be the relative path from link parent to target",
     );
     assert!(link.exists(), "symlink must resolve to an existing directory");
@@ -127,8 +123,8 @@ fn force_symlink_dir_creates_missing_parent_directories() {
 #[cfg(windows)]
 #[test]
 fn windows_cross_drive_symlink_target_falls_back_to_absolute() {
-    let target = Path::new(r"C:\Users\runneradmin\setup-pnpm\store\@babel\plugin-x");
-    let link = Path::new(r"D:\a\pnpm\pnpm\node_modules\@babel\plugin-x");
+    let target = std::path::Path::new(r"C:\Users\runneradmin\setup-pnpm\store\@babel\plugin-x");
+    let link = std::path::Path::new(r"D:\a\pnpm\pnpm\node_modules\@babel\plugin-x");
 
     assert_eq!(relative_target_for(target, link), target);
 }
@@ -136,7 +132,8 @@ fn windows_cross_drive_symlink_target_falls_back_to_absolute() {
 #[cfg(windows)]
 #[test]
 fn windows_scoped_alias_path_gets_native_separators() {
-    let mixed = Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules").join("@scope/name");
+    let mixed = std::path::Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules")
+        .join("@scope/name");
     assert!(
         mixed.as_os_str().to_string_lossy().contains('/'),
         "the join must leave a forward slash for the rewrite to remove: {mixed:?}",
@@ -149,7 +146,7 @@ fn windows_scoped_alias_path_gets_native_separators() {
     );
     assert_eq!(
         native.as_ref(),
-        Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope\name"),
+        std::path::Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope\name",),
     );
 }
 
@@ -158,7 +155,8 @@ fn windows_scoped_alias_path_gets_native_separators() {
 #[cfg(windows)]
 #[test]
 fn windows_verbatim_path_forward_slashes_are_rewritten() {
-    let verbatim = Path::new(r"\\?\C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope/name");
+    let verbatim =
+        std::path::Path::new(r"\\?\C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope/name");
     let native = to_native_separators(verbatim);
     assert!(
         !native.as_os_str().to_string_lossy().contains('/'),
@@ -166,14 +164,14 @@ fn windows_verbatim_path_forward_slashes_are_rewritten() {
     );
     assert_eq!(
         native.as_ref(),
-        Path::new(r"\\?\C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope\name"),
+        std::path::Path::new(r"\\?\C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\@scope\name",),
     );
 }
 
 #[cfg(windows)]
 #[test]
 fn windows_native_path_is_borrowed_unchanged() {
-    let native = Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\dep");
+    let native = std::path::Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\dep");
     assert!(matches!(to_native_separators(native), std::borrow::Cow::Borrowed(_)));
     assert_eq!(to_native_separators(native).as_ref(), native);
 }
@@ -222,7 +220,7 @@ fn windows_concurrent_junction_creation_reuses_one_link() {
 
     for iteration in 0..10 {
         let link = root.path().join(format!("link-{iteration}"));
-        let barrier = Barrier::new(32);
+        let barrier = std::sync::Barrier::new(32);
         let outcomes = std::thread::scope(|scope| {
             let handles: Vec<_> = (0..32)
                 .map(|_| {
@@ -258,8 +256,8 @@ fn windows_concurrent_junction_creation_reuses_one_link() {
 #[cfg(windows)]
 #[test]
 fn windows_same_drive_symlink_target_stays_relative() {
-    let target = Path::new(r"C:\workspace\packages\pkg-a");
-    let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
+    let target = std::path::Path::new(r"C:\workspace\packages\pkg-a");
+    let link = std::path::Path::new(r"C:\workspace\app\node_modules\pkg-a");
 
     assert!(relative_target_for(target, link).is_relative());
 }
@@ -267,8 +265,8 @@ fn windows_same_drive_symlink_target_stays_relative() {
 #[cfg(windows)]
 #[test]
 fn windows_verbatim_and_plain_disk_resolve_to_same_root() {
-    let target = Path::new(r"\\?\C:\workspace\packages\pkg-a");
-    let link = Path::new(r"C:\workspace\app\node_modules\pkg-a");
+    let target = std::path::Path::new(r"\\?\C:\workspace\packages\pkg-a");
+    let link = std::path::Path::new(r"C:\workspace\app\node_modules\pkg-a");
 
     assert!(relative_target_for(target, link).is_relative());
 }
@@ -276,8 +274,8 @@ fn windows_verbatim_and_plain_disk_resolve_to_same_root() {
 #[cfg(windows)]
 #[test]
 fn windows_error_directory_falls_back_to_junctions() {
-    assert!(super::windows::should_fallback_to_junction(&io::Error::from_raw_os_error(267)));
-    assert!(!super::windows::should_fallback_to_junction(&io::Error::from_raw_os_error(123)));
+    assert!(super::windows::should_fallback_to_junction(&std::io::Error::from_raw_os_error(267)));
+    assert!(!super::windows::should_fallback_to_junction(&std::io::Error::from_raw_os_error(123)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- create Windows junctions under unique sibling paths before committing them to their final locations
- serialize only the final existence-check and rename step so concurrent package edges reuse the completed junction
- keep rename, inspection, and staging-cleanup failures visible without masking a concurrently completed destination
- cover concurrent same-link junction creation on Windows without mutating the process-wide writer cache

## Root cause

When true directory symlinks are unavailable, the Rust filesystem layer falls back to the `junction` crate. That crate creates a normal directory at the final link path and then converts it into a reparse point. Concurrent global-virtual-store edges could observe or replace that intermediate directory, causing `ERROR_DIRECTORY` (os error 267) during dependency installation.

The new path creates each junction at a unique sibling path, then commits it under a short process-wide lock. Other workers see only a complete junction and flow through the existing `AlreadyExists` reuse path.

## Validation

- `cargo test -p pacquet-fs`
- `cargo clippy -p pacquet-fs --all-targets -- --deny warnings`
- `PATH="$HOME/.cargo/bin:$PATH" just ready`
- `PATH="$HOME/.cargo/bin:$PATH" just dylint`

---
Written by an agent (GitHub Copilot CLI, gpt-5.6-sol).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved concurrent package linking failures on Windows when directory symlinks fall back to junctions.
  * Improved junction creation reliability and recovery under contention and missing parent directories.

* **Tests**
  * Added Windows concurrency regression coverage to stress simultaneous junction creation and verify correct reuse behavior.
  * Added Windows regression coverage for junction creation when intermediate parent directories are missing.

* **Chores**
  * Updated the Windows-focused changeset with a patch bump for the affected package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
