### PR TITLE
ci: fall back to the classic virtual store for the windows Rust test install

### DIFF
--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -144,6 +144,15 @@ jobs:
           tool: just
 
       - name: Install dependencies
+        # This step installs with the *released* packageManager, so an
+        # in-tree fix to the global virtual store's Windows symlink layout
+        # only reaches it one alpha release later (pnpm/pnpm#12991 is the
+        # latest example: merged, but every Windows run fails until it is
+        # published). Fall back to the classic virtual store on Windows so
+        # the Rust test job isn't coupled to that release lag; the other
+        # platforms keep dogfooding the global virtual store.
+        env:
+          PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE: ${{ runner.os == 'Windows' && 'false' || 'true' }}
         run: just install
 
       - name: Install cargo-nextest


### PR DESCRIPTION
## Summary

`Rust CI / Test / windows` fails on every run — on main and on every PR — in its "Install dependencies" step, which installs the repo's dependencies with the **released** `packageManager` binary. The repo dogfoods `enableGlobalVirtualStore: true`, and the global virtual store's Windows symlink layout is still being stabilized in-tree, so each fix only reaches this step one alpha release later. Latest example: `pnpm@12.0.0-alpha.10` fixed the mixed-separator paths (pnpm/pnpm#12976) but still fails with `Failed to create symlink … The directory name is invalid (os error 267)`; the fix for that (pnpm/pnpm#12991) is merged but unreleased, so Windows Rust CI stays red until the next alpha ships.

This PR overrides `enableGlobalVirtualStore` to `false` for the Windows leg of that one install step (via the `PNPM_CONFIG_ENABLE_GLOBAL_VIRTUAL_STORE` env override, which takes precedence over `pnpm-workspace.yaml`), so the job uses the classic per-project virtual store and is no longer coupled to the release lag. Linux and macOS keep dogfooding the global virtual store. Verified against the released `12.0.0-alpha.10` binary that the override falls back to the classic `node_modules/.pnpm` layout.

Related to pnpm/pnpm#12991.

## Squash Commit Body

```text
The Rust test job's dependency install runs with the released
packageManager, so an in-tree fix to the global virtual store's Windows
symlink layout only reaches the step one alpha release later —
pnpm/pnpm#12991 is the latest example: merged, but every Windows run
keeps failing on 'Failed to create symlink ... The directory name is
invalid (os error 267)' until it is published. Override
enableGlobalVirtualStore to false for the Windows leg of the install so
the job is not coupled to that release lag; Linux and macOS keep
dogfooding the global virtual store. Verified against the released
12.0.0-alpha.10 binary that the env override falls back to the classic
node_modules/.pnpm layout.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (CI-only
  change; no product code.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786660529&installation_id=145934176&pr_number=13010&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13010&signature=1b65da1a46866a6ed21b6aa148731695607eedb2e4357ba23ce7612c9366748a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows CI dependency installation reliability by using a compatible virtual store configuration.
  * Added documentation explaining the platform-specific installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->