### PR TITLE
docs: fix broken pacquet path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Fast, disk space efficient package manager:
 * **Works as a Node.js version manager.** See [pnpm runtime](https://pnpm.io/11.x/cli/runtime).
 * **Works everywhere.** Supports Windows, Linux, and macOS.
 * **Battle-tested.** Used in production by teams of [all sizes](https://pnpm.io/workspaces#usage-examples) since 2016.
-* **Experimental Rust port.** Includes [pacquet](./pacquet), an experimental port of the CLI written in Rust.
+* **Experimental Rust port.** Includes [pacquet](./pnpm), an experimental port of the CLI written in Rust.
 * [See the full feature comparison with npm and Yarn](https://pnpm.io/feature-comparison).
 
 To quote the [Rush](https://rushjs.io/) team:


### PR DESCRIPTION
## Summary

This PR updates the reference to the `pacquet` directory in the `README.md` file. The path is not correct due to the directory rename that occurred in #12913.

## Squash Commit Body

```text
docs: fix broken pacquet path in README

The directory was renamed in #12913. Updating its reference in README to reflect this change.
```

## Checklist

* [x] The change is implemented in both the TypeScript CLI and the Rust
`pnpm/` port, or the description notes what still needs porting.
* [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
package. Keep it short and written for pnpm users — it becomes a release note.
* [ ] Added or updated tests.
* [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786662530&installation_id=145934176&pr_number=13011&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13011&signature=5d1fb9bd3fef9542f88cac90133ec5f4f88c9e40fdd2283265e8be0814de636c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README link for the experimental Rust port to reference the correct project path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->