### PR TITLE
fix(cli): honor add virtual store directory

### DIFF
--- a/.changeset/pacquet-add-virtual-store-dir.md
+++ b/.changeset/pacquet-add-virtual-store-dir.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pacquet add --virtual-store-dir` to use the requested virtual store directory.

--- a/.changeset/pacquet-add-virtual-store-dir.md
+++ b/.changeset/pacquet-add-virtual-store-dir.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/config.reader": patch
 "pacquet": patch
+"pnpm": patch
 ---
 
-Fixed `pacquet add --virtual-store-dir` to use the requested virtual store directory.
+Fixed `pnpm add --virtual-store-dir` to use the requested virtual store directory consistently, preserve the configured or default directory for empty values, and report global-install conflicts before loading configuration.

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -7,7 +7,8 @@ use crate::{
     config_deps,
 };
 use clap::Args;
-use miette::Context;
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic};
 use pacquet_config::Config;
 use pacquet_package_manager::Add;
 use pacquet_package_manifest::DependencyGroup;
@@ -109,10 +110,9 @@ pub struct AddArgs {
     /// Dependencies are not downloaded. Only `pnpm-lock.yaml` is updated.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
-    /// The directory with links to the store (default is `node_modules/.pnpm`).
-    /// All direct and indirect dependencies of the project are linked into this directory
-    #[clap(long = "virtual-store-dir", default_value = "node_modules/.pnpm")]
-    pub virtual_store_dir: Option<PathBuf>, // TODO: make use of this
+    /// Override the directory that contains links to the store for this add.
+    #[clap(long = "virtual-store-dir", value_name = "DIR")]
+    pub virtual_store_dir: Option<PathBuf>,
 
     /// Install the package globally, linking its bins into the global bin directory.
     #[clap(short = 'g', long)]
@@ -131,6 +131,11 @@ pub struct AddArgs {
     pub force: bool,
 }
 
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display(r#"Configuration conflict. "virtual-store-dir" may not be used with "global""#)]
+#[diagnostic(code(ERR_PNPM_CONFIG_CONFLICT_VIRTUAL_STORE_DIR_WITH_GLOBAL))]
+struct VirtualStoreDirWithGlobal;
+
 impl AddArgs {
     pub(crate) fn apply_cli_config(&self, config: &mut Config) {
         config.ignore_scripts = resolve_bool_override(
@@ -139,6 +144,13 @@ impl AddArgs {
             config.ignore_scripts,
         );
         config.force = self.force || config.force;
+    }
+
+    pub(crate) fn validate_global_virtual_store_dir(&self) -> miette::Result<()> {
+        if self.virtual_store_dir.is_some() {
+            return Err(VirtualStoreDirWithGlobal.into());
+        }
+        Ok(())
     }
 
     /// The `--config` selectors parsed into the `name → specifier` pairs to

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -201,6 +201,15 @@ fn parse_store_dir(value: &str) -> Result<PathBuf, std::convert::Infallible> {
 }
 
 impl CliArgs {
+    pub(crate) fn validate_config_conflicts(&self) -> miette::Result<()> {
+        if let CliCommand::Add(args) = &self.command
+            && args.global
+        {
+            args.validate_global_virtual_store_dir()?;
+        }
+        Ok(())
+    }
+
     pub fn validate_command_scoped_global_options(&self) -> Result<(), clap::Error> {
         if self.resume_from.is_some() {
             self.validate_run_scoped_global_option("--resume-from")?;

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -28,6 +28,7 @@ use super::{
     unlink::UnlinkArgs,
     update::UpdateArgs,
 };
+use crate::config_overrides::apply_virtual_store_dir_override;
 use miette::Context;
 use pacquet_default_reporter::DefaultReporter;
 use pacquet_reporter::{NdjsonReporter, SilentReporter};
@@ -56,6 +57,9 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
     Ok(Box::pin(async move {
         let cfg = config()?;
         args.apply_cli_config(cfg);
+        if let Some(virtual_store_dir) = args.virtual_store_dir.as_deref() {
+            apply_virtual_store_dir_override(cfg, virtual_store_dir, dir);
+        }
         let (config_root, package_manager_to_sync) =
             derive_config_root_and_package_manager_to_sync(cfg, dir)
                 .wrap_err("derive workspace root and package manager policy")?;

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -58,6 +58,27 @@ where
     Ok(())
 }
 
+pub(crate) fn apply_virtual_store_dir_override(
+    config: &mut Config,
+    virtual_store_dir: &Path,
+    dir: &Path,
+) {
+    let workspace_dir = config.workspace_dir.as_deref().unwrap_or(dir);
+    let resolved = if virtual_store_dir.is_absolute() {
+        virtual_store_dir.to_path_buf()
+    } else {
+        workspace_dir.join(virtual_store_dir)
+    };
+    config.virtual_store_dir = lexical_normalize(&resolved);
+    config.explicit_settings.insert(
+        "virtualStoreDir".to_string(),
+        serde_json::Value::String(virtual_store_dir.to_string_lossy().into_owned()),
+    );
+    let global_virtual_store_dir_explicit =
+        config.explicit_settings.contains_key("globalVirtualStoreDir");
+    config.apply_global_virtual_store_derivation(true, global_virtual_store_dir_explicit);
+}
+
 fn home_relative_store_dir(store_dir: &Path) -> Option<&Path> {
     let store_dir = store_dir.to_str()?;
     store_dir.strip_prefix("~/").or_else(|| store_dir.strip_prefix(r"~\")).map(Path::new)

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -63,6 +63,9 @@ pub(crate) fn apply_virtual_store_dir_override(
     virtual_store_dir: &Path,
     dir: &Path,
 ) {
+    if virtual_store_dir.as_os_str().is_empty() {
+        return;
+    }
     let workspace_dir = config.workspace_dir.as_deref().unwrap_or(dir);
     let resolved = if virtual_store_dir.is_absolute() {
         virtual_store_dir.to_path_buf()

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -1,4 +1,4 @@
-use super::{ConfigOverrides, apply_store_dir_override};
+use super::{ConfigOverrides, apply_store_dir_override, apply_virtual_store_dir_override};
 use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker};
 use pacquet_store_dir::STORE_VERSION;
 use pretty_assertions::assert_eq;
@@ -327,5 +327,32 @@ fn empty_store_dir_override_uses_the_injected_default_provider() {
     assert_eq!(
         config.explicit_settings.get("storeDir"),
         Some(&serde_json::Value::String(String::new())),
+    );
+}
+
+#[test]
+fn empty_virtual_store_dir_override_preserves_the_configured_value() {
+    let workspace_dir = std::env::temp_dir().join("pacquet-virtual-store-dir-workspace");
+    let configured_virtual_store_dir = workspace_dir.join(".configured-store");
+    let mut config = Config {
+        workspace_dir: Some(workspace_dir.clone()),
+        virtual_store_dir: configured_virtual_store_dir.clone(),
+        ..Config::default()
+    };
+    config.explicit_settings.insert(
+        "virtualStoreDir".to_string(),
+        serde_json::Value::String(".configured-store".to_string()),
+    );
+
+    apply_virtual_store_dir_override(
+        &mut config,
+        std::path::Path::new(""),
+        &workspace_dir.join("packages/app"),
+    );
+
+    assert_eq!(config.virtual_store_dir, configured_virtual_store_dir);
+    assert_eq!(
+        config.explicit_settings.get("virtualStoreDir"),
+        Some(&serde_json::Value::String(".configured-store".to_string())),
     );
 }

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -65,6 +65,7 @@ pub fn main() -> miette::Result<()> {
         }
         Err(err) => err.exit(),
     };
+    args.validate_config_conflicts()?;
     if let Err(err) = args.validate_command_scoped_global_options() {
         err.exit();
     }

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -16,7 +16,11 @@ use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 #[cfg(unix)]
 use std::fs;
-use std::{ffi::OsStr, path::PathBuf, process::Command};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::Command,
+};
 use tempfile::TempDir;
 
 fn exec_pacquet_in_temp_cwd<Args>(args: Args) -> (TempDir, PathBuf, AddMockedRegistry)
@@ -28,6 +32,154 @@ where
         CommandTempCwd::init().add_mocked_registry();
     pacquet.with_args(args).assert().success();
     (root, workspace, npmrc_info)
+}
+
+fn prepare_hermetic_local_add_fixture(
+    workspace: &Path,
+    virtual_store_dir: &str,
+    extra_workspace_settings: &str,
+) {
+    std::fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!(
+            "storeDir: ../pacquet-store\ncacheDir: ../pacquet-cache\nvirtualStoreDir: {virtual_store_dir}\nenableGlobalVirtualStore: false\n{extra_workspace_settings}",
+        ),
+    )
+    .expect("write hermetic workspace settings");
+
+    let local_package = workspace.join("fixtures/local-pkg");
+    std::fs::create_dir_all(&local_package).expect("create local package directory");
+    std::fs::write(
+        local_package.join("package.json"),
+        serde_json::json!({ "name": "local-pkg", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write local package manifest");
+}
+
+#[test]
+fn add_without_flag_preserves_configured_virtual_store_dir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    prepare_hermetic_local_add_fixture(&workspace, ".configured-store", "");
+
+    pacquet.with_args(["add", "local-pkg@file:./fixtures/local-pkg"]).assert().success();
+
+    let configured_lockfile = workspace.join(".configured-store/lock.yaml");
+    assert!(configured_lockfile.is_file(), "missing {}", configured_lockfile.display());
+    let default_store = workspace.join("node_modules/.pnpm");
+    assert!(!default_store.exists(), "unexpected {}", default_store.display());
+    drop(root);
+}
+
+#[test]
+fn add_relative_virtual_store_dir_is_anchored_at_workspace_root() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    prepare_hermetic_local_add_fixture(&workspace, ".fixture-store", "packages:\n  - packages/*\n");
+
+    let package_dir = workspace.join("packages/app");
+    std::fs::create_dir_all(&package_dir).expect("create workspace package directory");
+    std::fs::write(
+        package_dir.join("package.json"),
+        serde_json::json!({ "name": "app", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write workspace package manifest");
+
+    pacquet
+        .with_args([
+            "--dir",
+            "packages/app",
+            "add",
+            "local-pkg@file:../../fixtures/local-pkg",
+            "--virtual-store-dir",
+            ".custom-store",
+        ])
+        .assert()
+        .success();
+
+    let custom_lockfile = workspace.join(".custom-store/lock.yaml");
+    assert!(custom_lockfile.is_file(), "missing {}", custom_lockfile.display());
+    let package_relative_store = package_dir.join(".custom-store");
+    assert!(!package_relative_store.exists(), "unexpected {}", package_relative_store.display());
+    let configured_store = workspace.join(".fixture-store");
+    assert!(!configured_store.exists(), "unexpected {}", configured_store.display());
+    let default_store = workspace.join("node_modules/.pnpm");
+    assert!(!default_store.exists(), "unexpected {}", default_store.display());
+    drop(root);
+}
+
+#[test]
+fn add_honors_virtual_store_dir_override() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    prepare_hermetic_local_add_fixture(&workspace, ".fixture-store", "");
+
+    pacquet
+        .with_args([
+            "add",
+            "local-pkg@file:./fixtures/local-pkg",
+            "--virtual-store-dir",
+            ".custom-store",
+        ])
+        .assert()
+        .success();
+
+    let custom_store = workspace.join(".custom-store");
+    let custom_lockfile = custom_store.join("lock.yaml");
+    assert!(custom_lockfile.is_file(), "missing {}", custom_lockfile.display());
+    let local_manifest =
+        custom_store.join("local-pkg@file+fixtures+local-pkg/node_modules/local-pkg/package.json");
+    assert!(local_manifest.is_file(), "missing {}", local_manifest.display());
+    let configured_store = workspace.join(".fixture-store");
+    assert!(!configured_store.exists(), "unexpected {}", configured_store.display());
+    let default_store = workspace.join("node_modules/.pnpm");
+    assert!(
+        !default_store.exists(),
+        "add must not create the default virtual store at {} when an override is supplied",
+        default_store.display(),
+    );
+    drop(root);
+}
+
+#[test]
+fn add_global_rejects_virtual_store_dir_before_loading_global_config() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+    let xdg_config_home = root.path().join("xdg-config");
+    let pnpm_config_dir = xdg_config_home.join("pnpm");
+    std::fs::create_dir_all(&pnpm_config_dir).expect("create isolated pnpm config directory");
+    std::fs::write(pnpm_config_dir.join("config.yaml"), "invalid: [\n")
+        .expect("write deliberately invalid global config");
+
+    let output = pacquet
+        .with_env("PNPM_HOME", root.path().join("pnpm-home"))
+        .with_env("HOME", root.path().join("home"))
+        .with_env("USERPROFILE", root.path().join("home"))
+        .with_env("XDG_CONFIG_HOME", &xdg_config_home)
+        .with_env("XDG_DATA_HOME", root.path().join("xdg-data"))
+        .with_args([
+            "add",
+            "-g",
+            "local-pkg@file:./fixtures/local-pkg",
+            "--virtual-store-dir",
+            ".custom-store",
+        ])
+        .output()
+        .expect("run global add conflict");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "global add must reject the option");
+    assert!(
+        stderr.contains("ERR_PNPM_CONFIG_CONFLICT_VIRTUAL_STORE_DIR_WITH_GLOBAL"),
+        "stderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains(
+            r#"Configuration conflict. "virtual-store-dir" may not be used with "global""#,
+        ),
+        "stderr:\n{stderr}",
+    );
+    assert!(
+        !stderr.contains("config.yaml"),
+        "the CLI conflict must win before global config parsing; stderr:\n{stderr}",
+    );
+    drop(root);
 }
 
 #[test]

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -126,6 +126,11 @@ export async function getConfig (opts: {
     }
   }
 
+  if (cliOptions['global'] && cliOptions['virtual-store-dir'] != null) {
+    throw new PnpmError('CONFIG_CONFLICT_VIRTUAL_STORE_DIR_WITH_GLOBAL',
+      'Configuration conflict. "virtual-store-dir" may not be used with "global"')
+  }
+
   if (cliOptions.dir) {
     cliOptions.dir = await realpathMissing(cliOptions.dir)
   }
@@ -256,7 +261,7 @@ export async function getConfig (opts: {
   const warnings = npmrcResult.warnings
 
   const configFromCliOpts = Object.fromEntries(Object.entries(cliOptions)
-    .filter(([_, value]) => typeof value !== 'undefined')
+    .filter(([name, value]) => typeof value !== 'undefined' && (name !== 'virtual-store-dir' || value !== ''))
     .map(([name, value]) => [camelcase(name, { locale: 'en-US' }), value])
   )
 
@@ -425,10 +430,6 @@ export async function getConfig (opts: {
           'Configuration conflict. "lockfile-dir" may not be used with "global"')
       }
       delete pnpmConfig.lockfileDir
-    }
-    if (opts.cliOptions['virtual-store-dir']) {
-      throw new PnpmError('CONFIG_CONFLICT_VIRTUAL_STORE_DIR_WITH_GLOBAL',
-        'Configuration conflict. "virtual-store-dir" may not be used with "global"')
     }
     if (pnpmConfig.enableGlobalVirtualStore == null) {
       pnpmConfig.enableGlobalVirtualStore = true

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -410,6 +410,75 @@ test('throw error if --virtual-store-dir is used with --global', async () => {
   })
 })
 
+test('throw error if empty --virtual-store-dir is used with --global', async () => {
+  await expect(getConfig({
+    cliOptions: {
+      global: true,
+      'virtual-store-dir': '',
+    },
+    env,
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })).rejects.toMatchObject({
+    code: 'ERR_PNPM_CONFIG_CONFLICT_VIRTUAL_STORE_DIR_WITH_GLOBAL',
+    message: 'Configuration conflict. "virtual-store-dir" may not be used with "global"',
+  })
+})
+
+test('throw --virtual-store-dir global conflict before reading global config', async () => {
+  prepareEmpty()
+  fs.mkdirSync('.config/pnpm', { recursive: true })
+  fs.writeFileSync('.config/pnpm/config.yaml', 'invalid: [\n')
+  const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = path.resolve('.config')
+
+  try {
+    await expect(getConfig({
+      cliOptions: {
+        global: true,
+        'virtual-store-dir': 'pkgs',
+      },
+      env,
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })).rejects.toMatchObject({
+      code: 'ERR_PNPM_CONFIG_CONFLICT_VIRTUAL_STORE_DIR_WITH_GLOBAL',
+      message: 'Configuration conflict. "virtual-store-dir" may not be used with "global"',
+    })
+  } finally {
+    if (originalXdgConfigHome == null) {
+      delete process.env.XDG_CONFIG_HOME
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+    }
+  }
+})
+
+test('empty --virtual-store-dir preserves the configured virtual store directory', async () => {
+  prepareEmpty()
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    virtualStoreDir: '.configured-store',
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {
+      'virtual-store-dir': '',
+    },
+    env,
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.virtualStoreDir).toBe('.configured-store')
+})
+
 test('.npmrc does not load pnpm settings', async () => {
   prepareEmpty()
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

> [!IMPORTANT]
> This branch must incorporate pnpm/pnpm#13066 before this PR can merge. The intended sequence is to merge pnpm/pnpm#13066 into `main`, then rebase or update this branch onto the latest `main` so the zizmor security check runs with the shared fix.

Pacquet now applies `add --virtual-store-dir <dir>` to the effective configuration before installation state is initialized. Relative values are resolved from the workspace root, while an absent flag continues to preserve the configured or default virtual store directory.

Global add rejects the option with pnpm's existing `ERR_PNPM_CONFIG_CONFLICT_VIRTUAL_STORE_DIR_WITH_GLOBAL` diagnostic before package-manager switching or configuration loading can report a different error.

The TypeScript CLI already accepted non-empty overrides, but it checked the global conflict only after reading configuration and treated an empty value as an override. The config reader now reports the conflict before loading global configuration and ignores empty non-global overrides so the configured or default virtual store directory is preserved.

## Squash Commit Body

```text
Pacquet parsed `add --virtual-store-dir` but discarded the value and also supplied an incorrect unused default. Treat the argument as an optional invocation override, resolve relative paths from the workspace root, and apply it to the same configuration passed to `State::init`.

Validate the incompatible global combination immediately after argument parsing in Pacquet and before configuration loading in the TypeScript CLI. Treat an empty non-global override as absent so both implementations preserve the configured or default directory, while an empty override combined with --global still reports the stable pnpm conflict diagnostic.

Add real-CLI regressions for local overrides, workspace-root anchoring, absent-flag configuration preservation, and global error precedence, plus config-reader regressions for empty values and pre-load conflict validation.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786671611&installation_id=145934176&pr_number=13012&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13012&signature=0ceb7fde29349a3f2b35c275e920eb1e99b5a1c81786242f912428d3d4dc0997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm add --virtual-store-dir` / `pacquet add --virtual-store-dir` so the provided directory is consistently respected.
  * Relative `--virtual-store-dir` values are now resolved from the workspace root.
  * `--virtual-store-dir` correctly overrides workspace virtual store settings and prevents creating the default virtual store.
  * If `--virtual-store-dir` is provided as empty, the configured virtual store directory is preserved.
  * Improved validation to prevent using `--virtual-store-dir` with global installs (`pnpm add -g` / `--global`), surfacing conflicts before global config is loaded.
* **Tests**
  * Added CLI and config reader coverage for these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->