### PR TITLE
fix(pacquet): keep side effects out of frozen stores

### DIFF
--- a/.changeset/frozen-side-effects-cache.md
+++ b/.changeset/frozen-side-effects-cache.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Prevented `frozenStore` installs from adding lifecycle-script output to the content-addressable store when side-effects caching is enabled.

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -605,6 +605,7 @@ impl BuildModules<'_> {
             && engine_name.is_some()
             && side_effects_maps_by_snapshot.is_some_and(|map| !map.is_empty());
         let write_gate_active = side_effects_cache_write
+            && !frozen_store
             && engine_name.is_some()
             && store_index_writer.is_some()
             && store_dir.is_some();
@@ -1094,10 +1095,10 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     // `PackageFilesIndex.sideEffects[cache_key] = diff` mutation
     // so a future install can skip the rebuild.
     //
-    // The gate is `(is_patched || has_side_effects) &&
-    // side_effects_cache_write` — a patched-only snapshot still
-    // uploads its post-patch state so subsequent installs hit the
-    // cache.
+    // A frozen store short-circuits before `upload`: its disabled index writer
+    // drops queued rows, but `upload` writes CAFS files before queuing them.
+    // Otherwise a patched-only snapshot still uploads its post-patch state so
+    // subsequent installs hit the cache.
     //
     // The other preconditions: cache_key composable (engine + graph
     // present), `packages` map available for the integrity lookup,
@@ -1110,6 +1111,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     // build.
     if (is_patched || has_side_effects)
         && side_effects_cache_write
+        && !frozen_store
         && let Some(writer) = store_index_writer
         && let Some(store) = store_dir
         && let Some(cache_key) = cache_key.as_deref()

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -1866,8 +1866,25 @@ async fn frozen_store_skips_side_effects_upload() {
     drop(writer);
     writer_task.await.expect("await writer").expect("disabled writer succeeds");
 
-    assert!(pkg_dir.join("generated.txt").exists(), "postinstall must run outside the store");
-    assert_eq!(snapshot_regular_files(store_dir.root()), store_before);
+    let generated_file = pkg_dir.join("generated.txt");
+    eprintln!("Expected generated file: {}", generated_file.display());
+    assert!(generated_file.exists(), "postinstall must run outside the store");
+
+    let store_after = snapshot_regular_files(store_dir.root());
+    if store_after != store_before {
+        eprintln!("Store regular files differ:");
+        for (path, contents) in &store_after {
+            if store_before.get(path) != Some(contents) {
+                eprintln!("  added or modified: {}", path.display());
+            }
+        }
+        for path in store_before.keys() {
+            if !store_after.contains_key(path) {
+                eprintln!("  removed: {}", path.display());
+            }
+        }
+    }
+    assert_eq!(store_after, store_before);
 }
 
 /// Uploading errors do not interrupt the install: the install

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -1783,6 +1783,93 @@ async fn write_path_disabled_skips_upload() {
     assert!(row.side_effects.is_none(), "write disabled must NOT populate side_effects");
 }
 
+#[cfg(unix)]
+#[tokio::test(flavor = "current_thread")]
+async fn frozen_store_skips_side_effects_upload() {
+    use pacquet_store_dir::{StoreDir, StoreIndexWriter};
+
+    let pkg_key = key("@pnpm/postinstall-modifies-source", "1.0.0");
+    let integrity_str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let snapshots = HashMap::from([(pkg_key.clone(), SnapshotEntry::default())]);
+    let packages: HashMap<pacquet_lockfile::PackageKey, pacquet_lockfile::PackageMetadata> =
+        HashMap::from([(
+            pkg_key.without_peer(),
+            pacquet_lockfile::PackageMetadata {
+                resolution: pacquet_lockfile::LockfileResolution::Registry(
+                    pacquet_lockfile::RegistryResolution {
+                        integrity: integrity_str.parse().expect("parse integrity"),
+                    },
+                ),
+                version: None,
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: None,
+                peer_dependencies_meta: None,
+            },
+        )]);
+    let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
+    let policy = policy_from_specs([], true);
+
+    let store_root = tempdir().expect("create store dir");
+    let store_dir = StoreDir::from(store_root.path().to_path_buf());
+    store_dir.init().expect("init store");
+    let virtual_store_dir = tempdir().expect("create vstore dir");
+    let modules_dir = tempdir().expect("create modules dir");
+    let lockfile_dir = tempdir().expect("create lockfile dir");
+    let (pkg_dir, _actual_mode) =
+        create_postinstall_modifies_source_fixture(virtual_store_dir.path(), &pkg_key);
+    let store_before = snapshot_regular_files(store_dir.root());
+    let (writer, writer_task) = StoreIndexWriter::spawn_disabled();
+
+    BuildModules {
+        layout: &VirtualStoreLayout::legacy(
+            virtual_store_dir.path(),
+            pacquet_config::default_virtual_store_dir_max_length() as usize,
+        ),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        packages: Some(&packages),
+        importers: &importers,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        requires_build_by_snapshot: None,
+        engine_name: Some("darwin;arm64;node20"),
+        side_effects_cache: true,
+        side_effects_cache_write: true,
+        store_dir: Some(&store_dir),
+        store_index_writer: Some(&writer),
+        patches: None,
+
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        extra_env: &HashMap::new(),
+        unsafe_perm: true,
+        child_concurrency: 1,
+        skipped: &SkippedSnapshots::default(),
+        pkg_root_by_key: None,
+        gather_ancestor_bin_paths: false,
+        frozen_store: true,
+        ignore_scripts: false,
+        import_method: PackageImportMethod::Auto,
+        logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
+    }
+    .run::<SilentReporter>()
+    .expect("build modules must complete cleanly");
+
+    drop(writer);
+    writer_task.await.expect("await writer").expect("disabled writer succeeds");
+
+    assert!(pkg_dir.join("generated.txt").exists(), "postinstall must run outside the store");
+    assert_eq!(snapshot_regular_files(store_dir.root()), store_before);
+}
+
 /// Uploading errors do not interrupt the install: the install
 /// completes (the postinstall ran, the generated file is on disk)
 /// but the `SQLite` row's `side_effects` stays empty.
@@ -1962,6 +2049,27 @@ fn sha512_hex(buf: &[u8]) -> String {
     use sha2::{Digest, Sha512};
     let digest = Sha512::digest(buf);
     format!("{digest:x}")
+}
+
+#[cfg(unix)]
+fn snapshot_regular_files(root: &Path) -> std::collections::BTreeMap<PathBuf, Vec<u8>> {
+    let mut snapshot = std::collections::BTreeMap::new();
+    let mut directories = vec![root.to_path_buf()];
+    while let Some(directory) = directories.pop() {
+        for entry in fs::read_dir(&directory).expect("read snapshot directory") {
+            let entry = entry.expect("read snapshot entry");
+            let file_type = entry.file_type().expect("read snapshot entry type");
+            if file_type.is_dir() {
+                directories.push(entry.path());
+            } else if file_type.is_file() {
+                let path = entry.path();
+                let relative = path.strip_prefix(root).expect("snapshot path is under root");
+                snapshot
+                    .insert(relative.to_path_buf(), fs::read(&path).expect("read snapshot file"));
+            }
+        }
+    }
+    snapshot
 }
 
 /// When `BuildModules.patches` contains an entry for a snapshot,

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -1867,8 +1867,11 @@ async fn frozen_store_skips_side_effects_upload() {
     writer_task.await.expect("await writer").expect("disabled writer succeeds");
 
     let generated_file = pkg_dir.join("generated.txt");
-    eprintln!("Expected generated file: {}", generated_file.display());
-    assert!(generated_file.exists(), "postinstall must run outside the store");
+    let generated_file_exists = generated_file.exists();
+    if !generated_file_exists {
+        eprintln!("Expected generated file: {}", generated_file.display());
+    }
+    assert!(generated_file_exists, "postinstall must run outside the store");
 
     let store_after = snapshot_regular_files(store_dir.root());
     if store_after != store_before {

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -1815,6 +1815,10 @@ async fn frozen_store_skips_side_effects_upload() {
         )]);
     let importers = root_importers(&[("@pnpm/postinstall-modifies-source", "1.0.0")]);
     let policy = policy_from_specs([], true);
+    let side_effects_maps = crate::SideEffectsMapsBySnapshot::from([(
+        pkg_key.clone(),
+        std::sync::Arc::new(HashMap::new()),
+    )]);
 
     let store_root = tempdir().expect("create store dir");
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
@@ -1838,7 +1842,7 @@ async fn frozen_store_skips_side_effects_upload() {
         packages: Some(&packages),
         importers: &importers,
         allow_build_policy: &policy,
-        side_effects_maps_by_snapshot: None,
+        side_effects_maps_by_snapshot: Some(&side_effects_maps),
         requires_build_by_snapshot: None,
         engine_name: Some("darwin;arm64;node20"),
         side_effects_cache: true,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Pacquet could still add files to its content-addressable store during a `frozenStore` install when side-effects caching was enabled. The store index writer was disabled, but the lifecycle-script output had already been uploaded before that writer discarded the index update.

This change stops the upload before it starts when the store is frozen. Lifecycle scripts still run in the installed package, but the store itself remains unchanged.

The new regression test records every regular file in the store before the build and verifies that the set and contents are identical afterward.

The TypeScript CLI does not need a matching change because this leak comes from pacquet's upload ordering.

Related to pnpm/pnpm#11703.

## Squash Commit Body

```text
A disabled store index writer is not enough to make the side-effects-cache path read-only. Pacquet uploads lifecycle-script output to the content-addressable store before it queues the index update, so frozenStore installs could still add store files even though the queued update was discarded.

Skip side-effects-cache write preparation and upload when frozenStore is enabled. Keep lifecycle scripts running in the installed package. Add a regression test that compares the complete set and contents of regular store files before and after the build.

Related to pnpm/pnpm#11703.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786676195&installation_id=145934176&pr_number=13013&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13013&signature=859489df5208a6ef1b9f5adb292aa46cc44eaaec21b17d9a3f829de8f14f7aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed side-effects caching behavior in frozen-store mode so lifecycle-script outputs are not added to the content-addressable store.
  * Disabled cache-based dependency-graph activation and cache upload/write paths when using frozen-store.
* **Tests**
  * Added a Unix test confirming frozen-store installs still run post-install scripts while keeping store regular files byte-for-byte unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->