### PR TITLE
fix(resolver): recover after metadata cache loss

### DIFF
--- a/.changeset/recover-metadata-cache-race.md
+++ b/.changeset/recover-metadata-cache-race.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Retry package metadata once without validators when a cached body disappears after a `304 Not Modified` response.
+Recover from a metadata cache entry that disappears (concurrent cache cleanup, antivirus) after the registry has already answered the conditional request with `304 Not Modified`. The metadata is re-requested once without cache validators instead of failing the install with `ERR_PNPM_CACHE_MISSING_AFTER_304`.

--- a/.changeset/recover-metadata-cache-race.md
+++ b/.changeset/recover-metadata-cache-race.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Retry package metadata once without validators when a cached body disappears after a `304 Not Modified` response.

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -77,16 +77,6 @@ pub enum FetchMetadataError {
         pkg_name: String,
     },
 
-    /// `META_CACHE_MISSING_AFTER_304`. The mirror existed when we read
-    /// its headers but vanished before the full read on a 304 response
-    /// — concurrent cache cleanup, antivirus, etc.
-    #[display("Metadata cache for {pkg_name} disappeared between headers read and full read.")]
-    #[diagnostic(code(ERR_PNPM_CACHE_MISSING_AFTER_304))]
-    CacheMissingAfter304 {
-        #[error(not(source))]
-        pkg_name: String,
-    },
-
     /// The blocking task that deserializes a packument body panicked
     /// or was cancelled by runtime shutdown.
     #[display("Failed to parse metadata from {url}: {error}")]

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -98,6 +98,11 @@ pub(crate) struct MetadataRequestOptions<'a> {
     pub auth_headers: &'a AuthHeaders,
     pub etag: Option<&'a str>,
     pub modified: Option<&'a str>,
+    /// Ask for the packument as a cold cache would: [`Self::etag`] and
+    /// [`Self::modified`] are dropped rather than sent, and `Cache-Control:
+    /// no-cache` keeps an intermediary from validating them on our behalf.
+    /// Set when the mirror those validators describe is known to be gone, so
+    /// only a body — never a `304` — can satisfy the request.
     pub bypass_cache: bool,
     pub retry_opts: RetryOpts,
 }
@@ -105,6 +110,10 @@ pub(crate) struct MetadataRequestOptions<'a> {
 /// Send a metadata GET, retrying an unsolicited 304 once with intermediary
 /// cache reuse disabled. A repeated 304 cannot validate any local body and is
 /// reported with the same error in both pnpm implementations.
+///
+/// A [`MetadataRequestOptions::bypass_cache`] request has already given up its
+/// validators, so that retry would only repeat itself: its 304 fails straight
+/// away instead.
 pub(crate) async fn send_metadata_request<'a>(
     opts: &MetadataRequestOptions<'a>,
 ) -> Result<(ThrottledClientGuard<'a>, Response), FetchMetadataError> {

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -98,6 +98,7 @@ pub(crate) struct MetadataRequestOptions<'a> {
     pub auth_headers: &'a AuthHeaders,
     pub etag: Option<&'a str>,
     pub modified: Option<&'a str>,
+    pub bypass_cache: bool,
     pub retry_opts: RetryOpts,
 }
 
@@ -107,8 +108,9 @@ pub(crate) struct MetadataRequestOptions<'a> {
 pub(crate) async fn send_metadata_request<'a>(
     opts: &MetadataRequestOptions<'a>,
 ) -> Result<(ThrottledClientGuard<'a>, Response), FetchMetadataError> {
-    let etag = opts.etag.filter(|value| !value.is_empty());
-    let modified = opts.modified.filter(|value| !value.is_empty());
+    let etag = if opts.bypass_cache { None } else { opts.etag.filter(|value| !value.is_empty()) };
+    let modified =
+        if opts.bypass_cache { None } else { opts.modified.filter(|value| !value.is_empty()) };
     let has_validator = etag.is_some() || modified.is_some();
     let build_request = |client: &reqwest::Client, bypass_cache: bool| {
         let mut request = client.get(opts.url).header(header::ACCEPT, opts.accept);
@@ -129,7 +131,7 @@ pub(crate) async fn send_metadata_request<'a>(
 
     let (client, response) =
         send_with_retry(opts.http_client, opts.url, opts.retry_opts, |client| {
-            build_request(client, false)
+            build_request(client, opts.bypass_cache)
         })
         .await
         .map_err(|error| FetchMetadataError::Network {
@@ -138,6 +140,12 @@ pub(crate) async fn send_metadata_request<'a>(
         })?;
     if response.status() != StatusCode::NOT_MODIFIED || has_validator {
         return Ok((client, response));
+    }
+    if opts.bypass_cache {
+        drop(client);
+        return Err(FetchMetadataError::NotModifiedWithoutCache {
+            pkg_name: opts.pkg_name.to_string(),
+        });
     }
 
     drop(client);
@@ -177,6 +185,7 @@ pub async fn fetch_full_metadata(
             auth_headers: opts.auth_headers,
             etag: opts.etag,
             modified: opts.modified,
+            bypass_cache: false,
             retry_opts: opts.retry_opts,
         })
         .await?;

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -19,11 +19,12 @@ use std::{
 };
 
 use pacquet_network::{
-    AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials, retry_async,
+    AuthHeaders, RetryOpts, ThrottledClient, ThrottledClientGuard, redact_url_credentials,
+    retry_async,
 };
 use pacquet_registry::Package;
 use pipe_trait::Pipe;
-use reqwest::{StatusCode, header};
+use reqwest::{Response, StatusCode, header};
 
 use crate::{
     FetchMetadataError,
@@ -112,7 +113,7 @@ pub async fn fetch_full_metadata_cached(
     // outlive the attempt that discovered the loss: re-validating against a
     // mirror already known to be gone would 304 into the same dead end.
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
-        let (client, response) = send_metadata_request(&MetadataRequestOptions {
+        let request = MetadataRequestOptions {
             pkg_name,
             url: &url,
             accept,
@@ -122,38 +123,16 @@ pub async fn fetch_full_metadata_cached(
             modified: cache_headers.as_ref().and_then(|headers| headers.modified.as_deref()),
             bypass_cache: cache_bypass.load(Ordering::Relaxed),
             retry_opts: opts.retry_opts,
-        })
-        .await?;
+        };
+        let (client, response) = send_metadata_request(&request).await?;
 
         let (client, response) = if response.status() == StatusCode::NOT_MODIFIED {
-            // No body to stream — release the connection and its
-            // network-concurrency permit before the mirror disk read.
-            drop(client);
-            let Some(path) = mirror_path.as_deref() else {
-                // 304 without an existing cache to fall back on — the
-                // registry over-reached on `If-None-Match: <stale>`.
-                // Surfaces as `META_NOT_MODIFIED_WITHOUT_CACHE`.
-                return Err(FetchMetadataError::NotModifiedWithoutCache {
-                    pkg_name: pkg_name.to_string(),
-                });
-            };
-            if let Some(meta) = load_meta_async(Some(path)).await {
-                renew_mirror_freshness(path);
-                return Ok(meta);
+            match recover_from_not_modified(client, &request, mirror_path.as_deref(), &cache_bypass)
+                .await?
+            {
+                NotModifiedRecovery::Serve(meta) => return Ok(meta),
+                NotModifiedRecovery::Refetched(client, response) => (client, response),
             }
-            cache_bypass.store(true, Ordering::Relaxed);
-            send_metadata_request(&MetadataRequestOptions {
-                pkg_name,
-                url: &url,
-                accept,
-                http_client: opts.http_client,
-                auth_headers: opts.auth_headers,
-                etag: None,
-                modified: None,
-                bypass_cache: true,
-                retry_opts: opts.retry_opts,
-            })
-            .await?
         } else {
             (client, response)
         };
@@ -233,6 +212,56 @@ pub async fn fetch_full_metadata_cached(
         meta.pipe(Ok)
     })
     .await
+}
+
+/// Outcome of a `304 Not Modified` once it is honoured against the mirror.
+enum NotModifiedRecovery<'a> {
+    /// The mirror body was still on disk; serve it.
+    Serve(Package),
+    /// The mirror had vanished, so a cache-bypassing refetch returned a body.
+    Refetched(ThrottledClientGuard<'a>, Response),
+}
+
+/// Honour a `304 Not Modified` against the on-disk mirror.
+///
+/// Serves the mirror body when it is still present. When the mirror vanished
+/// after the conditional request (concurrent store cleanup, antivirus, ...)
+/// the 304 validates nothing, so re-request once as a cold cache would —
+/// flipping `cache_bypass` so the retrying [`retry_async`] loop stays bypassed
+/// too — which the registry can only answer with a body or an error, never
+/// another 304. A 304 with no mirror at all is `META_NOT_MODIFIED_WITHOUT_CACHE`.
+async fn recover_from_not_modified<'a>(
+    client: ThrottledClientGuard<'a>,
+    request: &MetadataRequestOptions<'a>,
+    mirror_path: Option<&Path>,
+    cache_bypass: &AtomicBool,
+) -> Result<NotModifiedRecovery<'a>, FetchMetadataError> {
+    // No body to stream — release the connection and its network-concurrency
+    // permit before the mirror disk read.
+    drop(client);
+    let Some(path) = mirror_path else {
+        return Err(FetchMetadataError::NotModifiedWithoutCache {
+            pkg_name: request.pkg_name.to_string(),
+        });
+    };
+    if let Some(meta) = load_meta_async(Some(path)).await {
+        renew_mirror_freshness(path);
+        return Ok(NotModifiedRecovery::Serve(meta));
+    }
+    cache_bypass.store(true, Ordering::Relaxed);
+    let (client, response) = send_metadata_request(&MetadataRequestOptions {
+        pkg_name: request.pkg_name,
+        url: request.url,
+        accept: request.accept,
+        http_client: request.http_client,
+        auth_headers: request.auth_headers,
+        etag: None,
+        modified: None,
+        bypass_cache: true,
+        retry_opts: request.retry_opts,
+    })
+    .await?;
+    Ok(NotModifiedRecovery::Refetched(client, response))
 }
 
 /// Bump the mirror file's mtime to "now" after a `304 Not Modified`.

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -108,27 +108,19 @@ pub async fn fetch_full_metadata_cached(
     let should_filter_metadata = opts.full_metadata && opts.filter_metadata;
     let cache_bypass = AtomicBool::new(false);
 
-    // A retry keeps the request in bypass mode after a conditional
-    // `304` loses its mirror body.
+    // A body retry re-enters this closure from the top, so the bypass has to
+    // outlive the attempt that discovered the loss: re-validating against a
+    // mirror already known to be gone would 304 into the same dead end.
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
-        let bypass_cache = cache_bypass.load(Ordering::Relaxed);
         let (client, response) = send_metadata_request(&MetadataRequestOptions {
             pkg_name,
             url: &url,
             accept,
             http_client: opts.http_client,
             auth_headers: opts.auth_headers,
-            etag: if bypass_cache {
-                None
-            } else {
-                cache_headers.as_ref().and_then(|headers| headers.etag.as_deref())
-            },
-            modified: if bypass_cache {
-                None
-            } else {
-                cache_headers.as_ref().and_then(|headers| headers.modified.as_deref())
-            },
-            bypass_cache,
+            etag: cache_headers.as_ref().and_then(|headers| headers.etag.as_deref()),
+            modified: cache_headers.as_ref().and_then(|headers| headers.modified.as_deref()),
+            bypass_cache: cache_bypass.load(Ordering::Relaxed),
             retry_opts: opts.retry_opts,
         })
         .await?;

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -13,7 +13,10 @@
 //! own indexed shape (see [`crate::mirror`]) so warm loads hydrate
 //! only the version fragments a pick consults.
 
-use std::path::Path;
+use std::{
+    path::Path,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use pacquet_network::{
     AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials, retry_async,
@@ -103,24 +106,34 @@ pub async fn fetch_full_metadata_cached(
     let cache_headers = load_meta_headers_async(mirror_path.as_deref()).await;
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     let should_filter_metadata = opts.full_metadata && opts.filter_metadata;
+    let cache_bypass = AtomicBool::new(false);
 
-    // A body-read retry re-issues the whole request, conditional
-    // headers and all, so a `304` stays a success that returns the
-    // cached mirror body rather than re-fetching it.
+    // A retry keeps the request in bypass mode after a conditional
+    // `304` loses its mirror body.
     retry_async(&url, opts.retry_opts, FetchMetadataError::is_body_retryable, || async {
+        let bypass_cache = cache_bypass.load(Ordering::Relaxed);
         let (client, response) = send_metadata_request(&MetadataRequestOptions {
             pkg_name,
             url: &url,
             accept,
             http_client: opts.http_client,
             auth_headers: opts.auth_headers,
-            etag: cache_headers.as_ref().and_then(|headers| headers.etag.as_deref()),
-            modified: cache_headers.as_ref().and_then(|headers| headers.modified.as_deref()),
+            etag: if bypass_cache {
+                None
+            } else {
+                cache_headers.as_ref().and_then(|headers| headers.etag.as_deref())
+            },
+            modified: if bypass_cache {
+                None
+            } else {
+                cache_headers.as_ref().and_then(|headers| headers.modified.as_deref())
+            },
+            bypass_cache,
             retry_opts: opts.retry_opts,
         })
         .await?;
 
-        if response.status() == StatusCode::NOT_MODIFIED {
+        let (client, response) = if response.status() == StatusCode::NOT_MODIFIED {
             // No body to stream — release the connection and its
             // network-concurrency permit before the mirror disk read.
             drop(client);
@@ -132,12 +145,26 @@ pub async fn fetch_full_metadata_cached(
                     pkg_name: pkg_name.to_string(),
                 });
             };
-            let meta = load_meta_async(Some(path)).await.ok_or_else(|| {
-                FetchMetadataError::CacheMissingAfter304 { pkg_name: pkg_name.to_string() }
-            })?;
-            renew_mirror_freshness(path);
-            return Ok(meta);
-        }
+            if let Some(meta) = load_meta_async(Some(path)).await {
+                renew_mirror_freshness(path);
+                return Ok(meta);
+            }
+            cache_bypass.store(true, Ordering::Relaxed);
+            send_metadata_request(&MetadataRequestOptions {
+                pkg_name,
+                url: &url,
+                accept,
+                http_client: opts.http_client,
+                auth_headers: opts.auth_headers,
+                etag: None,
+                modified: None,
+                bypass_cache: true,
+                retry_opts: opts.retry_opts,
+            })
+            .await?
+        } else {
+            (client, response)
+        };
 
         let response = response.error_for_status().map_err(|error| {
             FetchMetadataError::Network { url: redact_url_credentials(&url), error }

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -7,7 +7,7 @@ use crate::{
     FetchMetadataError,
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, get_pkg_mirror_path,
-        load_meta, load_meta_headers,
+        load_meta, load_meta_headers, save_meta_indexed,
     },
 };
 
@@ -178,6 +178,253 @@ async fn repeated_unsolicited_304_reports_missing_cache() {
     ));
     first.assert_async().await;
     second.assert_async().await;
+}
+
+#[tokio::test]
+async fn full_metadata_cache_loss_after_304_retries_once_without_validators() {
+    assert_cache_loss_after_304_recovers(true, FULL_META_DIR, true).await;
+}
+
+#[tokio::test]
+async fn abbreviated_metadata_cache_loss_after_304_retries_once_without_validators() {
+    assert_cache_loss_after_304_recovers(false, ABBREVIATED_META_DIR, false).await;
+}
+
+#[tokio::test]
+async fn cache_loss_after_304_stops_after_one_fallback() {
+    let mut server = mockito::Server::new_async().await;
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let mirror_path = write_stale_mirror(cache.path(), FULL_META_DIR, &registry);
+    let raced_mirror = mirror_path.clone();
+    let first = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", r#"W/"stale""#)
+        .with_status(304)
+        .with_body_from_request(move |_| {
+            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            Vec::new()
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let second = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", Matcher::Missing)
+        .match_header("if-modified-since", Matcher::Missing)
+        .match_header("cache-control", "no-cache")
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: false,
+        retry_opts: no_retry_opts(),
+    };
+
+    let error = fetch_full_metadata_cached("acme", &opts).await.expect_err("fallback 304 fails");
+    assert!(matches!(
+        error,
+        FetchMetadataError::NotModifiedWithoutCache { ref pkg_name } if pkg_name == "acme"
+    ));
+    first.assert_async().await;
+    second.assert_async().await;
+}
+
+#[tokio::test]
+async fn cache_loss_after_304_body_retry_remains_bypassed() {
+    let mut server = mockito::Server::new_async().await;
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let mirror_path = write_stale_mirror(cache.path(), FULL_META_DIR, &registry);
+    let raced_mirror = mirror_path.clone();
+    let first = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", r#"W/"stale""#)
+        .with_status(304)
+        .with_body_from_request(move |_| {
+            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            Vec::new()
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let broken = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", Matcher::Missing)
+        .match_header("if-modified-since", Matcher::Missing)
+        .match_header("cache-control", "no-cache")
+        .with_status(200)
+        .with_header("content-encoding", "gzip")
+        .with_body("this is not valid gzip")
+        .expect(1)
+        .create_async()
+        .await;
+    let recovered = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", Matcher::Missing)
+        .match_header("if-modified-since", Matcher::Missing)
+        .match_header("cache-control", "no-cache")
+        .with_status(200)
+        .with_header("etag", r#"W/"after-retry""#)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: false,
+        retry_opts: fast_retry_opts(),
+    };
+
+    let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("body retry succeeds");
+    assert_eq!(pkg.name, "acme");
+    first.assert_async().await;
+    broken.assert_async().await;
+    recovered.assert_async().await;
+    let persisted = load_meta(&mirror_path).expect("mirror readable");
+    assert_eq!(persisted.name, "acme");
+    let headers = load_meta_headers(&mirror_path).expect("headers readable");
+    assert_eq!(headers.etag.as_deref(), Some(r#"W/"after-retry""#));
+}
+
+#[tokio::test]
+async fn cache_loss_after_304_registry_error_propagates() {
+    let mut server = mockito::Server::new_async().await;
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let mirror_path = write_stale_mirror(cache.path(), FULL_META_DIR, &registry);
+    let raced_mirror = mirror_path.clone();
+    let first = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", r#"W/"stale""#)
+        .with_status(304)
+        .with_body_from_request(move |_| {
+            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            Vec::new()
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let forbidden = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", Matcher::Missing)
+        .match_header("if-modified-since", Matcher::Missing)
+        .match_header("cache-control", "no-cache")
+        .with_status(403)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata: true,
+        filter_metadata: false,
+        retry_opts: no_retry_opts(),
+    };
+
+    let error = fetch_full_metadata_cached("acme", &opts).await.expect_err("403 propagates");
+    assert!(matches!(
+        error,
+        FetchMetadataError::Network { ref error, .. }
+            if error.status() == Some(reqwest::StatusCode::FORBIDDEN)
+    ));
+    first.assert_async().await;
+    forbidden.assert_async().await;
+}
+
+async fn assert_cache_loss_after_304_recovers(
+    full_metadata: bool,
+    meta_dir: &str,
+    scripts_expected: bool,
+) {
+    let mut server = mockito::Server::new_async().await;
+    let cache = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let mirror_path = write_stale_mirror(cache.path(), meta_dir, &registry);
+    let raced_mirror = mirror_path.clone();
+    let first = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", r#"W/"stale""#)
+        .with_status(304)
+        .with_body_from_request(move |_| {
+            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            Vec::new()
+        })
+        .expect(1)
+        .create_async()
+        .await;
+    let response_body = PACKAGE_BODY.replace(
+        r#""dist": {"#,
+        r#""scripts": { "postinstall": "echo cache-race-marker" }, "dist": {"#,
+    );
+    let second = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", Matcher::Missing)
+        .match_header("if-modified-since", Matcher::Missing)
+        .match_header("cache-control", "no-cache")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_header("etag", r#"W/"fresh""#)
+        .with_body(response_body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataCachedOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        cache_dir: Some(cache.path()),
+        full_metadata,
+        filter_metadata: false,
+        retry_opts: no_retry_opts(),
+    };
+
+    let pkg = fetch_full_metadata_cached("acme", &opts).await.expect("fallback returns metadata");
+    assert_eq!(pkg.name, "acme");
+    let manifest = pkg.versions.get("1.0.0").expect("version");
+    assert_eq!(manifest.other.contains_key("scripts"), scripts_expected);
+    let persisted = load_meta(&mirror_path).expect("mirror readable");
+    let persisted_manifest = persisted.versions.get("1.0.0").expect("persisted version");
+    assert_eq!(persisted_manifest.other.contains_key("scripts"), scripts_expected);
+    let headers = load_meta_headers(&mirror_path).expect("headers readable");
+    assert_eq!(headers.etag.as_deref(), Some(r#"W/"fresh""#));
+    first.assert_async().await;
+    second.assert_async().await;
+}
+
+fn write_stale_mirror(
+    cache_dir: &std::path::Path,
+    meta_dir: &str,
+    registry: &str,
+) -> std::path::PathBuf {
+    let mirror_path = get_pkg_mirror_path(cache_dir, meta_dir, registry, "acme").expect("path");
+    let meta = serde_json::from_str(PACKAGE_BODY).expect("package body");
+    save_meta_indexed(&mirror_path, &meta, Some(r#"W/"stale""#)).expect("write stale mirror");
+    mirror_path
 }
 
 #[tokio::test]

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -54,6 +54,19 @@ export interface FetchMetadataNotModifiedResult {
   notModified: true
 }
 
+/**
+ * A 304 answers a validator with "the body you already have is current". Sent
+ * without one — either because nothing was cached or because `cacheBypass`
+ * dropped the validators to recover a lost cache entry — it refers to a body
+ * nobody holds, so there is nothing to serve and nothing left to retry.
+ */
+export function notModifiedWithoutCacheError (pkgName: string): PnpmError {
+  return new PnpmError(
+    'META_NOT_MODIFIED_WITHOUT_CACHE',
+    `Registry returned 304 for ${pkgName} without an existing cache to refresh.`
+  )
+}
+
 export class RegistryResponseError extends FetchError {
   public readonly pkgName: string
 
@@ -168,9 +181,7 @@ export async function fetchMetadataFromFromRegistry (
           ifModifiedSince,
           retry: fetchOpts.retry,
           timeout: fetchOpts.timeout,
-          ...(cacheBypass
-            ? { headers: { 'cache-control': 'no-cache' } }
-            : {}),
+          headers: cacheBypass ? { 'cache-control': 'no-cache' } : undefined,
         }
         response = await fetchOpts.fetch(uri, requestOptions) as RegistryResponse
         if (response.status === 304 && !hasValidator && !cacheBypass) {
@@ -196,10 +207,7 @@ export async function fetchMetadataFromFromRegistry (
       }
       if (response.status === 304) {
         if (!hasValidator) {
-          reject(new PnpmError(
-            'META_NOT_MODIFIED_WITHOUT_CACHE',
-            `Registry returned 304 for ${pkgName} without an existing cache to refresh.`
-          ))
+          reject(notModifiedWithoutCacheError(pkgName))
           return
         }
         resolve({ notModified: true })

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -54,19 +54,6 @@ export interface FetchMetadataNotModifiedResult {
   notModified: true
 }
 
-/**
- * A 304 answers a validator with "the body you already have is current". Sent
- * without one — either because nothing was cached or because `cacheBypass`
- * dropped the validators to recover a lost cache entry — it refers to a body
- * nobody holds, so there is nothing to serve and nothing left to retry.
- */
-export function notModifiedWithoutCacheError (pkgName: string): PnpmError {
-  return new PnpmError(
-    'META_NOT_MODIFIED_WITHOUT_CACHE',
-    `Registry returned 304 for ${pkgName} without an existing cache to refresh.`
-  )
-}
-
 export class RegistryResponseError extends FetchError {
   public readonly pkgName: string
 
@@ -263,6 +250,19 @@ export async function fetchMetadataFromFromRegistry (
       }
     })
   })
+}
+
+/**
+ * A 304 answers a validator with "the body you already have is current". Sent
+ * without one — either because nothing was cached or because `cacheBypass`
+ * dropped the validators to recover a lost cache entry — it refers to a body
+ * nobody holds, so there is nothing to serve and nothing left to retry.
+ */
+export function notModifiedWithoutCacheError (pkgName: string): PnpmError {
+  return new PnpmError(
+    'META_NOT_MODIFIED_WITHOUT_CACHE',
+    `Registry returned 304 for ${pkgName} without an existing cache to refresh.`
+  )
 }
 
 /**

--- a/pnpm11/resolving/npm-resolver/src/fetch.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetch.ts
@@ -130,6 +130,7 @@ export interface FetchMetadataFromFromRegistryOptions {
 export interface FetchMetadataOptions {
   registry: string
   authHeaderValue?: string
+  cacheBypass?: boolean
   fullMetadata?: boolean
   etag?: string
   modified?: string
@@ -140,6 +141,7 @@ export async function fetchMetadataFromFromRegistry (
   pkgName: string,
   {
     authHeaderValue,
+    cacheBypass = false,
     etag: cachedEtag,
     fullMetadata,
     modified: cachedModified,
@@ -148,8 +150,11 @@ export async function fetchMetadataFromFromRegistry (
 ): Promise<FetchMetadataResult | FetchMetadataNotModifiedResult> {
   const uri = toUri(pkgName, registry)
   const op = retry.operation(fetchOpts.retry)
-  const ifModifiedSince = cachedModified ? new Date(cachedModified).toUTCString() : undefined
-  const hasValidator = Boolean(cachedEtag || ifModifiedSince)
+  const ifNoneMatch = cacheBypass ? undefined : cachedEtag
+  const ifModifiedSince = cacheBypass || !cachedModified
+    ? undefined
+    : new Date(cachedModified).toUTCString()
+  const hasValidator = Boolean(ifNoneMatch || ifModifiedSince)
   return new Promise((resolve, reject) => {
     op.attempt(async (attempt) => {
       let response: RegistryResponse
@@ -159,13 +164,16 @@ export async function fetchMetadataFromFromRegistry (
           authHeaderValue,
           compress: true,
           fullMetadata,
-          ifNoneMatch: cachedEtag,
+          ifNoneMatch,
           ifModifiedSince,
           retry: fetchOpts.retry,
           timeout: fetchOpts.timeout,
+          ...(cacheBypass
+            ? { headers: { 'cache-control': 'no-cache' } }
+            : {}),
         }
         response = await fetchOpts.fetch(uri, requestOptions) as RegistryResponse
-        if (response.status === 304 && !hasValidator) {
+        if (response.status === 304 && !hasValidator && !cacheBypass) {
           response = await fetchOpts.fetch(uri, {
             ...requestOptions,
             headers: {

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -4,6 +4,7 @@ import type { PackageMeta } from '@pnpm/resolving.registry.types'
 import {
   fetchMetadataFromFromRegistry,
   type FetchMetadataFromFromRegistryOptions,
+  type FetchMetadataResult,
   notModifiedWithoutCacheError,
 } from './fetch.js'
 import { getPkgMirrorPath, loadMeta, loadMetaHeaders, prepareJsonForDisk, saveMeta } from './pickPackage.js'
@@ -63,40 +64,43 @@ async function fetchMetadataCached (
   const pkgMirror = opts.cacheDir != null
     ? getPkgMirrorPath(opts.cacheDir, opts.metaDir, opts.registry, pkgName)
     : null
+
+  // Persist a freshly downloaded body so the next install can do a headers-only
+  // conditional GET, then hand its meta back. Fire-and-forget — a cache-write
+  // failure isn't a reason to fail the caller; the next install just won't get
+  // the speedup.
+  const persistAndReturn = (result: FetchMetadataResult): PackageMeta => {
+    if (pkgMirror != null) {
+      saveMeta(pkgMirror, prepareJsonForDisk(result.meta, result.etag, result.jsonText)).catch(() => {})
+    }
+    return result.meta
+  }
+
   const cacheHeaders = pkgMirror != null ? await loadMetaHeaders(pkgMirror) : null
-  let result = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
+  const conditional = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
     registry: opts.registry,
     authHeaderValue: opts.authHeaderValue,
     fullMetadata: opts.fullMetadata,
     etag: cacheHeaders?.etag,
     modified: cacheHeaders?.modified,
   })
-  if (result.notModified) {
-    if (pkgMirror == null) {
-      // We didn't send conditional headers (no cacheDir), but the registry
-      // returned 304 anyway. There's no body to fall back on.
-      throw notModifiedWithoutCacheError(pkgName)
-    }
-    const meta = await loadMeta(pkgMirror)
-    if (meta != null) return meta
-    // The mirror vanished between the headers read and this read (concurrent
-    // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask
-    // again as a cold cache would, which the registry can only answer with a
-    // body or an error — never another 304.
-    result = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
-      registry: opts.registry,
-      authHeaderValue: opts.authHeaderValue,
-      cacheBypass: true,
-      fullMetadata: opts.fullMetadata,
-    })
-    if (result.notModified) throw notModifiedWithoutCacheError(pkgName)
-  }
-  if (pkgMirror != null) {
-    // Persist so the next install can do a headers-only conditional GET.
-    // Fire-and-forget — a cache-write failure isn't a reason to fail the
-    // caller; the next install just won't get the speedup.
-    const json = prepareJsonForDisk(result.meta, result.etag, result.jsonText)
-    saveMeta(pkgMirror, json).catch(() => {})
-  }
-  return result.meta
+  if (!conditional.notModified) return persistAndReturn(conditional)
+
+  // 304: serve the mirror body the validators vouched for.
+  if (pkgMirror == null) throw notModifiedWithoutCacheError(pkgName)
+  const cached = await loadMeta(pkgMirror)
+  if (cached != null) return cached
+
+  // The mirror vanished between the headers read and this read (concurrent
+  // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask again
+  // as a cold cache would, which the registry can only answer with a body or an
+  // error — never another 304.
+  const refetched = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
+    registry: opts.registry,
+    authHeaderValue: opts.authHeaderValue,
+    cacheBypass: true,
+    fullMetadata: opts.fullMetadata,
+  })
+  if (refetched.notModified) throw notModifiedWithoutCacheError(pkgName)
+  return persistAndReturn(refetched)
 }

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -5,7 +5,6 @@ import {
   fetchMetadataFromFromRegistry,
   type FetchMetadataFromFromRegistryOptions,
   type FetchMetadataResult,
-  notModifiedWithoutCacheError,
 } from './fetch.js'
 import { getPkgMirrorPath, loadMeta, loadMetaHeaders, prepareJsonForDisk, saveMeta } from './pickPackage.js'
 
@@ -75,8 +74,10 @@ async function fetchMetadataCached (
   })
   if (!conditional.notModified) return persistAndReturn(conditional)
 
-  // 304: serve the mirror body the validators vouched for.
-  if (pkgMirror == null) throw notModifiedWithoutCacheError(pkgName)
+  // A 304 only resolves as `notModified` when a validator was sent, which
+  // requires cache headers loaded from a mirror — so a null mirror here is an
+  // unreachable invariant breach.
+  if (pkgMirror == null) throw new Error(`Unexpected 304 for ${pkgName} without a metadata cache`)
   const cached = await loadMeta(pkgMirror)
   if (cached != null) return cached
 
@@ -90,7 +91,9 @@ async function fetchMetadataCached (
     cacheBypass: true,
     fullMetadata: opts.fullMetadata,
   })
-  if (refetched.notModified) throw notModifiedWithoutCacheError(pkgName)
+  // Unreachable narrowing guard: the cache-bypassing request sends no validator,
+  // so fetchMetadataFromFromRegistry rejects a repeated 304 before returning.
+  if (refetched.notModified) throw new Error(`Unexpected 304 for ${pkgName} on a cache-bypassing refetch`)
   return persistAndReturn(refetched)
 
   // Persist a freshly downloaded body so the next install can do a headers-only

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -1,8 +1,11 @@
 import { ABBREVIATED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
-import { PnpmError } from '@pnpm/error'
 import type { PackageMeta } from '@pnpm/resolving.registry.types'
 
-import { fetchMetadataFromFromRegistry, type FetchMetadataFromFromRegistryOptions } from './fetch.js'
+import {
+  fetchMetadataFromFromRegistry,
+  type FetchMetadataFromFromRegistryOptions,
+  notModifiedWithoutCacheError,
+} from './fetch.js'
 import { getPkgMirrorPath, loadMeta, loadMetaHeaders, prepareJsonForDisk, saveMeta } from './pickPackage.js'
 
 export interface FetchMetadataCachedOptions {
@@ -68,32 +71,25 @@ async function fetchMetadataCached (
     etag: cacheHeaders?.etag,
     modified: cacheHeaders?.modified,
   })
-  if ('notModified' in result && result.notModified) {
+  if (result.notModified) {
     if (pkgMirror == null) {
       // We didn't send conditional headers (no cacheDir), but the registry
       // returned 304 anyway. There's no body to fall back on.
-      throw new PnpmError(
-        'META_NOT_MODIFIED_WITHOUT_CACHE',
-        `Registry returned 304 for ${pkgName} without an existing cache to refresh.`
-      )
+      throw notModifiedWithoutCacheError(pkgName)
     }
     const meta = await loadMeta(pkgMirror)
-    if (meta == null) {
-      result = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
-        registry: opts.registry,
-        authHeaderValue: opts.authHeaderValue,
-        cacheBypass: true,
-        fullMetadata: opts.fullMetadata,
-      })
-      if ('notModified' in result && result.notModified) {
-        throw new PnpmError(
-          'META_NOT_MODIFIED_WITHOUT_CACHE',
-          `Registry returned 304 for ${pkgName} without an existing cache to refresh.`
-        )
-      }
-    } else {
-      return meta
-    }
+    if (meta != null) return meta
+    // The mirror vanished between the headers read and this read (concurrent
+    // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask
+    // again as a cold cache would, which the registry can only answer with a
+    // body or an error — never another 304.
+    result = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
+      registry: opts.registry,
+      authHeaderValue: opts.authHeaderValue,
+      cacheBypass: true,
+      fullMetadata: opts.fullMetadata,
+    })
+    if (result.notModified) throw notModifiedWithoutCacheError(pkgName)
   }
   if (pkgMirror != null) {
     // Persist so the next install can do a headers-only conditional GET.

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -100,10 +100,10 @@ async function fetchMetadataCached (
   // conditional GET, then hand its meta back. Fire-and-forget — a cache-write
   // failure isn't a reason to fail the caller; the next install just won't get
   // the speedup.
-  function persistAndReturn (result: FetchMetadataResult): PackageMeta {
+  function persistAndReturn (fetched: FetchMetadataResult): PackageMeta {
     if (pkgMirror != null) {
-      saveMeta(pkgMirror, prepareJsonForDisk(result.meta, result.etag, result.jsonText)).catch(() => {})
+      saveMeta(pkgMirror, prepareJsonForDisk(fetched.meta, fetched.etag, fetched.jsonText)).catch(() => {})
     }
-    return result.meta
+    return fetched.meta
   }
 }

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -61,7 +61,7 @@ async function fetchMetadataCached (
     ? getPkgMirrorPath(opts.cacheDir, opts.metaDir, opts.registry, pkgName)
     : null
   const cacheHeaders = pkgMirror != null ? await loadMetaHeaders(pkgMirror) : null
-  const result = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
+  let result = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
     registry: opts.registry,
     authHeaderValue: opts.authHeaderValue,
     fullMetadata: opts.fullMetadata,
@@ -79,14 +79,21 @@ async function fetchMetadataCached (
     }
     const meta = await loadMeta(pkgMirror)
     if (meta == null) {
-      // Cache file vanished between header-load and meta-load (concurrent
-      // store cleanup, antivirus, etc.).
-      throw new PnpmError(
-        'META_CACHE_MISSING_AFTER_304',
-        `Metadata cache for ${pkgName} disappeared between headers read and full read.`
-      )
+      result = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
+        registry: opts.registry,
+        authHeaderValue: opts.authHeaderValue,
+        cacheBypass: true,
+        fullMetadata: opts.fullMetadata,
+      })
+      if ('notModified' in result && result.notModified) {
+        throw new PnpmError(
+          'META_NOT_MODIFIED_WITHOUT_CACHE',
+          `Registry returned 304 for ${pkgName} without an existing cache to refresh.`
+        )
+      }
+    } else {
+      return meta
     }
-    return meta
   }
   if (pkgMirror != null) {
     // Persist so the next install can do a headers-only conditional GET.

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -65,17 +65,6 @@ async function fetchMetadataCached (
     ? getPkgMirrorPath(opts.cacheDir, opts.metaDir, opts.registry, pkgName)
     : null
 
-  // Persist a freshly downloaded body so the next install can do a headers-only
-  // conditional GET, then hand its meta back. Fire-and-forget — a cache-write
-  // failure isn't a reason to fail the caller; the next install just won't get
-  // the speedup.
-  const persistAndReturn = (result: FetchMetadataResult): PackageMeta => {
-    if (pkgMirror != null) {
-      saveMeta(pkgMirror, prepareJsonForDisk(result.meta, result.etag, result.jsonText)).catch(() => {})
-    }
-    return result.meta
-  }
-
   const cacheHeaders = pkgMirror != null ? await loadMetaHeaders(pkgMirror) : null
   const conditional = await fetchMetadataFromFromRegistry(fetchOpts, pkgName, {
     registry: opts.registry,
@@ -103,4 +92,15 @@ async function fetchMetadataCached (
   })
   if (refetched.notModified) throw notModifiedWithoutCacheError(pkgName)
   return persistAndReturn(refetched)
+
+  // Persist a freshly downloaded body so the next install can do a headers-only
+  // conditional GET, then hand its meta back. Fire-and-forget — a cache-write
+  // failure isn't a reason to fail the caller; the next install just won't get
+  // the speedup.
+  function persistAndReturn (result: FetchMetadataResult): PackageMeta {
+    if (pkgMirror != null) {
+      saveMeta(pkgMirror, prepareJsonForDisk(result.meta, result.etag, result.jsonText)).catch(() => {})
+    }
+    return result.meta
+  }
 }

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -14,7 +14,11 @@ import { renameOverwrite } from 'rename-overwrite'
 import semver from 'semver'
 
 import { clearMeta } from './clearMeta.js'
-import type { FetchMetadataNotModifiedResult, FetchMetadataResult } from './fetch.js'
+import {
+  type FetchMetadataNotModifiedResult,
+  type FetchMetadataResult,
+  notModifiedWithoutCacheError,
+} from './fetch.js'
 import type { RegistryPackageSpec } from './parseBareSpecifier.js'
 import {
   pickLowestVersionByVersionRange,
@@ -427,18 +431,17 @@ export async function pickPackage (
             pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
           }
         }
+        // The mirror vanished between the headers read and this read
+        // (concurrent store cleanup, antivirus, ...), so the 304 now validates
+        // nothing. Ask again as a cold cache would, which the registry can
+        // only answer with a body or an error — never another 304.
         fetchResult = await ctx.fetch(spec.name, {
           authHeaderValue: opts.authHeaderValue,
           cacheBypass: true,
           fullMetadata,
           registry: opts.registry,
         })
-        if (fetchResult.notModified) {
-          throw new PnpmError(
-            'META_NOT_MODIFIED_WITHOUT_CACHE',
-            `Registry returned 304 for ${spec.name} without an existing cache to refresh.`
-          )
-        }
+        if (fetchResult.notModified) throw notModifiedWithoutCacheError(spec.name)
       }
 
       let meta = fetchResult.meta

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -215,7 +215,7 @@ function cacheDiskLoadedMeta (metaCache: PackageMetaCache, cacheKey: string, met
 
 export async function pickPackage (
   ctx: {
-    fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
+    fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, cacheBypass?: boolean, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
     fullMetadata?: boolean
     metaCache: PackageMetaCache
     cacheDir: string
@@ -427,8 +427,18 @@ export async function pickPackage (
             pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
           }
         }
-        throw new PnpmError('CACHE_MISSING_AFTER_304',
-          `Metadata cache for ${spec.name} is unreadable after receiving 304 Not Modified`)
+        fetchResult = await ctx.fetch(spec.name, {
+          authHeaderValue: opts.authHeaderValue,
+          cacheBypass: true,
+          fullMetadata,
+          registry: opts.registry,
+        })
+        if (fetchResult.notModified) {
+          throw new PnpmError(
+            'META_NOT_MODIFIED_WITHOUT_CACHE',
+            `Registry returned 304 for ${spec.name} without an existing cache to refresh.`
+          )
+        }
       }
 
       let meta = fetchResult.meta
@@ -530,7 +540,7 @@ export async function pickPackage (
 // so callers can persist it to disk and avoid re-fetching on next install.
 async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   ctx: {
-    fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
+    fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, cacheBypass?: boolean, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
     offline?: boolean
   },
   spec: RegistryPackageSpec,

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -288,38 +288,38 @@ export async function pickPackage (
   }
 
   return runLimited(pkgMirror, async (limit) => {
-    let metaCachedInStore: PackageMeta | null | undefined
+    let diskMeta: PackageMeta | null | undefined
     if (ctx.offline === true || ctx.preferOffline === true || opts.pickLowestVersion) {
-      metaCachedInStore = await limit(async () => loadMeta(pkgMirror))
+      diskMeta = await limit(async () => loadMeta(pkgMirror))
 
       if (ctx.offline) {
-        if (metaCachedInStore != null) {
+        if (diskMeta != null) {
           // maybeUpgradeAbbreviatedMetaForReleaseAge short-circuits when
           // offline, so a later in-memory cache hit returns this same meta
           // without any network access.
-          cacheDiskLoadedMeta(ctx.metaCache, cacheKey, metaCachedInStore)
+          cacheDiskLoadedMeta(ctx.metaCache, cacheKey, diskMeta)
           return {
-            meta: metaCachedInStore,
-            pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
+            meta: diskMeta,
+            pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, diskMeta),
           }
         }
 
         throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
       }
 
-      if (metaCachedInStore != null) {
+      if (diskMeta != null) {
         // Disk-cached meta may be abbreviated; upgrade for the maturity check
         // before letting pickMatchingVersionFinal warn-and-skip on missing time.
-        const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, metaCachedInStore)
-        metaCachedInStore = upgrade.meta
+        const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, diskMeta)
+        diskMeta = upgrade.meta
         if (upgrade.upgradedFrom != null) {
           // Persist so the next install skips this upgrade fetch entirely.
           if (!opts.dryRun) {
-            metaCachedInStore = persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
+            diskMeta = persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
           }
-          ctx.metaCache.set(cacheKey, metaCachedInStore)
+          ctx.metaCache.set(cacheKey, diskMeta)
         }
-        const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore)
+        const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
         if (pickedPackage) {
           // A cache hit re-runs maybeUpgradeAbbreviatedMetaForReleaseAge, so
           // serving this meta from memory can't bypass the release-age
@@ -327,10 +327,10 @@ export async function pickPackage (
           // registry-validated upgraded meta, don't overwrite it with a
           // disk-sourced marking.
           if (upgrade.upgradedFrom == null) {
-            cacheDiskLoadedMeta(ctx.metaCache, cacheKey, metaCachedInStore)
+            cacheDiskLoadedMeta(ctx.metaCache, cacheKey, diskMeta)
           }
           return {
-            meta: metaCachedInStore,
+            meta: diskMeta,
             pickedPackage,
           }
         }
@@ -338,16 +338,16 @@ export async function pickPackage (
     }
 
     if (!opts.includeLatestTag && !opts.updateChecksums && spec.type === 'version') {
-      metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
+      diskMeta = diskMeta ?? await limit(async () => loadMeta(pkgMirror))
       // use the cached meta only if it has the required package version
       // otherwise it is probably out of date
-      if ((metaCachedInStore?.versions?.[spec.fetchSpec]) != null) {
+      if ((diskMeta?.versions?.[spec.fetchSpec]) != null) {
         try {
-          const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, metaCachedInStore)
+          const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, diskMeta)
           if (pickedPackage) {
-            cacheDiskLoadedMeta(ctx.metaCache, cacheKey, metaCachedInStore)
+            cacheDiskLoadedMeta(ctx.metaCache, cacheKey, diskMeta)
             return {
-              meta: metaCachedInStore,
+              meta: diskMeta,
               pickedPackage,
             }
           }
@@ -362,13 +362,13 @@ export async function pickPackage (
     if (opts.publishedBy && opts.publishedByExclude?.(spec.name) !== true) {
       const mtime = await limit(async () => getFileMtime(pkgMirror))
       if (mtime != null && mtime >= opts.publishedBy) {
-        metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
-        if (metaCachedInStore != null) {
+        diskMeta = diskMeta ?? await limit(async () => loadMeta(pkgMirror))
+        if (diskMeta != null) {
           try {
-            const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, metaCachedInStore)
+            const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, diskMeta)
             if (pickedPackage) {
               return {
-                meta: metaCachedInStore,
+                meta: diskMeta,
                 pickedPackage,
               }
             }
@@ -383,8 +383,8 @@ export async function pickPackage (
       // Load only the cache headers (etag, modified) for conditional request headers.
       // This avoids reading and parsing the full metadata file (which can be megabytes)
       // when the registry returns 200 and the old metadata would be discarded anyway.
-      const cacheHeaders = metaCachedInStore != null
-        ? { etag: metaCachedInStore.etag, modified: metaCachedInStore.modified ?? metaCachedInStore.time?.modified }
+      const cacheHeaders = diskMeta != null
+        ? { etag: diskMeta.etag, modified: diskMeta.modified ?? diskMeta.time?.modified }
         : await limit(async () => loadMetaHeaders(pkgMirror))
       const conditional = await ctx.fetch(spec.name, {
         authHeaderValue: opts.authHeaderValue,
@@ -398,8 +398,8 @@ export async function pickPackage (
       if (!conditional.notModified) return await persistFreshMeta(conditional)
 
       // 304: the cached mirror is still current.
-      metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
-      if (metaCachedInStore != null) return await serveValidatedMeta(metaCachedInStore)
+      diskMeta = diskMeta ?? await limit(async () => loadMeta(pkgMirror))
+      if (diskMeta != null) return await serveValidatedMeta(diskMeta)
 
       // The mirror vanished between the headers read and this read (concurrent
       // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -379,78 +379,48 @@ export async function pickPackage (
       }
     }
 
-    try {
-      // Load only the cache headers (etag, modified) for conditional request headers.
-      // This avoids reading and parsing the full metadata file (which can be megabytes)
-      // when the registry returns 200 and the old metadata would be discarded anyway.
-      const cacheHeaders = metaCachedInStore != null
-        ? { etag: metaCachedInStore.etag, modified: metaCachedInStore.modified ?? metaCachedInStore.time?.modified }
-        : await limit(async () => loadMetaHeaders(pkgMirror))
-      let fetchResult = await ctx.fetch(spec.name, {
-        authHeaderValue: opts.authHeaderValue,
-        fullMetadata,
-        etag: cacheHeaders?.etag,
-        modified: cacheHeaders?.modified,
-        registry: opts.registry,
-      })
-
-      // 304 Not Modified — registry confirmed local cache is still fresh.
-      // Now we need the full metadata, so load it from disk.
-      if (fetchResult.notModified) {
-        metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
-        if (metaCachedInStore != null) {
-          // The registry just vouched that the cached packument equals its
-          // current one, so the validation clock restarts now: bump the
-          // mirror's mtime so the publishedBy freshness shortcut above can
-          // fire again on the next install. Without this, a mirror older
-          // than minimumReleaseAge re-validates on every subsequent
-          // install — a 304 never rewrites the file. Fire-and-forget: a
-          // read-only cache dir only costs another conditional request.
-          if (!opts.dryRun) {
-            const now = new Date()
-            fs.utimes(pkgMirror, now, now).catch(() => {})
-          }
-          // The cached metadata may be abbreviated (no per-version `time`).
-          // When minimumReleaseAge is active we need `time` for the maturity check,
-          // so upgrade to full metadata via a follow-up fetch when warranted.
-          // Without this, repeat installs of recently-modified packages would
-          // silently bypass the maturity check via the warn-and-skip fallback.
-          const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(
-            ctx, spec, opts, metaCachedInStore
-          )
-          metaCachedInStore = upgrade.meta
-          if (upgrade.upgradedFrom != null && !opts.dryRun) {
-            // Persist the upgraded full metadata to disk so subsequent installs
-            // skip this upgrade fetch entirely (the cached meta will then have
-            // `time` populated, so the upgrade condition won't trigger).
-            metaCachedInStore = persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
-          }
-          ctx.metaCache.set(cacheKey, metaCachedInStore)
-          return {
-            meta: metaCachedInStore,
-            pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, metaCachedInStore),
-          }
-        }
-        // The mirror vanished between the headers read and this read
-        // (concurrent store cleanup, antivirus, ...), so the 304 now validates
-        // nothing. Ask again as a cold cache would, which the registry can
-        // only answer with a body or an error — never another 304.
-        fetchResult = await ctx.fetch(spec.name, {
-          authHeaderValue: opts.authHeaderValue,
-          cacheBypass: true,
-          fullMetadata,
-          registry: opts.registry,
-        })
-        if (fetchResult.notModified) throw notModifiedWithoutCacheError(spec.name)
+    // A 304 whose cached body is still on disk: the registry vouched the
+    // packument is current, so restart its validation clock, upgrade
+    // abbreviated -> full when the maturity check needs `time`, and serve it.
+    const serveValidatedMeta = async (cached: PackageMeta): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> => {
+      // The registry just vouched that the cached packument equals its current
+      // one, so the validation clock restarts now: bump the mirror's mtime so
+      // the publishedBy freshness shortcut above can fire again on the next
+      // install. Without this, a mirror older than minimumReleaseAge
+      // re-validates on every subsequent install — a 304 never rewrites the
+      // file. Fire-and-forget: a read-only cache dir only costs another
+      // conditional request.
+      if (!opts.dryRun) {
+        const now = new Date()
+        fs.utimes(pkgMirror, now, now).catch(() => {})
       }
+      // The cached metadata may be abbreviated (no per-version `time`). When
+      // minimumReleaseAge is active we need `time` for the maturity check, so
+      // upgrade to full metadata via a follow-up fetch when warranted. Without
+      // this, repeat installs of recently-modified packages would silently
+      // bypass the maturity check via the warn-and-skip fallback.
+      const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, cached)
+      let meta = upgrade.meta
+      if (upgrade.upgradedFrom != null && !opts.dryRun) {
+        // Persist the upgraded full metadata to disk so subsequent installs
+        // skip this upgrade fetch entirely (the cached meta will then have
+        // `time` populated, so the upgrade condition won't trigger).
+        meta = persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
+      }
+      ctx.metaCache.set(cacheKey, meta)
+      return {
+        meta,
+        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
+      }
+    }
 
-      let meta = fetchResult.meta
-      let resultToSave: FetchMetadataResult = fetchResult
+    // A freshly downloaded 200 body: when minimumReleaseAge needs the
+    // per-version `time` an abbreviated document omits, upgrade to full
+    // metadata; then filter, persist to the mirror, and cache it.
+    const persistFreshMeta = async (fetched: FetchMetadataResult): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> => {
+      let meta = fetched.meta
+      let resultToSave: FetchMetadataResult = fetched
 
-      // When minimumReleaseAge is active and we fetched abbreviated metadata,
-      // check if the package was recently modified and needs full metadata
-      // for per-version time-based filtering.
-      //
       // This two-step approach is intentional: abbreviated metadata is much smaller,
       // and most packages won't have been modified recently enough to need the full
       // document. We only upgrade to full metadata when the package's modification
@@ -516,6 +486,43 @@ export async function pickPackage (
         meta,
         pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
       }
+    }
+
+    try {
+      // Load only the cache headers (etag, modified) for conditional request headers.
+      // This avoids reading and parsing the full metadata file (which can be megabytes)
+      // when the registry returns 200 and the old metadata would be discarded anyway.
+      const cacheHeaders = metaCachedInStore != null
+        ? { etag: metaCachedInStore.etag, modified: metaCachedInStore.modified ?? metaCachedInStore.time?.modified }
+        : await limit(async () => loadMetaHeaders(pkgMirror))
+      const conditional = await ctx.fetch(spec.name, {
+        authHeaderValue: opts.authHeaderValue,
+        fullMetadata,
+        etag: cacheHeaders?.etag,
+        modified: cacheHeaders?.modified,
+        registry: opts.registry,
+      })
+      // 200 — the registry sent a fresh body; persist and return it. `await`
+      // keeps a persist-path failure inside this try's cached-meta fallback.
+      if (!conditional.notModified) return await persistFreshMeta(conditional)
+
+      // 304 Not Modified — the registry confirmed the mirror is still fresh, so
+      // serve the body it vouched for.
+      metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
+      if (metaCachedInStore != null) return await serveValidatedMeta(metaCachedInStore)
+
+      // The mirror vanished between the headers read and this read (concurrent
+      // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask
+      // again as a cold cache would, which the registry can only answer with a
+      // body or an error — never another 304.
+      const refetched = await ctx.fetch(spec.name, {
+        authHeaderValue: opts.authHeaderValue,
+        cacheBypass: true,
+        fullMetadata,
+        registry: opts.registry,
+      })
+      if (refetched.notModified) throw notModifiedWithoutCacheError(spec.name)
+      return await persistFreshMeta(refetched)
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
       const meta = await loadMeta(pkgMirror) // TODO: add test for this usecase

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -379,10 +379,57 @@ export async function pickPackage (
       }
     }
 
+    try {
+      // Load only the cache headers (etag, modified) for conditional request headers.
+      // This avoids reading and parsing the full metadata file (which can be megabytes)
+      // when the registry returns 200 and the old metadata would be discarded anyway.
+      const cacheHeaders = metaCachedInStore != null
+        ? { etag: metaCachedInStore.etag, modified: metaCachedInStore.modified ?? metaCachedInStore.time?.modified }
+        : await limit(async () => loadMetaHeaders(pkgMirror))
+      const conditional = await ctx.fetch(spec.name, {
+        authHeaderValue: opts.authHeaderValue,
+        fullMetadata,
+        etag: cacheHeaders?.etag,
+        modified: cacheHeaders?.modified,
+        registry: opts.registry,
+      })
+      // 200 — the registry sent a fresh body; persist and return it. `await`
+      // keeps a persist-path failure inside this try's cached-meta fallback.
+      if (!conditional.notModified) return await persistFreshMeta(conditional)
+
+      // 304 Not Modified — the registry confirmed the mirror is still fresh, so
+      // serve the body it vouched for.
+      metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
+      if (metaCachedInStore != null) return await serveValidatedMeta(metaCachedInStore)
+
+      // The mirror vanished between the headers read and this read (concurrent
+      // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask
+      // again as a cold cache would, which the registry can only answer with a
+      // body or an error — never another 304.
+      const refetched = await ctx.fetch(spec.name, {
+        authHeaderValue: opts.authHeaderValue,
+        cacheBypass: true,
+        fullMetadata,
+        registry: opts.registry,
+      })
+      if (refetched.notModified) throw notModifiedWithoutCacheError(spec.name)
+      return await persistFreshMeta(refetched)
+    } catch (err: any) { // eslint-disable-line
+      err.spec = spec
+      const meta = await loadMeta(pkgMirror) // TODO: add test for this usecase
+      if (meta == null) throw err
+      logger.error(err, err)
+      logger.debug({ message: `Using cached meta from ${pkgMirror}` })
+      return {
+        meta,
+        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
+      }
+    }
+
     // A 304 whose cached body is still on disk: the registry vouched the
     // packument is current, so restart its validation clock, upgrade
     // abbreviated -> full when the maturity check needs `time`, and serve it.
-    const serveValidatedMeta = async (cached: PackageMeta): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> => {
+    async function serveValidatedMeta (cached: PackageMeta): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> {
       // The registry just vouched that the cached packument equals its current
       // one, so the validation clock restarts now: bump the mirror's mtime so
       // the publishedBy freshness shortcut above can fire again on the next
@@ -417,7 +464,7 @@ export async function pickPackage (
     // A freshly downloaded 200 body: when minimumReleaseAge needs the
     // per-version `time` an abbreviated document omits, upgrade to full
     // metadata; then filter, persist to the mirror, and cache it.
-    const persistFreshMeta = async (fetched: FetchMetadataResult): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> => {
+    async function persistFreshMeta (fetched: FetchMetadataResult): Promise<{ meta: PackageMeta, pickedPackage: PackageInRegistry | null }> {
       let meta = fetched.meta
       let resultToSave: FetchMetadataResult = fetched
 
@@ -482,53 +529,6 @@ export async function pickPackage (
       meta.etag = resultToSave.etag
       // only save meta to cache, when it is fresh
       ctx.metaCache.set(cacheKey, meta)
-      return {
-        meta,
-        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
-      }
-    }
-
-    try {
-      // Load only the cache headers (etag, modified) for conditional request headers.
-      // This avoids reading and parsing the full metadata file (which can be megabytes)
-      // when the registry returns 200 and the old metadata would be discarded anyway.
-      const cacheHeaders = metaCachedInStore != null
-        ? { etag: metaCachedInStore.etag, modified: metaCachedInStore.modified ?? metaCachedInStore.time?.modified }
-        : await limit(async () => loadMetaHeaders(pkgMirror))
-      const conditional = await ctx.fetch(spec.name, {
-        authHeaderValue: opts.authHeaderValue,
-        fullMetadata,
-        etag: cacheHeaders?.etag,
-        modified: cacheHeaders?.modified,
-        registry: opts.registry,
-      })
-      // 200 — the registry sent a fresh body; persist and return it. `await`
-      // keeps a persist-path failure inside this try's cached-meta fallback.
-      if (!conditional.notModified) return await persistFreshMeta(conditional)
-
-      // 304 Not Modified — the registry confirmed the mirror is still fresh, so
-      // serve the body it vouched for.
-      metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
-      if (metaCachedInStore != null) return await serveValidatedMeta(metaCachedInStore)
-
-      // The mirror vanished between the headers read and this read (concurrent
-      // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask
-      // again as a cold cache would, which the registry can only answer with a
-      // body or an error — never another 304.
-      const refetched = await ctx.fetch(spec.name, {
-        authHeaderValue: opts.authHeaderValue,
-        cacheBypass: true,
-        fullMetadata,
-        registry: opts.registry,
-      })
-      if (refetched.notModified) throw notModifiedWithoutCacheError(spec.name)
-      return await persistFreshMeta(refetched)
-    } catch (err: any) { // eslint-disable-line
-      err.spec = spec
-      const meta = await loadMeta(pkgMirror) // TODO: add test for this usecase
-      if (meta == null) throw err
-      logger.error(err, err)
-      logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
         pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -393,12 +393,11 @@ export async function pickPackage (
         modified: cacheHeaders?.modified,
         registry: opts.registry,
       })
-      // 200 — the registry sent a fresh body; persist and return it. `await`
-      // keeps a persist-path failure inside this try's cached-meta fallback.
+      // `return await` (not `return`) so a failure inside persistFreshMeta lands
+      // in this try's cached-meta fallback instead of escaping it.
       if (!conditional.notModified) return await persistFreshMeta(conditional)
 
-      // 304 Not Modified — the registry confirmed the mirror is still fresh, so
-      // serve the body it vouched for.
+      // 304: the cached mirror is still current.
       metaCachedInStore = metaCachedInStore ?? await limit(async () => loadMeta(pkgMirror))
       if (metaCachedInStore != null) return await serveValidatedMeta(metaCachedInStore)
 

--- a/pnpm11/resolving/npm-resolver/test/ifModifiedSince.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/ifModifiedSince.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { afterEach, beforeEach, expect, test } from '@jest/globals'
-import { ABBREVIATED_META_DIR } from '@pnpm/constants'
+import { ABBREVIATED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
 import { createFetchFromRegistry } from '@pnpm/network.fetch'
 import { createNpmResolver } from '@pnpm/resolving.npm-resolver'
 import { fixtures } from '@pnpm/test-fixtures'
@@ -10,6 +10,11 @@ import type { Registries } from '@pnpm/types'
 import { loadJsonFileSync } from 'load-json-file'
 import { temporaryDirectory } from 'tempy'
 
+import {
+  fetchAbbreviatedMetadataCached,
+  fetchFullMetadataCached,
+} from '../src/fetchFullMetadataCached.js'
+import { getPkgMirrorPath, prepareJsonForDisk, saveMeta } from '../src/pickPackage.js'
 import { getMockAgent, retryLoadJsonFile, setupMockAgent, teardownMockAgent } from './utils/index.js'
 
 const f = fixtures(import.meta.dirname)
@@ -25,6 +30,29 @@ const isPositiveMeta = loadJsonFileSync<any>(f.find('is-positive.json'))
 const fetch = createFetchFromRegistry({})
 const getAuthHeader = () => undefined
 const createResolveFromNpm = createNpmResolver.bind(null, fetch, getAuthHeader)
+
+type CachedMetadataFetcher = typeof fetchFullMetadataCached
+type CachedMetadata = Awaited<ReturnType<CachedMetadataFetcher>>
+
+const cachedMetadataCases = [
+  {
+    fetchMetadata: fetchFullMetadataCached,
+    kind: 'full',
+    metaDir: FULL_META_DIR,
+    stripsScripts: false,
+  },
+  {
+    fetchMetadata: fetchAbbreviatedMetadataCached,
+    kind: 'abbreviated',
+    metaDir: ABBREVIATED_META_DIR,
+    stripsScripts: true,
+  },
+] satisfies ReadonlyArray<{
+  fetchMetadata: CachedMetadataFetcher
+  kind: 'full' | 'abbreviated'
+  metaDir: string
+  stripsScripts: boolean
+}>
 
 afterEach(async () => {
   await teardownMockAgent()
@@ -228,3 +256,187 @@ test('report an invalid response when an unconditional 304 retry also returns 30
     message: 'Registry returned 304 for is-positive without an existing cache to refresh.',
   })
 })
+
+test.each(cachedMetadataCases)('cached $kind metadata retries once without validators when the body disappears after 304', async ({
+  fetchMetadata,
+  metaDir,
+  stripsScripts,
+}) => {
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, metaDir, registries.default, 'is-positive')
+  await saveMeta(pkgMirror, prepareJsonForDisk(isPositiveMeta, '"stale"'))
+  const responseMeta = structuredClone(isPositiveMeta)
+  responseMeta.versions['3.1.0'].scripts = { postinstall: 'echo cache-race-marker' }
+
+  const registry = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: { 'if-none-match': '"stale"' },
+    })
+    .reply(() => {
+      fs.rmSync(pkgMirror)
+      return { statusCode: 304, data: '' }
+    })
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: matchCacheBypassHeaders,
+    })
+    .reply(200, responseMeta, {
+      headers: {
+        etag: '"fresh"',
+        'content-type': 'application/json',
+      },
+    })
+
+  const result = await fetchMetadata({
+    fetch,
+    retry: { retries: 0 },
+    timeout: 30_000,
+    fetchWarnTimeoutMs: 30_000,
+  }, 'is-positive', {
+    cacheDir,
+    registry: registries.default,
+  })
+
+  expect(result.name).toBe('is-positive')
+  expect(result.versions['3.1.0'].scripts == null).toBe(stripsScripts)
+  const persisted = await retryLoadJsonFile<CachedMetadata>(pkgMirror)
+  expect(persisted.etag).toBe('"fresh"')
+  expect(persisted.name).toBe('is-positive')
+  expect(persisted.versions['3.1.0'].scripts == null).toBe(stripsScripts)
+  getMockAgent().assertNoPendingInterceptors()
+})
+
+test('cached metadata stops after one cache-loss fallback', async () => {
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, FULL_META_DIR, registries.default, 'is-positive')
+  await saveMeta(pkgMirror, prepareJsonForDisk(isPositiveMeta, '"stale"'))
+
+  const registry = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: { 'if-none-match': '"stale"' },
+    })
+    .reply(() => {
+      fs.rmSync(pkgMirror)
+      return { statusCode: 304, data: '' }
+    })
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: matchCacheBypassHeaders,
+    })
+    .reply(304, '')
+
+  await expect(fetchFullMetadataCached({
+    fetch,
+    retry: { retries: 0 },
+    timeout: 30_000,
+    fetchWarnTimeoutMs: 30_000,
+  }, 'is-positive', {
+    cacheDir,
+    registry: registries.default,
+  })).rejects.toMatchObject({ code: 'ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE' })
+  getMockAgent().assertNoPendingInterceptors()
+})
+
+test('cached metadata keeps body retries in cache-bypass mode', async () => {
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, FULL_META_DIR, registries.default, 'is-positive')
+  await saveMeta(pkgMirror, prepareJsonForDisk(isPositiveMeta, '"stale"'))
+
+  const registry = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: { 'if-none-match': '"stale"' },
+    })
+    .reply(() => {
+      fs.rmSync(pkgMirror)
+      return { statusCode: 304, data: '' }
+    })
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: matchCacheBypassHeaders,
+    })
+    .reply(200, '{')
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: matchCacheBypassHeaders,
+    })
+    .reply(200, isPositiveMeta, {
+      headers: { etag: '"after-retry"' },
+    })
+
+  const result = await fetchFullMetadataCached({
+    fetch,
+    retry: { retries: 1, factor: 1, minTimeout: 1, maxTimeout: 1 },
+    timeout: 30_000,
+    fetchWarnTimeoutMs: 30_000,
+  }, 'is-positive', {
+    cacheDir,
+    registry: registries.default,
+  })
+
+  expect(result.name).toBe('is-positive')
+  getMockAgent().assertNoPendingInterceptors()
+  const persisted = await retryLoadJsonFile<CachedMetadata>(pkgMirror)
+  expect(persisted.etag).toBe('"after-retry"')
+})
+
+test('cached metadata propagates a cache-loss fallback registry error', async () => {
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, FULL_META_DIR, registries.default, 'is-positive')
+  await saveMeta(pkgMirror, prepareJsonForDisk(isPositiveMeta, '"stale"'))
+
+  const registry = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: { 'if-none-match': '"stale"' },
+    })
+    .reply(() => {
+      fs.rmSync(pkgMirror)
+      return { statusCode: 304, data: '' }
+    })
+  registry
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: matchCacheBypassHeaders,
+    })
+    .reply(403, '')
+
+  await expect(fetchFullMetadataCached({
+    fetch,
+    retry: { retries: 0 },
+    timeout: 30_000,
+    fetchWarnTimeoutMs: 30_000,
+  }, 'is-positive', {
+    cacheDir,
+    registry: registries.default,
+  })).rejects.toMatchObject({
+    code: 'ERR_PNPM_FETCH_403',
+    response: { status: 403 },
+  })
+  getMockAgent().assertNoPendingInterceptors()
+})
+
+function matchCacheBypassHeaders (headers: Record<string, string>): boolean {
+  return headers['if-none-match'] === undefined &&
+    headers['if-modified-since'] === undefined &&
+    headers['cache-control'] === 'no-cache'
+}

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -279,3 +279,117 @@ test('a disk-promoted cache entry that cannot satisfy the spec falls back to the
   expect(second.pickedPackage?.version).toBe('2.0.0')
   expect(fetchedNames).toEqual(['foo'])
 })
+
+test('pickPackage retries once without validators when a 304 loses its cache body', async () => {
+  const meta = fooMeta()
+  meta.versions['1.0.0'].scripts = { postinstall: 'echo cache-race-marker' }
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, '"stale"'))
+
+  type CacheBypassFetchMetadataOptions = FetchMetadataOptions & { cacheBypass?: boolean }
+  const fetchCalls: CacheBypassFetchMetadataOptions[] = []
+  const ctx = {
+    fetch: async (_pkgName: string, opts: FetchMetadataOptions) => {
+      fetchCalls.push(opts)
+      if (fetchCalls.length === 1) {
+        rmSync(pkgMirror)
+        return { notModified: true as const }
+      }
+      return { meta, jsonText: JSON.stringify(meta), etag: '"fresh"' }
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+    filterMetadata: true,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+
+  const result = await pickPackage(ctx, spec, {
+    registry: REGISTRY,
+    dryRun: false,
+    preferredVersionSelectors: undefined,
+  })
+
+  expect(result.pickedPackage?.version).toBe('1.0.0')
+  expect(fetchCalls).toHaveLength(2)
+  expect(fetchCalls[0]).toMatchObject({ etag: '"stale"' })
+  expect(fetchCalls[1]).toMatchObject({ cacheBypass: true })
+  expect(fetchCalls[1].etag).toBeUndefined()
+  expect(fetchCalls[1].modified).toBeUndefined()
+  expect(result.meta.etag).toBe('"fresh"')
+  expect(result.meta.versions['1.0.0'].scripts).toBeUndefined()
+  expect(ctx.metaCache.get(getPkgMetaCacheKey(REGISTRY, 'foo', false, true))).toBe(result.meta)
+
+  const mirror = await readMirrorWithRetry(pkgMirror, 100)
+  expect(mirror).toBeDefined()
+  if (mirror == null) throw new Error('fresh mirror was not persisted')
+  const newlineIdx = mirror.indexOf('\n')
+  const persistedHeaders = JSON.parse(mirror.slice(0, newlineIdx))
+  const persistedMeta = JSON.parse(mirror.slice(newlineIdx + 1))
+  expect(persistedHeaders.etag).toBe('"fresh"')
+  expect(persistedMeta.versions['1.0.0'].scripts).toBeUndefined()
+})
+
+test('pickPackage stops after one cache-loss fallback', async () => {
+  const meta = fooMeta()
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, '"stale"'))
+
+  type CacheBypassFetchMetadataOptions = FetchMetadataOptions & { cacheBypass?: boolean }
+  const fetchCalls: CacheBypassFetchMetadataOptions[] = []
+  const ctx = {
+    fetch: async (_pkgName: string, opts: FetchMetadataOptions) => {
+      fetchCalls.push(opts)
+      if (fetchCalls.length === 1) rmSync(pkgMirror)
+      return { notModified: true as const }
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+
+  await expect(pickPackage(ctx, spec, {
+    registry: REGISTRY,
+    dryRun: false,
+    preferredVersionSelectors: undefined,
+  })).rejects.toMatchObject({ code: 'ERR_PNPM_META_NOT_MODIFIED_WITHOUT_CACHE' })
+  expect(fetchCalls).toHaveLength(2)
+  expect(fetchCalls[1]).toMatchObject({ cacheBypass: true })
+  expect(fetchCalls[1].etag).toBeUndefined()
+  expect(fetchCalls[1].modified).toBeUndefined()
+})
+
+test('pickPackage propagates a cache-loss fallback error', async () => {
+  const meta = fooMeta()
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, '"stale"'))
+
+  type CacheBypassFetchMetadataOptions = FetchMetadataOptions & { cacheBypass?: boolean }
+  const fetchCalls: CacheBypassFetchMetadataOptions[] = []
+  const fallbackError = new Error('fallback failed')
+  const ctx = {
+    fetch: async (_pkgName: string, opts: FetchMetadataOptions) => {
+      fetchCalls.push(opts)
+      if (fetchCalls.length === 1) {
+        rmSync(pkgMirror)
+        return { notModified: true as const }
+      }
+      throw fallbackError
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+
+  await expect(pickPackage(ctx, spec, {
+    registry: REGISTRY,
+    dryRun: false,
+    preferredVersionSelectors: undefined,
+  })).rejects.toBe(fallbackError)
+  expect(fetchCalls).toHaveLength(2)
+  expect(fetchCalls[1]).toMatchObject({ cacheBypass: true })
+  expect(fetchCalls[1].etag).toBeUndefined()
+  expect(fetchCalls[1].modified).toBeUndefined()
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Recover when a registry responds with `304 Not Modified` after the corresponding metadata cache entry has disappeared.

Both the TypeScript resolver and pacquet now retry the request once without cache validators, then reuse their existing metadata normalization and persistence paths. The retry remains bounded and does not recursively fall back to stale app metadata.

Regression tests cover the picker path, the cached full-metadata helper, the absence of conditional headers on the retry, and preservation of the bypass state across Rust body and decoding retries.

## Squash Commit Body

```text
Treat a 304 response without a matching metadata cache entry as a recoverable cache race. Retry the registry request once without conditional validators and feed the fresh response through the normal cache persistence path.

Implement the same bounded recovery in the TypeScript resolver and pacquet, including Rust retries that occur while reading or decoding the response body. Add regression coverage for both resolver implementations.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786687953&installation_id=145934176&pr_number=13014&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13014&signature=e4985a467d2e5dbd52dd3f826832ac9ae63ee60b1231fe9d21132c63e56e8574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when cached package metadata disappears after the registry returns “not modified” (304), preventing resolver failures.
  - Added a controlled fallback that retries metadata once in cache-bypass mode (no conditional validators) when the cached mirror body can’t be loaded.
  - Ensures refreshed metadata is saved back to the mirror with updated headers, covering both full and abbreviated cache formats.
  - Propagates registry/network errors and stops after the single intended fallback when recovery isn’t possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->