### PR TITLE
fix(pnpr): shut down cleanly on SIGTERM

### DIFF
--- a/.changeset/pnpr-sigterm-shutdown.md
+++ b/.changeset/pnpr-sigterm-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+Handled SIGTERM as a graceful pnpr shutdown signal on Unix.

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -613,7 +613,22 @@ impl Connected<IncomingStream<'_, NodelayTcpListener>> for PeerAddr {
 }
 
 async fn shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+
+        let mut terminate = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = terminate.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+
     tracing::info!("shutdown signal received");
 }
 

--- a/pnpr/crates/pnpr/tests/shutdown.rs
+++ b/pnpr/crates/pnpr/tests/shutdown.rs
@@ -147,7 +147,7 @@ fn spawn_ready_pnpr(root: &Path) -> ChildGuard {
         }
     }
     panic!(
-        "pnpr exited before serving /-/ping on {SPAWN_ATTEMPTS} fresh ports; last exit: {last_exit:?}"
+        "pnpr exited before serving /-/ping on {SPAWN_ATTEMPTS} fresh ports; last exit: {last_exit:?}",
     );
 }
 

--- a/pnpr/crates/pnpr/tests/shutdown.rs
+++ b/pnpr/crates/pnpr/tests/shutdown.rs
@@ -1,0 +1,153 @@
+#![cfg(unix)]
+
+use std::{
+    io::{Read as _, Write as _},
+    net::{SocketAddr, TcpListener, TcpStream},
+    process::{Child, Command, ExitStatus, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+use tempfile::TempDir;
+
+const PROCESS_TIMEOUT: Duration = Duration::from_secs(5);
+const POLL_INTERVAL: Duration = Duration::from_millis(20);
+const IO_SLICE: Duration = Duration::from_millis(250);
+
+struct ChildGuard(Option<Child>);
+
+impl ChildGuard {
+    fn child_mut(&mut self) -> &mut Child {
+        self.0.as_mut().expect("child guard is armed")
+    }
+
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn remaining(deadline: Instant) -> Option<Duration> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    (!remaining.is_zero()).then_some(remaining)
+}
+
+fn responds_to_ping(addr: SocketAddr, deadline: Instant) -> bool {
+    let Some(timeout) = remaining(deadline) else {
+        return false;
+    };
+    let Ok(mut stream) = TcpStream::connect_timeout(&addr, timeout.min(IO_SLICE)) else {
+        return false;
+    };
+
+    let Some(timeout) = remaining(deadline) else {
+        return false;
+    };
+    if stream.set_write_timeout(Some(timeout.min(IO_SLICE))).is_err()
+        || stream
+            .write_all(b"GET /-/ping HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .is_err()
+    {
+        return false;
+    }
+
+    let mut response = Vec::new();
+    loop {
+        let Some(timeout) = remaining(deadline) else {
+            return false;
+        };
+        if stream.set_read_timeout(Some(timeout.min(IO_SLICE))).is_err() {
+            return false;
+        }
+        let mut chunk = [0_u8; 512];
+        let read = match stream.read(&mut chunk) {
+            Ok(0) | Err(_) => return false,
+            Ok(read) => read,
+        };
+        response.extend_from_slice(&chunk[..read]);
+        if response.windows(2).any(|window| window == b"\r\n") {
+            return response.starts_with(b"HTTP/1.1 200 ");
+        }
+        if response.len() > 4096 {
+            return false;
+        }
+    }
+}
+
+fn wait_until_ready(child: &mut ChildGuard, addr: SocketAddr) {
+    let deadline = Instant::now() + PROCESS_TIMEOUT;
+    loop {
+        if let Some(status) = child.child_mut().try_wait().expect("poll pnpr readiness") {
+            child.disarm();
+            panic!("pnpr exited before serving /-/ping: {status}");
+        }
+        if responds_to_ping(addr, deadline) {
+            return;
+        }
+        let Some(remaining) = remaining(deadline) else {
+            panic!("pnpr did not serve /-/ping within {PROCESS_TIMEOUT:?}");
+        };
+        thread::sleep(remaining.min(POLL_INTERVAL));
+    }
+}
+
+fn wait_for_exit(child: &mut ChildGuard) -> ExitStatus {
+    let deadline = Instant::now() + PROCESS_TIMEOUT;
+    loop {
+        if let Some(status) = child.child_mut().try_wait().expect("poll pnpr shutdown") {
+            return status;
+        }
+        let Some(remaining) = remaining(deadline) else {
+            panic!("pnpr did not stop within {PROCESS_TIMEOUT:?}");
+        };
+        thread::sleep(remaining.min(POLL_INTERVAL));
+    }
+}
+
+#[test]
+fn sigterm_stops_server_gracefully() {
+    let root = TempDir::new().expect("create isolated pnpr root");
+    let storage = root.path().join("storage");
+    let home = root.path().join("home");
+    let xdg_config_home = root.path().join("xdg-config");
+    std::fs::create_dir_all(&storage).expect("create isolated storage");
+    std::fs::create_dir_all(&home).expect("create isolated home");
+    std::fs::create_dir_all(&xdg_config_home).expect("create isolated config home");
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("reserve loopback port");
+    let addr = listener.local_addr().expect("read reserved address");
+    drop(listener);
+
+    let child = Command::new(env!("CARGO_BIN_EXE_pnpr"))
+        .arg("--listen")
+        .arg(addr.to_string())
+        .arg("--storage")
+        .arg(&storage)
+        .current_dir(root.path())
+        .env("XDG_CONFIG_HOME", &xdg_config_home)
+        .env("HOME", &home)
+        .env("USERPROFILE", &home)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn pnpr");
+    let mut child = ChildGuard(Some(child));
+
+    wait_until_ready(&mut child, addr);
+    let pid = child.child_mut().id() as libc::pid_t;
+    // SAFETY: The PID belongs to the guarded, unreaped child, so the OS cannot recycle it before this call.
+    let result = unsafe { libc::kill(pid, libc::SIGTERM) };
+    assert_eq!(result, 0, "send SIGTERM: {}", std::io::Error::last_os_error());
+
+    let status = wait_for_exit(&mut child);
+    child.disarm();
+    assert!(status.success(), "pnpr exited unsuccessfully after SIGTERM: {status}");
+}

--- a/pnpr/crates/pnpr/tests/shutdown.rs
+++ b/pnpr/crates/pnpr/tests/shutdown.rs
@@ -3,6 +3,7 @@
 use std::{
     io::{Read as _, Write as _},
     net::{SocketAddr, TcpListener, TcpStream},
+    path::Path,
     process::{Child, Command, ExitStatus, Stdio},
     thread,
     time::{Duration, Instant},
@@ -12,6 +13,7 @@ use tempfile::TempDir;
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(5);
 const POLL_INTERVAL: Duration = Duration::from_millis(20);
 const IO_SLICE: Duration = Duration::from_millis(250);
+const SPAWN_ATTEMPTS: usize = 5;
 
 struct ChildGuard(Option<Child>);
 
@@ -81,21 +83,72 @@ fn responds_to_ping(addr: SocketAddr, deadline: Instant) -> bool {
     }
 }
 
-fn wait_until_ready(child: &mut ChildGuard, addr: SocketAddr) {
+enum Readiness {
+    Ready,
+    Exited(ExitStatus),
+}
+
+fn wait_until_ready(child: &mut ChildGuard, addr: SocketAddr) -> Readiness {
     let deadline = Instant::now() + PROCESS_TIMEOUT;
     loop {
         if let Some(status) = child.child_mut().try_wait().expect("poll pnpr readiness") {
             child.disarm();
-            panic!("pnpr exited before serving /-/ping: {status}");
+            return Readiness::Exited(status);
         }
         if responds_to_ping(addr, deadline) {
-            return;
+            return Readiness::Ready;
         }
         let Some(remaining) = remaining(deadline) else {
             panic!("pnpr did not serve /-/ping within {PROCESS_TIMEOUT:?}");
         };
         thread::sleep(remaining.min(POLL_INTERVAL));
     }
+}
+
+/// Reserving an ephemeral port and re-binding it from pnpr is inherently
+/// racy: between `drop(listener)` and pnpr's own bind, another process can
+/// claim the port. pnpr cannot advertise an OS-assigned address (`--listen
+/// 127.0.0.1:0` would also bake port 0 into `public_url`), so instead the
+/// reserve/spawn cycle retries on a fresh port whenever pnpr exits before
+/// becoming ready.
+fn spawn_ready_pnpr(root: &Path) -> ChildGuard {
+    let storage = root.join("storage");
+    let home = root.join("home");
+    let xdg_config_home = root.join("xdg-config");
+    std::fs::create_dir_all(&storage).expect("create isolated storage");
+    std::fs::create_dir_all(&home).expect("create isolated home");
+    std::fs::create_dir_all(&xdg_config_home).expect("create isolated config home");
+
+    let mut last_exit = None;
+    for _ in 0..SPAWN_ATTEMPTS {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("reserve loopback port");
+        let addr = listener.local_addr().expect("read reserved address");
+        drop(listener);
+
+        let child = Command::new(env!("CARGO_BIN_EXE_pnpr"))
+            .arg("--listen")
+            .arg(addr.to_string())
+            .arg("--storage")
+            .arg(&storage)
+            .current_dir(root)
+            .env("XDG_CONFIG_HOME", &xdg_config_home)
+            .env("HOME", &home)
+            .env("USERPROFILE", &home)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn pnpr");
+        let mut child = ChildGuard(Some(child));
+
+        match wait_until_ready(&mut child, addr) {
+            Readiness::Ready => return child,
+            Readiness::Exited(status) => last_exit = Some(status),
+        }
+    }
+    panic!(
+        "pnpr exited before serving /-/ping on {SPAWN_ATTEMPTS} fresh ports; last exit: {last_exit:?}"
+    );
 }
 
 fn wait_for_exit(child: &mut ChildGuard) -> ExitStatus {
@@ -114,34 +167,7 @@ fn wait_for_exit(child: &mut ChildGuard) -> ExitStatus {
 #[test]
 fn sigterm_stops_server_gracefully() {
     let root = TempDir::new().expect("create isolated pnpr root");
-    let storage = root.path().join("storage");
-    let home = root.path().join("home");
-    let xdg_config_home = root.path().join("xdg-config");
-    std::fs::create_dir_all(&storage).expect("create isolated storage");
-    std::fs::create_dir_all(&home).expect("create isolated home");
-    std::fs::create_dir_all(&xdg_config_home).expect("create isolated config home");
-
-    let listener = TcpListener::bind("127.0.0.1:0").expect("reserve loopback port");
-    let addr = listener.local_addr().expect("read reserved address");
-    drop(listener);
-
-    let child = Command::new(env!("CARGO_BIN_EXE_pnpr"))
-        .arg("--listen")
-        .arg(addr.to_string())
-        .arg("--storage")
-        .arg(&storage)
-        .current_dir(root.path())
-        .env("XDG_CONFIG_HOME", &xdg_config_home)
-        .env("HOME", &home)
-        .env("USERPROFILE", &home)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn pnpr");
-    let mut child = ChildGuard(Some(child));
-
-    wait_until_ready(&mut child, addr);
+    let mut child = spawn_ready_pnpr(root.path());
     let pid = child.child_mut().id() as libc::pid_t;
     // SAFETY: The PID belongs to the guarded, unreaped child, so the OS cannot recycle it before this call.
     let result = unsafe { libc::kill(pid, libc::SIGTERM) };


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

> [!IMPORTANT]
> This branch must incorporate pnpm/pnpm#13066 before this PR can merge. The intended sequence is to merge pnpm/pnpm#13066 into `main`, then rebase or update this branch onto the latest `main` so the zizmor security check runs with the shared fix.

Handle SIGTERM as a graceful pnpr shutdown signal on Unix, in addition to the existing Ctrl+C handling.

This lets process supervisors stop pnpr without terminating it by signal. The new integration test starts the real pnpr binary, waits until it serves `/-/ping`, sends SIGTERM, and verifies that it exits successfully.

## Squash Commit Body

```text
Listen for SIGTERM alongside Ctrl+C on Unix so process supervisors can trigger pnpr's graceful shutdown path. Keep the existing Ctrl+C behavior on non-Unix platforms.

Cover the behavior with an integration test that starts the pnpr binary, confirms it is serving requests, sends SIGTERM, and asserts a successful exit status.
```

## Checklist

- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786687982&installation_id=145934176&pr_number=13015&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13015&signature=83265d063d2002a5bce2719e1c3a11dea6b7da657f181f8fe1559b7b2c331bdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On Unix systems, pnpr now shuts down gracefully when receiving `SIGTERM`.
  * Ctrl-C shutdown behavior remains supported.

* **Bug Fixes**
  * Improved termination handling to ensure pnpr exits cleanly in response to system signals.

* **Tests**
  * Added a Unix-only integration test to verify graceful `SIGTERM` shutdown, including process cleanup and readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->