### PR TITLE
fix(pnpr): preserve workspace project metadata

### DIFF
--- a/.changeset/pnpr-workspace-identity.md
+++ b/.changeset/pnpr-workspace-identity.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/pnpr.client": patch
+"pnpm": patch
+"@pnpm/pnpr": patch
+---
+
+Fixed pnpr workspace resolution to preserve project names and versions for `workspace:` dependencies.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10071,6 +10071,9 @@ importers:
         specifier: workspace:*
         version: link:../../pnpm11/lockfile/types
     devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.4.1
       '@pnpm/pnpr.client':
         specifier: workspace:*
         version: 'link:'

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2675,6 +2675,8 @@ async function installViaPnprServer (
     const projectsList = allInstallProjects && allInstallProjects.length > 1
       ? allInstallProjects.map(p => ({
         dir: (path.relative(lockfileDir, p.rootDir) || '.').split(path.sep).join('/'),
+        name: p.manifest.name,
+        version: p.manifest.version,
         dependencies: p.manifest.dependencies,
         devDependencies: p.manifest.devDependencies,
         optionalDependencies: p.manifest.optionalDependencies,
@@ -2683,6 +2685,8 @@ async function installViaPnprServer (
 
     const { lockfile, stats: pnprStats } = await resolveViaPnprServer({
       registryUrl: opts.pnprServer!,
+      name: projectsList ? undefined : manifest.name,
+      version: projectsList ? undefined : manifest.version,
       dependencies: projectsList ? undefined : manifest.dependencies,
       devDependencies: projectsList ? undefined : manifest.devDependencies,
       optionalDependencies: projectsList ? undefined : manifest.optionalDependencies,

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -1,0 +1,128 @@
+import path from 'node:path'
+
+import { afterEach, expect, jest, test } from '@jest/globals'
+import type { MutateModulesOptions, ProjectOptions } from '@pnpm/installing.deps-installer'
+import type { ResolveViaPnprServerOptions, ResolveViaPnprServerResult } from '@pnpm/pnpr.client'
+import { prepareEmpty, preparePackages } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { ProjectManifest, ProjectRootDir } from '@pnpm/types'
+
+import { testDefaults } from '../utils/index.js'
+
+const originalCwd = process.cwd()
+const storeControllers: StoreController[] = []
+const resolveViaPnprServer = jest.fn(async (
+  options: ResolveViaPnprServerOptions
+): Promise<ResolveViaPnprServerResult> => {
+  const importerDirs = options.projects?.map(({ dir }) => dir) ?? ['.']
+  return {
+    lockfile: {
+      lockfileVersion: '9.0',
+      importers: Object.fromEntries(importerDirs.map((dir) => [dir, { specifiers: {} }])),
+      packages: {},
+    },
+    stats: { totalPackages: 0 },
+  }
+})
+
+jest.unstable_mockModule('@pnpm/pnpr.client', () => ({ resolveViaPnprServer }))
+
+const { install, mutateModules } = await import('@pnpm/installing.deps-installer')
+
+afterEach(async () => {
+  try {
+    await Promise.all(storeControllers.splice(0).map(async (storeController) => storeController.close()))
+    resolveViaPnprServer.mockClear()
+  } finally {
+    process.chdir(originalCwd)
+  }
+})
+
+test("pnpr forwards a single project's name and version", async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir)
+
+  await install(manifest, options)
+
+  expect(resolveViaPnprServer).toHaveBeenCalledTimes(1)
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    name: 'app',
+    version: '1.2.3',
+    dependencies: undefined,
+    devDependencies: undefined,
+    optionalDependencies: undefined,
+    projects: undefined,
+  }))
+})
+
+test("pnpr forwards every workspace project's name and version", async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const appManifest: ProjectManifest = {
+    name: 'app',
+    version: '1.0.0',
+    dependencies: { lib: 'workspace:*' },
+  }
+  const libManifest: ProjectManifest = { name: 'lib', version: '2.0.0' }
+  preparePackages([
+    { location: 'packages/app', package: appManifest },
+    { location: 'packages/lib', package: libManifest },
+  ], { tempDir: path.join(workspaceRoot, '.fixture-anchor') })
+
+  const appRootDir = path.join(workspaceRoot, 'packages/app') as ProjectRootDir
+  const libRootDir = path.join(workspaceRoot, 'packages/lib') as ProjectRootDir
+  const allProjects = [
+    { buildIndex: 0, manifest: appManifest, rootDir: appRootDir },
+    { buildIndex: 0, manifest: libManifest, rootDir: libRootDir },
+  ] satisfies ProjectOptions[]
+  const options = createOptions(workspaceRoot, appRootDir, { allProjects })
+
+  await mutateModules([
+    { mutation: 'install', rootDir: appRootDir },
+    { mutation: 'install', rootDir: libRootDir },
+  ], options)
+
+  expect(resolveViaPnprServer).toHaveBeenCalledTimes(1)
+  const projects = resolveViaPnprServer.mock.calls[0][0].projects
+  expect(projects).toStrictEqual([
+    {
+      dir: 'packages/app',
+      name: 'app',
+      version: '1.0.0',
+      dependencies: { lib: 'workspace:*' },
+      devDependencies: undefined,
+      optionalDependencies: undefined,
+    },
+    {
+      dir: 'packages/lib',
+      name: 'lib',
+      version: '2.0.0',
+      dependencies: undefined,
+      devDependencies: undefined,
+      optionalDependencies: undefined,
+    },
+  ])
+  for (const project of projects ?? []) {
+    expect(path.isAbsolute(project.dir)).toBe(false)
+    expect(project.dir).not.toContain('\\')
+  }
+})
+
+function createOptions (
+  workspaceRoot: string,
+  rootDir: ProjectRootDir,
+  overrides: Partial<MutateModulesOptions> = {}
+): MutateModulesOptions {
+  const options = testDefaults({
+    pnprServer: 'http://pnpr.test',
+    lockfileOnly: true,
+    dir: rootDir,
+    lockfileDir: workspaceRoot,
+    storeDir: path.join(workspaceRoot, '.store'),
+    cacheDir: path.join(workspaceRoot, '.cache'),
+    ...overrides,
+  })
+  storeControllers.push(options.storeController)
+  return options
+}

--- a/pnpr/client/package.json
+++ b/pnpr/client/package.json
@@ -25,8 +25,9 @@
   ],
   "scripts": {
     "start": "tsgo --watch",
-    "lint": "eslint \"src/**/*.ts\"",
-    "test": "pn compile",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "test": "pn compile && pn .test",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest",
     "prepublishOnly": "tsgo --build",
     "compile": "tsgo --build && pn lint --fix"
   },
@@ -35,6 +36,7 @@
     "@pnpm/lockfile.types": "workspace:*"
   },
   "devDependencies": {
+    "@jest/globals": "catalog:",
     "@pnpm/pnpr.client": "workspace:*",
     "@pnpm/types": "workspace:*"
   },

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -11,6 +11,8 @@ import type { ResponseMetadata } from './protocol.js'
 export interface PnprProject {
   /** Relative dir within the workspace (e.g. "." or "packages/foo") */
   dir: string
+  name?: string
+  version?: string
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
   optionalDependencies?: Record<string, string>
@@ -19,6 +21,10 @@ export interface PnprProject {
 export interface ResolveViaPnprServerOptions {
   /** URL of the pnpr server */
   registryUrl: string
+  /** Project name to resolve (single project) */
+  name?: string
+  /** Project version to resolve (single project) */
+  version?: string
   /** Dependencies to resolve (single project) */
   dependencies?: Record<string, string>
   /** Dev dependencies to resolve (single project) */
@@ -89,6 +95,8 @@ export async function resolveViaPnprServer (
 ): Promise<ResolveViaPnprServerResult> {
   const projects = opts.projects ?? [{
     dir: '.',
+    name: opts.name,
+    version: opts.version,
     dependencies: opts.dependencies,
     devDependencies: opts.devDependencies,
     optionalDependencies: opts.optionalDependencies,

--- a/pnpr/client/test/resolveViaPnprServer.test.ts
+++ b/pnpr/client/test/resolveViaPnprServer.test.ts
@@ -1,0 +1,96 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { expect, test } from '@jest/globals'
+import { resolveViaPnprServer, type ResolveViaPnprServerOptions } from '@pnpm/pnpr.client'
+
+interface CapturedResolveRequest {
+  projects: Array<Record<string, unknown>>
+}
+
+test('serializes name and version for the single-project compatibility options', async () => {
+  const options = {
+    name: 'app',
+    version: '1.2.3',
+    dependencies: {},
+  }
+
+  const request = await captureResolveRequest(options)
+
+  expect(request.projects).toEqual([{
+    dir: '.',
+    name: 'app',
+    version: '1.2.3',
+    dependencies: {},
+  }])
+})
+
+test('serializes name and version for every explicit project', async () => {
+  const projects = [
+    {
+      dir: 'packages/app',
+      name: 'app',
+      version: '1.0.0',
+      dependencies: { lib: 'workspace:*' },
+    },
+    {
+      dir: 'packages/lib',
+      name: 'lib',
+      version: '2.0.0',
+      dependencies: {},
+    },
+  ]
+
+  const request = await captureResolveRequest({ projects })
+
+  expect(request.projects).toEqual(projects)
+})
+
+test('omits absent identity fields instead of serializing null', async () => {
+  const request = await captureResolveRequest({ dependencies: {} })
+
+  expect(Object.hasOwn(request.projects[0], 'name')).toBe(false)
+  expect(Object.hasOwn(request.projects[0], 'version')).toBe(false)
+})
+
+async function captureResolveRequest (
+  options: Omit<ResolveViaPnprServerOptions, 'registryUrl'>
+): Promise<CapturedResolveRequest> {
+  let capturedRequest: CapturedResolveRequest | undefined
+  const server = http.createServer(async (request, response) => {
+    const chunks: Buffer[] = []
+    for await (const chunk of request) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+    capturedRequest = JSON.parse(Buffer.concat(chunks).toString('utf8')) as CapturedResolveRequest
+    response.end(`${JSON.stringify({
+      type: 'done',
+      lockfile: { lockfileVersion: '9.0', importers: { '.': {} } },
+      stats: { totalPackages: 0 },
+    })}\n`)
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  try {
+    const { port } = server.address() as AddressInfo
+    await resolveViaPnprServer({
+      ...options,
+      registryUrl: `http://127.0.0.1:${port}/`,
+    })
+    if (capturedRequest == null) {
+      throw new Error('The pnpr client did not send a resolve request')
+    }
+    return capturedRequest
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error == null ? resolve() : reject(error))
+    })
+  }
+}

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -719,6 +719,8 @@ fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Opt
         .map(|project| {
             serde_json::json!({
                 "dir": project.dir,
+                "name": project.name,
+                "version": project.version,
                 "dependencies": project.dependencies,
                 "devDependencies": project.dev_dependencies,
                 "optionalDependencies": project.optional_dependencies,

--- a/pnpr/crates/pnpr/src/resolver/protocol.rs
+++ b/pnpr/crates/pnpr/src/resolver/protocol.rs
@@ -16,6 +16,10 @@ pub struct ResolveRequestProject {
     #[serde(default = "root_dir")]
     pub dir: String,
     #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
     pub dependencies: DepMap,
     #[serde(default)]
     pub dev_dependencies: DepMap,
@@ -119,6 +123,8 @@ pub struct ResolveRequest {
 /// across the legacy single-project body and the `projects` array.
 pub struct ProjectDeps {
     pub dir: String,
+    pub name: Option<String>,
+    pub version: Option<String>,
     pub dependencies: DepMap,
     pub dev_dependencies: DepMap,
     pub optional_dependencies: DepMap,
@@ -135,6 +141,8 @@ impl ResolveRequest {
                 .iter()
                 .map(|project| ProjectDeps {
                     dir: project.dir.clone(),
+                    name: project.name.clone(),
+                    version: project.version.clone(),
                     dependencies: project.dependencies.clone(),
                     dev_dependencies: project.dev_dependencies.clone(),
                     optional_dependencies: project.optional_dependencies.clone(),
@@ -143,6 +151,8 @@ impl ResolveRequest {
         }
         vec![ProjectDeps {
             dir: root_dir(),
+            name: None,
+            version: None,
             dependencies: self.dependencies.clone().unwrap_or_default(),
             dev_dependencies: self.dev_dependencies.clone().unwrap_or_default(),
             optional_dependencies: self.optional_dependencies.clone().unwrap_or_default(),

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -89,9 +89,11 @@ pub async fn resolve(
             dir.join(rel)
         };
         tokio::fs::create_dir_all(&project_dir).await?;
+        let name = project.name.clone().unwrap_or_else(|| importer_manifest_name(rel));
+        let version = project.version.as_deref().unwrap_or("0.0.0");
         let manifest_json = serde_json::json!({
-            "name": importer_manifest_name(rel),
-            "version": "0.0.0",
+            "name": name,
+            "version": version,
             "dependencies": project.dependencies,
             "devDependencies": project.dev_dependencies,
             "optionalDependencies": project.optional_dependencies,
@@ -264,8 +266,8 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
     let temp = tempfile::Builder::new().prefix("pnpr-frozen-").tempdir().ok()?;
     let manifest_path = temp.path().join("package.json");
     let manifest_json = serde_json::json!({
-        "name": "pnpr-resolve",
-        "version": "0.0.0",
+        "name": project.name.as_deref().unwrap_or("pnpr-resolve"),
+        "version": project.version.as_deref().unwrap_or("0.0.0"),
         "dependencies": project.dependencies,
         "devDependencies": project.dev_dependencies,
         "optionalDependencies": project.optional_dependencies,

--- a/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
@@ -1,4 +1,10 @@
 use super::{importer_manifest_name, sanitized_importer_dir};
+use crate::resolver::protocol::ResolveRequest;
+use pacquet_config::Config;
+use pacquet_lockfile::{ImporterDepVersion, Lockfile, PkgName};
+use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_store_dir::StoreDir;
+use std::sync::Arc;
 
 #[test]
 fn root_and_trailing_slashes_normalize_to_dot() {
@@ -34,4 +40,149 @@ fn manifest_names_are_distinct_per_dir() {
     // `/` → `-` alone would collide these two; escaping `-` first keeps
     // the mapping injective.
     assert_ne!(importer_manifest_name("packages/foo"), importer_manifest_name("packages-foo"));
+}
+
+#[tokio::test]
+async fn workspace_star_uses_forwarded_project_name() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": "packages/app",
+                "name": "app",
+                "version": "1.0.0",
+                "dependencies": { "lib": "workspace:*" }
+            },
+            {
+                "dir": "packages/lib",
+                "name": "lib",
+                "version": "1.2.3"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
+}
+
+#[tokio::test]
+async fn workspace_range_uses_forwarded_project_version() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": "packages/app",
+                "name": "app",
+                "version": "1.0.0",
+                "dependencies": { "lib": "workspace:^1.0.0" }
+            },
+            {
+                "dir": "packages/lib",
+                "name": "lib",
+                "version": "1.2.3"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
+}
+
+#[tokio::test]
+async fn workspace_name_without_version_uses_default_version() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": "packages/app",
+                "name": "app",
+                "version": "1.0.0",
+                "dependencies": { "lib": "workspace:^0.0.0" }
+            },
+            {
+                "dir": "packages/lib",
+                "name": "lib"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
+}
+
+#[tokio::test]
+async fn workspace_version_without_name_uses_synthetic_name() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": ".",
+                "dependencies": {
+                    "pnpr-importer-packages-lib": "workspace:^1.0.0"
+                }
+            },
+            {
+                "dir": "packages/lib",
+                "version": "1.2.3"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, ".", "pnpr-importer-packages-lib", "packages/lib");
+}
+
+#[tokio::test]
+async fn legacy_projects_without_identity_use_synthetic_name_and_version() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": ".",
+                "dependencies": {
+                    "pnpr-importer-packages-lib": "workspace:^0.0.0"
+                }
+            },
+            {
+                "dir": "packages/lib"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, ".", "pnpr-importer-packages-lib", "packages/lib");
+}
+
+async fn resolve_json(request: serde_json::Value) -> Lockfile {
+    let temp = tempfile::tempdir().expect("create resolver test directory");
+    let mut config = Config::new();
+    config.offline = true;
+    config.enable_global_virtual_store = false;
+    config.store_dir = StoreDir::new(temp.path().join("store"));
+    config.cache_dir = temp.path().join("cache");
+    config.modules_dir = temp.path().join("node_modules");
+    config.virtual_store_dir = temp.path().join("node_modules/.pnpm");
+    let config = Box::leak(Box::new(config));
+    let request: ResolveRequest = serde_json::from_value(request).expect("resolve request parses");
+
+    super::resolve(
+        config,
+        &Arc::new(ThrottledClient::new_for_installs()),
+        &request,
+        &Arc::new(AuthHeaders::default()),
+        None,
+    )
+    .await
+    .expect("offline workspace resolution succeeds")
+}
+
+fn assert_workspace_link(lockfile: &Lockfile, importer: &str, alias: &str, expected_target: &str) {
+    let dependencies = lockfile
+        .importers
+        .get(importer)
+        .expect("importer exists")
+        .dependencies
+        .as_ref()
+        .expect("importer dependencies exist");
+    let alias = PkgName::parse(alias).expect("dependency alias parses");
+    let dependency = dependencies.get(&alias).expect("workspace dependency exists");
+    match &dependency.version {
+        ImporterDepVersion::Link(target) => assert_eq!(target, expected_target),
+        version => panic!("expected workspace link, got {version:?}"),
+    }
 }

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -186,6 +186,29 @@ fn resolution_cache_key_normalizes_single_project_requests() {
 }
 
 #[test]
+fn resolution_cache_key_changes_with_project_identity() {
+    let request = |name: &str, version: &str| {
+        serde_json::from_value::<ResolveRequest>(serde_json::json!({
+            "projects": [{
+                "dir": ".",
+                "name": name,
+                "version": version,
+                "dependencies": { "foo": "^1.0.0" }
+            }]
+        }))
+        .expect("resolve request parses")
+    };
+    let base = request("app", "1.0.0");
+    let renamed = request("renamed-app", "1.0.0");
+    let reversioned = request("app", "2.0.0");
+
+    let config = config();
+    let base_key = resolution_cache_key(&config, &base);
+    assert_ne!(base_key, resolution_cache_key(&config, &renamed));
+    assert_ne!(base_key, resolution_cache_key(&config, &reversioned));
+}
+
+#[test]
 fn resolution_cache_key_changes_with_dependencies_and_policy() {
     let base = ResolveRequest {
         dependencies: Some(deps(&[("foo", "^1.0.0")])),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

> [!IMPORTANT]
> This branch must incorporate pnpm/pnpm#13066 before this PR can merge. The intended sequence is to merge pnpm/pnpm#13066 into `main`, then rebase or update this branch onto the latest `main` so the zizmor security check runs with the shared fix.

Preserve workspace project names and versions when TypeScript pnpm delegates resolution to pnpr.

The TypeScript installer and pnpr client now include each project's identity in the resolve request. The Rust server uses that identity when building temporary manifests, frozen-lockfile input, and resolution cache keys, while retaining the existing synthetic fallbacks for older clients.

Regression tests cover the single-project and workspace request shapes, `workspace:` name/version matching, compatibility fallbacks, frozen resolution, and cache separation.

Pacquet does not yet support workspace installs, so it has no equivalent multi-project pnpr request to update in this PR. Its current single-project Rust pnpr client remains unchanged; workspace identity forwarding will need to be added when Pacquet workspace support lands.

## Squash Commit Body

```text
Forward project names and versions from the TypeScript installer through the pnpr protocol. Use the forwarded identity in temporary manifests, frozen-lockfile resolution, and cache keys so workspace protocol dependencies resolve against the real project metadata.

Keep backward-compatible synthetic name and version fallbacks for clients that omit the new optional fields. Add TypeScript and Rust regression coverage for request encoding, workspace matching, frozen resolution, and cache identity.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed workspace dependency resolution to preserve project names and versions.
  - Improved handling of `workspace:` dependencies across multi-project workspaces.
  - Prevented resolution cache collisions when projects differ by name or version.
  - Maintained compatibility for projects without identity metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->