### PR TITLE
fix(pnpr): honor lockfile options

### DIFF
--- a/.changeset/pnpr-lockfile-controls.md
+++ b/.changeset/pnpr-lockfile-controls.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/lockfile.fs": patch
+"@pnpm/pnpr.client": patch
+"pnpm": patch
+---
+
+Fixed installs through a pnpr server to preserve the on-disk lockfile shape and honor frozen-lockfile controls and configured lockfile read/write settings.

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2659,12 +2659,23 @@ async function installViaPnprServer (
   try {
     const lockfileDir = opts.lockfileDir ?? rootDir
 
-    // Read the existing lockfile (if any) in its on-disk shape — that's
-    // what the pnpr server protocol carries, so no conversion is needed before
-    // sending it.
-    const existingLockfile = await readWantedLockfileFile(lockfileDir, {
-      ignoreIncompatible: true,
-    }).catch(() => null)
+    const useLockfile = opts.useLockfile ?? true
+    const saveLockfile = opts.saveLockfile ?? true
+    const existingLockfile = useLockfile
+      ? await readWantedLockfileFile(lockfileDir, {
+        ignoreIncompatible: true,
+        useGitBranchLockfile: opts.useGitBranchLockfile,
+        mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+      }).catch(() => null)
+      : null
+    const hasNonEmptyLockfile = existingLockfile != null &&
+      Object.values(existingLockfile.importers ?? {}).some((importer) =>
+        !isEmpty(importer.dependencies ?? {}) ||
+        !isEmpty(importer.devDependencies ?? {}) ||
+        !isEmpty(importer.optionalDependencies ?? {})
+      )
+    const frozenLockfile = opts.frozenLockfile ||
+      (opts.frozenLockfileIfExists && hasNonEmptyLockfile)
 
     logger.info({ message: 'Resolving dependencies via the pnpr server', prefix: rootDir })
 
@@ -2697,16 +2708,22 @@ async function installViaPnprServer (
       overrides: opts.overrides,
       minimumReleaseAge: opts.minimumReleaseAge,
       lockfile: existingLockfile ?? undefined,
+      frozenLockfile,
+      preferFrozenLockfile: opts.preferFrozenLockfile,
+      ignoreManifestCheck: opts.ignorePackageManifest,
+      trustLockfile: opts.trustLockfile,
     })
 
-    await writeWantedLockfileAndRecordVerified({
-      lockfileDir,
-      lockfile,
-      cacheDir: opts.cacheDir,
-      resolutionVerifiers: opts.resolutionVerifiers,
-      useGitBranchLockfile: opts.useGitBranchLockfile,
-      mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
-    })
+    if (useLockfile && saveLockfile) {
+      await writeWantedLockfileAndRecordVerified({
+        lockfileDir,
+        lockfile,
+        cacheDir: opts.cacheDir,
+        resolutionVerifiers: opts.resolutionVerifiers,
+        useGitBranchLockfile: opts.useGitBranchLockfile,
+        mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+      })
+    }
 
     logger.info({
       message: `Resolved ${pnprStats.totalPackages} packages`,

--- a/pnpm11/installing/deps-installer/test/install/pnprClientLockfileOptions.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprClientLockfileOptions.ts
@@ -1,0 +1,61 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { expect, test } from '@jest/globals'
+import { resolveViaPnprServer } from '@pnpm/pnpr.client'
+
+test('pnpr client serializes lockfile controls under the exact wire names', async () => {
+  let requestBody: Record<string, unknown> | undefined
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => {
+      requestBody = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>
+      res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+      res.end(`${JSON.stringify({
+        type: 'done',
+        lockfile: {
+          lockfileVersion: '9.0',
+          importers: { '.': {} },
+          packages: {},
+          snapshots: {},
+        },
+        stats: { totalPackages: 0 },
+      })}\n`)
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+  try {
+    const { port } = server.address() as AddressInfo
+    await resolveViaPnprServer({
+      registryUrl: `http://127.0.0.1:${port}`,
+      frozenLockfile: false,
+      preferFrozenLockfile: false,
+      ignoreManifestCheck: true,
+      trustLockfile: true,
+    })
+  } finally {
+    server.closeAllConnections()
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err == null) resolve()
+        else reject(err)
+      })
+    })
+  }
+
+  const expectedControls = {
+    frozenLockfile: false,
+    preferFrozenLockfile: false,
+    ignoreManifestCheck: true,
+    trustLockfile: true,
+  }
+  expect(Object.fromEntries(
+    Object.keys(expectedControls).map((key) => [key, requestBody?.[key]])
+  )).toEqual(expectedControls)
+  expect(requestBody).not.toHaveProperty('frozen_lockfile')
+  expect(requestBody).not.toHaveProperty('prefer_frozen_lockfile')
+  expect(requestBody).not.toHaveProperty('ignore_manifest_check')
+  expect(requestBody).not.toHaveProperty('trust_lockfile')
+})

--- a/pnpm11/installing/deps-installer/test/install/pnprLockfileOptions.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprLockfileOptions.ts
@@ -1,4 +1,8 @@
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+
 import { beforeEach, expect, jest, test } from '@jest/globals'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
 import type { InstallOptions } from '@pnpm/installing.deps-installer'
 import type { LockfileFile, LockfileObject } from '@pnpm/lockfile.types'
 import type { ResolveViaPnprServerOptions, ResolveViaPnprServerResult } from '@pnpm/pnpr.client'
@@ -17,12 +21,12 @@ const minimalLockfile: LockfileObject = {
 
 const lockfileFs = await import('@pnpm/lockfile.fs')
 const readWantedLockfileFile = jest.fn<typeof lockfileFs.readWantedLockfileFile>()
-const writeWantedLockfile = jest.fn<typeof lockfileFs.writeWantedLockfile>()
 
+// The lockfile write stays real so tests can assert on the on-disk outcome
+// instead of counting calls to an implementation detail.
 jest.unstable_mockModule('@pnpm/lockfile.fs', () => ({
   ...lockfileFs,
   readWantedLockfileFile,
-  writeWantedLockfile,
 }))
 
 const resolveViaPnprServer = jest.fn<
@@ -38,8 +42,6 @@ const { install } = await import('@pnpm/installing.deps-installer')
 beforeEach(() => {
   readWantedLockfileFile.mockReset()
   readWantedLockfileFile.mockResolvedValue(null)
-  writeWantedLockfile.mockReset()
-  writeWantedLockfile.mockResolvedValue(minimalLockfile)
   resolveViaPnprServer.mockReset()
   resolveViaPnprServer.mockResolvedValue({
     lockfile: minimalLockfile,
@@ -151,15 +153,15 @@ test.each([
 })
 
 test.each([
-  { useLockfile: false, saveLockfile: false, expectedReads: 0, expectedWrites: 0 },
-  { useLockfile: false, saveLockfile: true, expectedReads: 0, expectedWrites: 0 },
-  { useLockfile: true, saveLockfile: false, expectedReads: 1, expectedWrites: 0 },
-  { useLockfile: true, saveLockfile: true, expectedReads: 1, expectedWrites: 1 },
+  { useLockfile: false, saveLockfile: false, expectedReads: 0, writesLockfile: false },
+  { useLockfile: false, saveLockfile: true, expectedReads: 0, writesLockfile: false },
+  { useLockfile: true, saveLockfile: false, expectedReads: 1, writesLockfile: false },
+  { useLockfile: true, saveLockfile: true, expectedReads: 1, writesLockfile: true },
 ])('pnpr honors lockfile I/O settings ($useLockfile, $saveLockfile)', async ({
   useLockfile,
   saveLockfile,
   expectedReads,
-  expectedWrites,
+  writesLockfile,
 }) => {
   const existingLockfile: LockfileFile = {
     lockfileVersion: '9.0',
@@ -170,7 +172,7 @@ test.each([
   await runInstall({ useLockfile, saveLockfile })
 
   expect(readWantedLockfileFile).toHaveBeenCalledTimes(expectedReads)
-  expect(writeWantedLockfile).toHaveBeenCalledTimes(expectedWrites)
+  expect(existsSync(path.join(process.cwd(), WANTED_LOCKFILE))).toBe(writesLockfile)
   expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
     lockfile: useLockfile ? existingLockfile : undefined,
   }))

--- a/pnpm11/installing/deps-installer/test/install/pnprLockfileOptions.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprLockfileOptions.ts
@@ -1,0 +1,193 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+import type { InstallOptions } from '@pnpm/installing.deps-installer'
+import type { LockfileFile, LockfileObject } from '@pnpm/lockfile.types'
+import type { ResolveViaPnprServerOptions, ResolveViaPnprServerResult } from '@pnpm/pnpr.client'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { ProjectId, ProjectManifest } from '@pnpm/types'
+
+import { testDefaults } from '../utils/index.js'
+
+const minimalLockfile: LockfileObject = {
+  lockfileVersion: '9.0',
+  importers: {
+    ['.' as ProjectId]: { specifiers: {} },
+  },
+  packages: {},
+}
+
+const lockfileFs = await import('@pnpm/lockfile.fs')
+const readWantedLockfileFile = jest.fn<typeof lockfileFs.readWantedLockfileFile>()
+const writeWantedLockfile = jest.fn<typeof lockfileFs.writeWantedLockfile>()
+
+jest.unstable_mockModule('@pnpm/lockfile.fs', () => ({
+  ...lockfileFs,
+  readWantedLockfileFile,
+  writeWantedLockfile,
+}))
+
+const resolveViaPnprServer = jest.fn<
+  (opts: ResolveViaPnprServerOptions) => Promise<ResolveViaPnprServerResult>
+>()
+
+jest.unstable_mockModule('@pnpm/pnpr.client', () => ({
+  resolveViaPnprServer,
+}))
+
+const { install } = await import('@pnpm/installing.deps-installer')
+
+beforeEach(() => {
+  readWantedLockfileFile.mockReset()
+  readWantedLockfileFile.mockResolvedValue(null)
+  writeWantedLockfile.mockReset()
+  writeWantedLockfile.mockResolvedValue(minimalLockfile)
+  resolveViaPnprServer.mockReset()
+  resolveViaPnprServer.mockResolvedValue({
+    lockfile: minimalLockfile,
+    stats: { totalPackages: 0 },
+  })
+})
+
+test('pnpr forwards frozenLockfile when the lockfile is missing', async () => {
+  await runInstall({ frozenLockfile: true })
+
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    frozenLockfile: true,
+    lockfile: undefined,
+  }))
+})
+
+test('pnpr derives frozenLockfileIfExists without additional mutation after reading', async () => {
+  const existingLockfile: LockfileFile = {
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        dependencies: {
+          foo: { specifier: '1.0.0', version: '1.0.0' },
+        },
+      },
+    },
+    packages: {
+      'foo@1.0.0': {
+        resolution: { integrity: 'sha512-test' },
+      },
+    },
+    snapshots: {
+      'foo@1.0.0': {},
+    },
+  }
+  const expectedLockfile = structuredClone(existingLockfile)
+  readWantedLockfileFile.mockResolvedValueOnce(existingLockfile)
+
+  await runInstall({
+    manifest: { dependencies: { foo: '2.0.0' } },
+    frozenLockfile: false,
+    frozenLockfileIfExists: true,
+  })
+
+  expect(existingLockfile).toStrictEqual(expectedLockfile)
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    frozenLockfile: true,
+    lockfile: expectedLockfile,
+  }))
+})
+
+test('pnpr does not freeze frozenLockfileIfExists when no lockfile exists', async () => {
+  await runInstall({ frozenLockfileIfExists: true })
+
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    frozenLockfile: false,
+    lockfile: undefined,
+  }))
+})
+
+test('pnpr does not freeze frozenLockfileIfExists for an empty lockfile', async () => {
+  const emptyLockfile: LockfileFile = {
+    lockfileVersion: '9.0',
+    importers: { '.': {} },
+  }
+  readWantedLockfileFile.mockResolvedValueOnce(emptyLockfile)
+
+  await runInstall({ frozenLockfileIfExists: true })
+
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    frozenLockfile: false,
+    lockfile: emptyLockfile,
+  }))
+})
+
+test('pnpr forwards preferFrozenLockfile false and lockfile verification controls', async () => {
+  await runInstall({
+    preferFrozenLockfile: false,
+    ignorePackageManifest: true,
+    trustLockfile: true,
+  })
+
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    preferFrozenLockfile: false,
+    ignoreManifestCheck: true,
+    trustLockfile: true,
+  }))
+})
+
+test.each([
+  { useGitBranchLockfile: true, mergeGitBranchLockfiles: false },
+  { useGitBranchLockfile: false, mergeGitBranchLockfiles: true },
+  { useGitBranchLockfile: true, mergeGitBranchLockfiles: true },
+])('pnpr forwards git-branch lockfile selection to the read ($useGitBranchLockfile, $mergeGitBranchLockfiles)', async ({
+  useGitBranchLockfile,
+  mergeGitBranchLockfiles,
+}) => {
+  await runInstall({
+    useGitBranchLockfile,
+    mergeGitBranchLockfiles,
+    saveLockfile: false,
+  })
+
+  expect(readWantedLockfileFile).toHaveBeenCalledWith(expect.any(String), {
+    ignoreIncompatible: true,
+    useGitBranchLockfile,
+    mergeGitBranchLockfiles,
+  })
+})
+
+test.each([
+  { useLockfile: false, saveLockfile: false, expectedReads: 0, expectedWrites: 0 },
+  { useLockfile: false, saveLockfile: true, expectedReads: 0, expectedWrites: 0 },
+  { useLockfile: true, saveLockfile: false, expectedReads: 1, expectedWrites: 0 },
+  { useLockfile: true, saveLockfile: true, expectedReads: 1, expectedWrites: 1 },
+])('pnpr honors lockfile I/O settings ($useLockfile, $saveLockfile)', async ({
+  useLockfile,
+  saveLockfile,
+  expectedReads,
+  expectedWrites,
+}) => {
+  const existingLockfile: LockfileFile = {
+    lockfileVersion: '9.0',
+    importers: { '.': {} },
+  }
+  readWantedLockfileFile.mockResolvedValueOnce(existingLockfile)
+
+  await runInstall({ useLockfile, saveLockfile })
+
+  expect(readWantedLockfileFile).toHaveBeenCalledTimes(expectedReads)
+  expect(writeWantedLockfile).toHaveBeenCalledTimes(expectedWrites)
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    lockfile: useLockfile ? existingLockfile : undefined,
+  }))
+})
+
+async function runInstall (
+  opts: Partial<InstallOptions> & { manifest?: ProjectManifest } = {}
+): Promise<void> {
+  prepareEmpty()
+  const { manifest = {}, ...installOptions } = opts
+  await install(manifest, testDefaults({
+    pnprServer: 'http://pnpr.test',
+    lockfileOnly: true,
+    useLockfile: true,
+    saveLockfile: true,
+    frozenLockfile: false,
+    frozenLockfileIfExists: false,
+    ...installOptions,
+  }))
+}

--- a/pnpm11/lockfile/fs/src/lockfileFormatConverters.ts
+++ b/pnpm11/lockfile/fs/src/lockfileFormatConverters.ts
@@ -137,7 +137,10 @@ export function convertToLockfileObject (lockfile: LockfileFile): LockfileObject
   const packages: PackageSnapshots = {}
   for (const [depPath, pkg] of Object.entries(lockfile.snapshots ?? {})) {
     const pkgId = removeSuffix(depPath)
-    const snapshot = Object.assign(pkg, lockfile.packages?.[pkgId])
+    const snapshot = Object.assign({}, pkg, lockfile.packages?.[pkgId])
+    if (snapshot.resolution != null) {
+      snapshot.resolution = { ...snapshot.resolution }
+    }
     // Defense-in-depth for pruned lockfiles (older `turbo prune --docker`,
     // pre vercel/turborepo#12825): a peer-variant injected workspace
     // snapshot whose base `packages:` entry was dropped now has a null

--- a/pnpm11/lockfile/fs/test/lockfileV6Converters.test.ts
+++ b/pnpm11/lockfile/fs/test/lockfileV6Converters.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@jest/globals'
+import type { LockfileFile } from '@pnpm/lockfile.types'
 import type { DepPath } from '@pnpm/types'
 
 import { convertToLockfileFile, convertToLockfileObject } from '../lib/lockfileFormatConverters.js'
@@ -92,6 +93,37 @@ test('convertToLockfileFile()', () => {
   }
   expect(convertToLockfileFile(lockfileV5)).toEqual(lockfileV6)
   expect(convertToLockfileObject(lockfileV6)).toEqual(lockfileV5)
+})
+
+test('convertToLockfileObject() does not mutate its LockfileFile input', () => {
+  const lockfileFile: LockfileFile = {
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        dependencies: {
+          foo: { specifier: '1.0.0', version: '1.0.0' },
+        },
+      },
+    },
+    packages: {
+      'foo@1.0.0': {
+        resolution: {
+          tarball: 'https://codeload.github.com/example/foo/tar.gz/0000000000000000000000000000000000000000',
+        },
+      },
+    },
+    snapshots: {
+      'foo@1.0.0': {},
+    },
+  }
+  const expectedLockfileFile = structuredClone(lockfileFile)
+
+  const lockfileObject = convertToLockfileObject(lockfileFile)
+
+  expect(lockfileObject.packages?.['foo@1.0.0' as DepPath]?.resolution).toMatchObject({
+    gitHosted: true,
+  })
+  expect(lockfileFile).toStrictEqual(expectedLockfileFile)
 })
 
 test('convertToLockfileObject() reconstructs a dropped directory resolution for a pruned file: peer-variant, but never for a file: tarball', () => {

--- a/pnpm11/lockfile/fs/test/read.test.ts
+++ b/pnpm11/lockfile/fs/test/read.test.ts
@@ -13,6 +13,7 @@ const {
   existsNonEmptyWantedLockfile,
   readCurrentLockfile,
   readWantedLockfile,
+  readWantedLockfileFile,
   writeCurrentLockfile,
   writeWantedLockfile,
 } = await import('@pnpm/lockfile.fs')
@@ -80,6 +81,29 @@ test('readWantedLockfile() does not use a YAML exception message when its reason
   await expect(readWantedLockfile(projectPath, { ignoreIncompatible: false })).rejects.toMatchObject({
     code: 'ERR_PNPM_BROKEN_LOCKFILE',
     message: `The lockfile at "${path.join(projectPath, 'pnpm-lock.yaml')}" is broken: Unable to parse YAML (2:3)`,
+  })
+})
+
+test('readWantedLockfileFile() returns the unmodified on-disk shape', async () => {
+  expect(await readWantedLockfileFile(path.join('fixtures', '7'), {
+    ignoreIncompatible: false,
+  })).toStrictEqual({
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        dependencies: {
+          'is-positive': { specifier: '^1.0.0', version: '1.0.0' },
+        },
+      },
+    },
+    packages: {
+      'is-positive@1.0.0': {
+        resolution: { integrity: 'sha1-ChbBDewTLAqLCzb793Fo5VDvg/g=' },
+      },
+    },
+    snapshots: {
+      'is-positive@1.0.0': {},
+    },
   })
 })
 

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -49,6 +49,10 @@ export interface ResolveViaPnprServerOptions {
   authorization?: string
   /** Overrides */
   overrides?: Record<string, string>
+  frozenLockfile?: boolean
+  preferFrozenLockfile?: boolean
+  ignoreManifestCheck?: boolean
+  trustLockfile?: boolean
   /** Node.js version for resolution */
   nodeVersion?: string
   /** Minimum release age in minutes */
@@ -115,6 +119,10 @@ export async function resolveViaPnprServer (
     // protocol carries (split `packages`/`snapshots`, `{ specifier, version }`
     // importer deps).
     lockfile: opts.lockfile,
+    frozenLockfile: opts.frozenLockfile,
+    preferFrozenLockfile: opts.preferFrozenLockfile,
+    ignoreManifestCheck: opts.ignoreManifestCheck,
+    trustLockfile: opts.trustLockfile,
   })
 
   const body = await postResolve(opts.registryUrl, requestBody, opts.authorization)


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

> [!IMPORTANT]
> This branch must incorporate pnpm/pnpm#13066 before this PR can merge. The intended sequence is to merge pnpm/pnpm#13066 into `main`, then rebase or update this branch onto the latest `main` so the zizmor security check runs with the shared fix.

Make TypeScript installs through a pnpr server honor the configured lockfile controls.

The installer now respects `useLockfile`, `saveLockfile`, frozen-lockfile settings, and Git branch lockfile read options. It forwards the supported resolver controls to pnpr, writes only when both lockfile use and saving are enabled, and treats `frozenLockfileIfExists` as active only for a non-empty lockfile.

The lockfile converter now builds independent package snapshots instead of mutating the on-disk lockfile object that is also sent through the pnpr protocol. Regression tests cover the option truth table, frozen behavior, Git branch lockfiles, and converter purity.

Pacquet uses a separate Rust pnpr client that already forwards `frozenLockfile`, `preferFrozenLockfile`, `ignoreManifestCheck`, and `trustLockfile`, and its single `lockfile` setting gates both reads and writes. Pacquet does not yet expose TypeScript pnpm's distinct `saveLockfile` or Git branch lockfile controls; those broader parity gaps are outside this TypeScript-path fix.

## Squash Commit Body

```text
Preserve pnpm's lockfile controls when dependency resolution is delegated to pnpr. Read the configured lockfile variant, derive frozen behavior from a non-empty lockfile, forward supported resolver options, and skip writes when lockfile use or saving is disabled.

Make conversion from the on-disk lockfile shape non-mutating so preparing local installer state cannot alter the protocol input. Add focused coverage for lockfile options and conversion purity.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786689070&installation_id=145934176&pr_number=13017&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13017&signature=18407ac064022bcc353f45b57b66dcaa24bdb9bf192653e9bbdc60962db30b76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * pnpr server installs now preserve the on-disk lockfile format.
  * pnpr installations now honor frozen-lockfile behavior and lockfile read/write settings, including when lockfiles are missing.
  * Lockfile and related manifest/verification policy options are now sent to the pnpr server.

* **Bug Fixes**
  * Prevented lockfile conversion from mutating the original lockfile input data.
  * Improved behavior for installs when lockfile controls are disabled or not applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->