### PR TITLE
fix(fs): repair dangling junction parent before symlinking on Windows

### DIFF
--- a/.changeset/pacquet-symlink-dangling-junction-parent.md
+++ b/.changeset/pacquet-symlink-dangling-junction-parent.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed installs failing on Windows with `ERROR_DIRECTORY` (os error 267) when re-linking over a global store whose directory junctions were restored in a dangling state (for example, a `store/v11` directory brought back by a CI cache, since tar can't round-trip a Windows reparse point). `create_dir_all` accepts such a junction because it keeps the directory attribute, but `CreateSymbolicLinkW` can't create a child link through it. The symlink writer now rebuilds the broken parent directory and retries instead of aborting the install.

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -206,6 +206,34 @@ fn force_symlink_inner(
         Err(error) => error,
     };
 
+    // Windows `CreateSymbolicLinkW` reports `ERROR_DIRECTORY` (os error
+    // 267) when a component of the link path is a reparse point whose
+    // target is gone — most often the slot's `node_modules` junction
+    // brought back in a dangling state by a tar-based CI store-cache
+    // restore. `create_dir_all` accepts such a reparse point because it
+    // keeps the directory attribute, but a child link can't be created
+    // through a dangling junction, and the error is neither `NotFound`
+    // nor `AlreadyExists`, so the recovery below never sees it. A
+    // dangling reparse point has no live children to lose, so replace the
+    // broken parent with a real directory and retry once.
+    #[cfg(windows)]
+    {
+        if !rename_tried
+            && initial_err.raw_os_error() == Some(ERROR_DIRECTORY)
+            && let Some(parent) = link.parent()
+            && is_reparse_point(parent)
+        {
+            let removed = match remove_symlink_dir(parent) {
+                Ok(()) => true,
+                Err(error) => error.kind() == io::ErrorKind::NotFound,
+            };
+            if removed && fs::create_dir_all(parent).is_ok() {
+                return force_symlink_inner(target, link, true);
+            }
+            return Err(initial_err);
+        }
+    }
+
     match initial_err.kind() {
         io::ErrorKind::NotFound => {
             // Wrap the mkdir failure so callers see *which* step
@@ -274,6 +302,22 @@ fn force_symlink_inner(
         outcome.warning = Some(warning);
         Ok(outcome)
     }
+}
+
+/// Windows `ERROR_DIRECTORY` — "the directory name is invalid."
+#[cfg(windows)]
+const ERROR_DIRECTORY: i32 = 267;
+
+/// Whether `path` is a reparse point (a symbolic link or a junction).
+/// Unlike [`std::fs::FileType::is_symlink`], which is `false` for
+/// junctions, this reads the raw reparse-point attribute, so a dangling
+/// junction is caught too.
+#[cfg(windows)]
+fn is_reparse_point(path: &Path) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    fs::symlink_metadata(path)
+        .is_ok_and(|meta| meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0)
 }
 
 /// Lexical "does the existing link resolve to the wanted target?"

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -4,13 +4,13 @@
 //! pnpm [`symlink-dir`](https://github.com/pnpm/symlink-dir) npm
 //! package.
 
-#[cfg(windows)]
-use super::relative_target_for;
 #[cfg(unix)]
 use super::symlink_dir;
 #[cfg(windows)]
 use super::to_native_separators;
 use super::{ForceSymlinkOutcome, force_symlink_dir, read_symlink_dir};
+#[cfg(windows)]
+use super::{is_reparse_point, relative_target_for};
 use std::fs;
 #[cfg(windows)]
 use std::path::Path;
@@ -176,6 +176,39 @@ fn windows_native_path_is_borrowed_unchanged() {
     let native = Path::new(r"C:\store\v11\links\@\pkg\1.0.0\hash\node_modules\dep");
     assert!(matches!(to_native_separators(native), std::borrow::Cow::Borrowed(_)));
     assert_eq!(to_native_separators(native).as_ref(), native);
+}
+
+/// Regression for the Windows CI failure where a warm install re-links
+/// over a global store restored from `actions/cache`: the slot's
+/// `node_modules` comes back as a dangling junction (tar can't round-trip
+/// a Windows reparse point), so `CreateSymbolicLinkW` rejects the child
+/// link with `ERROR_DIRECTORY` (os error 267). `force_symlink_dir` must
+/// rebuild the broken parent and still produce a working link.
+#[cfg(windows)]
+#[test]
+fn windows_force_symlink_dir_repairs_dangling_junction_parent() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("store").join("dep").join("node_modules").join("dep");
+    fs::create_dir_all(&target).expect("create target dir");
+
+    // Build a slot `node_modules` that is a dangling junction: point it at
+    // a directory, then delete that directory. Windows keeps the reparse
+    // point (with the directory attribute) but its target is now missing —
+    // the state a cache restore leaves behind.
+    let node_modules = root.path().join("store").join("consumer").join("node_modules");
+    let junction_target = root.path().join("gone");
+    fs::create_dir_all(node_modules.parent().unwrap()).expect("create slot dir");
+    fs::create_dir_all(&junction_target).expect("create junction target");
+    junction::create(&junction_target, &node_modules).expect("create junction");
+    fs::remove_dir_all(&junction_target).expect("delete junction target -> dangling");
+    assert!(is_reparse_point(&node_modules), "node_modules must be a dangling reparse point");
+
+    let link = node_modules.join("dep");
+    force_symlink_dir(&target, &link).expect("force_symlink_dir must repair the parent and link");
+
+    let resolved_link = fs::canonicalize(&link).expect("canonicalize the repaired symlink");
+    let resolved_target = fs::canonicalize(&target).expect("canonicalize target");
+    assert_eq!(resolved_link, resolved_target, "the link must resolve to the real target");
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Summary

Fixes the Windows install failure surfaced by the alpha.11 bump in [pnpm/pnpm#13003](https://github.com/pnpm/pnpm/pull/13003), where `Rust CI / Test / windows` → "Install dependencies" aborts with:

```
× installing dependencies
╰─▶ ...\node_modules\@pnpm\exe\store\v11\links\@\arraybuffer.prototype.slice\...\node_modules\es-abstract
    → ...\links\@\es-abstract\...\node_modules\es-abstract:
    The directory name is invalid. (os error 267)
```

The failing step is a **warm** `pnpm install --frozen-lockfile` that re-links over a global store (`store/v11`) restored from `actions/cache`. `actions/cache` uses tar, which can't round-trip a Windows reparse point, so a slot's `node_modules` junction comes back **dangling**. `create_dir_all` accepts it (a reparse point keeps the directory attribute), but `CreateSymbolicLinkW` can't create a child link *through* a dangling junction and fails with `ERROR_DIRECTORY` (os error 267). That error is neither `NotFound` nor `AlreadyExists`, so `force_symlink_inner` fell straight through to its `_ => return Err(...)` arm and aborted the whole install.

The fix: on `ERROR_DIRECTORY`, when the link's parent is a reparse point (symlink **or** junction), remove the broken junction, rebuild a real directory, and retry once. A dangling reparse point has no live children to lose, so the rebuild is safe. The parent is the correct target — `create_dir_all` runs before the symlink and would have failed earlier if any ancestor *above* `node_modules` were the broken component.

This is a **different trigger of the same errno** as the scoped-alias forward-slash fixes ([pnpm/pnpm#12976](https://github.com/pnpm/pnpm/pull/12976), [pnpm/pnpm#12991](https://github.com/pnpm/pnpm/pull/12991)) — no forward slash is involved here, so separator normalization does not cover it.

**Pacquet-only.** The TypeScript CLI links via the external [`symlink-dir`](https://github.com/pnpm/symlink-dir) npm package (junction-based on Windows), which is not in this repo's workspaces, so there is no TypeScript counterpart to change here.

**Verification note:** the reparse-point reproduction can only run on Windows, so it is exercised by this PR's Windows CI, not locally. Locally I confirmed it compiles for `x86_64-pc-windows-gnu` (lib + tests), clippy is clean natively and for the Windows target with `--deny warnings`, dylint is clean, and all native `pacquet-fs` tests pass.

## Squash Commit Body

```text
A warm `pnpm install` that re-links over a global store restored from a
CI cache fails on Windows with ERROR_DIRECTORY (os error 267): tar can't
round-trip a Windows reparse point, so a slot's `node_modules` junction
comes back dangling. `create_dir_all` accepts it because a reparse point
keeps the directory attribute, but `CreateSymbolicLinkW` can't create a
child link through a dangling junction, and the error is neither NotFound
nor AlreadyExists, so `force_symlink_inner` aborted the install.

On ERROR_DIRECTORY, when the link's parent is a reparse point, remove the
broken junction, rebuild a real directory, and retry once. A dangling
reparse point has no live children to lose, so the rebuild is safe. The
parent is the right target: `create_dir_all` runs before the symlink and
would have failed earlier if any ancestor above `node_modules` were the
broken component. Reparse points are detected via the raw attribute
because `FileType::is_symlink` is false for junctions.

This is a different trigger of the same errno as the scoped-alias
forward-slash fix in pnpm/pnpm#12991 (no forward slash is involved here),
so that normalization does not cover it.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. *(Pacquet-only; the TypeScript CLI uses the external `symlink-dir` package — see Summary.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786692823&installation_id=145934176&pr_number=13020&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13020&signature=b1258df165415c79cb3814a20eb9f8a811f23ca1109f55097267beee4b500a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows install failures when relinking over broken global store directory junctions, including cases where CI cache restores leave dangling reparse-point parents.
  * The installer now detects the dangling parent, rebuilds the missing directory, and retries symlink/junction creation instead of aborting.
* **Tests**
  * Added a Windows regression test covering repair of links underneath dangling `node_modules` junctions after cache restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->