### PR TITLE
fix(global): keep local package specs during update --latest

### DIFF
--- a/.changeset/global-update-latest-local-specs.md
+++ b/.changeset/global-update-latest-local-specs.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/global.commands": patch
+"pnpm": patch
 "pacquet": patch
 ---
 

--- a/.changeset/global-update-latest-local-specs.md
+++ b/.changeset/global-update-latest-local-specs.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/global.commands": patch
+"pacquet": patch
+---
+
+Fixed `pnpm update --global --latest` failing with a 404 error when a linked local package is installed globally. Local packages (`link:`/`file:`) keep their spec during a global update instead of being resolved from the registry. See pnpm/pnpm#12854.

--- a/.changeset/global-update-latest-local-specs.md
+++ b/.changeset/global-update-latest-local-specs.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm update --global --latest` failing with a 404 error when a linked local package is installed globally. Local packages (`link:`/`file:`) keep their spec during a global update instead of being resolved from the registry. See pnpm/pnpm#12854.
+Fixed `pnpm update --global --latest` failing with a 404 error when a globally installed package was not added from the registry by name. Packages installed from a local path (`link:`/`file:`), a git repository, a tarball URL, an `npm:` alias, or a named registry now keep their spec during a global update instead of being looked up by name in the default registry. See pnpm/pnpm#12854.

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -206,11 +206,7 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
     }
 
     for pkg in &to_update {
-        let selectors: Vec<String> = pkg
-            .dependencies
-            .iter()
-            .map(|(alias, spec)| if latest { alias.clone() } else { format!("{alias}@{spec}") })
-            .collect();
+        let selectors = update_selectors(&pkg.dependencies, latest);
         let (install_dir, config) = Box::pin(run_group_install::<Reporter>(
             base_config,
             &global_pkg_dir,
@@ -269,6 +265,29 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
         .wrap_err("link global package bins")?;
     }
     Ok(())
+}
+
+/// With `--latest`, registry packages become bare aliases so their latest
+/// version is resolved. Local packages (`link:`/`file:`) always keep their
+/// spec, as they don't resolve from a registry and have no latest version
+/// to query.
+fn update_selectors(dependencies: &[(String, String)], latest: bool) -> Vec<String> {
+    dependencies
+        .iter()
+        .map(
+            |(alias, spec)| {
+                if latest && !is_local_spec(spec) {
+                    alias.clone()
+                } else {
+                    format!("{alias}@{spec}")
+                }
+            },
+        )
+        .collect()
+}
+
+fn is_local_spec(spec: &str) -> bool {
+    spec.starts_with("link:") || spec.starts_with("file:")
 }
 
 /// `pnpm remove -g`. Removes the bins, hash symlinks, and install dirs of

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -406,27 +406,29 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
     Ok(())
 }
 
-/// With `--latest`, registry packages become bare aliases so their latest
-/// version is resolved. Local packages (`link:`/`file:`) always keep their
-/// spec, as they don't resolve from a registry and have no latest version
-/// to query.
+/// With `--latest`, a dependency is reduced to its bare alias so the newest
+/// registry version is resolved.
 fn update_selectors(dependencies: &[(String, String)], latest: bool) -> Vec<String> {
     dependencies
         .iter()
-        .map(
-            |(alias, spec)| {
-                if latest && !is_local_spec(spec) {
-                    alias.clone()
-                } else {
-                    format!("{alias}@{spec}")
-                }
-            },
-        )
+        .map(|(alias, spec)| {
+            if latest && is_plain_version_spec(spec) {
+                alias.clone()
+            } else {
+                format!("{alias}@{spec}")
+            }
+        })
         .collect()
 }
 
-fn is_local_spec(spec: &str) -> bool {
-    spec.starts_with("link:") || spec.starts_with("file:")
+/// Only a plain version range may be dropped in favor of the bare alias.
+/// Every other spec form (`link:`, `file:`, a git or tarball URL, an `npm:`
+/// alias, a named registry) also says where the package comes from, so the
+/// alias alone would be resolved from the default registry: a different
+/// package gets installed, or the lookup 404s and aborts the groups that
+/// have not been updated yet.
+fn is_plain_version_spec(spec: &str) -> bool {
+    !spec.contains(':')
 }
 
 /// `pnpm remove -g`. Removes the bins, hash symlinks, and install dirs of

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -336,11 +336,7 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
     }
 
     for pkg in &to_update {
-        let selectors: Vec<String> = pkg
-            .dependencies
-            .iter()
-            .map(|(alias, spec)| if latest { alias.clone() } else { format!("{alias}@{spec}") })
-            .collect();
+        let selectors = update_selectors(&pkg.dependencies, latest);
         let (install_dir, config) = Box::pin(run_group_install::<Reporter>(
             base_config,
             &global_pkg_dir,
@@ -408,6 +404,29 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
         .wrap_err("remove existing global installs")?;
     }
     Ok(())
+}
+
+/// With `--latest`, registry packages become bare aliases so their latest
+/// version is resolved. Local packages (`link:`/`file:`) always keep their
+/// spec, as they don't resolve from a registry and have no latest version
+/// to query.
+fn update_selectors(dependencies: &[(String, String)], latest: bool) -> Vec<String> {
+    dependencies
+        .iter()
+        .map(
+            |(alias, spec)| {
+                if latest && !is_local_spec(spec) {
+                    alias.clone()
+                } else {
+                    format!("{alias}@{spec}")
+                }
+            },
+        )
+        .collect()
+}
+
+fn is_local_spec(spec: &str) -> bool {
+    spec.starts_with("link:") || spec.starts_with("file:")
 }
 
 /// `pnpm remove -g`. Removes the bins, hash symlinks, and install dirs of

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -267,27 +267,29 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
     Ok(())
 }
 
-/// With `--latest`, registry packages become bare aliases so their latest
-/// version is resolved. Local packages (`link:`/`file:`) always keep their
-/// spec, as they don't resolve from a registry and have no latest version
-/// to query.
+/// With `--latest`, a dependency is reduced to its bare alias so the newest
+/// registry version is resolved.
 fn update_selectors(dependencies: &[(String, String)], latest: bool) -> Vec<String> {
     dependencies
         .iter()
-        .map(
-            |(alias, spec)| {
-                if latest && !is_local_spec(spec) {
-                    alias.clone()
-                } else {
-                    format!("{alias}@{spec}")
-                }
-            },
-        )
+        .map(|(alias, spec)| {
+            if latest && is_plain_version_spec(spec) {
+                alias.clone()
+            } else {
+                format!("{alias}@{spec}")
+            }
+        })
         .collect()
 }
 
-fn is_local_spec(spec: &str) -> bool {
-    spec.starts_with("link:") || spec.starts_with("file:")
+/// Only a plain version range may be dropped in favor of the bare alias.
+/// Every other spec form (`link:`, `file:`, a git or tarball URL, an `npm:`
+/// alias, a named registry) also says where the package comes from, so the
+/// alias alone would be resolved from the default registry: a different
+/// package gets installed, or the lookup 404s and aborts the groups that
+/// have not been updated yet.
+fn is_plain_version_spec(spec: &str) -> bool {
+    !spec.contains(':')
 }
 
 /// `pnpm remove -g`. Removes the bins, hash symlinks, and install dirs of

--- a/pnpm/crates/cli/src/cli_args/global/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     infer_local_package_alias, is_windows_drive_path, replacement_aliases, resolve_local_param,
-    should_replace_existing_package, split_comma_separated,
+    should_replace_existing_package, split_comma_separated, update_selectors,
 };
 use pacquet_global::GlobalPackageInfo;
 use std::path::{Path, PathBuf};
@@ -26,6 +26,31 @@ fn detects_windows_drive_paths() {
     assert!(is_windows_drive_path(r"C:\foo"));
     assert!(is_windows_drive_path("d:/bar"));
     assert!(!is_windows_drive_path("foo"));
+}
+
+#[test]
+fn latest_update_queries_the_registry_only_for_registry_packages() {
+    let dependencies = vec![
+        ("private-linked-pkg".to_string(), "link:/home/user/private-linked-pkg".to_string()),
+        ("local-tarball-pkg".to_string(), "file:/home/user/local-tarball-pkg.tgz".to_string()),
+        ("foo".to_string(), "^1.0.0".to_string()),
+    ];
+    assert_eq!(
+        update_selectors(&dependencies, true),
+        vec![
+            "private-linked-pkg@link:/home/user/private-linked-pkg",
+            "local-tarball-pkg@file:/home/user/local-tarball-pkg.tgz",
+            "foo",
+        ],
+    );
+    assert_eq!(
+        update_selectors(&dependencies, false),
+        vec![
+            "private-linked-pkg@link:/home/user/private-linked-pkg",
+            "local-tarball-pkg@file:/home/user/local-tarball-pkg.tgz",
+            "foo@^1.0.0",
+        ],
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/global/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     infer_local_package_alias, is_windows_drive_path, replacement_aliases, resolve_local_param,
-    should_replace_existing_package, split_comma_separated,
+    should_replace_existing_package, split_comma_separated, update_selectors,
 };
 use pnpm_global::GlobalPackageInfo;
 use std::path::{Path, PathBuf};
@@ -26,6 +26,31 @@ fn detects_windows_drive_paths() {
     assert!(is_windows_drive_path(r"C:\foo"));
     assert!(is_windows_drive_path("d:/bar"));
     assert!(!is_windows_drive_path("foo"));
+}
+
+#[test]
+fn latest_update_queries_the_registry_only_for_registry_packages() {
+    let dependencies = vec![
+        ("private-linked-pkg".to_string(), "link:/home/user/private-linked-pkg".to_string()),
+        ("local-tarball-pkg".to_string(), "file:/home/user/local-tarball-pkg.tgz".to_string()),
+        ("foo".to_string(), "^1.0.0".to_string()),
+    ];
+    assert_eq!(
+        update_selectors(&dependencies, true),
+        vec![
+            "private-linked-pkg@link:/home/user/private-linked-pkg",
+            "local-tarball-pkg@file:/home/user/local-tarball-pkg.tgz",
+            "foo",
+        ],
+    );
+    assert_eq!(
+        update_selectors(&dependencies, false),
+        vec![
+            "private-linked-pkg@link:/home/user/private-linked-pkg",
+            "local-tarball-pkg@file:/home/user/local-tarball-pkg.tgz",
+            "foo@^1.0.0",
+        ],
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/global/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global/tests.rs
@@ -29,27 +29,33 @@ fn detects_windows_drive_paths() {
 }
 
 #[test]
-fn latest_update_queries_the_registry_only_for_registry_packages() {
+fn latest_update_drops_the_spec_only_of_plain_version_dependencies() {
     let dependencies = vec![
         ("private-linked-pkg".to_string(), "link:/home/user/private-linked-pkg".to_string()),
         ("local-tarball-pkg".to_string(), "file:/home/user/local-tarball-pkg.tgz".to_string()),
+        ("git-pkg".to_string(), "github:user/git-pkg".to_string()),
+        ("remote-tarball-pkg".to_string(), "https://example.com/pkg.tgz".to_string()),
+        ("aliased-pkg".to_string(), "npm:other-pkg@^2.0.0".to_string()),
+        ("named-registry-pkg".to_string(), "gh:^3.0.0".to_string()),
         ("foo".to_string(), "^1.0.0".to_string()),
+        ("bar".to_string(), "next".to_string()),
     ];
     assert_eq!(
         update_selectors(&dependencies, true),
         vec![
             "private-linked-pkg@link:/home/user/private-linked-pkg",
             "local-tarball-pkg@file:/home/user/local-tarball-pkg.tgz",
+            "git-pkg@github:user/git-pkg",
+            "remote-tarball-pkg@https://example.com/pkg.tgz",
+            "aliased-pkg@npm:other-pkg@^2.0.0",
+            "named-registry-pkg@gh:^3.0.0",
             "foo",
+            "bar",
         ],
     );
     assert_eq!(
         update_selectors(&dependencies, false),
-        vec![
-            "private-linked-pkg@link:/home/user/private-linked-pkg",
-            "local-tarball-pkg@file:/home/user/local-tarball-pkg.tgz",
-            "foo@^1.0.0",
-        ],
+        dependencies.iter().map(|(alias, spec)| format!("{alias}@{spec}")).collect::<Vec<String>>(),
     );
 }
 

--- a/pnpm11/global/commands/src/globalUpdate.ts
+++ b/pnpm11/global/commands/src/globalUpdate.ts
@@ -76,10 +76,6 @@ export async function handleGlobalUpdate (
   return undefined
 }
 
-function isLocalSpec (spec: string): boolean {
-  return spec.startsWith('link:') || spec.startsWith('file:')
-}
-
 async function updateGlobalPackageGroup (
   opts: GlobalUpdateOptions,
   globalDir: string,
@@ -91,10 +87,8 @@ async function updateGlobalPackageGroup (
 
   // When --latest, just pass alias names to get the latest version.
   // Otherwise, pass alias@spec to update within the existing range.
-  // Local packages (link:/file:) always keep their spec, as they don't
-  // resolve from a registry and have no latest version to query.
   const depSpecs = Object.entries(pkg.dependencies).map(
-    ([alias, spec]) => opts.latest && !isLocalSpec(spec) ? alias : `${alias}@${spec}`
+    ([alias, spec]) => opts.latest && isPlainVersionSpec(spec) ? alias : `${alias}@${spec}`
   )
 
   const include = {
@@ -169,4 +163,14 @@ async function updateGlobalPackageGroup (
   // Link bins from new installation
   await linkBinsOfPackages(pkgs, globalBinDir, { excludeBins: binsToSkip })
   await opts.updateResolutionPolicyManifest?.(resolutionPolicyViolations, globalDir)
+}
+
+// Only a plain version range may be dropped in favor of the bare alias.
+// Every other spec form (`link:`, `file:`, a git or tarball URL, an `npm:`
+// alias, a named registry) also says where the package comes from, so the
+// alias alone would be resolved from the default registry: a different
+// package gets installed, or the lookup 404s and aborts the groups that
+// have not been updated yet.
+function isPlainVersionSpec (spec: string): boolean {
+  return !spec.includes(':')
 }

--- a/pnpm11/global/commands/src/globalUpdate.ts
+++ b/pnpm11/global/commands/src/globalUpdate.ts
@@ -76,6 +76,10 @@ export async function handleGlobalUpdate (
   return undefined
 }
 
+function isLocalSpec (spec: string): boolean {
+  return spec.startsWith('link:') || spec.startsWith('file:')
+}
+
 async function updateGlobalPackageGroup (
   opts: GlobalUpdateOptions,
   globalDir: string,
@@ -87,8 +91,10 @@ async function updateGlobalPackageGroup (
 
   // When --latest, just pass alias names to get the latest version.
   // Otherwise, pass alias@spec to update within the existing range.
+  // Local packages (link:/file:) always keep their spec, as they don't
+  // resolve from a registry and have no latest version to query.
   const depSpecs = Object.entries(pkg.dependencies).map(
-    ([alias, spec]) => opts.latest ? alias : `${alias}@${spec}`
+    ([alias, spec]) => opts.latest && !isLocalSpec(spec) ? alias : `${alias}@${spec}`
   )
 
   const include = {

--- a/pnpm11/global/commands/src/globalUpdate.ts
+++ b/pnpm11/global/commands/src/globalUpdate.ts
@@ -72,6 +72,10 @@ export async function handleGlobalUpdate (
   return undefined
 }
 
+function isLocalSpec (spec: string): boolean {
+  return spec.startsWith('link:') || spec.startsWith('file:')
+}
+
 async function updateGlobalPackageGroup (
   opts: GlobalUpdateOptions,
   globalDir: string,
@@ -83,8 +87,10 @@ async function updateGlobalPackageGroup (
 
   // When --latest, just pass alias names to get the latest version.
   // Otherwise, pass alias@spec to update within the existing range.
+  // Local packages (link:/file:) always keep their spec, as they don't
+  // resolve from a registry and have no latest version to query.
   const depSpecs = Object.entries(pkg.dependencies).map(
-    ([alias, spec]) => opts.latest ? alias : `${alias}@${spec}`
+    ([alias, spec]) => opts.latest && !isLocalSpec(spec) ? alias : `${alias}@${spec}`
   )
 
   const include = {

--- a/pnpm11/global/commands/src/globalUpdate.ts
+++ b/pnpm11/global/commands/src/globalUpdate.ts
@@ -72,10 +72,6 @@ export async function handleGlobalUpdate (
   return undefined
 }
 
-function isLocalSpec (spec: string): boolean {
-  return spec.startsWith('link:') || spec.startsWith('file:')
-}
-
 async function updateGlobalPackageGroup (
   opts: GlobalUpdateOptions,
   globalDir: string,
@@ -87,10 +83,8 @@ async function updateGlobalPackageGroup (
 
   // When --latest, just pass alias names to get the latest version.
   // Otherwise, pass alias@spec to update within the existing range.
-  // Local packages (link:/file:) always keep their spec, as they don't
-  // resolve from a registry and have no latest version to query.
   const depSpecs = Object.entries(pkg.dependencies).map(
-    ([alias, spec]) => opts.latest && !isLocalSpec(spec) ? alias : `${alias}@${spec}`
+    ([alias, spec]) => opts.latest && isPlainVersionSpec(spec) ? alias : `${alias}@${spec}`
   )
 
   const include = {
@@ -162,4 +156,14 @@ async function updateGlobalPackageGroup (
     protectedBins,
   })
   await opts.updateResolutionPolicyManifest?.(resolutionPolicyViolations, globalDir)
+}
+
+// Only a plain version range may be dropped in favor of the bare alias.
+// Every other spec form (`link:`, `file:`, a git or tarball URL, an `npm:`
+// alias, a named registry) also says where the package comes from, so the
+// alias alone would be resolved from the default registry: a different
+// package gets installed, or the lookup 404s and aborts the groups that
+// have not been updated yet.
+function isPlainVersionSpec (spec: string): boolean {
+  return !spec.includes(':')
 }

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -114,3 +114,39 @@ test('global update only updates interactively selected groups', async () => {
     ['foo@^1.0.0']
   )
 })
+
+test('global update --latest keeps the spec of local packages instead of querying the registry', async () => {
+  createInstallDir.mockReturnValueOnce('/global/v11/install-3')
+  getHashLink.mockReturnValueOnce('/global/v11/hash-local')
+  scanGlobalPackages.mockReturnValue([
+    {
+      dependencies: {
+        'private-linked-pkg': 'link:/home/user/projects/private-linked-pkg',
+        'local-tarball-pkg': 'file:/home/user/tarballs/local-tarball-pkg.tgz',
+        foo: '^1.0.0',
+      },
+      hash: 'hash-local',
+      installDir: '/global/v11/old-local',
+    },
+  ])
+
+  await handleGlobalUpdate({
+    bin: '/global/bin',
+    globalPkgDir: '/global/v11',
+    latest: true,
+  } as any, [], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  expect(installGlobalPackages).toHaveBeenCalledTimes(1)
+  expect(installGlobalPackages).toHaveBeenCalledWith(
+    expect.objectContaining({
+      dir: '/global/v11/install-3',
+      global: false,
+      omitSummaryLog: true,
+    }),
+    [
+      'private-linked-pkg@link:/home/user/projects/private-linked-pkg',
+      'local-tarball-pkg@file:/home/user/tarballs/local-tarball-pkg.tgz',
+      'foo',
+    ]
+  )
+})

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -115,7 +115,7 @@ test('global update only updates interactively selected groups', async () => {
   )
 })
 
-test('global update --latest keeps the spec of local packages instead of querying the registry', async () => {
+test('global update --latest drops the spec only of plain version dependencies', async () => {
   createInstallDir.mockReturnValueOnce('/global/v11/install-3')
   getHashLink.mockReturnValueOnce('/global/v11/hash-local')
   scanGlobalPackages.mockReturnValue([
@@ -123,7 +123,12 @@ test('global update --latest keeps the spec of local packages instead of queryin
       dependencies: {
         'private-linked-pkg': 'link:/home/user/projects/private-linked-pkg',
         'local-tarball-pkg': 'file:/home/user/tarballs/local-tarball-pkg.tgz',
+        'git-pkg': 'github:user/git-pkg',
+        'remote-tarball-pkg': 'https://example.com/pkg.tgz',
+        'aliased-pkg': 'npm:other-pkg@^2.0.0',
+        'named-registry-pkg': 'gh:^3.0.0',
         foo: '^1.0.0',
+        bar: 'next',
       },
       hash: 'hash-local',
       installDir: '/global/v11/old-local',
@@ -146,7 +151,12 @@ test('global update --latest keeps the spec of local packages instead of queryin
     [
       'private-linked-pkg@link:/home/user/projects/private-linked-pkg',
       'local-tarball-pkg@file:/home/user/tarballs/local-tarball-pkg.tgz',
+      'git-pkg@github:user/git-pkg',
+      'remote-tarball-pkg@https://example.com/pkg.tgz',
+      'aliased-pkg@npm:other-pkg@^2.0.0',
+      'named-registry-pkg@gh:^3.0.0',
       'foo',
+      'bar',
     ]
   )
 })

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -174,3 +174,39 @@ test('global update does not clean up or persist policy when activation fails', 
   expect(cleanupReplacedGlobalInstalls).not.toHaveBeenCalled()
   expect(updateResolutionPolicyManifest).not.toHaveBeenCalled()
 })
+
+test('global update --latest keeps the spec of local packages instead of querying the registry', async () => {
+  createInstallDir.mockReturnValueOnce('/global/v11/install-3')
+  getHashLink.mockReturnValueOnce('/global/v11/hash-local')
+  scanGlobalPackages.mockReturnValue([
+    {
+      dependencies: {
+        'private-linked-pkg': 'link:/home/user/projects/private-linked-pkg',
+        'local-tarball-pkg': 'file:/home/user/tarballs/local-tarball-pkg.tgz',
+        foo: '^1.0.0',
+      },
+      hash: 'hash-local',
+      installDir: '/global/v11/old-local',
+    },
+  ])
+
+  await handleGlobalUpdate({
+    bin: '/global/bin',
+    globalPkgDir: '/global/v11',
+    latest: true,
+  } as any, [], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  expect(installGlobalPackages).toHaveBeenCalledTimes(1)
+  expect(installGlobalPackages).toHaveBeenCalledWith(
+    expect.objectContaining({
+      dir: '/global/v11/install-3',
+      global: false,
+      omitSummaryLog: true,
+    }),
+    [
+      'private-linked-pkg@link:/home/user/projects/private-linked-pkg',
+      'local-tarball-pkg@file:/home/user/tarballs/local-tarball-pkg.tgz',
+      'foo',
+    ]
+  )
+})

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -175,7 +175,7 @@ test('global update does not clean up or persist policy when activation fails', 
   expect(updateResolutionPolicyManifest).not.toHaveBeenCalled()
 })
 
-test('global update --latest keeps the spec of local packages instead of querying the registry', async () => {
+test('global update --latest drops the spec only of plain version dependencies', async () => {
   createInstallDir.mockReturnValueOnce('/global/v11/install-3')
   getHashLink.mockReturnValueOnce('/global/v11/hash-local')
   scanGlobalPackages.mockReturnValue([
@@ -183,7 +183,12 @@ test('global update --latest keeps the spec of local packages instead of queryin
       dependencies: {
         'private-linked-pkg': 'link:/home/user/projects/private-linked-pkg',
         'local-tarball-pkg': 'file:/home/user/tarballs/local-tarball-pkg.tgz',
+        'git-pkg': 'github:user/git-pkg',
+        'remote-tarball-pkg': 'https://example.com/pkg.tgz',
+        'aliased-pkg': 'npm:other-pkg@^2.0.0',
+        'named-registry-pkg': 'gh:^3.0.0',
         foo: '^1.0.0',
+        bar: 'next',
       },
       hash: 'hash-local',
       installDir: '/global/v11/old-local',
@@ -206,7 +211,12 @@ test('global update --latest keeps the spec of local packages instead of queryin
     [
       'private-linked-pkg@link:/home/user/projects/private-linked-pkg',
       'local-tarball-pkg@file:/home/user/tarballs/local-tarball-pkg.tgz',
+      'git-pkg@github:user/git-pkg',
+      'remote-tarball-pkg@https://example.com/pkg.tgz',
+      'aliased-pkg@npm:other-pkg@^2.0.0',
+      'named-registry-pkg@gh:^3.0.0',
       'foo',
+      'bar',
     ]
   )
 })


### PR DESCRIPTION
## Summary

`pnpm update -g --latest` fails when a globally installed package is a local one (`pnpm add -g .` / `pnpm link -g`): the update collapses every dependency of a global package group to its bare alias to resolve the latest version, so a `link:`/`file:` spec recorded in the group's `package.json` turns into a registry lookup by name. For private packages that lookup fails with `ERR_PNPM_FETCH_404`, and since groups update sequentially, every remaining global package update is aborted too.

Local packages now keep the `alias@spec` selector form that the non-`--latest` path already uses, so they are relinked as-is while registry packages still update to latest. The Rust port had the same logic and is fixed the same way.

Closes pnpm/pnpm#12854

## Testing

Repro from the issue, against a registry that refuses connections (`--registry=http://127.0.0.1:9/`), with a private package linked via `pnpm add -g .`:

- before: `pnpm update -g --latest` → `GET http://127.0.0.1:9/test-pnpm-global-private-12854` → `ERR_PNPM_META_FETCH_FAIL`
- after: completes offline, the linked package stays linked, no registry request is made for it

New unit tests fail on the previous behavior on both sides (jest: expected `alias@link:...`, received bare alias; cargo: same shape).

## Squash Commit Body

```text
pnpm update -g --latest built each global group's install selectors by
collapsing every dependency to its bare alias so the latest version is
resolved from the registry. Packages installed with `pnpm add -g .` or
`pnpm link -g` are recorded with a link:/file: spec, so the collapse sent
their name to the registry, which fails with ERR_PNPM_FETCH_404 for
private packages, and the sequential group loop then aborted the update
of every remaining global package as well.

Local specs (link:/file:) now keep the alias@spec selector form the
non-latest path already uses, so they are relinked as-is while registry
packages still update to latest. Implemented in both the TypeScript CLI
and the Rust port.

Closes pnpm/pnpm#12854
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786700974&installation_id=145934176&pr_number=13024&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13024&signature=a4e234bd13993dda96bac1d7139708e059c03af39814d1c13a01f79d996d065d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm update --global --latest` failures caused by incorrect registry lookups for packages installed from local paths, Git repositories, tarball URLs, aliases, or named registries.
  * Global updates now preserve these package specifications while applying latest-version behavior to standard registry dependencies.
  * Improved reliability when updating global packages with mixed dependency sources.
* **Tests**
  * Added coverage for preserving non-standard package specifications and correctly handling plain version dependencies during global updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->