### PR TITLE
chore: update lockfile, Node.js, and pnpm versions, and fix Windows store-cache installs

### DIFF
--- a/.changeset/pacquet-symlink-heal-dangling-junction.md
+++ b/.changeset/pacquet-symlink-heal-dangling-junction.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed installs failing on Windows when a symlink's parent `node_modules` was a dangling directory junction (for example, a store restored from a CI cache, which tar can't round-trip). The symlink writer now removes the dangling junction and rebuilds a real directory before linking, instead of aborting.

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -134,7 +134,13 @@ jobs:
       - name: Cache pnpm
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: ci-pnpm-v11-${{ matrix.os }}
+          # `-2` invalidates the prior cache. On Windows the cached store
+          # includes the global-virtual-store `links/` reparse points,
+          # which tar can't round-trip, so a restored store is corrupt and
+          # a warm install fails creating symlinks with ERROR_DIRECTORY
+          # (os error 267). Forcing a cold store confirms that; the durable
+          # fix is to stop caching `links/`.
+          key: ci-pnpm-v11-${{ matrix.os }}-2
           path: |
             ${{ env.PNPM_HOME }}/store/v11
             ${{ env.HOME }}/.local/share/pnpm/store/v11

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -134,16 +134,19 @@ jobs:
       - name: Cache pnpm
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          # `-2` invalidates the prior cache. On Windows the cached store
-          # includes the global-virtual-store `links/` reparse points,
-          # which tar can't round-trip, so a restored store is corrupt and
-          # a warm install fails creating symlinks with ERROR_DIRECTORY
-          # (os error 267). Forcing a cold store confirms that; the durable
-          # fix is to stop caching `links/`.
-          key: ci-pnpm-v11-${{ matrix.os }}-2
+          # The global-virtual-store `links/` tree is Windows directory
+          # junctions, which tar (actions/cache) can't round-trip — a
+          # restored store comes back with dangling junctions and installs
+          # fail creating symlinks. Exclude `links/` from the cache; pnpm
+          # regenerates it fresh on every install anyway, so only the CAS
+          # content is cached. The `nolinks` key abandons the old caches
+          # that still hold `links/`.
+          key: ci-pnpm-v11-nolinks-${{ matrix.os }}
           path: |
             ${{ env.PNPM_HOME }}/store/v11
+            !${{ env.PNPM_HOME }}/store/v11/links
             ${{ env.HOME }}/.local/share/pnpm/store/v11
+            !${{ env.HOME }}/.local/share/pnpm/store/v11/links
         timeout-minutes: 1
         continue-on-error: true
 

--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "shx": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@12.0.0-alpha.11",
+  "packageManager": "pnpm@12.0.0-alpha.12",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "12.0.0-alpha.11",
+      "version": "12.0.0-alpha.12",
       "onFail": "download"
     },
     "runtime": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,115 +7,115 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 12.0.0-alpha.11
-        version: 12.0.0-alpha.11
+        specifier: 12.0.0-alpha.12
+        version: 12.0.0-alpha.12
       pnpm:
-        specifier: 12.0.0-alpha.11
-        version: 12.0.0-alpha.11
+        specifier: 12.0.0-alpha.12
+        version: 12.0.0-alpha.12
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.11':
-    resolution: {integrity: sha512-UKIeRyLwR1fBMVUYc0wixaC/9jji/8fqLtAqPvGQKGhLL++5RLHE85hBzE/X6/za7/TLWQzKHQyqJDQfkACSxg==}
+  '@pnpm/exe.darwin-arm64@12.0.0-alpha.12':
+    resolution: {integrity: sha512-yhC9K7LEOu9cfWRcjPGffzt3uhzk9RK/Pg9iVzzW1hkDxq0UCjP+IV/DNE7Wbo7dGlqAoQOTWe9/cYWRDFEOaA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.11':
-    resolution: {integrity: sha512-OneL3q/FSDer8GA8HKBzeAG5owOccuydGg760dKM4umzW+nzLrsnR6XNe6zIigdOHpdAVqyYOqkgdJ+SVkBdIw==}
+  '@pnpm/exe.darwin-x64@12.0.0-alpha.12':
+    resolution: {integrity: sha512-Pt4HhdbAZiQDunRerxcBLiMCW69SO4DSy3M34p0vWM+lAavNU0O725LsG2TNV5wo7c06k6vT/c1es/2byoLHnQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.11':
-    resolution: {integrity: sha512-Os8y7q/HcJz/nmonzIxz2a0CJpojvYKSQ6CNXmQCJXMywoGTaA2bS9vM1haPHRS9/krT5YAvBnj5xIHkF7tiDQ==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.12':
+    resolution: {integrity: sha512-ibuujYbiUEQ+oLkJsqlELU9pKymfdsYlk8CLudzZ6cAyAuNpSC7usTRZ4NCERJ9Qf2rccbMPz46XKxVeuUA0ow==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.11':
-    resolution: {integrity: sha512-1lQh/33VCLO+Vs+hnjB1a38jRicOWWRPEaRmSRH0+ZY+s8hjdRZKL5MqNEPivB2KhFX1uSCLRhwULW9XF3qU8w==}
+  '@pnpm/exe.linux-arm64@12.0.0-alpha.12':
+    resolution: {integrity: sha512-lZ3iNZG+mxOelhOQMhLg3J99ayFi+u8GC58lxI2PJplfzuptSyTA4AMBy9Uq6wxDedVq4kYMhJ51NJa84nDkpQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.11':
-    resolution: {integrity: sha512-lee0D4LJL9S63CWNDTCIP7MxCQZS0JgH9AXo+FaWw4nCQr6j2ZYOEAgtboLGenzebSi8NbHTMgo631sW9D9ieg==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.12':
+    resolution: {integrity: sha512-v+9mcVvtN3YFbKxqAIn84C+iSs6V4PvNMt15CUG0slQ+9yL0pvQi+IHHvjRHRMxTEIHnuIVUjHDgQgQae28FWA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-alpha.11':
-    resolution: {integrity: sha512-5opvItZ2UteQE8rYjJgtReTtLcHuyIvrXq/blEIAdaMy7HBZ2efTxB9gk0GsB7lJYhS+kL+llTphn7TpJyKwzQ==}
+  '@pnpm/exe.linux-x64@12.0.0-alpha.12':
+    resolution: {integrity: sha512-u6r20bzZqdTh0nX72bod452EWKQouBeUgQMKwFpXYvFSxBn1a7E8leFEL67UMpgSDgiKhHHL+QYf+7/Hajp5Lw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.11':
-    resolution: {integrity: sha512-VUB1p7BP7m0mhnPMsNYX9SkUqyZIoEhi4hVNMZG5HAlyUYGX3+D89g+PMKFH1xMmiBbE7ofItJH3Cj8szXen/Q==}
+  '@pnpm/exe.win32-arm64@12.0.0-alpha.12':
+    resolution: {integrity: sha512-P3ZMTGMpptHifGIktu58dMI8BUmu5gTDk+dLku4VYdb8lC2eR5xz/TimGh5tNdCCFeYtz4wOIN6mylPMVWW+Fw==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-alpha.11':
-    resolution: {integrity: sha512-J+TziCaVc41HiqYIRoEQQSeiuY9/1te3+5zcdwbkpE3I91dGJ2aNwVOzTCaPiPKfzDQ5oZgzHvuVkll//Ag7Cw==}
+  '@pnpm/exe.win32-x64@12.0.0-alpha.12':
+    resolution: {integrity: sha512-djCQaGtKa7Z+2cS2eKzgEcBRHv3cHbX8X5d9O022wDdP1Lo2brLhjJg92ubONMzhS0UJb8oz6WeV3N+EtTu7nQ==}
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0-alpha.11':
-    resolution: {integrity: sha512-a86Ro4w3IJITNiRWsvzqw3MyV0bQS3HOcDswhemf2UytGdAV8H1erkSJAA/EJzrbF8AeRBWiTJ9R8OirgRF+YQ==}
+  '@pnpm/exe@12.0.0-alpha.12':
+    resolution: {integrity: sha512-M/Yy0fe0tFTu7/1+27Ak8IWJ+9GO9ulg2E5C7tf95hyk9FYfP35FBzKfZmBhEdOJDZeKBlklBC5xeHT+tCtkPg==}
     engines: {node: '>=18.*'}
     hasBin: true
 
-  pnpm@12.0.0-alpha.11:
-    resolution: {integrity: sha512-Srr2waL5P1My/zjNfUr+9W7G34mSeO5i2DVjRwbe2ufXRfjImVtU49cEQFcliwgueMQRpWmgDmw3o2ZADVRY5A==}
+  pnpm@12.0.0-alpha.12:
+    resolution: {integrity: sha512-DUIQ4O5saqCjCyqrD8wdluBMI7COHMj7+gOp1P5blVcRwI9ma1v+oMHwIf4drCBOfWsLdPoUkXN09IWKxKaORg==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.11':
+  '@pnpm/exe.darwin-arm64@12.0.0-alpha.12':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.11':
+  '@pnpm/exe.darwin-x64@12.0.0-alpha.12':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.11':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.12':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.11':
+  '@pnpm/exe.linux-arm64@12.0.0-alpha.12':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.11':
+  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.12':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-alpha.11':
+  '@pnpm/exe.linux-x64@12.0.0-alpha.12':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.11':
+  '@pnpm/exe.win32-arm64@12.0.0-alpha.12':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-alpha.11':
+  '@pnpm/exe.win32-x64@12.0.0-alpha.12':
     optional: true
 
-  '@pnpm/exe@12.0.0-alpha.11':
+  '@pnpm/exe@12.0.0-alpha.12':
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.11
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.11
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.11
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.11
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.11
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.11
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.11
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.11
+      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.12
+      '@pnpm/exe.darwin-x64': 12.0.0-alpha.12
+      '@pnpm/exe.linux-arm64': 12.0.0-alpha.12
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.12
+      '@pnpm/exe.linux-x64': 12.0.0-alpha.12
+      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.12
+      '@pnpm/exe.win32-arm64': 12.0.0-alpha.12
+      '@pnpm/exe.win32-x64': 12.0.0-alpha.12
 
-  pnpm@12.0.0-alpha.11:
+  pnpm@12.0.0-alpha.12:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.11
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.11
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.11
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.11
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.11
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.11
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.11
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.11
+      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.12
+      '@pnpm/exe.darwin-x64': 12.0.0-alpha.12
+      '@pnpm/exe.linux-arm64': 12.0.0-alpha.12
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.12
+      '@pnpm/exe.linux-x64': 12.0.0-alpha.12
+      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.12
+      '@pnpm/exe.win32-arm64': 12.0.0-alpha.12
+      '@pnpm/exe.win32-x64': 12.0.0-alpha.12
 
 ---
 lockfileVersion: '9.0'

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -206,40 +206,12 @@ fn force_symlink_inner(
         Err(error) => error,
     };
 
-    // Windows `CreateSymbolicLinkW` reports `ERROR_DIRECTORY` (os error
-    // 267) when a component of the link path is a reparse point whose
-    // target is gone — most often the slot's `node_modules` junction
-    // brought back in a dangling state by a tar-based CI store-cache
-    // restore. `create_dir_all` accepts such a reparse point because it
-    // keeps the directory attribute, but a child link can't be created
-    // through a dangling junction, and the error is neither `NotFound`
-    // nor `AlreadyExists`, so the recovery below never sees it. A
-    // dangling reparse point has no live children to lose, so replace the
-    // broken parent with a real directory and retry once.
-    #[cfg(windows)]
-    {
-        if !rename_tried
-            && initial_err.raw_os_error() == Some(ERROR_DIRECTORY)
-            && let Some(parent) = link.parent()
-            && is_reparse_point(parent)
-        {
-            let removed = match remove_symlink_dir(parent) {
-                Ok(()) => true,
-                Err(error) => error.kind() == io::ErrorKind::NotFound,
-            };
-            if removed && fs::create_dir_all(parent).is_ok() {
-                return force_symlink_inner(target, link, true);
-            }
-            return Err(initial_err);
-        }
-    }
-
     match initial_err.kind() {
         io::ErrorKind::NotFound => {
             // Wrap the mkdir failure so callers see *which* step
             // tripped.
             if let Some(parent) = link.parent() {
-                fs::create_dir_all(parent).map_err(|mkdir_err| {
+                create_dir_all_healing_reparse(parent).map_err(|mkdir_err| {
                     io::Error::new(
                         mkdir_err.kind(),
                         format!(
@@ -304,9 +276,29 @@ fn force_symlink_inner(
     }
 }
 
-/// Windows `ERROR_DIRECTORY` — "the directory name is invalid."
-#[cfg(windows)]
-const ERROR_DIRECTORY: i32 = 267;
+/// Like [`std::fs::create_dir_all`], but heals a dangling reparse point
+/// squatting on `dir`.
+///
+/// On Windows a junction whose target is gone — the shape a tar-based CI
+/// cache restore leaves behind — keeps the directory attribute, so
+/// `create_dir_all` reports `AlreadyExists` yet no child can be created
+/// through it. Removing the dangling reparse point (which unlinks only
+/// the junction, never a live target) and recreating a real directory
+/// clears the way. On Unix this is a plain `create_dir_all`.
+fn create_dir_all_healing_reparse(dir: &Path) -> io::Result<()> {
+    let error = match fs::create_dir_all(dir) {
+        Ok(()) => return Ok(()),
+        Err(error) => error,
+    };
+    #[cfg(windows)]
+    {
+        if is_reparse_point(dir) {
+            remove_symlink_dir(dir)?;
+            return fs::create_dir_all(dir);
+        }
+    }
+    Err(error)
+}
 
 /// Whether `path` is a reparse point (a symbolic link or a junction).
 /// Unlike [`std::fs::FileType::is_symlink`], which is `false` for

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -178,12 +178,14 @@ fn windows_native_path_is_borrowed_unchanged() {
     assert_eq!(to_native_separators(native).as_ref(), native);
 }
 
-/// Regression for the Windows CI failure where a warm install re-links
-/// over a global store restored from `actions/cache`: the slot's
-/// `node_modules` comes back as a dangling junction (tar can't round-trip
-/// a Windows reparse point), so `CreateSymbolicLinkW` rejects the child
-/// link with `ERROR_DIRECTORY` (os error 267). `force_symlink_dir` must
-/// rebuild the broken parent and still produce a working link.
+/// Regression for the Windows failure where a symlink's parent slot is a
+/// dangling junction — the shape a tar-based CI cache restore leaves
+/// behind (tar can't round-trip a Windows reparse point). The child link
+/// can't be created through the dangling junction, and `create_dir_all`
+/// can't rebuild the slot because the junction still occupies it (it
+/// fails with `AlreadyExists`, os error 183). `force_symlink_dir` must
+/// remove the dangling reparse point, rebuild a real directory, and still
+/// produce a working link.
 #[cfg(windows)]
 #[test]
 fn windows_force_symlink_dir_repairs_dangling_junction_parent() {


### PR DESCRIPTION
> [!NOTE]
> **Beyond the routine version bump, this PR carries two fixes added while getting Windows Rust CI green.** Root cause: with `enableGlobalVirtualStore: true`, the CI-cached pnpm store holds Windows directory junctions (`store/v11/links/`) that `tar` (`actions/cache`) can't round-trip, so a restored store came back with dangling junctions and installs failed creating symlinks with `os error 267`.
>
> - **`ci`: exclude the global-virtual-store `links/` tree from the store cache.** `links/` is now excluded from the cached path (pnpm regenerates it fresh on every install); only the CAS content is cached. The new `nolinks` cache key abandons the old caches that still hold `links/`. This is the actual fix for the CI failure.
> - **`fix(fs)`: heal a dangling junction parent when materializing a symlink.** Robustness for a store that already has dangling junctions: `CreateSymbolicLinkW` through one returns `NotFound`, then `create_dir_all` fails with `AlreadyExists` (os error 183) because the junction still occupies the slot — so the writer now removes the dangling reparse point and rebuilds a real directory before linking. (Corrects the alpha.12 attempt, which keyed on the wrong errno — `ERROR_DIRECTORY`/267 — and never fired.)

---

This automated PR refreshes the project's pinned versions:

- Updates the lockfile to the latest compatible versions of dependencies.
- Bumps Node.js to the latest 26.x release, propagated into the CI, release, and benchmark workflows via the meta-updater.
- Bumps pnpm to the latest `next-12` release (`packageManager` and `devEngines.packageManager`).

Created by the update-lockfile workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786703453&installation_id=145934176&pr_number=13026&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13026&signature=429e74fc4519574bebafea96b69e9171a078cc2fe13ba5d8de7f55a874e1faea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s pnpm toolchain to the latest configured prerelease version.
  * Kept the required Node.js runtime version unchanged.
* **Chores**
  * Adjusted CI caching for the pnpm store to reliably avoid corrupted installs on Windows by busting the cache key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
