### PR TITLE
fix(install): validate every workspace importer under --frozen-lockfile

### DIFF
--- a/.changeset/frozen-lockfile-workspace-importers.md
+++ b/.changeset/frozen-lockfile-workspace-importers.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm install --frozen-lockfile` now validates every workspace project's `package.json` against the lockfile, not just the root one. A stale workspace manifest (or a project missing from `importers`) fails with `ERR_PNPM_OUTDATED_LOCKFILE` instead of exiting 0 and silently ignoring the drifted dependency; the auto-frozen fast path falls through to a fresh resolve in the same situations.

--- a/pnpm/crates/cli/tests/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/lockfile_only.rs
@@ -292,12 +292,11 @@ fn lockfile_only_updates_importers_when_a_project_is_added() {
     );
 
     // Add a second project, re-run lockfile-only, and confirm both
-    // importers are recorded. `--no-prefer-frozen-lockfile` forces the
-    // fresh-resolve path: pacquet's auto-frozen freshness gate
-    // (`check_lockfile_freshness`) only validates the root importer
-    // today, so it wouldn't notice a newly-added sibling and would
-    // otherwise short-circuit to the frozen path. The flag makes the
-    // re-resolve unconditional.
+    // importers are recorded. The auto-frozen freshness gate
+    // (`check_lockfile_freshness`) validates every importer, so the
+    // newly-added sibling's missing `importers` entry routes this run
+    // to the fresh-resolve path — no `--no-prefer-frozen-lockfile`
+    // needed.
     fs::create_dir_all(workspace.join("packages/project-2")).expect("mkdir project-2");
     fs::write(
         workspace.join("packages/project-2/package.json"),
@@ -305,10 +304,7 @@ fn lockfile_only_updates_importers_when_a_project_is_added() {
     )
     .expect("write project-2 package.json");
 
-    pacquet_at(&workspace)
-        .with_args(["install", "--lockfile-only", "--no-prefer-frozen-lockfile"])
-        .assert()
-        .success();
+    pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
 
     let lockfile = fs::read_to_string(&lockfile_path).expect("re-read pnpm-lock.yaml");
     assert!(

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -395,3 +395,179 @@ fn install_does_not_scaffold_a_root_manifest_in_a_workspace() {
 
     drop((root, mock_instance));
 }
+
+/// A fresh `pacquet` command rooted at `workspace`. `std::process::Command`
+/// isn't `Clone` and each invocation consumes the builder, so tests that
+/// run pacquet more than once rebuild it here.
+fn pacquet_at(workspace: &std::path::Path) -> std::process::Command {
+    std::process::Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(workspace)
+}
+
+/// Write a two-sibling workspace (root + `packages/a` + `packages/b`)
+/// and install it so `pnpm-lock.yaml` records every importer. Shared
+/// setup for the frozen-gate regression tests below.
+fn install_two_project_workspace(workspace: &std::path::Path) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::create_dir_all(workspace.join("packages/a")).expect("mkdir packages/a");
+    fs::write(
+        workspace.join("packages/a/package.json"),
+        serde_json::json!({
+            "name": "@scope/a",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/a/package.json");
+
+    fs::create_dir_all(workspace.join("packages/b")).expect("mkdir packages/b");
+    fs::write(
+        workspace.join("packages/b/package.json"),
+        serde_json::json!({ "name": "@scope/b", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write packages/b/package.json");
+
+    pacquet_at(workspace).with_arg("install").assert().success();
+}
+
+/// Regression test for the frozen freshness gate only validating the
+/// root importer: a dependency added to a *sibling* project's manifest
+/// without regenerating the lockfile must fail `--frozen-lockfile`
+/// (`ERR_PNPM_OUTDATED_LOCKFILE`), exactly like the same drift in the
+/// root manifest — not exit 0 with the new dependency silently ignored.
+#[test]
+fn frozen_install_rejects_a_stale_workspace_project_manifest() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    install_two_project_workspace(&workspace);
+
+    // Drift packages/a: add a dep the lockfile doesn't record.
+    fs::write(
+        workspace.join("packages/a/package.json"),
+        serde_json::json!({
+            "name": "@scope/a",
+            "version": "1.0.0",
+            "dependencies": {
+                "@pnpm.e2e/hello-world-js-bin": "1.0.0",
+                "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("rewrite packages/a/package.json");
+
+    let output = pacquet_at(&workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .output()
+        .expect("run frozen install");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "frozen install must fail on a stale workspace project manifest\nstderr:\n{stderr}",
+    );
+    // miette hard-wraps the rendered error, so collapse whitespace
+    // before matching the message text.
+    let stderr_flat = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        stderr_flat.contains("not up to date with package.json"),
+        "expected the outdated-lockfile error\nstderr:\n{stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// A workspace project added after the last lockfile write has no
+/// `importers` entry, so `--frozen-lockfile` must fail rather than
+/// materialize a tree that silently omits the new project.
+#[test]
+fn frozen_install_rejects_a_workspace_project_missing_from_the_lockfile() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    install_two_project_workspace(&workspace);
+
+    fs::create_dir_all(workspace.join("packages/c")).expect("mkdir packages/c");
+    fs::write(
+        workspace.join("packages/c/package.json"),
+        serde_json::json!({ "name": "@scope/c", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write packages/c/package.json");
+
+    let output = pacquet_at(&workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .output()
+        .expect("run frozen install");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "frozen install must fail when a workspace project has no importers entry\nstderr:\n{stderr}",
+    );
+    // miette hard-wraps the rendered error, so collapse whitespace
+    // before matching the message text.
+    let stderr_flat = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        stderr_flat.contains(r#"importers["packages/c"]"#),
+        "expected the missing-importer error naming packages/c\nstderr:\n{stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// The auto-frozen fast path (`preferFrozenLockfile`, the default) must
+/// treat a stale sibling manifest as fall-through to fresh resolve —
+/// the drifted dependency gets installed and the lockfile updated,
+/// instead of the frozen path short-circuiting and ignoring it.
+#[test]
+fn auto_frozen_path_falls_through_on_a_stale_workspace_project_manifest() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    install_two_project_workspace(&workspace);
+
+    fs::write(
+        workspace.join("packages/a/package.json"),
+        serde_json::json!({
+            "name": "@scope/a",
+            "version": "1.0.0",
+            "dependencies": {
+                "@pnpm.e2e/hello-world-js-bin": "1.0.0",
+                "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("rewrite packages/a/package.json");
+
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let a_dep = workspace.join("packages/a/node_modules/@pnpm.e2e/hello-world-js-bin-parent");
+    assert!(
+        is_symlink_or_junction(&a_dep).expect("query packages/a symlink"),
+        "the dependency added to packages/a must be installed by the fall-through resolve",
+    );
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("hello-world-js-bin-parent"),
+        "the regenerated lockfile must record the new packages/a dependency:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -813,7 +813,8 @@ where
                 current_lockfile.as_ref().and_then(|current| {
                     check_lockfile_freshness(
                         current,
-                        manifest,
+                        &workspace_root,
+                        &project_manifests,
                         config,
                         &catalogs,
                         ignore_manifest_check,
@@ -958,8 +959,15 @@ where
             // The check is run for its side effect (the typed
             // outcome) — the borrowed lockfile / manifest are consumed
             // again inside the frozen branch below.
-            check_lockfile_freshness(lockfile, manifest, config, &catalogs, ignore_manifest_check)
-                .map_err(InstallError::from)?;
+            check_lockfile_freshness(
+                lockfile,
+                &workspace_root,
+                &project_manifests,
+                config,
+                &catalogs,
+                ignore_manifest_check,
+            )
+            .map_err(InstallError::from)?;
             true
         } else if update_checksums {
             false
@@ -974,7 +982,8 @@ where
             if prefer_frozen_lockfile {
                 match check_lockfile_freshness(
                     lockfile,
-                    manifest,
+                    &workspace_root,
+                    &project_manifests,
                     config,
                     &catalogs,
                     ignore_manifest_check,
@@ -1778,7 +1787,8 @@ where
 /// `ignoredOptionalDependencies`) still runs.
 fn check_lockfile_freshness(
     lockfile: &Lockfile,
-    manifest: &PackageManifest,
+    workspace_root: &Path,
+    project_manifests: &[(std::path::PathBuf, &PackageManifest)],
     config: &Config,
     catalogs: &Catalogs,
     ignore_manifest_check: bool,
@@ -1790,17 +1800,24 @@ fn check_lockfile_freshness(
         return Ok(());
     }
 
-    // Pacquet has only one importer today (<https://github.com/pnpm/pacquet/issues/431> tracks workspaces),
-    // so the root project is the only thing to verify; once
-    // workspaces land this becomes a per-project loop over
-    // `lockfile.importers`.
-    check_importer_satisfies(
-        lockfile,
-        manifest,
-        Lockfile::ROOT_IMPORTER_KEY,
-        config,
-        parsed_overrides_opt.as_deref(),
-    )
+    // Every importer must satisfy the lockfile, not just the root: a
+    // stale workspace project manifest would otherwise pass the frozen
+    // gate silently (exit 0) with the drifted dependency ignored.
+    // Mirrors pnpm's `allProjectsAreUpToDate` and the per-project loop
+    // in [`crate::optimistic_repeat_install`]. A project absent from
+    // `lockfile.importers` surfaces as `NoImporter` — fatal under
+    // `--frozen-lockfile`, fall-through to fresh-resolve in state 2.
+    for (project_dir, project_manifest) in project_manifests {
+        let importer_id = pacquet_workspace::importer_id_from_root_dir(workspace_root, project_dir);
+        check_importer_satisfies(
+            lockfile,
+            project_manifest,
+            &importer_id,
+            config,
+            parsed_overrides_opt.as_deref(),
+        )?;
+    }
+    Ok(())
 }
 
 /// Parse `pnpm.overrides` from the config. Values can use the


### PR DESCRIPTION
Fixes #13025.

### Problem

`check_lockfile_freshness` still carried its pre-workspaces TODO ("once workspaces land this becomes a per-project loop over `lockfile.importers`") and only ran `check_importer_satisfies` for the root importer. Consequences:

- A stale workspace project `package.json` (dependency added/removed without regenerating the lockfile) passed `pnpm install --frozen-lockfile` with exit 0, and the drifted dependency was silently ignored — defeating the CI/Docker integrity gate.
- A workspace project added after the last lockfile write was silently omitted instead of failing frozen installs.
- The auto-frozen fast path (`preferFrozenLockfile`) short-circuited to frozen materialization in both situations instead of falling through to a fresh resolve.

Root-manifest drift was already correctly rejected with `ERR_PNPM_OUTDATED_LOCKFILE`.

### Fix

Loop over the already-built `project_manifests` list (root + every workspace project) and run `check_importer_satisfies` per importer, deriving each importer id with the existing `pacquet_workspace::importer_id_from_root_dir`. This mirrors JS pnpm's `allProjectsAreUpToDate` and the per-project loop `optimistic_repeat_install` already does. All three `check_lockfile_freshness` call sites (explicit frozen, auto-frozen dispatch, synthesized-lockfile) get the behavior.

A project absent from `lockfile.importers` surfaces as the existing `NoImporter` error — fatal under `--frozen-lockfile`, fall-through to fresh resolve in the auto-frozen state. The `--no-prefer-frozen-lockfile` workaround (and its bug-documenting comment) in the `lockfile_only` test is removed accordingly.

### Tests

New integration coverage in `workspace_install.rs`:

- `frozen_install_rejects_a_stale_workspace_project_manifest` — sibling drift fails frozen with the outdated-lockfile error.
- `frozen_install_rejects_a_workspace_project_missing_from_the_lockfile` — new project with no `importers` entry fails frozen, naming the importer.
- `auto_frozen_path_falls_through_on_a_stale_workspace_project_manifest` — default install resolves fresh, installs the drifted dep, and updates the lockfile.

`cargo test -p pacquet-package-manager` (717 passed), `-p pacquet-cli --test workspace_install --test lockfile_only` (13 passed), `cargo fmt --check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786704040&installation_id=145934176&pr_number=13028&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13028&signature=b7a670a61e1b0e5b296f6bcd47145ea3f8653dc707c24a6305dbe04214022427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm install --frozen-lockfile` now validates every workspace project against the lockfile.
  * Installations fail with an outdated-lockfile error when a workspace manifest changes or a project is missing from the lockfile.
  * Automatic frozen installs now re-resolve dependencies when workspace changes make the lockfile stale.

* **Tests**
  * Added coverage for changed workspace manifests, newly added projects, and automatic lockfile updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->