### PR TITLE
fix(cli): match pnpm's JSON error output for publish --json failures

### DIFF
--- a/.changeset/pacquet-publish-json-errors.md
+++ b/.changeset/pacquet-publish-json-errors.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Changed `pacquet publish --json` failures to match pnpm's JSON error output: errors are printed as a JSON envelope on stdout, and the human diagnostic is no longer rendered to stderr for this path.
+Changed `pacquet publish --json` failures to match pnpm's JSON output: errors are printed as a compact JSON envelope on stdout, explicit reporter output is suppressed, and the human diagnostic is no longer rendered to stderr for this path.

--- a/.changeset/pacquet-publish-json-errors.md
+++ b/.changeset/pacquet-publish-json-errors.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Changed `pacquet publish --json` failures to match pnpm's JSON output: errors are printed as a compact JSON envelope on stdout, explicit reporter output is suppressed, and the human diagnostic is no longer rendered to stderr for this path.
+Changed `pacquet publish --json` failures to match pnpm's JSON output: errors are printed as a JSON envelope on stdout, explicit reporter output is suppressed, and the human diagnostic is no longer rendered to stderr for this path.

--- a/.changeset/pacquet-publish-json-errors.md
+++ b/.changeset/pacquet-publish-json-errors.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Changed `pacquet publish --json` failures to match pnpm's JSON error output: errors are printed as a JSON envelope on stdout, and the human diagnostic is no longer rendered to stderr for this path.

--- a/.changeset/pacquet-publish-json-reporter.md
+++ b/.changeset/pacquet-publish-json-reporter.md
@@ -1,5 +1,0 @@
----
-"pacquet": patch
----
-
-Fixed `pacquet publish --json --reporter=ndjson` and other explicit reporter selections so `--json` keeps stdout as a single machine-readable JSON value, matching pnpm.

--- a/.changeset/pacquet-publish-json-reporter.md
+++ b/.changeset/pacquet-publish-json-reporter.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pacquet publish --json --reporter=ndjson` and other explicit reporter selections so `--json` keeps stdout as a single machine-readable JSON value, matching pnpm.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -415,24 +415,16 @@ fn print_json_error(error: &miette::Report) {
     let output = serde_json::json!({
         "error": error_body,
     });
-    println!(
-        "{}",
-        serde_json::to_string_pretty(&output).expect("a JSON error envelope serializes"),
-    );
+    let output = serde_json::to_string(&output).expect("a JSON error envelope serializes");
+    println!("{output}");
 }
 
 fn json_error_message(error: &miette::Report) -> String {
-    let messages =
-        error.chain().map(ToString::to_string).fold(Vec::new(), |mut messages, message| {
-            if messages.last() != Some(&message) {
-                messages.push(message);
-            }
-            messages
-        });
-    match messages.as_slice() {
-        [context, source, ..] if context == "pack the package" => source.clone(),
-        [_, ..] => messages.join(": "),
-        [] => error.to_string(),
+    let mut messages = error.chain().map(ToString::to_string);
+    match (messages.next(), messages.next()) {
+        (Some(context), Some(source)) if context == "pack the package" => source,
+        (Some(message), _) => message,
+        (None, _) => error.to_string(),
     }
 }
 
@@ -444,4 +436,39 @@ fn otp_non_interactive_error(error: &miette::Report) -> Option<&OtpNonInteractiv
 
 fn now_millis() -> u128 {
     std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).map_or(0, |d| d.as_millis())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use miette::Diagnostic;
+
+    #[derive(Debug, derive_more::Display, derive_more::Error, Diagnostic)]
+    #[display("canonical publish failure")]
+    #[diagnostic(code(ERR_PNPM_TEST_JSON_ERROR))]
+    struct CanonicalError {
+        #[error(source)]
+        source: SensitiveCause,
+    }
+
+    #[derive(Debug, derive_more::Display, derive_more::Error)]
+    #[display("registry response included token=secret")]
+    struct SensitiveCause;
+
+    #[test]
+    fn json_error_message_omits_nested_causes() {
+        let error = miette::Report::new(CanonicalError { source: SensitiveCause });
+        let message = json_error_message(&error);
+
+        assert_eq!(message, "canonical publish failure");
+        assert!(!message.contains("token=secret"));
+    }
+
+    #[test]
+    fn json_error_message_unwraps_pack_context() {
+        let error = miette::Report::new(CanonicalError { source: SensitiveCause })
+            .wrap_err("pack the package");
+
+        assert_eq!(json_error_message(&error), "canonical publish failure");
+    }
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -439,36 +439,4 @@ fn now_millis() -> u128 {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use miette::Diagnostic;
-
-    #[derive(Debug, derive_more::Display, derive_more::Error, Diagnostic)]
-    #[display("canonical publish failure")]
-    #[diagnostic(code(ERR_PNPM_TEST_JSON_ERROR))]
-    struct CanonicalError {
-        #[error(source)]
-        source: SensitiveCause,
-    }
-
-    #[derive(Debug, derive_more::Display, derive_more::Error)]
-    #[display("registry response included token=secret")]
-    struct SensitiveCause;
-
-    #[test]
-    fn json_error_message_omits_nested_causes() {
-        let error = miette::Report::new(CanonicalError { source: SensitiveCause });
-        let message = json_error_message(&error);
-
-        assert_eq!(message, "canonical publish failure");
-        assert!(!message.contains("token=secret"));
-    }
-
-    #[test]
-    fn json_error_message_unwraps_pack_context() {
-        let error = miette::Report::new(CanonicalError { source: SensitiveCause })
-            .wrap_err("pack the package");
-
-        assert_eq!(json_error_message(&error), "canonical publish failure");
-    }
-}
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -415,14 +415,16 @@ fn print_json_error(error: &miette::Report) {
     let output = serde_json::json!({
         "error": error_body,
     });
-    let output = serde_json::to_string(&output).expect("a JSON error envelope serializes");
+    // pnpm's `errorHandler` prints the envelope with `JSON.stringify(_, null, 2)`;
+    // match its two-space indentation byte-for-byte.
+    let output = serde_json::to_string_pretty(&output).expect("a JSON error envelope serializes");
     println!("{output}");
 }
 
 fn json_error_message(error: &miette::Report) -> String {
     let mut messages = error.chain().map(ToString::to_string);
     match (messages.next(), messages.next()) {
-        (Some(context), Some(source)) if context == "pack the package" => source,
+        (Some(context), Some(source)) if context == super::pack::PACK_ERROR_CONTEXT => source,
         (Some(message), _) => message,
         (None, _) => error.to_string(),
     }

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -10,6 +10,7 @@ use crate::{
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::{Config, Host, default_pnpm_home_dir};
 use pacquet_default_reporter::SummaryScope;
+use pacquet_network_web_auth::OtpNonInteractiveError;
 use pacquet_reporter::{ExecutionTimeLog, LogEvent, LogLevel};
 use std::{future::Future, path::Path, pin::Pin};
 
@@ -398,17 +399,47 @@ fn prints_json_errors(command: &CliCommand) -> bool {
 
 fn print_json_error(error: &miette::Report) {
     let code = error.code().map(|code| code.to_string()).unwrap_or_else(|| "pnpm".to_string());
-    let message = error.chain().last().map_or_else(|| error.to_string(), ToString::to_string);
+    let message = json_error_message(error);
+    let mut error_body = serde_json::json!({
+        "code": code,
+        "message": message,
+    });
+    if let Some(otp_error) = otp_non_interactive_error(error) {
+        if let Some(auth_url) = &otp_error.auth_url {
+            error_body["authUrl"] = serde_json::Value::String(auth_url.clone());
+        }
+        if let Some(done_url) = &otp_error.done_url {
+            error_body["doneUrl"] = serde_json::Value::String(done_url.clone());
+        }
+    }
     let output = serde_json::json!({
-        "error": {
-            "code": code,
-            "message": message,
-        },
+        "error": error_body,
     });
     println!(
         "{}",
         serde_json::to_string_pretty(&output).expect("a JSON error envelope serializes"),
     );
+}
+
+fn json_error_message(error: &miette::Report) -> String {
+    let messages =
+        error.chain().map(ToString::to_string).fold(Vec::new(), |mut messages, message| {
+            if messages.last() != Some(&message) {
+                messages.push(message);
+            }
+            messages
+        });
+    match messages.as_slice() {
+        [context, source, ..] if context == "pack the package" => source.clone(),
+        [_, ..] => messages.join(": "),
+        [] => error.to_string(),
+    }
+}
+
+fn otp_non_interactive_error(error: &miette::Report) -> Option<&OtpNonInteractiveError> {
+    error
+        .downcast_ref::<OtpNonInteractiveError>()
+        .or_else(|| error.chain().find_map(|cause| cause.downcast_ref::<OtpNonInteractiveError>()))
 }
 
 fn now_millis() -> u128 {

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -184,6 +184,7 @@ impl CliArgs {
                 | CliCommand::PatchCommit(_)
                 | CliCommand::PatchRemove(_),
         );
+        let print_json_errors = prints_json_errors(&command);
         let manifest_path = dir.join("package.json");
         // Load config anchored at `anchor`, reading `.npmrc` /
         // `pnpm-workspace.yaml` from there.
@@ -268,7 +269,24 @@ impl CliArgs {
             global_config: &global_config,
             state: &state,
         };
-        route(command, &ctx)?.await?;
+        match route(command, &ctx) {
+            Ok(future) => {
+                if let Err(error) = future.await {
+                    if print_json_errors {
+                        print_json_error(&error);
+                        std::process::exit(1);
+                    }
+                    return Err(error);
+                }
+            }
+            Err(error) => {
+                if print_json_errors {
+                    print_json_error(&error);
+                    std::process::exit(1);
+                }
+                return Err(error);
+            }
+        }
 
         // The `Done in ...` footer covers the whole command, mirroring pnpm's
         // `pnpm:execution-time` emit in `main.ts`. Only the install-family
@@ -372,6 +390,25 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
             unreachable!("completion returns before configuration")
         }
     }
+}
+
+fn prints_json_errors(command: &CliCommand) -> bool {
+    matches!(command, CliCommand::Publish(args) if args.flags.json)
+}
+
+fn print_json_error(error: &miette::Report) {
+    let code = error.code().map(|code| code.to_string()).unwrap_or_else(|| "pnpm".to_string());
+    let message = error.chain().last().map_or_else(|| error.to_string(), ToString::to_string);
+    let output = serde_json::json!({
+        "error": {
+            "code": code,
+            "message": message,
+        },
+    });
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&output).expect("a JSON error envelope serializes"),
+    );
 }
 
 fn now_millis() -> u128 {

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -398,7 +398,7 @@ fn prints_json_errors(command: &CliCommand) -> bool {
 }
 
 fn print_json_error(error: &miette::Report) {
-    let code = error.code().map(|code| code.to_string()).unwrap_or_else(|| "pnpm".to_string());
+    let code = error.code().map_or_else(|| "pnpm".to_string(), |code| code.to_string());
     let message = json_error_message(error);
     let mut error_body = serde_json::json!({
         "code": code,

--- a/pnpm/crates/cli/src/cli_args/dispatch/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch/tests.rs
@@ -1,4 +1,5 @@
 use super::json_error_message;
+use crate::cli_args::pack::PACK_ERROR_CONTEXT;
 use miette::Diagnostic;
 
 #[derive(Debug, derive_more::Display, derive_more::Error, Diagnostic)]
@@ -25,7 +26,7 @@ fn json_error_message_omits_nested_causes() {
 #[test]
 fn json_error_message_unwraps_pack_context() {
     let error =
-        miette::Report::new(CanonicalError { source: SensitiveCause }).wrap_err("pack the package");
+        miette::Report::new(CanonicalError { source: SensitiveCause }).wrap_err(PACK_ERROR_CONTEXT);
 
     assert_eq!(json_error_message(&error), "canonical publish failure");
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch/tests.rs
@@ -1,0 +1,31 @@
+use super::json_error_message;
+use miette::Diagnostic;
+
+#[derive(Debug, derive_more::Display, derive_more::Error, Diagnostic)]
+#[display("canonical publish failure")]
+#[diagnostic(code(ERR_PNPM_TEST_JSON_ERROR))]
+struct CanonicalError {
+    #[error(source)]
+    source: SensitiveCause,
+}
+
+#[derive(Debug, derive_more::Display, derive_more::Error)]
+#[display("registry response included token=secret")]
+struct SensitiveCause;
+
+#[test]
+fn json_error_message_omits_nested_causes() {
+    let error = miette::Report::new(CanonicalError { source: SensitiveCause });
+    let message = json_error_message(&error);
+
+    assert_eq!(message, "canonical publish failure");
+    assert!(!message.contains("token=secret"));
+}
+
+#[test]
+fn json_error_message_unwraps_pack_context() {
+    let error =
+        miette::Report::new(CanonicalError { source: SensitiveCause }).wrap_err("pack the package");
+
+    assert_eq!(json_error_message(&error), "canonical publish failure");
+}

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -331,6 +331,9 @@ pub(super) fn publish<'a>(
     let dir = ctx.dir;
     let recursive = ctx.recursive;
     args.flags.report_summary |= ctx.recursive_report_summary;
+    if args.flags.json {
+        return Ok(Box::pin(args.run::<SilentReporter>(dir, config, recursive)));
+    }
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => {
             Box::pin(args.run::<DefaultReporter>(dir, config, recursive))

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -29,6 +29,12 @@ use std::{
     sync::Arc,
 };
 
+/// The `wrap_err` framing `pack` and `publish` attach to a failed pack.
+/// [`super::dispatch`]'s `--json` error path matches on it to surface the
+/// underlying pack diagnostic instead of this wrapper, so the two sites must
+/// share one definition.
+pub(crate) const PACK_ERROR_CONTEXT: &str = "pack the package";
+
 /// The catalogs `catalog:` specifiers resolve against when packing a
 /// package for `pack` / `publish`: the hook-injected set when an
 /// `updateConfig` pnpmfile provided one ([`Config::catalogs`] is `Some`),
@@ -110,7 +116,7 @@ impl PackArgs {
             let result = api::<Reporter, Host>(&options)
                 .await
                 .map_err(miette::Report::new)
-                .wrap_err("pack the package")?;
+                .wrap_err(PACK_ERROR_CONTEXT)?;
             Ok(format_pack_output(&[to_pack_result_json(&result)], self.json, false))
         }
     }

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -321,7 +321,7 @@ impl PublishArgs {
         pack_api::<Reporter, PackHost>(&options)
             .await
             .map_err(miette::Report::new)
-            .wrap_err("pack the package")
+            .wrap_err(crate::cli_args::pack::PACK_ERROR_CONTEXT)
     }
 
     /// Map the CLI flags and resolved [`Config`] onto the publish options.

--- a/pnpm/crates/cli/tests/publish.rs
+++ b/pnpm/crates/cli/tests/publish.rs
@@ -326,9 +326,62 @@ fn json_flag_prints_errors_to_stdout() {
         String::from_utf8_lossy(&output.stderr),
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed: Value = serde_json::from_str(&stdout).expect("stdout is a JSON error envelope");
+    let parsed: Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout is a JSON error envelope: {error}; stdout: {stdout}; stderr: {}",
+            String::from_utf8_lossy(&output.stderr),
+        )
+    });
     assert_eq!(parsed["error"]["code"], "ERR_PNPM_PACKAGE_VERSION_NOT_FOUND");
     assert_eq!(parsed["error"]["message"], "Package version is not defined in the package.json.");
+}
+
+#[test]
+fn json_flag_preserves_webauth_urls_on_noninteractive_otp_errors() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_project(
+        dir.path(),
+        &registry,
+        &json!({ "name": "test-publish-otp-json", "version": "1.0.0" }),
+    );
+    let mock = server
+        .mock("PUT", "/test-publish-otp-json")
+        .with_status(401)
+        .with_body(
+            json!({
+                "error": "one-time pass required",
+                "authUrl": "https://auth.example/login?token=abc",
+                "doneUrl": "https://auth.example/done?token=abc",
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create();
+
+    let output = publish(dir.path(), &["--json"]);
+    assert!(!output.status.success(), "publish requiring OTP must fail without a TTY");
+    assert!(
+        output.stderr.is_empty(),
+        "--json errors must not be rendered to stderr; stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout is a JSON error envelope: {error}; stdout: {stdout}; stderr: {}",
+            String::from_utf8_lossy(&output.stderr),
+        )
+    });
+    assert_eq!(parsed["error"]["code"], "ERR_PNPM_OTP_NON_INTERACTIVE");
+    assert_eq!(
+        parsed["error"]["message"],
+        "The registry requires additional authentication, but pnpm is not running in an interactive terminal",
+    );
+    assert_eq!(parsed["error"]["authUrl"], "https://auth.example/login?token=abc");
+    assert_eq!(parsed["error"]["doneUrl"], "https://auth.example/done?token=abc");
+    mock.assert();
 }
 
 /// `prepublishOnly` runs through `sh -c` before packing, so a script that writes

--- a/pnpm/crates/cli/tests/publish.rs
+++ b/pnpm/crates/cli/tests/publish.rs
@@ -363,7 +363,7 @@ fn json_flag_prints_errors_to_stdout() {
     });
     assert_eq!(
         stdout,
-        "{\"error\":{\"code\":\"ERR_PNPM_PACKAGE_VERSION_NOT_FOUND\",\"message\":\"Package version is not defined in the package.json.\"}}\n",
+        "{\n  \"error\": {\n    \"code\": \"ERR_PNPM_PACKAGE_VERSION_NOT_FOUND\",\n    \"message\": \"Package version is not defined in the package.json.\"\n  }\n}\n",
     );
 }
 

--- a/pnpm/crates/cli/tests/publish.rs
+++ b/pnpm/crates/cli/tests/publish.rs
@@ -310,6 +310,35 @@ fn json_flag_prints_the_per_package_summary() {
 }
 
 #[test]
+fn json_flag_suppresses_explicit_reporter_output() {
+    let dir = tempfile::tempdir().expect("workspace");
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    write_project(
+        dir.path(),
+        &registry,
+        &json!({ "name": "test-publish-json-reporter", "version": "1.0.0" }),
+    );
+    server.mock("PUT", "/test-publish-json-reporter").with_status(200).with_body("{}").create();
+
+    let output = publish(dir.path(), &["--json", "--reporter=ndjson"]);
+    assert_success(&output);
+    assert!(
+        output.stderr.is_empty(),
+        "--json must suppress explicit reporter output; stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout is one JSON value: {error}; stdout: {stdout}; stderr: {}",
+            String::from_utf8_lossy(&output.stderr),
+        )
+    });
+    assert_eq!(parsed["id"], "test-publish-json-reporter@1.0.0");
+}
+
+#[test]
 fn json_flag_prints_errors_to_stdout() {
     let dir = tempfile::tempdir().expect("workspace");
     write_project(

--- a/pnpm/crates/cli/tests/publish.rs
+++ b/pnpm/crates/cli/tests/publish.rs
@@ -309,6 +309,28 @@ fn json_flag_prints_the_per_package_summary() {
     );
 }
 
+#[test]
+fn json_flag_prints_errors_to_stdout() {
+    let dir = tempfile::tempdir().expect("workspace");
+    write_project(
+        dir.path(),
+        "https://registry.example/",
+        &json!({ "name": "test-publish-no-version" }),
+    );
+
+    let output = publish(dir.path(), &["--dry-run", "--json"]);
+    assert!(!output.status.success(), "publish without a version must fail");
+    assert!(
+        output.stderr.is_empty(),
+        "--json errors must not be rendered to stderr; stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: Value = serde_json::from_str(&stdout).expect("stdout is a JSON error envelope");
+    assert_eq!(parsed["error"]["code"], "ERR_PNPM_PACKAGE_VERSION_NOT_FOUND");
+    assert_eq!(parsed["error"]["message"], "Package version is not defined in the package.json.");
+}
+
 /// `prepublishOnly` runs through `sh -c` before packing, so a script that writes
 /// a file leaves it in the package dir; the publish `PUT` still happens.
 #[cfg(unix)]

--- a/pnpm/crates/cli/tests/publish.rs
+++ b/pnpm/crates/cli/tests/publish.rs
@@ -355,14 +355,16 @@ fn json_flag_prints_errors_to_stdout() {
         String::from_utf8_lossy(&output.stderr),
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let parsed: Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+    serde_json::from_str::<Value>(&stdout).unwrap_or_else(|error| {
         panic!(
             "stdout is a JSON error envelope: {error}; stdout: {stdout}; stderr: {}",
             String::from_utf8_lossy(&output.stderr),
         )
     });
-    assert_eq!(parsed["error"]["code"], "ERR_PNPM_PACKAGE_VERSION_NOT_FOUND");
-    assert_eq!(parsed["error"]["message"], "Package version is not defined in the package.json.");
+    assert_eq!(
+        stdout,
+        "{\"error\":{\"code\":\"ERR_PNPM_PACKAGE_VERSION_NOT_FOUND\",\"message\":\"Package version is not defined in the package.json.\"}}\n",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

I found this issue while trying to test pnpm 12 with Changesets.

## Squash Commit Body

```text
Made pacquet's `--json` error reporting print to `stdout` in the raw form (without human-readable formatting). This allows the output to be machine-processed.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786704734&installation_id=145934176&pr_number=13029&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13029&signature=9dfc647a5c6413bd38ab8b6ecbe5fb5eb5bb8ea9e2cf789a5a0d59a0f857a964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured JSON error output for `pacquet publish --json`, including a JSON error envelope and exit code `1`.
  * In JSON mode, diagnostic/reporters are suppressed (including when `--reporter=ndjson` is set).
  * OTP non-interactive authentication errors now include `authUrl`/`doneUrl` in the JSON error payload when available.
* **Bug Fixes**
  * Prevented sensitive nested error details from appearing in the user-facing JSON error message.
* **Tests**
  * Added integration and unit tests to verify JSON success/failure output and message sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->