### PR TITLE
fix(pacquet): honor workspace install filters

### DIFF
--- a/.changeset/pacquet-install-filters.md
+++ b/.changeset/pacquet-install-filters.md
@@ -3,4 +3,4 @@
 "@pnpm/pnpr": patch
 ---
 
-Fixed filtered workspace installs to batch selected project mutations, preserve complete lockfile state, and materialize only the selected dependency closure.
+Fixed Pacquet workspace commands to honor project filters, preserve complete lockfile state, and materialize only the selected dependency closure, including pnpr-backed installs.

--- a/.changeset/pacquet-install-filters.md
+++ b/.changeset/pacquet-install-filters.md
@@ -1,0 +1,6 @@
+---
+"pacquet": patch
+"@pnpm/pnpr": patch
+---
+
+Fixed filtered workspace installs to batch selected project mutations, preserve complete lockfile state, and materialize only the selected dependency closure.

--- a/.changeset/pnpr-workspace-identity.md
+++ b/.changeset/pnpr-workspace-identity.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/pnpr.client": patch
+"pnpm": patch
+"@pnpm/pnpr": patch
+---
+
+Fixed pnpr workspace resolution to preserve project names and versions for `workspace:` dependencies.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10089,6 +10089,9 @@ importers:
         specifier: workspace:*
         version: link:../../pnpm11/lockfile/types
     devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.4.1
       '@pnpm/pnpr.client':
         specifier: workspace:*
         version: 'link:'

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -1,7 +1,8 @@
 use crate::{
     State,
     cli_args::{
-        install::resolve_bool_override, supported_architectures::SupportedArchitecturesArgs,
+        install::resolve_bool_override, pipelines::InstallFamilySelection,
+        supported_architectures::SupportedArchitecturesArgs,
     },
     config_deps,
 };
@@ -215,6 +216,59 @@ impl AddArgs {
         .await
     }
 
+    pub(crate) async fn run_selected<Reporter: self::Reporter + 'static>(
+        self,
+        mut state: State,
+        selection: InstallFamilySelection,
+    ) -> miette::Result<()> {
+        let supported_architectures =
+            self.supported_architectures.apply_to(state.config.supported_architectures.clone());
+        let save_catalog_name = self
+            .save_catalog_name
+            .clone()
+            .or_else(|| self.save_catalog.then(|| "default".to_string()))
+            .or_else(|| state.config.save_catalog_name.clone());
+        let pinned_version =
+            PinnedVersion::from_save_options(self.save_exact, self.save_prefix.as_deref());
+        let InstallFamilySelection {
+            workspace_root: _,
+            mut projects,
+            ordered_dirs,
+            selected_dirs,
+            active_manifest_is_standin,
+        } = selection;
+        let lockfile_path = state.lockfile_path();
+        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+            &mut state;
+        let lockfile =
+            lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+
+        Add {
+            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            http_client,
+            http_client_arc: std::sync::Arc::clone(http_client),
+            config,
+            manifest,
+            lockfile,
+            lockfile_path: Some(&lockfile_path),
+            dependency_groups: self.dependency_options.dependency_groups(),
+            package_names: &self.package_names,
+            pinned_version,
+            save_catalog_name,
+            resolved_packages,
+            supported_architectures,
+            lockfile_only: self.lockfile_only,
+        }
+        .run_selected::<Reporter>(
+            &mut projects,
+            &ordered_dirs,
+            selected_dirs.as_ref(),
+            active_manifest_is_standin,
+        )
+        .await
+        .wrap_err("adding a new package")
+    }
+
     /// `pnpm add -g`: install the package into the global packages
     /// directory and link its bins. Delegates to
     /// [`crate::cli_args::global::handle_global_add`].
@@ -295,13 +349,12 @@ where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
     // TODO: if a package already exists in another dependency group, don't remove the existing entry.
+    let lockfile_path = state.lockfile_path();
     let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
         &mut state;
     let lockfile =
         lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
 
-    let lockfile_path =
-        manifest.path().parent().map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
     Add {
         tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
         http_client,
@@ -309,7 +362,7 @@ where
         config,
         manifest,
         lockfile,
-        lockfile_path: lockfile_path.as_deref(),
+        lockfile_path: Some(&lockfile_path),
         dependency_groups,
         package_names,
         pinned_version,

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -170,11 +170,7 @@ impl AuditArgs {
             .unwrap_or(ConfigAuditLevel::Low);
         let fix_method = self.resolve_fix_method()?;
 
-        let lockfile_dir = state
-            .manifest
-            .path()
-            .parent()
-            .map_or_else(|| state.manifest.path().to_path_buf(), std::path::Path::to_path_buf);
+        let lockfile_dir = state.lockfile_dir().to_path_buf();
         // pnpm writes settings to `workspaceDir ?? rootProjectManifestDir`.
         let settings_dir =
             state.config.workspace_dir.clone().unwrap_or_else(|| lockfile_dir.clone());
@@ -191,8 +187,7 @@ impl AuditArgs {
             let Some(lockfile) = lockfile else {
                 return Err(AuditError::NoLockfile.into());
             };
-            let env_lockfile_dir = state.config.workspace_dir.as_deref().unwrap_or(&lockfile_dir);
-            let env_lockfile = EnvLockfile::read(env_lockfile_dir)
+            let env_lockfile = EnvLockfile::read(&lockfile_dir)
                 .map_err(|err| miette::Report::new(err).wrap_err("load the env lockfile"))?;
             match audit(
                 lockfile,
@@ -325,11 +320,7 @@ impl AuditArgs {
     /// Ports pnpm's `auditSignatures`.
     async fn run_signatures(&self, state: State) -> miette::Result<AuditOutcome> {
         let include = self.dependency_options.include();
-        let lockfile_dir = state
-            .manifest
-            .path()
-            .parent()
-            .map_or_else(|| state.manifest.path().to_path_buf(), std::path::Path::to_path_buf);
+        let lockfile_dir = state.lockfile_dir().to_path_buf();
 
         let packages = {
             let lockfile = state
@@ -339,8 +330,7 @@ impl AuditArgs {
             let Some(lockfile) = lockfile else {
                 return Err(AuditError::NoLockfile.into());
             };
-            let env_lockfile_dir = state.config.workspace_dir.as_deref().unwrap_or(&lockfile_dir);
-            let env_lockfile = EnvLockfile::read(env_lockfile_dir)
+            let env_lockfile = EnvLockfile::read(&lockfile_dir)
                 .map_err(|err| miette::Report::new(err).wrap_err("load the env lockfile"))?;
             let audit_request = lockfile_to_audit_request(lockfile, env_lockfile.as_ref(), include);
             let registries: HashMap<String, String> =
@@ -1889,11 +1879,11 @@ async fn fix_with_update<Reporter: self::Reporter + 'static>(
     });
 
     {
+        let lockfile_path = state.lockfile_path();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             state;
         let lockfile =
             lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
-        let lockfile_path = manifest.path().parent().map(|parent| parent.join(Lockfile::FILE_NAME));
         Update {
             tarball_mem_cache: Arc::clone(tarball_mem_cache),
             resolved_packages,
@@ -1902,7 +1892,7 @@ async fn fix_with_update<Reporter: self::Reporter + 'static>(
             config,
             manifest,
             lockfile,
-            lockfile_path: lockfile_path.as_deref(),
+            lockfile_path: Some(&lockfile_path),
             packages: &[],
             latest: false,
             save_exact: false,

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -10,9 +10,10 @@ use pacquet_config::{Config, LinkWorkspacePackages, NodeLinker, PackageImportMet
 use pacquet_directory_fetcher::DirectoryFetcher;
 use pacquet_fs::{lexical_normalize, remove_symlink_dir};
 use pacquet_lockfile::{
-    DirectoryResolution, ImporterDepVersion, Lockfile, LockfileResolution, MaybeLazyLockfile,
-    PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, ProjectSnapshot, ResolvedDependencyMap,
-    ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, TarballResolution, VersionPart,
+    DirectoryResolution, ImporterDepVersion, LazyLockfile, Lockfile, LockfileResolution,
+    MaybeLazyLockfile, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, ProjectSnapshot,
+    ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
+    TarballResolution, VersionPart,
 };
 use pacquet_package_manager::{
     ImportIndexedDirOpts, Install, UpdateSeedPolicy, import_indexed_dir,
@@ -324,6 +325,7 @@ impl DeployArgs {
         // every platform are materialized (see `Config::force`).
         deploy_config.force = self.force;
 
+        let legacy = matches!(&mode, DeployInstallMode::Legacy);
         match mode {
             DeployInstallMode::Legacy => {}
             DeployInstallMode::Shared { workspace_config } => {
@@ -338,8 +340,19 @@ impl DeployArgs {
         }
 
         let deploy_config = Config::leak(deploy_config);
-        let state = State::init(deploy_dir.join("package.json"), deploy_config, frozen_lockfile)
-            .wrap_err("initialize the deploy install state")?;
+        let mut state =
+            State::init(deploy_dir.join("package.json"), deploy_config, frozen_lockfile)
+                .wrap_err("initialize the deploy install state")?;
+        if legacy {
+            // Legacy deploy still resolves workspace dependencies from the
+            // source workspace, but its synthetic project owns a lockfile in
+            // the deploy directory.
+            state.lockfile = if state.config.lockfile || frozen_lockfile {
+                LazyLockfile::deferred(deploy_dir.to_path_buf())
+            } else {
+                LazyLockfile::disabled()
+            };
+        }
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
 
@@ -358,7 +371,7 @@ impl DeployArgs {
         let dependency_groups =
             self.install_args.dependency_options.dependency_groups().collect::<Vec<_>>();
 
-        Install {
+        let install = Install {
             tarball_mem_cache: Arc::clone(tarball_mem_cache),
             http_client,
             http_client_arc: Arc::clone(http_client),
@@ -388,9 +401,12 @@ impl DeployArgs {
             disable_optimistic_repeat_install: true,
             pnpmfile_hook_override: None,
             workspace_projects_override: None,
+        };
+        if legacy {
+            install.run_with_root_importer::<ReporterT>().await
+        } else {
+            install.run::<ReporterT>().await
         }
-        .run::<ReporterT>()
-        .await
         .wrap_err("installing deployed dependencies")
     }
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -15,7 +15,8 @@ use super::{
     patch_commit::PatchCommitArgs,
     patch_remove::PatchRemoveArgs,
     pipelines::{
-        DedupePipeline, DeployPipeline, InstallPipeline, PrunePipeline, apply_install_cli_config,
+        AddPipeline, DedupePipeline, DeployPipeline, InstallPipeline, PrunePipeline,
+        RemovePipeline, UpdatePipeline, apply_install_cli_config,
         derive_config_root_and_package_manager_to_sync,
     },
     prune::PruneArgs,
@@ -26,7 +27,6 @@ use super::{
     unlink::UnlinkArgs,
     update::UpdateArgs,
 };
-use crate::State;
 use miette::Context;
 use pacquet_default_reporter::DefaultReporter;
 use pacquet_reporter::{NdjsonReporter, SilentReporter};
@@ -44,22 +44,39 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
             ReporterType::Silent => Box::pin(args.run_global::<SilentReporter>(config, dir)),
         });
     }
+    // Parsed up front: `AddPipeline::run` scaffolds a `package.json` through
+    // `State::init`, and an invalid selector must be rejected before that.
     let config_dependencies = args.parse_config_dependencies()?;
-    let config = (ctx.config)()?;
-    args.apply_cli_config(config);
-    let command_state = State::init(ctx.manifest_path.to_path_buf(), config, false)
-        .wrap_err("initialize the state")?;
-    Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>(command_state, config_dependencies))
+    let dir = ctx.dir;
+    let manifest_path = ctx.manifest_path;
+    let reporter = ctx.reporter;
+    let recursive_sort = ctx.recursive_sort;
+    let config = ctx.config;
+    Ok(Box::pin(async move {
+        let cfg = config()?;
+        args.apply_cli_config(cfg);
+        let (config_root, package_manager_to_sync) =
+            derive_config_root_and_package_manager_to_sync(cfg, dir)
+                .wrap_err("derive workspace root and package manager policy")?;
+        let pipeline = AddPipeline {
+            args,
+            cfg,
+            config_root,
+            package_manager_to_sync,
+            prefix: dir.to_path_buf(),
+            manifest_path: manifest_path.to_path_buf(),
+            recursive_sort,
+            config_dependencies,
+        };
+        match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                Box::pin(pipeline.run::<DefaultReporter>()).await?;
+            }
+            ReporterType::Ndjson => Box::pin(pipeline.run::<NdjsonReporter>()).await?,
+            ReporterType::Silent => Box::pin(pipeline.run::<SilentReporter>()).await?,
         }
-        ReporterType::Ndjson => {
-            Box::pin(args.run::<NdjsonReporter>(command_state, config_dependencies))
-        }
-        ReporterType::Silent => {
-            Box::pin(args.run::<SilentReporter>(command_state, config_dependencies))
-        }
-    })
+        Ok(())
+    }))
 }
 
 pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<CommandFuture<'a>> {
@@ -73,14 +90,34 @@ pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<C
             ReporterType::Silent => Box::pin(args.run_global::<SilentReporter>(config)),
         });
     }
-    let command_state = (ctx.state)(false)?;
-    Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>(command_state))
+    let dir = ctx.dir;
+    let manifest_path = ctx.manifest_path;
+    let reporter = ctx.reporter;
+    let recursive_sort = ctx.recursive_sort;
+    let config = ctx.config;
+    Ok(Box::pin(async move {
+        let cfg = config()?;
+        let (config_root, package_manager_to_sync) =
+            derive_config_root_and_package_manager_to_sync(cfg, dir)
+                .wrap_err("derive workspace root and package manager policy")?;
+        let pipeline = UpdatePipeline {
+            args,
+            cfg,
+            config_root,
+            package_manager_to_sync,
+            prefix: dir.to_path_buf(),
+            manifest_path: manifest_path.to_path_buf(),
+            recursive_sort,
+        };
+        match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                Box::pin(pipeline.run::<DefaultReporter>()).await?;
+            }
+            ReporterType::Ndjson => Box::pin(pipeline.run::<NdjsonReporter>()).await?,
+            ReporterType::Silent => Box::pin(pipeline.run::<SilentReporter>()).await?,
         }
-        ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
-        ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
-    })
+        Ok(())
+    }))
 }
 
 pub(super) fn remove<'a>(ctx: &RunCtx<'a>, args: RemoveArgs) -> miette::Result<CommandFuture<'a>> {
@@ -88,14 +125,34 @@ pub(super) fn remove<'a>(ctx: &RunCtx<'a>, args: RemoveArgs) -> miette::Result<C
         global::handle_global_remove((ctx.global_config)()?, &args.package_names)?;
         return Ok(Box::pin(std::future::ready(Ok(()))));
     }
-    let command_state = (ctx.state)(false)?;
-    Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>(command_state))
+    let dir = ctx.dir;
+    let manifest_path = ctx.manifest_path;
+    let reporter = ctx.reporter;
+    let recursive_sort = ctx.recursive_sort;
+    let config = ctx.config;
+    Ok(Box::pin(async move {
+        let cfg = config()?;
+        let (config_root, package_manager_to_sync) =
+            derive_config_root_and_package_manager_to_sync(cfg, dir)
+                .wrap_err("derive workspace root and package manager policy")?;
+        let pipeline = RemovePipeline {
+            args,
+            cfg,
+            config_root,
+            package_manager_to_sync,
+            prefix: dir.to_path_buf(),
+            manifest_path: manifest_path.to_path_buf(),
+            recursive_sort,
+        };
+        match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                Box::pin(pipeline.run::<DefaultReporter>()).await?;
+            }
+            ReporterType::Ndjson => Box::pin(pipeline.run::<NdjsonReporter>()).await?,
+            ReporterType::Silent => Box::pin(pipeline.run::<SilentReporter>()).await?,
         }
-        ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
-        ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
-    })
+        Ok(())
+    }))
 }
 
 pub(super) fn install<'a>(
@@ -105,6 +162,7 @@ pub(super) fn install<'a>(
     let dir = ctx.dir;
     let manifest_path = ctx.manifest_path;
     let reporter = ctx.reporter;
+    let recursive_sort = ctx.recursive_sort;
     let config = ctx.config;
     Ok(Box::pin(async move {
         // Boxed for `clippy::large_stack_frames`: the three
@@ -147,7 +205,9 @@ pub(super) fn install<'a>(
                 cfg,
                 config_root,
                 package_manager_to_sync,
+                prefix: dir.to_path_buf(),
                 manifest_path: manifest_path.to_path_buf(),
+                recursive_sort,
                 require_lockfile,
                 frozen_lockfile,
             };

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -60,7 +60,7 @@ pub(super) fn outdated<'a>(
     args: OutdatedArgs,
 ) -> miette::Result<CommandFuture<'a>> {
     if args.global {
-        let config = (ctx.config)()?;
+        let config = (ctx.global_config)()?;
         return Ok(Box::pin(async move {
             if args.run_global(config).await? == OutdatedOutcome::Outdated {
                 #[expect(

--- a/pnpm/crates/cli/src/cli_args/fetch.rs
+++ b/pnpm/crates/cli/src/cli_args/fetch.rs
@@ -15,6 +15,7 @@ pub struct FetchArgs {
 
 impl FetchArgs {
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
+        let lockfile_path = state.lockfile_path();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
 
@@ -22,15 +23,6 @@ impl FetchArgs {
         let has_both = prod == dev;
         let include_prod = has_both || prod;
         let include_dev = has_both || dev;
-
-        // The lockfile-verification gate keys its on-disk cache off
-        // `<manifest_dir>/pnpm-lock.yaml`, matching `pacquet install`.
-        // Once workspace support lands (pacquet#431), this becomes
-        // `workspace_root` to match where the lockfile actually lives.
-        let lockfile_path = manifest
-            .path()
-            .parent()
-            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
 
         Install {
             tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
@@ -40,7 +32,7 @@ impl FetchArgs {
             manifest,
             emit_initial_manifest: true,
             lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
-            lockfile_path: lockfile_path.as_deref(),
+            lockfile_path: Some(&lockfile_path),
             // Optional dependencies follow production, so `--dev` (which
             // excludes production) excludes optional deps too.
             dependency_groups: std::iter::empty()

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -14,7 +14,7 @@ pub struct ImportArgs {
 
 impl ImportArgs {
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+        let State { tarball_mem_cache, http_client, config, manifest, resolved_packages, .. } =
             &state;
         let dir = manifest.path().parent().expect("manifest path always has a parent dir");
         let lockfile_path = dir.join("pnpm-lock.yaml");
@@ -26,6 +26,7 @@ impl ImportArgs {
                 .into_diagnostic()
                 .wrap_err("backing up existing pnpm-lock.yaml")?;
         }
+        let import_lockfile = pacquet_lockfile::LazyLockfile::preloaded(None);
 
         let install_result = if let Some(pnpr_server) =
             self.pnpr_server.as_deref().or(config.pnpr_server.as_deref())
@@ -48,6 +49,7 @@ impl ImportArgs {
                     ignore_manifest_check: false,
                     trust_lockfile: false,
                     lockfile_path: Some(lockfile_path.as_path()),
+                    use_state_lockfile: false,
                 },
             )
             .await
@@ -60,7 +62,7 @@ impl ImportArgs {
                 config,
                 manifest,
                 emit_initial_manifest: true,
-                lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
+                lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(&import_lockfile),
                 lockfile_path: Some(lockfile_path.as_path()),
                 dependency_groups: [
                     DependencyGroup::Prod,

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1,15 +1,25 @@
-use crate::{State, cli_args::supported_architectures::SupportedArchitecturesArgs};
+use crate::{
+    State,
+    cli_args::{
+        pipelines::InstallFamilySelection, recursive::discover_workspace_projects,
+        supported_architectures::SupportedArchitecturesArgs,
+    },
+};
 use clap::{Args, ValueEnum};
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic};
 use pacquet_config::NodeLinker;
 use pacquet_lockfile::{Lockfile, LockfileResolution, MaybeLazyLockfile};
+use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_package_manager::{
-    Install, InstallFrozenLockfileError, LockfileVerificationOverride, TarballPrefetcher,
-    UpToDateFastPathCheck, UpdateSeedPolicy, install_already_up_to_date,
+    Install, InstallFrozenLockfileError, LockfileVerificationOverride, SkippedSnapshots,
+    TarballPrefetcher, UpToDateFastPathCheck, UpdateSeedPolicy, WorkspaceInstallSelection,
+    install_already_up_to_date, materialization_closure, merge_filtered_wanted_lockfile,
 };
 use pacquet_package_manifest::DependencyGroup;
-use pacquet_pnpr_client::{PnprClient, PnprClientError, ResolveOptions, VerifyLockfileOptions};
+use pacquet_pnpr_client::{
+    PnprClient, PnprClientError, ResolveProject, ResolveProjectsOptions, VerifyLockfileOptions,
+};
 use pacquet_reporter::Reporter;
 
 const BENCHMARK_PNPR_SERVER_REGISTRY_ENV: &str = "PACQUET_BENCHMARK_PNPR_SERVER_REGISTRY";
@@ -309,6 +319,22 @@ impl InstallArgs {
     }
 
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
+        Box::pin(self.run_inner::<Reporter>(state, None)).await
+    }
+
+    pub(crate) async fn run_selected<Reporter: self::Reporter + 'static>(
+        self,
+        state: State,
+        selection: InstallFamilySelection,
+    ) -> miette::Result<()> {
+        Box::pin(self.run_inner::<Reporter>(state, Some(selection))).await
+    }
+
+    async fn run_inner<Reporter: self::Reporter + 'static>(
+        self,
+        state: State,
+        selection: Option<InstallFamilySelection>,
+    ) -> miette::Result<()> {
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
         let InstallArgs {
@@ -388,14 +414,7 @@ impl InstallArgs {
         // yaml/npmrc value for this invocation. Mirrors pnpm's
         // override-on-explicit-flag semantics.
         let node_linker = node_linker.map_or(config.node_linker, NodeLinkerArg::into_config);
-        // The lockfile-verification gate keys its on-disk cache off
-        // `<manifest_dir>/pnpm-lock.yaml`. Once workspace support
-        // lands (pacquet#431), this becomes `workspace_root` to
-        // match where the lockfile actually lives.
-        let lockfile_path = manifest
-            .path()
-            .parent()
-            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
+        let lockfile_path = state.lockfile_path();
 
         // pnpr fast path: when a `pnprServer` URL is configured, offload
         // resolution + fetching to it, then link `node_modules` from the
@@ -407,9 +426,10 @@ impl InstallArgs {
             if dry_run {
                 return Err(DryRunIncompatibleWithPnpr.into());
             }
-            return install_via_pnpr::<Reporter>(
+            return Box::pin(install_via_pnpr_inner::<Reporter>(
                 &state,
                 pnpr_server,
+                selection.as_ref(),
                 PnprLink {
                     dependency_groups: dependency_options.dependency_groups().collect(),
                     supported_architectures,
@@ -421,13 +441,14 @@ impl InstallArgs {
                     lockfile_only,
                     ignore_manifest_check,
                     trust_lockfile,
-                    lockfile_path: lockfile_path.as_deref(),
+                    lockfile_path: Some(&lockfile_path),
+                    use_state_lockfile: true,
                 },
-            )
+            ))
             .await;
         }
 
-        Install {
+        let install = Install {
             tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
             http_client,
             http_client_arc: std::sync::Arc::clone(http_client),
@@ -435,7 +456,7 @@ impl InstallArgs {
             manifest,
             emit_initial_manifest: true,
             lockfile: MaybeLazyLockfile::Lazy(lockfile),
-            lockfile_path: lockfile_path.as_deref(),
+            lockfile_path: Some(&lockfile_path),
             dependency_groups: dependency_options.dependency_groups(),
             frozen_lockfile,
             prefer_frozen_lockfile,
@@ -460,12 +481,27 @@ impl InstallArgs {
             disable_optimistic_repeat_install: false,
             pnpmfile_hook_override: None,
             workspace_projects_override: None,
+        };
+        match selection.as_ref() {
+            Some(selection) => {
+                install.run_selected::<Reporter>(workspace_install_selection(selection)).await
+            }
+            None => install.run::<Reporter>().await,
         }
-        .run::<Reporter>()
-        .await
         .wrap_err("installing dependencies")?;
 
         Ok(())
+    }
+}
+
+fn workspace_install_selection(
+    selection: &InstallFamilySelection,
+) -> WorkspaceInstallSelection<'_> {
+    WorkspaceInstallSelection {
+        all_projects: &selection.projects,
+        ordered_dirs: &selection.ordered_dirs,
+        selected_dirs: selection.selected_dirs.as_ref(),
+        active_manifest_is_standin: selection.active_manifest_is_standin,
     }
 }
 
@@ -505,6 +541,7 @@ pub(crate) struct PnprLink<'a> {
     /// input lockfile when the user opted out, mirroring the local path.
     pub(crate) trust_lockfile: bool,
     pub(crate) lockfile_path: Option<&'a std::path::Path>,
+    pub(crate) use_state_lockfile: bool,
 }
 
 /// `frozenStore` was enabled together with a configured `pnprServer`.
@@ -539,7 +576,35 @@ struct FrozenStoreIncompatibleWithPnpr;
 )]
 struct DryRunIncompatibleWithPnpr;
 
-/// Resolve a single project through a `pnpr` server, then link it.
+fn resolve_project(
+    dir: String,
+    manifest: &pacquet_package_manifest::PackageManifest,
+) -> ResolveProject {
+    ResolveProject {
+        dir,
+        name: manifest.value().get("name").and_then(|value| value.as_str()).map(str::to_string),
+        version: manifest
+            .value()
+            .get("version")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        dependencies: manifest
+            .dependencies([DependencyGroup::Prod])
+            .map(|(name, spec)| (name.to_string(), spec.to_string()))
+            .collect(),
+        dev_dependencies: manifest
+            .dependencies([DependencyGroup::Dev])
+            .map(|(name, spec)| (name.to_string(), spec.to_string()))
+            .collect(),
+        optional_dependencies: manifest
+            .dependencies([DependencyGroup::Optional])
+            .map(|(name, spec)| (name.to_string(), spec.to_string()))
+            .collect(),
+    }
+}
+
+/// Resolve the active project or selected workspace projects through a
+/// `pnpr` server, then link them.
 ///
 /// Sends the client's registries to the server, which resolves against
 /// them and returns the resolved lockfile; writes that lockfile, then
@@ -552,6 +617,15 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     pnpr_server: &str,
     link: PnprLink<'_>,
 ) -> miette::Result<()> {
+    Box::pin(install_via_pnpr_inner::<Reporter>(state, pnpr_server, None, link)).await
+}
+
+async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
+    state: &State,
+    pnpr_server: &str,
+    selection: Option<&InstallFamilySelection>,
+    link: PnprLink<'_>,
+) -> miette::Result<()> {
     // The pnpr server resolves dependencies and streams missing files
     // straight into the store, so this path inherently writes the store.
     // `frozenStore` promises the store is complete and read-only, so the
@@ -562,21 +636,48 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         return Err(FrozenStoreIncompatibleWithPnpr.into());
     }
 
-    let dependencies = state
-        .manifest
-        .dependencies([DependencyGroup::Prod])
-        .map(|(name, spec)| (name.to_string(), spec.to_string()))
-        .collect();
-    let dev_dependencies = state
-        .manifest
-        .dependencies([DependencyGroup::Dev])
-        .map(|(name, spec)| (name.to_string(), spec.to_string()))
-        .collect();
-    let optional_dependencies = state
-        .manifest
-        .dependencies([DependencyGroup::Optional])
-        .map(|(name, spec)| (name.to_string(), spec.to_string()))
-        .collect();
+    let previous_wanted = if link.use_state_lockfile {
+        state
+            .lockfile
+            .get()
+            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?
+            .cloned()
+    } else {
+        None
+    };
+    let selection_importer_ids = selection.map(|selection| {
+        let real_importer_ids = selection
+            .projects
+            .iter()
+            .map(|project| {
+                pacquet_workspace::importer_id_from_root_dir(
+                    &selection.workspace_root,
+                    &project.root_dir,
+                )
+            })
+            .collect();
+        let selected_importer_ids = selection
+            .selected_dirs
+            .iter()
+            .map(|project_dir| {
+                pacquet_workspace::importer_id_from_root_dir(&selection.workspace_root, project_dir)
+            })
+            .collect();
+        (real_importer_ids, selected_importer_ids)
+    });
+    let partial_selection = selection_importer_ids.as_ref().is_some_and(
+        |(real_importer_ids, selected_importer_ids)| real_importer_ids != selected_importer_ids,
+    );
+    let projects = resolve_projects_for_pnpr(state, selection, link.use_state_lockfile)?;
+    let full_workspace_importer_ids = (selection.is_none()
+        && link.use_state_lockfile
+        && state.config.shared_workspace_lockfile
+        && state.config.workspace_dir.is_some())
+    .then(|| {
+        let importer_ids: std::collections::HashSet<_> =
+            projects.iter().map(|project| project.dir.clone()).collect();
+        (importer_ids.clone(), importer_ids)
+    });
 
     let overrides = state
         .config
@@ -600,10 +701,8 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     // server-side now — both for reused entries (the input-lockfile
     // verifier) and freshly-resolved ones (the resolver's pick-time
     // gate, since the policy is wired into the server's config).
-    let opts = ResolveOptions {
-        dependencies,
-        dev_dependencies,
-        optional_dependencies,
+    let opts = ResolveProjectsOptions {
+        projects,
         registry: resolve_registry,
         named_registries: state.config.named_registries.clone(),
         // Only the caller's identity to pnpr is sent. Upstream registry
@@ -611,11 +710,7 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         // route policy, so they stay out of the request body.
         authorization: state.config.auth_headers.for_url(pnpr_server),
         overrides,
-        lockfile: state
-            .lockfile
-            .get()
-            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?
-            .cloned(),
+        lockfile: previous_wanted.clone(),
         frozen_lockfile: link.frozen_lockfile,
         prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
         ignore_manifest_check: link.ignore_manifest_check,
@@ -631,32 +726,72 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     };
 
     let client = PnprClient::new(pnpr_server);
-    let lockfile_dir =
-        state.manifest.path().parent().expect("manifest path always has a parent dir");
+    let lockfile_dir = link.lockfile_path.and_then(|path| path.parent()).unwrap_or_else(|| {
+        state.manifest.path().parent().expect("manifest path always has a parent dir")
+    });
+    let lockfile_path = link
+        .lockfile_path
+        .map_or_else(|| lockfile_dir.join(Lockfile::FILE_NAME), std::path::Path::to_path_buf);
 
     if link.frozen_lockfile
-        && !link.lockfile_only
-        && let Some(lockfile) = state
-            .lockfile
-            .get()
-            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?
+        && (selection.is_some() || !link.lockfile_only)
+        && let Some(lockfile) = previous_wanted.as_ref()
     {
-        let prefetcher = TarballPrefetcher::new(
-            state.config,
-            &state.http_client,
-            &state.tarball_mem_cache,
-            None,
-            &lockfile_dir.to_string_lossy(),
-        )
-        .await;
-        prefetcher.prefetch_lockfile(lockfile, state.config).await;
-        tokio::task::yield_now().await;
+        let prefetcher = if link.lockfile_only {
+            None
+        } else {
+            let selected_prefetch_lockfile =
+                selection_importer_ids.as_ref().map(|(_, selected_importer_ids)| {
+                    let hoisted_importer_ids = matches!(link.node_linker, NodeLinker::Hoisted)
+                        .then(|| {
+                            lockfile
+                                .importers
+                                .keys()
+                                .cloned()
+                                .collect::<std::collections::HashSet<_>>()
+                        });
+                    let initial_importer_ids =
+                        hoisted_importer_ids.as_ref().unwrap_or(selected_importer_ids);
+                    materialization_closure(
+                        lockfile,
+                        lockfile_dir,
+                        initial_importer_ids,
+                        IncludedDependencies {
+                            dependencies: link.dependency_groups.contains(&DependencyGroup::Prod),
+                            dev_dependencies: link
+                                .dependency_groups
+                                .contains(&DependencyGroup::Dev),
+                            optional_dependencies: link
+                                .dependency_groups
+                                .contains(&DependencyGroup::Optional),
+                        },
+                        &SkippedSnapshots::new(),
+                    )
+                    .lockfile
+                });
+            let prefetcher = TarballPrefetcher::new(
+                state.config,
+                &state.http_client,
+                &state.tarball_mem_cache,
+                None,
+                &lockfile_dir.to_string_lossy(),
+            )
+            .await;
+            prefetcher
+                .prefetch_lockfile(
+                    selected_prefetch_lockfile.as_ref().unwrap_or(lockfile),
+                    state.config,
+                )
+                .await;
+            tokio::task::yield_now().await;
+            Some(prefetcher)
+        };
 
         let lockfile_verification_override: Option<LockfileVerificationOverride<'_>> =
             if link.trust_lockfile {
                 None
             } else {
-                let verify_opts = VerifyLockfileOptions::from_resolve_options(&opts)
+                let verify_opts = VerifyLockfileOptions::from_resolve_projects_options(&opts)
                     .expect("frozen pnpr verification requires the loaded lockfile");
                 let verify_client = PnprClient::new(pnpr_server);
                 Some(Box::pin(async move {
@@ -692,7 +827,7 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             resolved_packages: &state.resolved_packages,
             supported_architectures: link.supported_architectures,
             node_linker: link.node_linker,
-            lockfile_only: false,
+            lockfile_only: link.lockfile_only,
             dry_run: false,
             update_seed_policy: UpdateSeedPolicy::KeepAll,
             auth_override: None,
@@ -704,13 +839,24 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
             workspace_projects_override: None,
         };
 
-        let result = match lockfile_verification_override {
-            Some(lockfile_verification_override) => {
+        let result = match (selection, lockfile_verification_override) {
+            (Some(selection), Some(lockfile_verification_override)) => {
+                Box::pin(install.run_selected_with_lockfile_verification::<Reporter>(
+                    workspace_install_selection(selection),
+                    lockfile_verification_override,
+                ))
+                .await
+            }
+            (Some(selection), None) => {
+                Box::pin(install.run_selected::<Reporter>(workspace_install_selection(selection)))
+                    .await
+            }
+            (None, Some(lockfile_verification_override)) => {
                 install
                     .run_with_lockfile_verification::<Reporter>(lockfile_verification_override)
                     .await
             }
-            None => install.run::<Reporter>().await,
+            (None, None) => install.run::<Reporter>().await,
         };
         // On failure the prefetcher is dropped, not shut down: shutdown
         // waits for every in-flight prefetch download (each task holds a
@@ -719,19 +865,23 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         // best-effort — a dropped row only costs a later re-download.
         result.wrap_err("restoring dependencies from the local lockfile via pnpr verification")?;
 
-        prefetcher.shutdown().await;
+        if let Some(prefetcher) = prefetcher {
+            prefetcher.shutdown().await;
+        }
 
         return Ok(());
     }
 
     // Under `--lockfile-only` nothing is materialized, so skip the
     // prefetcher entirely and consume the stream with a no-op callback.
-    // Otherwise spawn a prefetcher that fires each tarball download as
-    // its `package` frame streams in, so fetch overlaps the server's
-    // resolution ([pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234));
-    // the frozen materialization install below then finds every tarball
-    // already in the shared mem cache.
-    let prefetcher = if link.lockfile_only {
+    // A partial install also waits for the merged lockfile before fetching,
+    // because only then is the selected workspace closure known. Otherwise
+    // spawn a prefetcher that fires each tarball download as its `package`
+    // frame streams in, so fetch overlaps the server's resolution
+    // ([pnpm/pnpm#12234](https://github.com/pnpm/pnpm/issues/12234)); the
+    // frozen materialization install below then finds every tarball already
+    // in the shared mem cache.
+    let prefetcher = if link.lockfile_only || partial_selection {
         None
     } else {
         Some(
@@ -749,7 +899,7 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     let result = match prefetcher.as_ref() {
         Some(prefetcher) => {
             client
-                .resolve_streaming(opts, |pkg| {
+                .resolve_projects_streaming(opts, |pkg| {
                     let tarball = benchmark_registry_override.as_ref().map_or_else(
                         || pkg.tarball.clone(),
                         |registry| registry.client_tarball_url(&pkg.tarball),
@@ -764,7 +914,7 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
                 })
                 .await
         }
-        None => client.resolve(opts).await,
+        None => client.resolve_projects(opts).await,
     };
     let mut outcome = match result {
         Ok(outcome) => outcome,
@@ -782,11 +932,26 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     if let Some(registry) = benchmark_registry_override.as_ref() {
         registry.rewrite_lockfile(&mut outcome.lockfile);
     }
+    if let (Some((real_importer_ids, selected_importer_ids)), Some(workspace_root)) = (
+        selection_importer_ids.as_ref().or(full_workspace_importer_ids.as_ref()),
+        selection
+            .map(|selection| selection.workspace_root.as_path())
+            .or(state.config.workspace_dir.as_deref()),
+    ) {
+        outcome.lockfile = merge_filtered_wanted_lockfile(
+            previous_wanted.as_ref(),
+            outcome.lockfile,
+            real_importer_ids,
+            selected_importer_ids,
+            workspace_root,
+        )
+        .map_err(miette::Report::new)?;
+    }
 
     if state.config.lockfile {
         outcome
             .lockfile
-            .save_to_path(&lockfile_dir.join(Lockfile::FILE_NAME))
+            .save_to_path(&lockfile_path)
             .map_err(|err| miette::miette!("{err}"))
             .wrap_err("writing the pnpr-resolved lockfile")?;
     }
@@ -799,7 +964,7 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         return Ok(());
     }
 
-    Install {
+    let install = Install {
         tarball_mem_cache: std::sync::Arc::clone(&state.tarball_mem_cache),
         http_client: &state.http_client,
         http_client_arc: std::sync::Arc::clone(&state.http_client),
@@ -835,9 +1000,13 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
         disable_optimistic_repeat_install: false,
         pnpmfile_hook_override: None,
         workspace_projects_override: None,
+    };
+    match selection {
+        Some(selection) => {
+            Box::pin(install.run_selected::<Reporter>(workspace_install_selection(selection))).await
+        }
+        None => install.run::<Reporter>().await,
     }
-    .run::<Reporter>()
-    .await
     .wrap_err("linking dependencies resolved via the pnpr server")?;
 
     // The materialization install has awaited every tarball's mem-cache
@@ -849,6 +1018,39 @@ pub(crate) async fn install_via_pnpr<Reporter: self::Reporter + 'static>(
     }
 
     Ok(())
+}
+
+fn resolve_projects_for_pnpr(
+    state: &State,
+    selection: Option<&InstallFamilySelection>,
+    use_state_lockfile: bool,
+) -> miette::Result<Vec<ResolveProject>> {
+    if let Some(selection) = selection {
+        return Ok(resolve_workspace_projects(&selection.workspace_root, &selection.projects));
+    }
+    if use_state_lockfile
+        && state.config.shared_workspace_lockfile
+        && let Some(workspace_root) = state.config.workspace_dir.as_deref()
+    {
+        let (projects, _) = discover_workspace_projects(workspace_root)?;
+        return Ok(resolve_workspace_projects(workspace_root, &projects));
+    }
+    Ok(vec![resolve_project(".".to_string(), &state.manifest)])
+}
+
+fn resolve_workspace_projects(
+    workspace_root: &std::path::Path,
+    projects: &[pacquet_workspace::Project],
+) -> Vec<ResolveProject> {
+    projects
+        .iter()
+        .map(|project| {
+            resolve_project(
+                pacquet_workspace::importer_id_from_root_dir(workspace_root, &project.root_dir),
+                &project.manifest,
+            )
+        })
+        .collect()
 }
 
 struct PnprBenchmarkRegistryOverride {

--- a/pnpm/crates/cli/src/cli_args/link.rs
+++ b/pnpm/crates/cli/src/cli_args/link.rs
@@ -127,14 +127,9 @@ impl LinkArgs {
         }
 
         let state = State::init(manifest_path, config, false).wrap_err("initialize the state")?;
-
+        let lockfile_path = state.lockfile_path();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
-
-        let lockfile_path = manifest
-            .path()
-            .parent()
-            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
 
         Install {
             tarball_mem_cache: Arc::clone(tarball_mem_cache),
@@ -144,7 +139,7 @@ impl LinkArgs {
             manifest,
             emit_initial_manifest: true,
             lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
-            lockfile_path: lockfile_path.as_deref(),
+            lockfile_path: Some(&lockfile_path),
             dependency_groups: [
                 DependencyGroup::Prod,
                 DependencyGroup::Dev,

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -197,18 +197,6 @@ fn resolve_target(
     }
 }
 
-/// Map each direct dependency key to its lockfile-pinned semver version.
-/// Only the root importer is consulted (pacquet's single-project scope);
-/// entries whose resolved version is not a plain semver (`link:`,
-/// `file:`, non-semver runtimes) are omitted.
-#[cfg(test)]
-fn current_versions_from_lockfile(
-    lockfile: Option<&Lockfile>,
-    include_direct: &[DependencyGroup],
-) -> HashMap<String, Version> {
-    current_versions_from_importer(lockfile, Lockfile::ROOT_IMPORTER_KEY, include_direct)
-}
-
 fn current_versions_from_importer(
     lockfile: Option<&Lockfile>,
     importer_id: &str,

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -97,7 +97,27 @@ pub async fn collect_outdated(
     http_client: &ThrottledClient,
     query: &OutdatedQuery<'_>,
 ) -> miette::Result<Vec<OutdatedPackage>> {
-    let current_versions = current_versions_from_lockfile(lockfile, query.include_direct);
+    collect_outdated_for_importer(
+        manifest,
+        lockfile,
+        Lockfile::ROOT_IMPORTER_KEY,
+        config,
+        http_client,
+        query,
+    )
+    .await
+}
+
+pub(crate) async fn collect_outdated_for_importer(
+    manifest: &PackageManifest,
+    lockfile: Option<&Lockfile>,
+    importer_id: &str,
+    config: &Config,
+    http_client: &ThrottledClient,
+    query: &OutdatedQuery<'_>,
+) -> miette::Result<Vec<OutdatedPackage>> {
+    let current_versions =
+        current_versions_from_importer(lockfile, importer_id, query.include_direct);
     let current_versions = &current_versions;
 
     // Gather the lockfile-pinned direct dependencies to inspect, then
@@ -181,12 +201,23 @@ fn resolve_target(
 /// Only the root importer is consulted (pacquet's single-project scope);
 /// entries whose resolved version is not a plain semver (`link:`,
 /// `file:`, non-semver runtimes) are omitted.
+#[cfg(test)]
 fn current_versions_from_lockfile(
     lockfile: Option<&Lockfile>,
     include_direct: &[DependencyGroup],
 ) -> HashMap<String, Version> {
+    current_versions_from_importer(lockfile, Lockfile::ROOT_IMPORTER_KEY, include_direct)
+}
+
+fn current_versions_from_importer(
+    lockfile: Option<&Lockfile>,
+    importer_id: &str,
+    include_direct: &[DependencyGroup],
+) -> HashMap<String, Version> {
     let mut map = HashMap::new();
-    let Some(importer) = lockfile.and_then(Lockfile::root_project) else { return map };
+    let Some(importer) = lockfile.and_then(|lockfile| lockfile.importers.get(importer_id)) else {
+        return map;
+    };
     for (name, spec) in importer.dependencies_by_groups(include_direct.iter().copied()) {
         if let Some(version) = spec.version.ver_peer().and_then(|ver| ver.version_semver()) {
             map.insert(name.to_string(), version.clone());
@@ -305,6 +336,7 @@ impl OutdatedArgs {
 
         let config = state.config;
         let manifest = &state.manifest;
+        let importer_id = state.active_importer_id();
         let lockfile = state
             .lockfile
             .get()
@@ -341,8 +373,15 @@ impl OutdatedArgs {
             match_names: matcher.as_ref(),
             include_deprecated: true,
         };
-        let mut outdated =
-            collect_outdated(manifest, lockfile, config, http_client, &query).await?;
+        let mut outdated = collect_outdated_for_importer(
+            manifest,
+            lockfile,
+            &importer_id,
+            config,
+            http_client,
+            &query,
+        )
+        .await?;
 
         sort_outdated(&mut outdated, self.sort_by);
 
@@ -372,6 +411,14 @@ impl OutdatedArgs {
                 "Unable to find the global packages directory"
             )
         })?;
+        // The pnpm home may contain a workspace config, but each global
+        // install group owns its package.json and lockfile. Keep project
+        // lookup anchored to the scanned group while retaining the global
+        // registry and network settings.
+        let mut isolated_config = config.clone();
+        isolated_config.workspace_dir = None;
+        isolated_config.shared_workspace_lockfile = false;
+        let config = Config::leak(isolated_config);
 
         let include = self.dependency_options.include();
         let target_version =

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    Change, OutdatedDependencyOptions, OutdatedPackage, classify, current_versions_from_lockfile,
+    Change, OutdatedDependencyOptions, OutdatedPackage, classify, current_versions_from_importer,
     render_json, render_latest, sort_outdated,
 };
 use node_semver::Version;
@@ -50,7 +50,11 @@ fn current_versions_omit_local_refs() {
         "        version: 1.0.0"
     })
     .expect("parse fixture lockfile");
-    let versions = current_versions_from_lockfile(Some(&lockfile), &[DependencyGroup::Dev]);
+    let versions = current_versions_from_importer(
+        Some(&lockfile),
+        Lockfile::ROOT_IMPORTER_KEY,
+        &[DependencyGroup::Dev],
+    );
     dbg!(&versions);
     assert_eq!(versions, HashMap::from([("is-positive".to_string(), v("1.0.0"))]));
 }

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -1,15 +1,100 @@
 use super::{
+    add::AddArgs,
     dedupe::{self, DedupeArgs},
     deploy::DeployArgs,
     install::{InstallArgs, resolve_bool_override},
     package_manager::{PackageManagerToSync, package_manager_to_sync},
     prune::PruneArgs,
+    recursive::{
+        AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+        sort_filtered_projects,
+    },
+    remove::RemoveArgs,
+    update::UpdateArgs,
 };
 use crate::{State, config_deps};
 use miette::Context;
 use pacquet_config::Config;
 use pacquet_reporter::Reporter;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+pub(crate) struct InstallFamilySelection {
+    pub(crate) workspace_root: PathBuf,
+    pub(crate) projects: Vec<pacquet_workspace::Project>,
+    pub(crate) ordered_dirs: Vec<PathBuf>,
+    pub(crate) selected_dirs: Arc<HashSet<PathBuf>>,
+    pub(crate) active_manifest_is_standin: bool,
+}
+
+fn select_install_family_projects(
+    cfg: &Config,
+    prefix: &Path,
+    manifest_path: &Path,
+    recursive_sort: bool,
+    auto_exclude_root: bool,
+) -> miette::Result<Option<InstallFamilySelection>> {
+    if !cfg.recursive {
+        return Ok(None);
+    }
+    if !cfg.shared_workspace_lockfile {
+        return Err(miette::miette!(
+            code = "ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED",
+            "Recursive and filtered install-family commands with `sharedWorkspaceLockfile=false` are not supported yet."
+        ));
+    }
+
+    let workspace_root = cfg.workspace_dir.as_deref().unwrap_or(prefix).to_path_buf();
+    let (projects, workspace_patterns) = discover_workspace_projects(&workspace_root)?;
+    let (ordered_dirs, selected_dirs) = {
+        let selection = select_recursive_projects(
+            &projects,
+            cfg,
+            prefix,
+            if auto_exclude_root {
+                AutoExcludeRoot::Enabled { workspace_patterns: workspace_patterns.as_deref() }
+            } else {
+                AutoExcludeRoot::Disabled
+            },
+        )?;
+        let ordered_dirs = if recursive_sort {
+            sort_filtered_projects(
+                &selection.selected,
+                selection.full_graph(),
+                selection.prod_all.as_ref(),
+                &selection.prod_only_selected,
+            )
+            .into_iter()
+            .flatten()
+            .collect()
+        } else {
+            selection.selected.keys().cloned().collect()
+        };
+        let selected_dirs = Arc::new(selection.selected.keys().cloned().collect());
+        (ordered_dirs, selected_dirs)
+    };
+
+    let active_dir = manifest_path.parent().expect("manifest path always has a parent dir");
+    let normalized_active_dir = pacquet_fs::lexical_normalize(active_dir);
+    let active_manifest_is_standin = !active_dir.join("package.json").is_file()
+        && pacquet_workspace::try_read_project_manifest(active_dir)
+            .map_err(miette::Report::new)?
+            .is_none()
+        && !projects.iter().any(|project| {
+            pacquet_fs::lexical_normalize(&project.root_dir) == normalized_active_dir
+        });
+
+    Ok(Some(InstallFamilySelection {
+        workspace_root,
+        projects,
+        ordered_dirs,
+        selected_dirs,
+        active_manifest_is_standin,
+    }))
+}
 
 /// The reporter-generic body of `pacquet install`: it threads one `Reporter`
 /// type through config-dependency sync, the `updateConfig` hooks, and the
@@ -20,7 +105,9 @@ pub(crate) struct InstallPipeline {
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
     pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
+    pub(crate) prefix: PathBuf,
     pub(crate) manifest_path: PathBuf,
+    pub(crate) recursive_sort: bool,
     pub(crate) require_lockfile: bool,
     pub(crate) frozen_lockfile: bool,
 }
@@ -32,7 +119,9 @@ impl InstallPipeline {
             cfg,
             config_root,
             package_manager_to_sync,
+            prefix,
             manifest_path,
+            recursive_sort,
             require_lockfile,
             frozen_lockfile,
         } = self;
@@ -48,10 +137,169 @@ impl InstallPipeline {
         }
         config_deps::install_config_deps::<Reporter>(cfg, &config_root, frozen_lockfile).await?;
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        let selection =
+            select_install_family_projects(cfg, &prefix, &manifest_path, recursive_sort, false)?;
+        if selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty()) {
+            return Ok(());
+        }
         let cfg: &'static Config = cfg;
         let state =
             State::init(manifest_path, cfg, require_lockfile).wrap_err("initialize the state")?;
-        Box::pin(args.run::<Reporter>(state)).await
+        match selection {
+            Some(selection) => Box::pin(args.run_selected::<Reporter>(state, selection)).await,
+            None => Box::pin(args.run::<Reporter>(state)).await,
+        }
+    }
+}
+
+pub(crate) struct AddPipeline {
+    pub(crate) args: AddArgs,
+    pub(crate) cfg: &'static mut Config,
+    pub(crate) config_root: PathBuf,
+    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
+    pub(crate) prefix: PathBuf,
+    pub(crate) manifest_path: PathBuf,
+    pub(crate) recursive_sort: bool,
+    /// [`AddArgs::parse_config_dependencies`]'s output, parsed by the dispatch
+    /// before this pipeline scaffolds a manifest. `Some` exactly when
+    /// `--config` was passed.
+    pub(crate) config_dependencies: Option<BTreeMap<String, String>>,
+}
+
+impl AddPipeline {
+    pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
+        let AddPipeline {
+            args,
+            cfg,
+            config_root,
+            package_manager_to_sync,
+            prefix,
+            manifest_path,
+            recursive_sort,
+            config_dependencies,
+        } = self;
+        if let Some(pm) = package_manager_to_sync.as_ref() {
+            config_deps::sync_package_manager_dependencies(
+                cfg,
+                &config_root,
+                &pm.specifier,
+                &pm.version,
+                false,
+            )
+            .await?;
+        }
+        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
+        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        // `--config` targets the workspace's configuration dependencies, not
+        // any project's manifest, so it bypasses project selection entirely.
+        let selection = if config_dependencies.is_some() {
+            None
+        } else {
+            select_install_family_projects(cfg, &prefix, &manifest_path, recursive_sort, true)?
+        };
+        if selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty()) {
+            return Ok(());
+        }
+        let cfg: &'static Config = cfg;
+        let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+        match selection {
+            Some(selection) => Box::pin(args.run_selected::<Reporter>(state, selection)).await,
+            None => Box::pin(args.run::<Reporter>(state, config_dependencies)).await,
+        }
+    }
+}
+
+pub(crate) struct UpdatePipeline {
+    pub(crate) args: UpdateArgs,
+    pub(crate) cfg: &'static mut Config,
+    pub(crate) config_root: PathBuf,
+    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
+    pub(crate) prefix: PathBuf,
+    pub(crate) manifest_path: PathBuf,
+    pub(crate) recursive_sort: bool,
+}
+
+impl UpdatePipeline {
+    pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
+        let UpdatePipeline {
+            args,
+            cfg,
+            config_root,
+            package_manager_to_sync,
+            prefix,
+            manifest_path,
+            recursive_sort,
+        } = self;
+        if let Some(pm) = package_manager_to_sync.as_ref() {
+            config_deps::sync_package_manager_dependencies(
+                cfg,
+                &config_root,
+                &pm.specifier,
+                &pm.version,
+                false,
+            )
+            .await?;
+        }
+        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
+        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        let selection =
+            select_install_family_projects(cfg, &prefix, &manifest_path, recursive_sort, false)?;
+        if selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty()) {
+            return Ok(());
+        }
+        let cfg: &'static Config = cfg;
+        let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+        match selection {
+            Some(selection) => Box::pin(args.run_selected::<Reporter>(state, selection)).await,
+            None => Box::pin(args.run::<Reporter>(state)).await,
+        }
+    }
+}
+
+pub(crate) struct RemovePipeline {
+    pub(crate) args: RemoveArgs,
+    pub(crate) cfg: &'static mut Config,
+    pub(crate) config_root: PathBuf,
+    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
+    pub(crate) prefix: PathBuf,
+    pub(crate) manifest_path: PathBuf,
+    pub(crate) recursive_sort: bool,
+}
+
+impl RemovePipeline {
+    pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
+        let RemovePipeline {
+            args,
+            cfg,
+            config_root,
+            package_manager_to_sync,
+            prefix,
+            manifest_path,
+            recursive_sort,
+        } = self;
+        if let Some(pm) = package_manager_to_sync.as_ref() {
+            config_deps::sync_package_manager_dependencies(
+                cfg,
+                &config_root,
+                &pm.specifier,
+                &pm.version,
+                false,
+            )
+            .await?;
+        }
+        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
+        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        let selection =
+            select_install_family_projects(cfg, &prefix, &manifest_path, recursive_sort, false)?;
+        if selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty()) {
+            return Ok(());
+        }
+        let cfg: &'static Config = cfg;
+        let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+        match selection {
+            Some(selection) => Box::pin(args.run_selected::<Reporter>(state, selection)).await,
+            None => Box::pin(args.run::<Reporter>(state)).await,
+        }
     }
 }
 
@@ -161,7 +409,7 @@ impl DedupePipeline {
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
         let cfg: &'static Config = cfg;
         let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-        args.run::<Reporter>(state, existing, guard, &lockfile_path).await
+        Box::pin(args.run::<Reporter>(state, existing, guard, &lockfile_path)).await
     }
 }
 
@@ -225,6 +473,6 @@ impl PrunePipeline {
             resolve_bool_override(args.ignore_scripts, args.no_ignore_scripts, cfg.ignore_scripts);
         let cfg: &'static Config = cfg;
         let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-        args.run::<Reporter>(state).await
+        Box::pin(args.run::<Reporter>(state)).await
     }
 }

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -6,8 +6,8 @@ use super::{
     package_manager::{PackageManagerToSync, package_manager_to_sync},
     prune::PruneArgs,
     recursive::{
-        AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
-        sort_filtered_projects,
+        AutoExcludeRoot, RecursiveSharedLockfileUnsupported, discover_workspace_projects,
+        select_recursive_projects, sort_filtered_projects,
     },
     remove::RemoveArgs,
     update::UpdateArgs,
@@ -41,10 +41,10 @@ fn select_install_family_projects(
         return Ok(None);
     }
     if !cfg.shared_workspace_lockfile {
-        return Err(miette::miette!(
-            code = "ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED",
-            "Recursive and filtered install-family commands with `sharedWorkspaceLockfile=false` are not supported yet."
-        ));
+        return Err(RecursiveSharedLockfileUnsupported::new(
+            "Recursive and filtered install-family commands",
+        )
+        .into());
     }
 
     let workspace_root = cfg.workspace_dir.as_deref().unwrap_or(prefix).to_path_buf();

--- a/pnpm/crates/cli/src/cli_args/prune.rs
+++ b/pnpm/crates/cli/src/cli_args/prune.rs
@@ -34,13 +34,9 @@ impl PruneArgs {
     }
 
     pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
+        let lockfile_path = state.lockfile_path();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
-
-        let lockfile_path = manifest
-            .path()
-            .parent()
-            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
 
         let dependency_groups: Vec<DependencyGroup> = self.dependency_groups().collect();
 
@@ -52,7 +48,7 @@ impl PruneArgs {
             manifest,
             emit_initial_manifest: true,
             lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
-            lockfile_path: lockfile_path.as_deref(),
+            lockfile_path: Some(&lockfile_path),
             dependency_groups,
             frozen_lockfile: false,
             prefer_frozen_lockfile: None,

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::Config;
-use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
+use pacquet_lockfile::MaybeLazyLockfile;
 use pacquet_modules_yaml::{Host, read_modules_layout, read_modules_manifest};
 use pacquet_package_manager::{
     Install, RebuildOptions, UpdateSeedPolicy, allow_build_key_from_ignored_build,
@@ -74,10 +74,9 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
     state: &State,
     selected_names: Option<Vec<String>>,
 ) -> miette::Result<()> {
+    let lockfile_path = state.lockfile_path();
     let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
         state;
-
-    let lockfile_path = manifest.path().parent().map(|parent| parent.join(Lockfile::FILE_NAME));
 
     let rebuild = RebuildOptions {
         selected_names: selected_names.map(|names| names.into_iter().collect::<HashSet<_>>()),
@@ -93,7 +92,7 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
         manifest,
         emit_initial_manifest: true,
         lockfile: MaybeLazyLockfile::Lazy(lockfile),
-        lockfile_path: lockfile_path.as_deref(),
+        lockfile_path: Some(&lockfile_path),
         // Reuse exactly the dependency groups the current `node_modules`
         // was materialized with, so a rebuild never widens the installed
         // set (see [`rebuild_dependency_groups`]).

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -42,6 +42,30 @@ pub struct ResumeFromNotFound {
     pub resume_from: String,
 }
 
+/// `{operation} with `sharedWorkspaceLockfile=false` is not supported yet.`
+///
+/// Every workspace-aware command reads and rewrites one shared
+/// `pnpm-lock.yaml`; the per-project lockfiles that
+/// `sharedWorkspaceLockfile=false` produces have no reader here yet. pnpm
+/// itself supports the combination, so this is a known gap rather than a
+/// rejected configuration — it fails loudly instead of silently installing
+/// something other than what was asked for.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("{operation} with `sharedWorkspaceLockfile=false` is not supported yet.")]
+#[diagnostic(code(ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED))]
+pub struct RecursiveSharedLockfileUnsupported {
+    /// The user-facing description of what was attempted, e.g.
+    /// ``Recursive and filtered `pnpm why` ``.
+    #[error(not(source))]
+    pub operation: String,
+}
+
+impl RecursiveSharedLockfileUnsupported {
+    pub fn new(operation: impl Into<String>) -> Self {
+        RecursiveSharedLockfileUnsupported { operation: operation.into() }
+    }
+}
+
 /// Sort the `--filter`-selected workspace projects into topologically
 /// ordered chunks: every project in chunk `i` depends only on projects in
 /// earlier chunks, so chunk `i` may run after chunks `0..i`.

--- a/pnpm/crates/cli/src/cli_args/remove.rs
+++ b/pnpm/crates/cli/src/cli_args/remove.rs
@@ -1,4 +1,4 @@
-use crate::State;
+use crate::{State, cli_args::pipelines::InstallFamilySelection};
 use clap::Args;
 use miette::Context;
 use pacquet_package_manager::Remove;
@@ -58,15 +58,12 @@ impl RemoveArgs {
         self,
         mut state: State,
     ) -> miette::Result<()> {
+        let lockfile_path = state.lockfile_path();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &mut state;
         let lockfile =
             lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
 
-        let lockfile_path = manifest
-            .path()
-            .parent()
-            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
         Remove {
             tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
             http_client,
@@ -74,7 +71,7 @@ impl RemoveArgs {
             config,
             manifest,
             lockfile,
-            lockfile_path: lockfile_path.as_deref(),
+            lockfile_path: Some(&lockfile_path),
             package_names: &self.package_names,
             save_type: self.dependency_options.save_type(),
             resolved_packages,
@@ -82,6 +79,48 @@ impl RemoveArgs {
             lockfile_only: self.lockfile_only,
         }
         .run::<Reporter>()
+        .await
+        .wrap_err("removing a package")
+    }
+
+    pub(crate) async fn run_selected<Reporter: self::Reporter + 'static>(
+        self,
+        mut state: State,
+        selection: InstallFamilySelection,
+    ) -> miette::Result<()> {
+        let InstallFamilySelection {
+            workspace_root: _,
+            mut projects,
+            ordered_dirs,
+            selected_dirs,
+            active_manifest_is_standin,
+        } = selection;
+        let lockfile_path = state.lockfile_path();
+        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+            &mut state;
+        let lockfile =
+            lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+
+        Remove {
+            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            http_client,
+            http_client_arc: std::sync::Arc::clone(http_client),
+            config,
+            manifest,
+            lockfile,
+            lockfile_path: Some(&lockfile_path),
+            package_names: &self.package_names,
+            save_type: self.dependency_options.save_type(),
+            resolved_packages,
+            supported_architectures: config.supported_architectures.clone(),
+            lockfile_only: self.lockfile_only,
+        }
+        .run_selected::<Reporter>(
+            &mut projects,
+            &ordered_dirs,
+            selected_dirs.as_ref(),
+            active_manifest_is_standin,
+        )
         .await
         .wrap_err("removing a package")
     }

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry,
 };
-use pacquet_package_manager::importer_root_dir;
+use pacquet_package_manager::{importer_root_dir, validate_importer_id};
 use pacquet_package_manifest::{extract_author, extract_homepage, safe_read_package_json_from_dir};
 use std::{
     collections::{HashMap, HashSet},
@@ -376,8 +376,15 @@ fn collect_components(
 
     let manifest_value = match filter_importer_ids {
         Some(&[single_id]) => {
-            let importer_dir = importer_root_dir(&lockfile_dir, single_id);
-            safe_read_package_json_from_dir(&importer_dir).ok().flatten().unwrap_or_else(|| {
+            // `single_id` is a raw lockfile importer key; validate it before
+            // it turns into an on-disk path so a crafted `../foo` or absolute
+            // key cannot read a `package.json` outside the workspace.
+            let manifest = validate_importer_id(single_id).ok().and_then(|()| {
+                safe_read_package_json_from_dir(&importer_root_dir(&lockfile_dir, single_id))
+                    .ok()
+                    .flatten()
+            });
+            manifest.unwrap_or_else(|| {
                 if single_id == state.active_importer_id() {
                     state.manifest.value().clone()
                 } else {
@@ -448,7 +455,7 @@ fn collect_components(
         let parent_purl =
             ws_purl_by_importer.get(&importer_id).cloned().unwrap_or_else(|| root_purl.clone());
 
-        let importer_peer_names = if exclude_peers {
+        let importer_peer_names = if exclude_peers && validate_importer_id(&importer_id).is_ok() {
             let importer_dir = importer_root_dir(&lockfile_dir, &importer_id);
             safe_read_package_json_from_dir(&importer_dir)
                 .ok()
@@ -494,6 +501,7 @@ fn collect_components(
                 if let Some(link_target) = spec.version.as_link_target() {
                     if let Some(target_id) = normalize_link_path(&importer_id, link_target)
                         && lockfile.importers.contains_key(target_id.as_str())
+                        && validate_importer_id(&target_id).is_ok()
                     {
                         let ws_dir = importer_root_dir(&lockfile_dir, &target_id);
                         if let Ok(Some(ws_manifest)) = safe_read_package_json_from_dir(&ws_dir) {

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -3,18 +3,18 @@
 //! Ports pnpm's
 //! [`sbom` command](https://github.com/pnpm/pnpm/blob/2b4952e804/pnpm11/deps/compliance/commands/src/sbom/sbom.ts).
 
-use crate::State;
+use crate::{State, cli_args::recursive::RecursiveSharedLockfileUnsupported};
 use clap::Args;
 use indexmap::IndexMap;
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry,
 };
+use pacquet_package_manager::importer_root_dir;
 use pacquet_package_manifest::{extract_author, extract_homepage, safe_read_package_json_from_dir};
 use std::{
-    borrow::Cow,
     collections::{HashMap, HashSet},
     io::Write,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -376,11 +376,7 @@ fn collect_components(
 
     let manifest_value = match filter_importer_ids {
         Some(&[single_id]) => {
-            let importer_dir: Cow<'_, Path> = if single_id == "." {
-                Cow::Borrowed(&lockfile_dir)
-            } else {
-                Cow::Owned(lockfile_dir.join(single_id))
-            };
+            let importer_dir = importer_root_dir(&lockfile_dir, single_id);
             safe_read_package_json_from_dir(&importer_dir).ok().flatten().unwrap_or_else(|| {
                 if single_id == state.active_importer_id() {
                     state.manifest.value().clone()
@@ -453,11 +449,7 @@ fn collect_components(
             ws_purl_by_importer.get(&importer_id).cloned().unwrap_or_else(|| root_purl.clone());
 
         let importer_peer_names = if exclude_peers {
-            let importer_dir = if importer_id == "." {
-                lockfile_dir.clone()
-            } else {
-                lockfile_dir.join(&importer_id)
-            };
+            let importer_dir = importer_root_dir(&lockfile_dir, &importer_id);
             safe_read_package_json_from_dir(&importer_dir)
                 .ok()
                 .flatten()
@@ -503,11 +495,7 @@ fn collect_components(
                     if let Some(target_id) = normalize_link_path(&importer_id, link_target)
                         && lockfile.importers.contains_key(target_id.as_str())
                     {
-                        let ws_dir = if target_id == "." {
-                            lockfile_dir.clone()
-                        } else {
-                            lockfile_dir.join(&target_id)
-                        };
+                        let ws_dir = importer_root_dir(&lockfile_dir, &target_id);
                         if let Ok(Some(ws_manifest)) = safe_read_package_json_from_dir(&ws_dir) {
                             let ws_name = ws_manifest
                                 .get("name")
@@ -708,10 +696,9 @@ impl SbomArgs {
         if !state.config.shared_workspace_lockfile
             && (state.config.recursive || self.split || !state.config.filter.is_empty())
         {
-            return Err(miette::miette!(
-                code = "ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED",
-                "Filtered and split `pacquet sbom` with `sharedWorkspaceLockfile=false` is not supported yet."
-            ));
+            return Err(
+                RecursiveSharedLockfileUnsupported::new("Filtered and split `pnpm sbom`").into()
+            );
         }
         if let Some(ref spec_ver) = self.spec_version {
             if self.format != SbomFormat::CycloneDx {

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -11,6 +11,7 @@ use pacquet_lockfile::{
 };
 use pacquet_package_manifest::{extract_author, extract_homepage, safe_read_package_json_from_dir};
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     io::Write,
     path::{Path, PathBuf},
@@ -371,18 +372,30 @@ fn collect_components(
         ));
     };
 
-    let project_root_dir =
-        state.manifest.path().parent().unwrap_or_else(|| Path::new(".")).to_path_buf();
+    let lockfile_dir = state.lockfile_dir().to_path_buf();
 
     let manifest_value = match filter_importer_ids {
-        Some(&[single_id]) if single_id != "." => {
-            let importer_dir = project_root_dir.join(single_id);
-            safe_read_package_json_from_dir(&importer_dir)
-                .ok()
-                .flatten()
-                .unwrap_or_else(|| state.manifest.value().clone())
+        Some(&[single_id]) => {
+            let importer_dir: Cow<'_, Path> = if single_id == "." {
+                Cow::Borrowed(&lockfile_dir)
+            } else {
+                Cow::Owned(lockfile_dir.join(single_id))
+            };
+            safe_read_package_json_from_dir(&importer_dir).ok().flatten().unwrap_or_else(|| {
+                if single_id == state.active_importer_id() {
+                    state.manifest.value().clone()
+                } else {
+                    serde_json::json!({})
+                }
+            })
         }
-        _ => state.manifest.value().clone(),
+        _ => safe_read_package_json_from_dir(&lockfile_dir).ok().flatten().unwrap_or_else(|| {
+            if state.active_importer_id() == "." {
+                state.manifest.value().clone()
+            } else {
+                serde_json::json!({})
+            }
+        }),
     };
     let root_name =
         manifest_value.get("name").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
@@ -400,7 +413,8 @@ fn collect_components(
 
     let dep_types = detect_dep_types(lockfile, include.optional_dependencies);
 
-    let virtual_store_dir = (!lockfile_only).then(|| project_root_dir.join("node_modules/.pnpm"));
+    let virtual_store_dir =
+        (!lockfile_only).then(|| state.config.effective_virtual_store_dir().to_path_buf());
 
     let ctx = WalkContext {
         snapshots: lockfile.snapshots.as_ref(),
@@ -440,9 +454,9 @@ fn collect_components(
 
         let importer_peer_names = if exclude_peers {
             let importer_dir = if importer_id == "." {
-                project_root_dir.clone()
+                lockfile_dir.clone()
             } else {
-                project_root_dir.join(&importer_id)
+                lockfile_dir.join(&importer_id)
             };
             safe_read_package_json_from_dir(&importer_dir)
                 .ok()
@@ -490,9 +504,9 @@ fn collect_components(
                         && lockfile.importers.contains_key(target_id.as_str())
                     {
                         let ws_dir = if target_id == "." {
-                            project_root_dir.clone()
+                            lockfile_dir.clone()
                         } else {
-                            project_root_dir.join(&target_id)
+                            lockfile_dir.join(&target_id)
                         };
                         if let Ok(Some(ws_manifest)) = safe_read_package_json_from_dir(&ws_dir) {
                             let ws_name = ws_manifest
@@ -691,6 +705,14 @@ fn walk_snapshot(
 
 impl SbomArgs {
     pub async fn run(self, state: State) -> miette::Result<()> {
+        if !state.config.shared_workspace_lockfile
+            && (state.config.recursive || self.split || !state.config.filter.is_empty())
+        {
+            return Err(miette::miette!(
+                code = "ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED",
+                "Filtered and split `pacquet sbom` with `sharedWorkspaceLockfile=false` is not supported yet."
+            ));
+        }
         if let Some(ref spec_ver) = self.spec_version {
             if self.format != SbomFormat::CycloneDx {
                 return Err(miette::miette!(
@@ -729,7 +751,7 @@ impl SbomArgs {
         let importer_ids = if state.config.filter.is_empty() {
             all_importer_ids
         } else {
-            let project_root = state.manifest.path().parent().unwrap_or_else(|| Path::new("."));
+            let project_root = state.lockfile_dir();
             all_importer_ids
                 .into_iter()
                 .filter(|id| {

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -14,7 +14,7 @@ use pacquet_package_manifest::{extract_author, extract_homepage, safe_read_packa
 use std::{
     collections::{HashMap, HashSet},
     io::Write,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
@@ -147,6 +147,23 @@ struct SbomResult {
     root_bugs_url: Option<String>,
     components: Vec<SbomComponent>,
     relationships: Vec<SbomRelationship>,
+}
+
+/// Resolve a lockfile importer key to the on-disk directory whose
+/// `package.json` the SBOM reads, returning `None` when that directory does
+/// not stay inside the lockfile dir. Mirrors pnpm's SBOM importer handling
+/// (`sbom.ts`): `validate_importer_id` is the cheap lexical pre-filter, then
+/// both the lockfile dir and the importer dir are canonicalized so a
+/// *symlinked* importer directory can't resolve outside the workspace, and a
+/// resolved path outside the root is skipped rather than read. `importer_id`
+/// comes from an untrusted lockfile.
+fn confined_importer_dir(lockfile_dir: &Path, importer_id: &str) -> Option<PathBuf> {
+    if validate_importer_id(importer_id).is_err() {
+        return None;
+    }
+    let lockfile_root = std::fs::canonicalize(lockfile_dir).ok()?;
+    let importer_dir = std::fs::canonicalize(importer_root_dir(lockfile_dir, importer_id)).ok()?;
+    importer_dir.starts_with(&lockfile_root).then_some(importer_dir)
 }
 
 fn extract_repository(manifest: &serde_json::Value) -> Option<String> {
@@ -376,14 +393,12 @@ fn collect_components(
 
     let manifest_value = match filter_importer_ids {
         Some(&[single_id]) => {
-            // `single_id` is a raw lockfile importer key; validate it before
-            // it turns into an on-disk path so a crafted `../foo` or absolute
-            // key cannot read a `package.json` outside the workspace.
-            let manifest = validate_importer_id(single_id).ok().and_then(|()| {
-                safe_read_package_json_from_dir(&importer_root_dir(&lockfile_dir, single_id))
-                    .ok()
-                    .flatten()
-            });
+            // `single_id` is a raw lockfile importer key; confine it to the
+            // workspace before it turns into an on-disk path so neither a
+            // crafted `../foo`/absolute key nor a symlinked importer dir can
+            // read a `package.json` outside the workspace.
+            let manifest = confined_importer_dir(&lockfile_dir, single_id)
+                .and_then(|dir| safe_read_package_json_from_dir(&dir).ok().flatten());
             manifest.unwrap_or_else(|| {
                 if single_id == state.active_importer_id() {
                     state.manifest.value().clone()
@@ -455,11 +470,9 @@ fn collect_components(
         let parent_purl =
             ws_purl_by_importer.get(&importer_id).cloned().unwrap_or_else(|| root_purl.clone());
 
-        let importer_peer_names = if exclude_peers && validate_importer_id(&importer_id).is_ok() {
-            let importer_dir = importer_root_dir(&lockfile_dir, &importer_id);
-            safe_read_package_json_from_dir(&importer_dir)
-                .ok()
-                .flatten()
+        let importer_peer_names = if exclude_peers {
+            confined_importer_dir(&lockfile_dir, &importer_id)
+                .and_then(|dir| safe_read_package_json_from_dir(&dir).ok().flatten())
                 .map(|m| peer_names_from_manifest(&m))
                 .unwrap_or_default()
         } else {
@@ -498,65 +511,63 @@ fn collect_components(
                 {
                     continue;
                 }
-                if let Some(link_target) = spec.version.as_link_target() {
-                    if let Some(target_id) = normalize_link_path(&importer_id, link_target)
-                        && lockfile.importers.contains_key(target_id.as_str())
-                        && validate_importer_id(&target_id).is_ok()
-                    {
-                        let ws_dir = importer_root_dir(&lockfile_dir, &target_id);
-                        if let Ok(Some(ws_manifest)) = safe_read_package_json_from_dir(&ws_dir) {
-                            let ws_name = ws_manifest
-                                .get("name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or(&name.to_string())
-                                .to_string();
-                            let ws_version = ws_manifest
-                                .get("version")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("0.0.0")
-                                .to_string();
-                            let ws_purl = build_purl(&ws_name, &ws_version);
-                            let name_str = name.to_string();
-                            let dev_only = dev_dep_names.contains(&name_str)
-                                && !prod_dep_names.contains(&name_str);
-                            relationships.push(SbomRelationship {
-                                from: parent_purl.clone(),
-                                to: ws_purl.clone(),
-                            });
-                            let ws_dep_type =
-                                if dev_only { DepType::DevOnly } else { DepType::ProdOnly };
-                            if let Some(existing) = components_map.get_mut(&ws_purl) {
-                                if !dev_only && existing.dep_type == DepType::DevOnly {
-                                    existing.dep_type = DepType::ProdOnly;
-                                }
-                            } else {
-                                components_map.insert(
-                                    ws_purl.clone(),
-                                    SbomComponent {
-                                        name: ws_name,
-                                        version: ws_version,
-                                        purl: ws_purl.clone(),
-                                        dep_type: ws_dep_type,
-                                        integrity: None,
-                                        tarball_url: None,
-                                        license: ws_manifest
-                                            .get("license")
-                                            .and_then(|v| v.as_str())
-                                            .map(ToString::to_string),
-                                        description: ws_manifest
-                                            .get("description")
-                                            .and_then(|v| v.as_str())
-                                            .map(ToString::to_string),
-                                        author: extract_author(&ws_manifest),
-                                        homepage: extract_homepage(&ws_manifest),
-                                        repository: extract_repository(&ws_manifest),
-                                        bugs_url: extract_bugs_url(&ws_manifest),
-                                    },
-                                );
+                if let Some(link_target) = spec.version.as_link_target()
+                    && let Some(target_id) = normalize_link_path(&importer_id, link_target)
+                    && lockfile.importers.contains_key(target_id.as_str())
+                    && let Some(ws_dir) = confined_importer_dir(&lockfile_dir, &target_id)
+                {
+                    if let Ok(Some(ws_manifest)) = safe_read_package_json_from_dir(&ws_dir) {
+                        let ws_name = ws_manifest
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(&name.to_string())
+                            .to_string();
+                        let ws_version = ws_manifest
+                            .get("version")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("0.0.0")
+                            .to_string();
+                        let ws_purl = build_purl(&ws_name, &ws_version);
+                        let name_str = name.to_string();
+                        let dev_only = dev_dep_names.contains(&name_str)
+                            && !prod_dep_names.contains(&name_str);
+                        relationships.push(SbomRelationship {
+                            from: parent_purl.clone(),
+                            to: ws_purl.clone(),
+                        });
+                        let ws_dep_type =
+                            if dev_only { DepType::DevOnly } else { DepType::ProdOnly };
+                        if let Some(existing) = components_map.get_mut(&ws_purl) {
+                            if !dev_only && existing.dep_type == DepType::DevOnly {
+                                existing.dep_type = DepType::ProdOnly;
                             }
-                            ws_purl_by_importer.insert(target_id.clone(), ws_purl);
-                            importer_queue.push(target_id);
+                        } else {
+                            components_map.insert(
+                                ws_purl.clone(),
+                                SbomComponent {
+                                    name: ws_name,
+                                    version: ws_version,
+                                    purl: ws_purl.clone(),
+                                    dep_type: ws_dep_type,
+                                    integrity: None,
+                                    tarball_url: None,
+                                    license: ws_manifest
+                                        .get("license")
+                                        .and_then(|v| v.as_str())
+                                        .map(ToString::to_string),
+                                    description: ws_manifest
+                                        .get("description")
+                                        .and_then(|v| v.as_str())
+                                        .map(ToString::to_string),
+                                    author: extract_author(&ws_manifest),
+                                    homepage: extract_homepage(&ws_manifest),
+                                    repository: extract_repository(&ws_manifest),
+                                    bugs_url: extract_bugs_url(&ws_manifest),
+                                },
+                            );
                         }
+                        ws_purl_by_importer.insert(target_id.clone(), ws_purl);
+                        importer_queue.push(target_id);
                     }
                 } else if let Some(snapshot_key) = spec.version.resolved_key(name) {
                     walk_snapshot(

--- a/pnpm/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom/tests.rs
@@ -1,8 +1,46 @@
 use super::{
-    base64_to_hex, build_purl, classify_license, encode_purl_name, extract_author,
-    extract_repository, is_simple_spdx_id, normalize_link_path, peer_names_from_manifest,
-    sanitize_spdx_id, split_scoped_name, strip_url_credentials,
+    base64_to_hex, build_purl, classify_license, confined_importer_dir, encode_purl_name,
+    extract_author, extract_repository, is_simple_spdx_id, normalize_link_path,
+    peer_names_from_manifest, sanitize_spdx_id, split_scoped_name, strip_url_credentials,
 };
+
+#[test]
+fn confined_importer_dir_accepts_dirs_inside_the_lockfile_root() {
+    let root = tempfile::tempdir().expect("create lockfile dir");
+    std::fs::create_dir_all(root.path().join("packages/foo")).expect("create importer dir");
+
+    // The root importer and an in-tree sub-importer both resolve inside the
+    // lockfile dir, so both are readable.
+    let canonical_root = std::fs::canonicalize(root.path()).expect("canonicalize root");
+    assert_eq!(confined_importer_dir(root.path(), "."), Some(canonical_root.clone()));
+    assert_eq!(
+        confined_importer_dir(root.path(), "packages/foo"),
+        Some(canonical_root.join("packages/foo")),
+    );
+}
+
+#[test]
+fn confined_importer_dir_rejects_lexical_escapes() {
+    let root = tempfile::tempdir().expect("create lockfile dir");
+    for id in ["..", "../foo", "/abs/path", "C:/x"] {
+        assert!(confined_importer_dir(root.path(), id).is_none(), "expected {id:?} to be rejected");
+    }
+}
+
+/// A lexically clean importer key whose directory is a symlink pointing
+/// outside the workspace must not be read — the canonicalize + containment
+/// check catches what the lexical `validate_importer_id` filter cannot.
+#[cfg(unix)]
+#[test]
+fn confined_importer_dir_rejects_symlinked_escape() {
+    let root = tempfile::tempdir().expect("create lockfile dir");
+    let outside = tempfile::tempdir().expect("create outside dir");
+    std::fs::create_dir_all(root.path().join("packages")).expect("create packages dir");
+    std::os::unix::fs::symlink(outside.path(), root.path().join("packages/escape"))
+        .expect("create escaping symlink");
+
+    assert!(confined_importer_dir(root.path(), "packages/escape").is_none());
+}
 
 #[test]
 fn encode_purl_name_unscoped() {

--- a/pnpm/crates/cli/src/cli_args/unlink.rs
+++ b/pnpm/crates/cli/src/cli_args/unlink.rs
@@ -61,14 +61,9 @@ impl UnlinkArgs {
         }
 
         let state = State::init(manifest_path, config, false).wrap_err("initialize the state")?;
-
+        let lockfile_path = state.lockfile_path();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
-
-        let lockfile_path = manifest
-            .path()
-            .parent()
-            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
 
         Install {
             tarball_mem_cache: Arc::clone(tarball_mem_cache),
@@ -78,7 +73,7 @@ impl UnlinkArgs {
             manifest,
             emit_initial_manifest: true,
             lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
-            lockfile_path: lockfile_path.as_deref(),
+            lockfile_path: Some(&lockfile_path),
             dependency_groups: [
                 DependencyGroup::Prod,
                 DependencyGroup::Dev,

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -1,4 +1,9 @@
-use crate::{State, cli_args::supported_architectures::SupportedArchitecturesArgs};
+use crate::{
+    State,
+    cli_args::{
+        pipelines::InstallFamilySelection, supported_architectures::SupportedArchitecturesArgs,
+    },
+};
 use clap::Args;
 use miette::Context;
 use pacquet_config::Config;
@@ -117,6 +122,8 @@ impl UpdateArgs {
             return Err(miette::miette!("`pnpm update --workspace` is not supported yet."));
         }
 
+        let lockfile_path = state.lockfile_path();
+        let active_importer_id = state.active_importer_id();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &mut state;
         let lockfile =
@@ -125,15 +132,11 @@ impl UpdateArgs {
         let supported_architectures =
             self.supported_architectures.apply_to(config.supported_architectures.clone());
 
-        let lockfile_path = manifest
-            .path()
-            .parent()
-            .map(|parent| parent.join(pacquet_lockfile::Lockfile::FILE_NAME));
-
         let packages = if self.interactive {
             match crate::cli_args::update_interactive::select_packages(
                 manifest,
                 lockfile,
+                &active_importer_id,
                 config,
                 http_client,
                 self.latest,
@@ -159,7 +162,7 @@ impl UpdateArgs {
             config,
             manifest,
             lockfile,
-            lockfile_path: lockfile_path.as_deref(),
+            lockfile_path: Some(&lockfile_path),
             packages: &packages,
             latest: self.latest,
             save_exact: self.save_exact,
@@ -171,6 +174,78 @@ impl UpdateArgs {
             resolution_observer: None,
         }
         .run::<Reporter>()
+        .await
+        .wrap_err("updating dependencies")
+    }
+
+    pub(crate) async fn run_selected<Reporter: self::Reporter + 'static>(
+        self,
+        mut state: State,
+        selection: InstallFamilySelection,
+    ) -> miette::Result<()> {
+        if self.workspace {
+            return Err(miette::miette!(
+                "`pacquet update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pacquet."
+            ));
+        }
+
+        let lockfile_path = state.lockfile_path();
+        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
+            &mut state;
+        let lockfile =
+            lockfile.get().map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+        let supported_architectures =
+            self.supported_architectures.apply_to(config.supported_architectures.clone());
+        let packages = if self.interactive {
+            match crate::cli_args::update_interactive::select_packages_for_projects(
+                &selection,
+                lockfile,
+                config,
+                http_client,
+                self.latest,
+                &self.dependency_options.include_direct(),
+            )
+            .await?
+            {
+                Some(selected) => selected,
+                None => return Ok(()),
+            }
+        } else {
+            self.packages.clone()
+        };
+        let InstallFamilySelection {
+            workspace_root: _,
+            mut projects,
+            ordered_dirs,
+            selected_dirs,
+            active_manifest_is_standin,
+        } = selection;
+
+        Update {
+            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+            resolved_packages,
+            http_client,
+            http_client_arc: std::sync::Arc::clone(http_client),
+            config,
+            manifest,
+            lockfile,
+            lockfile_path: Some(&lockfile_path),
+            packages: &packages,
+            latest: self.latest,
+            save_exact: self.save_exact,
+            save: !self.no_save,
+            include_direct: self.dependency_options.include_direct(),
+            depth: self.depth.unwrap_or(usize::MAX),
+            supported_architectures,
+            lockfile_only: self.lockfile_only,
+            resolution_observer: None,
+        }
+        .run_selected::<Reporter>(
+            &mut projects,
+            &ordered_dirs,
+            selected_dirs.as_ref(),
+            active_manifest_is_standin,
+        )
         .await
         .wrap_err("updating dependencies")
     }

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -185,7 +185,7 @@ impl UpdateArgs {
     ) -> miette::Result<()> {
         if self.workspace {
             return Err(miette::miette!(
-                "`pacquet update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pacquet."
+                "`pnpm update --workspace` is not supported yet; workspace-protocol version linking has not been ported yet."
             ));
         }
 

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -109,6 +109,12 @@ pub struct UpdateArgs {
     pub workspace: bool,
 }
 
+/// The `pnpm update --workspace` rejection message. `--workspace` needs
+/// workspace-protocol version linking, which has not been ported yet, so
+/// every dispatch path — plain, selected, and global — refuses it with the
+/// same wording rather than silently doing a plain update.
+const WORKSPACE_UPDATE_UNSUPPORTED: &str = "`pnpm update --workspace` is not supported yet.";
+
 impl UpdateArgs {
     pub async fn run<Reporter: self::Reporter + 'static>(
         self,
@@ -119,7 +125,7 @@ impl UpdateArgs {
         // silently doing a plain update. (`--global` is routed to
         // [`Self::run_global`] before `run` is reached.)
         if self.workspace {
-            return Err(miette::miette!("`pnpm update --workspace` is not supported yet."));
+            return Err(miette::miette!("{WORKSPACE_UPDATE_UNSUPPORTED}"));
         }
 
         let lockfile_path = state.lockfile_path();
@@ -184,9 +190,7 @@ impl UpdateArgs {
         selection: InstallFamilySelection,
     ) -> miette::Result<()> {
         if self.workspace {
-            return Err(miette::miette!(
-                "`pnpm update --workspace` is not supported yet; workspace-protocol version linking has not been ported yet."
-            ));
+            return Err(miette::miette!("{WORKSPACE_UPDATE_UNSUPPORTED}"));
         }
 
         let lockfile_path = state.lockfile_path();
@@ -258,7 +262,7 @@ impl UpdateArgs {
         config: &'static Config,
     ) -> miette::Result<()> {
         if self.workspace {
-            return Err(miette::miette!("`pnpm update --workspace` is not supported yet."));
+            return Err(miette::miette!("{WORKSPACE_UPDATE_UNSUPPORTED}"));
         }
         if self.interactive {
             return Err(miette::miette!(

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -6,20 +6,30 @@
 //! user picked so the regular update path can run with them as selectors.
 //!
 //! The outdated set is computed by the shared
-//! [`collect_outdated`], which also backs `pacquet outdated`. The two
+//! [`collect_outdated_for_importer`], whose root-importer wrapper also backs
+//! `pacquet outdated`. The two
 //! callers differ only in
 //! the [`TargetVersion`] they compare against: `update` targets the
 //! version a bump would move to (the `latest` tag under `--latest`,
 //! otherwise the highest in-range version). The choice list is
 //! intentionally flat; the prompt is a `dialoguer` multi-select.
 
-use crate::cli_args::outdated::{OutdatedQuery, TargetVersion, collect_outdated};
+use crate::cli_args::{
+    outdated::{OutdatedPackage, OutdatedQuery, TargetVersion, collect_outdated_for_importer},
+    pipelines::InstallFamilySelection,
+};
 use dialoguer::MultiSelect;
 use miette::{IntoDiagnostic, miette};
 use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use std::collections::HashSet;
+
+struct InteractiveUpdateProject<'a> {
+    manifest: &'a PackageManifest,
+    importer_id: String,
+}
 
 /// Gather outdated direct dependencies, prompt the user, and return the
 /// selected package names. `Ok(None)` means "nothing to do" — either no
@@ -28,11 +38,51 @@ use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 pub async fn select_packages(
     manifest: &PackageManifest,
     lockfile: Option<&Lockfile>,
+    importer_id: &str,
     config: &Config,
     http_client: &ThrottledClient,
     latest: bool,
     include_direct: &[DependencyGroup],
 ) -> miette::Result<Option<Vec<String>>> {
+    let projects = [InteractiveUpdateProject { manifest, importer_id: importer_id.to_string() }];
+    let choices =
+        collect_choices(&projects, lockfile, config, http_client, latest, include_direct).await?;
+    prompt_for_packages(&choices, latest)
+}
+
+pub(crate) async fn select_packages_for_projects(
+    selection: &InstallFamilySelection,
+    lockfile: Option<&Lockfile>,
+    config: &Config,
+    http_client: &ThrottledClient,
+    latest: bool,
+    include_direct: &[DependencyGroup],
+) -> miette::Result<Option<Vec<String>>> {
+    let projects = selection
+        .projects
+        .iter()
+        .filter(|project| selection.selected_dirs.contains(&project.root_dir))
+        .map(|project| InteractiveUpdateProject {
+            manifest: &project.manifest,
+            importer_id: pacquet_workspace::importer_id_from_root_dir(
+                &selection.workspace_root,
+                &project.root_dir,
+            ),
+        })
+        .collect::<Vec<_>>();
+    let choices =
+        collect_choices(&projects, lockfile, config, http_client, latest, include_direct).await?;
+    prompt_for_packages(&choices, latest)
+}
+
+async fn collect_choices(
+    projects: &[InteractiveUpdateProject<'_>],
+    lockfile: Option<&Lockfile>,
+    config: &Config,
+    http_client: &ThrottledClient,
+    latest: bool,
+    include_direct: &[DependencyGroup],
+) -> miette::Result<Vec<OutdatedPackage>> {
     let target_version = if latest { TargetVersion::Latest } else { TargetVersion::WithinRange };
     let query = OutdatedQuery {
         target_version,
@@ -40,8 +90,39 @@ pub async fn select_packages(
         match_names: None,
         include_deprecated: false,
     };
-    let choices = collect_outdated(manifest, lockfile, config, http_client, &query).await?;
+    let choices = futures_util::future::join_all(projects.iter().map(|project| {
+        collect_outdated_for_importer(
+            project.manifest,
+            lockfile,
+            &project.importer_id,
+            config,
+            http_client,
+            &query,
+        )
+    }))
+    .await;
+    let mut unique = HashSet::new();
+    let mut collected = Vec::new();
+    for choices in choices {
+        for choice in choices? {
+            let key = (
+                choice.alias.clone(),
+                choice.package_name.clone(),
+                choice.current.to_string(),
+                choice.target.to_string(),
+            );
+            if unique.insert(key) {
+                collected.push(choice);
+            }
+        }
+    }
+    Ok(collected)
+}
 
+fn prompt_for_packages(
+    choices: &[OutdatedPackage],
+    latest: bool,
+) -> miette::Result<Option<Vec<String>>> {
     if choices.is_empty() {
         let message = if latest {
             "All of your dependencies are already up to date"
@@ -72,3 +153,6 @@ pub async fn select_packages(
     }
     Ok(Some(selected))
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -1,0 +1,183 @@
+use super::{InteractiveUpdateProject, collect_choices};
+use pacquet_config::Config;
+use pacquet_lockfile::Lockfile;
+use pacquet_network::ThrottledClient;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use serde_json::json;
+
+const TEST_INTEGRITY: &str = "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==";
+
+#[tokio::test]
+async fn collects_choices_from_each_selected_workspace_importer() {
+    let temp = tempfile::tempdir().expect("create temporary workspace");
+    let foo = manifest_with_dependency(temp.path(), "packages/a", "foo");
+    let bar = manifest_with_dependency(temp.path(), "packages/b", "bar");
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+importers:
+  packages/a:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+  packages/b:
+    dependencies:
+      bar:
+        specifier: ^1.0.0
+        version: 1.0.0
+",
+    )
+    .expect("parse workspace lockfile");
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let foo_mock = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(package_body("foo", &registry))
+        .expect(1)
+        .create_async()
+        .await;
+    let bar_mock = server
+        .mock("GET", "/bar")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(package_body("bar", &registry))
+        .expect(1)
+        .create_async()
+        .await;
+    let mut config = Config::new();
+    config.registry = registry;
+    let projects = [
+        InteractiveUpdateProject { manifest: &foo, importer_id: "packages/a".to_string() },
+        InteractiveUpdateProject { manifest: &bar, importer_id: "packages/b".to_string() },
+    ];
+
+    let choices = collect_choices(
+        &projects,
+        Some(&lockfile),
+        &config,
+        &ThrottledClient::default(),
+        false,
+        &[DependencyGroup::Prod],
+    )
+    .await
+    .expect("collect interactive choices");
+
+    assert_eq!(
+        choices.iter().map(|choice| choice.alias.as_str()).collect::<Vec<_>>(),
+        vec!["foo", "bar"],
+    );
+    foo_mock.assert_async().await;
+    bar_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn keeps_distinct_aliases_for_the_same_package() {
+    let temp = tempfile::tempdir().expect("create temporary workspace");
+    let direct = manifest_with_dependency_spec(temp.path(), "packages/a", ("foo", "^1.0.0"));
+    let alias =
+        manifest_with_dependency_spec(temp.path(), "packages/b", ("fooAlias", "npm:foo@^1.0.0"));
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+importers:
+  packages/a:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+  packages/b:
+    dependencies:
+      fooAlias:
+        specifier: npm:foo@^1.0.0
+        version: foo@1.0.0
+",
+    )
+    .expect("parse workspace lockfile");
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let foo_mock = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(package_body("foo", &registry))
+        .expect(2)
+        .create_async()
+        .await;
+    let mut config = Config::new();
+    config.registry = registry;
+    let projects = [
+        InteractiveUpdateProject { manifest: &direct, importer_id: "packages/a".to_string() },
+        InteractiveUpdateProject { manifest: &alias, importer_id: "packages/b".to_string() },
+    ];
+
+    let choices = collect_choices(
+        &projects,
+        Some(&lockfile),
+        &config,
+        &ThrottledClient::default(),
+        false,
+        &[DependencyGroup::Prod],
+    )
+    .await
+    .expect("collect interactive choices");
+
+    assert_eq!(
+        choices.iter().map(|choice| choice.alias.as_str()).collect::<Vec<_>>(),
+        vec!["foo", "fooAlias"],
+    );
+    foo_mock.assert_async().await;
+}
+
+fn manifest_with_dependency(
+    root: &std::path::Path,
+    relative: &str,
+    dependency: &str,
+) -> PackageManifest {
+    manifest_with_dependency_spec(root, relative, (dependency, "^1.0.0"))
+}
+
+fn manifest_with_dependency_spec(
+    root: &std::path::Path,
+    relative: &str,
+    dependency: (&str, &str),
+) -> PackageManifest {
+    let (dependency, specifier) = dependency;
+    let project_dir = root.join(relative);
+    std::fs::create_dir_all(&project_dir).expect("create project directory");
+    let manifest_path = project_dir.join("package.json");
+    std::fs::write(
+        &manifest_path,
+        json!({
+            "name": relative.replace('/', "-"),
+            "dependencies": { dependency: specifier },
+        })
+        .to_string(),
+    )
+    .expect("write project manifest");
+    PackageManifest::from_path(manifest_path).expect("read project manifest")
+}
+
+fn package_body(name: &str, registry: &str) -> String {
+    let version = |version: &str| {
+        json!({
+            "name": name,
+            "version": version,
+            "dist": {
+                "integrity": TEST_INTEGRITY,
+                "tarball": format!("{registry}{name}/-/{name}-{version}.tgz"),
+            },
+        })
+    };
+    json!({
+        "name": name,
+        "dist-tags": { "latest": "1.1.0" },
+        "versions": {
+            "1.0.0": version("1.0.0"),
+            "1.1.0": version("1.1.0"),
+        },
+    })
+    .to_string()
+}

--- a/pnpm/crates/cli/src/cli_args/why.rs
+++ b/pnpm/crates/cli/src/cli_args/why.rs
@@ -1,10 +1,18 @@
 //! `pnpm why` — show the packages that depend on `<pkg>`.
 
-use crate::{State, cli_args::sanitize::sanitize};
+use crate::{
+    State,
+    cli_args::{
+        recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
+        sanitize::sanitize,
+    },
+};
 use clap::Args;
 use owo_colors::{OwoColorize, Stream};
 use pacquet_config::matcher::{Matcher, create_matcher};
 use pacquet_lockfile::{Lockfile, PackageKey, PackageMetadata, PkgNameVerPeer};
+use pacquet_modules_yaml::IncludedDependencies;
+use pacquet_package_manager::{SkippedSnapshots, materialization_closure};
 use pacquet_package_manifest::DependencyGroup;
 use std::{
     collections::{HashMap, HashSet},
@@ -76,7 +84,14 @@ impl WhyArgs {
                 "`pnpm why` requires a package name or pattern"
             ));
         }
+        if state.config.recursive && !state.config.shared_workspace_lockfile {
+            return Err(miette::miette!(
+                code = "ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED",
+                "Recursive and filtered `pacquet why` with `sharedWorkspaceLockfile=false` is not supported yet."
+            ));
+        }
 
+        let active_importer_id = state.active_importer_id();
         let lockfile = state
             .lockfile
             .get()
@@ -85,6 +100,37 @@ impl WhyArgs {
         let Some(lockfile) = lockfile else {
             return Ok(());
         };
+        let initial_importer_ids = if state.config.recursive
+            && (!state.config.filter.is_empty() || !state.config.filter_prod.is_empty())
+        {
+            let workspace_root = state.lockfile_dir();
+            let (projects, _) = discover_workspace_projects(workspace_root)?;
+            let prefix =
+                state.manifest.path().parent().expect("manifest path always has a parent dir");
+            select_recursive_projects(&projects, state.config, prefix, AutoExcludeRoot::Disabled)?
+                .selected
+                .keys()
+                .map(|project_dir| {
+                    pacquet_workspace::importer_id_from_root_dir(workspace_root, project_dir)
+                })
+                .collect()
+        } else if state.config.recursive {
+            lockfile.importers.keys().cloned().collect()
+        } else {
+            HashSet::from([active_importer_id.clone()])
+        };
+        let lockfile = materialization_closure(
+            lockfile,
+            state.lockfile_dir(),
+            &initial_importer_ids,
+            IncludedDependencies {
+                dependencies: true,
+                dev_dependencies: true,
+                optional_dependencies: true,
+            },
+            &SkippedSnapshots::new(),
+        )
+        .lockfile;
 
         let matcher = create_matcher(&self.packages);
 
@@ -99,7 +145,7 @@ impl WhyArgs {
 
         let mut importer_info = HashMap::new();
         for importer_id in lockfile.importers.keys() {
-            if importer_id == Lockfile::ROOT_IMPORTER_KEY {
+            if importer_id == &active_importer_id {
                 importer_info.insert(
                     importer_id.clone(),
                     ImporterInfo { name: root_name.clone(), version: root_version.clone() },
@@ -112,7 +158,7 @@ impl WhyArgs {
             }
         }
 
-        let results = build_dependents_tree(lockfile, &matcher, &importer_info, self.depth);
+        let results = build_dependents_tree(&lockfile, &matcher, &importer_info, self.depth);
 
         if results.is_empty() {
             return Ok(());

--- a/pnpm/crates/cli/src/cli_args/why.rs
+++ b/pnpm/crates/cli/src/cli_args/why.rs
@@ -3,7 +3,10 @@
 use crate::{
     State,
     cli_args::{
-        recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
+        recursive::{
+            AutoExcludeRoot, RecursiveSharedLockfileUnsupported, discover_workspace_projects,
+            select_recursive_projects,
+        },
         sanitize::sanitize,
     },
 };
@@ -85,10 +88,10 @@ impl WhyArgs {
             ));
         }
         if state.config.recursive && !state.config.shared_workspace_lockfile {
-            return Err(miette::miette!(
-                code = "ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED",
-                "Recursive and filtered `pacquet why` with `sharedWorkspaceLockfile=false` is not supported yet."
-            ));
+            return Err(RecursiveSharedLockfileUnsupported::new(
+                "Recursive and filtered `pnpm why`",
+            )
+            .into());
         }
 
         let active_importer_id = state.active_importer_id();

--- a/pnpm/crates/cli/src/state.rs
+++ b/pnpm/crates/cli/src/state.rs
@@ -7,7 +7,10 @@ use pacquet_package_manager::ResolvedPackages;
 use pacquet_package_manifest::{PackageManifest, PackageManifestError};
 use pacquet_tarball::MemCache;
 use pipe_trait::Pipe;
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// Application state when running `pacquet run` or `pacquet install`.
 pub struct State {
@@ -66,11 +69,14 @@ impl State {
     ) -> Result<Self, InitStateError> {
         let should_load = config.lockfile || require_lockfile;
         let lockfile = if should_load {
-            manifest_path
-                .parent()
-                .expect("manifest path always has a parent dir")
-                .to_path_buf()
-                .pipe(LazyLockfile::deferred)
+            let manifest_dir =
+                manifest_path.parent().expect("manifest path always has a parent dir");
+            if config.shared_workspace_lockfile {
+                config.workspace_dir.clone().unwrap_or_else(|| manifest_dir.to_path_buf())
+            } else {
+                manifest_dir.to_path_buf()
+            }
+            .pipe(LazyLockfile::deferred)
         } else {
             LazyLockfile::disabled()
         };
@@ -95,6 +101,26 @@ impl State {
             tarball_mem_cache: Arc::new(MemCache::new()),
             resolved_packages: ResolvedPackages::new(),
         })
+    }
+
+    pub fn lockfile_dir(&self) -> &Path {
+        let manifest_dir =
+            self.manifest.path().parent().expect("manifest path always has a parent dir");
+        if self.config.shared_workspace_lockfile {
+            self.config.workspace_dir.as_deref().unwrap_or(manifest_dir)
+        } else {
+            manifest_dir
+        }
+    }
+
+    pub fn lockfile_path(&self) -> PathBuf {
+        self.lockfile_dir().join(pacquet_lockfile::Lockfile::FILE_NAME)
+    }
+
+    pub fn active_importer_id(&self) -> String {
+        let project_dir =
+            self.manifest.path().parent().expect("manifest path always has a parent dir");
+        pacquet_workspace::importer_id_from_root_dir(self.lockfile_dir(), project_dir)
     }
 }
 
@@ -127,3 +153,6 @@ fn load_or_create_manifest(
     }
     manifest_path.pipe(PackageManifest::create_if_needed).map_err(InitStateError::Manifest)
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/state/tests.rs
+++ b/pnpm/crates/cli/src/state/tests.rs
@@ -1,0 +1,41 @@
+use super::State;
+use pacquet_config::Config;
+
+#[test]
+fn workspace_state_anchors_lockfile_at_workspace_root() {
+    let temp = tempfile::tempdir().expect("create temporary workspace");
+    let workspace_root = temp.path().to_path_buf();
+    let project_dir = workspace_root.join("packages/app");
+    std::fs::create_dir_all(&project_dir).expect("create project directory");
+    let manifest_path = project_dir.join("package.json");
+    std::fs::write(&manifest_path, r#"{"name":"app"}"#).expect("write project manifest");
+
+    let config =
+        Config::leak(Config { workspace_dir: Some(workspace_root.clone()), ..Config::default() });
+    let state = State::init(manifest_path, config, false).expect("initialize state");
+
+    assert_eq!(state.lockfile_dir(), workspace_root);
+    assert_eq!(state.lockfile_path(), workspace_root.join(pacquet_lockfile::Lockfile::FILE_NAME));
+    assert_eq!(state.active_importer_id(), "packages/app");
+}
+
+#[test]
+fn workspace_state_anchors_per_project_lockfile_at_project_root() {
+    let temp = tempfile::tempdir().expect("create temporary workspace");
+    let workspace_root = temp.path().to_path_buf();
+    let project_dir = workspace_root.join("packages/app");
+    std::fs::create_dir_all(&project_dir).expect("create project directory");
+    let manifest_path = project_dir.join("package.json");
+    std::fs::write(&manifest_path, r#"{"name":"app"}"#).expect("write project manifest");
+
+    let config = Config::leak(Config {
+        workspace_dir: Some(workspace_root),
+        shared_workspace_lockfile: false,
+        ..Config::default()
+    });
+    let state = State::init(manifest_path, config, false).expect("initialize state");
+
+    assert_eq!(state.lockfile_dir(), project_dir);
+    assert_eq!(state.lockfile_path(), project_dir.join(pacquet_lockfile::Lockfile::FILE_NAME));
+    assert_eq!(state.active_importer_id(), ".");
+}

--- a/pnpm/crates/cli/tests/deploy.rs
+++ b/pnpm/crates/cli/tests/deploy.rs
@@ -475,6 +475,27 @@ fn legacy_deploy_installs_selected_project() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn legacy_deploy_without_lockfile_installs_selected_project_at_root() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, false);
+
+    pacquet
+        .with_env("PNPM_CONFIG_LOCKFILE", "false")
+        .with_args(["--filter", "app", "deploy", "--legacy", "--prod", "legacy-deploy-no-lockfile"])
+        .assert()
+        .success();
+
+    let deploy_dir = workspace.join("legacy-deploy-no-lockfile");
+    assert!(deploy_dir.join("node_modules/lib").exists());
+    assert!(!deploy_dir.join("legacy-deploy-no-lockfile/node_modules").exists());
+    assert!(!deploy_dir.join("pnpm-lock.yaml").exists());
+
+    drop((root, mock_instance));
+}
+
 fn pacquet_cmd(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -344,6 +344,64 @@ fn global_add_ignores_caller_project_npmrc_registry() {
     drop(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn global_outdated_reads_each_global_install_lockfile() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let pnpm_home = root.path().join("pnpm-home");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write caller workspace manifest");
+
+    global_command(&workspace, &pnpm_home)
+        .with_arg("add")
+        .with_arg("-g")
+        .with_arg("@pnpm.e2e/pkg-with-1-dep@100.0.0")
+        .assert()
+        .success();
+    let global_pkg_dir = pnpm_home.join("global/v11");
+    let links = symlink_entries(&global_pkg_dir);
+    assert_eq!(links.len(), 1, "global add should create one install-group link");
+    let install_dir = fs::canonicalize(&links[0]).expect("resolve global install-group link");
+    assert!(install_dir.join("package.json").is_file());
+    assert!(install_dir.join("pnpm-lock.yaml").is_file());
+
+    fs::write(workspace.join(".npmrc"), "registry=http://127.0.0.1:1/\n")
+        .expect("poison caller registry");
+
+    let output = global_command(&workspace, &pnpm_home)
+        .with_arg("outdated")
+        .with_arg("-g")
+        .with_arg("--format")
+        .with_arg("json")
+        .output()
+        .expect("run outdated -g");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "global dependency should be outdated; stdout: {}; stderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse outdated -g JSON");
+    let entry = &report["@pnpm.e2e/pkg-with-1-dep"];
+    assert_eq!(entry["current"], "100.0.0");
+    assert_eq!(entry["latest"], "100.1.0");
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("No lockfile in directory"),
+        "outdated -g must not read the caller workspace lockfile: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    drop((root, npmrc_info));
+}
+
 /// `pacquet list -g` with nothing installed reports the empty state rather
 /// than erroring. No registry needed.
 #[test]

--- a/pnpm/crates/cli/tests/install_filters.rs
+++ b/pnpm/crates/cli/tests/install_filters.rs
@@ -1,0 +1,1370 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, SnapshotEntry};
+use pacquet_modules_yaml::{Host, Modules, read_modules_manifest, write_modules_manifest};
+use pacquet_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fs::is_symlink_or_junction,
+};
+use pacquet_workspace_state::WorkspaceState;
+use pretty_assertions::assert_eq;
+use serde_json::{Map, Value, json};
+use std::{
+    collections::{BTreeSet, HashMap},
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+use tempfile::TempDir;
+
+const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+const CATALOG_FOO: &str = "@pnpm.e2e/foo";
+const HELLO: &str = "@pnpm.e2e/hello-world-js-bin";
+const HELLO_PARENT: &str = "@pnpm.e2e/hello-world-js-bin-parent";
+const NO_DEPS: &str = "@foo/no-deps";
+const PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
+
+#[derive(Clone, Copy, Default)]
+struct ManifestDeps<'a> {
+    prod: &'a [(&'a str, &'a str)],
+    dev: &'a [(&'a str, &'a str)],
+    optional: &'a [(&'a str, &'a str)],
+}
+
+struct FilteredWorkspace {
+    _root: TempDir,
+    workspace: PathBuf,
+    registry: AddMockedRegistry,
+}
+
+impl FilteredWorkspace {
+    fn new() -> Self {
+        let CommandTempCwd { root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let fixture = Self { _root: root, workspace, registry: npmrc_info };
+        fixture.append_workspace_yaml("packages:\n  - 'packages/*'\n");
+        fixture
+    }
+
+    fn append_workspace_yaml(&self, text: &str) {
+        let path = self.workspace.join("pnpm-workspace.yaml");
+        let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+        if !yaml.ends_with('\n') {
+            yaml.push('\n');
+        }
+        yaml.push_str(text);
+        fs::write(path, yaml).expect("write pnpm-workspace.yaml");
+    }
+
+    fn write_root_manifest(&self, name: &str, deps: ManifestDeps<'_>) {
+        write_manifest(&self.workspace, name, deps);
+    }
+
+    fn project(&self, dir: &str, name: &str, deps: ManifestDeps<'_>) -> PathBuf {
+        let project = self.workspace.join("packages").join(dir);
+        write_manifest(&project, name, deps);
+        project
+    }
+
+    fn command_at<I, S>(&self, cwd: &Path, args: I) -> Output
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(cwd)
+            .env("PNPM_CONFIG_REGISTRY", self.registry.mock_instance.url())
+            .arg("--reporter=ndjson")
+            .args(args)
+            .output()
+            .expect("run pacquet")
+    }
+
+    fn run<I, S>(&self, args: I) -> Vec<Value>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.run_at(&self.workspace, args)
+    }
+
+    fn run_at<I, S>(&self, cwd: &Path, args: I) -> Vec<Value>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let output = self.command_at(cwd, args);
+        assert_success(&output);
+        ndjson_records(&output)
+    }
+
+    fn wanted(&self) -> Lockfile {
+        read_lockfile(&self.workspace.join("pnpm-lock.yaml"))
+    }
+
+    fn current(&self) -> Lockfile {
+        read_lockfile(&self.workspace.join("node_modules/.pnpm/lock.yaml"))
+    }
+
+    fn modules(&self) -> Modules {
+        read_modules_manifest::<Host>(&self.workspace.join("node_modules"))
+            .expect("read .modules.yaml")
+            .expect(".modules.yaml exists")
+    }
+
+    fn write_modules(&self, modules: Modules) {
+        write_modules_manifest::<Host>(&self.workspace.join("node_modules"), modules)
+            .expect("write .modules.yaml");
+    }
+
+    fn state(&self) -> WorkspaceState {
+        let path = self.workspace.join("node_modules/.pnpm-workspace-state-v1.json");
+        serde_json::from_str(&fs::read_to_string(path).expect("read workspace state"))
+            .expect("parse workspace state")
+    }
+
+    fn package_map(&self) -> Value {
+        let path = self.workspace.join("node_modules/.package-map.json");
+        serde_json::from_str(&fs::read_to_string(path).expect("read package map"))
+            .expect("parse package map")
+    }
+
+    fn slot(&self, name: &str, version: &str) -> PathBuf {
+        self.workspace
+            .join("node_modules/.pnpm")
+            .join(format!("{}@{version}", name.replace('/', "+")))
+    }
+}
+
+fn write_manifest(project: &Path, name: &str, deps: ManifestDeps<'_>) {
+    fs::create_dir_all(project).expect("create project directory");
+    let mut manifest = Map::from_iter([
+        ("name".to_string(), Value::String(name.to_string())),
+        ("version".to_string(), Value::String("1.0.0".to_string())),
+        ("private".to_string(), Value::Bool(true)),
+    ]);
+    insert_dependency_group(&mut manifest, "dependencies", deps.prod);
+    insert_dependency_group(&mut manifest, "devDependencies", deps.dev);
+    insert_dependency_group(&mut manifest, "optionalDependencies", deps.optional);
+    fs::write(
+        project.join("package.json"),
+        serde_json::to_string_pretty(&Value::Object(manifest)).expect("serialize package.json"),
+    )
+    .expect("write package.json");
+}
+
+fn insert_dependency_group(manifest: &mut Map<String, Value>, group: &str, deps: &[(&str, &str)]) {
+    if deps.is_empty() {
+        return;
+    }
+    manifest.insert(
+        group.to_string(),
+        Value::Object(
+            deps.iter()
+                .map(|(name, spec)| (name.to_string(), Value::String(spec.to_string())))
+                .collect(),
+        ),
+    );
+}
+
+fn read_manifest(project: &Path) -> Value {
+    serde_json::from_str(
+        &fs::read_to_string(project.join("package.json")).expect("read package.json"),
+    )
+    .expect("parse package.json")
+}
+
+fn write_manifest_value(project: &Path, manifest: &Value) {
+    fs::write(
+        project.join("package.json"),
+        serde_json::to_string_pretty(manifest).expect("serialize package.json"),
+    )
+    .expect("write package.json");
+}
+
+fn set_dependency(project: &Path, group: &str, name: &str, spec: &str) {
+    let mut manifest = read_manifest(project);
+    let object = manifest.as_object_mut().expect("manifest is an object");
+    let dependencies = object.entry(group).or_insert_with(|| json!({}));
+    dependencies
+        .as_object_mut()
+        .expect("dependency group is an object")
+        .insert(name.to_string(), Value::String(spec.to_string()));
+    write_manifest_value(project, &manifest);
+}
+
+fn set_version(project: &Path, version: &str) {
+    let path = project.join("package.json");
+    let mut manifest: Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("read package.json"))
+            .expect("parse package.json");
+    manifest["version"] = Value::String(version.to_string());
+    fs::write(path, serde_json::to_string_pretty(&manifest).expect("serialize package.json"))
+        .expect("write package.json");
+}
+
+fn replace_dependencies(project: &Path, deps: &[(&str, &str)]) {
+    let mut manifest = read_manifest(project);
+    manifest["dependencies"] = Value::Object(
+        deps.iter()
+            .map(|(name, spec)| (name.to_string(), Value::String(spec.to_string())))
+            .collect(),
+    );
+    write_manifest_value(project, &manifest);
+}
+
+fn dependency_spec(project: &Path, group: &str, name: &str) -> Option<String> {
+    read_manifest(project)
+        .get(group)
+        .and_then(Value::as_object)
+        .and_then(|dependencies| dependencies.get(name))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn read_lockfile(path: &Path) -> Lockfile {
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read lockfile {}: {error}", path.display()));
+    serde_saphyr::from_str(&contents)
+        .unwrap_or_else(|error| panic!("parse lockfile {}: {error}\n{contents}", path.display()))
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+fn ndjson_records(output: &Output) -> Vec<Value> {
+    [&output.stderr[..], &output.stdout[..]]
+        .into_iter()
+        .flat_map(|stream| {
+            String::from_utf8_lossy(stream).lines().map(str::to_string).collect::<Vec<_>>()
+        })
+        .filter_map(|line| serde_json::from_str(&line).ok())
+        .collect()
+}
+
+fn importing_started_count(records: &[Value]) -> usize {
+    records
+        .iter()
+        .filter(|record| {
+            record.get("name").and_then(Value::as_str) == Some("pnpm:stage")
+                && record.get("stage").and_then(Value::as_str) == Some("importing_started")
+        })
+        .count()
+}
+
+fn initial_manifest_prefixes(records: &[Value]) -> Vec<String> {
+    records
+        .iter()
+        .filter(|record| {
+            record.get("name").and_then(Value::as_str) == Some("pnpm:package-manifest")
+                && record.get("initial").is_some()
+        })
+        .filter_map(|record| record.get("prefix").and_then(Value::as_str).map(str::to_string))
+        .collect()
+}
+
+fn importer<'a>(lockfile: &'a Lockfile, id: &str) -> &'a ProjectSnapshot {
+    lockfile
+        .importers
+        .get(id)
+        .unwrap_or_else(|| panic!("missing importer {id:?}: {:?}", lockfile.importers.keys()))
+}
+
+fn importer_version(lockfile: &Lockfile, id: &str, name: &str) -> String {
+    let name: PkgName = name.parse().expect("parse package name");
+    let snapshot = importer(lockfile, id);
+    snapshot
+        .dependencies
+        .as_ref()
+        .and_then(|dependencies| dependencies.get(&name))
+        .or_else(|| {
+            snapshot.dev_dependencies.as_ref().and_then(|dependencies| dependencies.get(&name))
+        })
+        .or_else(|| {
+            snapshot.optional_dependencies.as_ref().and_then(|dependencies| dependencies.get(&name))
+        })
+        .unwrap_or_else(|| panic!("missing dependency {name} in importer {id}"))
+        .version
+        .to_string()
+}
+
+fn importer_specifier(lockfile: &Lockfile, id: &str, name: &str) -> String {
+    let name: PkgName = name.parse().expect("parse package name");
+    importer(lockfile, id)
+        .dependencies
+        .as_ref()
+        .and_then(|dependencies| dependencies.get(&name))
+        .unwrap_or_else(|| panic!("missing dependency {name} in importer {id}"))
+        .specifier
+        .clone()
+}
+
+fn importer_ids(lockfile: &Lockfile) -> BTreeSet<String> {
+    lockfile.importers.keys().cloned().collect()
+}
+
+fn snapshot_entries(lockfile: &Lockfile, name: &str) -> Vec<(String, SnapshotEntry)> {
+    lockfile
+        .snapshots
+        .as_ref()
+        .into_iter()
+        .flatten()
+        .filter(|(key, _)| key.to_string().starts_with(&format!("{name}@")))
+        .map(|(key, snapshot)| (key.to_string(), snapshot.clone()))
+        .collect()
+}
+
+fn has_snapshot(lockfile: &Lockfile, name: &str, version: &str) -> bool {
+    lockfile.snapshots.as_ref().is_some_and(|snapshots| {
+        snapshots.keys().any(|key| {
+            let key = key.to_string();
+            key == format!("{name}@{version}") || key.starts_with(&format!("{name}@{version}("))
+        })
+    })
+}
+
+fn has_link(project: &Path, name: &str) -> bool {
+    is_symlink_or_junction(&project.join("node_modules").join(name)).unwrap_or(false)
+}
+
+fn canonical_path(path: &Path) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|error| panic!("canonicalize {}: {error}", path.display()))
+        .to_string_lossy()
+        .into_owned()
+}
+
+fn assert_stage_once(records: &[Value]) {
+    assert_eq!(importing_started_count(records), 1, "one install pipeline must import once");
+}
+
+fn assert_full_wanted(lockfile: &Lockfile, ids: &[&str]) {
+    assert_eq!(
+        importer_ids(lockfile),
+        ids.iter().map(ToString::to_string).collect(),
+        "wanted lockfile must retain every real importer",
+    );
+}
+
+#[test]
+fn filtered_add_mutates_only_selected_importers() {
+    let fixture = FilteredWorkspace::new();
+    let selected_a = fixture.project("selected-a", "selected-a", ManifestDeps::default());
+    let selected_b = fixture.project("selected-b", "selected-b", ManifestDeps::default());
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    let before = fixture.wanted();
+    let unselected_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    let records = fixture.run([
+        "--filter",
+        "selected-a",
+        "--filter",
+        "selected-b",
+        "add",
+        HELLO,
+        "--lockfile-only",
+    ]);
+    let after = fixture.wanted();
+
+    assert_eq!(dependency_spec(&selected_a, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    assert_eq!(dependency_spec(&selected_b, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+    assert_eq!(importer(&after, "packages/unselected"), importer(&before, "packages/unselected"));
+    assert_full_wanted(
+        &after,
+        &["packages/selected-a", "packages/selected-b", "packages/unselected"],
+    );
+    assert_stage_once(&records);
+}
+
+#[test]
+fn filtered_update_mutates_only_selected_importers() {
+    let fixture = FilteredWorkspace::new();
+    let selected_a = fixture.project(
+        "selected-a",
+        "selected-a",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    let selected_b = fixture.project(
+        "selected-b",
+        "selected-b",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    for project in [&selected_a, &selected_b, &unselected] {
+        set_dependency(project, "dependencies", DEP, "^100.0.0");
+    }
+    let before = fixture.wanted();
+    let unselected_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    let records = fixture.run([
+        "--filter",
+        "selected-a",
+        "--filter",
+        "selected-b",
+        "update",
+        DEP,
+        "--latest",
+        "--lockfile-only",
+    ]);
+    let after = fixture.wanted();
+
+    assert_eq!(dependency_spec(&selected_a, "dependencies", DEP).as_deref(), Some("^101.0.0"));
+    assert_eq!(dependency_spec(&selected_b, "dependencies", DEP).as_deref(), Some("^101.0.0"));
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+    assert_eq!(importer(&after, "packages/unselected"), importer(&before, "packages/unselected"));
+    assert_eq!(importer_version(&after, "packages/unselected", DEP), "100.0.0");
+    assert_full_wanted(
+        &after,
+        &["packages/selected-a", "packages/selected-b", "packages/unselected"],
+    );
+    assert_stage_once(&records);
+}
+
+#[test]
+fn filtered_remove_mutates_only_selected_importers() {
+    let fixture = FilteredWorkspace::new();
+    let selected_a = fixture.project(
+        "selected-a",
+        "selected-a",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let selected_b = fixture.project(
+        "selected-b",
+        "selected-b",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    let before = fixture.wanted();
+    let unselected_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    let records = fixture.run([
+        "--filter",
+        "selected-a",
+        "--filter",
+        "selected-b",
+        "remove",
+        HELLO,
+        "--lockfile-only",
+    ]);
+    let after = fixture.wanted();
+
+    assert_eq!(dependency_spec(&selected_a, "dependencies", HELLO), None);
+    assert_eq!(dependency_spec(&selected_b, "dependencies", HELLO), None);
+    assert_eq!(dependency_spec(&selected_b, "dependencies", PARENT).as_deref(), Some("100.0.0"));
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+    assert_eq!(importer(&after, "packages/unselected"), importer(&before, "packages/unselected"));
+    assert_full_wanted(
+        &after,
+        &["packages/selected-a", "packages/selected-b", "packages/unselected"],
+    );
+    assert_stage_once(&records);
+}
+
+#[test]
+fn filtered_update_from_selected_child_uses_discovered_manifest_as_source_of_truth() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "0.0.0")], ..Default::default() },
+    );
+    let sibling = fixture.project(
+        "sibling",
+        "sibling",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    let before = fixture.wanted();
+    let sibling_manifest = fs::read(sibling.join("package.json")).expect("read manifest");
+    fixture.run_at(&selected, ["--filter", ".", "update", HELLO, "--latest", "--lockfile-only"]);
+    let after = fixture.wanted();
+
+    assert_eq!(dependency_spec(&selected, "dependencies", HELLO).as_deref(), Some("1.0.0"));
+    assert_eq!(importer_specifier(&after, "packages/selected", HELLO), "1.0.0");
+    assert_eq!(importer_version(&after, "packages/selected", HELLO), "1.0.0");
+    assert_eq!(fs::read(sibling.join("package.json")).expect("read manifest"), sibling_manifest,);
+    assert_eq!(importer(&after, "packages/sibling"), importer(&before, "packages/sibling"));
+    assert!(!after.importers.contains_key("."), "missing root must not become an importer");
+}
+
+#[test]
+fn filtered_update_preserves_prior_importer_when_unselected_manifest_changed_externally() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "0.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    let before = fixture.wanted();
+    let prior_importer = importer(&before, "packages/unselected").clone();
+    let prior_parent = snapshot_entries(&before, PARENT);
+    let prior_child = snapshot_entries(&before, DEP);
+    replace_dependencies(&unselected, &[(HELLO_PARENT, "1.0.0")]);
+    let external_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    fixture.run(["--filter", "selected", "update", HELLO, "--latest", "--lockfile-only"]);
+    let after = fixture.wanted();
+
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        external_manifest,
+    );
+    assert_eq!(importer(&after, "packages/unselected"), &prior_importer);
+    assert_eq!(snapshot_entries(&after, PARENT), prior_parent);
+    assert_eq!(snapshot_entries(&after, DEP), prior_child);
+    assert!(snapshot_entries(&after, HELLO_PARENT).is_empty());
+    assert_eq!(dependency_spec(&selected, "dependencies", HELLO).as_deref(), Some("1.0.0"));
+    assert_eq!(importer_version(&after, "packages/selected", HELLO), "1.0.0");
+}
+
+fn compatible_update_scenario(selected_dir: &str, unselected_dir: &str) {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        selected_dir,
+        "selected",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        unselected_dir,
+        "unselected",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    set_dependency(&selected, "dependencies", DEP, "^100.0.0");
+    set_dependency(&unselected, "dependencies", DEP, "^100.0.0");
+    let unselected_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    fixture.run(["--filter", "selected", "update", DEP, "--lockfile-only"]);
+    let lockfile = fixture.wanted();
+
+    assert_eq!(importer_version(&lockfile, &format!("packages/{selected_dir}"), DEP), "100.1.0");
+    assert_eq!(importer_version(&lockfile, &format!("packages/{unselected_dir}"), DEP), "100.0.0",);
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+}
+
+#[test]
+fn filtered_compatible_update_does_not_cross_importer_cache_boundaries() {
+    compatible_update_scenario("a-selected", "z-unselected");
+    compatible_update_scenario("z-selected", "a-unselected");
+}
+
+#[test]
+fn filtered_compatible_update_keeps_workspace_manifest_preferences() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    set_dependency(&selected, "dependencies", DEP, "^100.0.0");
+    let unselected_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+
+    fixture.run(["--filter", "selected", "update", DEP, "--lockfile-only"]);
+    let lockfile = fixture.wanted();
+
+    assert_eq!(importer_version(&lockfile, "packages/selected", DEP), "100.0.0");
+    assert_eq!(importer_version(&lockfile, "packages/unselected", DEP), "100.0.0");
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+}
+
+fn transitive_update_scenario(
+    selected_dir: &str,
+    unselected_dir: &str,
+) -> (HashMap<pacquet_lockfile::PackageKey, SnapshotEntry>, String) {
+    let fixture = FilteredWorkspace::new();
+    let deps = || ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() };
+    let selected = fixture.project(selected_dir, "selected", deps());
+    let unselected = fixture.project(unselected_dir, "unselected", deps());
+    fixture.run(["install", "--lockfile-only"]);
+    let selected_manifest = fs::read(selected.join("package.json")).expect("read manifest");
+    let unselected_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    let before = fixture.wanted();
+    let selected_ref = importer_version(&before, &format!("packages/{selected_dir}"), PARENT);
+    let unselected_ref = importer_version(&before, &format!("packages/{unselected_dir}"), PARENT);
+    fixture.run(["--filter", "selected", "update", DEP, "--lockfile-only"]);
+    let after = fixture.wanted();
+
+    assert_eq!(fs::read(selected.join("package.json")).expect("read manifest"), selected_manifest);
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+    assert_eq!(importer_version(&after, &format!("packages/{selected_dir}"), PARENT), selected_ref,);
+    assert_eq!(
+        importer_version(&after, &format!("packages/{unselected_dir}"), PARENT),
+        unselected_ref,
+    );
+    let parents = snapshot_entries(&after, PARENT);
+    assert_eq!(parents.len(), 1, "one parent snapshot must have one canonical child set");
+    let child_name: PkgName = DEP.parse().expect("parse child package name");
+    let child = parents[0]
+        .1
+        .dependencies
+        .as_ref()
+        .and_then(|dependencies| dependencies.get(&child_name))
+        .expect("parent snapshot has child")
+        .to_string();
+    assert_eq!(child, "100.1.0");
+    (after.snapshots.expect("snapshots exist"), child)
+}
+
+#[test]
+fn filtered_transitive_update_keeps_one_canonical_shared_snapshot() {
+    let (selected_first, selected_first_child) =
+        transitive_update_scenario("a-selected", "z-unselected");
+    let (unselected_first, unselected_first_child) =
+        transitive_update_scenario("z-selected", "a-unselected");
+    assert_eq!(selected_first_child, unselected_first_child);
+    assert_eq!(selected_first, unselected_first);
+}
+
+fn assert_selected_isolated_closure(
+    fixture: &FilteredWorkspace,
+    selected: &Path,
+    unselected: &Path,
+) {
+    assert!(has_link(selected, HELLO), "selected direct link must exist");
+    assert!(fixture.slot(HELLO, "1.0.0").exists(), "selected virtual-store slot must exist");
+    assert!(!unselected.join("node_modules").exists(), "unselected node_modules must be absent");
+    assert!(!fixture.slot(PARENT, "100.0.0").exists(), "unselected direct slot must be absent");
+    assert!(!fixture.slot(DEP, "100.1.0").exists(), "unselected transitive slot must be absent");
+    let wanted = fixture.wanted();
+    assert_full_wanted(&wanted, &["packages/selected", "packages/unselected"]);
+    assert!(has_snapshot(&wanted, PARENT, "100.0.0"));
+    assert!(has_snapshot(&wanted, DEP, "100.1.0"));
+    let current = fixture.current();
+    assert_eq!(importer_ids(&current), BTreeSet::from(["packages/selected".to_string()]));
+    assert!(!has_snapshot(&current, PARENT, "100.0.0"));
+    assert!(!has_snapshot(&current, DEP, "100.1.0"));
+    let state = fixture.state();
+    assert_eq!(
+        state.projects.keys().cloned().collect::<BTreeSet<_>>(),
+        [selected, unselected].into_iter().map(canonical_path).collect(),
+    );
+    assert!(state.filtered_install);
+}
+
+#[test]
+fn filtered_fresh_install_materializes_only_selected_isolated_closure() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["--filter", "selected", "install"]);
+    assert_selected_isolated_closure(&fixture, &selected, &unselected);
+}
+
+#[test]
+fn filtered_frozen_install_materializes_only_selected_isolated_closure() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    fixture.run(["--filter", "selected", "install", "--frozen-lockfile"]);
+    assert_selected_isolated_closure(&fixture, &selected, &unselected);
+}
+
+#[test]
+fn unfiltered_install_after_filtered_install_restores_all_projects() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["--filter", "selected", "install"]);
+    assert_selected_isolated_closure(&fixture, &selected, &unselected);
+
+    fixture.run(["install"]);
+    assert!(has_link(&selected, HELLO));
+    assert!(has_link(&unselected, PARENT));
+    assert!(fixture.slot(PARENT, "100.0.0").exists());
+    assert!(fixture.slot(DEP, "100.1.0").exists());
+    assert_full_wanted(&fixture.current(), &["packages/selected", "packages/unselected"]);
+    assert!(!fixture.state().filtered_install);
+}
+
+#[test]
+fn filtered_frozen_install_checks_only_selected_manifest_specifiers() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    let before = fixture.wanted();
+    let prior_importer = importer(&before, "packages/unselected").clone();
+    let prior_parent = snapshot_entries(&before, PARENT);
+    let prior_child = snapshot_entries(&before, DEP);
+    replace_dependencies(&unselected, &[(HELLO_PARENT, "1.0.0")]);
+    let external_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+
+    fixture.run(["--filter", "selected", "install", "--frozen-lockfile"]);
+    let after = fixture.wanted();
+    assert!(has_link(&selected, HELLO));
+    assert!(!unselected.join("node_modules").exists());
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        external_manifest,
+    );
+    assert_eq!(importer(&after, "packages/unselected"), &prior_importer);
+    assert_eq!(snapshot_entries(&after, PARENT), prior_parent);
+    assert_eq!(snapshot_entries(&after, DEP), prior_child);
+
+    replace_dependencies(&selected, &[(NO_DEPS, "1.0.0")]);
+    let output = fixture
+        .command_at(&fixture.workspace, ["--filter", "selected", "install", "--frozen-lockfile"]);
+    assert!(!output.status.success(), "selected manifest mismatch must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("pacquet_package_manager::outdated_lockfile")
+            && stderr.contains("Cannot install with \"frozen-lockfile\"")
+            && stderr.contains("pnpm-lock.yaml is not up"),
+        "expected the existing frozen-lockfile mismatch diagnostic:\n{stderr}",
+    );
+}
+
+fn map_contains(value: &Value, needle: &str) -> bool {
+    match value {
+        Value::Object(object) => {
+            object.iter().any(|(key, value)| key.contains(needle) || map_contains(value, needle))
+        }
+        Value::Array(array) => array.iter().any(|value| map_contains(value, needle)),
+        Value::String(value) => value.contains(needle),
+        Value::Null | Value::Bool(_) | Value::Number(_) => false,
+    }
+}
+
+#[test]
+fn filtered_install_after_full_install_preserves_unselected_materialization() {
+    let fixture = FilteredWorkspace::new();
+    fixture.append_workspace_yaml(
+        "nodeExperimentalPackageMap: true\nhoistPattern:\n  - '*'\nmodulesCacheMaxAge: 0\n",
+    );
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install"]);
+    let before_wanted = fixture.wanted();
+    let before_current = fixture.current();
+    let prior_wanted_importer = importer(&before_wanted, "packages/unselected").clone();
+    let prior_current_importer = importer(&before_current, "packages/unselected").clone();
+    let prior_parent = snapshot_entries(&before_wanted, PARENT);
+    let prior_child = snapshot_entries(&before_wanted, DEP);
+    let prior_current_parent = snapshot_entries(&before_current, PARENT);
+    let prior_current_child = snapshot_entries(&before_current, DEP);
+    let prior_package_map = fixture.package_map();
+    assert!(map_contains(&prior_package_map, PARENT));
+    assert!(map_contains(&prior_package_map, DEP));
+    let mut modules = fixture.modules();
+    let prior_hoisted: HashMap<_, _> = modules
+        .hoisted_dependencies
+        .iter()
+        .filter(|(key, _)| key.contains(PARENT) || key.contains(DEP))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    assert!(!prior_hoisted.is_empty(), "unselected hoist metadata must be present");
+    let pending_id = snapshot_entries(&before_wanted, PARENT)[0].0.clone();
+    modules.pending_builds.push(pending_id.clone());
+    fixture.write_modules(modules);
+    let retained_link = unselected.join("node_modules").join(PARENT);
+    let retained_parent_slot = fixture.slot(PARENT, "100.0.0");
+    let retained_child_slot = fixture.slot(DEP, "100.1.0");
+    let obsolete_selected_slot = fixture.slot(HELLO, "1.0.0");
+    assert!(has_link(&unselected, PARENT));
+    assert!(retained_parent_slot.exists());
+    assert!(retained_child_slot.exists());
+    assert!(obsolete_selected_slot.exists());
+
+    replace_dependencies(&selected, &[(NO_DEPS, "1.0.0")]);
+    replace_dependencies(&unselected, &[(HELLO_PARENT, "1.0.0")]);
+    let external_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    fixture.run(["--filter", "selected", "install"]);
+    let after_wanted = fixture.wanted();
+    let after_current = fixture.current();
+
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        external_manifest,
+    );
+    assert_eq!(importer(&after_wanted, "packages/unselected"), &prior_wanted_importer);
+    assert_eq!(snapshot_entries(&after_wanted, PARENT), prior_parent);
+    assert_eq!(snapshot_entries(&after_wanted, DEP), prior_child);
+    assert!(snapshot_entries(&after_wanted, HELLO_PARENT).is_empty());
+    assert!(retained_link.exists());
+    assert!(retained_parent_slot.exists());
+    assert!(retained_child_slot.exists());
+    assert_eq!(importer(&after_current, "packages/unselected"), &prior_current_importer);
+    assert_eq!(snapshot_entries(&after_current, PARENT), prior_current_parent);
+    assert_eq!(snapshot_entries(&after_current, DEP), prior_current_child);
+    let after_package_map = fixture.package_map();
+    assert!(map_contains(&after_package_map, PARENT));
+    assert!(map_contains(&after_package_map, DEP));
+    let after_modules = fixture.modules();
+    for (key, value) in prior_hoisted {
+        assert_eq!(after_modules.hoisted_dependencies.get(&key), Some(&value));
+    }
+    assert!(after_modules.pending_builds.contains(&pending_id));
+    assert!(!obsolete_selected_slot.exists());
+    assert!(!has_snapshot(&after_current, HELLO, "1.0.0"));
+    assert!(has_link(&selected, NO_DEPS));
+    assert!(fixture.slot(NO_DEPS, "1.0.0").exists());
+    assert_eq!(importer_version(&after_wanted, "packages/selected", NO_DEPS), "1.0.0");
+    assert_eq!(importer_version(&after_current, "packages/selected", NO_DEPS), "1.0.0");
+}
+
+fn importer_has_group_dependency(
+    lockfile: &Lockfile,
+    id: &str,
+    group: &str,
+    dependency: &str,
+) -> bool {
+    let name: PkgName = dependency.parse().expect("parse package name");
+    let importer = importer(lockfile, id);
+    match group {
+        "dependencies" => importer.dependencies.as_ref(),
+        "devDependencies" => importer.dev_dependencies.as_ref(),
+        "optionalDependencies" => importer.optional_dependencies.as_ref(),
+        _ => panic!("unsupported dependency group {group}"),
+    }
+    .is_some_and(|dependencies| dependencies.contains_key(&name))
+}
+
+#[test]
+fn filtered_prod_install_prunes_direct_links_only_in_selected_projects() {
+    let fixture = FilteredWorkspace::new();
+    let deps = || ManifestDeps {
+        prod: &[(HELLO, "1.0.0")],
+        dev: &[(NO_DEPS, "1.0.0")],
+        ..Default::default()
+    };
+    let selected = fixture.project("selected", "selected", deps());
+    let unselected = fixture.project("unselected", "unselected", deps());
+    fixture.run(["install"]);
+    assert!(has_link(&selected, NO_DEPS));
+    assert!(has_link(&unselected, NO_DEPS));
+
+    fixture.run(["--filter", "selected", "install", "--prod"]);
+    let current = fixture.current();
+    assert!(!has_link(&selected, NO_DEPS));
+    assert!(has_link(&unselected, NO_DEPS));
+    assert!(!importer_has_group_dependency(
+        &current,
+        "packages/selected",
+        "devDependencies",
+        NO_DEPS,
+    ));
+    assert!(importer_has_group_dependency(
+        &current,
+        "packages/unselected",
+        "devDependencies",
+        NO_DEPS,
+    ));
+    assert!(has_snapshot(&current, NO_DEPS, "1.0.0"));
+}
+
+#[test]
+fn sequential_filtered_prod_installs_prune_each_selected_project() {
+    let fixture = FilteredWorkspace::new();
+    let deps = || ManifestDeps {
+        prod: &[(HELLO, "1.0.0")],
+        dev: &[(NO_DEPS, "1.0.0")],
+        ..Default::default()
+    };
+    let first = fixture.project("first", "first", deps());
+    let second = fixture.project("second", "second", deps());
+    fixture.run(["install"]);
+    assert!(has_link(&first, NO_DEPS));
+    assert!(has_link(&second, NO_DEPS));
+
+    fixture.run(["--filter", "first", "install", "--prod"]);
+    assert!(!has_link(&first, NO_DEPS));
+    assert!(has_link(&second, NO_DEPS));
+
+    fixture.run(["--filter", "second", "install", "--prod"]);
+    assert!(!has_link(&second, NO_DEPS));
+}
+
+#[test]
+fn filtered_prod_install_prunes_workspace_link_closure_projects() {
+    let fixture = FilteredWorkspace::new();
+    fixture.append_workspace_yaml("linkWorkspacePackages: true\n");
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[("linked", "workspace:*")], ..Default::default() },
+    );
+    let linked = fixture.project(
+        "linked",
+        "linked",
+        ManifestDeps {
+            prod: &[(HELLO, "1.0.0")],
+            dev: &[(NO_DEPS, "1.0.0")],
+            ..Default::default()
+        },
+    );
+    fixture.run(["install"]);
+    assert!(has_link(&selected, "linked"));
+    assert!(has_link(&linked, NO_DEPS));
+
+    fixture.run(["--filter", "selected", "install", "--prod"]);
+
+    assert!(has_link(&selected, "linked"));
+    assert!(!has_link(&linked, NO_DEPS));
+}
+
+#[test]
+fn filtered_install_keeps_full_cleanup_for_shared_layout_drift() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let _unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install"]);
+    let root_sentinel = fixture.workspace.join("node_modules/shared-layout-sentinel");
+    let slot_sentinel = fixture.slot(PARENT, "100.0.0").join("layout-sentinel");
+    fs::write(&root_sentinel, "stale").expect("write root sentinel");
+    fs::write(&slot_sentinel, "stale").expect("write slot sentinel");
+    let modules_path = fixture.workspace.join("node_modules/.modules.yaml");
+    let mut raw_modules: Value =
+        serde_json::from_str(&fs::read_to_string(&modules_path).expect("read .modules.yaml"))
+            .expect("parse .modules.yaml as JSON");
+    raw_modules["layoutVersion"] = json!(4);
+    fs::write(
+        &modules_path,
+        serde_json::to_string_pretty(&raw_modules).expect("serialize incompatible modules"),
+    )
+    .expect("write incompatible .modules.yaml");
+
+    fixture.run(["--filter", "selected", "install"]);
+    assert!(!root_sentinel.exists());
+    assert!(!slot_sentinel.exists());
+    assert!(has_link(&selected, HELLO));
+    let current = fixture.current();
+    assert_eq!(importer_ids(&current), BTreeSet::from(["packages/selected".to_string()]));
+    assert!(!has_snapshot(&current, PARENT, "100.0.0"));
+    let modules = fixture.modules();
+    assert!(!modules.pending_builds.iter().any(|entry| entry.contains(PARENT)));
+    assert!(!modules.hoisted_dependencies.keys().any(|entry| entry.contains(PARENT)));
+}
+
+#[test]
+fn filtered_hoisted_install_materializes_full_shared_graph_but_links_only_selected_projects() {
+    let fixture = FilteredWorkspace::new();
+    fixture.append_workspace_yaml("nodeLinker: hoisted\nnodeExperimentalPackageMap: true\n");
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["--filter", "selected", "install"]);
+
+    for dependency in [HELLO, PARENT, DEP] {
+        assert!(
+            fixture.workspace.join("node_modules").join(dependency).is_dir(),
+            "hoisted shared graph is missing {dependency}",
+        );
+    }
+    assert!(selected.join("node_modules").join(HELLO).exists());
+    assert!(!unselected.join("node_modules").exists());
+    assert_full_wanted(&fixture.wanted(), &["packages/selected", "packages/unselected"]);
+    let current = fixture.current();
+    assert_full_wanted(&current, &["packages/selected", "packages/unselected"]);
+    assert!(has_snapshot(&current, PARENT, "100.0.0"));
+    assert!(has_snapshot(&current, DEP, "100.1.0"));
+    let package_map = fixture.package_map();
+    assert_eq!(
+        package_map["packages"]["../packages/unselected"]["dependencies"]["unselected"],
+        json!("../packages/unselected"),
+    );
+}
+
+#[test]
+fn filtered_isolated_install_expands_workspace_link_closure() {
+    let fixture = FilteredWorkspace::new();
+    fixture.append_workspace_yaml("linkWorkspacePackages: deep\n");
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[("second", "workspace:*")], ..Default::default() },
+    );
+    let second = fixture.project(
+        "second",
+        "second",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    let third = fixture.project(
+        "third",
+        DEP,
+        ManifestDeps { prod: &[("selected", "workspace:*")], ..Default::default() },
+    );
+    set_version(&third, "100.1.0");
+    let unrelated = fixture.project(
+        "unrelated",
+        "unrelated",
+        ManifestDeps { prod: &[(NO_DEPS, "1.0.0")], ..Default::default() },
+    );
+    fixture.run(["--filter", "selected", "install"]);
+
+    assert!(has_link(&selected, "second"));
+    assert!(has_link(&second, PARENT));
+    assert!(has_link(&third, "selected"));
+    assert!(fixture.slot(PARENT, "100.0.0").exists());
+    assert!(!unrelated.join("node_modules").exists());
+    assert!(!fixture.slot(NO_DEPS, "1.0.0").exists());
+    assert_full_wanted(
+        &fixture.wanted(),
+        &["packages/second", "packages/selected", "packages/third", "packages/unrelated"],
+    );
+}
+
+#[test]
+fn filtered_pnp_install_uses_isolated_placeholder_scope() {
+    let fixture = FilteredWorkspace::new();
+    fixture.append_workspace_yaml("nodeLinker: pnp\n");
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["--filter", "selected", "install"]);
+
+    assert!(has_link(&selected, HELLO));
+    assert!(fixture.slot(HELLO, "1.0.0").exists());
+    assert!(!unselected.join("node_modules").exists());
+    assert!(!fixture.slot(PARENT, "100.0.0").exists());
+    assert!(!fixture.slot(DEP, "100.1.0").exists());
+    assert_full_wanted(&fixture.wanted(), &["packages/selected", "packages/unselected"]);
+    assert!(!fixture.workspace.join("node_modules/.package-map.json").exists());
+}
+
+#[test]
+fn install_selection_uses_post_update_config_workspace_graph() {
+    let fixture = FilteredWorkspace::new();
+    let app = fixture.project(
+        "app",
+        "app",
+        ManifestDeps { prod: &[("lib", "1.0.0")], ..Default::default() },
+    );
+    let lib = fixture.project("lib", "lib", ManifestDeps::default());
+    fs::write(
+        fixture.workspace.join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.linkWorkspacePackages = true; return config } } }\n",
+    )
+    .expect("write updateConfig hook");
+
+    fixture.run(["--filter", "app...", "add", HELLO, "--lockfile-only"]);
+    let wanted = fixture.wanted();
+    assert_eq!(dependency_spec(&app, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    assert_eq!(dependency_spec(&lib, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    assert_eq!(importer_version(&wanted, "packages/app", "lib"), "link:../lib");
+    assert_eq!(importer_version(&wanted, "packages/lib", HELLO), "1.0.0");
+}
+
+fn recursive_add_prefixes(no_sort: bool) -> (Vec<String>, String, String) {
+    let fixture = FilteredWorkspace::new();
+    let app = fixture.project(
+        "app",
+        "app",
+        ManifestDeps { prod: &[("lib", "workspace:*")], ..Default::default() },
+    );
+    let lib = fixture.project("lib", "lib", ManifestDeps::default());
+    let args = if no_sort {
+        vec!["--no-sort", "--filter", "app...", "add", HELLO, "--lockfile-only"]
+    } else {
+        vec!["--filter", "app...", "add", HELLO, "--lockfile-only"]
+    };
+    let prefixes = initial_manifest_prefixes(&fixture.run(args));
+    (prefixes, canonical_path(&app), canonical_path(&lib))
+}
+
+#[test]
+fn recursive_no_sort_preserves_selector_discovery_order() {
+    let (sorted, app, lib) = recursive_add_prefixes(false);
+    assert_eq!(sorted, vec![lib, app]);
+    let (unsorted, app, lib) = recursive_add_prefixes(true);
+    assert_eq!(unsorted, vec![app, lib]);
+}
+
+#[test]
+fn workspace_without_root_manifest_does_not_create_root_importer() {
+    let fixture = FilteredWorkspace::new();
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["--filter", "selected", "install"]);
+
+    assert!(!fixture.workspace.join("package.json").exists());
+    let wanted = fixture.wanted();
+    assert_full_wanted(&wanted, &["packages/selected", "packages/unselected"]);
+    assert!(!wanted.importers.contains_key("."));
+    let state = fixture.state();
+    assert_eq!(
+        state.projects.keys().cloned().collect::<BTreeSet<_>>(),
+        [selected, unselected].into_iter().map(|path| canonical_path(&path)).collect(),
+    );
+    assert!(!state.projects.contains_key(&canonical_path(&fixture.workspace)));
+}
+
+#[test]
+fn workspace_non_project_subdirectory_does_not_create_active_importer() {
+    let fixture = FilteredWorkspace::new();
+    fixture.write_root_manifest("workspace-root", ManifestDeps::default());
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    let scratch = fixture.workspace.join("tools/scratch");
+    fs::create_dir_all(&scratch).expect("create non-project subdirectory");
+    fixture.run_at(&scratch, ["--filter", "selected", "install"]);
+
+    assert!(!scratch.join("package.json").exists());
+    let wanted = fixture.wanted();
+    assert_full_wanted(&wanted, &[".", "packages/selected", "packages/unselected"]);
+    assert!(!wanted.importers.contains_key("tools/scratch"));
+    let state = fixture.state();
+    assert_eq!(
+        state.projects.keys().cloned().collect::<BTreeSet<_>>(),
+        [&fixture.workspace, &selected, &unselected]
+            .into_iter()
+            .map(|path| canonical_path(path))
+            .collect(),
+    );
+    assert!(!state.projects.contains_key(&canonical_path(&scratch)));
+}
+
+#[test]
+fn filtered_install_rejects_per_project_workspace_lockfiles() {
+    let fixture = FilteredWorkspace::new();
+    fixture.append_workspace_yaml("sharedWorkspaceLockfile: false\n");
+    fixture.project("app", "app", ManifestDeps::default());
+
+    let output =
+        fixture.command_at(&fixture.workspace, ["--filter", "app", "install", "--lockfile-only"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED")
+            && stderr.contains("sharedWorkspaceLockfile=false"),
+        "stderr: {stderr}",
+    );
+    assert!(!fixture.workspace.join("pnpm-lock.yaml").exists());
+}
+
+#[test]
+fn recursive_add_auto_excludes_workspace_root() {
+    let fixture = FilteredWorkspace::new();
+    fixture.write_root_manifest("workspace-root", ManifestDeps::default());
+    let member_a = fixture.project("member-a", "member-a", ManifestDeps::default());
+    let member_b = fixture.project("member-b", "member-b", ManifestDeps::default());
+    fixture.run(["-r", "add", HELLO, "--lockfile-only"]);
+    let wanted = fixture.wanted();
+
+    assert_eq!(dependency_spec(&fixture.workspace, "dependencies", HELLO), None);
+    assert_eq!(dependency_spec(&member_a, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    assert_eq!(dependency_spec(&member_b, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    assert!(!importer_has_group_dependency(&wanted, ".", "dependencies", HELLO));
+    assert!(importer_has_group_dependency(&wanted, "packages/member-a", "dependencies", HELLO,));
+    assert!(importer_has_group_dependency(&wanted, "packages/member-b", "dependencies", HELLO,));
+}
+
+#[test]
+fn filter_matching_every_real_project_is_not_partial() {
+    let fixture = FilteredWorkspace::new();
+    let member_a = fixture.project(
+        "member-a",
+        "member-a",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let member_b = fixture.project(
+        "member-b",
+        "member-b",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["--filter", "*", "install"]);
+    let state = fixture.state();
+
+    assert!(!state.filtered_install);
+    assert_eq!(
+        state.projects.keys().cloned().collect::<BTreeSet<_>>(),
+        [&member_a, &member_b].into_iter().map(|path| canonical_path(path)).collect(),
+    );
+    assert_full_wanted(&fixture.wanted(), &["packages/member-a", "packages/member-b"]);
+    assert_full_wanted(&fixture.current(), &["packages/member-a", "packages/member-b"]);
+    assert!(has_link(&member_a, HELLO));
+    assert!(has_link(&member_b, PARENT));
+}
+
+#[test]
+fn filtered_install_refreshes_unselected_catalog_importers_when_catalog_changes() {
+    let fixture = FilteredWorkspace::new();
+    fixture.append_workspace_yaml(&format!("catalog:\n  '{CATALOG_FOO}': 1.0.0\n"));
+    fixture.project("app", "app", ManifestDeps::default());
+    fixture.project(
+        "catalog-consumer",
+        "catalog-consumer",
+        ManifestDeps { prod: &[(CATALOG_FOO, "catalog:")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    assert_eq!(
+        importer_version(&fixture.wanted(), "packages/catalog-consumer", CATALOG_FOO),
+        "1.0.0",
+    );
+
+    let workspace_yaml_path = fixture.workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml = fs::read_to_string(&workspace_yaml_path).expect("read workspace yaml");
+    fs::write(
+        &workspace_yaml_path,
+        workspace_yaml
+            .replace(&format!("'{CATALOG_FOO}': 1.0.0"), &format!("'{CATALOG_FOO}': 2.0.0")),
+    )
+    .expect("update catalog");
+
+    fixture.run(["--filter", "app", "install", "--lockfile-only"]);
+    let wanted = fixture.wanted();
+    assert_eq!(importer_version(&wanted, "packages/catalog-consumer", CATALOG_FOO), "2.0.0",);
+    let catalog = wanted
+        .catalogs
+        .as_ref()
+        .and_then(|catalogs| catalogs.get("default"))
+        .and_then(|entries| entries.get(CATALOG_FOO))
+        .expect("catalog snapshot");
+    assert_eq!(catalog.specifier, "2.0.0");
+    assert_eq!(catalog.version, "2.0.0");
+}
+
+#[test]
+fn active_manifest_outside_workspace_patterns_keeps_install_filtered() {
+    let fixture = FilteredWorkspace::new();
+    let member = fixture.project(
+        "member",
+        "member",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let local = fixture.workspace.join("tools/local");
+    write_manifest(
+        &local,
+        "local",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+
+    fixture.run_at(&local, ["--filter", "*", "install"]);
+
+    let state = fixture.state();
+    assert!(state.filtered_install);
+    assert_eq!(
+        state.projects.keys().cloned().collect::<BTreeSet<_>>(),
+        [&member, &local].into_iter().map(|path| canonical_path(path)).collect(),
+    );
+    assert!(has_link(&member, HELLO));
+    assert!(!local.join("node_modules").exists());
+}

--- a/pnpm/crates/cli/tests/install_filters.rs
+++ b/pnpm/crates/cli/tests/install_filters.rs
@@ -338,7 +338,7 @@ fn has_link(project: &Path, name: &str) -> bool {
 }
 
 fn canonical_path(path: &Path) -> String {
-    fs::canonicalize(path)
+    dunce::canonicalize(path)
         .unwrap_or_else(|error| panic!("canonicalize {}: {error}", path.display()))
         .to_string_lossy()
         .into_owned()

--- a/pnpm/crates/cli/tests/install_filters.rs
+++ b/pnpm/crates/cli/tests/install_filters.rs
@@ -25,7 +25,7 @@ const HELLO_PARENT: &str = "@pnpm.e2e/hello-world-js-bin-parent";
 const NO_DEPS: &str = "@foo/no-deps";
 const PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
 
-#[derive(Clone, Copy, Default)]
+#[derive(Default, Clone, Copy)]
 struct ManifestDeps<'a> {
     prod: &'a [(&'a str, &'a str)],
     dev: &'a [(&'a str, &'a str)],
@@ -68,10 +68,10 @@ impl FilteredWorkspace {
         project
     }
 
-    fn command_at<I, S>(&self, cwd: &Path, args: I) -> Output
+    fn command_at<Args, Arg>(&self, cwd: &Path, args: Args) -> Output
     where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
+        Args: IntoIterator<Item = Arg>,
+        Arg: AsRef<OsStr>,
     {
         Command::cargo_bin("pnpm")
             .expect("find the pnpm binary")
@@ -83,18 +83,18 @@ impl FilteredWorkspace {
             .expect("run pacquet")
     }
 
-    fn run<I, S>(&self, args: I) -> Vec<Value>
+    fn run<Args, Arg>(&self, args: Args) -> Vec<Value>
     where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
+        Args: IntoIterator<Item = Arg>,
+        Arg: AsRef<OsStr>,
     {
         self.run_at(&self.workspace, args)
     }
 
-    fn run_at<I, S>(&self, cwd: &Path, args: I) -> Vec<Value>
+    fn run_at<Args, Arg>(&self, cwd: &Path, args: Args) -> Vec<Value>
     where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
+        Args: IntoIterator<Item = Arg>,
+        Arg: AsRef<OsStr>,
     {
         let output = self.command_at(cwd, args);
         assert_success(&output);
@@ -542,7 +542,7 @@ fn filtered_update_from_selected_child_uses_discovered_manifest_as_source_of_tru
     assert_eq!(dependency_spec(&selected, "dependencies", HELLO).as_deref(), Some("1.0.0"));
     assert_eq!(importer_specifier(&after, "packages/selected", HELLO), "1.0.0");
     assert_eq!(importer_version(&after, "packages/selected", HELLO), "1.0.0");
-    assert_eq!(fs::read(sibling.join("package.json")).expect("read manifest"), sibling_manifest,);
+    assert_eq!(fs::read(sibling.join("package.json")).expect("read manifest"), sibling_manifest);
     assert_eq!(importer(&after, "packages/sibling"), importer(&before, "packages/sibling"));
     assert!(!after.importers.contains_key("."), "missing root must not become an importer");
 }
@@ -602,7 +602,7 @@ fn compatible_update_scenario(selected_dir: &str, unselected_dir: &str) {
     let lockfile = fixture.wanted();
 
     assert_eq!(importer_version(&lockfile, &format!("packages/{selected_dir}"), DEP), "100.1.0");
-    assert_eq!(importer_version(&lockfile, &format!("packages/{unselected_dir}"), DEP), "100.0.0",);
+    assert_eq!(importer_version(&lockfile, &format!("packages/{unselected_dir}"), DEP), "100.0.0");
     assert_eq!(
         fs::read(unselected.join("package.json")).expect("read manifest"),
         unselected_manifest,
@@ -665,7 +665,7 @@ fn transitive_update_scenario(
         fs::read(unselected.join("package.json")).expect("read manifest"),
         unselected_manifest,
     );
-    assert_eq!(importer_version(&after, &format!("packages/{selected_dir}"), PARENT), selected_ref,);
+    assert_eq!(importer_version(&after, &format!("packages/{selected_dir}"), PARENT), selected_ref);
     assert_eq!(
         importer_version(&after, &format!("packages/{unselected_dir}"), PARENT),
         unselected_ref,
@@ -820,7 +820,7 @@ fn filtered_frozen_install_checks_only_selected_manifest_specifiers() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("pacquet_package_manager::outdated_lockfile")
-            && stderr.contains("Cannot install with \"frozen-lockfile\"")
+            && stderr.contains(r#"Cannot install with "frozen-lockfile""#)
             && stderr.contains("pnpm-lock.yaml is not up"),
         "expected the existing frozen-lockfile mismatch diagnostic:\n{stderr}",
     );
@@ -1361,7 +1361,7 @@ fn filtered_install_refreshes_unselected_catalog_importers_when_catalog_changes(
 
     fixture.run(["--filter", "app", "install", "--lockfile-only"]);
     let wanted = fixture.wanted();
-    assert_eq!(importer_version(&wanted, "packages/catalog-consumer", CATALOG_FOO), "2.0.0",);
+    assert_eq!(importer_version(&wanted, "packages/catalog-consumer", CATALOG_FOO), "2.0.0");
     let catalog = wanted
         .catalogs
         .as_ref()

--- a/pnpm/crates/cli/tests/install_filters.rs
+++ b/pnpm/crates/cli/tests/install_filters.rs
@@ -819,7 +819,7 @@ fn filtered_frozen_install_checks_only_selected_manifest_specifiers() {
     assert!(!output.status.success(), "selected manifest mismatch must fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("pacquet_package_manager::outdated_lockfile")
+        stderr.contains("ERR_PNPM_OUTDATED_LOCKFILE")
             && stderr.contains(r#"Cannot install with "frozen-lockfile""#)
             && stderr.contains("pnpm-lock.yaml is not up"),
         "expected the existing frozen-lockfile mismatch diagnostic:\n{stderr}",

--- a/pnpm/crates/cli/tests/install_filters.rs
+++ b/pnpm/crates/cli/tests/install_filters.rs
@@ -30,6 +30,7 @@ struct ManifestDeps<'a> {
     prod: &'a [(&'a str, &'a str)],
     dev: &'a [(&'a str, &'a str)],
     optional: &'a [(&'a str, &'a str)],
+    peer: &'a [(&'a str, &'a str)],
 }
 
 struct FilteredWorkspace {
@@ -148,6 +149,7 @@ fn write_manifest(project: &Path, name: &str, deps: ManifestDeps<'_>) {
     insert_dependency_group(&mut manifest, "dependencies", deps.prod);
     insert_dependency_group(&mut manifest, "devDependencies", deps.dev);
     insert_dependency_group(&mut manifest, "optionalDependencies", deps.optional);
+    insert_dependency_group(&mut manifest, "peerDependencies", deps.peer);
     fs::write(
         project.join("package.json"),
         serde_json::to_string_pretty(&Value::Object(manifest)).expect("serialize package.json"),
@@ -352,6 +354,34 @@ fn assert_full_wanted(lockfile: &Lockfile, ids: &[&str]) {
         ids.iter().map(ToString::to_string).collect(),
         "wanted lockfile must retain every real importer",
     );
+}
+
+#[test]
+fn full_recursive_install_keeps_the_unfiltered_up_to_date_path() {
+    let fixture = FilteredWorkspace::new();
+    fixture.project("app", "app", ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() });
+    fixture.project(
+        "lib",
+        "lib",
+        ManifestDeps {
+            prod: &[(PARENT, "100.0.0")],
+            peer: &[(HELLO, "1.0.0")],
+            ..Default::default()
+        },
+    );
+    fixture.run(["install"]);
+    let lockfile_path = fixture.workspace.join("pnpm-lock.yaml");
+    let before = fs::read(&lockfile_path).expect("read lockfile");
+    fs::write(&lockfile_path, &before).expect("rewrite lockfile without changing its contents");
+
+    let records = fixture.run(["--recursive", "install"]);
+
+    assert_eq!(fs::read(lockfile_path).expect("read lockfile"), before);
+    assert_eq!(importing_started_count(&records), 0, "a full selection must not relink");
+    assert!(records.iter().any(|record| {
+        record.get("name").and_then(Value::as_str) == Some("pnpm")
+            && record.get("message").and_then(Value::as_str) == Some("Already up to date")
+    }));
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/outdated.rs
+++ b/pnpm/crates/cli/tests/outdated.rs
@@ -49,6 +49,36 @@ fn outdated_reports_newer_version() {
     drop((root, anchor));
 }
 
+#[test]
+fn outdated_from_workspace_member_reads_member_importer() {
+    let (root, workspace, anchor) = setup();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    write_manifest(&workspace, "{}");
+    let member = workspace.join("packages/app");
+    fs::create_dir_all(&member).expect("create workspace member");
+    fs::write(
+        member.join("package.json"),
+        format!(
+            r#"{{ "name": "app", "version": "1.0.0", "dependencies": {{ "{DEP}": "^100.0.0" }} }}"#,
+        ),
+    )
+    .expect("write member package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&member, ["outdated"]).output().expect("run member outdated");
+
+    assert_eq!(output.status.code(), Some(1), "member dependency should be outdated");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(DEP), "report should use the member importer: {stdout}");
+    assert!(
+        stdout.contains("100.1.0"),
+        "report should show the member's current version: {stdout}"
+    );
+
+    drop((root, anchor));
+}
+
 /// `--compatible` compares against the highest in-range version, so a
 /// dependency already at the top of its range is not reported even when a
 /// newer major exists.

--- a/pnpm/crates/cli/tests/outdated.rs
+++ b/pnpm/crates/cli/tests/outdated.rs
@@ -73,7 +73,7 @@ fn outdated_from_workspace_member_reads_member_importer() {
     assert!(stdout.contains(DEP), "report should use the member importer: {stdout}");
     assert!(
         stdout.contains("100.1.0"),
-        "report should show the member's current version: {stdout}"
+        "report should show the member's current version: {stdout}",
     );
 
     drop((root, anchor));

--- a/pnpm/crates/cli/tests/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/pnpr_install.rs
@@ -473,7 +473,7 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
     assert_eq!(workspace_snapshot_entries(&after, WORKSPACE_PARENT), prior_parent);
     assert_eq!(workspace_snapshot_entries(&after, WORKSPACE_DEP), prior_child);
     assert!(workspace_snapshot_entries(&after, WORKSPACE_HELLO_PARENT).is_empty());
-    assert_eq!(workspace_importer_version(&after, "packages/selected", WORKSPACE_HELLO), "1.0.0",);
+    assert_eq!(workspace_importer_version(&after, "packages/selected", WORKSPACE_HELLO), "1.0.0");
     assert!(!after.importers.contains_key("."));
 
     if lockfile_only {
@@ -543,7 +543,7 @@ fn filtered_workspace_pnpr_reports_a_missing_selected_importer_without_panicking
     );
     assert!(
         !stderr.contains("panicked at"),
-        "the malformed response must not panic; got:\n{stderr}"
+        "the malformed response must not panic; got:\n{stderr}",
     );
     resolve_mock.assert();
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/pnpr_install.rs
@@ -10,6 +10,7 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, SnapshotEntry};
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::is_symlink_or_junction,
@@ -260,6 +261,316 @@ fn import_via_pnpr_server_writes_lockfile_without_linking() {
     assert!(workspace.join("pnpm-lock.yaml").exists(), "pnpr should write the lockfile");
     assert!(!workspace.join("node_modules").exists(), "import must not link node_modules");
     assert!(!store_dir.join("v11/index.db").exists(), "import must not populate the client store");
+
+    drop((root, mock_instance));
+}
+
+const WORKSPACE_DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+const WORKSPACE_HELLO: &str = "@pnpm.e2e/hello-world-js-bin";
+const WORKSPACE_HELLO_PARENT: &str = "@pnpm.e2e/hello-world-js-bin-parent";
+const WORKSPACE_PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
+
+fn configure_workspace(workspace: &Path) {
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(path, yaml).expect("write pnpm-workspace.yaml");
+}
+
+fn write_workspace_project(workspace: &Path, dir: &str, name: &str, dependency: (&str, &str)) {
+    let project = workspace.join("packages").join(dir);
+    fs::create_dir_all(&project).expect("create workspace project");
+    fs::write(
+        project.join("package.json"),
+        serde_json::to_string_pretty(&serde_json::json!({
+            "name": name,
+            "version": "1.0.0",
+            "private": true,
+            "dependencies": { dependency.0: dependency.1 },
+        }))
+        .expect("serialize package.json"),
+    )
+    .expect("write package.json");
+}
+
+fn replace_workspace_dependency(workspace: &Path, dir: &str, dependency: (&str, &str)) {
+    let path = workspace.join("packages").join(dir).join("package.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("read package.json"))
+            .expect("parse package.json");
+    manifest["dependencies"] = serde_json::json!({ dependency.0: dependency.1 });
+    fs::write(path, serde_json::to_string_pretty(&manifest).expect("serialize package.json"))
+        .expect("write package.json");
+}
+
+fn read_workspace_lockfile(workspace: &Path) -> Lockfile {
+    let path = workspace.join("pnpm-lock.yaml");
+    let contents = fs::read_to_string(&path).expect("read pnpm-lock.yaml");
+    serde_saphyr::from_str(&contents)
+        .unwrap_or_else(|error| panic!("parse {}: {error}\n{contents}", path.display()))
+}
+
+fn read_workspace_current_lockfile(workspace: &Path) -> Lockfile {
+    let path = workspace.join("node_modules/.pnpm/lock.yaml");
+    let contents = fs::read_to_string(&path).expect("read current lockfile");
+    serde_saphyr::from_str(&contents)
+        .unwrap_or_else(|error| panic!("parse {}: {error}\n{contents}", path.display()))
+}
+
+fn workspace_importer<'a>(lockfile: &'a Lockfile, id: &str) -> &'a ProjectSnapshot {
+    lockfile
+        .importers
+        .get(id)
+        .unwrap_or_else(|| panic!("missing importer {id}: {:?}", lockfile.importers.keys()))
+}
+
+fn workspace_importer_version(lockfile: &Lockfile, id: &str, dependency: &str) -> String {
+    let name: PkgName = dependency.parse().expect("parse package name");
+    workspace_importer(lockfile, id)
+        .dependencies
+        .as_ref()
+        .and_then(|dependencies| dependencies.get(&name))
+        .unwrap_or_else(|| panic!("missing {dependency} from importer {id}"))
+        .version
+        .to_string()
+}
+
+fn workspace_snapshot_entries(lockfile: &Lockfile, name: &str) -> Vec<(String, SnapshotEntry)> {
+    lockfile
+        .snapshots
+        .as_ref()
+        .into_iter()
+        .flatten()
+        .filter(|(key, _)| key.to_string().starts_with(&format!("{name}@")))
+        .map(|(key, entry)| (key.to_string(), entry.clone()))
+        .collect()
+}
+
+fn workspace_has_link(workspace: &Path, project: &str, dependency: &str) -> bool {
+    is_symlink_or_junction(
+        &workspace.join("packages").join(project).join("node_modules").join(dependency),
+    )
+    .unwrap_or(false)
+}
+
+fn workspace_slot(workspace: &Path, dependency: &str, version: &str) -> std::path::PathBuf {
+    workspace.join("node_modules/.pnpm").join(format!("{}@{version}", dependency.replace('/', "+")))
+}
+
+fn assert_standard_workspace_pnpr_from(project: Option<&str>) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+    configure_workspace(&workspace);
+    write_workspace_project(&workspace, "app", "app", (WORKSPACE_HELLO, "1.0.0"));
+    write_workspace_project(&workspace, "lib", "lib", (WORKSPACE_PARENT, "100.0.0"));
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    let cwd = project.map_or_else(|| workspace.clone(), |project| workspace.join(project));
+    pacquet_at(&cwd)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["install", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+
+    let wanted = read_workspace_lockfile(&workspace);
+    assert_eq!(
+        wanted.importers.keys().cloned().collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["packages/app".to_string(), "packages/lib".to_string(),]),
+    );
+    assert!(workspace_has_link(&workspace, "app", WORKSPACE_HELLO));
+    assert!(workspace_has_link(&workspace, "lib", WORKSPACE_PARENT));
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn standard_workspace_install_via_pnpr_from_root_resolves_every_real_importer() {
+    assert_standard_workspace_pnpr_from(None);
+}
+
+#[test]
+fn standard_workspace_install_via_pnpr_from_member_resolves_every_real_importer() {
+    assert_standard_workspace_pnpr_from(Some("packages/app"));
+}
+
+#[test]
+fn frozen_lockfile_only_workspace_install_via_pnpr_from_member_uses_every_real_importer() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+    configure_workspace(&workspace);
+    write_workspace_project(&workspace, "app", "app", (WORKSPACE_HELLO, "1.0.0"));
+    write_workspace_project(&workspace, "lib", "lib", (WORKSPACE_PARENT, "100.0.0"));
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["install", "--lockfile-only"])
+        .assert()
+        .success();
+    let before = read_workspace_lockfile(&workspace);
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    pacquet_at(&workspace.join("packages/app"))
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["install", "--frozen-lockfile", "--lockfile-only", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+
+    assert_eq!(read_workspace_lockfile(&workspace), before);
+    assert!(!workspace.join("node_modules").exists());
+    assert!(!workspace.join("packages/app/node_modules").exists());
+    assert!(!workspace.join("packages/lib/node_modules").exists());
+
+    drop((root, mock_instance));
+}
+
+fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, store_dir, mock_instance, .. } = npmrc_info;
+    configure_workspace(&workspace);
+    write_workspace_project(&workspace, "selected", "selected", (WORKSPACE_HELLO, "0.0.0"));
+    write_workspace_project(&workspace, "unselected", "unselected", (WORKSPACE_PARENT, "100.0.0"));
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["install", "--lockfile-only"])
+        .assert()
+        .success();
+    let before = read_workspace_lockfile(&workspace);
+    let prior_unselected = workspace_importer(&before, "packages/unselected").clone();
+    let prior_parent = workspace_snapshot_entries(&before, WORKSPACE_PARENT);
+    let prior_child = workspace_snapshot_entries(&before, WORKSPACE_DEP);
+    replace_workspace_dependency(&workspace, "selected", (WORKSPACE_HELLO, "1.0.0"));
+    replace_workspace_dependency(&workspace, "unselected", (WORKSPACE_HELLO_PARENT, "1.0.0"));
+    let unselected_manifest =
+        fs::read(workspace.join("packages/unselected/package.json")).expect("read manifest");
+    if lockfile_only {
+        fs::remove_dir_all(&store_dir).expect("remove baseline client store");
+    }
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+    let mut args = vec!["--filter", "selected", "install", "--pnpr-server", &pnpr_url];
+    if lockfile_only {
+        args.push("--lockfile-only");
+    }
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(args)
+        .assert()
+        .success();
+    let after = read_workspace_lockfile(&workspace);
+
+    assert_eq!(
+        fs::read(workspace.join("packages/unselected/package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+    assert_eq!(workspace_importer(&after, "packages/unselected"), &prior_unselected);
+    assert_eq!(workspace_snapshot_entries(&after, WORKSPACE_PARENT), prior_parent);
+    assert_eq!(workspace_snapshot_entries(&after, WORKSPACE_DEP), prior_child);
+    assert!(workspace_snapshot_entries(&after, WORKSPACE_HELLO_PARENT).is_empty());
+    assert_eq!(workspace_importer_version(&after, "packages/selected", WORKSPACE_HELLO), "1.0.0",);
+    assert!(!after.importers.contains_key("."));
+
+    if lockfile_only {
+        assert!(!workspace.join("node_modules").exists());
+        assert!(!store_dir.join("v11/index.db").exists());
+    } else {
+        assert!(workspace_has_link(&workspace, "selected", WORKSPACE_HELLO));
+        assert!(!workspace.join("packages/unselected/node_modules").exists());
+        assert!(workspace_slot(&workspace, WORKSPACE_HELLO, "1.0.0").exists());
+        assert!(!workspace_slot(&workspace, WORKSPACE_HELLO, "0.0.0").exists());
+        assert!(!workspace_slot(&workspace, WORKSPACE_PARENT, "100.0.0").exists());
+        assert!(!workspace_slot(&workspace, WORKSPACE_DEP, "100.1.0").exists());
+        let current = read_workspace_current_lockfile(&workspace);
+        assert_eq!(
+            current.importers.keys().cloned().collect::<std::collections::BTreeSet<_>>(),
+            std::collections::BTreeSet::from(["packages/selected".to_string()]),
+        );
+    }
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn filtered_workspace_install_via_pnpr_materializes_only_selected_closure() {
+    assert_filtered_workspace_pnpr(false);
+}
+
+#[test]
+fn filtered_workspace_pnpr_lockfile_only_merges_prior_wanted_without_root_importer() {
+    assert_filtered_workspace_pnpr(true);
+}
+
+#[test]
+fn filtered_workspace_pnpr_reports_a_missing_selected_importer_without_panicking() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    configure_workspace(&workspace);
+    write_workspace_project(&workspace, "selected", "selected", (WORKSPACE_HELLO, "1.0.0"));
+    write_workspace_project(&workspace, "unselected", "unselected", (WORKSPACE_PARENT, "1.0.0"));
+
+    let mut server = mockito::Server::new();
+    let response = serde_json::json!({
+        "type": "done",
+        "lockfile": { "lockfileVersion": "9.0" },
+        "stats": { "totalPackages": 0 },
+    });
+    let resolve_mock = server
+        .mock("POST", "/-/pnpr/v0/resolve")
+        .with_status(200)
+        .with_header("content-type", "application/x-ndjson")
+        .with_body(format!("{response}\n"))
+        .expect(1)
+        .create();
+
+    let output = pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["--filter", "selected", "install", "--pnpr-server", &server.url()])
+        .output()
+        .expect("run filtered install against a malformed pnpr response");
+
+    assert!(!output.status.success(), "a malformed pnpr lockfile must fail the install");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("fresh lockfile is missing importer packages/selected"),
+        "stderr must identify the missing selected importer; got:\n{stderr}",
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "the malformed response must not panic; got:\n{stderr}"
+    );
+    resolve_mock.assert();
+    drop((root, mock_instance));
+}
+
+#[test]
+fn filtered_workspace_pnpr_resolves_workspace_protocol_from_project_identity() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+    configure_workspace(&workspace);
+    write_workspace_project(&workspace, "app", "app", ("lib", "workspace:*"));
+    write_workspace_project(&workspace, "lib", "lib", (WORKSPACE_HELLO, "1.0.0"));
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["--filter", "app", "install", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+
+    let wanted = read_workspace_lockfile(&workspace);
+    assert_eq!(workspace_importer_version(&wanted, "packages/app", "lib"), "link:../lib");
+    assert!(workspace_has_link(&workspace, "app", "lib"));
+    assert!(workspace_has_link(&workspace, "lib", WORKSPACE_HELLO));
+    assert!(workspace_slot(&workspace, WORKSPACE_HELLO, "1.0.0").exists());
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/prune.rs
+++ b/pnpm/crates/cli/tests/prune.rs
@@ -35,6 +35,31 @@ fn prune_writes_lockfile() {
 }
 
 #[test]
+fn prune_from_workspace_member_writes_the_workspace_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(workspace.join("package.json"), r#"{ "name": "workspace-root" }"#)
+        .expect("write root package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    let member = workspace.join("packages/app");
+    fs::create_dir_all(&member).expect("create workspace member");
+    fs::write(
+        member.join("package.json"),
+        r#"{ "name": "app", "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" } }"#,
+    )
+    .expect("write member package.json");
+
+    pacquet.with_current_dir(&member).with_arg("prune").assert().success();
+
+    assert!(workspace.join("pnpm-lock.yaml").is_file());
+    assert!(!member.join("pnpm-lock.yaml").exists());
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn prune_with_prod_only_omits_dev_deps() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/sbom.rs
+++ b/pnpm/crates/cli/tests/sbom.rs
@@ -100,6 +100,26 @@ fn sbom_missing_format_fails() {
 }
 
 #[test]
+fn split_sbom_rejects_per_project_workspace_lockfiles() {
+    let tmp = copy_fixture("simple-sbom");
+    fs::write(tmp.path().join("pnpm-workspace.yaml"), "sharedWorkspaceLockfile: false\n")
+        .expect("write workspace manifest");
+
+    let output =
+        pacquet(tmp.path(), ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
+            .output()
+            .expect("run split pacquet sbom");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED")
+            && stderr.contains("sharedWorkspaceLockfile=false"),
+        "stderr: {stderr}",
+    );
+}
+
+#[test]
 fn sbom_prod_excludes_dev() {
     let tmp = copy_fixture("with-dev-dependency");
     let parsed = run_sbom_json(tmp.path(), "cyclonedx", &["--prod"]);
@@ -765,6 +785,44 @@ fn sbom_workspace_split_each_line_has_correct_root() {
         boms.iter().filter_map(|bom| bom["metadata"]["component"]["name"].as_str()).collect();
     assert!(root_names.contains(&"app-a"), "split should include app-a");
     assert!(root_names.contains(&"app-b"), "split should include app-b");
+}
+
+#[test]
+fn sbom_workspace_split_from_member_anchors_importers_at_workspace_root() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let member = tmp.path().join("app-a");
+    let output =
+        pacquet(&member, ["sbom", "--sbom-format", "cyclonedx", "--lockfile-only", "--split"])
+            .output()
+            .expect("run pacquet from workspace member");
+
+    assert!(
+        output.status.success(),
+        "member sbom failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let boms = output
+        .stdout
+        .split(|byte| *byte == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_slice::<serde_json::Value>(line).expect("valid JSON"))
+        .collect::<Vec<_>>();
+    let root_names = boms
+        .iter()
+        .filter_map(|bom| bom["metadata"]["component"]["name"].as_str())
+        .collect::<Vec<_>>();
+
+    assert!(root_names.contains(&"app-a"), "split should include app-a: {root_names:?}");
+    assert!(root_names.contains(&"app-b"), "split should include app-b: {root_names:?}");
+    assert!(root_names.contains(&"shared-lib"), "split should include shared-lib: {root_names:?}");
+}
+
+#[test]
+fn sbom_workspace_from_member_uses_the_workspace_root_component() {
+    let tmp = copy_fixture("workspace-sbom-populated");
+    let parsed = run_sbom_json(&tmp.path().join("app-a"), "cyclonedx", &[]);
+
+    assert_eq!(parsed["metadata"]["component"]["name"], "workspace-sbom-root");
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/why.rs
+++ b/pnpm/crates/cli/tests/why.rs
@@ -5,6 +5,7 @@ use std::{ffi::OsStr, fs, path::Path, process::Command};
 use tempfile::TempDir;
 
 const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+const HELLO: &str = "@pnpm.e2e/hello-world-js-bin";
 const PKG: &str = "@pnpm.e2e/pkg-with-1-dep";
 
 fn setup() -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
@@ -39,6 +40,29 @@ fn why_fails_without_package_name() {
     assert!(
         stderr.contains("requires a package name"),
         "should show error about missing package name: {stderr}",
+    );
+}
+
+#[test]
+fn filtered_why_rejects_per_project_workspace_lockfiles() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
+    write_manifest(&workspace, "{}");
+
+    let output = pacquet(&workspace, ["--filter", ".", "why", PKG])
+        .output()
+        .expect("run filtered pacquet why");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED")
+            && stderr.contains("sharedWorkspaceLockfile=false"),
+        "stderr: {stderr}",
     );
 }
 
@@ -116,4 +140,134 @@ fn why_depth_limits_output() {
     assert!(full_stdout.contains("test-why"), "full output shows project: {full_stdout}");
     assert!(depth1_stdout.contains(DEP), "depth=1 output still shows the target: {depth1_stdout}");
     assert!(depth1_stdout.contains(PKG), "depth=1 output shows direct parent: {depth1_stdout}");
+}
+
+#[test]
+fn why_from_workspace_member_stays_within_forward_workspace_link_closure() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    write_manifest(&workspace, "{}");
+
+    let app = workspace.join("packages/app");
+    let linked = workspace.join("packages/linked");
+    let sibling = workspace.join("packages/sibling");
+    for project in [&app, &linked, &sibling] {
+        fs::create_dir_all(project).expect("create workspace project");
+    }
+    fs::write(
+        app.join("package.json"),
+        r#"{ "name": "app", "version": "1.0.0", "dependencies": { "linked": "workspace:*" } }"#,
+    )
+    .expect("write app package.json");
+    fs::write(
+        linked.join("package.json"),
+        format!(
+            r#"{{ "name": "linked", "version": "1.0.0", "dependencies": {{ "{PKG}": "100.0.0" }} }}"#,
+        ),
+    )
+    .expect("write linked package.json");
+    fs::write(
+        sibling.join("package.json"),
+        format!(
+            r#"{{ "name": "sibling", "version": "1.0.0", "dependencies": {{ "{HELLO}": "1.0.0" }} }}"#,
+        ),
+    )
+    .expect("write sibling package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let sibling_output = pacquet(&app, ["why", HELLO]).output().expect("query sibling dependency");
+    assert!(sibling_output.status.success(), "why should succeed: {sibling_output:?}");
+    let sibling_stdout = String::from_utf8_lossy(&sibling_output.stdout);
+    assert!(
+        sibling_stdout.is_empty(),
+        "a dependency reachable only from a sibling must not be reported: {sibling_stdout}",
+    );
+
+    let linked_output = pacquet(&app, ["why", PKG]).output().expect("query linked dependency");
+    assert!(linked_output.status.success(), "why should succeed: {linked_output:?}");
+    let linked_stdout = String::from_utf8_lossy(&linked_output.stdout);
+    assert!(linked_stdout.contains(PKG), "linked dependency should be reported: {linked_stdout}");
+    assert!(
+        linked_stdout.contains("packages/linked"),
+        "the forward workspace-link closure should be retained: {linked_stdout}",
+    );
+}
+
+#[test]
+fn filtered_why_excludes_unselected_workspace_siblings() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    write_manifest(&workspace, "{}");
+
+    let app = workspace.join("packages/app");
+    let sibling = workspace.join("packages/sibling");
+    fs::create_dir_all(&app).expect("create app project");
+    fs::create_dir_all(&sibling).expect("create sibling project");
+    fs::write(
+        app.join("package.json"),
+        format!(
+            r#"{{ "name": "app", "version": "1.0.0", "dependencies": {{ "{PKG}": "100.0.0" }} }}"#,
+        ),
+    )
+    .expect("write app package.json");
+    fs::write(
+        sibling.join("package.json"),
+        format!(
+            r#"{{ "name": "sibling", "version": "1.0.0", "dependencies": {{ "{HELLO}": "1.0.0" }} }}"#,
+        ),
+    )
+    .expect("write sibling package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let excluded = pacquet(&workspace, ["--filter", "app", "why", HELLO])
+        .output()
+        .expect("query unselected sibling dependency");
+    assert!(excluded.status.success(), "filtered why should succeed: {excluded:?}");
+    assert!(
+        String::from_utf8_lossy(&excluded.stdout).is_empty(),
+        "a dependency reachable only from an unselected sibling must not be reported: {}",
+        String::from_utf8_lossy(&excluded.stdout),
+    );
+
+    let included = pacquet(&workspace, ["--filter", "app", "why", PKG])
+        .output()
+        .expect("query selected dependency");
+    assert!(included.status.success(), "filtered why should succeed: {included:?}");
+    assert!(
+        String::from_utf8_lossy(&included.stdout).contains(PKG),
+        "a selected dependency should be reported: {}",
+        String::from_utf8_lossy(&included.stdout),
+    );
+}
+
+#[test]
+fn recursive_why_includes_all_workspace_projects() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    write_manifest(&workspace, "{}");
+    let sibling = workspace.join("packages/sibling");
+    fs::create_dir_all(&sibling).expect("create workspace project");
+    fs::write(
+        sibling.join("package.json"),
+        format!(
+            r#"{{ "name": "sibling", "version": "1.0.0", "dependencies": {{ "{HELLO}": "1.0.0" }} }}"#,
+        ),
+    )
+    .expect("write sibling package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["-r", "why", HELLO])
+        .output()
+        .expect("query recursive workspace dependency");
+
+    assert!(output.status.success(), "recursive why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(HELLO), "recursive why should include sibling dependencies: {stdout}");
+    assert!(
+        stdout.contains("packages/sibling"),
+        "recursive why should include the sibling importer: {stdout}",
+    );
 }

--- a/pnpm/crates/lockfile-preferred-versions/src/lib.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/lib.rs
@@ -5,9 +5,9 @@
 //! entry, and an entry that appears in both buckets has its weight bumped
 //! by the lockfile weight so it outranks single-source matches.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use pacquet_lockfile::{PackageKey, SnapshotEntry};
+use pacquet_lockfile::{PackageKey, PkgName, SnapshotEntry};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
     DIRECT_DEP_SELECTOR_WEIGHT, EXISTING_VERSION_SELECTOR_WEIGHT, PreferredVersions,
@@ -29,6 +29,21 @@ pub fn get_preferred_versions_from_lockfile_and_manifests(
     snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
     manifests: &[&PackageManifest],
 ) -> PreferredVersions {
+    get_preferred_versions_from_lockfile_and_manifests_excluding(
+        snapshots,
+        manifests,
+        &HashSet::new(),
+    )
+}
+
+/// Build a [`PreferredVersions`] map while withholding lockfile pins for
+/// `excluded_names`. Manifest-derived preferences remain workspace-wide.
+#[must_use]
+pub fn get_preferred_versions_from_lockfile_and_manifests_excluding(
+    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
+    manifests: &[&PackageManifest],
+    excluded_names: &HashSet<PkgName>,
+) -> PreferredVersions {
     let mut preferred: PreferredVersions = PreferredVersions::new();
     for manifest in manifests {
         for (name, spec) in manifest.dependencies([
@@ -47,7 +62,7 @@ pub fn get_preferred_versions_from_lockfile_and_manifests(
         }
     }
     if let Some(snapshots) = snapshots {
-        add_preferred_versions_from_lockfile(snapshots, &mut preferred);
+        add_preferred_versions_from_lockfile(snapshots, excluded_names, &mut preferred);
     }
     preferred
 }
@@ -57,11 +72,15 @@ pub fn get_preferred_versions_from_lockfile_and_manifests(
 /// rather than overwriting them.
 fn add_preferred_versions_from_lockfile(
     snapshots: &HashMap<PackageKey, SnapshotEntry>,
+    excluded_names: &HashSet<PkgName>,
     preferred: &mut PreferredVersions,
 ) {
     let mut unique_name_versions: HashMap<String, std::collections::HashSet<String>> =
         HashMap::new();
     for key in snapshots.keys() {
+        if excluded_names.contains(&key.name) {
+            continue;
+        }
         let name = key.name.to_string();
         // The lockfile records `file:`-protocol deps with a non-semver
         // version part. The preferred-versions map only feeds the semver

--- a/pnpm/crates/lockfile-preferred-versions/src/tests.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/tests.rs
@@ -1,6 +1,9 @@
-use std::{collections::HashMap, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 
-use pacquet_lockfile::{PackageKey, SnapshotEntry};
+use pacquet_lockfile::{PackageKey, PkgName, SnapshotEntry};
 use pacquet_package_manifest::PackageManifest;
 use pacquet_resolving_resolver_base::{
     DIRECT_DEP_SELECTOR_WEIGHT, EXISTING_VERSION_SELECTOR_WEIGHT, VersionSelectorEntry,
@@ -8,7 +11,10 @@ use pacquet_resolving_resolver_base::{
 };
 use pretty_assertions::assert_eq;
 
-use super::get_preferred_versions_from_lockfile_and_manifests;
+use super::{
+    get_preferred_versions_from_lockfile_and_manifests,
+    get_preferred_versions_from_lockfile_and_manifests_excluding,
+};
 
 #[expect(
     clippy::needless_pass_by_value,
@@ -108,6 +114,34 @@ fn dual_source_match_bumps_weight() {
     let entry = preferred.get("foo").unwrap().get("1.0.0").unwrap();
     assert_eq!(selector_type_of(entry), VersionSelectorType::Version);
     assert_eq!(weight_of(entry), DIRECT_DEP_SELECTOR_WEIGHT + EXISTING_VERSION_SELECTOR_WEIGHT);
+}
+
+#[test]
+fn excluded_lockfile_pins_keep_preferences_from_every_manifest() {
+    let mut snapshots = HashMap::new();
+    snapshots.insert(PackageKey::from_str("foo@1.0.0").unwrap(), SnapshotEntry::default());
+    snapshots.insert(PackageKey::from_str("bar@2.0.0").unwrap(), SnapshotEntry::default());
+    let (_selected_tmp, selected) = fake_manifest(serde_json::json!({
+        "dependencies": { "foo": "^1.0.0" },
+    }));
+    let (_sibling_tmp, sibling) = fake_manifest(serde_json::json!({
+        "dependencies": { "foo": "1.0.0" },
+    }));
+    let excluded = HashSet::from([PkgName::from_str("foo").unwrap()]);
+
+    let preferred = get_preferred_versions_from_lockfile_and_manifests_excluding(
+        Some(&snapshots),
+        &[&selected, &sibling],
+        &excluded,
+    );
+
+    let foo = preferred.get("foo").expect("foo manifest preferences");
+    assert_eq!(weight_of(foo.get("^1.0.0").unwrap()), DIRECT_DEP_SELECTOR_WEIGHT);
+    assert_eq!(weight_of(foo.get("1.0.0").unwrap()), DIRECT_DEP_SELECTOR_WEIGHT);
+    assert_eq!(
+        weight_of(preferred.get("bar").unwrap().get("2.0.0").unwrap()),
+        EXISTING_VERSION_SELECTOR_WEIGHT,
+    );
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -1,9 +1,10 @@
 use crate::{
     CatalogDecision, CatalogModeDep, CatalogVersionMismatchError, Install, InstallError,
-    ResolvedPackages, UpdateSeedPolicy, decide_catalog_outcome, emit_initial_package_manifest,
-    package_manifest_prefix,
+    ResolvedPackages, UpdateSeedPolicy, WorkspaceInstallSelection, decide_catalog_outcome,
+    emit_initial_package_manifest, package_manifest_prefix,
     resolution_policy::{PickPolicy, pick_package_context},
     resolve_latest::LatestPicker,
+    selected_project_indices,
 };
 use derive_more::{Display, Error};
 use futures_util::{StreamExt, stream::FuturesOrdered};
@@ -28,6 +29,7 @@ use pacquet_resolving_npm_resolver::{
 };
 use pacquet_tarball::MemCache;
 use pacquet_workspace_manifest_writer::{UpdateWorkspaceManifestError, update_workspace_manifest};
+use std::{collections::HashSet, path::PathBuf};
 
 #[must_use]
 pub struct Add<'a, DependencyGroupList>
@@ -147,88 +149,42 @@ where
             supported_architectures,
             lockfile_only,
         } = self;
+        let dependency_groups = dependency_groups.into_iter().collect::<Vec<_>>();
 
-        // Read the workspace catalogs so `catalogMode` / `--save-catalog`
-        // can reconcile the added version against them, the same read a
-        // partial install does before resolving. `manifest_dir` is
-        // owned so it can outlive the manifest mutation below.
-        let manifest_dir =
-            manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf();
-        let workspace_dir_opt = pacquet_workspace::find_workspace_dir(&manifest_dir)
-            .map_err(AddError::FindWorkspaceDir)?;
-        let workspace_manifest = match workspace_dir_opt.as_deref() {
-            Some(dir) => pacquet_workspace::read_workspace_manifest(dir)
-                .map_err(AddError::ReadWorkspaceManifest)?,
-            None => None,
-        };
-        let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-            .map_err(AddError::InvalidCatalogsConfiguration)?;
-        let prefix =
-            workspace_dir_opt.as_deref().unwrap_or(&manifest_dir).to_string_lossy().into_owned();
-        let dependency_groups: Vec<DependencyGroup> = dependency_groups.into_iter().collect();
         let latest_picker = tokio::sync::OnceCell::new();
         let meta_cache = std::sync::Arc::new(InMemoryPackageMetaCache::default());
         let fetch_locker = shared_packument_fetch_locker();
-        let resolved_dependencies = {
-            let mut resolution_futures = FuturesOrdered::new();
-            for package_name in package_names {
-                resolution_futures.push_back(resolve_added_dependency(
-                    package_name,
-                    config,
-                    manifest,
-                    lockfile,
-                    http_client,
-                    &http_client_arc,
-                    &latest_picker,
-                    pinned_version,
-                    save_catalog_name.as_deref(),
-                    &catalogs,
-                    &prefix,
-                    &dependency_groups,
-                    &meta_cache,
-                    &fetch_locker,
-                ));
-            }
-            let mut dependencies = Vec::with_capacity(package_names.len());
-            while let Some(result) = resolution_futures.next().await {
-                let dependency = result?;
-                if let Some(warning) = &dependency.warning {
-                    Reporter::emit(warning);
-                }
-                dependencies.push(dependency);
-            }
-            dependencies
-        };
-
-        emit_initial_package_manifest::<Reporter>(manifest);
-
-        for dependency in &resolved_dependencies {
-            for dependency_group in &dependency_groups {
-                manifest
-                    .add_dependency(
-                        &dependency.package_name,
-                        &dependency.manifest_specifier,
-                        *dependency_group,
-                    )
-                    .map_err(AddError::AddDependencyToManifest)?;
-            }
-        }
-
-        let mut updated_catalogs = Catalogs::new();
-        for dependency in resolved_dependencies {
-            for (catalog_name, entries) in dependency.updated_catalogs {
-                updated_catalogs.entry(catalog_name).or_default().extend(entries);
-            }
-        }
+        let catalog_ctx = read_catalog_ctx(manifest, config)?;
+        let updated_catalogs = prepare_manifest::<Reporter>(
+            manifest,
+            http_client,
+            &http_client_arc,
+            config,
+            lockfile,
+            &dependency_groups,
+            package_names,
+            &latest_picker,
+            pinned_version,
+            save_catalog_name.as_deref(),
+            &catalog_ctx.catalogs,
+            &catalog_ctx.prefix,
+            &meta_cache,
+            &fetch_locker,
+        )
+        .await?;
 
         // Write the new catalog entry to `pnpm-workspace.yaml` before the
         // install so the resolver reads it back and the lockfile's
         // `catalogs:` snapshot records the resolved version.
         if !updated_catalogs.is_empty() {
-            let workspace_dir = workspace_dir_opt.unwrap_or(manifest_dir);
-            update_workspace_manifest(&workspace_dir, &updated_catalogs)
+            update_workspace_manifest(&catalog_ctx.workspace_dir, &updated_catalogs)
                 .map_err(AddError::WriteWorkspaceManifest)?;
         }
+        let catalogs_override = (!updated_catalogs.is_empty()).then(|| {
+            let mut catalogs = catalog_ctx.catalogs;
+            merge_catalogs(&mut catalogs, &updated_catalogs);
+            catalogs
+        });
 
         Install {
             tarball_mem_cache,
@@ -270,7 +226,7 @@ where
             auth_override: None,
             resolution_observer: None,
             peer_issues_sink: None,
-            catalogs_override: None,
+            catalogs_override,
             disable_optimistic_repeat_install: false,
             pnpmfile_hook_override: None,
             workspace_projects_override: None,
@@ -279,28 +235,309 @@ where
         .await
         .map_err(AddError::Install)?;
 
-        let updated = manifest.save_and_get_written_value().map_err(AddError::SaveManifest)?;
-
-        // `pnpm:package-manifest updated` fires once after the manifest
-        // is rewritten so consumers (e.g. the audit pipeline that diffs
-        // initial vs updated) see the post-add shape. `prefix` is the manifest's parent
-        // directory, matching what `Install::run` derived for the
-        // matching `initial` event.
-        //
-        // `parent()` only returns `None` when the path has no parent
-        // (a root or empty); fall back to the manifest path itself
-        // so a degenerate `package.json` placed directly at `/`
-        // doesn't crash the post-save emit. `to_string_lossy`
-        // coerces non-UTF-8 path bytes to U+FFFD instead of
-        // panicking.
-        let prefix = package_manifest_prefix(manifest);
-        Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
-            level: LogLevel::Debug,
-            message: PackageManifestMessage::Updated { prefix, updated },
-        }));
+        persist_manifest::<Reporter>(manifest)?;
 
         Ok(())
     }
+
+    pub async fn run_selected<Reporter: self::Reporter + 'static>(
+        self,
+        projects: &mut [pacquet_workspace::Project],
+        ordered_dirs: &[PathBuf],
+        selected_dirs: &HashSet<PathBuf>,
+        active_manifest_is_standin: bool,
+    ) -> Result<(), AddError> {
+        let Add {
+            tarball_mem_cache,
+            http_client,
+            http_client_arc,
+            config,
+            manifest,
+            lockfile,
+            lockfile_path,
+            dependency_groups,
+            package_names,
+            pinned_version,
+            save_catalog_name,
+            resolved_packages,
+            supported_architectures,
+            lockfile_only,
+        } = self;
+        let dependency_groups = dependency_groups.into_iter().collect::<Vec<_>>();
+        let selected_indices = selected_project_indices(projects, ordered_dirs, selected_dirs);
+        if selected_indices.is_empty() {
+            return Ok(());
+        }
+        let prepared = prepare_selected_manifests::<Reporter>(
+            projects,
+            &selected_indices,
+            http_client,
+            &http_client_arc,
+            config,
+            lockfile,
+            &dependency_groups,
+            package_names,
+            pinned_version,
+            save_catalog_name.as_deref(),
+        )
+        .await?;
+        if !prepared.updated_catalogs.is_empty() {
+            update_workspace_manifest(&prepared.workspace_dir, &prepared.updated_catalogs)
+                .map_err(AddError::WriteWorkspaceManifest)?;
+        }
+
+        Box::pin(
+            Install {
+                tarball_mem_cache,
+                http_client,
+                http_client_arc,
+                config,
+                manifest,
+                emit_initial_manifest: false,
+                lockfile: MaybeLazyLockfile::Loaded(lockfile),
+                lockfile_path,
+                dependency_groups,
+                frozen_lockfile: false,
+                prefer_frozen_lockfile: Some(false),
+                ignore_manifest_check: false,
+                skip_runtimes: config.skip_runtimes,
+                trust_lockfile: config.trust_lockfile,
+                update_checksums: false,
+                is_full_install: false,
+                resolved_packages,
+                supported_architectures,
+                node_linker: config.node_linker,
+                lockfile_only,
+                dry_run: false,
+                update_seed_policy: UpdateSeedPolicy::KeepAll,
+                auth_override: None,
+                resolution_observer: None,
+                peer_issues_sink: None,
+                catalogs_override: prepared.catalogs_override,
+                disable_optimistic_repeat_install: false,
+                pnpmfile_hook_override: None,
+                workspace_projects_override: None,
+            }
+            .run_selected::<Reporter>(WorkspaceInstallSelection {
+                all_projects: projects,
+                ordered_dirs,
+                selected_dirs,
+                active_manifest_is_standin,
+            }),
+        )
+        .await
+        .map_err(AddError::Install)?;
+
+        persist_selected_manifests::<Reporter>(projects, &selected_indices)?;
+        Ok(())
+    }
+}
+
+struct AddCatalogCtx {
+    catalogs: Catalogs,
+    workspace_dir: PathBuf,
+    prefix: String,
+}
+
+struct SelectedAddPreparation {
+    updated_catalogs: Catalogs,
+    catalogs_override: Option<Catalogs>,
+    workspace_dir: PathBuf,
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "selected add preparation reuses the command's resolution inputs"
+)]
+async fn prepare_selected_manifests<'a, Reporter: self::Reporter>(
+    projects: &mut [pacquet_workspace::Project],
+    selected_indices: &[usize],
+    http_client: &'a ThrottledClient,
+    http_client_arc: &std::sync::Arc<ThrottledClient>,
+    config: &'a Config,
+    lockfile: Option<&Lockfile>,
+    dependency_groups: &[DependencyGroup],
+    package_names: &[String],
+    pinned_version: PinnedVersion,
+    save_catalog_name: Option<&str>,
+) -> Result<SelectedAddPreparation, AddError> {
+    let first_index = *selected_indices.first().expect("selected add requires a project");
+    let catalog_ctx = read_catalog_ctx(&projects[first_index].manifest, config)?;
+    let mut catalogs = catalog_ctx.catalogs;
+    let mut updated_catalogs = Catalogs::new();
+    // One picker, packument cache, and fetch locker across every selected
+    // project: the picker is created on first use (a selection that resolves
+    // no `latest` tag never builds one), and the shared caches keep the same
+    // package from being fetched once per project.
+    let latest_picker = tokio::sync::OnceCell::new();
+    let meta_cache = std::sync::Arc::new(InMemoryPackageMetaCache::default());
+    let fetch_locker = shared_packument_fetch_locker();
+
+    for &index in selected_indices {
+        let updates = prepare_manifest::<Reporter>(
+            &mut projects[index].manifest,
+            http_client,
+            http_client_arc,
+            config,
+            lockfile,
+            dependency_groups,
+            package_names,
+            &latest_picker,
+            pinned_version,
+            save_catalog_name,
+            &catalogs,
+            &catalog_ctx.prefix,
+            &meta_cache,
+            &fetch_locker,
+        )
+        .await?;
+        merge_catalogs(&mut catalogs, &updates);
+        merge_catalogs(&mut updated_catalogs, &updates);
+    }
+
+    let catalogs_override = (!updated_catalogs.is_empty()).then_some(catalogs);
+    Ok(SelectedAddPreparation {
+        updated_catalogs,
+        catalogs_override,
+        workspace_dir: catalog_ctx.workspace_dir,
+    })
+}
+
+/// Resolve every selector against `catalogs` concurrently, then apply them
+/// to `manifest`.
+///
+/// Every selector is resolved before the manifest is touched so the
+/// `initial` manifest event still reports the pre-add shape exactly once,
+/// however many selectors a single `add` carries. `FuturesOrdered` overlaps
+/// the registry requests while keeping the buffered catalog warnings and the
+/// applied dependencies in selector order. The `latest_picker`,
+/// `meta_cache`, and `fetch_locker` are threaded in so one selected-add pass
+/// shares packument state across every project it touches.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "manifest preparation consumes the add command's resolution inputs"
+)]
+async fn prepare_manifest<'a, Reporter: self::Reporter>(
+    manifest: &mut PackageManifest,
+    http_client: &'a ThrottledClient,
+    http_client_arc: &std::sync::Arc<ThrottledClient>,
+    config: &'a Config,
+    lockfile: Option<&Lockfile>,
+    dependency_groups: &[DependencyGroup],
+    package_names: &[String],
+    latest_picker: &tokio::sync::OnceCell<LatestPicker<'a>>,
+    pinned_version: PinnedVersion,
+    save_catalog_name: Option<&str>,
+    catalogs: &Catalogs,
+    prefix: &str,
+    meta_cache: &std::sync::Arc<InMemoryPackageMetaCache>,
+    fetch_locker: &PackumentFetchLocker,
+) -> Result<Catalogs, AddError> {
+    let resolved_dependencies = {
+        let mut resolution_futures = FuturesOrdered::new();
+        for package_selector in package_names {
+            resolution_futures.push_back(resolve_added_dependency(
+                package_selector,
+                config,
+                manifest,
+                lockfile,
+                http_client,
+                http_client_arc,
+                latest_picker,
+                pinned_version,
+                save_catalog_name,
+                catalogs,
+                prefix,
+                dependency_groups,
+                meta_cache,
+                fetch_locker,
+            ));
+        }
+        let mut dependencies = Vec::with_capacity(package_names.len());
+        while let Some(result) = resolution_futures.next().await {
+            let dependency = result?;
+            if let Some(warning) = &dependency.warning {
+                Reporter::emit(warning);
+            }
+            dependencies.push(dependency);
+        }
+        dependencies
+    };
+
+    emit_initial_package_manifest::<Reporter>(manifest);
+
+    for dependency in &resolved_dependencies {
+        for &dependency_group in dependency_groups {
+            manifest
+                .add_dependency(
+                    &dependency.package_name,
+                    &dependency.manifest_specifier,
+                    dependency_group,
+                )
+                .map_err(AddError::AddDependencyToManifest)?;
+        }
+    }
+
+    let mut updated_catalogs = Catalogs::new();
+    for dependency in resolved_dependencies {
+        merge_catalogs(&mut updated_catalogs, &dependency.updated_catalogs);
+    }
+    Ok(updated_catalogs)
+}
+
+fn read_catalog_ctx(
+    manifest: &PackageManifest,
+    config: &Config,
+) -> Result<AddCatalogCtx, AddError> {
+    let manifest_dir =
+        manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf();
+    let workspace_dir_opt =
+        pacquet_workspace::find_workspace_dir(&manifest_dir).map_err(AddError::FindWorkspaceDir)?;
+    let catalogs = if let Some(catalogs) = config.catalogs.clone() {
+        catalogs
+    } else {
+        let workspace_manifest = match workspace_dir_opt.as_deref() {
+            Some(dir) => pacquet_workspace::read_workspace_manifest(dir)
+                .map_err(AddError::ReadWorkspaceManifest)?,
+            None => None,
+        };
+        get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+            .map_err(AddError::InvalidCatalogsConfiguration)?
+    };
+    let workspace_dir = workspace_dir_opt.unwrap_or(manifest_dir);
+    let prefix = workspace_dir.to_string_lossy().into_owned();
+    Ok(AddCatalogCtx { catalogs, workspace_dir, prefix })
+}
+
+fn merge_catalogs(target: &mut Catalogs, updates: &Catalogs) {
+    for (catalog_name, entries) in updates {
+        let catalog = target.entry(catalog_name.clone()).or_default();
+        for (dependency, specifier) in entries {
+            catalog.insert(dependency.clone(), specifier.clone());
+        }
+    }
+}
+
+fn persist_selected_manifests<Reporter: self::Reporter>(
+    projects: &mut [pacquet_workspace::Project],
+    selected_indices: &[usize],
+) -> Result<(), AddError> {
+    for &index in selected_indices {
+        persist_manifest::<Reporter>(&mut projects[index].manifest)?;
+    }
+    Ok(())
+}
+
+fn persist_manifest<Reporter: self::Reporter>(
+    manifest: &mut PackageManifest,
+) -> Result<(), AddError> {
+    let updated = manifest.save_and_get_written_value().map_err(AddError::SaveManifest)?;
+    let prefix = package_manifest_prefix(manifest);
+    Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
+        level: LogLevel::Debug,
+        message: PackageManifestMessage::Updated { prefix, updated },
+    }));
+    Ok(())
 }
 
 struct ResolvedAddedDependency {

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -1,11 +1,17 @@
-use super::{Add, AddError, node_runtime_version_spec, normalized_save_specifier};
+use super::{
+    Add, AddError, node_runtime_version_spec, normalized_save_specifier,
+    persist_selected_manifests, prepare_selected_manifests, selected_project_indices,
+};
 use crate::ResolvedPackages;
 use pacquet_config::Config;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::{LogEvent, LogLevel, Reporter, SilentReporter};
+use pacquet_workspace::Project;
+use serde_json::json;
 use std::{
+    collections::HashSet,
     sync::{Arc, Condvar, Mutex},
     time::Duration,
 };
@@ -583,4 +589,133 @@ fn node_runtime_version_spec_matches_only_explicit_node_runtime_requests() {
     // Deno and bun echo the requested spec back, so they save verbatim.
     assert_eq!(node_runtime_version_spec("deno", Some("runtime:2")), None);
     assert_eq!(node_runtime_version_spec("bun", Some("runtime:latest")), None);
+}
+
+#[tokio::test]
+async fn selected_add_prepares_and_persists_only_selected_projects() {
+    let dir = tempdir().expect("create tempdir");
+    std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n  - '*'\n")
+        .expect("write workspace manifest");
+    let mut projects =
+        ["a", "b", "c"].into_iter().map(|name| empty_project(dir.path(), name)).collect::<Vec<_>>();
+    let ordered_dirs = [projects[1].root_dir.clone(), projects[0].root_dir.clone()];
+    let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
+    let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
+    let config = Config::new();
+    let http_client = ThrottledClient::default();
+    let http_client_arc = Arc::new(ThrottledClient::default());
+
+    prepare_selected_manifests::<SilentReporter>(
+        &mut projects,
+        &indices,
+        &http_client,
+        &http_client_arc,
+        &config,
+        None,
+        &[DependencyGroup::Prod],
+        std::slice::from_ref(&"foo@workspace:*".to_string()),
+        PinnedVersion::Major,
+        None,
+    )
+    .await
+    .expect("prepare selected manifests");
+    persist_selected_manifests::<SilentReporter>(&mut projects, &indices)
+        .expect("persist selected manifests");
+
+    assert_eq!(dependency_specifier(&projects[0].manifest, "foo"), Some("workspace:*"));
+    assert_eq!(dependency_specifier(&projects[1].manifest, "foo"), Some("workspace:*"));
+    assert_eq!(dependency_specifier(&projects[2].manifest, "foo"), None);
+    assert_eq!(
+        saved_dependency_specifier(&projects[0].manifest, "foo"),
+        Some("workspace:*".to_string()),
+    );
+    assert_eq!(
+        saved_dependency_specifier(&projects[1].manifest, "foo"),
+        Some("workspace:*".to_string()),
+    );
+    assert_eq!(saved_dependency_specifier(&projects[2].manifest, "foo"), None);
+}
+
+#[tokio::test]
+async fn selected_add_merges_catalog_updates_in_command_order() {
+    let dir = tempdir().expect("create tempdir");
+    std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n  - '*'\n")
+        .expect("write workspace manifest");
+    let mut projects = vec![
+        project_with_foo(dir.path(), "a", "1.0.0"),
+        project_with_foo(dir.path(), "b", "2.0.0"),
+    ];
+    let ordered_dirs = [projects[1].root_dir.clone(), projects[0].root_dir.clone()];
+    let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
+    let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
+    let config = Config::new();
+    let http_client = ThrottledClient::default();
+    let http_client_arc = Arc::new(ThrottledClient::default());
+
+    let prepared = prepare_selected_manifests::<SilentReporter>(
+        &mut projects,
+        &indices,
+        &http_client,
+        &http_client_arc,
+        &config,
+        None,
+        &[DependencyGroup::Prod],
+        std::slice::from_ref(&"foo".to_string()),
+        PinnedVersion::Major,
+        Some("default"),
+    )
+    .await
+    .expect("prepare selected manifests");
+
+    assert_eq!(dependency_specifier(&projects[0].manifest, "foo"), Some("1.0.0"));
+    assert_eq!(dependency_specifier(&projects[1].manifest, "foo"), Some("catalog:"));
+    assert_eq!(
+        prepared
+            .updated_catalogs
+            .get("default")
+            .and_then(|catalog| catalog.get("foo"))
+            .map(String::as_str),
+        Some("2.0.0"),
+    );
+    assert_eq!(
+        prepared
+            .catalogs_override
+            .as_ref()
+            .and_then(|catalogs| catalogs.get("default"))
+            .and_then(|catalog| catalog.get("foo"))
+            .map(String::as_str),
+        Some("2.0.0"),
+    );
+}
+
+fn empty_project(root: &std::path::Path, name: &str) -> Project {
+    let root_dir = root.join(name);
+    std::fs::create_dir_all(&root_dir).expect("create project directory");
+    let package_json = root_dir.join("package.json");
+    std::fs::write(&package_json, json!({ "name": name }).to_string()).expect("write package.json");
+    Project {
+        root_dir,
+        manifest: PackageManifest::from_path(package_json).expect("read package.json"),
+    }
+}
+
+fn project_with_foo(root: &std::path::Path, name: &str, specifier: &str) -> Project {
+    let project = empty_project(root, name);
+    let mut manifest = project.manifest;
+    manifest.add_dependency("foo", specifier, DependencyGroup::Prod).expect("add foo dependency");
+    manifest.save().expect("save package.json");
+    Project { root_dir: project.root_dir, manifest }
+}
+
+fn dependency_specifier<'a>(manifest: &'a PackageManifest, name: &str) -> Option<&'a str> {
+    manifest
+        .dependencies([DependencyGroup::Prod])
+        .find(|(dependency, _)| *dependency == name)
+        .map(|(_, specifier)| specifier)
+}
+
+fn saved_dependency_specifier(manifest: &PackageManifest, name: &str) -> Option<String> {
+    let saved =
+        PackageManifest::from_path(manifest.path().to_path_buf()).expect("reread package.json");
+    dependency_specifier(&saved, name).map(str::to_string)
 }

--- a/pnpm/crates/package-manager/src/current_lockfile.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile.rs
@@ -14,15 +14,268 @@
 //! those slots were already on disk and skip work that should
 //! actually run.
 
-use std::collections::{HashMap, HashSet, VecDeque};
-
-use pacquet_lockfile::{
-    Lockfile, PackageKey, PkgName, ProjectSnapshot, ResolvedDependencyMap, SnapshotDepRef,
-    SnapshotEntry,
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    path::Path,
 };
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_lockfile::{Lockfile, PackageKey, ProjectSnapshot, ResolvedDependencyMap};
 use pacquet_modules_yaml::IncludedDependencies;
 
 use crate::SkippedSnapshots;
+
+pub struct MaterializationClosure {
+    pub lockfile: Lockfile,
+    pub importer_ids: HashSet<String>,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum MergeFilteredWantedLockfileError {
+    #[display("fresh lockfile is missing importer {importer_id}")]
+    #[diagnostic(code(pacquet_package_manager::missing_fresh_lockfile_importer))]
+    MissingImporter {
+        #[error(not(source))]
+        importer_id: String,
+    },
+}
+
+#[must_use]
+pub fn materialization_closure(
+    lockfile: &Lockfile,
+    workspace_root: &Path,
+    initial_importer_ids: &HashSet<String>,
+    included: IncludedDependencies,
+    skipped: &SkippedSnapshots,
+) -> MaterializationClosure {
+    let reachable =
+        collect_reachable(lockfile, workspace_root, initial_importer_ids, included, |key| {
+            skipped.contains(key)
+        });
+    let metadata_reachable =
+        collect_reachable(lockfile, workspace_root, initial_importer_ids, included, |key| {
+            skipped.contains_optional_excluded(key)
+        });
+    let reachable_metadata = metadata_reachable
+        .snapshot_keys
+        .iter()
+        .map(PackageKey::without_peer)
+        .collect::<HashSet<_>>();
+    let importers = lockfile
+        .importers
+        .iter()
+        .filter(|(id, _)| reachable.importer_ids.contains(*id))
+        .map(|(id, importer)| {
+            (id.clone(), filter_importer(importer, included, &reachable.snapshot_keys))
+        })
+        .collect();
+    let snapshots = lockfile.snapshots.as_ref().map(|snapshots| {
+        snapshots
+            .iter()
+            .filter(|(key, _)| reachable.snapshot_keys.contains(*key))
+            .map(|(key, snapshot)| (key.clone(), snapshot.clone()))
+            .collect()
+    });
+    let packages = lockfile.packages.as_ref().map(|packages| {
+        packages
+            .iter()
+            .filter(|(key, _)| reachable_metadata.contains(*key))
+            .map(|(key, package)| (key.clone(), package.clone()))
+            .collect()
+    });
+
+    MaterializationClosure {
+        lockfile: Lockfile {
+            lockfile_version: lockfile.lockfile_version,
+            settings: lockfile.settings.clone(),
+            catalogs: lockfile.catalogs.clone(),
+            overrides: lockfile.overrides.clone(),
+            package_extensions_checksum: lockfile.package_extensions_checksum.clone(),
+            pnpmfile_checksum: lockfile.pnpmfile_checksum.clone(),
+            ignored_optional_dependencies: lockfile.ignored_optional_dependencies.clone(),
+            patched_dependencies: lockfile.patched_dependencies.clone(),
+            importers,
+            packages,
+            snapshots,
+        },
+        importer_ids: reachable.importer_ids,
+    }
+}
+
+pub fn merge_filtered_wanted_lockfile(
+    previous_wanted: Option<&Lockfile>,
+    mut freshly_resolved: Lockfile,
+    real_importer_ids: &HashSet<String>,
+    selected_importer_ids: &HashSet<String>,
+    workspace_root: &Path,
+) -> Result<Lockfile, MergeFilteredWantedLockfileError> {
+    // Global resolution inputs describe every importer. If any of them
+    // changed, retaining an old unselected importer would pair stale pins
+    // with fresh catalogs, overrides, hooks, or lockfile settings.
+    let can_reuse_unselected_importers = previous_wanted.is_some_and(|previous| {
+        previous.lockfile_version == freshly_resolved.lockfile_version
+            && previous.settings == freshly_resolved.settings
+            && previous.catalogs == freshly_resolved.catalogs
+            && previous.overrides == freshly_resolved.overrides
+            && previous.package_extensions_checksum == freshly_resolved.package_extensions_checksum
+            && previous.pnpmfile_checksum == freshly_resolved.pnpmfile_checksum
+            && previous.ignored_optional_dependencies
+                == freshly_resolved.ignored_optional_dependencies
+            && previous.patched_dependencies == freshly_resolved.patched_dependencies
+    });
+    let mut fresh_importers = std::mem::take(&mut freshly_resolved.importers);
+    let fresh_packages = freshly_resolved.packages.take();
+    let fresh_snapshots = freshly_resolved.snapshots.take();
+    let mut importer_ids = real_importer_ids.iter().collect::<Vec<_>>();
+    importer_ids.sort();
+    freshly_resolved.importers = importer_ids
+        .into_iter()
+        .map(|importer_id| {
+            let previous_importer =
+                previous_wanted.and_then(|lockfile| lockfile.importers.get(importer_id));
+            let importer = match previous_importer {
+                Some(previous_importer)
+                    if can_reuse_unselected_importers
+                        && !selected_importer_ids.contains(importer_id) =>
+                {
+                    previous_importer.clone()
+                }
+                _ => fresh_importers.remove(importer_id).ok_or_else(|| {
+                    MergeFilteredWantedLockfileError::MissingImporter {
+                        importer_id: importer_id.clone(),
+                    }
+                })?,
+            };
+            Ok((importer_id.clone(), importer))
+        })
+        .collect::<Result<_, MergeFilteredWantedLockfileError>>()?;
+    freshly_resolved.packages = overlay_package_maps(
+        previous_wanted.and_then(|lockfile| lockfile.packages.as_ref()),
+        fresh_packages,
+    );
+    freshly_resolved.snapshots = overlay_package_maps(
+        previous_wanted.and_then(|lockfile| lockfile.snapshots.as_ref()),
+        fresh_snapshots,
+    );
+    let final_importer_ids = freshly_resolved.importers.keys().cloned().collect();
+    Ok(materialization_closure(
+        &freshly_resolved,
+        workspace_root,
+        &final_importer_ids,
+        all_dependencies(),
+        &SkippedSnapshots::new(),
+    )
+    .lockfile)
+}
+
+pub(crate) fn merge_filtered_current_lockfile(
+    previous_current: Option<&Lockfile>,
+    wanted: &Lockfile,
+    requested_importer_ids: &HashSet<String>,
+    included: IncludedDependencies,
+    skipped: &SkippedSnapshots,
+    workspace_root: &Path,
+) -> Lockfile {
+    let selected =
+        materialization_closure(wanted, workspace_root, requested_importer_ids, included, skipped);
+    let Some(previous_current) = previous_current else {
+        return selected.lockfile;
+    };
+    let retained_importers = previous_current
+        .importers
+        .iter()
+        .filter(|(importer_id, _)| !selected.importer_ids.contains(*importer_id))
+        .map(|(importer_id, importer)| (importer_id.clone(), importer.clone()))
+        .collect::<HashMap<_, _>>();
+    let retained_importer_ids = retained_importers.keys().cloned().collect();
+    let retained_source = lockfile_with_graph(
+        previous_current,
+        retained_importers,
+        previous_current.packages.clone(),
+        previous_current.snapshots.clone(),
+    );
+    let retained = materialization_closure(
+        &retained_source,
+        workspace_root,
+        &retained_importer_ids,
+        all_dependencies(),
+        &SkippedSnapshots::new(),
+    );
+    let mut importers = retained.lockfile.importers;
+    importers.extend(selected.lockfile.importers);
+    let selected_packages = selected.lockfile.packages;
+    let packages =
+        overlay_package_maps(previous_current.packages.as_ref(), selected_packages.clone());
+    let snapshots =
+        overlay_package_maps(retained.lockfile.snapshots.as_ref(), selected.lockfile.snapshots);
+    let merged = lockfile_with_graph(wanted, importers, packages, snapshots);
+    let final_importer_ids = merged.importers.keys().cloned().collect();
+    let mut final_lockfile = materialization_closure(
+        &merged,
+        workspace_root,
+        &final_importer_ids,
+        all_dependencies(),
+        &SkippedSnapshots::new(),
+    )
+    .lockfile;
+    if let Some(selected_packages) = selected_packages {
+        final_lockfile.packages.get_or_insert_default().extend(selected_packages);
+    }
+    if let (Some(merged_packages), Some(final_packages)) =
+        (merged.packages.as_ref(), final_lockfile.packages.as_mut())
+    {
+        for skipped_key in skipped.iter() {
+            if skipped.contains_optional_excluded(skipped_key) {
+                continue;
+            }
+            let metadata_key = skipped_key.without_peer();
+            if let Some(metadata) = merged_packages.get(&metadata_key) {
+                final_packages.insert(metadata_key, metadata.clone());
+            }
+        }
+    }
+    final_lockfile
+}
+
+fn all_dependencies() -> IncludedDependencies {
+    IncludedDependencies { dependencies: true, dev_dependencies: true, optional_dependencies: true }
+}
+
+fn overlay_package_maps<Value: Clone>(
+    previous: Option<&HashMap<PackageKey, Value>>,
+    fresh: Option<HashMap<PackageKey, Value>>,
+) -> Option<HashMap<PackageKey, Value>> {
+    if previous.is_none() && fresh.is_none() {
+        return None;
+    }
+    let mut merged = previous.cloned().unwrap_or_default();
+    if let Some(fresh) = fresh {
+        merged.extend(fresh);
+    }
+    Some(merged)
+}
+
+fn lockfile_with_graph(
+    source: &Lockfile,
+    importers: HashMap<String, ProjectSnapshot>,
+    packages: Option<HashMap<PackageKey, pacquet_lockfile::PackageMetadata>>,
+    snapshots: Option<HashMap<PackageKey, pacquet_lockfile::SnapshotEntry>>,
+) -> Lockfile {
+    Lockfile {
+        lockfile_version: source.lockfile_version,
+        settings: source.settings.clone(),
+        catalogs: source.catalogs.clone(),
+        overrides: source.overrides.clone(),
+        package_extensions_checksum: source.package_extensions_checksum.clone(),
+        pnpmfile_checksum: source.pnpmfile_checksum.clone(),
+        ignored_optional_dependencies: source.ignored_optional_dependencies.clone(),
+        patched_dependencies: source.patched_dependencies.clone(),
+        importers,
+        packages,
+        snapshots,
+    }
+}
 
 /// Build the "current lockfile" shape from the wanted lockfile by
 /// applying the install-time `include` set and skip set.
@@ -40,73 +293,8 @@ pub fn filter_lockfile_for_current(
     included: IncludedDependencies,
     skipped: &SkippedSnapshots,
 ) -> Lockfile {
-    let reachable = collect_reachable(&lockfile.importers, lockfile.snapshots.as_ref(), |key| {
-        skipped.contains(key)
-    });
-    let metadata_reachable =
-        collect_reachable(&lockfile.importers, lockfile.snapshots.as_ref(), |key| {
-            skipped.contains_optional_excluded(key)
-        });
-
-    // Reachable metadata keys: snapshot keys without the peer suffix.
-    // The `packages:` map is keyed by `metadata_key` (e.g.
-    // `react-dom@17.0.2`), not by snapshot key
-    // (e.g. `react-dom@17.0.2(react@17.0.2)`); a single metadata
-    // entry can back multiple peer-variant snapshots. Compute the
-    // union of `without_peer()` keys so peer-variant survivors keep
-    // their shared metadata row.
-    let mut reachable_metadata: HashSet<PackageKey> = HashSet::new();
-    for snap_key in &metadata_reachable {
-        reachable_metadata.insert(snap_key.without_peer());
-    }
-
-    let importers = lockfile
-        .importers
-        .iter()
-        .map(|(id, imp)| (id.clone(), filter_importer(imp, included, &reachable)))
-        .collect();
-
-    let snapshots = lockfile.snapshots.as_ref().map(|snapshots| {
-        snapshots
-            .iter()
-            .filter(|(k, _)| reachable.contains(*k))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect::<HashMap<_, _>>()
-    });
-
-    let packages = lockfile.packages.as_ref().map(|packages| {
-        packages
-            .iter()
-            .filter(|(k, _)| reachable_metadata.contains(*k))
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect::<HashMap<_, _>>()
-    });
-
-    Lockfile {
-        lockfile_version: lockfile.lockfile_version,
-        settings: lockfile.settings.clone(),
-        // The current lockfile is a filtered view of the wanted one;
-        // catalog snapshots carry over verbatim.
-        catalogs: lockfile.catalogs.clone(),
-        overrides: lockfile.overrides.clone(),
-        package_extensions_checksum: lockfile.package_extensions_checksum.clone(),
-        // Carried over verbatim — the current lockfile is a filtered
-        // view of the wanted one, so its pnpmfile checksum round-trips.
-        pnpmfile_checksum: lockfile.pnpmfile_checksum.clone(),
-        // Preserve the wanted lockfile's `ignored_optional_dependencies`
-        // verbatim — the current lockfile is a filtered view of the
-        // wanted one, and a future drift check between this recorded
-        // set and the next install's `Config` value relies on the
-        // round-trip. Slice 7 wire-up.
-        ignored_optional_dependencies: lockfile.ignored_optional_dependencies.clone(),
-        // Carried over verbatim: the current lockfile is a filtered
-        // view of the wanted one, so the recorded patch hashes survive
-        // the round-trip into `node_modules/.pnpm/lock.yaml`.
-        patched_dependencies: lockfile.patched_dependencies.clone(),
-        importers,
-        packages,
-        snapshots,
-    }
+    let all_importer_ids = lockfile.importers.keys().cloned().collect();
+    materialization_closure(lockfile, Path::new(""), &all_importer_ids, included, skipped).lockfile
 }
 
 /// Per-importer filter: drop dep maps whose `include` flag is
@@ -149,88 +337,134 @@ fn retain_reachable(map: &mut ResolvedDependencyMap, reachable: &HashSet<Package
     });
 }
 
-/// BFS the snapshot graph from every importer-root dep, skipping keys
-/// selected by `should_skip`. Returns the set of snapshot keys that
-/// survive.
-fn collect_reachable<ShouldSkip>(
-    importers: &HashMap<String, ProjectSnapshot>,
-    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
-    should_skip: ShouldSkip,
-) -> HashSet<PackageKey>
-where
-    ShouldSkip: Fn(&PackageKey) -> bool,
-{
-    let Some(snapshots) = snapshots else { return HashSet::new() };
-
-    let mut reachable: HashSet<PackageKey> = HashSet::new();
-    let mut queue: VecDeque<PackageKey> = VecDeque::new();
-
-    // Seed the queue from every importer-level dep map. The
-    // `include` filter isn't applied here on purpose — all three
-    // maps are walked unconditionally at this stage, and only the
-    // importer-level *output* clears the maps that were excluded. A
-    // snapshot reachable through any importer map stays in the
-    // snapshot graph as long as it's not in `skipped`; the
-    // per-importer clearing happens separately in [`filter_importer`].
-    for importer in importers.values() {
-        for map in [
-            importer.dependencies.as_ref(),
-            importer.dev_dependencies.as_ref(),
-            importer.optional_dependencies.as_ref(),
-        ]
-        .into_iter()
-        .flatten()
-        {
-            for (name, spec) in map {
-                let Some(key) = spec.version.resolved_key(name) else { continue };
-                if should_skip(&key) {
-                    continue;
-                }
-                if snapshots.contains_key(&key) {
-                    queue.push_back(key);
-                }
-            }
-        }
-    }
-
-    while let Some(key) = queue.pop_front() {
-        if !reachable.insert(key.clone()) {
-            continue;
-        }
-        let Some(snap) = snapshots.get(&key) else { continue };
-        for dep_map in
-            [snap.dependencies.as_ref(), snap.optional_dependencies.as_ref()].into_iter().flatten()
-        {
-            for (alias, dep_ref) in dep_map {
-                if let Some(child) = resolve_child(alias, dep_ref, snapshots, &should_skip) {
-                    queue.push_back(child);
-                }
-            }
-        }
-    }
-
-    reachable
+struct ReachableLockfileGraph {
+    importer_ids: HashSet<String>,
+    snapshot_keys: HashSet<PackageKey>,
 }
 
-/// Resolve a snapshot child to its `PackageKey`, dropping it if the
-/// target should be skipped or is absent from the snapshot map.
-fn resolve_child<ShouldSkip>(
-    alias: &PkgName,
-    dep_ref: &SnapshotDepRef,
-    snapshots: &HashMap<PackageKey, SnapshotEntry>,
-    should_skip: &ShouldSkip,
-) -> Option<PackageKey>
+fn collect_reachable<ShouldSkip>(
+    lockfile: &Lockfile,
+    workspace_root: &Path,
+    initial_importer_ids: &HashSet<String>,
+    included: IncludedDependencies,
+    should_skip: ShouldSkip,
+) -> ReachableLockfileGraph
 where
     ShouldSkip: Fn(&PackageKey) -> bool,
 {
-    // `link:` deps live outside the virtual store and have no
-    // snapshot to reach — they aren't part of the reachable-snapshot
-    // graph this helper computes.
-    let resolved = dep_ref.resolve(alias)?;
-    if should_skip(&resolved) {
-        return None;
+    let snapshots = lockfile.snapshots.as_ref();
+    let mut known_importer_ids = lockfile.importers.keys().cloned().collect::<Vec<_>>();
+    known_importer_ids.sort();
+    let known_importers = known_importer_ids
+        .into_iter()
+        .map(|id| {
+            (pacquet_fs::lexical_normalize(&crate::importer_root_dir(workspace_root, &id)), id)
+        })
+        .collect::<HashMap<_, _>>();
+    let mut importer_ids = HashSet::new();
+    let mut snapshot_keys = HashSet::new();
+    let mut importer_queue = initial_importer_ids.iter().cloned().collect::<VecDeque<_>>();
+    let mut snapshot_queue = VecDeque::new();
+
+    while !importer_queue.is_empty() || !snapshot_queue.is_empty() {
+        while let Some(importer_id) = importer_queue.pop_front() {
+            if importer_ids.contains(&importer_id) {
+                continue;
+            }
+            let Some(importer) = lockfile.importers.get(&importer_id) else { continue };
+            importer_ids.insert(importer_id.clone());
+            let importer_dir = crate::importer_root_dir(workspace_root, &importer_id);
+            for map in [
+                included.dependencies.then_some(importer.dependencies.as_ref()).flatten(),
+                included.dev_dependencies.then_some(importer.dev_dependencies.as_ref()).flatten(),
+                included
+                    .optional_dependencies
+                    .then_some(importer.optional_dependencies.as_ref())
+                    .flatten(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                for (name, spec) in map {
+                    if let Some(target) = spec.version.as_link_target() {
+                        enqueue_linked_importer(
+                            &importer_dir,
+                            target,
+                            &known_importers,
+                            &mut importer_queue,
+                        );
+                    } else if let Some(key) = spec.version.resolved_key(name)
+                        && !should_skip(&key)
+                        && snapshots.is_some_and(|snapshots| snapshots.contains_key(&key))
+                    {
+                        snapshot_queue.push_back(key);
+                    }
+                }
+            }
+        }
+
+        while let Some(key) = snapshot_queue.pop_front() {
+            if !snapshot_keys.insert(key.clone()) {
+                continue;
+            }
+            let Some(snapshot) = snapshots.and_then(|snapshots| snapshots.get(&key)) else {
+                continue;
+            };
+            for map in [
+                snapshot.dependencies.as_ref(),
+                included
+                    .optional_dependencies
+                    .then_some(snapshot.optional_dependencies.as_ref())
+                    .flatten(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                for (alias, dep_ref) in map {
+                    if let Some(target) = dep_ref.as_link_target() {
+                        enqueue_linked_importer(
+                            workspace_root,
+                            target,
+                            &known_importers,
+                            &mut importer_queue,
+                        );
+                    } else if let Some(child) = dep_ref.resolve(alias)
+                        && !should_skip(&child)
+                        && snapshots.is_some_and(|snapshots| snapshots.contains_key(&child))
+                    {
+                        snapshot_queue.push_back(child);
+                    }
+                }
+            }
+        }
     }
-    snapshots.contains_key(&resolved).then_some(resolved)
+
+    ReachableLockfileGraph { importer_ids, snapshot_keys }
+}
+
+fn enqueue_linked_importer(
+    base: &Path,
+    target: &str,
+    known_importers: &HashMap<std::path::PathBuf, String>,
+    importer_queue: &mut VecDeque<String>,
+) {
+    if let Some(importer_id) = linked_importer_id(base, target, known_importers) {
+        importer_queue.push_back(importer_id);
+    }
+}
+
+fn linked_importer_id(
+    base: &Path,
+    target: &str,
+    known_importers: &HashMap<std::path::PathBuf, String>,
+) -> Option<String> {
+    let target = Path::new(target);
+    let resolved = if target.is_absolute() {
+        pacquet_fs::lexical_normalize(target)
+    } else {
+        pacquet_fs::lexical_normalize(&base.join(target))
+    };
+    known_importers.get(&resolved).cloned()
 }
 
 #[cfg(test)]

--- a/pnpm/crates/package-manager/src/current_lockfile.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile.rs
@@ -103,6 +103,20 @@ pub fn materialization_closure(
     }
 }
 
+/// Build the complete wanted lockfile for a filtered install: the
+/// selected importers take their freshly-resolved entries, and every other
+/// importer in `real_importer_ids` keeps the pins `previous_wanted`
+/// recorded. The wanted lockfile stays workspace-global no matter how
+/// narrow the filter is, so `pnpm install --filter` never truncates the
+/// entries of the projects it did not touch.
+///
+/// `freshly_resolved` must contain an entry for every id in
+/// `real_importer_ids`, not just the selected ones: when a global
+/// resolution input (settings, catalogs, overrides, a pnpmfile, ...) drifts
+/// from `previous_wanted`, the previous entries cannot be reused and every
+/// importer falls back to its fresh entry. Resolving only the selected
+/// subset therefore fails with [`MergeFilteredWantedLockfileError::MissingImporter`]
+/// exactly when those inputs changed.
 pub fn merge_filtered_wanted_lockfile(
     previous_wanted: Option<&Lockfile>,
     mut freshly_resolved: Lockfile,
@@ -294,6 +308,11 @@ pub fn filter_lockfile_for_current(
     skipped: &SkippedSnapshots,
 ) -> Lockfile {
     let all_importer_ids = lockfile.importers.keys().cloned().collect();
+    // Every importer is a root here, so no importer has to be *discovered*
+    // through a `link:` dep and the walk needs no real workspace root to
+    // resolve those links against. The empty root keeps the walk in the
+    // lockfile-relative space importer IDs already use — `importer_root_dir("", id)`
+    // is `id` — so link resolution stays correct rather than merely unused.
     materialization_closure(lockfile, Path::new(""), &all_importer_ids, included, skipped).lockfile
 }
 

--- a/pnpm/crates/package-manager/src/current_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile/tests.rs
@@ -989,6 +989,38 @@ fn merge_filtered_wanted_lockfile_rejects_a_missing_selected_importer() {
 }
 
 #[test]
+fn merge_filtered_wanted_lockfile_keeps_a_dependency_free_importer() {
+    // A dependency-free importer is *present-but-empty* in the fresh
+    // lockfile, not absent: pnpm's `pruneLockfile` records it as
+    // `{ specifiers: {} }` and the pnpr resolver returns every requested
+    // importer. So an unfiltered full-workspace merge that lists a dep-free
+    // project in `real_importer_ids` finds its empty snapshot and merges it
+    // without a `MissingImporter` error (that error is reserved for an
+    // importer genuinely absent from the fresh lockfile — a partial
+    // resolution — as the sibling test above covers).
+    let app_id = "packages/app".to_string();
+    let lib_id = "packages/lib".to_string();
+    let fresh_app = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("dep", "1.0.0")])),
+        ..Default::default()
+    };
+    let mut fresh = lockfile_with_top_level("same", 0);
+    fresh.importers = HashMap::from([
+        (app_id.clone(), fresh_app.clone()),
+        (lib_id.clone(), ProjectSnapshot::default()),
+    ]);
+    fresh.snapshots = Some(HashMap::from([(key("dep", "1.0.0"), SnapshotEntry::default())]));
+
+    let all = HashSet::from([app_id.clone(), lib_id.clone()]);
+    let merged =
+        super::merge_filtered_wanted_lockfile(None, fresh, &all, &all, Path::new("/workspace"))
+            .expect("a dependency-free importer present as an empty snapshot must not error");
+
+    assert_eq!(merged.importers.get(&app_id), Some(&fresh_app));
+    assert_eq!(merged.importers.get(&lib_id), Some(&ProjectSnapshot::default()));
+}
+
+#[test]
 fn merge_filtered_current_lockfile_preserves_prior_importers_across_sequential_runs() {
     let first_id = "packages/first".to_string();
     let second_id = "packages/second".to_string();

--- a/pnpm/crates/package-manager/src/current_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile/tests.rs
@@ -694,7 +694,7 @@ fn nested_importer_and_peer_snapshot_links_use_distinct_bases() {
 
     assert_eq!(
         closure.importer_ids,
-        HashSet::from([nested_id, importer_target_id, snapshot_target_id])
+        HashSet::from([nested_id, importer_target_id, snapshot_target_id]),
     );
 }
 
@@ -900,7 +900,7 @@ fn merge_filtered_wanted_lockfile_refreshes_all_importers_when_global_inputs_cha
     assert!(!snapshots.contains_key(&key("old-child", "1.0.0")));
     assert_eq!(
         merged.packages.as_ref().unwrap().get(&key("shared", "1.0.0")),
-        expected_shared_metadata.as_ref()
+        expected_shared_metadata.as_ref(),
     );
     assert_eq!(merged.lockfile_version, expected_lockfile_version);
     assert_eq!(merged.settings, expected_settings);
@@ -1156,7 +1156,7 @@ fn merge_filtered_current_lockfile_uses_one_fresh_shared_snapshot() {
     assert!(!snapshots.contains_key(&key("old-child", "1.0.0")));
     assert_eq!(
         merged.packages.as_ref().unwrap().get(&key("shared", "1.0.0")),
-        Some(&fresh_shared_metadata)
+        Some(&fresh_shared_metadata),
     );
 }
 

--- a/pnpm/crates/package-manager/src/current_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile/tests.rs
@@ -1,11 +1,16 @@
 //! Unit tests for [`super::filter_lockfile_for_current`].
 
-use std::collections::HashMap;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    path::Path,
+};
 
+use indexmap::IndexMap;
 use pacquet_lockfile::{
-    ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileVersion, PackageKey,
-    PackageMetadata, PkgName, PkgVerPeer, ProjectSnapshot, ResolvedDependencyMap,
-    ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, TarballResolution,
+    CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileSettings,
+    LockfileVersion, PackageKey, PackageMetadata, PkgName, PkgVerPeer, ProjectSnapshot,
+    ResolvedCatalogEntry, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef,
+    SnapshotEntry, TarballResolution,
 };
 use pacquet_modules_yaml::IncludedDependencies;
 use pretty_assertions::assert_eq;
@@ -28,6 +33,13 @@ fn importer_dep(version: &str) -> ResolvedDependencySpec {
     ResolvedDependencySpec {
         specifier: version.to_string(),
         version: ImporterDepVersion::Regular(ver(version)),
+    }
+}
+
+fn importer_link(target: &str) -> ResolvedDependencySpec {
+    ResolvedDependencySpec {
+        specifier: "workspace:*".to_string(),
+        version: ImporterDepVersion::Link(target.to_string()),
     }
 }
 
@@ -81,6 +93,44 @@ fn empty_lockfile() -> Lockfile {
 
 fn include_all() -> IncludedDependencies {
     IncludedDependencies { dependencies: true, dev_dependencies: true, optional_dependencies: true }
+}
+
+fn lockfile_with_top_level(marker: &str, minor: u16) -> Lockfile {
+    let catalogs = CatalogSnapshots::from([(
+        "default".to_string(),
+        BTreeMap::from([(
+            "catalog-pkg".to_string(),
+            ResolvedCatalogEntry {
+                specifier: format!("{marker}-specifier"),
+                version: format!("{marker}-version"),
+            },
+        )]),
+    )]);
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer { major: 9, minor }).unwrap(),
+        settings: Some(LockfileSettings {
+            auto_install_peers: marker == "fresh",
+            dedupe_peers: Some(marker == "fresh"),
+            exclude_links_from_lockfile: marker != "fresh",
+            inject_workspace_packages: marker == "fresh",
+            peers_suffix_max_length: Some(if marker == "fresh" { 2000 } else { 1000 }),
+        }),
+        catalogs: Some(catalogs),
+        overrides: Some(IndexMap::from([(
+            "override-pkg".to_string(),
+            format!("{marker}-override"),
+        )])),
+        package_extensions_checksum: Some(format!("{marker}-extensions")),
+        pnpmfile_checksum: Some(format!("{marker}-pnpmfile")),
+        ignored_optional_dependencies: Some(vec![format!("{marker}-ignored")]),
+        patched_dependencies: Some(BTreeMap::from([(
+            "patched@1.0.0".to_string(),
+            format!("{marker}-patch"),
+        )])),
+        importers: HashMap::new(),
+        packages: None,
+        snapshots: None,
+    }
 }
 
 #[test]
@@ -384,4 +434,774 @@ fn orphan_snapshots_are_pruned() {
     assert_eq!(snaps.len(), 1);
     assert!(snaps.contains_key(&key("a", "1.0.0")));
     assert!(!snaps.contains_key(&key("orphan", "1.0.0")));
+}
+
+#[test]
+fn materialization_closure_traverses_importer_snapshot_and_link_cycles() {
+    let nested_id = "packages/nested/a".to_string();
+    let linked_id = "packages/b".to_string();
+    let shared_id = "packages/shared".to_string();
+    let disjoint_id = "packages/disjoint".to_string();
+
+    let mut nested_deps = importer_map(&[("start", "1.0.0")]);
+    nested_deps.insert(pkg("linked-workspace"), importer_link("../../../packages/b"));
+    let mut linked_deps = importer_map(&[("linked-pkg", "1.0.0")]);
+    linked_deps.insert(pkg("back-to-start"), importer_link("../nested/a"));
+
+    let importers = HashMap::from([
+        (
+            nested_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(nested_deps),
+                dev_dependencies: Some(importer_map(&[("dev-only", "1.0.0")])),
+                optional_dependencies: Some(importer_map(&[("optional-only", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+        (
+            linked_id.clone(),
+            ProjectSnapshot { dependencies: Some(linked_deps), ..Default::default() },
+        ),
+        (
+            shared_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(importer_map(&[("shared-pkg", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+        (
+            disjoint_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(importer_map(&[("disjoint", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+    ]);
+
+    let snapshots = HashMap::from([
+        (
+            key("start", "1.0.0"),
+            SnapshotEntry {
+                dependencies: Some(HashMap::from([
+                    (pkg("child"), SnapshotDepRef::Plain(ver("1.0.0"))),
+                    (pkg("common"), SnapshotDepRef::Plain(ver("1.0.0"))),
+                    (pkg("shared-workspace"), SnapshotDepRef::Link("packages/shared".to_string())),
+                ])),
+                ..Default::default()
+            },
+        ),
+        (key("child", "1.0.0"), snapshot_with_deps(&[("start", "1.0.0")])),
+        (key("linked-pkg", "1.0.0"), snapshot_with_deps(&[("common", "1.0.0")])),
+        (key("common", "1.0.0"), SnapshotEntry::default()),
+        (
+            key("shared-pkg", "1.0.0"),
+            SnapshotEntry {
+                dependencies: Some(HashMap::from([(
+                    pkg("back-to-nested"),
+                    SnapshotDepRef::Link("packages/nested/a".to_string()),
+                )])),
+                ..Default::default()
+            },
+        ),
+        (key("dev-only", "1.0.0"), SnapshotEntry::default()),
+        (key("optional-only", "1.0.0"), SnapshotEntry::default()),
+        (key("disjoint", "1.0.0"), SnapshotEntry::default()),
+    ]);
+    let lockfile = Lockfile { importers, snapshots: Some(snapshots), ..empty_lockfile() };
+    let selected = HashSet::from([nested_id.clone()]);
+    let included = IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: false,
+        optional_dependencies: false,
+    };
+
+    let closure = super::materialization_closure(
+        &lockfile,
+        Path::new("/workspace"),
+        &selected,
+        included,
+        &SkippedSnapshots::new(),
+    );
+
+    assert_eq!(closure.importer_ids, HashSet::from([nested_id.clone(), linked_id, shared_id]));
+    assert!(!closure.importer_ids.contains(&disjoint_id));
+    let nested = closure.lockfile.importers.get(&nested_id).unwrap();
+    assert!(nested.dev_dependencies.is_none());
+    assert!(nested.optional_dependencies.is_none());
+    let reached = closure.lockfile.snapshots.as_ref().unwrap();
+    for reached_key in [
+        key("start", "1.0.0"),
+        key("child", "1.0.0"),
+        key("linked-pkg", "1.0.0"),
+        key("common", "1.0.0"),
+        key("shared-pkg", "1.0.0"),
+    ] {
+        assert!(reached.contains_key(&reached_key), "missing {reached_key}");
+    }
+    assert!(!reached.contains_key(&key("dev-only", "1.0.0")));
+    assert!(!reached.contains_key(&key("optional-only", "1.0.0")));
+    assert!(!reached.contains_key(&key("disjoint", "1.0.0")));
+}
+
+#[test]
+fn materialization_closure_excludes_transitive_optional_shared_snapshot_when_disabled() {
+    let selected_id = "packages/selected".to_string();
+    let unselected_id = "packages/unselected".to_string();
+    let lockfile = Lockfile {
+        importers: HashMap::from([
+            (
+                selected_id.clone(),
+                ProjectSnapshot {
+                    dependencies: Some(importer_map(&[("parent", "1.0.0")])),
+                    ..Default::default()
+                },
+            ),
+            (
+                unselected_id,
+                ProjectSnapshot {
+                    dependencies: Some(importer_map(&[("shared", "1.0.0")])),
+                    ..Default::default()
+                },
+            ),
+        ]),
+        snapshots: Some(HashMap::from([
+            (
+                key("parent", "1.0.0"),
+                SnapshotEntry {
+                    optional_dependencies: Some(HashMap::from([(
+                        pkg("shared"),
+                        SnapshotDepRef::Plain(ver("1.0.0")),
+                    )])),
+                    ..Default::default()
+                },
+            ),
+            (key("shared", "1.0.0"), SnapshotEntry::default()),
+        ])),
+        ..empty_lockfile()
+    };
+    let included = IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: true,
+        optional_dependencies: false,
+    };
+
+    let closure = super::materialization_closure(
+        &lockfile,
+        Path::new("/workspace"),
+        &HashSet::from([selected_id.clone()]),
+        included,
+        &SkippedSnapshots::new(),
+    );
+
+    assert_eq!(closure.importer_ids, HashSet::from([selected_id]));
+    let snapshots = closure.lockfile.snapshots.as_ref().unwrap();
+    assert!(snapshots.contains_key(&key("parent", "1.0.0")));
+    assert!(!snapshots.contains_key(&key("shared", "1.0.0")));
+}
+
+#[test]
+fn materialization_closure_excludes_optional_snapshot_link_when_optionals_are_disabled() {
+    let selected_id = "packages/selected".to_string();
+    let linked_id = "packages/linked".to_string();
+    let lockfile = Lockfile {
+        importers: HashMap::from([
+            (
+                selected_id.clone(),
+                ProjectSnapshot {
+                    dependencies: Some(importer_map(&[("parent", "1.0.0")])),
+                    ..Default::default()
+                },
+            ),
+            (
+                linked_id.clone(),
+                ProjectSnapshot {
+                    dependencies: Some(importer_map(&[("linked-pkg", "1.0.0")])),
+                    ..Default::default()
+                },
+            ),
+        ]),
+        snapshots: Some(HashMap::from([
+            (
+                key("parent", "1.0.0"),
+                SnapshotEntry {
+                    optional_dependencies: Some(HashMap::from([(
+                        pkg("linked"),
+                        SnapshotDepRef::Link("packages/linked".to_string()),
+                    )])),
+                    ..Default::default()
+                },
+            ),
+            (key("linked-pkg", "1.0.0"), SnapshotEntry::default()),
+        ])),
+        ..empty_lockfile()
+    };
+    let included = IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: true,
+        optional_dependencies: false,
+    };
+
+    let closure = super::materialization_closure(
+        &lockfile,
+        Path::new("/workspace"),
+        &HashSet::from([selected_id.clone()]),
+        included,
+        &SkippedSnapshots::new(),
+    );
+
+    assert_eq!(closure.importer_ids, HashSet::from([selected_id]));
+    assert!(!closure.importer_ids.contains(&linked_id));
+    let snapshots = closure.lockfile.snapshots.as_ref().unwrap();
+    assert!(snapshots.contains_key(&key("parent", "1.0.0")));
+    assert!(!snapshots.contains_key(&key("linked-pkg", "1.0.0")));
+}
+
+#[test]
+fn nested_importer_and_peer_snapshot_links_use_distinct_bases() {
+    let nested_id = "packages/nested/a".to_string();
+    let importer_target_id = "packages/importer-target".to_string();
+    let snapshot_target_id = "packages/snapshot-target".to_string();
+    let provider_version = "1.0.0(peer@2.0.0)";
+    let mut dependencies = importer_map(&[("provider", provider_version)]);
+    dependencies.insert(pkg("importer-target"), importer_link("../../../packages/importer-target"));
+    let importers = HashMap::from([
+        (
+            nested_id.clone(),
+            ProjectSnapshot { dependencies: Some(dependencies), ..Default::default() },
+        ),
+        (importer_target_id.clone(), ProjectSnapshot::default()),
+        (snapshot_target_id.clone(), ProjectSnapshot::default()),
+    ]);
+    let snapshots = HashMap::from([(
+        key("provider", provider_version),
+        SnapshotEntry {
+            dependencies: Some(HashMap::from([(
+                pkg("snapshot-target"),
+                SnapshotDepRef::Link("packages/snapshot-target".to_string()),
+            )])),
+            ..Default::default()
+        },
+    )]);
+    let lockfile = Lockfile { importers, snapshots: Some(snapshots), ..empty_lockfile() };
+
+    let closure = super::materialization_closure(
+        &lockfile,
+        Path::new("/workspace"),
+        &HashSet::from([nested_id.clone()]),
+        include_all(),
+        &SkippedSnapshots::new(),
+    );
+
+    assert_eq!(
+        closure.importer_ids,
+        HashSet::from([nested_id, importer_target_id, snapshot_target_id])
+    );
+}
+
+#[test]
+fn materialization_closure_ignores_unknown_link_targets() {
+    let mut dependencies = importer_map(&[("parent", "1.0.0")]);
+    dependencies.insert(pkg("outside"), importer_link("../outside"));
+    let importers = HashMap::from([
+        (
+            Lockfile::ROOT_IMPORTER_KEY.to_string(),
+            ProjectSnapshot { dependencies: Some(dependencies), ..Default::default() },
+        ),
+        ("packages/known".to_string(), ProjectSnapshot::default()),
+    ]);
+    let snapshots = HashMap::from([(
+        key("parent", "1.0.0"),
+        SnapshotEntry {
+            dependencies: Some(HashMap::from([(
+                pkg("missing"),
+                SnapshotDepRef::Link("packages/missing".to_string()),
+            )])),
+            ..Default::default()
+        },
+    )]);
+    let lockfile = Lockfile { importers, snapshots: Some(snapshots), ..empty_lockfile() };
+
+    let closure = super::materialization_closure(
+        &lockfile,
+        Path::new("/workspace"),
+        &HashSet::from([Lockfile::ROOT_IMPORTER_KEY.to_string()]),
+        include_all(),
+        &SkippedSnapshots::new(),
+    );
+
+    assert_eq!(closure.importer_ids, HashSet::from([Lockfile::ROOT_IMPORTER_KEY.to_string()]));
+    assert_eq!(closure.lockfile.importers.len(), 1);
+}
+
+#[test]
+fn materialization_closure_does_not_follow_reverse_workspace_links() {
+    let selected_id = "packages/shared".to_string();
+    let dependent_id = "packages/app".to_string();
+    let mut dependent_dependencies = importer_map(&[("app-only", "1.0.0")]);
+    dependent_dependencies.insert(pkg("shared"), importer_link("../shared"));
+    let lockfile = Lockfile {
+        importers: HashMap::from([
+            (
+                selected_id.clone(),
+                ProjectSnapshot {
+                    dependencies: Some(importer_map(&[("shared-only", "1.0.0")])),
+                    ..Default::default()
+                },
+            ),
+            (
+                dependent_id.clone(),
+                ProjectSnapshot {
+                    dependencies: Some(dependent_dependencies),
+                    ..Default::default()
+                },
+            ),
+        ]),
+        snapshots: Some(HashMap::from([
+            (key("shared-only", "1.0.0"), SnapshotEntry::default()),
+            (key("app-only", "1.0.0"), SnapshotEntry::default()),
+        ])),
+        ..empty_lockfile()
+    };
+
+    let closure = super::materialization_closure(
+        &lockfile,
+        Path::new("/workspace"),
+        &HashSet::from([selected_id.clone()]),
+        include_all(),
+        &SkippedSnapshots::new(),
+    );
+
+    assert_eq!(closure.importer_ids, HashSet::from([selected_id]));
+    assert!(!closure.importer_ids.contains(&dependent_id));
+    let snapshots = closure.lockfile.snapshots.as_ref().unwrap();
+    assert!(snapshots.contains_key(&key("shared-only", "1.0.0")));
+    assert!(!snapshots.contains_key(&key("app-only", "1.0.0")));
+}
+
+#[test]
+fn merge_filtered_wanted_lockfile_refreshes_all_importers_when_global_inputs_change() {
+    let selected_id = "packages/selected".to_string();
+    let retained_id = "packages/retained".to_string();
+    let removed_id = "packages/removed".to_string();
+    let new_id = "packages/new".to_string();
+
+    let prior_retained = ProjectSnapshot {
+        specifiers: Some(HashMap::from([("retained".to_string(), "prior".to_string())])),
+        dependencies: Some(importer_map(&[("retained", "1.0.0"), ("shared", "1.0.0")])),
+        ..Default::default()
+    };
+    let mut previous = lockfile_with_top_level("prior", 0);
+    previous.importers = HashMap::from([
+        (
+            selected_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(importer_map(&[("selected-old", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+        (retained_id.clone(), prior_retained),
+        (
+            removed_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(importer_map(&[("removed", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+    ]);
+    previous.snapshots = Some(HashMap::from([
+        (key("selected-old", "1.0.0"), SnapshotEntry::default()),
+        (key("retained", "1.0.0"), snapshot_with_deps(&[("retained-child", "1.0.0")])),
+        (key("retained-child", "1.0.0"), SnapshotEntry::default()),
+        (key("shared", "1.0.0"), snapshot_with_deps(&[("old-child", "1.0.0")])),
+        (key("old-child", "1.0.0"), SnapshotEntry::default()),
+        (key("removed", "1.0.0"), SnapshotEntry::default()),
+    ]));
+    previous.packages = Some(
+        previous
+            .snapshots
+            .as_ref()
+            .unwrap()
+            .keys()
+            .map(|package_key| {
+                (package_key.without_peer(), package_metadata(&format!("prior-{package_key}")))
+            })
+            .collect(),
+    );
+
+    let fresh_selected = ProjectSnapshot {
+        specifiers: Some(HashMap::from([("selected-new".to_string(), "fresh".to_string())])),
+        dependencies: Some(importer_map(&[("selected-new", "2.0.0"), ("shared", "1.0.0")])),
+        ..Default::default()
+    };
+    let fresh_new = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("new-pkg", "1.0.0")])),
+        ..Default::default()
+    };
+    let mut fresh = lockfile_with_top_level("fresh", 1);
+    let fresh_retained = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("fresh-only", "2.0.0")])),
+        ..Default::default()
+    };
+    fresh.importers = HashMap::from([
+        (selected_id.clone(), fresh_selected.clone()),
+        (retained_id.clone(), fresh_retained.clone()),
+        (new_id.clone(), fresh_new.clone()),
+    ]);
+    let fresh_shared = snapshot_with_deps(&[("fresh-child", "2.0.0")]);
+    fresh.snapshots = Some(HashMap::from([
+        (key("selected-new", "2.0.0"), SnapshotEntry::default()),
+        (key("shared", "1.0.0"), fresh_shared.clone()),
+        (key("fresh-child", "2.0.0"), SnapshotEntry::default()),
+        (key("fresh-only", "2.0.0"), SnapshotEntry::default()),
+        (key("new-pkg", "1.0.0"), SnapshotEntry::default()),
+    ]));
+    fresh.packages = Some(
+        fresh
+            .snapshots
+            .as_ref()
+            .unwrap()
+            .keys()
+            .map(|package_key| {
+                (package_key.without_peer(), package_metadata(&format!("fresh-{package_key}")))
+            })
+            .collect(),
+    );
+    let expected_lockfile_version = fresh.lockfile_version;
+    let expected_settings = fresh.settings.clone();
+    let expected_catalogs = fresh.catalogs.clone();
+    let expected_overrides = fresh.overrides.clone();
+    let expected_package_extensions_checksum = fresh.package_extensions_checksum.clone();
+    let expected_pnpmfile_checksum = fresh.pnpmfile_checksum.clone();
+    let expected_ignored_optional_dependencies = fresh.ignored_optional_dependencies.clone();
+    let expected_patched_dependencies = fresh.patched_dependencies.clone();
+    let expected_shared_metadata =
+        fresh.packages.as_ref().unwrap().get(&key("shared", "1.0.0")).cloned();
+
+    let merged = super::merge_filtered_wanted_lockfile(
+        Some(&previous),
+        fresh,
+        &HashSet::from([selected_id.clone(), retained_id.clone(), new_id.clone()]),
+        &HashSet::from([selected_id.clone()]),
+        Path::new("/workspace"),
+    )
+    .expect("the fresh lockfile contains every required importer");
+
+    assert_eq!(merged.importers.get(&selected_id), Some(&fresh_selected));
+    assert_eq!(merged.importers.get(&retained_id), Some(&fresh_retained));
+    assert_eq!(merged.importers.get(&new_id), Some(&fresh_new));
+    assert!(!merged.importers.contains_key(&removed_id));
+    let snapshots = merged.snapshots.as_ref().unwrap();
+    assert!(!snapshots.contains_key(&key("retained", "1.0.0")));
+    assert!(!snapshots.contains_key(&key("retained-child", "1.0.0")));
+    assert!(snapshots.contains_key(&key("fresh-only", "2.0.0")));
+    assert!(!snapshots.contains_key(&key("selected-old", "1.0.0")));
+    assert_eq!(snapshots.get(&key("shared", "1.0.0")), Some(&fresh_shared));
+    assert!(snapshots.contains_key(&key("fresh-child", "2.0.0")));
+    assert!(!snapshots.contains_key(&key("old-child", "1.0.0")));
+    assert_eq!(
+        merged.packages.as_ref().unwrap().get(&key("shared", "1.0.0")),
+        expected_shared_metadata.as_ref()
+    );
+    assert_eq!(merged.lockfile_version, expected_lockfile_version);
+    assert_eq!(merged.settings, expected_settings);
+    assert_eq!(merged.catalogs, expected_catalogs);
+    assert_eq!(merged.overrides, expected_overrides);
+    assert_eq!(merged.package_extensions_checksum, expected_package_extensions_checksum);
+    assert_eq!(merged.pnpmfile_checksum, expected_pnpmfile_checksum);
+    assert_eq!(merged.ignored_optional_dependencies, expected_ignored_optional_dependencies);
+    assert_eq!(merged.patched_dependencies, expected_patched_dependencies);
+}
+
+#[test]
+fn merge_filtered_wanted_lockfile_preserves_unselected_importers_when_global_inputs_match() {
+    let selected_id = "packages/selected".to_string();
+    let retained_id = "packages/retained".to_string();
+    let prior_retained = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("retained-old", "1.0.0")])),
+        ..Default::default()
+    };
+    let mut previous = lockfile_with_top_level("same", 0);
+    previous.importers = HashMap::from([
+        (
+            selected_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(importer_map(&[("selected-old", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+        (retained_id.clone(), prior_retained.clone()),
+    ]);
+    previous.snapshots = Some(HashMap::from([
+        (key("selected-old", "1.0.0"), SnapshotEntry::default()),
+        (key("retained-old", "1.0.0"), SnapshotEntry::default()),
+    ]));
+
+    let fresh_selected = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("selected-new", "2.0.0")])),
+        ..Default::default()
+    };
+    let mut fresh = lockfile_with_top_level("same", 0);
+    fresh.importers = HashMap::from([
+        (selected_id.clone(), fresh_selected.clone()),
+        (
+            retained_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(importer_map(&[("retained-fresh", "2.0.0")])),
+                ..Default::default()
+            },
+        ),
+    ]);
+    fresh.snapshots = Some(HashMap::from([
+        (key("selected-new", "2.0.0"), SnapshotEntry::default()),
+        (key("retained-fresh", "2.0.0"), SnapshotEntry::default()),
+    ]));
+
+    let merged = super::merge_filtered_wanted_lockfile(
+        Some(&previous),
+        fresh,
+        &HashSet::from([selected_id.clone(), retained_id.clone()]),
+        &HashSet::from([selected_id.clone()]),
+        Path::new("/workspace"),
+    )
+    .expect("fresh lockfile contains every real importer");
+
+    assert_eq!(merged.importers.get(&selected_id), Some(&fresh_selected));
+    assert_eq!(merged.importers.get(&retained_id), Some(&prior_retained));
+    let snapshots = merged.snapshots.as_ref().expect("merged snapshots");
+    assert!(snapshots.contains_key(&key("selected-new", "2.0.0")));
+    assert!(snapshots.contains_key(&key("retained-old", "1.0.0")));
+    assert!(!snapshots.contains_key(&key("selected-old", "1.0.0")));
+    assert!(!snapshots.contains_key(&key("retained-fresh", "2.0.0")));
+}
+
+#[test]
+fn merge_filtered_wanted_lockfile_rejects_a_missing_selected_importer() {
+    let error = super::merge_filtered_wanted_lockfile(
+        None,
+        empty_lockfile(),
+        &HashSet::from(["packages/selected".to_string()]),
+        &HashSet::from(["packages/selected".to_string()]),
+        Path::new("/workspace"),
+    )
+    .expect_err("a selected importer missing from the fresh lockfile must be rejected");
+
+    assert_eq!(error.to_string(), "fresh lockfile is missing importer packages/selected");
+}
+
+#[test]
+fn merge_filtered_current_lockfile_preserves_prior_importers_across_sequential_runs() {
+    let first_id = "packages/first".to_string();
+    let second_id = "packages/second".to_string();
+    let mut previous = lockfile_with_top_level("prior", 0);
+    let prior_first = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("first-old", "1.0.0")])),
+        ..Default::default()
+    };
+    previous.importers = HashMap::from([
+        (first_id.clone(), prior_first.clone()),
+        (
+            second_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(importer_map(&[("second-old", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+    ]);
+    previous.snapshots = Some(HashMap::from([
+        (key("first-old", "1.0.0"), SnapshotEntry::default()),
+        (key("second-old", "1.0.0"), SnapshotEntry::default()),
+    ]));
+
+    let mut wanted = lockfile_with_top_level("fresh", 1);
+    let fresh_second = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("second-new", "2.0.0")])),
+        ..Default::default()
+    };
+    wanted.importers = HashMap::from([
+        (
+            first_id.clone(),
+            ProjectSnapshot {
+                dependencies: Some(importer_map(&[("fresh-only-first", "2.0.0")])),
+                ..Default::default()
+            },
+        ),
+        (second_id.clone(), fresh_second.clone()),
+    ]);
+    wanted.snapshots = Some(HashMap::from([
+        (key("fresh-only-first", "2.0.0"), SnapshotEntry::default()),
+        (key("second-new", "2.0.0"), SnapshotEntry::default()),
+    ]));
+    let expected_settings = wanted.settings.clone();
+
+    let merged = super::merge_filtered_current_lockfile(
+        Some(&previous),
+        &wanted,
+        &HashSet::from([second_id.clone()]),
+        include_all(),
+        &SkippedSnapshots::new(),
+        Path::new("/workspace"),
+    );
+
+    assert_eq!(merged.importers.get(&first_id), Some(&prior_first));
+    assert_eq!(merged.importers.get(&second_id), Some(&fresh_second));
+    let snapshots = merged.snapshots.as_ref().unwrap();
+    assert!(snapshots.contains_key(&key("first-old", "1.0.0")));
+    assert!(snapshots.contains_key(&key("second-new", "2.0.0")));
+    assert!(!snapshots.contains_key(&key("second-old", "1.0.0")));
+    assert!(!snapshots.contains_key(&key("fresh-only-first", "2.0.0")));
+    assert_eq!(merged.settings, expected_settings);
+}
+
+#[test]
+fn merge_filtered_current_lockfile_does_not_restore_a_skipped_selected_snapshot() {
+    let selected_id = "packages/selected".to_string();
+    let selected_importer = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("parent", "1.0.0")])),
+        ..Default::default()
+    };
+    let snapshots = HashMap::from([
+        (key("parent", "1.0.0"), snapshot_with_deps(&[("child", "1.0.0")])),
+        (key("child", "1.0.0"), SnapshotEntry::default()),
+    ]);
+    let packages = HashMap::from([
+        (key("parent", "1.0.0"), package_metadata("parent")),
+        (key("child", "1.0.0"), package_metadata("child")),
+    ]);
+    let previous = Lockfile {
+        importers: HashMap::from([(selected_id.clone(), selected_importer.clone())]),
+        snapshots: Some(snapshots.clone()),
+        packages: Some(packages.clone()),
+        ..empty_lockfile()
+    };
+    let wanted = Lockfile {
+        importers: HashMap::from([(selected_id.clone(), selected_importer)]),
+        snapshots: Some(snapshots),
+        packages: Some(packages),
+        ..empty_lockfile()
+    };
+    let mut skipped = SkippedSnapshots::new();
+    skipped.insert_installability(key("parent", "1.0.0"));
+
+    let merged = super::merge_filtered_current_lockfile(
+        Some(&previous),
+        &wanted,
+        &HashSet::from([selected_id]),
+        include_all(),
+        &skipped,
+        Path::new("/workspace"),
+    );
+
+    let snapshots = merged.snapshots.as_ref().unwrap();
+    assert!(!snapshots.contains_key(&key("parent", "1.0.0")));
+    assert!(!snapshots.contains_key(&key("child", "1.0.0")));
+    let packages = merged.packages.as_ref().unwrap();
+    assert!(packages.contains_key(&key("parent", "1.0.0")));
+    assert!(packages.contains_key(&key("child", "1.0.0")));
+}
+
+#[test]
+fn merge_filtered_current_lockfile_uses_one_fresh_shared_snapshot() {
+    let retained_id = "packages/retained".to_string();
+    let selected_id = "packages/selected".to_string();
+    let mut previous = empty_lockfile();
+    previous.importers = HashMap::from([(
+        retained_id.clone(),
+        ProjectSnapshot {
+            dependencies: Some(importer_map(&[("shared", "1.0.0")])),
+            ..Default::default()
+        },
+    )]);
+    previous.snapshots = Some(HashMap::from([
+        (key("shared", "1.0.0"), snapshot_with_deps(&[("old-child", "1.0.0")])),
+        (key("old-child", "1.0.0"), SnapshotEntry::default()),
+    ]));
+    previous.packages = Some(HashMap::from([
+        (key("shared", "1.0.0"), package_metadata("old-shared")),
+        (key("old-child", "1.0.0"), package_metadata("old-child")),
+    ]));
+
+    let mut wanted = empty_lockfile();
+    wanted.importers = HashMap::from([(
+        selected_id.clone(),
+        ProjectSnapshot {
+            dependencies: Some(importer_map(&[("shared", "1.0.0")])),
+            ..Default::default()
+        },
+    )]);
+    let fresh_shared = snapshot_with_deps(&[("fresh-child", "2.0.0")]);
+    let fresh_shared_metadata = package_metadata("fresh-shared");
+    wanted.snapshots = Some(HashMap::from([
+        (key("shared", "1.0.0"), fresh_shared.clone()),
+        (key("fresh-child", "2.0.0"), SnapshotEntry::default()),
+    ]));
+    wanted.packages = Some(HashMap::from([
+        (key("shared", "1.0.0"), fresh_shared_metadata.clone()),
+        (key("fresh-child", "2.0.0"), package_metadata("fresh-child")),
+    ]));
+
+    let merged = super::merge_filtered_current_lockfile(
+        Some(&previous),
+        &wanted,
+        &HashSet::from([selected_id.clone()]),
+        include_all(),
+        &SkippedSnapshots::new(),
+        Path::new("/workspace"),
+    );
+
+    assert!(merged.importers.contains_key(&retained_id));
+    assert!(merged.importers.contains_key(&selected_id));
+    let snapshots = merged.snapshots.as_ref().unwrap();
+    assert_eq!(snapshots.get(&key("shared", "1.0.0")), Some(&fresh_shared));
+    assert!(snapshots.contains_key(&key("fresh-child", "2.0.0")));
+    assert!(!snapshots.contains_key(&key("old-child", "1.0.0")));
+    assert_eq!(
+        merged.packages.as_ref().unwrap().get(&key("shared", "1.0.0")),
+        Some(&fresh_shared_metadata)
+    );
+}
+
+#[test]
+fn merge_filtered_current_lockfile_replaces_link_reached_importers() {
+    let selected_id = "packages/a".to_string();
+    let linked_id = "packages/b".to_string();
+    let mut previous = empty_lockfile();
+    previous.importers = HashMap::from([(
+        linked_id.clone(),
+        ProjectSnapshot {
+            dependencies: Some(importer_map(&[("linked-old", "1.0.0")])),
+            ..Default::default()
+        },
+    )]);
+    previous.snapshots =
+        Some(HashMap::from([(key("linked-old", "1.0.0"), SnapshotEntry::default())]));
+
+    let mut selected_dependencies = ResolvedDependencyMap::new();
+    selected_dependencies.insert(pkg("linked"), importer_link("../b"));
+    let fresh_linked = ProjectSnapshot {
+        dependencies: Some(importer_map(&[("linked-new", "2.0.0")])),
+        ..Default::default()
+    };
+    let mut wanted = empty_lockfile();
+    wanted.importers = HashMap::from([
+        (
+            selected_id.clone(),
+            ProjectSnapshot { dependencies: Some(selected_dependencies), ..Default::default() },
+        ),
+        (linked_id.clone(), fresh_linked.clone()),
+    ]);
+    wanted.snapshots =
+        Some(HashMap::from([(key("linked-new", "2.0.0"), SnapshotEntry::default())]));
+
+    let merged = super::merge_filtered_current_lockfile(
+        Some(&previous),
+        &wanted,
+        &HashSet::from([selected_id]),
+        include_all(),
+        &SkippedSnapshots::new(),
+        Path::new("/workspace"),
+    );
+
+    assert_eq!(merged.importers.get(&linked_id), Some(&fresh_linked));
+    assert!(merged.snapshots.as_ref().unwrap().contains_key(&key("linked-new", "2.0.0")));
+    assert!(!merged.snapshots.as_ref().unwrap().contains_key(&key("linked-old", "1.0.0")));
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1327,6 +1327,109 @@ fn workspace_link_child_renders_as_snapshot_link() {
 }
 
 #[test]
+fn snapshot_link_uses_lockfile_root_while_importer_link_uses_project_root() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "app",
+        "version": "1.0.0",
+        "dependencies": {
+            "consumer": "1.0.0",
+            "peer": "workspace:*",
+            "shared": "workspace:*",
+            "wrapper": "1.0.0",
+        },
+    }));
+    let shared = make_link_node("packages/shared", json!({ "name": "shared", "version": "1.0.0" }));
+    let peer = make_link_node("packages/peer", json!({ "name": "peer", "version": "1.0.0" }));
+    let wrapper = make_node(
+        "wrapper",
+        "1.0.0",
+        json!({ "name": "wrapper", "version": "1.0.0" }),
+        BTreeMap::from([("shared".to_string(), shared.dep_path.clone())]),
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+    let mut consumer = make_node(
+        "consumer",
+        "1.0.0",
+        json!({
+            "name": "consumer",
+            "version": "1.0.0",
+            "peerDependencies": { "peer": "*" },
+        }),
+        BTreeMap::from([("peer".to_string(), peer.dep_path.clone())]),
+        BTreeMap::from([(
+            "peer".to_string(),
+            PeerDep { version: "*".to_string(), optional: false, meta_only: false },
+        )]),
+        HashSet::new(),
+    );
+    consumer.dep_path = DepPath::from("consumer@1.0.0(peer@packages+peer)");
+    consumer.resolved_peer_names.insert("peer".to_string());
+
+    let mut graph = DependenciesGraph::new();
+    for node in [shared, peer, wrapper, consumer] {
+        graph.insert(node.dep_path.clone(), node);
+    }
+    let direct = BTreeMap::from([
+        ("consumer".to_string(), DepPath::from("consumer@1.0.0(peer@packages+peer)")),
+        ("peer".to_string(), DepPath::from("link:../../../packages/peer")),
+        ("shared".to_string(), DepPath::from("link:../../../packages/shared")),
+        ("wrapper".to_string(), DepPath::from("wrapper@1.0.0")),
+    ]);
+    let importers = BTreeMap::from([(
+        "apps/nested/app".to_string(),
+        ImporterLockfileInput { manifest: &manifest, direct_dependencies_by_alias: direct },
+    )]);
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        importers,
+        graph: &graph,
+        auto_install_peers: false,
+        dedupe_peers: false,
+        exclude_links_from_lockfile: false,
+        inject_workspace_packages: false,
+        peers_suffix_max_length: None,
+        overrides: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        catalogs: &EMPTY_CATALOGS,
+        registry: "https://registry.npmjs.org",
+        lockfile_include_tarball_url: false,
+    });
+
+    let importer = lockfile.importers.get("apps/nested/app").expect("nested importer");
+    let importer_dependencies = importer.dependencies.as_ref().expect("importer dependencies");
+    for name in ["shared", "peer"] {
+        let dependency = importer_dependencies.get(&PkgName::parse(name).unwrap()).unwrap();
+        match &dependency.version {
+            ImporterDepVersion::Link(target) => {
+                assert_eq!(target, &format!("../../../packages/{name}"));
+            }
+            other => panic!("expected importer Link(..), got {other:?}"),
+        }
+    }
+
+    let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
+    let wrapper_key: PackageKey = "wrapper@1.0.0".parse().unwrap();
+    let wrapper_dependencies = snapshots[&wrapper_key].dependencies.as_ref().unwrap();
+    assert_eq!(
+        wrapper_dependencies.get(&PkgName::parse("shared").unwrap()),
+        Some(&SnapshotDepRef::Link("packages/shared".to_string())),
+    );
+    let consumer_snapshot = snapshots
+        .iter()
+        .find(|(key, _)| key.to_string().starts_with("consumer@1.0.0("))
+        .map(|(_, snapshot)| snapshot)
+        .expect("consumer peer snapshot");
+    assert_eq!(
+        consumer_snapshot.dependencies.as_ref().unwrap().get(&PkgName::parse("peer").unwrap()),
+        Some(&SnapshotDepRef::Link("packages/peer".to_string())),
+    );
+}
+
+#[test]
 fn multi_importer_workspace_writes_per_project_lockfile_entries() {
     let (_a_tmp, a_manifest) = write_manifest(json!({
         "name": "a",

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -826,7 +826,7 @@ where
                 })
                 .collect(),
         };
-        let requested_importer_ids = selection.as_ref().map(|selection| {
+        let selected_importer_ids = selection.as_ref().map(|selection| {
             selection
                 .selected_dirs
                 .iter()
@@ -841,9 +841,10 @@ where
                 pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir)
             })
             .collect::<HashSet<_>>();
-        let filtered_install = requested_importer_ids
+        let filtered_install = selected_importer_ids
             .as_ref()
             .is_some_and(|selected_importer_ids| selected_importer_ids != &real_importer_ids);
+        let requested_importer_ids = if filtered_install { selected_importer_ids } else { None };
         // Only a full `pacquet install` may short-circuit. `add` and
         // `remove` mutate the manifest in memory and persist it after
         // this run returns, so the on-disk mtimes the check reads still
@@ -856,7 +857,7 @@ where
         // read as up to date and skip the registry re-resolution.
         let optimistic_decision = is_full_install
             && matches!(update_seed_policy, UpdateSeedPolicy::KeepAll)
-            && selection.is_none()
+            && !filtered_install
             && !frozen_lockfile
             && !disable_optimistic_repeat_install
             && check_optimistic_repeat_install(&OptimisticRepeatInstallCheck {
@@ -1259,7 +1260,7 @@ where
         }
         let old_modules = modules_manifest_res.ok().flatten();
         let modules_manifest = old_modules.as_ref();
-        let previous_modules_metadata = if selection.is_some() && !resolve_only {
+        let previous_modules_metadata = if filtered_install && !resolve_only {
             pacquet_modules_yaml::read_modules_manifest::<Host>(&config.modules_dir).ok().flatten()
         } else {
             None
@@ -1358,7 +1359,7 @@ where
                     }
                 }
             } else {
-                if selection.is_some() {
+                if filtered_install {
                     return Err(InstallError::UnsafeFilteredModulesDir {
                         modules_dir: config.modules_dir.clone(),
                         workspace_root: workspace_root.clone(),
@@ -1381,7 +1382,7 @@ where
             && !is_inconsistent
             && let Some(modules) = modules_manifest
             && let Some(current) = current_lockfile.as_ref()
-            && (selection.is_some() || modules.included != included)
+            && (filtered_install || modules.included != included)
         {
             let selected_prune_importer_ids = requested_importer_ids.as_ref().map(|requested| {
                 crate::materialization_closure(
@@ -1393,7 +1394,7 @@ where
                 )
                 .importer_ids
             });
-            let previously_included = if selection.is_some() {
+            let previously_included = if filtered_install {
                 IncludedDependencies {
                     dependencies: true,
                     dev_dependencies: true,
@@ -1414,7 +1415,7 @@ where
         }
 
         if take_frozen_path
-            && selection.is_none()
+            && !filtered_install
             && let Some(wanted_lockfile) = lockfile
             && let Some(current) = current_lockfile.as_ref()
             && wanted_lockfile == current
@@ -1835,7 +1836,7 @@ where
             .cloned()
             .collect::<Vec<_>>();
 
-        if selection.is_some()
+        if filtered_install
             && !matches!(node_linker, NodeLinker::Hoisted)
             && crate::should_write_package_map(config, node_linker)
             && let Some(current) = materialized_current_lockfile.as_ref()
@@ -1997,7 +1998,7 @@ where
             &ignored_builds,
             pruned_at,
         );
-        if selection.is_some()
+        if filtered_install
             && !matches!(node_linker, NodeLinker::Hoisted)
             && !is_inconsistent
             && let (Some(previous), Some(current), Some(selected)) = (
@@ -2164,7 +2165,7 @@ fn check_lockfile_freshness(
             lockfile,
             manifest,
             importer_id,
-            config.auto_install_peers,
+            config,
             &ignored_optional_matcher,
             parsed_overrides_opt.as_deref(),
         )?;
@@ -2233,7 +2234,7 @@ pub(crate) fn check_importer_satisfies(
     lockfile: &Lockfile,
     manifest: &PackageManifest,
     importer_id: &str,
-    auto_install_peers: bool,
+    config: &Config,
     ignored_optional_matcher: &pacquet_config::matcher::Matcher,
     parsed_overrides: Option<&[pacquet_config_parse_overrides::VersionOverride]>,
 ) -> Result<(), FreshnessCheckError> {
@@ -2249,16 +2250,26 @@ pub(crate) fn check_importer_satisfies(
     // override pass conceptually returns a new manifest
     // from the perspective of every consumer downstream of the
     // resolver.
-    let overrider_manifest_holder;
-    let manifest_for_freshness: &PackageManifest = if let Some(parsed) = parsed_overrides {
+    // `auto_install_peers` is folded into `satisfies_package_manifest`
+    // itself, so the manifest is cloned here only for the two mutations the
+    // comparison needs done up front: applying `pnpm.overrides` and dropping
+    // `link:` deps under `exclude_links_from_lockfile`.
+    let normalized_manifest_holder;
+    let manifest_for_freshness: &PackageManifest = if parsed_overrides.is_some()
+        || config.exclude_links_from_lockfile
+    {
         let root_dir = manifest.path().parent().unwrap_or_else(|| Path::new("."));
-        let overrider = crate::VersionsOverrider::new(parsed, root_dir);
-        overrider_manifest_holder = {
+        normalized_manifest_holder = {
             let mut cloned: PackageManifest = manifest.clone();
-            overrider.apply(&mut cloned, Some(root_dir));
+            if let Some(parsed) = parsed_overrides {
+                crate::VersionsOverrider::new(parsed, root_dir).apply(&mut cloned, Some(root_dir));
+            }
+            if config.exclude_links_from_lockfile {
+                exclude_linked_dependencies(&mut cloned);
+            }
             cloned
         };
-        &overrider_manifest_holder
+        &normalized_manifest_holder
     } else {
         manifest
     };
@@ -2278,7 +2289,7 @@ pub(crate) fn check_importer_satisfies(
     satisfies_package_manifest(
         importer,
         manifest_for_freshness,
-        auto_install_peers,
+        config.auto_install_peers,
         is_ignored_optional,
     )
     .map_err(FreshnessCheckError::Stale)
@@ -2309,6 +2320,25 @@ fn manifest_has_effective_dependencies(
             pacquet_package_manifest::DependencyGroup::Optional,
         ])
         .any(|(name, _)| !ignored.contains(name))
+}
+
+fn exclude_linked_dependencies(manifest: &mut PackageManifest) {
+    let Some(manifest) = manifest.value_mut().as_object_mut() else {
+        return;
+    };
+    for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
+        let group: &str = group.into();
+        if let Some(dependencies) =
+            manifest.get_mut(group).and_then(serde_json::Value::as_object_mut)
+        {
+            dependencies.retain(|_, specifier| {
+                let Some(specifier) = specifier.as_str() else {
+                    return true;
+                };
+                !specifier.starts_with("link:")
+            });
+        }
+    }
 }
 
 /// Outcome of [`check_lockfile_freshness`]. Splits "user

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -3011,7 +3011,18 @@ fn build_project_manifests_list<'a>(
             }
         })
         .collect::<Vec<_>>();
-    if !active_project_was_discovered && root_manifest.path().is_file() {
+    let active_manifest_has_dependencies = root_manifest
+        .dependencies([
+            DependencyGroup::Prod,
+            DependencyGroup::Dev,
+            DependencyGroup::Optional,
+            DependencyGroup::Peer,
+        ])
+        .next()
+        .is_some();
+    if !active_project_was_discovered
+        && (root_manifest.path().is_file() || active_manifest_has_dependencies)
+    {
         list.push((active_dir.to_path_buf(), root_manifest));
     }
     list

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -18,7 +18,7 @@ use pacquet_executor::{
 };
 use pacquet_lockfile::{
     LazyLockfile, LoadLockfileError, Lockfile, MaybeLazyLockfile, SaveLockfileError,
-    StalenessReason, satisfies_package_manifest,
+    StalenessReason, VersionPart, satisfies_package_manifest,
 };
 use pacquet_lockfile_verification::{
     VerifyError, VerifyLockfileResolutionsOptions, record_lockfile_verified,
@@ -40,7 +40,7 @@ use pacquet_workspace_state::{
     ProjectEntry, UpdateWorkspaceStateError, WorkspaceState, now_millis, update_workspace_state,
 };
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     io::IsTerminal,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
@@ -91,6 +91,36 @@ pub type PeerIssuesSink = Arc<
         std::collections::BTreeMap<String, pacquet_resolving_deps_resolver::PeerDependencyIssues>,
     >,
 >;
+
+pub struct WorkspaceInstallSelection<'a> {
+    pub all_projects: &'a [pacquet_workspace::Project],
+    pub ordered_dirs: &'a [PathBuf],
+    pub selected_dirs: &'a HashSet<PathBuf>,
+    pub active_manifest_is_standin: bool,
+}
+
+pub(crate) fn selected_project_indices(
+    projects: &[pacquet_workspace::Project],
+    ordered_dirs: &[PathBuf],
+    selected_dirs: &HashSet<PathBuf>,
+) -> Vec<usize> {
+    let project_indices = projects
+        .iter()
+        .enumerate()
+        .map(|(index, project)| (project.root_dir.as_path(), index))
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut seen_dirs = HashSet::with_capacity(selected_dirs.len());
+    let indices = ordered_dirs
+        .iter()
+        .filter(|dir| selected_dirs.contains(*dir))
+        .map(|dir| {
+            assert!(seen_dirs.insert(dir.as_path()), "selected project must be ordered once");
+            *project_indices.get(dir.as_path()).expect("every selected project must be discovered")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(seen_dirs.len(), selected_dirs.len(), "every selected project must be ordered");
+    indices
+}
 
 /// This subroutine does everything `pacquet install` is supposed to do.
 #[must_use]
@@ -373,6 +403,12 @@ pub enum InstallError {
     #[display("Failed to remove modules directory contents: {_0}")]
     RemoveModulesDir(#[error(source)] std::io::Error),
 
+    #[display(
+        "Cannot safely repair the filtered install because the modules directory at {modules_dir:?} is outside the workspace root at {workspace_root:?}"
+    )]
+    #[diagnostic(code(pacquet_package_manager::unsafe_filtered_modules_dir))]
+    UnsafeFilteredModulesDir { modules_dir: PathBuf, workspace_root: PathBuf },
+
     /// Surfaces a failure while removing the direct-dep links an
     /// `included` drift excluded — the non-destructive counterpart of
     /// the purge. See [`crate::prune_direct_deps_excluded_by_groups`].
@@ -496,13 +532,24 @@ pub enum InstallError {
     ConfigConflictFrozenStoreWithForce,
 }
 
+#[derive(Default)]
+struct InstallRunOptions<'install, 'selection> {
+    lockfile_verification_override: Option<LockfileVerificationOverride<'install>>,
+    rebuild: Option<RebuildOptions>,
+    selection: Option<WorkspaceInstallSelection<'selection>>,
+    root_manifest_as_workspace_root: bool,
+    /// Forces the interactive-prompt eligibility that is otherwise derived
+    /// from the process environment, so tests can exercise both branches.
+    prompt_eligibility_override: Option<bool>,
+}
+
 impl<'a, DependencyGroupList> Install<'a, DependencyGroupList>
 where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
     /// Execute the subroutine.
     pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), InstallError> {
-        self.run_inner::<Reporter>(None, None, None).await
+        Box::pin(self.run_inner::<Reporter>(InstallRunOptions::default())).await
     }
 
     #[cfg(test)]
@@ -510,14 +557,58 @@ where
         self,
         can_prompt: bool,
     ) -> Result<(), InstallError> {
-        self.run_inner::<Reporter>(None, None, Some(can_prompt)).await
+        Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
+            prompt_eligibility_override: Some(can_prompt),
+            ..Default::default()
+        }))
+        .await
     }
 
     pub async fn run_with_lockfile_verification<Reporter: self::Reporter + 'static>(
         self,
         lockfile_verification_override: LockfileVerificationOverride<'a>,
     ) -> Result<(), InstallError> {
-        self.run_inner::<Reporter>(Some(lockfile_verification_override), None, None).await
+        Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
+            lockfile_verification_override: Some(lockfile_verification_override),
+            ..Default::default()
+        }))
+        .await
+    }
+
+    pub async fn run_selected<Reporter: self::Reporter + 'static>(
+        self,
+        selection: WorkspaceInstallSelection<'_>,
+    ) -> Result<(), InstallError> {
+        Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
+            selection: Some(selection),
+            ..Default::default()
+        }))
+        .await
+    }
+
+    pub async fn run_selected_with_lockfile_verification<Reporter: self::Reporter + 'static>(
+        self,
+        selection: WorkspaceInstallSelection<'_>,
+        lockfile_verification_override: LockfileVerificationOverride<'a>,
+    ) -> Result<(), InstallError> {
+        Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
+            lockfile_verification_override: Some(lockfile_verification_override),
+            selection: Some(selection),
+            ..Default::default()
+        }))
+        .await
+    }
+
+    /// Execute with the active manifest mapped to the root importer while
+    /// retaining workspace discovery for `workspace:` dependency resolution.
+    pub async fn run_with_root_importer<Reporter: self::Reporter + 'static>(
+        self,
+    ) -> Result<(), InstallError> {
+        Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
+            root_manifest_as_workspace_root: true,
+            ..Default::default()
+        }))
+        .await
     }
 
     /// Execute as a forced rebuild: take the frozen path against the
@@ -537,15 +628,24 @@ where
         rebuild: RebuildOptions,
     ) -> Result<(), InstallError> {
         assert!(self.frozen_lockfile, "run_rebuild requires frozen_lockfile = true");
-        self.run_inner::<Reporter>(None, Some(rebuild), None).await
+        Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
+            rebuild: Some(rebuild),
+            ..Default::default()
+        }))
+        .await
     }
 
     async fn run_inner<Reporter: self::Reporter + 'static>(
         self,
-        lockfile_verification_override: Option<LockfileVerificationOverride<'a>>,
-        rebuild: Option<RebuildOptions>,
-        prompt_eligibility_override: Option<bool>,
+        options: InstallRunOptions<'a, '_>,
     ) -> Result<(), InstallError> {
+        let InstallRunOptions {
+            lockfile_verification_override,
+            rebuild,
+            selection,
+            root_manifest_as_workspace_root,
+            prompt_eligibility_override,
+        } = options;
         let Install {
             tarball_mem_cache,
             resolved_packages,
@@ -671,11 +771,17 @@ where
         // An embedder that supplies its importers in memory
         // (`workspace_projects_override`) bypasses the on-disk walk
         // entirely; the override's `Vec` is used verbatim.
-        let workspace_projects = match workspace_projects_override {
-            Some(projects) => Some(projects),
-            None => load_workspace_projects(&workspace_root, workspace_manifest.as_ref())
+        let workspace_projects_are_overridden = workspace_projects_override.is_some();
+        let loaded_workspace_projects = match (selection.as_ref(), workspace_projects_override) {
+            (Some(_), _) => None,
+            (None, Some(projects)) => Some(projects),
+            (None, None) => load_workspace_projects(&workspace_root, workspace_manifest.as_ref())
                 .map_err(InstallError::FindWorkspaceProjects)?,
         };
+        let workspace_projects = selection.as_ref().map_or_else(
+            || loaded_workspace_projects.as_deref(),
+            |selection| Some(selection.all_projects),
+        );
 
         // Optimistic repeat-install short-circuit. When nothing has
         // changed since the previous successful install (settings,
@@ -688,8 +794,56 @@ where
         // headless install should always go through the dispatch so a
         // `NoLockfile` or `OutdatedLockfile` error still fires when
         // the lockfile is missing or stale.
-        let project_manifests =
-            build_project_manifests_list(&workspace_root, manifest, workspace_projects.as_deref());
+        let manifest_is_root_importer = root_manifest_as_workspace_root
+            || workspace_projects_are_overridden
+            || !config.shared_workspace_lockfile;
+        let project_manifests = match selection.as_ref() {
+            Some(selection) => build_selected_project_manifests_list(
+                manifest,
+                selection.all_projects,
+                selection.active_manifest_is_standin,
+            ),
+            None if manifest_is_root_importer => build_root_importer_project_manifests_list(
+                &workspace_root,
+                manifest,
+                workspace_projects,
+            ),
+            None => build_project_manifests_list(&workspace_root, manifest, workspace_projects),
+        };
+        let manifest_freshness_inputs = match selection.as_ref() {
+            Some(selection) => selected_manifest_freshness_inputs(
+                &workspace_root,
+                &project_manifests,
+                selection.selected_dirs,
+            ),
+            None => project_manifests
+                .iter()
+                .map(|(project_dir, manifest)| {
+                    (
+                        pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
+                        *manifest,
+                    )
+                })
+                .collect(),
+        };
+        let requested_importer_ids = selection.as_ref().map(|selection| {
+            selection
+                .selected_dirs
+                .iter()
+                .map(|project_dir| {
+                    pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir)
+                })
+                .collect::<HashSet<_>>()
+        });
+        let real_importer_ids = project_manifests
+            .iter()
+            .map(|(project_dir, _)| {
+                pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir)
+            })
+            .collect::<HashSet<_>>();
+        let filtered_install = requested_importer_ids
+            .as_ref()
+            .is_some_and(|selected_importer_ids| selected_importer_ids != &real_importer_ids);
         // Only a full `pacquet install` may short-circuit. `add` and
         // `remove` mutate the manifest in memory and persist it after
         // this run returns, so the on-disk mtimes the check reads still
@@ -702,6 +856,7 @@ where
         // read as up to date and skip the registry re-resolution.
         let optimistic_decision = is_full_install
             && matches!(update_seed_policy, UpdateSeedPolicy::KeepAll)
+            && selection.is_none()
             && !frozen_lockfile
             && !disable_optimistic_repeat_install
             && check_optimistic_repeat_install(&OptimisticRepeatInstallCheck {
@@ -830,8 +985,7 @@ where
                 current_lockfile.as_ref().and_then(|current| {
                     check_lockfile_freshness(
                         current,
-                        &workspace_root,
-                        &project_manifests,
+                        &manifest_freshness_inputs,
                         config,
                         &catalogs,
                         ignore_manifest_check,
@@ -979,8 +1133,7 @@ where
             // again inside the frozen branch below.
             check_lockfile_freshness(
                 lockfile,
-                &workspace_root,
-                &project_manifests,
+                &manifest_freshness_inputs,
                 config,
                 &catalogs,
                 ignore_manifest_check,
@@ -1001,8 +1154,7 @@ where
             if prefer_frozen_lockfile {
                 match check_lockfile_freshness(
                     lockfile,
-                    &workspace_root,
-                    &project_manifests,
+                    &manifest_freshness_inputs,
                     config,
                     &catalogs,
                     ignore_manifest_check,
@@ -1107,6 +1259,11 @@ where
         }
         let old_modules = modules_manifest_res.ok().flatten();
         let modules_manifest = old_modules.as_ref();
+        let previous_modules_metadata = if selection.is_some() && !resolve_only {
+            pacquet_modules_yaml::read_modules_manifest::<Host>(&config.modules_dir).ok().flatten()
+        } else {
+            None
+        };
 
         // The purge keys off *layout* drift only, not `included`: an
         // included (`--prod`<->full) change is handled by relinking, so it
@@ -1201,6 +1358,12 @@ where
                     }
                 }
             } else {
+                if selection.is_some() {
+                    return Err(InstallError::UnsafeFilteredModulesDir {
+                        modules_dir: config.modules_dir.clone(),
+                        workspace_root: workspace_root.clone(),
+                    });
+                }
                 tracing::warn!(
                     ?config.modules_dir,
                     "refusing to remove inconsistent modules directory outside the project root",
@@ -1208,28 +1371,50 @@ where
             }
         }
 
-        // An included-only drift (`--prod`<->full, `--no-optional`)
-        // skips the purge above, so the direct-dep links the previous
-        // install created for now-excluded groups would linger — and
-        // stay resolvable — after the relink. Remove exactly those
-        // (plus their bin shims), leaving everything else in place.
+        // Remove direct links from dependency groups excluded by this
+        // run. Unfiltered installs can use the global `included` value
+        // recorded in `.modules.yaml`; filtered installs may retain
+        // importers materialized with different group sets, so they
+        // conservatively prune every excluded group from only the
+        // selected workspace-link closure.
         if !resolve_only
             && !is_inconsistent
             && let Some(modules) = modules_manifest
-            && modules.included != included
             && let Some(current) = current_lockfile.as_ref()
+            && (selection.is_some() || modules.included != included)
         {
+            let selected_prune_importer_ids = requested_importer_ids.as_ref().map(|requested| {
+                crate::materialization_closure(
+                    current,
+                    &workspace_root,
+                    requested,
+                    included,
+                    &crate::SkippedSnapshots::new(),
+                )
+                .importer_ids
+            });
+            let previously_included = if selection.is_some() {
+                IncludedDependencies {
+                    dependencies: true,
+                    dev_dependencies: true,
+                    optional_dependencies: true,
+                }
+            } else {
+                modules.included
+            };
             crate::prune_direct_deps_excluded_by_groups(
                 current,
-                modules.included,
+                previously_included,
                 included,
                 &workspace_root,
                 config,
+                selected_prune_importer_ids.as_ref(),
             )
             .map_err(InstallError::PruneDirectDeps)?;
         }
 
         if take_frozen_path
+            && selection.is_none()
             && let Some(wanted_lockfile) = lockfile
             && let Some(current) = current_lockfile.as_ref()
             && wanted_lockfile == current
@@ -1295,6 +1480,7 @@ where
                     included,
                     &catalogs,
                     &project_manifests,
+                    filtered_install,
                 ),
             )
             .map_err(InstallError::WriteWorkspaceState)?;
@@ -1319,8 +1505,66 @@ where
             Option<Lockfile>,
         ) = if take_frozen_path {
             let lockfile = lockfile.expect("dispatch verified lockfile is present");
-            let Lockfile { lockfile_version, importers, packages, snapshots, .. } = lockfile;
+            let initial_materialization_ids = requested_importer_ids.as_ref().map(|selected| {
+                if matches!(node_linker, NodeLinker::Hoisted) {
+                    lockfile.importers.keys().cloned().collect()
+                } else {
+                    selected.clone()
+                }
+            });
+            let empty_skipped = crate::SkippedSnapshots::new();
+            let materialization = initial_materialization_ids.as_ref().map(|importer_ids| {
+                crate::materialization_closure(
+                    lockfile,
+                    &workspace_root,
+                    importer_ids,
+                    included,
+                    &empty_skipped,
+                )
+            });
+            let materialization_lockfile =
+                materialization.as_ref().map_or(lockfile, |closure| &closure.lockfile);
+            let project_anchor_ids = match requested_importer_ids.as_ref() {
+                Some(selected) if matches!(node_linker, NodeLinker::Hoisted) => selected.clone(),
+                Some(_) => materialization
+                    .as_ref()
+                    .expect("selected install has a materialization closure")
+                    .importer_ids
+                    .clone(),
+                None => real_importer_ids.clone(),
+            };
+            let frozen_project_manifests = project_manifests
+                .iter()
+                .filter(|(project_dir, _)| {
+                    let importer_id =
+                        pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir);
+                    project_anchor_ids.contains(&importer_id)
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            let Lockfile { lockfile_version, importers, packages, snapshots, .. } =
+                materialization_lockfile;
             assert_eq!(lockfile_version.major, 9); // compatibility check already happens at serde, but this still helps preventing programmer mistakes.
+
+            let mut frozen_verification_override = lockfile_verification_override;
+            if requested_importer_ids.is_some() {
+                if let Some(verification_override) = frozen_verification_override.take() {
+                    verification_override.await.map_err(map_frozen_lockfile_error)?;
+                } else {
+                    verify_lockfile_eagerly::<Reporter>(
+                        lockfile,
+                        &resolution_verifiers,
+                        derived_lockfile_path.as_deref(),
+                        &config.cache_dir,
+                    )
+                    .await?;
+                }
+            }
+            let frozen_resolution_verifiers = if requested_importer_ids.is_some() {
+                &[][..]
+            } else {
+                resolution_verifiers.as_slice()
+            };
 
             let frozen_result = InstallFrozenLockfile {
                 http_client,
@@ -1328,9 +1572,9 @@ where
                 importers,
                 packages: packages.as_ref(),
                 snapshots: snapshots.as_ref(),
-                lockfile,
-                resolution_verifiers: &resolution_verifiers,
-                lockfile_verification_override,
+                lockfile: materialization_lockfile,
+                resolution_verifiers: frozen_resolution_verifiers,
+                lockfile_verification_override: frozen_verification_override,
                 lockfile_path: derived_lockfile_path.as_deref(),
                 current_lockfile: current_lockfile.as_ref(),
                 current_snapshots: current_lockfile
@@ -1340,7 +1584,8 @@ where
                     .as_ref()
                     .and_then(|lockfile| lockfile.packages.as_ref()),
                 dependency_groups,
-                project_manifests: &project_manifests,
+                project_manifests: &frozen_project_manifests,
+                package_map_project_manifests: &project_manifests,
                 logged_methods: &logged_methods,
                 workspace_root: &workspace_root,
                 requester: &prefix,
@@ -1420,7 +1665,7 @@ where
             // `Install::run` for the optimistic-repeat-install check
             // so we don't pay the workspace scan twice on a
             // fresh-install fall-through.
-            let workspace_packages = build_workspace_packages_map(workspace_projects.as_deref());
+            let workspace_packages = build_workspace_packages_map(workspace_projects);
             // Build the per-importer manifest list. The root importer
             // (`"."`) always reuses the in-memory `Install.manifest`
             // — `pacquet add` mutates that value before calling install,
@@ -1428,23 +1673,15 @@ where
             // miss the freshly-added dep. Sibling importers come from
             // the `find_workspace_projects` walk, which read them off
             // disk for `workspace_packages` already.
-            let importer_manifests: BTreeMap<String, &PackageManifest> = {
-                let mut map = BTreeMap::new();
-                map.insert(Lockfile::ROOT_IMPORTER_KEY.to_string(), manifest);
-                if let Some(projects) = workspace_projects.as_deref() {
-                    for project in projects {
-                        let id = pacquet_workspace::importer_id_from_root_dir(
-                            &workspace_root,
-                            &project.root_dir,
-                        );
-                        if id == Lockfile::ROOT_IMPORTER_KEY {
-                            continue;
-                        }
-                        map.insert(id, &project.manifest);
-                    }
-                }
-                map
-            };
+            let importer_manifests: BTreeMap<String, &PackageManifest> = project_manifests
+                .iter()
+                .map(|(project_dir, manifest)| {
+                    (
+                        pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
+                        *manifest,
+                    )
+                })
+                .collect();
             let fresh_result = InstallWithFreshLockfile {
                 tarball_mem_cache,
                 resolved_packages,
@@ -1480,6 +1717,8 @@ where
                 resolution_observer,
                 peer_issues_sink: peer_issues_sink.clone(),
                 pnpmfile_hook_override,
+                real_importer_ids: requested_importer_ids.as_ref().map(|_| &real_importer_ids),
+                selected_importer_ids: requested_importer_ids.as_ref(),
             }
             .run::<Reporter>()
             .await
@@ -1540,6 +1779,106 @@ where
             return Ok(());
         }
 
+        let materialized_wanted_lockfile = fresh_lockfile.as_ref().or(lockfile);
+        let selected_current_lockfile = materialized_wanted_lockfile.and_then(|wanted| {
+            requested_importer_ids.as_ref().map(|requested| {
+                crate::materialization_closure(
+                    wanted,
+                    &workspace_root,
+                    requested,
+                    included,
+                    &install_skipped,
+                )
+                .lockfile
+            })
+        });
+        let materialized_current_lockfile = materialized_wanted_lockfile.map(|wanted| {
+            if requested_importer_ids.is_some() && matches!(node_linker, NodeLinker::Hoisted) {
+                crate::filter_lockfile_for_current(wanted, included, &install_skipped)
+            } else if let Some(requested_importer_ids) = requested_importer_ids.as_ref() {
+                crate::merge_filtered_current_lockfile(
+                    (!is_inconsistent).then_some(current_lockfile.as_ref()).flatten(),
+                    wanted,
+                    requested_importer_ids,
+                    included,
+                    &install_skipped,
+                    &workspace_root,
+                )
+            } else {
+                crate::filter_lockfile_for_current(wanted, included, &install_skipped)
+            }
+        });
+        let project_anchor_importer_ids = match requested_importer_ids.as_ref() {
+            Some(requested) if matches!(node_linker, NodeLinker::Hoisted) => requested.clone(),
+            Some(requested) => materialized_wanted_lockfile.map_or_else(
+                || requested.clone(),
+                |wanted| {
+                    crate::materialization_closure(
+                        wanted,
+                        &workspace_root,
+                        requested,
+                        included,
+                        &install_skipped,
+                    )
+                    .importer_ids
+                },
+            ),
+            None => real_importer_ids.clone(),
+        };
+        let materialized_project_manifests = project_manifests
+            .iter()
+            .filter(|(project_dir, _)| {
+                let importer_id =
+                    pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir);
+                project_anchor_importer_ids.contains(&importer_id)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if selection.is_some()
+            && !matches!(node_linker, NodeLinker::Hoisted)
+            && crate::should_write_package_map(config, node_linker)
+            && let Some(current) = materialized_current_lockfile.as_ref()
+        {
+            let runtime_major =
+                crate::install_frozen_lockfile::find_runtime_node_major(current.snapshots.as_ref());
+            let configured_major = config
+                .node_version
+                .as_deref()
+                .and_then(crate::install_frozen_lockfile::parse_major_from_version);
+            let engine_name = match runtime_major.or(configured_major) {
+                Some(major) => Some(pacquet_graph_hasher::engine_name(major, None, None)),
+                None if config.enable_global_virtual_store => tokio::task::spawn_blocking(|| {
+                    pacquet_graph_hasher::detect_node_major()
+                        .map(|major| pacquet_graph_hasher::engine_name(major, None, None))
+                })
+                .await
+                .ok()
+                .flatten(),
+                None => None,
+            };
+            let allow_build_policy = crate::AllowBuildPolicy::from_config(config)
+                .expect("allow-build policy was validated by the install path");
+            let layout = crate::VirtualStoreLayout::new(
+                config,
+                engine_name.as_deref(),
+                current.snapshots.as_ref(),
+                current.packages.as_ref(),
+                Some(&allow_build_policy),
+            );
+            crate::package_map::write_package_map(
+                current,
+                &crate::package_map::PackageMapOptions {
+                    lockfile_dir: &workspace_root,
+                    modules_dir: &config.modules_dir,
+                    package_map_type: config.node_package_map_type,
+                    layout: &layout,
+                    project_manifests: &project_manifests,
+                },
+            )
+            .map_err(InstallError::WritePackageMap)?;
+        }
+
         // Materialize `link:` direct deps straight from the in-memory
         // project manifests. `excludeLinksFromLockfile` keeps them out
         // of the lockfile importers, so the lockfile-driven symlink
@@ -1550,7 +1889,7 @@ where
         // dedupe decisions). See [`crate::link_manifest_link_deps`].
         crate::link_manifest_link_deps::<Reporter>(
             &workspace_root,
-            &project_manifests,
+            &materialized_project_manifests,
             fresh_lockfile.as_ref().or(lockfile).and_then(|lockfile| {
                 (!lockfile.importers.is_empty()).then_some(&lockfile.importers)
             }),
@@ -1599,7 +1938,7 @@ where
             config.modules_cache_max_age,
             now,
         ) {
-            match fresh_lockfile.as_ref().or(lockfile) {
+            match materialized_current_lockfile.as_ref() {
                 // Sweep the canonicalized prune target returned by the
                 // containment check, never the raw configured path: deleting
                 // from the validated path closes the time-of-check/time-of-use
@@ -1647,29 +1986,30 @@ where
         // patterns, included dependency groups, store dir, and registries
         // so a later install (or another tool) can detect a layout change
         // and prune accordingly.
-        write_modules_manifest::<Host>(
-            &config.modules_dir,
-            build_modules_manifest(
-                config,
-                node_linker,
-                included,
-                hoisted_dependencies,
-                hoisted_locations,
-                injected_deps,
-                &install_skipped,
-                &ignored_builds,
-                pruned_at,
-            ),
-        )
-        .map_err(InstallError::WriteModules)?;
-
-        let filtered_current_lockfile = if take_frozen_path {
-            lockfile.map(|lockfile| {
-                crate::filter_lockfile_for_current(lockfile, included, &install_skipped)
-            })
-        } else {
-            None
-        };
+        let mut next_modules = build_modules_manifest(
+            config,
+            node_linker,
+            included,
+            hoisted_dependencies,
+            hoisted_locations,
+            injected_deps,
+            &install_skipped,
+            &ignored_builds,
+            pruned_at,
+        );
+        if selection.is_some()
+            && !matches!(node_linker, NodeLinker::Hoisted)
+            && !is_inconsistent
+            && let (Some(previous), Some(current), Some(selected)) = (
+                previous_modules_metadata.as_ref(),
+                materialized_current_lockfile.as_ref(),
+                selected_current_lockfile.as_ref(),
+            )
+        {
+            merge_filtered_modules_metadata(&mut next_modules, previous, current, selected);
+        }
+        write_modules_manifest::<Host>(&config.modules_dir, next_modules)
+            .map_err(InstallError::WriteModules)?;
 
         // Write `<virtual_store_dir>/lock.yaml`. Captures what was
         // actually materialized so the next install can diff each
@@ -1680,13 +2020,12 @@ where
         // reinstall would otherwise diff against a graph that never
         // finished committing (review on <https://github.com/pnpm/pacquet/pull/442>).
         //
-        // Workspace installs (<https://github.com/pnpm/pacquet/issues/431>) ship every importer's section of
-        // the wanted lockfile unchanged because the install fans out
-        // across all of them. Once `--filter` lands (Stage 2 of
-        // <https://github.com/pnpm/pacquet/issues/299>), this needs to narrow to the filtered lockfile
-        // (selected importers × engine filter) so the saved current
-        // lockfile reflects only what was actually materialized.
-        if take_frozen_path && let Some(lockfile) = filtered_current_lockfile.as_ref() {
+        // A filtered isolated/PnP install merges its newly materialized
+        // closure into compatible prior current state, while a hoisted
+        // install records the full shared graph it materialized. This
+        // keeps the file aligned with physical state without discarding
+        // unselected slots that remain on disk.
+        if let Some(lockfile) = materialized_current_lockfile.as_ref() {
             // Filter the wanted lockfile down to the snapshots that
             // were actually materialized: dep maps the user excluded
             // (`--no-optional`, `--no-dev`) plus snapshots the
@@ -1695,17 +2034,6 @@ where
             // diffs against this filtered shape so dropped snapshots
             // aren't mistaken for already-done work.
             lockfile
-                .save_current_to_virtual_store_dir(&config.virtual_store_dir)
-                .map_err(InstallError::SaveCurrentLockfile)?;
-        } else if let Some(fresh_lockfile) = fresh_lockfile.as_ref() {
-            // Fresh-install path: mirror the frozen behavior by
-            // persisting `<virtual_store_dir>/lock.yaml` from the
-            // freshly-built wanted lockfile after removing snapshots
-            // the install skipped before materialization. The save is
-            // gated on the same `config.lockfile` knob the wanted-side
-            // write honors (`fresh_lockfile` is `None` when the
-            // opt-out fired).
-            crate::filter_lockfile_for_current(fresh_lockfile, included, &install_skipped)
                 .save_current_to_virtual_store_dir(&config.virtual_store_dir)
                 .map_err(InstallError::SaveCurrentLockfile)?;
         }
@@ -1740,7 +2068,7 @@ where
         // scripts when `ignoreScripts` is set.
         if is_full_install && !config.ignore_scripts {
             run_projects_lifecycle_scripts::<Reporter>(
-                &project_manifests,
+                &materialized_project_manifests,
                 config,
                 node_linker,
                 &workspace_root,
@@ -1762,6 +2090,7 @@ where
                 included,
                 &catalogs,
                 &project_manifests,
+                filtered_install,
             ),
         )
         .map_err(InstallError::WriteWorkspaceState)?;
@@ -1808,8 +2137,7 @@ where
 /// `ignoredOptionalDependencies`) still runs.
 fn check_lockfile_freshness(
     lockfile: &Lockfile,
-    workspace_root: &Path,
-    project_manifests: &[(PathBuf, &PackageManifest)],
+    manifest_freshness_inputs: &[(String, &PackageManifest)],
     config: &Config,
     catalogs: &Catalogs,
     ignore_manifest_check: bool,
@@ -1825,10 +2153,9 @@ fn check_lockfile_freshness(
     let ignored_optional_matcher = pacquet_config::matcher::create_matcher(
         config.ignored_optional_dependencies.as_deref().unwrap_or_default(),
     );
-    for (project_dir, manifest) in project_manifests {
-        let importer_id = pacquet_workspace::importer_id_from_root_dir(workspace_root, project_dir);
+    for (importer_id, manifest) in manifest_freshness_inputs {
         if allow_missing_dependency_free_importers
-            && !lockfile.importers.contains_key(&importer_id)
+            && !lockfile.importers.contains_key(importer_id)
             && !manifest_has_effective_dependencies(manifest, &ignored_optional_matcher)
         {
             continue;
@@ -1836,7 +2163,7 @@ fn check_lockfile_freshness(
         check_importer_satisfies(
             lockfile,
             manifest,
-            &importer_id,
+            importer_id,
             config.auto_install_peers,
             &ignored_optional_matcher,
             parsed_overrides_opt.as_deref(),
@@ -2238,6 +2565,116 @@ fn build_modules_manifest(
     }
 }
 
+fn merge_filtered_modules_metadata(
+    next: &mut Modules,
+    previous: &Modules,
+    current: &Lockfile,
+    selected: &Lockfile,
+) {
+    for (dep_path, aliases) in &previous.hoisted_dependencies {
+        if !retained_only_dep_path(current, selected, dep_path) {
+            continue;
+        }
+        let retained_aliases = next.hoisted_dependencies.entry(dep_path.clone()).or_default();
+        for (alias, kind) in aliases {
+            retained_aliases.entry(alias.clone()).or_insert(*kind);
+        }
+    }
+    if let Some(previous_locations) = previous.hoisted_locations.as_ref() {
+        for (dep_path, locations) in previous_locations {
+            if !retained_only_dep_path(current, selected, dep_path) {
+                continue;
+            }
+            let retained_locations = next.hoisted_locations.get_or_insert_default();
+            let retained = retained_locations.entry(dep_path.clone()).or_default();
+            for location in locations {
+                if !retained.contains(location) {
+                    retained.push(location.clone());
+                }
+            }
+        }
+    }
+    let new_pending_builds = std::mem::take(&mut next.pending_builds);
+    for dep_path in &previous.pending_builds {
+        if retained_only_dep_path(current, selected, dep_path)
+            && !next.pending_builds.contains(dep_path)
+        {
+            next.pending_builds.push(dep_path.clone());
+        }
+    }
+    for dep_path in new_pending_builds {
+        if !next.pending_builds.contains(&dep_path) {
+            next.pending_builds.push(dep_path);
+        }
+    }
+    let new_ignored_builds = next.ignored_builds.take();
+    if let Some(previous_ignored) = previous.ignored_builds.as_ref() {
+        for dep_path in previous_ignored {
+            if retained_only_dep_path(current, selected, dep_path.as_str()) {
+                let retained_ignored = next.ignored_builds.get_or_insert_default();
+                retained_ignored.insert(dep_path.clone());
+            }
+        }
+    }
+    if let Some(new_ignored_builds) = new_ignored_builds
+        && !new_ignored_builds.is_empty()
+    {
+        next.ignored_builds.get_or_insert_default().extend(new_ignored_builds);
+    }
+    let new_skipped = std::mem::take(&mut next.skipped);
+    for dep_path in &previous.skipped {
+        if retained_only_dep_path(current, selected, dep_path) && !next.skipped.contains(dep_path) {
+            next.skipped.push(dep_path.clone());
+        }
+    }
+    for dep_path in new_skipped {
+        if !next.skipped.contains(&dep_path) {
+            next.skipped.push(dep_path);
+        }
+    }
+    let current_injected_sources = injected_source_paths(current);
+    let selected_injected_sources = injected_source_paths(selected);
+    if let Some(previous_injected) = previous.injected_deps.as_ref() {
+        for (source, targets) in previous_injected {
+            if current_injected_sources.contains(source)
+                && !selected_injected_sources.contains(source)
+            {
+                let retained_injected = next.injected_deps.get_or_insert_default();
+                retained_injected.entry(source.clone()).or_insert_with(|| targets.clone());
+            }
+        }
+    }
+}
+
+fn retained_only_dep_path(current: &Lockfile, selected: &Lockfile, dep_path: &str) -> bool {
+    current_contains_dep_path(current, dep_path) && !current_contains_dep_path(selected, dep_path)
+}
+
+fn injected_source_paths(lockfile: &Lockfile) -> HashSet<String> {
+    lockfile
+        .snapshots
+        .iter()
+        .flat_map(|snapshots| snapshots.keys())
+        .chain(lockfile.packages.iter().flat_map(|packages| packages.keys()))
+        .filter_map(|key| match key.suffix.version() {
+            VersionPart::File(path) => Some(path.strip_prefix("./").unwrap_or(path).to_string()),
+            VersionPart::Semver(_) | VersionPart::NonSemver(_) => None,
+        })
+        .collect()
+}
+
+fn current_contains_dep_path(current: &Lockfile, dep_path: &str) -> bool {
+    if current.importers.contains_key(dep_path) {
+        return true;
+    }
+    let Ok(key) = dep_path.parse::<pacquet_lockfile::PackageKey>() else { return false };
+    current.snapshots.as_ref().is_some_and(|snapshots| snapshots.contains_key(&key))
+        || current
+            .packages
+            .as_ref()
+            .is_some_and(|packages| packages.contains_key(&key.without_peer()))
+}
+
 /// Read a string field off a project manifest, returning `None` when
 /// the field is missing or not a JSON string. Pnpm tolerates either
 /// shape — `name`/`version` are advisory metadata in this context, so
@@ -2335,15 +2772,6 @@ fn run_projects_lifecycle_scripts<Reporter: self::Reporter>(
     Ok(())
 }
 
-/// Assemble the `(root_dir, manifest)` list every importer the
-/// install would walk. Always includes the root manifest; adds each
-/// sibling project from `workspace_projects` when present. The root
-/// importer always reuses the in-memory `Install.manifest` — `pacquet
-/// add` mutates that value before calling install, so re-reading from
-/// disk would walk the pre-add shape.
-///
-/// `workspace_projects.is_none()` covers single-project installs (no
-/// `pnpm-workspace.yaml`) — the only manifest is the root one.
 /// Inputs for [`install_already_up_to_date`].
 pub struct UpToDateFastPathCheck<'a> {
     pub config: &'a Config,
@@ -2387,11 +2815,15 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<P
         load_workspace_projects(&workspace_root, workspace_manifest.as_ref()).ok()?;
     let project_manifests =
         build_project_manifests_list(&workspace_root, manifest, workspace_projects.as_deref());
-    // Same lockfile source as `State::init`'s (the manifest's
-    // directory), so the pre-runtime check and the in-pipeline check
-    // reach their verdicts from the same file.
+    // Match the install pipeline's lockfile source: shared workspaces
+    // read the root lockfile, while per-project workspaces read the
+    // active project's lockfile.
     let lockfile = if config.lockfile {
-        LazyLockfile::deferred(manifest_dir.to_path_buf())
+        LazyLockfile::deferred(if config.shared_workspace_lockfile {
+            workspace_root.clone()
+        } else {
+            manifest_dir.to_path_buf()
+        })
     } else {
         LazyLockfile::disabled()
     };
@@ -2532,16 +2964,85 @@ fn build_project_manifests_list<'a>(
     root_manifest: &'a PackageManifest,
     workspace_projects: Option<&'a [pacquet_workspace::Project]>,
 ) -> Vec<(std::path::PathBuf, &'a PackageManifest)> {
-    let mut list = vec![(workspace_root.to_path_buf(), root_manifest)];
-    if let Some(projects) = workspace_projects {
-        for project in projects {
-            if project.root_dir == *workspace_root {
-                continue;
+    let Some(projects) = workspace_projects else {
+        return vec![(workspace_root.to_path_buf(), root_manifest)];
+    };
+    let active_dir = root_manifest.path().parent().expect("manifest path always has a parent dir");
+    let normalized_active_dir = pacquet_fs::lexical_normalize(active_dir);
+    let mut active_project_was_discovered = false;
+    let mut list = projects
+        .iter()
+        .map(|project| {
+            if pacquet_fs::lexical_normalize(&project.root_dir) == normalized_active_dir {
+                active_project_was_discovered = true;
+                (project.root_dir.clone(), root_manifest)
+            } else {
+                (project.root_dir.clone(), &project.manifest)
             }
-            list.push((project.root_dir.clone(), &project.manifest));
-        }
+        })
+        .collect::<Vec<_>>();
+    if !active_project_was_discovered && root_manifest.path().is_file() {
+        list.push((active_dir.to_path_buf(), root_manifest));
     }
     list
+}
+
+fn build_root_importer_project_manifests_list<'a>(
+    workspace_root: &Path,
+    root_manifest: &'a PackageManifest,
+    workspace_projects: Option<&'a [pacquet_workspace::Project]>,
+) -> Vec<(PathBuf, &'a PackageManifest)> {
+    let mut list = vec![(workspace_root.to_path_buf(), root_manifest)];
+    if let Some(projects) = workspace_projects {
+        list.extend(
+            projects
+                .iter()
+                .filter(|project| project.root_dir != workspace_root)
+                .map(|project| (project.root_dir.clone(), &project.manifest)),
+        );
+    }
+    list
+}
+
+fn build_selected_project_manifests_list<'a>(
+    active_manifest: &'a PackageManifest,
+    projects: &'a [pacquet_workspace::Project],
+    active_manifest_is_standin: bool,
+) -> Vec<(PathBuf, &'a PackageManifest)> {
+    let mut manifests = projects
+        .iter()
+        .map(|project| (project.root_dir.clone(), &project.manifest))
+        .collect::<Vec<_>>();
+    let active_dir =
+        active_manifest.path().parent().expect("manifest path always has a parent dir");
+    let normalized_active_dir = pacquet_fs::lexical_normalize(active_dir);
+    let active_project_was_discovered = projects
+        .iter()
+        .any(|project| pacquet_fs::lexical_normalize(&project.root_dir) == normalized_active_dir);
+    if !active_manifest_is_standin && !active_project_was_discovered {
+        manifests.push((active_dir.to_path_buf(), active_manifest));
+    }
+    manifests
+}
+
+fn selected_manifest_freshness_inputs<'a>(
+    workspace_root: &Path,
+    project_manifests: &[(PathBuf, &'a PackageManifest)],
+    selected_dirs: &HashSet<PathBuf>,
+) -> Vec<(String, &'a PackageManifest)> {
+    let selected_dirs =
+        selected_dirs.iter().map(|dir| pacquet_fs::lexical_normalize(dir)).collect::<HashSet<_>>();
+    let mut inputs = project_manifests
+        .iter()
+        .filter(|(project_dir, _)| {
+            selected_dirs.contains(&pacquet_fs::lexical_normalize(project_dir))
+        })
+        .map(|(project_dir, manifest)| {
+            (pacquet_workspace::importer_id_from_root_dir(workspace_root, project_dir), *manifest)
+        })
+        .collect::<Vec<_>>();
+    inputs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    inputs
 }
 
 fn configured_or_discovered_workspace_dir(
@@ -2633,6 +3134,7 @@ pub(crate) fn build_workspace_state(
     included: IncludedDependencies,
     catalogs: &Catalogs,
     project_manifests: &[(std::path::PathBuf, &PackageManifest)],
+    filtered_install: bool,
 ) -> WorkspaceState {
     WorkspaceState {
         // Record the freshness baseline from the lockfile this install
@@ -2655,10 +3157,7 @@ pub(crate) fn build_workspace_state(
         .unwrap_or_else(now_millis),
         projects: build_projects_map(project_manifests),
         pnpmfiles: crate::optimistic_repeat_install::current_pnpmfiles(workspace_root),
-        // Pacquet has no `--filter` yet (issue <https://github.com/pnpm/pacquet/issues/299> stage 2). Hard-code
-        // `false` so pnpm doesn't treat the install as partial and
-        // skip the cache.
-        filtered_install: false,
+        filtered_install,
         config_dependencies: config.config_dependencies.clone(),
         // Settings construction is shared with
         // `optimistic_repeat_install::current_settings` so the

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -3003,9 +3003,9 @@ fn build_project_manifests_list<'a>(
     let mut list = projects
         .iter()
         .map(|project| {
-            if pacquet_fs::lexical_normalize(&project.root_dir) == normalized_active_dir {
+            if project_dirs_equal(&project.root_dir, &normalized_active_dir) {
                 active_project_was_discovered = true;
-                (project.root_dir.clone(), root_manifest)
+                (active_dir.to_path_buf(), root_manifest)
             } else {
                 (project.root_dir.clone(), &project.manifest)
             }
@@ -3038,7 +3038,7 @@ fn build_root_importer_project_manifests_list<'a>(
         list.extend(
             projects
                 .iter()
-                .filter(|project| project.root_dir != workspace_root)
+                .filter(|project| !project_dirs_equal(&project.root_dir, workspace_root))
                 .map(|project| (project.root_dir.clone(), &project.manifest)),
         );
     }
@@ -3059,11 +3059,20 @@ fn build_selected_project_manifests_list<'a>(
     let normalized_active_dir = pacquet_fs::lexical_normalize(active_dir);
     let active_project_was_discovered = projects
         .iter()
-        .any(|project| pacquet_fs::lexical_normalize(&project.root_dir) == normalized_active_dir);
+        .any(|project| project_dirs_equal(&project.root_dir, &normalized_active_dir));
     if !active_manifest_is_standin && !active_project_was_discovered {
         manifests.push((active_dir.to_path_buf(), active_manifest));
     }
     manifests
+}
+
+fn project_dirs_equal(left: &Path, right: &Path) -> bool {
+    let left = pacquet_fs::lexical_normalize(left);
+    let right = pacquet_fs::lexical_normalize(right);
+    left == right
+        || std::fs::canonicalize(left)
+            .and_then(|left| std::fs::canonicalize(right).map(|right| left == right))
+            .unwrap_or(false)
 }
 
 fn selected_manifest_freshness_inputs<'a>(

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -26,7 +26,7 @@ use pacquet_lockfile_verification::{
 };
 use pacquet_modules_yaml::{
     Host, IncludedDependencies, LayoutVersion, Modules, NodeLinker as ModulesNodeLinker,
-    WriteModulesError, write_modules_manifest,
+    ReadModulesError, WriteModulesError, write_modules_manifest,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
@@ -374,6 +374,14 @@ pub enum InstallError {
 
     #[diagnostic(transparent)]
     WriteModules(#[error(source)] WriteModulesError),
+
+    /// A filtered install rewrites `.modules.yaml` from the selected
+    /// projects' state merged over the previous file's. Without the
+    /// previous contents the rewrite would drop every unselected
+    /// project's `pendingBuilds` / `ignoredBuilds` / `injectedDeps`, so an
+    /// unreadable file fails the install instead of silently pruning it.
+    #[diagnostic(transparent)]
+    ReadModules(#[error(source)] ReadModulesError),
 
     /// Surfaces a corrupted `<virtual_store_dir>/lock.yaml` rather
     /// than silently skipping the optimization.
@@ -1260,8 +1268,17 @@ where
         }
         let old_modules = modules_manifest_res.ok().flatten();
         let modules_manifest = old_modules.as_ref();
-        let previous_modules_metadata = if filtered_install && !resolve_only {
-            pacquet_modules_yaml::read_modules_manifest::<Host>(&config.modules_dir).ok().flatten()
+        // A filtered install rewrites `.modules.yaml` from the selected
+        // projects' state merged over the previous file's, so losing the
+        // previous contents would drop every unselected project's entries.
+        // An unreadable *layout* is already handled as an inconsistent
+        // `node_modules` — the purge rebuilds everything and the merge is
+        // skipped — but a file whose layout parses while some later field
+        // does not would otherwise merge against `None` and silently prune
+        // those entries, so that case fails instead.
+        let previous_modules_metadata = if filtered_install && !resolve_only && !read_failed {
+            pacquet_modules_yaml::read_modules_manifest::<Host>(&config.modules_dir)
+                .map_err(InstallError::ReadModules)?
         } else {
             None
         };
@@ -2662,6 +2679,11 @@ fn merge_filtered_modules_metadata(
             next.skipped.push(dep_path);
         }
     }
+    // A source the selected install re-materialized has its targets
+    // recomputed in `next`, so the previous file's targets for it are
+    // stale — a bumped injected dep moves to a new virtual-store slot and
+    // the old one is gone. Only sources no selected importer touched carry
+    // their previous targets forward.
     let current_injected_sources = injected_source_paths(current);
     let selected_injected_sources = injected_source_paths(selected);
     if let Some(previous_injected) = previous.injected_deps.as_ref() {
@@ -2998,12 +3020,12 @@ fn build_project_manifests_list<'a>(
         return vec![(workspace_root.to_path_buf(), root_manifest)];
     };
     let active_dir = root_manifest.path().parent().expect("manifest path always has a parent dir");
-    let normalized_active_dir = pacquet_fs::lexical_normalize(active_dir);
+    let active_dir_matcher = ProjectDirMatcher::new(active_dir);
     let mut active_project_was_discovered = false;
     let mut list = projects
         .iter()
         .map(|project| {
-            if project_dirs_equal(&project.root_dir, &normalized_active_dir) {
+            if active_dir_matcher.matches(&project.root_dir) {
                 active_project_was_discovered = true;
                 (active_dir.to_path_buf(), root_manifest)
             } else {
@@ -3035,10 +3057,11 @@ fn build_root_importer_project_manifests_list<'a>(
 ) -> Vec<(PathBuf, &'a PackageManifest)> {
     let mut list = vec![(workspace_root.to_path_buf(), root_manifest)];
     if let Some(projects) = workspace_projects {
+        let workspace_root_matcher = ProjectDirMatcher::new(workspace_root);
         list.extend(
             projects
                 .iter()
-                .filter(|project| !project_dirs_equal(&project.root_dir, workspace_root))
+                .filter(|project| !workspace_root_matcher.matches(&project.root_dir))
                 .map(|project| (project.root_dir.clone(), &project.manifest)),
         );
     }
@@ -3056,23 +3079,44 @@ fn build_selected_project_manifests_list<'a>(
         .collect::<Vec<_>>();
     let active_dir =
         active_manifest.path().parent().expect("manifest path always has a parent dir");
-    let normalized_active_dir = pacquet_fs::lexical_normalize(active_dir);
-    let active_project_was_discovered = projects
-        .iter()
-        .any(|project| project_dirs_equal(&project.root_dir, &normalized_active_dir));
+    let active_dir_matcher = ProjectDirMatcher::new(active_dir);
+    let active_project_was_discovered =
+        projects.iter().any(|project| active_dir_matcher.matches(&project.root_dir));
     if !active_manifest_is_standin && !active_project_was_discovered {
         manifests.push((active_dir.to_path_buf(), active_manifest));
     }
     manifests
 }
 
-fn project_dirs_equal(left: &Path, right: &Path) -> bool {
-    let left = pacquet_fs::lexical_normalize(left);
-    let right = pacquet_fs::lexical_normalize(right);
-    left == right
-        || std::fs::canonicalize(left)
-            .and_then(|left| std::fs::canonicalize(right).map(|right| left == right))
-            .unwrap_or(false)
+/// Matches workspace project roots against one fixed directory.
+///
+/// Two paths can name the same project without being equal as strings —
+/// a symlinked workspace root, or `/tmp` against its `/private/tmp` target
+/// on macOS — so a lexical mismatch falls back to comparing canonical
+/// paths. Canonicalizing touches the filesystem once per candidate, so the
+/// fixed side is resolved up front rather than once per project.
+struct ProjectDirMatcher {
+    normalized: PathBuf,
+    canonical: Option<PathBuf>,
+}
+
+impl ProjectDirMatcher {
+    fn new(dir: &Path) -> Self {
+        let normalized = pacquet_fs::lexical_normalize(dir);
+        let canonical = std::fs::canonicalize(&normalized).ok();
+        ProjectDirMatcher { normalized, canonical }
+    }
+
+    fn matches(&self, project_dir: &Path) -> bool {
+        let project_dir = pacquet_fs::lexical_normalize(project_dir);
+        if project_dir == self.normalized {
+            return true;
+        }
+        let Some(canonical) = self.canonical.as_deref() else {
+            return false;
+        };
+        std::fs::canonicalize(project_dir).is_ok_and(|project_dir| project_dir == canonical)
+    }
 }
 
 fn selected_manifest_freshness_inputs<'a>(

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -7426,7 +7426,7 @@ fn sync_fast_path_reads_the_workspace_root_wanted_lockfile_from_a_member() {
             version: Some("1.0.0".to_string()),
         },
     );
-    let validated_at = pacquet_workspace_state::now_millis();
+    let validated_at = 0;
     workspace_state::update_workspace_state(
         &workspace_root,
         &pacquet_workspace_state::WorkspaceState {

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -4,8 +4,8 @@
 )]
 
 use super::{
-    Install, InstallError, UpToDateFastPathCheck, install_already_up_to_date,
-    load_workspace_projects, should_write_package_map,
+    Install, InstallError, UpToDateFastPathCheck, exclude_linked_dependencies,
+    install_already_up_to_date, load_workspace_projects, should_write_package_map,
 };
 use crate::{InstallWithFreshLockfileError, MinimumReleaseAgeError};
 use pacquet_config::{Config, NodePackageMapType};
@@ -47,6 +47,35 @@ fn empty_test_lockfile() -> Lockfile {
         packages: None,
         snapshots: None,
     }
+}
+
+#[test]
+fn exclude_linked_dependencies_drops_link_deps_from_every_group() {
+    let mut manifest = PackageManifest::from_value(
+        std::path::PathBuf::from("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "direct": "1.0.0",
+                "linked": "link:../linked"
+            },
+            "devDependencies": {
+                "declared-peer": "2.0.0",
+                "linked-dev": "link:../dev"
+            }
+        }),
+    );
+
+    exclude_linked_dependencies(&mut manifest);
+    assert_eq!(
+        manifest
+            .dependencies([DependencyGroup::Prod])
+            .collect::<std::collections::BTreeMap<_, _>>(),
+        std::collections::BTreeMap::from([("direct", "1.0.0")]),
+    );
+    assert_eq!(
+        manifest.dependencies([DependencyGroup::Dev]).collect::<Vec<_>>(),
+        vec![("declared-peer", "2.0.0")],
+    );
 }
 
 /// Reading wrapper over [`super::modules_consistent_with`] for the tests

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -7455,7 +7455,7 @@ fn sync_fast_path_reads_the_workspace_root_wanted_lockfile_from_a_member() {
     };
 
     assert_eq!(install_already_up_to_date(&check).as_deref(), Some(&*workspace_root));
-    assert_eq!(std::fs::read_to_string(&wanted_path).expect("reread wanted lockfile"), current,);
+    assert_eq!(std::fs::read_to_string(&wanted_path).expect("reread wanted lockfile"), current);
 
     std::fs::write(project_root.join(Lockfile::FILE_NAME), current).expect("write member lockfile");
     std::fs::write(&wanted_path, "not: [valid").expect("write invalid root lockfile");
@@ -7473,7 +7473,7 @@ fn sync_fast_path_reads_the_workspace_root_wanted_lockfile_from_a_member() {
         node_linker: pacquet_config::NodeLinker::Isolated,
     };
 
-    assert_eq!(install_already_up_to_date(&per_project_check).as_deref(), Some(&*workspace_root),);
+    assert_eq!(install_already_up_to_date(&per_project_check).as_deref(), Some(&*workspace_root));
 }
 
 /// `--frozen-lockfile` disables the optimistic short-circuit because

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{InstallWithFreshLockfileError, MinimumReleaseAgeError};
 use pacquet_config::{Config, NodePackageMapType};
-use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
+use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion, MaybeLazyLockfile};
 use pacquet_modules_yaml::{
     DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, Host, LayoutVersion, Modules, NodeLinker,
     read_modules_manifest, write_modules_manifest,
@@ -32,6 +32,22 @@ use pipe_trait::Pipe;
 use std::{fs, sync::Mutex};
 use tempfile::tempdir;
 use text_block_macros::text_block;
+
+fn empty_test_lockfile() -> Lockfile {
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer { major: 9, minor: 0 }).unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: std::collections::HashMap::new(),
+        packages: None,
+        snapshots: None,
+    }
+}
 
 /// Reading wrapper over [`super::modules_consistent_with`] for the tests
 /// that exercise the `.modules.yaml`-absent and drift cases. Production
@@ -1559,6 +1575,7 @@ mod build_workspace_state_tests {
             IncludedDependencies::default(),
             &BTreeMap::default(),
             &[],
+            false,
         );
         assert!(state.projects.is_empty());
         assert!(state.last_validated_timestamp > 0);
@@ -1592,6 +1609,7 @@ mod build_workspace_state_tests {
             IncludedDependencies::default(),
             &BTreeMap::default(),
             &project_manifests,
+            false,
         );
 
         assert_eq!(state.projects.len(), packages.len());
@@ -1627,6 +1645,7 @@ mod build_workspace_state_tests {
             IncludedDependencies::default(),
             &BTreeMap::default(),
             &[],
+            false,
         );
         assert_eq!(state.config_dependencies, config.config_dependencies);
     }
@@ -6361,6 +6380,169 @@ fn unapproved_recorded_ignored_builds_surfaces_invalid_allow_builds() {
     assert!(super::unapproved_recorded_ignored_builds(&modules, config).is_err());
 }
 
+#[test]
+fn filtered_modules_metadata_preserves_only_retained_unselected_entries() {
+    let package_key = |name: &str, version: &str| {
+        pacquet_lockfile::PackageKey::new(
+            pacquet_lockfile::PkgName::parse(name).unwrap(),
+            version.parse::<pacquet_lockfile::PkgVerPeer>().unwrap(),
+        )
+    };
+    let retained = "retained@1.0.0";
+    let selected = "selected@2.0.0";
+    let shared = "shared@1.0.0";
+    let stale_selected = "selected@1.0.0";
+    let retained_file = package_key("retained-file", "file:packages/retained-source");
+    let selected_file = package_key("selected-file", "file:packages/selected-source");
+    let shared_file = package_key("shared-file", "file:packages/shared-source");
+    let current = Lockfile {
+        snapshots: Some(std::collections::HashMap::from([
+            (package_key("retained", "1.0.0"), Default::default()),
+            (package_key("selected", "2.0.0"), Default::default()),
+            (package_key("shared", "1.0.0"), Default::default()),
+            (retained_file, Default::default()),
+            (selected_file.clone(), Default::default()),
+            (shared_file.clone(), Default::default()),
+        ])),
+        ..empty_test_lockfile()
+    };
+    let selected_current = Lockfile {
+        snapshots: Some(std::collections::HashMap::from([
+            (package_key("selected", "2.0.0"), Default::default()),
+            (package_key("shared", "1.0.0"), Default::default()),
+            (selected_file, Default::default()),
+            (shared_file, Default::default()),
+        ])),
+        ..empty_test_lockfile()
+    };
+    let previous = Modules {
+        hoisted_dependencies: std::collections::BTreeMap::from([
+            (
+                retained.to_string(),
+                std::collections::BTreeMap::from([(
+                    "retained-alias".to_string(),
+                    pacquet_modules_yaml::HoistKind::Private,
+                )]),
+            ),
+            (
+                shared.to_string(),
+                std::collections::BTreeMap::from([(
+                    "stale-shared-alias".to_string(),
+                    pacquet_modules_yaml::HoistKind::Private,
+                )]),
+            ),
+            (
+                stale_selected.to_string(),
+                std::collections::BTreeMap::from([(
+                    "stale-selected-alias".to_string(),
+                    pacquet_modules_yaml::HoistKind::Private,
+                )]),
+            ),
+        ]),
+        hoisted_locations: Some(std::collections::BTreeMap::from([
+            (retained.to_string(), vec!["retained/location".to_string()]),
+            (shared.to_string(), vec!["stale/shared/location".to_string()]),
+        ])),
+        pending_builds: vec![retained.to_string(), shared.to_string(), stale_selected.to_string()],
+        ignored_builds: Some(
+            [retained, shared, stale_selected]
+                .into_iter()
+                .map(|value| pacquet_modules_yaml::DepPath::from(value.to_string()))
+                .collect(),
+        ),
+        skipped: vec![retained.to_string(), shared.to_string(), stale_selected.to_string()],
+        injected_deps: Some(std::collections::BTreeMap::from([
+            ("packages/retained-source".to_string(), vec!["retained/target".to_string()]),
+            ("packages/selected-source".to_string(), vec!["stale/selected/target".to_string()]),
+            ("packages/shared-source".to_string(), vec!["stale/shared/target".to_string()]),
+        ])),
+        ..Default::default()
+    };
+    let mut next = Modules {
+        hoisted_dependencies: std::collections::BTreeMap::from([(
+            selected.to_string(),
+            std::collections::BTreeMap::from([(
+                "selected-alias".to_string(),
+                pacquet_modules_yaml::HoistKind::Private,
+            )]),
+        )]),
+        hoisted_locations: Some(std::collections::BTreeMap::from([(
+            selected.to_string(),
+            vec!["selected/location".to_string()],
+        )])),
+        pending_builds: vec![selected.to_string()],
+        ignored_builds: Some(
+            std::iter::once(pacquet_modules_yaml::DepPath::from(selected.to_string())).collect(),
+        ),
+        skipped: vec![selected.to_string()],
+        injected_deps: Some(std::collections::BTreeMap::from([
+            ("packages/selected-source".to_string(), vec!["selected/target".to_string()]),
+            ("packages/shared-source".to_string(), vec!["shared/target".to_string()]),
+        ])),
+        ..Default::default()
+    };
+
+    super::merge_filtered_modules_metadata(&mut next, &previous, &current, &selected_current);
+
+    assert!(next.hoisted_dependencies.contains_key(retained));
+    assert!(next.hoisted_dependencies.contains_key(selected));
+    assert!(!next.hoisted_dependencies.contains_key(shared));
+    assert!(!next.hoisted_dependencies.contains_key(stale_selected));
+    assert_eq!(
+        next.hoisted_locations.as_ref().unwrap(),
+        &std::collections::BTreeMap::from([
+            (retained.to_string(), vec!["retained/location".to_string()]),
+            (selected.to_string(), vec!["selected/location".to_string()]),
+        ]),
+    );
+    assert_eq!(next.pending_builds, [retained.to_string(), selected.to_string()]);
+    assert_eq!(
+        next.ignored_builds
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(pacquet_modules_yaml::DepPath::as_str)
+            .collect::<Vec<_>>(),
+        [retained, selected],
+    );
+    assert_eq!(next.skipped, [retained.to_string(), selected.to_string()]);
+    assert_eq!(
+        next.injected_deps.as_ref().unwrap(),
+        &std::collections::BTreeMap::from([
+            ("packages/retained-source".to_string(), vec!["retained/target".to_string()],),
+            ("packages/selected-source".to_string(), vec!["selected/target".to_string()],),
+            ("packages/shared-source".to_string(), vec!["shared/target".to_string()],),
+        ]),
+    );
+}
+
+#[test]
+fn filtered_modules_metadata_keeps_empty_optional_maps_omitted() {
+    let current = empty_test_lockfile();
+    let previous = Modules {
+        hoisted_locations: Some(std::collections::BTreeMap::from([(
+            "stale@1.0.0".to_string(),
+            vec!["stale/location".to_string()],
+        )])),
+        ignored_builds: Some(
+            std::iter::once(pacquet_modules_yaml::DepPath::from("stale@1.0.0".to_string()))
+                .collect(),
+        ),
+        injected_deps: Some(std::collections::BTreeMap::from([(
+            "packages/stale".to_string(),
+            vec!["stale/target".to_string()],
+        )])),
+        ..Default::default()
+    };
+    let mut next = Modules::default();
+
+    super::merge_filtered_modules_metadata(&mut next, &previous, &current, &current);
+
+    assert!(next.hoisted_locations.is_none());
+    assert!(next.ignored_builds.is_none());
+    assert!(next.injected_deps.is_none());
+}
+
 /// [`is_modules_yaml_consistent`] returns `false` when
 /// `.modules.yaml` is missing, so a first install (no prior state)
 /// can't be mistaken for an up-to-date install.
@@ -7153,6 +7335,116 @@ fn sync_fast_path_matches_optimistic_short_circuit() {
     // is off and no current lockfile exists), so the content re-check
     // cannot vouch for it either.
     assert_eq!(install_already_up_to_date(&check), None, "modified manifest must fall through");
+}
+
+#[test]
+fn sync_fast_path_reads_the_workspace_root_wanted_lockfile_from_a_member() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path().join("workspace");
+    let project_root = workspace_root.join("packages/app");
+    let modules_dir = workspace_root.join("node_modules");
+    let virtual_store_dir = modules_dir.join(".pnpm");
+    std::fs::create_dir_all(&project_root).expect("create workspace member");
+    std::fs::create_dir_all(project_root.join("node_modules"))
+        .expect("create member modules directory");
+    std::fs::create_dir_all(&virtual_store_dir).expect("create virtual store");
+    std::fs::write(workspace_root.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    std::fs::write(
+        workspace_root.join("package.json"),
+        r#"{ "name": "workspace-root", "version": "1.0.0" }"#,
+    )
+    .expect("write root manifest");
+    let manifest_path = project_root.join("package.json");
+    std::fs::write(
+        &manifest_path,
+        r#"{ "name": "app", "version": "1.0.0", "dependencies": { "sibling": "link:../../sibling" } }"#,
+    )
+    .expect("write member manifest");
+    let manifest = PackageManifest::from_path(manifest_path).expect("read member manifest");
+
+    let current = "lockfileVersion: '9.0'\nimporters:\n  .: {}\n  packages/app:\n    dependencies:\n      sibling:\n        specifier: link:../../sibling\n        version: link:../../sibling\n";
+    std::fs::write(virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME), current)
+        .expect("write current lockfile");
+    std::fs::write(project_root.join(Lockfile::FILE_NAME), "not: [valid")
+        .expect("write invalid member lockfile");
+    let wanted_path = workspace_root.join(Lockfile::FILE_NAME);
+    std::fs::write(&wanted_path, current).expect("write wanted lockfile");
+
+    let mut config = Config::new();
+    config.workspace_dir = Some(workspace_root.clone());
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir;
+    config.virtual_store_dir = virtual_store_dir;
+    let config = config.leak();
+    let included = pacquet_modules_yaml::IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: true,
+        optional_dependencies: true,
+    };
+    let mut projects = std::collections::BTreeMap::new();
+    projects.insert(
+        workspace_root.to_string_lossy().into_owned(),
+        workspace_state::ProjectEntry {
+            name: Some("workspace-root".to_string()),
+            version: Some("1.0.0".to_string()),
+        },
+    );
+    projects.insert(
+        project_root.to_string_lossy().into_owned(),
+        workspace_state::ProjectEntry {
+            name: Some("app".to_string()),
+            version: Some("1.0.0".to_string()),
+        },
+    );
+    let validated_at = pacquet_workspace_state::now_millis();
+    workspace_state::update_workspace_state(
+        &workspace_root,
+        &pacquet_workspace_state::WorkspaceState {
+            last_validated_timestamp: validated_at,
+            projects,
+            pnpmfiles: Vec::new(),
+            filtered_install: false,
+            config_dependencies: None,
+            settings: crate::optimistic_repeat_install::current_settings(
+                config,
+                pacquet_config::NodeLinker::Isolated,
+                included,
+            ),
+        },
+    )
+    .expect("seed workspace state");
+    let check = UpToDateFastPathCheck {
+        config,
+        manifest: &manifest,
+        dependency_groups: vec![
+            DependencyGroup::Prod,
+            DependencyGroup::Dev,
+            DependencyGroup::Optional,
+        ],
+        node_linker: pacquet_config::NodeLinker::Isolated,
+    };
+
+    assert_eq!(install_already_up_to_date(&check).as_deref(), Some(&*workspace_root));
+    assert_eq!(std::fs::read_to_string(&wanted_path).expect("reread wanted lockfile"), current,);
+
+    std::fs::write(project_root.join(Lockfile::FILE_NAME), current).expect("write member lockfile");
+    std::fs::write(&wanted_path, "not: [valid").expect("write invalid root lockfile");
+    let mut per_project_config = config.clone();
+    per_project_config.shared_workspace_lockfile = false;
+    let per_project_config = Config::leak(per_project_config);
+    let per_project_check = UpToDateFastPathCheck {
+        config: per_project_config,
+        manifest: &manifest,
+        dependency_groups: vec![
+            DependencyGroup::Prod,
+            DependencyGroup::Dev,
+            DependencyGroup::Optional,
+        ],
+        node_linker: pacquet_config::NodeLinker::Isolated,
+    };
+
+    assert_eq!(install_already_up_to_date(&per_project_check).as_deref(), Some(&*workspace_root),);
 }
 
 /// `--frozen-lockfile` disables the optimistic short-circuit because

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -103,6 +103,8 @@ where
     pub current_packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
     pub dependency_groups: DependencyGroupList,
     pub project_manifests: &'a [(PathBuf, &'a pacquet_package_manifest::PackageManifest)],
+    pub package_map_project_manifests:
+        &'a [(PathBuf, &'a pacquet_package_manifest::PackageManifest)],
     /// Install-scoped dedupe state for `pnpm:package-import-method`.
     /// See `link_file::log_method_once`.
     pub logged_methods: &'a AtomicU8,
@@ -583,6 +585,7 @@ where
             current_packages,
             dependency_groups,
             project_manifests,
+            package_map_project_manifests,
             logged_methods,
             workspace_root,
             requester,
@@ -1169,6 +1172,7 @@ where
                     importers,
                     dependency_groups: &dependency_groups,
                     project_manifests,
+                    package_map_project_manifests,
                     walker_lockfile_dir: workspace_root,
                     symlink_workspace_root: workspace_root,
                     host_node: host_node.as_ref(),
@@ -1470,7 +1474,14 @@ pub(crate) struct HoistedLinkerInputs<'a> {
     pub(crate) layout: &'a VirtualStoreLayout,
     pub(crate) importers: &'a HashMap<String, ProjectSnapshot>,
     pub(crate) dependency_groups: &'a [DependencyGroup],
+    /// Selected project anchors whose direct dependencies and workspace
+    /// links are written by this filtered run.
     pub(crate) project_manifests: &'a [(PathBuf, &'a pacquet_package_manifest::PackageManifest)],
+    /// Every real importer manifest represented in the full hoisted graph.
+    /// The shared package map needs all project names for self-reference
+    /// entries even though direct links are limited to selected anchors.
+    pub(crate) package_map_project_manifests:
+        &'a [(PathBuf, &'a pacquet_package_manifest::PackageManifest)],
     /// Lockfile root the walker resolves hoisted directories against.
     pub(crate) walker_lockfile_dir: &'a Path,
     /// Anchor for [`crate::SymlinkDirectDependencies`]'s per-importer
@@ -1552,6 +1563,7 @@ pub(crate) fn run_hoisted_linker<Reporter: self::Reporter>(
         importers,
         dependency_groups,
         project_manifests,
+        package_map_project_manifests,
         walker_lockfile_dir,
         symlink_workspace_root,
         host_node,
@@ -1639,6 +1651,12 @@ pub(crate) fn run_hoisted_linker<Reporter: self::Reporter>(
         requester,
     };
     link_hoisted_modules::<Reporter>(&link_opts).map_err(HoistedLinkerError::LinkHoistedModules)?;
+    link_selected_hoisted_direct_dependencies(
+        config,
+        walker_lockfile_dir,
+        project_manifests,
+        &walker_result.direct_dependencies_by_importer_id,
+    )?;
     crate::package_map::write_hoisted_package_map(
         lockfile,
         &walker_result,
@@ -1646,7 +1664,7 @@ pub(crate) fn run_hoisted_linker<Reporter: self::Reporter>(
             lockfile_dir: walker_lockfile_dir,
             modules_dir: &config.modules_dir,
             package_map_type: config.node_package_map_type,
-            project_manifests,
+            project_manifests: package_map_project_manifests,
         },
     )
     .map_err(HoistedLinkerError::WritePackageMap)?;
@@ -1701,6 +1719,58 @@ pub(crate) fn run_hoisted_linker<Reporter: self::Reporter>(
         hoisted_locations: walker_result.hoisted_locations,
         hoisted_pkg_root_by_key: Some(pkg_root_by_key),
     })
+}
+
+fn link_selected_hoisted_direct_dependencies(
+    config: &Config,
+    lockfile_dir: &Path,
+    project_manifests: &[(PathBuf, &pacquet_package_manifest::PackageManifest)],
+    direct_dependencies_by_importer_id: &crate::DirectDependenciesByImporterId,
+) -> Result<(), HoistedLinkerError> {
+    let modules_dir_name =
+        config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+    for (project_dir, _) in project_manifests {
+        let importer_id = pacquet_workspace::importer_id_from_root_dir(lockfile_dir, project_dir);
+        let Some(direct_dependencies) = direct_dependencies_by_importer_id.get(&importer_id) else {
+            continue;
+        };
+        let modules_dir = project_dir.join(modules_dir_name);
+        let mut linked_names = Vec::new();
+        for (alias, target) in direct_dependencies {
+            let link_path =
+                crate::safe_join_modules_dir::safe_join_modules_dir(&modules_dir, alias).map_err(
+                    |source| {
+                        HoistedLinkerError::SymlinkDirectDependencies(
+                            SymlinkDirectDependenciesError::SymlinkPackage {
+                                importer_id: importer_id.clone(),
+                                name: alias.clone(),
+                                source: SymlinkPackageError::InvalidAlias(source),
+                            },
+                        )
+                    },
+                )?;
+            if pacquet_fs::lexical_normalize(&link_path) == pacquet_fs::lexical_normalize(target) {
+                linked_names.push(alias.clone());
+                continue;
+            }
+            crate::symlink_package(target, &link_path).map_err(|source| {
+                HoistedLinkerError::SymlinkDirectDependencies(
+                    SymlinkDirectDependenciesError::SymlinkPackage {
+                        importer_id: importer_id.clone(),
+                        name: alias.clone(),
+                        source,
+                    },
+                )
+            })?;
+            linked_names.push(alias.clone());
+        }
+        crate::link_direct_dep_bins(&modules_dir, &linked_names).map_err(|source| {
+            HoistedLinkerError::SymlinkDirectDependencies(SymlinkDirectDependenciesError::LinkBins(
+                source,
+            ))
+        })?;
+    }
+    Ok(())
 }
 
 /// Clone the lockfile with every importer's excluded dep groups

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -2404,7 +2404,7 @@ fn is_partial_workspace_selection(
 ) -> bool {
     matches!(
         (real_importer_ids, selected_importer_ids),
-        (Some(real), Some(selected)) if real != selected
+        (Some(real), Some(selected)) if real != selected,
     )
 }
 

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -19,6 +19,7 @@ use pacquet_engine_runtime_deno_resolver::DenoResolver;
 use pacquet_engine_runtime_node_resolver::NodeResolver;
 use pacquet_hooks::finder;
 use pacquet_lockfile::{Lockfile, LockfileResolution, SaveLockfileError};
+use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{
@@ -199,6 +200,8 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     /// disk lookup entirely; `None` (every CLI install) falls back to
     /// [`finder::load_pnpmfile`]. See [`crate::Install::pnpmfile_hook_override`].
     pub pnpmfile_hook_override: Option<Arc<dyn pacquet_hooks::PnpmfileHooks>>,
+    pub real_importer_ids: Option<&'a std::collections::HashSet<String>>,
+    pub selected_importer_ids: Option<&'a std::collections::HashSet<String>>,
 }
 
 /// Which lockfile-pinned `(name, version)` pairs to *withhold* from the
@@ -226,6 +229,64 @@ pub enum UpdateSeedPolicy {
     /// — matched names (at any depth) re-resolve while everything else
     /// keeps its pin. Keyed by package name (scope included).
     DropOnly(std::collections::HashSet<String>),
+    ByImporter(BTreeMap<String, ImporterUpdateSeedPolicy>),
+}
+
+#[derive(Debug, Clone)]
+pub enum ImporterUpdateSeedPolicy {
+    DropAll,
+    DropOnly(std::collections::HashSet<String>),
+}
+
+fn update_reuse_scopes(
+    policy: &UpdateSeedPolicy,
+) -> (
+    pacquet_resolving_deps_resolver::UpdateReuseScope,
+    BTreeMap<String, pacquet_resolving_deps_resolver::UpdateReuseScope>,
+) {
+    use pacquet_resolving_deps_resolver::UpdateReuseScope;
+
+    match policy {
+        UpdateSeedPolicy::KeepAll => (UpdateReuseScope::All, BTreeMap::new()),
+        UpdateSeedPolicy::DropAll => (UpdateReuseScope::None, BTreeMap::new()),
+        UpdateSeedPolicy::DropOnly(names) => {
+            (UpdateReuseScope::Except(names.clone()), BTreeMap::new())
+        }
+        UpdateSeedPolicy::ByImporter(policies) => (
+            UpdateReuseScope::All,
+            policies
+                .iter()
+                .map(|(importer_id, policy)| {
+                    let scope = match policy {
+                        ImporterUpdateSeedPolicy::DropAll => UpdateReuseScope::None,
+                        ImporterUpdateSeedPolicy::DropOnly(names) => {
+                            UpdateReuseScope::Except(names.clone())
+                        }
+                    };
+                    (importer_id.clone(), scope)
+                })
+                .collect(),
+        ),
+    }
+}
+
+fn full_resolution_required<'a>(
+    has_reusable_seed: bool,
+    importer_ids: impl IntoIterator<Item = &'a str>,
+    default_scope: &pacquet_resolving_deps_resolver::UpdateReuseScope,
+    scopes_by_importer: &BTreeMap<String, pacquet_resolving_deps_resolver::UpdateReuseScope>,
+) -> bool {
+    use pacquet_resolving_deps_resolver::UpdateReuseScope;
+
+    !has_reusable_seed
+        || importer_ids.into_iter().all(|importer_id| {
+            let scope = if matches!(default_scope, UpdateReuseScope::None) {
+                default_scope
+            } else {
+                scopes_by_importer.get(importer_id).unwrap_or(default_scope)
+            };
+            matches!(scope, UpdateReuseScope::None)
+        })
 }
 
 /// Error type of [`InstallWithFreshLockfile`].
@@ -331,6 +392,9 @@ pub enum InstallWithFreshLockfileError {
     /// pass before virtual-store materialization starts.
     #[diagnostic(transparent)]
     Installability(#[error(source)] Box<pacquet_package_is_installable::InstallabilityError>),
+
+    #[diagnostic(transparent)]
+    MergeFilteredWantedLockfile(#[error(source)] crate::MergeFilteredWantedLockfileError),
 
     /// Failed to resolve and hash `patchedDependencies` against the
     /// workspace directory.
@@ -530,6 +594,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             resolution_observer,
             peer_issues_sink,
             pnpmfile_hook_override,
+            real_importer_ids,
+            selected_importer_ids,
         } = self;
 
         // The pnpr override when supplied, else the config's npmrc headers;
@@ -541,6 +607,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .as_ref()
             .and_then(|observer| observer.minimum_release_age_exclude_override());
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
+        let filtered_isolated =
+            is_partial_workspace_selection(real_importer_ids, selected_importer_ids) && !is_hoisted;
         // Materialise the caller's iterator into a `Vec` so the same
         // group set can be replayed into both the resolver (consumes
         // the iterator) and `SymlinkDirectDependencies` (needs to walk
@@ -867,7 +935,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // `pnpm-lock.yaml` and must not touch the store, so resolution
         // runs through the bare chain with no background download. This is
         // the `dryRun: opts.lockfileOnly` path.
-        let resolver: Box<dyn Resolver> = if lockfile_only {
+        let resolver: Box<dyn Resolver> = if lockfile_only || filtered_isolated {
             inner_resolver
         } else {
             Box::new(PrefetchingResolver::<Reporter>::new(
@@ -1008,46 +1076,81 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             importer_manifests.values().copied().collect();
         // `pacquet update` withholds the lockfile pins for the names it
         // is bumping so they re-resolve to highest-in-range; everything
-        // else keeps its pin. `DropOnly` builds a filtered snapshot map
-        // (owned, so it outlives the seed build) excluding the matched
-        // names; `DropAll` passes `None` so no pin seeds the table.
+        // else keeps its pin. Manifest preferences remain workspace-wide.
         let lockfile_snapshots = wanted_lockfile.and_then(|lockfile| lockfile.snapshots.as_ref());
-        let filtered_snapshots;
-        let seed_snapshots = match &update_seed_policy {
-            UpdateSeedPolicy::KeepAll => lockfile_snapshots,
-            UpdateSeedPolicy::DropAll => None,
-            UpdateSeedPolicy::DropOnly(names) => match lockfile_snapshots {
-                None => None,
-                Some(snapshots) => {
-                    // The update-target set is small (CLI selectors / direct
-                    // deps); the snapshot map is large. Parse the targets to
-                    // `PkgName` once so the per-snapshot filter compares
-                    // against `key.name` directly instead of allocating a
-                    // `String` per key.
-                    let drop: std::collections::HashSet<pacquet_lockfile::PkgName> = names
-                        .iter()
-                        .filter_map(|name| pacquet_lockfile::PkgName::parse(name.as_str()).ok())
-                        .collect();
-                    filtered_snapshots = snapshots
-                        .iter()
-                        .filter(|(key, _)| !drop.contains(&key.name))
-                        .map(|(key, entry)| (key.clone(), entry.clone()))
-                        .collect::<HashMap<_, _>>();
-                    Some(&filtered_snapshots)
-                }
-            },
+        let all_preferred_versions = match &update_seed_policy {
+            UpdateSeedPolicy::KeepAll | UpdateSeedPolicy::ByImporter(_) => {
+                pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
+                    lockfile_snapshots,
+                    manifests_for_preferred.as_slice(),
+                )
+            }
+            UpdateSeedPolicy::DropAll => {
+                pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
+                    None,
+                    manifests_for_preferred.as_slice(),
+                )
+            }
+            UpdateSeedPolicy::DropOnly(names) => {
+                let excluded_names = names
+                    .iter()
+                    .filter_map(|name| pacquet_lockfile::PkgName::parse(name.as_str()).ok())
+                    .collect();
+                pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests_excluding(
+                    lockfile_snapshots,
+                    manifests_for_preferred.as_slice(),
+                    &excluded_names,
+                )
+            }
         };
-        let all_preferred_versions =
-            pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
-                seed_snapshots,
-                manifests_for_preferred.as_slice(),
-            );
         // The picker biases toward this seed so pins that still satisfy
         // their range survive the re-resolve. Move the map into the `Arc`
         // (no extra clone) so each per-importer `ResolveOptions` shares it
         // with a refcount bump rather than deep-cloning the map.
         let preferred_versions_seed = Arc::new(all_preferred_versions);
-
+        let mut preferred_versions_seeds_by_importer = BTreeMap::new();
+        if let UpdateSeedPolicy::ByImporter(policies) = &update_seed_policy {
+            let mut drop_all_seed = None;
+            let mut drop_only_seeds = HashMap::new();
+            for (importer_id, policy) in policies {
+                let seed = match policy {
+                    ImporterUpdateSeedPolicy::DropAll => Arc::clone(
+                        drop_all_seed.get_or_insert_with(|| {
+                            Arc::new(
+                                pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
+                                    None,
+                                    manifests_for_preferred.as_slice(),
+                                ),
+                            )
+                        }),
+                    ),
+                    ImporterUpdateSeedPolicy::DropOnly(names) => {
+                        let mut cache_key = names.iter().cloned().collect::<Vec<_>>();
+                        cache_key.sort_unstable();
+                        if let Some(seed) = drop_only_seeds.get(&cache_key) {
+                            Arc::clone(seed)
+                        } else {
+                            let excluded_names = names
+                                .iter()
+                                .filter_map(|name| {
+                                    pacquet_lockfile::PkgName::parse(name.as_str()).ok()
+                                })
+                                .collect();
+                            let seed = Arc::new(
+                                pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests_excluding(
+                                    lockfile_snapshots,
+                                    manifests_for_preferred.as_slice(),
+                                    &excluded_names,
+                                ),
+                            );
+                            drop_only_seeds.insert(cache_key, Arc::clone(&seed));
+                            seed
+                        }
+                    }
+                };
+                preferred_versions_seeds_by_importer.insert(importer_id.clone(), seed);
+            }
+        }
         // Resolve `pnpm-workspace.yaml`'s `patchedDependencies` once
         // per install. The resolver consults the grouped record at
         // every per-node lookup to attach `(patch_hash=<hash>)` to the
@@ -1141,13 +1244,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // `pacquet update` must re-resolve its targets to highest-in-range,
         // so suppress reuse for them (and their subtrees). Custom resolvers
         // may widen this to `None` via `shouldRefreshResolution`.
-        let mut update_reuse_scope = match &update_seed_policy {
-            UpdateSeedPolicy::KeepAll => pacquet_resolving_deps_resolver::UpdateReuseScope::All,
-            UpdateSeedPolicy::DropAll => pacquet_resolving_deps_resolver::UpdateReuseScope::None,
-            UpdateSeedPolicy::DropOnly(names) => {
-                pacquet_resolving_deps_resolver::UpdateReuseScope::Except(names.clone())
-            }
-        };
+        let (mut update_reuse_scope, mut update_reuse_scopes_by_importer) =
+            update_reuse_scopes(&update_seed_policy);
 
         // A throwing hook propagates and aborts.
         if let Some(lockfile) = wanted_lockfile
@@ -1159,6 +1257,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .map_err(InstallWithFreshLockfileError::CustomResolverForceResolve)?
         {
             update_reuse_scope = pacquet_resolving_deps_resolver::UpdateReuseScope::None;
+            update_reuse_scopes_by_importer.clear();
         }
 
         // Hand the resolver the prior lockfile so it can reuse
@@ -1176,11 +1275,12 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // versions overrider, so only a resolution with no reuse at all
         // collects the complete declared-range set the convergence
         // staleness check needs.
-        let full_resolution = lockfile_reuse_seed.is_none()
-            || matches!(
-                update_reuse_scope,
-                pacquet_resolving_deps_resolver::UpdateReuseScope::None,
-            );
+        let full_resolution = full_resolution_required(
+            lockfile_reuse_seed.is_some(),
+            importer_manifests.keys().map(String::as_str),
+            &update_reuse_scope,
+            &update_reuse_scopes_by_importer,
+        );
 
         let workspace_opts = pacquet_resolving_deps_resolver::WorkspaceResolveOptions {
             dedupe_peers: config.dedupe_peers,
@@ -1198,6 +1298,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             time_based,
             wanted_lockfile: lockfile_reuse_seed.cloned().map(Arc::new),
             update_reuse_scope,
+            update_reuse_scopes_by_importer,
             auto_install_peers: config.auto_install_peers,
             registries,
         };
@@ -1211,6 +1312,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             &dependency_groups,
             workspace_opts,
             |importer| {
+                let importer_preferred_versions = preferred_versions_seeds_by_importer
+                    .get(&importer.id)
+                    .unwrap_or(&preferred_versions_seed);
                 let project_dir = importer
                     .manifest
                     .path()
@@ -1226,7 +1330,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                     dedupe_peers: config.dedupe_peers,
                     // The per-importer hoist loop mutates its own copy, so
                     // clone the shared seed's map here (deref past the `Arc`).
-                    all_preferred_versions: (*preferred_versions_seed).clone(),
+                    all_preferred_versions: importer_preferred_versions.as_ref().clone(),
                     patched_dependencies: patched_dependencies.clone(),
                     // `pick_lowest_direct` / `subdep_published_by` are
                     // authoritative from `resolve_workspace` (it computes
@@ -1238,7 +1342,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                     pick_lowest_direct,
                     subdep_published_by: published_by,
                     base_opts: ResolveOptions {
-                        preferred_versions: Arc::clone(&preferred_versions_seed),
+                        preferred_versions: Arc::clone(importer_preferred_versions),
                         default_tag: Some("latest".to_string()),
                         published_by,
                         published_by_exclude: published_by_exclude.clone(),
@@ -1384,7 +1488,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // there is no `node_modules`, `.modules.yaml`, or current
         // lockfile — a lockfile-only resolve pass.
         if lockfile_only {
-            let built_lockfile = build_fresh_lockfile(FreshLockfileBuildOptions {
+            let freshly_resolved = build_fresh_lockfile(FreshLockfileBuildOptions {
                 config,
                 importer_manifests: &importer_manifests,
                 graph: &merged_graph,
@@ -1397,6 +1501,19 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .map_err(|error| {
                 InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
             })?;
+            let built_lockfile = match (real_importer_ids, selected_importer_ids) {
+                (Some(real_importer_ids), Some(selected_importer_ids)) => {
+                    crate::merge_filtered_wanted_lockfile(
+                        wanted_lockfile,
+                        freshly_resolved,
+                        real_importer_ids,
+                        selected_importer_ids,
+                        lockfile_dir,
+                    )
+                    .map_err(InstallWithFreshLockfileError::MergeFilteredWantedLockfile)?
+                }
+                _ => freshly_resolved,
+            };
             // `--dry-run` builds the would-be lockfile so the caller can
             // diff it, but never persists it. A plain `--lockfile-only`
             // writes it (unless `lockfile: false`).
@@ -1464,7 +1581,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // serialize on `Arc<Mutex<StoreIndex>>` for warm packages
         // that weren't reached by the resolve-time prefetch (e.g.
         // resolutions without a structured `name@version`).
-        let cache_keys: Vec<String> = collect_prefetch_cache_keys_from_graph(&merged_graph);
+        let cache_keys: Vec<String> = if filtered_isolated {
+            Vec::new()
+        } else {
+            collect_prefetch_cache_keys_from_graph(&merged_graph)
+        };
         let cache_keys_len = cache_keys.len();
         let phase_start = std::time::Instant::now();
         let prefetch = pacquet_tarball::prefetch_cas_paths(
@@ -1530,7 +1651,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // [`Self::wanted_lockfile`], which is the *previous* run's
         // lockfile threaded in for preferred-versions seeding.
         let phase_start = std::time::Instant::now();
-        let built_lockfile = build_fresh_lockfile(FreshLockfileBuildOptions {
+        let freshly_resolved = build_fresh_lockfile(FreshLockfileBuildOptions {
             config,
             importer_manifests: &importer_manifests,
             graph: &merged_graph,
@@ -1543,18 +1664,55 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         .map_err(|error| {
             InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
         })?;
+        let built_lockfile = match (real_importer_ids, selected_importer_ids) {
+            (Some(real_importer_ids), Some(selected_importer_ids)) => {
+                crate::merge_filtered_wanted_lockfile(
+                    wanted_lockfile,
+                    freshly_resolved,
+                    real_importer_ids,
+                    selected_importer_ids,
+                    lockfile_dir,
+                )
+                .map_err(InstallWithFreshLockfileError::MergeFilteredWantedLockfile)?
+            }
+            _ => freshly_resolved,
+        };
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "build_fresh_lockfile",
             elapsed_ms = phase_start.elapsed().as_millis() as u64,
             "phase complete",
         );
+        let included = IncludedDependencies {
+            dependencies: dependency_groups.contains(&DependencyGroup::Prod),
+            dev_dependencies: dependency_groups.contains(&DependencyGroup::Dev),
+            optional_dependencies: dependency_groups.contains(&DependencyGroup::Optional),
+        };
+        let initial_materialization_ids = selected_importer_ids.map(|selected_importer_ids| {
+            if is_hoisted {
+                built_lockfile.importers.keys().cloned().collect()
+            } else {
+                selected_importer_ids.clone()
+            }
+        });
+        let empty_skipped = SkippedSnapshots::new();
+        let initial_materialization = initial_materialization_ids.as_ref().map(|importer_ids| {
+            crate::materialization_closure(
+                &built_lockfile,
+                lockfile_dir,
+                importer_ids,
+                included,
+                &empty_skipped,
+            )
+        });
+        let initial_materialization_lockfile =
+            initial_materialization.as_ref().map_or(&built_lockfile, |closure| &closure.lockfile);
         // `--force` bypasses the installability checks outright (see
         // `Config::force`): no skip set is computed and the hoisted
         // walker emits every dep, so no host detection is needed either.
         let needs_installability_check = !config.force
-            && built_lockfile.packages.as_ref().is_some_and(|packages| {
-                built_lockfile.snapshots.as_ref().is_some_and(|snapshots| {
+            && initial_materialization_lockfile.packages.as_ref().is_some_and(|packages| {
+                initial_materialization_lockfile.snapshots.as_ref().is_some_and(|snapshots| {
                     crate::any_installability_constraint(snapshots, packages)
                 })
             });
@@ -1601,7 +1759,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // so it overlaps `CreateVirtualStore`'s I/O, except under the
         // global virtual store whose layout needs it synchronously.
         let runtime_pinned_major = crate::install_frozen_lockfile::find_runtime_node_major(
-            built_lockfile.snapshots.as_ref(),
+            initial_materialization_lockfile.snapshots.as_ref(),
         );
         let (engine_name, deferred_engine_handle): (
             Option<String>,
@@ -1641,8 +1799,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let layout = VirtualStoreLayout::new(
             config,
             layout_engine_name,
-            built_lockfile.snapshots.as_ref(),
-            built_lockfile.packages.as_ref(),
+            initial_materialization_lockfile.snapshots.as_ref(),
+            initial_materialization_lockfile.packages.as_ref(),
             Some(&allow_build_policy),
         );
         if config.enable_global_virtual_store {
@@ -1656,8 +1814,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
 
         let mut skipped = if needs_installability_check {
             match (
-                built_lockfile.snapshots.as_ref(),
-                built_lockfile.packages.as_ref(),
+                initial_materialization_lockfile.snapshots.as_ref(),
+                initial_materialization_lockfile.packages.as_ref(),
                 installability_host.as_ref(),
             ) {
                 (Some(snapshots), Some(packages), Some(host)) => {
@@ -1692,7 +1850,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // optionals (e.g. `@pnpm/exe`'s platform binary).
         if is_full_install
             && !dependency_groups.contains(&DependencyGroup::Optional)
-            && let Some(snapshots) = built_lockfile.snapshots.as_ref()
+            && let Some(snapshots) = initial_materialization_lockfile.snapshots.as_ref()
         {
             for (key, snapshot) in snapshots {
                 if snapshot.optional {
@@ -1700,6 +1858,27 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 }
             }
         }
+
+        let final_materialization = initial_materialization_ids.as_ref().map(|importer_ids| {
+            crate::materialization_closure(
+                &built_lockfile,
+                lockfile_dir,
+                importer_ids,
+                included,
+                &skipped,
+            )
+        });
+        let materialization_lockfile =
+            final_materialization.as_ref().map_or(&built_lockfile, |closure| &closure.lockfile);
+        let materialization_importer_ids = final_materialization.as_ref().map_or_else(
+            || built_lockfile.importers.keys().cloned().collect(),
+            |closure| closure.importer_ids.clone(),
+        );
+        let project_anchor_importer_ids = match selected_importer_ids {
+            Some(selected_importer_ids) if is_hoisted => selected_importer_ids.clone(),
+            Some(_) => materialization_importer_ids.clone(),
+            None => materialization_importer_ids.clone(),
+        };
 
         // Materialise the virtual store via the same phased
         // warm/cold-batch pipeline the frozen-lockfile path uses. The
@@ -1729,8 +1908,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         } = CreateVirtualStore {
             http_client,
             config,
-            packages: built_lockfile.packages.as_ref(),
-            snapshots: built_lockfile.snapshots.as_ref(),
+            packages: materialization_lockfile.packages.as_ref(),
+            snapshots: materialization_lockfile.snapshots.as_ref(),
             current_snapshots: None,
             current_packages: None,
             layout: &layout,
@@ -1822,6 +2001,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let (hoisted_dependencies, hoisted_locations) = if is_hoisted {
             let project_manifests = importer_manifests
                 .iter()
+                .filter(|(id, _)| project_anchor_importer_ids.contains(id.as_str()))
+                .map(|(id, manifest)| (lockfile_dir.join(id), *manifest))
+                .collect::<Vec<_>>();
+            let package_map_project_manifests = importer_manifests
+                .iter()
                 .map(|(id, manifest)| (lockfile_dir.join(id), *manifest))
                 .collect::<Vec<_>>();
             // Reuse the host probed once above for the engine-name key, so
@@ -1832,15 +2016,16 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             let output = crate::install_frozen_lockfile::run_hoisted_linker::<Reporter>(
                 crate::install_frozen_lockfile::HoistedLinkerInputs {
                     config,
-                    lockfile: &built_lockfile,
+                    lockfile: materialization_lockfile,
                     // No previous-install `<virtual_store_dir>/lock.yaml`
                     // is threaded into the fresh path yet, so the
                     // walker runs without an orphan diff.
                     current_lockfile: None,
                     layout: &layout,
-                    importers: &built_lockfile.importers,
+                    importers: &materialization_lockfile.importers,
                     dependency_groups: &dependency_groups,
                     project_manifests: &project_manifests,
+                    package_map_project_manifests: &package_map_project_manifests,
                     walker_lockfile_dir: lockfile_dir,
                     symlink_workspace_root: symlink_root,
                     host_node: host_node.as_ref(),
@@ -1867,6 +2052,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             let hoisted_workspace_packages = config.hoist_workspace_packages.then(|| {
                 importer_manifests
                     .iter()
+                    .filter(|(id, _)| materialization_importer_ids.contains(id.as_str()))
                     .filter(|(id, _)| id.as_str() != ".")
                     .filter_map(|(id, manifest)| {
                         let name = manifest.value().get("name")?.as_str()?;
@@ -1879,9 +2065,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             });
             let pre_hoist = crate::install_frozen_lockfile::compute_hoist_plan(
                 config,
-                built_lockfile.snapshots.as_ref(),
-                built_lockfile.packages.as_ref(),
-                &built_lockfile.importers,
+                materialization_lockfile.snapshots.as_ref(),
+                materialization_lockfile.packages.as_ref(),
+                &materialization_lockfile.importers,
                 &dependency_groups,
                 &skipped,
                 false,
@@ -1904,11 +2090,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             // (Bit's capsule installs pass such projects), so they
             // bypass the malformed-lockfile importer-key rejection.
             let trusted_importer_ids: std::collections::HashSet<String> =
-                importer_manifests.keys().cloned().collect();
+                project_anchor_importer_ids.clone();
             SymlinkDirectDependencies {
                 config,
                 layout: &layout,
-                importers: &built_lockfile.importers,
+                importers: &materialization_lockfile.importers,
                 dependency_groups: dependency_groups.iter().copied(),
                 workspace_root: symlink_root,
                 skipped: &skipped,
@@ -1926,6 +2112,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             // [`link_root_component_members`].
             let root_component_importers: std::collections::HashSet<String> = importer_manifests
                 .iter()
+                .filter(|(id, _)| project_anchor_importer_ids.contains(id.as_str()))
                 .filter(|(_, manifest)| {
                     manifest.install_config_hoisting_limits()
                         == Some(crate::HOISTING_LIMITS_WORKSPACES)
@@ -1934,7 +2121,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 .collect();
             link_root_component_members(
                 &layout,
-                &built_lockfile.importers,
+                &materialization_lockfile.importers,
                 &root_component_importers,
                 &dependency_groups,
                 &skipped,
@@ -1992,7 +2179,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 || std::ffi::OsString::from("node_modules"),
                 std::ffi::OsStr::to_os_string,
             );
-            for importer_id in importer_manifests.keys() {
+            for importer_id in &project_anchor_importer_ids {
                 let project_dir = crate::symlink_direct_dependencies::importer_root_dir(
                     symlink_root,
                     importer_id,
@@ -2025,7 +2212,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             // ~95% slot short-circuit the frozen path enjoys.
             LinkVirtualStoreBins {
                 layout: &layout,
-                snapshots: built_lockfile.snapshots.as_ref(),
+                snapshots: materialization_lockfile.snapshots.as_ref(),
                 packages: None,
                 package_manifests: &package_manifests,
                 skipped: &skipped,
@@ -2064,10 +2251,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         if crate::should_write_package_map(config, node_linker) {
             let project_manifests = importer_manifests
                 .iter()
+                .filter(|(id, _)| project_anchor_importer_ids.contains(id.as_str()))
                 .map(|(id, manifest)| (lockfile_dir.join(id), *manifest))
                 .collect::<Vec<_>>();
             crate::package_map::write_package_map(
-                &built_lockfile,
+                materialization_lockfile,
                 &crate::package_map::PackageMapOptions {
                     lockfile_dir,
                     modules_dir: &config.modules_dir,
@@ -2106,9 +2294,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 workspace_root: lockfile_dir,
                 top_level_bin_root: symlink_root,
                 layout: &layout,
-                snapshots: built_lockfile.snapshots.as_ref(),
-                packages: built_lockfile.packages.as_ref(),
-                importers: &built_lockfile.importers,
+                snapshots: materialization_lockfile.snapshots.as_ref(),
+                packages: materialization_lockfile.packages.as_ref(),
+                importers: &materialization_lockfile.importers,
                 dependency_groups: &dependency_groups,
                 // Reuse the record resolved earlier for the resolver so the
                 // patch files aren't hashed a second time.
@@ -2178,8 +2366,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let injected_deps = crate::collect_injected_deps(
             &layout,
             lockfile_dir,
-            built_lockfile.snapshots.as_ref(),
-            built_lockfile.packages.as_ref(),
+            materialization_lockfile.snapshots.as_ref(),
+            materialization_lockfile.packages.as_ref(),
             &skipped,
             is_hoisted.then_some(&hoisted_locations),
         );
@@ -2208,6 +2396,16 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             skipped,
         })
     }
+}
+
+fn is_partial_workspace_selection(
+    real_importer_ids: Option<&std::collections::HashSet<String>>,
+    selected_importer_ids: Option<&std::collections::HashSet<String>>,
+) -> bool {
+    matches!(
+        (real_importer_ids, selected_importer_ids),
+        (Some(real), Some(selected)) if real != selected
+    )
 }
 
 /// Walk the merged resolver graph and emit the `{integrity}\t{pkg_id}`

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -1,4 +1,7 @@
-use super::compute_package_extensions_checksum;
+use super::{
+    ImporterUpdateSeedPolicy, UpdateSeedPolicy, compute_package_extensions_checksum,
+    full_resolution_required, is_partial_workspace_selection, update_reuse_scopes,
+};
 use pacquet_config::{Config, PackageExtension};
 use pretty_assertions::assert_eq;
 
@@ -17,6 +20,17 @@ fn config_with_extensions(entries: &[(&str, &[(&str, &str)])]) -> Box<Config> {
     let mut config = Config::new();
     config.package_extensions = Some(extensions);
     Box::new(config)
+}
+
+#[test]
+fn full_workspace_selection_keeps_resolution_prefetch_enabled() {
+    let real = std::collections::HashSet::from(["a".to_string(), "b".to_string()]);
+    let all_selected = real.clone();
+    let partial = std::collections::HashSet::from(["a".to_string()]);
+
+    assert!(!is_partial_workspace_selection(Some(&real), Some(&all_selected)));
+    assert!(is_partial_workspace_selection(Some(&real), Some(&partial)));
+    assert!(!is_partial_workspace_selection(None, None));
 }
 
 /// Ports `installing/.../packageExtensions.ts:103-153`
@@ -65,4 +79,56 @@ fn compute_checksum_is_none_for_explicit_empty_map() {
     let mut config = Config::new();
     config.package_extensions = Some(indexmap::IndexMap::new());
     assert_eq!(compute_package_extensions_checksum(&config), None);
+}
+
+#[test]
+fn importer_scoped_update_full_resolution_requires_every_importer_to_disable_reuse() {
+    use pacquet_resolving_deps_resolver::UpdateReuseScope;
+
+    let importer_ids = ["selected", "unselected"];
+    let mixed =
+        std::collections::BTreeMap::from([("selected".to_string(), UpdateReuseScope::None)]);
+    assert!(!full_resolution_required(true, importer_ids, &UpdateReuseScope::All, &mixed,));
+
+    let all_none = std::collections::BTreeMap::from([
+        ("selected".to_string(), UpdateReuseScope::None),
+        ("unselected".to_string(), UpdateReuseScope::None),
+    ]);
+    assert!(full_resolution_required(true, importer_ids, &UpdateReuseScope::All, &all_none,));
+    assert!(full_resolution_required(
+        false,
+        importer_ids,
+        &UpdateReuseScope::All,
+        &std::collections::BTreeMap::new(),
+    ));
+}
+
+#[test]
+fn importer_scoped_update_custom_refresh_widens_every_importer() {
+    use pacquet_resolving_deps_resolver::UpdateReuseScope;
+
+    let scoped = std::collections::BTreeMap::from([(
+        "selected".to_string(),
+        UpdateReuseScope::Except(std::collections::HashSet::from(["pkg".to_string()])),
+    )]);
+    assert!(full_resolution_required(
+        true,
+        ["selected", "unselected"],
+        &UpdateReuseScope::None,
+        &scoped,
+    ));
+}
+
+#[test]
+fn importer_scoped_update_absent_importer_keeps_all_reuse() {
+    use pacquet_resolving_deps_resolver::UpdateReuseScope;
+
+    let policy = UpdateSeedPolicy::ByImporter(std::collections::BTreeMap::from([(
+        "selected".to_string(),
+        ImporterUpdateSeedPolicy::DropAll,
+    )]));
+    let (default_scope, scopes) = update_reuse_scopes(&policy);
+    assert_eq!(default_scope, UpdateReuseScope::All);
+    assert_eq!(scopes.get("selected"), Some(&UpdateReuseScope::None));
+    assert!(!scopes.contains_key("unselected"));
 }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -608,7 +608,7 @@ fn modified_manifests_match_lockfile(
             wanted,
             project.manifest,
             &importer_id,
-            config.auto_install_peers,
+            config,
             &ignored_optional_matcher,
             parsed_overrides.as_deref(),
         ) {

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -288,6 +288,7 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
                     included,
                     catalogs,
                     project_manifests,
+                    false,
                 );
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {
                     tracing::warn!(
@@ -1598,6 +1599,7 @@ pub fn check_deps_status_before_run(
                     included,
                     catalogs,
                     project_manifests,
+                    state.filtered_install,
                 );
                 // The gate ignored `dev`/`optional`/`production` drift
                 // above; writing today's (default-group) values here

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -281,6 +281,11 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
             // repeat of the content check, so it degrades rather than
             // fails.
             if is_workspace_install {
+                // This path refreshes the timestamp without materializing
+                // anything, so it carries the previous run's
+                // `filtered_install` forward: clearing it would claim every
+                // importer is materialized when a filtered install left the
+                // unselected ones untouched.
                 let new_state = crate::install::build_workspace_state(
                     workspace_root,
                     config,
@@ -288,7 +293,7 @@ pub fn check_optimistic_repeat_install(check: &OptimisticRepeatInstallCheck<'_>)
                     included,
                     catalogs,
                     project_manifests,
-                    false,
+                    state.filtered_install,
                 );
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {
                     tracing::warn!(

--- a/pnpm/crates/package-manager/src/prune_direct_deps.rs
+++ b/pnpm/crates/package-manager/src/prune_direct_deps.rs
@@ -67,9 +67,10 @@ pub enum PruneDirectDepsError {
 }
 
 /// Remove the direct-dependency links that `old_included` selected but
-/// `new_included` does not, for every importer recorded in the current
-/// lockfile (`<virtual_store_dir>/lock.yaml` — what the previous install
-/// actually materialized).
+/// `new_included` does not from the current lockfile
+/// (`<virtual_store_dir>/lock.yaml` — what the previous install actually
+/// materialized). When `trusted_importer_ids` is set, only those importers
+/// are eligible for removal.
 ///
 /// Runs when `.modules.yaml` records a different `included` set than the
 /// current install wants while the layout itself is unchanged: that
@@ -103,6 +104,7 @@ pub fn prune_direct_deps_excluded_by_groups(
     new_included: IncludedDependencies,
     workspace_root: &Path,
     config: &Config,
+    trusted_importer_ids: Option<&HashSet<String>>,
 ) -> Result<(), PruneDirectDepsError> {
     let old_groups = selected_groups(old_included);
     let new_groups = selected_groups(new_included);
@@ -117,6 +119,9 @@ pub fn prune_direct_deps_excluded_by_groups(
         config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
 
     for (importer_id, snapshot) in &current_lockfile.importers {
+        if trusted_importer_ids.is_some_and(|importer_ids| !importer_ids.contains(importer_id)) {
+            continue;
+        }
         // A malformed importer key is rejected with a typed error by
         // the symlink pass; never *delete* based on one.
         if validate_importer_id(importer_id).is_err() {

--- a/pnpm/crates/package-manager/src/prune_direct_deps.rs
+++ b/pnpm/crates/package-manager/src/prune_direct_deps.rs
@@ -67,10 +67,17 @@ pub enum PruneDirectDepsError {
 }
 
 /// Remove the direct-dependency links that `old_included` selected but
-/// `new_included` does not from the current lockfile
-/// (`<virtual_store_dir>/lock.yaml` — what the previous install actually
-/// materialized). When `trusted_importer_ids` is set, only those importers
-/// are eligible for removal.
+/// `new_included` does not, for every importer recorded in the current
+/// lockfile (`<virtual_store_dir>/lock.yaml` — what the previous install
+/// actually materialized). When `prunable_importer_ids` is set, only links
+/// belonging to those importers are eligible for removal; a filtered
+/// install leaves every other importer's links untouched because it never
+/// re-materialized them.
+///
+/// Unrelated to [`crate::SymlinkDirectDependencies::trusted_importer_ids`],
+/// which names importers allowed to *skip* ID validation. This set never
+/// widens what may be deleted — every removal still passes the same
+/// validation and containment checks.
 ///
 /// Runs when `.modules.yaml` records a different `included` set than the
 /// current install wants while the layout itself is unchanged: that
@@ -104,7 +111,7 @@ pub fn prune_direct_deps_excluded_by_groups(
     new_included: IncludedDependencies,
     workspace_root: &Path,
     config: &Config,
-    trusted_importer_ids: Option<&HashSet<String>>,
+    prunable_importer_ids: Option<&HashSet<String>>,
 ) -> Result<(), PruneDirectDepsError> {
     let old_groups = selected_groups(old_included);
     let new_groups = selected_groups(new_included);
@@ -119,7 +126,7 @@ pub fn prune_direct_deps_excluded_by_groups(
         config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
 
     for (importer_id, snapshot) in &current_lockfile.importers {
-        if trusted_importer_ids.is_some_and(|importer_ids| !importer_ids.contains(importer_id)) {
+        if prunable_importer_ids.is_some_and(|importer_ids| !importer_ids.contains(importer_id)) {
             continue;
         }
         // A malformed importer key is rejected with a typed error by

--- a/pnpm/crates/package-manager/src/prune_direct_deps/tests.rs
+++ b/pnpm/crates/package-manager/src/prune_direct_deps/tests.rs
@@ -6,7 +6,11 @@ use pacquet_lockfile::{
 };
 use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_testing_utils::fs::is_symlink_or_junction;
-use std::{collections::HashMap, fs, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::Path,
+};
 use tempfile::tempdir;
 
 fn lockfile_with_root_importer(snapshot: ProjectSnapshot) -> Lockfile {
@@ -116,6 +120,7 @@ fn removes_only_excluded_direct_dep_links_and_their_bins() {
         PROD_ONLY,
         workspace_root,
         config,
+        None,
     )
     .expect("prune should succeed");
 
@@ -163,6 +168,7 @@ fn refuses_to_prune_through_a_modules_dir_escaping_the_workspace() {
         PROD_ONLY,
         &workspace_root,
         config,
+        None,
     )
     .expect("prune should succeed");
 
@@ -201,6 +207,7 @@ fn skips_shim_removal_through_a_symlinked_bin_dir() {
         PROD_ONLY,
         workspace_root,
         config,
+        None,
     )
     .expect("prune should succeed");
 
@@ -241,6 +248,7 @@ fn refuses_to_unlink_through_a_symlinked_scope_dir() {
         PROD_ONLY,
         workspace_root,
         config,
+        None,
     )
     .expect("prune should succeed");
 
@@ -274,8 +282,57 @@ fn widening_the_selection_removes_nothing() {
         FULL,
         workspace_root,
         config,
+        None,
     )
     .expect("prune should succeed");
 
     assert!(is_symlink_or_junction(&modules_dir.join("keep-me")).unwrap());
+}
+
+#[test]
+fn prune_direct_deps_respects_trusted_importer_allow_set() {
+    let dir = tempdir().unwrap();
+    let workspace_root = dir.path();
+    let selected_modules = workspace_root.join("packages/selected/node_modules");
+    let unselected_modules = workspace_root.join("packages/unselected/node_modules");
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = workspace_root.join("node_modules");
+    config.virtual_store_dir = config.modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    link_dep(&selected_modules, "selected-dev", None);
+    link_dep(&unselected_modules, "unselected-dev", None);
+    let mut current_lockfile = lockfile_with_root_importer(ProjectSnapshot::default());
+    current_lockfile.importers = HashMap::from([
+        (
+            "packages/selected".to_string(),
+            ProjectSnapshot {
+                dev_dependencies: Some(dep_map(&[("selected-dev", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+        (
+            "packages/unselected".to_string(),
+            ProjectSnapshot {
+                dev_dependencies: Some(dep_map(&[("unselected-dev", "1.0.0")])),
+                ..Default::default()
+            },
+        ),
+    ]);
+    let trusted_importer_ids = HashSet::from(["packages/selected".to_string()]);
+
+    prune_direct_deps_excluded_by_groups(
+        &current_lockfile,
+        FULL,
+        PROD_ONLY,
+        workspace_root,
+        config,
+        Some(&trusted_importer_ids),
+    )
+    .expect("prune should succeed");
+
+    assert!(selected_modules.join("selected-dev").symlink_metadata().is_err());
+    assert!(is_symlink_or_junction(&unselected_modules.join("unselected-dev")).unwrap());
 }

--- a/pnpm/crates/package-manager/src/prune_direct_deps/tests.rs
+++ b/pnpm/crates/package-manager/src/prune_direct_deps/tests.rs
@@ -321,7 +321,7 @@ fn prune_direct_deps_respects_trusted_importer_allow_set() {
             },
         ),
     ]);
-    let trusted_importer_ids = HashSet::from(["packages/selected".to_string()]);
+    let prunable_importer_ids = HashSet::from(["packages/selected".to_string()]);
 
     prune_direct_deps_excluded_by_groups(
         &current_lockfile,
@@ -329,7 +329,7 @@ fn prune_direct_deps_respects_trusted_importer_allow_set() {
         PROD_ONLY,
         workspace_root,
         config,
-        Some(&trusted_importer_ids),
+        Some(&prunable_importer_ids),
     )
     .expect("prune should succeed");
 

--- a/pnpm/crates/package-manager/src/remove.rs
+++ b/pnpm/crates/package-manager/src/remove.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Install, InstallError, ResolvedPackages, UpdateSeedPolicy, emit_initial_package_manifest,
-    package_manifest_prefix,
+    Install, InstallError, ResolvedPackages, UpdateSeedPolicy, WorkspaceInstallSelection,
+    emit_initial_package_manifest, package_manifest_prefix, selected_project_indices,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -90,9 +90,7 @@ impl Remove<'_> {
         } = self;
 
         validate_removable(manifest, package_names, save_type).map_err(RemoveError::Validation)?;
-
-        emit_initial_package_manifest::<Reporter>(manifest);
-        manifest.remove_dependencies(package_names, save_type);
+        prepare_manifest::<Reporter>(manifest, package_names, save_type);
 
         Install {
             tarball_mem_cache,
@@ -106,11 +104,7 @@ impl Remove<'_> {
             // `pnpm remove`'s `include` defaults to every dependency
             // group (`production`/`dev`/`optional` !== false), so the
             // re-resolve walks all three.
-            dependency_groups: [
-                DependencyGroup::Prod,
-                DependencyGroup::Dev,
-                DependencyGroup::Optional,
-            ],
+            dependency_groups: DIRECT_GROUPS,
             frozen_lockfile: false,
             // `pacquet remove` mutates the manifest, so the lockfile is
             // necessarily stale — short-circuit the prefer-frozen fast
@@ -147,19 +141,140 @@ impl Remove<'_> {
         .await
         .map_err(RemoveError::Install)?;
 
-        let updated = manifest.save_and_get_written_value().map_err(RemoveError::SaveManifest)?;
-
-        // `pnpm:package-manifest updated` mirrors the post-mutation emit
-        // pnpm fires after rewriting the manifest. See the parallel emit
-        // in `add.rs` for the `prefix` derivation rationale.
-        let prefix = package_manifest_prefix(manifest);
-        Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
-            level: LogLevel::Debug,
-            message: PackageManifestMessage::Updated { prefix, updated },
-        }));
+        persist_manifest::<Reporter>(manifest)?;
 
         Ok(())
     }
+
+    pub async fn run_selected<Reporter: self::Reporter + 'static>(
+        self,
+        projects: &mut [pacquet_workspace::Project],
+        ordered_dirs: &[std::path::PathBuf],
+        selected_dirs: &HashSet<std::path::PathBuf>,
+        active_manifest_is_standin: bool,
+    ) -> Result<(), RemoveError> {
+        let Remove {
+            tarball_mem_cache,
+            http_client,
+            http_client_arc,
+            config,
+            manifest,
+            lockfile,
+            lockfile_path,
+            package_names,
+            save_type,
+            resolved_packages,
+            supported_architectures,
+            lockfile_only,
+        } = self;
+        let selected_indices = selected_project_indices(projects, ordered_dirs, selected_dirs);
+        if selected_indices.is_empty() {
+            return Ok(());
+        }
+
+        validate_selected_remove(package_names).map_err(RemoveError::Validation)?;
+        prepare_selected_manifests::<Reporter>(
+            projects,
+            &selected_indices,
+            package_names,
+            save_type,
+        );
+
+        Install {
+            tarball_mem_cache,
+            http_client,
+            http_client_arc,
+            config,
+            manifest,
+            emit_initial_manifest: false,
+            lockfile: MaybeLazyLockfile::Loaded(lockfile),
+            lockfile_path,
+            dependency_groups: DIRECT_GROUPS,
+            frozen_lockfile: false,
+            prefer_frozen_lockfile: Some(false),
+            ignore_manifest_check: false,
+            skip_runtimes: config.skip_runtimes,
+            trust_lockfile: config.trust_lockfile,
+            update_checksums: false,
+            is_full_install: false,
+            resolved_packages,
+            supported_architectures,
+            node_linker: config.node_linker,
+            lockfile_only,
+            dry_run: false,
+            update_seed_policy: UpdateSeedPolicy::KeepAll,
+            auth_override: None,
+            resolution_observer: None,
+            peer_issues_sink: None,
+            catalogs_override: None,
+            disable_optimistic_repeat_install: false,
+            pnpmfile_hook_override: None,
+            workspace_projects_override: None,
+        }
+        .run_selected::<Reporter>(WorkspaceInstallSelection {
+            all_projects: projects,
+            ordered_dirs,
+            selected_dirs,
+            active_manifest_is_standin,
+        })
+        .await
+        .map_err(RemoveError::Install)?;
+
+        persist_selected_manifests::<Reporter>(projects, &selected_indices)?;
+        Ok(())
+    }
+}
+
+const DIRECT_GROUPS: [DependencyGroup; 3] =
+    [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
+
+fn validate_selected_remove(package_names: &[String]) -> Result<(), RemoveValidationError> {
+    if package_names.is_empty() {
+        return Err(RemoveValidationError::MustRemoveSomething);
+    }
+    Ok(())
+}
+
+fn prepare_selected_manifests<Reporter: self::Reporter>(
+    projects: &mut [pacquet_workspace::Project],
+    selected_indices: &[usize],
+    package_names: &[String],
+    save_type: Option<DependencyGroup>,
+) {
+    for &index in selected_indices {
+        prepare_manifest::<Reporter>(&mut projects[index].manifest, package_names, save_type);
+    }
+}
+
+fn prepare_manifest<Reporter: self::Reporter>(
+    manifest: &mut PackageManifest,
+    package_names: &[String],
+    save_type: Option<DependencyGroup>,
+) {
+    emit_initial_package_manifest::<Reporter>(manifest);
+    manifest.remove_dependencies(package_names, save_type);
+}
+
+fn persist_selected_manifests<Reporter: self::Reporter>(
+    projects: &mut [pacquet_workspace::Project],
+    selected_indices: &[usize],
+) -> Result<(), RemoveError> {
+    for &index in selected_indices {
+        persist_manifest::<Reporter>(&mut projects[index].manifest)?;
+    }
+    Ok(())
+}
+
+fn persist_manifest<Reporter: self::Reporter>(
+    manifest: &mut PackageManifest,
+) -> Result<(), RemoveError> {
+    let updated = manifest.save_and_get_written_value().map_err(RemoveError::SaveManifest)?;
+    let prefix = package_manifest_prefix(manifest);
+    Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
+        level: LogLevel::Debug,
+        message: PackageManifestMessage::Updated { prefix, updated },
+    }));
+    Ok(())
 }
 
 /// The up-front guards `pacquet remove` applies before mutating the

--- a/pnpm/crates/package-manager/src/remove/tests.rs
+++ b/pnpm/crates/package-manager/src/remove/tests.rs
@@ -1,10 +1,16 @@
 //! Up-front validation cases for the `remove` handler. Each case
 //! errors before any install runs, exercising [`validate_removable`].
 
-use super::{RemoveValidationError, validate_removable};
+use super::{
+    RemoveValidationError, persist_selected_manifests, prepare_selected_manifests,
+    selected_project_indices, validate_removable, validate_selected_remove,
+};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_reporter::SilentReporter;
+use pacquet_workspace::Project;
 use pretty_assertions::assert_eq;
 use serde_json::json;
+use std::{collections::HashSet, path::PathBuf};
 use tempfile::TempDir;
 
 #[expect(
@@ -115,4 +121,80 @@ fn validate_removable_accepts_present_dependencies() {
     validate_removable(&manifest, &strings(&["foo", "bar"]), None).expect("both names present");
     validate_removable(&manifest, &strings(&["bar"]), Some(DependencyGroup::Dev))
         .expect("bar present in devDependencies");
+}
+
+#[test]
+fn selected_remove_prepares_and_persists_only_selected_projects() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let mut projects = ["a", "b", "c"]
+        .into_iter()
+        .map(|name| project_with_dependencies(dir.path(), name, &["foo", "keep"]))
+        .collect::<Vec<_>>();
+    let ordered_dirs = [projects[1].root_dir.clone(), projects[0].root_dir.clone()];
+    let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
+    let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
+
+    validate_selected_remove(&strings(&["foo"])).expect("every selected manifest contains foo");
+    prepare_selected_manifests::<SilentReporter>(&mut projects, &indices, &strings(&["foo"]), None);
+    persist_selected_manifests::<SilentReporter>(&mut projects, &indices)
+        .expect("persist selected manifests");
+
+    assert_eq!(dependency_names(&projects[0].manifest), ["keep"]);
+    assert_eq!(dependency_names(&projects[1].manifest), ["keep"]);
+    assert_eq!(dependency_names(&projects[2].manifest), ["foo", "keep"]);
+    assert_eq!(saved_dependency_names(&projects[0].manifest), ["keep"]);
+    assert_eq!(saved_dependency_names(&projects[1].manifest), ["keep"]);
+    assert_eq!(saved_dependency_names(&projects[2].manifest), ["foo", "keep"]);
+}
+
+#[test]
+fn selected_remove_ignores_projects_without_the_requested_dependency() {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    let mut projects = vec![
+        project_with_dependencies(dir.path(), "a", &["foo"]),
+        project_with_dependencies(dir.path(), "b", &["bar"]),
+    ];
+    let ordered_dirs = projects.iter().map(|project| project.root_dir.clone()).collect::<Vec<_>>();
+    let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
+    let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
+
+    validate_selected_remove(&strings(&["foo"]))
+        .expect("missing dependencies are ignored in recursive remove");
+    prepare_selected_manifests::<SilentReporter>(&mut projects, &indices, &strings(&["foo"]), None);
+
+    assert_eq!(dependency_names(&projects[0].manifest), Vec::<String>::new());
+    assert_eq!(dependency_names(&projects[1].manifest), ["bar"]);
+}
+
+#[test]
+fn selected_remove_still_requires_a_dependency_name() {
+    let error = validate_selected_remove(&[]).expect_err("empty recursive removal must fail");
+    assert!(matches!(error, RemoveValidationError::MustRemoveSomething));
+}
+
+fn project_with_dependencies(root: &std::path::Path, name: &str, dependencies: &[&str]) -> Project {
+    let root_dir = root.join(name);
+    std::fs::create_dir_all(&root_dir).expect("create project directory");
+    let package_json = root_dir.join("package.json");
+    let dependencies = dependencies
+        .iter()
+        .map(|dependency| ((*dependency).to_string(), json!("1.0.0")))
+        .collect::<serde_json::Map<_, _>>();
+    std::fs::write(
+        &package_json,
+        json!({ "name": name, "dependencies": dependencies }).to_string(),
+    )
+    .expect("write package.json");
+    Project {
+        root_dir,
+        manifest: PackageManifest::from_path(package_json).expect("read package.json"),
+    }
+}
+
+fn dependency_names(manifest: &PackageManifest) -> Vec<String> {
+    manifest.available_dependency_names(Some(DependencyGroup::Prod))
+}
+
+fn saved_dependency_names(manifest: &PackageManifest) -> Vec<String> {
+    dependency_names(&PackageManifest::from_path(PathBuf::from(manifest.path())).expect("reread"))
 }

--- a/pnpm/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/pnpm/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -366,7 +366,10 @@ where
 /// keeps lockfiles written by pacquet and pnpm interchangeable. The
 /// returned path is platform-native (`Path::join` handles the
 /// conversion on Windows).
-pub(crate) fn importer_root_dir(workspace_root: &Path, importer_id: &str) -> PathBuf {
+/// The on-disk root of the project a lockfile importer ID names, relative
+/// to `workspace_root` (which is normally the lockfile directory).
+#[must_use]
+pub fn importer_root_dir(workspace_root: &Path, importer_id: &str) -> PathBuf {
     if importer_id == "." {
         workspace_root.to_path_buf()
     } else {

--- a/pnpm/crates/package-manager/src/symlink_direct_dependencies.rs
+++ b/pnpm/crates/package-manager/src/symlink_direct_dependencies.rs
@@ -98,7 +98,7 @@ where
     /// they came from the install's own project list (the programmatic
     /// API's in-memory projects, or `pnpm-workspace.yaml` discovery),
     /// not from parsed lockfile input. These bypass
-    /// `validate_importer_id`: a declared project may legitimately
+    /// [`validate_importer_id`]: a declared project may legitimately
     /// live outside the lockfile dir (importer id `..` or `../foo`) —
     /// Bit's capsule installs do exactly that, and pnpm v11 linked
     /// such importers without complaint. Ids *not* in this set keep
@@ -269,9 +269,13 @@ where
 /// drive prefix, a `..` segment — is either malformed or hostile, so
 /// surface it as a typed error rather than silently letting
 /// `Path::join` produce an off-workspace path.
-pub(crate) fn validate_importer_id(
-    importer_id: &str,
-) -> Result<(), SymlinkDirectDependenciesError> {
+/// Reject a lockfile importer key that cannot be safely joined onto the
+/// lockfile dir: absolute paths, Windows drive prefixes, backslash
+/// separators, and `..` traversal segments. `.` (the root importer) and any
+/// ordinary POSIX-relative sub-path are accepted. Callers that turn an
+/// importer key into an on-disk path — via [`importer_root_dir`] — must run
+/// this first when the key comes from an untrusted lockfile.
+pub fn validate_importer_id(importer_id: &str) -> Result<(), SymlinkDirectDependenciesError> {
     let unsafe_path = || SymlinkDirectDependenciesError::UnsafeImporterPath {
         importer_id: importer_id.to_string(),
     };

--- a/pnpm/crates/package-manager/src/symlink_direct_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/symlink_direct_dependencies/tests.rs
@@ -1,4 +1,4 @@
-use super::{SymlinkDirectDependencies, SymlinkDirectDependenciesError};
+use super::{SymlinkDirectDependencies, SymlinkDirectDependenciesError, validate_importer_id};
 use crate::SkippedSnapshots;
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, ProjectSnapshot, ResolvedDependencyMap, ResolvedDependencySpec};
@@ -9,6 +9,25 @@ use pacquet_reporter::{
 use pacquet_testing_utils::fs::is_symlink_or_junction;
 use std::{collections::HashMap, fs, path::PathBuf, sync::Mutex};
 use tempfile::tempdir;
+
+#[test]
+fn validate_importer_id_accepts_root_and_relative_keys() {
+    for id in [".", "packages/foo", "packages/foo/bar", "a.b/c"] {
+        assert!(validate_importer_id(id).is_ok(), "expected {id:?} to be accepted");
+    }
+}
+
+#[test]
+fn validate_importer_id_rejects_escaping_keys() {
+    // A lockfile importer key is joined onto the lockfile dir to read the
+    // project's manifest; these forms would escape it, so they must be
+    // rejected before any on-disk read.
+    for id in
+        ["", "..", "../foo", "packages/../../etc", "/abs/path", r"packages\foo", "C:/x", "C:x"]
+    {
+        assert!(validate_importer_id(id).is_err(), "expected {id:?} to be rejected");
+    }
+}
 
 /// `pnpm:root added` fires once per direct dependency, after the
 /// symlink under `node_modules/` has been created. The captured

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -1,7 +1,8 @@
 use crate::{
-    CatalogDecision, CatalogModeDep, CatalogVersionMismatchError, Install, InstallError,
-    ResolvedPackages, UpdateSeedPolicy, decide_catalog, emit_initial_package_manifest,
-    package_manifest_prefix, resolution_policy::PickPolicy, resolve_latest::LatestPicker,
+    CatalogDecision, CatalogModeDep, CatalogVersionMismatchError, ImporterUpdateSeedPolicy,
+    Install, InstallError, ResolvedPackages, UpdateSeedPolicy, WorkspaceInstallSelection,
+    decide_catalog, emit_initial_package_manifest, package_manifest_prefix,
+    resolution_policy::PickPolicy, resolve_latest::LatestPicker, selected_project_indices,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -19,7 +20,11 @@ use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMe
 use pacquet_resolving_npm_resolver::{shared_packument_fetch_locker, which_version_is_pinned};
 use pacquet_tarball::MemCache;
 use pacquet_workspace_manifest_writer::{UpdateWorkspaceManifestError, update_workspace_manifest};
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// The three dependency groups `pacquet update` considers as "direct"
 /// targets, in the order pnpm's `updateProjectManifest` walks them.
@@ -111,8 +116,8 @@ pub enum UpdateError {
     #[diagnostic(code(ERR_PNPM_LATEST_WITH_SPEC))]
     LatestWithSpec(#[error(not(source))] String),
 
-    /// Package selectors were given (with `--depth 0` and without
-    /// `--latest`) but none matched a direct dependency.
+    /// Package selectors were given with `--depth 0` but none matched a
+    /// direct dependency.
     #[display("None of the specified packages were found in the dependencies.")]
     #[diagnostic(code(ERR_PNPM_NO_PACKAGE_IN_DEPENDENCIES))]
     NoPackageInDependencies,
@@ -214,358 +219,44 @@ impl Update<'_> {
         crate::minimum_release_age::ensure_strict_minimum_release_age_can_save(config, save)
             .map_err(UpdateError::MinimumReleaseAge)?;
 
-        // `pacquet update` has no `--save-prefix` flag yet, so `save_exact`
-        // alone selects between an exact pin and the default caret range.
-        let pinned_version = PinnedVersion::from_save_options(save_exact, None);
-
-        let mut latest_picker: Option<LatestPicker> = None;
-
-        let selectors: Vec<ParsedSelector> =
-            packages.iter().map(|input| parse_update_param(input)).collect();
-
-        // `--latest` forbids versioned selectors.
-        if latest {
-            let with_spec: Vec<&str> = packages
-                .iter()
-                .zip(&selectors)
-                .filter(|(_, sel)| sel.version.is_some())
-                .map(|(raw, _)| raw.as_str())
-                .collect();
-            if !with_spec.is_empty() {
-                return Err(UpdateError::LatestWithSpec(with_spec.join(", ")));
-            }
-        }
-
-        // Snapshot the direct dependencies in the included groups before
-        // any manifest mutation, so the matcher and the `--latest`
-        // rewrite both see the pre-update shape.
-        let direct: Vec<(String, DependencyGroup, String)> = include_direct
-            .iter()
-            .flat_map(|&group| {
-                manifest
-                    .dependencies([group])
-                    .map(move |(name, spec)| (name.to_string(), group, spec.to_string()))
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-
-        let updates_all_groups = DIRECT_GROUPS.iter().all(|group| include_direct.contains(group));
-
-        // The workspace catalogs, read lazily on first use via
-        // `ensure_catalog_ctx`. They are needed only to bump a `catalog:`
-        // dependency under `--latest` (to preserve the entry's operator) and
-        // to reconcile rewrites under a non-`manual` `catalogMode`, so the
-        // no-op paths (a compatible bump, an unmatched `--latest` selector)
-        // never touch `pnpm-workspace.yaml`.
-        let mut catalog_ctx: Option<CatalogCtx> = None;
-
-        // Names whose lockfile pins to withhold so they re-resolve, and
-        // the per-direct-dep manifest rewrites (`--latest` / versioned
-        // selector only).
-        let mut drop_names: HashSet<String> = HashSet::new();
-        let mut rewrites: Vec<(String, DependencyGroup, String)> = Vec::new();
-
-        // Mirror pnpm's gate for the name matcher: bare-name selectors,
-        // `depth > 0`, and no `--latest` use `updateMatching`, applied to
-        // every package name at any depth.
-        let use_name_matcher = !selectors.is_empty()
-            && selectors.iter().all(|sel| sel.version.is_none())
-            && depth > 0
-            && !latest;
-
-        let seed_policy = if selectors.is_empty() {
-            // `updateConfig.ignoreDependencies` applies only when the user
-            // gave no selectors: the listed name globs are excluded from
-            // the update so they keep their lockfile pins. The filter runs
-            // against the *included* direct deps, so group narrowing
-            // (`--prod` / `--dev` / `--no-optional`) still scopes the
-            // update.
-            let ignore_patterns =
-                config.update_config.ignore_dependencies.as_deref().unwrap_or_default();
-            // Only compile a matcher when there's something to ignore, so
-            // the common (no ignore list) path skips it entirely.
-            let ignore_matcher =
-                (!ignore_patterns.is_empty()).then(|| create_matcher(ignore_patterns));
-            let is_ignored =
-                |name: &str| ignore_matcher.as_ref().is_some_and(|matcher| matcher.matches(name));
-
-            for (name, group, prev) in &direct {
-                if is_ignored(name) {
-                    continue;
-                }
-                if latest && !is_workspace_local_path_specifier(prev) {
-                    let picker = ensure_latest_picker(
-                        &mut latest_picker,
-                        config,
-                        http_client,
-                        resolution_observer.as_ref(),
-                    )?;
-                    let version = resolve_latest_version(picker, name, lockfile_only).await?;
-                    let pin =
-                        latest_pin(&mut catalog_ctx, manifest, config, prev, name, pinned_version)?;
-                    rewrites.push((name.clone(), *group, version.serialize(pin)));
-                }
-                drop_names.insert(name.clone());
-            }
-
-            if updates_all_groups && ignore_patterns.is_empty() {
-                // `pnpm update` (no selectors, no narrowing, no ignore
-                // list) re-resolves the whole graph to highest-in-range.
-                UpdateSeedPolicy::DropAll
-            } else if updates_all_groups {
-                // Whole-graph update minus the ignored names: drop every
-                // locked name that isn't ignored so the ignored ones keep
-                // their pins.
-                //
-                // Skip the expansion when `--latest` selected no direct
-                // dependency (every included direct dep was ignored): a
-                // true no-op. A non-`--latest` update with no direct match
-                // still re-resolves the non-ignored *indirect* deps
-                // (updating indirect dependencies only), so the expansion
-                // must run in that case.
-                if !(latest && drop_names.is_empty())
-                    && let Some(snapshots) = lockfile.and_then(|lf| lf.snapshots.as_ref())
-                {
-                    for key in snapshots.keys() {
-                        let name = key.name.to_string();
-                        if !is_ignored(&name) {
-                            drop_names.insert(name);
-                        }
-                    }
-                }
-                UpdateSeedPolicy::DropOnly(drop_names)
+        let mut latest_picker = None;
+        let Some(prepared) = prepare_manifest::<Reporter>(
+            manifest,
+            http_client,
+            config,
+            lockfile,
+            packages,
+            latest,
+            save_exact,
+            save,
+            &include_direct,
+            depth,
+            None,
+            &mut latest_picker,
+            lockfile_only,
+            resolution_observer.as_ref(),
+        )
+        .await?
+        else {
+            return if depth == 0 && !packages.is_empty() && !latest {
+                Err(UpdateError::NoPackageInDependencies)
             } else {
-                // Group-narrowed: only the included direct deps (minus
-                // ignored) and their same-named transitive occurrences
-                // re-resolve.
-                UpdateSeedPolicy::DropOnly(drop_names)
-            }
-        } else if use_name_matcher {
-            let patterns: Vec<String> = selectors.iter().map(|sel| sel.pattern.clone()).collect();
-            let matcher = create_matcher(&patterns);
-            for (name, _, _) in &direct {
-                if matcher.matches(name) {
-                    drop_names.insert(name.clone());
-                }
-            }
-            // Match against every locked package name too, so a selector
-            // that names a transitive-only dependency still bumps it.
-            if let Some(snapshots) = lockfile.and_then(|lf| lf.snapshots.as_ref()) {
-                for key in snapshots.keys() {
-                    let name = key.name.to_string();
-                    if matcher.matches(&name) {
-                        drop_names.insert(name);
-                    }
-                }
-            }
-            UpdateSeedPolicy::DropOnly(drop_names)
-        } else {
-            // Versioned selectors and/or `--latest`: match direct
-            // dependencies only and write the new range into the
-            // manifest.
-            let patterns: Vec<String> = selectors.iter().map(|sel| sel.pattern.clone()).collect();
-            let matcher = create_matcher(&patterns);
-            let matched_direct: Vec<(String, DependencyGroup, String)> = direct
-                .iter()
-                .filter(|(name, _, _)| matcher.matches(name))
-                .map(|(name, group, prev)| (name.clone(), *group, prev.clone()))
-                .collect();
-
-            if matched_direct.is_empty() {
-                // No direct dependency matched the selectors.
-                if latest {
-                    // `--latest` with an unmatched selector is a no-op.
-                    return Ok(());
-                }
-                if depth == 0 {
-                    return Err(UpdateError::NoPackageInDependencies);
-                }
-                // `depth > 0`: update only the matching *indirect*
-                // dependencies (no manifest rewrite). Reached here only
-                // for versioned selectors — bare-name selectors with
-                // `depth > 0` take the name-matcher branch above.
-                if let Some(snapshots) = lockfile.and_then(|lf| lf.snapshots.as_ref()) {
-                    for key in snapshots.keys() {
-                        let name = key.name.to_string();
-                        if matcher.matches(&name) {
-                            drop_names.insert(name);
-                        }
-                    }
-                }
-                // With no manifest entry to write the version into, and
-                // update results always matching what a fresh install
-                // would resolve, the selector's version part cannot take
-                // effect — say so and point at the mechanism that does
-                // pin transitive dependencies. The recommended override
-                // is scoped to the dependents' declared range so it
-                // cannot violate any consumer's range; the range itself
-                // is not known at this layer (it lives in the
-                // dependents' manifests), hence the placeholder.
-                for sel in &selectors {
-                    let Some(version) = sel.version.as_deref() else { continue };
-                    tracing::warn!(
-                        target: "pacquet_package_manager::update",
-                        pattern = sel.pattern,
-                        version,
-                        r#""{}" is not a direct dependency, so the requested version "{version}" is ignored — "{}" is updated to what a fresh install would resolve. To force a version of a transitive dependency, add an override scoped to the range its dependents declare to pnpm-workspace.yaml, e.g.: overrides: {{ "{}@<declared range>": "{version}" }}"#,
-                        sel.pattern,
-                        sel.pattern,
-                        sel.pattern,
-                    );
-                }
-                UpdateSeedPolicy::DropOnly(drop_names)
-            } else {
-                for (name, group, prev) in &matched_direct {
-                    drop_names.insert(name.clone());
-                    if latest && !is_workspace_local_path_specifier(prev) {
-                        let picker = ensure_latest_picker(
-                            &mut latest_picker,
-                            config,
-                            http_client,
-                            resolution_observer.as_ref(),
-                        )?;
-                        let version = resolve_latest_version(picker, name, lockfile_only).await?;
-                        let pin = latest_pin(
-                            &mut catalog_ctx,
-                            manifest,
-                            config,
-                            prev,
-                            name,
-                            pinned_version,
-                        )?;
-                        rewrites.push((name.clone(), *group, version.serialize(pin)));
-                    } else if let Some(spec) = selectors
-                        .iter()
-                        .find(|sel| matcher_one(&sel.pattern).matches(name))
-                        .and_then(|sel| sel.version.clone())
-                    {
-                        rewrites.push((name.clone(), *group, spec));
-                    }
-                }
-                UpdateSeedPolicy::DropOnly(drop_names)
-            }
+                Ok(())
+            };
         };
-
-        // Reconcile the about-to-be-written versions against the workspace
-        // catalogs. Two things happen here:
-        //
-        // * A `--latest` bump of a `catalog:` dependency keeps the manifest
-        //   reference and flows the resolved version into the catalog entry,
-        //   for **every** `catalogMode` — pnpm never rewrites a `catalog:`
-        //   reference to a direct version on update.
-        // * Auto-cataloging (pnpm's `installSome` gate plus `catalogLookup`):
-        //   under strict/prefer a direct version is rewritten to `catalog:`
-        //   and recorded for write-back. This does not engage under
-        //   `manual`.
-        //
-        // Only rewritten deps carry a user-chosen version, so a bare `update`
-        // (compatible bump) produces no rewrites and nothing to reconcile.
-        //
-        // `catalog_ctx` is already populated when a `catalog:` dependency was
-        // bumped above (so its reference must be preserved); otherwise it is
-        // read here only for the non-`manual` auto-cataloging pass.
-        let mut updated_catalogs: Catalogs = Catalogs::new();
-        let mut workspace_dir_for_catalogs = None;
-        if !rewrites.is_empty()
-            && (config.catalog_mode != CatalogMode::Manual || catalog_ctx.is_some())
-        {
-            let ctx = ensure_catalog_ctx(&mut catalog_ctx, manifest, config)?;
-            let mut reconciled: Vec<(String, DependencyGroup, String)> =
-                Vec::with_capacity(rewrites.len());
-            for (name, group, spec) in rewrites {
-                let prev = direct
-                    .iter()
-                    .find(|(prev_name, prev_group, _)| *prev_name == name && *prev_group == group)
-                    .map(|(_, _, prev_spec)| prev_spec.as_str());
-
-                // `--latest` on a `catalog:` dependency keeps the reference in
-                // the manifest (it is left out of `reconciled`) and bumps the
-                // catalog entry — with the entry's own range operator, applied
-                // by `latest_pin` above.
-                if latest && let Some(catalog_name) = prev.and_then(parse_catalog_protocol) {
-                    updated_catalogs
-                        .entry(catalog_name.to_string())
-                        .or_default()
-                        .insert(name.clone(), spec);
-                    continue;
-                }
-
-                if config.catalog_mode == CatalogMode::Manual {
-                    reconciled.push((name, group, spec));
-                    continue;
-                }
-
-                let dep = CatalogModeDep {
-                    alias: name.as_str(),
-                    bare_specifier: spec.as_str(),
-                    prev_specifier: prev,
-                };
-                match decide_catalog::<Reporter>(
-                    config.catalog_mode,
-                    None,
-                    &ctx.catalogs,
-                    &dep,
-                    &ctx.prefix,
-                )
-                .map_err(UpdateError::CatalogVersionMismatch)?
-                {
-                    CatalogDecision::KeepDirect => reconciled.push((name, group, spec)),
-                    CatalogDecision::Catalog { manifest_specifier, updated_entry } => {
-                        if let Some(entry) = updated_entry {
-                            updated_catalogs
-                                .entry(entry.catalog_name)
-                                .or_default()
-                                .insert(name.clone(), entry.specifier);
-                        }
-                        reconciled.push((name, group, manifest_specifier));
-                    }
-                }
-            }
-            rewrites = reconciled;
-            workspace_dir_for_catalogs =
-                ctx.workspace_dir_opt.clone().or_else(|| Some(ctx.manifest_dir.clone()));
-        }
-
-        // Apply the manifest rewrites in memory before resolving so the
-        // install picks the new ranges. Under `--no-save` the in-memory
-        // mutation still drives resolution (so `pnpm-lock.yaml` updates)
-        // but the manifest is not persisted below.
-        let persist_manifest = save && !rewrites.is_empty();
-        if persist_manifest {
-            emit_initial_package_manifest::<Reporter>(manifest);
-        }
-        for (name, group, spec) in &rewrites {
-            manifest.add_dependency(name, spec, *group).map_err(UpdateError::UpdateManifest)?;
-        }
-
-        // Persist the new catalog entries to `pnpm-workspace.yaml`. Gated on
-        // `save`: `--no-save` persists nothing to disk.
         if save
-            && !updated_catalogs.is_empty()
-            && let Some(workspace_dir) = &workspace_dir_for_catalogs
+            && !prepared.updated_catalogs.is_empty()
+            && let Some(workspace_dir) = &prepared.workspace_dir_for_catalogs
         {
-            update_workspace_manifest(workspace_dir, &updated_catalogs)
+            update_workspace_manifest(workspace_dir, &prepared.updated_catalogs)
                 .map_err(UpdateError::WriteWorkspaceManifest)?;
         }
-
-        // Drive the install's resolution from the bumped catalogs in memory,
-        // rather than relying on the on-disk `pnpm-workspace.yaml`. This is
-        // what lets `--no-save` still update the lockfile for a `catalog:`
-        // bump (the entry is not written to disk, but resolution must see
-        // it). The override is the complete catalogs set: the existing
-        // entries overlaid with the bumped/new ones.
-        let catalogs_override = (!updated_catalogs.is_empty()).then(|| {
-            let mut merged =
-                catalog_ctx.as_ref().map(|ctx| ctx.catalogs.clone()).unwrap_or_default();
-            for (catalog_name, entries) in &updated_catalogs {
-                let catalog = merged.entry(catalog_name.clone()).or_default();
-                for (dep, spec) in entries {
-                    catalog.insert(dep.clone(), spec.clone());
-                }
-            }
-            merged
-        });
-
+        let UpdatePreparation {
+            seed_policy,
+            persist_manifest: should_persist_manifest,
+            catalogs_override,
+            ..
+        } = prepared;
         Install {
             tarball_mem_cache,
             http_client,
@@ -609,19 +300,531 @@ impl Update<'_> {
         .await
         .map_err(UpdateError::Install)?;
 
-        if persist_manifest {
-            let updated =
-                manifest.save_and_get_written_value().map_err(UpdateError::SaveManifest)?;
-
-            let prefix = package_manifest_prefix(manifest);
-            Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
-                level: LogLevel::Debug,
-                message: PackageManifestMessage::Updated { prefix, updated },
-            }));
+        if should_persist_manifest {
+            persist_manifest::<Reporter>(manifest)?;
         }
 
         Ok(())
     }
+
+    pub async fn run_selected<Reporter: self::Reporter + 'static>(
+        self,
+        projects: &mut [pacquet_workspace::Project],
+        ordered_dirs: &[PathBuf],
+        selected_dirs: &HashSet<PathBuf>,
+        active_manifest_is_standin: bool,
+    ) -> Result<(), UpdateError> {
+        let Update {
+            tarball_mem_cache,
+            resolved_packages,
+            http_client,
+            http_client_arc,
+            config,
+            manifest,
+            lockfile,
+            lockfile_path,
+            packages,
+            latest,
+            save_exact,
+            save,
+            include_direct,
+            depth,
+            supported_architectures,
+            lockfile_only,
+            resolution_observer,
+        } = self;
+
+        crate::minimum_release_age::ensure_strict_minimum_release_age_can_save(config, save)
+            .map_err(UpdateError::MinimumReleaseAge)?;
+
+        let selected_indices = selected_project_indices(projects, ordered_dirs, selected_dirs);
+        if selected_indices.is_empty() {
+            return Ok(());
+        }
+        let workspace_root = config.workspace_dir.as_deref().unwrap_or_else(|| {
+            manifest.path().parent().expect("manifest path always has a parent dir")
+        });
+        let prepared = prepare_selected_manifests::<Reporter>(
+            projects,
+            &selected_indices,
+            workspace_root,
+            http_client,
+            config,
+            lockfile,
+            packages,
+            latest,
+            save_exact,
+            save,
+            &include_direct,
+            depth,
+            lockfile_only,
+            resolution_observer.as_ref(),
+        )
+        .await?;
+        if !prepared.any_work {
+            return Ok(());
+        }
+        if save
+            && !prepared.updated_catalogs.is_empty()
+            && let Some(workspace_dir) = &prepared.workspace_dir_for_catalogs
+        {
+            update_workspace_manifest(workspace_dir, &prepared.updated_catalogs)
+                .map_err(UpdateError::WriteWorkspaceManifest)?;
+        }
+
+        Install {
+            tarball_mem_cache,
+            http_client,
+            http_client_arc,
+            config,
+            manifest,
+            emit_initial_manifest: false,
+            lockfile: MaybeLazyLockfile::Loaded(lockfile),
+            lockfile_path,
+            dependency_groups: DIRECT_GROUPS,
+            frozen_lockfile: false,
+            prefer_frozen_lockfile: Some(false),
+            ignore_manifest_check: false,
+            skip_runtimes: config.skip_runtimes,
+            trust_lockfile: config.trust_lockfile,
+            update_checksums: false,
+            is_full_install: packages.is_empty(),
+            resolved_packages,
+            supported_architectures,
+            node_linker: config.node_linker,
+            lockfile_only,
+            dry_run: false,
+            update_seed_policy: UpdateSeedPolicy::ByImporter(prepared.seed_policies),
+            auth_override: None,
+            resolution_observer,
+            peer_issues_sink: None,
+            catalogs_override: prepared.catalogs_override,
+            disable_optimistic_repeat_install: false,
+            pnpmfile_hook_override: None,
+            workspace_projects_override: None,
+        }
+        .run_selected::<Reporter>(WorkspaceInstallSelection {
+            all_projects: projects,
+            ordered_dirs,
+            selected_dirs,
+            active_manifest_is_standin,
+        })
+        .await
+        .map_err(UpdateError::Install)?;
+
+        persist_selected_manifests::<Reporter>(projects, &prepared.persist_indices)?;
+        Ok(())
+    }
+}
+
+struct UpdatePreparation {
+    seed_policy: UpdateSeedPolicy,
+    persist_manifest: bool,
+    updated_catalogs: Catalogs,
+    catalogs_override: Option<Catalogs>,
+    workspace_dir_for_catalogs: Option<PathBuf>,
+}
+
+struct SelectedUpdatePreparation {
+    seed_policies: BTreeMap<String, ImporterUpdateSeedPolicy>,
+    persist_indices: Vec<usize>,
+    updated_catalogs: Catalogs,
+    catalogs_override: Option<Catalogs>,
+    workspace_dir_for_catalogs: Option<PathBuf>,
+    any_work: bool,
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "manifest preparation consumes the update command's matching inputs"
+)]
+async fn prepare_manifest<'a, Reporter: self::Reporter>(
+    manifest: &mut PackageManifest,
+    http_client: &'a ThrottledClient,
+    config: &'a Config,
+    lockfile: Option<&Lockfile>,
+    packages: &[String],
+    latest: bool,
+    save_exact: bool,
+    save: bool,
+    include_direct: &[DependencyGroup],
+    depth: usize,
+    catalogs_seed: Option<&Catalogs>,
+    latest_picker: &mut Option<LatestPicker<'a>>,
+    lockfile_only: bool,
+    resolution_observer: Option<&Arc<dyn crate::ResolutionObserver>>,
+) -> Result<Option<UpdatePreparation>, UpdateError> {
+    // `pacquet update` has no `--save-prefix` flag yet, so `save_exact`
+    // selects between an exact pin and the default caret range.
+    let pinned_version = PinnedVersion::from_save_options(save_exact, None);
+    let selectors = packages.iter().map(|input| parse_update_param(input)).collect::<Vec<_>>();
+    // `--latest` forbids versioned selectors.
+    if latest {
+        let with_spec = packages
+            .iter()
+            .zip(&selectors)
+            .filter(|(_, selector)| selector.version.is_some())
+            .map(|(raw, _)| raw.as_str())
+            .collect::<Vec<_>>();
+        if !with_spec.is_empty() {
+            return Err(UpdateError::LatestWithSpec(with_spec.join(", ")));
+        }
+    }
+
+    // Snapshot direct dependencies before mutation so matching and rewrites
+    // both see the original manifest shape.
+    let direct = include_direct
+        .iter()
+        .flat_map(|&group| {
+            manifest
+                .dependencies([group])
+                .map(move |(name, spec)| (name.to_string(), group, spec.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let updates_all_groups = DIRECT_GROUPS.iter().all(|group| include_direct.contains(group));
+    // Catalogs stay lazy unless an earlier selected project already produced
+    // the complete in-memory catalog set for this batch.
+    let mut catalog_ctx = catalogs_seed
+        .map(|catalogs| read_catalog_ctx_with_catalogs(manifest, catalogs.clone()))
+        .transpose()?;
+    let mut drop_names = HashSet::new();
+    let mut rewrites = Vec::new();
+    // Bare-name selectors with depth update matching names at any depth.
+    let use_name_matcher = !selectors.is_empty()
+        && selectors.iter().all(|selector| selector.version.is_none())
+        && depth > 0
+        && !latest;
+
+    let seed_policy = if selectors.is_empty() {
+        // `updateConfig.ignoreDependencies` applies only when no selector was
+        // supplied and remains scoped by the included direct groups.
+        let ignore_patterns =
+            config.update_config.ignore_dependencies.as_deref().unwrap_or_default();
+        let ignore_matcher = (!ignore_patterns.is_empty()).then(|| create_matcher(ignore_patterns));
+        let is_ignored =
+            |name: &str| ignore_matcher.as_ref().is_some_and(|matcher| matcher.matches(name));
+        for (name, group, previous) in &direct {
+            if is_ignored(name) {
+                continue;
+            }
+            if latest && !is_workspace_local_path_specifier(previous) {
+                let picker =
+                    ensure_latest_picker(latest_picker, config, http_client, resolution_observer)?;
+                let version = resolve_latest_version(picker, name, lockfile_only).await?;
+                let pin =
+                    latest_pin(&mut catalog_ctx, manifest, config, previous, name, pinned_version)?;
+                rewrites.push((name.clone(), *group, version.serialize(pin)));
+            }
+            drop_names.insert(name.clone());
+        }
+        if updates_all_groups && ignore_patterns.is_empty() {
+            // A bare, ungated update re-resolves the whole graph.
+            UpdateSeedPolicy::DropAll
+        } else {
+            if updates_all_groups
+                && !(latest && drop_names.is_empty())
+                && let Some(snapshots) = lockfile.and_then(|lockfile| lockfile.snapshots.as_ref())
+            {
+                for key in snapshots.keys() {
+                    let name = key.name.to_string();
+                    if !is_ignored(&name) {
+                        drop_names.insert(name);
+                    }
+                }
+            }
+            UpdateSeedPolicy::DropOnly(drop_names)
+        }
+    } else if use_name_matcher {
+        let patterns =
+            selectors.iter().map(|selector| selector.pattern.clone()).collect::<Vec<_>>();
+        let matcher = create_matcher(&patterns);
+        for (name, _, _) in &direct {
+            if matcher.matches(name) {
+                drop_names.insert(name.clone());
+            }
+        }
+        // Lockfile names keep transitive-only matches in the update scope.
+        if let Some(snapshots) = lockfile.and_then(|lockfile| lockfile.snapshots.as_ref()) {
+            for key in snapshots.keys() {
+                let name = key.name.to_string();
+                if matcher.matches(&name) {
+                    drop_names.insert(name);
+                }
+            }
+        }
+        UpdateSeedPolicy::DropOnly(drop_names)
+    } else {
+        let patterns =
+            selectors.iter().map(|selector| selector.pattern.clone()).collect::<Vec<_>>();
+        let matcher = create_matcher(&patterns);
+        let matched_direct =
+            direct.iter().filter(|(name, _, _)| matcher.matches(name)).cloned().collect::<Vec<_>>();
+        if matched_direct.is_empty() {
+            if depth == 0 {
+                return Ok(None);
+            }
+            // An unmatched `--latest` selector is a no-op. Deeper versioned
+            // selectors can still target lockfile names but cannot force that
+            // version.
+            if latest {
+                return Ok(None);
+            }
+            if let Some(snapshots) = lockfile.and_then(|lockfile| lockfile.snapshots.as_ref()) {
+                for key in snapshots.keys() {
+                    let name = key.name.to_string();
+                    if matcher.matches(&name) {
+                        drop_names.insert(name);
+                    }
+                }
+            }
+            for selector in &selectors {
+                let Some(version) = selector.version.as_deref() else { continue };
+                tracing::warn!(
+                    target: "pacquet_package_manager::update",
+                    pattern = selector.pattern,
+                    version,
+                    r#""{}" is not a direct dependency, so the requested version "{version}" is ignored — "{}" is updated to what a fresh install would resolve. To force a version of a transitive dependency, add an override scoped to the range its dependents declare to pnpm-workspace.yaml, e.g.: overrides: {{ "{}@<declared range>": "{version}" }}"#,
+                    selector.pattern,
+                    selector.pattern,
+                    selector.pattern,
+                );
+            }
+        } else {
+            for (name, group, previous) in &matched_direct {
+                drop_names.insert(name.clone());
+                if latest && !is_workspace_local_path_specifier(previous) {
+                    let picker = ensure_latest_picker(
+                        latest_picker,
+                        config,
+                        http_client,
+                        resolution_observer,
+                    )?;
+                    let version = resolve_latest_version(picker, name, lockfile_only).await?;
+                    let pin = latest_pin(
+                        &mut catalog_ctx,
+                        manifest,
+                        config,
+                        previous,
+                        name,
+                        pinned_version,
+                    )?;
+                    rewrites.push((name.clone(), *group, version.serialize(pin)));
+                } else if let Some(specifier) = selectors
+                    .iter()
+                    .find(|selector| matcher_one(&selector.pattern).matches(name))
+                    .and_then(|selector| selector.version.clone())
+                {
+                    rewrites.push((name.clone(), *group, specifier));
+                }
+            }
+        }
+        UpdateSeedPolicy::DropOnly(drop_names)
+    };
+
+    // Reconcile only manifest rewrites. Existing `catalog:` references retain
+    // their group, and non-manual catalog modes may promote direct versions.
+    let mut updated_catalogs = Catalogs::new();
+    let mut workspace_dir_for_catalogs = None;
+    if !rewrites.is_empty() && (config.catalog_mode != CatalogMode::Manual || catalog_ctx.is_some())
+    {
+        let ctx = ensure_catalog_ctx(&mut catalog_ctx, manifest, config)?;
+        let mut reconciled = Vec::with_capacity(rewrites.len());
+        for (name, group, specifier) in rewrites {
+            let previous = direct
+                .iter()
+                .find(|(previous_name, previous_group, _)| {
+                    *previous_name == name && *previous_group == group
+                })
+                .map(|(_, _, previous_specifier)| previous_specifier.as_str());
+            if latest && let Some(catalog_name) = previous.and_then(parse_catalog_protocol) {
+                updated_catalogs
+                    .entry(catalog_name.to_string())
+                    .or_default()
+                    .insert(name, specifier);
+                continue;
+            }
+            if config.catalog_mode == CatalogMode::Manual {
+                reconciled.push((name, group, specifier));
+                continue;
+            }
+            let dependency = CatalogModeDep {
+                alias: &name,
+                bare_specifier: &specifier,
+                prev_specifier: previous,
+            };
+            match decide_catalog::<Reporter>(
+                config.catalog_mode,
+                None,
+                &ctx.catalogs,
+                &dependency,
+                &ctx.prefix,
+            )
+            .map_err(UpdateError::CatalogVersionMismatch)?
+            {
+                CatalogDecision::KeepDirect => reconciled.push((name, group, specifier)),
+                CatalogDecision::Catalog { manifest_specifier, updated_entry } => {
+                    if let Some(entry) = updated_entry {
+                        updated_catalogs
+                            .entry(entry.catalog_name)
+                            .or_default()
+                            .insert(name.clone(), entry.specifier);
+                    }
+                    reconciled.push((name, group, manifest_specifier));
+                }
+            }
+        }
+        rewrites = reconciled;
+        workspace_dir_for_catalogs =
+            ctx.workspace_dir_opt.clone().or_else(|| Some(ctx.manifest_dir.clone()));
+    }
+
+    // `--no-save` still mutates the in-memory manifest used for resolution,
+    // while leaving package.json and reporter manifest events untouched.
+    let persist_manifest = save && !rewrites.is_empty();
+    if persist_manifest {
+        emit_initial_package_manifest::<Reporter>(manifest);
+    }
+    for (name, group, specifier) in &rewrites {
+        manifest.add_dependency(name, specifier, *group).map_err(UpdateError::UpdateManifest)?;
+    }
+    // The install must resolve against the complete catalog set even when
+    // `--no-save` deliberately skips the workspace-manifest write.
+    let catalogs_override = (!updated_catalogs.is_empty()).then(|| {
+        let mut merged = catalog_ctx.as_ref().map(|ctx| ctx.catalogs.clone()).unwrap_or_default();
+        merge_catalogs(&mut merged, &updated_catalogs);
+        merged
+    });
+    Ok(Some(UpdatePreparation {
+        seed_policy,
+        persist_manifest,
+        updated_catalogs,
+        catalogs_override,
+        workspace_dir_for_catalogs,
+    }))
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "selected update preparation reuses the command's matching inputs"
+)]
+async fn prepare_selected_manifests<'a, Reporter: self::Reporter>(
+    projects: &mut [pacquet_workspace::Project],
+    selected_indices: &[usize],
+    workspace_root: &Path,
+    http_client: &'a ThrottledClient,
+    config: &'a Config,
+    lockfile: Option<&Lockfile>,
+    packages: &[String],
+    latest: bool,
+    save_exact: bool,
+    save: bool,
+    include_direct: &[DependencyGroup],
+    depth: usize,
+    lockfile_only: bool,
+    resolution_observer: Option<&Arc<dyn crate::ResolutionObserver>>,
+) -> Result<SelectedUpdatePreparation, UpdateError> {
+    // One picker across every selected project: it is created on first
+    // use, so a selection that resolves no `latest` tag never builds one.
+    let mut latest_picker = None;
+    let mut seed_policies = BTreeMap::new();
+    let mut persist_indices = Vec::new();
+    let mut updated_catalogs = Catalogs::new();
+    let mut catalogs_override = None;
+    let mut workspace_dir_for_catalogs = None;
+    let mut any_work = false;
+
+    for &index in selected_indices {
+        let Some(prepared) = prepare_manifest::<Reporter>(
+            &mut projects[index].manifest,
+            http_client,
+            config,
+            lockfile,
+            packages,
+            latest,
+            save_exact,
+            save,
+            include_direct,
+            depth,
+            catalogs_override.as_ref(),
+            &mut latest_picker,
+            lockfile_only,
+            resolution_observer,
+        )
+        .await?
+        else {
+            continue;
+        };
+        any_work = true;
+        let importer_id =
+            pacquet_workspace::importer_id_from_root_dir(workspace_root, &projects[index].root_dir);
+        match prepared.seed_policy {
+            UpdateSeedPolicy::KeepAll => {}
+            UpdateSeedPolicy::DropAll => {
+                seed_policies.insert(importer_id, ImporterUpdateSeedPolicy::DropAll);
+            }
+            UpdateSeedPolicy::DropOnly(names) => {
+                seed_policies.insert(importer_id, ImporterUpdateSeedPolicy::DropOnly(names));
+            }
+            UpdateSeedPolicy::ByImporter(_) => {
+                unreachable!("per-manifest preparation never produces importer policies")
+            }
+        }
+        if prepared.persist_manifest {
+            persist_indices.push(index);
+        }
+        merge_catalogs(&mut updated_catalogs, &prepared.updated_catalogs);
+        if let Some(complete_catalogs) = prepared.catalogs_override {
+            catalogs_override = Some(complete_catalogs);
+        }
+        if workspace_dir_for_catalogs.is_none() {
+            workspace_dir_for_catalogs = prepared.workspace_dir_for_catalogs;
+        }
+    }
+
+    if depth == 0 && !packages.is_empty() && !latest && !any_work {
+        return Err(UpdateError::NoPackageInDependencies);
+    }
+
+    Ok(SelectedUpdatePreparation {
+        seed_policies,
+        persist_indices,
+        updated_catalogs,
+        catalogs_override,
+        workspace_dir_for_catalogs,
+        any_work,
+    })
+}
+
+fn merge_catalogs(target: &mut Catalogs, updates: &Catalogs) {
+    for (catalog_name, entries) in updates {
+        let catalog = target.entry(catalog_name.clone()).or_default();
+        for (dependency, specifier) in entries {
+            catalog.insert(dependency.clone(), specifier.clone());
+        }
+    }
+}
+
+fn persist_selected_manifests<Reporter: self::Reporter>(
+    projects: &mut [pacquet_workspace::Project],
+    selected_indices: &[usize],
+) -> Result<(), UpdateError> {
+    for &index in selected_indices {
+        persist_manifest::<Reporter>(&mut projects[index].manifest)?;
+    }
+    Ok(())
+}
+
+fn persist_manifest<Reporter: self::Reporter>(
+    manifest: &mut PackageManifest,
+) -> Result<(), UpdateError> {
+    let updated = manifest.save_and_get_written_value().map_err(UpdateError::SaveManifest)?;
+    let prefix = package_manifest_prefix(manifest);
+    Reporter::emit(&LogEvent::PackageManifest(PackageManifestLog {
+        level: LogLevel::Debug,
+        message: PackageManifestMessage::Updated { prefix, updated },
+    }));
+    Ok(())
 }
 
 /// Compile a single pattern into a matcher. Used to map a matched direct
@@ -708,6 +911,19 @@ fn read_catalog_ctx(
         get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
             .map_err(UpdateError::InvalidCatalogsConfiguration)?
     };
+    let prefix =
+        workspace_dir_opt.as_deref().unwrap_or(&manifest_dir).to_string_lossy().into_owned();
+    Ok(CatalogCtx { catalogs, workspace_dir_opt, manifest_dir, prefix })
+}
+
+fn read_catalog_ctx_with_catalogs(
+    manifest: &PackageManifest,
+    catalogs: Catalogs,
+) -> Result<CatalogCtx, UpdateError> {
+    let manifest_dir =
+        manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf();
+    let workspace_dir_opt = pacquet_workspace::find_workspace_dir(&manifest_dir)
+        .map_err(UpdateError::FindWorkspaceDir)?;
     let prefix =
         workspace_dir_opt.as_deref().unwrap_or(&manifest_dir).to_string_lossy().into_owned();
     Ok(CatalogCtx { catalogs, workspace_dir_opt, manifest_dir, prefix })

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -1,4 +1,15 @@
-use super::{is_workspace_local_path_specifier, parse_update_param};
+use super::{
+    is_workspace_local_path_specifier, parse_update_param, persist_selected_manifests,
+    prepare_selected_manifests, selected_project_indices,
+};
+use pacquet_config::{CatalogMode, Config};
+use pacquet_network::ThrottledClient;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_reporter::SilentReporter;
+use pacquet_workspace::Project;
+use serde_json::json;
+use std::collections::HashSet;
+use tempfile::tempdir;
 
 #[test]
 fn parses_bare_name_without_version() {
@@ -78,4 +89,199 @@ fn workspace_range_specifiers_are_not_local_paths() {
     ] {
         assert!(!is_workspace_local_path_specifier(spec), "expected {spec} not to be a local path");
     }
+}
+
+#[tokio::test]
+async fn selected_update_prepares_and_persists_only_selected_projects() {
+    let dir = tempdir().expect("create tempdir");
+    std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n  - '*'\n")
+        .expect("write workspace manifest");
+    let mut projects = ["a", "b", "c"]
+        .into_iter()
+        .map(|name| project_with_foo(dir.path(), name))
+        .collect::<Vec<_>>();
+    let ordered_dirs = [projects[1].root_dir.clone(), projects[0].root_dir.clone()];
+    let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
+    let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
+    let config = Config::new();
+    let http_client = ThrottledClient::default();
+
+    let prepared = prepare_selected_manifests::<SilentReporter>(
+        &mut projects,
+        &indices,
+        dir.path(),
+        &http_client,
+        &config,
+        None,
+        &["foo@2.0.0".to_string()],
+        false,
+        false,
+        true,
+        &[DependencyGroup::Prod],
+        0,
+        false,
+        None,
+    )
+    .await
+    .expect("prepare selected manifests");
+    persist_selected_manifests::<SilentReporter>(&mut projects, &prepared.persist_indices)
+        .expect("persist selected manifests");
+
+    assert_eq!(dependency_specifier(&projects[0].manifest), "2.0.0");
+    assert_eq!(dependency_specifier(&projects[1].manifest), "2.0.0");
+    assert_eq!(dependency_specifier(&projects[2].manifest), "^1.0.0");
+    assert_eq!(saved_dependency_specifier(&projects[0].manifest), "2.0.0");
+    assert_eq!(saved_dependency_specifier(&projects[1].manifest), "2.0.0");
+    assert_eq!(saved_dependency_specifier(&projects[2].manifest), "^1.0.0");
+    assert_eq!(prepared.seed_policies.len(), 2);
+}
+
+#[tokio::test]
+async fn selected_update_no_save_mutates_in_memory_without_persisting() {
+    let dir = tempdir().expect("create tempdir");
+    std::fs::write(dir.path().join("pnpm-workspace.yaml"), "packages:\n  - '*'\n")
+        .expect("write workspace manifest");
+    let mut projects =
+        ["a", "b"].into_iter().map(|name| project_with_foo(dir.path(), name)).collect::<Vec<_>>();
+    let ordered_dirs = [projects[0].root_dir.clone()];
+    let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
+    let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
+    let mut config = Config::new();
+    config.catalog_mode = CatalogMode::Prefer;
+    let http_client = ThrottledClient::default();
+
+    let prepared = prepare_selected_manifests::<SilentReporter>(
+        &mut projects,
+        &indices,
+        dir.path(),
+        &http_client,
+        &config,
+        None,
+        &["foo@2.0.0".to_string()],
+        false,
+        false,
+        false,
+        &[DependencyGroup::Prod],
+        0,
+        false,
+        None,
+    )
+    .await
+    .expect("prepare selected manifests");
+
+    assert_eq!(dependency_specifier(&projects[0].manifest), "catalog:");
+    assert_eq!(dependency_specifier(&projects[1].manifest), "^1.0.0");
+    assert_eq!(saved_dependency_specifier(&projects[0].manifest), "^1.0.0");
+    assert!(prepared.persist_indices.is_empty());
+    assert_eq!(
+        prepared
+            .catalogs_override
+            .as_ref()
+            .and_then(|catalogs| catalogs.get("default"))
+            .and_then(|catalog| catalog.get("foo"))
+            .map(String::as_str),
+        Some("2.0.0"),
+    );
+}
+
+#[tokio::test]
+async fn selected_update_depth_zero_skips_projects_without_a_matching_dependency() {
+    let dir = tempdir().expect("create tempdir");
+    let mut projects = [project_without_foo(dir.path(), "a"), project_with_foo(dir.path(), "b")];
+    let selected_indices = [0, 1];
+    let config = Config::new();
+    let http_client = ThrottledClient::default();
+
+    let prepared = prepare_selected_manifests::<SilentReporter>(
+        &mut projects,
+        &selected_indices,
+        dir.path(),
+        &http_client,
+        &config,
+        None,
+        &["foo@2.0.0".to_string()],
+        false,
+        false,
+        true,
+        &[DependencyGroup::Prod],
+        0,
+        false,
+        None,
+    )
+    .await
+    .expect("prepare selected manifests");
+
+    assert_eq!(dependency_specifier(&projects[1].manifest), "2.0.0");
+    assert_eq!(prepared.persist_indices, vec![1]);
+}
+
+#[tokio::test]
+async fn selected_update_latest_depth_zero_is_noop_when_no_project_matches() {
+    let dir = tempdir().expect("create tempdir");
+    let mut projects = [project_without_foo(dir.path(), "a"), project_without_foo(dir.path(), "b")];
+    let selected_indices = [0, 1];
+    let config = Config::new();
+    let http_client = ThrottledClient::default();
+
+    let prepared = prepare_selected_manifests::<SilentReporter>(
+        &mut projects,
+        &selected_indices,
+        dir.path(),
+        &http_client,
+        &config,
+        None,
+        &["foo".to_string()],
+        true,
+        false,
+        true,
+        &[DependencyGroup::Prod],
+        0,
+        false,
+        None,
+    )
+    .await
+    .expect("unmatched latest update is a no-op");
+
+    assert!(!prepared.any_work);
+    assert!(prepared.persist_indices.is_empty());
+}
+
+fn project_with_foo(root: &std::path::Path, name: &str) -> Project {
+    let root_dir = root.join(name);
+    std::fs::create_dir_all(&root_dir).expect("create project directory");
+    let package_json = root_dir.join("package.json");
+    std::fs::write(
+        &package_json,
+        json!({ "name": name, "dependencies": { "foo": "^1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+    Project {
+        root_dir,
+        manifest: PackageManifest::from_path(package_json).expect("read package.json"),
+    }
+}
+
+fn project_without_foo(root: &std::path::Path, name: &str) -> Project {
+    let root_dir = root.join(name);
+    std::fs::create_dir_all(&root_dir).expect("create project directory");
+    let package_json = root_dir.join("package.json");
+    std::fs::write(&package_json, json!({ "name": name }).to_string()).expect("write package.json");
+    Project {
+        root_dir,
+        manifest: PackageManifest::from_path(package_json).expect("read package.json"),
+    }
+}
+
+fn dependency_specifier(manifest: &PackageManifest) -> &str {
+    manifest
+        .dependencies([DependencyGroup::Prod])
+        .find(|(name, _)| *name == "foo")
+        .map(|(_, specifier)| specifier)
+        .expect("foo dependency")
+}
+
+fn saved_dependency_specifier(manifest: &PackageManifest) -> String {
+    let saved =
+        PackageManifest::from_path(manifest.path().to_path_buf()).expect("reread package.json");
+    dependency_specifier(&saved).to_string()
 }

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -410,9 +410,12 @@ impl PnprClient {
         // importers this request is about — the requested projects plus
         // whatever the input lockfile already carried — so a hostile server
         // cannot introduce dependencies for a project that was never sent.
-        // Only containment is checked, not presence: pnpm omits
-        // dependency-free importers, so a requested project may legitimately
-        // have no entry.
+        // This is a containment check (every returned importer was
+        // requested), which is the injection boundary; it deliberately does
+        // not require every requested importer to be present. A dependency-
+        // free importer is still present-but-empty (pnpm records it as
+        // `{ specifiers: {} }`), and a genuinely missing importer is surfaced
+        // downstream by the lockfile merge, not a way to inject dependencies.
         let permitted_importers: HashSet<String> = opts
             .projects
             .iter()

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -17,7 +17,7 @@
 //! `/~<name>/` registry endpoint (which may cache them server-side under
 //! its own private namespace).
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use derive_more::{Display, Error, From};
 use futures_util::StreamExt as _;
@@ -405,6 +405,20 @@ impl PnprClient {
         opts: ResolveProjectsOptions,
         mut on_package: impl FnMut(ResolvedPackage),
     ) -> Result<ResolveOutcome, PnprClientError> {
+        // The server's response is untrusted, and the caller merges the
+        // returned lockfile into `pnpm-lock.yaml`. Constrain it to the
+        // importers this request is about — the requested projects plus
+        // whatever the input lockfile already carried — so a hostile server
+        // cannot introduce dependencies for a project that was never sent.
+        // Only containment is checked, not presence: pnpm omits
+        // dependency-free importers, so a requested project may legitimately
+        // have no entry.
+        let permitted_importers: HashSet<String> = opts
+            .projects
+            .iter()
+            .map(|project| project.dir.clone())
+            .chain(opts.lockfile.iter().flat_map(|lockfile| lockfile.importers.keys().cloned()))
+            .collect();
         let request = serde_json::json!({
             "projects": opts.projects,
             "registry": opts.registry,
@@ -472,6 +486,15 @@ impl PnprClient {
                         });
                     }
                     Frame::Done { lockfile, stats } => {
+                        if let Some(unexpected) = lockfile
+                            .importers
+                            .keys()
+                            .find(|importer| !permitted_importers.contains(*importer))
+                        {
+                            return Err(PnprClientError::Protocol(format!(
+                                "/-/pnpr/v0/resolve returned an importer that was not requested: {unexpected:?}",
+                            )));
+                        }
                         return Ok(ResolveOutcome { lockfile: *lockfile, stats });
                     }
                     Frame::Error { message } => return Err(PnprClientError::Server(message)),

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -25,7 +25,7 @@ use pacquet_config::TrustPolicy;
 use pacquet_lockfile::Lockfile;
 use pacquet_lockfile_verification::{RenderedViolation, VerifyError};
 use reqwest::Client;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Dependency map (`name` -> `version range`).
 pub type DepMap = BTreeMap<String, String>;
@@ -82,6 +82,72 @@ pub struct ResolveOptions {
     pub trust_policy_ignore_after: Option<u64>,
 }
 
+/// One workspace project sent to the pnpr resolver.
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveProject {
+    /// Importer directory relative to the lockfile directory, in POSIX form.
+    pub dir: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    pub dependencies: DepMap,
+    pub dev_dependencies: DepMap,
+    pub optional_dependencies: DepMap,
+}
+
+/// Inputs for a multi-project workspace resolution.
+#[derive(Clone)]
+pub struct ResolveProjectsOptions {
+    pub projects: Vec<ResolveProject>,
+    pub registry: String,
+    pub named_registries: DepMap,
+    pub authorization: Option<String>,
+    pub overrides: Option<serde_json::Value>,
+    pub lockfile: Option<Lockfile>,
+    pub frozen_lockfile: bool,
+    pub prefer_frozen_lockfile: Option<bool>,
+    pub ignore_manifest_check: bool,
+    pub trust_lockfile: bool,
+    pub minimum_release_age: Option<u64>,
+    pub minimum_release_age_exclude: Option<Vec<String>>,
+    pub minimum_release_age_ignore_missing_time: bool,
+    pub trust_policy: TrustPolicy,
+    pub trust_policy_exclude: Option<Vec<String>>,
+    pub trust_policy_ignore_after: Option<u64>,
+}
+
+impl From<ResolveOptions> for ResolveProjectsOptions {
+    fn from(opts: ResolveOptions) -> Self {
+        Self {
+            projects: vec![ResolveProject {
+                dir: ".".to_string(),
+                name: None,
+                version: None,
+                dependencies: opts.dependencies,
+                dev_dependencies: opts.dev_dependencies,
+                optional_dependencies: opts.optional_dependencies,
+            }],
+            registry: opts.registry,
+            named_registries: opts.named_registries,
+            authorization: opts.authorization,
+            overrides: opts.overrides,
+            lockfile: opts.lockfile,
+            frozen_lockfile: opts.frozen_lockfile,
+            prefer_frozen_lockfile: opts.prefer_frozen_lockfile,
+            ignore_manifest_check: opts.ignore_manifest_check,
+            trust_lockfile: opts.trust_lockfile,
+            minimum_release_age: opts.minimum_release_age,
+            minimum_release_age_exclude: opts.minimum_release_age_exclude,
+            minimum_release_age_ignore_missing_time: opts.minimum_release_age_ignore_missing_time,
+            trust_policy: opts.trust_policy,
+            trust_policy_exclude: opts.trust_policy_exclude,
+            trust_policy_ignore_after: opts.trust_policy_ignore_after,
+        }
+    }
+}
+
 /// Inputs for `/-/pnpr/v0/verify-lockfile`, the resolution-free trust verdict
 /// used by frozen restores that already know the local lockfile is fresh.
 #[derive(Clone)]
@@ -103,18 +169,27 @@ pub struct VerifyLockfileOptions {
 impl VerifyLockfileOptions {
     #[must_use]
     pub fn from_resolve_options(opts: &ResolveOptions) -> Option<Self> {
+        Self::from_owned_resolve_projects_options(opts.clone().into())
+    }
+
+    #[must_use]
+    pub fn from_resolve_projects_options(opts: &ResolveProjectsOptions) -> Option<Self> {
+        Self::from_owned_resolve_projects_options(opts.clone())
+    }
+
+    fn from_owned_resolve_projects_options(opts: ResolveProjectsOptions) -> Option<Self> {
         Some(Self {
-            registry: opts.registry.clone(),
-            named_registries: opts.named_registries.clone(),
-            authorization: opts.authorization.clone(),
-            overrides: opts.overrides.clone(),
-            lockfile: opts.lockfile.clone()?,
+            registry: opts.registry,
+            named_registries: opts.named_registries,
+            authorization: opts.authorization,
+            overrides: opts.overrides,
+            lockfile: opts.lockfile?,
             trust_lockfile: opts.trust_lockfile,
             minimum_release_age: opts.minimum_release_age,
-            minimum_release_age_exclude: opts.minimum_release_age_exclude.clone(),
+            minimum_release_age_exclude: opts.minimum_release_age_exclude,
             minimum_release_age_ignore_missing_time: opts.minimum_release_age_ignore_missing_time,
             trust_policy: opts.trust_policy,
-            trust_policy_exclude: opts.trust_policy_exclude.clone(),
+            trust_policy_exclude: opts.trust_policy_exclude,
             trust_policy_ignore_after: opts.trust_policy_ignore_after,
         })
     }
@@ -236,7 +311,16 @@ impl PnprClient {
     /// resolved lockfile, ignoring the streamed per-package frames.
     /// Equivalent to [`Self::resolve_streaming`] with a no-op callback.
     pub async fn resolve(&self, opts: ResolveOptions) -> Result<ResolveOutcome, PnprClientError> {
-        self.resolve_streaming(opts, |_| {}).await
+        self.resolve_projects(opts.into()).await
+    }
+
+    /// Resolve workspace projects against the server and return the resolved
+    /// lockfile, ignoring the streamed per-package frames.
+    pub async fn resolve_projects(
+        &self,
+        opts: ResolveProjectsOptions,
+    ) -> Result<ResolveOutcome, PnprClientError> {
+        self.resolve_projects_streaming(opts, |_| {}).await
     }
 
     /// Ask the server to verify a lockfile under the client's registry
@@ -309,15 +393,20 @@ impl PnprClient {
     pub async fn resolve_streaming(
         &self,
         opts: ResolveOptions,
+        on_package: impl FnMut(ResolvedPackage),
+    ) -> Result<ResolveOutcome, PnprClientError> {
+        self.resolve_projects_streaming(opts.into(), on_package).await
+    }
+
+    /// Resolve workspace projects, invoking `on_package` once per resolved
+    /// tarball before the terminal lockfile frame arrives.
+    pub async fn resolve_projects_streaming(
+        &self,
+        opts: ResolveProjectsOptions,
         mut on_package: impl FnMut(ResolvedPackage),
     ) -> Result<ResolveOutcome, PnprClientError> {
         let request = serde_json::json!({
-            "projects": [{
-                "dir": ".",
-                "dependencies": opts.dependencies,
-                "devDependencies": opts.dev_dependencies,
-                "optionalDependencies": opts.optional_dependencies,
-            }],
+            "projects": opts.projects,
             "registry": opts.registry,
             "namedRegistries": opts.named_registries,
             "overrides": opts.overrides,

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -141,10 +141,13 @@ async fn capture_one_request_with_response(listener: TcpListener, response: Stri
             break;
         }
         buffer.extend_from_slice(&chunk[..read]);
-        // Stop once the full body (per Content-Length) has arrived.
-        let text = String::from_utf8_lossy(&buffer);
-        if let Some(headers_end) = text.find("\r\n\r\n") {
-            let content_length = text[..headers_end]
+        // Stop once the full body (per Content-Length) has arrived. The
+        // boundary is located in the raw bytes so the index stays aligned
+        // with `buffer.len()` below: decoding first would rewrite any
+        // non-UTF-8 byte as a longer replacement character and shift it.
+        if let Some(headers_end) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+            let headers = String::from_utf8_lossy(&buffer[..headers_end]);
+            let content_length = headers
                 .lines()
                 .find_map(|line| {
                     let (name, value) = line.split_once(':')?;
@@ -321,6 +324,53 @@ async fn multi_project_request_sends_every_workspace_project_without_a_synthetic
             },
         ]),
     );
+}
+
+/// The resolved lockfile is merged into the caller's `pnpm-lock.yaml`, so
+/// a server that answers with an importer nobody asked about would be
+/// writing dependencies into an unrelated project. The response is
+/// rejected rather than merged.
+#[tokio::test]
+async fn an_importer_outside_the_request_is_rejected() {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind capture");
+    let addr = listener.local_addr().expect("capture addr");
+    let done = serde_json::json!({
+        "type": "done",
+        "lockfile": {
+            "lockfileVersion": "9.0",
+            "importers": {
+                "packages/app": {},
+                "packages/attacker": {},
+            },
+        },
+        "stats": { "totalPackages": 0 },
+    });
+    let body = format!("{done}\n");
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/x-ndjson\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    );
+    let capture = tokio::spawn(capture_one_request_with_response(listener, response));
+
+    let client = PnprClient::new(format!("http://{addr}/"));
+    let mut opts: ResolveProjectsOptions =
+        options("https://registry.example.test/", "Bearer token", BTreeMap::new()).into();
+    opts.projects = vec![ResolveProject {
+        dir: "packages/app".to_string(),
+        name: Some("app".to_string()),
+        version: Some("1.0.0".to_string()),
+        dependencies: BTreeMap::new(),
+        dev_dependencies: BTreeMap::new(),
+        optional_dependencies: BTreeMap::new(),
+    }];
+
+    let error = match client.resolve_projects(opts).await {
+        Ok(_) => panic!("an unrequested importer must not be accepted"),
+        Err(error) => error.to_string(),
+    };
+    assert!(error.contains("packages/attacker"), "unexpected error: {error}");
+
+    capture.await.expect("capture task");
 }
 
 /// End-to-end: the test registry gates `@pnpm.e2e/needs-auth` behind

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -19,7 +19,10 @@ use std::{
     time::Duration,
 };
 
-use pacquet_pnpr_client::{PnprClient, PnprClientError, ResolveOptions, VerifyLockfileOptions};
+use pacquet_pnpr_client::{
+    PnprClient, PnprClientError, ResolveOptions, ResolveProject, ResolveProjectsOptions,
+    VerifyLockfileOptions,
+};
 use pacquet_testing_utils::registry::TestRegistry;
 use tempfile::TempDir;
 use tokio::{
@@ -126,9 +129,9 @@ async fn wait_until_ready(addr: SocketAddr) {
     panic!("pnpr server never became ready at {addr}");
 }
 
-/// Accept one HTTP request, return its full raw bytes (headers + body),
-/// and answer `500` so the client stops after the capture.
-async fn capture_one_request(listener: TcpListener) -> String {
+/// Accept one HTTP request, return its full raw bytes (headers + body), and
+/// send the supplied raw HTTP response.
+async fn capture_one_request_with_response(listener: TcpListener, response: String) -> String {
     let (mut socket, _) = listener.accept().await.expect("accept request");
     let mut buffer = Vec::new();
     let mut chunk = [0u8; 4096];
@@ -156,11 +159,18 @@ async fn capture_one_request(listener: TcpListener) -> String {
             }
         }
     }
-    let _ = socket
-        .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 4\r\nConnection: close\r\n\r\nstop")
-        .await;
+    let _ = socket.write_all(response.as_bytes()).await;
     let _ = socket.shutdown().await;
     String::from_utf8_lossy(&buffer).into_owned()
+}
+
+async fn capture_one_request(listener: TcpListener) -> String {
+    capture_one_request_with_response(
+        listener,
+        "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 4\r\nConnection: close\r\n\r\nstop"
+            .to_string(),
+    )
+    .await
 }
 
 fn deps<const COUNT: usize>(entries: [(&str, &str); COUNT]) -> BTreeMap<String, String> {
@@ -235,6 +245,81 @@ async fn sends_the_identity_header_but_no_upstream_credentials() {
     assert!(
         !request.contains("authHeaders"),
         "the request body must not carry upstream credentials, got:\n{request}",
+    );
+}
+
+#[tokio::test]
+async fn multi_project_request_sends_every_workspace_project_without_a_synthetic_root() {
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.expect("bind capture");
+    let addr = listener.local_addr().expect("capture addr");
+    let done = serde_json::json!({
+        "type": "done",
+        "lockfile": {
+            "lockfileVersion": "9.0",
+            "importers": {
+                "packages/app": {},
+                "packages/lib": {},
+            },
+        },
+        "stats": { "totalPackages": 0 },
+    });
+    let body = format!("{done}\n");
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/x-ndjson\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    );
+    let capture = tokio::spawn(capture_one_request_with_response(listener, response));
+
+    let client = PnprClient::new(format!("http://{addr}/"));
+    let mut opts: ResolveProjectsOptions =
+        options("https://registry.example.test/", "Bearer token", BTreeMap::new()).into();
+    opts.projects = vec![
+        ResolveProject {
+            dir: "packages/app".to_string(),
+            name: Some("app".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: deps([("app-dependency", "1.0.0")]),
+            dev_dependencies: BTreeMap::new(),
+            optional_dependencies: BTreeMap::new(),
+        },
+        ResolveProject {
+            dir: "packages/lib".to_string(),
+            name: Some("lib".to_string()),
+            version: Some("2.0.0".to_string()),
+            dependencies: BTreeMap::new(),
+            dev_dependencies: deps([("lib-tool", "2.0.0")]),
+            optional_dependencies: BTreeMap::new(),
+        },
+    ];
+
+    let outcome = client.resolve_projects(opts).await.expect("multi-project response should parse");
+    let mut importer_ids = outcome.lockfile.importers.keys().cloned().collect::<Vec<_>>();
+    importer_ids.sort();
+    assert_eq!(importer_ids, ["packages/app".to_string(), "packages/lib".to_string()]);
+
+    let request = capture.await.expect("capture task");
+    let (_, body) = request.split_once("\r\n\r\n").expect("captured HTTP request has a body");
+    let body: serde_json::Value = serde_json::from_str(body).expect("request body is JSON");
+    assert_eq!(
+        body["projects"],
+        serde_json::json!([
+            {
+                "dir": "packages/app",
+                "name": "app",
+                "version": "1.0.0",
+                "dependencies": { "app-dependency": "1.0.0" },
+                "devDependencies": {},
+                "optionalDependencies": {},
+            },
+            {
+                "dir": "packages/lib",
+                "name": "lib",
+                "version": "2.0.0",
+                "dependencies": {},
+                "devDependencies": { "lib-tool": "2.0.0" },
+                "optionalDependencies": {},
+            },
+        ]),
     );
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -19,7 +19,7 @@ use serde_json::Value;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex, MutexGuard},
 };
 
@@ -49,7 +49,7 @@ use pacquet_lockfile::{
 /// reuse. An excluded package re-resolves to highest-in-range, and its
 /// whole subtree re-resolves with it (so the bump's new transitive deps
 /// are picked up).
-#[derive(Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum UpdateReuseScope {
     /// Reuse every still-satisfied dependency. `install` / `add`.
     #[default]
@@ -491,6 +491,11 @@ where
 /// `link:packages/lib` would hand `packages/app` the same string,
 /// which from `packages/app` points at the non-existent
 /// `packages/app/packages/lib`.
+///
+/// The final two fields isolate importers with active update policies
+/// and record whether this wanted dependency is an explicit update target.
+/// Ordinary keep-all importers use no importer scope and retain the existing
+/// cross-importer cache sharing.
 type WantedKey = (
     Option<String>,
     Option<String>,
@@ -501,7 +506,11 @@ type WantedKey = (
     Option<PathBuf>,
     Option<PkgNameVerPeer>,
     Vec<(String, Vec<String>)>,
+    Option<String>,
+    bool,
 );
+
+type SubtreeReuseKey = (Option<String>, PkgNameVerPeer);
 
 /// Whether a wanted dep's resolution is computed relative to the
 /// consuming importer's directory rather than being
@@ -543,6 +552,7 @@ type ChildSpec = (String, String, bool);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ChildrenOwner {
+    update_active: bool,
     depth: i32,
     importer_order: usize,
     parent_path: Vec<String>,
@@ -551,6 +561,9 @@ struct ChildrenOwner {
 
 impl ChildrenOwner {
     fn wins_over(&self, other: &Self) -> bool {
+        if self.update_active != other.update_active {
+            return self.update_active;
+        }
         (&self.depth, &self.importer_order, &self.parent_path)
             < (&other.depth, &other.importer_order, &other.parent_path)
     }
@@ -591,11 +604,15 @@ pub struct WorkspaceTreeCtx {
     /// re-resolves its target deps to highest-in-range, so a reused
     /// resolution would defeat the bump. See [`UpdateReuseScope`].
     update_reuse_scope: UpdateReuseScope,
-    /// Memoises [`fn@subtree_fully_reusable`] per snapshot key so the
-    /// recursive reusability check runs once per package across the
-    /// whole walk. `true` means the package and its entire transitive
-    /// subtree can be synthesized from the prior lockfile.
-    subtree_reusable: Mutex<HashMap<PkgNameVerPeer, bool>>,
+    /// Importer overrides used by filtered workspace updates. IDs absent from
+    /// this map keep the workspace default above.
+    update_reuse_scopes_by_importer: BTreeMap<String, UpdateReuseScope>,
+    /// Memoises [`fn@subtree_fully_reusable`] per update scope and snapshot
+    /// key. Keep-all importers share one scope; update-active importers use
+    /// isolated scopes so one importer's reuse answer cannot leak to another.
+    /// `true` means the package and its entire transitive subtree can be
+    /// synthesized from the prior lockfile.
+    subtree_reusable: Mutex<HashMap<SubtreeReuseKey, bool>>,
     pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>,
     /// `context.log(...)` sink for the `pnpmfile_hook`'s `readPackage`
     /// calls, pre-bound to the install's reporter, project prefix, and
@@ -620,9 +637,9 @@ pub struct WorkspaceTreeCtx {
     registries: HashMap<String, String>,
     /// `pkg id → importer id` of the importer whose occurrence owns
     /// that package's shared children context. Ownership is chosen by
-    /// `(depth, importer order, parent path)`: a package's subtree is
-    /// recorded once per id, and a non-owner occurrence reuses the owner
-    /// occurrence's children and missing-peer report. Consumed via
+    /// update-active status followed by `(depth, importer order, parent path)`:
+    /// a package's subtree is recorded once per id, and a non-owner occurrence
+    /// reuses the owner occurrence's children and missing-peer report. Consumed via
     /// [`crate::HoistMissingScope`].
     first_importer_by_pkg: Mutex<HashMap<String, String>>,
     /// Per package: the missing-peer names reported by the *initial*
@@ -677,6 +694,7 @@ impl Default for WorkspaceTreeCtx {
             manifest_hook: None,
             wanted_lockfile: None,
             update_reuse_scope: UpdateReuseScope::All,
+            update_reuse_scopes_by_importer: BTreeMap::new(),
             subtree_reusable: Mutex::new(HashMap::new()),
             pnpmfile_hook: None,
             read_package_log: None,
@@ -798,6 +816,22 @@ impl WorkspaceTreeCtx {
     }
 
     #[must_use]
+    pub fn with_update_reuse_scopes_by_importer(
+        mut self,
+        scopes: BTreeMap<String, UpdateReuseScope>,
+    ) -> Self {
+        self.update_reuse_scopes_by_importer = scopes;
+        self
+    }
+
+    fn update_reuse_scope_for(&self, importer_id: &str) -> &UpdateReuseScope {
+        if matches!(self.update_reuse_scope, UpdateReuseScope::None) {
+            return &self.update_reuse_scope;
+        }
+        self.update_reuse_scopes_by_importer.get(importer_id).unwrap_or(&self.update_reuse_scope)
+    }
+
+    #[must_use]
     pub fn with_pnpmfile_hook(mut self, pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>) -> Self {
         self.pnpmfile_hook = pnpmfile_hook;
         self
@@ -884,6 +918,9 @@ impl WorkspaceTreeCtx {
 /// envelopes via the shared maps.
 pub struct TreeCtx {
     base_opts: ResolveOptions,
+    /// Absolute root used to make ownerless snapshot `link:` ids stable
+    /// across importers at different depths.
+    lockfile_dir: PathBuf,
     /// [`ResolveOptions`] handed to the resolver for importer-level
     /// (direct) dependencies — `depth == 0`. Differs from `base_opts`
     /// only in `pick_lowest_version`, which is set under
@@ -919,10 +956,16 @@ impl TreeCtx {
     /// the same workspace ctx.
     #[must_use]
     pub fn new(base_opts: ResolveOptions) -> Self {
+        let lockfile_dir = if base_opts.lockfile_dir.as_os_str().is_empty() {
+            base_opts.project_dir.clone()
+        } else {
+            base_opts.lockfile_dir.clone()
+        };
         TreeCtx {
             direct_opts: base_opts.clone(),
             subdep_opts: base_opts.clone(),
             base_opts,
+            lockfile_dir: pacquet_fs::lexical_normalize(&lockfile_dir),
             catalogs: Catalogs::new(),
             workspace: Arc::new(WorkspaceTreeCtx::default()),
             patched_dependencies: None,
@@ -936,16 +979,28 @@ impl TreeCtx {
     /// `workspace` alive across importers (typically via
     /// `Arc::clone(&workspace)`).
     pub fn with_workspace(workspace: Arc<WorkspaceTreeCtx>, base_opts: ResolveOptions) -> Self {
+        let lockfile_dir = if base_opts.lockfile_dir.as_os_str().is_empty() {
+            base_opts.project_dir.clone()
+        } else {
+            base_opts.lockfile_dir.clone()
+        };
         TreeCtx {
             direct_opts: base_opts.clone(),
             subdep_opts: base_opts.clone(),
             base_opts,
+            lockfile_dir: pacquet_fs::lexical_normalize(&lockfile_dir),
             catalogs: Catalogs::new(),
             workspace,
             patched_dependencies: None,
             importer_id: pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY.to_string(),
             importer_order: 0,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn with_lockfile_dir(mut self, lockfile_dir: &Path) -> Self {
+        self.lockfile_dir = pacquet_fs::lexical_normalize(lockfile_dir);
+        self
     }
 
     /// Derive the depth-specific resolve options from `resolutionMode`.
@@ -992,6 +1047,15 @@ impl TreeCtx {
     #[must_use]
     pub fn workspace(&self) -> &Arc<WorkspaceTreeCtx> {
         &self.workspace
+    }
+
+    fn update_reuse_scope(&self) -> &UpdateReuseScope {
+        self.workspace.update_reuse_scope_for(&self.importer_id)
+    }
+
+    fn update_cache_scope(&self) -> Option<String> {
+        (!matches!(self.update_reuse_scope(), UpdateReuseScope::All))
+            .then(|| self.importer_id.clone())
     }
 
     /// Set the importer this context walks for. See [`TreeCtx`]'s
@@ -1422,6 +1486,7 @@ where
             view
         })
         .unwrap_or_default();
+    let update_target = is_update_target(ctx.update_reuse_scope(), &wanted);
     let cache_key: WantedKey = (
         wanted.alias.clone(),
         wanted.bare_specifier.clone(),
@@ -1432,6 +1497,8 @@ where
         project_scope,
         prior_key.clone(),
         overlay_versions.clone(),
+        ctx.update_cache_scope(),
+        update_target,
     );
     let result =
         match resolve_wanted_cached(ctx, resolver, &wanted, opts, pick_overlay.as_ref(), cache_key)
@@ -1880,7 +1947,7 @@ where
     // update target list — so the picker's held-back-update warning fires
     // only for the packages the user actually asked to update.
     let needs_overlay = !cache_key.8.is_empty();
-    let update_target = is_update_target(&ctx.workspace.update_reuse_scope, wanted);
+    let update_target = cache_key.10;
     let needs_update = update_target != opts.update_requested;
     let owned_opts;
     let opts = if needs_overlay || needs_update {
@@ -2013,6 +2080,8 @@ where
                     // reused by edges that carry no currentPkg either.
                     None,
                     Vec::new(),
+                    ctx.update_cache_scope(),
+                    is_update_target(ctx.update_reuse_scope(), &wanted),
                 );
                 let _ = resolve_wanted_cached(ctx, resolver, &wanted, opts, None, cache_key).await;
             }
@@ -2164,6 +2233,7 @@ fn claim_children_owner(
     ancestor_ids: &[String],
 ) -> ChildrenOwnerClaim {
     let owner = ChildrenOwner {
+        update_active: !matches!(ctx.update_reuse_scope(), UpdateReuseScope::All),
         depth,
         importer_order: ctx.importer_order,
         parent_path: ancestor_ids.to_vec(),
@@ -2227,7 +2297,7 @@ fn try_reuse_node(
     prior_key: Option<&PkgNameVerPeer>,
 ) -> Option<ReusedNode> {
     let lockfile = ctx.workspace.wanted_lockfile.as_ref()?;
-    if matches!(ctx.workspace.update_reuse_scope, UpdateReuseScope::None) {
+    if matches!(ctx.update_reuse_scope(), UpdateReuseScope::None) {
         return None;
     }
     let alias = wanted.alias.as_deref()?;
@@ -2430,21 +2500,22 @@ fn subtree_fully_reusable(
     lockfile: &pacquet_lockfile::Lockfile,
     key: &PkgNameVerPeer,
 ) -> bool {
-    if let Some(&cached) = lock_recoverable(&ctx.workspace.subtree_reusable).get(key) {
+    let memo_key = (ctx.update_cache_scope(), key.clone());
+    if let Some(&cached) = lock_recoverable(&ctx.workspace.subtree_reusable).get(&memo_key) {
         return cached;
     }
     // Provisionally mark non-reusable so a cycle back to `key` resolves to
     // `false` (re-resolve) instead of recursing forever — see the doc above
     // for why `false` rather than `true`.
-    lock_recoverable(&ctx.workspace.subtree_reusable).insert(key.clone(), false);
+    lock_recoverable(&ctx.workspace.subtree_reusable).insert(memo_key.clone(), false);
     // A `pacquet update` target anywhere in the subtree forces the whole
     // subtree to re-resolve so the bump's new transitive deps are picked
     // up — update names match at any depth.
     let name = key.name.to_string();
-    let reusable = !update_excludes(&ctx.workspace.update_reuse_scope, &name)
+    let reusable = !update_excludes(ctx.update_reuse_scope(), &name)
         && synthesize_reused_result(lockfile, key, &name).is_some()
         && subtree_children_reusable(ctx, lockfile, key);
-    lock_recoverable(&ctx.workspace.subtree_reusable).insert(key.clone(), reusable);
+    lock_recoverable(&ctx.workspace.subtree_reusable).insert(memo_key, reusable);
     reusable
 }
 
@@ -2521,6 +2592,8 @@ where
         // Reused resolutions are exact pins — preference overlays
         // can't change the pick, so the no-overlay bucket is right.
         Vec::new(),
+        ctx.update_cache_scope(),
+        is_update_target(ctx.update_reuse_scope(), &wanted),
     );
     lock_recoverable(&ctx.workspace.resolved_by_wanted)
         .entry(cache_key)
@@ -2779,17 +2852,18 @@ async fn build_pkg_id_with_patch_hash(
     result: &pacquet_resolving_resolver_base::ResolveResult,
 ) -> Result<String, ResolveDependencyTreeError> {
     let raw_id = result.id.as_str();
-    // `link:`-resolved workspace deps are short-circuited downstream
-    // by `id.starts_with("link:")` checks (see [`is_link`] in the
-    // tree walker and `importer_dep_version`'s
-    // `dep_path_str.strip_prefix("link:")` arm). Leaving the id
-    // unprefixed preserves those short-circuits; pacquet does not yet
-    // model the separate linked-dependency branch that would prefix
-    // them.
-    //
-    // [`is_link`]: fn@resolve_node
-    if raw_id.starts_with("link:") {
-        return Ok(raw_id.to_string());
+    if let Some(target) = raw_id.strip_prefix("link:") {
+        let target = std::path::Path::new(target);
+        let absolute_target = if target.is_absolute() {
+            pacquet_fs::lexical_normalize(target)
+        } else {
+            pacquet_fs::lexical_normalize(&ctx.base_opts.project_dir.join(target))
+        };
+        let relative_target =
+            pathdiff::diff_paths(&absolute_target, &ctx.lockfile_dir).unwrap_or(absolute_target);
+        let relative_target = relative_target.display().to_string().replace('\\', "/");
+        let relative_target = if relative_target.is_empty() { "." } else { &relative_target };
+        return Ok(format!("link:{relative_target}"));
     }
     // Resolvers that learn the name from the fetched manifest (git,
     // tarball, directory) leave `name_ver` unset. The `name` is read

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -1,9 +1,106 @@
-use pacquet_lockfile::PkgNameVerPeer;
+use pacquet_lockfile::{DirectoryResolution, LockfileResolution, PkgNameVerPeer};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_resolving_resolver_base::{
+    LatestQuery, PkgResolutionId, ResolveFuture, ResolveLatestFuture, ResolveOptions,
+    ResolveResult, Resolver, WantedDependency,
+};
 
-use super::landed_on_prior_entry;
+use super::{ResolveDependencyTreeOptions, landed_on_prior_entry, resolve_dependency_tree};
 
 fn key(raw: &str) -> PkgNameVerPeer {
     raw.parse().expect("parse snapshot key")
+}
+
+struct NestedWorkspaceLinkResolver {
+    target_dir: std::path::PathBuf,
+}
+
+impl Resolver for NestedWorkspaceLinkResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let target_dir = self.target_dir.clone();
+        let project_dir = opts.project_dir.clone();
+        let alias = wanted.alias.clone().unwrap_or_default();
+        Box::pin(async move {
+            if alias != "shared" {
+                return Ok(None);
+            }
+            let relative = pathdiff::diff_paths(target_dir, project_dir)
+                .expect("target can be relativized")
+                .display()
+                .to_string()
+                .replace('\\', "/");
+            Ok(Some(ResolveResult {
+                id: PkgResolutionId::from(format!("link:{relative}")),
+                name_ver: None,
+                latest: None,
+                published_at: None,
+                manifest: Some(std::sync::Arc::new(
+                    serde_json::json!({ "name": "shared", "version": "1.0.0" }),
+                )),
+                resolution: LockfileResolution::Directory(DirectoryResolution {
+                    directory: relative,
+                }),
+                resolved_via: "workspace".to_string(),
+                normalized_bare_specifier: None,
+                alias: Some(alias),
+                policy_violation: None,
+            }))
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+#[tokio::test]
+async fn canonical_snapshot_link_id_is_relative_to_lockfile_root() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let manifest_path = temp.path().join("package.json");
+    std::fs::write(
+        &manifest_path,
+        serde_json::to_string(&serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "shared": "workspace:*" },
+        }))
+        .expect("serialize manifest"),
+    )
+    .expect("write manifest");
+    let manifest = PackageManifest::from_path(manifest_path).expect("parse manifest");
+    let project_dir = std::path::PathBuf::from("/repo/apps/nested/app");
+    let lockfile_dir = std::path::PathBuf::from("/repo");
+    let resolver = NestedWorkspaceLinkResolver { target_dir: lockfile_dir.join("packages/shared") };
+
+    let tree = resolve_dependency_tree(
+        &resolver,
+        &manifest,
+        [DependencyGroup::Prod],
+        ResolveDependencyTreeOptions {
+            base_opts: ResolveOptions { project_dir, lockfile_dir, ..ResolveOptions::default() },
+            patched_dependencies: None,
+            manifest_hook: None,
+            pnpmfile_hook: None,
+            read_package_log: None,
+            auto_install_peers: false,
+        },
+    )
+    .await
+    .expect("resolve nested workspace link");
+
+    let direct = tree.direct.first().expect("shared direct dependency");
+    assert_eq!(direct.id, "link:packages/shared");
+    assert_eq!(direct.node_id, crate::NodeId::leaf("link:packages/shared"));
+    assert!(tree.packages.contains_key("link:packages/shared"));
+    assert!(!tree.packages.contains_key("link:../../../packages/shared"));
 }
 
 #[test]
@@ -41,6 +138,7 @@ fn owner_missing_record_is_written_once_per_generation() {
 
     let ctx = WorkspaceTreeCtx::default();
     let owner = ChildrenOwner {
+        update_active: false,
         depth: 1,
         importer_order: 0,
         parent_path: vec!["root-dep@1.0.0".to_string()],
@@ -79,6 +177,29 @@ fn owner_missing_record_is_written_once_per_generation() {
         Some(0),
         "a new ownership generation records afresh",
     );
+}
+
+#[test]
+fn importer_scoped_update_owner_wins_before_discovery_order() {
+    use super::ChildrenOwner;
+
+    let ordinary = ChildrenOwner {
+        update_active: false,
+        depth: 0,
+        importer_order: 0,
+        parent_path: Vec::new(),
+        importer_id: "unselected".to_string(),
+    };
+    let update_active = ChildrenOwner {
+        update_active: true,
+        depth: 10,
+        importer_order: 10,
+        parent_path: vec!["later".to_string()],
+        importer_id: "selected".to_string(),
+    };
+
+    assert!(update_active.wins_over(&ordinary));
+    assert!(!ordinary.wins_over(&update_active));
 }
 
 mod higher_direct_dep_version {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -299,6 +299,7 @@ pub(crate) struct ImporterHoistState {
     dedupe_peers: bool,
     exclude_links_from_lockfile: bool,
     lockfile_dir: Option<std::path::PathBuf>,
+    project_dir: std::path::PathBuf,
     modules_dir: Option<std::path::PathBuf>,
 }
 
@@ -348,7 +349,10 @@ impl ImporterHoistState {
             auto_install_peers,
             &catalogs,
         )?;
+        let project_dir = base_opts.project_dir.clone();
+        let tree_lockfile_dir = lockfile_dir.clone().unwrap_or_else(|| project_dir.clone());
         let ctx = TreeCtx::with_workspace(workspace, base_opts)
+            .with_lockfile_dir(&tree_lockfile_dir)
             .with_importer_id(importer_id)
             .with_importer_order(importer_order)
             .with_patched_dependencies(patched_dependencies)
@@ -372,6 +376,7 @@ impl ImporterHoistState {
             dedupe_peers,
             exclude_links_from_lockfile,
             lockfile_dir,
+            project_dir,
             modules_dir,
         })
     }
@@ -382,6 +387,7 @@ impl ImporterHoistState {
             dedupe_peers: self.dedupe_peers,
             exclude_links_from_lockfile: self.exclude_links_from_lockfile,
             lockfile_dir: self.lockfile_dir.clone(),
+            project_dir: Some(self.project_dir.clone()),
             modules_dir: self.modules_dir.clone(),
             hoist_missing_scope: None,
             hoisted_peer_provider_node_ids: self.hoisted_peer_provider_node_ids.clone(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -97,6 +97,10 @@ fn importer_relative_link_dep_path(
     } else {
         pacquet_fs::lexical_normalize(&lockfile_dir.join(target))
     };
+    // `diff_paths` walks both paths component-wise, so a base still
+    // carrying `.` / `..` segments would consume them as real directories
+    // and count the wrong number of `..` hops back out.
+    let project_dir = pacquet_fs::lexical_normalize(project_dir);
     let relative_target = pathdiff::diff_paths(&absolute_target, project_dir)
         .unwrap_or(absolute_target)
         .display()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -102,7 +102,6 @@ fn importer_relative_link_dep_path(
         .display()
         .to_string()
         .replace('\\', "/");
-    let relative_target = if relative_target.is_empty() { "." } else { &relative_target };
     DepPath::from(format!("link:{relative_target}"))
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -80,6 +80,32 @@ fn link_node_id_as_dep_path(node_id: &NodeId) -> Option<DepPath> {
     id.starts_with("link:").then(|| DepPath::from(id.to_string()))
 }
 
+fn importer_relative_link_dep_path(
+    dep_path: &DepPath,
+    lockfile_dir: Option<&Path>,
+    project_dir: Option<&Path>,
+) -> DepPath {
+    let Some(target) = dep_path.as_str().strip_prefix("link:") else {
+        return dep_path.clone();
+    };
+    let (Some(lockfile_dir), Some(project_dir)) = (lockfile_dir, project_dir) else {
+        return dep_path.clone();
+    };
+    let target = Path::new(target);
+    let absolute_target = if target.is_absolute() {
+        pacquet_fs::lexical_normalize(target)
+    } else {
+        pacquet_fs::lexical_normalize(&lockfile_dir.join(target))
+    };
+    let relative_target = pathdiff::diff_paths(&absolute_target, project_dir)
+        .unwrap_or(absolute_target)
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    let relative_target = if relative_target.is_empty() { "." } else { &relative_target };
+    DepPath::from(format!("link:{relative_target}"))
+}
+
 fn node_id_sort_key(node_id: &NodeId) -> String {
     match node_id {
         NodeId::Counter(value) => format!("0:{value:020}"),
@@ -120,6 +146,10 @@ pub struct ResolvePeersOptions {
     /// and (b) as the base for the relative path the remapped link
     /// node id encodes. `None` disables the remap.
     pub lockfile_dir: Option<std::path::PathBuf>,
+
+    /// Absolute root of the importer whose direct dependency map is
+    /// being rendered. Snapshot graph edges remain lockfile-root-relative.
+    pub project_dir: Option<std::path::PathBuf>,
 
     /// Absolute path of the importer's `node_modules` directory. Used
     /// to compose `<modules_dir>/<alias>` as the remap target.
@@ -195,6 +225,7 @@ impl Default for ResolvePeersOptions {
             dedupe_peers: false,
             exclude_links_from_lockfile: false,
             lockfile_dir: None,
+            project_dir: None,
             modules_dir: None,
             hoist_missing_scope: None,
             hoisted_peer_provider_node_ids: std::collections::HashSet::new(),
@@ -397,7 +428,13 @@ pub fn resolve_peers_workspace(
             .direct
             .iter()
             .map(|dep| {
-                (dep.alias.clone(), walker.final_dep_path_of(&dep.node_id, &final_dep_paths))
+                let dep_path = walker.final_dep_path_of(&dep.node_id, &final_dep_paths);
+                let dep_path = importer_relative_link_dep_path(
+                    &dep_path,
+                    Some(lockfile_dir),
+                    Some(&importer.root_dir),
+                );
+                (dep.alias.clone(), dep_path)
             })
             .collect();
         direct_dependencies_by_importer.insert(importer.id.clone(), direct_by_alias);
@@ -687,8 +724,13 @@ impl Walker<'_> {
         // per-node records keyed by the corrected depPaths.
         let final_dep_paths = self.build_final_dep_paths();
         for dep in &direct {
-            direct_by_alias
-                .insert(dep.alias.clone(), self.final_dep_path_of(&dep.node_id, &final_dep_paths));
+            let dep_path = self.final_dep_path_of(&dep.node_id, &final_dep_paths);
+            let dep_path = importer_relative_link_dep_path(
+                &dep_path,
+                self.opts.lockfile_dir.as_deref(),
+                self.opts.project_dir.as_deref(),
+            );
+            direct_by_alias.insert(dep.alias.clone(), dep_path);
         }
         let graph = self.build_final_graph(&final_dep_paths);
         let resolved_peer_providers_by_alias = self.resolved_peer_providers_by_alias;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1492,7 +1492,7 @@ fn linked_peer_provider_uses_root_relative_snapshot_ref_in_workspace_fallback() 
         .values()
         .find(|node| node.resolved_package_id == "consumer@1.0.0")
         .expect("consumer graph node");
-    assert_eq!(consumer.children.get("peer"), Some(&DepPath::from("link:packages/peer")),);
+    assert_eq!(consumer.children.get("peer"), Some(&DepPath::from("link:packages/peer")));
 }
 
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -11,8 +11,10 @@ use crate::{
     },
 };
 use pacquet_deps_path::DepPath;
-use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
-use pacquet_resolving_resolver_base::ResolveResult;
+use pacquet_lockfile::{
+    DirectoryResolution, LockfileResolution, PkgName, PkgNameVer, TarballResolution,
+};
+use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     str::FromStr,
@@ -1417,6 +1419,110 @@ fn pruned_hoisted_provider_falls_back_in_workspace_pass() {
     );
 }
 
+#[test]
+fn linked_peer_provider_uses_root_relative_snapshot_ref_in_workspace_fallback() {
+    let peer = NodeId::leaf("link:packages/peer");
+    let consumer = NodeId::next();
+    let importer = ImporterPeerInput {
+        id: "apps/nested/app".to_string(),
+        direct: vec![
+            DirectDep {
+                alias: "consumer".to_string(),
+                node_id: consumer.clone(),
+                id: "consumer@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "peer".to_string(),
+                node_id: peer.clone(),
+                id: "link:packages/peer".to_string(),
+            },
+        ],
+        root_dir: std::path::PathBuf::from("/repo/apps/nested/app"),
+        modules_dir: None,
+    };
+    let mut tree = ResolvedTree {
+        direct: Vec::new(),
+        packages: HashMap::from([
+            (
+                "link:packages/peer".to_string(),
+                linked_package("peer", "link:packages/peer", "packages/peer"),
+            ),
+            ("consumer@1.0.0".to_string(), package("consumer", "1.0.0", &[("peer", "*")], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (peer.clone(), tree_node("link:packages/peer", BTreeMap::new(), -1)),
+            (consumer, tree_node("consumer@1.0.0", BTreeMap::new(), 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["peer".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers_workspace(
+        &mut tree,
+        &[importer],
+        std::path::Path::new("/repo"),
+        false,
+        false,
+        false,
+        ResolvePeersOptions {
+            lockfile_dir: Some(std::path::PathBuf::from("/repo")),
+            hoisted_peer_provider_node_ids: HashSet::from([peer]),
+            ..ResolvePeersOptions::default()
+        },
+    );
+
+    assert_eq!(
+        result.direct_dependencies_by_importer["apps/nested/app"]["peer"].as_str(),
+        "link:../../../packages/peer",
+    );
+    let consumer = result
+        .graph
+        .values()
+        .find(|node| node.resolved_package_id == "consumer@1.0.0")
+        .expect("consumer graph node");
+    assert_eq!(consumer.children.get("peer"), Some(&DepPath::from("link:packages/peer")),);
+}
+
+#[test]
+fn single_importer_link_is_rendered_relative_to_project_root() {
+    let shared = NodeId::leaf("link:packages/shared");
+    let mut tree = ResolvedTree {
+        direct: vec![DirectDep {
+            alias: "shared".to_string(),
+            node_id: shared.clone(),
+            id: "link:packages/shared".to_string(),
+        }],
+        packages: HashMap::from([(
+            "link:packages/shared".to_string(),
+            linked_package("shared", "link:packages/shared", "packages/shared"),
+        )]),
+        dependencies_tree: HashMap::from([(
+            shared,
+            tree_node("link:packages/shared", BTreeMap::new(), -1),
+        )]),
+        all_peer_dep_names: HashSet::new(),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers(
+        &mut tree,
+        ResolvePeersOptions {
+            lockfile_dir: Some(std::path::PathBuf::from("/repo")),
+            project_dir: Some(std::path::PathBuf::from("/repo/apps/nested/app")),
+            ..ResolvePeersOptions::default()
+        },
+    );
+
+    assert_eq!(
+        result.direct_dependencies_by_alias["shared"].as_str(),
+        "link:../../../packages/shared",
+    );
+}
+
 /// Mirror of the TS test "pruned hoisted peer providers that peer-depend on
 /// each other are resolved together" (`deps-resolver/test/resolvePeers.ts`):
 /// two pruned providers form a peer cycle, so each one's suffix depends on
@@ -1693,6 +1799,29 @@ fn package_with_peer_dependencies(
         peer_dependencies,
         optional: false,
         is_leaf,
+    }
+}
+
+fn linked_package(name: &str, id: &str, directory: &str) -> ResolvedPackage {
+    ResolvedPackage {
+        id: id.to_string(),
+        result: Arc::new(ResolveResult {
+            id: PkgResolutionId::from(id.to_string()),
+            name_ver: None,
+            latest: None,
+            published_at: None,
+            manifest: Some(Arc::new(serde_json::json!({ "name": name, "version": "1.0.0" }))),
+            resolution: LockfileResolution::Directory(DirectoryResolution {
+                directory: directory.to_string(),
+            }),
+            resolved_via: "workspace".to_string(),
+            normalized_bare_specifier: None,
+            alias: Some(name.to_string()),
+            policy_violation: None,
+        }),
+        peer_dependencies: BTreeMap::new(),
+        optional: false,
+        is_leaf: true,
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     ImporterPeerInput, NodeRecord, ResolvePeersOptions, Walker,
-    dep_path_with_allowed_peer_segments, peer_segment_names, resolve_peers,
-    resolve_peers_workspace, satisfies_with_prereleases,
+    dep_path_with_allowed_peer_segments, importer_relative_link_dep_path, peer_segment_names,
+    resolve_peers, resolve_peers_workspace, satisfies_with_prereleases,
 };
 use crate::{
     dependencies_graph::{DependenciesGraph, PeerDependencyIssues},
@@ -17,6 +17,7 @@ use pacquet_lockfile::{
 use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    path::Path,
     str::FromStr,
     sync::Arc,
 };
@@ -28,6 +29,15 @@ const PATCHED_WORKFLOWS_SDK: &str = concat!(
     "(better-sqlite3@12.8.0)",
     "(express@4.21.2)",
 );
+
+#[test]
+fn importer_relative_self_link_keeps_an_empty_target() {
+    let workspace = Path::new("workspace");
+    assert_eq!(
+        importer_relative_link_dep_path(&DepPath::from("link:."), Some(workspace), Some(workspace),),
+        DepPath::from("link:"),
+    );
+}
 
 #[test]
 fn parses_peer_suffix_after_patch_hash() {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -39,6 +39,28 @@ fn importer_relative_self_link_keeps_an_empty_target() {
     );
 }
 
+/// The link target is relative to the importer, so a project dir that
+/// still carries `.` / `..` segments must be normalized before it is used
+/// as the base — otherwise those segments are counted as real directories
+/// and the target gains extra `..` hops.
+#[test]
+fn importer_relative_link_normalizes_the_project_dir() {
+    let expected = DepPath::from("link:../lib");
+    for project_dir in
+        ["workspace/packages/app", "workspace/packages/./app", "workspace/packages/nested/../app"]
+    {
+        assert_eq!(
+            importer_relative_link_dep_path(
+                &DepPath::from("link:packages/lib"),
+                Some(Path::new("workspace")),
+                Some(Path::new(project_dir)),
+            ),
+            expected,
+            "unexpected link target for project dir {project_dir:?}",
+        );
+    }
+}
+
 #[test]
 fn parses_peer_suffix_after_patch_hash() {
     let dep_path = DepPath::from(PATCHED_WORKFLOWS_SDK);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -29,7 +29,11 @@ use crate::{
 use chrono::{DateTime, Duration, Utc};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{Resolver, WantedDependency, parse_packument_timestamp};
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::PathBuf,
+    sync::Arc,
+};
 
 /// One importer's input to [`fn@resolve_workspace`].
 pub struct WorkspaceImporter<'a> {
@@ -91,6 +95,10 @@ pub struct WorkspaceResolveOptions {
     /// Which dependencies `pacquet update` excludes from lockfile-
     /// resolution reuse. [`UpdateReuseScope::All`] for `install` / `add`.
     pub update_reuse_scope: UpdateReuseScope,
+
+    /// Per-importer update scopes for filtered workspace updates. An importer
+    /// absent from this map uses [`Self::update_reuse_scope`].
+    pub update_reuse_scopes_by_importer: BTreeMap<String, UpdateReuseScope>,
 
     /// `pnpmfileHook` applied to every resolved manifest before it
     /// enters the wanted-dep cache. Workspace-wide (one hook per
@@ -166,6 +174,7 @@ where
         time_based,
         wanted_lockfile,
         update_reuse_scope,
+        update_reuse_scopes_by_importer,
         auto_install_peers,
         registries,
     } = opts;
@@ -174,6 +183,7 @@ where
             .with_manifest_hook(manifest_hook)
             .with_wanted_lockfile(wanted_lockfile)
             .with_update_reuse_scope(update_reuse_scope)
+            .with_update_reuse_scopes_by_importer(update_reuse_scopes_by_importer)
             .with_pnpmfile_hook(pnpmfile_hook)
             .with_read_package_log(read_package_log)
             .with_skipped_optional_log(skipped_optional_log)
@@ -282,6 +292,7 @@ where
         dedupe_peers,
         exclude_links_from_lockfile,
         lockfile_dir: Some(lockfile_dir.clone()),
+        project_dir: None,
         // Per-importer; resolve_peers_workspace swaps the
         // ImporterPeerInput's modules_dir into walker.opts before each
         // importer's walk.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -532,7 +532,7 @@ async fn canonical_snapshot_link_keeps_direct_links_relative_to_each_importer() 
     );
     let wrapper =
         result.peers.graph.get(&crate::DepPath::from("wrapper@1.0.0")).expect("wrapper graph node");
-    assert_eq!(wrapper.children.get("shared"), Some(&crate::DepPath::from("link:packages/shared")),);
+    assert_eq!(wrapper.children.get("shared"), Some(&crate::DepPath::from("link:packages/shared")));
     assert!(result.merged_tree.packages.contains_key("link:packages/shared"));
     assert!(!result.merged_tree.packages.contains_key("link:../../../packages/shared"));
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -75,6 +75,18 @@ impl Resolver for ProjectRelativeWorkspaceResolver {
         let target_dir = self.target_dir.clone();
         let project_dir = opts.project_dir.clone();
         Box::pin(async move {
+            if alias == "wrapper" && range == "1.0.0" {
+                return Ok(Some(fake_result(
+                    "wrapper",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "wrapper",
+                        "version": "1.0.0",
+                        "dependencies": { "shared": "^1.0.0" },
+                    }),
+                )));
+            }
             if alias != "shared" || range != "^1.0.0" {
                 return Ok(None);
             }
@@ -194,8 +206,240 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         time_based,
         wanted_lockfile: None,
         update_reuse_scope: crate::UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
         auto_install_peers: false,
         registries: HashMap::new(),
+    }
+}
+
+fn importer_scoped_update_lockfile(
+    importer_ids: &[&str],
+    direct_name: &str,
+    direct_specifier: &str,
+    direct_version: &str,
+    transitive: Option<(&str, &str)>,
+) -> pacquet_lockfile::Lockfile {
+    use pacquet_lockfile::{
+        ComVer, ImporterDepVersion, Lockfile, LockfileVersion, PackageMetadata, PkgName,
+        PkgNameVerPeer, PkgVerPeer, ProjectSnapshot, RegistryResolution, ResolvedDependencySpec,
+        SnapshotDepRef, SnapshotEntry,
+    };
+
+    let direct_name = PkgName::parse(direct_name).expect("parse direct package name");
+    let direct_version = direct_version.parse::<PkgVerPeer>().expect("parse direct version");
+    let direct_key = PkgNameVerPeer::new(direct_name.clone(), direct_version.clone());
+    let importers = importer_ids
+        .iter()
+        .map(|importer_id| {
+            let dependencies = HashMap::from([(
+                direct_name.clone(),
+                ResolvedDependencySpec {
+                    specifier: direct_specifier.to_string(),
+                    version: ImporterDepVersion::Regular(direct_version.clone()),
+                },
+            )]);
+            (
+                (*importer_id).to_string(),
+                ProjectSnapshot { dependencies: Some(dependencies), ..ProjectSnapshot::default() },
+            )
+        })
+        .collect();
+    let metadata = || {
+        PackageMetadata {
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+                .parse()
+                .expect("parse integrity"),
+        }),
+        version: None,
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+    };
+    let mut packages = HashMap::from([(direct_key.clone(), metadata())]);
+    let mut snapshots = HashMap::from([(direct_key.clone(), SnapshotEntry::default())]);
+    if let Some((child_name, child_version)) = transitive {
+        let child_name = PkgName::parse(child_name).expect("parse child package name");
+        let child_version = child_version.parse::<PkgVerPeer>().expect("parse child version");
+        let child_key = PkgNameVerPeer::new(child_name.clone(), child_version.clone());
+        packages.insert(child_key.clone(), metadata());
+        snapshots.insert(child_key, SnapshotEntry::default());
+        snapshots.insert(
+            direct_key,
+            SnapshotEntry {
+                dependencies: Some(HashMap::from([(
+                    child_name,
+                    SnapshotDepRef::Plain(child_version),
+                )])),
+                ..SnapshotEntry::default()
+            },
+        );
+    }
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).expect("lockfile v9"),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers,
+        packages: Some(packages),
+        snapshots: Some(snapshots),
+    }
+}
+
+async fn resolve_importer_scoped_update_direct(
+    order: [&str; 2],
+    selected_scope: crate::UpdateReuseScope,
+) -> HashMap<String, String> {
+    let (_selected_tmp, selected_manifest) =
+        fake_manifest(serde_json::json!({ "pkg": "^100.0.0" }));
+    let (_unselected_tmp, unselected_manifest) =
+        fake_manifest(serde_json::json!({ "pkg": "^100.0.0" }));
+    let manifests =
+        HashMap::from([("selected", &selected_manifest), ("unselected", &unselected_manifest)]);
+    let importers = order
+        .iter()
+        .map(|id| WorkspaceImporter { id: (*id).to_string(), manifest: manifests[id] })
+        .collect::<Vec<_>>();
+    let resolver = RecordingResolver {
+        table: HashMap::from([(
+            ("pkg".to_string(), "^100.0.0".to_string()),
+            fake_result(
+                "pkg",
+                "100.1.0",
+                None,
+                serde_json::json!({ "name": "pkg", "version": "100.1.0" }),
+            ),
+        )]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let mut opts = workspace_opts(false, false);
+    opts.wanted_lockfile = Some(std::sync::Arc::new(importer_scoped_update_lockfile(
+        &["selected", "unselected"],
+        "pkg",
+        "^100.0.0",
+        "100.0.0",
+        None,
+    )));
+    opts.update_reuse_scopes_by_importer =
+        BTreeMap::from([("selected".to_string(), selected_scope)]);
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+        })
+        .await
+        .expect("resolve importer-scoped update");
+    result
+        .peers
+        .direct_dependencies_by_importer
+        .into_iter()
+        .map(|(importer_id, dependencies)| (importer_id, dependencies["pkg"].as_str().to_string()))
+        .collect()
+}
+
+#[tokio::test]
+async fn importer_scoped_update_drop_only_is_order_independent() {
+    for order in [["selected", "unselected"], ["unselected", "selected"]] {
+        let direct = resolve_importer_scoped_update_direct(
+            order,
+            crate::UpdateReuseScope::Except(std::collections::HashSet::from(["pkg".to_string()])),
+        )
+        .await;
+        assert_eq!(direct["selected"], "pkg@100.1.0");
+        assert_eq!(direct["unselected"], "pkg@100.0.0");
+    }
+}
+
+#[tokio::test]
+async fn importer_scoped_update_drop_all_is_order_independent() {
+    for order in [["selected", "unselected"], ["unselected", "selected"]] {
+        let direct =
+            resolve_importer_scoped_update_direct(order, crate::UpdateReuseScope::None).await;
+        assert_eq!(direct["selected"], "pkg@100.1.0");
+        assert_eq!(direct["unselected"], "pkg@100.0.0");
+    }
+}
+
+#[tokio::test]
+async fn importer_scoped_update_route_owns_shared_parent_children_in_either_order() {
+    for order in [["selected", "unselected"], ["unselected", "selected"]] {
+        let (_selected_tmp, selected_manifest) =
+            fake_manifest(serde_json::json!({ "parent": "^1.0.0" }));
+        let (_unselected_tmp, unselected_manifest) =
+            fake_manifest(serde_json::json!({ "parent": "^1.0.0" }));
+        let manifests =
+            HashMap::from([("selected", &selected_manifest), ("unselected", &unselected_manifest)]);
+        let importers = order
+            .iter()
+            .map(|id| WorkspaceImporter { id: (*id).to_string(), manifest: manifests[id] })
+            .collect::<Vec<_>>();
+        let resolver = RecordingResolver {
+            table: HashMap::from([
+                (
+                    ("parent".to_string(), "^1.0.0".to_string()),
+                    fake_result(
+                        "parent",
+                        "1.0.0",
+                        None,
+                        serde_json::json!({
+                            "name": "parent",
+                            "version": "1.0.0",
+                            "dependencies": { "pkg": "^100.0.0" },
+                        }),
+                    ),
+                ),
+                (
+                    ("pkg".to_string(), "^100.0.0".to_string()),
+                    fake_result(
+                        "pkg",
+                        "100.1.0",
+                        None,
+                        serde_json::json!({ "name": "pkg", "version": "100.1.0" }),
+                    ),
+                ),
+            ]),
+            seen: Mutex::new(HashMap::new()),
+        };
+        let mut opts = workspace_opts(false, false);
+        opts.wanted_lockfile = Some(std::sync::Arc::new(importer_scoped_update_lockfile(
+            &["selected", "unselected"],
+            "parent",
+            "^1.0.0",
+            "1.0.0",
+            Some(("pkg", "100.0.0")),
+        )));
+        opts.update_reuse_scopes_by_importer = BTreeMap::from([(
+            "selected".to_string(),
+            crate::UpdateReuseScope::Except(std::collections::HashSet::from(["pkg".to_string()])),
+        )]);
+        let result =
+            resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+                importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+            })
+            .await
+            .expect("resolve shared parent update");
+
+        for importer_id in ["selected", "unselected"] {
+            assert_eq!(
+                result.peers.direct_dependencies_by_importer[importer_id]["parent"].as_str(),
+                "parent@1.0.0",
+            );
+        }
+        let parent_children =
+            result.merged_tree.children_by_id.get("parent@1.0.0").expect("parent children");
+        assert_eq!(parent_children.len(), 1);
+        assert_eq!(parent_children[0].pkg_id, "pkg@100.1.0");
     }
 }
 
@@ -210,26 +454,26 @@ async fn workspace_link_results_are_cached_per_importer_project_dir() {
         WorkspaceImporter { id: "packages/a".to_string(), manifest: &a_manifest },
         WorkspaceImporter { id: "apps/b".to_string(), manifest: &b_manifest },
     ];
+    let lockfile_dir = std::path::PathBuf::from("/repo");
+    let mut opts = workspace_opts(false, false);
+    opts.lockfile_dir.clone_from(&lockfile_dir);
 
-    let result = resolve_workspace(
-        &resolver,
-        &importers,
-        &[DependencyGroup::Prod],
-        workspace_opts(false, false),
-        |importer| {
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
             let project_dir = match importer.id.as_str() {
                 "packages/a" => std::path::PathBuf::from("/repo/packages/a"),
                 "apps/b" => std::path::PathBuf::from("/repo/apps/b"),
                 _ => unreachable!("unexpected importer"),
             };
             let mut opts = importer_opts(project_dir, None);
+            opts.lockfile_dir = Some(lockfile_dir.clone());
+            opts.base_opts.lockfile_dir.clone_from(&lockfile_dir);
             opts.base_opts.always_try_workspace_packages = true;
             opts.base_opts.workspace_packages = Some(std::collections::BTreeMap::default());
             opts
-        },
-    )
-    .await
-    .expect("resolve workspace");
+        })
+        .await
+        .expect("resolve workspace");
 
     assert_eq!(
         result.peers.direct_dependencies_by_importer["packages/a"]["shared"].as_str(),
@@ -239,6 +483,58 @@ async fn workspace_link_results_are_cached_per_importer_project_dir() {
         result.peers.direct_dependencies_by_importer["apps/b"]["shared"].as_str(),
         "link:../../packages/shared",
     );
+}
+
+#[tokio::test]
+async fn canonical_snapshot_link_keeps_direct_links_relative_to_each_importer() {
+    let (_nested_tmp, nested_manifest) = fake_manifest(serde_json::json!({
+        "shared": "^1.0.0",
+        "wrapper": "1.0.0",
+    }));
+    let (_shallow_tmp, shallow_manifest) = fake_manifest(serde_json::json!({
+        "shared": "^1.0.0",
+        "wrapper": "1.0.0",
+    }));
+    let lockfile_dir = std::path::PathBuf::from("/repo");
+    let resolver =
+        ProjectRelativeWorkspaceResolver { target_dir: lockfile_dir.join("packages/shared") };
+    let importers = vec![
+        WorkspaceImporter { id: "apps/nested/app".to_string(), manifest: &nested_manifest },
+        WorkspaceImporter { id: "packages/consumer".to_string(), manifest: &shallow_manifest },
+    ];
+    let mut opts = workspace_opts(false, false);
+    opts.lockfile_dir.clone_from(&lockfile_dir);
+
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            let project_dir = match importer.id.as_str() {
+                "apps/nested/app" => std::path::PathBuf::from("/repo/apps/nested/app"),
+                "packages/consumer" => std::path::PathBuf::from("/repo/packages/consumer"),
+                _ => unreachable!("unexpected importer"),
+            };
+            let mut opts = importer_opts(project_dir, None);
+            opts.lockfile_dir = Some(lockfile_dir.clone());
+            opts.base_opts.lockfile_dir.clone_from(&lockfile_dir);
+            opts.base_opts.always_try_workspace_packages = true;
+            opts.base_opts.workspace_packages = Some(std::collections::BTreeMap::default());
+            opts
+        })
+        .await
+        .expect("resolve workspace");
+
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["apps/nested/app"]["shared"].as_str(),
+        "link:../../../packages/shared",
+    );
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["packages/consumer"]["shared"].as_str(),
+        "link:../shared",
+    );
+    let wrapper =
+        result.peers.graph.get(&crate::DepPath::from("wrapper@1.0.0")).expect("wrapper graph node");
+    assert_eq!(wrapper.children.get("shared"), Some(&crate::DepPath::from("link:packages/shared")),);
+    assert!(result.merged_tree.packages.contains_key("link:packages/shared"));
+    assert!(!result.merged_tree.packages.contains_key("link:../../../packages/shared"));
 }
 
 #[tokio::test]

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2675,6 +2675,8 @@ async function installViaPnprServer (
     const projectsList = allInstallProjects && allInstallProjects.length > 1
       ? allInstallProjects.map(p => ({
         dir: (path.relative(lockfileDir, p.rootDir) || '.').split(path.sep).join('/'),
+        name: p.manifest.name,
+        version: p.manifest.version,
         dependencies: p.manifest.dependencies,
         devDependencies: p.manifest.devDependencies,
         optionalDependencies: p.manifest.optionalDependencies,
@@ -2683,6 +2685,8 @@ async function installViaPnprServer (
 
     const { lockfile, stats: pnprStats } = await resolveViaPnprServer({
       registryUrl: opts.pnprServer!,
+      name: projectsList ? undefined : manifest.name,
+      version: projectsList ? undefined : manifest.version,
       dependencies: projectsList ? undefined : manifest.dependencies,
       devDependencies: projectsList ? undefined : manifest.devDependencies,
       optionalDependencies: projectsList ? undefined : manifest.optionalDependencies,

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -1,0 +1,128 @@
+import path from 'node:path'
+
+import { afterEach, expect, jest, test } from '@jest/globals'
+import type { MutateModulesOptions, ProjectOptions } from '@pnpm/installing.deps-installer'
+import type { ResolveViaPnprServerOptions, ResolveViaPnprServerResult } from '@pnpm/pnpr.client'
+import { prepareEmpty, preparePackages } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { ProjectManifest, ProjectRootDir } from '@pnpm/types'
+
+import { testDefaults } from '../utils/index.js'
+
+const originalCwd = process.cwd()
+const storeControllers: StoreController[] = []
+const resolveViaPnprServer = jest.fn(async (
+  options: ResolveViaPnprServerOptions
+): Promise<ResolveViaPnprServerResult> => {
+  const importerDirs = options.projects?.map(({ dir }) => dir) ?? ['.']
+  return {
+    lockfile: {
+      lockfileVersion: '9.0',
+      importers: Object.fromEntries(importerDirs.map((dir) => [dir, { specifiers: {} }])),
+      packages: {},
+    },
+    stats: { totalPackages: 0 },
+  }
+})
+
+jest.unstable_mockModule('@pnpm/pnpr.client', () => ({ resolveViaPnprServer }))
+
+const { install, mutateModules } = await import('@pnpm/installing.deps-installer')
+
+afterEach(async () => {
+  try {
+    await Promise.all(storeControllers.splice(0).map(async (storeController) => storeController.close()))
+    resolveViaPnprServer.mockClear()
+  } finally {
+    process.chdir(originalCwd)
+  }
+})
+
+test("pnpr forwards a single project's name and version", async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir)
+
+  await install(manifest, options)
+
+  expect(resolveViaPnprServer).toHaveBeenCalledTimes(1)
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    name: 'app',
+    version: '1.2.3',
+    dependencies: undefined,
+    devDependencies: undefined,
+    optionalDependencies: undefined,
+    projects: undefined,
+  }))
+})
+
+test("pnpr forwards every workspace project's name and version", async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const appManifest: ProjectManifest = {
+    name: 'app',
+    version: '1.0.0',
+    dependencies: { lib: 'workspace:*' },
+  }
+  const libManifest: ProjectManifest = { name: 'lib', version: '2.0.0' }
+  preparePackages([
+    { location: 'packages/app', package: appManifest },
+    { location: 'packages/lib', package: libManifest },
+  ], { tempDir: path.join(workspaceRoot, '.fixture-anchor') })
+
+  const appRootDir = path.join(workspaceRoot, 'packages/app') as ProjectRootDir
+  const libRootDir = path.join(workspaceRoot, 'packages/lib') as ProjectRootDir
+  const allProjects = [
+    { buildIndex: 0, manifest: appManifest, rootDir: appRootDir },
+    { buildIndex: 0, manifest: libManifest, rootDir: libRootDir },
+  ] satisfies ProjectOptions[]
+  const options = createOptions(workspaceRoot, appRootDir, { allProjects })
+
+  await mutateModules([
+    { mutation: 'install', rootDir: appRootDir },
+    { mutation: 'install', rootDir: libRootDir },
+  ], options)
+
+  expect(resolveViaPnprServer).toHaveBeenCalledTimes(1)
+  const projects = resolveViaPnprServer.mock.calls[0][0].projects
+  expect(projects).toStrictEqual([
+    {
+      dir: 'packages/app',
+      name: 'app',
+      version: '1.0.0',
+      dependencies: { lib: 'workspace:*' },
+      devDependencies: undefined,
+      optionalDependencies: undefined,
+    },
+    {
+      dir: 'packages/lib',
+      name: 'lib',
+      version: '2.0.0',
+      dependencies: undefined,
+      devDependencies: undefined,
+      optionalDependencies: undefined,
+    },
+  ])
+  for (const project of projects ?? []) {
+    expect(path.isAbsolute(project.dir)).toBe(false)
+    expect(project.dir).not.toContain('\\')
+  }
+})
+
+function createOptions (
+  workspaceRoot: string,
+  rootDir: ProjectRootDir,
+  overrides: Partial<MutateModulesOptions> = {}
+): MutateModulesOptions {
+  const options = testDefaults({
+    pnprServer: 'http://pnpr.test',
+    lockfileOnly: true,
+    dir: rootDir,
+    lockfileDir: workspaceRoot,
+    storeDir: path.join(workspaceRoot, '.store'),
+    cacheDir: path.join(workspaceRoot, '.cache'),
+    ...overrides,
+  })
+  storeControllers.push(options.storeController)
+  return options
+}

--- a/pnpr/client/package.json
+++ b/pnpr/client/package.json
@@ -25,8 +25,9 @@
   ],
   "scripts": {
     "start": "tsgo --watch",
-    "lint": "eslint \"src/**/*.ts\"",
-    "test": "pn compile",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "test": "pn compile && pn .test",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest",
     "prepublishOnly": "tsgo --build",
     "compile": "tsgo --build && pn lint --fix"
   },
@@ -35,6 +36,7 @@
     "@pnpm/lockfile.types": "workspace:*"
   },
   "devDependencies": {
+    "@jest/globals": "catalog:",
     "@pnpm/pnpr.client": "workspace:*",
     "@pnpm/types": "workspace:*"
   },

--- a/pnpr/client/src/index.ts
+++ b/pnpr/client/src/index.ts
@@ -1,2 +1,2 @@
 export { type ResponseMetadata } from './protocol.js'
-export { resolveViaPnprServer, type ResolveViaPnprServerOptions, type ResolveViaPnprServerResult } from './resolveViaPnprServer.js'
+export { type PnprProject, resolveViaPnprServer, type ResolveViaPnprServerOptions, type ResolveViaPnprServerResult } from './resolveViaPnprServer.js'

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -11,6 +11,8 @@ import type { ResponseMetadata } from './protocol.js'
 export interface PnprProject {
   /** Relative dir within the workspace (e.g. "." or "packages/foo") */
   dir: string
+  name?: string
+  version?: string
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
   optionalDependencies?: Record<string, string>
@@ -19,6 +21,10 @@ export interface PnprProject {
 export interface ResolveViaPnprServerOptions {
   /** URL of the pnpr server */
   registryUrl: string
+  /** Project name to resolve (single project) */
+  name?: string
+  /** Project version to resolve (single project) */
+  version?: string
   /** Dependencies to resolve (single project) */
   dependencies?: Record<string, string>
   /** Dev dependencies to resolve (single project) */
@@ -89,6 +95,8 @@ export async function resolveViaPnprServer (
 ): Promise<ResolveViaPnprServerResult> {
   const projects = opts.projects ?? [{
     dir: '.',
+    name: opts.name,
+    version: opts.version,
     dependencies: opts.dependencies,
     devDependencies: opts.devDependencies,
     optionalDependencies: opts.optionalDependencies,

--- a/pnpr/client/test/resolveViaPnprServer.test.ts
+++ b/pnpr/client/test/resolveViaPnprServer.test.ts
@@ -1,0 +1,96 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { expect, test } from '@jest/globals'
+import { resolveViaPnprServer, type ResolveViaPnprServerOptions } from '@pnpm/pnpr.client'
+
+interface CapturedResolveRequest {
+  projects: Array<Record<string, unknown>>
+}
+
+test('serializes name and version for the single-project compatibility options', async () => {
+  const options = {
+    name: 'app',
+    version: '1.2.3',
+    dependencies: {},
+  }
+
+  const request = await captureResolveRequest(options)
+
+  expect(request.projects).toEqual([{
+    dir: '.',
+    name: 'app',
+    version: '1.2.3',
+    dependencies: {},
+  }])
+})
+
+test('serializes name and version for every explicit project', async () => {
+  const projects = [
+    {
+      dir: 'packages/app',
+      name: 'app',
+      version: '1.0.0',
+      dependencies: { lib: 'workspace:*' },
+    },
+    {
+      dir: 'packages/lib',
+      name: 'lib',
+      version: '2.0.0',
+      dependencies: {},
+    },
+  ]
+
+  const request = await captureResolveRequest({ projects })
+
+  expect(request.projects).toEqual(projects)
+})
+
+test('omits absent identity fields instead of serializing null', async () => {
+  const request = await captureResolveRequest({ dependencies: {} })
+
+  expect(Object.hasOwn(request.projects[0], 'name')).toBe(false)
+  expect(Object.hasOwn(request.projects[0], 'version')).toBe(false)
+})
+
+async function captureResolveRequest (
+  options: Omit<ResolveViaPnprServerOptions, 'registryUrl'>
+): Promise<CapturedResolveRequest> {
+  let capturedRequest: CapturedResolveRequest | undefined
+  const server = http.createServer(async (request, response) => {
+    const chunks: Buffer[] = []
+    for await (const chunk of request) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+    }
+    capturedRequest = JSON.parse(Buffer.concat(chunks).toString('utf8')) as CapturedResolveRequest
+    response.end(`${JSON.stringify({
+      type: 'done',
+      lockfile: { lockfileVersion: '9.0', importers: { '.': {} } },
+      stats: { totalPackages: 0 },
+    })}\n`)
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  try {
+    const { port } = server.address() as AddressInfo
+    await resolveViaPnprServer({
+      ...options,
+      registryUrl: `http://127.0.0.1:${port}/`,
+    })
+    if (capturedRequest == null) {
+      throw new Error('The pnpr client did not send a resolve request')
+    }
+    return capturedRequest
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => error == null ? resolve() : reject(error))
+    })
+  }
+}

--- a/pnpr/client/test/resolveViaPnprServer.test.ts
+++ b/pnpr/client/test/resolveViaPnprServer.test.ts
@@ -2,7 +2,7 @@ import http from 'node:http'
 import type { AddressInfo } from 'node:net'
 
 import { expect, test } from '@jest/globals'
-import { resolveViaPnprServer, type ResolveViaPnprServerOptions } from '@pnpm/pnpr.client'
+import { type PnprProject, resolveViaPnprServer, type ResolveViaPnprServerOptions } from '@pnpm/pnpr.client'
 
 interface CapturedResolveRequest {
   projects: Array<Record<string, unknown>>
@@ -26,7 +26,7 @@ test('serializes name and version for the single-project compatibility options',
 })
 
 test('serializes name and version for every explicit project', async () => {
-  const projects = [
+  const projects: PnprProject[] = [
     {
       dir: 'packages/app',
       name: 'app',

--- a/pnpr/client/test/tsconfig.json
+++ b/pnpr/client/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../node_modules/.test.lib",
+    "rootDir": "..",
+    "isolatedModules": true
+  },
+  "include": [
+    "**/*.ts",
+    "../../../pnpm11/__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -719,6 +719,8 @@ fn resolution_cache_key(config: &PacquetConfig, request: &ResolveRequest) -> Opt
         .map(|project| {
             serde_json::json!({
                 "dir": project.dir,
+                "name": project.name,
+                "version": project.version,
                 "dependencies": project.dependencies,
                 "devDependencies": project.dev_dependencies,
                 "optionalDependencies": project.optional_dependencies,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -466,7 +466,9 @@ pub(crate) async fn handle_resolve(
     let footprint_for_store = Arc::clone(&footprint);
     let cache_secret = Arc::clone(&runtime.resolution_cache_secret);
     tokio::spawn(async move {
-        match resolve::resolve(config, &client, &request, &request_auth, Some(observer)).await {
+        match Box::pin(resolve::resolve(config, &client, &request, &request_auth, Some(observer)))
+            .await
+        {
             Ok(lockfile) => {
                 let lockfile = tarball_router.route_lockfile(config, &lockfile);
                 if let Some(osv_index) = final_osv_index.as_ref() {

--- a/pnpr/crates/pnpr/src/resolver/protocol.rs
+++ b/pnpr/crates/pnpr/src/resolver/protocol.rs
@@ -16,6 +16,10 @@ pub struct ResolveRequestProject {
     #[serde(default = "root_dir")]
     pub dir: String,
     #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
     pub dependencies: DepMap,
     #[serde(default)]
     pub dev_dependencies: DepMap,
@@ -119,6 +123,8 @@ pub struct ResolveRequest {
 /// across the legacy single-project body and the `projects` array.
 pub struct ProjectDeps {
     pub dir: String,
+    pub name: Option<String>,
+    pub version: Option<String>,
     pub dependencies: DepMap,
     pub dev_dependencies: DepMap,
     pub optional_dependencies: DepMap,
@@ -135,6 +141,8 @@ impl ResolveRequest {
                 .iter()
                 .map(|project| ProjectDeps {
                     dir: project.dir.clone(),
+                    name: project.name.clone(),
+                    version: project.version.clone(),
                     dependencies: project.dependencies.clone(),
                     dev_dependencies: project.dev_dependencies.clone(),
                     optional_dependencies: project.optional_dependencies.clone(),
@@ -143,6 +151,8 @@ impl ResolveRequest {
         }
         vec![ProjectDeps {
             dir: root_dir(),
+            name: None,
+            version: None,
             dependencies: self.dependencies.clone().unwrap_or_default(),
             dev_dependencies: self.dev_dependencies.clone().unwrap_or_default(),
             optional_dependencies: self.optional_dependencies.clone().unwrap_or_default(),

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -19,6 +19,7 @@ use pacquet_package_manager::{Install, ResolutionObserver, ResolvedPackages};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::SilentReporter;
 use pacquet_tarball::MemCache;
+use tokio::io::AsyncWriteExt;
 
 use super::protocol::ResolveRequest;
 
@@ -99,7 +100,31 @@ pub async fn resolve(
         });
         let manifest_bytes = serde_json::to_vec(&manifest_json)
             .map_err(|err| ResolveError::Install(err.to_string()))?;
-        tokio::fs::write(project_dir.join("package.json"), manifest_bytes).await?;
+        // The temp dir starts empty and the `seen_dirs` check above already
+        // rejected byte-equal dirs, so an existing `package.json` means two
+        // importer dirs addressed the same directory — `packages/Foo` and
+        // `packages/foo` on a case-insensitive filesystem. Creating the file
+        // exclusively lets the host's own path semantics catch that, which a
+        // string comparison here cannot do portably.
+        match tokio::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(project_dir.join("package.json"))
+            .await
+        {
+            Ok(mut file) => {
+                file.write_all(&manifest_bytes).await?;
+                // `tokio::fs::File` buffers and does not flush on drop, so
+                // the manifest has to be flushed before it is read back.
+                file.flush().await?;
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                return Err(ResolveError::Install(format!(
+                    "duplicate importer dir: {rel:?} resolves to a directory already written by another importer",
+                )));
+            }
+            Err(err) => return Err(err.into()),
+        }
     }
 
     // Only declare a workspace when there are members; a lone root
@@ -259,7 +284,9 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
         return None;
     }
     let project = projects.pop()?;
-    if project.dir != "." && !project.dir.is_empty() {
+    // `.` is the only root importer `sanitized_importer_dir` accepts, so
+    // this fast path must not recognize any other spelling of it.
+    if project.dir != "." {
         return None;
     }
     let importer = lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY)?;

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -89,9 +89,11 @@ pub async fn resolve(
             dir.join(rel)
         };
         tokio::fs::create_dir_all(&project_dir).await?;
+        let name = project.name.clone().unwrap_or_else(|| importer_manifest_name(rel));
+        let version = project.version.as_deref().unwrap_or("0.0.0");
         let manifest_json = serde_json::json!({
-            "name": importer_manifest_name(rel),
-            "version": "0.0.0",
+            "name": name,
+            "version": version,
             "dependencies": project.dependencies,
             "devDependencies": project.dev_dependencies,
             "optionalDependencies": project.optional_dependencies,
@@ -264,8 +266,8 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
     let temp = tempfile::Builder::new().prefix("pnpr-frozen-").tempdir().ok()?;
     let manifest_path = temp.path().join("package.json");
     let manifest_json = serde_json::json!({
-        "name": "pnpr-resolve",
-        "version": "0.0.0",
+        "name": project.name.as_deref().unwrap_or("pnpr-resolve"),
+        "version": project.version.as_deref().unwrap_or("0.0.0"),
         "dependencies": project.dependencies,
         "devDependencies": project.dev_dependencies,
         "optionalDependencies": project.optional_dependencies,

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -52,12 +52,11 @@ impl From<std::io::Error> for ResolveError {
 /// tarball downloads happen later from upstream URLs or an upstream's
 /// `/~<name>/` registry endpoint.
 ///
-/// A single-project request resolves one root (`.`) importer. A
-/// multi-project request is reconstructed as a real workspace in the
-/// temp dir — root manifest, `pnpm-workspace.yaml` listing the member
-/// dirs, and a `package.json` per member — so pacquet's install path
-/// discovers and resolves every importer in one pass, producing a
-/// lockfile keyed by the same POSIX importer dirs the client sent.
+/// A request is reconstructed as a real workspace in the temp dir — a
+/// `package.json` per requested project and, when there are members, a
+/// `pnpm-workspace.yaml` listing their dirs — so pacquet's install path
+/// discovers and resolves every importer in one pass, producing a lockfile
+/// keyed by the same POSIX importer dirs the client sent.
 pub async fn resolve(
     config: &'static Config,
     client: &Arc<ThrottledClient>,
@@ -103,15 +102,6 @@ pub async fn resolve(
         tokio::fs::write(project_dir.join("package.json"), manifest_bytes).await?;
     }
 
-    // A workspace needs a root manifest at its root even when the client
-    // didn't send a `.` importer (e.g. a member-only filtered install).
-    if !wrote_root {
-        let root_json = serde_json::json!({ "name": "pnpr-resolve", "version": "0.0.0" });
-        let root_bytes =
-            serde_json::to_vec(&root_json).map_err(|err| ResolveError::Install(err.to_string()))?;
-        tokio::fs::write(dir.join("package.json"), root_bytes).await?;
-    }
-
     // Only declare a workspace when there are members; a lone root
     // importer resolves as a plain single project (no workspace file).
     if !member_dirs.is_empty() {
@@ -131,8 +121,18 @@ pub async fn resolve(
     }
 
     let manifest_path = dir.join("package.json");
-    let manifest = PackageManifest::from_path(manifest_path)
-        .map_err(|err| ResolveError::Manifest(err.to_string()))?;
+    let manifest = if wrote_root {
+        PackageManifest::from_path(manifest_path)
+            .map_err(|err| ResolveError::Manifest(err.to_string()))?
+    } else {
+        // Install needs an active manifest, but keeping this stand-in in
+        // memory prevents workspace discovery from inventing a `.` importer
+        // that the client did not request.
+        PackageManifest::from_value(
+            manifest_path,
+            serde_json::json!({ "name": "pnpr-resolve", "version": "0.0.0" }),
+        )
+    };
 
     // Seed resolution from the client's lockfile when present, matching
     // pnpm's resolution-reuse: frozen → use it as-is (already verified
@@ -283,25 +283,25 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
 
 /// Validate a client-supplied importer dir before joining it onto the
 /// server's temp dir. The client normalizes to POSIX relative paths, so
-/// anything absolute, backslash-bearing, or containing a `..`/empty
-/// component is rejected rather than risking a write outside the temp
-/// workspace. Returns the canonical `.` for the root.
+/// anything absolute, backslash- or colon-bearing, or containing a
+/// non-canonical component is rejected rather than risking a write outside
+/// the temp workspace or allowing two importer IDs to address the same path.
+/// The exact `.` value is the only accepted root importer.
 fn sanitized_importer_dir(dir: &str) -> Result<&str, ResolveError> {
-    if dir.is_empty() || dir == "." {
+    if dir == "." {
         return Ok(".");
     }
-    let trimmed = dir.trim_end_matches('/');
-    // A now-empty string means the input was only slashes (`/`, `////`):
-    // an absolute path, not the root — reject it rather than collapse it
-    // to `.` by trimming.
-    if trimmed.is_empty()
-        || trimmed.starts_with('/')
-        || trimmed.contains('\\')
-        || trimmed.split('/').any(|component| component == ".." || component.is_empty())
+    if dir.is_empty()
+        || dir.starts_with('/')
+        || dir.contains('\\')
+        || dir.contains(':')
+        || dir
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
     {
         return Err(ResolveError::Install(format!("unsafe importer dir: {dir:?}")));
     }
-    Ok(trimmed)
+    Ok(dir)
 }
 
 /// A synthetic, unique `name` for an importer's throwaway manifest. The

--- a/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
@@ -7,10 +7,8 @@ use pacquet_store_dir::StoreDir;
 use std::sync::Arc;
 
 #[test]
-fn root_and_trailing_slashes_normalize_to_dot() {
+fn exact_dot_is_the_only_root_importer() {
     assert_eq!(sanitized_importer_dir(".").unwrap(), ".");
-    assert_eq!(sanitized_importer_dir("").unwrap(), ".");
-    assert_eq!(sanitized_importer_dir("packages/foo/").unwrap(), "packages/foo");
 }
 
 #[test]
@@ -21,11 +19,35 @@ fn nested_member_dirs_pass_through() {
 
 #[test]
 fn traversal_absolute_and_backslash_dirs_are_rejected() {
-    // `/` and `////` are slashes-only: they must be rejected, not trimmed
-    // down to the root importer.
-    for unsafe_dir in
-        ["../escape", "packages/../../etc", "/abs/path", r"packages\foo", "a//b", "/", "////"]
+    for unsafe_dir in [
+        "../escape",
+        "packages/../../etc",
+        "/abs/path",
+        "//server/share",
+        r"packages\foo",
+        r"\\server\share",
+    ] {
+        assert!(
+            sanitized_importer_dir(unsafe_dir).is_err(),
+            "expected {unsafe_dir:?} to be rejected",
+        );
+    }
+}
+
+#[test]
+fn empty_and_dot_components_are_rejected() {
+    for unsafe_dir in ["", "/", "////", "a//b", "packages/foo/", "./packages/foo", "packages/./foo"]
     {
+        assert!(
+            sanitized_importer_dir(unsafe_dir).is_err(),
+            "expected {unsafe_dir:?} to be rejected",
+        );
+    }
+}
+
+#[test]
+fn windows_drive_and_colon_forms_are_rejected() {
+    for unsafe_dir in ["C:/outside", "C:relative", "packages/foo:bar"] {
         assert!(
             sanitized_importer_dir(unsafe_dir).is_err(),
             "expected {unsafe_dir:?} to be rejected",
@@ -62,6 +84,30 @@ async fn workspace_star_uses_forwarded_project_name() {
     .await;
 
     assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
+}
+
+#[tokio::test]
+async fn workspace_without_root_project_has_no_synthetic_root_importer() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": "packages/app",
+                "name": "app",
+                "version": "1.0.0"
+            },
+            {
+                "dir": "packages/lib",
+                "name": "lib",
+                "version": "1.2.3"
+            }
+        ]
+    })))
+    .await;
+
+    assert_eq!(
+        lockfile.importers.keys().map(String::as_str).collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["packages/app", "packages/lib"]),
+    );
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
@@ -1,4 +1,10 @@
 use super::{importer_manifest_name, sanitized_importer_dir};
+use crate::resolver::protocol::ResolveRequest;
+use pacquet_config::Config;
+use pacquet_lockfile::{ImporterDepVersion, Lockfile, PkgName};
+use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_store_dir::StoreDir;
+use std::sync::Arc;
 
 #[test]
 fn root_and_trailing_slashes_normalize_to_dot() {
@@ -34,4 +40,149 @@ fn manifest_names_are_distinct_per_dir() {
     // `/` → `-` alone would collide these two; escaping `-` first keeps
     // the mapping injective.
     assert_ne!(importer_manifest_name("packages/foo"), importer_manifest_name("packages-foo"));
+}
+
+#[tokio::test]
+async fn workspace_star_uses_forwarded_project_name() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": "packages/app",
+                "name": "app",
+                "version": "1.0.0",
+                "dependencies": { "lib": "workspace:*" }
+            },
+            {
+                "dir": "packages/lib",
+                "name": "lib",
+                "version": "1.2.3"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
+}
+
+#[tokio::test]
+async fn workspace_range_uses_forwarded_project_version() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": "packages/app",
+                "name": "app",
+                "version": "1.0.0",
+                "dependencies": { "lib": "workspace:^1.0.0" }
+            },
+            {
+                "dir": "packages/lib",
+                "name": "lib",
+                "version": "1.2.3"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
+}
+
+#[tokio::test]
+async fn workspace_name_without_version_uses_default_version() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": "packages/app",
+                "name": "app",
+                "version": "1.0.0",
+                "dependencies": { "lib": "workspace:^0.0.0" }
+            },
+            {
+                "dir": "packages/lib",
+                "name": "lib"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
+}
+
+#[tokio::test]
+async fn workspace_version_without_name_uses_synthetic_name() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": ".",
+                "dependencies": {
+                    "pnpr-importer-packages-lib": "workspace:^1.0.0"
+                }
+            },
+            {
+                "dir": "packages/lib",
+                "version": "1.2.3"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, ".", "pnpr-importer-packages-lib", "packages/lib");
+}
+
+#[tokio::test]
+async fn legacy_projects_without_identity_use_synthetic_name_and_version() {
+    let lockfile = Box::pin(resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": ".",
+                "dependencies": {
+                    "pnpr-importer-packages-lib": "workspace:^0.0.0"
+                }
+            },
+            {
+                "dir": "packages/lib"
+            }
+        ]
+    })))
+    .await;
+
+    assert_workspace_link(&lockfile, ".", "pnpr-importer-packages-lib", "packages/lib");
+}
+
+async fn resolve_json(request: serde_json::Value) -> Lockfile {
+    let temp = tempfile::tempdir().expect("create resolver test directory");
+    let mut config = Config::new();
+    config.offline = true;
+    config.enable_global_virtual_store = false;
+    config.store_dir = StoreDir::new(temp.path().join("store"));
+    config.cache_dir = temp.path().join("cache");
+    config.modules_dir = temp.path().join("node_modules");
+    config.virtual_store_dir = temp.path().join("node_modules/.pnpm");
+    let config = Box::leak(Box::new(config));
+    let request: ResolveRequest = serde_json::from_value(request).expect("resolve request parses");
+
+    super::resolve(
+        config,
+        &Arc::new(ThrottledClient::new_for_installs()),
+        &request,
+        &Arc::new(AuthHeaders::default()),
+        None,
+    )
+    .await
+    .expect("offline workspace resolution succeeds")
+}
+
+fn assert_workspace_link(lockfile: &Lockfile, importer: &str, alias: &str, expected_target: &str) {
+    let dependencies = lockfile
+        .importers
+        .get(importer)
+        .expect("importer exists")
+        .dependencies
+        .as_ref()
+        .expect("importer dependencies exist");
+    let alias = PkgName::parse(alias).expect("dependency alias parses");
+    let dependency = dependencies.get(&alias).expect("workspace dependency exists");
+    match &dependency.version {
+        ImporterDepVersion::Link(target) => assert_eq!(target, expected_target),
+        version => panic!("expected workspace link, got {version:?}"),
+    }
 }

--- a/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
@@ -194,7 +194,55 @@ async fn legacy_projects_without_identity_use_synthetic_name_and_version() {
     assert_workspace_link(&lockfile, ".", "pnpr-importer-packages-lib", "packages/lib");
 }
 
+/// `packages/Foo` and `packages/foo` are two directories on a
+/// case-sensitive filesystem and one directory on a case-insensitive one.
+/// Both outcomes are acceptable; what must never happen is one importer's
+/// `package.json` overwriting the other's and both resolving to the same
+/// dependency map. The two aliases depend on different workspace siblings,
+/// so a collision is visible in the resolved links rather than only in the
+/// importer keys, which survive the overwrite either way.
+#[tokio::test]
+async fn case_aliasing_importer_dirs_never_drop_a_project() {
+    let outcome = Box::pin(try_resolve_json(serde_json::json!({
+        "projects": [
+            {
+                "dir": "packages/Foo",
+                "name": "foo-upper",
+                "version": "1.0.0",
+                "dependencies": { "lib-upper": "workspace:*" }
+            },
+            {
+                "dir": "packages/foo",
+                "name": "foo-lower",
+                "version": "1.0.0",
+                "dependencies": { "lib-lower": "workspace:*" }
+            },
+            { "dir": "packages/lib-upper", "name": "lib-upper", "version": "1.0.0" },
+            { "dir": "packages/lib-lower", "name": "lib-lower", "version": "1.0.0" }
+        ]
+    })))
+    .await;
+
+    match outcome {
+        Ok(lockfile) => {
+            assert_workspace_link(&lockfile, "packages/Foo", "lib-upper", "../lib-upper");
+            assert_workspace_link(&lockfile, "packages/foo", "lib-lower", "../lib-lower");
+        }
+        Err(error) => {
+            let error = format!("{error:?}");
+            assert!(
+                error.contains("duplicate importer dir"),
+                "a case-insensitive filesystem must reject the alias, got {error}",
+            );
+        }
+    }
+}
+
 async fn resolve_json(request: serde_json::Value) -> Lockfile {
+    try_resolve_json(request).await.expect("offline workspace resolution succeeds")
+}
+
+async fn try_resolve_json(request: serde_json::Value) -> Result<Lockfile, super::ResolveError> {
     let temp = tempfile::tempdir().expect("create resolver test directory");
     let mut config = Config::new();
     config.offline = true;
@@ -214,7 +262,6 @@ async fn resolve_json(request: serde_json::Value) -> Lockfile {
         None,
     )
     .await
-    .expect("offline workspace resolution succeeds")
 }
 
 fn assert_workspace_link(lockfile: &Lockfile, importer: &str, alias: &str, expected_target: &str) {

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -186,6 +186,29 @@ fn resolution_cache_key_normalizes_single_project_requests() {
 }
 
 #[test]
+fn resolution_cache_key_changes_with_project_identity() {
+    let request = |name: &str, version: &str| {
+        serde_json::from_value::<ResolveRequest>(serde_json::json!({
+            "projects": [{
+                "dir": ".",
+                "name": name,
+                "version": version,
+                "dependencies": { "foo": "^1.0.0" }
+            }]
+        }))
+        .expect("resolve request parses")
+    };
+    let base = request("app", "1.0.0");
+    let renamed = request("renamed-app", "1.0.0");
+    let reversioned = request("app", "2.0.0");
+
+    let config = config();
+    let base_key = resolution_cache_key(&config, &base);
+    assert_ne!(base_key, resolution_cache_key(&config, &renamed));
+    assert_ne!(base_key, resolution_cache_key(&config, &reversioned));
+}
+
+#[test]
 fn resolution_cache_key_changes_with_dependencies_and_policy() {
     let base = ResolveRequest {
         dependencies: Some(deps(&[("foo", "^1.0.0")])),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

> [!IMPORTANT]
> This branch must incorporate pnpm/pnpm#13066 before this PR can merge. The intended sequence is to merge pnpm/pnpm#13066 into `main`, then rebase or update this branch onto the latest `main` so the zizmor security check runs with the shared fix.

- Make Pacquet's workspace-aware install, add, update, remove, prune, deploy, audit, fetch, outdated, why, and SBOM paths honor the selected project set instead of processing the workspace as an unscoped install.
- Batch selected manifest mutations into one install pass, keep the wanted lockfile complete, and materialize only the selected dependency closure in the current lockfile and `node_modules` state.
- Preserve the normal unfiltered fast and frozen paths when a recursive selection covers every importer, including `autoInstallPeers`, excluded explicit links, and workspace self-link serialization.
- Send and merge multi-importer pnpr resolution requests with strict response validation. The TypeScript CLI already has the filtered-workspace behavior; this brings Pacquet into parity.

This Draft PR is stacked on pnpm/pnpm#13016, which supplies the workspace project identity metadata used by pnpr. It must be rebased after that PR lands; the five commits after the dependency commit contain this PR's implementation.

Verification included the repository pre-push hook, workspace `cargo check`, strict Clippy and rustdoc, targeted library and integration suites, self-hosted regular and recursive lockfile-only installs with no `pnpm-lock.yaml` changes, and the Windows-equivalent workspace path regression.

## Squash Commit Body

```text
Pacquet's recursive command pipeline previously dispatched selected projects independently or lost the selection before package-manager execution. This could overwrite earlier manifest mutations, truncate workspace lockfile state, or materialize projects outside the requested filter.

Thread one workspace selection through command dispatch and package-manager execution, batch manifest mutations into a single install, retain the complete wanted lockfile, and derive current-lockfile and node_modules state from the selected dependency closure. Apply the same workspace root and selection semantics to query, state, global, deploy, and pnpr-backed paths.

Keep full-workspace recursive installs on the ordinary unfiltered fast and frozen paths, and add regression coverage for filtering, lockfile preservation, dependency closure materialization, pnpr multi-importer responses, and TypeScript parity edge cases.

Depends on pnpm/pnpm#13016.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786708852&installation_id=145934176&pr_number=13030&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13030&signature=b29dc9e50e9002ae92a95d5348927365b988e171d4a990e398bc4d6e6d9569a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filtered workspace installs can now install only a selected projects’ dependency closure, including pnpr-server resolution.
  * Selection scope is applied consistently across add/update/remove/install/why/outdated/recursive operations.

* **Bug Fixes**
  * Improved lockfile sourcing consistency by using state-derived lockfile paths across commands (add/update/remove/install/audit/fetch/link/prune/rebuild/unlink/etc.).
  * Strengthened lockfile filtering/merge/materialization to keep unselected importers consistent.
  * SBOM generation now safely confines importer paths to the lockfile root.

* **Tests**
  * Added extensive e2e/unit coverage for filtered installs, pnpr multi-project resolution/identity forwarding, importer-scoped outdated/why/sbom behavior, and recursive shared-lockfile failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->