### PR TITLE
fix(self-update): link platform binaries from GVS dependency slots

### DIFF
--- a/.changeset/quiet-slots-link.md
+++ b/.changeset/quiet-slots-link.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+---
+
+Fixed `pnpm self-update` failing to link native platform binaries stored in sibling global virtual store slots.

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -415,8 +415,8 @@ export function linkExePlatformBinary (installDir: string, wrapperPkgName: strin
   // GVS dependencies link to sibling slots through the install root. The real
   // adjacent scope remains necessary for legacy virtual-store layouts.
   const scopeDirs = new Set([
-    path.join(installDir, 'node_modules', '@pnpm'),
     adjacentScopeDir,
+    path.join(installDir, 'node_modules', '@pnpm'),
   ])
   const candidateDirNames = [
     exePlatformPkgDirName(platform, arch, libcFamily),

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -408,25 +408,30 @@ export function linkExePlatformBinary (installDir: string, wrapperPkgName: strin
   const arch = process.arch
   const libcFamily = familySync()
   const executable = platform === 'win32' ? 'pnpm.exe' : 'pnpm'
-  // Resolve the platform binary by its explicit adjacent path in the real
-  // virtual store, not via Node resolution: a `node_modules` walk could be
-  // shadowed by a higher-precedence `@pnpm/<dirName>` in a repo-controlled
-  // `store-dir`. `@pnpm/exe`'s parent is already `@pnpm`; `pnpm` descends into it.
   const wrapperRealDir = fs.realpathSync(wrapperDir)
-  const scopeDir = wrapperPkgName.startsWith('@')
+  const adjacentScopeDir = wrapperPkgName.startsWith('@')
     ? path.dirname(wrapperRealDir)
     : path.join(path.dirname(wrapperRealDir), '@pnpm')
+  // GVS dependencies link to sibling slots through the install root. The real
+  // adjacent scope remains necessary for legacy virtual-store layouts.
+  const scopeDirs = new Set([
+    path.join(installDir, 'node_modules', '@pnpm'),
+    adjacentScopeDir,
+  ])
   const candidateDirNames = [
     exePlatformPkgDirName(platform, arch, libcFamily),
     exePlatformPkgDirNameNext(platform, arch, libcFamily),
   ]
   let src: string | undefined
-  for (const dirName of candidateDirNames) {
-    const candidate = path.join(scopeDir, dirName, executable)
-    if (fs.existsSync(candidate)) {
-      src = candidate
-      break
+  for (const scopeDir of scopeDirs) {
+    for (const dirName of candidateDirNames) {
+      const candidate = path.join(scopeDir, dirName, executable)
+      if (fs.existsSync(candidate)) {
+        src = candidate
+        break
+      }
     }
+    if (src != null) break
   }
   if (src == null) return
   const dest = path.join(wrapperDir, executable)

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1270,6 +1270,33 @@ describe('linkExePlatformBinary', () => {
     expect(result).toBe(fakeBinaryContent)
   })
 
+  test('runs the self-update wrapper when its platform binary is in a sibling GVS slot', () => {
+    const dir = tempDir(false)
+    const wrapperSlot = path.join(dir, 'links', 'wrapper', 'node_modules', '@pnpm', 'exe')
+    const platformSlot = path.join(dir, 'links', 'platform', 'node_modules', '@pnpm', platformPkgName)
+    const wrapperDir = path.join(dir, 'node_modules', '@pnpm', 'exe')
+    const platformDir = path.join(dir, 'node_modules', '@pnpm', platformPkgName)
+
+    fs.mkdirSync(wrapperSlot, { recursive: true })
+    fs.mkdirSync(platformSlot, { recursive: true })
+    fs.writeFileSync(path.join(wrapperSlot, executable), 'This file intentionally left blank')
+    fs.writeFileSync(path.join(wrapperSlot, 'package.json'), JSON.stringify({
+      bin: { pnpm: 'pnpm', pn: 'pn', pnpx: 'pnpx', pnx: 'pnx' },
+    }))
+    fs.linkSync(fs.realpathSync(process.execPath), path.join(platformSlot, executable))
+
+    fs.mkdirSync(path.dirname(wrapperDir), { recursive: true })
+    fs.mkdirSync(path.dirname(platformDir), { recursive: true })
+    fs.symlinkSync(wrapperSlot, wrapperDir)
+    fs.symlinkSync(platformSlot, platformDir)
+
+    linkExePlatformBinary(dir)
+
+    const result = spawn.sync(path.join(wrapperDir, executable), ['--version'])
+    expect(result.status).toBe(0)
+    expect(result.stdout.toString().trim()).toBe(process.version)
+  })
+
   // Regression coverage for https://github.com/pnpm/pnpm/issues/11486 — the
   // `pn` / `pnpx` / `pnx` aliases were broken in MSYS2 / Git Bash on Windows.
   // Root cause: linkExePlatformBinary pointed those bin entries at .cmd files,

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1237,12 +1237,15 @@ describe('linkExePlatformBinary', () => {
     expect(result).toBe(fakeBinaryContent)
   })
 
-  test('links @pnpm/exe when its platform dependency is in a sibling GVS slot', () => {
+  test.each([
+    ['legacy', platformPkgName],
+    ['newer', exePlatformPkgDirNameNext(platform, arch, libcFamily)],
+  ])('links @pnpm/exe when its %s platform dependency is in a sibling GVS slot', (_scheme, siblingPlatformPkgName) => {
     const dir = tempDir(false)
     const wrapperSlot = path.join(dir, 'links', 'wrapper', 'node_modules', '@pnpm', 'exe')
-    const platformSlot = path.join(dir, 'links', 'platform', 'node_modules', '@pnpm', platformPkgName)
+    const platformSlot = path.join(dir, 'links', 'platform', 'node_modules', '@pnpm', siblingPlatformPkgName)
     const wrapperDir = path.join(dir, 'node_modules', '@pnpm', 'exe')
-    const platformDir = path.join(dir, 'node_modules', '@pnpm', platformPkgName)
+    const platformDir = path.join(dir, 'node_modules', '@pnpm', siblingPlatformPkgName)
 
     fs.mkdirSync(wrapperSlot, { recursive: true })
     fs.mkdirSync(platformSlot, { recursive: true })

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1283,7 +1283,7 @@ describe('linkExePlatformBinary', () => {
     fs.writeFileSync(path.join(wrapperSlot, 'package.json'), JSON.stringify({
       bin: { pnpm: 'pnpm', pn: 'pn', pnpx: 'pnpx', pnx: 'pnx' },
     }))
-    fs.linkSync(fs.realpathSync(process.execPath), path.join(platformSlot, executable))
+    fs.copyFileSync(fs.realpathSync(process.execPath), path.join(platformSlot, executable))
 
     fs.mkdirSync(path.dirname(wrapperDir), { recursive: true })
     fs.mkdirSync(path.dirname(platformDir), { recursive: true })

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1237,6 +1237,33 @@ describe('linkExePlatformBinary', () => {
     expect(result).toBe(fakeBinaryContent)
   })
 
+  test('links @pnpm/exe when its platform dependency is in a sibling GVS slot', () => {
+    const dir = tempDir(false)
+    const wrapperSlot = path.join(dir, 'links', 'wrapper', 'node_modules', '@pnpm', 'exe')
+    const platformSlot = path.join(dir, 'links', 'platform', 'node_modules', '@pnpm', platformPkgName)
+    const wrapperDir = path.join(dir, 'node_modules', '@pnpm', 'exe')
+    const platformDir = path.join(dir, 'node_modules', '@pnpm', platformPkgName)
+
+    fs.mkdirSync(wrapperSlot, { recursive: true })
+    fs.mkdirSync(platformSlot, { recursive: true })
+    fs.writeFileSync(path.join(wrapperSlot, executable), 'This file intentionally left blank')
+    fs.writeFileSync(path.join(wrapperSlot, 'package.json'), JSON.stringify({
+      bin: { pnpm: 'pnpm', pn: 'pn', pnpx: 'pnpx', pnx: 'pnx' },
+    }))
+    const fakeBinaryContent = '#!/bin/sh\necho "fake pnpm binary"'
+    fs.writeFileSync(path.join(platformSlot, executable), fakeBinaryContent)
+
+    fs.mkdirSync(path.dirname(wrapperDir), { recursive: true })
+    fs.mkdirSync(path.dirname(platformDir), { recursive: true })
+    fs.symlinkSync(wrapperSlot, wrapperDir)
+    fs.symlinkSync(platformSlot, platformDir)
+
+    linkExePlatformBinary(dir)
+
+    const result = fs.readFileSync(path.join(wrapperDir, executable), 'utf8')
+    expect(result).toBe(fakeBinaryContent)
+  })
+
   // Regression coverage for https://github.com/pnpm/pnpm/issues/11486 — the
   // `pn` / `pnpx` / `pnx` aliases were broken in MSYS2 / Git Bash on Windows.
   // Root cause: linkExePlatformBinary pointed those bin entries at .cmd files,

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1103,7 +1103,7 @@ describe('linkExePlatformBinary', () => {
   const libcFamily = familySync()
   const platformPkgName = exePlatformPkgDirName(platform, arch, libcFamily)
 
-  test('links platform binary in pnpm symlinked node_modules layout', () => {
+  test('prefers the wrapper-adjacent platform binary in a symlinked node_modules layout', () => {
     const dir = tempDir(false)
 
     // Create a virtual store layout like pnpm produces:
@@ -1113,6 +1113,7 @@ describe('linkExePlatformBinary', () => {
     const vsExeDir = path.join(dir, 'node_modules', '.pnpm', '@pnpm+exe@1.0.0', 'node_modules', '@pnpm', 'exe')
     const vsPlatformDir = path.join(dir, 'node_modules', '.pnpm', '@pnpm+exe@1.0.0', 'node_modules', '@pnpm', platformPkgName)
     const topLevelExeDir = path.join(dir, 'node_modules', '@pnpm', 'exe')
+    const topLevelPlatformDir = path.join(dir, 'node_modules', '@pnpm', platformPkgName)
 
     // Create the virtual store directories
     fs.mkdirSync(vsExeDir, { recursive: true })
@@ -1130,6 +1131,8 @@ describe('linkExePlatformBinary', () => {
     // Create the top-level symlink: node_modules/@pnpm/exe -> virtual store
     fs.mkdirSync(path.join(dir, 'node_modules', '@pnpm'), { recursive: true })
     fs.symlinkSync(vsExeDir, topLevelExeDir)
+    fs.mkdirSync(topLevelPlatformDir)
+    fs.writeFileSync(path.join(topLevelPlatformDir, executable), 'wrong platform binary')
 
     // Run the function
     linkExePlatformBinary(dir)


### PR DESCRIPTION
## Summary

- Resolve self-update platform binaries through the install root when the global virtual store places the wrapper and native package in sibling slots.
- Prefer the wrapper-adjacent dependency when available and use the install-root link only as a fallback.
- Add regression coverage for the scoped `@pnpm/exe` wrapper layout reported on Windows, Linux, and macOS. The Rust self-updater already supports sibling GVS slots.

Closes pnpm/pnpm#12962.
Closes pnpm/pnpm#13036.
Related to pnpm/pnpm#12865.

## Validation

- `pnpm --filter @pnpm/engine.pm.commands test` - 68 passed, 1 skipped
- `pnpm run compile-only` - passed
- `pnpm run lint -- --quiet` - passed
- `pnpm change status` - passed

## Squash Commit Body

```text
Self-update installs wrappers with lifecycle scripts disabled and then links the
native platform binary manually. With the global virtual store enabled, the
wrapper and its platform dependency can resolve to different hashed slots, so
searching only beside the wrapper's real path misses the binary and leaves the
published placeholder in place.

Prefer the wrapper's exact real-adjacent dependency, then fall back to its
install-root link. This supports sibling GVS slots without a parent-directory
module-resolution search and preserves flat and legacy virtual-store layouts.

Closes pnpm/pnpm#12962 and pnpm/pnpm#13036.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset.
- [x] Added or updated tests.



---
Written by an agent (OpenAI Codex, GPT-5.5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm self-update` failures when linking native platform binaries stored in sibling global virtual store slots.
  * Improved how the correct platform executable is selected across supported platform package layouts.
  * Ensured the wrapper-adjacent binary is used when multiple candidate binaries are present.
* **Tests**
  * Added regression coverage for both legacy and current platform package directory naming schemes.
  * Added checks for sibling store scenarios and verified the updated wrapper binary runs successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->