### PR TITLE
fix(pack): let package .npmignore override workspace ignores

### DIFF
--- a/.changeset/nice-packs-ignore.md
+++ b/.changeset/nice-packs-ignore.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/fs.packlist": patch
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed `pnpm pack` applying workspace-root ignore rules when a workspace package has its own `.npmignore` file.

--- a/pnpm/crates/fs-packlist/src/lib.rs
+++ b/pnpm/crates/fs-packlist/src/lib.rs
@@ -121,10 +121,10 @@ pub struct PacklistOptions<'a> {
 }
 
 /// Variant of [`packlist`] that lets callers pass workspace context.
-/// Workspace packages honor ancestor `.npmignore` / `.gitignore` files
-/// between the workspace root and the package, matching npm-packlist's
-/// `prefix` / `workspaces` behavior. Callers without workspace context
-/// keep the safer package-only walk.
+/// Workspace packages without a package-level `.npmignore` honor ancestor
+/// `.npmignore` / `.gitignore` files between the workspace root and the
+/// package, matching npm-packlist's `prefix` / `workspaces` behavior. Callers
+/// without workspace context keep the safer package-only walk.
 pub fn packlist_with_options(
     pkg_dir: &Path,
     manifest: &Value,
@@ -416,6 +416,9 @@ fn add_workspace_ignore_files(
     workspace_dir: Option<&Path>,
 ) -> Result<(), PacklistError> {
     let Some(workspace_dir) = workspace_dir else { return Ok(()) };
+    if pkg_dir.join(".npmignore").is_file() {
+        return Ok(());
+    }
     let Ok(rel) = pkg_dir.strip_prefix(workspace_dir) else { return Ok(()) };
     if rel.as_os_str().is_empty() {
         return Ok(());

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -486,12 +486,11 @@ fn workspace_root_npmignore_takes_precedence_over_gitignore() {
     );
 }
 
-// A package-level `.npmignore` negation must win over a workspace-root
-// ignore: the workspace-root file is added at the lowest precedence tier
-// (`WalkBuilder::add_ignore`), below the package's own discovered ignore
-// files, matching npm-packlist's ancestor-first ordering.
+// A package-level `.npmignore` disables workspace-root ignore inheritance.
+// Keep a negation case to verify the package file remains authoritative even
+// when its matching ancestor rule is no longer loaded.
 #[test]
-fn package_npmignore_negation_overrides_workspace_root_gitignore() {
+fn package_npmignore_negation_includes_workspace_gitignored_file() {
     let dir = tempdir().unwrap();
     fs::write(dir.path().join(".gitignore"), "dist/\n").unwrap();
     let root = dir.path().join("packages").join("pkg");
@@ -514,6 +513,34 @@ fn package_npmignore_negation_overrides_workspace_root_gitignore() {
         "package-level `!dist/` must re-include files the workspace-root .gitignore excluded; received {out:?}",
     );
     assert!(out.contains(&"src/index.js".to_string()), "{out:?}");
+}
+
+#[test]
+fn package_npmignore_disables_workspace_root_gitignore() {
+    let dir = tempdir().unwrap();
+    fs::write(dir.path().join(".gitignore"), "dist/\n").unwrap();
+    let root = dir.path().join("packages").join("pkg");
+    fs::create_dir_all(&root).unwrap();
+    touch(&root, "package.json");
+    write(&root, ".npmignore", "src/ignored.js\n");
+    touch(&root, "dist/generated.js");
+    touch(&root, "src/index.js");
+    touch(&root, "src/ignored.js");
+
+    let manifest = json!({ "name": "x", "version": "0.0.0" });
+    let out = packlist_with_options(
+        &root,
+        &manifest,
+        PacklistOptions { workspace_dir: Some(dir.path()) },
+    )
+    .unwrap();
+
+    assert!(
+        out.contains(&"dist/generated.js".to_string()),
+        "package-level .npmignore must disable workspace-root .gitignore; received {out:?}",
+    );
+    assert!(out.contains(&"src/index.js".to_string()), "{out:?}");
+    assert!(!out.contains(&"src/ignored.js".to_string()), "{out:?}");
 }
 
 #[test]

--- a/pnpm11/fs/packlist/src/index.ts
+++ b/pnpm11/fs/packlist/src/index.ts
@@ -28,7 +28,16 @@ export async function packlist (pkgDir: string, opts?: {
   const workspaceDir = opts?.workspaceDir == null ? undefined : path.resolve(opts.workspaceDir)
   const pkg = opts?.manifest ?? readPackageJson(resolvedPkgDir)
   const tree = buildRootTree(resolvedPkgDir, pkg)
-  const packlistOpts = workspaceDir != null && workspaceDir !== resolvedPkgDir && isSubdir(workspaceDir, resolvedPkgDir)
+  const hasWorkspaceContext = workspaceDir != null && workspaceDir !== resolvedPkgDir && isSubdir(workspaceDir, resolvedPkgDir)
+  let hasNpmIgnore = false
+  if (hasWorkspaceContext) {
+    try {
+      hasNpmIgnore = (await fs.promises.stat(path.join(resolvedPkgDir, '.npmignore'))).isFile()
+    } catch (err: unknown) {
+      if (!util.types.isNativeError(err) || !('code' in err) || err.code !== 'ENOENT') throw err
+    }
+  }
+  const packlistOpts = hasWorkspaceContext && !hasNpmIgnore
     ? { prefix: workspaceDir, workspaces: [resolvedPkgDir] }
     : undefined
   const files = await npmPacklist(tree, packlistOpts)

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -441,7 +441,7 @@ test('pack: uses workspace root gitignore for workspace packages', async () => {
   expect(workspaceOutput).not.toContain('dist/generated.js')
 })
 
-test('pack: package-level .npmignore negation overrides workspace root gitignore', async () => {
+test('pack: package-level .npmignore negation prevents workspace root gitignore inheritance', async () => {
   preparePackages([
     {
       name: 'project',
@@ -471,6 +471,40 @@ test('pack: package-level .npmignore negation overrides workspace root gitignore
 
   expect(output).toContain('src/index.js')
   expect(output).toContain('dist/generated.js')
+})
+
+test('pack: package-level .npmignore disables workspace root gitignore', async () => {
+  preparePackages([
+    {
+      name: 'project',
+      version: '1.0.0',
+    },
+  ])
+
+  const workspaceDir = process.cwd()
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['project'] })
+  fs.writeFileSync('.gitignore', 'dist/\n', 'utf8')
+
+  process.chdir('project')
+  fs.writeFileSync('.npmignore', 'src/ignored.js\n', 'utf8')
+  fs.mkdirSync('dist')
+  fs.mkdirSync('src')
+  fs.writeFileSync('dist/generated.js', 'generated', 'utf8')
+  fs.writeFileSync('src/index.js', 'source', 'utf8')
+  fs.writeFileSync('src/ignored.js', 'ignored', 'utf8')
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    dryRun: true,
+    workspaceDir,
+  })
+
+  expect(output).toContain('dist/generated.js')
+  expect(output).toContain('src/index.js')
+  expect(output).not.toContain('src/ignored.js')
 })
 
 // A symlinked workspace-root LICENSE must not be injected: following it would


### PR DESCRIPTION
## Summary

- Stop applying workspace-root ignore files when a workspace package has its own `.npmignore`.
- Keep workspace-root inheritance unchanged for packages without `.npmignore`.
- Cover the same precedence rule in the TypeScript and Rust packlists.

Closes pnpm/pnpm#13032.

## Validation

- TypeScript pack tests: 42 passed
- Rust packlist tests: 33 passed
- Affected TypeScript package compile and ESLint checks passed
- Strict all-target `pacquet-fs-packlist` Clippy and rustfmt passed
- Changeset release-plan validation passed

The repository pre-push TypeScript gate also passed. Full-workspace Rust Clippy exceeded the local filesystem while compiling unrelated crates after the affected crate's strict Clippy check had passed.

## Squash Commit Body

```text
The workspace-aware packlist path always supplied ancestor ignore files after
pnpm/pnpm#12878. npm pack semantics instead treat a package-level .npmignore
as replacing those ancestor rules, so an unrelated package ignore file could
still leave files excluded by the workspace root's .gitignore.

Detect a package-root .npmignore before adding workspace context in both the
TypeScript and Rust packlists. Packages without one continue to inherit the
workspace rules. Add parity regressions that verify the package rule remains
active while the ancestor rule is no longer applied.

Closes pnpm/pnpm#13032.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users - it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (OpenAI Codex, GPT-5.5).