### PR TITLE
ci: migrate workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,7 @@ concurrency:
 jobs:
   benchmark:
     name: Run Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 180
 
     steps:

--- a/.github/workflows/ci-performance-bencher-upload.yml
+++ b/.github/workflows/ci-performance-bencher-upload.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   upload:
     name: Upload CI performance results
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: >-
       (
         github.event.workflow_run.conclusion == 'success' ||

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
       contents: read  # for actions/checkout to fetch code
       security-events: write  # for github/codeql-action/autobuild to send a status report
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     strategy:
       fail-fast: false

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   create-release-pr:
     if: github.repository == 'pnpm/pnpm' # Only run on the main repository, not forks
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       # The husky hooks are a developer safety net; CI has its own gates. Without
       # this, `pnpm install` wires the hooks and the pre-push hook runs the full

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     environment: release
     permissions:
       contents: read

--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     if: github.repository == 'pnpm/pnpm' # Only run on the main repository, not forks
     name: Ecosystem E2E / Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -64,7 +64,7 @@ jobs:
     if: github.repository == 'pnpm/pnpm' # Only run on the main repository, not forks
     name: Ecosystem E2E / ${{ matrix.stack }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     # Bound the blast radius: a hung build or serve subprocess can't pin a
     # runner indefinitely.
     timeout-minutes: 60

--- a/.github/workflows/pacquet-cargo-unused.yml
+++ b/.github/workflows/pacquet-cargo-unused.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   bloat:
     name: Cargo Unused Features
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -36,7 +36,7 @@ jobs:
 
   check-dependencies:
     name: Check Unused Dependencies
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -97,9 +97,7 @@ jobs:
             os_label: windows
           - os: blacksmith-8vcpu-ubuntu-2404
             os_label: ubuntu
-          # Blacksmith offers no macOS runners, so this leg stays on the
-          # GitHub-hosted image.
-          - os: macos-latest
+          - os: blacksmith-12vcpu-macos-latest
             os_label: macos
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   comment:
     name: Post benchmark comment
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # Only post when the upstream benchmark ran on a PR and succeeded.
     # Same gating as the original in-workflow comment, which only ran
     # on the success path of the previous steps.
@@ -106,7 +106,7 @@ jobs:
         # workflow run, which is exactly the workflow_run pattern.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: integrated-benchmark-report-ubuntu-latest
+          name: integrated-benchmark-report-blacksmith-8vcpu-ubuntu-2404
           path: benchmark-artifact
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -106,7 +106,7 @@ jobs:
         # workflow run, which is exactly the workflow_run pattern.
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: integrated-benchmark-report-blacksmith-8vcpu-ubuntu-2404
+          name: integrated-benchmark-report-ubuntu-latest
           path: benchmark-artifact
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -566,7 +566,7 @@ jobs:
       - name: Upload benchmark report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: integrated-benchmark-report-${{ matrix.os }}
+          name: integrated-benchmark-report-ubuntu-latest
           path: benchmark-artifact/
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        os: [ubuntu-latest] # windows is skipped because of complexity, macos is skipped because of inconsistency
+        os: [blacksmith-8vcpu-ubuntu-2404] # windows is skipped because of complexity, macOS is skipped because of inconsistency
     name: Run benchmark on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/pacquet-micro-benchmark.yml
+++ b/.github/workflows/pacquet-micro-benchmark.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload benchmark results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: benchmark-results-${{ matrix.os }}
+          name: benchmark-results-ubuntu-latest
           path: ./target/criterion
 
   benchmark-compare:
@@ -93,7 +93,7 @@ jobs:
       - name: Linux | Download PR benchmark results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: benchmark-results-blacksmith-8vcpu-ubuntu-2404
+          name: benchmark-results-ubuntu-latest
           path: ./target/criterion
 
       - name: Linux | Compare benchmark results

--- a/.github/workflows/pacquet-micro-benchmark.yml
+++ b/.github/workflows/pacquet-micro-benchmark.yml
@@ -26,7 +26,7 @@ jobs:
   benchmark:
     strategy:
       matrix:
-        os: [ubuntu-latest] # `macos-latest` is too unstable to be useful for benchmark, the variance is always huge.
+        os: [blacksmith-8vcpu-ubuntu-2404] # macOS is too unstable to be useful for benchmark, the variance is always huge.
     name: Run benchmark on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -75,7 +75,7 @@ jobs:
           path: ./target/criterion
 
   benchmark-compare:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     name: Compare Benchmarks
     needs:
       - benchmark
@@ -93,7 +93,7 @@ jobs:
       - name: Linux | Download PR benchmark results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: benchmark-results-ubuntu-latest
+          name: benchmark-results-blacksmith-8vcpu-ubuntu-2404
           path: ./target/criterion
 
       - name: Linux | Compare benchmark results

--- a/.github/workflows/pr-review-automation-privileged.yml
+++ b/.github/workflows/pr-review-automation-privileged.yml
@@ -24,7 +24,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'pull_request_review' &&
       contains(fromJSON('["coderabbitai[bot]", "qodo-free-for-open-source-projects[bot]", "zkochan"]'), github.event.workflow_run.actor.login)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     concurrency:
       group: pr-review-automation-${{ github.event.workflow_run.head_sha }}-${{ github.event.workflow_run.actor.login }}
       cancel-in-progress: true

--- a/.github/workflows/pr-review-automation.yml
+++ b/.github/workflows/pr-review-automation.yml
@@ -20,7 +20,7 @@ jobs:
     if: >-
       github.event.review.state == 'approved' &&
       contains(fromJSON('["coderabbitai[bot]", "qodo-free-for-open-source-projects[bot]", "zkochan"]'), github.event.review.user.login)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions: {}
     steps:
       - name: Record the review trigger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   validate-release-ref:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions: {}
     steps:
       - name: Validate release ref
@@ -51,7 +51,7 @@ jobs:
   plan:
     name: Plan (which products need publishing)
     needs: validate-release-ref
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     outputs:
@@ -152,6 +152,7 @@ jobs:
     # macos-latest runner is Apple Silicon and can execute the arm64 binary.
     # Note: this does NOT fix the darwin-x64 crash (nodejs/node#62893) — that's
     # an upstream Node.js SEA bug independent of signing; see pack-app docs.
+    # npm trusted publishing still requires this publish job to run on GitHub-hosted macOS.
     runs-on: macos-latest
     environment: release
     steps:
@@ -225,35 +226,35 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: blacksmith-8vcpu-windows-2025
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
 
-          - os: windows-latest
+          - os: blacksmith-8vcpu-windows-2025
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
 
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
 
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
 
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
 
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
 
-          - os: macos-latest
+          - os: blacksmith-12vcpu-macos-latest
             target: x86_64-apple-darwin
             code-target: darwin-x64
 
-          - os: macos-latest
+          - os: blacksmith-12vcpu-macos-latest
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 
@@ -362,6 +363,7 @@ jobs:
 
   publish-rust:
     name: Publish pnpm (Rust) and @pnpm/napi to npm
+    # npm trusted publishing still requires this publish job to run on GitHub-hosted Linux.
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -434,7 +436,7 @@ jobs:
 
   github-release-rust:
     name: Draft GitHub release for pnpm (Rust)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write # create the draft release and its tag
     needs:
@@ -478,35 +480,35 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
+          - os: blacksmith-8vcpu-windows-2025
             target: x86_64-pc-windows-msvc
             code-target: win32-x64
 
-          - os: windows-latest
+          - os: blacksmith-8vcpu-windows-2025
             target: aarch64-pc-windows-msvc
             code-target: win32-arm64
 
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-linux-gnu
             code-target: linux-x64
 
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: aarch64-unknown-linux-gnu
             code-target: linux-arm64
 
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-linux-musl
             code-target: linux-x64-musl
 
-          - os: ubuntu-latest
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
 
-          - os: macos-latest
+          - os: blacksmith-12vcpu-macos-latest
             target: x86_64-apple-darwin
             code-target: darwin-x64
 
-          - os: macos-latest
+          - os: blacksmith-12vcpu-macos-latest
             target: aarch64-apple-darwin
             code-target: darwin-arm64
 
@@ -582,6 +584,7 @@ jobs:
 
   publish-pnpr:
     name: Publish @pnpm/pnpr to npm
+    # npm trusted publishing still requires this publish job to run on GitHub-hosted Linux.
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -639,7 +642,7 @@ jobs:
 
   docker-pnpr:
     name: Publish the pnpr Docker image
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     environment: release
     needs:
       - plan

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -29,7 +29,7 @@ jobs:
       github.event.pull_request.merged == true &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.head.ref == format('release-pr/{0}', github.event.pull_request.base.ref)
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout the merge commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,9 +232,7 @@ jobs:
           benchmark="${BENCHMARK}.chunk${TEST_CHUNK}"
           cli_benchmark="${cli_benchmark}.chunk${TEST_CHUNK}"
         fi
-        # Map both GitHub-hosted (`ubuntu-latest`) and Blacksmith
-        # (`blacksmith-8vcpu-ubuntu-2404`) labels to the bare OS slug the
-        # Bencher testbed name requires.
+        # Map runner labels to the bare OS slug the Bencher testbed name requires.
         case "$PLATFORM" in
           *ubuntu*) platform_slug=ubuntu ;;
           *windows*) platform_slug=windows ;;

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   triage:
     name: Triage issue
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # Skip automated issues (Renovate, Dependabot, bots) — they are not user
     # reports and each triage run consumes Warp credits.
     if: github.event.issue.user.type != 'Bot'

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -16,7 +16,7 @@ jobs:
   tag-in-registry:
     name: Tagging ${{ github.event.inputs.version }} as ${{ github.event.inputs.tag }}
     environment: release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - uses: garnet-org/action@2b7fc9d79b54f551b43358c27424a36064b3e078 # v2.0.2
       with:
@@ -67,7 +67,7 @@ jobs:
         fi
 
   publish-to-winget:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: release
     needs: tag-in-registry
     steps:
@@ -79,7 +79,7 @@ jobs:
           token: ${{ secrets.WINGET_TOKEN }}
 
   post-to-reddit:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: release
     needs: tag-in-registry
     steps:
@@ -94,7 +94,7 @@ jobs:
           url: https://github.com/pnpm/pnpm/releases/tag/v${{ github.event.inputs.version }}
 
   post-to-mastodon:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: release
     needs: tag-in-registry
     steps:
@@ -109,4 +109,3 @@ jobs:
         env:
           MASTODON_URL: "https://fosstodon.org/"
           MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }} # access token
-

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   update-lockfile:
     if: github.repository == 'pnpm/pnpm' # Only run on the main repository, not forks
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       # The husky hooks are a developer safety net; CI has its own gates. Without
       # this, the full install wires the hooks and the pre-push hook runs the TS

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   zizmor:
     name: zizmor latest via PyPI
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       security-events: write
       contents: read


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Moves non-npm-trusted-publishing GitHub Actions jobs to Blacksmith runners, including Linux, Windows, and macOS build/test matrices.

Keeps the npm trusted-publishing jobs on GitHub-hosted runners because npm trusted publishing still requires cloud-hosted runners, and keeps benchmark artifact names stable for workflow_run consumers.

## Squash Commit Body

```text
Move non-npm-trusted-publishing GitHub Actions jobs to Blacksmith runner labels.

Use larger Blacksmith runners for heavier build, Docker, benchmark, Windows, and macOS jobs, while leaving the npm OIDC trusted-publishing publish jobs on GitHub-hosted runners. npm trusted publishing currently does not support self-hosted runner providers, so the TypeScript pnpm publish job, Rust pnpm publish job, and pnpr publish job keep their GitHub-hosted labels.

Keep benchmark artifact names stable so follow-up workflow_run jobs on the default branch keep matching the producing benchmark jobs.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. This is workflow-only and does not change CLI behavior.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786729597&installation_id=145934176&pr_number=13043&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13043&signature=39df8c39be8e427c52a28c0048b097802c38beb47e0745ffef8f1da1a9d92c44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CI, benchmarking, testing, release/tagging, automation, and security workflows to run on pinned Blacksmith Linux/macOS runners instead of generic `*-latest` images.
  - Adjusted benchmark-related artifact naming to keep report upload/download consistent across the workflows.
  - Updated a CI matrix runner (macOS) and minor inline comments, while preserving existing workflow logic, steps, triggers, and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->