### PR TITLE
fix(resolver): bound minimumReleaseAge latest fallback

### DIFF
--- a/.changeset/minimum-release-age-latest-bound.md
+++ b/.changeset/minimum-release-age-latest-bound.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.registry.pkg-metadata-filter": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Prevented `minimumReleaseAge` from replacing `latest` with a SemVer-greater version than the registry tag target.

--- a/.changeset/minimum-release-age-latest-bound.md
+++ b/.changeset/minimum-release-age-latest-bound.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Prevented `minimumReleaseAge` from replacing `latest` with a SemVer-greater version than the registry tag target.
+Prevented `minimumReleaseAge` from replacing `latest` with a SemVer-greater version than the registry tag target [#13034](https://github.com/pnpm/pnpm/issues/13034).

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -371,9 +371,9 @@ pub fn pick_lowest_version_by_version_range(
 /// Filter a packument to versions published at or before `cutoff`,
 /// then rewrite each `dist-tag` to the highest within-cutoff version
 /// that still belongs to the tag's original "family" (same major
-/// for non-`latest` tags, no newer than the original `latest` target,
-/// same prerelease/release status, and preferring non-deprecated
-/// versions when both are present).
+/// for non-`latest` tags, no newer than the original target for
+/// `latest`, matching prerelease/release status, and preferring
+/// non-deprecated versions when both are present).
 ///
 /// Panics if `meta.time` is `None` — the caller (the publishedBy
 /// branch in [`pick_package_from_meta`]) only invokes this with full

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -371,8 +371,9 @@ pub fn pick_lowest_version_by_version_range(
 /// Filter a packument to versions published at or before `cutoff`,
 /// then rewrite each `dist-tag` to the highest within-cutoff version
 /// that still belongs to the tag's original "family" (same major
-/// for non-`latest` tags, same prerelease/release status, and
-/// preferring non-deprecated versions when both are present).
+/// for non-`latest` tags, no newer than the original `latest` target,
+/// same prerelease/release status, and preferring non-deprecated
+/// versions when both are present).
 ///
 /// Panics if `meta.time` is `None` — the caller (the publishedBy
 /// branch in [`pick_package_from_meta`]) only invokes this with full
@@ -389,30 +390,42 @@ pub fn filter_pkg_metadata_by_publish_date(
          caller must check before invoking",
     );
 
-    filter_pkg_metadata_versions(meta, |version| {
-        let mature = time
-            .get(version)
-            .and_then(serde_json::Value::as_str)
-            .and_then(parse_packument_timestamp)
-            .is_some_and(|date| date <= cutoff);
-        let trusted =
-            trusted_versions.is_some_and(|allow| allow.iter().any(|allowed| allowed == version));
-        mature || trusted
-    })
+    filter_pkg_metadata_versions_with_latest_bound(
+        meta,
+        |version| {
+            let mature = time
+                .get(version)
+                .and_then(serde_json::Value::as_str)
+                .and_then(parse_packument_timestamp)
+                .is_some_and(|date| date <= cutoff);
+            let trusted = trusted_versions
+                .is_some_and(|allow| allow.iter().any(|allowed| allowed == version));
+            mature || trusted
+        },
+        true,
+    )
 }
 
 /// Filter a packument's versions by string while keeping dist-tags
 /// usable. Tags that still point at a kept version are preserved; tags
-/// whose target was removed are rewritten using the publish-date
-/// filter's dist-tag rules: `latest` may move to the best remaining
-/// version across any major, while other tags stay within the removed
-/// target's major/prerelease lane.
+/// whose target was removed are rewritten using the generic dist-tag
+/// rules: `latest` may move to the best remaining version across any
+/// major, while other tags stay within the removed target's
+/// major/prerelease lane.
 #[must_use]
-pub fn filter_pkg_metadata_versions(meta: &Package, mut keep: impl FnMut(&str) -> bool) -> Package {
+pub fn filter_pkg_metadata_versions(meta: &Package, keep: impl FnMut(&str) -> bool) -> Package {
+    filter_pkg_metadata_versions_with_latest_bound(meta, keep, false)
+}
+
+fn filter_pkg_metadata_versions_with_latest_bound(
+    meta: &Package,
+    mut keep: impl FnMut(&str) -> bool,
+    bound_latest: bool,
+) -> Package {
     // Decide on version strings alone; slots move as raw fragments, so
     // the filter never hydrates a manifest.
     let filtered_versions = meta.versions.filtered(|version| keep(version));
-    let dist_tags = repopulate_dist_tags(meta, &filtered_versions);
+    let dist_tags = repopulate_dist_tags(meta, &filtered_versions, bound_latest);
 
     Package {
         name: meta.name.clone(),
@@ -430,6 +443,7 @@ pub fn filter_pkg_metadata_versions(meta: &Package, mut keep: impl FnMut(&str) -
 fn repopulate_dist_tags(
     meta: &Package,
     filtered_versions: &PackageVersions,
+    bound_latest: bool,
 ) -> std::collections::HashMap<String, String> {
     let mut dist_tags_within_date = std::collections::HashMap::new();
     // Candidate versions parsed once per filter call and shared by
@@ -461,6 +475,9 @@ fn repopulate_dist_tags(
         let mut best_index: Option<usize> = None;
         for (index, slot) in candidates.iter().enumerate() {
             let (candidate, _, _) = slot;
+            if bound_latest && tag == "latest" && candidate > &original {
+                continue;
+            }
             if tag != "latest" && candidate.major != original.major {
                 continue;
             }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -12,7 +12,8 @@ use pretty_assertions::assert_eq;
 use super::{
     PickPackageFromMetaError, PickPackageFromMetaOptions, PickVersionByVersionRangeOptions,
     RegistryPackageSpec, RegistryPackageSpecType, filter_pkg_metadata_by_publish_date,
-    pick_lowest_version_by_version_range, pick_package_from_meta, pick_version_by_version_range,
+    filter_pkg_metadata_versions, pick_lowest_version_by_version_range, pick_package_from_meta,
+    pick_version_by_version_range,
 };
 
 fn parse_iso(input: &str) -> DateTime<Utc> {
@@ -485,6 +486,43 @@ fn filter_rewrites_dist_tag_to_within_cutoff_max_of_same_major() {
         Some("1.1.0"),
         "latest is allowed to cross majors when its original target dropped",
     );
+}
+
+#[test]
+fn filter_latest_fallback_does_not_exceed_original_tag_target() {
+    let mut pkg = make_package(
+        "acme",
+        &[("3.0.0", None), ("3.0.1", None), ("4.0.0", None)],
+        &[("latest", "3.0.1")],
+    );
+    pkg.time = Some(make_time_map(&[
+        ("3.0.0", "2026-07-01T00:00:00.000Z"),
+        ("3.0.1", "2026-07-15T12:00:00.000Z"),
+        ("4.0.0", "2025-10-10T00:00:00.000Z"),
+    ]));
+    let cutoff = parse_iso("2026-07-15T00:00:00.000Z");
+    let filtered = filter_pkg_metadata_by_publish_date(&pkg, cutoff, None);
+
+    assert_eq!(filtered.dist_tag("latest"), Some("3.0.0"));
+
+    let mut pkg_without_safe_fallback =
+        make_package("acme", &[("3.0.1", None), ("4.0.0", None)], &[("latest", "3.0.1")]);
+    pkg_without_safe_fallback.time = Some(make_time_map(&[
+        ("3.0.1", "2026-07-15T12:00:00.000Z"),
+        ("4.0.0", "2025-10-10T00:00:00.000Z"),
+    ]));
+    let filtered = filter_pkg_metadata_by_publish_date(&pkg_without_safe_fallback, cutoff, None);
+
+    assert_eq!(filtered.dist_tag("latest"), None);
+}
+
+#[test]
+fn generic_version_filter_keeps_unbounded_latest_repopulation() {
+    let pkg = make_package("acme", &[("1.0.0", None), ("2.0.0", None)], &[("latest", "1.0.0")]);
+
+    let filtered = filter_pkg_metadata_versions(&pkg, |version| version != "1.0.0");
+
+    assert_eq!(filtered.dist_tag("latest"), Some("2.0.0"));
 }
 
 #[test]

--- a/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
@@ -48,6 +48,7 @@ export function filterPkgMetadataByPublishDate (
       const candidateParsed = tryParseSemver(candidate)
       if (
         !candidateParsed ||
+        (tag === 'latest' && candidateParsed.compare(originalSemVer) > 0) ||
         (tag !== 'latest' && candidateParsed.major !== originalSemVer.major) ||
         (candidateParsed.prerelease.length > 0) !== originalIsPrerelease
       ) continue

--- a/pnpm11/resolving/registry/pkg-metadata-filter/test/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/test/index.ts
@@ -64,3 +64,43 @@ test('filterPkgMetadataByPublishDate', () => {
     },
   }, cutoff)).toMatchSnapshot()
 })
+
+test('latest fallback does not exceed the original dist-tag target', () => {
+  const cutoff = new Date('2026-07-15T00:00:00.000Z')
+  const name = 'latest-fallback'
+  const packageVersion = (version: string) => ({
+    name,
+    version,
+    dist: { tarball: `https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`, shasum: '' },
+  })
+
+  const pkgDoc = {
+    name,
+    versions: {
+      '3.0.0': packageVersion('3.0.0'),
+      '3.0.1': packageVersion('3.0.1'),
+      '4.0.0': packageVersion('4.0.0'),
+    },
+    'dist-tags': {
+      latest: '3.0.1',
+    },
+    time: {
+      '3.0.0': '2026-07-01T00:00:00.000Z',
+      '3.0.1': '2026-07-15T12:00:00.000Z',
+      '4.0.0': '2025-10-10T00:00:00.000Z',
+    },
+  }
+
+  const filtered = filterPkgMetadataByPublishDate(pkgDoc, cutoff)
+
+  expect(filtered['dist-tags'].latest).toBe('3.0.0')
+
+  const withoutSafeFallback = filterPkgMetadataByPublishDate({
+    ...pkgDoc,
+    versions: {
+      '3.0.1': packageVersion('3.0.1'),
+      '4.0.0': packageVersion('4.0.0'),
+    },
+  }, cutoff)
+  expect(withoutSafeFallback['dist-tags'].latest).toBeUndefined()
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13034.

- keep a reconstructed `latest` tag at or below the registry's original tag target when `minimumReleaseAge` filters that target
- apply the same rule in TypeScript pnpm and pacquet without changing generic package-version filtering

## Squash Commit Body

```text
When minimumReleaseAge filtered the current latest target, the fallback scanned mature releases across every major. A chronologically older but SemVer-greater release could therefore replace the registry's authoritative latest selection.

Bound latest fallback candidates to versions at or below the original tag target in both resolver implementations. Leave the tag unset when no safe fallback exists, and keep pacquet's generic version-filter behavior unchanged for package-version guards.

Closes pnpm/pnpm#13034.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users - it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (OpenAI Codex, GPT-5.5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Publish-age filtering now ensures the `latest` dist-tag never resolves to a version newer than the registry’s originally targeted `latest`, even when cutoff or trusted-version rules exclude it.
  - Updated `latest` dist-tag repopulation so fallback respects the original bound.
- **Tests**
  - Added unit and Jest coverage for publish-date “latest fallback” edge cases, including when the cutoff excludes the original `latest` target.
- **Chores**
  - Added a patch release changeset clarifying `minimumReleaseAge` won’t override `latest` with a newer SemVer than the registry tag target (see `#13034`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->