### PR TITLE
fix(release): verify all npm release tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,9 @@ jobs:
             test -n "$tarball"
             node -e '
               const manifest = require(require("node:path").resolve(process.argv[1]))
-              for (const file of [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]) {
+              const files = [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]
+              if (!files.some((file) => !/[?*[]/.test(file))) throw new Error("No literal payload files declared by " + manifest.name)
+              for (const file of files) {
                 if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
               }
             ' "$package/package.json" | while IFS= read -r file; do
@@ -504,7 +506,9 @@ jobs:
             test -n "$tarball"
             node -e '
               const manifest = require(require("node:path").resolve(process.argv[1]))
-              for (const file of [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]) {
+              const files = [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]
+              if (!files.some((file) => !/[?*[]/.test(file))) throw new Error("No literal payload files declared by " + manifest.name)
+              for (const file of files) {
                 if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
               }
             ' "$package/package.json" | while IFS= read -r file; do
@@ -799,7 +803,9 @@ jobs:
             test -n "$tarball"
             node -e '
               const manifest = require(require("node:path").resolve(process.argv[1]))
-              for (const file of [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]) {
+              const files = [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]
+              if (!files.some((file) => !/[?*[]/.test(file))) throw new Error("No literal payload files declared by " + manifest.name)
+              for (const file of files) {
                 if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
               }
             ' "$package/package.json" | while IFS= read -r file; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -417,6 +417,45 @@ jobs:
           cat pnpm/npm/napi/package.json
           for package in pnpm/npm/pacquet-* pnpm/npm/napi.*; do cat $package/package.json ; echo ; done
 
+      - name: Verify generated npm packages
+        # `pnpm publish` packages its input immediately before upload. Verify
+        # those tarballs before the first immutable npm publish, including the
+        # wrapper's preinstall path on this Linux runner.
+        run: |
+          set -euo pipefail
+          release_tarballs=$(mktemp -d)
+          for package in pnpm/npm/pacquet-* pnpm/npm/napi.* pnpm/npm/napi pnpm/npm/pnpm-exe pnpm/npm/pnpm; do
+            package_tarballs="$release_tarballs/${package//\//_}"
+            mkdir "$package_tarballs"
+            (
+              cd "$package"
+              pnpm pack --pack-destination "$package_tarballs"
+            )
+
+            tarball=$(find "$package_tarballs" -type f -name '*.tgz' -print -quit)
+            test -n "$tarball"
+            node -e '
+              const manifest = require(require("node:path").resolve(process.argv[1]))
+              for (const file of [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]) {
+                if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
+              }
+            ' "$package/package.json" | while IFS= read -r file; do
+              test -s "$package/$file"
+              test "$(tar -xOf "$tarball" "package/$file" | sha256sum | cut -d ' ' -f 1)" = "$(sha256sum "$package/$file" | cut -d ' ' -f 1)"
+            done
+          done
+
+          smoke_dir=$(mktemp -d)
+          native_tarball=$(find "$release_tarballs/pnpm_npm_pacquet-linux-x64" -type f -name '*.tgz' -print -quit)
+          wrapper_tarball=$(find "$release_tarballs/pnpm_npm_pnpm" -type f -name '*.tgz' -print -quit)
+          mkdir -p "$smoke_dir/node_modules/@pnpm/exe.linux-x64" "$smoke_dir/node_modules/pnpm"
+          tar -xzf "$native_tarball" \
+            -C "$smoke_dir/node_modules/@pnpm/exe.linux-x64" --strip-components=1
+          tar -xzf "$wrapper_tarball" \
+            -C "$smoke_dir/node_modules/pnpm" --strip-components=1
+          node "$smoke_dir/node_modules/pnpm/install.js"
+          "$smoke_dir/node_modules/pnpm/pnpm" --version
+
       # Everything publishes via trusted publishing: the `pnpm` / `@pnpm/exe`
       # trusted publishers are bound to this workflow file (they are shared
       # with the TypeScript release job above), and the natives' and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,14 +184,38 @@ jobs:
             tarball=$(find "$package_tarballs" -type f -name '*.tgz' -print -quit)
             test -n "$tarball"
             node -e '
-              const manifest = require(require("node:path").resolve(process.argv[1]))
-              const files = [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]
-              if (!files.some((file) => !/[?*[]/.test(file))) throw new Error("No literal payload files declared by " + manifest.name)
-              for (const file of files) {
-                if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
+              const fs = require("node:fs")
+              const path = require("node:path")
+              const manifestPath = path.resolve(process.argv[1])
+              const manifest = require(manifestPath)
+              const packageDir = path.dirname(manifestPath)
+              const excluded = (manifest.files ?? []).filter((file) => file.startsWith("!")).map((file) => globToRegExp(file.slice(1)))
+              const files = new Set()
+              for (const file of manifest.files ?? []) {
+                if (!file.startsWith("!") && !/[?*[]/.test(file)) add(file)
+              }
+              for (const file of manifest.publishConfig?.executableFiles ?? []) add(file)
+              for (const file of Object.values(typeof manifest.bin === "string" ? { default: manifest.bin } : manifest.bin ?? {})) add(file)
+              if (files.size === 0) throw new Error("No literal payload files declared by " + manifest.name)
+              console.log([...files].join("\n"))
+
+              function add(file) {
+                const relative = file.replace(/^\.\//, "")
+                if (excluded.some((pattern) => pattern.test(relative))) return
+                const source = path.join(packageDir, relative)
+                const stat = fs.statSync(source, { throwIfNoEntry: false })
+                if (stat?.isFile()) {
+                  files.add(relative)
+                  return
+                }
+                if (!stat?.isDirectory()) throw new Error("Missing payload file " + source)
+                for (const entry of fs.readdirSync(source, { withFileTypes: true })) add(path.join(relative, entry.name))
+              }
+
+              function globToRegExp(pattern) {
+                return new RegExp("^" + pattern.replace(/[.+^{}()|[\]\\]/g, "\\$&").replace(/\*\*\//g, "\x00").replace(/\*\*/g, "\x01").replace(/\*/g, "[^/]*").replace(/\x00/g, "(?:.*/)?").replace(/\x01/g, ".*") + String.fromCharCode(36))
               }
             ' "$package/package.json" | while IFS= read -r file; do
-              if [ ! -f "$package/$file" ]; then continue; fi
               test -s "$package/$file"
               test "$(tar -xOf "$tarball" "package/$file" | shasum -a 256 | cut -d ' ' -f 1)" = "$(shasum -a 256 "$package/$file" | cut -d ' ' -f 1)"
             done
@@ -505,14 +529,38 @@ jobs:
             tarball=$(find "$package_tarballs" -type f -name '*.tgz' -print -quit)
             test -n "$tarball"
             node -e '
-              const manifest = require(require("node:path").resolve(process.argv[1]))
-              const files = [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]
-              if (!files.some((file) => !/[?*[]/.test(file))) throw new Error("No literal payload files declared by " + manifest.name)
-              for (const file of files) {
-                if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
+              const fs = require("node:fs")
+              const path = require("node:path")
+              const manifestPath = path.resolve(process.argv[1])
+              const manifest = require(manifestPath)
+              const packageDir = path.dirname(manifestPath)
+              const excluded = (manifest.files ?? []).filter((file) => file.startsWith("!")).map((file) => globToRegExp(file.slice(1)))
+              const files = new Set()
+              for (const file of manifest.files ?? []) {
+                if (!file.startsWith("!") && !/[?*[]/.test(file)) add(file)
+              }
+              for (const file of manifest.publishConfig?.executableFiles ?? []) add(file)
+              for (const file of Object.values(typeof manifest.bin === "string" ? { default: manifest.bin } : manifest.bin ?? {})) add(file)
+              if (files.size === 0) throw new Error("No literal payload files declared by " + manifest.name)
+              console.log([...files].join("\n"))
+
+              function add(file) {
+                const relative = file.replace(/^\.\//, "")
+                if (excluded.some((pattern) => pattern.test(relative))) return
+                const source = path.join(packageDir, relative)
+                const stat = fs.statSync(source, { throwIfNoEntry: false })
+                if (stat?.isFile()) {
+                  files.add(relative)
+                  return
+                }
+                if (!stat?.isDirectory()) throw new Error("Missing payload file " + source)
+                for (const entry of fs.readdirSync(source, { withFileTypes: true })) add(path.join(relative, entry.name))
+              }
+
+              function globToRegExp(pattern) {
+                return new RegExp("^" + pattern.replace(/[.+^{}()|[\]\\]/g, "\\$&").replace(/\*\*\//g, "\x00").replace(/\*\*/g, "\x01").replace(/\*/g, "[^/]*").replace(/\x00/g, "(?:.*/)?").replace(/\x01/g, ".*") + String.fromCharCode(36))
               }
             ' "$package/package.json" | while IFS= read -r file; do
-              if [ ! -f "$package/$file" ]; then continue; fi
               test -s "$package/$file"
               test "$(tar -xOf "$tarball" "package/$file" | sha256sum | cut -d ' ' -f 1)" = "$(sha256sum "$package/$file" | cut -d ' ' -f 1)"
             done
@@ -802,14 +850,38 @@ jobs:
             tarball=$(find "$package_tarballs" -type f -name '*.tgz' -print -quit)
             test -n "$tarball"
             node -e '
-              const manifest = require(require("node:path").resolve(process.argv[1]))
-              const files = [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]
-              if (!files.some((file) => !/[?*[]/.test(file))) throw new Error("No literal payload files declared by " + manifest.name)
-              for (const file of files) {
-                if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
+              const fs = require("node:fs")
+              const path = require("node:path")
+              const manifestPath = path.resolve(process.argv[1])
+              const manifest = require(manifestPath)
+              const packageDir = path.dirname(manifestPath)
+              const excluded = (manifest.files ?? []).filter((file) => file.startsWith("!")).map((file) => globToRegExp(file.slice(1)))
+              const files = new Set()
+              for (const file of manifest.files ?? []) {
+                if (!file.startsWith("!") && !/[?*[]/.test(file)) add(file)
+              }
+              for (const file of manifest.publishConfig?.executableFiles ?? []) add(file)
+              for (const file of Object.values(typeof manifest.bin === "string" ? { default: manifest.bin } : manifest.bin ?? {})) add(file)
+              if (files.size === 0) throw new Error("No literal payload files declared by " + manifest.name)
+              console.log([...files].join("\n"))
+
+              function add(file) {
+                const relative = file.replace(/^\.\//, "")
+                if (excluded.some((pattern) => pattern.test(relative))) return
+                const source = path.join(packageDir, relative)
+                const stat = fs.statSync(source, { throwIfNoEntry: false })
+                if (stat?.isFile()) {
+                  files.add(relative)
+                  return
+                }
+                if (!stat?.isDirectory()) throw new Error("Missing payload file " + source)
+                for (const entry of fs.readdirSync(source, { withFileTypes: true })) add(path.join(relative, entry.name))
+              }
+
+              function globToRegExp(pattern) {
+                return new RegExp("^" + pattern.replace(/[.+^{}()|[\]\\]/g, "\\$&").replace(/\*\*\//g, "\x00").replace(/\*\*/g, "\x01").replace(/\*/g, "[^/]*").replace(/\x00/g, "(?:.*/)?").replace(/\x01/g, ".*") + String.fromCharCode(36))
               }
             ' "$package/package.json" | while IFS= read -r file; do
-              if [ ! -f "$package/$file" ]; then continue; fi
               test -s "$package/$file"
               test "$(tar -xOf "$tarball" "package/$file" | sha256sum | cut -d ' ' -f 1)" = "$(sha256sum "$package/$file" | cut -d ' ' -f 1)"
             done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,16 +136,14 @@ jobs:
             echo "pnpr_tag=$PNPR_TAG"
           } | tee -a "$GITHUB_OUTPUT"
 
-  release:
-    name: Release the TypeScript pnpm CLI
+  verify-ts-release:
+    name: Verify TypeScript pnpm release artifacts
     needs:
       - validate-release-ref
       - plan
     if: needs.plan.outputs.ts == 'true'
     permissions:
-      id-token: write  # Required for OIDC
-      contents: write  # for softprops/action-gh-release to create GitHub release
-      attestations: write  # for actions/attest-build-provenance
+      contents: read
     # Runs on macOS so the darwin artifacts can be ad-hoc signed with native
     # `codesign` (no need to build/install `ldid` on the runner) and so
     # `verify-binary.mjs` can smoke-test the darwin-arm64 SEA in place — a
@@ -153,6 +151,78 @@ jobs:
     # Note: this does NOT fix the darwin-x64 crash (nodejs/node#62893) — that's
     # an upstream Node.js SEA bug independent of signing; see pack-app docs.
     # npm trusted publishing still requires this publish job to run on GitHub-hosted macOS.
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: garnet-org/action@2b7fc9d79b54f551b43358c27424a36064b3e078 # v2.0.2
+        with:
+          api_token: ${{ secrets.GARNET_API_TOKEN }}
+      - name: Install pnpm and Node
+        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        with:
+          runtime: node@26.5.0
+      - name: Build TypeScript executable artifacts
+        run: pn --filter=@pnpm/exe run build-artifacts
+
+      - name: Verify TypeScript npm packages
+        # Inspect the same tarballs that publish will upload before the first
+        # immutable npm publish, including the generated platform packages.
+        run: |
+          set -euo pipefail
+          release_tarballs=$(mktemp -d)
+          for package in pnpm11/pnpm/artifacts/{darwin-arm64,exe,linux-arm64,linux-arm64-musl,linux-x64,linux-x64-musl,win32-arm64,win32-x64} pnpm11/pnpm; do
+            package_tarballs="$release_tarballs/${package//\//_}"
+            mkdir "$package_tarballs"
+            (
+              cd "$package"
+              pn pack --pack-destination "$package_tarballs"
+            )
+
+            tarball=$(find "$package_tarballs" -type f -name '*.tgz' -print -quit)
+            test -n "$tarball"
+            node -e '
+              const manifest = require(require("node:path").resolve(process.argv[1]))
+              for (const file of [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]) {
+                if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
+              }
+            ' "$package/package.json" | while IFS= read -r file; do
+              if [ ! -f "$package/$file" ]; then continue; fi
+              test -s "$package/$file"
+              test "$(tar -xOf "$tarball" "package/$file" | shasum -a 256 | cut -d ' ' -f 1)" = "$(shasum -a 256 "$package/$file" | cut -d ' ' -f 1)"
+            done
+          done
+
+          pnpm_tarball=$(find "$release_tarballs/pnpm11_pnpm" -type f -name '*.tgz' -print -quit)
+          test -n "$pnpm_tarball"
+
+          smoke_dir=$(mktemp -d)
+          tar -xzf "$pnpm_tarball" -C "$smoke_dir"
+          node "$smoke_dir/package/bin/pnpm.mjs" --version
+
+          exe_tarball=$(find "$release_tarballs/pnpm11_pnpm_artifacts_exe" -type f -name '*.tgz' -print -quit)
+          native_tarball=$(find "$release_tarballs/pnpm11_pnpm_artifacts_darwin-arm64" -type f -name '*.tgz' -print -quit)
+          test -n "$exe_tarball"
+          test -n "$native_tarball"
+          mkdir -p "$smoke_dir/node_modules/@pnpm/exe" "$smoke_dir/node_modules/@pnpm/macos-arm64"
+          tar -xzf "$exe_tarball" -C "$smoke_dir/node_modules/@pnpm/exe" --strip-components=1
+          tar -xzf "$native_tarball" -C "$smoke_dir/node_modules/@pnpm/macos-arm64" --strip-components=1
+          node "$smoke_dir/node_modules/@pnpm/exe/setup.js"
+          "$smoke_dir/node_modules/@pnpm/exe/pnpm" --version
+
+  release:
+    name: Release the TypeScript pnpm CLI
+    needs:
+      - validate-release-ref
+      - plan
+      - verify-ts-release
+    if: needs.plan.outputs.ts == 'true'
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: write  # for softprops/action-gh-release to create GitHub release
+      attestations: write  # for actions/attest-build-provenance
     runs-on: macos-latest
     environment: release
     steps:
@@ -173,12 +243,13 @@ jobs:
       # force trusted publishing for a given package today is to run its publish in a
       # step that doesn't have NPM_TOKEN set. See https://github.com/pnpm/pnpm/pull/11495
       # for the longer-term fix that lets OIDC override a configured token.
+      - name: Build TypeScript executable artifacts
+        run: pn --filter=@pnpm/exe run build-artifacts
+
       - name: Publish @pnpm/exe (trusted publishing)
         # No NPM_TOKEN: pnpm has no static token to short-circuit on, so it will perform
         # the OIDC token exchange against npm's trusted-publishing config for `@pnpm/exe`.
-        # The exe artifacts must be built before the publish, so they're built here too.
         run: |
-          pn --filter=@pnpm/exe run build-artifacts
           pn --filter=@pnpm/exe publish --tag=next-11 --access=public --provenance
       - name: Publish internal workspace packages (static token)
         # The other workspace packages don't have trusted publishing configured on npm,
@@ -361,14 +432,11 @@ jobs:
             *.tar.gz
             *.node
 
-  publish-rust:
-    name: Publish pnpm (Rust) and @pnpm/napi to npm
-    # npm trusted publishing still requires this publish job to run on GitHub-hosted Linux.
+  verify-rust-artifacts:
+    name: Verify pnpm (Rust) npm artifacts
     runs-on: ubuntu-latest
-    environment: release
     permissions:
-      # Required for npm trusted publishing and provenance attestations via OIDC.
-      id-token: write
+      contents: read
     needs:
       - plan
       - build-rust
@@ -415,7 +483,7 @@ jobs:
           node pnpm/npm/napi/scripts/generate-packages.mjs
           cat pnpm/npm/pnpm/package.json
           cat pnpm/npm/napi/package.json
-          for package in pnpm/npm/pacquet-* pnpm/npm/napi.*; do cat $package/package.json ; echo ; done
+          for package in pnpm/npm/pacquet-* pnpm/npm/napi.*; do cat "$package/package.json" ; echo ; done
 
       - name: Verify generated npm packages
         # `pnpm publish` packages its input immediately before upload. Verify
@@ -440,6 +508,7 @@ jobs:
                 if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
               }
             ' "$package/package.json" | while IFS= read -r file; do
+              if [ ! -f "$package/$file" ]; then continue; fi
               test -s "$package/$file"
               test "$(tar -xOf "$tarball" "package/$file" | sha256sum | cut -d ' ' -f 1)" = "$(sha256sum "$package/$file" | cut -d ' ' -f 1)"
             done
@@ -448,6 +517,8 @@ jobs:
           smoke_dir=$(mktemp -d)
           native_tarball=$(find "$release_tarballs/pnpm_npm_pacquet-linux-x64" -type f -name '*.tgz' -print -quit)
           wrapper_tarball=$(find "$release_tarballs/pnpm_npm_pnpm" -type f -name '*.tgz' -print -quit)
+          test -n "$native_tarball"
+          test -n "$wrapper_tarball"
           mkdir -p "$smoke_dir/node_modules/@pnpm/exe.linux-x64" "$smoke_dir/node_modules/pnpm"
           tar -xzf "$native_tarball" \
             -C "$smoke_dir/node_modules/@pnpm/exe.linux-x64" --strip-components=1
@@ -455,6 +526,52 @@ jobs:
             -C "$smoke_dir/node_modules/pnpm" --strip-components=1
           node "$smoke_dir/node_modules/pnpm/install.js"
           "$smoke_dir/node_modules/pnpm/pnpm" --version
+
+  publish-rust:
+    name: Publish pnpm (Rust) and @pnpm/napi to npm
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # Required for npm trusted publishing and provenance attestations via OIDC.
+      id-token: write
+    needs:
+      - plan
+      - build-rust
+      - verify-rust-artifacts
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm and Node
+        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        with:
+          runtime: node@22
+          install: false
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binaries-rust-*
+          merge-multiple: true
+
+      - name: Extract archives
+        run: |
+          for archive in pnpm-*.zip; do
+            rm -rf extract && mkdir extract
+            unzip -q "$archive" -d extract
+            mv extract/pnpm.exe "${archive%.zip}.exe"
+          done
+          for archive in pnpm-*.tar.gz; do
+            rm -rf extract && mkdir extract
+            tar -xzf "$archive" -C extract
+            mv extract/pnpm "${archive%.tar.gz}"
+          done
+
+      - name: Generate npm packages
+        run: |
+          node pnpm/npm/pnpm/scripts/generate-packages.mjs
+          node pnpm/npm/napi/scripts/generate-packages.mjs
 
       # Everything publishes via trusted publishing: the `pnpm` / `@pnpm/exe`
       # trusted publishers are bound to this workflow file (they are shared
@@ -621,14 +738,11 @@ jobs:
             *.tar.gz
             *.sha256
 
-  publish-pnpr:
-    name: Publish @pnpm/pnpr to npm
-    # npm trusted publishing still requires this publish job to run on GitHub-hosted Linux.
+  verify-pnpr-artifacts:
+    name: Verify pnpr npm artifacts
     runs-on: ubuntu-latest
-    environment: release
     permissions:
-      # Required for npm trusted publishing and provenance attestations via OIDC.
-      id-token: write
+      contents: read
     needs:
       - plan
       - build-pnpr
@@ -655,13 +769,98 @@ jobs:
           args: unzip -qq *.zip -d .
 
       - name: Extract tarballs
-        run: ls *.gz | xargs -i tar xf {}
+        run: |
+          for archive in ./*.gz; do
+            tar xf "$archive"
+          done
 
       - name: Generate npm packages
         run: |
           node pnpr/npm/pnpr/scripts/generate-packages.mjs
           cat pnpr/npm/pnpr/package.json
-          for package in pnpr/npm/pnpr*; do cat $package/package.json ; echo ; done
+          for package in pnpr/npm/pnpr*; do cat "$package/package.json" ; echo ; done
+
+      - name: Verify generated npm packages
+        # `pnpm publish` packages its input immediately before upload. Verify
+        # those tarballs, then exercise the wrapper's native-binary install
+        # path before the first immutable npm publish.
+        run: |
+          set -euo pipefail
+          release_tarballs=$(mktemp -d)
+          for package in pnpr/npm/pnpr-* pnpr/npm/pnpr; do
+            package_tarballs="$release_tarballs/${package//\//_}"
+            mkdir "$package_tarballs"
+            (
+              cd "$package"
+              pnpm pack --pack-destination "$package_tarballs"
+            )
+
+            tarball=$(find "$package_tarballs" -type f -name '*.tgz' -print -quit)
+            test -n "$tarball"
+            node -e '
+              const manifest = require(require("node:path").resolve(process.argv[1]))
+              for (const file of [...(manifest.files ?? []), ...(manifest.publishConfig?.executableFiles ?? [])]) {
+                if (!/[?*[]/.test(file)) console.log(file.replace(/^\.\//, ""))
+              }
+            ' "$package/package.json" | while IFS= read -r file; do
+              if [ ! -f "$package/$file" ]; then continue; fi
+              test -s "$package/$file"
+              test "$(tar -xOf "$tarball" "package/$file" | sha256sum | cut -d ' ' -f 1)" = "$(sha256sum "$package/$file" | cut -d ' ' -f 1)"
+            done
+          done
+
+          smoke_dir=$(mktemp -d)
+          native_tarball=$(find "$release_tarballs/pnpr_npm_pnpr-linux-x64" -type f -name '*.tgz' -print -quit)
+          wrapper_tarball=$(find "$release_tarballs/pnpr_npm_pnpr" -type f -name '*.tgz' -print -quit)
+          test -n "$native_tarball"
+          test -n "$wrapper_tarball"
+          mkdir -p "$smoke_dir/node_modules/@pnpm/pnpr.linux-x64" "$smoke_dir/node_modules/@pnpm/pnpr"
+          tar -xzf "$native_tarball" -C "$smoke_dir/node_modules/@pnpm/pnpr.linux-x64" --strip-components=1
+          tar -xzf "$wrapper_tarball" -C "$smoke_dir/node_modules/@pnpm/pnpr" --strip-components=1
+          node "$smoke_dir/node_modules/@pnpm/pnpr/install.js"
+          "$smoke_dir/node_modules/@pnpm/pnpr/bin/pnpr" --version
+
+  publish-pnpr:
+    name: Publish @pnpm/pnpr to npm
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # Required for npm trusted publishing and provenance attestations via OIDC.
+      id-token: write
+    needs:
+      - plan
+      - build-pnpr
+      - verify-pnpr-artifacts
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm and Node
+        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        with:
+          runtime: node@22
+          install: false
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binaries-pnpr-*
+          merge-multiple: true
+
+      - name: Unzip
+        uses: montudor/action-zip@0852c26906e00f8a315c704958823928d8018b28 # v1.0.0
+        with:
+          args: unzip -qq *.zip -d .
+
+      - name: Extract tarballs
+        run: |
+          for archive in ./*.gz; do
+            tar xf "$archive"
+          done
+
+      - name: Generate npm packages
+        run: node pnpr/npm/pnpr/scripts/generate-packages.mjs
 
       - name: Publish npm packages
         # Auth is via npm's trusted publishing: `id-token: write` above grants


### PR DESCRIPTION
## Summary

Adds pre-publish verification gates for every npm package released by this workflow: Rust pacquet, the v11 JavaScript CLI and `@pnpm/exe`, and pnpr. Dedicated read-only verification jobs pack generated packages, verify declared literal payload files are non-empty and byte-for-byte identical to their source artifacts, and smoke-test the relevant installed command before a separate trusted-publishing job can run.

## Squash Commit Body

```text
Release jobs could package and publish generated native or executable payloads
without a release-time signal if a packlist regression omitted a required file.
Add read-only verification jobs before each trusted-publishing job. They pack every
generated package, verify its declared literal payload files against the source
artifacts, and smoke-test the v11 plain-JS CLI, the v11 executable wrapper
with its native package, and the pnpr wrapper with its Linux native package.

Keeping the smoke tests outside OIDC-enabled publishing jobs prevents an
artifact executed during verification from obtaining a trusted-publishing token.
The verification tarballs live outside package directories so they cannot become
part of subsequently published archives.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Release
  workflow only.)*
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786732010&installation_id=145934176&pr_number=13045&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13045&signature=a42646279b8618db6a166dcb983eea448952e87c9c7576f2a99aad9f21ab338a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stronger pre-publication checks to ensure generated npm packages match the exact staged sources byte-for-byte.
  * Validates all declared payload files are included and identical to the originals.
* **Tests**
  * Added a Linux-x64 style install/run smoke test to confirm the wrapper setup and main executable work correctly after extraction.
* **CI / Release**
  * Updated the release pipeline to run artifact verification for all supported product lines and tightened the publish steps for cleaner, deterministic packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->