### PR TITLE
fix(cli): render clean/purge Removing paths relative to cwd on Windows

### DIFF
--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -4,7 +4,7 @@ use super::{
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::Config;
-use pacquet_fs::{is_subdir, lexical_normalize};
+use pacquet_fs::{is_subdir, lexical_normalize, relative_path};
 use pacquet_workspace::read_project_manifest_only;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
@@ -97,6 +97,12 @@ fn script_of(
 /// Remove `node_modules` contents and (optionally) lockfiles from the
 /// current project or every workspace project.
 fn clean_builtin(ctx: &RunCtx<'_>, config: &Config, remove_lockfile: bool) -> miette::Result<()> {
+    // The `Removing <path>` lines render each target relative to the cwd.
+    // It is canonicalized once here so it shares the symlink-resolved
+    // representation of the paths built from the canonicalized `--dir`; on
+    // Windows the raw `current_dir()` can differ (casing, 8.3 short names,
+    // junctions) and defeat the relative-path computation.
+    let cwd = std::env::current_dir().and_then(dunce::canonicalize).unwrap_or_default();
     // `pnpm clean` resolves the modules dir relative to each project
     // directory, not against a single absolute prefix, so strip the
     // config anchor back to the leaf and rejoin per project.
@@ -111,14 +117,14 @@ fn clean_builtin(ctx: &RunCtx<'_>, config: &Config, remove_lockfile: bool) -> mi
     for dir in &dirs {
         let full_modules_dir = dir.join(modules_leaf);
         if has_contents_to_remove(&full_modules_dir) {
-            print_removing(&full_modules_dir);
+            print_removing(&cwd, &full_modules_dir);
             remove_modules_dir_contents(&full_modules_dir)?;
         }
     }
     if remove_lockfile {
         let lockfile_path = root_dir.join("pnpm-lock.yaml");
         if lockfile_path.exists() {
-            print_removing(&lockfile_path);
+            print_removing(&cwd, &lockfile_path);
             std::fs::remove_file(&lockfile_path)
                 .or_else(|error| {
                     if error.kind() == std::io::ErrorKind::NotFound { Ok(()) } else { Err(error) }
@@ -140,7 +146,7 @@ fn clean_builtin(ctx: &RunCtx<'_>, config: &Config, remove_lockfile: bool) -> mi
         && is_subdir(root_dir, &resolved_virtual_store_dir)
         && resolved_virtual_store_dir.exists()
     {
-        print_removing(&resolved_virtual_store_dir);
+        print_removing(&cwd, &resolved_virtual_store_dir);
         remove_path(&resolved_virtual_store_dir)?;
     }
     Ok(())
@@ -186,18 +192,11 @@ fn is_pnpm_entry(name: &str) -> bool {
     !name.starts_with('.') || PNPM_HIDDEN_ENTRIES.contains(&name)
 }
 
-/// Print `Removing <path>` relative to the current working directory,
-/// matching pnpm's `path.relative(process.cwd(), p)` formatting. An
-/// empty relative path renders as `.`.
-///
-/// The cwd is canonicalized so it shares the symlink-resolved
-/// representation of the paths built from the canonicalized `--dir`.
-/// On Windows the raw `current_dir()` can differ from that form (casing,
-/// 8.3 short names, junctions), which would otherwise leave the two paths
-/// without a common prefix and leak the full absolute path.
-fn print_removing(path: &Path) {
-    let base = std::env::current_dir().and_then(dunce::canonicalize).unwrap_or_default();
-    let relative = pathdiff::diff_paths(path, &base).unwrap_or_else(|| path.to_path_buf());
+/// Print `Removing <path>`, with `path` rendered relative to `base` (the
+/// canonicalized cwd), matching pnpm's `path.relative(process.cwd(), p)`
+/// formatting. An empty relative path renders as `.`.
+fn print_removing(base: &Path, path: &Path) {
+    let relative = relative_path(base, path);
     let owned: PathBuf =
         if relative.as_os_str().is_empty() { PathBuf::from(".") } else { relative };
     println!("Removing {}", owned.display());

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -189,36 +189,16 @@ fn is_pnpm_entry(name: &str) -> bool {
 /// Print `Removing <path>` relative to the current working directory,
 /// matching pnpm's `path.relative(process.cwd(), p)` formatting. An
 /// empty relative path renders as `.`.
+///
+/// The cwd is canonicalized so it shares the symlink-resolved
+/// representation of the paths built from the canonicalized `--dir`.
+/// On Windows the raw `current_dir()` can differ from that form (casing,
+/// 8.3 short names, junctions), which would otherwise leave the two paths
+/// without a common prefix and leak the full absolute path.
 fn print_removing(path: &Path) {
-    let cwd = std::env::current_dir().unwrap_or_default();
-    let relative = strip_prefix_case_insensitive(path, &cwd).unwrap_or_else(|| path.to_path_buf());
+    let base = std::env::current_dir().and_then(dunce::canonicalize).unwrap_or_default();
+    let relative = pathdiff::diff_paths(path, &base).unwrap_or_else(|| path.to_path_buf());
     let owned: PathBuf =
         if relative.as_os_str().is_empty() { PathBuf::from(".") } else { relative };
     println!("Removing {}", owned.display());
-}
-
-/// Like [`Path::strip_prefix`], but falls back to a case-insensitive
-/// comparison on Windows where `current_dir()` may differ in casing.
-fn strip_prefix_case_insensitive(path: &Path, base: &Path) -> Option<PathBuf> {
-    path.strip_prefix(base)
-        .ok()
-        .map(Path::to_path_buf)
-        .or_else(|| case_insensitive_strip_prefix(path, base))
-}
-
-/// On Windows, `current_dir()` may return different casing than the
-/// canonical path. This fallback strips the base using a case-insensitive
-/// comparison.
-#[cfg(windows)]
-fn case_insensitive_strip_prefix(path: &Path, base: &Path) -> Option<PathBuf> {
-    let path_s = path.to_string_lossy().to_lowercase();
-    let base_s = base.to_string_lossy().to_lowercase();
-    let rest = path_s.strip_prefix(&base_s)?;
-    let byte_offset = path.to_string_lossy().len() - rest.len();
-    Some(PathBuf::from(&path.to_string_lossy()[byte_offset..]))
-}
-
-#[cfg(not(windows))]
-fn case_insensitive_strip_prefix(_path: &Path, _base: &Path) -> Option<PathBuf> {
-    None
 }

--- a/pnpm/crates/cli/tests/clean.rs
+++ b/pnpm/crates/cli/tests/clean.rs
@@ -104,8 +104,13 @@ fn clean_works_in_a_workspace() {
     assert!(output.status.success(), "pacquet clean should succeed");
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("Removing pkg1/node_modules"), "expected pkg1: {stdout}");
-    assert!(stdout.contains("Removing pkg2/node_modules"), "expected pkg2: {stdout}");
+    // `pnpm` prints the module dir relative to the cwd with the platform's
+    // path separator (via `path.relative`), so build the expected text the
+    // same way rather than hard-coding a `/`.
+    let expected_pkg1 = format!("Removing {}", Path::new("pkg1").join("node_modules").display());
+    let expected_pkg2 = format!("Removing {}", Path::new("pkg2").join("node_modules").display());
+    assert!(stdout.contains(&expected_pkg1), "expected pkg1: {stdout}");
+    assert!(stdout.contains(&expected_pkg2), "expected pkg2: {stdout}");
     assert!(!pkg1.join("node_modules").join("a").exists(), "pkg1 package removed");
     assert!(!pkg2.join("node_modules").join("b").exists(), "pkg2 package removed");
 

--- a/pnpm/crates/fs/src/lib.rs
+++ b/pnpm/crates/fs/src/lib.rs
@@ -1,12 +1,14 @@
 mod ensure_file;
 mod is_subdir;
 mod lexical_normalize;
+mod relative_path;
 mod symlink_dir;
 mod write_atomic;
 
 pub use ensure_file::*;
 pub use is_subdir::is_subdir;
 pub use lexical_normalize::lexical_normalize;
+pub use relative_path::relative_path;
 pub use symlink_dir::*;
 pub use write_atomic::write_atomic;
 

--- a/pnpm/crates/fs/src/relative_path.rs
+++ b/pnpm/crates/fs/src/relative_path.rs
@@ -1,0 +1,59 @@
+use std::path::{Path, PathBuf};
+
+/// Express `path` relative to `base`, mirroring Node's
+/// `path.relative(base, path)`: the shortest relative path when the two
+/// share a filesystem root, otherwise the absolute `path` (Node likewise
+/// returns the absolute target when the inputs cannot be related).
+///
+/// On Windows the two `Prefix` components must match (drive letters
+/// case-folded) before diffing; without that guard [`pathdiff::diff_paths`]
+/// emits a re-anchored garbage path across drives or UNC shares.
+#[must_use]
+pub fn relative_path(base: &Path, path: &Path) -> PathBuf {
+    relative_path_inner(base, path)
+}
+
+#[cfg(windows)]
+fn relative_path_inner(base: &Path, path: &Path) -> PathBuf {
+    let base = dunce::simplified(base);
+    let path = dunce::simplified(path);
+    if !same_path_root(path, base) {
+        return path.to_path_buf();
+    }
+    pathdiff::diff_paths(path, base).unwrap_or_else(|| path.to_path_buf())
+}
+
+#[cfg(not(windows))]
+fn relative_path_inner(base: &Path, path: &Path) -> PathBuf {
+    pathdiff::diff_paths(path, base).unwrap_or_else(|| path.to_path_buf())
+}
+
+/// Whether `a` and `b` have an identical `Component::Prefix` after
+/// `dunce::simplified`, with drive letters case-folded. UNC shares
+/// only match when their server/share are written with identical
+/// casing and variant — the check has to stay in lockstep with what
+/// `pathdiff::diff_paths` will tolerate, since a variant-tolerant or
+/// case-tolerant comparison here would let the downstream diff emit
+/// a re-anchored garbage path on a `Prefix` mismatch it cannot relate.
+#[cfg(windows)]
+fn same_path_root(a: &Path, b: &Path) -> bool {
+    fn first_prefix(path: &Path) -> Option<std::path::Prefix<'_>> {
+        match path.components().next()? {
+            std::path::Component::Prefix(p) => Some(p.kind()),
+            _ => None,
+        }
+    }
+    fn case_normalize(prefix: std::path::Prefix<'_>) -> std::path::Prefix<'_> {
+        use std::path::Prefix::{Disk, VerbatimDisk};
+        match prefix {
+            Disk(d) => Disk(d.to_ascii_uppercase()),
+            VerbatimDisk(d) => VerbatimDisk(d.to_ascii_uppercase()),
+            other => other,
+        }
+    }
+    match (first_prefix(a), first_prefix(b)) {
+        (Some(pa), Some(pb)) => case_normalize(pa) == case_normalize(pb),
+        (None, None) => true,
+        _ => false,
+    }
+}

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -71,52 +71,7 @@ fn to_native_separators(path: &Path) -> Cow<'_, Path> {
 /// two arguments.
 fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
     let parent = link.parent().unwrap_or_else(|| Path::new(""));
-    relative_target_inner(original, parent)
-}
-
-#[cfg(windows)]
-fn relative_target_inner(original: &Path, parent: &Path) -> PathBuf {
-    let original = dunce::simplified(original);
-    let parent = dunce::simplified(parent);
-    if !same_path_root(original, parent) {
-        return original.to_path_buf();
-    }
-    pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
-}
-
-#[cfg(not(windows))]
-fn relative_target_inner(original: &Path, parent: &Path) -> PathBuf {
-    pathdiff::diff_paths(original, parent).unwrap_or_else(|| original.to_path_buf())
-}
-
-/// Whether `a` and `b` have an identical `Component::Prefix` after
-/// `dunce::simplified`, with drive letters case-folded. UNC shares
-/// only match when their server/share are written with identical
-/// casing and variant — the check has to stay in lockstep with what
-/// `pathdiff::diff_paths` will tolerate, since a variant-tolerant or
-/// case-tolerant comparison here would let the downstream diff emit
-/// a re-anchored garbage path on a `Prefix` mismatch it cannot relate.
-#[cfg(windows)]
-fn same_path_root(a: &Path, b: &Path) -> bool {
-    fn first_prefix(path: &Path) -> Option<std::path::Prefix<'_>> {
-        match path.components().next()? {
-            std::path::Component::Prefix(p) => Some(p.kind()),
-            _ => None,
-        }
-    }
-    fn case_normalize(prefix: std::path::Prefix<'_>) -> std::path::Prefix<'_> {
-        use std::path::Prefix::{Disk, VerbatimDisk};
-        match prefix {
-            Disk(d) => Disk(d.to_ascii_uppercase()),
-            VerbatimDisk(d) => VerbatimDisk(d.to_ascii_uppercase()),
-            other => other,
-        }
-    }
-    match (first_prefix(a), first_prefix(b)) {
-        (Some(pa), Some(pb)) => case_normalize(pa) == case_normalize(pb),
-        (None, None) => true,
-        _ => false,
-    }
+    crate::relative_path(parent, original)
 }
 
 /// Remove a symlink (or junction on Windows) previously created with


### PR DESCRIPTION
## Summary

The `Rust CI / Test / windows` job started failing on `main` (run [29437828132](https://github.com/pnpm/pnpm/actions/runs/29437828132/job/87428869222)) in the newly added `clean` / `purge` command tests (`pnpm/crates/cli/tests/clean.rs`), which had never run on Windows before.

`pnpm clean` / `pnpm purge` built its `Removing <path>` lines by stripping `std::env::current_dir()` from targets that are anchored on the symlink-**canonicalized** `--dir` (dispatch runs `dunce::canonicalize`). On Windows those two representations diverge (casing, 8.3 short names, junctions), so the prefix strip found no common base and leaked the full absolute path (`C:\Users\...\workspace\node_modules`) instead of the relative `node_modules`.

The fix derives the relative path against the *canonicalized* working directory, so the base shares the targets' representation. The `clean_works_in_a_workspace` test now builds its expected `Removing pkg/node_modules` text with the platform separator instead of a hard-coded `/`.

This is a `pacquet`-only fix: the TypeScript CLI already uses `path.relative(process.cwd(), p)` and does not canonicalize its dir, so it never had this bug.

### Follow-up (addressing review feedback)

- The canonicalized cwd is computed once per `clean` run and threaded into `print_removing`, instead of once per removed path.
- The relative-path computation is now the shared `pacquet_fs::relative_path`, extracted from `symlink_dir`'s existing root-guarded diff. It carries the Windows `same_path_root` guard, so a target on a different drive / UNC share renders as the absolute path (matching Node's `path.relative`) rather than a re-anchored garbage path; `symlink_dir` delegates to the same helper instead of duplicating it.

## Squash Commit Body

```text
fix(cli): render clean/purge Removing paths relative to cwd on Windows

`pnpm clean` / `pnpm purge` built its `Removing <path>` lines by stripping
the raw `current_dir()` from targets that are anchored on the
symlink-canonicalized `--dir`. On Windows those two representations diverge
(casing, 8.3 short names, junctions), so the prefix strip found no common
base and leaked the full absolute path into the output, failing the Windows
`clean` integration tests on main.

Derive the relative path against the canonicalized working directory, so the
base shares the targets' representation. The relative-path computation is the
shared `pacquet_fs::relative_path` helper, extracted from `symlink_dir`'s
root-guarded diff: on a Windows `Prefix` mismatch (different drive / UNC
share) it returns the absolute path, matching Node's `path.relative`, rather
than a re-anchored garbage path. The canonicalized cwd is computed once per
clean run. The workspace test builds its expected `Removing pkg/node_modules`
text with the platform separator instead of a hard-coded `/`.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. <!-- pacquet-only fix; the TypeScript CLI already behaves correctly, as explained above. -->
- [x] Added or updated tests. <!-- Existing Windows-only-failing test fixed to assert with the platform separator; the implementation change is covered by the existing `clean` and `symlink_dir` tests. -->

---
Written by an agent (Claude Code, claude-opus-4-8).
