### PR TITLE
fix(resolver): skip failures below optional deps

### DIFF
--- a/.changeset/optional-transitive-resolution.md
+++ b/.changeset/optional-transitive-resolution.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Skip unresolved transitive dependencies of optional packages instead of failing the install.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1444,7 +1444,7 @@ where
             Err(
                 err @ (ResolveDependencyTreeError::Resolve(_)
                 | ResolveDependencyTreeError::SpecNotSupported { .. }),
-            ) if wanted.optional.unwrap_or(false) => {
+            ) if current_is_optional => {
                 if wanted_lockfile_contains_satisfying_entry(
                     ctx.workspace.wanted_lockfile.as_deref(),
                     &wanted,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -731,6 +731,12 @@ struct FailingAliasResolver {
     failing: std::collections::HashSet<String>,
 }
 
+#[derive(Clone, Copy, Debug)]
+enum TransitiveFailure {
+    Resolve,
+    SpecNotSupported,
+}
+
 impl Resolver for FailingAliasResolver {
     fn resolve<'a>(
         &'a self,
@@ -782,6 +788,49 @@ fn optional_failure_fixture() -> (tempfile::TempDir, PackageManifest, FailingAli
             ),
         )]),
         failing: std::collections::HashSet::from(["broken".to_string()]),
+    };
+    (tmp, manifest, resolver)
+}
+
+fn transitive_failure_fixture(
+    parent_optional: bool,
+    failure: TransitiveFailure,
+) -> (tempfile::TempDir, PackageManifest, FailingAliasResolver) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("package.json");
+    let json = if parent_optional {
+        serde_json::json!({
+            "name": "root",
+            "version": "0.0.0",
+            "optionalDependencies": { "parent": "1.0.0" },
+        })
+    } else {
+        serde_json::json!({
+            "name": "root",
+            "version": "0.0.0",
+            "dependencies": { "parent": "1.0.0" },
+        })
+    };
+    std::fs::write(&path, serde_json::to_string(&json).unwrap()).expect("write package.json");
+    let manifest = PackageManifest::from_path(path).expect("parse package.json");
+    let resolver = FailingAliasResolver {
+        table: HashMap::from([(
+            ("parent".to_string(), "1.0.0".to_string()),
+            fake_result(
+                "parent",
+                "1.0.0",
+                None,
+                serde_json::json!({
+                    "name": "parent",
+                    "version": "1.0.0",
+                    "dependencies": { "broken": "1.0.0" },
+                }),
+            ),
+        )]),
+        failing: match failure {
+            TransitiveFailure::Resolve => std::collections::HashSet::from(["broken".to_string()]),
+            TransitiveFailure::SpecNotSupported => std::collections::HashSet::new(),
+        },
     };
     (tmp, manifest, resolver)
 }
@@ -918,4 +967,83 @@ async fn skips_an_optional_dependency_when_the_locked_entry_does_not_satisfy_the
 
     let direct = &result.peers.direct_dependencies_by_importer["."];
     assert!(!direct.contains_key("broken"), "the failing optional edge is dropped: {direct:?}");
+}
+
+#[tokio::test]
+async fn skips_supported_resolution_failures_below_optional_dependency() {
+    for failure in [TransitiveFailure::Resolve, TransitiveFailure::SpecNotSupported] {
+        let (_tmp, manifest, resolver) = transitive_failure_fixture(true, failure);
+        let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+        let skipped = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let mut opts = workspace_opts(false, false);
+        opts.skipped_optional_log = Some(std::sync::Arc::new({
+            let skipped = std::sync::Arc::clone(&skipped);
+            move |notification| skipped.lock().unwrap().push(notification)
+        }));
+        let result = resolve_workspace(
+            &resolver,
+            &importers,
+            &[DependencyGroup::Prod, DependencyGroup::Optional],
+            opts,
+            |_| importer_opts(std::path::PathBuf::from("/repo"), None),
+        )
+        .await
+        .unwrap_or_else(|err| {
+            panic!("{failure:?} below an optional parent must be skipped: {err}")
+        });
+
+        let direct = &result.peers.direct_dependencies_by_importer["."];
+        assert!(direct.contains_key("parent"), "the optional parent remains resolved: {direct:?}");
+        assert_eq!(result.merged_tree.packages.len(), 1);
+        let parent = result.merged_tree.packages.get("parent@1.0.0").expect("resolved parent");
+        assert!(parent.optional, "the retained parent remains optional: {parent:?}");
+
+        let skipped = skipped.lock().unwrap();
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].name.as_deref(), Some("broken"));
+        assert_eq!(skipped[0].parents.len(), 1);
+        assert_eq!(skipped[0].parents[0].id, "parent@1.0.0");
+        match failure {
+            TransitiveFailure::Resolve => assert!(
+                skipped[0].details.contains("No matching version found for broken@1.0.0"),
+                "resolver error is reported: {}",
+                skipped[0].details,
+            ),
+            TransitiveFailure::SpecNotSupported => assert!(
+                skipped[0].details.contains("isn't supported by any available resolver"),
+                "unsupported-spec error is reported: {}",
+                skipped[0].details,
+            ),
+        }
+    }
+}
+
+#[tokio::test]
+async fn propagates_supported_resolution_failures_below_required_dependency() {
+    for failure in [TransitiveFailure::Resolve, TransitiveFailure::SpecNotSupported] {
+        let (_tmp, manifest, resolver) = transitive_failure_fixture(false, failure);
+        let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+        let result = resolve_workspace(
+            &resolver,
+            &importers,
+            &[DependencyGroup::Prod, DependencyGroup::Optional],
+            workspace_opts(false, false),
+            |_| importer_opts(std::path::PathBuf::from("/repo"), None),
+        )
+        .await;
+
+        let Err(crate::ResolveImporterError::Resolve(err)) = result else {
+            panic!("{failure:?} below a required parent must fail resolution");
+        };
+        match failure {
+            TransitiveFailure::Resolve => assert!(
+                matches!(err, crate::ResolveDependencyTreeError::Resolve(_)),
+                "unexpected resolver error: {err}",
+            ),
+            TransitiveFailure::SpecNotSupported => assert!(
+                matches!(err, crate::ResolveDependencyTreeError::SpecNotSupported { .. }),
+                "unexpected unsupported-spec error: {err}",
+            ),
+        }
+    }
 }

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -74,8 +74,8 @@ Supporting tests:
 - [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:419` `optional dependency has bigger priority than regular dependency`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:436` `only skip optional dependencies`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:470` `skip optional dependency that does not support the current OS, when doing install on a subset of workspace projects`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:540` `do not fail on unsupported dependency of optional dependency`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:552` `fail on unsupported dependency of optional dependency`
+- [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:540` `do not fail on unsupported dependency of optional dependency` — `resolve_workspace::tests::skips_supported_resolution_failures_below_optional_dependency` covers both supported resolver-error variants and preserves the optional parent.
+- [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:552` `fail on unsupported dependency of optional dependency` — `resolve_workspace::tests::propagates_supported_resolution_failures_below_required_dependency` keeps both resolver-error variants fatal below a required parent.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:563` `do not fail on an optional dependency that has a non-optional dependency with a failing postinstall script`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:574` `fail on a package with failing postinstall if the package is both an optional and non-optional dependency`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:618` `remove optional dependencies that are not used`


### PR DESCRIPTION
## Summary

Pacquet already propagated an optional parent's state to its transitive dependencies, but its resolver error guard checked only whether the failing dependency was directly optional. Use the propagated optionality so supported resolution failures below optional dependencies are skipped while required paths still fail.

The TypeScript CLI already behaves this way. This restores parity for the Rust implementation.

Fixes pnpm/pnpm#13041.

Validation:

- `cargo nextest run -p pacquet-resolving-deps-resolver supported_resolution_failures_below`
- `cargo nextest run -p pacquet-resolving-deps-resolver` (186 tests)
- `cargo fmt --check`
- `cargo clippy --locked -p pacquet-resolving-deps-resolver --all-targets -- --deny warnings`
- `pnpm change status`

The full workspace `just ready`, dylint, typos, and cross-platform checks were not run locally. CI will cover those broader checks.

## Squash Commit Body

```text
The dependency walker already computes propagated optionality from the
current edge and its parent, but the supported resolution-error guard
checked only the current edge.

Use the propagated value so resolver failures and unsupported specs below
optional parents are skipped. Keep both error variants fatal below required
parents.

Fixes pnpm/pnpm#13041.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package.
- [x] Added or updated tests.

---
Prepared with agent assistance from Codex (GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786741451&installation_id=145934176&pr_number=13050&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13050&signature=73ca35eed956467656902aeb5d7964f347076b1cb74f2017596beecc6b68c4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
