### PR TITLE
fix(release): install clang for Windows ARM64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,6 +367,15 @@ jobs:
         with:
           tool: cross
 
+      - name: Install clang-cl for Windows ARM64
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --quiet --norestart
+          if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
+
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache
       # entry inject code into the published, attested release binaries.
@@ -731,6 +740,15 @@ jobs:
         uses: taiki-e/install-action@bffeee26d4db9be238a4ea78d8826604ebcb594d # v2.82.5
         with:
           tool: cross
+
+      - name: Install clang-cl for Windows ARM64
+        if: matrix.target == 'aarch64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --quiet --norestart
+          if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache


### PR DESCRIPTION
## Summary

Fix the Rust release workflow’s Windows ARM64 builds. The failed `v12.0.0-alpha.13` release fell back from `cross` to the Windows host compiler, but the runner did not include `clang-cl`, which `aws-lc-sys` requires for `aarch64-pc-windows-msvc`.

Install the Visual Studio LLVM compiler and toolset components only for that matrix target, in both pacquet and pnpr native build jobs. TypeScript pnpm release jobs and their queued v11 changesets are unchanged.

Related failed job: https://github.com/pnpm/pnpm/actions/runs/29450790131/job/87472548179

## Squash Commit Body

```text
Install clang-cl for Windows ARM64 release builds.

The release runner lacks the compiler required by aws-lc-sys when cross falls
back to the Windows host for aarch64-pc-windows-msvc. Install the Visual Studio
LLVM components only on that matrix target for pacquet and pnpr builds.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.

---

Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786742168&installation_id=145934176&pr_number=13051&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13051&signature=07b630b6fb42aee564d6759a7ce534da16e1dc8cd113bb824c885b5918cfb07e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows ARM64 release packaging by ensuring the required clang-cl toolchain components are installed during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->