### PR TITLE
fix(release): select clang for Windows ARM64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,6 +375,15 @@ jobs:
           $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
           & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --quiet --norestart
           if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
+          $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
+          $deadline = (Get-Date).AddMinutes(5)
+          do {
+            $clangCl = Get-ChildItem -Path $llvmDir -Filter clang-cl.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($null -eq $clangCl) { Start-Sleep -Seconds 5 }
+          } while ($null -eq $clangCl -and (Get-Date) -lt $deadline)
+          if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
+          & $clangCl.FullName --version
+          "CC_aarch64_pc_windows_msvc=$($clangCl.FullName)" >> $env:GITHUB_ENV
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache
@@ -749,6 +758,15 @@ jobs:
           $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
           & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --quiet --norestart
           if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
+          $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
+          $deadline = (Get-Date).AddMinutes(5)
+          do {
+            $clangCl = Get-ChildItem -Path $llvmDir -Filter clang-cl.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($null -eq $clangCl) { Start-Sleep -Seconds 5 }
+          } while ($null -eq $clangCl -and (Get-Date) -lt $deadline)
+          if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
+          & $clangCl.FullName --version
+          "CC_aarch64_pc_windows_msvc=$($clangCl.FullName)" >> $env:GITHUB_ENV
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,13 +377,21 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
           $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
           $deadline = (Get-Date).AddMinutes(5)
+          $installerRunning = $true
+          $clangCl = $null
           do {
-            $clangCl = Get-ChildItem -Path $llvmDir -Filter clang-cl.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-            if ($null -eq $clangCl) { Start-Sleep -Seconds 5 }
-          } while ($null -eq $clangCl -and (Get-Date) -lt $deadline)
+            $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
+            $clangCl = @(
+              (Join-Path $llvmDir 'ARM64\bin\clang-cl.exe'),
+              (Join-Path $llvmDir 'x64\bin\clang-cl.exe')
+            ) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+            if ($installerRunning -or $null -eq $clangCl) { Start-Sleep -Seconds 5 }
+          } while (($installerRunning -or $null -eq $clangCl) -and (Get-Date) -lt $deadline)
+          if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }
           if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
-          & $clangCl.FullName --version
-          "CC_aarch64_pc_windows_msvc=$($clangCl.FullName)" >> $env:GITHUB_ENV
+          & $clangCl --version
+          "CC_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
+          "CXX_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache
@@ -760,13 +768,21 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
           $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
           $deadline = (Get-Date).AddMinutes(5)
+          $installerRunning = $true
+          $clangCl = $null
           do {
-            $clangCl = Get-ChildItem -Path $llvmDir -Filter clang-cl.exe -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
-            if ($null -eq $clangCl) { Start-Sleep -Seconds 5 }
-          } while ($null -eq $clangCl -and (Get-Date) -lt $deadline)
+            $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
+            $clangCl = @(
+              (Join-Path $llvmDir 'ARM64\bin\clang-cl.exe'),
+              (Join-Path $llvmDir 'x64\bin\clang-cl.exe')
+            ) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+            if ($installerRunning -or $null -eq $clangCl) { Start-Sleep -Seconds 5 }
+          } while (($installerRunning -or $null -eq $clangCl) -and (Get-Date) -lt $deadline)
+          if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }
           if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
-          & $clangCl.FullName --version
-          "CC_aarch64_pc_windows_msvc=$($clangCl.FullName)" >> $env:GITHUB_ENV
+          & $clangCl --version
+          "CC_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
+          "CXX_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache


### PR DESCRIPTION
## Summary

Follow up on the failed Rust release after pnpm/pnpm#13051. The Visual Studio LLVM components were installed, but Cargo still used `cl.exe`; the release log shows both `ring` and `aws-lc-sys` selected the default/missing compiler instead of `clang-cl`.

Wait for `clang-cl.exe` to be available after the installer runs, verify it, and export its resolved path through `CC_aarch64_pc_windows_msvc`. This covers both pacquet and pnpr Windows ARM64 release builds.

Related failed job: https://github.com/pnpm/pnpm/actions/runs/29451537207/job/87475018266

## Squash Commit Body

```text
Select clang for Windows ARM64 release builds.

The prior release fix installed the Visual Studio LLVM components but did not
select clang-cl for Cargo. Wait for the compiler and export it for the ARM64
target so ring and aws-lc-sys do not fall back to cl.exe.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.

---

Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786742751&installation_id=145934176&pr_number=13052&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13052&signature=0c2d7e3ea0c8c23938e2a1adf5e6e12464b69b26d8c9cecaca6cfdeb9136039d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Windows ARM64 release build preparation by automatically locating the Clang compiler after Visual Studio setup.
  * Added a short wait period with clear failure behavior if the compiler is not found.
  * Ensures the ARM64 build uses the discovered compiler consistently for successful cross-compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->