### PR TITLE
fix(release): use x64 host clang for Windows ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,10 +381,8 @@ jobs:
           $clangCl = $null
           do {
             $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
-            $clangCl = @(
-              (Join-Path $llvmDir 'ARM64\bin\clang-cl.exe'),
-              (Join-Path $llvmDir 'x64\bin\clang-cl.exe')
-            ) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+            $clangCl = Join-Path $llvmDir 'x64\bin\clang-cl.exe'
+            if (-not (Test-Path -LiteralPath $clangCl)) { $clangCl = $null }
             if ($installerRunning -or $null -eq $clangCl) { Start-Sleep -Seconds 5 }
           } while (($installerRunning -or $null -eq $clangCl) -and (Get-Date) -lt $deadline)
           if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }
@@ -772,10 +770,8 @@ jobs:
           $clangCl = $null
           do {
             $installerRunning = @(Get-Process -Name 'vs_installer', 'vs_setup', 'setup' -ErrorAction SilentlyContinue).Count -gt 0
-            $clangCl = @(
-              (Join-Path $llvmDir 'ARM64\bin\clang-cl.exe'),
-              (Join-Path $llvmDir 'x64\bin\clang-cl.exe')
-            ) | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+            $clangCl = Join-Path $llvmDir 'x64\bin\clang-cl.exe'
+            if (-not (Test-Path -LiteralPath $clangCl)) { $clangCl = $null }
             if ($installerRunning -or $null -eq $clangCl) { Start-Sleep -Seconds 5 }
           } while (($installerRunning -or $null -eq $clangCl) -and (Get-Date) -lt $deadline)
           if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }


### PR DESCRIPTION
## Summary

Fix the Windows ARM64 Rust release failure from https://github.com/pnpm/pnpm/actions/runs/29452369898/job/87477777637. The runner is x64, but the previous workflow selected the ARM64-host `clang-cl.exe`, which Windows cannot execute.

Keep the installer completion check, but select only `VC\Tools\Llvm\x64\bin\clang-cl.exe` and export it for the ARM64 target. This applies to both pacquet and pnpr release builds.

## Squash Commit Body

```text
Use the runnable x64-host clang-cl when cross-compiling release artifacts for Windows ARM64.

Visual Studio installs compiler binaries for more than one host architecture. The
release runner is x64, so selecting the ARM64-host executable fails before Cargo
can build the ARM64 target.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.

---

Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786743682&installation_id=145934176&pr_number=13053&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13053&signature=df5b9000935658dc9cad50ea653d0787bf2689629ee54182a76219622e288a49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows ARM64 release packaging by consistently selecting the intended Clang compiler.
  * Preserved validation and failure handling when the required compiler installation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->