### PR TITLE
fix(release): add clang to Windows ARM64 path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,8 +388,13 @@ jobs:
           if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }
           if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
           & $clangCl --version
+          $clangDir = Split-Path -Parent $clangCl
+          $clang = Join-Path $clangDir 'clang.exe'
+          if (-not (Test-Path -LiteralPath $clang)) { throw "clang was not installed under $clangDir" }
+          & $clang --version
           "CC_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
           "CXX_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
+          $clangDir >> $env:GITHUB_PATH
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache
@@ -777,8 +782,13 @@ jobs:
           if ($installerRunning) { throw 'Visual Studio installer did not finish within five minutes' }
           if ($null -eq $clangCl) { throw "clang-cl was not installed under $llvmDir" }
           & $clangCl --version
+          $clangDir = Split-Path -Parent $clangCl
+          $clang = Join-Path $clangDir 'clang.exe'
+          if (-not (Test-Path -LiteralPath $clang)) { throw "clang was not installed under $clangDir" }
+          & $clang --version
           "CC_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
           "CXX_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
+          $clangDir >> $env:GITHUB_PATH
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache


### PR DESCRIPTION
## Summary

Fix the Windows ARM64 pnpr release failure from https://github.com/pnpm/pnpm/actions/runs/29452919716/job/87479553115. The workflow correctly selects and exports `clang-cl.exe`, but `ring` intentionally invokes `clang` by name for this target. The LLVM directory was not on `PATH`, so that invocation failed.

Verify `clang.exe` alongside `clang-cl.exe` and add the LLVM bin directory to `GITHUB_PATH` for the subsequent Rust build. This applies to both pacquet and pnpr release jobs.

## Squash Commit Body

```text
Expose the Visual Studio LLVM directory to Windows ARM64 release builds.

ring invokes clang by name for the Windows ARM64 target, independently of the
target-specific CC setting. Adding the verified LLVM bin directory to PATH lets
that invocation resolve the same x64-host compiler installation.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.

---

Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786744146&installation_id=145934176&pr_number=13054&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13054&signature=fe12c0239d2402f2a92d15f09e65d59c557d983389f8e1d28272e50f4b55ab8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows ARM64 release builds by ensuring required LLVM tools are detected and available during packaging.
  * Added validation and version reporting for the Clang compiler to improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->