### PR TITLE
fix(release): configure MSVC for Windows ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,7 +373,7 @@ jobs:
         run: |
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
-          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --quiet --norestart
+          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart
           if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
           $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
           $deadline = (Get-Date).AddMinutes(5)
@@ -395,6 +395,15 @@ jobs:
           "CC_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
           "CXX_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
           $clangDir >> $env:GITHUB_PATH
+          $vcvarsall = Join-Path $installPath 'VC\Auxiliary\Build\vcvarsall.bat'
+          $targetEnvironment = cmd.exe /c "`"$vcvarsall`" amd64_arm64 > nul && set"
+          if ($LASTEXITCODE -ne 0) { throw "vcvarsall exited with $LASTEXITCODE" }
+          if (-not ($targetEnvironment -match '(?i)^LIB=.*\\arm64')) { throw 'vcvarsall did not configure ARM64 libraries' }
+          foreach ($line in $targetEnvironment) {
+            if ($line -match '^(INCLUDE|LIB|LIBPATH|PATH)=(.*)$') {
+              "$($matches[1])=$($matches[2])" >> $env:GITHUB_ENV
+            }
+          }
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache
@@ -767,7 +776,7 @@ jobs:
         run: |
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
           $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
-          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --quiet --norestart
+          & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe" modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --quiet --norestart
           if ($LASTEXITCODE -ne 0) { throw "Visual Studio installer exited with $LASTEXITCODE" }
           $llvmDir = Join-Path $installPath 'VC\Tools\Llvm'
           $deadline = (Get-Date).AddMinutes(5)
@@ -789,6 +798,15 @@ jobs:
           "CC_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
           "CXX_aarch64_pc_windows_msvc=$clangCl" >> $env:GITHUB_ENV
           $clangDir >> $env:GITHUB_PATH
+          $vcvarsall = Join-Path $installPath 'VC\Auxiliary\Build\vcvarsall.bat'
+          $targetEnvironment = cmd.exe /c "`"$vcvarsall`" amd64_arm64 > nul && set"
+          if ($LASTEXITCODE -ne 0) { throw "vcvarsall exited with $LASTEXITCODE" }
+          if (-not ($targetEnvironment -match '(?i)^LIB=.*\\arm64')) { throw 'vcvarsall did not configure ARM64 libraries' }
+          foreach ($line in $targetEnvironment) {
+            if ($line -match '^(INCLUDE|LIB|LIBPATH|PATH)=(.*)$') {
+              "$($matches[1])=$($matches[2])" >> $env:GITHUB_ENV
+            }
+          }
 
       # No build cache: GitHub Actions caches are writable by any workflow on
       # the default branch, so restoring one here would let a poisoned cache


### PR DESCRIPTION
## Summary

Fix the Windows ARM64 linker failure from https://github.com/pnpm/pnpm/actions/runs/29453420807/job/87481166699. The C code now compiles, but the final link receives x64 Windows SDK and MSVC libraries, causing `LNK4272` and unresolved C runtime symbols.

Install the ARM64 MSVC component and configure Visual Studio's supported `amd64_arm64` cross-target environment. Export its `PATH`, `INCLUDE`, `LIB`, and `LIBPATH` values for the following Rust build, while asserting that the resulting library path contains ARM64 libraries. This applies to both pacquet and pnpr release jobs.

## Squash Commit Body

```text
Configure the MSVC cross-target environment for Windows ARM64 release builds.

The LLVM compiler configuration allowed C sources to compile, but linking still
used x64 SDK and MSVC libraries. Install the ARM64 toolset and forward the
amd64_arm64 vcvarsall environment to the Rust build steps.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.

---

Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786745168&installation_id=145934176&pr_number=13055&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13055&signature=e393c70679f84e360f76b4681a57fd6ff6a9c4a91a63135b4db75496651834dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows ARM64 release builds by installing and configuring the required ARM64 compiler toolchain.
  * Added validation to ensure ARM64 build environment variables are correctly set before packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->