### PR TITLE
fix(lockfile): compare equivalent git specifiers

### DIFF
--- a/.changeset/fresh-gits-agree.md
+++ b/.changeset/fresh-gits-agree.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed frozen installs incorrectly treating equivalent Git dependency specifiers as a stale lockfile. See pnpm/pnpm#13039.

--- a/.changeset/fresh-gits-agree.md
+++ b/.changeset/fresh-gits-agree.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/lockfile.verification": patch
+"pnpm": patch
 "pacquet": patch
 ---
 
-Fixed frozen installs incorrectly treating equivalent Git dependency specifiers as a stale lockfile. See pnpm/pnpm#13039.
+Fixed frozen installs incorrectly treating equivalent Git dependency specifiers as a stale lockfile. See [#13039](https://github.com/pnpm/pnpm/issues/13039).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4388,6 +4388,7 @@ dependencies = [
  "pacquet-diagnostics",
  "pacquet-fs",
  "pacquet-package-manifest",
+ "pacquet-resolving-parse-wanted-dependency",
  "pipe-trait",
  "pretty_assertions",
  "serde",

--- a/pnpm/crates/lockfile/Cargo.toml
+++ b/pnpm/crates/lockfile/Cargo.toml
@@ -11,11 +11,12 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-pacquet-catalogs-types   = { workspace = true }
-pacquet-crypto-hash      = { workspace = true }
-pacquet-diagnostics      = { workspace = true }
-pacquet-fs               = { workspace = true }
-pacquet-package-manifest = { workspace = true }
+pacquet-catalogs-types                    = { workspace = true }
+pacquet-crypto-hash                       = { workspace = true }
+pacquet-diagnostics                       = { workspace = true }
+pacquet-fs                                = { workspace = true }
+pacquet-package-manifest                  = { workspace = true }
+pacquet-resolving-parse-wanted-dependency = { workspace = true }
 
 derive_more      = { workspace = true }
 indexmap         = { workspace = true }

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -17,6 +17,7 @@ use crate::{Lockfile, ProjectSnapshot};
 use derive_more::{Display, Error};
 use pacquet_catalogs_types::Catalogs;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_resolving_parse_wanted_dependency::git_specifiers_are_equivalent;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 #[derive(Clone, Copy)]
@@ -369,8 +370,10 @@ fn all_catalogs_are_up_to_date(
 ) -> bool {
     snapshot.iter().flat_map(|catalogs| catalogs.iter()).all(|(catalog_name, catalog)| {
         catalog.iter().all(|(alias, entry)| {
-            catalogs_config.get(catalog_name).and_then(|catalog| catalog.get(alias))
-                == Some(&entry.specifier)
+            catalogs_config
+                .get(catalog_name)
+                .and_then(|catalog| catalog.get(alias))
+                .is_some_and(|specifier| dependency_specifiers_equal(&entry.specifier, specifier))
         })
     })
 }
@@ -483,7 +486,7 @@ pub fn satisfies_package_manifest(
                 .and_then(|name| importer_field.and_then(|map| map.get(name)))
                 .map(|spec| spec.specifier.as_str());
             match importer_spec {
-                Some(spec) if spec == *manifest_spec => {}
+                Some(spec) if dependency_specifiers_equal(spec, manifest_spec) => {}
                 Some(spec) => {
                     return Err(StalenessReason::DepSpecifierMismatch {
                         field: field_name,
@@ -627,11 +630,15 @@ fn diff_flat_records(
     for k in lhs_keys.intersection(&rhs_keys) {
         let lhs_spec = &lockfile_specs[*k];
         let rhs_spec = &manifest_specs[*k];
-        if lhs_spec != rhs_spec {
+        if !dependency_specifiers_equal(lhs_spec, rhs_spec) {
             diff.modified.insert((**k).clone(), (lhs_spec.clone(), rhs_spec.clone()));
         }
     }
     diff
+}
+
+fn dependency_specifiers_equal(left: &str, right: &str) -> bool {
+    left == right || git_specifiers_are_equivalent(left, right)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/lockfile/src/freshness/tests.rs
+++ b/pnpm/crates/lockfile/src/freshness/tests.rs
@@ -60,6 +60,68 @@ fn matching_manifest_and_lockfile_satisfies() {
 }
 
 #[test]
+fn equivalent_git_specifiers_satisfy_manifest() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      is-positive:"
+        "        specifier: git+https://github.com/kevva/is-positive.git#97edff6"
+        "        version: git+https://github.com/kevva/is-positive.git#97edff6"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    let (_dir, manifest) = manifest_from_json(
+        r#"{
+        "name": "x",
+        "version": "1.0.0",
+        "dependencies": {
+            "is-positive": "git://github.com/kevva/is-positive#97edff6"
+        }
+    }"#,
+    );
+    satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+        .expect("equivalent git specifiers must satisfy the manifest");
+}
+
+#[test]
+fn different_git_specifiers_do_not_satisfy_manifest() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      is-positive:"
+        "        specifier: git+https://github.com/kevva/is-positive.git#97edff6"
+        "        version: git+https://github.com/kevva/is-positive.git#97edff6"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    for specifier in [
+        "git+https://gitlab.com/kevva/is-positive.git#97edff6",
+        "git+https://github.com/kevva/different.git#97edff6",
+        "git+https://github.com/kevva/is-positive.git#different",
+    ] {
+        let (_dir, manifest) = manifest_from_json(&format!(
+            r#"{{
+            "name": "x",
+            "version": "1.0.0",
+            "dependencies": {{
+                "is-positive": "{specifier}"
+            }}
+        }}"#,
+        ));
+        let error = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+            .expect_err("different git specifiers must leave the manifest stale");
+        assert!(
+            matches!(error, StalenessReason::SpecifiersDiffer(_)),
+            "SPECIFIER: {specifier}\nERROR: {error:?}",
+        );
+    }
+}
+
+#[test]
 fn manifest_adds_dep_returns_specifier_diff() {
     let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
         "lockfileVersion: '9.0'"
@@ -574,6 +636,28 @@ fn check_settings_passes_when_catalog_snapshot_matches_config() {
         BTreeMap::from([("react".to_string(), "^18.2.0".to_string())]),
     )]);
     assert!(check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs)).is_ok());
+}
+
+#[test]
+fn check_settings_accepts_equivalent_git_catalog_specifiers() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "catalogs:"
+        "  default:"
+        "    is-positive:"
+        "      specifier: git+https://github.com/kevva/is-positive.git#97edff6"
+        "      version: git+https://github.com/kevva/is-positive.git#97edff6"
+    })
+    .expect("parse lockfile with catalogs");
+    let catalogs = Catalogs::from([(
+        "default".to_string(),
+        BTreeMap::from([(
+            "is-positive".to_string(),
+            "github:kevva/is-positive#97edff6".to_string(),
+        )]),
+    )]);
+    check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs))
+        .expect("equivalent git catalog specifiers must be current");
 }
 
 #[test]

--- a/pnpm/crates/resolving-parse-wanted-dependency/src/git_specifier.rs
+++ b/pnpm/crates/resolving-parse-wanted-dependency/src/git_specifier.rs
@@ -2,7 +2,8 @@
 ///
 /// Hosted shortcuts and bare GitHub shortcuts compare with `git://`,
 /// `git+https://`, and hosted `https://` forms after adding or removing the
-/// conventional `.git` suffix. Authentication-bearing, query-bearing, SSH,
+/// conventional `.git` suffix. Hostnames compare case-insensitively; the
+/// repository path and ref do not. Authentication-bearing, query-bearing, SSH,
 /// and plain HTTP specifiers remain distinct.
 #[must_use]
 pub fn git_specifiers_are_equivalent(left: &str, right: &str) -> bool {
@@ -52,10 +53,12 @@ fn normalize_url(specifier: &str) -> Option<String> {
     {
         return None;
     }
-    if scheme.eq_ignore_ascii_case("https") && !is_known_host(host) && !path.ends_with(".git") {
+    // Hostnames are case-insensitive; the repository path and ref are not.
+    let host = host.to_ascii_lowercase();
+    if scheme.eq_ignore_ascii_case("https") && !is_known_host(&host) && !path.ends_with(".git") {
         return None;
     }
-    normalize_parts(host, path, committish)
+    normalize_parts(&host, path, committish)
 }
 
 fn normalize_parts(host: &str, path: &str, committish: Option<&str>) -> Option<String> {

--- a/pnpm/crates/resolving-parse-wanted-dependency/src/git_specifier.rs
+++ b/pnpm/crates/resolving-parse-wanted-dependency/src/git_specifier.rs
@@ -1,0 +1,102 @@
+/// Returns whether both inputs identify the same supported Git repository and ref.
+///
+/// Hosted shortcuts and bare GitHub shortcuts compare with `git://`,
+/// `git+https://`, and hosted `https://` forms after adding or removing the
+/// conventional `.git` suffix. Authentication-bearing, query-bearing, SSH,
+/// and plain HTTP specifiers remain distinct.
+#[must_use]
+pub fn git_specifiers_are_equivalent(left: &str, right: &str) -> bool {
+    let Some(left) = normalize_git_specifier(left) else {
+        return false;
+    };
+    let Some(right) = normalize_git_specifier(right) else {
+        return false;
+    };
+    left == right
+}
+
+fn normalize_git_specifier(specifier: &str) -> Option<String> {
+    normalize_shortcut(specifier).or_else(|| normalize_url(specifier))
+}
+
+fn normalize_shortcut(specifier: &str) -> Option<String> {
+    let (repository, committish) = split_committish(specifier)?;
+    let (host, path) = if let Some(path) = repository.strip_prefix("github:") {
+        ("github.com", path)
+    } else if let Some(path) = repository.strip_prefix("gitlab:") {
+        ("gitlab.com", path)
+    } else if let Some(path) = repository.strip_prefix("bitbucket:") {
+        ("bitbucket.org", path)
+    } else if is_github_shorthand(repository) {
+        ("github.com", repository)
+    } else {
+        return None;
+    };
+    normalize_parts(host, path, committish)
+}
+
+fn normalize_url(specifier: &str) -> Option<String> {
+    let (repository, committish) = split_committish(specifier)?;
+    let (scheme, location) = repository.split_once("://")?;
+    if !scheme.eq_ignore_ascii_case("git")
+        && !scheme.eq_ignore_ascii_case("git+https")
+        && !scheme.eq_ignore_ascii_case("https")
+    {
+        return None;
+    }
+    let (host, path) = location.split_once('/')?;
+    if host.is_empty()
+        || host.contains('@')
+        || host.contains('?')
+        || host.chars().any(char::is_whitespace)
+    {
+        return None;
+    }
+    if scheme.eq_ignore_ascii_case("https") && !is_known_host(host) && !path.ends_with(".git") {
+        return None;
+    }
+    normalize_parts(host, path, committish)
+}
+
+fn normalize_parts(host: &str, path: &str, committish: Option<&str>) -> Option<String> {
+    if path.is_empty()
+        || path.starts_with('/')
+        || path.ends_with('/')
+        || path.contains("//")
+        || path.contains('@')
+        || path.contains('?')
+        || path.chars().any(char::is_whitespace)
+        || path.split('/').any(str::is_empty)
+    {
+        return None;
+    }
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    if path.is_empty() || path.ends_with('/') {
+        return None;
+    }
+    match committish.filter(|committish| !committish.is_empty()) {
+        Some(committish) => Some(format!("git+https://{host}/{path}.git#{committish}")),
+        None => Some(format!("git+https://{host}/{path}.git")),
+    }
+}
+
+fn split_committish(specifier: &str) -> Option<(&str, Option<&str>)> {
+    let Some((repository, committish)) = specifier.split_once('#') else {
+        return Some((specifier, None));
+    };
+    (!committish.contains('#')).then_some((repository, Some(committish)))
+}
+
+fn is_github_shorthand(repository: &str) -> bool {
+    !repository.starts_with('.')
+        && !repository.chars().any(char::is_whitespace)
+        && !repository.contains([':', '@'])
+        && repository.split('/').count() == 2
+}
+
+fn is_known_host(host: &str) -> bool {
+    matches!(host, "github.com" | "gitlab.com" | "bitbucket.org")
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-parse-wanted-dependency/src/git_specifier/tests.rs
+++ b/pnpm/crates/resolving-parse-wanted-dependency/src/git_specifier/tests.rs
@@ -16,6 +16,10 @@ fn recognizes_equivalent_git_specifiers() {
         ("bitbucket:group/repository#main", "git+https://bitbucket.org/group/repository.git#main"),
         ("kevva/is-positive#97edff6", "https://github.com/kevva/is-positive.git#97edff6"),
         ("github:kevva/is-positive", "GIT+HTTPS://github.com/kevva/is-positive.git"),
+        (
+            "git+https://GitHub.com/kevva/is-positive.git#97edff6",
+            "git+https://github.com/kevva/is-positive.git#97edff6",
+        ),
     ] {
         assert!(git_specifiers_are_equivalent(left, right), "LEFT: {left}\nRIGHT: {right}");
     }
@@ -31,6 +35,7 @@ fn distinguishes_different_git_specifiers() {
         "git+https://github.com/kevva/is-positive.git#different",
         "git+ssh://git@github.com/kevva/is-positive.git#97edff6",
         "https://example.com/not-a-git-dependency",
+        "git+https://github.com/kevva/Is-Positive.git#97edff6",
         "^1.0.0",
     ] {
         assert!(

--- a/pnpm/crates/resolving-parse-wanted-dependency/src/git_specifier/tests.rs
+++ b/pnpm/crates/resolving-parse-wanted-dependency/src/git_specifier/tests.rs
@@ -1,0 +1,45 @@
+use super::git_specifiers_are_equivalent;
+
+#[test]
+fn recognizes_equivalent_git_specifiers() {
+    for (left, right) in [
+        (
+            "git://github.com/kevva/is-positive.git#97edff6",
+            "git+https://github.com/kevva/is-positive.git#97edff6",
+        ),
+        ("git://github.com/org/lsp-mcp#main", "git+https://github.com/org/lsp-mcp.git#main"),
+        (
+            "github:kevva/is-positive#97edff6",
+            "git+https://github.com/kevva/is-positive.git#97edff6",
+        ),
+        ("gitlab:group/repository#main", "git+https://gitlab.com/group/repository.git#main"),
+        ("bitbucket:group/repository#main", "git+https://bitbucket.org/group/repository.git#main"),
+        ("kevva/is-positive#97edff6", "https://github.com/kevva/is-positive.git#97edff6"),
+        ("github:kevva/is-positive", "GIT+HTTPS://github.com/kevva/is-positive.git"),
+    ] {
+        assert!(git_specifiers_are_equivalent(left, right), "LEFT: {left}\nRIGHT: {right}");
+    }
+}
+
+#[test]
+fn distinguishes_different_git_specifiers() {
+    let canonical = "git+https://github.com/kevva/is-positive.git#97edff6";
+    for different in [
+        "git+https://gitlab.com/kevva/is-positive.git#97edff6",
+        "git+https://github.com/other/is-positive.git#97edff6",
+        "git+https://github.com/kevva/other.git#97edff6",
+        "git+https://github.com/kevva/is-positive.git#different",
+        "git+ssh://git@github.com/kevva/is-positive.git#97edff6",
+        "https://example.com/not-a-git-dependency",
+        "^1.0.0",
+    ] {
+        assert!(
+            !git_specifiers_are_equivalent(canonical, different),
+            "LEFT: {canonical}\nRIGHT: {different}",
+        );
+        assert!(
+            !git_specifiers_are_equivalent(different, canonical),
+            "LEFT: {different}\nRIGHT: {canonical}",
+        );
+    }
+}

--- a/pnpm/crates/resolving-parse-wanted-dependency/src/lib.rs
+++ b/pnpm/crates/resolving-parse-wanted-dependency/src/lib.rs
@@ -1,10 +1,13 @@
-//! Splits a raw dependency string from the manifest (or the CLI's `add`
-//! argument) into its `(alias, bareSpecifier)` halves so the downstream
-//! resolvers can decide which protocol is at play.
+//! Parses dependency strings before resolver dispatch. This crate splits a
+//! raw manifest or `add` argument into its `(alias, bareSpecifier)` halves and
+//! compares the supported equivalent forms of Git specifiers.
 
 pub mod validate_npm_package_name;
 
+pub use git_specifier::git_specifiers_are_equivalent;
 pub use validate_npm_package_name::is_valid_old_npm_package_name;
+
+mod git_specifier;
 
 /// The `(alias, bareSpecifier)` split for a raw dependency string. At
 /// least one of the two fields is always populated.

--- a/pnpm11/lockfile/verification/src/allCatalogsAreUpToDate.ts
+++ b/pnpm11/lockfile/verification/src/allCatalogsAreUpToDate.ts
@@ -1,11 +1,13 @@
 import type { Catalogs } from '@pnpm/catalogs.types'
 import type { CatalogSnapshots } from '@pnpm/lockfile.types'
 
+import { dependencySpecifiersAreEqual } from './gitSpecifiersAreEquivalent.js'
+
 export function allCatalogsAreUpToDate (
   catalogsConfig: Catalogs,
   snapshot: CatalogSnapshots | undefined
 ): boolean {
   return Object.entries(snapshot ?? {})
     .every(([catalogName, catalog]) => Object.entries(catalog ?? {})
-      .every(([alias, entry]) => entry.specifier === catalogsConfig[catalogName]?.[alias]))
+      .every(([alias, entry]) => dependencySpecifiersAreEqual(entry.specifier, catalogsConfig[catalogName]?.[alias])))
 }

--- a/pnpm11/lockfile/verification/src/diffFlatRecords.ts
+++ b/pnpm11/lockfile/verification/src/diffFlatRecords.ts
@@ -18,7 +18,11 @@ export interface Diff<Key, Value> {
   modified: Array<Modified<Key, Value>>
 }
 
-export function diffFlatRecords<Key extends string | number | symbol, Value> (left: Record<Key, Value>, right: Record<Key, Value>): Diff<Key, Value> {
+export function diffFlatRecords<Key extends string | number | symbol, Value> (
+  left: Record<Key, Value>,
+  right: Record<Key, Value>,
+  areValuesEqual: (left: Value, right: Value) => boolean = (a, b) => a === b
+): Diff<Key, Value> {
   const result: Diff<Key, Value> = {
     added: [],
     removed: [],
@@ -28,7 +32,7 @@ export function diffFlatRecords<Key extends string | number | symbol, Value> (le
   for (const [key, value] of Object.entries(left) as Array<[Key, Value]>) {
     if (!Object.hasOwn(right, key)) {
       result.removed.push({ key, value })
-    } else if (value !== right[key]) {
+    } else if (!areValuesEqual(value, right[key])) {
       result.modified.push({ key, left: value, right: right[key] })
     }
   }

--- a/pnpm11/lockfile/verification/src/gitSpecifiersAreEquivalent.ts
+++ b/pnpm11/lockfile/verification/src/gitSpecifiersAreEquivalent.ts
@@ -1,0 +1,115 @@
+const KNOWN_HOSTS = new Set(['github.com', 'gitlab.com', 'bitbucket.org'])
+
+/**
+ * `true` when a lockfile specifier and a manifest specifier denote the same
+ * dependency. Falls back to Git specifier equivalence when they aren't byte
+ * equal, so a lockfile written with the canonical `git+https://….git#<sha>`
+ * form still satisfies a manifest that uses `git://`, a hosted shortcut, or
+ * the bare `owner/repo` form. `undefined` on either side is never equal to a
+ * present specifier.
+ */
+export function dependencySpecifiersAreEqual (
+  lockfileSpecifier: string | undefined,
+  manifestSpecifier: string | undefined
+): boolean {
+  if (lockfileSpecifier === manifestSpecifier) return true
+  if (lockfileSpecifier == null || manifestSpecifier == null) return false
+  return gitSpecifiersAreEquivalent(lockfileSpecifier, manifestSpecifier)
+}
+
+/**
+ * Returns whether both inputs identify the same supported Git repository and
+ * ref. Hosted shortcuts and bare GitHub shortcuts compare with `git://`,
+ * `git+https://`, and hosted `https://` forms after adding or removing the
+ * conventional `.git` suffix. Authentication-bearing, query-bearing, SSH, and
+ * plain HTTP specifiers remain distinct.
+ */
+export function gitSpecifiersAreEquivalent (left: string, right: string): boolean {
+  const normalizedLeft = normalizeGitSpecifier(left)
+  if (normalizedLeft == null) return false
+  const normalizedRight = normalizeGitSpecifier(right)
+  if (normalizedRight == null) return false
+  return normalizedLeft === normalizedRight
+}
+
+function normalizeGitSpecifier (specifier: string): string | undefined {
+  return normalizeShortcut(specifier) ?? normalizeUrl(specifier)
+}
+
+function normalizeShortcut (specifier: string): string | undefined {
+  const split = splitCommittish(specifier)
+  if (split == null) return undefined
+  const { repository, committish } = split
+  let host: string
+  let path: string
+  if (repository.startsWith('github:')) {
+    host = 'github.com'
+    path = repository.slice('github:'.length)
+  } else if (repository.startsWith('gitlab:')) {
+    host = 'gitlab.com'
+    path = repository.slice('gitlab:'.length)
+  } else if (repository.startsWith('bitbucket:')) {
+    host = 'bitbucket.org'
+    path = repository.slice('bitbucket:'.length)
+  } else if (isGithubShorthand(repository)) {
+    host = 'github.com'
+    path = repository
+  } else {
+    return undefined
+  }
+  return normalizeParts(host, path, committish)
+}
+
+function normalizeUrl (specifier: string): string | undefined {
+  const split = splitCommittish(specifier)
+  if (split == null) return undefined
+  const { repository, committish } = split
+  const schemeEnd = repository.indexOf('://')
+  if (schemeEnd === -1) return undefined
+  const scheme = repository.slice(0, schemeEnd).toLowerCase()
+  if (scheme !== 'git' && scheme !== 'git+https' && scheme !== 'https') return undefined
+  const location = repository.slice(schemeEnd + '://'.length)
+  const slash = location.indexOf('/')
+  if (slash === -1) return undefined
+  const host = location.slice(0, slash)
+  const path = location.slice(slash + 1)
+  if (host === '' || host.includes('@') || host.includes('?') || /\s/.test(host)) return undefined
+  if (scheme === 'https' && !KNOWN_HOSTS.has(host) && !path.endsWith('.git')) return undefined
+  return normalizeParts(host, path, committish)
+}
+
+function normalizeParts (host: string, path: string, committish: string | undefined): string | undefined {
+  if (
+    path === '' ||
+    path.startsWith('/') ||
+    path.endsWith('/') ||
+    path.includes('//') ||
+    path.includes('@') ||
+    path.includes('?') ||
+    /\s/.test(path) ||
+    path.split('/').some((segment) => segment === '')
+  ) {
+    return undefined
+  }
+  const repositoryPath = path.endsWith('.git') ? path.slice(0, -'.git'.length) : path
+  if (repositoryPath === '' || repositoryPath.endsWith('/')) return undefined
+  return committish != null && committish !== ''
+    ? `git+https://${host}/${repositoryPath}.git#${committish}`
+    : `git+https://${host}/${repositoryPath}.git`
+}
+
+function splitCommittish (specifier: string): { repository: string, committish: string | undefined } | undefined {
+  const hashIndex = specifier.indexOf('#')
+  if (hashIndex === -1) return { repository: specifier, committish: undefined }
+  const committish = specifier.slice(hashIndex + 1)
+  if (committish.includes('#')) return undefined
+  return { repository: specifier.slice(0, hashIndex), committish }
+}
+
+function isGithubShorthand (repository: string): boolean {
+  return !repository.startsWith('.') &&
+    !/\s/.test(repository) &&
+    !repository.includes(':') &&
+    !repository.includes('@') &&
+    repository.split('/').length === 2
+}

--- a/pnpm11/lockfile/verification/src/gitSpecifiersAreEquivalent.ts
+++ b/pnpm11/lockfile/verification/src/gitSpecifiersAreEquivalent.ts
@@ -21,8 +21,9 @@ export function dependencySpecifiersAreEqual (
  * Returns whether both inputs identify the same supported Git repository and
  * ref. Hosted shortcuts and bare GitHub shortcuts compare with `git://`,
  * `git+https://`, and hosted `https://` forms after adding or removing the
- * conventional `.git` suffix. Authentication-bearing, query-bearing, SSH, and
- * plain HTTP specifiers remain distinct.
+ * conventional `.git` suffix. Hostnames compare case-insensitively; the
+ * repository path and ref do not. Authentication-bearing, query-bearing, SSH,
+ * and plain HTTP specifiers remain distinct.
  */
 export function gitSpecifiersAreEquivalent (left: string, right: string): boolean {
   const normalizedLeft = normalizeGitSpecifier(left)
@@ -71,7 +72,8 @@ function normalizeUrl (specifier: string): string | undefined {
   const location = repository.slice(schemeEnd + '://'.length)
   const slash = location.indexOf('/')
   if (slash === -1) return undefined
-  const host = location.slice(0, slash)
+  // Hostnames are case-insensitive; the repository path and ref are not.
+  const host = location.slice(0, slash).toLowerCase()
   const path = location.slice(slash + 1)
   if (host === '' || host.includes('@') || host.includes('?') || /\s/.test(host)) return undefined
   if (scheme === 'https' && !KNOWN_HOSTS.has(host) && !path.endsWith('.git')) return undefined

--- a/pnpm11/lockfile/verification/src/satisfiesPackageManifest.ts
+++ b/pnpm11/lockfile/verification/src/satisfiesPackageManifest.ts
@@ -8,6 +8,7 @@ import { equals, omit, pickBy } from 'ramda'
 import semver from 'semver'
 
 import { type Diff, diffFlatRecords, isEqual } from './diffFlatRecords.js'
+import { dependencySpecifiersAreEqual } from './gitSpecifiersAreEquivalent.js'
 
 export function satisfiesPackageManifest (
   opts: {
@@ -38,7 +39,7 @@ export function satisfiesPackageManifest (
     existingDeps = pickNonLinkedDeps(existingDeps)
     specs = pickNonLinkedDeps(specs)
   }
-  const specsDiff = diffFlatRecords(specs, existingDeps)
+  const specsDiff = diffFlatRecords(specs, existingDeps, dependencySpecifiersAreEqual)
   if (!isEqual(specsDiff)) {
     return {
       satisfies: false,
@@ -90,7 +91,7 @@ export function satisfiesPackageManifest (
       }
     }
     for (const depName of pkgDepNames) {
-      if (!importerDeps[depName] || importer.specifiers?.[depName] !== pkgDeps[depName]) {
+      if (!importerDeps[depName] || !dependencySpecifiersAreEqual(importer.specifiers?.[depName], pkgDeps[depName])) {
         return {
           satisfies: false,
           detailedReason: `importer ${depField}.${depName} specifier ${importer.specifiers[depName]} don't match package manifest specifier (${pkgDeps[depName]})`,

--- a/pnpm11/lockfile/verification/test/allCatalogsAreUpToDate.test.ts
+++ b/pnpm11/lockfile/verification/test/allCatalogsAreUpToDate.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@jest/globals'
+import { allCatalogsAreUpToDate } from '@pnpm/lockfile.verification'
+
+test('allCatalogsAreUpToDate() accepts an equivalent Git catalog specifier', () => {
+  expect(allCatalogsAreUpToDate(
+    { default: { 'is-positive': 'github:kevva/is-positive#97edff6' } },
+    {
+      default: {
+        'is-positive': {
+          specifier: 'git+https://github.com/kevva/is-positive.git#97edff6',
+          version: 'git+https://github.com/kevva/is-positive.git#97edff6',
+        },
+      },
+    }
+  )).toBe(true)
+})
+
+test('allCatalogsAreUpToDate() reports drift for a different Git catalog specifier', () => {
+  expect(allCatalogsAreUpToDate(
+    { default: { 'is-positive': 'github:kevva/different#97edff6' } },
+    {
+      default: {
+        'is-positive': {
+          specifier: 'git+https://github.com/kevva/is-positive.git#97edff6',
+          version: 'git+https://github.com/kevva/is-positive.git#97edff6',
+        },
+      },
+    }
+  )).toBe(false)
+})
+
+test('allCatalogsAreUpToDate() still matches plain specifiers', () => {
+  expect(allCatalogsAreUpToDate(
+    { default: { react: '^18.2.0' } },
+    { default: { react: { specifier: '^18.2.0', version: '18.2.0' } } }
+  )).toBe(true)
+})

--- a/pnpm11/lockfile/verification/test/gitSpecifiersAreEquivalent.test.ts
+++ b/pnpm11/lockfile/verification/test/gitSpecifiersAreEquivalent.test.ts
@@ -14,6 +14,10 @@ test('recognizes equivalent git specifiers', () => {
     ['bitbucket:group/repository#main', 'git+https://bitbucket.org/group/repository.git#main'],
     ['kevva/is-positive#97edff6', 'https://github.com/kevva/is-positive.git#97edff6'],
     ['github:kevva/is-positive', 'GIT+HTTPS://github.com/kevva/is-positive.git'],
+    [
+      'git+https://GitHub.com/kevva/is-positive.git#97edff6',
+      'git+https://github.com/kevva/is-positive.git#97edff6',
+    ],
   ]) {
     expect(gitSpecifiersAreEquivalent(left, right)).toBe(true)
     expect(gitSpecifiersAreEquivalent(right, left)).toBe(true)
@@ -29,6 +33,7 @@ test('distinguishes different git specifiers', () => {
     'git+https://github.com/kevva/is-positive.git#different',
     'git+ssh://git@github.com/kevva/is-positive.git#97edff6',
     'https://example.com/not-a-git-dependency',
+    'git+https://github.com/kevva/Is-Positive.git#97edff6',
     '^1.0.0',
   ]) {
     expect(gitSpecifiersAreEquivalent(canonical, different)).toBe(false)

--- a/pnpm11/lockfile/verification/test/gitSpecifiersAreEquivalent.test.ts
+++ b/pnpm11/lockfile/verification/test/gitSpecifiersAreEquivalent.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@jest/globals'
+
+import { gitSpecifiersAreEquivalent } from '../src/gitSpecifiersAreEquivalent.js'
+
+test('recognizes equivalent git specifiers', () => {
+  for (const [left, right] of [
+    [
+      'git://github.com/kevva/is-positive.git#97edff6',
+      'git+https://github.com/kevva/is-positive.git#97edff6',
+    ],
+    ['git://github.com/org/lsp-mcp#main', 'git+https://github.com/org/lsp-mcp.git#main'],
+    ['github:kevva/is-positive#97edff6', 'git+https://github.com/kevva/is-positive.git#97edff6'],
+    ['gitlab:group/repository#main', 'git+https://gitlab.com/group/repository.git#main'],
+    ['bitbucket:group/repository#main', 'git+https://bitbucket.org/group/repository.git#main'],
+    ['kevva/is-positive#97edff6', 'https://github.com/kevva/is-positive.git#97edff6'],
+    ['github:kevva/is-positive', 'GIT+HTTPS://github.com/kevva/is-positive.git'],
+  ]) {
+    expect(gitSpecifiersAreEquivalent(left, right)).toBe(true)
+    expect(gitSpecifiersAreEquivalent(right, left)).toBe(true)
+  }
+})
+
+test('distinguishes different git specifiers', () => {
+  const canonical = 'git+https://github.com/kevva/is-positive.git#97edff6'
+  for (const different of [
+    'git+https://gitlab.com/kevva/is-positive.git#97edff6',
+    'git+https://github.com/other/is-positive.git#97edff6',
+    'git+https://github.com/kevva/other.git#97edff6',
+    'git+https://github.com/kevva/is-positive.git#different',
+    'git+ssh://git@github.com/kevva/is-positive.git#97edff6',
+    'https://example.com/not-a-git-dependency',
+    '^1.0.0',
+  ]) {
+    expect(gitSpecifiersAreEquivalent(canonical, different)).toBe(false)
+    expect(gitSpecifiersAreEquivalent(different, canonical)).toBe(false)
+  }
+})

--- a/pnpm11/lockfile/verification/test/satisfiesPackageManifest.ts
+++ b/pnpm11/lockfile/verification/test/satisfiesPackageManifest.ts
@@ -395,4 +395,38 @@ test('satisfiesPackageManifest()', () => {
     satisfies: false,
     detailedReason: 'The importer resolution is broken at dependency "@apollo/client": version "3.13.8" doesn\'t satisfy range "3.3.7"',
   })
+
+  // Equivalent Git specifiers (the lockfile records the canonical
+  // `git+https://….git#<sha>` form pnpm writes, the manifest keeps `git://…`)
+  // must satisfy. https://github.com/pnpm/pnpm/issues/13039
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { 'is-positive': 'git+https://github.com/kevva/is-positive.git#97edff6' },
+      specifiers: { 'is-positive': 'git+https://github.com/kevva/is-positive.git#97edff6' },
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { 'is-positive': 'git://github.com/kevva/is-positive.git#97edff6' },
+    }
+  )).toStrictEqual({ satisfies: true })
+
+  // A different Git repository/ref stays stale.
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      dependencies: { 'is-positive': 'git+https://github.com/kevva/is-positive.git#97edff6' },
+      specifiers: { 'is-positive': 'git+https://github.com/kevva/is-positive.git#97edff6' },
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      dependencies: { 'is-positive': 'git+https://github.com/kevva/different.git#97edff6' },
+    }
+  )).toStrictEqual({
+    satisfies: false,
+    detailedReason: `specifiers in the lockfile don't match specifiers in package.json:
+* 1 dependencies are mismatched:
+  - is-positive (lockfile: git+https://github.com/kevva/is-positive.git#97edff6, manifest: git+https://github.com/kevva/different.git#97edff6)
+`,
+  })
 })


### PR DESCRIPTION
## Summary

Both pnpm stacks compared Git dependency specifiers byte-for-byte during lockfile freshness checks, so a lockfile that records the canonical `git+https://….git#<sha>` form was rejected as stale when a manifest or catalog used an equivalent form (`git://`, a `github:`/`gitlab:`/`bitbucket:` shortcut, a bare `owner/repo`, or a missing `.git` suffix).

Add a Git specifier equivalence check and apply it at every freshness comparison gate — importer specifiers, per-dependency checks, and catalog entries — in **both** stacks. Repository hosts, paths, and refs remain distinct; authentication-bearing, query-bearing, SSH, and plain-HTTP specifiers are never treated as equivalent.

- **pacquet (Rust):** a cycle-safe helper in the leaf `resolving-parse-wanted-dependency` crate, used from `lockfile`'s freshness check.
- **TypeScript pnpm:** the same equivalence relation in `@pnpm/lockfile.verification` (`satisfiesPackageManifest`, `diffFlatRecords`, `allCatalogsAreUpToDate`), so both implementations agree byte-for-byte. (The in-repo TypeScript freshness check previously used raw string comparison, so the fix is applied here too rather than assuming parity.)

Closes pnpm/pnpm#13039.

Validation:

- **Rust:** `cargo nextest run -p pacquet-lockfile -p pacquet-resolving-parse-wanted-dependency` — 256 tests passed; `cargo fmt --check`, `cargo clippy --all-targets --workspace`, and `cargo dylint` clean.
- **TypeScript:** `pnpm --filter @pnpm/lockfile.verification test` — compiles and 28 tests pass.
- Full pre-push workspace checks pass (TypeScript compile + lint, Rust fmt/clippy/doc/dylint/typos/taplo).

## Squash Commit Body

```text
Lockfile freshness compared importer and catalog Git specifiers as raw strings
in both the Rust (pacquet) and TypeScript stacks, so a canonical git+https
lockfile entry was rejected when a manifest or catalog used git:// or a hosted
shortcut.

Add a Git specifier equivalence check and apply it at every freshness
comparison gate — importer specifiers, per-dependency checks, and catalog
entries — in both stacks. Preserve host, repository, and ref differences while
accepting supported protocol, shortcut, and .git suffix representations.

Closes pnpm/pnpm#13039.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Prepared with agent assistance from Codex (GPT-5). TypeScript parity mirror and this description update by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786746505&installation_id=145934176&pr_number=13056&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13056&signature=b3ecea6817992f28fc2b76958bf9b71b8a6440df65cfb0d59ca0250a4c973840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Frozen installs no longer incorrectly report stale lockfiles when Git dependency specifiers are different but equivalent (e.g., shorthand vs canonical forms).
  * Lockfile freshness checks and catalog/manifest comparisons now treat equivalent Git specifiers as matching, including during settings drift detection and flat record diffing.
* **Tests**
  * Added Jest/Rust coverage for Git specifier normalization/equivalence and for verifying correct stale/non-stale outcomes across catalog and manifest validation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
