### PR TITLE
chore: update lockfile, Node.js, and pnpm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "shx": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@12.0.0-alpha.12",
+  "packageManager": "pnpm@12.0.0-alpha.13",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "12.0.0-alpha.12",
+      "version": "12.0.0-alpha.13",
       "onFail": "download"
     },
     "runtime": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,115 +7,115 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 12.0.0-alpha.12
-        version: 12.0.0-alpha.12
+        specifier: 12.0.0-alpha.13
+        version: 12.0.0-alpha.13
       pnpm:
-        specifier: 12.0.0-alpha.12
-        version: 12.0.0-alpha.12
+        specifier: 12.0.0-alpha.13
+        version: 12.0.0-alpha.13
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.12':
-    resolution: {integrity: sha512-yhC9K7LEOu9cfWRcjPGffzt3uhzk9RK/Pg9iVzzW1hkDxq0UCjP+IV/DNE7Wbo7dGlqAoQOTWe9/cYWRDFEOaA==}
+  '@pnpm/exe.darwin-arm64@12.0.0-alpha.13':
+    resolution: {integrity: sha512-89yh3Pli/xAKwvf6PEeCoMv2niK1OdQwnGMTv1FHT6en/r+Y3WPCUuovDLNs2JYntoWgVrAadmKzn0zMP1Fy5Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.12':
-    resolution: {integrity: sha512-Pt4HhdbAZiQDunRerxcBLiMCW69SO4DSy3M34p0vWM+lAavNU0O725LsG2TNV5wo7c06k6vT/c1es/2byoLHnQ==}
+  '@pnpm/exe.darwin-x64@12.0.0-alpha.13':
+    resolution: {integrity: sha512-/2qIm10bu6CHtxa76hk7cNGhkApo52+d8Gqr9m6bPe+K4wB9blJ5s2TttRAXnMZUnjpi3486u72tu4nm5YikJQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.12':
-    resolution: {integrity: sha512-ibuujYbiUEQ+oLkJsqlELU9pKymfdsYlk8CLudzZ6cAyAuNpSC7usTRZ4NCERJ9Qf2rccbMPz46XKxVeuUA0ow==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.13':
+    resolution: {integrity: sha512-Z4z7Y2Ph/uhgt2PrdU+8LJw+J4ovdm9vzSc1RehvIZaeKnEiotBjeuVHBSzhjZ6HFhrBN0yAwHaZ20zk19wrtA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.12':
-    resolution: {integrity: sha512-lZ3iNZG+mxOelhOQMhLg3J99ayFi+u8GC58lxI2PJplfzuptSyTA4AMBy9Uq6wxDedVq4kYMhJ51NJa84nDkpQ==}
+  '@pnpm/exe.linux-arm64@12.0.0-alpha.13':
+    resolution: {integrity: sha512-cNFtuMJU2/J9uFyXS1CH9tIAU5rYtRZsqvR26UmrEbWi0Z7CGzUHQ16QGg5mA3bQO4ifH5btMIpsE8bYVRhkcQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.12':
-    resolution: {integrity: sha512-v+9mcVvtN3YFbKxqAIn84C+iSs6V4PvNMt15CUG0slQ+9yL0pvQi+IHHvjRHRMxTEIHnuIVUjHDgQgQae28FWA==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.13':
+    resolution: {integrity: sha512-pM3AhLXR/vgsxIq9d1Sa5Sfk/Cu69Vfy+ORRuouBT+I5Z2fb3AKDEJT7x4+x1hR22hce9SiGPdonxfyfdiymbg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-alpha.12':
-    resolution: {integrity: sha512-u6r20bzZqdTh0nX72bod452EWKQouBeUgQMKwFpXYvFSxBn1a7E8leFEL67UMpgSDgiKhHHL+QYf+7/Hajp5Lw==}
+  '@pnpm/exe.linux-x64@12.0.0-alpha.13':
+    resolution: {integrity: sha512-lQAKnnUGB3TOHmIqJnZCJx0rKMS4ipdtW2SoDc6RVM+37Obq1F8lK7yS7P32g1DZLnNdbjLxshQw2CszthCqww==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.12':
-    resolution: {integrity: sha512-P3ZMTGMpptHifGIktu58dMI8BUmu5gTDk+dLku4VYdb8lC2eR5xz/TimGh5tNdCCFeYtz4wOIN6mylPMVWW+Fw==}
+  '@pnpm/exe.win32-arm64@12.0.0-alpha.13':
+    resolution: {integrity: sha512-fzfV76v41Ln4RxhOF88uOcIKXMROWEiwBNcKrfnPfjxlIEhAwVL4zNnwg3aQUgjEecduRr7WNPKtZa+CNhc1JA==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-alpha.12':
-    resolution: {integrity: sha512-djCQaGtKa7Z+2cS2eKzgEcBRHv3cHbX8X5d9O022wDdP1Lo2brLhjJg92ubONMzhS0UJb8oz6WeV3N+EtTu7nQ==}
+  '@pnpm/exe.win32-x64@12.0.0-alpha.13':
+    resolution: {integrity: sha512-lSA7yJdwY5qRZml9eTv+kyGSe1iOWEe3O0z05zFn/SBnIrag9yDsSdkzJuqlndhImUDOY+P652H5rAX8ePFeAw==}
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0-alpha.12':
-    resolution: {integrity: sha512-M/Yy0fe0tFTu7/1+27Ak8IWJ+9GO9ulg2E5C7tf95hyk9FYfP35FBzKfZmBhEdOJDZeKBlklBC5xeHT+tCtkPg==}
+  '@pnpm/exe@12.0.0-alpha.13':
+    resolution: {integrity: sha512-hmf6jKAoZRz5lV+zGmvQVt9N/WdKNXcoBeR2CpwpF3wYPTTr+yoeLl6dv9JQqAi0KFWDfYAV/o43vdvAUB7weQ==}
     engines: {node: '>=18.*'}
     hasBin: true
 
-  pnpm@12.0.0-alpha.12:
-    resolution: {integrity: sha512-DUIQ4O5saqCjCyqrD8wdluBMI7COHMj7+gOp1P5blVcRwI9ma1v+oMHwIf4drCBOfWsLdPoUkXN09IWKxKaORg==}
+  pnpm@12.0.0-alpha.13:
+    resolution: {integrity: sha512-fszjp9grIXCBd1W0QouI0Cf2zi7XZwfqY8+8xr9n7JoIqdfEXa+xZuwlrfMlnCWbBZH7c21Wby4RqR+iIxJacg==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.12':
+  '@pnpm/exe.darwin-arm64@12.0.0-alpha.13':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.12':
+  '@pnpm/exe.darwin-x64@12.0.0-alpha.13':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.12':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.13':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.12':
+  '@pnpm/exe.linux-arm64@12.0.0-alpha.13':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.12':
+  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.13':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-alpha.12':
+  '@pnpm/exe.linux-x64@12.0.0-alpha.13':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.12':
+  '@pnpm/exe.win32-arm64@12.0.0-alpha.13':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-alpha.12':
+  '@pnpm/exe.win32-x64@12.0.0-alpha.13':
     optional: true
 
-  '@pnpm/exe@12.0.0-alpha.12':
+  '@pnpm/exe@12.0.0-alpha.13':
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.12
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.12
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.12
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.12
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.12
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.12
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.12
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.12
+      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.13
+      '@pnpm/exe.darwin-x64': 12.0.0-alpha.13
+      '@pnpm/exe.linux-arm64': 12.0.0-alpha.13
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.13
+      '@pnpm/exe.linux-x64': 12.0.0-alpha.13
+      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.13
+      '@pnpm/exe.win32-arm64': 12.0.0-alpha.13
+      '@pnpm/exe.win32-x64': 12.0.0-alpha.13
 
-  pnpm@12.0.0-alpha.12:
+  pnpm@12.0.0-alpha.13:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.12
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.12
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.12
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.12
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.12
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.12
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.12
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.12
+      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.13
+      '@pnpm/exe.darwin-x64': 12.0.0-alpha.13
+      '@pnpm/exe.linux-arm64': 12.0.0-alpha.13
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.13
+      '@pnpm/exe.linux-x64': 12.0.0-alpha.13
+      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.13
+      '@pnpm/exe.win32-arm64': 12.0.0-alpha.13
+      '@pnpm/exe.win32-x64': 12.0.0-alpha.13
 
 ---
 lockfileVersion: '9.0'
@@ -13369,8 +13369,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.389:
-    resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+  electron-to-chromium@1.5.391:
+    resolution: {integrity: sha512-YmCu4856jkgKT1Nh6fwRdeVrM6Ydf/fBnq51tpmSfX+jOcUMTxh31yH6hjKScRenhB2oDSvA9oooxcpjogPeig==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -20423,7 +20423,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
-      electron-to-chromium: 1.5.389
+      electron-to-chromium: 1.5.391
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
@@ -21023,7 +21023,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.389: {}
+  electron-to-chromium@1.5.391: {}
 
   emittery@0.13.1: {}
 


### PR DESCRIPTION
This automated PR refreshes the project's pinned versions:

- Updates the lockfile to the latest compatible versions of dependencies.
- Bumps Node.js to the latest 26.x release, propagated into the CI, release, and benchmark workflows via the meta-updater.
- Bumps pnpm to the latest `next-12` release (`packageManager` and `devEngines.packageManager`).

Created by the update-lockfile workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786746670&installation_id=145934176&pr_number=13057&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13057&signature=0e0cae5f966362e2df0b76e1949eab02129d3961298d2dfed644dec098868cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package manager configuration to the latest specified pnpm prerelease version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->