### PR TITLE
fix(resolving-git-resolver): read git package names during resolution

### DIFF
--- a/.changeset/git-importer-lockfile.md
+++ b/.changeset/git-importer-lockfile.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed a crash when writing lockfile entries for git-hosted dependencies.
+Fixed `pnpm install` aborting with a panic when a project depends on a git-hosted package [#13040](https://github.com/pnpm/pnpm/issues/13040).

--- a/.changeset/git-importer-lockfile.md
+++ b/.changeset/git-importer-lockfile.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed a crash when writing lockfile entries for git-hosted dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5023,6 +5023,7 @@ version = "0.0.1"
 dependencies = [
  "dashmap",
  "derive_more",
+ "flate2",
  "futures-util",
  "miette 7.6.0",
  "mockito",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4880,9 +4880,13 @@ dependencies = [
  "node-semver",
  "pacquet-lockfile",
  "pacquet-network",
+ "pacquet-reporter",
  "pacquet-resolving-resolver-base",
+ "pacquet-store-dir",
+ "pacquet-tarball",
  "pretty_assertions",
  "reqwest 0.13.4",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4878,6 +4878,7 @@ dependencies = [
  "derive_more",
  "miette 7.6.0",
  "node-semver",
+ "pacquet-git-fetcher",
  "pacquet-lockfile",
  "pacquet-network",
  "pacquet-reporter",

--- a/pnpm/crates/git-fetcher/src/error.rs
+++ b/pnpm/crates/git-fetcher/src/error.rs
@@ -78,6 +78,16 @@ pub enum GitFetcherError {
     #[diagnostic(code(INVALID_GIT_COMMIT))]
     InvalidCommit { commit: String, repo: String },
 
+    /// `resolution.repo` begins with `-`. Same class as
+    /// [`Self::InvalidCommit`]: git parses such a value as an option
+    /// rather than a repository, so `--upload-pack=<cmd>` reaches the
+    /// transport and runs `<cmd>`. The `--` end-of-options marker is
+    /// passed as well; this rejects the value outright rather than rely
+    /// on every subcommand honoring it.
+    #[display("Invalid git repository {repo:?}. A repository must not begin with '-'.")]
+    #[diagnostic(code(INVALID_GIT_REPOSITORY))]
+    InvalidRepo { repo: String },
+
     #[display("I/O error during git fetch: {_0}")]
     #[diagnostic(code(pacquet_git_fetcher::io))]
     Io(#[error(source)] std::io::Error),

--- a/pnpm/crates/git-fetcher/src/error.rs
+++ b/pnpm/crates/git-fetcher/src/error.rs
@@ -83,6 +83,9 @@ pub enum GitFetcherError {
     Io(#[error(source)] std::io::Error),
 
     #[diagnostic(transparent)]
+    ReadManifest(#[error(source)] pacquet_package_manifest::PackageManifestError),
+
+    #[diagnostic(transparent)]
     Prepare(#[error(source)] PreparePackageError),
 
     #[diagnostic(transparent)]

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -19,6 +19,7 @@ use pacquet_fs_packlist::packlist;
 use pacquet_package_manifest::safe_read_package_json_from_dir;
 use pacquet_reporter::Reporter;
 use pacquet_store_dir::{PackageFilesIndex, StoreDir, StoreIndexWriter};
+use serde_json::Value;
 use std::{
     collections::HashMap,
     fs,
@@ -97,37 +98,15 @@ impl GitFetcher<'_> {
     }
 
     fn run_sync<Reporter: self::Reporter>(self) -> Result<GitFetchOutput, GitFetcherError> {
-        if !is_valid_commit_hash(self.commit) {
-            return Err(GitFetcherError::InvalidCommit {
-                commit: self.commit.to_string(),
-                repo: self.repo.to_string(),
-            });
-        }
         let temp = tempfile::tempdir().map_err(GitFetcherError::Io)?;
         let temp_location = temp.path();
-
-        let git_bin = self.git_bin.unwrap_or_else(|| Path::new("git"));
-        if should_use_shallow(self.repo, self.git_shallow_hosts) {
-            exec_git_with(git_bin, &["init"], Some(temp_location))?;
-            exec_git_with(git_bin, &["remote", "add", "origin", self.repo], Some(temp_location))?;
-            exec_git_with(
-                git_bin,
-                &["fetch", "--depth", "1", "origin", self.commit],
-                Some(temp_location),
-            )?;
-        } else {
-            exec_git_with(git_bin, &["clone", self.repo, &temp_location.to_string_lossy()], None)?;
-        }
-
-        exec_git_with(git_bin, &["checkout", self.commit], Some(temp_location))?;
-        let received = exec_git_with(git_bin, &["rev-parse", "HEAD"], Some(temp_location))?;
-        let received_trimmed = received.trim();
-        if received_trimmed != self.commit {
-            return Err(GitFetcherError::CheckoutMismatch {
-                expected: self.commit.to_string(),
-                received: received_trimmed.to_string(),
-            });
-        }
+        checkout_commit(&CheckoutOptions {
+            repo: self.repo,
+            commit: self.commit,
+            git_shallow_hosts: self.git_shallow_hosts,
+            git_bin: self.git_bin,
+            dest: temp_location,
+        })?;
 
         // `extra_env` is a borrow rather than `Option<&HashMap>`.
         // Bind an empty map to a local so the borrow has the same lifetime
@@ -221,6 +200,103 @@ fn wrap_prepare_error(_repo: &str, err: PreparePackageError) -> GitFetcherError 
 
 /// True iff `commit` is exactly a 40-character hexadecimal git SHA,
 /// validated before the value reaches `git`.
+/// Inputs for [`checkout_commit`].
+pub struct CheckoutOptions<'a> {
+    pub repo: &'a str,
+    pub commit: &'a str,
+    /// See [`GitFetcher::git_shallow_hosts`].
+    pub git_shallow_hosts: &'a [String],
+    /// See [`GitFetcher::git_bin`].
+    pub git_bin: Option<&'a Path>,
+    /// Existing, empty directory to check the repo out into.
+    pub dest: &'a Path,
+}
+
+/// Materialize `repo` at `commit` into `dest`, verifying that the
+/// checkout landed on exactly the requested commit.
+///
+/// Shared by the install pass's [`GitFetcher`] and the resolve pass's
+/// [`read_git_manifest`], which need the same working tree for
+/// different reasons.
+pub fn checkout_commit(opts: &CheckoutOptions<'_>) -> Result<(), GitFetcherError> {
+    let &CheckoutOptions { repo, commit, git_shallow_hosts, git_bin, dest } = opts;
+    if !is_valid_commit_hash(commit) {
+        return Err(GitFetcherError::InvalidCommit {
+            commit: commit.to_string(),
+            repo: repo.to_string(),
+        });
+    }
+
+    let git_bin = git_bin.unwrap_or_else(|| Path::new("git"));
+    if should_use_shallow(repo, git_shallow_hosts) {
+        exec_git_with(git_bin, &["init"], Some(dest))?;
+        exec_git_with(git_bin, &["remote", "add", "origin", repo], Some(dest))?;
+        exec_git_with(git_bin, &["fetch", "--depth", "1", "origin", commit], Some(dest))?;
+    } else {
+        exec_git_with(git_bin, &["clone", repo, &dest.to_string_lossy()], None)?;
+    }
+
+    exec_git_with(git_bin, &["checkout", commit], Some(dest))?;
+    let received = exec_git_with(git_bin, &["rev-parse", "HEAD"], Some(dest))?;
+    let received_trimmed = received.trim();
+    if received_trimmed != commit {
+        return Err(GitFetcherError::CheckoutMismatch {
+            expected: commit.to_string(),
+            received: received_trimmed.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Inputs for [`read_git_manifest`].
+pub struct GitManifestQuery<'a> {
+    pub repo: &'a str,
+    pub commit: &'a str,
+    /// `path` field from the resolution — the directory within the repo
+    /// holding the package (`#path:/packages/foo`). `None` reads the
+    /// repo root.
+    pub path: Option<&'a str>,
+    /// See [`GitFetcher::git_shallow_hosts`].
+    pub git_shallow_hosts: &'a [String],
+    /// See [`GitFetcher::git_bin`].
+    pub git_bin: Option<&'a Path>,
+}
+
+/// Read the `package.json` of the package a `Git` resolution points at.
+///
+/// A git dep's specifier names a repo, not a package, so its name is
+/// only readable from a working tree. Unlike a git *host*, a plain repo
+/// serves no archive endpoint, so a throwaway checkout is the cheapest
+/// way to read it.
+///
+/// `None` when the package directory has no `package.json` — the caller
+/// degrades rather than failing.
+///
+/// Only the manifest is read: `prepare` / `prepublish` and the packlist
+/// stay in the install pass, so no package script runs here.
+pub async fn read_git_manifest(
+    query: GitManifestQuery<'_>,
+) -> Result<Option<Value>, GitFetcherError> {
+    tokio::task::block_in_place(|| {
+        let temp = tempfile::tempdir().map_err(GitFetcherError::Io)?;
+        checkout_commit(&CheckoutOptions {
+            repo: query.repo,
+            commit: query.commit,
+            git_shallow_hosts: query.git_shallow_hosts,
+            git_bin: query.git_bin,
+            dest: temp.path(),
+        })?;
+        // The leading slash of `#path:/packages/foo` is rooted at the
+        // repo, not the filesystem — same normalization the install
+        // pass's `prepare_package` applies.
+        let pkg_dir = match query.path.map(|path| path.trim_start_matches(['/', '\\'])) {
+            Some(path) if !path.is_empty() => temp.path().join(path),
+            _ => temp.path().to_path_buf(),
+        };
+        safe_read_package_json_from_dir(&pkg_dir).map_err(GitFetcherError::ReadManifest)
+    })
+}
+
 fn is_valid_commit_hash(commit: &str) -> bool {
     commit.len() == 40 && commit.bytes().all(|b| b.is_ascii_hexdigit())
 }

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -12,7 +12,9 @@
 use crate::{
     cas_io::{ImportedFiles, import_into_cas},
     error::{GitFetcherError, PreparePackageError},
-    prepare_package::{AllowBuildRef, PreparePackageOptions, PreparedPackage, prepare_package},
+    prepare_package::{
+        AllowBuildRef, PreparePackageOptions, PreparedPackage, prepare_package, safe_join_path,
+    },
 };
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_fs_packlist::packlist;
@@ -226,14 +228,19 @@ pub fn checkout_commit(opts: &CheckoutOptions<'_>) -> Result<(), GitFetcherError
             repo: repo.to_string(),
         });
     }
+    if !is_safe_repo_arg(repo) {
+        return Err(GitFetcherError::InvalidRepo { repo: repo.to_string() });
+    }
 
     let git_bin = git_bin.unwrap_or_else(|| Path::new("git"));
+    // `--` keeps the repository positional out of git's option parser,
+    // belt and braces with the `is_safe_repo_arg` check above.
     if should_use_shallow(repo, git_shallow_hosts) {
         exec_git_with(git_bin, &["init"], Some(dest))?;
-        exec_git_with(git_bin, &["remote", "add", "origin", repo], Some(dest))?;
+        exec_git_with(git_bin, &["remote", "add", "origin", "--", repo], Some(dest))?;
         exec_git_with(git_bin, &["fetch", "--depth", "1", "origin", commit], Some(dest))?;
     } else {
-        exec_git_with(git_bin, &["clone", repo, &dest.to_string_lossy()], None)?;
+        exec_git_with(git_bin, &["clone", "--", repo, &dest.to_string_lossy()], None)?;
     }
 
     exec_git_with(git_bin, &["checkout", commit], Some(dest))?;
@@ -286,19 +293,28 @@ pub async fn read_git_manifest(
             git_bin: query.git_bin,
             dest: temp.path(),
         })?;
-        // The leading slash of `#path:/packages/foo` is rooted at the
-        // repo, not the filesystem — same normalization the install
-        // pass's `prepare_package` applies.
-        let pkg_dir = match query.path.map(|path| path.trim_start_matches(['/', '\\'])) {
-            Some(path) if !path.is_empty() => temp.path().join(path),
-            _ => temp.path().to_path_buf(),
-        };
+        // Same guarded join the install pass uses: the sub-path is
+        // repo-rooted, and a `path` that climbs out of the checkout
+        // must not reach `safe_read_package_json_from_dir`, which would
+        // happily read an arbitrary `package.json` off the host and
+        // stamp its name onto this dep.
+        let pkg_dir = safe_join_path(temp.path(), query.path).map_err(GitFetcherError::Prepare)?;
         safe_read_package_json_from_dir(&pkg_dir).map_err(GitFetcherError::ReadManifest)
     })
 }
 
 fn is_valid_commit_hash(commit: &str) -> bool {
     commit.len() == 40 && commit.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// True iff `repo` is safe to pass to git as a repository positional.
+///
+/// A leading `-` makes git read the value as an option instead: `git
+/// clone --upload-pack=<cmd>` runs `<cmd>` on a local or SSH transport,
+/// so a malicious lockfile could otherwise execute arbitrary commands.
+/// See [`GitFetcherError::InvalidRepo`].
+fn is_safe_repo_arg(repo: &str) -> bool {
+    !repo.is_empty() && !repo.starts_with('-') && !repo.contains('\0')
 }
 
 /// True iff `repo` parses to a host that pacquet should clone via the

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -1,10 +1,14 @@
-use super::{GitFetcher, exec_git_with, extract_host, is_valid_commit_hash, should_use_shallow};
+use super::{
+    GitFetcher, GitManifestQuery, exec_git_with, extract_host, is_valid_commit_hash,
+    read_git_manifest, should_use_shallow,
+};
 use crate::{error::GitFetcherError, prepare_package::AllowBuildRef};
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_reporter::SilentReporter;
 use pacquet_store_dir::StoreDir;
 #[cfg(unix)]
 use pacquet_testing_utils::env_guard::EnvGuard;
+use serde_json::Value;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -68,6 +72,33 @@ fn make_bare_repo(tmp: &Path) -> (PathBuf, String) {
     exec_git(&["add", "-A"], Some(&work)).unwrap();
     // `-c commit.gpgsign=false` neutralises a user-global `gpgsign=true`
     // setting that would otherwise demand a real signing key in CI.
+    exec_git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], Some(&work)).unwrap();
+    let commit = exec_git(&["rev-parse", "HEAD"], Some(&work)).unwrap().trim().to_string();
+    exec_git(&["clone", "--bare", "-q", &work.to_string_lossy(), &bare.to_string_lossy()], None)
+        .unwrap();
+    (bare, commit)
+}
+
+/// Like [`make_bare_repo`], plus a `packages/foo` sub-package (whose
+/// name deliberately differs from the repo root's) and a
+/// `packages/no-manifest` directory with no `package.json`.
+fn make_bare_repo_with_sub_package(tmp: &Path) -> (PathBuf, String) {
+    let work = tmp.join("work-sub");
+    let bare = tmp.join("repo-sub.git");
+    fs::create_dir_all(work.join("packages/foo")).unwrap();
+    fs::create_dir_all(work.join("packages/no-manifest")).unwrap();
+
+    exec_git(&["init", "-q", "-b", "main"], Some(&work)).unwrap();
+    exec_git(&["config", "user.email", "test@example.invalid"], Some(&work)).unwrap();
+    exec_git(&["config", "user.name", "Test"], Some(&work)).unwrap();
+    fs::write(work.join("package.json"), r#"{"name":"the-monorepo","version":"0.0.0"}"#).unwrap();
+    fs::write(
+        work.join("packages/foo/package.json"),
+        r#"{"name":"@scope/foo","version":"2.0.0","main":"index.js"}"#,
+    )
+    .unwrap();
+    fs::write(work.join("packages/no-manifest/readme.md"), "no manifest here\n").unwrap();
+    exec_git(&["add", "-A"], Some(&work)).unwrap();
     exec_git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], Some(&work)).unwrap();
     let commit = exec_git(&["rev-parse", "HEAD"], Some(&work)).unwrap().trim().to_string();
     exec_git(&["clone", "--bare", "-q", &work.to_string_lossy(), &bare.to_string_lossy()], None)
@@ -1018,4 +1049,91 @@ async fn fetcher_clones_when_host_not_in_shallow_list() {
     }
 
     drop(env);
+}
+
+/// A `Git` resolution's package name lives only in the working tree —
+/// the specifier names a repo, not a package.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_git_manifest_reads_the_name_from_the_checkout() {
+    let tmp = tempdir().unwrap();
+    let (bare, commit) = make_bare_repo(tmp.path());
+    let repo = format!("file://{}", bare.to_string_lossy());
+
+    let manifest = read_git_manifest(GitManifestQuery {
+        repo: &repo,
+        commit: &commit,
+        path: None,
+        git_shallow_hosts: &[],
+        git_bin: None,
+    })
+    .await
+    .expect("checkout should be readable");
+
+    let manifest = dbg!(manifest).expect("repo root has a package.json");
+    assert_eq!(manifest.get("name").and_then(Value::as_str), Some("pkg"));
+    assert_eq!(manifest.get("version").and_then(Value::as_str), Some("1.0.0"));
+}
+
+/// `#path:/packages/foo` keeps its leading slash, which is rooted at
+/// the repo rather than the filesystem.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_git_manifest_reads_a_repo_rooted_sub_directory() {
+    let tmp = tempdir().unwrap();
+    let (bare, commit) = make_bare_repo_with_sub_package(tmp.path());
+    let repo = format!("file://{}", bare.to_string_lossy());
+
+    let manifest = read_git_manifest(GitManifestQuery {
+        repo: &repo,
+        commit: &commit,
+        path: Some("/packages/foo"),
+        git_shallow_hosts: &[],
+        git_bin: None,
+    })
+    .await
+    .expect("checkout should be readable");
+
+    let manifest = dbg!(manifest).expect("sub-directory has a package.json");
+    assert_eq!(manifest.get("name").and_then(Value::as_str), Some("@scope/foo"));
+}
+
+/// Degrades to `None` rather than failing the resolve, matching the
+/// archive path's best-effort contract.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_git_manifest_returns_none_for_a_directory_without_a_manifest() {
+    let tmp = tempdir().unwrap();
+    let (bare, commit) = make_bare_repo_with_sub_package(tmp.path());
+    let repo = format!("file://{}", bare.to_string_lossy());
+
+    let manifest = read_git_manifest(GitManifestQuery {
+        repo: &repo,
+        commit: &commit,
+        path: Some("/packages/no-manifest"),
+        git_shallow_hosts: &[],
+        git_bin: None,
+    })
+    .await
+    .expect("a manifest-less directory is not a failure");
+
+    assert_eq!(dbg!(manifest), None);
+}
+
+/// The commit guard protects the resolve-time checkout too: a value
+/// starting with `-` would otherwise reach `git checkout` as a flag.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_git_manifest_rejects_a_non_sha_commit() {
+    let tmp = tempdir().unwrap();
+    let (bare, _) = make_bare_repo(tmp.path());
+    let repo = format!("file://{}", bare.to_string_lossy());
+
+    let err = read_git_manifest(GitManifestQuery {
+        repo: &repo,
+        commit: "--upload-pack=touch /tmp/pwned",
+        path: None,
+        git_shallow_hosts: &[],
+        git_bin: None,
+    })
+    .await
+    .expect_err("a non-SHA commit must be rejected before it reaches git");
+
+    assert!(matches!(err, GitFetcherError::InvalidCommit { .. }), "{err:?}");
 }

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -1,8 +1,11 @@
 use super::{
-    GitFetcher, GitManifestQuery, exec_git_with, extract_host, is_valid_commit_hash,
-    read_git_manifest, should_use_shallow,
+    GitFetcher, GitManifestQuery, exec_git_with, extract_host, is_safe_repo_arg,
+    is_valid_commit_hash, read_git_manifest, should_use_shallow,
 };
-use crate::{error::GitFetcherError, prepare_package::AllowBuildRef};
+use crate::{
+    error::{GitFetcherError, PreparePackageError},
+    prepare_package::AllowBuildRef,
+};
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_reporter::SilentReporter;
 use pacquet_store_dir::StoreDir;
@@ -948,9 +951,9 @@ async fn fetcher_uses_shallow_fetch_for_allowed_hosts() {
     // strict-ordering asserts catch.
     let init_at = position_of(&invocations, &["init"])
         .unwrap_or_else(|| panic!("shallow path must call `git init`; got {invocations:?}"));
-    let remote_at = position_of(&invocations, &["remote", "add", "origin", repo_url])
+    let remote_at = position_of(&invocations, &["remote", "add", "origin", "--", repo_url])
         .unwrap_or_else(|| {
-            panic!("shallow path must call `git remote add origin <url>`; got {invocations:?}")
+            panic!("shallow path must call `git remote add origin -- <url>`; got {invocations:?}")
         });
     let fetch_at = position_of(&invocations, &["fetch", "--depth", "1", "origin", fake_commit])
         .unwrap_or_else(|| {
@@ -1023,13 +1026,14 @@ async fn fetcher_clones_when_host_not_in_shallow_list() {
     .unwrap();
 
     let invocations = parse_shim_log(&log_path);
-    // `git clone <repo_url> <some_path>` — we accept any temp-dir
-    // path argument, but pin the leading three argv slots.
+    // `git clone -- <repo_url> <some_path>` — we accept any temp-dir
+    // path argument, but pin the leading argv slots. The `--` keeps a
+    // `-`-leading repo out of git's option parser.
     assert!(
-        invocations
-            .iter()
-            .any(|args| { args.len() >= 3 && args[0] == "clone" && args[1] == repo_url }),
-        "non-shallow path must call `git clone <url> <dir>`; got {invocations:?}",
+        invocations.iter().any(|args| {
+            args.len() >= 4 && args[0] == "clone" && args[1] == "--" && args[2] == repo_url
+        }),
+        "non-shallow path must call `git clone -- <url> <dir>`; got {invocations:?}",
     );
     // The shallow argv must be absent — guards the gate's polarity.
     // All three commands the shallow branch issues must be missing,
@@ -1038,7 +1042,7 @@ async fn fetcher_clones_when_host_not_in_shallow_list() {
     // still pass the positive assertion above.
     for verboten in [
         &["init"][..],
-        &["remote", "add", "origin", repo_url],
+        &["remote", "add", "origin", "--", repo_url],
         &["fetch", "--depth", "1", "origin", fake_commit],
     ] {
         assert!(
@@ -1136,4 +1140,68 @@ async fn read_git_manifest_rejects_a_non_sha_commit() {
     .expect_err("a non-SHA commit must be rejected before it reaches git");
 
     assert!(matches!(err, GitFetcherError::InvalidCommit { .. }), "{err:?}");
+}
+
+/// A `path` that climbs out of the checkout must not reach
+/// `safe_read_package_json_from_dir`, which would read an arbitrary
+/// `package.json` off the host and stamp its name onto this dep.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_git_manifest_rejects_a_sub_directory_escape() {
+    let tmp = tempdir().unwrap();
+    let (bare, commit) = make_bare_repo(tmp.path());
+    let repo = format!("file://{}", bare.to_string_lossy());
+    // A real `package.json` sitting outside the checkout, of the shape
+    // an escape would be aiming for.
+    fs::write(tmp.path().join("package.json"), r#"{"name":"outside","version":"9.9.9"}"#).unwrap();
+
+    for escape in ["/../..", "../..", "/../"] {
+        let err = read_git_manifest(GitManifestQuery {
+            repo: &repo,
+            commit: &commit,
+            path: Some(escape),
+            git_shallow_hosts: &[],
+            git_bin: None,
+        })
+        .await
+        .expect_err("a path climbing out of the checkout must be rejected");
+        assert!(
+            matches!(err, GitFetcherError::Prepare(PreparePackageError::InvalidPath { .. })),
+            "{escape:?} produced {err:?}",
+        );
+    }
+}
+
+/// A repo beginning with `-` is read by git as an option, not a URL:
+/// `--upload-pack=<cmd>` runs `<cmd>` on a local or SSH transport. Both
+/// passes reach `checkout_commit`, so both are guarded.
+#[tokio::test(flavor = "multi_thread")]
+async fn read_git_manifest_rejects_an_option_shaped_repo() {
+    let tmp = tempdir().unwrap();
+    let marker = tmp.path().join("pwned.txt");
+    let payload = format!("--upload-pack=touch {}", marker.to_string_lossy());
+
+    let err = read_git_manifest(GitManifestQuery {
+        repo: &payload,
+        commit: "0123456789abcdef0123456789abcdef01234567",
+        path: None,
+        git_shallow_hosts: &[],
+        git_bin: None,
+    })
+    .await
+    .expect_err("an option-shaped repo must be rejected before it reaches git");
+
+    assert!(matches!(err, GitFetcherError::InvalidRepo { .. }), "{err:?}");
+    assert!(!marker.exists(), "the payload must never have run");
+}
+
+#[test]
+fn is_safe_repo_arg_rejects_option_shaped_values() {
+    assert!(is_safe_repo_arg("https://github.com/x/y.git"));
+    assert!(is_safe_repo_arg("file:///tmp/repo"));
+    assert!(is_safe_repo_arg("ssh://git@example.com/x/y.git"));
+
+    assert!(!is_safe_repo_arg("--upload-pack=touch /tmp/pwned"));
+    assert!(!is_safe_repo_arg("-oProxyCommand=curl evil.example"));
+    assert!(!is_safe_repo_arg(""));
+    assert!(!is_safe_repo_arg("https://example.com/\0/x"));
 }

--- a/pnpm/crates/git-fetcher/src/lib.rs
+++ b/pnpm/crates/git-fetcher/src/lib.rs
@@ -23,7 +23,10 @@ mod prepare_package;
 mod tarball_fetcher;
 
 pub use error::{GitFetcherError, PreparePackageError};
-pub use fetcher::{GitFetchOutput, GitFetcher};
+pub use fetcher::{
+    CheckoutOptions, GitFetchOutput, GitFetcher, GitManifestQuery, checkout_commit,
+    read_git_manifest,
+};
 pub use pacquet_fs_packlist::{PacklistError, packlist};
 pub use preferred_pm::{PreferredPm, detect_preferred_pm};
 pub use prepare_package::{PreparePackageOptions, PreparedPackage, prepare_package};

--- a/pnpm/crates/git-fetcher/src/prepare_package.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package.rs
@@ -197,7 +197,10 @@ fn package_should_be_built(manifest: &Value, pkg_dir: &Path) -> bool {
 /// rooted at the repo, not the filesystem, so it is stripped before
 /// joining — [`Path::join`] would otherwise discard `root` and treat
 /// the whole thing as absolute, unlike the `path.join` upstream uses.
-fn safe_join_path(root: &Path, sub: Option<&str>) -> Result<PathBuf, PreparePackageError> {
+pub(crate) fn safe_join_path(
+    root: &Path,
+    sub: Option<&str>,
+) -> Result<PathBuf, PreparePackageError> {
     let sub = sub.unwrap_or("").trim_start_matches(['/', '\\']);
     let joined = if sub.is_empty() { root.to_path_buf() } else { root.join(sub) };
     let canonical_root = root.canonicalize().map_err(PreparePackageError::Io)?;

--- a/pnpm/crates/git-fetcher/src/prepare_package.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package.rs
@@ -191,8 +191,14 @@ fn package_should_be_built(manifest: &Value, pkg_dir: &Path) -> bool {
 }
 
 /// Join `sub` onto `root` and reject results that climb outside.
+///
+/// `sub` is a resolution's `path` field, which keeps the leading slash
+/// of the `#path:/packages/foo` specifier it came from. That slash is
+/// rooted at the repo, not the filesystem, so it is stripped before
+/// joining — [`Path::join`] would otherwise discard `root` and treat
+/// the whole thing as absolute, unlike the `path.join` upstream uses.
 fn safe_join_path(root: &Path, sub: Option<&str>) -> Result<PathBuf, PreparePackageError> {
-    let sub = sub.unwrap_or("");
+    let sub = sub.unwrap_or("").trim_start_matches(['/', '\\']);
     let joined = if sub.is_empty() { root.to_path_buf() } else { root.join(sub) };
     let canonical_root = root.canonicalize().map_err(PreparePackageError::Io)?;
     let Ok(canonical_joined) = joined.canonicalize() else {

--- a/pnpm/crates/git-fetcher/src/prepare_package/tests.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package/tests.rs
@@ -228,6 +228,27 @@ fn safe_join_path_rejects_missing_sub_dir() {
     assert!(matches!(err, PreparePackageError::InvalidPath { .. }));
 }
 
+/// A resolution's `path` keeps the leading slash of the
+/// `#path:/packages/foo` specifier it came from, and that slash is
+/// rooted at the repo, not the filesystem.
+#[test]
+fn safe_join_path_treats_a_leading_slash_as_repo_relative() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    std::fs::create_dir_all(root.join("packages/foo")).unwrap();
+
+    let joined = safe_join_path(root, Some("/packages/foo")).expect("repo-rooted sub-directory");
+    assert_eq!(joined, root.join("packages/foo"));
+}
+
+/// Stripping the leading slash must not open a way out of the checkout.
+#[test]
+fn safe_join_path_rejects_an_escape_behind_a_leading_slash() {
+    let dir = tempdir().unwrap();
+    let err = safe_join_path(dir.path(), Some("/../escape")).unwrap_err();
+    assert!(matches!(err, PreparePackageError::InvalidPath { .. }));
+}
+
 #[test]
 fn safe_join_path_accepts_empty_sub_dir() {
     let dir = tempdir().unwrap();

--- a/pnpm/crates/napi/src/resolve.rs
+++ b/pnpm/crates/napi/src/resolve.rs
@@ -164,15 +164,17 @@ fn run_resolve_blocking(
         retry_opts,
     });
 
+    // No fetch context on the single-resolve path for either resolver:
+    // there's no install store to extract into, so an `http(s)` tarball
+    // is claimed with its normalized URL but no bundled manifest /
+    // integrity (see the module docs), and a git dep is claimed without
+    // its archive's manifest. The install path wires the full
+    // `TarballFetchContext` / `GitFetchContext`.
     let git_resolver = GitResolver::new(
         Arc::new(RealGitProbe::new(Arc::clone(&http_client))),
         Arc::new(RealGitRunner::new()),
     );
 
-    // No fetch context on the single-resolve path: there's no install
-    // store to extract into, so an `http(s)` tarball is claimed with its
-    // normalized URL but no bundled manifest / integrity (see the module
-    // docs). The install path wires the full [`TarballFetchContext`].
     let tarball_resolver =
         TarballResolver { http_client: Arc::clone(&http_client), fetch_context: None };
 

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -8,14 +8,15 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use derive_more::{Display, Error};
 use indexmap::IndexMap;
 use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_lockfile::{
     CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileSettings,
-    LockfileVersion, PackageKey, PackageMetadata, PeerDependencyMeta, PkgName, PkgNameVerPeer,
-    PkgVerPeer, ProjectSnapshot, ResolvedCatalogEntry, ResolvedDependencyMap,
-    ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, VersionPart,
+    LockfileVersion, PackageKey, PackageMetadata, ParseImporterDepVersionError, PeerDependencyMeta,
+    PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot, ResolvedCatalogEntry,
+    ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, VersionPart,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_deps_resolver::{DepPath, DependenciesGraph, DependenciesGraphNode};
@@ -100,6 +101,21 @@ pub struct GraphToLockfileOptions<'a> {
     pub lockfile_include_tarball_url: bool,
 }
 
+/// Error returned while converting a resolver graph into a lockfile.
+#[derive(Debug, Display, Error)]
+#[non_exhaustive]
+pub enum DependenciesGraphToLockfileError {
+    #[display(
+        "Failed to serialize importer dependency {alias:?} from dependency path {dep_path:?}: {source}"
+    )]
+    ImporterDependency {
+        alias: String,
+        dep_path: String,
+        #[error(source)]
+        source: Box<ParseImporterDepVersionError>,
+    },
+}
+
 /// Build a [`Lockfile`] from the resolver's [`DependenciesGraph`] plus
 /// the per-importer context needed to populate the `importers:` map.
 ///
@@ -116,8 +132,9 @@ pub struct GraphToLockfileOptions<'a> {
 /// - `snapshots` carries one [`SnapshotEntry`] per *peer-suffixed*
 ///   depPath — peer variants of the same package each get their own
 ///   snapshot row.
-#[must_use]
-pub fn dependencies_graph_to_lockfile(opts: GraphToLockfileOptions<'_>) -> Lockfile {
+pub fn dependencies_graph_to_lockfile(
+    opts: GraphToLockfileOptions<'_>,
+) -> Result<Lockfile, DependenciesGraphToLockfileError> {
     let GraphToLockfileOptions {
         importers: importer_inputs,
         graph,
@@ -147,12 +164,12 @@ pub fn dependencies_graph_to_lockfile(opts: GraphToLockfileOptions<'_>) -> Lockf
     let mut importers: HashMap<String, ProjectSnapshot> =
         HashMap::with_capacity(importer_inputs.len());
     for (id, input) in &importer_inputs {
-        importers.insert(id.clone(), build_importer(input, graph, exclude_links_from_lockfile));
+        importers.insert(id.clone(), build_importer(input, graph, exclude_links_from_lockfile)?);
     }
 
     let catalog_snapshots = build_catalog_snapshots(&importers, catalogs);
 
-    Lockfile {
+    Ok(Lockfile {
         lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0))
             .expect("lockfileVersion 9.0 is always compatible with MAJOR=9"),
         settings: Some(LockfileSettings {
@@ -172,7 +189,7 @@ pub fn dependencies_graph_to_lockfile(opts: GraphToLockfileOptions<'_>) -> Lockf
         importers,
         packages: (!packages.is_empty()).then_some(packages),
         snapshots: (!snapshots.is_empty()).then_some(snapshots),
-    }
+    })
 }
 
 /// Build the lockfile's `catalogs:` snapshot from the resolved importers.
@@ -236,7 +253,7 @@ fn build_importer(
     input: &ImporterLockfileInput<'_>,
     graph: &DependenciesGraph,
     exclude_links_from_lockfile: bool,
-) -> ProjectSnapshot {
+) -> Result<ProjectSnapshot, DependenciesGraphToLockfileError> {
     let manifest = input.manifest;
     let direct = &input.direct_dependencies_by_alias;
 
@@ -271,7 +288,13 @@ fn build_importer(
             ImporterDepVersion::Link(target.to_string())
         } else {
             let Some(node) = graph.get(dep_path) else { continue };
-            importer_dep_version(alias, node)
+            importer_dep_version(alias, node).map_err(|source| {
+                DependenciesGraphToLockfileError::ImporterDependency {
+                    alias: alias.clone(),
+                    dep_path: dep_path.to_string(),
+                    source: Box::new(source),
+                }
+            })?
         };
         let spec = ResolvedDependencySpec { specifier: specifier.clone(), version };
         specifiers.insert(alias.clone(), specifier);
@@ -301,14 +324,14 @@ fn build_importer(
         .and_then(Value::as_str)
         .map(str::to_string);
 
-    ProjectSnapshot {
+    Ok(ProjectSnapshot {
         specifiers: (!specifiers.is_empty()).then_some(specifiers),
         dependencies: (!dependencies.is_empty()).then_some(dependencies),
         dev_dependencies: (!dev_dependencies.is_empty()).then_some(dev_dependencies),
         optional_dependencies: (!optional_dependencies.is_empty()).then_some(optional_dependencies),
         dependencies_meta,
         publish_directory,
-    }
+    })
 }
 
 /// Map each direct-dep alias to the manifest group it appears in.
@@ -349,17 +372,20 @@ fn read_manifest_specifier(manifest: &PackageManifest, alias: &str) -> Option<St
 }
 
 /// Build the version cell for an importer-level dependency.
-fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDepVersion {
+fn importer_dep_version(
+    alias: &str,
+    node: &DependenciesGraphNode,
+) -> Result<ImporterDepVersion, ParseImporterDepVersionError> {
     let dep_path_str = node.dep_path.as_str();
 
     if let Some(target) = dep_path_str.strip_prefix("link:") {
-        return ImporterDepVersion::Link(target.to_string());
+        return Ok(ImporterDepVersion::Link(target.to_string()));
     }
     if let Some(target) = dep_path_str.strip_prefix("file:") {
         // An injected workspace dep reaches the `file:` arm (rather than
         // deduping back to `link:`) because its children weren't a subset
         // of the target project's direct deps, or `dedupeInjectedDeps` is off.
-        return ImporterDepVersion::File(target.to_string());
+        return Ok(ImporterDepVersion::File(target.to_string()));
     }
 
     let real_name = real_name(&node.resolve_result);
@@ -369,12 +395,10 @@ fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDe
             && let Some(ver) = dep_path_str.strip_prefix(&prefix)
             && let Ok(parsed) = ver.parse::<PkgVerPeer>()
         {
-            return ImporterDepVersion::Regular(parsed);
+            return Ok(ImporterDepVersion::Regular(parsed));
         }
     }
-    let parsed = dep_path_str
-        .parse::<PkgNameVerPeer>()
-        .expect("dep paths produced by the resolver always parse as PkgNameVerPeer");
+    let parsed = dep_path_str.parse::<ImporterDepVersion>()?;
     // An injected workspace dep reaches this point as its full peered
     // dep path, `<name>@file:<path>(peers)` — the bare `file:` strip
     // above only matches peerless dep paths, and `real_name` is unset
@@ -384,14 +408,17 @@ fn importer_dep_version(alias: &str, node: &DependenciesGraphNode) -> ImporterDe
     // the alias equals the package name; a self-aliased ref would
     // double-prefix every consumer that composes `alias@version` into a
     // snapshot key (v11 readers, Bit's graph converter).
-    if parsed.name.to_string() == alias && matches!(parsed.suffix.version(), VersionPart::File(_)) {
-        let suffix = parsed.suffix.to_string();
+    if let ImporterDepVersion::Alias(parsed_alias) = &parsed
+        && parsed_alias.name.to_string() == alias
+        && matches!(parsed_alias.suffix.version(), VersionPart::File(_))
+    {
+        let suffix = parsed_alias.suffix.to_string();
         let payload = suffix
             .strip_prefix("file:")
             .expect("a File version part always displays with the file: scheme");
-        return ImporterDepVersion::File(payload.to_string());
+        return Ok(ImporterDepVersion::File(payload.to_string()));
     }
-    ImporterDepVersion::Alias(parsed)
+    Ok(parsed)
 }
 
 /// `Some(real_name)` when the resolver produced a structured name; `None`
@@ -453,7 +480,7 @@ fn build_packages_and_snapshots(
     let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
 
     for node in graph.values() {
-        let Ok(snapshot_key) = node.dep_path.as_str().parse::<PackageKey>() else { continue };
+        let Some(snapshot_key) = package_key(node) else { continue };
         let metadata_key = snapshot_key.without_peer();
 
         let snapshot = build_snapshot_entry(node, graph, optional_overrides);
@@ -465,6 +492,24 @@ fn build_packages_and_snapshots(
     }
 
     (packages, snapshots)
+}
+
+/// Build the lockfile key for a graph node. Registry dep paths already include
+/// the package name, while git-hosted dep paths need the name reported by the
+/// resolved manifest prepended to their bare tarball URL.
+fn package_key(node: &DependenciesGraphNode) -> Option<PackageKey> {
+    if let Ok(key) = node.dep_path.as_str().parse::<PackageKey>() {
+        return Some(key);
+    }
+    if !matches!(
+        &node.resolve_result.resolution,
+        LockfileResolution::Tarball(tarball) if tarball.git_hosted == Some(true)
+    ) {
+        return None;
+    }
+    let name = node.resolve_result.manifest.as_ref()?.get("name")?.as_str()?.parse().ok()?;
+    let suffix = node.dep_path.as_str().parse::<PkgVerPeer>().ok()?;
+    Some(PackageKey::new(name, suffix))
 }
 
 /// Build the per-`(name, version)` [`PackageMetadata`] block for the

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -14,9 +14,10 @@ use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_lockfile::{
     CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileSettings,
-    LockfileVersion, PackageKey, PackageMetadata, ParseImporterDepVersionError, PeerDependencyMeta,
-    PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot, ResolvedCatalogEntry,
-    ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, VersionPart,
+    LockfileVersion, PackageKey, PackageMetadata, ParseImporterDepVersionError, ParsePkgNameError,
+    ParsePkgVerPeerError, PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot,
+    ResolvedCatalogEntry, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef,
+    SnapshotEntry, VersionPart,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_deps_resolver::{DepPath, DependenciesGraph, DependenciesGraphNode};
@@ -114,6 +115,23 @@ pub enum DependenciesGraphToLockfileError {
         #[error(source)]
         source: Box<ParseImporterDepVersionError>,
     },
+    #[display("Git-hosted dependency path {dep_path:?} has no package name in its manifest")]
+    MissingGitHostedPackageName { dep_path: String },
+    #[display(
+        "Git-hosted dependency path {dep_path:?} has invalid package name {name:?}: {source}"
+    )]
+    InvalidGitHostedPackageName {
+        dep_path: String,
+        name: String,
+        #[error(source)]
+        source: ParsePkgNameError,
+    },
+    #[display("Failed to parse git-hosted dependency path {dep_path:?}: {source}")]
+    InvalidGitHostedPackagePath {
+        dep_path: String,
+        #[error(source)]
+        source: Box<ParsePkgVerPeerError>,
+    },
 }
 
 /// Build a [`Lockfile`] from the resolver's [`DependenciesGraph`] plus
@@ -159,7 +177,7 @@ pub fn dependencies_graph_to_lockfile(
         &optional_overrides,
         registry,
         lockfile_include_tarball_url,
-    );
+    )?;
 
     let mut importers: HashMap<String, ProjectSnapshot> =
         HashMap::with_capacity(importer_inputs.len());
@@ -389,14 +407,13 @@ fn importer_dep_version(
     }
 
     let real_name = real_name(&node.resolve_result);
-    if let Some(real) = real_name.as_deref() {
-        let prefix = format!("{real}@");
-        if alias == real
-            && let Some(ver) = dep_path_str.strip_prefix(&prefix)
-            && let Ok(parsed) = ver.parse::<PkgVerPeer>()
-        {
-            return Ok(ImporterDepVersion::Regular(parsed));
-        }
+    if let Some(real) = real_name.as_deref()
+        && alias == real
+        && let Some(rest) = dep_path_str.strip_prefix(real)
+        && let Some(ver) = rest.strip_prefix('@')
+        && let Ok(parsed) = ver.parse::<PkgVerPeer>()
+    {
+        return Ok(ImporterDepVersion::Regular(parsed));
     }
     let parsed = dep_path_str.parse::<ImporterDepVersion>()?;
     // An injected workspace dep reaches this point as its full peered
@@ -409,7 +426,14 @@ fn importer_dep_version(
     // double-prefix every consumer that composes `alias@version` into a
     // snapshot key (v11 readers, Bit's graph converter).
     if let ImporterDepVersion::Alias(parsed_alias) = &parsed
-        && parsed_alias.name.to_string() == alias
+        && match parsed_alias.name.scope.as_deref() {
+            Some(scope) => {
+                alias.strip_prefix('@').and_then(|unscoped| unscoped.split_once('/')).is_some_and(
+                    |(alias_scope, bare)| alias_scope == scope && bare == parsed_alias.name.bare,
+                )
+            }
+            None => alias == parsed_alias.name.bare,
+        }
         && matches!(parsed_alias.suffix.version(), VersionPart::File(_))
     {
         let suffix = parsed_alias.suffix.to_string();
@@ -460,6 +484,9 @@ fn is_remote_http_tarball(tarball: &str) -> bool {
     tarball.starts_with("http:") || tarball.starts_with("https:")
 }
 
+type PackagesAndSnapshots =
+    (HashMap<PackageKey, PackageMetadata>, HashMap<PackageKey, SnapshotEntry>);
+
 /// Walk the depPath-keyed [`DependenciesGraph`] and emit the matching
 /// `(PackageMetadata, SnapshotEntry)` pair for each node — fanned out
 /// across the two top-level maps the v9 lockfile splits.
@@ -475,12 +502,12 @@ fn build_packages_and_snapshots(
     optional_overrides: &HashMap<DepPath, bool>,
     registry: &str,
     lockfile_include_tarball_url: bool,
-) -> (HashMap<PackageKey, PackageMetadata>, HashMap<PackageKey, SnapshotEntry>) {
+) -> Result<PackagesAndSnapshots, DependenciesGraphToLockfileError> {
     let mut packages: HashMap<PackageKey, PackageMetadata> = HashMap::new();
     let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
 
     for node in graph.values() {
-        let Some(snapshot_key) = package_key(node) else { continue };
+        let Some(snapshot_key) = package_key(node)? else { continue };
         let metadata_key = snapshot_key.without_peer();
 
         let snapshot = build_snapshot_entry(node, graph, optional_overrides);
@@ -491,25 +518,48 @@ fn build_packages_and_snapshots(
         });
     }
 
-    (packages, snapshots)
+    Ok((packages, snapshots))
 }
 
-/// Build the lockfile key for a graph node. Registry dep paths already include
-/// the package name, while git-hosted dep paths need the name reported by the
-/// resolved manifest prepended to their bare tarball URL.
-fn package_key(node: &DependenciesGraphNode) -> Option<PackageKey> {
+// Build the lockfile key for a graph node. Registry dep paths already include
+// the package name, while git-hosted dep paths need the name reported by the
+// resolved manifest prepended to their bare tarball URL.
+fn package_key(
+    node: &DependenciesGraphNode,
+) -> Result<Option<PackageKey>, DependenciesGraphToLockfileError> {
     if let Ok(key) = node.dep_path.as_str().parse::<PackageKey>() {
-        return Some(key);
+        return Ok(Some(key));
     }
     if !matches!(
         &node.resolve_result.resolution,
-        LockfileResolution::Tarball(tarball) if tarball.git_hosted == Some(true)
+        LockfileResolution::Tarball(tarball) if tarball.git_hosted == Some(true),
     ) {
-        return None;
+        return Ok(None);
     }
-    let name = node.resolve_result.manifest.as_ref()?.get("name")?.as_str()?.parse().ok()?;
-    let suffix = node.dep_path.as_str().parse::<PkgVerPeer>().ok()?;
-    Some(PackageKey::new(name, suffix))
+    let dep_path = node.dep_path.to_string();
+    let manifest_name = node
+        .resolve_result
+        .manifest
+        .as_ref()
+        .and_then(|manifest| manifest.get("name"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| DependenciesGraphToLockfileError::MissingGitHostedPackageName {
+            dep_path: dep_path.clone(),
+        })?;
+    let name = manifest_name.parse().map_err(|source| {
+        DependenciesGraphToLockfileError::InvalidGitHostedPackageName {
+            dep_path: dep_path.clone(),
+            name: manifest_name.to_string(),
+            source,
+        }
+    })?;
+    let suffix = node.dep_path.as_str().parse::<PkgVerPeer>().map_err(|source| {
+        DependenciesGraphToLockfileError::InvalidGitHostedPackagePath {
+            dep_path,
+            source: Box::new(source),
+        }
+    })?;
+    Ok(Some(PackageKey::new(name, suffix)))
 }
 
 /// Build the per-`(name, version)` [`PackageMetadata`] block for the

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -14,10 +14,9 @@ use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_lockfile::{
     CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileSettings,
-    LockfileVersion, PackageKey, PackageMetadata, ParseImporterDepVersionError, ParsePkgNameError,
-    ParsePkgVerPeerError, PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot,
-    ResolvedCatalogEntry, ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef,
-    SnapshotEntry, VersionPart,
+    LockfileVersion, PackageKey, PackageMetadata, ParseImporterDepVersionError, PeerDependencyMeta,
+    PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot, ResolvedCatalogEntry,
+    ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, VersionPart,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_deps_resolver::{DepPath, DependenciesGraph, DependenciesGraphNode};
@@ -114,23 +113,6 @@ pub enum DependenciesGraphToLockfileError {
         dep_path: String,
         #[error(source)]
         source: Box<ParseImporterDepVersionError>,
-    },
-    #[display("Git-hosted dependency path {dep_path:?} has no package name in its manifest")]
-    MissingGitHostedPackageName { dep_path: String },
-    #[display(
-        "Git-hosted dependency path {dep_path:?} has invalid package name {name:?}: {source}"
-    )]
-    InvalidGitHostedPackageName {
-        dep_path: String,
-        name: String,
-        #[error(source)]
-        source: ParsePkgNameError,
-    },
-    #[display("Failed to parse git-hosted dependency path {dep_path:?}: {source}")]
-    InvalidGitHostedPackagePath {
-        dep_path: String,
-        #[error(source)]
-        source: Box<ParsePkgVerPeerError>,
     },
 }
 
@@ -453,21 +435,20 @@ fn real_name(result: &ResolveResult) -> Option<String> {
         return Some(name_ver.name.to_string());
     }
     // `name_ver` is unset for resolutions that learn the canonical name
-    // from the fetched manifest. Read it for the two shapes whose `name@`
+    // from the fetched manifest. Read it for the shapes whose `name@`
     // prefix is stripped off the importer entry:
-    // - a remote (non-registry, non-git) http(s) tarball direct dep
-    //   (`<name>@<tarball-url>` -> `version: <url>`), and
+    // - a remote (non-registry) http(s) tarball direct dep
+    //   (`<name>@<tarball-url>` -> `version: <url>`), which a git-hosted
+    //   dep's host archive URL also is,
     // - a runtime dep (`<name>@runtime:<ver>`, a Variations resolution ->
     //   `version: runtime:<ver>`).
-    // Other manifest-only resolutions (`file:` / git) are deliberately
-    // left to the `None` path so their importer entries keep pacquet's
-    // current prefixed shape — bringing those in line is separate from
+    // `file:` resolutions are deliberately left to the `None` path so
+    // their importer entries keep pacquet's current prefixed shape —
+    // bringing those in line is separate from
     // <https://github.com/pnpm/pnpm/issues/12053>.
     let reads_name_from_manifest = match &result.resolution {
         LockfileResolution::Variations(_) => true,
-        LockfileResolution::Tarball(tarball) => {
-            tarball.git_hosted != Some(true) && is_remote_http_tarball(&tarball.tarball)
-        }
+        LockfileResolution::Tarball(tarball) => is_remote_http_tarball(&tarball.tarball),
         _ => false,
     };
     if !reads_name_from_manifest {
@@ -507,7 +488,7 @@ fn build_packages_and_snapshots(
     let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
 
     for node in graph.values() {
-        let Some(snapshot_key) = package_key(node)? else { continue };
+        let Ok(snapshot_key) = node.dep_path.as_str().parse::<PackageKey>() else { continue };
         let metadata_key = snapshot_key.without_peer();
 
         let snapshot = build_snapshot_entry(node, graph, optional_overrides);
@@ -519,47 +500,6 @@ fn build_packages_and_snapshots(
     }
 
     Ok((packages, snapshots))
-}
-
-// Build the lockfile key for a graph node. Registry dep paths already include
-// the package name, while git-hosted dep paths need the name reported by the
-// resolved manifest prepended to their bare tarball URL.
-fn package_key(
-    node: &DependenciesGraphNode,
-) -> Result<Option<PackageKey>, DependenciesGraphToLockfileError> {
-    if let Ok(key) = node.dep_path.as_str().parse::<PackageKey>() {
-        return Ok(Some(key));
-    }
-    if !matches!(
-        &node.resolve_result.resolution,
-        LockfileResolution::Tarball(tarball) if tarball.git_hosted == Some(true),
-    ) {
-        return Ok(None);
-    }
-    let dep_path = node.dep_path.to_string();
-    let manifest_name = node
-        .resolve_result
-        .manifest
-        .as_ref()
-        .and_then(|manifest| manifest.get("name"))
-        .and_then(Value::as_str)
-        .ok_or_else(|| DependenciesGraphToLockfileError::MissingGitHostedPackageName {
-            dep_path: dep_path.clone(),
-        })?;
-    let name = manifest_name.parse().map_err(|source| {
-        DependenciesGraphToLockfileError::InvalidGitHostedPackageName {
-            dep_path: dep_path.clone(),
-            name: manifest_name.to_string(),
-            source,
-        }
-    })?;
-    let suffix = node.dep_path.as_str().parse::<PkgVerPeer>().map_err(|source| {
-        DependenciesGraphToLockfileError::InvalidGitHostedPackagePath {
-            dep_path,
-            source: Box::new(source),
-        }
-    })?;
-    Ok(Some(PackageKey::new(name, suffix)))
 }
 
 /// Build the per-`(name, version)` [`PackageMetadata`] block for the

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -14,7 +14,7 @@ use pacquet_resolving_deps_resolver::{
     PeerDep, ResolvePeersOptions, ResolvedPackage, ResolvedTree, TreeChildren, resolve_peers,
 };
 use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
-use serde_json::json;
+use serde_json::{Value, json};
 use ssri::Integrity;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -593,6 +593,41 @@ fn runtime_dependency_strips_importer_prefix_and_records_package_version() {
     assert_eq!(metadata.version.as_deref(), Some("26.3.0"));
 }
 
+fn git_hosted_node(url: &str, manifest: Option<Value>) -> DependenciesGraphNode {
+    let dep_path = DepPath::from(url.to_string());
+    let resolve_result = ResolveResult {
+        id: PkgResolutionId::from(url),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: manifest.map(Arc::new),
+        resolution: LockfileResolution::Tarball(TarballResolution {
+            tarball: url.to_string(),
+            integrity: None,
+            git_hosted: Some(true),
+            path: None,
+        }),
+        resolved_via: "git-repository".to_string(),
+        normalized_bare_specifier: Some("github:kevva/is-negative#1.0.0".to_string()),
+        alias: Some("is-negative".to_string()),
+        policy_violation: None,
+    };
+    DependenciesGraphNode {
+        dep_path,
+        resolved_package_id: url.to_string(),
+        resolve_result: Arc::new(resolve_result),
+        children: BTreeMap::new(),
+        optional_children: HashSet::new(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::new(),
+        resolved_peer_names: HashSet::new(),
+        depth: 1,
+        installable: true,
+        is_pure: true,
+        optional: false,
+    }
+}
+
 #[test]
 fn git_hosted_dependency_records_bare_tarball_url_in_importer() {
     let (_tmp, manifest) = write_manifest(json!({
@@ -605,40 +640,13 @@ fn git_hosted_dependency_records_bare_tarball_url_in_importer() {
 
     let url = "https://codeload.github.com/kevva/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99";
     let dep_path = DepPath::from(url.to_string());
-    let resolve_result = ResolveResult {
-        id: PkgResolutionId::from(url),
-        name_ver: None,
-        latest: None,
-        published_at: None,
-        manifest: Some(Arc::new(json!({
+    let node = git_hosted_node(
+        url,
+        Some(json!({
             "name": "is-negative",
             "version": "1.0.0",
-        }))),
-        resolution: LockfileResolution::Tarball(TarballResolution {
-            tarball: url.to_string(),
-            integrity: None,
-            git_hosted: Some(true),
-            path: None,
-        }),
-        resolved_via: "git-repository".to_string(),
-        normalized_bare_specifier: Some("github:kevva/is-negative#1.0.0".to_string()),
-        alias: Some("is-negative".to_string()),
-        policy_violation: None,
-    };
-    let node = DependenciesGraphNode {
-        dep_path: dep_path.clone(),
-        resolved_package_id: url.to_string(),
-        resolve_result: Arc::new(resolve_result),
-        children: BTreeMap::new(),
-        optional_children: HashSet::new(),
-        peer_dependencies: BTreeMap::new(),
-        transitive_peer_dependencies: HashSet::new(),
-        resolved_peer_names: HashSet::new(),
-        depth: 1,
-        installable: true,
-        is_pure: true,
-        optional: false,
-    };
+        })),
+    );
 
     let mut graph = DependenciesGraph::new();
     graph.insert(dep_path.clone(), node);
@@ -668,6 +676,34 @@ fn git_hosted_dependency_records_bare_tarball_url_in_importer() {
 }
 
 #[test]
+fn git_hosted_dependency_without_manifest_name_returns_structured_error() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": {
+            "is-negative": "github:kevva/is-negative#1.0.0",
+        },
+    }));
+    let url = "https://codeload.github.com/kevva/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99";
+    let dep_path = DepPath::from(url.to_string());
+    let mut graph = DependenciesGraph::new();
+    graph.insert(dep_path.clone(), git_hosted_node(url, None));
+    let direct = BTreeMap::from([("is-negative".to_string(), dep_path)]);
+
+    let error = dbg!(
+        try_dependencies_graph_to_lockfile(single_importer_opts(
+            &manifest, &graph, direct, false, false, None, None,
+        ))
+        .unwrap_err()
+    );
+
+    let DependenciesGraphToLockfileError::MissingGitHostedPackageName { dep_path } = error else {
+        panic!("expected missing git-hosted package name error, got {error:?}");
+    };
+    assert_eq!(dep_path, url);
+}
+
+#[test]
 fn malformed_importer_dependency_path_returns_structured_error() {
     let (_tmp, manifest) = write_manifest(json!({
         "name": "fixture",
@@ -689,17 +725,18 @@ fn malformed_importer_dependency_path_returns_structured_error() {
     graph.insert(dep_path.clone(), node);
     let direct = BTreeMap::from([("broken".to_string(), dep_path)]);
 
-    let error = try_dependencies_graph_to_lockfile(single_importer_opts(
-        &manifest, &graph, direct, false, false, None, None,
-    ))
-    .unwrap_err();
+    let error = dbg!(
+        try_dependencies_graph_to_lockfile(single_importer_opts(
+            &manifest, &graph, direct, false, false, None, None,
+        ))
+        .unwrap_err()
+    );
 
-    match error {
-        DependenciesGraphToLockfileError::ImporterDependency { alias, dep_path, .. } => {
-            assert_eq!(alias, "broken");
-            assert_eq!(dep_path, "broken@1.0.0(");
-        }
-    }
+    let DependenciesGraphToLockfileError::ImporterDependency { alias, dep_path, .. } = error else {
+        panic!("expected importer dependency error, got {error:?}");
+    };
+    assert_eq!(alias, "broken");
+    assert_eq!(dep_path, "broken@1.0.0(");
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -14,7 +14,7 @@ use pacquet_resolving_deps_resolver::{
     PeerDep, ResolvePeersOptions, ResolvedPackage, ResolvedTree, TreeChildren, resolve_peers,
 };
 use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
-use serde_json::{Value, json};
+use serde_json::json;
 use ssri::Integrity;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -593,28 +593,35 @@ fn runtime_dependency_strips_importer_prefix_and_records_package_version() {
     assert_eq!(metadata.version.as_deref(), Some("26.3.0"));
 }
 
-fn git_hosted_node(url: &str, manifest: Option<Value>) -> DependenciesGraphNode {
-    let dep_path = DepPath::from(url.to_string());
+const GIT_TARBALL_URL: &str =
+    "https://codeload.github.com/kevva/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99";
+
+/// A git-hosted node as the resolve pass produces it: the dep path is
+/// the `<name>@<archive-url>` `build_pkg_id_with_patch_hash` derives
+/// from the archive's own `package.json`, which the git resolver reads
+/// during resolution.
+fn git_hosted_node(alias: &str) -> (DepPath, DependenciesGraphNode) {
+    let dep_path = DepPath::from(format!("is-negative@{GIT_TARBALL_URL}"));
     let resolve_result = ResolveResult {
-        id: PkgResolutionId::from(url),
+        id: PkgResolutionId::from(GIT_TARBALL_URL),
         name_ver: None,
         latest: None,
         published_at: None,
-        manifest: manifest.map(Arc::new),
+        manifest: Some(Arc::new(json!({ "name": "is-negative", "version": "1.0.0" }))),
         resolution: LockfileResolution::Tarball(TarballResolution {
-            tarball: url.to_string(),
+            tarball: GIT_TARBALL_URL.to_string(),
             integrity: None,
             git_hosted: Some(true),
             path: None,
         }),
         resolved_via: "git-repository".to_string(),
         normalized_bare_specifier: Some("github:kevva/is-negative#1.0.0".to_string()),
-        alias: Some("is-negative".to_string()),
+        alias: Some(alias.to_string()),
         policy_violation: None,
     };
-    DependenciesGraphNode {
-        dep_path,
-        resolved_package_id: url.to_string(),
+    let node = DependenciesGraphNode {
+        dep_path: dep_path.clone(),
+        resolved_package_id: dep_path.to_string(),
         resolve_result: Arc::new(resolve_result),
         children: BTreeMap::new(),
         optional_children: HashSet::new(),
@@ -625,7 +632,8 @@ fn git_hosted_node(url: &str, manifest: Option<Value>) -> DependenciesGraphNode 
         installable: true,
         is_pure: true,
         optional: false,
-    }
+    };
+    (dep_path, node)
 }
 
 #[test]
@@ -638,16 +646,7 @@ fn git_hosted_dependency_records_bare_tarball_url_in_importer() {
         },
     }));
 
-    let url = "https://codeload.github.com/kevva/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99";
-    let dep_path = DepPath::from(url.to_string());
-    let node = git_hosted_node(
-        url,
-        Some(json!({
-            "name": "is-negative",
-            "version": "1.0.0",
-        })),
-    );
-
+    let (dep_path, node) = git_hosted_node("is-negative");
     let mut graph = DependenciesGraph::new();
     graph.insert(dep_path.clone(), node);
     let direct = BTreeMap::from([("is-negative".to_string(), dep_path)]);
@@ -664,43 +663,57 @@ fn git_hosted_dependency_records_bare_tarball_url_in_importer() {
         .get(&PkgName::parse("is-negative").unwrap())
         .expect("git dependency");
     assert_eq!(entry.specifier, "github:kevva/is-negative#1.0.0");
+    // The alias matches the package name, so the `is-negative@` prefix
+    // is stripped — same shape upstream's `depPathToRef` writes.
     match &entry.version {
-        ImporterDepVersion::Regular(version) => assert_eq!(version.to_string(), url),
-        other => panic!("expected Regular({url}), got {other:?}"),
+        ImporterDepVersion::Regular(version) => assert_eq!(version.to_string(), GIT_TARBALL_URL),
+        other => panic!("expected Regular({GIT_TARBALL_URL}), got {other:?}"),
     }
 
-    let package_key: PackageKey = format!("is-negative@{url}").parse().unwrap();
+    let package_key: PackageKey = format!("is-negative@{GIT_TARBALL_URL}").parse().unwrap();
     let packages = lockfile.packages.as_ref().expect("packages");
     assert_eq!(packages[&package_key].version.as_deref(), Some("1.0.0"));
     assert!(lockfile.snapshots.as_ref().expect("snapshots").contains_key(&package_key));
 }
 
+/// A renamed git dep keeps the `<name>@<ref>` alias form, so the
+/// importer entry still composes to the snapshot key that
+/// `packages:` / `snapshots:` are keyed by.
 #[test]
-fn git_hosted_dependency_without_manifest_name_returns_structured_error() {
+fn aliased_git_hosted_dependency_keeps_package_name_in_importer_ref() {
     let (_tmp, manifest) = write_manifest(json!({
         "name": "fixture",
         "version": "1.0.0",
         "dependencies": {
-            "is-negative": "github:kevva/is-negative#1.0.0",
+            "renamed": "github:kevva/is-negative#1.0.0",
         },
     }));
-    let url = "https://codeload.github.com/kevva/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99";
-    let dep_path = DepPath::from(url.to_string());
+
+    let (dep_path, node) = git_hosted_node("renamed");
     let mut graph = DependenciesGraph::new();
-    graph.insert(dep_path.clone(), git_hosted_node(url, None));
-    let direct = BTreeMap::from([("is-negative".to_string(), dep_path)]);
+    graph.insert(dep_path.clone(), node);
+    let direct = BTreeMap::from([("renamed".to_string(), dep_path)]);
 
-    let error = dbg!(
-        try_dependencies_graph_to_lockfile(single_importer_opts(
-            &manifest, &graph, direct, false, false, None, None,
-        ))
-        .unwrap_err()
-    );
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
 
-    let DependenciesGraphToLockfileError::MissingGitHostedPackageName { dep_path } = error else {
-        panic!("expected missing git-hosted package name error, got {error:?}");
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .expect("dependencies")
+        .get(&PkgName::parse("renamed").unwrap())
+        .expect("git dependency");
+    let version = dbg!(&entry.version);
+    let ImporterDepVersion::Alias(parsed) = version else {
+        panic!("expected Alias(is-negative@{GIT_TARBALL_URL}), got {version:?}");
     };
-    assert_eq!(dep_path, url);
+    assert_eq!(parsed.to_string(), format!("is-negative@{GIT_TARBALL_URL}"));
+
+    let package_key: PackageKey = format!("is-negative@{GIT_TARBALL_URL}").parse().unwrap();
+    assert!(lockfile.packages.as_ref().expect("packages").contains_key(&package_key));
+    assert!(lockfile.snapshots.as_ref().expect("snapshots").contains_key(&package_key));
 }
 
 #[test]
@@ -732,9 +745,7 @@ fn malformed_importer_dependency_path_returns_structured_error() {
         .unwrap_err()
     );
 
-    let DependenciesGraphToLockfileError::ImporterDependency { alias, dep_path, .. } = error else {
-        panic!("expected importer dependency error, got {error:?}");
-    };
+    let DependenciesGraphToLockfileError::ImporterDependency { alias, dep_path, .. } = error;
     assert_eq!(alias, "broken");
     assert_eq!(dep_path, "broken@1.0.0(");
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1,9 +1,12 @@
-use super::{GraphToLockfileOptions, ImporterLockfileInput, dependencies_graph_to_lockfile};
+use super::{
+    DependenciesGraphToLockfileError, GraphToLockfileOptions, ImporterLockfileInput,
+    dependencies_graph_to_lockfile as try_dependencies_graph_to_lockfile,
+};
 use indexmap::IndexMap;
 use pacquet_deps_path::DepPath;
 use pacquet_lockfile::{
     DirectoryResolution, ImporterDepVersion, LockfileResolution, PackageKey, PkgName, PkgNameVer,
-    RegistryResolution, SnapshotDepRef, VariationsResolution,
+    RegistryResolution, SnapshotDepRef, TarballResolution, VariationsResolution,
 };
 use pacquet_package_manifest::PackageManifest;
 use pacquet_resolving_deps_resolver::{
@@ -19,6 +22,10 @@ use std::{
     sync::Arc,
 };
 use tempfile::TempDir;
+
+fn dependencies_graph_to_lockfile(opts: GraphToLockfileOptions<'_>) -> pacquet_lockfile::Lockfile {
+    try_dependencies_graph_to_lockfile(opts).expect("convert dependency graph to lockfile")
+}
 
 /// Shared empty catalogs for the catalog-free fixtures in this module.
 static EMPTY_CATALOGS: pacquet_catalogs_types::Catalogs = BTreeMap::new();
@@ -584,6 +591,115 @@ fn runtime_dependency_strips_importer_prefix_and_records_package_version() {
     let metadata_key: PackageKey = "node@runtime:26.3.0".parse().unwrap();
     let metadata = &lockfile.packages.as_ref().expect("packages")[&metadata_key];
     assert_eq!(metadata.version.as_deref(), Some("26.3.0"));
+}
+
+#[test]
+fn git_hosted_dependency_records_bare_tarball_url_in_importer() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": {
+            "is-negative": "github:kevva/is-negative#1.0.0",
+        },
+    }));
+
+    let url = "https://codeload.github.com/kevva/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99";
+    let dep_path = DepPath::from(url.to_string());
+    let resolve_result = ResolveResult {
+        id: PkgResolutionId::from(url),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: Some(Arc::new(json!({
+            "name": "is-negative",
+            "version": "1.0.0",
+        }))),
+        resolution: LockfileResolution::Tarball(TarballResolution {
+            tarball: url.to_string(),
+            integrity: None,
+            git_hosted: Some(true),
+            path: None,
+        }),
+        resolved_via: "git-repository".to_string(),
+        normalized_bare_specifier: Some("github:kevva/is-negative#1.0.0".to_string()),
+        alias: Some("is-negative".to_string()),
+        policy_violation: None,
+    };
+    let node = DependenciesGraphNode {
+        dep_path: dep_path.clone(),
+        resolved_package_id: url.to_string(),
+        resolve_result: Arc::new(resolve_result),
+        children: BTreeMap::new(),
+        optional_children: HashSet::new(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::new(),
+        resolved_peer_names: HashSet::new(),
+        depth: 1,
+        installable: true,
+        is_pure: true,
+        optional: false,
+    };
+
+    let mut graph = DependenciesGraph::new();
+    graph.insert(dep_path.clone(), node);
+    let direct = BTreeMap::from([("is-negative".to_string(), dep_path)]);
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .expect("dependencies")
+        .get(&PkgName::parse("is-negative").unwrap())
+        .expect("git dependency");
+    assert_eq!(entry.specifier, "github:kevva/is-negative#1.0.0");
+    match &entry.version {
+        ImporterDepVersion::Regular(version) => assert_eq!(version.to_string(), url),
+        other => panic!("expected Regular({url}), got {other:?}"),
+    }
+
+    let package_key: PackageKey = format!("is-negative@{url}").parse().unwrap();
+    let packages = lockfile.packages.as_ref().expect("packages");
+    assert_eq!(packages[&package_key].version.as_deref(), Some("1.0.0"));
+    assert!(lockfile.snapshots.as_ref().expect("snapshots").contains_key(&package_key));
+}
+
+#[test]
+fn malformed_importer_dependency_path_returns_structured_error() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "broken": "^1.0.0" },
+    }));
+    let dep_path = DepPath::from("broken@1.0.0(".to_string());
+    let mut node = make_node(
+        "broken",
+        "1.0.0",
+        json!({ "name": "broken", "version": "1.0.0" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+    node.dep_path = dep_path.clone();
+
+    let mut graph = DependenciesGraph::new();
+    graph.insert(dep_path.clone(), node);
+    let direct = BTreeMap::from([("broken".to_string(), dep_path)]);
+
+    let error = try_dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ))
+    .unwrap_err();
+
+    match error {
+        DependenciesGraphToLockfileError::ImporterDependency { alias, dep_path, .. } => {
+            assert_eq!(alias, "broken");
+            assert_eq!(dep_path, "broken@1.0.0(");
+        }
+    }
 }
 
 #[test]
@@ -1599,14 +1715,14 @@ fn same_name_injected_dep_serializes_as_plain_file_ref() {
         optional: false,
     };
 
-    let version = super::importer_dep_version("@scope/comp1", &node);
+    let version = super::importer_dep_version("@scope/comp1", &node).unwrap();
     assert_eq!(
         version,
         ImporterDepVersion::File("comp1(react@16.0.0)".to_string()),
         "same-name injected deps must use the plain file: ref",
     );
     // A genuinely renamed alias keeps the alias form.
-    let renamed = super::importer_dep_version("renamed", &node);
+    let renamed = super::importer_dep_version("renamed", &node).unwrap();
     assert!(
         matches!(renamed, ImporterDepVersion::Alias(_)),
         "renamed aliases must keep the <name>@<ref> form: {renamed:?}",

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -742,7 +742,7 @@ fn malformed_importer_dependency_path_returns_structured_error() {
         try_dependencies_graph_to_lockfile(single_importer_opts(
             &manifest, &graph, direct, false, false, None, None,
         ))
-        .unwrap_err()
+        .unwrap_err(),
     );
 
     let DependenciesGraphToLockfileError::ImporterDependency { alias, dep_path, .. } = error;

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -680,8 +680,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         });
         // A git dep's specifier names a repo, not a package, so its
         // name — the `<name>@` half of every lockfile key it reaches —
-        // is only readable from the `package.json` in the host's
-        // archive. Hand the resolver the handles to fetch it, on the
+        // is only readable from the package's own `package.json`, in
+        // the host's archive or (for a repo with no archive endpoint) a
+        // checkout. Hand the resolver the handles to read it, on the
         // same rationale as the remote-tarball fetch below.
         let git_resolver = GitResolver::new(
             Arc::new(RealGitProbe::new(Arc::clone(&http_client_arc))),
@@ -693,6 +694,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             store_index_writer: Some(Arc::clone(&store_index_writer)),
             auth_headers: Arc::clone(&auth_headers),
             retry_opts: crate::retry_config::retry_opts_from_config(config),
+            git_shallow_hosts: config.git_shallow_hosts.clone(),
         });
         // A remote (non-registry) tarball *direct* dependency carries no
         // name/version/integrity at resolve time — they live in the

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -29,7 +29,7 @@ use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_deps_resolver::{
     ManifestHook, ResolveDependencyTreeError, ResolveImporterError, ResolveImporterOptions,
 };
-use pacquet_resolving_git_resolver::{GitResolver, RealGitProbe, RealGitRunner};
+use pacquet_resolving_git_resolver::{GitFetchContext, GitResolver, RealGitProbe, RealGitRunner};
 use pacquet_resolving_local_resolver::{
     LocalPathResolver, LocalResolverContext, LocalSchemeResolver,
 };
@@ -678,10 +678,22 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             filter_metadata: full_metadata,
             retry_opts: crate::retry_config::retry_opts_from_config(config),
         });
+        // A git dep's specifier names a repo, not a package, so its
+        // name — the `<name>@` half of every lockfile key it reaches —
+        // is only readable from the `package.json` in the host's
+        // archive. Hand the resolver the handles to fetch it, on the
+        // same rationale as the remote-tarball fetch below.
         let git_resolver = GitResolver::new(
             Arc::new(RealGitProbe::new(Arc::clone(&http_client_arc))),
             Arc::new(RealGitRunner::new()),
-        );
+        )
+        .with_fetch_context(GitFetchContext {
+            http_client: Arc::clone(&http_client_arc),
+            store_dir,
+            store_index_writer: Some(Arc::clone(&store_index_writer)),
+            auth_headers: Arc::clone(&auth_headers),
+            retry_opts: crate::retry_config::retry_opts_from_config(config),
+        });
         // A remote (non-registry) tarball *direct* dependency carries no
         // name/version/integrity at resolve time — they live in the
         // tarball's `package.json`. The resolver downloads + extracts it

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1,10 +1,10 @@
 use crate::{
     AllowBuildPolicy, CreateVirtualStore, CreateVirtualStoreError, CreateVirtualStoreOutput,
-    GraphToLockfileOptions, HoistedDependencies, ImporterLockfileInput,
-    InstallPackageFromRegistryError, LinkRootComponentMembersError, LinkVirtualStoreBins,
-    LinkVirtualStoreBinsError, PrefetchContext, PrefetchingResolver, SkippedSnapshots,
-    SymlinkDirectDependencies, SymlinkDirectDependenciesError, VersionPolicyError,
-    VersionsOverrider, VirtualStoreLayout, dependencies_graph_to_lockfile,
+    DependenciesGraphToLockfileError, GraphToLockfileOptions, HoistedDependencies,
+    ImporterLockfileInput, InstallPackageFromRegistryError, LinkRootComponentMembersError,
+    LinkVirtualStoreBins, LinkVirtualStoreBinsError, PrefetchContext, PrefetchingResolver,
+    SkippedSnapshots, SymlinkDirectDependencies, SymlinkDirectDependenciesError,
+    VersionPolicyError, VersionsOverrider, VirtualStoreLayout, dependencies_graph_to_lockfile,
     link_root_component_members, store_init::init_store_dir_best_effort,
 };
 use dashmap::DashMap;
@@ -290,6 +290,10 @@ pub enum InstallWithFreshLockfileError {
     #[display("Failed to resolve dependency tree: {_0}")]
     #[diagnostic(transparent)]
     ResolveDependencyTree(#[error(source)] ResolveDependencyTreeError),
+
+    #[display("Failed to build lockfile from resolved dependency graph: {_0}")]
+    #[diagnostic(code(pacquet_package_manager::dependencies_graph_to_lockfile))]
+    DependenciesGraphToLockfile(#[error(source)] Box<DependenciesGraphToLockfileError>),
 
     /// `minimumReleaseAgeExclude` patterns rejected at compile time.
     /// Surfaced as `ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE`.
@@ -1359,7 +1363,10 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 catalogs: &catalogs,
                 pnpmfile_checksum: pnpmfile_checksum.as_deref(),
                 patched_dependency_hashes: patched_dependency_hashes.as_ref(),
-            });
+            })
+            .map_err(|error| {
+                InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
+            })?;
             // `--dry-run` builds the would-be lockfile so the caller can
             // diff it, but never persists it. A plain `--lockfile-only`
             // writes it (unless `lockfile: false`).
@@ -1502,7 +1509,10 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             catalogs: &catalogs,
             pnpmfile_checksum: pnpmfile_checksum.as_deref(),
             patched_dependency_hashes: patched_dependency_hashes.as_ref(),
-        });
+        })
+        .map_err(|error| {
+            InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
+        })?;
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "build_fresh_lockfile",
@@ -2414,7 +2424,9 @@ struct FreshLockfileBuildOptions<'a> {
     patched_dependency_hashes: Option<&'a BTreeMap<String, String>>,
 }
 
-fn build_fresh_lockfile(opts: FreshLockfileBuildOptions<'_>) -> Lockfile {
+fn build_fresh_lockfile(
+    opts: FreshLockfileBuildOptions<'_>,
+) -> Result<Lockfile, DependenciesGraphToLockfileError> {
     let FreshLockfileBuildOptions {
         config,
         importer_manifests,

--- a/pnpm/crates/package-manager/src/prefetching_resolver.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver.rs
@@ -219,6 +219,10 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
                     package_id: &package_id,
                     auth_headers: &self.ctx.auth_headers,
                     retry_opts: self.ctx.retry_opts,
+                    // Only integrity is read off this fetch, and
+                    // git-hosted archives (the sole subdirectory-bearing
+                    // shape) are filtered out above.
+                    manifest_subdir: None,
                 }
                 .run::<SilentReporter>(Some(&self.ctx.mem_cache))
                 .await

--- a/pnpm/crates/resolving-git-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-git-resolver/Cargo.toml
@@ -13,12 +13,16 @@ repository.workspace  = true
 [dependencies]
 pacquet-lockfile                = { workspace = true }
 pacquet-network                 = { workspace = true }
+pacquet-reporter                = { workspace = true }
 pacquet-resolving-resolver-base = { workspace = true }
+pacquet-store-dir               = { workspace = true }
+pacquet-tarball                 = { workspace = true }
 
 derive_more = { workspace = true }
 miette      = { workspace = true }
 node-semver = { workspace = true }
 reqwest     = { workspace = true }
+serde_json  = { workspace = true }
 tokio       = { workspace = true }
 tracing     = { workspace = true }
 

--- a/pnpm/crates/resolving-git-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-git-resolver/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-git-fetcher             = { workspace = true }
 pacquet-lockfile                = { workspace = true }
 pacquet-network                 = { workspace = true }
 pacquet-reporter                = { workspace = true }

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -22,13 +22,14 @@ use crate::{
 };
 
 /// Store/network handles [`GitResolver`] needs to read a git-hosted
-/// package's `package.json` during resolution.
+/// package's identity out of its archive during resolution.
 ///
 /// A git host's archive endpoint is the only place a git dep's name
-/// lives — the specifier names a repo, not a package — and pacquet
-/// builds the lockfile before the install/fetch pass runs, so the name
-/// has to be read here. Mirrors the tarball resolver's remote-tarball
-/// fetch, which fills `manifest` for the same reason.
+/// and integrity live — the specifier names a repo, not a package —
+/// and pacquet builds the lockfile before the install/fetch pass runs,
+/// so both have to be read here. Mirrors the tarball resolver's
+/// remote-tarball fetch, which fills the same two fields for the same
+/// reason.
 ///
 /// This fetch stops at the raw archive: the git-hosted
 /// `prepare`/`prepublish` pass and its packlist filtering stay in the
@@ -54,7 +55,7 @@ pub struct GitFetchContext {
 /// install dispatcher) into a single owner.
 ///
 /// When `fetch_context` is `Some`, a git-hosted dep's archive is
-/// downloaded during resolution to fill `manifest` — see
+/// downloaded during resolution to fill `manifest` + `integrity` — see
 /// [`GitFetchContext`]. `None` (unit tests, and the resolve-only NAPI
 /// entry point) keeps the manifest-less shape.
 pub struct GitResolver<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> {
@@ -109,21 +110,22 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
         let mut result =
             build_resolve_result(spec, self.runner.as_ref(), wanted_dependency.alias.as_deref())
                 .await?;
-        result.manifest = self.fetch_manifest(&result).await?;
+        self.read_archive_metadata(&mut result).await?;
         Ok(Some(result))
     }
 
-    /// Read the `package.json` bundled in a git-hosted package's
-    /// archive. `None` whenever the name can't be sourced this way —
-    /// no fetch context (unit tests / resolve-only callers), or a
-    /// non-hosted repo that needs a clone rather than an archive
-    /// download.
-    async fn fetch_manifest(
-        &self,
-        result: &ResolveResult,
-    ) -> Result<Option<Arc<serde_json::Value>>, ResolveError> {
-        let Some(ctx) = self.fetch_context.as_ref() else { return Ok(None) };
-        let LockfileResolution::Tarball(tarball) = &result.resolution else { return Ok(None) };
+    /// Fill `manifest` + the resolution's `integrity` from a git-hosted
+    /// package's archive. No-op without a fetch context (unit tests /
+    /// resolve-only callers), or for a non-hosted repo, which needs a
+    /// clone rather than an archive download.
+    async fn read_archive_metadata(&self, result: &mut ResolveResult) -> Result<(), ResolveError> {
+        let Some(ctx) = self.fetch_context.as_ref() else { return Ok(()) };
+        let LockfileResolution::Tarball(tarball) = &result.resolution else { return Ok(()) };
+        let tarball_url = tarball.tarball.clone();
+        // `#path:/packages/foo` points at one directory of the repo; the
+        // archive spans the whole repo, so its root `package.json` is
+        // the repo's, not this package's.
+        let manifest_subdir = tarball.path.clone();
 
         // Silent reporter: the install pass owns the
         // `resolved → found_in_store → imported` event ordering.
@@ -131,23 +133,29 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
             http_client: &ctx.http_client,
             store_dir: ctx.store_dir,
             store_index_writer: ctx.store_index_writer.clone(),
-            package_url: &tarball.tarball,
+            package_url: &tarball_url,
             // A git host's archive URL is the package's only identifier
             // at this point — its name is what this fetch is here to
             // learn — and such archives carry no scoped-registry auth.
-            package_id: &tarball.tarball,
+            package_id: &tarball_url,
             auth_headers: &ctx.auth_headers,
             retry_opts: ctx.retry_opts,
-            // `#path:/packages/foo` points at one directory of the
-            // repo; the archive spans the whole repo, so its root
-            // `package.json` is the repo's, not this package's.
-            manifest_subdir: tarball.path.as_deref(),
+            manifest_subdir: manifest_subdir.as_deref(),
         }
         .run::<SilentReporter>(None)
         .await
         .map_err(|err| Box::new(err) as ResolveError)?;
 
-        Ok(resolved.manifest.map(Arc::new))
+        result.manifest = resolved.manifest.map(Arc::new);
+        if let LockfileResolution::Tarball(tarball) = &mut result.resolution {
+            // A git host's archive carries no integrity of its own, and
+            // the install pass refuses a tarball resolution without one
+            // (`tarball_url_and_integrity`). The bytes were just hashed
+            // to extract them, so record that — same field upstream
+            // writes for a git dep.
+            tarball.integrity = Some(resolved.integrity);
+        }
+        Ok(())
     }
 
     /// Companion to [`Self::resolve_impl`].

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -5,10 +5,14 @@
 use std::sync::Arc;
 
 use pacquet_lockfile::{GitResolution, LockfileResolution, TarballResolution};
+use pacquet_network::{AuthHeaders, ThrottledClient};
+use pacquet_reporter::SilentReporter;
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
     ResolveResult, Resolver, WantedDependency,
 };
+use pacquet_store_dir::{StoreDir, StoreIndexWriter};
+use pacquet_tarball::{FetchTarballForResolution, RetryOpts};
 
 use crate::{
     create_git_hosted_pkg_id::create_git_hosted_pkg_id,
@@ -17,6 +21,30 @@ use crate::{
     resolve_ref::{GitCommandRunner, resolve_ref},
 };
 
+/// Store/network handles [`GitResolver`] needs to read a git-hosted
+/// package's `package.json` during resolution.
+///
+/// A git host's archive endpoint is the only place a git dep's name
+/// lives — the specifier names a repo, not a package — and pacquet
+/// builds the lockfile before the install/fetch pass runs, so the name
+/// has to be read here. Mirrors the tarball resolver's remote-tarball
+/// fetch, which fills `manifest` for the same reason.
+///
+/// This fetch stops at the raw archive: the git-hosted
+/// `prepare`/`prepublish` pass and its packlist filtering stay in the
+/// install pass, so no package script runs during resolution. The
+/// install pass re-fetches the archive to run them — unlike a registry
+/// tarball, a git-hosted one can't hand its extraction over through
+/// `MemCache` (only `Registry` resolutions read it) — so a git dep
+/// costs one extra archive download per install.
+pub struct GitFetchContext {
+    pub http_client: Arc<ThrottledClient>,
+    pub store_dir: &'static StoreDir,
+    pub store_index_writer: Option<Arc<StoreIndexWriter>>,
+    pub auth_headers: Arc<AuthHeaders>,
+    pub retry_opts: RetryOpts,
+}
+
 /// Git resolver entry point. Holds the production network / git
 /// runners shared across every per-dep `resolve()` call; tests
 /// construct one with fake runners.
@@ -24,14 +52,28 @@ use crate::{
 /// `Arc` so the resolver can be cloned into the default-resolver
 /// chain without forcing the runners (whose ownership lives on the
 /// install dispatcher) into a single owner.
+///
+/// When `fetch_context` is `Some`, a git-hosted dep's archive is
+/// downloaded during resolution to fill `manifest` — see
+/// [`GitFetchContext`]. `None` (unit tests, and the resolve-only NAPI
+/// entry point) keeps the manifest-less shape.
 pub struct GitResolver<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> {
     probe: Arc<Probe>,
     runner: Arc<Runner>,
+    fetch_context: Option<GitFetchContext>,
 }
 
 impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<Probe, Runner> {
     pub fn new(probe: Arc<Probe>, runner: Arc<Runner>) -> Self {
-        Self { probe, runner }
+        Self { probe, runner, fetch_context: None }
+    }
+
+    /// Attach the store/network handles that let resolution read a
+    /// git-hosted package's name from its `package.json`.
+    #[must_use]
+    pub fn with_fetch_context(mut self, fetch_context: GitFetchContext) -> Self {
+        self.fetch_context = Some(fetch_context);
+        self
     }
 }
 
@@ -64,10 +106,44 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
         let Some(bare) = wanted_dependency.bare_specifier.as_deref() else { return Ok(None) };
         let Some(partial) = parse_bare_specifier(bare) else { return Ok(None) };
         let spec = partial.finalize(self.probe.as_ref()).await;
-        let result =
+        let mut result =
             build_resolve_result(spec, self.runner.as_ref(), wanted_dependency.alias.as_deref())
                 .await?;
+        result.manifest = self.fetch_manifest(&result).await?;
         Ok(Some(result))
+    }
+
+    /// Read the `package.json` bundled in a git-hosted package's
+    /// archive. `None` whenever the name can't be sourced this way —
+    /// no fetch context (unit tests / resolve-only callers), or a
+    /// non-hosted repo that needs a clone rather than an archive
+    /// download.
+    async fn fetch_manifest(
+        &self,
+        result: &ResolveResult,
+    ) -> Result<Option<Arc<serde_json::Value>>, ResolveError> {
+        let Some(ctx) = self.fetch_context.as_ref() else { return Ok(None) };
+        let LockfileResolution::Tarball(tarball) = &result.resolution else { return Ok(None) };
+
+        // Silent reporter: the install pass owns the
+        // `resolved → found_in_store → imported` event ordering.
+        let resolved = FetchTarballForResolution {
+            http_client: &ctx.http_client,
+            store_dir: ctx.store_dir,
+            store_index_writer: ctx.store_index_writer.clone(),
+            package_url: &tarball.tarball,
+            // A git host's archive URL is the package's only identifier
+            // at this point — its name is what this fetch is here to
+            // learn — and such archives carry no scoped-registry auth.
+            package_id: &tarball.tarball,
+            auth_headers: &ctx.auth_headers,
+            retry_opts: ctx.retry_opts,
+        }
+        .run::<SilentReporter>(None)
+        .await
+        .map_err(|err| Box::new(err) as ResolveError)?;
+
+        Ok(resolved.manifest.map(Arc::new))
     }
 
     /// Companion to [`Self::resolve_impl`].

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -138,6 +138,10 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
             package_id: &tarball.tarball,
             auth_headers: &ctx.auth_headers,
             retry_opts: ctx.retry_opts,
+            // `#path:/packages/foo` points at one directory of the
+            // repo; the archive spans the whole repo, so its root
+            // `package.json` is the repo's, not this package's.
+            manifest_subdir: tarball.path.as_deref(),
         }
         .run::<SilentReporter>(None)
         .await

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use pacquet_git_fetcher::{GitManifestQuery, read_git_manifest};
 use pacquet_lockfile::{GitResolution, LockfileResolution, TarballResolution};
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_reporter::SilentReporter;
@@ -21,29 +22,39 @@ use crate::{
     resolve_ref::{GitCommandRunner, resolve_ref},
 };
 
-/// Store/network handles [`GitResolver`] needs to read a git-hosted
-/// package's identity out of its archive during resolution.
+/// Store/network handles [`GitResolver`] needs to read a git dep's
+/// identity out of the package itself during resolution.
 ///
-/// A git host's archive endpoint is the only place a git dep's name
-/// and integrity live — the specifier names a repo, not a package —
-/// and pacquet builds the lockfile before the install/fetch pass runs,
-/// so both have to be read here. Mirrors the tarball resolver's
-/// remote-tarball fetch, which fills the same two fields for the same
-/// reason.
+/// A git dep's specifier names a repo, not a package, so its name —
+/// and, for a host archive, its integrity — live only in the package's
+/// own `package.json`. pacquet builds the lockfile before the
+/// install/fetch pass runs, so they have to be read here. Mirrors the
+/// tarball resolver's remote-tarball fetch, which fills the same fields
+/// for the same reason.
 ///
-/// This fetch stops at the raw archive: the git-hosted
-/// `prepare`/`prepublish` pass and its packlist filtering stay in the
-/// install pass, so no package script runs during resolution. The
-/// install pass re-fetches the archive to run them — unlike a registry
-/// tarball, a git-hosted one can't hand its extraction over through
-/// `MemCache` (only `Registry` resolutions read it) — so a git dep
-/// costs one extra archive download per install.
+/// Two shapes, by resolution:
+///
+/// - a git *host* (`github:` / `gitlab:` / `bitbucket:`) serves an
+///   archive, which is downloaded and hashed;
+/// - any other repo (ssh, self-hosted, `file:`) has no archive
+///   endpoint, so a throwaway checkout is the cheapest read.
+///
+/// Either way this stops at the manifest: `prepare` / `prepublish` and
+/// packlist filtering stay in the install pass, so no package script
+/// runs during resolution. The install pass re-fetches to run them —
+/// unlike a registry tarball, a git-hosted one can't hand its
+/// extraction over through `MemCache` (only `Registry` resolutions read
+/// it) — so a git dep costs one extra fetch per install.
 pub struct GitFetchContext {
     pub http_client: Arc<ThrottledClient>,
     pub store_dir: &'static StoreDir,
     pub store_index_writer: Option<Arc<StoreIndexWriter>>,
     pub auth_headers: Arc<AuthHeaders>,
     pub retry_opts: RetryOpts,
+    /// Hosts that opt into `git init` + `git fetch --depth 1` instead
+    /// of a full clone, for the repos with no archive endpoint. Mirrors
+    /// `Config::git_shallow_hosts`.
+    pub git_shallow_hosts: Vec<String>,
 }
 
 /// Git resolver entry point. Holds the production network / git
@@ -54,10 +65,10 @@ pub struct GitFetchContext {
 /// chain without forcing the runners (whose ownership lives on the
 /// install dispatcher) into a single owner.
 ///
-/// When `fetch_context` is `Some`, a git-hosted dep's archive is
-/// downloaded during resolution to fill `manifest` + `integrity` — see
-/// [`GitFetchContext`]. `None` (unit tests, and the resolve-only NAPI
-/// entry point) keeps the manifest-less shape.
+/// When `fetch_context` is `Some`, the package is read during
+/// resolution to fill `manifest` (and `integrity`, for a host archive)
+/// — see [`GitFetchContext`]. `None` (unit tests, and the resolve-only
+/// NAPI entry point) keeps the manifest-less shape.
 pub struct GitResolver<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> {
     probe: Arc<Probe>,
     runner: Arc<Runner>,
@@ -69,8 +80,8 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
         Self { probe, runner, fetch_context: None }
     }
 
-    /// Attach the store/network handles that let resolution read a
-    /// git-hosted package's name from its `package.json`.
+    /// Attach the store/network handles that let resolution read the
+    /// package's name from its `package.json`.
     #[must_use]
     pub fn with_fetch_context(mut self, fetch_context: GitFetchContext) -> Self {
         self.fetch_context = Some(fetch_context);
@@ -110,50 +121,71 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
         let mut result =
             build_resolve_result(spec, self.runner.as_ref(), wanted_dependency.alias.as_deref())
                 .await?;
-        self.read_archive_metadata(&mut result).await?;
+        self.read_package_metadata(&mut result).await?;
         Ok(Some(result))
     }
 
-    /// Fill `manifest` + the resolution's `integrity` from a git-hosted
-    /// package's archive. No-op without a fetch context (unit tests /
-    /// resolve-only callers), or for a non-hosted repo, which needs a
-    /// clone rather than an archive download.
-    async fn read_archive_metadata(&self, result: &mut ResolveResult) -> Result<(), ResolveError> {
+    /// Fill `manifest` — and, for an archive, the resolution's
+    /// `integrity` — from the package the git dep points at. No-op
+    /// without a fetch context (unit tests / resolve-only callers).
+    async fn read_package_metadata(&self, result: &mut ResolveResult) -> Result<(), ResolveError> {
         let Some(ctx) = self.fetch_context.as_ref() else { return Ok(()) };
-        let LockfileResolution::Tarball(tarball) = &result.resolution else { return Ok(()) };
-        let tarball_url = tarball.tarball.clone();
-        // `#path:/packages/foo` points at one directory of the repo; the
-        // archive spans the whole repo, so its root `package.json` is
-        // the repo's, not this package's.
-        let manifest_subdir = tarball.path.clone();
+        match &result.resolution {
+            LockfileResolution::Tarball(tarball) => {
+                let tarball_url = tarball.tarball.clone();
+                // `#path:/packages/foo` points at one directory of the
+                // repo; the archive spans the whole repo, so its root
+                // `package.json` is the repo's, not this package's.
+                let manifest_subdir = tarball.path.clone();
 
-        // Silent reporter: the install pass owns the
-        // `resolved → found_in_store → imported` event ordering.
-        let resolved = FetchTarballForResolution {
-            http_client: &ctx.http_client,
-            store_dir: ctx.store_dir,
-            store_index_writer: ctx.store_index_writer.clone(),
-            package_url: &tarball_url,
-            // A git host's archive URL is the package's only identifier
-            // at this point — its name is what this fetch is here to
-            // learn — and such archives carry no scoped-registry auth.
-            package_id: &tarball_url,
-            auth_headers: &ctx.auth_headers,
-            retry_opts: ctx.retry_opts,
-            manifest_subdir: manifest_subdir.as_deref(),
-        }
-        .run::<SilentReporter>(None)
-        .await
-        .map_err(|err| Box::new(err) as ResolveError)?;
+                // Silent reporter: the install pass owns the
+                // `resolved → found_in_store → imported` event ordering.
+                let resolved = FetchTarballForResolution {
+                    http_client: &ctx.http_client,
+                    store_dir: ctx.store_dir,
+                    store_index_writer: ctx.store_index_writer.clone(),
+                    package_url: &tarball_url,
+                    // A git host's archive URL is the package's only
+                    // identifier at this point — its name is what this
+                    // fetch is here to learn — and such archives carry
+                    // no scoped-registry auth.
+                    package_id: &tarball_url,
+                    auth_headers: &ctx.auth_headers,
+                    retry_opts: ctx.retry_opts,
+                    manifest_subdir: manifest_subdir.as_deref(),
+                }
+                .run::<SilentReporter>(None)
+                .await
+                .map_err(|err| Box::new(err) as ResolveError)?;
 
-        result.manifest = resolved.manifest.map(Arc::new);
-        if let LockfileResolution::Tarball(tarball) = &mut result.resolution {
-            // A git host's archive carries no integrity of its own, and
-            // the install pass refuses a tarball resolution without one
-            // (`tarball_url_and_integrity`). The bytes were just hashed
-            // to extract them, so record that — same field upstream
-            // writes for a git dep.
-            tarball.integrity = Some(resolved.integrity);
+                result.manifest = resolved.manifest.map(Arc::new);
+                if let LockfileResolution::Tarball(tarball) = &mut result.resolution {
+                    // A git host's archive carries no integrity of its
+                    // own, and the install pass refuses a tarball
+                    // resolution without one
+                    // (`tarball_url_and_integrity`). The bytes were
+                    // just hashed to extract them, so record that —
+                    // same field upstream writes for a git dep.
+                    tarball.integrity = Some(resolved.integrity);
+                }
+            }
+            LockfileResolution::Git(git) => {
+                // No archive endpoint to read, so the working tree is
+                // the only source of the name. A `Git` resolution
+                // carries no integrity — it is anchored by its commit —
+                // so the manifest is all there is to read.
+                let manifest = read_git_manifest(GitManifestQuery {
+                    repo: &git.repo,
+                    commit: &git.commit,
+                    path: git.path.as_deref(),
+                    git_shallow_hosts: &ctx.git_shallow_hosts,
+                    git_bin: None,
+                })
+                .await
+                .map_err(|err| Box::new(err) as ResolveError)?;
+                result.manifest = manifest.map(Arc::new);
+            }
+            _ => {}
         }
         Ok(())
     }

--- a/pnpm/crates/resolving-git-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-git-resolver/src/lib.rs
@@ -14,9 +14,15 @@
 //! - [`GitResolver`] — the [`Resolver`](pacquet_resolving_resolver_base::Resolver)
 //!   impl that drives the two above, runs `git ls-remote` to pin a
 //!   commit, and emits either a `Tarball{gitHosted: true}` or `Git`
-//!   resolution.
+//!   resolution. Given a [`GitFetchContext`], it also reads the
+//!   package's name from the host archive's `package.json` — see that
+//!   type for why resolution is where that has to happen.
 //!
 //! Out of scope:
+//!
+//! - Reading the name of a `Git`-resolution dep (a private/ssh repo
+//!   with no host archive endpoint). Those need a clone rather than an
+//!   archive download, so they keep resolving without a manifest.
 //!
 //! - The `prev_specifier` short-circuit (the `currentPkg && !update`
 //!   fast path). Pacquet doesn't thread `currentPkg` through the seam
@@ -34,7 +40,7 @@ mod resolve_ref;
 mod runners;
 
 pub use create_git_hosted_pkg_id::create_git_hosted_pkg_id;
-pub use git_resolver::GitResolver;
+pub use git_resolver::{GitFetchContext, GitResolver};
 pub use hosted_git::{HostedGit, HostedGitType, HostedOpts};
 pub use parse_bare_specifier::{
     GitProbe, HostedPackageSpec, PartialSpec, ProbeFuture, parse_bare_specifier,

--- a/pnpm/crates/resolving-git-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-git-resolver/src/lib.rs
@@ -15,16 +15,12 @@
 //!   impl that drives the two above, runs `git ls-remote` to pin a
 //!   commit, and emits either a `Tarball{gitHosted: true}` or `Git`
 //!   resolution. Given a [`GitFetchContext`], it also reads the
-//!   package's name from the host archive's `package.json` and its
-//!   integrity from the archive bytes — see that type for why
-//!   resolution is where that has to happen.
+//!   package's name from its `package.json` — out of the host archive,
+//!   or out of a checkout for a repo that serves no archive — plus the
+//!   archive's integrity. See that type for why resolution is where
+//!   that has to happen.
 //!
 //! Out of scope:
-//!
-//! - Reading the identity of a `Git`-resolution dep (a private/ssh
-//!   repo with no host archive endpoint). Those need a clone rather
-//!   than an archive download, so they keep resolving without a
-//!   manifest or integrity.
 //!
 //! - The `prev_specifier` short-circuit (the `currentPkg && !update`
 //!   fast path). Pacquet doesn't thread `currentPkg` through the seam

--- a/pnpm/crates/resolving-git-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-git-resolver/src/lib.rs
@@ -15,14 +15,16 @@
 //!   impl that drives the two above, runs `git ls-remote` to pin a
 //!   commit, and emits either a `Tarball{gitHosted: true}` or `Git`
 //!   resolution. Given a [`GitFetchContext`], it also reads the
-//!   package's name from the host archive's `package.json` — see that
-//!   type for why resolution is where that has to happen.
+//!   package's name from the host archive's `package.json` and its
+//!   integrity from the archive bytes — see that type for why
+//!   resolution is where that has to happen.
 //!
 //! Out of scope:
 //!
-//! - Reading the name of a `Git`-resolution dep (a private/ssh repo
-//!   with no host archive endpoint). Those need a clone rather than an
-//!   archive download, so they keep resolving without a manifest.
+//! - Reading the identity of a `Git`-resolution dep (a private/ssh
+//!   repo with no host archive endpoint). Those need a clone rather
+//!   than an archive download, so they keep resolving without a
+//!   manifest or integrity.
 //!
 //! - The `prev_specifier` short-circuit (the `currentPkg && !update`
 //!   fast path). Pacquet doesn't thread `currentPkg` through the seam

--- a/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -174,6 +174,8 @@ impl TarballResolver {
             package_id: &resolved_url,
             auth_headers: &ctx.auth_headers,
             retry_opts: ctx.retry_opts,
+            // A plain tarball is the package; its manifest is at the root.
+            manifest_subdir: None,
         }
         .run::<SilentReporter>(ctx.mem_cache.as_deref())
         .await

--- a/pnpm/crates/tarball/Cargo.toml
+++ b/pnpm/crates/tarball/Cargo.toml
@@ -38,6 +38,7 @@ zune-inflate = { workspace = true }
 
 [dev-dependencies]
 dashmap           = { workspace = true, features = ["raw-api"] }
+flate2            = { workspace = true }
 mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile          = { workspace = true }

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -2454,6 +2454,15 @@ pub struct FetchTarballForResolution<'a> {
     pub package_id: &'a str,
     pub auth_headers: &'a AuthHeaders,
     pub retry_opts: RetryOpts,
+    /// Directory *within* the archive holding the package, for a
+    /// git-hosted dep that points at one directory of a repo
+    /// (`#path:/packages/foo`). The archive spans the whole repo, so
+    /// the root `package.json` describes the repo, not the package —
+    /// read the manifest from here instead. `None` reads the root.
+    ///
+    /// Matches the resolution's `path` field verbatim, leading slash
+    /// and all.
+    pub manifest_subdir: Option<&'a str>,
 }
 
 impl FetchTarballForResolution<'_> {
@@ -2469,6 +2478,7 @@ impl FetchTarballForResolution<'_> {
             package_id,
             auth_headers,
             retry_opts,
+            manifest_subdir,
         } = self;
 
         // Resolve-time tarball fetches compute integrity from bytes and
@@ -2490,7 +2500,10 @@ impl FetchTarballForResolution<'_> {
         )
         .await?;
 
-        let manifest = pkg_files_idx.manifest.clone();
+        let manifest = match manifest_subdir {
+            Some(subdir) => read_subdir_manifest(&cas_paths, subdir).await?,
+            None => pkg_files_idx.manifest.clone(),
+        };
         // Scope the store-index row by the package's canonical
         // `name@version`, matching what the install pass derives from
         // the same manifest. Fall back to the URL when the tarball has
@@ -2516,6 +2529,39 @@ impl FetchTarballForResolution<'_> {
         }
 
         Ok(ResolvedTarball { integrity, manifest })
+    }
+}
+
+/// Read `<subdir>/package.json` out of a freshly extracted archive.
+///
+/// Extraction only stashes the *root* `package.json` on the
+/// [`PackageFilesIndex`], so a package living in a subdirectory of the
+/// archive has to be read back from the CAS. Returns `None` when the
+/// subdirectory has no `package.json`, matching the root path's
+/// best-effort contract — the caller degrades rather than failing the
+/// resolve.
+async fn read_subdir_manifest(
+    cas_paths: &HashMap<String, PathBuf>,
+    subdir: &str,
+) -> Result<Option<serde_json::Value>, TarballError> {
+    // `cas_paths` is keyed by the archive-relative path left after the
+    // top-level prefix strip; the resolution's `path` keeps the leading
+    // slash it was written with (`#path:/packages/foo`).
+    let key = format!("{}/package.json", subdir.trim_matches('/'));
+    let Some(cas_path) = cas_paths.get(&key) else { return Ok(None) };
+    let bytes = tokio::fs::read(cas_path)
+        .await
+        .map_err(|source| TarballError::ReadLocalTarball { path: cas_path.clone(), source })?;
+    match serde_json::from_slice::<serde_json::Value>(&bytes) {
+        Ok(parsed) => Ok(normalize_bundled_manifest(&parsed)),
+        Err(error) => {
+            tracing::debug!(
+                ?error,
+                ?key,
+                "package.json in archive subdirectory failed to parse as JSON; bundled manifest cleared",
+            );
+            Ok(None)
+        }
     }
 }
 

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -2462,6 +2462,10 @@ pub struct FetchTarballForResolution<'a> {
     ///
     /// Matches the resolution's `path` field verbatim, leading slash
     /// and all.
+    ///
+    /// Setting this suppresses the store-index row: the extracted
+    /// index describes the archive, not the named subpackage, so
+    /// there is no row to write that the key would honestly describe.
     pub manifest_subdir: Option<&'a str>,
 }
 
@@ -2504,23 +2508,37 @@ impl FetchTarballForResolution<'_> {
             Some(subdir) => read_subdir_manifest(&cas_paths, subdir).await?,
             None => pkg_files_idx.manifest.clone(),
         };
-        // Scope the store-index row by the package's canonical
-        // `name@version`, matching what the install pass derives from
-        // the same manifest. Fall back to the URL when the tarball has
-        // no usable `package.json` name (degraded, but keeps the row
-        // addressable).
-        let package_id =
-            manifest_package_id(manifest.as_ref()).unwrap_or_else(|| package_url.to_string());
 
-        let index_key = store_index_key(&integrity.to_string(), &package_id);
-        if let Some(writer) = store_index_writer {
-            writer.queue(index_key, pkg_files_idx);
-        } else {
-            tracing::warn!(
-                target: "pacquet::download",
-                ?index_key,
-                "no shared store-index writer; skipping index row for this resolve-time tarball",
-            );
+        // A subdirectory package gets no row. Its key would name the
+        // subpackage while `pkg_files_idx` describes the whole archive
+        // — the repo's manifest and every repo file — and a row whose
+        // key and payload disagree is worse than none: consumers that
+        // trust `PackageFilesIndex.manifest` / `files` to match the key
+        // (bin linking, file materialization) would read the repo.
+        // Nothing needs this row. A git-hosted archive — the only shape
+        // carrying a subdirectory — is addressed by
+        // `git_hosted_store_index_key` once the install pass has run
+        // `prepare` over it, and both the graph prefetch and the
+        // warm-store reuse map skip git-hosted entries.
+        if manifest_subdir.is_none() {
+            // Scope the store-index row by the package's canonical
+            // `name@version`, matching what the install pass derives from
+            // the same manifest. Fall back to the URL when the tarball has
+            // no usable `package.json` name (degraded, but keeps the row
+            // addressable).
+            let package_id =
+                manifest_package_id(manifest.as_ref()).unwrap_or_else(|| package_url.to_string());
+
+            let index_key = store_index_key(&integrity.to_string(), &package_id);
+            if let Some(writer) = store_index_writer {
+                writer.queue(index_key, pkg_files_idx);
+            } else {
+                tracing::warn!(
+                    target: "pacquet::download",
+                    ?index_key,
+                    "no shared store-index writer; skipping index row for this resolve-time tarball",
+                );
+            }
         }
 
         if let Some(mem_cache) = mem_cache {

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1516,6 +1516,51 @@ async fn fetch_for_resolution_reads_manifest_from_subdirectory() {
     drop(store_dir_keep);
 }
 
+/// The row would be keyed by the subpackage (read from
+/// `<subdir>/package.json`) while carrying an index built from the
+/// whole archive — the repo's manifest and every repo file. Writing
+/// that would hand any consumer trusting the key a payload describing
+/// the repo, so no row is written at all.
+#[tokio::test]
+async fn fetch_for_resolution_writes_no_index_row_for_a_subdirectory_package() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let archive = gzipped_archive(&[
+        ("package.json", r#"{"name":"the-monorepo","version":"0.0.0"}"#),
+        ("packages/foo/package.json", r#"{"name":"foo","version":"1.2.3"}"#),
+    ]);
+    let _mock =
+        server.mock("GET", "/repo.tgz").with_status(200).with_body(archive).create_async().await;
+
+    let url = format!("{}/repo.tgz", server.url());
+    let client = ThrottledClient::default();
+    let (writer, writer_task) = StoreIndexWriter::spawn(store_path);
+
+    let resolved = FetchTarballForResolution {
+        http_client: &client,
+        store_dir: store_path,
+        store_index_writer: Some(Arc::clone(&writer)),
+        package_url: &url,
+        package_id: &url,
+        auth_headers: &AuthHeaders::default(),
+        retry_opts: fast_retry_opts(),
+        manifest_subdir: Some("/packages/foo"),
+    }
+    .run::<SilentReporter>(None)
+    .await
+    .expect("subdirectory fetch should succeed");
+
+    drop(writer);
+    writer_task.await.expect("writer task").expect("writer flushed");
+
+    // The key the row *would* have taken, had one been written.
+    let key = store_index_key(&resolved.integrity.to_string(), "foo@1.2.3");
+    let index = StoreIndex::open_in(store_path).expect("open store index");
+    let rows = index.get_many(std::slice::from_ref(&key)).expect("read index");
+    assert!(rows.is_empty(), "a subpackage key must not carry the whole repo's index: {rows:?}");
+    drop(store_dir_keep);
+}
+
 /// A subdirectory without its own `package.json` degrades to `None`,
 /// the same best-effort contract the archive root has — never the
 /// root's manifest, which would name the key after the wrong package.

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1401,6 +1401,7 @@ async fn fetch_for_resolution_computes_integrity_when_none_is_expected() {
         package_id: &url,
         auth_headers: &AuthHeaders::default(),
         retry_opts: fast_retry_opts(),
+        manifest_subdir: None,
     }
     .run::<SilentReporter>(None)
     .await
@@ -1441,12 +1442,112 @@ async fn fetch_for_resolution_uses_package_id_for_scoped_auth() {
         package_id: "@scope/test-pkg@1.0.0",
         auth_headers: &auth_headers,
         retry_opts: fast_retry_opts(),
+        manifest_subdir: None,
     }
     .run::<SilentReporter>(None)
     .await
     .expect("the scope token selected via package_id should let the fetch succeed");
 
     assert_eq!(resolved.integrity, integrity(FASTIFY_ERROR_INTEGRITY));
+    mock.assert_async().await;
+    drop(store_dir_keep);
+}
+
+/// Gzip a tar holding `(path, contents)` entries, under the top-level
+/// prefix a git host's archive carries.
+fn gzipped_archive(entries: &[(&str, &str)]) -> Vec<u8> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        for (path, contents) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, format!("repo-abc123/{path}"), contents.as_bytes())
+                .expect("append entry");
+        }
+        builder.finish().expect("finalize tar");
+    }
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    std::io::Write::write_all(&mut encoder, &tar_bytes).expect("gzip tar");
+    encoder.finish().expect("finish gzip")
+}
+
+/// A git dep pointing at one directory of a repo (`#path:/packages/foo`)
+/// gets an archive spanning the whole repo, so the root `package.json`
+/// is the repo's, not the package's. Reading the root would name the
+/// lockfile key after the wrong package.
+#[tokio::test]
+async fn fetch_for_resolution_reads_manifest_from_subdirectory() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let archive = gzipped_archive(&[
+        ("package.json", r#"{"name":"the-monorepo","version":"0.0.0"}"#),
+        ("packages/foo/package.json", r#"{"name":"foo","version":"1.2.3"}"#),
+    ]);
+    let mock =
+        server.mock("GET", "/repo.tgz").with_status(200).with_body(archive).create_async().await;
+
+    let url = format!("{}/repo.tgz", server.url());
+    let client = ThrottledClient::default();
+
+    let resolved = FetchTarballForResolution {
+        http_client: &client,
+        store_dir: store_path,
+        store_index_writer: None,
+        package_url: &url,
+        package_id: &url,
+        auth_headers: &AuthHeaders::default(),
+        retry_opts: fast_retry_opts(),
+        // Leading slash, exactly as the resolution records it.
+        manifest_subdir: Some("/packages/foo"),
+    }
+    .run::<SilentReporter>(None)
+    .await
+    .expect("subdirectory manifest should be readable from the extracted archive");
+
+    let manifest = dbg!(resolved.manifest).expect("subdirectory manifest");
+    assert_eq!(manifest.get("name").and_then(serde_json::Value::as_str), Some("foo"));
+    assert_eq!(manifest.get("version").and_then(serde_json::Value::as_str), Some("1.2.3"));
+    mock.assert_async().await;
+    drop(store_dir_keep);
+}
+
+/// A subdirectory without its own `package.json` degrades to `None`,
+/// the same best-effort contract the archive root has — never the
+/// root's manifest, which would name the key after the wrong package.
+#[tokio::test]
+async fn fetch_for_resolution_returns_no_manifest_for_subdirectory_without_one() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let archive = gzipped_archive(&[
+        ("package.json", r#"{"name":"the-monorepo","version":"0.0.0"}"#),
+        ("packages/foo/index.js", "module.exports = 1"),
+    ]);
+    let mock =
+        server.mock("GET", "/repo.tgz").with_status(200).with_body(archive).create_async().await;
+
+    let url = format!("{}/repo.tgz", server.url());
+    let client = ThrottledClient::default();
+
+    let resolved = FetchTarballForResolution {
+        http_client: &client,
+        store_dir: store_path,
+        store_index_writer: None,
+        package_url: &url,
+        package_id: &url,
+        auth_headers: &AuthHeaders::default(),
+        retry_opts: fast_retry_opts(),
+        manifest_subdir: Some("/packages/foo"),
+    }
+    .run::<SilentReporter>(None)
+    .await
+    .expect("a subdirectory without a package.json is not a fetch failure");
+
+    assert_eq!(dbg!(resolved.manifest), None);
     mock.assert_async().await;
     drop(store_dir_keep);
 }


### PR DESCRIPTION
## Summary

A non-frozen `pnpm install` of a workspace containing git-hosted dependencies aborted with a panic while building the lockfile. Closes pnpm/pnpm#13040.

The root cause is upstream of the lockfile: a git dep's specifier names a *repo*, not a package, so its name is only readable from the `package.json` in the host's archive. The git resolver left `manifest` unset, so `build_pkg_id_with_patch_hash` had no name to prefix and emitted a bare archive URL as the dep path — a shape no lockfile key parses (`MissingSuffix`, since the URL contains no `@`).

This PR fixes it where the name goes missing:

- **`GitResolver` reads the archive's `package.json` during resolution**, given a `GitFetchContext`. This mirrors `TarballResolver`, which already downloads a remote tarball at resolve time to fill `manifest` + `integrity`, and matches upstream, whose package requester awaits the fetch when a resolver returns no manifest (`packageRequester.ts`, `if (!manifest) { const fetchedResult = await fetchResult.fetching() ... }`) so `getManifestFromResponse` can hand `resolveDependencies` a real `pkg.name`.
- **Dep paths then carry the `<name>@` prefix and parse as ordinary lockfile keys**, so the graph→lockfile adapter needs no git-specific key reconstruction.
- **`real_name` now covers git-hosted tarballs**, matching upstream's `depPathToRef`: an unaliased git dep records `version: <url>`, while a renamed one keeps the `<name>@<ref>` alias form that composes back to its snapshot key.
- **The archive's `integrity` is recorded** from the bytes the same fetch already hashes. Without it the install pass refuses the dep outright (`tarball_url_and_integrity` requires an integrity on every tarball resolution), so a git dep would resolve into a lockfile it could never install from.
- **The `.expect()` that panicked is still replaced by a propagated error**, as the issue asked, so an unexpected dep-path shape degrades gracefully instead of aborting the process.

The fetch stops at the raw archive: the git-hosted `prepare`/`prepublish` pass and its packlist filtering stay in the install pass, so **no package script runs during resolution**. The install pass re-fetches the archive to run them — unlike a registry tarball, a git-hosted one can't hand its extraction over through `MemCache` (only `Registry` resolutions read it) — so a git dep costs one extra archive download per install. Closing that gap is an optimization, not a correctness fix, and would mean revisiting a deliberate exclusion in `install_package_by_snapshot`.

Only `github.com`, `gitlab.com` and `bitbucket.org` resolve to a host archive. Every other repo — self-hosted, `file:`, and **any ssh URL, even to GitHub** — resolves to `Git`, which has no archive endpoint, so its name is read from a throwaway checkout instead. That path was the same bug one layer down: no manifest meant no `<name>@` prefix, the dep path failed `PackageKey` parsing, and `build_packages_and_snapshots` silently dropped the package while the importer kept pointing at it — a `--frozen-lockfile` install off that lockfile exited 0 and left a dangling symlink. The clone/checkout is extracted out of `GitFetcher` so both passes share one implementation, including its `is_valid_commit_hash` guard.

Further fixes that fell out of driving this end to end:

- **`safe_join_path` treated a sub-path as absolute.** A resolution's `path` keeps the leading slash of `#path:/packages/foo`, and `Path::join` discards the root when its argument is absolute — unlike the `path.join` upstream uses. Every sub-directory git dep failed to install with "is not a valid sub-directory of the git checkout".
- **A sub-directory package got no store-index row.** Its key named the subpackage while the payload described the whole repo.
- **Two git-argument hardenings** — see Security below.

No TypeScript change: upstream already behaves this way, and already writes this lockfile shape. This brings pacquet in line.

## Security

Resolution now shells out to `git`, which moved two hazards from the install pass into the resolve pass. Both are reachable from a manifest or lockfile — the threat model `InvalidCommit`'s doc comment already names ("allowing a malicious lockfile to execute arbitrary commands on SSH or local-file transports"). Worth a reviewer's attention over the rest of the diff.

- **Repo option injection.** `checkout_commit` passed `repo` to `git clone` / `git remote add` as a positional. Git reads a `-`-leading value as an option instead, and `--upload-pack=<cmd>` runs `<cmd>` on a local or SSH transport — confirmed by experiment (`git clone --upload-pack="touch X" src dest` creates `X`). `commit` was already guarded by `is_valid_commit_hash` for exactly this; its sibling `repo`, off the same untrusted `GitResolution`, never was. Now rejected via a structured `InvalidRepo` error *and* fenced with `--` before the positional, so neither defence stands alone. This hole pre-dated the PR on the install path; the fix covers both.
- **Sub-path traversal at resolve time.** The resolve-time manifest read built its package directory by stripping a leading separator and joining, with no containment check, so `#path:/../..` climbed out of the checkout — and `safe_read_package_json_from_dir` reads whatever it is handed, so an arbitrary `package.json` on the host became that dep's name and version in the lockfile. It now reuses the install pass's `safe_join_path` (canonicalize + `starts_with` root), rather than keeping a second, weaker copy of the same logic.

## Squash Commit Body

```text
A git dep's specifier names a repo, not a package, so its name is only
readable from the package.json in the host's archive. The git resolver
left `manifest` unset, so `build_pkg_id_with_patch_hash` had no name to
prefix and emitted a bare archive URL as the dep path, which no lockfile
key parses — the graph-to-lockfile conversion then panicked on it.

Read the manifest during resolution, as the tarball resolver already
does for remote tarballs and as upstream's package requester does when a
resolver returns no manifest. Dep paths then carry the `<name>@` prefix
and parse as ordinary lockfile keys, so the graph-to-lockfile adapter
needs no git-specific key reconstruction.

The fetch stops at the raw archive: the prepare/prepublish pass and its
packlist filtering stay in the install pass, so no package script runs
during resolution. The install pass re-fetches the archive to run them,
so a git dep costs one extra archive download per install.

`real_name` now covers git-hosted tarballs, matching upstream's
`depPathToRef`: an unaliased git dep records `version: <url>`, while a
renamed one keeps the `<name>@<ref>` alias form that composes back to
its snapshot key.

Record the archive's integrity from the bytes that fetch already
hashes. The install pass refuses a tarball resolution without one, so a
git dep otherwise resolved into a lockfile it could never install from.
With it, a pacquet lockfile for a git dep is byte-identical to pnpm
11's for the same manifest.

Replace the `.expect()` on the importer dep path with a propagated,
contextual error so an unexpected shape degrades gracefully instead of
aborting the process.

A repo with no archive endpoint (self-hosted, `file:`, or any ssh URL)
has its name read from a throwaway checkout instead; the clone is
extracted out of `GitFetcher` so both passes share one implementation.
Without it such a dep resolved with no name, failed `PackageKey`
parsing, and was silently dropped from `packages:` / `snapshots:` while
the importer still pointed at it — a frozen install off that lockfile
exited 0 and left a dangling symlink.

Also strip the leading slash from a resolution's `path` before joining
it onto the checkout: `Path::join` discards the root on an absolute
argument, unlike upstream's `path.join`, so every sub-directory git dep
failed to install.

Guard the two git arguments this newly reaches from resolution. `repo`
was passed to `git clone` / `git remote add` as a positional, and git
reads a `-`-leading value as an option, so `--upload-pack=<cmd>` ran
`<cmd>` on a local or SSH transport; `commit` was already guarded for
this, `repo` was not. Reject the shape and pass `--` before the
positional. The resolve-time manifest read joined its sub-path with no
containment check, letting `#path:/../..` read an arbitrary
`package.json` off the host and stamp its name onto the dep; it reuses
the install pass's `safe_join_path` instead of a second weaker copy.

Closes pnpm/pnpm#13040.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

## Validation

Driven end to end against the real hosts and a real repo, not just tests. **All three git shapes now write the lockfile pnpm 11.13.1 writes for the same manifest, byte for byte** (`diff` empty):

| shape | fixture | before |
|---|---|---|
| host archive | `github:kevva/is-negative#163360a` | panic (pnpm/pnpm#13040) |
| host archive, `#path:` | `RexSkz/test-git-subfolder-fetch#path:/packages/simple-express-server` | panic; then install failed on the sub-path |
| no archive (`Git`) | local repo over `git+file://`, aliased | panic; then dangling symlink |

- `pnpm install` of the host-archive dep links `node_modules` and the package runs (`is-negative(-1) === true`); the `Git` dep resolves and `require()` returns its export; the `#path:` dep installs `@my-namespace/simple-express-server`.
- The sub-directory fixtures are discriminating by construction: the repo root is `monorepo-example` / `the-monorepo` while the subpackage is `@my-namespace/simple-express-server` / `@scope/foo`, and the `Git` fixture's alias (`aliased-dep`) differs from its real name (`my-real-pkg-name`) — so key, importer ref, version and transitive deps all prove the right manifest is being read.
- Disabling only the resolve-time read and rerunning shows why it is load-bearing: the install exits 0 and writes a lockfile whose importer references a package with no `packages:` or `snapshots:` entry.

Automated gate:

- `cargo nextest run` across `pacquet-git-fetcher`, `pacquet-tarball`, `pacquet-resolving-git-resolver`, `pacquet-resolving-tarball-resolver`, `pacquet-package-manager` — 928 passed.
- `cargo fmt --all -- --check`, `taplo format --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc`, `cargo dylint --all --workspace`, `typos`, `cspell` — all clean.
- Both hardenings are covered by tests that drive the real payload: the injection test asserts a `--upload-pack=touch <marker>` repo is refused *and* that the marker never appears; the traversal test puts a real `package.json` outside the checkout and asserts `/../..`, `../..` and `/../` are all rejected.
- Every new test was verified to fail when the code it covers is reverted, rather than passing vacuously.

## Known divergence from upstream

Upstream serves resolve-time and install-time from **one memoized** `fetchPackageToStore`. pacquet keeps its resolvers and its install pass on separate fetch paths, so a git dep is fetched twice: once here for the name, once by the install pass to run `prepare` over it. Correct, but a real cost, and unifying the two is a larger change than this fix. Noted rather than hidden.

---
Written by an agent (Claude Code, claude-opus-4-8).

