### PR TITLE
fix(release): verify and package TypeScript CLI artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,15 @@ on:
       # v0.x/v1.x that pnpr's low version numbers would otherwise collide with.
       - "v*.*.*"
       - "pnpr@*.*.*"
-  # Manual trigger for rerunning a tag release. Dispatching this workflow from a
-  # branch fails before publishing because release artifacts are only built on
-  # version tags.
+  # Manual trigger for rerunning a tag release or verifying TypeScript release
+  # artifacts from a branch without publishing.
   workflow_dispatch:
+    inputs:
+      verify_ts_release:
+        description: Verify TypeScript release artifacts without publishing
+        required: false
+        type: boolean
+        default: false
 
 # A release PR that bumps several products auto-tags each one (tag-release.yml),
 # so several version tags can land together and start a run apiece. Serialize
@@ -43,6 +48,9 @@ jobs:
             refs/tags/v*.*.*) ;;
             refs/tags/pnpr@*.*.*) ;;
             *)
+              if [ "${{ inputs.verify_ts_release }}" = "true" ]; then
+                exit 0
+              fi
               echo "::error::The release workflow must run from a version tag like v11.9.0 or pnpr@0.2.0. Current ref: ${GITHUB_REF}"
               exit 1
               ;;
@@ -141,7 +149,7 @@ jobs:
     needs:
       - validate-release-ref
       - plan
-    if: needs.plan.outputs.ts == 'true'
+    if: needs.plan.outputs.ts == 'true' || inputs.verify_ts_release
     permissions:
       contents: read
     # Runs on macOS so the darwin artifacts can be ad-hoc signed with native
@@ -252,7 +260,7 @@ jobs:
       - validate-release-ref
       - plan
       - verify-ts-release
-    if: needs.plan.outputs.ts == 'true'
+    if: needs.plan.outputs.ts == 'true' && !inputs.verify_ts_release
     permissions:
       id-token: write  # Required for OIDC
       contents: write  # for softprops/action-gh-release to create GitHub release
@@ -323,7 +331,7 @@ jobs:
 
   build-rust:
     needs: plan
-    if: needs.plan.outputs.rust == 'true'
+    if: needs.plan.outputs.rust == 'true' && !inputs.verify_ts_release
     permissions:
       contents: read
       id-token: write # needed for actions/attest-build-provenance
@@ -726,7 +734,7 @@ jobs:
 
   build-pnpr:
     needs: plan
-    if: needs.plan.outputs.pnpr == 'true'
+    if: needs.plan.outputs.pnpr == 'true' && !inputs.verify_ts_release
     permissions:
       contents: read
       id-token: write # needed for actions/attest-build-provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,8 @@ jobs:
         uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
         with:
           runtime: node@26.5.0
+      - name: Override workspace ignores for the TypeScript pnpm package
+        run: ': > pnpm11/pnpm/.npmignore'
       - name: Build TypeScript executable artifacts
         run: pn --filter=@pnpm/exe run build-artifacts
 
@@ -285,6 +287,8 @@ jobs:
         uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
         with:
           runtime: node@26.5.0
+      - name: Override workspace ignores for the TypeScript pnpm package
+        run: ': > pnpm11/pnpm/.npmignore'
       # The publish phase is split into three sequential steps to control which packages
       # use trusted publishing (OIDC) vs. a static token. `pnpm publish` currently bails
       # out of OIDC as soon as a static `_authToken` is configured, so the only way to

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,7 +232,18 @@ jobs:
           native_tarball=$(find "$release_tarballs/pnpm11_pnpm_artifacts_darwin-arm64" -type f -name '*.tgz' -print -quit)
           test -n "$exe_tarball"
           test -n "$native_tarball"
-          npm install --prefix "$smoke_dir" --ignore-scripts=false "$exe_tarball" "$native_tarball"
+          (
+            cd "$smoke_dir"
+            command -v node
+            node --version
+            command -v npm
+            npm --version
+            npm config get ignore-scripts
+            npm config get strict-allow-scripts
+            npm install --foreground-scripts --ignore-scripts=false --loglevel verbose "$exe_tarball" "$native_tarball"
+          )
+          ls -l "$smoke_dir/node_modules/@pnpm/exe/pnpm"
+          file "$smoke_dir/node_modules/@pnpm/exe/pnpm"
           "$smoke_dir/node_modules/@pnpm/exe/pnpm" --version
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,15 @@ jobs:
 
           smoke_dir=$(mktemp -d)
           tar -xzf "$pnpm_tarball" -C "$smoke_dir"
-          node "$smoke_dir/package/bin/pnpm.mjs" --version
+          command -v node
+          node --version
+          set +e
+          node "$smoke_dir/package/bin/pnpm.mjs" --version >"$smoke_dir/pnpm.stdout" 2>"$smoke_dir/pnpm.stderr"
+          pnpm_exit=$?
+          set -e
+          cat "$smoke_dir/pnpm.stdout"
+          cat "$smoke_dir/pnpm.stderr" >&2
+          test "$pnpm_exit" -eq 0
 
           exe_tarball=$(find "$release_tarballs/pnpm11_pnpm_artifacts_exe" -type f -name '*.tgz' -print -quit)
           native_tarball=$(find "$release_tarballs/pnpm11_pnpm_artifacts_darwin-arm64" -type f -name '*.tgz' -print -quit)
@@ -242,8 +250,6 @@ jobs:
           test -n "$native_tarball"
           (
             cd "$smoke_dir"
-            command -v node
-            node --version
             command -v npm
             npm --version
             npm config get ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,7 +224,7 @@ jobs:
                 return new RegExp("^" + pattern.replace(/[.+^{}()|[\]\\]/g, "\\$&").replace(/\*\*\//g, "\x00").replace(/\*\*/g, "\x01").replace(/\*/g, "[^/]*").replace(/\x00/g, "(?:.*/)?").replace(/\x01/g, ".*") + String.fromCharCode(36))
               }
             ' "$package/package.json" | while IFS= read -r file; do
-              test -s "$package/$file"
+              test -f "$package/$file"
               test "$(tar -xOf "$tarball" "package/$file" | shasum -a 256 | cut -d ' ' -f 1)" = "$(shasum -a 256 "$package/$file" | cut -d ' ' -f 1)"
             done
           done
@@ -621,7 +621,7 @@ jobs:
                 return new RegExp("^" + pattern.replace(/[.+^{}()|[\]\\]/g, "\\$&").replace(/\*\*\//g, "\x00").replace(/\*\*/g, "\x01").replace(/\*/g, "[^/]*").replace(/\x00/g, "(?:.*/)?").replace(/\x01/g, ".*") + String.fromCharCode(36))
               }
             ' "$package/package.json" | while IFS= read -r file; do
-              test -s "$package/$file"
+              test -f "$package/$file"
               test "$(tar -xOf "$tarball" "package/$file" | sha256sum | cut -d ' ' -f 1)" = "$(sha256sum "$package/$file" | cut -d ' ' -f 1)"
             done
           done
@@ -980,7 +980,7 @@ jobs:
                 return new RegExp("^" + pattern.replace(/[.+^{}()|[\]\\]/g, "\\$&").replace(/\*\*\//g, "\x00").replace(/\*\*/g, "\x01").replace(/\*/g, "[^/]*").replace(/\x00/g, "(?:.*/)?").replace(/\x01/g, ".*") + String.fromCharCode(36))
               }
             ' "$package/package.json" | while IFS= read -r file; do
-              test -s "$package/$file"
+              test -f "$package/$file"
               test "$(tar -xOf "$tarball" "package/$file" | sha256sum | cut -d ' ' -f 1)" = "$(sha256sum "$package/$file" | cut -d ' ' -f 1)"
             done
           done


### PR DESCRIPTION
## Summary

- add a manual TypeScript release-artifact verification mode that cannot publish
- allow legitimate empty files when checking packed payloads
- prevent the workspace-root `dist` ignore from removing the TypeScript CLI bundle during pack and publish
- install the executable smoke-test tarballs from outside the checkout so npm does not inherit pnpm-only `devEngines` constraints

The no-publish verification passed in https://github.com/pnpm/pnpm/actions/runs/29460017538, including the packed TypeScript CLI, npm lifecycle installation, and native executable smoke test. The release job was skipped.

## Squash Commit Body

```text
The TypeScript release preflight rejected valid empty files and allowed the
workspace root gitignore to remove the CLI dist directory from the pnpm
tarball. Its executable installation test also ran npm from inside a checkout
whose devEngines requires pnpm.

Accept empty regular files while retaining byte-for-byte hash verification,
isolate the pnpm package from workspace ignore rules before building, and run
the npm lifecycle smoke test from its temporary install directory. Add a
manual verification-only dispatch that exercises the complete artifact build
and smoke test while keeping every publish job disabled.
```

## Checklist

- [x] This is release-workflow-only; no TypeScript or Rust CLI behavior needs porting.
- [x] No changeset is needed because no published package source changed.
- [x] Verified with the no-publish release-artifact workflow.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786752147&installation_id=145934176&pr_number=13063&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13063&signature=511c28cf015326d3f6dce2d3ae08cf591fce97a000f4a6ba81269969dc58e276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual workflow option to verify TypeScript release artifacts without publishing them.

* **Bug Fixes**
  * Improved release artifact verification to recognize valid files even when they are empty.
  * Expanded TypeScript package smoke tests with clearer runtime diagnostics, installation checks, and command validation.
  * Improved consistency across TypeScript, Rust, and pnpr artifact checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->