### PR TITLE
fix(release): generate GitHub notes from pending changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,8 +329,11 @@ jobs:
         with:
           subject-path: 'dist/*'
       - name: Generate release description
-        run: pn make-release-description
+        run: |
+          pn make-release-description
+          test -s RELEASE.md
       - name: Release
+        id: github-release
         # `gh release create` could replace this, but the release pipeline is
         # sensitive and softprops/action-gh-release is widely battle-tested.
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
@@ -338,6 +341,14 @@ jobs:
           draft: true
           files: dist/*
           body_path: RELEASE.md
+      - name: Verify draft release description
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ steps.github-release.outputs.id }}
+        run: |
+          test -n "$RELEASE_ID"
+          body_length=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.body | length')
+          test "$body_length" -gt 0
 
   build-rust:
     needs: plan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,8 +363,9 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > "$release_json"
           RELEASE_JSON="$release_json" node <<'NODE'
           const fs = require('node:fs')
-          const actual = JSON.parse(fs.readFileSync(process.env.RELEASE_JSON, 'utf8')).body
-          const expected = fs.readFileSync('RELEASE.md', 'utf8')
+          const normalizeNewlines = (text) => text?.replace(/\r\n?/g, '\n')
+          const actual = normalizeNewlines(JSON.parse(fs.readFileSync(process.env.RELEASE_JSON, 'utf8')).body)
+          const expected = normalizeNewlines(fs.readFileSync('RELEASE.md', 'utf8'))
           if (actual !== expected) throw new Error('GitHub draft release body does not match RELEASE.md')
           NODE
           gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F draft=false > /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,16 +338,24 @@ jobs:
         # sensitive and softprops/action-gh-release is widely battle-tested.
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
+          draft: true
           files: dist/*
           body_path: RELEASE.md
-      - name: Verify published release description
+      - name: Verify and publish release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ steps.github-release.outputs.id }}
         run: |
           test -n "$RELEASE_ID"
-          body_length=$(gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.body | length')
-          test "$body_length" -gt 0
+          release_json=$(mktemp)
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > "$release_json"
+          RELEASE_JSON="$release_json" node <<'NODE'
+          const fs = require('node:fs')
+          const actual = JSON.parse(fs.readFileSync(process.env.RELEASE_JSON, 'utf8')).body
+          const expected = fs.readFileSync('RELEASE.md', 'utf8')
+          if (actual !== expected) throw new Error('GitHub draft release body does not match RELEASE.md')
+          NODE
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F draft=false > /dev/null
 
   build-rust:
     needs: plan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,9 +329,21 @@ jobs:
         with:
           subject-path: 'dist/*'
       - name: Generate release description
+        env:
+          TS_VERSION: ${{ needs.plan.outputs.ts_version }}
         run: |
-          pn make-release-description
-          test -s RELEASE.md
+          rm -f RELEASE.md
+          if pn make-release-description && test -s RELEASE.md; then
+            exit 0
+          fi
+          echo "::warning::Release notes could not be generated; publishing the release with a diagnostic description"
+          cat > RELEASE.md <<EOF
+          ## Release notes unavailable
+
+          pnpm ${TS_VERSION} was published successfully, but its release notes could not be generated from the pending changelog. The release artifacts are still available below.
+
+          See the [release workflow run](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) for the generation error.
+          EOF
       - name: Release
         id: github-release
         # `gh release create` could replace this, but the release pipeline is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -338,10 +338,9 @@ jobs:
         # sensitive and softprops/action-gh-release is widely battle-tested.
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
-          draft: true
           files: dist/*
           body_path: RELEASE.md
-      - name: Verify draft release description
+      - name: Verify published release description
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ steps.github-release.outputs.id }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1194,6 +1194,9 @@ importers:
 
   pnpm11/__utils__/get-release-text:
     dependencies:
+      '@pnpm/error':
+        specifier: workspace:*
+        version: link:../../core/error
       '@pnpm/releasing.versioning':
         specifier: workspace:*
         version: link:../../releasing/versioning

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1194,6 +1194,9 @@ importers:
 
   pnpm11/__utils__/get-release-text:
     dependencies:
+      '@pnpm/releasing.versioning':
+        specifier: workspace:*
+        version: link:../../releasing/versioning
       mdast-util-to-string:
         specifier: 'catalog:'
         version: 4.0.0
@@ -1210,9 +1213,18 @@ importers:
         specifier: 'catalog:'
         version: 6.0.3
     devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.4.1
       '@pnpm/get-release-text':
         specifier: workspace:*
         version: 'link:'
+      '@pnpm/jest-config':
+        specifier: workspace:*
+        version: link:../jest-config
+      cross-env:
+        specifier: 'catalog:'
+        version: 10.1.0
 
   pnpm11/__utils__/jest-config:
     dependencies:

--- a/pnpm11/__utils__/get-release-text/package.json
+++ b/pnpm11/__utils__/get-release-text/package.json
@@ -5,9 +5,13 @@
   "type": "module",
   "scripts": {
     "write-release-text": "node src/main.ts",
-    "lint": "eslint src/**/*.ts"
+    "compile": "tsgo --build",
+    "lint": "eslint src/**/*.ts test/**/*.ts",
+    "test": "pn compile && pn .test",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
+    "@pnpm/releasing.versioning": "workspace:*",
     "mdast-util-to-string": "catalog:",
     "remark-parse": "catalog:",
     "remark-stringify": "catalog:",
@@ -15,7 +19,13 @@
     "vfile": "catalog:"
   },
   "devDependencies": {
-    "@pnpm/get-release-text": "workspace:*"
+    "@jest/globals": "catalog:",
+    "@pnpm/get-release-text": "workspace:*",
+    "@pnpm/jest-config": "workspace:*",
+    "cross-env": "catalog:"
+  },
+  "jest": {
+    "preset": "@pnpm/jest-config"
   },
   "keywords": [
     "pnpm",

--- a/pnpm11/__utils__/get-release-text/package.json
+++ b/pnpm11/__utils__/get-release-text/package.json
@@ -11,6 +11,7 @@
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
+    "@pnpm/error": "workspace:*",
     "@pnpm/releasing.versioning": "workspace:*",
     "mdast-util-to-string": "catalog:",
     "remark-parse": "catalog:",

--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { PnpmError } from '@pnpm/error'
 import { readPendingChangelog } from '@pnpm/releasing.versioning'
 import { toString as mdastToString } from 'mdast-util-to-string'
 import remarkParse from 'remark-parse'
@@ -28,7 +29,7 @@ export async function writeReleaseText (workspaceDir: string): Promise<void> {
   const pnpm = JSON.parse(await fs.readFile(path.join(pnpmDir, 'package.json'), 'utf8'))
   const changelog = await readPendingChangelog(workspaceDir, pnpm.name, pnpm.version)
   if (changelog == null) {
-    throw new Error(`No pending changelog found for pnpm ${pnpm.version}`)
+    throw new PnpmError('MISSING_CHANGELOG', `No pending changelog found for pnpm ${pnpm.version}`)
   }
   const release = getChangelogEntry(changelog, pnpm.version)
   const releasePath = path.join(workspaceDir, 'RELEASE.md')
@@ -83,7 +84,7 @@ export function getChangelogEntry (changelog: string, version: string): Changelo
     }
   }
   if (headingStartInfo == null) {
-    throw new Error(`No changelog entry found for pnpm ${version}`)
+    throw new PnpmError('MISSING_CHANGELOG_ENTRY', `No changelog entry found for pnpm ${version}`)
   }
   ast['children'] = (ast['children'] as any).slice( // eslint-disable-line @typescript-eslint/no-explicit-any
     headingStartInfo.index + 1,

--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { readPendingChangelog } from '@pnpm/releasing.versioning'
 import { toString as mdastToString } from 'mdast-util-to-string'
 import remarkParse from 'remark-parse'
 import remarkStringify from 'remark-stringify'
@@ -17,18 +18,26 @@ export const BumpLevels = {
 
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(dirname, '../../../..')
-const pnpmDir = path.join(repoRoot, 'pnpm11/pnpm')
-const changelog = fs.readFileSync(path.join(pnpmDir, 'CHANGELOG.md'), 'utf8')
-const pnpm = JSON.parse(fs.readFileSync(path.join(pnpmDir, 'package.json'), 'utf8'))
-const release = getChangelogEntry(changelog, pnpm.version)
-fs.writeFileSync(path.join(repoRoot, 'RELEASE.md'), release.content)
+
+if (process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await writeReleaseText(repoRoot)
+}
+
+export async function writeReleaseText (workspaceDir: string): Promise<void> {
+  const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
+  const pnpm = JSON.parse(fs.readFileSync(path.join(pnpmDir, 'package.json'), 'utf8'))
+  const changelog = await readPendingChangelog(workspaceDir, pnpm.name, pnpm.version) ??
+    fs.readFileSync(path.join(pnpmDir, 'CHANGELOG.md'), 'utf8')
+  const release = getChangelogEntry(changelog, pnpm.version)
+  fs.writeFileSync(path.join(workspaceDir, 'RELEASE.md'), release.content)
+}
 
 interface ChangelogEntry {
   content: string
   highestLevel: number
 }
 
-function getChangelogEntry (changelog: string, version: string): ChangelogEntry {
+export function getChangelogEntry (changelog: string, version: string): ChangelogEntry {
   const ast = unified().use(remarkParse).parse(changelog)
 
   let highestLevel: number = BumpLevels.dep
@@ -68,12 +77,13 @@ function getChangelogEntry (changelog: string, version: string): ChangelogEntry 
       }
     }
   }
-  if (headingStartInfo != null) {
-    ast['children'] = (ast['children'] as any).slice( // eslint-disable-line @typescript-eslint/no-explicit-any
-      headingStartInfo.index + 1,
-      endIndex
-    )
+  if (headingStartInfo == null) {
+    throw new Error(`No changelog entry found for pnpm ${version}`)
   }
+  ast['children'] = (ast['children'] as any).slice( // eslint-disable-line @typescript-eslint/no-explicit-any
+    headingStartInfo.index + 1,
+    endIndex
+  )
   return {
     content: `${unified().use(remarkStringify).stringify(ast)}
 

--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -1,7 +1,8 @@
 /// <reference path="../../../__typings__/local.d.ts" />
-import fs from 'node:fs'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import util from 'node:util'
 
 import { readPendingChangelog } from '@pnpm/releasing.versioning'
 import { toString as mdastToString } from 'mdast-util-to-string'
@@ -25,11 +26,23 @@ if (process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(i
 
 export async function writeReleaseText (workspaceDir: string): Promise<void> {
   const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
-  const pnpm = JSON.parse(fs.readFileSync(path.join(pnpmDir, 'package.json'), 'utf8'))
-  const changelog = await readPendingChangelog(workspaceDir, pnpm.name, pnpm.version) ??
-    fs.readFileSync(path.join(pnpmDir, 'CHANGELOG.md'), 'utf8')
+  const pnpm = JSON.parse(await fs.readFile(path.join(pnpmDir, 'package.json'), 'utf8'))
+  let changelog = await readPendingChangelog(workspaceDir, pnpm.name, pnpm.version)
+  if (changelog == null) {
+    try {
+      changelog = await fs.readFile(path.join(pnpmDir, 'CHANGELOG.md'), 'utf8')
+    } catch (err: unknown) {
+      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
+        throw new Error(`No changelog found for pnpm ${pnpm.version}`, { cause: err })
+      }
+      throw err
+    }
+  }
   const release = getChangelogEntry(changelog, pnpm.version)
-  fs.writeFileSync(path.join(workspaceDir, 'RELEASE.md'), release.content)
+  const releasePath = path.join(workspaceDir, 'RELEASE.md')
+  const temporaryPath = `${releasePath}.${process.pid}.tmp`
+  await fs.writeFile(temporaryPath, release.content)
+  await fs.rename(temporaryPath, releasePath)
 }
 
 interface ChangelogEntry {

--- a/pnpm11/__utils__/get-release-text/src/main.ts
+++ b/pnpm11/__utils__/get-release-text/src/main.ts
@@ -2,7 +2,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import util from 'node:util'
 
 import { readPendingChangelog } from '@pnpm/releasing.versioning'
 import { toString as mdastToString } from 'mdast-util-to-string'
@@ -27,16 +26,9 @@ if (process.argv[1] != null && path.resolve(process.argv[1]) === fileURLToPath(i
 export async function writeReleaseText (workspaceDir: string): Promise<void> {
   const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
   const pnpm = JSON.parse(await fs.readFile(path.join(pnpmDir, 'package.json'), 'utf8'))
-  let changelog = await readPendingChangelog(workspaceDir, pnpm.name, pnpm.version)
+  const changelog = await readPendingChangelog(workspaceDir, pnpm.name, pnpm.version)
   if (changelog == null) {
-    try {
-      changelog = await fs.readFile(path.join(pnpmDir, 'CHANGELOG.md'), 'utf8')
-    } catch (err: unknown) {
-      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
-        throw new Error(`No changelog found for pnpm ${pnpm.version}`, { cause: err })
-      }
-      throw err
-    }
+    throw new Error(`No pending changelog found for pnpm ${pnpm.version}`)
   }
   const release = getChangelogEntry(changelog, pnpm.version)
   const releasePath = path.join(workspaceDir, 'RELEASE.md')

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -35,9 +35,21 @@ test('reports a missing changelog for the released version', async () => {
   await fs.mkdir(pnpmDir, { recursive: true })
   await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
 
-  await expect(writeReleaseText(workspaceDir)).rejects.toThrow('No pending changelog found for pnpm 11.13.1')
+  await expect(writeReleaseText(workspaceDir)).rejects.toMatchObject({
+    code: 'ERR_PNPM_MISSING_CHANGELOG',
+    message: 'No pending changelog found for pnpm 11.13.1',
+  })
 })
 
 test('rejects a changelog without the released version', () => {
-  expect(() => getChangelogEntry('# pnpm\n\n## 11.13.0\n', '11.13.1')).toThrow('No changelog entry found for pnpm 11.13.1')
+  let thrown: unknown
+  try {
+    getChangelogEntry('# pnpm\n\n## 11.13.0\n', '11.13.1')
+  } catch (err: unknown) {
+    thrown = err
+  }
+  expect(thrown).toMatchObject({
+    code: 'ERR_PNPM_MISSING_CHANGELOG_ENTRY',
+    message: 'No changelog entry found for pnpm 11.13.1',
+  })
 })

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -8,28 +8,36 @@ import { getChangelogEntry, writeReleaseText } from '../src/main.js'
 
 let workspaceDir: string
 
-beforeEach(() => {
-  workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get-release-text-'))
+beforeEach(async () => {
+  workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'get-release-text-'))
 })
 
-afterEach(() => {
-  fs.rmSync(workspaceDir, { recursive: true, force: true })
+afterEach(async () => {
+  await fs.rm(workspaceDir, { recursive: true, force: true })
 })
 
 test('writes the parked registry changelog section', async () => {
   const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
-  fs.mkdirSync(pnpmDir, { recursive: true })
-  fs.writeFileSync(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
-  fs.writeFileSync(path.join(pnpmDir, 'CHANGELOG.md'), '# pnpm\n\n## 11.13.0\n\nOld release.\n')
+  await fs.mkdir(pnpmDir, { recursive: true })
+  await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
+  await fs.writeFile(path.join(pnpmDir, 'CHANGELOG.md'), '# pnpm\n\n## 11.13.0\n\nOld release.\n')
   const pendingDir = path.join(workspaceDir, '.changeset/changelogs')
-  fs.mkdirSync(pendingDir, { recursive: true })
-  fs.writeFileSync(path.join(pendingDir, 'pnpm@11.13.1.md'), '## 11.13.1\n\n### Patch Changes\n\n- Fixed the release notes.\n')
+  await fs.mkdir(pendingDir, { recursive: true })
+  await fs.writeFile(path.join(pendingDir, 'pnpm@11.13.1.md'), '## 11.13.1\n\n### Patch Changes\n\n- Fixed the release notes.\n')
 
   await writeReleaseText(workspaceDir)
 
-  const release = fs.readFileSync(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
+  const release = await fs.readFile(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
   expect(release).toContain('Fixed the release notes.')
   expect(release).not.toContain('Old release.')
+})
+
+test('reports a missing changelog for the released version', async () => {
+  const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
+  await fs.mkdir(pnpmDir, { recursive: true })
+  await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
+
+  await expect(writeReleaseText(workspaceDir)).rejects.toThrow('No changelog found for pnpm 11.13.1')
 })
 
 test('rejects a changelog without the released version', () => {

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -16,11 +16,10 @@ afterEach(async () => {
   await fs.rm(workspaceDir, { recursive: true, force: true })
 })
 
-test('writes the parked registry changelog section', async () => {
+test('writes the pending registry changelog section', async () => {
   const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
   await fs.mkdir(pnpmDir, { recursive: true })
   await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
-  await fs.writeFile(path.join(pnpmDir, 'CHANGELOG.md'), '# pnpm\n\n## 11.13.0\n\nOld release.\n')
   const pendingDir = path.join(workspaceDir, '.changeset/changelogs')
   await fs.mkdir(pendingDir, { recursive: true })
   await fs.writeFile(path.join(pendingDir, 'pnpm@11.13.1.md'), '## 11.13.1\n\n### Patch Changes\n\n- Fixed the release notes.\n')
@@ -29,7 +28,6 @@ test('writes the parked registry changelog section', async () => {
 
   const release = await fs.readFile(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
   expect(release).toContain('Fixed the release notes.')
-  expect(release).not.toContain('Old release.')
 })
 
 test('reports a missing changelog for the released version', async () => {
@@ -37,7 +35,7 @@ test('reports a missing changelog for the released version', async () => {
   await fs.mkdir(pnpmDir, { recursive: true })
   await fs.writeFile(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
 
-  await expect(writeReleaseText(workspaceDir)).rejects.toThrow('No changelog found for pnpm 11.13.1')
+  await expect(writeReleaseText(workspaceDir)).rejects.toThrow('No pending changelog found for pnpm 11.13.1')
 })
 
 test('rejects a changelog without the released version', () => {

--- a/pnpm11/__utils__/get-release-text/test/main.ts
+++ b/pnpm11/__utils__/get-release-text/test/main.ts
@@ -1,0 +1,37 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, beforeEach, expect, test } from '@jest/globals'
+
+import { getChangelogEntry, writeReleaseText } from '../src/main.js'
+
+let workspaceDir: string
+
+beforeEach(() => {
+  workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'get-release-text-'))
+})
+
+afterEach(() => {
+  fs.rmSync(workspaceDir, { recursive: true, force: true })
+})
+
+test('writes the parked registry changelog section', async () => {
+  const pnpmDir = path.join(workspaceDir, 'pnpm11/pnpm')
+  fs.mkdirSync(pnpmDir, { recursive: true })
+  fs.writeFileSync(path.join(pnpmDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '11.13.1' }))
+  fs.writeFileSync(path.join(pnpmDir, 'CHANGELOG.md'), '# pnpm\n\n## 11.13.0\n\nOld release.\n')
+  const pendingDir = path.join(workspaceDir, '.changeset/changelogs')
+  fs.mkdirSync(pendingDir, { recursive: true })
+  fs.writeFileSync(path.join(pendingDir, 'pnpm@11.13.1.md'), '## 11.13.1\n\n### Patch Changes\n\n- Fixed the release notes.\n')
+
+  await writeReleaseText(workspaceDir)
+
+  const release = fs.readFileSync(path.join(workspaceDir, 'RELEASE.md'), 'utf8')
+  expect(release).toContain('Fixed the release notes.')
+  expect(release).not.toContain('Old release.')
+})
+
+test('rejects a changelog without the released version', () => {
+  expect(() => getChangelogEntry('# pnpm\n\n## 11.13.0\n', '11.13.1')).toThrow('No changelog entry found for pnpm 11.13.1')
+})

--- a/pnpm11/__utils__/get-release-text/test/tsconfig.json
+++ b/pnpm11/__utils__/get-release-text/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../node_modules/.test.lib",
+    "rootDir": "..",
+    "isolatedModules": true
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pnpm11/__utils__/get-release-text/tsconfig.json
+++ b/pnpm11/__utils__/get-release-text/tsconfig.json
@@ -11,6 +11,9 @@
   ],
   "references": [
     {
+      "path": "../../core/error"
+    },
+    {
       "path": "../../releasing/versioning"
     }
   ]

--- a/pnpm11/__utils__/get-release-text/tsconfig.json
+++ b/pnpm11/__utils__/get-release-text/tsconfig.json
@@ -9,5 +9,9 @@
     "src/**/*.ts",
     "../../__typings__/**/*.d.ts"
   ],
-  "references": []
+  "references": [
+    {
+      "path": "../../releasing/versioning"
+    }
+  ]
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Generate TypeScript pnpm GitHub release notes only from the pending registry-mode changelog section for the exact version being released.
- If release-note generation fails or produces an empty file, use a diagnostic body linked to the workflow run and continue publishing the artifacts and release page.
- Keep the GitHub release as a draft until its persisted body exactly matches `RELEASE.md`, then publish it with a body-preserving API update.

## Squash Commit Body

```text
The native release flow parks registry-mode changelog sections under
`.changeset/changelogs`, so use that as the only source for generated release
notes instead of the stale committed `CHANGELOG.md`.

Release-note metadata must not block publishing valid artifacts. If generation
fails, write a diagnostic release body with a link to the workflow run. Create
the GitHub release as a draft, compare its persisted body exactly with the
generated or diagnostic file, and publish it without resending the body.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786754211&installation_id=145934176&pr_number=13064&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13064&signature=cb74f35fb93cab4468e31791c365a0d502134455e0e017ca457172cfe729797b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release notes are generated from pending changelog entries and automatically set as the GitHub release description.
  - Releases are created as drafts first, then published only after the generated description is verified for consistency.
- **Bug Fixes**
  - Release-note generation now clearly errors when changelog/version entries are missing, and falls back to a safe description if generation fails.
- **Tests**
  - Added automated coverage for successful release-note generation and the main missing-changelog/missing-entry failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->