### PR TITLE
fix(ci): allow release tarball smoke install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,7 +180,8 @@ jobs:
       - name: Verify TypeScript npm packages
         # Inspect the same tarballs that publish will upload before the first
         # immutable npm publish, including the generated platform packages.
-        run: |
+        # The local release tarballs and their install scripts are the smoke-test inputs.
+        run: | # zizmor: ignore[adhoc-packages]
           set -euo pipefail
           release_tarballs=$(mktemp -d)
           for package in pnpm11/pnpm/artifacts/{darwin-arm64,exe,linux-arm64,linux-arm64-musl,linux-x64,linux-x64-musl,win32-arm64,win32-x64} pnpm11/pnpm; do


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

The release smoke test installs two tarballs that the workflow has just built. The install script is part of what the smoke test needs to check, so this command cannot use a committed lockfile.

zizmor 1.26.1 reports that intentional install as an `adhoc-packages` finding and fails pull request checks. This change ignores that rule only for the affected run block and explains why. Other zizmor findings remain enabled.

## Squash Commit Body

```text
The TypeScript release smoke test intentionally installs the local executable and native tarballs produced earlier in the same job. This checks the package install script and cannot be represented by a committed lockfile because the tarball paths are created at runtime.

Ignore the adhoc-packages rule only for this run block so pull request security checks continue to report every other zizmor finding.
```

## Checklist

- [x] This is repository CI only and does not change either pnpm implementation.
- [x] No changeset is needed because no published package changes.
- [x] Verified with the exact zizmor 1.26.1 version that failed CI.
- [x] No documentation update is needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786754247&installation_id=145934176&pr_number=13065&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13065&signature=7e7b9b34692996514e017c55ab3bd5afd194727fc0c7a0a470121a4565732e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Clarified release verification workflow comments and annotations.
  * No changes to exported functionality or end-user features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->