### PR TITLE
fix(ci): suppress intentional release tarball finding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,8 @@ jobs:
       - name: Verify TypeScript npm packages
         # Inspect the same tarballs that publish will upload before the first
         # immutable npm publish, including the generated platform packages.
+        # zizmor: ignore[adhoc-packages] -- This smoke test intentionally
+        # installs locally built release tarballs before publication.
         run: |
           set -euo pipefail
           release_tarballs=$(mktemp -d)


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Mark the TypeScript release smoke test's local tarball installation as an intentional `adhoc-packages` exception for zizmor.
- Keep the release verification behavior unchanged: the step still installs the freshly built executable and native tarballs before publication.
- Scope the suppression to the single release verification step so unrelated ad-hoc package installations remain reportable.

This fixes the false-positive zizmor failure currently shared by fork-based Draft PRs after the release smoke test was added to `main`.

## Squash Commit Body

```text
The TypeScript release verification step intentionally installs locally built executable and native tarballs so it can smoke-test the exact artifacts before their immutable npm publication. Zizmor classifies that installation as an ad-hoc package install even though the tarballs are produced earlier in the same trusted release job.

Add a step-scoped suppression with the release-specific rationale. The install command and release behavior remain unchanged, while unrelated ad-hoc package installations continue to be reported.
```

## Checklist

- [x] Verified `.github/workflows/release.yml` and the full repository with zizmor 1.26.1.
- [x] Ran the repository pre-push hook; TypeScript compile and lint passed, and the hook correctly skipped Rust checks because no Rust paths changed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786755269&installation_id=145934176&pr_number=13066&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13066&signature=05f538fc10778438aa879c7a90d84e0a2e9c1db51551cee1c61609172f5bf62d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification to the release verification workflow describing how locally built release packages are smoke-tested before publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->