### PR TITLE
fix(deps-resolver): remove reuse-only peer suffixes after dedupe

### DIFF
--- a/.changeset/peer-lockfile-drift-cleanup.md
+++ b/.changeset/peer-lockfile-drift-cleanup.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`pnpm install` no longer leaves peer dependency suffixes on unrelated packages when regenerating the lockfile after a manifest edit. The locked-peer-context reuse pass still resolves peers as before, but a following cleanup drops, per package, the peer suffixes a fresh resolution (and `pnpm dedupe`) would not have produced, so the deduplicated instances collapse during a plain `pnpm install`. This fixes lockfile drift where an unrelated `pnpm install` would add peer suffixes that `pnpm dedupe` would immediately remove.
+Fixed lockfile drift after manifest edits by removing reuse-only transitive peer suffixes without losing valid peer-context deduplication.

--- a/.changeset/peer-lockfile-drift-cleanup.md
+++ b/.changeset/peer-lockfile-drift-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+`pnpm install` no longer leaves peer dependency suffixes on unrelated packages when regenerating the lockfile after a manifest edit. The locked-peer-context reuse pass still resolves peers as before, but a following cleanup drops, per package, the peer suffixes a fresh resolution (and `pnpm dedupe`) would not have produced, so the deduplicated instances collapse during a plain `pnpm install`. This fixes lockfile drift where an unrelated `pnpm install` would add peer suffixes that `pnpm dedupe` would immediately remove.

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -301,6 +301,7 @@ export async function resolveDependencies (
     ? await resolvePeers({
       ...peerResolutionOpts,
       resolvedPeerProviderPaths: initiallyResolvedPeers.pathsByNodeId,
+      previousResolvedPeerNamesByNodeId: getResolvedPeerNamesByNodeId(initiallyResolvedPeers),
     })
     : initiallyResolvedPeers
 
@@ -618,4 +619,20 @@ function extendGraph (
     })
   }
   return graph
+}
+
+function getResolvedPeerNamesByNodeId (
+  resolved: {
+    dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<ResolvedPackage>
+    pathsByNodeId: Map<NodeId, DepPath>
+  }
+): Map<NodeId, Set<string>> {
+  const resolvedPeerNamesByNodeId = new Map<NodeId, Set<string>>()
+  for (const [nodeId, depPath] of resolved.pathsByNodeId.entries()) {
+    const node = resolved.dependenciesGraph[depPath]
+    if (node != null && node.resolvedPeerNames.size > 0) {
+      resolvedPeerNamesByNodeId.set(nodeId, node.resolvedPeerNames)
+    }
+  }
+  return resolvedPeerNamesByNodeId
 }

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -300,6 +300,7 @@ export async function resolveDependencies (
   } = treeHasLockedPeerContexts(dependenciesTree)
     ? await resolvePeers({
       ...peerResolutionOpts,
+      previousDependenciesGraph: initiallyResolvedPeers.dependenciesGraph,
       resolvedPeerProviderPaths: initiallyResolvedPeers.pathsByNodeId,
       previousResolvedPeerNamesByNodeId: getResolvedPeerNamesByNodeId(initiallyResolvedPeers),
     })

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { createPeerDepGraphHash, depPathToFilename, parseDepPath, type PeerId } from '@pnpm/deps.path'
+import { createPeerDepGraphHash, depPathToFilename, getPkgIdWithPatchHash, parseDepPath, type PeerId } from '@pnpm/deps.path'
 import { safeJoinModulesDir } from '@pnpm/fs.symlink-dependency'
 import type {
   DepPath,
@@ -109,6 +109,7 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     // lets the reuse pass drop a peer it bound laterally that a fresh resolution
     // (and `pnpm dedupe`) would have left unresolved — see dropSpuriousReusePeers.
     previousResolvedPeerNamesByNodeId?: Map<NodeId, Set<string>>
+    previousDependenciesGraph?: GenericDependenciesGraphWithResolvedChildren<T>
   }
 ): Promise<{
   dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<T>
@@ -299,6 +300,7 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       pathsByNodeId,
       depPathsByPkgId,
       dependenciesByProjectId,
+      previousDependenciesGraph: opts.previousDependenciesGraph,
       previousResolvedPeerNamesByNodeId: opts.previousResolvedPeerNamesByNodeId,
       dependenciesTree: opts.dependenciesTree,
       dedupePeers: opts.dedupePeers,
@@ -337,6 +339,7 @@ function dropSpuriousReusePeers<T extends PartialResolvedPackage> (
     pathsByNodeId: Map<NodeId, DepPath>
     depPathsByPkgId: Map<PkgIdWithPatchHash, Set<DepPath>>
     dependenciesByProjectId: DependenciesByProjectId
+    previousDependenciesGraph?: GenericDependenciesGraphWithResolvedChildren<T>
     previousResolvedPeerNamesByNodeId: Map<NodeId, Set<string>>
     dependenciesTree: DependenciesTree<T>
     dedupePeers?: boolean
@@ -462,28 +465,46 @@ function dropSpuriousReusePeers<T extends PartialResolvedPackage> (
 
   const remapped = (depPath: DepPath): DepPath => remap.get(depPath) ?? depPath
 
-  // Safety net: a strip is only valid when the reachable nodes that collapse
-  // onto a recomputed depPath are identical afterwards. If two would collide on
-  // the same depPath with different children, a dropped peer was actually
-  // load-bearing, so skip the cleanup entirely and keep the reuse pass output
-  // rather than risk losing a distinct instance. In practice this never fires;
-  // a fresh resolution distinguishes such nodes through a peer that is then kept.
-  const childrenSignatureByDepPath = new Map<DepPath, string>()
+  const candidatesByDepPath = new Map<DepPath, Array<{
+    children: Record<string, DepPath>
+    childDepPaths: Set<DepPath>
+    depPath: DepPath
+  }>>()
   for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
     if (!reachable.has(depPath)) continue
     const newDepPath = remapped(depPath)
     const spurious = spuriousPeersByDepPath.get(depPath)
-    const signature = Object.entries<DepPath>(node.children)
-      .filter(([alias]) => !spurious?.has(alias))
-      .map(([alias, childDepPath]) => `${alias}=${remapped(childDepPath)}`)
-      .sort()
-      .join('\n')
-    const existing = childrenSignatureByDepPath.get(newDepPath)
-    if (existing == null) {
-      childrenSignatureByDepPath.set(newDepPath, signature)
-    } else if (existing !== signature) {
-      return
+    const children = Object.fromEntries(
+      Object.entries<DepPath>(node.children)
+        .filter(([alias]) => !spurious?.has(alias))
+        .map(([alias, childDepPath]) => [alias, remapped(childDepPath)])
+    )
+    const childDepPaths = new Set(
+      Object.entries(children).map(([alias, childDepPath]) =>
+        opts.dedupePeers && node.peerDependencies?.[alias] != null
+          ? getPkgIdWithPatchHash(childDepPath) as unknown as DepPath
+          : childDepPath
+      )
+    )
+    const candidates = candidatesByDepPath.get(newDepPath)
+    const candidate = { children, childDepPaths, depPath }
+    if (candidates == null) {
+      candidatesByDepPath.set(newDepPath, [candidate])
+    } else {
+      candidates.push(candidate)
     }
+  }
+  const winnerByDepPath = new Map<DepPath, DepPath>()
+  for (const [newDepPath, candidates] of candidatesByDepPath.entries()) {
+    const previousChildren = opts.previousDependenciesGraph?.[newDepPath]?.children
+    const preferredChildren = previousChildren == null
+      ? undefined
+      : Object.fromEntries(
+        Object.entries(previousChildren).map(([alias, childDepPath]) => [alias, remapped(childDepPath)])
+      )
+    const winner = pickPeerCleanupWinner(candidates, newDepPath, preferredChildren)
+    if (winner == null) return
+    winnerByDepPath.set(newDepPath, winner.depPath)
   }
 
   // Rebuild the graph under the recomputed depPaths. Reachable nodes are written
@@ -500,12 +521,9 @@ function dropSpuriousReusePeers<T extends PartialResolvedPackage> (
   for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
     if (!reachable.has(depPath)) continue
     const newDepPath = remapped(depPath)
+    if (winnerByDepPath.get(newDepPath) !== depPath) continue
     const spurious = spuriousPeersByDepPath.get(depPath)
-    const children: Record<string, DepPath> = {}
-    for (const [alias, childDepPath] of Object.entries<DepPath>(node.children)) {
-      if (spurious?.has(alias)) continue
-      children[alias] = remapped(childDepPath)
-    }
+    const children = candidatesByDepPath.get(newDepPath)!.find((candidate) => candidate.depPath === depPath)!.children
     let resolvedPeerNames = node.resolvedPeerNames
     let resolvedPeerNodeIds = node.resolvedPeerNodeIds
     if (spurious != null) {
@@ -1111,6 +1129,43 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       }
     }
   }
+}
+
+export function pickPeerCleanupWinner<T extends {
+  children: Record<string, DepPath>
+  childDepPaths: Set<DepPath>
+  depPath: DepPath
+}> (
+  candidates: T[],
+  preferredDepPath?: DepPath,
+  preferredChildren?: Record<string, DepPath>
+): T | undefined {
+  const childrenSignature = (children: Record<string, DepPath> | undefined): string | undefined =>
+    children == null
+      ? undefined
+      : Object.entries(children)
+        .map(([alias, childDepPath]) => `${alias}=${childDepPath}`)
+        .sort()
+        .join('\n')
+  const preferredChildrenSignature = childrenSignature(preferredChildren)
+  return [...candidates]
+    .sort((candidate1, candidate2) => {
+      const preferredChildrenDiff =
+        Number(childrenSignature(candidate2.children) === preferredChildrenSignature) -
+        Number(childrenSignature(candidate1.children) === preferredChildrenSignature)
+      if (preferredChildrenSignature != null && preferredChildrenDiff !== 0) return preferredChildrenDiff
+      const preferredDiff =
+        Number(candidate2.depPath === preferredDepPath) - Number(candidate1.depPath === preferredDepPath)
+      if (preferredDiff !== 0) return preferredDiff
+      const countDiff = candidate2.childDepPaths.size - candidate1.childDepPaths.size
+      if (countDiff !== 0) return countDiff
+      return candidate1.depPath < candidate2.depPath ? -1 : candidate1.depPath > candidate2.depPath ? 1 : 0
+    })
+    .find((candidate) =>
+      candidates.every(({ childDepPaths }) =>
+        [...childDepPaths].every((childDepPath) => candidate.childDepPaths.has(childDepPath))
+      )
+    )
 }
 
 function getNodeIdsByPreviousDepPath<T> (dependenciesTree: DependenciesTree<T>): Map<DepPath, NodeId> {

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -42,6 +42,10 @@ export interface BaseGenericDependenciesGraphNode {
   isBuilt?: boolean
   isPure: boolean
   resolvedPeerNames: Set<string>
+  // The node id of every resolved peer, keyed by peer name. Kept so the
+  // dedupePeerDependents cleanup can recompute this instance's depPath after
+  // dropping a peer that was only bound by the locked-context reuse pass.
+  resolvedPeerNodeIds?: Map<string, NodeId>
   requiresBuild?: boolean
 }
 
@@ -100,6 +104,11 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     peersSuffixMaxLength: number
     workspaceProjectIds: Set<string>
     resolvedPeerProviderPaths?: Map<NodeId, DepPath>
+    // The resolved peer names each node had in the first (fresh) peer-resolution
+    // pass, keyed by node id. Present only for the locked-context reuse pass, it
+    // lets the reuse pass drop a peer it bound laterally that a fresh resolution
+    // (and `pnpm dedupe`) would have left unresolved — see dropSpuriousReusePeers.
+    previousResolvedPeerNamesByNodeId?: Map<NodeId, Set<string>>
   }
 ): Promise<{
   dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<T>
@@ -278,11 +287,259 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       }
     }
   }
+  // Runs after dedupePeerDependents so that compatible instances the reuse pass
+  // duplicated (e.g. the same package resolved with and without a bubbled-up
+  // transitive peer) have already been merged. Only then does each reachable
+  // instance carry a consistent set of children, so dropping a peer the fresh
+  // pass never resolved collapses it onto its deduplicated form without leaving
+  // a conflicting sibling behind.
+  if (opts.previousResolvedPeerNamesByNodeId != null) {
+    dropSpuriousReusePeers({
+      depGraph: depGraphWithResolvedChildren,
+      pathsByNodeId,
+      depPathsByPkgId,
+      dependenciesByProjectId,
+      previousResolvedPeerNamesByNodeId: opts.previousResolvedPeerNamesByNodeId,
+      dependenciesTree: opts.dependenciesTree,
+      dedupePeers: opts.dedupePeers,
+      peersSuffixMaxLength: opts.peersSuffixMaxLength,
+    })
+  }
   return {
     dependenciesGraph: depGraphWithResolvedChildren,
     dependenciesByProjectId,
     peerDependencyIssuesByProjects,
     pathsByNodeId,
+  }
+}
+
+// The locked-context reuse pass keeps a peer bound to the provider recorded in
+// the lockfile so a writable install does not rewrite still-valid dependency
+// instances. It finds that provider through a global lookup, so it can bind a
+// transitive (non-own) peer laterally to a provider in an unrelated subtree —
+// one the first (fresh) pass, and therefore `pnpm dedupe`, left unresolved.
+// That extra binding adds a peer suffix to the consumer that a fresh resolution
+// never produces, which is the lockfile drift in
+// https://github.com/pnpm/pnpm/issues/12756.
+//
+// Rather than stop the reuse pass from propagating the peer (which would forgo
+// the deduplication that resolving a shared provider can enable), this cleanup
+// runs after propagation and drops, per node, only the non-own peers the fresh
+// pass did not resolve for it. Own peers and genuinely reused contexts (a peer
+// the fresh pass also resolved, even to a different provider) are kept, so the
+// context-preservation the reuse pass exists for is untouched. Recomputing the
+// affected depPaths lets the now-canonical instances collapse onto their
+// deduplicated peers — the same result `pnpm dedupe` reaches — during a plain
+// `pnpm install`.
+function dropSpuriousReusePeers<T extends PartialResolvedPackage> (
+  opts: {
+    depGraph: GenericDependenciesGraphWithResolvedChildren<T>
+    pathsByNodeId: Map<NodeId, DepPath>
+    depPathsByPkgId: Map<PkgIdWithPatchHash, Set<DepPath>>
+    dependenciesByProjectId: DependenciesByProjectId
+    previousResolvedPeerNamesByNodeId: Map<NodeId, Set<string>>
+    dependenciesTree: DependenciesTree<T>
+    dedupePeers?: boolean
+    peersSuffixMaxLength: number
+  }
+): void {
+  const { depGraph } = opts
+
+  // Only nodes reachable from an importer end up in the lockfile. The reuse pass
+  // can leave behind unreferenced intermediate instances (e.g. a superseded peer
+  // context); ignoring them keeps the cleanup from seeing a phantom collision
+  // with a node that will be pruned anyway.
+  const reachable = new Set<DepPath>()
+  const reachableStack: DepPath[] = []
+  for (const deps of Object.values(opts.dependenciesByProjectId)) {
+    for (const depPath of deps.values()) {
+      if (!reachable.has(depPath)) {
+        reachable.add(depPath)
+        reachableStack.push(depPath)
+      }
+    }
+  }
+  while (reachableStack.length > 0) {
+    const depPath = reachableStack.pop()!
+    const node = depGraph[depPath]
+    if (node == null) continue
+    for (const childDepPath of Object.values<DepPath>(node.children)) {
+      if (!reachable.has(childDepPath)) {
+        reachable.add(childDepPath)
+        reachableStack.push(childDepPath)
+      }
+    }
+  }
+
+  // Every tree node that resolves to each depPath. A peer is only spurious for a
+  // depPath when the fresh pass left it unresolved for *every* position the
+  // depPath represents — otherwise the depPath stands for a context where the
+  // peer is genuine and must be kept.
+  const nodeIdsByDepPath = new Map<DepPath, NodeId[]>()
+  for (const [nodeId, depPath] of opts.pathsByNodeId.entries()) {
+    let nodeIds = nodeIdsByDepPath.get(depPath)
+    if (nodeIds == null) {
+      nodeIds = []
+      nodeIdsByDepPath.set(depPath, nodeIds)
+    }
+    nodeIds.push(nodeId)
+  }
+
+  const spuriousPeersByDepPath = new Map<DepPath, Set<string>>()
+  for (const [depPath, node] of Object.entries(depGraph)) {
+    if (!reachable.has(depPath as DepPath)) continue
+    if (node.resolvedPeerNames.size === 0) continue
+    // Recomputing a depPath needs every resolved peer's node id. If any is
+    // missing the suffix cannot be rebuilt faithfully, so leave the node as-is.
+    if (node.resolvedPeerNodeIds == null || node.resolvedPeerNodeIds.size !== node.resolvedPeerNames.size) continue
+    const ownPeerNames = node.peerDependencies == null ? new Set<string>() : new Set(Object.keys(node.peerDependencies))
+    const nodeIds = nodeIdsByDepPath.get(depPath as DepPath) ?? []
+    let spurious: Set<string> | undefined
+    for (const peerName of node.resolvedPeerNames) {
+      if (ownPeerNames.has(peerName)) continue
+      const genuine = nodeIds.some((nodeId) => opts.previousResolvedPeerNamesByNodeId.get(nodeId)?.has(peerName))
+      if (genuine) continue
+      spurious ??= new Set<string>()
+      spurious.add(peerName)
+    }
+    if (spurious != null) spuriousPeersByDepPath.set(depPath as DepPath, spurious)
+  }
+
+  if (spuriousPeersByDepPath.size === 0) return
+
+  // Recompute each node's depPath with its spurious peers removed. A depPath is
+  // a function of the kept peers' identifiers, and a non-deduped peer's
+  // identifier is the provider's own (possibly recomputed) depPath, so this
+  // memoized recursion mirrors how depPaths were first built while resolving
+  // provider remaps. A depPath already in progress is on a peer cycle; return
+  // it unchanged, matching how the first pass breaks such cycles.
+  const finalDepPathCache = new Map<DepPath, DepPath>()
+  const inProgress = new Set<DepPath>()
+  const finalDepPath = (depPath: DepPath): DepPath => {
+    const cached = finalDepPathCache.get(depPath)
+    if (cached != null) return cached
+    const node = depGraph[depPath]
+    if (node == null || inProgress.has(depPath)) return depPath
+    // A node whose resolved peers cannot be fully recomputed (see above) keeps
+    // its depPath; recomputing from a partial set would drop real peers.
+    if (node.resolvedPeerNames.size > 0 && (node.resolvedPeerNodeIds == null || node.resolvedPeerNodeIds.size !== node.resolvedPeerNames.size)) {
+      return depPath
+    }
+    inProgress.add(depPath)
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const peerIds: PeerId[] = []
+    if (node.resolvedPeerNodeIds != null) {
+      for (const [peerName, peerNodeId] of node.resolvedPeerNodeIds.entries()) {
+        if (spurious?.has(peerName)) continue
+        if (typeof peerNodeId === 'string' && peerNodeId.startsWith('link:')) {
+          peerIds.push({ name: peerName, version: linkPathToPeerVersion(peerNodeId.slice(5)) })
+        } else if (opts.dedupePeers) {
+          const peerNode = opts.dependenciesTree.get(peerNodeId)
+          if (peerNode != null) {
+            peerIds.push({ name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version })
+          }
+        } else {
+          const providerDepPath = node.children[peerName]
+          peerIds.push(providerDepPath != null ? finalDepPath(providerDepPath) : (peerNodeId as unknown as DepPath))
+        }
+      }
+    }
+    const suffix = peerIds.length === 0 ? '' : createPeerDepGraphHash(peerIds, opts.peersSuffixMaxLength)
+    const newDepPath = `${node.pkgIdWithPatchHash}${suffix}` as DepPath
+    inProgress.delete(depPath)
+    finalDepPathCache.set(depPath, newDepPath)
+    return newDepPath
+  }
+
+  const remap = new Map<DepPath, DepPath>()
+  for (const depPath of Object.keys(depGraph) as DepPath[]) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = finalDepPath(depPath)
+    if (newDepPath !== depPath) remap.set(depPath, newDepPath)
+  }
+
+  if (remap.size === 0) return
+
+  const remapped = (depPath: DepPath): DepPath => remap.get(depPath) ?? depPath
+
+  // Safety net: a strip is only valid when the reachable nodes that collapse
+  // onto a recomputed depPath are identical afterwards. If two would collide on
+  // the same depPath with different children, a dropped peer was actually
+  // load-bearing, so skip the cleanup entirely and keep the reuse pass output
+  // rather than risk losing a distinct instance. In practice this never fires;
+  // a fresh resolution distinguishes such nodes through a peer that is then kept.
+  const childrenSignatureByDepPath = new Map<DepPath, string>()
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = remapped(depPath)
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const signature = Object.entries<DepPath>(node.children)
+      .filter(([alias]) => !spurious?.has(alias))
+      .map(([alias, childDepPath]) => `${alias}=${remapped(childDepPath)}`)
+      .sort()
+      .join('\n')
+    const existing = childrenSignatureByDepPath.get(newDepPath)
+    if (existing == null) {
+      childrenSignatureByDepPath.set(newDepPath, signature)
+    } else if (existing !== signature) {
+      return
+    }
+  }
+
+  // Rebuild the graph under the recomputed depPaths. Reachable nodes are written
+  // last so a remapped reachable instance wins over any unreferenced node that
+  // happens to occupy its recomputed depPath. Nodes that collapse onto the same
+  // depPath are identical after dropping their spurious peers; a dropped peer's
+  // child entry is removed (it is already in transitivePeerDependencies) and
+  // every surviving child is remapped.
+  const newDepGraph: GenericDependenciesGraphWithResolvedChildren<T> = {}
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (reachable.has(depPath)) continue
+    newDepGraph[depPath] = node
+  }
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = remapped(depPath)
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const children: Record<string, DepPath> = {}
+    for (const [alias, childDepPath] of Object.entries<DepPath>(node.children)) {
+      if (spurious?.has(alias)) continue
+      children[alias] = remapped(childDepPath)
+    }
+    let resolvedPeerNames = node.resolvedPeerNames
+    let resolvedPeerNodeIds = node.resolvedPeerNodeIds
+    if (spurious != null) {
+      resolvedPeerNames = new Set([...node.resolvedPeerNames].filter((peerName) => !spurious.has(peerName)))
+      if (resolvedPeerNodeIds != null) {
+        resolvedPeerNodeIds = new Map([...resolvedPeerNodeIds].filter(([peerName]) => !spurious.has(peerName)))
+      }
+    }
+    newDepGraph[newDepPath] = {
+      ...node,
+      depPath: newDepPath,
+      children,
+      resolvedPeerNames,
+      resolvedPeerNodeIds,
+    }
+  }
+
+  for (const depPath of Object.keys(depGraph) as DepPath[]) {
+    delete depGraph[depPath]
+  }
+  Object.assign(depGraph, newDepGraph)
+
+  for (const [nodeId, depPath] of opts.pathsByNodeId.entries()) {
+    opts.pathsByNodeId.set(nodeId, remapped(depPath))
+  }
+
+  for (const [pkgId, depPaths] of opts.depPathsByPkgId.entries()) {
+    opts.depPathsByPkgId.set(pkgId, new Set([...depPaths].map(remapped)))
+  }
+
+  for (const deps of Object.values(opts.dependenciesByProjectId)) {
+    for (const [alias, depPath] of deps.entries()) {
+      deps.set(alias, remapped(depPath))
+    }
   }
 }
 
@@ -850,6 +1107,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
         peerDependencies,
         transitivePeerDependencies,
         resolvedPeerNames: new Set(allResolvedPeers.keys()),
+        resolvedPeerNodeIds: new Map(allResolvedPeers),
       }
     }
   }

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -10,7 +10,7 @@ import type {
 
 import type { NodeId } from '../lib/nextNodeId.js'
 import type { ChildrenMap, DependenciesTreeNode, PeerDependencies } from '../lib/resolveDependencies.js'
-import { type PartialResolvedPackage, resolvePeers } from '../lib/resolvePeers.js'
+import { type PartialResolvedPackage, pickPeerCleanupWinner, resolvePeers } from '../lib/resolvePeers.js'
 
 test('resolve peer dependencies of cyclic dependencies', async () => {
   const fooPkg = {
@@ -764,6 +764,86 @@ test('resolve peer dependencies with npm aliases', async () => {
     'foo/1.0.0(bar/1.0.0)',
     'foo/2.0.0(bar/2.0.0)',
   ])
+})
+
+test('peer cleanup selects a compatible child superset', () => {
+  const subset = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childDepPaths: new Set(['foo/1.0.0' as DepPath]),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  const superset = {
+    children: {
+      bar: 'bar/1.0.0' as DepPath,
+      foo: 'foo/1.0.0' as DepPath,
+    },
+    childDepPaths: new Set(['foo/1.0.0' as DepPath, 'bar/1.0.0' as DepPath]),
+    depPath: 'consumer/1.0.0(peer-b/1.0.0)' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([subset, superset])).toBe(superset)
+})
+
+test('peer cleanup rejects incompatible children', () => {
+  const foo = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childDepPaths: new Set(['foo/1.0.0' as DepPath]),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  const bar = {
+    children: { bar: 'bar/1.0.0' as DepPath },
+    childDepPaths: new Set(['bar/1.0.0' as DepPath]),
+    depPath: 'consumer/1.0.0(peer-b/1.0.0)' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([foo, bar])).toBeUndefined()
+})
+
+test('peer cleanup breaks equal-child ties by depPath', () => {
+  const later = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childDepPaths: new Set(['foo/1.0.0' as DepPath]),
+    depPath: 'consumer/1.0.0(peer-b/1.0.0)' as DepPath,
+  }
+  const earlier = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childDepPaths: new Set(['foo/1.0.0' as DepPath]),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([later, earlier])).toBe(earlier)
+})
+
+test('peer cleanup prefers an existing target depPath', () => {
+  const remapped = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childDepPaths: new Set(['foo/1.0.0' as DepPath]),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  const existing = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childDepPaths: new Set(['foo/1.0.0' as DepPath]),
+    depPath: 'consumer/1.0.0' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([remapped, existing], existing.depPath)).toBe(existing)
+})
+
+test('peer cleanup preserves the fresh child context when normalized children tie', () => {
+  const normalizedStorybook = 'storybook/10.2.13' as DepPath
+  const freshStorybook = 'storybook/10.2.13(react/18.3.1)' as DepPath
+  const otherStorybook = 'storybook/10.2.13(react/19.2.7)' as DepPath
+  const remapped = {
+    children: { storybook: freshStorybook },
+    childDepPaths: new Set([normalizedStorybook]),
+    depPath: 'consumer/1.0.0(supports-color/5.5.0)' as DepPath,
+  }
+  const existing = {
+    children: { storybook: otherStorybook },
+    childDepPaths: new Set([normalizedStorybook]),
+    depPath: 'consumer/1.0.0' as DepPath,
+  }
+  expect(pickPeerCleanupWinner(
+    [existing, remapped],
+    existing.depPath,
+    { storybook: freshStorybook }
+  )).toBe(remapped)
 })
 
 describe('locked peer provider preferences', () => {

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -887,6 +887,19 @@ describe('locked peer provider preferences', () => {
     }
   }
 
+  function resolvedPeerNamesByNodeId (
+    result: Awaited<ReturnType<typeof resolvePeers>>
+  ): Map<NodeId, Set<string>> {
+    const byNodeId = new Map<NodeId, Set<string>>()
+    for (const [nodeId, depPath] of result.pathsByNodeId.entries()) {
+      const node = result.dependenciesGraph[depPath]
+      if (node != null && node.resolvedPeerNames.size > 0) {
+        byNodeId.set(nodeId, node.resolvedPeerNames)
+      }
+    }
+    return byNodeId
+  }
+
   test('prefers a compatible locked provider that remains reachable in the current graph', async () => {
     const resolutionOpts = options(createTree(), new Map([
       ['peer', currentPeerNodeId],
@@ -1111,6 +1124,111 @@ describe('locked peer provider preferences', () => {
 
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('drops a spuriously reused optional peer that the fresh pass left unresolved', async () => {
+    // Regression test for https://github.com/pnpm/pnpm/issues/12756. `dep` has an
+    // OPTIONAL peer whose only provider (peer@2.0.0) lives in an unrelated sibling
+    // subtree (under retainer), so a fresh resolution leaves it unbound. The
+    // locked-context reuse pass still binds it under `consumer`'s `dep` — that
+    // propagation is intentionally preserved so a shared provider can deduplicate
+    // — which bubbles `peer` up onto `consumer` (it is not `consumer`'s own peer).
+    // The dropSpuriousReusePeers cleanup then removes that bubbled-up suffix from
+    // `consumer` because the fresh pass did not resolve `peer` for it, keeping a
+    // writable install aligned with `pnpm dedupe`.
+    const depNodeId = '>wrapper/1.0.0>consumer/1.0.0>dep/1.0.0>' as NodeId
+    const depPkg = {
+      name: 'dep',
+      pkgIdWithPatchHash: 'dep/1.0.0' as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies: {
+        peer: { version: '>=1', optional: true },
+      },
+      id: '' as PkgResolutionId,
+    }
+    const plainConsumerPkg = {
+      ...consumerPkg,
+      peerDependencies: {} as PeerDependencies,
+    }
+    const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [retainerNodeId, {
+        children: { peer: retainedPeerNodeId },
+        installable: true,
+        resolvedPackage: retainerPkg,
+        depth: 0,
+      }],
+      [retainedPeerNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer/2.0.0' as DepPath,
+        resolvedPackage: peer2Pkg,
+        depth: 1,
+      }],
+      [wrapperNodeId, {
+        children: { consumer: consumerNodeId },
+        installable: true,
+        resolvedPackage: wrapperPkg,
+        depth: 0,
+      }],
+      [consumerNodeId, {
+        children: { dep: depNodeId },
+        installable: true,
+        resolvedPackage: plainConsumerPkg,
+        depth: 1,
+      }],
+      [depNodeId, {
+        children: {},
+        installable: true,
+        lockedPeerContext: { peer: 'peer/2.0.0' as DepPath },
+        resolvedPackage: depPkg,
+        depth: 2,
+      }],
+    ])
+    const resolutionOpts = options(dependenciesTree, new Map([
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+
+    // Without the fresh-pass oracle the reuse pass still propagates the peer,
+    // bubbling the suffixed instance up onto consumer, which the cleanup removes.
+    const propagated = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+    expect(propagated.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
+
+    const cleaned = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+      previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+      dedupePeerDependents: true,
+    })
+    expect(cleaned.dependenciesGraph['consumer/1.0.0' as DepPath]).toBeTruthy()
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('keeps a genuine reused peer context that the fresh pass also resolved', async () => {
+    // The consumer's peer is REQUIRED and a provider (peer@1.0.0) is in scope, so
+    // the fresh pass resolves the peer and the reuse pass re-binds it to the
+    // locked peer@2.0.0. Because the fresh pass also resolved `peer`, the cleanup
+    // treats the context as genuine and keeps it — the context preservation the
+    // reuse pass exists for is not undone.
+    const resolutionOpts = options(createTree(), new Map([
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers(resolutionOpts)
+    const cleaned = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+      previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+      dedupePeerDependents: true,
+    })
+
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
**Closed in favor of #13109**

<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes [pnpm/pnpm#12756](https://github.com/pnpm/pnpm/issues/12756).

A writable `pnpm install` currently reuses peer providers recorded in the lockfile. For an optional transitive peer, that reuse can bind a provider from an unrelated subtree and bubble the peer through ancestors that a fresh resolution would leave peer-free. The result is large lockfile churn that a subsequent `pnpm dedupe` immediately removes.

### Why not short-circuit the peer resolution?

[pnpm/pnpm#12830](https://github.com/pnpm/pnpm/pull/12830) prevented the optional peer from resolving when no provider was visible in the current ancestor scope. Zoltan noted that resolving the peer can enable `dedupePeerDependents`.

That concern is reproducible. With a package that has optional peers `peer-p` and `peer-q`:

- one occurrence freshly resolves only `peer-p`;
- one freshly resolves only `peer-q`;
- a retained lockfile context can resolve both.

Allowing the retained `(peer-p)(peer-q)` context gives `dedupePeerDependents` a compatible superset and collapses both occurrences to one instance. Short-circuiting the retained peer leaves two instances.

This PR therefore allows locked peer contexts to resolve and participate in deduplication before removing their spurious transitive effects.

### How the cleanup works

1. The first peer-resolution pass records the peer names resolved at every node and retains its dependency graph as the canonical fresh context.
2. The locked-context reuse pass runs unchanged, including `dedupePeerDependents`.
3. After deduplication, `dropSpuriousReusePeers` examines only reachable graph nodes. A non-own peer is reuse-only when no fresh node represented by that depPath resolved the peer.
4. A memoized, cycle-safe walk recomputes affected depPaths without those reuse-only peers. Own peer contexts remain untouched, and `transitivePeerDependencies` is preserved.
5. If several old depPaths collapse onto one cleaned depPath, cleanup selects a deterministic candidate whose children are a compatible superset of every candidate:
   - own peer children are compared by package identity when `dedupePeers` is enabled, because nested peer contexts are intentionally omitted from that mode's peer IDs;
   - the fresh-pass child graph is preferred;
   - then an already-existing target depPath, dependency count, and lexical depPath order provide deterministic tie-breaks.
6. If no compatible superset exists, cleanup aborts conservatively and keeps the reuse-pass graph.

### Difference from pnpm/pnpm#12998

This keeps the propagate → dedupe → clean design introduced by [pnpm/pnpm#12998](https://github.com/pnpm/pnpm/pull/12998), but changes its collision safety.

The original PR required colliding candidates to have byte-identical children and aborted the entire cleanup otherwise. In the 246-project real-world reproduction, benign differences are common:

- one candidate can be a strict child-dependency superset of another;
- `dedupePeers` intentionally treats peer providers with the same package version but different nested peer contexts as equivalent.

That exact-signature guard aborted cleanup and left the original 456-line churn. Selecting a compatible superset preserves safety while allowing cleanup to complete. The fresh-pass graph and deterministic tie-breaks keep the chosen payload stable across resolution order.

### Performance

Benchmark setup:

- private 246-project workspace at commit `3a3e453ffb4b`;
- removed `@fluidx/localize-js` from `peerDependencies` in two manifests;
- restored the committed `pnpm-lock.yaml` before every run;
- compared bundles built from upstream `main` at `566864e3d1` and this PR at `4cfde87ed9`;
- command: `install --lockfile-only --prefer-offline --ignore-scripts`;
- caches warmed first, then five interleaved measured runs per build.

| Build | Wall time runs (s) | Median wall | Median CPU (user + sys) | Median max RSS |
| --- | --- | ---: | ---: | ---: |
| upstream `main` | 13.73, 13.62, 13.58, 13.21, 13.01 | 13.58 s | 21.81 s | 4.555 GiB |
| this PR | 22.20, 13.39, 13.43, 13.64, 13.31 | 13.43 s | 21.91 s | 4.456 GiB |

The first PR run had an external wall-clock outlier: its CPU time was 22.62 s, consistent with the other runs. By medians, the PR is 1.1% faster in wall time, 0.5% higher in CPU time, and 2.2% lower in max RSS. There is no measurable resolution slowdown.

The implementation deliberately avoids a third peer-resolution pass. An earlier three-pass prototype had a 36.94 s median versus 14.30 s for baseline (2.58× slower), with median RSS increasing from 4.57 GiB to 5.92 GiB. V8 profiles showed `resolvePeersOfChildren` self samples increasing from 43 to 1,481 and `resolvePeersOfNode` from 9 to 327: the extra pass traversed the peer tree again. This PR instead walks the already-deduplicated graph.

### Real-world lockfile result

| Build | `pnpm-lock.yaml` diff | Changed peer-suffix lines |
| --- | ---: | ---: |
| upstream `main` | 242 insertions, 214 deletions | 322 |
| this PR | 0 insertions, 6 intended deletions | 0 |

The PR lockfile hash is `3bf5ba4d37c90fe7a1284fbeb4281a0786d970884df596da557bdbafa4924307`, matching the `pnpm dedupe` result for the same manifest edits.

### Validation

- Full dependency-resolver suite: 15 suites, 143 tests passed.
- The minimal pnpm/pnpm#12756 reproduction produces byte-identical `pnpm install` and `pnpm dedupe` lockfiles.
- The two-optional-peer counterexample still resolves to one deduplicated union instance rather than the two instances produced by the early short-circuit.
- The 246-project resolution completes with the default Node heap and produces the dedupe-stable lockfile shown above.
- The pnpm bundle compiles, and the pre-push TypeScript, lint, Rust clippy, and Rust documentation checks pass.

### Rust parity

No Rust change is required. The regression is in the TypeScript resolver's locked-context reuse passes. The equivalent pacquet run did not reproduce the peer-suffix propagation.

## Squash Commit Body

```text
Fix lockfile drift caused by optional peer providers reused from unrelated
subtrees during writable installs.

Keep locked peer resolution and peer-dependent deduplication unchanged, then
remove only non-own peers that no corresponding fresh resolution produced.
Recompute affected depPaths after deduplication so canonical instances collapse
during pnpm install instead of requiring a later pnpm dedupe.

When cleaned depPaths collide, select a deterministic candidate whose children
are a compatible superset of all candidates. Account for dedupePeers
version-only peer IDs and prefer the fresh-pass child graph. Abort cleanup when
no safe candidate exists.

Fixes pnpm/pnpm#12756.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. No documentation change is needed for this internal lockfile-correctness fix.

---
Written by an agent (GitHub Copilot CLI, gpt-5.6-sol).
