### PR TITLE
fix(lockfile): fix installs when pnpm-lock.yaml is a symlink

### DIFF
--- a/.changeset/allow-symlinked-lockfile-reads.md
+++ b/.changeset/allow-symlinked-lockfile-reads.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"pacquet": patch
+---
+
+Allow reading a symlinked `pnpm-lock.yaml` while retaining the protection against writing through one.

--- a/.changeset/allow-symlinked-lockfile-reads.md
+++ b/.changeset/allow-symlinked-lockfile-reads.md
@@ -1,6 +1,7 @@
 ---
+"@pnpm/lockfile.fs": patch
 "pnpm": patch
 "pacquet": patch
 ---
 
-Allow reading a symlinked `pnpm-lock.yaml` while retaining the protection against writing through one.
+Fixed `pnpm install` failing with `ERR_PNPM_LOCKFILE_IS_SYMLINK` when `pnpm-lock.yaml` is a symlink, as build sandboxes such as Bazel and Nix stage it [#13073](https://github.com/pnpm/pnpm/issues/13073). Reading a lockfile through a symlink is allowed again, and an install that leaves the lockfile unchanged no longer rewrites it, so `--frozen-lockfile` no longer needs to write at all. Writing a *changed* lockfile through a symlink is still refused, as that would redirect the write onto the symlink's target.

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -142,10 +142,12 @@ fn read_lockfile_to_string_no_follow(path: &Path) -> io::Result<Option<String>> 
     read_lockfile_to_string_with(path, open_lockfile_no_follow)
 }
 
-/// Reads a whole lockfile, following a symlink. Reading through one is safe —
-/// planting a symlink already requires write access to the working tree — and
-/// build sandboxes stage `pnpm-lock.yaml` as a symlink
-/// (<https://github.com/pnpm/pnpm/issues/13073>). Only writes refuse a symlink.
+/// Reads a whole lockfile, following a symlink, as build sandboxes stage
+/// `pnpm-lock.yaml` (<https://github.com/pnpm/pnpm/issues/13073>). Refusing it
+/// here bought nothing: the main lockfile is loaded with an ordinary read that
+/// follows the link anyway, and a hostile repo can commit a hostile lockfile as
+/// a plain file regardless — the content is untrusted either way. Writes are the
+/// real boundary and still refuse a symlink, since a write lands on its target.
 fn read_lockfile_to_string(path: &Path) -> io::Result<Option<String>> {
     read_lockfile_to_string_with(path, |path| File::open(path))
 }

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -107,8 +107,7 @@ impl EnvLockfile {
     ///   importer (and its `configDependencies` map) exists.
     pub fn read(root_dir: &Path) -> Result<Option<Self>, LoadLockfileError> {
         let path = root_dir.join(Lockfile::FILE_NAME);
-        let Some(content) =
-            read_lockfile_to_string_no_follow(&path).map_err(LoadLockfileError::ReadFile)?
+        let Some(content) = read_lockfile_to_string(&path).map_err(LoadLockfileError::ReadFile)?
         else {
             return Ok(None);
         };
@@ -138,7 +137,18 @@ impl EnvLockfile {
 }
 
 fn read_lockfile_to_string_no_follow(path: &Path) -> io::Result<Option<String>> {
-    let mut file = match open_lockfile_no_follow(path) {
+    read_lockfile_to_string_with(path, open_lockfile_no_follow)
+}
+
+fn read_lockfile_to_string(path: &Path) -> io::Result<Option<String>> {
+    read_lockfile_to_string_with(path, |path| File::open(path))
+}
+
+fn read_lockfile_to_string_with(
+    path: &Path,
+    open_file: impl FnOnce(&Path) -> io::Result<File>,
+) -> io::Result<Option<String>> {
+    let mut file = match open_file(path) {
         Ok(file) => file,
         Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
         Err(error) => return Err(error),

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -14,7 +14,9 @@
 
 use crate::{
     LoadLockfileError, Lockfile, PackageKey, PackageMetadata, SaveLockfileError, SnapshotEntry,
-    extract_env_document, extract_main_document, serialize_yaml,
+    extract_env_document, extract_main_document,
+    save_lockfile::{ensure_lockfile_is_not_symlink, symlinked_lockfile_error},
+    serialize_yaml,
     yaml_documents::{YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START},
 };
 use pacquet_fs::write_atomic;
@@ -140,6 +142,10 @@ fn read_lockfile_to_string_no_follow(path: &Path) -> io::Result<Option<String>> 
     read_lockfile_to_string_with(path, open_lockfile_no_follow)
 }
 
+/// Reads a whole lockfile, following a symlink. Reading through one is safe —
+/// planting a symlink already requires write access to the working tree — and
+/// build sandboxes stage `pnpm-lock.yaml` as a symlink
+/// (<https://github.com/pnpm/pnpm/issues/13073>). Only writes refuse a symlink.
 fn read_lockfile_to_string(path: &Path) -> io::Result<Option<String>> {
     read_lockfile_to_string_with(path, |path| File::open(path))
 }
@@ -156,7 +162,7 @@ fn read_lockfile_to_string_with(
     let mut content = String::new();
     #[expect(
         clippy::verbose_file_reads,
-        reason = "Reading from the no-follow file handle avoids reopening the lockfile by path."
+        reason = "Reading from the caller's file handle avoids reopening the lockfile by path."
     )]
     file.read_to_string(&mut content)?;
     Ok(Some(content))
@@ -180,22 +186,6 @@ fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
 #[cfg(unix)]
 fn normalize_no_follow_error(path: &Path, error: io::Error) -> io::Error {
     if error.raw_os_error() == Some(libc::ELOOP) { symlinked_lockfile_error(path) } else { error }
-}
-
-fn ensure_lockfile_is_not_symlink(path: &Path) -> io::Result<()> {
-    match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() => Err(symlinked_lockfile_error(path)),
-        Ok(_) => Ok(()),
-        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
-    }
-}
-
-fn symlinked_lockfile_error(path: &Path) -> io::Error {
-    io::Error::new(
-        ErrorKind::InvalidInput,
-        format!("refusing to read or write symlinked lockfile at {}", path.display()),
-    )
 }
 
 #[cfg(test)]

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -142,12 +142,8 @@ fn read_lockfile_to_string_no_follow(path: &Path) -> io::Result<Option<String>> 
     read_lockfile_to_string_with(path, open_lockfile_no_follow)
 }
 
-/// Reads a whole lockfile, following a symlink, as build sandboxes stage
-/// `pnpm-lock.yaml` (<https://github.com/pnpm/pnpm/issues/13073>). Refusing it
-/// here bought nothing: the main lockfile is loaded with an ordinary read that
-/// follows the link anyway, and a hostile repo can commit a hostile lockfile as
-/// a plain file regardless — the content is untrusted either way. Writes are the
-/// real boundary and still refuse a symlink, since a write lands on its target.
+/// Reads a whole lockfile, following a symlink;
+/// [`ensure_lockfile_is_not_symlink`] covers why only writes refuse one.
 fn read_lockfile_to_string(path: &Path) -> io::Result<Option<String>> {
     read_lockfile_to_string_with(path, |path| File::open(path))
 }

--- a/pnpm/crates/lockfile/src/env_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile/tests.rs
@@ -1,4 +1,6 @@
-use super::{EnvLockfile, SpecifierAndResolution, read_lockfile_to_string_no_follow};
+#[cfg(unix)]
+use super::read_lockfile_to_string_no_follow;
+use super::{EnvLockfile, SpecifierAndResolution};
 use crate::{
     Lockfile, LockfileResolution, PackageKey, PackageMetadata, RegistryResolution, SnapshotEntry,
     extract_env_document,
@@ -86,7 +88,7 @@ fn write_preserves_existing_main_document() {
 
 #[cfg(unix)]
 #[test]
-fn read_rejects_symlinked_lockfile() {
+fn read_symlinked_lockfile() {
     let dir = TempDir::new().unwrap();
     let real_lockfile = dir.path().join("real-lockfile.yaml");
     std::fs::write(
@@ -96,9 +98,9 @@ fn read_rejects_symlinked_lockfile() {
     .unwrap();
     std::os::unix::fs::symlink(&real_lockfile, dir.path().join(Lockfile::FILE_NAME)).unwrap();
 
-    let error = EnvLockfile::read(dir.path()).expect_err("symlinked lockfile must fail");
+    let env = EnvLockfile::read(dir.path()).unwrap().expect("env document parses");
 
-    assert!(error.to_string().contains("symlinked lockfile"), "unexpected error: {error:?}");
+    assert_eq!(env.lockfile_version, "9.0");
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/lockfile/src/save_lockfile.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile.rs
@@ -72,9 +72,9 @@ pub enum SaveLockfileError {
 /// leading `---`).
 ///
 /// A byte-identical rewrite is skipped, so an up-to-date install leaves the
-/// lockfile — and its mtime — untouched. Reads follow a symlinked lockfile,
-/// but a write through one is refused: it would redirect the write onto the
-/// symlink's target (<https://github.com/pnpm/pnpm/issues/13073>).
+/// lockfile — and its mtime — untouched, and a symlinked lockfile that nothing
+/// changes is never refused (<https://github.com/pnpm/pnpm/issues/13073>). A
+/// write that does change bytes refuses a symlinked lockfile.
 ///
 /// The write is atomic: a crash mid-write leaves the previous lockfile intact
 /// rather than a truncated one. A missing parent directory is an error, not
@@ -102,11 +102,16 @@ pub fn save_value_to_path<Document: serde::Serialize>(
     write_atomic(path, output.as_bytes())
 }
 
-/// Refuses a symlinked lockfile before a write, so a repo-planted
-/// `pnpm-lock.yaml` symlink cannot redirect the write onto its target — any
-/// file the user can write. Callers that only read must not use this: reading
-/// through a symlink is safe, and build sandboxes stage the lockfile as one
-/// (<https://github.com/pnpm/pnpm/issues/13073>).
+/// Refuses a symlinked lockfile before a write: the lockfile must be a real file
+/// to be written. A writer that resolves the path lands on the link's target, so
+/// a repo-planted `pnpm-lock.yaml` redirects the write onto any file the user can
+/// write; a writer that renames over the link instead discards a lockfile a build
+/// sandbox staged deliberately.
+///
+/// Reads may follow the link and must not call this. Sandboxes stage
+/// `pnpm-lock.yaml` as a symlink (<https://github.com/pnpm/pnpm/issues/13073>),
+/// and lockfile content is untrusted however it is reached — a repository can
+/// commit whatever content it likes as a plain file.
 pub(crate) fn ensure_lockfile_is_not_symlink(path: &Path) -> io::Result<()> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => Err(symlinked_lockfile_error(path)),

--- a/pnpm/crates/lockfile/src/save_lockfile.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile.rs
@@ -70,22 +70,55 @@ pub enum SaveLockfileError {
 /// `${YAML_DOCUMENT_START}${envDoc}${YAML_DOCUMENT_SEPARATOR}${mainDoc}`.
 /// A lockfile with no env document round-trips byte-for-byte (no
 /// leading `---`).
+///
+/// A byte-identical rewrite is skipped, so an up-to-date install leaves the
+/// lockfile — and its mtime — untouched. Reads follow a symlinked lockfile,
+/// but a write through one is refused: it would redirect the write onto the
+/// symlink's target (<https://github.com/pnpm/pnpm/issues/13073>).
+///
+/// The write is atomic: a crash mid-write leaves the previous lockfile intact
+/// rather than a truncated one. A missing parent directory is an error, not
+/// something to create — the lockfile is written into an existing project.
 pub fn save_value_to_path<Document: serde::Serialize>(
     value: &Document,
     path: &Path,
 ) -> Result<(), SaveLockfileError> {
     let content = serialize_yaml::to_string(value).map_err(SaveLockfileError::SerializeYaml)?;
-    let env_prefix = match fs::read_to_string(path) {
-        Ok(existing) => extract_env_document(&existing)
-            .map(|env| format!("{YAML_DOCUMENT_START}{env}{YAML_DOCUMENT_SEPARATOR}")),
+    let existing = match fs::read_to_string(path) {
+        Ok(existing) => Some(existing),
         Err(error) if error.kind() == io::ErrorKind::NotFound => None,
         Err(error) => return Err(SaveLockfileError::WriteFile(error)),
     };
-    let output = match env_prefix {
-        Some(prefix) => format!("{prefix}{content}"),
+    let output = match existing.as_deref().and_then(extract_env_document) {
+        Some(env) => format!("{YAML_DOCUMENT_START}{env}{YAML_DOCUMENT_SEPARATOR}{content}"),
         None => content,
     };
-    fs::write(path, output).map_err(SaveLockfileError::WriteFile)
+    if existing.as_deref() == Some(output.as_str()) {
+        return Ok(());
+    }
+    ensure_lockfile_is_not_symlink(path).map_err(SaveLockfileError::WriteFile)?;
+    write_atomic(path, output.as_bytes())
+}
+
+/// Refuses a symlinked lockfile before a write, so a repo-planted
+/// `pnpm-lock.yaml` symlink cannot redirect the write onto its target — any
+/// file the user can write. Callers that only read must not use this: reading
+/// through a symlink is safe, and build sandboxes stage the lockfile as one
+/// (<https://github.com/pnpm/pnpm/issues/13073>).
+pub(crate) fn ensure_lockfile_is_not_symlink(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => Err(symlinked_lockfile_error(path)),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn symlinked_lockfile_error(path: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidInput,
+        format!("refusing to write symlinked lockfile at {}", path.display()),
+    )
 }
 
 impl Lockfile {
@@ -138,9 +171,41 @@ impl Lockfile {
     }
 }
 
+/// Make the freshly created temp file a faithful stand-in for `target`: flush
+/// it to disk so the rename can't publish a directory entry whose data didn't
+/// survive a power loss, and carry `target`'s mode across — the rename replaces
+/// `target` with this file, so a lockfile the user tightened would otherwise
+/// silently revert to the umask default.
+fn fill_temp_file(file: &mut fs::File, content: &[u8], target: &Path) -> io::Result<()> {
+    file.write_all(content)?;
+    file.sync_all()?;
+    carry_mode_across(file, target)
+}
+
+#[cfg(unix)]
+fn carry_mode_across(file: &fs::File, target: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // `symlink_metadata` so a symlinked target is never followed. Callers
+    // refuse a symlinked lockfile before reaching here; a fresh file keeps the
+    // umask default, matching a plain create.
+    let Ok(metadata) = fs::symlink_metadata(target) else { return Ok(()) };
+    if metadata.file_type().is_symlink() {
+        return Ok(());
+    }
+    file.set_permissions(fs::Permissions::from_mode(metadata.permissions().mode()))
+}
+
+#[cfg(not(unix))]
+fn carry_mode_across(_file: &fs::File, _target: &Path) -> io::Result<()> {
+    Ok(())
+}
+
 /// Write `content` to `target` via a temp file in the same directory
 /// followed by `rename`. The rename is atomic on Unix and replaces
-/// in-place on Windows, so an observer never sees a torn file.
+/// in-place on Windows, so an observer never sees a torn file, and a
+/// crash mid-write leaves the previous `target` intact. A missing parent
+/// directory surfaces as an error rather than being created.
 ///
 /// The temp file is opened with `O_CREAT | O_EXCL` (`create_new(true)`)
 /// rather than `create + truncate`, so we never follow a symlink or
@@ -180,7 +245,7 @@ fn write_atomic(target: &Path, content: &[u8]) -> Result<(), SaveLockfileError> 
             Err(error) => return Err(SaveLockfileError::WriteFile(error)),
         };
 
-        if let Err(error) = file.write_all(content) {
+        if let Err(error) = fill_temp_file(&mut file, content, target) {
             drop(file);
             let _ = fs::remove_file(&tmp);
             return Err(SaveLockfileError::WriteFile(error));

--- a/pnpm/crates/lockfile/src/save_lockfile.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile.rs
@@ -85,7 +85,9 @@ pub fn save_value_to_path<Document: serde::Serialize>(
 ) -> Result<(), SaveLockfileError> {
     let content = serialize_yaml::to_string(value).map_err(SaveLockfileError::SerializeYaml)?;
     let existing = match fs::read_to_string(path) {
-        Ok(existing) => Some(existing),
+        Ok(existing) => {
+            Some(existing.strip_prefix('\u{feff}').unwrap_or(&existing).replace("\r\n", "\n"))
+        }
         Err(error) if error.kind() == io::ErrorKind::NotFound => None,
         Err(error) => return Err(SaveLockfileError::WriteFile(error)),
     };
@@ -117,7 +119,7 @@ pub(crate) fn ensure_lockfile_is_not_symlink(path: &Path) -> io::Result<()> {
 pub(crate) fn symlinked_lockfile_error(path: &Path) -> io::Error {
     io::Error::new(
         io::ErrorKind::InvalidInput,
-        format!("refusing to write symlinked lockfile at {}", path.display()),
+        format!("Refusing to write symlinked lockfile at {}", path.display()),
     )
 }
 

--- a/pnpm/crates/lockfile/src/save_lockfile.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile.rs
@@ -71,14 +71,8 @@ pub enum SaveLockfileError {
 /// A lockfile with no env document round-trips byte-for-byte (no
 /// leading `---`).
 ///
-/// A byte-identical rewrite is skipped, so an up-to-date install leaves the
-/// lockfile — and its mtime — untouched, and a symlinked lockfile that nothing
-/// changes is never refused (<https://github.com/pnpm/pnpm/issues/13073>). A
-/// write that does change bytes refuses a symlinked lockfile.
-///
-/// The write is atomic: a crash mid-write leaves the previous lockfile intact
-/// rather than a truncated one. A missing parent directory is an error, not
-/// something to create — the lockfile is written into an existing project.
+/// A write that changes bytes is atomic and refuses a symlinked lockfile. A
+/// missing parent directory is an error, not something to create.
 pub fn save_value_to_path<Document: serde::Serialize>(
     value: &Document,
     path: &Path,
@@ -102,16 +96,10 @@ pub fn save_value_to_path<Document: serde::Serialize>(
     write_atomic(path, output.as_bytes())
 }
 
-/// Refuses a symlinked lockfile before a write: the lockfile must be a real file
-/// to be written. A writer that resolves the path lands on the link's target, so
-/// a repo-planted `pnpm-lock.yaml` redirects the write onto any file the user can
-/// write; a writer that renames over the link instead discards a lockfile a build
-/// sandbox staged deliberately.
-///
-/// Reads may follow the link and must not call this. Sandboxes stage
-/// `pnpm-lock.yaml` as a symlink (<https://github.com/pnpm/pnpm/issues/13073>),
-/// and lockfile content is untrusted however it is reached — a repository can
-/// commit whatever content it likes as a plain file.
+/// Refuses a symlinked lockfile before a write, which would land on the link's
+/// target — any file the user can write. Reads may follow it: sandboxes stage
+/// `pnpm-lock.yaml` as a symlink, and lockfile content is untrusted either way
+/// (<https://github.com/pnpm/pnpm/issues/13073>).
 pub(crate) fn ensure_lockfile_is_not_symlink(path: &Path) -> io::Result<()> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => Err(symlinked_lockfile_error(path)),
@@ -178,11 +166,10 @@ impl Lockfile {
     }
 }
 
-/// Make the freshly created temp file a faithful stand-in for `target`: flush
-/// it to disk so the rename can't publish a directory entry whose data didn't
-/// survive a power loss, and carry `target`'s mode across — the rename replaces
-/// `target` with this file, so a lockfile the user tightened would otherwise
-/// silently revert to the umask default.
+/// Makes the temp file a faithful stand-in for `target`: flushed, so the rename
+/// can't publish a directory entry whose data didn't survive a power loss, and
+/// carrying `target`'s mode, which the rename would otherwise reset to the umask
+/// default.
 fn fill_temp_file(file: &mut fs::File, content: &[u8], target: &Path) -> io::Result<()> {
     file.write_all(content)?;
     file.sync_all()?;
@@ -193,9 +180,7 @@ fn fill_temp_file(file: &mut fs::File, content: &[u8], target: &Path) -> io::Res
 fn carry_mode_across(file: &fs::File, target: &Path) -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt as _;
 
-    // `symlink_metadata` so a symlinked target is never followed. Callers
-    // refuse a symlinked lockfile before reaching here; a fresh file keeps the
-    // umask default, matching a plain create.
+    // `symlink_metadata` so a symlinked target is never followed.
     let Ok(metadata) = fs::symlink_metadata(target) else { return Ok(()) };
     if metadata.file_type().is_symlink() {
         return Ok(());

--- a/pnpm/crates/lockfile/src/save_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile/tests.rs
@@ -453,6 +453,22 @@ fn save_leaves_an_unchanged_lockfile_untouched() {
 }
 
 #[test]
+fn save_leaves_an_unchanged_crlf_lockfile_untouched() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    lockfile.save_to_path(&path).unwrap();
+    let crlf_content = std::fs::read_to_string(&path).unwrap().replace('\n', "\r\n");
+    std::fs::write(&path, &crlf_content).unwrap();
+    let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+    lockfile.save_to_path(&path).unwrap();
+
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), crlf_content);
+    assert_eq!(std::fs::metadata(&path).unwrap().modified().unwrap(), mtime_before);
+}
+
+#[test]
 fn save_leaves_an_unchanged_lockfile_with_env_document_untouched() {
     let dir = tempdir().unwrap();
     let path = dir.path().join(Lockfile::FILE_NAME);
@@ -497,12 +513,37 @@ fn save_accepts_symlinked_lockfile_when_nothing_changes() {
     let staged = dir.path().join("staged-lockfile.yaml");
     let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
     lockfile.save_to_path(&staged).unwrap();
+    let target_before = std::fs::read(&staged).unwrap();
+    let mtime_before = std::fs::metadata(&staged).unwrap().modified().unwrap();
     let path = dir.path().join(Lockfile::FILE_NAME);
     std::os::unix::fs::symlink(&staged, &path).unwrap();
 
     lockfile.save_to_path(&path).expect("an unchanged lockfile must not trip the symlink guard");
 
     assert!(std::fs::symlink_metadata(&path).unwrap().file_type().is_symlink());
+    assert_eq!(std::fs::read(&staged).unwrap(), target_before);
+    assert_eq!(std::fs::metadata(&staged).unwrap().modified().unwrap(), mtime_before);
+}
+
+#[cfg(unix)]
+#[test]
+fn save_accepts_unchanged_crlf_symlinked_lockfile() {
+    let dir = tempdir().unwrap();
+    let staged = dir.path().join("staged-lockfile.yaml");
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    lockfile.save_to_path(&staged).unwrap();
+    let crlf_content = std::fs::read_to_string(&staged).unwrap().replace('\n', "\r\n");
+    std::fs::write(&staged, &crlf_content).unwrap();
+    let mtime_before = std::fs::metadata(&staged).unwrap().modified().unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    std::os::unix::fs::symlink(&staged, &path).unwrap();
+
+    lockfile
+        .save_to_path(&path)
+        .expect("an unchanged CRLF lockfile must not trip the symlink guard");
+
+    assert_eq!(std::fs::read_to_string(&staged).unwrap(), crlf_content);
+    assert_eq!(std::fs::metadata(&staged).unwrap().modified().unwrap(), mtime_before);
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/lockfile/src/save_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/save_lockfile/tests.rs
@@ -437,3 +437,106 @@ fn write_atomic_rename_failure_surfaces_as_rename_file_error() {
         .collect();
     assert!(leftovers.is_empty(), "temp file should have been cleaned up, found: {leftovers:?}");
 }
+
+#[test]
+fn save_leaves_an_unchanged_lockfile_untouched() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    lockfile.save_to_path(&path).unwrap();
+    let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+    lockfile.save_to_path(&path).unwrap();
+
+    let mtime_after = std::fs::metadata(&path).unwrap().modified().unwrap();
+    assert_eq!(mtime_before, mtime_after, "an unchanged lockfile must not be rewritten");
+}
+
+#[test]
+fn save_leaves_an_unchanged_lockfile_with_env_document_untouched() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    lockfile.save_to_path(&path).unwrap();
+    let main_doc = std::fs::read_to_string(&path).unwrap();
+    let env_doc = "---\nlockfileVersion: '9.0'\nimporters:\n  .:\n    configDependencies: {}\npackages: {}\nsnapshots: {}\n---\n";
+    std::fs::write(&path, format!("{env_doc}{main_doc}")).unwrap();
+    let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+    lockfile.save_to_path(&path).unwrap();
+
+    let mtime_after = std::fs::metadata(&path).unwrap().modified().unwrap();
+    assert_eq!(mtime_before, mtime_after, "re-prepending the same env document must not rewrite");
+}
+
+#[cfg(unix)]
+#[test]
+fn save_refuses_symlinked_lockfile_without_touching_target() {
+    let dir = tempdir().unwrap();
+    let victim = dir.path().join("victim-file");
+    std::fs::write(&victim, "victim content").unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    std::os::unix::fs::symlink(&victim, &path).unwrap();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    let error = lockfile.save_to_path(&path).expect_err("a symlinked lockfile must not be written");
+
+    assert!(error.to_string().contains("symlinked lockfile"), "unexpected error: {error:?}");
+    assert!(std::fs::symlink_metadata(&path).unwrap().file_type().is_symlink());
+    assert_eq!(
+        std::fs::read_to_string(&victim).unwrap(),
+        "victim content",
+        "the symlink target must not be clobbered",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn save_accepts_symlinked_lockfile_when_nothing_changes() {
+    let dir = tempdir().unwrap();
+    let staged = dir.path().join("staged-lockfile.yaml");
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    lockfile.save_to_path(&staged).unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    std::os::unix::fs::symlink(&staged, &path).unwrap();
+
+    lockfile.save_to_path(&path).expect("an unchanged lockfile must not trip the symlink guard");
+
+    assert!(std::fs::symlink_metadata(&path).unwrap().file_type().is_symlink());
+}
+
+#[cfg(unix)]
+#[test]
+fn save_preserves_the_lockfile_permission_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    let mut lockfile: Lockfile =
+        serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+    lockfile.save_to_path(&path).unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+    // Re-save changed content so the write actually happens.
+    lockfile.packages = None;
+    lockfile.save_to_path(&path).unwrap();
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+    assert_eq!(mode, 0o640, "an atomic replace must carry the target's mode across");
+}
+
+#[test]
+fn save_leaves_no_temp_file_behind() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    let lockfile: Lockfile = serde_saphyr::from_str(LOCKFILE_YAML).expect("parse fixture lockfile");
+
+    lockfile.save_to_path(&path).unwrap();
+
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .filter(|name| name.to_string_lossy() != Lockfile::FILE_NAME)
+        .collect();
+    assert!(leftovers.is_empty(), "temp file should not be left behind, found: {leftovers:?}");
+}

--- a/pnpm11/installing/deps-installer/test/lockfile.ts
+++ b/pnpm11/installing/deps-installer/test/lockfile.ts
@@ -1643,3 +1643,54 @@ test('setting a custom peersSuffixMaxLength', async () => {
   expect(lockfile.settings.peersSuffixMaxLength).toBe(10)
   expect(lockfile.importers['.']?.dependencies?.['@pnpm.e2e/abc']?.version?.length).toBe(39)
 })
+
+// Covers https://github.com/pnpm/pnpm/issues/13073: build sandboxes such as
+// Bazel and Nix stage pnpm-lock.yaml as a symlink into the working tree. A
+// frozen install neither resolves nor changes the lockfile, so it must not
+// refuse the symlink — nor rewrite the file at all.
+const testOnNonWindows = process.platform === 'win32' ? test.skip : test
+
+// Stages an up-to-date lockfile outside the project and symlinks it in.
+async function prepareSymlinkedLockfile (manifest: ProjectManifest): Promise<string> {
+  await install(manifest, testDefaults({ lockfileOnly: true }))
+  const stagedLockfile = path.resolve('..', 'staged-lockfile.yaml')
+  fs.renameSync(WANTED_LOCKFILE, stagedLockfile)
+  fs.symlinkSync(stagedLockfile, WANTED_LOCKFILE, 'file')
+  return stagedLockfile
+}
+
+testOnNonWindows(`frozen lockfile-only install succeeds when ${WANTED_LOCKFILE} is a symlink`, async () => {
+  prepareEmpty()
+  const manifest = { dependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' } }
+  const stagedLockfile = await prepareSymlinkedLockfile(manifest)
+  const targetBefore = fs.readFileSync(stagedLockfile, 'utf8')
+
+  await install(manifest, testDefaults({ frozenLockfile: true, lockfileOnly: true }))
+
+  expect(fs.lstatSync(WANTED_LOCKFILE).isSymbolicLink()).toBe(true)
+  expect(fs.readFileSync(stagedLockfile, 'utf8')).toBe(targetBefore)
+})
+
+testOnNonWindows(`frozen install succeeds when ${WANTED_LOCKFILE} is a symlink`, async () => {
+  prepareEmpty()
+  const manifest = { dependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' } }
+  const stagedLockfile = await prepareSymlinkedLockfile(manifest)
+  const targetBefore = fs.readFileSync(stagedLockfile, 'utf8')
+
+  await install(manifest, testDefaults({ frozenLockfile: true }))
+
+  expect(fs.lstatSync(WANTED_LOCKFILE).isSymbolicLink()).toBe(true)
+  expect(fs.readFileSync(stagedLockfile, 'utf8')).toBe(targetBefore)
+})
+
+testOnNonWindows(`install refuses to write a changed lockfile through a symlinked ${WANTED_LOCKFILE}`, async () => {
+  prepareEmpty()
+  const stagedLockfile = await prepareSymlinkedLockfile({ dependencies: { '@pnpm.e2e/pkg-with-1-dep': '100.0.0' } })
+  const targetBefore = fs.readFileSync(stagedLockfile, 'utf8')
+
+  await expect(
+    install({ dependencies: { '@pnpm.e2e/foo': '100.0.0' } }, testDefaults({ lockfileOnly: true }))
+  ).rejects.toThrow(/symlinked lockfile/)
+
+  expect(fs.readFileSync(stagedLockfile, 'utf8')).toBe(targetBefore)
+})

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -81,18 +81,11 @@ async function writeLockfile (
 }
 
 /**
- * Writes a serialized lockfile. Only `pnpm-lock.yaml` is led by an env
- * document; `lock.yaml` and git-branch lockfiles are written as-is.
- *
- * The env document is preserved by re-reading it. Ideally it would be captured
- * during the initial lockfile read and passed through to the write functions,
- * but that would require threading it through 25+ call sites. Re-reading is
- * cheap since the file is likely still in the OS page cache.
- *
- * A byte-identical rewrite is skipped, so an up-to-date install — every
- * `--frozen-lockfile` run — leaves the lockfile and its mtime untouched, and a
- * symlinked lockfile that nothing changes is never refused
- * (https://github.com/pnpm/pnpm/issues/13073).
+ * Writes a serialized lockfile, re-reading the env document that leads
+ * `pnpm-lock.yaml` to preserve it. Ideally it would be captured during the
+ * initial lockfile read and passed through, but that would require threading it
+ * through 25+ call sites; re-reading is cheap since the file is likely still in
+ * the OS page cache.
  */
 async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mainDoc: string): Promise<void> {
   if (lockfileName !== WANTED_LOCKFILE) {
@@ -109,14 +102,9 @@ async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mai
 }
 
 /**
- * Replaces `pnpm-lock.yaml` through a temp file and `rename`, carrying the
- * target's ownership and mode onto the replacement.
- *
- * `rename` is what makes this safe: it replaces the final path component and
- * never resolves it, so a symlink swapped in after
- * {@link ensureLockfileIsNotSymlink} cannot redirect the write. The
- * `write-file-atomic` this file uses elsewhere resolves the destination with
- * `realpath`, which would follow such a swap.
+ * Publishes with `rename`, not the `write-file-atomic` used elsewhere here:
+ * `rename` never resolves the final path component, so a symlink swapped in
+ * after {@link ensureLockfileIsNotSymlink} cannot redirect the write.
  */
 async function writeWantedLockfileAtomic (lockfilePath: string, content: string): Promise<void> {
   await ensureLockfileIsNotSymlink(lockfilePath)
@@ -133,9 +121,8 @@ async function writeWantedLockfileAtomic (lockfilePath: string, content: string)
     tempFile = await fs.open(tempPath, 'wx', targetStat?.mode)
     await tempFile.writeFile(content)
     if (targetStat != null) {
-      // The rename replaces the target with this fresh file, so an install
-      // running as another user — root in a container over a bind-mounted repo —
-      // would hand the lockfile's owner a file they can no longer write.
+      // An install running as root, in a container over a bind-mounted repo,
+      // would otherwise leave the owner a lockfile they cannot write.
       await tempFile.chown(targetStat.uid, targetStat.gid).catch(ignoreUnprivilegedChown)
       await tempFile.chmod(targetStat.mode)
     }

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -12,7 +12,7 @@ import { convertToLockfileFile, convertToLockfileObject } from './lockfileFormat
 import { getWantedLockfileName } from './lockfileName.js'
 import { lockfileLogger as logger } from './logger.js'
 import { sortLockfileKeys } from './sortLockfileKeys.js'
-import { streamReadFirstYamlDocument, YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START } from './yamlDocuments.js'
+import { streamReadFirstYamlDocumentNoFollow, YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START } from './yamlDocuments.js'
 
 const LOCKFILE_YAML_FORMAT = {
   blankLines: true,
@@ -75,7 +75,7 @@ async function writeLockfile (
     // and passed through to the write functions, but that would require threading it
     // through 25+ call sites. Re-reading is cheap since the file is likely still
     // in the OS page cache and streaming stops at the first separator.
-    const envDoc = await streamReadFirstYamlDocument(lockfilePath)
+    const envDoc = await streamReadFirstYamlDocumentNoFollow(lockfilePath)
     const envPrefix = envDoc != null ? `${YAML_DOCUMENT_START}${envDoc}${YAML_DOCUMENT_SEPARATOR}` : ''
     await writeFileAtomic(lockfilePath, `${envPrefix}${yamlDoc}`)
   } else {
@@ -152,7 +152,7 @@ export async function writeLockfiles (
   // Preserve the env lockfile document at the top of pnpm-lock.yaml
   let envPrefix = ''
   if (wantedLockfileName === WANTED_LOCKFILE) {
-    const envDoc = await streamReadFirstYamlDocument(wantedLockfilePath)
+    const envDoc = await streamReadFirstYamlDocumentNoFollow(wantedLockfilePath)
     if (envDoc != null) {
       envPrefix = `${YAML_DOCUMENT_START}${envDoc}${YAML_DOCUMENT_SEPARATOR}`
     }

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -89,9 +89,9 @@ async function writeLockfile (
  * but that would require threading it through 25+ call sites. Re-reading is
  * cheap since the file is likely still in the OS page cache.
  *
- * A byte-identical rewrite is skipped. An up-to-date install — every
- * `--frozen-lockfile` run — would otherwise rewrite the lockfile for nothing,
- * and refuse a symlinked one over a write that changes no bytes
+ * A byte-identical rewrite is skipped, so an up-to-date install — every
+ * `--frozen-lockfile` run — leaves the lockfile and its mtime untouched, and a
+ * symlinked lockfile that nothing changes is never refused
  * (https://github.com/pnpm/pnpm/issues/13073).
  */
 async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mainDoc: string): Promise<void> {
@@ -112,10 +112,11 @@ async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mai
  * Replaces `pnpm-lock.yaml` through a temp file and `rename`, carrying the
  * target's ownership and mode onto the replacement.
  *
- * `write-file-atomic` is not used here because it resolves the destination with
- * `realpath`, which a symlink swapped in after {@link ensureLockfileIsNotSymlink}
- * would follow. `rename` replaces the final path component itself and never
- * resolves it, so the write cannot be redirected.
+ * `rename` is what makes this safe: it replaces the final path component and
+ * never resolves it, so a symlink swapped in after
+ * {@link ensureLockfileIsNotSymlink} cannot redirect the write. The
+ * `write-file-atomic` this file uses elsewhere resolves the destination with
+ * `realpath`, which would follow such a swap.
  */
 async function writeWantedLockfileAtomic (lockfilePath: string, content: string): Promise<void> {
   await ensureLockfileIsNotSymlink(lockfilePath)
@@ -133,10 +134,8 @@ async function writeWantedLockfileAtomic (lockfilePath: string, content: string)
     await tempFile.writeFile(content)
     if (targetStat != null) {
       // The rename replaces the target with this fresh file, so an install
-      // running as another user (root in a container over a bind-mounted repo)
-      // would otherwise hand the lockfile's owner a file they can no longer
-      // write. Ownership we aren't permitted to set is not fatal: the file just
-      // stays ours, exactly as `write-file-atomic` treats it.
+      // running as another user — root in a container over a bind-mounted repo —
+      // would hand the lockfile's owner a file they can no longer write.
       await tempFile.chown(targetStat.uid, targetStat.gid).catch(ignoreUnprivilegedChown)
       await tempFile.chmod(targetStat.mode)
     }

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -108,6 +108,15 @@ async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mai
   await writeWantedLockfileAtomic(lockfilePath, content)
 }
 
+/**
+ * Replaces `pnpm-lock.yaml` through a temp file and `rename`, carrying the
+ * target's ownership and mode onto the replacement.
+ *
+ * `write-file-atomic` is not used here because it resolves the destination with
+ * `realpath`, which a symlink swapped in after {@link ensureLockfileIsNotSymlink}
+ * would follow. `rename` replaces the final path component itself and never
+ * resolves it, so the write cannot be redirected.
+ */
 async function writeWantedLockfileAtomic (lockfilePath: string, content: string): Promise<void> {
   await ensureLockfileIsNotSymlink(lockfilePath)
   const targetStat = await fs.lstat(lockfilePath).catch((error: NodeJS.ErrnoException) => {
@@ -122,7 +131,15 @@ async function writeWantedLockfileAtomic (lockfilePath: string, content: string)
   try {
     tempFile = await fs.open(tempPath, 'wx', targetStat?.mode)
     await tempFile.writeFile(content)
-    if (targetStat != null) await tempFile.chmod(targetStat.mode)
+    if (targetStat != null) {
+      // The rename replaces the target with this fresh file, so an install
+      // running as another user (root in a container over a bind-mounted repo)
+      // would otherwise hand the lockfile's owner a file they can no longer
+      // write. Ownership we aren't permitted to set is not fatal: the file just
+      // stays ours, exactly as `write-file-atomic` treats it.
+      await tempFile.chown(targetStat.uid, targetStat.gid).catch(ignoreUnprivilegedChown)
+      await tempFile.chmod(targetStat.mode)
+    }
     await tempFile.sync()
     await tempFile.close()
     tempFile = undefined
@@ -136,6 +153,16 @@ async function writeWantedLockfileAtomic (lockfilePath: string, content: string)
     await tempFile?.close().catch(() => {})
     await fs.rm(tempPath, { force: true }).catch(() => {})
   }
+}
+
+/**
+ * `chown` is refused for an unprivileged process that doesn't own the target,
+ * and unimplemented on some filesystems. Neither is a reason to fail the write.
+ */
+function ignoreUnprivilegedChown (error: NodeJS.ErrnoException): void {
+  const tolerated = error.code === 'ENOSYS' ||
+    ((process.getuid == null || process.getuid() !== 0) && (error.code === 'EINVAL' || error.code === 'EPERM'))
+  if (!tolerated) throw error
 }
 
 function stripUndefinedDeep<T> (value: T): T {

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -12,7 +12,7 @@ import { convertToLockfileFile, convertToLockfileObject } from './lockfileFormat
 import { getWantedLockfileName } from './lockfileName.js'
 import { lockfileLogger as logger } from './logger.js'
 import { sortLockfileKeys } from './sortLockfileKeys.js'
-import { streamReadFirstYamlDocumentNoFollow, YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START } from './yamlDocuments.js'
+import { ensureLockfileIsNotSymlink, extractEnvDocument, readLockfileToString, YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START } from './yamlDocuments.js'
 
 const LOCKFILE_YAML_FORMAT = {
   blankLines: true,
@@ -69,24 +69,42 @@ async function writeLockfile (
   const lockfileToStringify = convertToLockfileFile(wantedLockfile)
   const yamlDoc = yamlStringify(lockfileToStringify)
 
-  if (lockfileFilename === WANTED_LOCKFILE) {
-    // Re-read the env document from the existing lockfile to preserve it.
-    // Ideally the env document would be captured during the initial lockfile read
-    // and passed through to the write functions, but that would require threading it
-    // through 25+ call sites. Re-reading is cheap since the file is likely still
-    // in the OS page cache and streaming stops at the first separator.
-    const envDoc = await streamReadFirstYamlDocumentNoFollow(lockfilePath)
-    const envPrefix = envDoc != null ? `${YAML_DOCUMENT_START}${envDoc}${YAML_DOCUMENT_SEPARATOR}` : ''
-    await writeFileAtomic(lockfilePath, `${envPrefix}${yamlDoc}`)
-  } else {
-    await writeFileAtomic(lockfilePath, yamlDoc)
-  }
+  await writeLockfileDoc(lockfilePath, lockfileFilename, yamlDoc)
 
   // YAML drops undefined on serialize, so the in-memory LockfileFile
   // can carry fields (like an unset settings.dedupePeers) that won't
   // survive a round-trip; strip them to mirror what the next reader
   // will parse back.
   return convertToLockfileObject(stripUndefinedDeep(lockfileToStringify) as LockfileFile)
+}
+
+/**
+ * Writes a serialized lockfile. Only `pnpm-lock.yaml` is led by an env
+ * document; `lock.yaml` and git-branch lockfiles are written as-is.
+ *
+ * The env document is preserved by re-reading it. Ideally it would be captured
+ * during the initial lockfile read and passed through to the write functions,
+ * but that would require threading it through 25+ call sites. Re-reading is
+ * cheap since the file is likely still in the OS page cache.
+ *
+ * A byte-identical rewrite is skipped. An up-to-date install — every
+ * `--frozen-lockfile` run — would otherwise rewrite the lockfile for nothing,
+ * and refuse a symlinked one over a write that changes no bytes
+ * (https://github.com/pnpm/pnpm/issues/13073).
+ */
+async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mainDoc: string): Promise<void> {
+  if (lockfileName !== WANTED_LOCKFILE) {
+    await writeFileAtomic(lockfilePath, mainDoc)
+    return
+  }
+  const existing = await readLockfileToString(lockfilePath)
+  const envDoc = existing == null ? null : extractEnvDocument(existing)
+  const content = envDoc == null
+    ? mainDoc
+    : `${YAML_DOCUMENT_START}${envDoc}${YAML_DOCUMENT_SEPARATOR}${mainDoc}`
+  if (existing === content) return
+  await ensureLockfileIsNotSymlink(lockfilePath)
+  await writeFileAtomic(lockfilePath, content)
 }
 
 function stripUndefinedDeep<T> (value: T): T {
@@ -149,22 +167,12 @@ export async function writeLockfiles (
   const wantedLockfileToStringify = convertToLockfileFile(opts.wantedLockfile)
   const yamlDoc = yamlStringify(wantedLockfileToStringify)
 
-  // Preserve the env lockfile document at the top of pnpm-lock.yaml
-  let envPrefix = ''
-  if (wantedLockfileName === WANTED_LOCKFILE) {
-    const envDoc = await streamReadFirstYamlDocumentNoFollow(wantedLockfilePath)
-    if (envDoc != null) {
-      envPrefix = `${YAML_DOCUMENT_START}${envDoc}${YAML_DOCUMENT_SEPARATOR}`
-    }
-  }
-  const wantedYamlDoc = `${envPrefix}${yamlDoc}`
-
   // in most cases the `pnpm-lock.yaml` and `node_modules/.pnpm-lock.yaml` are equal
   // in those cases the YAML document can be stringified only once for both files
   // which is more efficient
   if (opts.wantedLockfile === opts.currentLockfile) {
     await Promise.all([
-      writeFileAtomic(wantedLockfilePath, wantedYamlDoc),
+      writeLockfileDoc(wantedLockfilePath, wantedLockfileName, yamlDoc),
       (async () => {
         if (isEmptyLockfile(opts.wantedLockfile)) {
           await rimraf(currentLockfilePath)
@@ -195,7 +203,7 @@ export async function writeLockfiles (
   // current against a non-empty wanted; key off the current.
   const currentIsEmpty = isEmptyLockfile(opts.currentLockfile)
   await Promise.all([
-    writeFileAtomic(wantedLockfilePath, wantedYamlDoc),
+    writeLockfileDoc(wantedLockfilePath, wantedLockfileName, yamlDoc),
     (async () => {
       if (currentIsEmpty) {
         await rimraf(currentLockfilePath)

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from 'node:crypto'
 import { promises as fs } from 'node:fs'
+import type { FileHandle } from 'node:fs/promises'
 import path from 'node:path'
 
 import { WANTED_LOCKFILE } from '@pnpm/constants'
@@ -103,8 +105,37 @@ async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mai
     ? mainDoc
     : `${YAML_DOCUMENT_START}${envDoc}${YAML_DOCUMENT_SEPARATOR}${mainDoc}`
   if (existing === content) return
+  await writeWantedLockfileAtomic(lockfilePath, content)
+}
+
+async function writeWantedLockfileAtomic (lockfilePath: string, content: string): Promise<void> {
   await ensureLockfileIsNotSymlink(lockfilePath)
-  await writeFileAtomic(lockfilePath, content)
+  const targetStat = await fs.lstat(lockfilePath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return undefined
+    throw error
+  })
+  const tempPath = path.join(
+    path.dirname(lockfilePath),
+    `.${path.basename(lockfilePath)}.${process.pid}.${randomUUID()}.tmp`
+  )
+  let tempFile: FileHandle | undefined
+  try {
+    tempFile = await fs.open(tempPath, 'wx', targetStat?.mode)
+    await tempFile.writeFile(content)
+    if (targetStat != null) await tempFile.chmod(targetStat.mode)
+    await tempFile.sync()
+    await tempFile.close()
+    tempFile = undefined
+
+    // Check again at publication time. rename() replaces the final path entry
+    // itself and never resolves it, so a swap after this check cannot redirect
+    // the write through a symlink.
+    await ensureLockfileIsNotSymlink(lockfilePath)
+    await fs.rename(tempPath, lockfilePath)
+  } finally {
+    await tempFile?.close().catch(() => {})
+    await fs.rm(tempPath, { force: true }).catch(() => {})
+  }
 }
 
 function stripUndefinedDeep<T> (value: T): T {

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -18,14 +18,8 @@ const LOCKFILE_READ_FLAGS = constants.O_RDONLY | (process.platform === 'win32' ?
  * Stops reading as soon as the second document separator is found.
  * Returns null if the file doesn't exist or doesn't start with "---\n".
  *
- * Follows a symlinked lockfile, as build sandboxes stage `pnpm-lock.yaml`
- * (https://github.com/pnpm/pnpm/issues/13073). Refusing it here bought nothing:
- * `readWantedLockfile` reads the same file with a plain `readFile` and has always
- * followed the link, and a hostile repo can commit a hostile lockfile as a plain
- * file regardless — the content is untrusted either way.
- *
- * Writes are the real boundary and still refuse a symlink, because a write
- * follows the link and lands on its target; see {@link ensureLockfileIsNotSymlink}.
+ * Follows a symlinked lockfile; {@link ensureLockfileIsNotSymlink} covers why
+ * only writes refuse one.
  */
 export async function streamReadFirstYamlDocument (filePath: string, readBufferSize = READ_BUFFER_SIZE): Promise<string | null> {
   let fileHandle: FileHandle | undefined
@@ -122,11 +116,16 @@ async function openLockfileNoFollow (filePath: string): Promise<FileHandle> {
 }
 
 /**
- * Refuses a symlinked lockfile before a write. `write-file-atomic` resolves the
- * target with `realpath` before writing, so writing through a symlink lets a
- * repo-planted `pnpm-lock.yaml` redirect the write onto any file the user can
- * write. Callers that only read must not use this — see
- * {@link streamReadFirstYamlDocument}.
+ * Refuses a symlinked lockfile before a write: the lockfile must be a real file
+ * to be written. A writer that resolves the path lands on the link's target, so
+ * a repo-planted `pnpm-lock.yaml` redirects the write onto any file the user can
+ * write; a writer that renames over the link instead discards a lockfile a build
+ * sandbox staged deliberately.
+ *
+ * Reads may follow the link and must not call this. Sandboxes stage
+ * `pnpm-lock.yaml` as a symlink (https://github.com/pnpm/pnpm/issues/13073), and
+ * lockfile content is untrusted however it is reached — a repository can commit
+ * whatever content it likes as a plain file.
  */
 export async function ensureLockfileIsNotSymlink (filePath: string): Promise<void> {
   let stat

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -76,7 +76,7 @@ export async function streamReadFirstYamlDocument (filePath: string, readBufferS
  */
 export async function readLockfileToString (filePath: string): Promise<string | null> {
   try {
-    return await readFile(filePath, 'utf8')
+    return stripBom(await readFile(filePath, 'utf8')).replace(/\r\n/g, '\n')
   } catch (err: unknown) {
     if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
       return null

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -73,6 +73,11 @@ export async function streamReadFirstYamlDocument (filePath: string, readBufferS
 /**
  * Reads a whole lockfile, following a symlink. Returns null if it doesn't exist.
  * See {@link streamReadFirstYamlDocument} for why reads may follow symlinks.
+ *
+ * The BOM is stripped and CRLF normalized, matching what
+ * {@link streamReadFirstYamlDocument} yields, so a caller can compare the result
+ * against freshly serialized content without a lockfile's encoding alone
+ * counting as a change.
  */
 export async function readLockfileToString (filePath: string): Promise<string | null> {
   try {

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -18,10 +18,14 @@ const LOCKFILE_READ_FLAGS = constants.O_RDONLY | (process.platform === 'win32' ?
  * Stops reading as soon as the second document separator is found.
  * Returns null if the file doesn't exist or doesn't start with "---\n".
  *
- * Follows a symlinked lockfile. Reading through a symlink is safe — planting one
- * already requires write access to the working tree — and build sandboxes stage
- * `pnpm-lock.yaml` as a symlink (https://github.com/pnpm/pnpm/issues/13073).
- * Only writes refuse a symlink; see {@link ensureLockfileIsNotSymlink}.
+ * Follows a symlinked lockfile, as build sandboxes stage `pnpm-lock.yaml`
+ * (https://github.com/pnpm/pnpm/issues/13073). Refusing it here bought nothing:
+ * `readWantedLockfile` reads the same file with a plain `readFile` and has always
+ * followed the link, and a hostile repo can commit a hostile lockfile as a plain
+ * file regardless — the content is untrusted either way.
+ *
+ * Writes are the real boundary and still refuse a symlink, because a write
+ * follows the link and lands on its target; see {@link ensureLockfileIsNotSymlink}.
  */
 export async function streamReadFirstYamlDocument (filePath: string, readBufferSize = READ_BUFFER_SIZE): Promise<string | null> {
   let fileHandle: FileHandle | undefined

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -19,11 +19,19 @@ const LOCKFILE_READ_FLAGS = constants.O_RDONLY | (process.platform === 'win32' ?
  * Returns null if the file doesn't exist or doesn't start with "---\n".
  */
 export async function streamReadFirstYamlDocument (filePath: string, readBufferSize = READ_BUFFER_SIZE): Promise<string | null> {
+  return streamReadFirstYamlDocumentWithOpen(filePath, readBufferSize, () => open(filePath, constants.O_RDONLY))
+}
+
+export async function streamReadFirstYamlDocumentNoFollow (filePath: string, readBufferSize = READ_BUFFER_SIZE): Promise<string | null> {
+  return streamReadFirstYamlDocumentWithOpen(filePath, readBufferSize, () => openLockfileNoFollow(filePath))
+}
+
+async function streamReadFirstYamlDocumentWithOpen (filePath: string, readBufferSize: number, openFile: () => Promise<FileHandle>): Promise<string | null> {
   let fileHandle: FileHandle | undefined
   let buffer = ''
   let firstChunk = true
   try {
-    fileHandle = await openLockfileNoFollow(filePath)
+    fileHandle = await openFile()
     const decoder = new StringDecoder('utf8')
     const readBuffer = Buffer.allocUnsafe(normalizeReadBufferSize(readBufferSize))
     let position = 0

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -17,9 +17,6 @@ const LOCKFILE_READ_FLAGS = constants.O_RDONLY | (process.platform === 'win32' ?
  * The file must start with "---\n" to indicate it contains an env lockfile document.
  * Stops reading as soon as the second document separator is found.
  * Returns null if the file doesn't exist or doesn't start with "---\n".
- *
- * Follows a symlinked lockfile; {@link ensureLockfileIsNotSymlink} covers why
- * only writes refuse one.
  */
 export async function streamReadFirstYamlDocument (filePath: string, readBufferSize = READ_BUFFER_SIZE): Promise<string | null> {
   let fileHandle: FileHandle | undefined
@@ -68,15 +65,6 @@ export async function streamReadFirstYamlDocument (filePath: string, readBufferS
   }
 }
 
-/**
- * Reads a whole lockfile, following a symlink. Returns null if it doesn't exist.
- * See {@link streamReadFirstYamlDocument} for why reads may follow symlinks.
- *
- * The BOM is stripped and CRLF normalized, matching what
- * {@link streamReadFirstYamlDocument} yields, so a caller can compare the result
- * against freshly serialized content without a lockfile's encoding alone
- * counting as a change.
- */
 export async function readLockfileToString (filePath: string): Promise<string | null> {
   try {
     return stripBom(await readFile(filePath, 'utf8')).replace(/\r\n/g, '\n')
@@ -116,16 +104,10 @@ async function openLockfileNoFollow (filePath: string): Promise<FileHandle> {
 }
 
 /**
- * Refuses a symlinked lockfile before a write: the lockfile must be a real file
- * to be written. A writer that resolves the path lands on the link's target, so
- * a repo-planted `pnpm-lock.yaml` redirects the write onto any file the user can
- * write; a writer that renames over the link instead discards a lockfile a build
- * sandbox staged deliberately.
- *
- * Reads may follow the link and must not call this. Sandboxes stage
- * `pnpm-lock.yaml` as a symlink (https://github.com/pnpm/pnpm/issues/13073), and
- * lockfile content is untrusted however it is reached — a repository can commit
- * whatever content it likes as a plain file.
+ * Refuses a symlinked lockfile before a write, which would land on the link's
+ * target — any file the user can write. Reads may follow it: sandboxes stage
+ * `pnpm-lock.yaml` as a symlink, and lockfile content is untrusted either way
+ * (https://github.com/pnpm/pnpm/issues/13073).
  */
 export async function ensureLockfileIsNotSymlink (filePath: string): Promise<void> {
   let stat
@@ -157,11 +139,7 @@ function normalizeReadBufferSize (readBufferSize: number): number {
   return size > 0 ? size : READ_BUFFER_SIZE
 }
 
-/**
- * Extracts the env lockfile content (first YAML document) from a combined string,
- * or null when there is no leading env document. The string counterpart of
- * {@link streamReadFirstYamlDocument}, for callers that already hold the file.
- */
+/** The in-memory counterpart of {@link streamReadFirstYamlDocument}. */
 export function extractEnvDocument (content: string): string | null {
   content = content.replace(/\r\n/g, '\n')
   if (!content.startsWith(YAML_DOCUMENT_START)) return null

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -1,5 +1,5 @@
 import { constants } from 'node:fs'
-import { type FileHandle, lstat, open } from 'node:fs/promises'
+import { type FileHandle, lstat, open, readFile } from 'node:fs/promises'
 import { StringDecoder } from 'node:string_decoder'
 import util from 'node:util'
 
@@ -17,21 +17,18 @@ const LOCKFILE_READ_FLAGS = constants.O_RDONLY | (process.platform === 'win32' ?
  * The file must start with "---\n" to indicate it contains an env lockfile document.
  * Stops reading as soon as the second document separator is found.
  * Returns null if the file doesn't exist or doesn't start with "---\n".
+ *
+ * Follows a symlinked lockfile. Reading through a symlink is safe — planting one
+ * already requires write access to the working tree — and build sandboxes stage
+ * `pnpm-lock.yaml` as a symlink (https://github.com/pnpm/pnpm/issues/13073).
+ * Only writes refuse a symlink; see {@link ensureLockfileIsNotSymlink}.
  */
 export async function streamReadFirstYamlDocument (filePath: string, readBufferSize = READ_BUFFER_SIZE): Promise<string | null> {
-  return streamReadFirstYamlDocumentWithOpen(filePath, readBufferSize, () => open(filePath, constants.O_RDONLY))
-}
-
-export async function streamReadFirstYamlDocumentNoFollow (filePath: string, readBufferSize = READ_BUFFER_SIZE): Promise<string | null> {
-  return streamReadFirstYamlDocumentWithOpen(filePath, readBufferSize, () => openLockfileNoFollow(filePath))
-}
-
-async function streamReadFirstYamlDocumentWithOpen (filePath: string, readBufferSize: number, openFile: () => Promise<FileHandle>): Promise<string | null> {
   let fileHandle: FileHandle | undefined
   let buffer = ''
   let firstChunk = true
   try {
-    fileHandle = await openFile()
+    fileHandle = await open(filePath, constants.O_RDONLY)
     const decoder = new StringDecoder('utf8')
     const readBuffer = Buffer.allocUnsafe(normalizeReadBufferSize(readBufferSize))
     let position = 0
@@ -73,6 +70,21 @@ async function streamReadFirstYamlDocumentWithOpen (filePath: string, readBuffer
   }
 }
 
+/**
+ * Reads a whole lockfile, following a symlink. Returns null if it doesn't exist.
+ * See {@link streamReadFirstYamlDocument} for why reads may follow symlinks.
+ */
+export async function readLockfileToString (filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, 'utf8')
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
+      return null
+    }
+    throw err
+  }
+}
+
 export async function readLockfileToStringNoFollow (filePath: string): Promise<string | null> {
   let fileHandle: FileHandle | undefined
   try {
@@ -100,7 +112,14 @@ async function openLockfileNoFollow (filePath: string): Promise<FileHandle> {
   }
 }
 
-async function ensureLockfileIsNotSymlink (filePath: string): Promise<void> {
+/**
+ * Refuses a symlinked lockfile before a write. `write-file-atomic` resolves the
+ * target with `realpath` before writing, so writing through a symlink lets a
+ * repo-planted `pnpm-lock.yaml` redirect the write onto any file the user can
+ * write. Callers that only read must not use this — see
+ * {@link streamReadFirstYamlDocument}.
+ */
+export async function ensureLockfileIsNotSymlink (filePath: string): Promise<void> {
   let stat
   try {
     stat = await lstat(filePath)
@@ -116,7 +135,7 @@ async function ensureLockfileIsNotSymlink (filePath: string): Promise<void> {
 }
 
 function symlinkedLockfileError (filePath: string): PnpmError {
-  return new PnpmError('LOCKFILE_IS_SYMLINK', `Refusing to read or write symlinked lockfile at ${filePath}`)
+  return new PnpmError('LOCKFILE_IS_SYMLINK', `Refusing to write symlinked lockfile at ${filePath}`)
 }
 
 function canRejectDocumentStart (buffer: string): boolean {
@@ -128,6 +147,19 @@ function canRejectDocumentStart (buffer: string): boolean {
 function normalizeReadBufferSize (readBufferSize: number): number {
   const size = Number.isFinite(readBufferSize) ? Math.floor(readBufferSize) : READ_BUFFER_SIZE
   return size > 0 ? size : READ_BUFFER_SIZE
+}
+
+/**
+ * Extracts the env lockfile content (first YAML document) from a combined string,
+ * or null when there is no leading env document. The string counterpart of
+ * {@link streamReadFirstYamlDocument}, for callers that already hold the file.
+ */
+export function extractEnvDocument (content: string): string | null {
+  content = content.replace(/\r\n/g, '\n')
+  if (!content.startsWith(YAML_DOCUMENT_START)) return null
+  const sep = content.indexOf(YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START.length)
+  if (sep === -1) return null
+  return content.slice(YAML_DOCUMENT_START.length, sep)
 }
 
 /**

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -8,13 +8,15 @@ import { temporaryDirectory } from 'tempy'
 
 const testOnNonWindows = process.platform === 'win32' ? test.skip : test
 
-testOnNonWindows('readEnvLockfile rejects a symlinked lockfile', async () => {
+testOnNonWindows('readEnvLockfile reads a symlinked lockfile', async () => {
   const dir = temporaryDirectory()
   const realLockfile = path.join(dir, 'real-lockfile.yaml')
   fs.writeFileSync(realLockfile, '---\nlockfileVersion: "9.0"\nimporters:\n  .:\n    configDependencies: {}\npackages: {}\nsnapshots: {}\n---\n')
   fs.symlinkSync(realLockfile, path.join(dir, WANTED_LOCKFILE), 'file')
 
-  await expect(readEnvLockfile(dir)).rejects.toThrow(/symlinked lockfile/)
+  await expect(readEnvLockfile(dir)).resolves.toMatchObject({
+    lockfileVersion: '9.0',
+  })
 })
 
 testOnNonWindows('writeEnvLockfile rejects a symlinked lockfile without touching the target', async () => {

--- a/pnpm11/lockfile/fs/test/write.test.ts
+++ b/pnpm11/lockfile/fs/test/write.test.ts
@@ -422,3 +422,61 @@ test('readWantedLockfile() returns null for env-only lockfile with no main docum
   const lockfile = await readWantedLockfile(projectPath, { ignoreIncompatible: false })
   expect(lockfile).toBeNull()
 })
+
+const testOnNonWindows = process.platform === 'win32' ? test.skip : test
+
+const upToDateLockfile = {
+  importers: {
+    '.': {
+      dependencies: { 'is-positive': '1.0.0' },
+      specifiers: { 'is-positive': '^1.0.0' },
+    },
+  },
+  lockfileVersion: LOCKFILE_VERSION,
+  packages: {},
+  snapshots: {},
+}
+
+test('writeWantedLockfile() leaves an unchanged lockfile untouched', async () => {
+  const projectPath = temporaryDirectory()
+  const lockfilePath = path.join(projectPath, WANTED_LOCKFILE)
+  await writeWantedLockfile(projectPath, upToDateLockfile)
+  const mtimeBefore = fs.statSync(lockfilePath).mtimeMs
+
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  await writeWantedLockfile(projectPath, upToDateLockfile)
+
+  expect(fs.statSync(lockfilePath).mtimeMs).toBe(mtimeBefore)
+})
+
+testOnNonWindows('writeWantedLockfile() accepts a symlinked lockfile when nothing changes', async () => {
+  const projectPath = temporaryDirectory()
+  const realDir = temporaryDirectory()
+  const realLockfile = path.join(realDir, 'pnpm-lock.yaml')
+  await writeWantedLockfile(realDir, upToDateLockfile)
+  fs.symlinkSync(realLockfile, path.join(projectPath, WANTED_LOCKFILE), 'file')
+
+  await expect(writeWantedLockfile(projectPath, upToDateLockfile)).resolves.toBeTruthy()
+  expect(fs.lstatSync(path.join(projectPath, WANTED_LOCKFILE)).isSymbolicLink()).toBe(true)
+})
+
+testOnNonWindows('writeWantedLockfile() refuses a real write through a symlink', async () => {
+  const projectPath = temporaryDirectory()
+  const realDir = temporaryDirectory()
+  const realLockfile = path.join(realDir, 'pnpm-lock.yaml')
+  await writeWantedLockfile(realDir, upToDateLockfile)
+  const targetBefore = fs.readFileSync(realLockfile, 'utf8')
+  fs.symlinkSync(realLockfile, path.join(projectPath, WANTED_LOCKFILE), 'file')
+
+  const changed = {
+    ...upToDateLockfile,
+    importers: {
+      '.': {
+        dependencies: { 'is-negative': '1.0.0' },
+        specifiers: { 'is-negative': '^1.0.0' },
+      },
+    },
+  }
+  await expect(writeWantedLockfile(projectPath, changed)).rejects.toThrow(/symlinked lockfile/)
+  expect(fs.readFileSync(realLockfile, 'utf8')).toBe(targetBefore)
+})

--- a/pnpm11/lockfile/fs/test/write.test.ts
+++ b/pnpm11/lockfile/fs/test/write.test.ts
@@ -513,3 +513,52 @@ testOnNonWindows('writeWantedLockfile() refuses a real write through a symlink',
   await expect(writeWantedLockfile(projectPath, changed)).rejects.toThrow(/symlinked lockfile/)
   expect(fs.readFileSync(realLockfile, 'utf8')).toBe(targetBefore)
 })
+
+const changedLockfile = {
+  ...upToDateLockfile,
+  importers: {
+    '.': {
+      dependencies: { 'is-negative': '1.0.0' },
+      specifiers: { 'is-negative': '^1.0.0' },
+    },
+  },
+}
+
+// The replacement is a fresh file, so its mode has to be restored explicitly:
+// creating it honours the umask, which would strip bits the lockfile carried.
+testOnNonWindows('writeWantedLockfile() preserves the lockfile mode against the umask', async () => {
+  const projectPath = temporaryDirectory()
+  const lockfilePath = path.join(projectPath, WANTED_LOCKFILE)
+  await writeWantedLockfile(projectPath, upToDateLockfile)
+  fs.chmodSync(lockfilePath, 0o666)
+  const previousUmask = process.umask(0o022)
+  try {
+    await writeWantedLockfile(projectPath, changedLockfile)
+  } finally {
+    process.umask(previousUmask)
+  }
+
+  expect(fs.statSync(lockfilePath).mode & 0o777).toBe(0o666)
+})
+
+testOnNonWindows('writeWantedLockfile() preserves the lockfile ownership', async () => {
+  const projectPath = temporaryDirectory()
+  const lockfilePath = path.join(projectPath, WANTED_LOCKFILE)
+  await writeWantedLockfile(projectPath, upToDateLockfile)
+  const before = fs.statSync(lockfilePath)
+
+  await writeWantedLockfile(projectPath, changedLockfile)
+
+  // Only meaningful as a cross-user check, which needs root; this guards
+  // against the replacement landing on an unexpected owner.
+  const after = fs.statSync(lockfilePath)
+  expect(after.uid).toBe(before.uid)
+  expect(after.gid).toBe(before.gid)
+})
+
+testOnNonWindows('writeWantedLockfile() leaves no temp file behind', async () => {
+  const projectPath = temporaryDirectory()
+  await writeWantedLockfile(projectPath, upToDateLockfile)
+
+  expect(fs.readdirSync(projectPath)).toStrictEqual([WANTED_LOCKFILE])
+})

--- a/pnpm11/lockfile/fs/test/write.test.ts
+++ b/pnpm11/lockfile/fs/test/write.test.ts
@@ -449,15 +449,48 @@ test('writeWantedLockfile() leaves an unchanged lockfile untouched', async () =>
   expect(fs.statSync(lockfilePath).mtimeMs).toBe(mtimeBefore)
 })
 
+test('writeWantedLockfile() leaves an unchanged CRLF lockfile untouched', async () => {
+  const projectPath = temporaryDirectory()
+  const lockfilePath = path.join(projectPath, WANTED_LOCKFILE)
+  await writeWantedLockfile(projectPath, upToDateLockfile)
+  const crlfContent = fs.readFileSync(lockfilePath, 'utf8').replace(/\n/g, '\r\n')
+  fs.writeFileSync(lockfilePath, crlfContent)
+  const mtimeBefore = fs.statSync(lockfilePath).mtimeMs
+
+  await writeWantedLockfile(projectPath, upToDateLockfile)
+
+  expect(fs.readFileSync(lockfilePath, 'utf8')).toBe(crlfContent)
+  expect(fs.statSync(lockfilePath).mtimeMs).toBe(mtimeBefore)
+})
+
 testOnNonWindows('writeWantedLockfile() accepts a symlinked lockfile when nothing changes', async () => {
   const projectPath = temporaryDirectory()
   const realDir = temporaryDirectory()
   const realLockfile = path.join(realDir, 'pnpm-lock.yaml')
   await writeWantedLockfile(realDir, upToDateLockfile)
+  const targetBefore = fs.readFileSync(realLockfile, 'utf8')
+  const mtimeBefore = fs.statSync(realLockfile).mtimeMs
   fs.symlinkSync(realLockfile, path.join(projectPath, WANTED_LOCKFILE), 'file')
 
   await expect(writeWantedLockfile(projectPath, upToDateLockfile)).resolves.toBeTruthy()
   expect(fs.lstatSync(path.join(projectPath, WANTED_LOCKFILE)).isSymbolicLink()).toBe(true)
+  expect(fs.readFileSync(realLockfile, 'utf8')).toBe(targetBefore)
+  expect(fs.statSync(realLockfile).mtimeMs).toBe(mtimeBefore)
+})
+
+testOnNonWindows('writeWantedLockfile() accepts an unchanged CRLF symlinked lockfile', async () => {
+  const projectPath = temporaryDirectory()
+  const realDir = temporaryDirectory()
+  const realLockfile = path.join(realDir, WANTED_LOCKFILE)
+  await writeWantedLockfile(realDir, upToDateLockfile)
+  const crlfContent = fs.readFileSync(realLockfile, 'utf8').replace(/\n/g, '\r\n')
+  fs.writeFileSync(realLockfile, crlfContent)
+  const mtimeBefore = fs.statSync(realLockfile).mtimeMs
+  fs.symlinkSync(realLockfile, path.join(projectPath, WANTED_LOCKFILE), 'file')
+
+  await expect(writeWantedLockfile(projectPath, upToDateLockfile)).resolves.toBeTruthy()
+  expect(fs.readFileSync(realLockfile, 'utf8')).toBe(crlfContent)
+  expect(fs.statSync(realLockfile).mtimeMs).toBe(mtimeBefore)
 })
 
 testOnNonWindows('writeWantedLockfile() refuses a real write through a symlink', async () => {

--- a/pnpm11/lockfile/fs/test/yamlDocuments.test.ts
+++ b/pnpm11/lockfile/fs/test/yamlDocuments.test.ts
@@ -7,6 +7,7 @@ import { temporaryDirectory } from 'tempy'
 import {
   extractEnvDocument,
   extractMainDocument,
+  readLockfileToString,
   streamReadFirstYamlDocument,
 } from '../lib/yamlDocuments.js'
 
@@ -136,6 +137,16 @@ describe('streamReadFirstYamlDocument', () => {
 })
 
 describe('extractEnvDocument', () => {
+  test('whole-file reads strip a BOM and normalize CRLF', async () => {
+    const dir = temporaryDirectory()
+    const filePath = path.join(dir, 'test.yaml')
+    fs.writeFileSync(filePath, '\uFEFF---\r\nfoo: bar\r\n---\r\nlockfileVersion: 9.0\r\n')
+
+    await expect(readLockfileToString(filePath)).resolves.toBe(
+      '---\nfoo: bar\n---\nlockfileVersion: 9.0\n'
+    )
+  })
+
   test('returns null when content does not start with ---', () => {
     expect(extractEnvDocument('lockfileVersion: 9.0\npackages: {}\n')).toBeNull()
   })

--- a/pnpm11/lockfile/fs/test/yamlDocuments.test.ts
+++ b/pnpm11/lockfile/fs/test/yamlDocuments.test.ts
@@ -5,9 +5,9 @@ import { describe, expect, test } from '@jest/globals'
 import { temporaryDirectory } from 'tempy'
 
 import {
+  extractEnvDocument,
   extractMainDocument,
   streamReadFirstYamlDocument,
-  streamReadFirstYamlDocumentNoFollow,
 } from '../lib/yamlDocuments.js'
 
 const testOnNonWindows = process.platform === 'win32' ? test.skip : test
@@ -124,14 +124,42 @@ describe('streamReadFirstYamlDocument', () => {
     expect(result).toBe('foo: bar')
   })
 
-  testOnNonWindows('rejects a symlinked lockfile', async () => {
+  testOnNonWindows('reads through a symlinked lockfile', async () => {
     const dir = temporaryDirectory()
     const realLockfile = path.join(dir, 'real-lockfile.yaml')
     const lockfilePath = path.join(dir, 'pnpm-lock.yaml')
     fs.writeFileSync(realLockfile, '---\nfoo: bar\n---\nlockfileVersion: 9.0\n')
     fs.symlinkSync(realLockfile, lockfilePath, 'file')
 
-    await expect(streamReadFirstYamlDocumentNoFollow(lockfilePath)).rejects.toThrow(/symlinked lockfile/)
+    await expect(streamReadFirstYamlDocument(lockfilePath)).resolves.toBe('foo: bar')
+  })
+})
+
+describe('extractEnvDocument', () => {
+  test('returns null when content does not start with ---', () => {
+    expect(extractEnvDocument('lockfileVersion: 9.0\npackages: {}\n')).toBeNull()
+  })
+
+  test('returns null when content starts with --- but has no separator', () => {
+    expect(extractEnvDocument('---\nfoo: bar\n')).toBeNull()
+  })
+
+  test('returns the first document from a combined file', () => {
+    expect(extractEnvDocument('---\nfoo: bar\n---\nlockfileVersion: 9.0\n')).toBe('foo: bar')
+  })
+
+  test('handles CRLF line endings in combined file', () => {
+    const combined = '---\nfoo: bar\n---\nlockfileVersion: 9.0\n'.replace(/\n/g, '\r\n')
+    expect(extractEnvDocument(combined)).toBe('foo: bar')
+  })
+
+  test('agrees with streamReadFirstYamlDocument on a combined file', async () => {
+    const dir = temporaryDirectory()
+    const filePath = path.join(dir, 'test.yaml')
+    const combined = '---\nfoo: bar\n---\nlockfileVersion: 9.0\n'
+    fs.writeFileSync(filePath, combined)
+
+    expect(extractEnvDocument(combined)).toBe(await streamReadFirstYamlDocument(filePath))
   })
 })
 

--- a/pnpm11/lockfile/fs/test/yamlDocuments.test.ts
+++ b/pnpm11/lockfile/fs/test/yamlDocuments.test.ts
@@ -7,6 +7,7 @@ import { temporaryDirectory } from 'tempy'
 import {
   extractMainDocument,
   streamReadFirstYamlDocument,
+  streamReadFirstYamlDocumentNoFollow,
 } from '../lib/yamlDocuments.js'
 
 const testOnNonWindows = process.platform === 'win32' ? test.skip : test
@@ -130,7 +131,7 @@ describe('streamReadFirstYamlDocument', () => {
     fs.writeFileSync(realLockfile, '---\nfoo: bar\n---\nlockfileVersion: 9.0\n')
     fs.symlinkSync(realLockfile, lockfilePath, 'file')
 
-    await expect(streamReadFirstYamlDocument(lockfilePath)).rejects.toThrow(/symlinked lockfile/)
+    await expect(streamReadFirstYamlDocumentNoFollow(lockfilePath)).rejects.toThrow(/symlinked lockfile/)
   })
 })
 


### PR DESCRIPTION
## Summary

`pnpm install` fails with `ERR_PNPM_LOCKFILE_IS_SYMLINK` when `pnpm-lock.yaml` is a symlink, breaking build sandboxes (Bazel, Nix) that stage the lockfile that way. This restores those workflows while keeping the protection that matters.

Two halves, from opposite directions:

- **Reads follow symlinks again.** That guard never protected anything. `readWantedLockfile` reads the same file with a plain `readFile` and has always followed the link, so refusing it on the env-document read only broke sandboxes. A hostile repo can commit a hostile lockfile as a plain file regardless — lockfile content is untrusted either way. The guard arrived as a "consider this too" aside alongside the genuine write fix in pnpm/pnpm#12821.
- **An unchanged lockfile is no longer rewritten.** This is what actually fixes the reported command. `tryFrozenInstall` rewrites an already up-to-date `pnpm-lock.yaml`, so `--frozen-lockfile --lockfile-only` died on the *write*, not the read. Skipping a byte-identical rewrite means a frozen install never writes at all — and it's a small win for every frozen install, symlink or not.

Writing a *changed* lockfile through a symlink is still refused: `write-file-atomic` resolves the target with `realpath`, so writing through one redirects onto any file the user can write.

The same clobber is now closed in pacquet, where `save_value_to_path` wrote the wanted lockfile with `fs::write` — following symlinks, with no guard at all. It now refuses a symlinked lockfile and writes atomically.

Fixes pnpm/pnpm#13073

## Squash Commit Body

```text
Allowing symlinked reads did not fix pnpm/pnpm#13073. The reported
`--frozen-lockfile --lockfile-only` install fails on the *write*:
tryFrozenInstall rewrites an already up-to-date pnpm-lock.yaml, and the
write path refuses a symlink before it writes.

Skip a byte-identical rewrite instead. An up-to-date install -- every
frozen run -- no longer touches the lockfile at all, so one staged as a
symlink (Bazel, Nix) installs cleanly, while a write that changes bytes
still refuses the symlink: write-file-atomic resolves the target with
realpath, so writing through one redirects onto any file the user can
write.

Reading through a symlink stays allowed. That guard never protected
anything: readWantedLockfile reads the same file with a plain readFile and
has always followed the link, so refusing it on the env-document read only
broke sandboxes. A hostile repo can commit a hostile lockfile as a plain
file regardless -- lockfile content is untrusted either way. The guard
arrived as a "consider this too" aside alongside the write fix in
pnpm/pnpm#12821.

Close the same clobber in pacquet: save_value_to_path wrote the wanted
lockfile with fs::write, which follows symlinks and had no guard. It now
refuses a symlinked lockfile and writes atomically, carrying the target's
mode across the rename and flushing before it, matching write-file-atomic.
Share the symlink guard between both write paths rather than duplicate it.

Add install-level regression coverage for the reported command; the
existing unit tests passed while the bug remained.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

## Notes for reviewers

- **The error message changed.** `Refusing to read or write symlinked lockfile` → `Refusing to write symlinked lockfile`, since only writes refuse now. `ERR_PNPM_LOCKFILE_IS_SYMLINK` is unchanged, but it is a released string that tooling could match on.
- **pacquet's main-lockfile write is now atomic** (temp + rename), where it previously used `fs::write`. The shared writer carries the target's mode across the rename and flushes before it — `fs::write` truncated in place and kept the mode, so a naive rename would have silently reset `pnpm-lock.yaml` to the umask default. Both mirror `write-file-atomic`. One consequence of rename semantics: writing a read-only lockfile now succeeds, as it already does in the TypeScript CLI.
- **Test coverage.** The install-level tests are the ones that matter: the previous unit tests passed while the reported command stayed broken. `frozen lockfile-only install succeeds when pnpm-lock.yaml is a symlink` reproduces the issue and fails without this change. Atomicity itself is not directly unit-testable; the write now goes through the writer that already has error-path and temp-cleanup coverage.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786790437&installation_id=145934176&pr_number=13075&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13075&signature=7a5c95c6685f8ce3d3199de0ff0b221429043d5e2b4a0ed3bc86842960a8b158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Symlinked `pnpm-lock.yaml` files no longer fail to read, including `--frozen-lockfile` installs when no lockfile changes are required.
  * Lockfile writes remain safe: symlinked lockfile targets are updated only when the effective content is unchanged; changed content is still blocked.
  * Improved env-metadata preservation and idempotent lockfile updates (skips rewrites when byte-identical, with BOM/CRLF normalization).
* **Tests**
  * Updated and expanded cross-platform coverage for symlink behavior, env document extraction, and lockfile read/write idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

