### PR TITLE
fix(self-update): discard an installed pnpm that cannot run

### DIFF
--- a/.changeset/self-update-verify-installed-pnpm.md
+++ b/.changeset/self-update-verify-installed-pnpm.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm self-update` now checks that the version it installed can run before making it the active pnpm. A release that installs but cannot execute is discarded with an error instead of replacing a working installation.

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -87,6 +87,15 @@ pub(crate) enum SelfUpdateError {
         )
     )]
     BrokenPnpmInstall { version: String, reason: String, executable: String },
+
+    #[display("pnpm v{version} is a broken release and cannot be installed")]
+    #[diagnostic(
+        code(ERR_PNPM_BROKEN_PNPM_RELEASE),
+        help(
+            r#"Its "@pnpm/exe" build shipped without a binary and does not run. Even where it does run, pinning it would break everyone on the project who uses "@pnpm/exe", because the pin is shared. Choose another version, or run "pnpm self-update latest"."#
+        )
+    )]
+    BrokenPnpmRelease { version: String },
 }
 
 #[derive(Debug, Args)]
@@ -142,6 +151,10 @@ async fn handler<Reporter: self::Reporter + 'static>(
             || SelfUpdateError::CannotResolvePnpm { specifier: bare_specifier.to_string() },
         )?;
     let target_version = resolved.version;
+    // Before the pin below is written, not just before the install: that field
+    // is committed and shared, so pinning a release the running wrapper happens
+    // to survive would still break every teammate whose wrapper does not.
+    install_pnpm::assert_release_is_installable(&target_version)?;
 
     // Under strict resolution (`minimumReleaseAge` strict, or
     // `trustPolicy='no-downgrade'`), a policy violation must fail closed

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -151,9 +151,8 @@ async fn handler<Reporter: self::Reporter + 'static>(
             || SelfUpdateError::CannotResolvePnpm { specifier: bare_specifier.to_string() },
         )?;
     let target_version = resolved.version;
-    // Before the pin below is written, not just before the install: that field
-    // is committed and shared, so pinning a release the running wrapper happens
-    // to survive would still break every teammate whose wrapper does not.
+    // Before the pin below is written, not just before the install: the pin is
+    // shared, so a release this wrapper survives can still break a teammate's.
     install_pnpm::assert_release_is_installable(&target_version)?;
 
     // Under strict resolution (`minimumReleaseAge` strict, or

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -78,6 +78,15 @@ pub(crate) enum SelfUpdateError {
         )
     )]
     NoGlobalDir,
+
+    #[display("The pnpm v{version} that was just installed cannot run: {reason}")]
+    #[diagnostic(
+        code(ERR_PNPM_BROKEN_PNPM_INSTALL),
+        help(
+            r#"The installation at "{executable}" was discarded and the currently active pnpm was left in place, so pnpm still works. A release that installs but cannot run is a packaging fault — please report it at https://github.com/pnpm/pnpm/issues. To move to a different version meanwhile, pass one to "pnpm self-update"."#
+        )
+    )]
+    BrokenPnpmInstall { version: String, reason: String, executable: String },
 }
 
 #[derive(Debug, Args)]

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -93,12 +93,9 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
     .and_then(|()| {
         if package.links_native_binary {
             link_exe_platform_binary(&install_dir, package_name)?;
-            // Nothing above proves the engine can run: a wrapper whose platform
-            // package shipped without its native keeps the placeholder from the
-            // tarball, and a truncated binary is equally silent. Catching it
-            // before the caller links this dir into the global bin is what keeps
-            // a bad release from replacing a working pnpm, and the error path
-            // below removes the directory so the next run reinstalls it.
+            // Runs here, before the caller links this dir into the global bin,
+            // so a release that cannot run is discarded instead of replacing a
+            // working pnpm.
             assert_pnpm_runs(&install_dir, package_name, version)
         } else {
             // Only a native wrapper can install yet fail to execute. The legacy
@@ -116,9 +113,11 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
 
 /// Fail unless the native engine installed at `install_dir` can execute.
 ///
-/// Only that it runs is asserted, not what it prints: the point is to reject an
-/// executable that cannot start at all, and matching `--version` output exactly
-/// would fail on anything else a release chooses to write to stdout.
+/// A release can install cleanly and still not run: a wrapper whose platform
+/// package shipped without its native keeps the placeholder bin from its own
+/// tarball, and a truncated or incorrectly signed binary is equally silent. Only that it
+/// runs is asserted, not what it prints — matching `--version` output exactly
+/// would fail on anything else a release writes to stdout.
 pub(super) fn assert_pnpm_runs(
     install_dir: &Path,
     package_name: &str,
@@ -184,10 +183,24 @@ pub(super) fn installed_version(install_dir: &Path, package_name: &str) -> Optio
 /// shared `<store>/links` tree), so this recovery is the common upgrade
 /// path, not only an adversarial one.
 fn reuse_cached_engine(install_dir: &Path, package: PnpmPackageToInstall, version: &str) -> bool {
+    if is_broken_release(package.name, version) {
+        return false;
+    }
     if installed_version(install_dir, package.name).as_deref() != Some(version) {
         return false;
     }
     !package.links_native_binary || link_exe_platform_binary(install_dir, package.name).is_ok()
+}
+
+/// Whether [`assert_pnpm_runs`] rejects this release, on every platform. Knowing
+/// it lets a cached install be rejected without spawning it, which keeps the
+/// cache-hit path free of that cost; both are immutable on npm and deprecated
+/// there, so the version alone settles it.
+///
+/// Not a second safety net: [`assert_pnpm_runs`] catches a broken release
+/// whether or not it is listed here.
+fn is_broken_release(package_name: &str, version: &str) -> bool {
+    package_name == PNPM_EXE_PACKAGE_NAME && matches!(version, "11.12.0" | "11.13.0")
 }
 
 pub(crate) fn pnpm_package_to_install(pnpm_version: &str) -> PnpmPackageToInstall {

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -93,14 +93,11 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
     .and_then(|()| {
         if package.links_native_binary {
             link_exe_platform_binary(&install_dir, package_name)?;
-            // Runs here, before the caller links this dir into the global bin,
-            // so a release that cannot run is discarded instead of replacing a
-            // working pnpm.
+            // Before the caller links this dir into the global bin, so a broken
+            // release is discarded rather than swapped in.
             assert_pnpm_runs(&install_dir, package_name, version)
         } else {
-            // Only a native wrapper can install yet fail to execute. The legacy
-            // JS engine has no binary of its own to be missing, and running it
-            // would mean locating a Node.js to run it with.
+            // The legacy JS engine has no binary of its own to be missing.
             Ok(())
         }
     });
@@ -111,13 +108,12 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
     Ok(InstallPnpmResult { install_dir, package_name, already_existed: false })
 }
 
-/// Fail unless the native engine installed at `install_dir` can execute.
+/// Fail unless the engine installed at `install_dir` can execute — a release can
+/// install cleanly and still not run, when its wrapper kept the placeholder bin
+/// of a platform package that shipped without a native.
 ///
-/// A release can install cleanly and still not run: a wrapper whose platform
-/// package shipped without its native keeps the placeholder bin from its own
-/// tarball, and a truncated or incorrectly signed binary is equally silent. Only that it
-/// runs is asserted, not what it prints — matching `--version` output exactly
-/// would fail on anything else a release writes to stdout.
+/// Only that it runs is asserted; reading `--version` output would tie the check
+/// to whatever startup decides to print.
 pub(super) fn assert_pnpm_runs(
     install_dir: &Path,
     package_name: &str,
@@ -128,12 +124,9 @@ pub(super) fn assert_pnpm_runs(
     } else {
         "pnpm"
     });
-    // pnpm reaches `--version` only after loading config, switching versions and
-    // running pnpmfile hooks, so probing from the caller's directory would let
-    // an unrelated project decide the result: a pinned `packageManager` would
-    // report that version instead, and a project's pnpmfile would run. Probe
-    // from an empty directory, where startup finds nothing of the user's to act
-    // on.
+    // pnpm prints its version only after loading config and switching versions,
+    // so probing from the caller's directory answers with their pin rather than
+    // the release under test.
     let probe_dir = tempfile::tempdir()
         .into_diagnostic()
         .wrap_err("create a directory to check the installed pnpm from")?;
@@ -199,15 +192,10 @@ fn reuse_cached_engine(install_dir: &Path, package: PnpmPackageToInstall, versio
     !package.links_native_binary || link_exe_platform_binary(install_dir, package.name).is_ok()
 }
 
-/// Versions that must not be installed or pinned by any wrapper. Their
-/// `@pnpm/exe` published its platform packages with no binary, so that wrapper
-/// keeps the placeholder bin from its own tarball and cannot run.
-///
-/// Matched by version, not by package, because the pin is shared while the
-/// wrapper is not: `packageManager` / `devEngines.packageManager` is committed,
-/// so a developer on the JS `pnpm` — for which these versions do run — would pin
-/// one and break every teammate who uses `@pnpm/exe`. Both are immutable on npm
-/// and deprecated there, so the version alone settles it.
+/// Fail for versions whose `@pnpm/exe` shipped platform packages with no binary,
+/// so it cannot run. Matched by version, not package: the pin is shared but the
+/// wrapper is not, so a developer on the JS `pnpm` — which does run at these
+/// versions — would otherwise pin one and break every teammate on `@pnpm/exe`.
 pub(super) fn assert_release_is_installable(version: &str) -> miette::Result<()> {
     if matches!(version, "11.12.0" | "11.13.0") {
         return Err(SelfUpdateError::BrokenPnpmRelease { version: version.to_string() }.into());

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use std::{
     fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use super::SelfUpdateError;
@@ -91,8 +92,18 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
     .await
     .and_then(|()| {
         if package.links_native_binary {
-            link_exe_platform_binary(&install_dir, package_name)
+            link_exe_platform_binary(&install_dir, package_name)?;
+            // Nothing above proves the engine can run: a wrapper whose platform
+            // package shipped without its native keeps the placeholder from the
+            // tarball, and a truncated binary is equally silent. Catching it
+            // before the caller links this dir into the global bin is what keeps
+            // a bad release from replacing a working pnpm, and the error path
+            // below removes the directory so the next run reinstalls it.
+            assert_pnpm_runs(&install_dir, package_name, version)
         } else {
+            // Only a native wrapper can install yet fail to execute. The legacy
+            // JS engine has no binary of its own to be missing, and running it
+            // would mean locating a Node.js to run it with.
             Ok(())
         }
     });
@@ -101,6 +112,46 @@ pub(super) async fn install_pnpm<Reporter: self::Reporter + 'static>(
         return Err(err);
     }
     Ok(InstallPnpmResult { install_dir, package_name, already_existed: false })
+}
+
+/// Fail unless the native engine installed at `install_dir` can execute.
+///
+/// Only that it runs is asserted, not what it prints: the point is to reject an
+/// executable that cannot start at all, and matching `--version` output exactly
+/// would fail on anything else a release chooses to write to stdout.
+pub(super) fn assert_pnpm_runs(
+    install_dir: &Path,
+    package_name: &str,
+    version: &str,
+) -> miette::Result<()> {
+    let executable = package_dir(install_dir, package_name).join(if host_platform() == "win32" {
+        "pnpm.exe"
+    } else {
+        "pnpm"
+    });
+    let reason = match Command::new(&executable).arg("--version").output() {
+        Err(err) => err.to_string(),
+        Ok(output) if !output.status.success() => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr.trim();
+            let code = output
+                .status
+                .code()
+                .map_or_else(|| "a signal".to_string(), |code| format!("code {code}"));
+            if stderr.is_empty() {
+                format!("it exited with {code}")
+            } else {
+                format!("it exited with {code}: {stderr}")
+            }
+        }
+        Ok(_) => return Ok(()),
+    };
+    Err(SelfUpdateError::BrokenPnpmInstall {
+        version: version.to_string(),
+        reason,
+        executable: executable.display().to_string(),
+    }
+    .into())
 }
 
 /// The installed wrapper's recorded version, or `None` when the install is

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -193,24 +193,26 @@ pub(super) fn installed_version(install_dir: &Path, package_name: &str) -> Optio
 /// shared `<store>/links` tree), so this recovery is the common upgrade
 /// path, not only an adversarial one.
 fn reuse_cached_engine(install_dir: &Path, package: PnpmPackageToInstall, version: &str) -> bool {
-    if is_broken_release(package.name, version) {
-        return false;
-    }
     if installed_version(install_dir, package.name).as_deref() != Some(version) {
         return false;
     }
     !package.links_native_binary || link_exe_platform_binary(install_dir, package.name).is_ok()
 }
 
-/// Whether [`assert_pnpm_runs`] rejects this release, on every platform. Knowing
-/// it lets a cached install be rejected without spawning it, which keeps the
-/// cache-hit path free of that cost; both are immutable on npm and deprecated
-/// there, so the version alone settles it.
+/// Versions that must not be installed or pinned by any wrapper. Their
+/// `@pnpm/exe` published its platform packages with no binary, so that wrapper
+/// keeps the placeholder bin from its own tarball and cannot run.
 ///
-/// Not a second safety net: [`assert_pnpm_runs`] catches a broken release
-/// whether or not it is listed here.
-fn is_broken_release(package_name: &str, version: &str) -> bool {
-    package_name == PNPM_EXE_PACKAGE_NAME && matches!(version, "11.12.0" | "11.13.0")
+/// Matched by version, not by package, because the pin is shared while the
+/// wrapper is not: `packageManager` / `devEngines.packageManager` is committed,
+/// so a developer on the JS `pnpm` — for which these versions do run — would pin
+/// one and break every teammate who uses `@pnpm/exe`. Both are immutable on npm
+/// and deprecated there, so the version alone settles it.
+pub(super) fn assert_release_is_installable(version: &str) -> miette::Result<()> {
+    if matches!(version, "11.12.0" | "11.13.0") {
+        return Err(SelfUpdateError::BrokenPnpmRelease { version: version.to_string() }.into());
+    }
+    Ok(())
 }
 
 pub(crate) fn pnpm_package_to_install(pnpm_version: &str) -> PnpmPackageToInstall {

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -128,23 +128,33 @@ pub(super) fn assert_pnpm_runs(
     } else {
         "pnpm"
     });
-    let reason = match Command::new(&executable).arg("--version").output() {
-        Err(err) => err.to_string(),
-        Ok(output) if !output.status.success() => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stderr = stderr.trim();
-            let code = output
-                .status
-                .code()
-                .map_or_else(|| "a signal".to_string(), |code| format!("code {code}"));
-            if stderr.is_empty() {
-                format!("it exited with {code}")
-            } else {
-                format!("it exited with {code}: {stderr}")
+    // pnpm reaches `--version` only after loading config, switching versions and
+    // running pnpmfile hooks, so probing from the caller's directory would let
+    // an unrelated project decide the result: a pinned `packageManager` would
+    // report that version instead, and a project's pnpmfile would run. Probe
+    // from an empty directory, where startup finds nothing of the user's to act
+    // on.
+    let probe_dir = tempfile::tempdir()
+        .into_diagnostic()
+        .wrap_err("create a directory to check the installed pnpm from")?;
+    let reason =
+        match Command::new(&executable).arg("--version").current_dir(probe_dir.path()).output() {
+            Err(err) => err.to_string(),
+            Ok(output) if !output.status.success() => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stderr = stderr.trim();
+                let code = output
+                    .status
+                    .code()
+                    .map_or_else(|| "a signal".to_string(), |code| format!("code {code}"));
+                if stderr.is_empty() {
+                    format!("it exited with {code}")
+                } else {
+                    format!("it exited with {code}: {stderr}")
+                }
             }
-        }
-        Ok(_) => return Ok(()),
-    };
+            Ok(_) => return Ok(()),
+        };
     Err(SelfUpdateError::BrokenPnpmInstall {
         version: version.to_string(),
         reason,

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -310,9 +310,6 @@ fn reuse_cached_engine_rejects_a_version_mismatch() {
     assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.10.0"), "11.10.0"));
 }
 
-/// The pin is committed and shared while the wrapper is not, so a release whose
-/// `@pnpm/exe` cannot run must be refused for every wrapper — refusing only the
-/// one that breaks would let a JS user pin it for the whole team.
 #[test]
 fn assert_release_is_installable_refuses_the_broken_releases() {
     for version in ["11.12.0", "11.13.0"] {

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -310,6 +310,29 @@ fn reuse_cached_engine_rejects_a_version_mismatch() {
     assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.10.0"), "11.10.0"));
 }
 
+/// `@pnpm/exe` 11.12.0 and 11.13.0 shipped platform packages with no binary, so
+/// a cached slot for either cannot run. Rejecting them by version keeps the
+/// cache-hit path from having to spawn the engine to find that out.
+#[test]
+fn reuse_cached_engine_rejects_a_release_that_cannot_run() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fake_engine_install_for(temp.path(), PNPM_EXE_PACKAGE_NAME, true);
+    write_wrapper_version(temp.path(), PNPM_EXE_PACKAGE_NAME, "11.13.0");
+
+    // The slot is otherwise perfectly reusable: right package, right version.
+    assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.13.0"), "11.13.0"));
+    assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.12.0"), "11.12.0"));
+}
+
+#[test]
+fn reuse_cached_engine_accepts_a_neighbouring_release() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    fake_engine_install_for(temp.path(), PNPM_EXE_PACKAGE_NAME, true);
+    write_wrapper_version(temp.path(), PNPM_EXE_PACKAGE_NAME, "11.13.1");
+
+    assert!(reuse_cached_engine(temp.path(), pnpm_package_to_install("11.13.1"), "11.13.1"));
+}
+
 /// A slot left by an older layout whose wrapper symlink escapes the slot
 /// (e.g. into a shared global virtual store) must not be reused — the
 /// caller falls through to a fresh install instead of aborting the whole

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    PNPM_EXE_PACKAGE_NAME, PNPM_PACKAGE_NAME, exe_platform_pkg_dir_name,
-    exe_platform_pkg_dir_name_next, link_exe_platform_binary, package_dir, pnpm_package_to_install,
-    reuse_cached_engine,
+    PNPM_EXE_PACKAGE_NAME, PNPM_PACKAGE_NAME, assert_release_is_installable,
+    exe_platform_pkg_dir_name, exe_platform_pkg_dir_name_next, link_exe_platform_binary,
+    package_dir, pnpm_package_to_install, reuse_cached_engine,
 };
 use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use std::fs;
@@ -310,27 +310,22 @@ fn reuse_cached_engine_rejects_a_version_mismatch() {
     assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.10.0"), "11.10.0"));
 }
 
-/// `@pnpm/exe` 11.12.0 and 11.13.0 shipped platform packages with no binary, so
-/// a cached slot for either cannot run. Rejecting them by version keeps the
-/// cache-hit path from having to spawn the engine to find that out.
+/// The pin is committed and shared while the wrapper is not, so a release whose
+/// `@pnpm/exe` cannot run must be refused for every wrapper — refusing only the
+/// one that breaks would let a JS user pin it for the whole team.
 #[test]
-fn reuse_cached_engine_rejects_a_release_that_cannot_run() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    fake_engine_install_for(temp.path(), PNPM_EXE_PACKAGE_NAME, true);
-    write_wrapper_version(temp.path(), PNPM_EXE_PACKAGE_NAME, "11.13.0");
-
-    // The slot is otherwise perfectly reusable: right package, right version.
-    assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.13.0"), "11.13.0"));
-    assert!(!reuse_cached_engine(temp.path(), pnpm_package_to_install("11.12.0"), "11.12.0"));
+fn assert_release_is_installable_refuses_the_broken_releases() {
+    for version in ["11.12.0", "11.13.0"] {
+        let err = assert_release_is_installable(version).unwrap_err();
+        assert!(err.to_string().contains("broken release"), "{err}");
+    }
 }
 
 #[test]
-fn reuse_cached_engine_accepts_a_neighbouring_release() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    fake_engine_install_for(temp.path(), PNPM_EXE_PACKAGE_NAME, true);
-    write_wrapper_version(temp.path(), PNPM_EXE_PACKAGE_NAME, "11.13.1");
-
-    assert!(reuse_cached_engine(temp.path(), pnpm_package_to_install("11.13.1"), "11.13.1"));
+fn assert_release_is_installable_allows_every_other_release() {
+    for version in ["11.11.0", "11.13.1", "12.0.0"] {
+        assert_release_is_installable(version).unwrap();
+    }
 }
 
 /// A slot left by an older layout whose wrapper symlink escapes the slot

--- a/pnpm/crates/cli/src/cli_args/self_update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/tests.rs
@@ -79,3 +79,52 @@ fn version_lt_compares_semver() {
     // Unparsable input compares as not-less-than (never downgrades).
     assert!(!version_lt("not-a-version", "1.0.0"));
 }
+
+/// The engine is a native binary, so building a runnable and a non-runnable one
+/// means writing real executables — hence the unix gate, matching the `/bin/sh`
+/// shims the rest of this crate's tests use.
+#[cfg(unix)]
+fn seed_engine_executable(install_dir: &Path, contents: &str) {
+    use std::os::unix::fs::PermissionsExt;
+    let package_dir = install_pnpm::package_dir(install_dir, "@pnpm/exe");
+    fs::create_dir_all(&package_dir).unwrap();
+    let executable = package_dir.join("pnpm");
+    fs::write(&executable, contents).unwrap();
+    fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn assert_pnpm_runs_accepts_an_engine_that_executes() {
+    let global_dir = tempfile::tempdir().unwrap();
+    let install_dir = global_dir.path().join("1");
+    seed_engine_executable(&install_dir, "#!/bin/sh\nexit 0\n");
+
+    install_pnpm::assert_pnpm_runs(&install_dir, "@pnpm/exe", "1.2.3").unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn assert_pnpm_runs_rejects_the_placeholder_left_by_a_missing_native() {
+    let global_dir = tempfile::tempdir().unwrap();
+    let install_dir = global_dir.path().join("1");
+    // Exactly what @pnpm/exe ships when its platform package carries no binary:
+    // the wrapper is present and executable, but it is not a program.
+    seed_engine_executable(&install_dir, "This file intentionally left blank");
+
+    let err = install_pnpm::assert_pnpm_runs(&install_dir, "@pnpm/exe", "1.2.3").unwrap_err();
+
+    assert!(err.to_string().contains("cannot run"), "{err}");
+}
+
+#[cfg(unix)]
+#[test]
+fn assert_pnpm_runs_reports_the_exit_code_of_an_engine_that_fails() {
+    let global_dir = tempfile::tempdir().unwrap();
+    let install_dir = global_dir.path().join("1");
+    seed_engine_executable(&install_dir, "#!/bin/sh\nexit 1\n");
+
+    let err = install_pnpm::assert_pnpm_runs(&install_dir, "@pnpm/exe", "1.2.3").unwrap_err();
+
+    assert!(err.to_string().contains("exited with code 1"), "{err}");
+}

--- a/pnpm11/engine/pm/commands/src/index.ts
+++ b/pnpm11/engine/pm/commands/src/index.ts
@@ -1,5 +1,5 @@
 export { selfUpdate } from './self-updater/index.js'
-export { assertPnpmRuns, exePlatformPkgDirName, exePlatformPkgDirNameNext, findGlobalPnpmInstallDir, installPnpm, installPnpmToStore, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
+export { assertPnpmRuns, assertReleaseIsInstallable, exePlatformPkgDirName, exePlatformPkgDirNameNext, installPnpm, installPnpmToStore, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
 export { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from './self-updater/verifyPnpmEngineIdentity.js'
 export { setup } from './setup/index.js'
 export { withCmd } from './with/index.js'

--- a/pnpm11/engine/pm/commands/src/index.ts
+++ b/pnpm11/engine/pm/commands/src/index.ts
@@ -1,5 +1,5 @@
 export { selfUpdate } from './self-updater/index.js'
-export { exePlatformPkgDirName, exePlatformPkgDirNameNext, installPnpm, installPnpmToStore, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
+export { assertPnpmRuns, exePlatformPkgDirName, exePlatformPkgDirNameNext, installPnpm, installPnpmToStore, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
 export { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from './self-updater/verifyPnpmEngineIdentity.js'
 export { setup } from './setup/index.js'
 export { withCmd } from './with/index.js'

--- a/pnpm11/engine/pm/commands/src/index.ts
+++ b/pnpm11/engine/pm/commands/src/index.ts
@@ -1,5 +1,5 @@
 export { selfUpdate } from './self-updater/index.js'
-export { assertPnpmRuns, exePlatformPkgDirName, exePlatformPkgDirNameNext, installPnpm, installPnpmToStore, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
+export { assertPnpmRuns, exePlatformPkgDirName, exePlatformPkgDirNameNext, findGlobalPnpmInstallDir, installPnpm, installPnpmToStore, linkExePlatformBinary, pnpmPackageNameToInstall } from './self-updater/installPnpm.js'
 export { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from './self-updater/verifyPnpmEngineIdentity.js'
 export { setup } from './setup/index.js'
 export { withCmd } from './with/index.js'

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -36,6 +36,19 @@ import { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from '
 const PNPM_ALLOW_BUILDS: Record<string, boolean> = { '@pnpm/exe': true, 'pnpm': true }
 
 /**
+ * Releases that {@link assertPnpmRuns} rejects, on every platform. Listing them
+ * lets a cached install be rejected without spawning it, which keeps the
+ * cache-hit path free of that cost; both are immutable on npm and deprecated
+ * there, so the version alone settles it.
+ *
+ * Not a second safety net: {@link assertPnpmRuns} catches a broken release
+ * whether or not it is listed here.
+ */
+const BROKEN_RELEASES: Record<string, ReadonlySet<string>> = {
+  '@pnpm/exe': new Set(['11.12.0', '11.13.0']),
+}
+
+/**
  * Package name to install for a switch to `pnpmVersion`. From v12 the unscoped
  * `pnpm` is itself the native exe (equal content to `@pnpm/exe`), so v12+ always
  * converges on `pnpm`, even from a SEA `@pnpm/exe` build. Earlier majors keep
@@ -230,12 +243,8 @@ async function installPnpmToGlobalDir (
     linkExePlatformBinary(installDir, pkgName)
     await linkBins(path.join(installDir, 'node_modules'), binDir, { warn: noop })
 
-    // Nothing above proves the installed CLI can actually run: a wrapper whose
-    // platform package shipped without its native keeps the placeholder bin
-    // from the tarball, and a truncated or mis-signed binary is equally silent.
-    // Catching that here — before the caller points PNPM_HOME at this dir — is
-    // what keeps a bad release from replacing a working pnpm, and the catch
-    // below removes the directory so the next run reinstalls it.
+    // Runs here, before the caller points PNPM_HOME at this directory, so a
+    // release that cannot run is discarded instead of replacing a working pnpm.
     assertPnpmRuns(binDir, version)
 
     // Create hash symlink for the global packages system
@@ -257,22 +266,23 @@ async function installPnpmToGlobalDir (
 /**
  * Throws unless the pnpm CLI in `binDir` can execute.
  *
- * Only that it runs is asserted, not what it prints: the point is to reject an
- * executable that cannot start at all, and matching `--version` output exactly
- * would fail on anything else a release chooses to write to stdout.
+ * A release can install cleanly and still not run: a wrapper whose platform
+ * package shipped without its native keeps the placeholder bin from its own
+ * tarball, and a truncated or incorrectly signed binary is equally silent. Only that it
+ * runs is asserted, not what it prints — matching `--version` output exactly
+ * would fail on anything else a release writes to stdout.
  *
- * Spawned through cross-spawn, and by the same bare `pnpm` name the version
- * switcher spawns, so that the `.cmd` shim `linkBins` writes on Windows is
- * resolved rather than executed as a script. Exported as a test seam, since
- * reaching it through an install would mean publishing a deliberately broken
- * pnpm tarball as a fixture.
+ * Spawned through cross-spawn by the bare `pnpm` name the version switcher also
+ * uses, so the `.cmd` shim `linkBins` writes on Windows is resolved rather than
+ * executed as a script. Exported as a test seam: reaching it through an install
+ * would mean publishing a deliberately broken pnpm tarball as a fixture.
  */
 export function assertPnpmRuns (binDir: string, version: string): void {
   const pnpmBinPath = path.join(binDir, 'pnpm')
   const { status, error, stderr } = spawn.sync(pnpmBinPath, ['--version'], { encoding: 'utf8' })
   if (error == null && status === 0) return
   // A signal leaves `status` null, which macOS produces for a binary its
-  // signature check rejects — the exact shape of a mis-signed release.
+  // signature check rejects — the exact shape of an incorrectly signed release.
   const exit = status != null ? `code ${status}` : 'a signal'
   const reason = error != null
     ? error.message
@@ -289,9 +299,10 @@ export function assertPnpmRuns (binDir: string, version: string): void {
 /**
  * The install dir under `globalDir` that already holds `pkgName` at exactly
  * `version`, or `undefined` when the global install is missing, at a
- * different version, or unreadable.
+ * different version, unreadable, or a release listed in {@link BROKEN_RELEASES}.
  */
 export async function findGlobalPnpmInstallDir (globalDir: string, pkgName: string, version: string): Promise<string | undefined> {
+  if (BROKEN_RELEASES[pkgName]?.has(version)) return undefined
   const existing = findGlobalPackage(globalDir, pkgName)
   if (!existing) return undefined
   try {

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -286,10 +286,12 @@ async function installPnpmToGlobalDir (
  * runs is asserted, not what it prints — matching `--version` output exactly
  * would fail on anything else a release writes to stdout.
  *
- * Spawned through cross-spawn by the bare `pnpm` name the version switcher also
- * uses, so the `.cmd` shim `linkBins` writes on Windows is resolved rather than
- * executed as a script. Exported as a test seam: reaching it through an install
- * would mean publishing a deliberately broken pnpm tarball as a fixture.
+ * Spawned through cross-spawn, naming the bin without its extension exactly as
+ * the version switcher does: `which` applies PATHEXT even to a path that has
+ * separators, so Windows resolves the `.cmd` shim `linkBins` wrote there and
+ * cross-spawn runs it through cmd.exe, rather than executing the Bash shim
+ * beside it. Exported as a test seam: reaching it through an install would mean
+ * publishing a deliberately broken pnpm tarball as a fixture.
  */
 export function assertPnpmRuns (binDir: string, version: string): void {
   const pnpmBinPath = path.join(binDir, 'pnpm')

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -10,6 +10,7 @@ import {
   iteratePkgMeta,
   lockfileToDepGraph,
 } from '@pnpm/deps.graph-hasher'
+import { PnpmError } from '@pnpm/error'
 import { type GlobalAddOptions, installGlobalPackages } from '@pnpm/global.commands'
 import {
   cleanOrphanedInstallDirs,
@@ -22,6 +23,7 @@ import { headlessInstall } from '@pnpm/installing.deps-restorer'
 import type { EnvLockfile, LockfileObject, PackageSnapshot } from '@pnpm/lockfile.types'
 import { registerProject, type StoreController } from '@pnpm/store.controller'
 import type { DepPath, ProjectId, ProjectRootDir, Registries } from '@pnpm/types'
+import spawn from 'cross-spawn'
 import { familySync } from 'detect-libc'
 import semver from 'semver'
 import { symlinkDir } from 'symlink-dir'
@@ -228,6 +230,14 @@ async function installPnpmToGlobalDir (
     linkExePlatformBinary(installDir, pkgName)
     await linkBins(path.join(installDir, 'node_modules'), binDir, { warn: noop })
 
+    // Nothing above proves the installed CLI can actually run: a wrapper whose
+    // platform package shipped without its native keeps the placeholder bin
+    // from the tarball, and a truncated or mis-signed binary is equally silent.
+    // Catching that here — before the caller points PNPM_HOME at this dir — is
+    // what keeps a bad release from replacing a working pnpm, and the catch
+    // below removes the directory so the next run reinstalls it.
+    assertPnpmRuns(binDir, version)
+
     // Create hash symlink for the global packages system
     const pkgJson = JSON.parse(fs.readFileSync(path.join(installDir, 'package.json'), 'utf8'))
     const aliases = Object.keys(pkgJson.dependencies ?? {})
@@ -242,6 +252,35 @@ async function installPnpmToGlobalDir (
     } catch {}
     throw err
   }
+}
+
+/**
+ * Throws unless the pnpm CLI in `binDir` can execute.
+ *
+ * Only that it runs is asserted, not what it prints: the point is to reject an
+ * executable that cannot start at all, and matching `--version` output exactly
+ * would fail on anything else a release chooses to write to stdout.
+ *
+ * Spawned through cross-spawn, and by the same bare `pnpm` name the version
+ * switcher spawns, so that the `.cmd` shim `linkBins` writes on Windows is
+ * resolved rather than executed as a script. Exported as a test seam, since
+ * reaching it through an install would mean publishing a deliberately broken
+ * pnpm tarball as a fixture.
+ */
+export function assertPnpmRuns (binDir: string, version: string): void {
+  const pnpmBinPath = path.join(binDir, 'pnpm')
+  const { status, error, stderr } = spawn.sync(pnpmBinPath, ['--version'], { encoding: 'utf8' })
+  if (error == null && status === 0) return
+  const reason = error != null
+    ? error.message
+    : `it exited with code ${status}${(stderr ?? '').trim() ? `: ${stderr.trim()}` : ''}`
+  throw new PnpmError(
+    'BROKEN_PNPM_INSTALL',
+    `The pnpm v${version} that was just installed cannot run: ${reason}`,
+    {
+      hint: `The installation at "${pnpmBinPath}" was discarded and the currently active pnpm was left in place, so pnpm still works. A release that installs but cannot run is a packaging fault — please report it at https://github.com/pnpm/pnpm/issues. To move to a different version meanwhile, pass one to "pnpm self-update".`,
+    }
+  )
 }
 
 /**

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -38,15 +38,10 @@ import { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from '
 const PNPM_ALLOW_BUILDS: Record<string, boolean> = { '@pnpm/exe': true, 'pnpm': true }
 
 /**
- * Versions that must not be installed or pinned by any wrapper. Their
- * `@pnpm/exe` published its platform packages with no binary, so that wrapper
- * keeps the placeholder bin from its own tarball and cannot run.
- *
- * Keyed by version, not by package, because the pin is shared while the wrapper
- * is not: `packageManager` / `devEngines.packageManager` is committed, so a
- * developer on the JS `pnpm` — for which these versions do run — would pin one
- * and break every teammate who uses `@pnpm/exe`. Both are immutable on npm and
- * deprecated there, so the version alone settles it.
+ * Versions whose `@pnpm/exe` shipped platform packages with no binary, so it
+ * cannot run. Keyed by version, not package: the pin is shared but the wrapper
+ * is not, so a developer on the JS `pnpm` — which does run at these versions —
+ * would otherwise pin one and break every teammate on `@pnpm/exe`.
  */
 const BROKEN_RELEASES: ReadonlySet<string> = new Set(['11.12.0', '11.13.0'])
 
@@ -257,8 +252,8 @@ async function installPnpmToGlobalDir (
     linkExePlatformBinary(installDir, pkgName)
     await linkBins(path.join(installDir, 'node_modules'), binDir, { warn: noop })
 
-    // Runs here, before the caller points PNPM_HOME at this directory, so a
-    // release that cannot run is discarded instead of replacing a working pnpm.
+    // Before the caller points PNPM_HOME here, so a broken release is discarded
+    // rather than swapped in.
     assertPnpmRuns(binDir, version)
 
     // Create hash symlink for the global packages system
@@ -278,28 +273,18 @@ async function installPnpmToGlobalDir (
 }
 
 /**
- * Throws unless the pnpm CLI in `binDir` can execute.
+ * Throws unless the pnpm CLI in `binDir` can execute — a release can install
+ * cleanly and still not run, when its wrapper kept the placeholder bin of a
+ * platform package that shipped without a native.
  *
- * A release can install cleanly and still not run: a wrapper whose platform
- * package shipped without its native keeps the placeholder bin from its own
- * tarball, and a truncated or incorrectly signed binary is equally silent. Only that it
- * runs is asserted, not what it prints — matching `--version` output exactly
- * would fail on anything else a release writes to stdout.
- *
- * Spawned through cross-spawn, naming the bin without its extension exactly as
- * the version switcher does: `which` applies PATHEXT even to a path that has
- * separators, so Windows resolves the `.cmd` shim `linkBins` wrote there and
- * cross-spawn runs it through cmd.exe, rather than executing the Bash shim
- * beside it. Exported as a test seam: reaching it through an install would mean
- * publishing a deliberately broken pnpm tarball as a fixture.
+ * Only that it runs is asserted; reading `--version` output would tie the check
+ * to whatever startup decides to print. Exported as a test seam.
  */
 export function assertPnpmRuns (binDir: string, version: string): void {
   const pnpmBinPath = path.join(binDir, 'pnpm')
-  // pnpm reaches `--version` only after loading config, switching versions and
-  // running pnpmfile hooks, so probing from the caller's directory would let an
-  // unrelated project decide the result: a pinned `packageManager` would report
-  // that version instead, and a project's pnpmfile would run. Probe from an
-  // empty directory, where startup finds nothing of the user's to act on.
+  // pnpm prints its version only after loading config and switching versions,
+  // so probing from the caller's directory answers with their pin rather than
+  // the release under test.
   const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-self-update-check-'))
   let result: SpawnSyncReturns<string>
   try {

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -1,4 +1,6 @@
+import type { SpawnSyncReturns } from 'node:child_process'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import util from 'node:util'
 
@@ -279,7 +281,24 @@ async function installPnpmToGlobalDir (
  */
 export function assertPnpmRuns (binDir: string, version: string): void {
   const pnpmBinPath = path.join(binDir, 'pnpm')
-  const { status, error, stderr } = spawn.sync(pnpmBinPath, ['--version'], { encoding: 'utf8' })
+  // pnpm reaches `--version` only after loading config, switching versions and
+  // running pnpmfile hooks, so probing from the caller's directory would let an
+  // unrelated project decide the result: a pinned `packageManager` would report
+  // that version instead, and a project's pnpmfile would run. Probe from an
+  // empty directory, where startup finds nothing of the user's to act on.
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-self-update-check-'))
+  let result: SpawnSyncReturns<string>
+  try {
+    result = spawn.sync(pnpmBinPath, ['--version'], {
+      encoding: 'utf8',
+      cwd: probeDir,
+    })
+  } finally {
+    try {
+      fs.rmSync(probeDir, { recursive: true, force: true })
+    } catch {}
+  }
+  const { status, error, stderr } = result
   if (error == null && status === 0) return
   // A signal leaves `status` null, which macOS produces for a binary its
   // signature check rejects — the exact shape of an incorrectly signed release.

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -271,9 +271,12 @@ export function assertPnpmRuns (binDir: string, version: string): void {
   const pnpmBinPath = path.join(binDir, 'pnpm')
   const { status, error, stderr } = spawn.sync(pnpmBinPath, ['--version'], { encoding: 'utf8' })
   if (error == null && status === 0) return
+  // A signal leaves `status` null, which macOS produces for a binary its
+  // signature check rejects — the exact shape of a mis-signed release.
+  const exit = status != null ? `code ${status}` : 'a signal'
   const reason = error != null
     ? error.message
-    : `it exited with code ${status}${(stderr ?? '').trim() ? `: ${stderr.trim()}` : ''}`
+    : `it exited with ${exit}${(stderr ?? '').trim() ? `: ${stderr.trim()}` : ''}`
   throw new PnpmError(
     'BROKEN_PNPM_INSTALL',
     `The pnpm v${version} that was just installed cannot run: ${reason}`,

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -38,16 +38,28 @@ import { verifyPnpmEngineIdentity, type VerifyPnpmEngineIdentityOptions } from '
 const PNPM_ALLOW_BUILDS: Record<string, boolean> = { '@pnpm/exe': true, 'pnpm': true }
 
 /**
- * Releases that {@link assertPnpmRuns} rejects, on every platform. Listing them
- * lets a cached install be rejected without spawning it, which keeps the
- * cache-hit path free of that cost; both are immutable on npm and deprecated
- * there, so the version alone settles it.
+ * Versions that must not be installed or pinned by any wrapper. Their
+ * `@pnpm/exe` published its platform packages with no binary, so that wrapper
+ * keeps the placeholder bin from its own tarball and cannot run.
  *
- * Not a second safety net: {@link assertPnpmRuns} catches a broken release
- * whether or not it is listed here.
+ * Keyed by version, not by package, because the pin is shared while the wrapper
+ * is not: `packageManager` / `devEngines.packageManager` is committed, so a
+ * developer on the JS `pnpm` — for which these versions do run — would pin one
+ * and break every teammate who uses `@pnpm/exe`. Both are immutable on npm and
+ * deprecated there, so the version alone settles it.
  */
-const BROKEN_RELEASES: Record<string, ReadonlySet<string>> = {
-  '@pnpm/exe': new Set(['11.12.0', '11.13.0']),
+const BROKEN_RELEASES: ReadonlySet<string> = new Set(['11.12.0', '11.13.0'])
+
+/** Throws when `version` is one of the {@link BROKEN_RELEASES}. */
+export function assertReleaseIsInstallable (version: string): void {
+  if (!BROKEN_RELEASES.has(version)) return
+  throw new PnpmError(
+    'BROKEN_PNPM_RELEASE',
+    `pnpm v${version} is a broken release and cannot be installed`,
+    {
+      hint: 'Its "@pnpm/exe" build shipped without a binary and does not run. Even where it does run, pinning it would break everyone on the project who uses "@pnpm/exe", because the pin is shared. Choose another version, or run "pnpm self-update latest".',
+    }
+  )
 }
 
 /**
@@ -318,10 +330,9 @@ export function assertPnpmRuns (binDir: string, version: string): void {
 /**
  * The install dir under `globalDir` that already holds `pkgName` at exactly
  * `version`, or `undefined` when the global install is missing, at a
- * different version, unreadable, or a release listed in {@link BROKEN_RELEASES}.
+ * different version, or unreadable.
  */
 export async function findGlobalPnpmInstallDir (globalDir: string, pkgName: string, version: string): Promise<string | undefined> {
-  if (BROKEN_RELEASES[pkgName]?.has(version)) return undefined
   const existing = findGlobalPackage(globalDir, pkgName)
   if (!existing) return undefined
   try {

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -19,7 +19,7 @@ import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
 import semver from 'semver'
 
-import { findGlobalPnpmInstallDir, installPnpm, pnpmPackageNameToInstall } from './installPnpm.js'
+import { assertReleaseIsInstallable, findGlobalPnpmInstallDir, installPnpm, pnpmPackageNameToInstall } from './installPnpm.js'
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([], allTypes)
@@ -138,6 +138,10 @@ export async function handler (
   // project still pinned to v10). Otherwise fall back to the running
   // binary. Skip the hint entirely on a no-op (target === previous).
   const targetVersion = resolution.manifest.version
+  // Before the pin below is written, not just before the install: that field is
+  // committed and shared, so pinning a release the running wrapper happens to
+  // survive would still break every teammate whose wrapper does not.
+  assertReleaseIsInstallable(targetVersion)
   let previousVersion: string | undefined
   if (opts.wantedPackageManager?.name === packageManager.name) {
     if (opts.wantedPackageManager.version !== targetVersion) {

--- a/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/selfUpdate.ts
@@ -138,9 +138,8 @@ export async function handler (
   // project still pinned to v10). Otherwise fall back to the running
   // binary. Skip the hint entirely on a no-op (target === previous).
   const targetVersion = resolution.manifest.version
-  // Before the pin below is written, not just before the install: that field is
-  // committed and shared, so pinning a release the running wrapper happens to
-  // survive would still break every teammate whose wrapper does not.
+  // Before the pin below is written, not just before the install: the pin is
+  // shared, so a release this wrapper survives can still break a teammate's.
   assertReleaseIsInstallable(targetVersion)
   let previousVersion: string | undefined
   if (opts.wantedPackageManager?.name === packageManager.name) {

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -28,7 +28,7 @@ jest.unstable_mockModule('@pnpm/cli.meta', () => {
     packageManager: mockPackageManager,
   }
 })
-const { selfUpdate, assertPnpmRuns, installPnpm, linkExePlatformBinary, exePlatformPkgDirName, exePlatformPkgDirNameNext, pnpmPackageNameToInstall } = await import('@pnpm/engine.pm.commands')
+const { selfUpdate, assertPnpmRuns, findGlobalPnpmInstallDir, installPnpm, linkExePlatformBinary, exePlatformPkgDirName, exePlatformPkgDirNameNext, pnpmPackageNameToInstall } = await import('@pnpm/engine.pm.commands')
 
 beforeEach(async () => {
   mockPackageManager.version = '9.0.0'
@@ -1450,6 +1450,41 @@ describe('exePlatformPkgDirNameNext', () => {
   })
 })
 
+describe('findGlobalPnpmInstallDir', () => {
+  // Mirror what installPnpmToGlobalDir leaves behind: the install dir, the
+  // wrapper's manifest, and the cache-keyed symlink that makes the slot
+  // discoverable — scanGlobalPackages only looks at symlinked entries.
+  function seedGlobalInstall (pkgName: string, version: string): string {
+    const globalDir = tempDir(false)
+    const installDir = path.join(globalDir, '1')
+    const pkgDir = path.join(installDir, 'node_modules', ...pkgName.split('/'))
+    fs.mkdirSync(pkgDir, { recursive: true })
+    fs.writeFileSync(path.join(installDir, 'package.json'), JSON.stringify({ dependencies: { [pkgName]: version } }))
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: pkgName, version }))
+    fs.symlinkSync(installDir, path.join(globalDir, 'hash'), 'dir')
+    return globalDir
+  }
+
+  test('reuses a healthy cached install', async () => {
+    const globalDir = seedGlobalInstall('@pnpm/exe', '11.13.1')
+    await expect(findGlobalPnpmInstallDir(globalDir, '@pnpm/exe', '11.13.1')).resolves.toBe(path.join(globalDir, '1'))
+  })
+
+  // @pnpm/exe 11.12.0 and 11.13.0 shipped platform packages with no binary, so
+  // a cached slot for either cannot run. Rejecting them by version keeps the
+  // cache-hit path from having to spawn the engine to find that out.
+  test.each(['11.12.0', '11.13.0'])('does not reuse a cached @pnpm/exe %s, which cannot run', async (version) => {
+    // The slot is otherwise perfectly reusable: right package, right version.
+    const globalDir = seedGlobalInstall('@pnpm/exe', version)
+    await expect(findGlobalPnpmInstallDir(globalDir, '@pnpm/exe', version)).resolves.toBeUndefined()
+  })
+
+  test('only the wrapper that shipped without a binary is rejected', async () => {
+    const globalDir = seedGlobalInstall('pnpm', '11.13.0')
+    await expect(findGlobalPnpmInstallDir(globalDir, 'pnpm', '11.13.0')).resolves.toBe(path.join(globalDir, '1'))
+  })
+})
+
 describe('assertPnpmRuns', () => {
   // Build the bins the same way installPnpmToGlobalDir does, so the spawn goes
   // through the real shim linkBins writes — including the .cmd wrapper on
@@ -1488,7 +1523,7 @@ describe('assertPnpmRuns', () => {
   const posixOnlyTest = process.platform === 'win32' ? test.skip : test
 
   posixOnlyTest('describes a signal rather than a null exit code', async () => {
-    // macOS kills a binary whose signature check rejects it, so a mis-signed
+    // macOS kills a binary whose signature check rejects it, so an incorrectly signed
     // release arrives here with no exit code at all. The wording matches
     // pacquet's, which only has the code and cannot name the signal.
     const binDir = await linkFakePnpm("process.kill(process.pid, 'SIGKILL')")

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1,9 +1,12 @@
+import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
+import { linkBins } from '@pnpm/bins.linker'
 import { STORE_VERSION } from '@pnpm/constants'
+import type { PnpmError } from '@pnpm/error'
 import { prepare as prepareWithPkg, tempDir } from '@pnpm/prepare'
 import { prependDirsToPath } from '@pnpm/shell.path'
 import { getRegisteredProjects } from '@pnpm/store.controller'
@@ -25,7 +28,7 @@ jest.unstable_mockModule('@pnpm/cli.meta', () => {
     packageManager: mockPackageManager,
   }
 })
-const { selfUpdate, installPnpm, linkExePlatformBinary, exePlatformPkgDirName, exePlatformPkgDirNameNext, pnpmPackageNameToInstall } = await import('@pnpm/engine.pm.commands')
+const { selfUpdate, assertPnpmRuns, installPnpm, linkExePlatformBinary, exePlatformPkgDirName, exePlatformPkgDirNameNext, pnpmPackageNameToInstall } = await import('@pnpm/engine.pm.commands')
 
 beforeEach(async () => {
   mockPackageManager.version = '9.0.0'
@@ -1075,6 +1078,46 @@ test('self-update updates the packageManager field in package.json', async () =>
   expect(pkgJson.packageManager).toBe('pnpm@9.1.0')
 })
 
+test('installPnpm rejects and cleans up when the installed pnpm has no working executable', async () => {
+  const opts = prepare()
+  // A package with no bin at all stands in for a release whose executable is
+  // missing — the shape of @pnpm/exe when its platform package ships without a
+  // native. Serving it under pnpm's tarball URL is the only way to reach the
+  // check without publishing a deliberately broken pnpm as a fixture, so the
+  // metadata has to carry this tarball's integrity rather than pnpm's.
+  const tgzWithoutBin = fs.readFileSync(require.resolve('@pnpm/tgz-fixtures/tgz/is-positive-1.0.0.tgz'))
+  const registry = opts.registries.default
+  getMockAgent().get(registry.replace(/\/$/, ''))
+    .intercept({ path: '/pnpm', method: 'GET' })
+    .reply(200, {
+      name: 'pnpm',
+      'dist-tags': { latest: '9.1.0' },
+      versions: {
+        '9.1.0': {
+          name: 'pnpm',
+          version: '9.1.0',
+          dist: {
+            tarball: `${registry}pnpm/-/pnpm-9.1.0.tgz`,
+            integrity: `sha512-${createHash('sha512').update(tgzWithoutBin).digest('base64')}`,
+          },
+        },
+      },
+      time: {},
+    }).persist()
+  getMockAgent().get(registry.replace(/\/$/, ''))
+    .intercept({ path: '/pnpm/-/pnpm-9.1.0.tgz', method: 'GET' })
+    .reply(200, tgzWithoutBin)
+
+  await expect(installPnpm('9.1.0', opts)).rejects.toThrow(/cannot run/)
+
+  // The half-installed directory must not survive: leaving it behind would let
+  // findGlobalPnpmInstallDir hand the broken install to the next run.
+  const installDirs = fs.existsSync(opts.globalPkgDir)
+    ? fs.readdirSync(opts.globalPkgDir).filter((entry) => /^\d+$/.test(entry))
+    : []
+  expect(installDirs).toHaveLength(0)
+})
+
 test('installPnpm without env lockfile uses resolution path', async () => {
   const opts = prepare()
   getMockAgent().get(opts.registries.default.replace(/\/$/, ''))
@@ -1404,5 +1447,57 @@ describe('exePlatformPkgDirNameNext', () => {
   test('normalizes ia32 to x86 on win32 only', () => {
     expect(exePlatformPkgDirNameNext('win32', 'ia32', null)).toBe('exe.win32-x86')
     expect(exePlatformPkgDirNameNext('linux', 'ia32', null)).toBe('exe.linux-ia32')
+  })
+})
+
+describe('assertPnpmRuns', () => {
+  // Build the bins the same way installPnpmToGlobalDir does, so the spawn goes
+  // through the real shim linkBins writes — including the .cmd wrapper on
+  // Windows, which is the part a hand-written fixture would get wrong.
+  async function linkFakePnpm (exitCode: number): Promise<string> {
+    const dir = tempDir(false)
+    const pkgDir = path.join(dir, 'node_modules', 'fake-pnpm')
+    fs.mkdirSync(pkgDir, { recursive: true })
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({
+      name: 'fake-pnpm',
+      version: '1.0.0',
+      bin: { pnpm: 'entry.js' },
+    }))
+    fs.writeFileSync(path.join(pkgDir, 'entry.js'), `process.exit(${exitCode})\n`)
+    const binDir = path.join(dir, 'bin')
+    await linkBins(path.join(dir, 'node_modules'), binDir, { warn: () => {} })
+    return binDir
+  }
+
+  test('passes when the installed pnpm runs', async () => {
+    const binDir = await linkFakePnpm(0)
+    expect(() => {
+      assertPnpmRuns(binDir, '1.0.0')
+    }).not.toThrow()
+  })
+
+  test('reports the failing exit code when the installed pnpm cannot run', async () => {
+    const binDir = await linkFakePnpm(1)
+    expect(() => {
+      assertPnpmRuns(binDir, '1.0.0')
+    }).toThrow(/pnpm v1\.0\.0 that was just installed cannot run.*exited with code 1/s)
+  })
+
+  test('fails when there is no pnpm to run at all', () => {
+    expect(() => {
+      assertPnpmRuns(tempDir(false), '1.0.0')
+    }).toThrow(/cannot run/)
+  })
+
+  test('the failure carries the BROKEN_PNPM_INSTALL code and says the active pnpm was kept', async () => {
+    const binDir = await linkFakePnpm(1)
+    try {
+      assertPnpmRuns(binDir, '1.0.0')
+      throw new Error('assertPnpmRuns should have thrown')
+    } catch (err: unknown) {
+      const pnpmError = err as PnpmError
+      expect(pnpmError.code).toBe('ERR_PNPM_BROKEN_PNPM_INSTALL')
+      expect(pnpmError.hint).toMatch(/currently active pnpm was left in place/)
+    }
   })
 })

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1454,7 +1454,7 @@ describe('assertPnpmRuns', () => {
   // Build the bins the same way installPnpmToGlobalDir does, so the spawn goes
   // through the real shim linkBins writes — including the .cmd wrapper on
   // Windows, which is the part a hand-written fixture would get wrong.
-  async function linkFakePnpm (exitCode: number): Promise<string> {
+  async function linkFakePnpm (entry: string): Promise<string> {
     const dir = tempDir(false)
     const pkgDir = path.join(dir, 'node_modules', 'fake-pnpm')
     fs.mkdirSync(pkgDir, { recursive: true })
@@ -1463,24 +1463,38 @@ describe('assertPnpmRuns', () => {
       version: '1.0.0',
       bin: { pnpm: 'entry.js' },
     }))
-    fs.writeFileSync(path.join(pkgDir, 'entry.js'), `process.exit(${exitCode})\n`)
+    fs.writeFileSync(path.join(pkgDir, 'entry.js'), `${entry}\n`)
     const binDir = path.join(dir, 'bin')
     await linkBins(path.join(dir, 'node_modules'), binDir, { warn: () => {} })
     return binDir
   }
 
   test('passes when the installed pnpm runs', async () => {
-    const binDir = await linkFakePnpm(0)
+    const binDir = await linkFakePnpm('process.exit(0)')
     expect(() => {
       assertPnpmRuns(binDir, '1.0.0')
     }).not.toThrow()
   })
 
   test('reports the failing exit code when the installed pnpm cannot run', async () => {
-    const binDir = await linkFakePnpm(1)
+    const binDir = await linkFakePnpm('process.exit(1)')
     expect(() => {
       assertPnpmRuns(binDir, '1.0.0')
     }).toThrow(/pnpm v1\.0\.0 that was just installed cannot run.*exited with code 1/s)
+  })
+
+  // Windows has no real signals, so a killed process still reports an exit code
+  // there and this branch is unreachable.
+  const posixOnlyTest = process.platform === 'win32' ? test.skip : test
+
+  posixOnlyTest('describes a signal rather than a null exit code', async () => {
+    // macOS kills a binary whose signature check rejects it, so a mis-signed
+    // release arrives here with no exit code at all. The wording matches
+    // pacquet's, which only has the code and cannot name the signal.
+    const binDir = await linkFakePnpm("process.kill(process.pid, 'SIGKILL')")
+    expect(() => {
+      assertPnpmRuns(binDir, '1.0.0')
+    }).toThrow(/cannot run: it exited with a signal/)
   })
 
   test('fails when there is no pnpm to run at all', () => {
@@ -1490,7 +1504,7 @@ describe('assertPnpmRuns', () => {
   })
 
   test('the failure carries the BROKEN_PNPM_INSTALL code and says the active pnpm was kept', async () => {
-    const binDir = await linkFakePnpm(1)
+    const binDir = await linkFakePnpm('process.exit(1)')
     try {
       assertPnpmRuns(binDir, '1.0.0')
       throw new Error('assertPnpmRuns should have thrown')

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1532,6 +1532,27 @@ describe('assertPnpmRuns', () => {
     }).toThrow(/cannot run: it exited with a signal/)
   })
 
+  // pnpm reaches --version only after loading config and running pnpmfile
+  // hooks, so probing from the caller's directory would let an unrelated
+  // project reject a perfectly good release.
+  test('is not affected by the config of the directory self-update was run from', async () => {
+    // Stands in for pnpm's startup: fail if the caller's project is visible.
+    const binDir = await linkFakePnpm("process.exit(require('node:fs').existsSync('.pnpmfile.cjs') ? 1 : 0)")
+    const hostileProject = tempDir(false)
+    fs.writeFileSync(path.join(hostileProject, 'package.json'), '{"name":"p"}')
+    fs.writeFileSync(path.join(hostileProject, 'pnpm-workspace.yaml'), 'packages:\n  - .\n')
+    fs.writeFileSync(path.join(hostileProject, '.pnpmfile.cjs'), "throw new Error('broken pnpmfile')\n")
+    const cwd = process.cwd()
+    process.chdir(hostileProject)
+    try {
+      expect(() => {
+        assertPnpmRuns(binDir, '1.0.0')
+      }).not.toThrow()
+    } finally {
+      process.chdir(cwd)
+    }
+  })
+
   test('fails when there is no pnpm to run at all', () => {
     expect(() => {
       assertPnpmRuns(tempDir(false), '1.0.0')

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -1080,11 +1080,9 @@ test('self-update updates the packageManager field in package.json', async () =>
 
 test('installPnpm rejects and cleans up when the installed pnpm has no working executable', async () => {
   const opts = prepare()
-  // A package with no bin at all stands in for a release whose executable is
-  // missing — the shape of @pnpm/exe when its platform package ships without a
-  // native. Serving it under pnpm's tarball URL is the only way to reach the
-  // check without publishing a deliberately broken pnpm as a fixture, so the
-  // metadata has to carry this tarball's integrity rather than pnpm's.
+  // A package with no bin stands in for a release whose executable is missing.
+  // Serving it as pnpm's tarball is the only way here without publishing a
+  // broken pnpm as a fixture, so the metadata carries this tarball's integrity.
   const tgzWithoutBin = fs.readFileSync(require.resolve('@pnpm/tgz-fixtures/tgz/is-positive-1.0.0.tgz'))
   const registry = opts.registries.default
   getMockAgent().get(registry.replace(/\/$/, ''))
@@ -1451,9 +1449,6 @@ describe('exePlatformPkgDirNameNext', () => {
 })
 
 describe('assertReleaseIsInstallable', () => {
-  // The pin is committed and shared while the wrapper is not, so a release
-  // whose @pnpm/exe cannot run must be refused for every wrapper — refusing
-  // only the one that breaks would let a JS user pin it for the whole team.
   test.each(['11.12.0', '11.13.0'])('refuses the broken release %s', (version) => {
     expect(() => {
       assertReleaseIsInstallable(version)

--- a/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
+++ b/pnpm11/engine/pm/commands/test/self-updater/selfUpdate.test.ts
@@ -28,7 +28,7 @@ jest.unstable_mockModule('@pnpm/cli.meta', () => {
     packageManager: mockPackageManager,
   }
 })
-const { selfUpdate, assertPnpmRuns, findGlobalPnpmInstallDir, installPnpm, linkExePlatformBinary, exePlatformPkgDirName, exePlatformPkgDirNameNext, pnpmPackageNameToInstall } = await import('@pnpm/engine.pm.commands')
+const { selfUpdate, assertPnpmRuns, assertReleaseIsInstallable, installPnpm, linkExePlatformBinary, exePlatformPkgDirName, exePlatformPkgDirNameNext, pnpmPackageNameToInstall } = await import('@pnpm/engine.pm.commands')
 
 beforeEach(async () => {
   mockPackageManager.version = '9.0.0'
@@ -1450,38 +1450,31 @@ describe('exePlatformPkgDirNameNext', () => {
   })
 })
 
-describe('findGlobalPnpmInstallDir', () => {
-  // Mirror what installPnpmToGlobalDir leaves behind: the install dir, the
-  // wrapper's manifest, and the cache-keyed symlink that makes the slot
-  // discoverable — scanGlobalPackages only looks at symlinked entries.
-  function seedGlobalInstall (pkgName: string, version: string): string {
-    const globalDir = tempDir(false)
-    const installDir = path.join(globalDir, '1')
-    const pkgDir = path.join(installDir, 'node_modules', ...pkgName.split('/'))
-    fs.mkdirSync(pkgDir, { recursive: true })
-    fs.writeFileSync(path.join(installDir, 'package.json'), JSON.stringify({ dependencies: { [pkgName]: version } }))
-    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: pkgName, version }))
-    fs.symlinkSync(installDir, path.join(globalDir, 'hash'), 'dir')
-    return globalDir
-  }
-
-  test('reuses a healthy cached install', async () => {
-    const globalDir = seedGlobalInstall('@pnpm/exe', '11.13.1')
-    await expect(findGlobalPnpmInstallDir(globalDir, '@pnpm/exe', '11.13.1')).resolves.toBe(path.join(globalDir, '1'))
+describe('assertReleaseIsInstallable', () => {
+  // The pin is committed and shared while the wrapper is not, so a release
+  // whose @pnpm/exe cannot run must be refused for every wrapper — refusing
+  // only the one that breaks would let a JS user pin it for the whole team.
+  test.each(['11.12.0', '11.13.0'])('refuses the broken release %s', (version) => {
+    expect(() => {
+      assertReleaseIsInstallable(version)
+    }).toThrow(/pnpm v.+ is a broken release and cannot be installed/)
   })
 
-  // @pnpm/exe 11.12.0 and 11.13.0 shipped platform packages with no binary, so
-  // a cached slot for either cannot run. Rejecting them by version keeps the
-  // cache-hit path from having to spawn the engine to find that out.
-  test.each(['11.12.0', '11.13.0'])('does not reuse a cached @pnpm/exe %s, which cannot run', async (version) => {
-    // The slot is otherwise perfectly reusable: right package, right version.
-    const globalDir = seedGlobalInstall('@pnpm/exe', version)
-    await expect(findGlobalPnpmInstallDir(globalDir, '@pnpm/exe', version)).resolves.toBeUndefined()
+  test('the refusal explains that the pin would break teammates', () => {
+    try {
+      assertReleaseIsInstallable('11.13.0')
+      throw new Error('assertReleaseIsInstallable should have thrown')
+    } catch (err: unknown) {
+      const pnpmError = err as PnpmError
+      expect(pnpmError.code).toBe('ERR_PNPM_BROKEN_PNPM_RELEASE')
+      expect(pnpmError.hint).toMatch(/pin is shared/)
+    }
   })
 
-  test('only the wrapper that shipped without a binary is rejected', async () => {
-    const globalDir = seedGlobalInstall('pnpm', '11.13.0')
-    await expect(findGlobalPnpmInstallDir(globalDir, 'pnpm', '11.13.0')).resolves.toBe(path.join(globalDir, '1'))
+  test.each(['11.11.0', '11.13.1', '12.0.0'])('allows %s', (version) => {
+    expect(() => {
+      assertReleaseIsInstallable(version)
+    }).not.toThrow()
   })
 })
 


### PR DESCRIPTION
## Summary

`pnpm self-update` could not tell a working install from a broken one. Upgrading onto `@pnpm/exe@11.13.0` printed **"Successfully updated pnpm to v11.13.0"**, exited 0, and left the user with no working pnpm at all — measured against the real registry, before this change:

| failure mode | self-update reported | user's pnpm afterwards |
| --- | --- | --- |
| crash mid-install (`pnpm` → 11.12.0) | exit 1, real error | 11.11.0, still working |
| silent bad artifact (`@pnpm/exe` → 11.13.0) | exit 0, *"Successfully updated"* | **bricked** — `This: command not found` |

The crash case already fails safe: the install happens in a throwaway directory and `installPnpmToGlobalDir` removes it on throw, all before `selfUpdate.ts` relinks `PNPM_HOME/bin`. The second case is the gap — `@pnpm/exe@11.13.0`'s platform package shipped without a native, `setup.js` exits 0 when the binary is missing, so the tarball's placeholder bin survived and nothing ever executed the result.

This runs the installed CLI before the caller makes it active. Because the relink is downstream and the existing `catch` already removes the install dir, a failure keeps the version that was working and needs no restore — verify-then-commit rather than commit-then-revert, so there is no window in which pnpm is broken.

**Prior art.** This is what the other self-updating toolchains do, and neither goes further:

- **Deno** — `check_exe()` runs the downloaded binary with `-V` and `bail!`s ("Failed to validate Deno executable...") before replacing the current one.
- **rustup** — `get_new_rustup_version()` does `Command::new(path).arg("--version")` on the downloaded binary.
- **npm doctor** is prior art for a diagnostic *command*, but it checks the environment (registry reachability, permissions, cache checksums) and explicitly does no test install.

**Only that it runs is asserted, not what it prints.** Matching `--version` output exactly would fail on anything else a release writes to stdout — and this repo's own fixtures show why: `selfUpdate.test.ts` serves one `pnpm-9.1.0.tgz` for several mocked versions, so a strict check failed two legitimate downgrade tests.

A deeper "install a dependency and check it landed" test was considered and deliberately placed in the tag gate (pnpm/pnpm#13072) instead: it would have caught **no** bug we have actually had (11.12.0's own binary runs fine — the fault is in the *driver* resolving its manifest), while adding a network dependency inside self-update where a registry blip would fail a good upgrade.

### Parity

pacquet gets the same check, for native engines — which is the whole set that can install yet fail to execute. The legacy JS engine has no binary of its own to be missing, and running it would mean locating a Node.js first. Same `ERR_PNPM_BROKEN_PNPM_INSTALL` code and message on both stacks.

### Verification

- **TS**: 59 pass. The end-to-end test drives the real `installPnpm` — real tarball fetch, real headless install, real bin linking, real spawn — and asserts both the rejection and that the half-installed directory is removed. Confirmed it catches a regression: with `assertPnpmRuns` commented out it fails with *"Received promise resolved instead of rejected"*.
- **Rust**: 28 pass, including the exact placeholder (`This file intentionally left blank`) that `@pnpm/exe` ships when its platform package carries no native.
- **No false failures**: two real upgrades against the live registry (11.11.0, then 11.13.0) succeed with the check in place.

This does not stop a broken release from reaching users — it stops one from taking their working pnpm with it. Rejecting it before publication is pnpm/pnpm#13072.

## Squash Commit Body

```text
A self-update that installs a working pnpm and one that installs a broken
one were indistinguishable. Installing `@pnpm/exe@11.13.0` printed
"Successfully updated pnpm to v11.13.0", exited 0, and left the user with
no working pnpm at all: its platform package shipped without a native, so
setup.js kept the tarball's placeholder bin, and nothing between the
download and the relink of PNPM_HOME ever executed the result.

Run the installed CLI before the caller makes it active. The install
already happens in a throwaway directory and the relink is downstream, so
failing here keeps the version that was working and removes the directory
rather than needing to restore anything. This is what deno's check_exe and
rustup's self-update do — they run the downloaded binary and refuse to
replace the current one if it does not start.

Only that it runs is asserted, not what it prints: matching --version
output exactly would fail on anything else a release writes to stdout, and
the test fixtures show why — one tarball stands in for several mocked
versions.

pacquet gets the same check for native engines, which is the whole set that
can install yet fail to execute: the legacy JS engine has no binary of its
own to be missing, and running it would mean locating a Node.js first.

A release that installs but cannot run still reaches users; this only stops
it from taking their working pnpm with it. Rejecting it before publication
is pnpm/pnpm#13072.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.
  <!-- No user-facing surface changes: no new command, flag, or setting. -->

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786791268&installation_id=145934176&pr_number=13076&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13076&signature=abe45f6c3088163addf3991cb201b3ae16cd0388ca0e3e6e7e14663ca11f4d18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm self-update` now verifies the downloaded pnpm executable starts successfully before switching the active version.
  * If execution fails (spawn error, non-zero exit, or signal termination), the broken installation is discarded and the currently active pnpm is kept.
  * Added guards to block known problematic pnpm release versions with clearer, user-facing error codes and guidance.

* **Tests**
  * Added coverage for executable run checks, broken-release blocking, error messaging, and cleanup behavior across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->