### PR TITLE
fix: refuse a broken pnpm release when switching versions, not only on self-update

### DIFF
--- a/.changeset/refuse-broken-release-on-version-switch.md
+++ b/.changeset/refuse-broken-release-on-version-switch.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"pacquet": patch
+---
+
+A project pinned to a broken pnpm release via `packageManager` or `devEngines.packageManager` now reports which release is broken and what to do about it, instead of failing inside the installer. `pnpm self-update` already refused these releases; the version switch does too.

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -196,7 +196,7 @@ fn reuse_cached_engine(install_dir: &Path, package: PnpmPackageToInstall, versio
 /// so it cannot run. Matched by version, not package: the pin is shared but the
 /// wrapper is not, so a developer on the JS `pnpm` — which does run at these
 /// versions — would otherwise pin one and break every teammate on `@pnpm/exe`.
-pub(super) fn assert_release_is_installable(version: &str) -> miette::Result<()> {
+pub(crate) fn assert_release_is_installable(version: &str) -> miette::Result<()> {
     if matches!(version, "11.12.0" | "11.13.0") {
         return Err(SelfUpdateError::BrokenPnpmRelease { version: version.to_string() }.into());
     }

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -4,7 +4,7 @@ use super::{
         PACKAGE_MANAGER_SWITCH_ENV_VARS, WantedPackageManager, read_manifest_json,
         should_persist_package_manager_lockfile, version_satisfies, wanted_package_manager,
     },
-    self_update::install_pnpm::pnpm_package_to_install,
+    self_update::install_pnpm::{assert_release_is_installable, pnpm_package_to_install},
     with::{
         PackageManagerCheck,
         install_pnpm_to_store::{install_pnpm_from_env, install_pnpm_to_store},
@@ -61,6 +61,7 @@ pub(crate) async fn execute_switch(
             if version == PNPM_VERSION {
                 return Ok(false);
             }
+            assert_release_is_installable(&version)?;
             let bin_dir =
                 Box::pin(install_pnpm_from_env::<SilentReporter>(config, &env, &version)).await?;
             (version, bin_dir)
@@ -72,6 +73,7 @@ pub(crate) async fn execute_switch(
             if resolved.version == PNPM_VERSION {
                 return Ok(false);
             }
+            assert_release_is_installable(&resolved.version)?;
             let bin_dir = Box::pin(install_pnpm_to_store::<SilentReporter>(
                 config,
                 &env_root,

--- a/pnpm11/pnpm/src/switchCliVersion.test.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.test.ts
@@ -55,10 +55,19 @@ const readEnvLockfile = jest.fn<(rootDir: string) => Promise<EnvLockfile | null>
 const resolvePackageManagerIntegrities = jest.fn<(version: string, opts: object) => Promise<EnvLockfile>>(async () => envLockfile)
 const spawnSync = jest.fn(() => ({ status: 0 }))
 
+// Mutable so a test can pretend the running pnpm is itself a broken release.
+const mockPackageManager = { name: 'pnpm', version: '11.0.0' }
+const actualCliMeta = await import('@pnpm/cli.meta')
 jest.unstable_mockModule('@pnpm/cli.meta', () => ({
-  packageManager: { name: 'pnpm', version: '11.0.0' },
+  ...actualCliMeta,
+  packageManager: mockPackageManager,
 }))
+// Only the installer is faked. assertReleaseIsInstallable is the real one, so
+// the list of broken releases stays in a single place and these tests exercise
+// it rather than a copy.
+const actualEnginePmCommands = await import('@pnpm/engine.pm.commands')
 jest.unstable_mockModule('@pnpm/engine.pm.commands', () => ({
+  ...actualEnginePmCommands,
   installPnpmToStore,
 }))
 jest.unstable_mockModule('@pnpm/installing.env-installer', () => ({
@@ -81,6 +90,7 @@ jest.unstable_mockModule('cross-spawn', () => ({
 const { switchCliVersion } = await import('./switchCliVersion.js')
 
 beforeEach(() => {
+  mockPackageManager.version = '11.0.0'
   closeStore.mockClear()
   createStoreController.mockClear()
   installPnpmToStore.mockClear()
@@ -370,3 +380,63 @@ test('switchCliVersion rejects package-manager lockfile dependencies with non-re
   expect(installPnpmToStore).not.toHaveBeenCalled()
   expect(spawnSync).not.toHaveBeenCalled()
 })
+
+test('refuses to switch to a broken release instead of failing inside the installer', async () => {
+  const config = { rawConfig: {} } as unknown as Config
+  const context = {
+    rootProjectManifestDir: '/project',
+    wantedPackageManager: { name: 'pnpm', version: '11.12.0', fromDevEngines: true, onFail: 'download' },
+  } as unknown as ConfigContext
+  readEnvLockfile.mockResolvedValue(envLockfileFor('11.12.0'))
+
+  // Spied so that a regression, which would run the switch to completion and
+  // reach exit(), fails the test instead of ending the worker.
+  const exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+  try {
+    await expect(switchCliVersion(config, context)).rejects.toThrow(/11\.12\.0 is a broken release/)
+  } finally {
+    exit.mockRestore()
+  }
+
+  expect(installPnpmToStore).not.toHaveBeenCalled()
+})
+
+// The refusal must not strand anyone: a developer whose pnpm *is* a broken
+// release still needs it to run, or they have nothing to move off it with.
+test('does not refuse a broken release that is already the running version', async () => {
+  mockPackageManager.version = '11.12.0'
+  const config = { rawConfig: {} } as unknown as Config
+  const context = {
+    rootProjectManifestDir: '/project',
+    wantedPackageManager: { name: 'pnpm', version: '11.12.0', fromDevEngines: true, onFail: 'download' },
+  } as unknown as ConfigContext
+  readEnvLockfile.mockResolvedValue(envLockfileFor('11.12.0'))
+
+  await expect(switchCliVersion(config, context)).resolves.toBeUndefined()
+
+  expect(installPnpmToStore).not.toHaveBeenCalled()
+})
+
+test('still switches to a release that is not broken', async () => {
+  const config = { rawConfig: {} } as unknown as Config
+  const context = {
+    rootProjectManifestDir: '/project',
+    wantedPackageManager: { name: 'pnpm', version: '11.13.1', fromDevEngines: true, onFail: 'download' },
+  } as unknown as ConfigContext
+  readEnvLockfile.mockResolvedValue(envLockfileFor('11.13.1'))
+
+  const exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+  try {
+    await switchCliVersion(config, context)
+  } finally {
+    exit.mockRestore()
+  }
+
+  expect(installPnpmToStore).toHaveBeenCalledWith('11.13.1', expect.anything())
+})
+
+/** The fixture above, re-pointed at `version` — same shape, so it still passes the
+ * registry-resolution assertion the switcher makes before installing. */
+function envLockfileFor (version: string): EnvLockfile {
+  return JSON.parse(JSON.stringify(envLockfile).replaceAll('9.3.0', version)) as EnvLockfile
+}

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { packageManager } from '@pnpm/cli.meta'
 import { type Config, type ConfigContext, shouldPersistLockfile } from '@pnpm/config.reader'
-import { installPnpmToStore } from '@pnpm/engine.pm.commands'
+import { assertReleaseIsInstallable, installPnpmToStore } from '@pnpm/engine.pm.commands'
 import { PnpmError } from '@pnpm/error'
 import { isPackageManagerResolved, resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
 import { readEnvLockfile } from '@pnpm/lockfile.fs'
@@ -70,6 +70,16 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
   if (pmVersion === packageManager.version) {
     await storeToUse?.ctrl.close()
     return
+  }
+
+  // Deliberately after the check above: switching to a broken release is
+  // refused, but running one already installed is not. Someone whose pnpm is a
+  // broken release still needs it to work well enough to move off it.
+  try {
+    assertReleaseIsInstallable(pmVersion)
+  } catch (err: unknown) {
+    await storeToUse?.ctrl.close()
+    throw err
   }
 
   if (!envLockfile) {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#12959.

pnpm/pnpm#13076 stopped `pnpm self-update` from installing a broken release. It did not cover the **version switch**, which is the path most of the reports in #12959 actually describe — "every single pnpm add/install command failed". Measured on merged `main` (f15d67c418, which includes #13076), a project pinned through `devEngines.packageManager`:

| committed pin | before | after |
| --- | --- | --- |
| 11.11.0 | ok | ok |
| **11.12.0** | **`Cannot use 'in' operator to search for 'integrity' in undefined`** | refused, with a reason |
| **11.13.0** | ok | refused, with a reason |
| 11.13.1 | ok | ok |

`assertReleaseIsInstallable` — the list #13076 introduced — now guards the switch too, so both ways of acquiring a pnpm agree on which releases are refusable.

What a user sees instead of the TypeError:

```
[ERROR] pnpm v11.12.0 is a broken release and cannot be installed
Its "@pnpm/exe" build shipped without a binary and does not run. Even where it does run,
pinning it would break everyone on the project who uses "@pnpm/exe", because the pin is
shared. Choose another version, or run "pnpm self-update latest".
```

### Two decisions worth review

**The check is placed after the "already this version" early return.** Switching *to* a broken release is refused; running one that is already installed is not. Someone whose pnpm *is* 11.12.0 still needs it to work well enough to move off it — and `self-update` skips the switch entirely (`skipPackageManagerCheck`), so that escape stays open. A test covers this.

**11.13.0 is refused even though it runs.** For the JS `pnpm` wrapper 11.13.0 is fine — it is `@pnpm/exe@11.13.0` whose platform packages shipped without a binary. But the pin is shared and the wrapper is not, so a developer on the JS wrapper would pin a version that works for them and breaks every teammate on `@pnpm/exe`. This is a deliberate behaviour change: a repo pinned to 11.13.0 that currently works for JS-wrapper users will start failing, with the message above telling them what to do. Both versions are deprecated on npm.

### Verification

- **Rust**: 11 `switch_cli_version` + 30 `self_update` tests pass; clippy and fmt clean.
- **TypeScript**: 9 `switchCliVersion` tests pass, including three new ones — the refusal, that a non-broken release still switches, and that a broken release already running is *not* refused.
- **Regression-proving**: with the guard removed, `refuses to switch to a broken release` fails with `Received promise resolved instead of rejected`. It spies `process.exit` for that reason: without the spy a regression runs the switch to completion and reaches `exit()`, ending the worker instead of failing the test.
- **End to end**: the table above, against the real registry with the built bundle and an isolated `PNPM_HOME`/store per case.

The test file now spreads the real `@pnpm/engine.pm.commands` into its mock rather than stubbing `assertReleaseIsInstallable`, so the list of broken releases stays in one place and these tests exercise it instead of a copy.

### Not in this PR

pnpm/pnpm#12960 fixes the underlying `buildLockfileFromEnvLockfile` peer-suffix bug that made the bad manifest fatal. It is worth merging on its own merit — it is what stops a *future* release with peer-carrying dependencies from crashing the same way — but it is orthogonal to this, which is about refusing releases already known to be broken. It currently conflicts with #13076.

## Squash Commit Body

```text
A project pinned to 11.12.0 through `packageManager` or
`devEngines.packageManager` still failed on every command with `Cannot use
'in' operator to search for 'integrity' in undefined`. That is the report in
pnpm/pnpm#12959, and it is the shape most people hit: the pin is committed,
so one bad pin breaks everyone who clones the repo.

pnpm/pnpm#13076 refuses these releases, but only in `self-update`. The
version switch is the other way in, and it reached the installer instead,
where a release whose manifest declares dependencies crashes resolving them.

Refuse the same releases there. The check sits after the "already this
version" early return, deliberately: switching *to* a broken release is
refused, but running one that is already installed is not — a developer
whose pnpm is a broken release still needs it to work well enough to move
off it.

11.13.0 is refused too, though it runs for the JS wrapper. The pin is shared
and the wrapper is not, so pinning it works for whoever wrote the pin and
breaks every teammate on `@pnpm/exe`, whose native is missing.

Closes pnpm/pnpm#12959.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.
  <!-- No user-facing surface changes: no new command, flag, or setting. -->

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786811492&installation_id=145934176&pr_number=13082&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13082&signature=70c417351428a49d4e00f496cb22b8b31a7b86dc85984e399d94f8cb2893303c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release version switching now detects broken pnpm releases before installation.
  - Displays an actionable error identifying the unavailable release.
  - Continues to support switching when the target release is valid or already running.

- **Tests**
  - Added coverage for broken, valid, and currently active pnpm releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->