### PR TITLE
fix(deps-resolver): prefer compatible optional peer contexts

### DIFF
--- a/.changeset/preferred-optional-peer-contexts.md
+++ b/.changeset/preferred-optional-peer-contexts.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed lockfile drift from reused optional peer contexts while preserving peer-dependent deduplication.

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -53,6 +53,7 @@ import {
   type DependenciesByProjectId,
   type GenericDependenciesGraphNodeWithResolvedChildren,
   type GenericDependenciesGraphWithResolvedChildren,
+  mergeCompatibleLockedOptionalPeerContexts,
   resolvePeers,
 } from './resolvePeers.js'
 import { toResolveImporter } from './toResolveImporter.js'
@@ -300,6 +301,11 @@ export async function resolveDependencies (
   } = treeHasLockedPeerContexts(dependenciesTree)
     ? await resolvePeers({
       ...peerResolutionOpts,
+      allowedTransitivePeerNamesByNodeId: getResolvedPeerNamesByNodeId(initiallyResolvedPeers),
+      preferredLockedOptionalPeerContexts: getPreferredLockedOptionalPeerContexts(
+        dependenciesTree,
+        initiallyResolvedPeers
+      ),
       resolvedPeerProviderPaths: initiallyResolvedPeers.pathsByNodeId,
     })
     : initiallyResolvedPeers
@@ -450,6 +456,76 @@ function treeHasLockedPeerContexts (dependenciesTree: DependenciesTree<ResolvedP
     if (node.lockedPeerContext != null) return true
   }
   return false
+}
+
+function getResolvedPeerNamesByNodeId (
+  resolvedPeers: Awaited<ReturnType<typeof resolvePeers>>
+): Map<NodeId, Set<string>> {
+  const peerNamesByKey = new Map<string, Set<string>>()
+  const peerNamesByNodeId = new Map<NodeId, Set<string>>()
+  for (const [nodeId, depPath] of resolvedPeers.pathsByNodeId.entries()) {
+    const peerNames = resolvedPeers.dependenciesGraph[depPath]?.resolvedPeerNames ?? new Set()
+    const key = [...peerNames].sort().join('\0')
+    let sharedPeerNames = peerNamesByKey.get(key)
+    if (sharedPeerNames == null) {
+      sharedPeerNames = new Set(peerNames)
+      peerNamesByKey.set(key, sharedPeerNames)
+    }
+    peerNamesByNodeId.set(nodeId, sharedPeerNames)
+  }
+  return peerNamesByNodeId
+}
+
+function getPreferredLockedOptionalPeerContexts (
+  dependenciesTree: DependenciesTree<ResolvedPackage>,
+  initiallyResolvedPeers: Awaited<ReturnType<typeof resolvePeers>>
+): Map<PkgIdWithPatchHash, Map<string, DepPath>> {
+  const freshPeerNamesByPkgId = new Map<PkgIdWithPatchHash, Set<string>>()
+  for (const [nodeId, depPath] of initiallyResolvedPeers.pathsByNodeId) {
+    const node = dependenciesTree.get(nodeId)
+    if (node == null) continue
+    const pkg = node.resolvedPackage as ResolvedPackage
+    let freshPeerNames = freshPeerNamesByPkgId.get(pkg.pkgIdWithPatchHash)
+    if (freshPeerNames == null) {
+      freshPeerNames = new Set()
+      freshPeerNamesByPkgId.set(pkg.pkgIdWithPatchHash, freshPeerNames)
+    }
+    for (const peerName of initiallyResolvedPeers.dependenciesGraph[depPath]?.resolvedPeerNames ?? []) {
+      freshPeerNames.add(peerName)
+    }
+  }
+  const candidatesByPkgId = new Map<PkgIdWithPatchHash, Map<string, Map<string, DepPath>>>()
+  for (const node of dependenciesTree.values()) {
+    if (node.lockedPeerContext == null) continue
+    const pkg = node.resolvedPackage as ResolvedPackage
+    const context = new Map<string, DepPath>()
+    for (const [peerName, peerDepPath] of Object.entries(node.lockedPeerContext)) {
+      if (pkg.peerDependencies[peerName]?.optional === true) {
+        context.set(peerName, peerDepPath)
+      }
+    }
+    if (context.size === 0) continue
+    const signature = [...context].sort(([peerName1], [peerName2]) => peerName1.localeCompare(peerName2))
+      .map(([peerName, peerDepPath]) => `${peerName}=${peerDepPath}`)
+      .join('\n')
+    let candidates = candidatesByPkgId.get(pkg.pkgIdWithPatchHash)
+    if (candidates == null) {
+      candidates = new Map()
+      candidatesByPkgId.set(pkg.pkgIdWithPatchHash, candidates)
+    }
+    candidates.set(signature, context)
+  }
+  const preferredContexts = new Map<PkgIdWithPatchHash, Map<string, DepPath>>()
+  for (const [pkgId, candidatesBySignature] of candidatesByPkgId.entries()) {
+    preferredContexts.set(
+      pkgId,
+      mergeCompatibleLockedOptionalPeerContexts(
+        candidatesBySignature.values(),
+        freshPeerNamesByPkgId.get(pkgId)
+      )
+    )
+  }
+  return preferredContexts
 }
 
 function addDirectDependenciesToLockfile (

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -302,10 +302,7 @@ export async function resolveDependencies (
     ? await resolvePeers({
       ...peerResolutionOpts,
       allowedTransitivePeerNamesByNodeId: getResolvedPeerNamesByNodeId(initiallyResolvedPeers),
-      preferredLockedOptionalPeerContexts: getPreferredLockedOptionalPeerContexts(
-        dependenciesTree,
-        initiallyResolvedPeers
-      ),
+      preferredLockedOptionalPeerContexts: getPreferredLockedOptionalPeerContexts(dependenciesTree, initiallyResolvedPeers),
       resolvedPeerProviderPaths: initiallyResolvedPeers.pathsByNodeId,
     })
     : initiallyResolvedPeers

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -84,6 +84,28 @@ export interface ProjectToResolve {
 
 export type DependenciesByProjectId = Record<string, Map<string, DepPath>>
 
+export function mergeCompatibleLockedOptionalPeerContexts (
+  contexts: Iterable<Map<string, DepPath>>,
+  supportedPeerNames?: Set<string>
+): Map<string, DepPath> {
+  const merged = new Map<string, DepPath>()
+  const conflicts = new Set<string>()
+  for (const context of contexts) {
+    for (const [peerName, peerDepPath] of context) {
+      if (supportedPeerNames != null && !supportedPeerNames.has(peerName)) continue
+      if (conflicts.has(peerName)) continue
+      const currentPeerDepPath = merged.get(peerName)
+      if (currentPeerDepPath == null || currentPeerDepPath === peerDepPath) {
+        merged.set(peerName, peerDepPath)
+      } else {
+        merged.delete(peerName)
+        conflicts.add(peerName)
+      }
+    }
+  }
+  return merged
+}
+
 export async function resolvePeers<T extends PartialResolvedPackage> (
   opts: {
     allPeerDepNames: Set<string>
@@ -99,6 +121,8 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     resolvedImporters: ResolvedImporters
     peersSuffixMaxLength: number
     workspaceProjectIds: Set<string>
+    allowedTransitivePeerNamesByNodeId?: Map<NodeId, Set<string>>
+    preferredLockedOptionalPeerContexts?: Map<PkgIdWithPatchHash, Map<string, DepPath>>
     resolvedPeerProviderPaths?: Map<NodeId, DepPath>
   }
 ): Promise<{
@@ -127,6 +151,7 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
   const finishingList: FinishingResolutionPromise[] = []
   const peersCache = new Map<PkgIdWithPatchHash, PeersCacheItem[]>()
   const purePkgs = new Set<PkgIdWithPatchHash>()
+  const purePkgContexts = new Map<PkgIdWithPatchHash, Set<Set<string>>>()
   for (const { directNodeIdsByAlias, hoistedPeerProviderNodeIds, declaredDirectDependencies, explicitlyRequestedDirectDependencies, topParents, rootDir, id } of opts.projects) {
     const currentProviderSources: CurrentProviderSource[] = [{
       directNodeIdsByAlias,
@@ -182,11 +207,14 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       cycleBrokenNodeIds,
       depPathsByPkgId,
       nodeIdsByPreviousDepPath,
+      allowedTransitivePeerNamesByNodeId: opts.allowedTransitivePeerNamesByNodeId,
+      preferredLockedOptionalPeerContexts: opts.preferredLockedOptionalPeerContexts,
       resolvedPeerProviderPaths: opts.resolvedPeerProviderPaths,
       currentProviderSources,
       peersCache,
       peerDependencyIssues,
       purePkgs,
+      purePkgContexts,
       dedupePeers: opts.dedupePeers,
       peersSuffixMaxLength: opts.peersSuffixMaxLength,
       rootDir,
@@ -469,7 +497,9 @@ interface MissingPeerInfo {
 type MissingPeers = Map<string, MissingPeerInfo>
 
 interface PeersCacheItem {
+  allowedTransitivePeerNames?: Set<string>
   depPath: DeferredPromise<DepPath>
+  propagatedResolvedPeers?: Map<string, NodeId>
   resolvedPeers: Map<string, NodeId>
   missingPeers: MissingPeers
   // The node whose resolution created this entry and will resolve depPath.
@@ -485,6 +515,7 @@ interface PeersResolution {
 }
 
 interface ResolvePeersContext {
+  allowedTransitivePeerNamesByNodeId?: Map<NodeId, Set<string>>
   pathsByNodeId: Map<NodeId, DepPath>
   pathsByNodeIdPromises: Map<NodeId, DeferredPromise<DepPath>>
   // The await edges between dep path calculations, consumed by
@@ -496,6 +527,8 @@ interface ResolvePeersContext {
   cycleBrokenNodeIds: Set<NodeId>
   depPathsByPkgId?: Map<PkgIdWithPatchHash, Set<DepPath>>
   nodeIdsByPreviousDepPath: Map<DepPath, NodeId>
+  purePkgContexts: Map<PkgIdWithPatchHash, Set<Set<string>>>
+  preferredLockedOptionalPeerContexts?: Map<PkgIdWithPatchHash, Map<string, DepPath>>
   resolvedPeerProviderPaths?: Map<NodeId, DepPath>
   currentProviderSources: CurrentProviderSource[]
 }
@@ -534,6 +567,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     peerDependencyIssues: Pick<PeerDependencyIssues, 'bad' | 'missing'>
     peersCache: PeersCache
     purePkgs: Set<PkgIdWithPatchHash> // pure packages are those that don't rely on externally resolved peers
+    purePkgContexts: Map<PkgIdWithPatchHash, Set<Set<string>>>
     dedupePeers?: boolean
     rootDir: ProjectRootDir
     lockfileDir: string
@@ -541,16 +575,28 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   }
 ): Promise<PeersResolution & { finishing?: FinishingResolutionPromise, calculateDepPath?: CalculateDepPath }> {
   const node = ctx.dependenciesTree.get(nodeId)!
-  if (node.depth === -1) return { resolvedPeers: new Map<string, NodeId>(), missingPeers: new Map<string, MissingPeerInfo>() }
+  if (node.depth === -1) {
+    return {
+      resolvedPeers: new Map<string, NodeId>(),
+      missingPeers: new Map<string, MissingPeerInfo>(),
+    }
+  }
   const resolvedPackage = node.resolvedPackage as T
+  const allowedTransitivePeerNames = ctx.allowedTransitivePeerNamesByNodeId?.get(nodeId)
+  const isKnownPure = allowedTransitivePeerNames == null
+    ? ctx.purePkgs.has(resolvedPackage.pkgIdWithPatchHash)
+    : ctx.purePkgContexts.get(resolvedPackage.pkgIdWithPatchHash)?.has(allowedTransitivePeerNames) === true
   if (
-    ctx.purePkgs.has(resolvedPackage.pkgIdWithPatchHash) &&
+    isKnownPure &&
     ctx.depGraph[resolvedPackage.pkgIdWithPatchHash as unknown as DepPath].depth <= node.depth &&
     Object.keys(resolvedPackage.peerDependencies).length === 0
   ) {
     ctx.pathsByNodeId.set(nodeId, resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
     ctx.pathsByNodeIdPromises.get(nodeId)!.resolve(resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
-    return { resolvedPeers: new Map<string, NodeId>(), missingPeers: new Map<string, MissingPeerInfo>() }
+    return {
+      resolvedPeers: new Map<string, NodeId>(),
+      missingPeers: new Map<string, MissingPeerInfo>(),
+    }
   }
   if (typeof node.children === 'function') {
     node.children = node.children()
@@ -610,6 +656,10 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       const currentPeerDepPath = ctx.pathsByNodeId.get(peerNodeId)
       if (currentPeerDepPath != null && currentPeerDepPath !== previousPeerDepPath) continue
       if (hasCurrentPeerProviderThatMustWin(peerName, parentPkgs, ctx)) continue
+      if (peerDependency.optional === true && parentPkgs[peerName] == null) {
+        const preferredContext = ctx.preferredLockedOptionalPeerContexts?.get(resolvedPackage.pkgIdWithPatchHash)
+        if (preferredContext != null && preferredContext.get(peerName) !== previousPeerDepPath) continue
+      }
       const lockedPeer = toPkgByName([{
         alias: peerName,
         node: ctx.dependenciesTree.get(peerNodeId)!,
@@ -633,7 +683,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       parentPkgs[peerName] = lockedPeer
     }
   }
-  const hit = findHit(ctx, parentPkgs, resolvedPackage.pkgIdWithPatchHash)
+  const hit = findHit(ctx, parentPkgs, resolvedPackage.pkgIdWithPatchHash, nodeId)
   if (hit != null) {
     for (const [peerName, { range: wantedRange, optional }] of hit.missingPeers.entries()) {
       if (ctx.peerDependencyIssues.missing[peerName] == null) {
@@ -658,7 +708,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
         ctx.depGraph[depPath].depth = Math.min(ctx.depGraph[depPath].depth, node.depth)
         ctx.pathsByNodeIdPromises.get(nodeId)!.resolve(depPath)
       })(),
-      resolvedPeers: hit.resolvedPeers,
+      resolvedPeers: hit.propagatedResolvedPeers ?? hit.resolvedPeers,
     }
   }
 
@@ -686,11 +736,27 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       parentNodeIds,
     })
 
-  const allResolvedPeers = unknownResolvedPeersOfChildren
-  for (const [k, v] of resolvedPeers) {
-    allResolvedPeers.set(k, v)
+  const propagatedResolvedPeers = unknownResolvedPeersOfChildren
+  const allResolvedPeers = allowedTransitivePeerNames == null
+    ? propagatedResolvedPeers
+    : new Map(propagatedResolvedPeers)
+  const filteredTransitivePeerNames = new Set<string>()
+  if (allowedTransitivePeerNames != null) {
+    for (const peerName of allResolvedPeers.keys()) {
+      if (!allowedTransitivePeerNames.has(peerName)) {
+        allResolvedPeers.delete(peerName)
+        filteredTransitivePeerNames.add(peerName)
+      }
+    }
   }
+  for (const [k, v] of resolvedPeers) {
+    propagatedResolvedPeers.set(k, v)
+    allResolvedPeers.set(k, v)
+    filteredTransitivePeerNames.delete(k)
+  }
+  propagatedResolvedPeers.delete(node.resolvedPackage.name)
   allResolvedPeers.delete(node.resolvedPackage.name)
+  filteredTransitivePeerNames.delete(node.resolvedPackage.name)
 
   const allMissingPeers = new Map<string, MissingPeerInfo>()
   for (const [peer, range] of missingPeersOfChildren.entries()) {
@@ -701,7 +767,10 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   }
 
   let cache: PeersCacheItem
-  const isPure = allResolvedPeers.size === 0 && allMissingPeers.size === 0
+  const isPure =
+    allResolvedPeers.size === 0 &&
+    allMissingPeers.size === 0 &&
+    filteredTransitivePeerNames.size === 0
   // A cycle re-entry resolves against truncated children (the cycle is broken by
   // dropping the repeated package's subtree), so its empty/partial peer sets are
   // not authoritative for the package as a whole. Recording that verdict — as
@@ -713,11 +782,24 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     // Leave both caches untouched so later occurrences re-resolve (or hit the
     // authoritative entry of the same package) instead of reusing this partial one.
   } else if (isPure) {
-    ctx.purePkgs.add(resolvedPackage.pkgIdWithPatchHash)
+    if (allowedTransitivePeerNames == null) {
+      ctx.purePkgs.add(resolvedPackage.pkgIdWithPatchHash)
+    } else {
+      let contexts = ctx.purePkgContexts.get(resolvedPackage.pkgIdWithPatchHash)
+      if (contexts == null) {
+        contexts = new Set()
+        ctx.purePkgContexts.set(resolvedPackage.pkgIdWithPatchHash, contexts)
+      }
+      contexts.add(allowedTransitivePeerNames)
+    }
   } else {
     cache = {
+      allowedTransitivePeerNames,
       missingPeers: allMissingPeers,
       depPath: pDefer(),
+      propagatedResolvedPeers: filteredTransitivePeerNames.size === 0
+        ? undefined
+        : propagatedResolvedPeers,
       resolvedPeers: allResolvedPeers,
       ownerNodeId: nodeId,
     }
@@ -751,7 +833,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   }
 
   return {
-    resolvedPeers: allResolvedPeers,
+    resolvedPeers: propagatedResolvedPeers,
     missingPeers: allMissingPeers,
     calculateDepPath: calculateDepPathIfNeeded,
     finishing,
@@ -832,6 +914,11 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       for (const unknownPeer of missingPeersOfChildren.keys()) {
         if (!peerDependencies[unknownPeer]) {
           transitivePeerDependencies.add(unknownPeer)
+        }
+      }
+      for (const peerName of filteredTransitivePeerNames) {
+        if (!peerDependencies[peerName]) {
+          transitivePeerDependencies.add(peerName)
         }
       }
       ctx.depGraph[depPath] = {
@@ -984,15 +1071,17 @@ function parentPeerDiffers<T extends PartialResolvedPackage> (
 }
 
 function findHit<T extends PartialResolvedPackage> (ctx: {
+  allowedTransitivePeerNamesByNodeId?: Map<NodeId, Set<string>>
   parentPkgsOfNode: ParentPkgsOfNode
   peersCache: PeersCache
   purePkgs: Set<PkgIdWithPatchHash>
   pathsByNodeId: Map<NodeId, DepPath>
   dependenciesTree: DependenciesTree<T>
-}, parentPkgs: ParentRefs, pkgIdWithPatchHash: PkgIdWithPatchHash) {
+}, parentPkgs: ParentRefs, pkgIdWithPatchHash: PkgIdWithPatchHash, nodeId: NodeId) {
   const cacheItems = ctx.peersCache.get(pkgIdWithPatchHash)
   if (!cacheItems) return undefined
   return cacheItems.find((cache) => {
+    if (cache.allowedTransitivePeerNames !== ctx.allowedTransitivePeerNamesByNodeId?.get(nodeId)) return false
     for (const [name, cachedNodeId] of cache.resolvedPeers) {
       const parentPkgNodeId = parentPkgs[name]?.nodeId
       if (Boolean(parentPkgNodeId) !== Boolean(cachedNodeId)) return false
@@ -1207,7 +1296,11 @@ async function resolvePeersOfChildren<T extends PartialResolvedPackage> (
     }
   }
 
-  return { resolvedPeers: unknownResolvedPeersOfChildren, missingPeers: allMissingPeers, finishing }
+  return {
+    resolvedPeers: unknownResolvedPeersOfChildren,
+    missingPeers: allMissingPeers,
+    finishing,
+  }
 }
 
 function _resolvePeers<T extends PartialResolvedPackage> (

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -575,12 +575,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   }
 ): Promise<PeersResolution & { finishing?: FinishingResolutionPromise, calculateDepPath?: CalculateDepPath }> {
   const node = ctx.dependenciesTree.get(nodeId)!
-  if (node.depth === -1) {
-    return {
-      resolvedPeers: new Map<string, NodeId>(),
-      missingPeers: new Map<string, MissingPeerInfo>(),
-    }
-  }
+  if (node.depth === -1) return { resolvedPeers: new Map<string, NodeId>(), missingPeers: new Map<string, MissingPeerInfo>() }
   const resolvedPackage = node.resolvedPackage as T
   const allowedTransitivePeerNames = ctx.allowedTransitivePeerNamesByNodeId?.get(nodeId)
   const isKnownPure = allowedTransitivePeerNames == null
@@ -593,10 +588,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
   ) {
     ctx.pathsByNodeId.set(nodeId, resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
     ctx.pathsByNodeIdPromises.get(nodeId)!.resolve(resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
-    return {
-      resolvedPeers: new Map<string, NodeId>(),
-      missingPeers: new Map<string, MissingPeerInfo>(),
-    }
+    return { resolvedPeers: new Map<string, NodeId>(), missingPeers: new Map<string, MissingPeerInfo>() }
   }
   if (typeof node.children === 'function') {
     node.children = node.children()
@@ -1296,11 +1288,7 @@ async function resolvePeersOfChildren<T extends PartialResolvedPackage> (
     }
   }
 
-  return {
-    resolvedPeers: unknownResolvedPeersOfChildren,
-    missingPeers: allMissingPeers,
-    finishing,
-  }
+  return { resolvedPeers: unknownResolvedPeersOfChildren, missingPeers: allMissingPeers, finishing }
 }
 
 function _resolvePeers<T extends PartialResolvedPackage> (

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -10,11 +10,7 @@ import type {
 
 import type { NodeId } from '../lib/nextNodeId.js'
 import type { ChildrenMap, DependenciesTreeNode, PeerDependencies } from '../lib/resolveDependencies.js'
-import {
-  mergeCompatibleLockedOptionalPeerContexts,
-  type PartialResolvedPackage,
-  resolvePeers,
-} from '../lib/resolvePeers.js'
+import { mergeCompatibleLockedOptionalPeerContexts, type PartialResolvedPackage, resolvePeers } from '../lib/resolvePeers.js'
 
 test('resolve peer dependencies of cyclic dependencies', async () => {
   const fooPkg = {

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -10,7 +10,11 @@ import type {
 
 import type { NodeId } from '../lib/nextNodeId.js'
 import type { ChildrenMap, DependenciesTreeNode, PeerDependencies } from '../lib/resolveDependencies.js'
-import { type PartialResolvedPackage, resolvePeers } from '../lib/resolvePeers.js'
+import {
+  mergeCompatibleLockedOptionalPeerContexts,
+  type PartialResolvedPackage,
+  resolvePeers,
+} from '../lib/resolvePeers.js'
 
 test('resolve peer dependencies of cyclic dependencies', async () => {
   const fooPkg = {
@@ -1111,6 +1115,307 @@ describe('locked peer provider preferences', () => {
 
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+})
+
+describe('filtering reuse-only transitive peers', () => {
+  test('merges disjoint optional peer contexts and removes only conflicting providers', () => {
+    expect(mergeCompatibleLockedOptionalPeerContexts([
+      new Map([
+        ['peer-p', 'peer-p/1.0.0' as DepPath],
+        ['peer-r', 'peer-r/1.0.0' as DepPath],
+      ]),
+      new Map([
+        ['peer-q', 'peer-q/1.0.0' as DepPath],
+        ['peer-r', 'peer-r/2.0.0' as DepPath],
+      ]),
+    ], new Set(['peer-p', 'peer-q', 'peer-r']))).toStrictEqual(new Map([
+      ['peer-p', 'peer-p/1.0.0'],
+      ['peer-q', 'peer-q/1.0.0'],
+    ]))
+  })
+
+  test('does not retain a locked optional peer that no occurrence resolved freshly', () => {
+    expect(mergeCompatibleLockedOptionalPeerContexts([
+      new Map([['peer', 'peer/1.0.0' as DepPath]]),
+    ], new Set())).toStrictEqual(new Map())
+  })
+
+  const pkg = (name: string, peerDependencies: PeerDependencies = {}) => ({
+    name,
+    pkgIdWithPatchHash: `${name}/1.0.0` as PkgIdWithPatchHash,
+    version: '1.0.0',
+    peerDependencies,
+    id: '' as PkgResolutionId,
+  })
+
+  const options = (
+    dependenciesTree: Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>,
+    directNodeIdsByAlias: Map<string, NodeId>,
+    allPeerDepNames: string[]
+  ) => ({
+    allPeerDepNames: new Set(allPeerDepNames),
+    dedupePeerDependents: true,
+    projects: [{
+      directNodeIdsByAlias,
+      topParents: [],
+      rootDir: '' as ProjectRootDir,
+      id: '',
+    }],
+    resolvedImporters: {},
+    dependenciesTree,
+    virtualStoreDir: '',
+    virtualStoreDirMaxLength: 120,
+    lockfileDir: '',
+    peersSuffixMaxLength: 1000,
+    workspaceProjectIds: new Set<string>(),
+  })
+
+  function resolvedPeerNamesByNodeId (
+    result: Awaited<ReturnType<typeof resolvePeers>>
+  ): Map<NodeId, Set<string>> {
+    const peerNamesByKey = new Map<string, Set<string>>()
+    const resultByNodeId = new Map<NodeId, Set<string>>()
+    for (const [nodeId, depPath] of result.pathsByNodeId) {
+      const peerNames = result.dependenciesGraph[depPath]?.resolvedPeerNames ?? new Set()
+      const key = [...peerNames].sort().join('\0')
+      let sharedPeerNames = peerNamesByKey.get(key)
+      if (sharedPeerNames == null) {
+        sharedPeerNames = new Set(peerNames)
+        peerNamesByKey.set(key, sharedPeerNames)
+      }
+      resultByNodeId.set(nodeId, sharedPeerNames)
+    }
+    return resultByNodeId
+  }
+
+  test('keeps a locked peer on its dependent without bubbling it to ancestors', async () => {
+    const retainerNodeId = '>retainer/1.0.0>' as NodeId
+    const peerNodeId = '>retainer/1.0.0>peer/1.0.0>' as NodeId
+    const wrapperNodeId = '>wrapper/1.0.0>' as NodeId
+    const consumerNodeId = '>wrapper/1.0.0>consumer/1.0.0>' as NodeId
+    const depNodeId = '>wrapper/1.0.0>consumer/1.0.0>dep/1.0.0>' as NodeId
+    const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [retainerNodeId, {
+        children: { peer: peerNodeId },
+        installable: true,
+        resolvedPackage: pkg('retainer'),
+        depth: 0,
+      }],
+      [peerNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer/1.0.0' as DepPath,
+        resolvedPackage: pkg('peer'),
+        depth: 1,
+      }],
+      [wrapperNodeId, {
+        children: { consumer: consumerNodeId },
+        installable: true,
+        resolvedPackage: pkg('wrapper'),
+        depth: 0,
+      }],
+      [consumerNodeId, {
+        children: { dep: depNodeId },
+        installable: true,
+        resolvedPackage: pkg('consumer'),
+        depth: 1,
+      }],
+      [depNodeId, {
+        children: {},
+        installable: true,
+        lockedPeerContext: { peer: 'peer/1.0.0' as DepPath },
+        resolvedPackage: pkg('dep', {
+          peer: { version: '1.0.0', optional: true },
+        }),
+        depth: 2,
+      }],
+    ])
+    const resolutionOpts = options(dependenciesTree, new Map([
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]), ['peer'])
+    const initial = await resolvePeers(resolutionOpts)
+    const filtered = await resolvePeers({
+      ...resolutionOpts,
+      allowedTransitivePeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+      preferredLockedOptionalPeerContexts: new Map([
+        ['dep/1.0.0' as PkgIdWithPatchHash, new Map([['peer', 'peer/1.0.0' as DepPath]])],
+      ]),
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+
+    const wrapperDepPath = filtered.dependenciesByProjectId[''].get('wrapper')!
+    const consumerDepPath = filtered.dependenciesGraph[wrapperDepPath].children.consumer
+    expect(wrapperDepPath).toBe('wrapper/1.0.0')
+    expect(consumerDepPath).toBe('consumer/1.0.0')
+    expect(filtered.dependenciesGraph[consumerDepPath].children.dep).toBe('dep/1.0.0(peer/1.0.0)')
+    expect(filtered.dependenciesGraph[wrapperDepPath].transitivePeerDependencies).toStrictEqual(new Set(['peer']))
+  })
+
+  test('keeps a locked union context available to dedupePeerDependents', async () => {
+    const wrapperANodeId = '>wrapper-a/1.0.0>' as NodeId
+    const consumerANodeId = '>wrapper-a/1.0.0>consumer/1.0.0>' as NodeId
+    const peerQNodeId = '>wrapper-a/1.0.0>peer-q/1.0.0>' as NodeId
+    const wrapperBNodeId = '>wrapper-b/1.0.0>' as NodeId
+    const consumerBNodeId = '>wrapper-b/1.0.0>consumer/1.0.0>' as NodeId
+    const peerPNodeId = '>wrapper-b/1.0.0>peer-p/1.0.0>' as NodeId
+    const consumerPkg = pkg('consumer', {
+      'peer-p': { version: '1.0.0', optional: true },
+      'peer-q': { version: '1.0.0', optional: true },
+    })
+    const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [wrapperANodeId, {
+        children: { consumer: consumerANodeId, 'peer-q': peerQNodeId },
+        installable: true,
+        resolvedPackage: pkg('wrapper-a'),
+        depth: 0,
+      }],
+      [consumerANodeId, {
+        children: {},
+        installable: true,
+        lockedPeerContext: {
+          'peer-p': 'peer-p/1.0.0' as DepPath,
+          'peer-q': 'peer-q/1.0.0' as DepPath,
+        },
+        resolvedPackage: consumerPkg,
+        depth: 1,
+      }],
+      [peerQNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer-q/1.0.0' as DepPath,
+        resolvedPackage: pkg('peer-q'),
+        depth: 1,
+      }],
+      [wrapperBNodeId, {
+        children: { consumer: consumerBNodeId, 'peer-p': peerPNodeId },
+        installable: true,
+        resolvedPackage: pkg('wrapper-b'),
+        depth: 0,
+      }],
+      [consumerBNodeId, {
+        children: {},
+        installable: true,
+        resolvedPackage: consumerPkg,
+        depth: 1,
+      }],
+      [peerPNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer-p/1.0.0' as DepPath,
+        resolvedPackage: pkg('peer-p'),
+        depth: 1,
+      }],
+    ])
+    const resolutionOpts = options(dependenciesTree, new Map([
+      ['wrapper-a', wrapperANodeId],
+      ['wrapper-b', wrapperBNodeId],
+    ]), ['peer-p', 'peer-q'])
+    const initial = await resolvePeers(resolutionOpts)
+    const filtered = await resolvePeers({
+      ...resolutionOpts,
+      allowedTransitivePeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+      preferredLockedOptionalPeerContexts: new Map([
+        ['consumer/1.0.0' as PkgIdWithPatchHash, new Map([
+          ['peer-p', 'peer-p/1.0.0' as DepPath],
+          ['peer-q', 'peer-q/1.0.0' as DepPath],
+        ])],
+      ]),
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+    const unionDepPath = 'consumer/1.0.0(peer-p/1.0.0)(peer-q/1.0.0)' as DepPath
+    const wrapperADepPath = filtered.dependenciesByProjectId[''].get('wrapper-a')!
+    const wrapperBDepPath = filtered.dependenciesByProjectId[''].get('wrapper-b')!
+    expect(filtered.dependenciesGraph[wrapperADepPath].children.consumer).toBe(unionDepPath)
+    expect(filtered.dependenciesGraph[wrapperBDepPath].children.consumer).toBe(unionDepPath)
+  })
+
+  test('skips conflicting locked optional providers', async () => {
+    const retainerPNodeId = '>retainer-p>' as NodeId
+    const retainerQNodeId = '>retainer-q>' as NodeId
+    const peerPNodeId = '>retainer-p>peer-p>' as NodeId
+    const peerQNodeId = '>retainer-q>peer-q>' as NodeId
+    const wrapperANodeId = '>wrapper-a>' as NodeId
+    const wrapperBNodeId = '>wrapper-b>' as NodeId
+    const consumerANodeId = '>wrapper-a>consumer>' as NodeId
+    const consumerBNodeId = '>wrapper-b>consumer>' as NodeId
+    const consumerPkg = pkg('consumer', {
+      peer: { version: '>=1.0.0', optional: true },
+    })
+    const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [retainerPNodeId, {
+        children: { 'peer-p': peerPNodeId },
+        installable: true,
+        resolvedPackage: pkg('retainer-p'),
+        depth: 0,
+      }],
+      [retainerQNodeId, {
+        children: { 'peer-q': peerQNodeId },
+        installable: true,
+        resolvedPackage: pkg('retainer-q'),
+        depth: 0,
+      }],
+      [peerPNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer-p/1.0.0' as DepPath,
+        resolvedPackage: pkg('peer-p'),
+        depth: 1,
+      }],
+      [peerQNodeId, {
+        children: {},
+        installable: true,
+        previousDepPath: 'peer-q/1.0.0' as DepPath,
+        resolvedPackage: pkg('peer-q'),
+        depth: 1,
+      }],
+      [wrapperANodeId, {
+        children: { consumer: consumerANodeId },
+        installable: true,
+        resolvedPackage: pkg('wrapper-a'),
+        depth: 0,
+      }],
+      [wrapperBNodeId, {
+        children: { consumer: consumerBNodeId },
+        installable: true,
+        resolvedPackage: pkg('wrapper-b'),
+        depth: 0,
+      }],
+      [consumerANodeId, {
+        children: {},
+        installable: true,
+        lockedPeerContext: { peer: 'peer-p/1.0.0' as DepPath },
+        resolvedPackage: consumerPkg,
+        depth: 1,
+      }],
+      [consumerBNodeId, {
+        children: {},
+        installable: true,
+        lockedPeerContext: { peer: 'peer-q/1.0.0' as DepPath },
+        resolvedPackage: consumerPkg,
+        depth: 1,
+      }],
+    ])
+    const resolutionOpts = options(dependenciesTree, new Map([
+      ['retainer-p', retainerPNodeId],
+      ['retainer-q', retainerQNodeId],
+      ['wrapper-a', wrapperANodeId],
+      ['wrapper-b', wrapperBNodeId],
+    ]), ['peer-p', 'peer-q'])
+    const initial = await resolvePeers(resolutionOpts)
+    const filtered = await resolvePeers({
+      ...resolutionOpts,
+      allowedTransitivePeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+      preferredLockedOptionalPeerContexts: new Map([
+        ['consumer/1.0.0' as PkgIdWithPatchHash, new Map()],
+      ]),
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+    const wrapperAPath = filtered.dependenciesByProjectId[''].get('wrapper-a')!
+    const wrapperBPath = filtered.dependenciesByProjectId[''].get('wrapper-b')!
+    expect(filtered.dependenciesGraph[wrapperAPath].children.consumer).toBe('consumer/1.0.0')
+    expect(filtered.dependenciesGraph[wrapperBPath].children.consumer).toBe('consumer/1.0.0')
   })
 })
 


### PR DESCRIPTION
**Closed in favor of #13109**

<!-- A maintainer will only start reviewing once the automated code reviewers (CodeRabbit and Qodo) have approved and CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Alternative fix for [pnpm/pnpm#12756](https://github.com/pnpm/pnpm/issues/12756).

A writable `pnpm install` can reuse an optional peer provider recorded in the lockfile even when that provider is no longer visible from the package's current ancestor scope. The peer then bubbles through transitive parents, adding peer suffixes that a fresh resolution and `pnpm dedupe` do not produce.

This PR keeps the existing two peer-resolution passes. It does not short-circuit every optional locked peer, add a third resolution pass, or rewrite the completed graph afterward.

### How it works

The first peer-resolution pass provides two small oracles for the existing locked-context pass:

1. **Fresh peer names per node.** The resolved peer names for each node are interned into shared `Set` instances. During the locked-context pass, child-propagated peers absent from that node's fresh set are excluded from that node's depPath.
2. **Compatible optional locked contexts per package identity.** For each `pkgIdWithPatchHash`, pnpm collects optional peer providers recorded by the lockfile. It retains only:
   - peer names resolved freshly by at least one occurrence of the package;
   - provider depPaths that do not conflict across occurrences.

The locked-context pass then behaves as follows:

- A required peer is unchanged.
- A currently visible optional peer is unchanged.
- A lateral optional locked peer is reused only when it matches the package's compatible preferred context.
- A package's own peers are added after transitive filtering, so they remain available to `dedupePeerDependents`.
- The unfiltered resolved-peer map still propagates upward. Every ancestor applies its own fresh-peer filter, while the filtered peer name remains in `transitivePeerDependencies`.

The peer and pure-package caches are keyed by the interned fresh-peer `Set` identity, so equal contexts remain reusable without mixing different filter contexts.

### Why this preserves deduplication

Zoltan's concern on [pnpm/pnpm#12830](https://github.com/pnpm/pnpm/pull/12830#pullrequestreview-4658728214) is real.

The reproduction at [astegmaier/playground-pnpm-dedupe-short-circuiting](https://github.com/astegmaier/playground-pnpm-dedupe-short-circuiting) has a package with optional peers `peer-p` and `peer-q`:

- one fresh occurrence resolves only `peer-p`;
- another resolves only `peer-q`;
- a retained lockfile context resolves both.

The retained `(peer-p)(peer-q)` context is a compatible superset, so `dedupePeerDependents` can collapse the two occurrences to one instance. PR #12830 skips the lateral `peer-p` binding before that union exists and leaves two instances.

This PR retains the conflict-free `peer-p` + `peer-q` locked context because both names are supported by fresh occurrences. The package's own union context is therefore created and deduplicated, but neither peer is allowed to bubble onto an ancestor that did not resolve it freshly.

### Conflicting and stale contexts

The preferred context is a conflict-free union, not an arbitrary observed candidate:

- `{peer-p: p1}` and `{peer-q: q1}` retain both entries.
- `{peer: p1}` and `{peer: p2}` retain neither entry because the providers conflict.
- A locked optional peer that no occurrence resolved freshly is omitted as stale.

Each node can still pin only entries present in its own `lockedPeerContext`; the union is a consistency filter and never invents a provider for a node.

## Comparison of all four approaches

All comparisons below use each implementation rebased or cherry-picked onto current `main` at `f15d67c418`.

| Approach | Core strategy | Source diff | Original repro | Dedupe counterexample | Large monorepo at Microsoft |
| --- | --- | ---: | --- | --- | --- |
| [#12830](https://github.com/pnpm/pnpm/pull/12830) | Skip an optional lateral peer before resolution | +10 | Pass | **Fails:** 2 instances | Pass |
| [#12998](https://github.com/pnpm/pnpm/pull/12998) | Propagate, dedupe, then rewrite cleaned graph; exact-child collision guard | +275 | Pass | Pass | **Fails:** +242/−214 lockfile lines |
| [#13069](https://github.com/pnpm/pnpm/pull/13069) | #12998 plus compatible-superset collision merging and deterministic fresh-child preference | +332 | Pass | Pass | Pass: only 6 intended deletions |
| This PR | Filter propagation during the existing second pass; retain compatible locked contexts | +162/−8 | Pass | Pass | Pass: only 6 intended deletions |

Source size counts only `src/index.ts` and `src/resolvePeers.ts`; test additions are excluded.

### Correctness

- **#12830** fixes the reported drift with the smallest change, but its early short-circuit demonstrably loses a valid `dedupePeerDependents` opportunity.
- **#12998** preserves dedupe opportunities and has the right propagate → dedupe → clean model, but its global exact-child collision guard aborts cleanup on benign collisions in the large monorepo.
- **#13069** fixes #12998's collision handling and is the most conservative general graph-rewrite solution. It passes every known reproduction.
- **This PR** passes the same known reproductions without post-processing depPaths. It explicitly rejects conflicting providers and stale peer names before they can create ambiguous filtered contexts.

### Simplicity

- **#12830** remains by far the simplest implementation.
- **This PR** is larger because safe filtering needs a fresh-peer oracle, compatible-context selection, and context-aware caches, but it is approximately 51% smaller than #13069 in production source lines.
- **#12998/#13069** duplicate parts of depPath construction and rebuild several graph indexes after resolution. This PR leaves depPath construction and graph indexing in the normal resolver path.

### Speed and memory

Benchmark setup:

- large monorepo at Microsoft;
- removed the same workspace dependency from two manifests;
- restored the committed `pnpm-lock.yaml` before each run;
- command: `install --lockfile-only --prefer-offline --ignore-scripts`;
- all implementations built from current `main`;
- three interleaved runs per implementation.

| Approach | Runs (seconds) | Median | Median max RSS | Lockfile result |
| --- | --- | ---: | ---: | --- |
| #12830 | 27.47, 24.79, 23.71 | 24.79 s | 4.42 GiB | 6 intended deletions |
| #12998 | 25.63, 24.50, 22.82 | 24.50 s | 4.65 GiB | +242/−214 lines |
| #13069 | 26.77, 24.66, 17.35 | 24.66 s | 4.60 GiB | 6 intended deletions |
| This PR | 26.74, 24.24, 15.23 | 24.24 s | 4.41 GiB | 6 intended deletions |

The wall-time spread is dominated by shared cache and external I/O variance; the medians differ by less than 3%. There is no measurable slowdown from this approach, and it has the lowest measured median time and RSS in this sample.

## Validation

- Full `@pnpm/installing.deps-resolver` suite: 15 suites, 141 tests passed.
- The original minimal reproduction produces byte-identical `pnpm install` and `pnpm dedupe` lockfiles.
- The published `dedupePeerDependents` reproduction retains one `(peer-p)(peer-q)` union instance.
- The large-monorepo edit produces only the six intended importer deletions with zero peer-suffix churn.
- Three repeated large-monorepo runs completed with the default Node heap.
- The pnpm bundle and pre-push compile/lint checks pass.

## Rust parity

No Rust change is included. The regression depends on the TypeScript resolver's two-pass locked-context reuse path. The equivalent pacquet run did not reproduce the optional-peer propagation.

## Squash Commit Body

```text
Fix lockfile drift caused by optional peers reused from unrelated subtrees.

Use the fresh peer-resolution pass as an oracle for the existing locked-context
pass. Reuse only conflict-free optional peer providers supported by a fresh
occurrence of the same package. Filter child-propagated peer names from each
node's depPath when that node did not resolve the peer freshly, while retaining
the full propagated set for ancestor metadata.

Keep a package's own locked peers available to dedupePeerDependents, preserving
compatible union contexts that an early short-circuit would lose.

Fixes pnpm/pnpm#12756.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. No documentation change is needed for this internal lockfile-correctness fix.

---
Written by an agent (GitHub Copilot CLI, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786818444&installation_id=145934176&pr_number=13083&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13083&signature=82da1383d5c27a0e55194874de2105720e4f11eeb02b35563e352fa46db94799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

