### PR TITLE
test(cli): correct the stale frozen-gate comment in lockfile_only

### DIFF
--- a/pnpm/crates/cli/tests/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/lockfile_only.rs
@@ -293,11 +293,12 @@ fn lockfile_only_updates_importers_when_a_project_is_added() {
 
     // Add a second project, re-run lockfile-only, and confirm both
     // importers are recorded. `--no-prefer-frozen-lockfile` forces the
-    // fresh-resolve path: pacquet's auto-frozen freshness gate
-    // (`check_lockfile_freshness`) only validates the root importer
-    // today, so it wouldn't notice a newly-added sibling and would
-    // otherwise short-circuit to the frozen path. The flag makes the
-    // re-resolve unconditional.
+    // fresh-resolve path: project-2 declares no dependencies, so the
+    // auto-frozen freshness gate deliberately tolerates its missing
+    // importer entry (`allow_missing_dependency_free_importers`, matching
+    // the TypeScript CLI's `allProjectsAreUpToDate`) and would otherwise
+    // short-circuit to the frozen path without ever recording it. The
+    // flag makes the re-resolve unconditional.
     fs::create_dir_all(workspace.join("packages/project-2")).expect("mkdir project-2");
     fs::write(
         workspace.join("packages/project-2/package.json"),


### PR DESCRIPTION
## Summary

Corrects a test comment that pnpm/pnpm#13081 left stale, and that was already leading readers to the wrong conclusion.

The comment justifying `--no-prefer-frozen-lockfile` in `lockfile_only_updates_importers_when_a_project_is_added` said pacquet's auto-frozen freshness gate "only validates the root importer today". pnpm/pnpm#13081 made `check_lockfile_freshness` loop over every project manifest, so that stopped being true.

The flag itself still has to stay, for a reason that only became true in that same change: `project-2` declares no dependencies, and the auto-frozen gate now deliberately tolerates a missing importer entry for a dependency-free project (`allow_missing_dependency_free_importers` in `install.rs`, matching the TypeScript CLI's `allProjectsAreUpToDate`). Verified by removing the flag and running the test — it fails, with the re-read lockfile containing only `packages/project-1:` and no `packages/project-2:`, because the run short-circuits to the frozen path and never records the new importer.

This matters because the stale comment is actively misleading: pnpm/pnpm#13028 (now closed as superseded by pnpm/pnpm#13081) read it as leftover scaffolding and dropped the flag on that basis. Restating the comment against the real reason keeps the next reader from repeating that.

Test-only comment change — no changeset, no TypeScript counterpart.

## Squash Commit Body

```text
The comment justifying `--no-prefer-frozen-lockfile` in
`lockfile_only_updates_importers_when_a_project_is_added` claimed the auto-frozen
freshness gate validates only the root importer. That stopped being true in
pnpm/pnpm#13081, which made `check_lockfile_freshness` loop over every project
manifest.

The flag is still required, for a reason that only became true in that same
change: project-2 declares no dependencies, and the auto-frozen gate deliberately
tolerates a missing importer entry for a dependency-free project
(`allow_missing_dependency_free_importers`, matching the TypeScript CLI's
`allProjectsAreUpToDate`). Without the flag the run short-circuits to the frozen
path and never records the new importer, so the `packages/project-2:` assertion
fails.

Restate the comment against the actual reason so the next reader doesn't drop the
flag on the assumption it is leftover scaffolding.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Test-only comment in a pacquet test; no TypeScript counterpart. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <!-- No published package changes. -->
- [x] Added or updated tests.
  <!-- Comment on an existing test; `cargo nextest run -p pacquet-cli --test lockfile_only` passes 5/5. -->

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786825446&installation_id=145934176&pr_number=13085&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13085&signature=c1ba4e00b783546413ae338e0e11628cc6087addb78ae06efcbd75eb2714f927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified test documentation explaining when a newly added dependency-free project requires a fresh lockfile resolution.
  * Documented the relationship between lockfile resolution behavior and the relevant command-line option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->