### PR TITLE
fix(cli): call the CLI pnpm, not pacquet, in user-facing text

### DIFF
--- a/.changeset/pacquet-user-facing-pnpm-naming.md
+++ b/.changeset/pacquet-user-facing-pnpm-naming.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Error messages and `--help` text now refer to the CLI as `pnpm` instead of the internal `pacquet` name. Several messages previously suggested commands like `pacquet install --frozen-lockfile`, which is not a command users can run, and `pnpm add --help` documented the virtual store directory default as `node_modules/.pacquet` rather than the actual `node_modules/.pnpm`.

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -94,9 +94,9 @@ pub struct AddArgs {
     /// Dependencies are not downloaded. Only `pnpm-lock.yaml` is updated.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
-    /// The directory with links to the store (default is `node_modules/.pacquet`).
+    /// The directory with links to the store (default is `node_modules/.pnpm`).
     /// All direct and indirect dependencies of the project are linked into this directory
-    #[clap(long = "virtual-store-dir", default_value = "node_modules/.pacquet")]
+    #[clap(long = "virtual-store-dir", default_value = "node_modules/.pnpm")]
     pub virtual_store_dir: Option<PathBuf>, // TODO: make use of this
 
     /// Install the package globally, linking its bins into the global bin directory.
@@ -199,13 +199,11 @@ impl AddArgs {
         // `--config` (configurational dependency) and `--lockfile-only` have
         // no meaning for a global install; reject rather than silently ignore.
         if self.config {
-            return Err(miette::miette!(
-                "`pacquet add --config` cannot be combined with --global."
-            ));
+            return Err(miette::miette!("`pnpm add --config` cannot be combined with --global."));
         }
         if self.lockfile_only {
             return Err(miette::miette!(
-                "`pacquet add --lockfile-only` cannot be combined with --global."
+                "`pnpm add --lockfile-only` cannot be combined with --global."
             ));
         }
         let supported_architectures =

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -103,7 +103,7 @@ pub struct ConfigListArgs {
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum ConfigError {
-    #[display("`pacquet config {subcommand}` requires the config key")]
+    #[display("`pnpm config {subcommand}` requires the config key")]
     #[diagnostic(code(ERR_PNPM_CONFIG_NO_PARAMS))]
     NoParams { subcommand: String },
 

--- a/pnpm/crates/cli/src/cli_args/create.rs
+++ b/pnpm/crates/cli/src/cli_args/create.rs
@@ -44,7 +44,7 @@ pub struct CreateArgs {
 #[non_exhaustive]
 pub enum CreateError {
     #[display(
-        "Missing the template package name.\nThe correct usage is `pacquet create <name>` with <name> substituted for a package name."
+        "Missing the template package name.\nThe correct usage is `pnpm create <name>` with <name> substituted for a package name."
     )]
     #[diagnostic(code(ERR_PNPM_MISSING_ARGS))]
     MissingArgs,

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -300,9 +300,7 @@ impl OutdatedArgs {
     /// dependency was outdated; the caller decides the process exit code.
     pub async fn run(self, state: State) -> miette::Result<OutdatedOutcome> {
         if state.config.recursive {
-            return Err(miette::miette!(
-                "`pnpm outdated --recursive` is not supported yet; recursive workspace inspection has not been ported to pnpm."
-            ));
+            return Err(miette::miette!("`pnpm outdated --recursive` is not supported yet."));
         }
 
         let config = state.config;
@@ -366,9 +364,7 @@ impl OutdatedArgs {
     /// the aggregate.
     pub async fn run_global(self, config: &'static Config) -> miette::Result<OutdatedOutcome> {
         if config.recursive {
-            return Err(miette::miette!(
-                "`pnpm outdated --recursive` is not supported yet; recursive workspace inspection has not been ported to pnpm."
-            ));
+            return Err(miette::miette!("`pnpm outdated --recursive` is not supported yet."));
         }
         let global_pkg_dir = config.global_pkg_dir.clone().ok_or_else(|| {
             miette::miette!(

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -301,7 +301,7 @@ impl OutdatedArgs {
     pub async fn run(self, state: State) -> miette::Result<OutdatedOutcome> {
         if state.config.recursive {
             return Err(miette::miette!(
-                "`pacquet outdated --recursive` is not supported yet; recursive workspace inspection has not been ported to pacquet."
+                "`pnpm outdated --recursive` is not supported yet; recursive workspace inspection has not been ported to pnpm."
             ));
         }
 
@@ -328,7 +328,7 @@ impl OutdatedArgs {
             let dir = manifest.path().parent().unwrap_or_else(|| manifest.path()).display();
             return Err(miette::miette!(
                 code = "ERR_PNPM_OUTDATED_NO_LOCKFILE",
-                r#"No lockfile in directory "{dir}". Run `pacquet install` to generate one."#
+                r#"No lockfile in directory "{dir}". Run `pnpm install` to generate one."#
             ));
         }
 
@@ -367,7 +367,7 @@ impl OutdatedArgs {
     pub async fn run_global(self, config: &'static Config) -> miette::Result<OutdatedOutcome> {
         if config.recursive {
             return Err(miette::miette!(
-                "`pacquet outdated --recursive` is not supported yet; recursive workspace inspection has not been ported to pacquet."
+                "`pnpm outdated --recursive` is not supported yet; recursive workspace inspection has not been ported to pnpm."
             ));
         }
         let global_pkg_dir = config.global_pkg_dir.clone().ok_or_else(|| {

--- a/pnpm/crates/cli/src/cli_args/pack_app.rs
+++ b/pnpm/crates/cli/src/cli_args/pack_app.rs
@@ -95,7 +95,7 @@ pub struct PackAppArgs {
 #[non_exhaustive]
 pub enum PackAppError {
     #[display(
-        r#""pacquet pack-app" requires a CJS entry file — pass --entry <path> or set "pnpm.app.entry" in package.json."#
+        r#""pnpm pack-app" requires a CJS entry file — pass --entry <path> or set "pnpm.app.entry" in package.json."#
     )]
     #[diagnostic(code(ERR_PNPM_PACK_APP_MISSING_ENTRY))]
     MissingEntry,
@@ -151,7 +151,7 @@ pub enum PackAppError {
     },
 
     #[display(
-        r#""pacquet pack-app" requires at least one target — pass --target <triplet> or set "pnpm.app.targets" in package.json. Supported: {supported}"#
+        r#""pnpm pack-app" requires at least one target — pass --target <triplet> or set "pnpm.app.targets" in package.json. Supported: {supported}"#
     )]
     #[diagnostic(code(ERR_PNPM_PACK_APP_MISSING_TARGET))]
     MissingTarget {
@@ -388,7 +388,7 @@ impl PackAppArgs {
 
         let pacquet_bin = std::env::current_exe()
             .into_diagnostic()
-            .wrap_err("resolving the pacquet executable path")?;
+            .wrap_err("resolving the pnpm executable path")?;
 
         let mut results = Vec::with_capacity(targets.len());
         for target in &targets {
@@ -495,9 +495,8 @@ fn resolve_builder_binary(build_root: &Path, target_version: &str) -> miette::Re
         }
         .into());
     }
-    let pacquet_bin = std::env::current_exe()
-        .into_diagnostic()
-        .wrap_err("resolving the pacquet executable path")?;
+    let pacquet_bin =
+        std::env::current_exe().into_diagnostic().wrap_err("resolving the pnpm executable path")?;
     ensure_node_runtime(
         &pacquet_bin,
         build_root,
@@ -582,7 +581,7 @@ fn ensure_node_runtime(
         command.arg(format!("--libc={libc}"));
     }
     command.arg(format!("node@runtime:{version}"));
-    run_command(&mut command, "pacquet add node@runtime")?;
+    run_command(&mut command, "pnpm add node@runtime")?;
 
     if !binary_path.exists() {
         return Err(PackAppError::NodeBinaryMissing {

--- a/pnpm/crates/cli/src/cli_args/patch.rs
+++ b/pnpm/crates/cli/src/cli_args/patch.rs
@@ -41,7 +41,7 @@ pub enum PatchError {
     MissingPackageName,
 
     #[display("The modules directory is not ready for patching")]
-    #[diagnostic(code(ERR_PNPM_PATCH_NO_LOCKFILE), help("Run pacquet install first"))]
+    #[diagnostic(code(ERR_PNPM_PATCH_NO_LOCKFILE), help("Run `pnpm install` first"))]
     PatchNoLockfile,
 
     #[display("The target directory already exists: '{}'", edit_dir.display())]

--- a/pnpm/crates/cli/src/cli_args/patch_commit.rs
+++ b/pnpm/crates/cli/src/cli_args/patch_commit.rs
@@ -25,7 +25,7 @@ use std::{
 
 #[derive(Debug, Args)]
 pub struct PatchCommitArgs {
-    /// Directory created by `pacquet patch`.
+    /// Directory created by `pnpm patch`.
     pub patch_dir: PathBuf,
     /// The generated patch file will be saved to this directory.
     #[clap(long = "patches-dir", value_name = "dir")]
@@ -38,7 +38,7 @@ pub enum PatchCommitError {
     #[display("{} is not a valid patch directory", patch_dir.display())]
     #[diagnostic(
         code(ERR_PNPM_INVALID_PATCH_DIR),
-        help("A valid patch directory should be created by `pacquet patch`")
+        help("A valid patch directory should be created by `pnpm patch`")
     )]
     InvalidPatchDir { patch_dir: PathBuf },
 
@@ -55,7 +55,7 @@ pub enum PatchCommitError {
     },
 
     #[display("The modules directory is not ready for patching")]
-    #[diagnostic(code(ERR_PNPM_PATCH_NO_LOCKFILE), help("Run pacquet install first"))]
+    #[diagnostic(code(ERR_PNPM_PATCH_NO_LOCKFILE), help("Run `pnpm install` first"))]
     PatchNoLockfile,
 
     #[display("Failed to create patches directory {}: {source}", path.display())]

--- a/pnpm/crates/cli/src/cli_args/prefix.rs
+++ b/pnpm/crates/cli/src/cli_args/prefix.rs
@@ -20,7 +20,7 @@ pub enum PrefixError {
     /// `@pnpm/global.commands`) is not ported to pacquet yet; refuse rather
     /// than print a wrong path.
     #[display(
-        "`pacquet prefix --global` is not supported yet; global package management has not been ported to pacquet."
+        "`pnpm prefix --global` is not supported yet; global package management has not been ported to pnpm."
     )]
     #[diagnostic(code(pacquet_cli::prefix_global_unsupported))]
     GlobalUnsupported,

--- a/pnpm/crates/cli/src/cli_args/prefix.rs
+++ b/pnpm/crates/cli/src/cli_args/prefix.rs
@@ -19,9 +19,7 @@ pub enum PrefixError {
     /// `--global` is rejected because the global-dir machinery (pnpm's
     /// `@pnpm/global.commands`) is not ported to pacquet yet; refuse rather
     /// than print a wrong path.
-    #[display(
-        "`pnpm prefix --global` is not supported yet; global package management has not been ported to pnpm."
-    )]
+    #[display("`pnpm prefix --global` is not supported yet.")]
     #[diagnostic(code(pacquet_cli::prefix_global_unsupported))]
     GlobalUnsupported,
 

--- a/pnpm/crates/cli/src/cli_args/publish/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/recursive.rs
@@ -45,8 +45,8 @@ impl PublishArgs {
     ) -> miette::Result<Vec<PublishSummary>> {
         if self.flags.batch {
             return Err(miette::miette!(
-                help = "Publish without --batch; batched publishing is not yet ported to pacquet.",
-                "Batch publishing (--batch) is not yet supported by pacquet",
+                help = "Publish without --batch; batched publishing is not yet ported to pnpm.",
+                "Batch publishing (--batch) is not yet supported by pnpm",
             ));
         }
 

--- a/pnpm/crates/cli/src/cli_args/publish/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/recursive.rs
@@ -45,8 +45,8 @@ impl PublishArgs {
     ) -> miette::Result<Vec<PublishSummary>> {
         if self.flags.batch {
             return Err(miette::miette!(
-                help = "Publish without --batch; batched publishing is not yet ported to pnpm.",
-                "Batch publishing (--batch) is not yet supported by pnpm",
+                help = "Publish without --batch.",
+                "Batch publishing (--batch) is not yet supported",
             ));
         }
 

--- a/pnpm/crates/cli/src/cli_args/root.rs
+++ b/pnpm/crates/cli/src/cli_args/root.rs
@@ -18,7 +18,7 @@ pub enum RootError {
     /// `--global` is rejected because the global-dir machinery is not
     /// ported to pacquet yet; refuse rather than print a wrong path.
     #[display(
-        "`pacquet root --global` is not supported yet; global package management has not been ported to pacquet."
+        "`pnpm root --global` is not supported yet; global package management has not been ported to pnpm."
     )]
     #[diagnostic(code(pacquet_cli::root_global_unsupported))]
     GlobalUnsupported,

--- a/pnpm/crates/cli/src/cli_args/root.rs
+++ b/pnpm/crates/cli/src/cli_args/root.rs
@@ -17,9 +17,7 @@ pub struct RootArgs {
 pub enum RootError {
     /// `--global` is rejected because the global-dir machinery is not
     /// ported to pacquet yet; refuse rather than print a wrong path.
-    #[display(
-        "`pnpm root --global` is not supported yet; global package management has not been ported to pnpm."
-    )]
+    #[display("`pnpm root --global` is not supported yet.")]
     #[diagnostic(code(pacquet_cli::root_global_unsupported))]
     GlobalUnsupported,
 }

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -114,9 +114,7 @@ impl UpdateArgs {
         // silently doing a plain update. (`--global` is routed to
         // [`Self::run_global`] before `run` is reached.)
         if self.workspace {
-            return Err(miette::miette!(
-                "`pnpm update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pnpm."
-            ));
+            return Err(miette::miette!("`pnpm update --workspace` is not supported yet."));
         }
 
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
@@ -185,13 +183,11 @@ impl UpdateArgs {
         config: &'static Config,
     ) -> miette::Result<()> {
         if self.workspace {
-            return Err(miette::miette!(
-                "`pnpm update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pnpm."
-            ));
+            return Err(miette::miette!("`pnpm update --workspace` is not supported yet."));
         }
         if self.interactive {
             return Err(miette::miette!(
-                "`pnpm update --global --interactive` is not supported yet; interactive selection for global updates has not been ported to pnpm."
+                "`pnpm update --global --interactive` is not supported yet."
             ));
         }
         let supported_architectures =

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -115,7 +115,7 @@ impl UpdateArgs {
         // [`Self::run_global`] before `run` is reached.)
         if self.workspace {
             return Err(miette::miette!(
-                "`pacquet update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pacquet."
+                "`pnpm update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pnpm."
             ));
         }
 
@@ -186,12 +186,12 @@ impl UpdateArgs {
     ) -> miette::Result<()> {
         if self.workspace {
             return Err(miette::miette!(
-                "`pacquet update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pacquet."
+                "`pnpm update --workspace` is not supported yet; workspace-protocol version linking has not been ported to pnpm."
             ));
         }
         if self.interactive {
             return Err(miette::miette!(
-                "`pacquet update --global --interactive` is not supported yet; interactive selection for global updates has not been ported to pacquet."
+                "`pnpm update --global --interactive` is not supported yet; interactive selection for global updates has not been ported to pnpm."
             ));
         }
         let supported_architectures =

--- a/pnpm/crates/cli/src/cli_args/why.rs
+++ b/pnpm/crates/cli/src/cli_args/why.rs
@@ -1,4 +1,4 @@
-//! `pacquet why` — show the packages that depend on `<pkg>`.
+//! `pnpm why` — show the packages that depend on `<pkg>`.
 
 use crate::{State, cli_args::sanitize::sanitize};
 use clap::Args;
@@ -73,7 +73,7 @@ impl WhyArgs {
         if self.packages.is_empty() {
             return Err(miette::miette!(
                 code = "ERR_PNPM_MISSING_PACKAGE_NAME",
-                "`pacquet why` requires a package name or pattern"
+                "`pnpm why` requires a package name or pattern"
             ));
         }
 

--- a/pnpm/crates/modules-yaml/src/lib.rs
+++ b/pnpm/crates/modules-yaml/src/lib.rs
@@ -321,7 +321,7 @@ impl TryFrom<u32> for LayoutVersion {
 /// is not the one pacquet supports.
 #[derive(Debug, Display, Error)]
 #[display(
-    "Unsupported layout version {found}; this build of pacquet only supports layout version {}",
+    "Unsupported layout version {found}; this build of pnpm only supports layout version {}",
     LayoutVersion::VALUE
 )]
 pub struct UnsupportedLayoutVersionError {

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -283,7 +283,7 @@ where
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum InstallError {
     #[display(
-        "Headless installation requires a pnpm-lock.yaml file, but none was found. Run `pacquet install` without --frozen-lockfile to create one."
+        "Headless installation requires a pnpm-lock.yaml file, but none was found. Run `pnpm install` without --frozen-lockfile to create one."
     )]
     #[diagnostic(code(pacquet_package_manager::no_lockfile))]
     NoLockfile,
@@ -390,7 +390,7 @@ pub enum InstallError {
     #[diagnostic(
         code(pacquet_package_manager::outdated_lockfile),
         help(
-            "Regenerate the lockfile with `pnpm install --lockfile-only` so that pnpm-lock.yaml reflects the current package.json, then re-run `pacquet install --frozen-lockfile`."
+            "Regenerate the lockfile with `pnpm install --lockfile-only` so that pnpm-lock.yaml reflects the current package.json, then re-run `pnpm install --frozen-lockfile`."
         )
     )]
     OutdatedLockfile { reason: StalenessReason },

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -142,13 +142,13 @@ pub enum InstallPackageBySnapshotError {
     CreateVirtualDir(#[error(source)] CreateVirtualDirError),
 
     #[display(
-        "Package `{package_key}` has a tarball resolution without an `integrity` field; pacquet cannot verify the download and refuses to install it."
+        "Package `{package_key}` has a tarball resolution without an `integrity` field; pnpm cannot verify the download and refuses to install it."
     )]
     #[diagnostic(code(pacquet_package_manager::missing_tarball_integrity))]
     MissingTarballIntegrity { package_key: String },
 
     #[display(
-        "Package `{package_key}` uses a `{resolution_kind}` resolution, which pacquet does not yet support."
+        "Package `{package_key}` uses a `{resolution_kind}` resolution, which pnpm does not yet support."
     )]
     #[diagnostic(code(pacquet_package_manager::unsupported_resolution))]
     UnsupportedResolution { package_key: String, resolution_kind: &'static str },
@@ -217,7 +217,7 @@ pub enum InstallPackageBySnapshotError {
     /// or a future shape pacquet doesn't recognise rather than
     /// silently routing through and confusing the install pipeline.
     #[display(
-        "Package `{package_key}` carries a runtime variant whose inner resolution is `{inner_kind}` rather than `binary`; pacquet only knows how to install binary-shaped variants."
+        "Package `{package_key}` carries a runtime variant whose inner resolution is `{inner_kind}` rather than `binary`; pnpm only knows how to install binary-shaped variants."
     )]
     #[diagnostic(code(pacquet_package_manager::variant_has_non_binary_resolution))]
     VariantHasNonBinaryResolution { package_key: String, inner_kind: &'static str },

--- a/pnpm/crates/package-manager/src/patch.rs
+++ b/pnpm/crates/package-manager/src/patch.rs
@@ -78,7 +78,7 @@ pub enum WritePackageForPatchError {
     MissingPackageMetadata { package_key: String },
 
     #[display(
-        "Package `{package}` uses a `{resolution_kind}` resolution, which pacquet patch does not yet support."
+        "Package `{package}` uses a `{resolution_kind}` resolution, which `pnpm patch` does not yet support."
     )]
     #[diagnostic(code(pacquet_package_manager::patch_unsupported_resolution))]
     UnsupportedResolution { package: String, resolution_kind: &'static str },

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -165,7 +165,7 @@ pub enum TarballError {
     #[diagnostic(
         code(pacquet_tarball::verify_checksum_error),
         help(
-            "The downloaded tarball does not match the integrity recorded in the lockfile. If you trust the new content (legitimate republish, or stale local metadata cache), run `pnpm install --update-checksums` (or `pacquet install --update-checksums`). Otherwise treat this as a potential supply-chain issue and verify the new content first."
+            "The downloaded tarball does not match the integrity recorded in the lockfile. If you trust the new content (legitimate republish, or stale local metadata cache), run `pnpm install --update-checksums`. Otherwise treat this as a potential supply-chain issue and verify the new content first."
         )
     )]
     Checksum(VerifyChecksumError),
@@ -191,7 +191,7 @@ pub enum TarballError {
 
     #[from(ignore)]
     #[display(
-        "Archive at {url} advertised a Content-Length of {advertised_size} bytes, which exceeds what pacquet can allocate (either larger than `usize::MAX` on this target or memory pressure prevented a one-shot reservation)"
+        "Archive at {url} advertised a Content-Length of {advertised_size} bytes, which exceeds what pnpm can allocate (either larger than `usize::MAX` on this target or memory pressure prevented a one-shot reservation)"
     )]
     #[diagnostic(code(pacquet_tarball::tarball_too_large))]
     TarballTooLarge { url: String, advertised_size: u64 },


### PR DESCRIPTION
## Summary

`pacquet` is an in-repo name only — the shipped binary is `pnpm`. User-facing error messages, diagnostic help text, and `--help` output leaked the internal name, and several of them told users to run commands that do not exist. This came up while confirming the fix for pnpm/pnpm#13025, where the outdated-lockfile error ends with:

```
help: Regenerate the lockfile with `pnpm install --lockfile-only` so that
      pnpm-lock.yaml reflects the current package.json, then re-run `pacquet
      install --frozen-lockfile`.
```

The first half of that sentence is right and the second half is not copy-pasteable. A sweep found 18 files with the same class of problem.

### What changed

Typeable commands in messages — `pacquet install`, `pacquet add --config`, `pacquet add --lockfile-only`, `pacquet why`, `pacquet config <sub>`, `pacquet create <name>`, `pacquet outdated --recursive`, `pacquet update --workspace`, `pacquet update --global --interactive`, `pacquet root --global`, `pacquet prefix --global`, `pacquet patch`, `"pacquet pack-app"`, and `pacquet add node@runtime`.

Product-name prose — "pacquet cannot verify the download", "which pacquet does not yet support", "pacquet only knows how to install binary-shaped variants", "this build of pacquet only supports layout version", "exceeds what pacquet can allocate".

**Unsupported-feature messages get reworded, not renamed.** Eight messages read "X is not supported yet; Y has not been ported to pacquet." Renaming the product there would produce "… has not been ported to pnpm", which tells the user pnpm lacks a feature that pnpm v11 has — worse than the leaked name. The clause was an internal note that this implementation hasn't ported Y yet: true for developers, wrong once the sentence names the product. It is dropped, leaving "X is not supported yet." ("yet" already carries that support is planned). The reason stays in the Rust doc comments on the error variants, which still name pacquet since they are developer-facing. Affects `update --workspace` (x2), `update --global --interactive`, `prefix --global`, `root --global`, `outdated --recursive` (x2), and batched `publish`. Thanks to CodeRabbit for catching this on the first push.

Two were also factually wrong, not merely misnamed:

- **`pnpm add --help`** documented the virtual store directory default as `node_modules/.pacquet`, in both the doc comment and clap's `default_value`. The effective default from `default_virtual_store_dir()` is `node_modules/.pnpm`, so the help contradicted the behavior. The field is unused (`// TODO: make use of this`) and `pnpm add` already creates `.pnpm` on disk, so only the help output changes.
- **The tarball integrity error** offered `pnpm install --update-checksums` and then repeated it as ``(or `pacquet install --update-checksums`)``. The redundant parenthetical is dropped.

### Deliberately not changed

Internal, non-user-facing uses stay: tracing targets (`target: "pacquet::store_index"`), thread names (`pacquet-main`), temp-file prefixes (`.pacquet-tmp`, `pacquet-git-diff-`), the mirror cache magic (`pacquet-meta-v1`, changing it would invalidate caches), `expect()` panic messages, and test fixtures.

### Verified

Rebuilt the binary and checked the real output:

```
help: Regenerate the lockfile with `pnpm install --lockfile-only` so that
      pnpm-lock.yaml reflects the current package.json, then re-run `pnpm
      install --frozen-lockfile`.

$ pnpm add --help   →  [default: node_modules/.pnpm]
$ pnpm why          →  × `pnpm why` requires a package name or pattern
$ pnpm root -g      →  × `pnpm root --global` is not supported yet.
```

`cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo nextest run -p pacquet-cli --test why --test create --test root --test prefix --test outdated --test publish_recursive --test update` 76/76; `-p pacquet-modules-yaml -p pacquet-tarball` 90/90. The one test asserting on affected text (`tests/why.rs:40`) matches `"requires a package name"`, which is unchanged.

## Squash Commit Body

```text
`pacquet` is an in-repo name only; the shipped binary is `pnpm`. Error messages,
diagnostic help text, and `--help` output leaked the internal name, and several
told users to run commands that do not exist:

    help: ... then re-run `pacquet install --frozen-lockfile`.

Replace the leaked name across user-facing strings — typeable commands (`pacquet
install`, `pacquet add --config`, `pacquet why`, `pacquet create <name>`,
`pacquet outdated --recursive`, `"pacquet pack-app"`, and peers) and
product-name prose ("pacquet cannot verify the download", "this build of
pacquet", "not yet ported to pacquet").

Two were also factually wrong, not just misnamed:

- `pnpm add --help` documented the virtual store directory default as
  `node_modules/.pacquet` in both the doc comment and clap's `default_value`,
  while the effective default from `default_virtual_store_dir()` is
  `node_modules/.pnpm`. The field is unused (`TODO: make use of this`), so only
  the help output changed.
- The tarball integrity error offered `pnpm install --update-checksums` and then
  repeated it as `(or `pacquet install --update-checksums`)`. Drop the redundant
  parenthetical.

Internal uses stay as they are: tracing targets, thread names, temp-file
prefixes, the mirror cache magic, panic messages, and test fixtures are not
user-facing.

The TypeScript CLI has no counterpart to change — it never refers to pacquet.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: the TypeScript CLI never refers to pacquet, so there is nothing to mirror. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <!-- No new tests: this changes message wording only, verified against the built binary. Existing suites cover the affected commands. -->

---
Written by an agent (Claude Code, claude-opus-4-8).
