### PR TITLE
fix(install): record pnpm@<release version> in .modules.yaml

### DIFF
--- a/.changeset/modules-yaml-package-manager-pnpm.md
+++ b/.changeset/modules-yaml-package-manager-pnpm.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`node_modules/.modules.yaml` now records `packageManager` as `pnpm@<release version>` (for example `pnpm@12.0.0-alpha.13`), matching `pnpm --version` and the TypeScript CLI. It previously recorded the internal crate name and crate version, `pacquet@0.0.1`.

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -11,7 +11,7 @@ use pacquet_catalogs_config::{
     InvalidCatalogsConfigurationError, get_catalogs_from_workspace_manifest,
 };
 use pacquet_catalogs_types::Catalogs;
-use pacquet_config::{Config, NodeLinker};
+use pacquet_config::{Config, NodeLinker, PNPM_VERSION};
 use pacquet_executor::{
     LifecycleScriptError, RunPostinstallHooks,
     ScriptsPrependNodePath as ExecScriptsPrependNodePath, run_project_lifecycle_scripts,
@@ -2204,9 +2204,11 @@ fn build_modules_manifest(
         included,
         layout_version: Some(LayoutVersion),
         node_linker: Some(map_node_linker(node_linker)),
-        // `${name}@${version}`. `CARGO_PKG_VERSION`
-        // resolves at compile time to this crate's package version.
-        package_manager: concat!("pacquet@", env!("CARGO_PKG_VERSION")).to_string(),
+        // `${name}@${version}`, where the name is the CLI's published
+        // npm name. `pacquet` is an in-repo crate name that never
+        // reaches disk, and the crate version is not the release
+        // version.
+        package_manager: format!("pnpm@{PNPM_VERSION}"),
         public_hoist_pattern: config.public_hoist_pattern.clone(),
         // RFC 1123 / `toUTCString()` format. The caller decides whether
         // this is a fresh timestamp (a prune ran or first install) or the

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -1389,10 +1389,7 @@ async fn install_writes_modules_yaml() {
         registries.as_ref().and_then(|r| r.get("@private")).map(String::as_str),
         Some("https://private.example.com/npm/"),
     );
-    assert!(
-        package_manager.starts_with("pacquet@"),
-        "expected `pacquet@<version>`, got {package_manager:?}",
-    );
+    assert_eq!(package_manager, format!("pnpm@{}", pacquet_config::PNPM_VERSION));
 
     drop(dir);
 }


### PR DESCRIPTION
## Summary

`node_modules/.modules.yaml` recorded `packageManager: "pacquet@0.0.1"`, which is wrong on both halves:

- **The name.** `pacquet` is an in-repo crate name with no meaning outside this repository — the CLI ships as `pnpm`.
- **The version.** `CARGO_PKG_VERSION` is the crate's version (`0.0.1`), not the release version the user installed (`12.0.0-alpha.13`).

The TypeScript CLI writes `${name}@${version}` sourced from its own package.json, so it records `pnpm@11.x.x`. It also branches on `packageManager.name === 'pnpm'` when deriving `pnpmVersion` (`installing/deps-installer/src/install/index.ts:1133`), which shows the name half is meaningful rather than decorative.

This PR uses `pacquet_config::PNPM_VERSION` — the constant `pnpm --version` already prints. Its doc comment records that `pnpm bump` keeps it in sync with the npm wrapper package's version (`pnpm/npm/pnpm/package.json`) and that the release workflow verifies the two match before building, so it is the release version by construction rather than by convention.

### Risk

None to behavior. Neither stack reads the field back — I checked both: it is written by pacquet's `install.rs` and by the TypeScript `deps-installer` / `deps-restorer`, and read by neither. It is informational metadata. It is still part of the on-disk contract that external tooling can inspect, and it should not name a crate the user has never heard of.

### Verified

```
$ pnpm add is-odd@3.0.1
$ grep packageManager node_modules/.modules.yaml
  "packageManager": "pnpm@12.0.0-alpha.13",
$ pnpm --version
12.0.0-alpha.13
```

`cargo nextest run -p pacquet-package-manager` — 730/730 pass.

The existing test checked only the `starts_with("pacquet@")` prefix, so it would not have caught the wrong version. It is now an exact comparison against `pnpm@{PNPM_VERSION}`, which fails if the recorded name or version ever drifts from the release version.

Found while confirming the fix for pnpm/pnpm#13025. Related to pnpm/pnpm#13086, which cleans up the same internal name leaking into error messages and `--help` text; this one is separate because it changes data written to disk rather than wording, and warrants its own release note.

## Squash Commit Body

```text
`.modules.yaml` recorded `packageManager: "pacquet@0.0.1"`, which is wrong on
both halves. `pacquet` is an in-repo crate name that has no meaning outside this
repository — the CLI ships as `pnpm`. And `CARGO_PKG_VERSION` is the crate's
version (`0.0.1`), not the release version the user installed
(`12.0.0-alpha.13`).

The TypeScript CLI writes `${name}@${version}` sourced from its own package.json,
so it records `pnpm@11.x.x`. It also branches on `packageManager.name === 'pnpm'`
when deriving `pnpmVersion` (`installing/deps-installer/src/install/index.ts`),
which shows the name half is meaningful and not decorative.

Use `pacquet_config::PNPM_VERSION`, the constant `pnpm --version` already prints.
Its doc comment records that `pnpm bump` keeps it in sync with the npm wrapper
package's version and that the release workflow verifies the two match, so it is
the release version by construction.

Nothing reads the field back in either stack — it is informational metadata — so
this changes no behavior. It is still part of the on-disk contract that external
tooling can inspect, and it should not name a crate the user has never heard of.

Tighten the test from a `starts_with("pacquet@")` prefix check to an exact
comparison against `pnpm@{PNPM_VERSION}`, so a future drift between the recorded
name/version and the release version fails.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- The TypeScript CLI already writes `pnpm@<version>`; this brings pacquet to parity with it. No TypeScript change needed. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786828369&installation_id=145934176&pr_number=13087&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13087&signature=84257f57d280c3b78b9dc4392740038e6c12cad841ccddec3d19d769c7ce8e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated `.modules.yaml` metadata to report the correct `pnpm@<version>` package manager value.
  * Improved consistency between recorded package manager information and the version shown by the pnpm CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->