### PR TITLE
fix(deps-resolver): drop reuse-only peer suffixes after dedupe

### DIFF
--- a/.changeset/peer-lockfile-drift-cleanup.md
+++ b/.changeset/peer-lockfile-drift-cleanup.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed lockfile drift after manifest edits by removing reuse-only transitive peer suffixes without losing valid peer-context deduplication.

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -287,7 +287,12 @@ export async function resolveDependencies (
     peersSuffixMaxLength: opts.peersSuffixMaxLength,
     workspaceProjectIds: new Set([...opts.allProjectIds, ...Object.keys(opts.wantedLockfile.importers)]),
   }
-  const initiallyResolvedPeers = await resolvePeers(peerResolutionOpts)
+  const hasLockedPeerContexts = treeHasLockedPeerContexts(dependenciesTree)
+  const initiallyResolvedPeers = await resolvePeers({
+    ...peerResolutionOpts,
+    dedupeInjectedDeps: hasLockedPeerContexts ? false : opts.dedupeInjectedDeps,
+    dedupePeerDependents: hasLockedPeerContexts ? false : opts.dedupePeerDependents,
+  })
   // A second pass reuses the peer contexts already recorded in the lockfile so a
   // writable install does not rewrite dependency instances whose locked provider
   // is still valid and present. It can only differ from the first pass for nodes
@@ -297,10 +302,12 @@ export async function resolveDependencies (
     dependenciesGraph,
     dependenciesByProjectId,
     peerDependencyIssuesByProjects,
-  } = treeHasLockedPeerContexts(dependenciesTree)
+  } = hasLockedPeerContexts
     ? await resolvePeers({
       ...peerResolutionOpts,
+      previousDependenciesGraph: initiallyResolvedPeers.dependenciesGraph,
       resolvedPeerProviderPaths: initiallyResolvedPeers.pathsByNodeId,
+      previousResolvedPeerNamesByNodeId: getResolvedPeerNamesByNodeId(initiallyResolvedPeers),
     })
     : initiallyResolvedPeers
 
@@ -450,6 +457,22 @@ function treeHasLockedPeerContexts (dependenciesTree: DependenciesTree<ResolvedP
     if (node.lockedPeerContext != null) return true
   }
   return false
+}
+
+function getResolvedPeerNamesByNodeId (
+  resolved: {
+    dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<ResolvedPackage>
+    pathsByNodeId: Map<NodeId, DepPath>
+  }
+): Map<NodeId, Set<string>> {
+  const resolvedPeerNamesByNodeId = new Map<NodeId, Set<string>>()
+  for (const [nodeId, depPath] of resolved.pathsByNodeId.entries()) {
+    const node = resolved.dependenciesGraph[depPath]
+    if (node != null && node.resolvedPeerNames.size > 0) {
+      resolvedPeerNamesByNodeId.set(nodeId, node.resolvedPeerNames)
+    }
+  }
+  return resolvedPeerNamesByNodeId
 }
 
 function addDirectDependenciesToLockfile (

--- a/pnpm11/installing/deps-resolver/src/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/src/resolvePeers.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { createPeerDepGraphHash, depPathToFilename, parseDepPath, type PeerId } from '@pnpm/deps.path'
+import { createPeerDepGraphHash, depPathToFilename, getPkgIdWithPatchHash, parseDepPath, type PeerId } from '@pnpm/deps.path'
 import { safeJoinModulesDir } from '@pnpm/fs.symlink-dependency'
 import type {
   DepPath,
@@ -30,6 +30,8 @@ import type {
 } from './resolveDependencies.js'
 import type { ResolvedImporters } from './resolveDependencyTree.js'
 
+type ResolvedPeerId = ({ peerId: PeerId } | { depPath: DepPath }) & { nodeId: NodeId }
+
 export interface BaseGenericDependenciesGraphNode {
   // at this point the version is really needed only for logging
   modules: string
@@ -42,6 +44,8 @@ export interface BaseGenericDependenciesGraphNode {
   isBuilt?: boolean
   isPure: boolean
   resolvedPeerNames: Set<string>
+  // Exact hash inputs, keyed by peer name, for recomputing this depPath.
+  resolvedPeerIds?: Map<string, ResolvedPeerId>
   requiresBuild?: boolean
 }
 
@@ -100,6 +104,8 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
     peersSuffixMaxLength: number
     workspaceProjectIds: Set<string>
     resolvedPeerProviderPaths?: Map<NodeId, DepPath>
+    previousResolvedPeerNamesByNodeId?: Map<NodeId, Set<string>>
+    previousDependenciesGraph?: GenericDependenciesGraphWithResolvedChildren<T>
   }
 ): Promise<{
   dependenciesGraph: GenericDependenciesGraphWithResolvedChildren<T>
@@ -109,11 +115,11 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
 }> {
   const depGraph: GenericDependenciesGraph<T> = {}
   const pathsByNodeId = new Map<NodeId, DepPath>()
+  const resolvedOwnPeerNamesByNodeId = new Map<NodeId, Set<string>>()
   const pathsByNodeIdPromises = new Map<NodeId, DeferredPromise<DepPath>>()
   const awaitedPeerNodeIdsByNodeId = new Map<NodeId, Set<NodeId>>()
   const peersCacheOwnerByNodeId = new Map<NodeId, NodeId>()
   const cycleBrokenNodeIds = new Set<NodeId>()
-  const depPathsByPkgId = new Map<PkgIdWithPatchHash, Set<DepPath>>()
   const nodeIdsByPreviousDepPath = opts.resolvedPeerProviderPaths == null
     ? new Map<DepPath, NodeId>()
     : getNodeIdsByPreviousDepPath(opts.dependenciesTree)
@@ -176,11 +182,11 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       parentNodeIds: [],
       parentDepPathsChain: [],
       pathsByNodeId,
+      resolvedOwnPeerNamesByNodeId,
       pathsByNodeIdPromises,
       awaitedPeerNodeIdsByNodeId,
       peersCacheOwnerByNodeId,
       cycleBrokenNodeIds,
-      depPathsByPkgId,
       nodeIdsByPreviousDepPath,
       resolvedPeerProviderPaths: opts.resolvedPeerProviderPaths,
       currentProviderSources,
@@ -258,6 +264,7 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       dependenciesByProjectId[id].set(alias, pathsByNodeId.get(nodeId)!)
     }
   }
+  const pathsByNodeIdBeforeDedupe = new Map(pathsByNodeId)
   if (opts.dedupeInjectedDeps) {
     dedupeInjectedDeps({
       dependenciesByProjectId,
@@ -269,20 +276,392 @@ export async function resolvePeers<T extends PartialResolvedPackage> (
       workspaceProjectIds: opts.workspaceProjectIds,
     })
   }
-  if (opts.dedupePeerDependents) {
-    const duplicates = Array.from(depPathsByPkgId.values()).filter((item) => item.size > 1)
-    const allDepPathsMap = deduplicateAll(depGraphWithResolvedChildren, duplicates)
-    for (const { id } of opts.projects) {
-      for (const [alias, depPath] of dependenciesByProjectId[id].entries()) {
-        dependenciesByProjectId[id].set(alias, allDepPathsMap[depPath] ?? depPath)
-      }
-    }
+  const deduplicatedDepPaths = opts.dedupePeerDependents
+    ? dedupePeerDependents(depGraphWithResolvedChildren, dependenciesByProjectId)
+    : {}
+  if (opts.previousResolvedPeerNamesByNodeId != null) {
+    dropSpuriousReusePeers({
+      depGraph: depGraphWithResolvedChildren,
+      pathsByNodeId,
+      pathsByNodeIdBeforeDedupe,
+      dependenciesByProjectId,
+      dependenciesTree: opts.dependenciesTree,
+      deduplicatedDepPaths,
+      previousDependenciesGraph: opts.previousDependenciesGraph,
+      resolvedOwnPeerNamesByNodeId,
+      previousResolvedPeerNamesByNodeId: opts.previousResolvedPeerNamesByNodeId,
+      projects: opts.projects,
+      dedupePeers: opts.dedupePeers,
+      peersSuffixMaxLength: opts.peersSuffixMaxLength,
+      virtualStoreDir: opts.virtualStoreDir,
+      virtualStoreDirMaxLength: opts.virtualStoreDirMaxLength,
+    })
   }
   return {
     dependenciesGraph: depGraphWithResolvedChildren,
     dependenciesByProjectId,
     peerDependencyIssuesByProjects,
     pathsByNodeId,
+  }
+}
+
+function dedupePeerDependents<T extends PartialResolvedPackage> (
+  depGraph: GenericDependenciesGraphWithResolvedChildren<T>,
+  dependenciesByProjectId: DependenciesByProjectId
+): Record<DepPath, DepPath> {
+  const depPathsByPkgId = new Map<PkgIdWithPatchHash, Set<DepPath>>()
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    const depPaths = depPathsByPkgId.get(node.pkgIdWithPatchHash)
+    if (depPaths == null) {
+      depPathsByPkgId.set(node.pkgIdWithPatchHash, new Set([depPath]))
+    } else {
+      depPaths.add(depPath)
+    }
+  }
+  const duplicates = Array.from(depPathsByPkgId.values()).filter((depPaths) => depPaths.size > 1)
+  const deduplicatedDepPaths = deduplicateAll(depGraph, duplicates)
+  for (const depPath of Object.keys(deduplicatedDepPaths) as DepPath[]) {
+    let deduplicatedDepPath = deduplicatedDepPaths[depPath]
+    while (
+      deduplicatedDepPaths[deduplicatedDepPath] != null &&
+      deduplicatedDepPaths[deduplicatedDepPath] !== deduplicatedDepPath
+    ) {
+      deduplicatedDepPath = deduplicatedDepPaths[deduplicatedDepPath]
+    }
+    deduplicatedDepPaths[depPath] = deduplicatedDepPath
+  }
+  for (const [depPath, deduplicatedDepPath] of Object.entries(deduplicatedDepPaths) as Array<[DepPath, DepPath]>) {
+    const node = depGraph[depPath]
+    const deduplicatedNode = depGraph[deduplicatedDepPath]
+    if (node == null || deduplicatedNode == null) continue
+    deduplicatedNode.depth = Math.min(deduplicatedNode.depth, node.depth)
+    deduplicatedNode.installable ||= node.installable
+  }
+  for (const dependencies of Object.values(dependenciesByProjectId)) {
+    for (const [alias, depPath] of dependencies) {
+      dependencies.set(alias, deduplicatedDepPaths[depPath] ?? depPath)
+    }
+  }
+  return deduplicatedDepPaths
+}
+
+// The locked-context reuse pass keeps a peer bound to the provider recorded in
+// the lockfile so a writable install does not rewrite still-valid dependency
+// instances. It finds that provider through a global lookup, so it can bind a
+// transitive (non-own) peer laterally to a provider in an unrelated subtree —
+// one the first (fresh) pass, and therefore `pnpm dedupe`, left unresolved.
+// That extra binding adds a peer suffix to the consumer that a fresh resolution
+// never produces, which is the lockfile drift in
+// https://github.com/pnpm/pnpm/issues/12756.
+//
+// Rather than stop the reuse pass from propagating the peer (which would forgo
+// the deduplication that resolving a shared provider can enable), this cleanup
+// runs after propagation and drops, per node, only the non-own peers the fresh
+// pass did not resolve for it. Own peers and genuinely reused contexts (a peer
+// the fresh pass also resolved, even to a different provider) are kept, so the
+// context-preservation the reuse pass exists for is untouched. Recomputing the
+// affected depPaths lets the now-canonical instances collapse onto their
+// deduplicated peers — the same result `pnpm dedupe` reaches — during a plain
+// `pnpm install`.
+function dropSpuriousReusePeers<T extends PartialResolvedPackage> (
+  opts: {
+    depGraph: GenericDependenciesGraphWithResolvedChildren<T>
+    pathsByNodeId: Map<NodeId, DepPath>
+    pathsByNodeIdBeforeDedupe: Map<NodeId, DepPath>
+    dependenciesByProjectId: DependenciesByProjectId
+    dependenciesTree: DependenciesTree<T>
+    deduplicatedDepPaths: Record<DepPath, DepPath>
+    previousDependenciesGraph?: GenericDependenciesGraphWithResolvedChildren<T>
+    resolvedOwnPeerNamesByNodeId: Map<NodeId, Set<string>>
+    previousResolvedPeerNamesByNodeId: Map<NodeId, Set<string>>
+    projects: ProjectToResolve[]
+    dedupePeers?: boolean
+    peersSuffixMaxLength: number
+    virtualStoreDir: string
+    virtualStoreDirMaxLength: number
+  }
+): void {
+  const { depGraph } = opts
+  const deduplicated = (depPath: DepPath): DepPath => opts.deduplicatedDepPaths[depPath] ?? depPath
+
+  // Include graph nodes reached through package children or peer hash inputs.
+  // The reuse pass can leave other intermediate instances behind; ignoring those
+  // keeps cleanup from seeing collisions with nodes that will be pruned anyway.
+  const reachable = new Set<DepPath>()
+  const peerHashNodeIds = new Set<NodeId>()
+  const reachableStack: DepPath[] = []
+  for (const deps of Object.values(opts.dependenciesByProjectId)) {
+    for (const depPath of deps.values()) {
+      if (!reachable.has(depPath)) {
+        reachable.add(depPath)
+        reachableStack.push(depPath)
+      }
+    }
+  }
+  while (reachableStack.length > 0) {
+    const depPath = reachableStack.pop()!
+    const node = depGraph[depPath]
+    if (node == null) continue
+    for (const childDepPath of Object.values<DepPath>(node.children)) {
+      if (!reachable.has(childDepPath)) {
+        reachable.add(childDepPath)
+        reachableStack.push(childDepPath)
+      }
+    }
+    for (const resolvedPeerId of node.resolvedPeerIds?.values() ?? []) {
+      peerHashNodeIds.add(resolvedPeerId.nodeId)
+      const peerDepPath = 'depPath' in resolvedPeerId
+        ? resolvedPeerId.depPath
+        : opts.pathsByNodeIdBeforeDedupe.get(resolvedPeerId.nodeId)
+      if (peerDepPath == null) continue
+      if (depGraph[peerDepPath] != null && !reachable.has(peerDepPath)) {
+        reachable.add(peerDepPath)
+        reachableStack.push(peerDepPath)
+      }
+    }
+  }
+
+  // Every tree node that resolves to each depPath. A peer is only spurious for a
+  // depPath when the fresh pass left it unresolved for *every* position the
+  // depPath represents — otherwise the depPath stands for a context where the
+  // peer is genuine and must be kept.
+  const reachableNodeIds = new Set<NodeId>()
+  const reachableNodeIdsStack: NodeId[] = []
+  for (const project of opts.projects) {
+    for (const alias of opts.dependenciesByProjectId[project.id].keys()) {
+      const nodeId = project.directNodeIdsByAlias.get(alias)
+      if (nodeId != null && opts.dependenciesTree.has(nodeId) && !reachableNodeIds.has(nodeId)) {
+        reachableNodeIds.add(nodeId)
+        reachableNodeIdsStack.push(nodeId)
+      }
+    }
+  }
+  for (const nodeId of peerHashNodeIds) {
+    if (opts.dependenciesTree.has(nodeId) && !reachableNodeIds.has(nodeId)) {
+      reachableNodeIds.add(nodeId)
+      reachableNodeIdsStack.push(nodeId)
+    }
+  }
+  while (reachableNodeIdsStack.length > 0) {
+    const nodeId = reachableNodeIdsStack.pop()!
+    const node = opts.dependenciesTree.get(nodeId)!
+    if (typeof node.children === 'function') continue
+    const children = node.children
+    for (const childNodeId of Object.values(children)) {
+      if (opts.dependenciesTree.has(childNodeId) && !reachableNodeIds.has(childNodeId)) {
+        reachableNodeIds.add(childNodeId)
+        reachableNodeIdsStack.push(childNodeId)
+      }
+    }
+  }
+  const nodeIdsByDepPath = new Map<DepPath, NodeId[]>()
+  for (const [nodeId, depPath] of opts.pathsByNodeIdBeforeDedupe.entries()) {
+    if (!reachableNodeIds.has(nodeId) && !peerHashNodeIds.has(nodeId)) continue
+    for (const indexedDepPath of new Set([depPath, deduplicated(depPath)])) {
+      let nodeIds = nodeIdsByDepPath.get(indexedDepPath)
+      if (nodeIds == null) {
+        nodeIds = []
+        nodeIdsByDepPath.set(indexedDepPath, nodeIds)
+      }
+      nodeIds.push(nodeId)
+    }
+  }
+
+  const spuriousPeersByDepPath = new Map<DepPath, Set<string>>()
+  for (const [depPath, node] of Object.entries(depGraph)) {
+    if (!reachable.has(depPath as DepPath)) continue
+    if (node.resolvedPeerNames.size === 0) continue
+    // Recomputing a depPath needs every resolved peer's original hash input. If any is
+    // missing the suffix cannot be rebuilt faithfully, so leave the node as-is.
+    if (node.resolvedPeerIds == null || node.resolvedPeerIds.size !== node.resolvedPeerNames.size) continue
+    const nodeIds = nodeIdsByDepPath.get(depPath as DepPath) ?? []
+    if (nodeIds.length === 0) continue
+    let spurious: Set<string> | undefined
+    for (const peerName of node.resolvedPeerNames) {
+      const resolvedAsOwnPeer = nodeIds.some((nodeId) => opts.resolvedOwnPeerNamesByNodeId.get(nodeId)?.has(peerName))
+      if (resolvedAsOwnPeer) continue
+      const genuine = nodeIds.some((nodeId) => opts.previousResolvedPeerNamesByNodeId.get(nodeId)?.has(peerName))
+      if (genuine) continue
+      spurious ??= new Set<string>()
+      spurious.add(peerName)
+    }
+    if (spurious != null) spuriousPeersByDepPath.set(depPath as DepPath, spurious)
+  }
+
+  if (spuriousPeersByDepPath.size === 0) return
+
+  const peerGraph: Array<[string, string[]]> = []
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (!reachable.has(depPath) || node.resolvedPeerIds == null) continue
+    const peerDepPaths = [...node.resolvedPeerIds.values()]
+      .flatMap((resolvedPeerId) => 'depPath' in resolvedPeerId ? [deduplicated(resolvedPeerId.depPath)] : [])
+    if (peerDepPaths.length > 0) {
+      peerGraph.push([depPath, peerDepPaths])
+    }
+  }
+  const { cycles: peerCycles } = analyzeGraph(peerGraph as unknown as Graph) as unknown as { cycles: DepPath[][] }
+  const cyclicDepPaths = new Set(peerCycles.flat())
+  for (const depPath of cyclicDepPaths) {
+    spuriousPeersByDepPath.delete(depPath)
+  }
+
+  // Recompute each node's depPath with its spurious peers removed. A depPath is
+  // a function of the kept peers' identifiers, and a non-deduped peer's
+  // identifier is the provider's own (possibly recomputed) depPath, so this
+  // memoized recursion mirrors how depPaths were first built while resolving
+  // provider remaps. A depPath already in progress is on a peer cycle; return
+  // it unchanged, matching how the first pass breaks such cycles.
+  const finalDepPathCache = new Map<DepPath, DepPath>()
+  const inProgress = new Set<DepPath>()
+  const finalDepPath = (depPath: DepPath): DepPath => {
+    const cached = finalDepPathCache.get(depPath)
+    if (cached != null) return cached
+    const node = depGraph[depPath]
+    if (node == null || cyclicDepPaths.has(depPath) || inProgress.has(depPath)) return depPath
+    // A node whose resolved peers cannot be fully recomputed (see above) keeps
+    // its depPath; recomputing from a partial set would drop real peers.
+    if (node.resolvedPeerNames.size > 0 && (node.resolvedPeerIds == null || node.resolvedPeerIds.size !== node.resolvedPeerNames.size)) {
+      return depPath
+    }
+    inProgress.add(depPath)
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const peerIds: PeerId[] = []
+    if (node.resolvedPeerIds != null) {
+      for (const [peerName, resolvedPeerId] of node.resolvedPeerIds.entries()) {
+        if (spurious?.has(peerName)) continue
+        peerIds.push('depPath' in resolvedPeerId
+          ? finalDepPath(resolvedPeerId.depPath)
+          : resolvedPeerId.peerId)
+      }
+    }
+    const suffix = peerIds.length === 0 ? '' : createPeerDepGraphHash(peerIds, opts.peersSuffixMaxLength)
+    const newDepPath = `${node.pkgIdWithPatchHash}${suffix}` as DepPath
+    inProgress.delete(depPath)
+    finalDepPathCache.set(depPath, newDepPath)
+    return newDepPath
+  }
+
+  const remap = new Map<DepPath, DepPath>()
+  for (const depPath of Object.keys(depGraph) as DepPath[]) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = finalDepPath(depPath)
+    if (newDepPath !== depPath) remap.set(depPath, newDepPath)
+  }
+
+  if (remap.size === 0) return
+
+  const remapped = (depPath: DepPath): DepPath => remap.get(depPath) ?? depPath
+
+  const candidatesByDepPath = new Map<DepPath, Array<{
+    children: Record<string, DepPath>
+    childKeys: Set<string>
+    depth: number
+    depPath: DepPath
+    installable: boolean
+  }>>()
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = remapped(depPath)
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const children = Object.fromEntries(
+      Object.entries<DepPath>(node.children)
+        .filter(([alias]) => !spurious?.has(alias))
+        .map(([alias, childDepPath]) => [alias, remapped(childDepPath)])
+    )
+    const childKeys = new Set(Object.entries(children).map(([alias, childDepPath]) => {
+      const normalizedChildDepPath = opts.dedupePeers && node.resolvedPeerNames.has(alias)
+        ? getPkgIdWithPatchHash(childDepPath)
+        : childDepPath
+      return `${alias}\0${normalizedChildDepPath}`
+    }))
+    const candidates = candidatesByDepPath.get(newDepPath)
+    const candidate = { children, childKeys, depth: node.depth, depPath, installable: node.installable }
+    if (candidates == null) {
+      candidatesByDepPath.set(newDepPath, [candidate])
+    } else {
+      candidates.push(candidate)
+    }
+  }
+  const winnerByDepPath = new Map<DepPath, DepPath>()
+  for (const [newDepPath, candidates] of candidatesByDepPath.entries()) {
+    const previousChildren = opts.previousDependenciesGraph?.[newDepPath]?.children
+    const preferredChildren = previousChildren == null
+      ? undefined
+      : Object.fromEntries(
+        Object.entries(previousChildren).map(([alias, childDepPath]) => [alias, remapped(deduplicated(childDepPath))])
+      )
+    const winner = pickPeerCleanupWinner(candidates, newDepPath, preferredChildren)
+    if (winner == null) return
+    winnerByDepPath.set(newDepPath, winner.depPath)
+  }
+
+  // Rebuild the graph under the recomputed depPaths. Reachable nodes are written
+  // last so a remapped reachable instance wins over any unreferenced node that
+  // happens to occupy its recomputed depPath. Nodes that collapse onto the same
+  // depPath are identical after dropping their spurious peers; a dropped peer's
+  // child entry is removed (it is already in transitivePeerDependencies) and
+  // every surviving child is remapped.
+  const newDepGraph: GenericDependenciesGraphWithResolvedChildren<T> = {}
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (reachable.has(depPath)) continue
+    newDepGraph[depPath] = {
+      ...node,
+      children: Object.fromEntries(
+        Object.entries(node.children).map(([alias, childDepPath]) => [alias, remapped(childDepPath)])
+      ),
+    }
+  }
+  for (const [depPath, node] of Object.entries(depGraph) as Array<[DepPath, T & GenericDependenciesGraphNodeWithResolvedChildren]>) {
+    if (!reachable.has(depPath)) continue
+    const newDepPath = remapped(depPath)
+    if (winnerByDepPath.get(newDepPath) !== depPath) continue
+    const spurious = spuriousPeersByDepPath.get(depPath)
+    const candidates = candidatesByDepPath.get(newDepPath)!
+    const children = candidates.find((candidate) => candidate.depPath === depPath)!.children
+    const depth = Math.min(...candidates.map((candidate) => candidate.depth))
+    const installable = candidates.some((candidate) => candidate.installable)
+    let resolvedPeerNames = node.resolvedPeerNames
+    let resolvedPeerIds = node.resolvedPeerIds
+    if (spurious != null) {
+      resolvedPeerNames = new Set([...node.resolvedPeerNames].filter((peerName) => !spurious.has(peerName)))
+      resolvedPeerIds = resolvedPeerIds == null
+        ? undefined
+        : new Map([...resolvedPeerIds].filter(([peerName]) => !spurious.has(peerName)))
+    }
+    if (resolvedPeerIds != null && !cyclicDepPaths.has(depPath)) {
+      resolvedPeerIds = new Map([...resolvedPeerIds].map(([peerName, resolvedPeerId]): [string, ResolvedPeerId] => {
+        if (!('depPath' in resolvedPeerId)) return [peerName, resolvedPeerId]
+        const depPath = remapped(resolvedPeerId.depPath)
+        return [peerName, { depPath, nodeId: resolvedPeerId.nodeId }]
+      }))
+    }
+    const modules = path.join(opts.virtualStoreDir, depPathToFilename(newDepPath, opts.virtualStoreDirMaxLength), 'node_modules')
+    newDepGraph[newDepPath] = {
+      ...node,
+      depPath: newDepPath,
+      children,
+      depth,
+      dir: safeJoinModulesDir(modules, node.name),
+      installable,
+      modules,
+      resolvedPeerNames,
+      resolvedPeerIds,
+    }
+  }
+
+  for (const depPath of Object.keys(depGraph) as DepPath[]) {
+    delete depGraph[depPath]
+  }
+  Object.assign(depGraph, newDepGraph)
+
+  for (const [nodeId, depPath] of opts.pathsByNodeId.entries()) {
+    opts.pathsByNodeId.set(nodeId, remapped(depPath))
+  }
+
+  for (const deps of Object.values(opts.dependenciesByProjectId)) {
+    for (const [alias, depPath] of deps.entries()) {
+      deps.set(alias, remapped(depPath))
+    }
   }
 }
 
@@ -470,6 +849,7 @@ type MissingPeers = Map<string, MissingPeerInfo>
 
 interface PeersCacheItem {
   depPath: DeferredPromise<DepPath>
+  resolvedOwnPeerNames: Set<string>
   resolvedPeers: Map<string, NodeId>
   missingPeers: MissingPeers
   // The node whose resolution created this entry and will resolve depPath.
@@ -486,6 +866,7 @@ interface PeersResolution {
 
 interface ResolvePeersContext {
   pathsByNodeId: Map<NodeId, DepPath>
+  resolvedOwnPeerNamesByNodeId: Map<NodeId, Set<string>>
   pathsByNodeIdPromises: Map<NodeId, DeferredPromise<DepPath>>
   // The await edges between dep path calculations, consumed by
   // breakDepPathAwaitCycles: which pathsByNodeIdPromises entries each node's
@@ -494,7 +875,6 @@ interface ResolvePeersContext {
   awaitedPeerNodeIdsByNodeId: Map<NodeId, Set<NodeId>>
   peersCacheOwnerByNodeId: Map<NodeId, NodeId>
   cycleBrokenNodeIds: Set<NodeId>
-  depPathsByPkgId?: Map<PkgIdWithPatchHash, Set<DepPath>>
   nodeIdsByPreviousDepPath: Map<DepPath, NodeId>
   resolvedPeerProviderPaths?: Map<NodeId, DepPath>
   currentProviderSources: CurrentProviderSource[]
@@ -650,6 +1030,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       })
     }
     ctx.peersCacheOwnerByNodeId.set(nodeId, hit.ownerNodeId)
+    ctx.resolvedOwnPeerNamesByNodeId.set(nodeId, hit.resolvedOwnPeerNames)
     return {
       missingPeers: hit.missingPeers,
       finishing: (async () => {
@@ -685,6 +1066,8 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
       rootDir: ctx.rootDir,
       parentNodeIds,
     })
+  const resolvedOwnPeerNames = new Set(resolvedPeers.keys())
+  ctx.resolvedOwnPeerNamesByNodeId.set(nodeId, resolvedOwnPeerNames)
 
   const allResolvedPeers = unknownResolvedPeersOfChildren
   for (const [k, v] of resolvedPeers) {
@@ -718,6 +1101,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     cache = {
       missingPeers: allMissingPeers,
       depPath: pDefer(),
+      resolvedOwnPeerNames,
       resolvedPeers: allResolvedPeers,
       ownerNodeId: nodeId,
     }
@@ -733,20 +1117,22 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
     addDepPathToGraph(resolvedPackage.pkgIdWithPatchHash as unknown as DepPath)
   } else {
     const peerIds: PeerId[] = []
+    const resolvedPeerIds = new Map<string, ResolvedPeerId>()
     const pendingPeers: PendingPeer[] = []
     for (const [alias, peerNodeId] of allResolvedPeers.entries()) {
-      const peerId = peerNodeIdToPeerId(alias, peerNodeId, ctx)
-      if (peerId != null) {
-        peerIds.push(peerId)
+      const resolvedPeerId = peerNodeIdToResolvedPeerId(alias, peerNodeId, ctx)
+      if (resolvedPeerId != null) {
+        resolvedPeerIds.set(alias, resolvedPeerId)
+        peerIds.push('depPath' in resolvedPeerId ? resolvedPeerId.depPath : resolvedPeerId.peerId)
       } else {
         pendingPeers.push({ alias, nodeId: peerNodeId })
       }
     }
     if (pendingPeers.length === 0) {
       const peerDepGraphHash = createPeerDepGraphHash(peerIds, ctx.peersSuffixMaxLength)
-      addDepPathToGraph(`${resolvedPackage.pkgIdWithPatchHash}${peerDepGraphHash}` as DepPath)
+      addDepPathToGraph(`${resolvedPackage.pkgIdWithPatchHash}${peerDepGraphHash}` as DepPath, resolvedPeerIds)
     } else {
-      calculateDepPathIfNeeded = calculateDepPath.bind(null, peerIds, pendingPeers)
+      calculateDepPathIfNeeded = calculateDepPath.bind(null, peerIds, resolvedPeerIds, pendingPeers)
     }
   }
 
@@ -759,6 +1145,7 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
 
   async function calculateDepPath (
     peerIds: PeerId[],
+    resolvedPeerIds: Map<string, ResolvedPeerId>,
     pendingPeerNodes: PendingPeer[],
     cycles: string[][]
   ): Promise<void> {
@@ -786,12 +1173,15 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
             const id = `${name}@${version}`
             ctx.cycleBrokenNodeIds.add(pendingPeer.nodeId)
             ctx.pathsByNodeIdPromises.get(pendingPeer.nodeId)?.resolve(id as DepPath)
+            resolvedPeerIds.set(pendingPeer.alias, { peerId: id, nodeId: pendingPeer.nodeId })
             return id
           }
           if (ctx.dedupePeers) {
             const peerNode = ctx.dependenciesTree.get(pendingPeer.nodeId)
             if (peerNode) {
-              return { name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version }
+              const peerId = { name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version }
+              resolvedPeerIds.set(pendingPeer.alias, { peerId, nodeId: pendingPeer.nodeId })
+              return peerId
             }
           }
           let awaitedPeerNodeIds = ctx.awaitedPeerNodeIdsByNodeId.get(nodeId)
@@ -800,24 +1190,27 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
             ctx.awaitedPeerNodeIdsByNodeId.set(nodeId, awaitedPeerNodeIds)
           }
           awaitedPeerNodeIds.add(pendingPeer.nodeId)
-          return ctx.pathsByNodeIdPromises.get(pendingPeer.nodeId)!.promise
+          const depPath = await ctx.pathsByNodeIdPromises.get(pendingPeer.nodeId)!.promise
+          resolvedPeerIds.set(
+            pendingPeer.alias,
+            ctx.cycleBrokenNodeIds.has(pendingPeer.nodeId)
+              ? { peerId: depPath, nodeId: pendingPeer.nodeId }
+              : { depPath, nodeId: pendingPeer.nodeId }
+          )
+          return depPath
         })
       ),
     ], ctx.peersSuffixMaxLength)
-    addDepPathToGraph(`${resolvedPackage.pkgIdWithPatchHash}${peerDepGraphHash}` as DepPath)
+    addDepPathToGraph(`${resolvedPackage.pkgIdWithPatchHash}${peerDepGraphHash}` as DepPath, resolvedPeerIds)
   }
 
-  function addDepPathToGraph (depPath: DepPath): void {
+  function addDepPathToGraph (
+    depPath: DepPath,
+    resolvedPeerIds?: Map<string, ResolvedPeerId>
+  ): void {
     cache?.depPath.resolve(depPath)
     ctx.pathsByNodeId.set(nodeId, depPath)
     ctx.pathsByNodeIdPromises.get(nodeId)!.resolve(depPath)
-    if (ctx.depPathsByPkgId != null) {
-      if (!ctx.depPathsByPkgId.has(resolvedPackage.pkgIdWithPatchHash)) {
-        ctx.depPathsByPkgId.set(resolvedPackage.pkgIdWithPatchHash, new Set([depPath]))
-      } else {
-        ctx.depPathsByPkgId.get(resolvedPackage.pkgIdWithPatchHash)!.add(depPath)
-      }
-    }
     const peerDependencies = { ...resolvedPackage.peerDependencies }
     if (!ctx.depGraph[depPath] || ctx.depGraph[depPath].depth > node.depth) {
       const modules = path.join(ctx.virtualStoreDir, depPathToFilename(depPath, ctx.virtualStoreDirMaxLength), 'node_modules')
@@ -850,9 +1243,47 @@ async function resolvePeersOfNode<T extends PartialResolvedPackage> (
         peerDependencies,
         transitivePeerDependencies,
         resolvedPeerNames: new Set(allResolvedPeers.keys()),
+        resolvedPeerIds,
       }
     }
   }
+}
+
+export function pickPeerCleanupWinner<T extends {
+  children: Record<string, DepPath>
+  childKeys: Set<string>
+  depPath: DepPath
+}> (
+  candidates: T[],
+  preferredDepPath?: DepPath,
+  preferredChildren?: Record<string, DepPath>
+): T | undefined {
+  const childrenSignature = (children: Record<string, DepPath> | undefined): string | undefined =>
+    children == null
+      ? undefined
+      : Object.entries(children)
+        .map(([alias, childDepPath]) => `${alias}=${childDepPath}`)
+        .sort()
+        .join('\n')
+  const preferredChildrenSignature = childrenSignature(preferredChildren)
+  return [...candidates]
+    .sort((candidate1, candidate2) => {
+      const preferredChildrenDiff =
+        Number(childrenSignature(candidate2.children) === preferredChildrenSignature) -
+        Number(childrenSignature(candidate1.children) === preferredChildrenSignature)
+      if (preferredChildrenSignature != null && preferredChildrenDiff !== 0) return preferredChildrenDiff
+      const preferredDiff =
+        Number(candidate2.depPath === preferredDepPath) - Number(candidate1.depPath === preferredDepPath)
+      if (preferredDiff !== 0) return preferredDiff
+      const countDiff = candidate2.childKeys.size - candidate1.childKeys.size
+      if (countDiff !== 0) return countDiff
+      return candidate1.depPath < candidate2.depPath ? -1 : candidate1.depPath > candidate2.depPath ? 1 : 0
+    })
+    .find((candidate) =>
+      candidates.every(({ childKeys }) =>
+        [...childKeys].every((childKey) => candidate.childKeys.has(childKey))
+      )
+    )
 }
 
 function getNodeIdsByPreviousDepPath<T> (dependenciesTree: DependenciesTree<T>): Map<DepPath, NodeId> {
@@ -1292,18 +1723,21 @@ function getLocationFromParentNodeIds<T> (
   }
 }
 
-function peerNodeIdToPeerId<T extends PartialResolvedPackage> (
+function peerNodeIdToResolvedPeerId<T extends PartialResolvedPackage> (
   alias: string,
   peerNodeId: NodeId,
   ctx: ResolvePeersContext & {
     dedupePeers?: boolean
     dependenciesTree: DependenciesTree<T>
   }
-): PeerId | undefined {
+): ResolvedPeerId | undefined {
   if (typeof peerNodeId === 'string' && peerNodeId.startsWith('link:')) {
     return {
-      name: alias,
-      version: linkPathToPeerVersion(peerNodeId.slice(5)),
+      peerId: {
+        name: alias,
+        version: linkPathToPeerVersion(peerNodeId.slice(5)),
+      },
+      nodeId: peerNodeId,
     }
   }
   if (ctx.dedupePeers) {
@@ -1311,10 +1745,17 @@ function peerNodeIdToPeerId<T extends PartialResolvedPackage> (
     // This eliminates nested peer suffixes like (foo@1.0.0(bar@2.0.0)).
     const peerNode = ctx.dependenciesTree.get(peerNodeId)
     if (peerNode) {
-      return { name: peerNode.resolvedPackage.name, version: peerNode.resolvedPackage.version }
+      return {
+        peerId: {
+          name: peerNode.resolvedPackage.name,
+          version: peerNode.resolvedPackage.version,
+        },
+        nodeId: peerNodeId,
+      }
     }
   }
-  return ctx.pathsByNodeId.get(peerNodeId)
+  const depPath = ctx.pathsByNodeId.get(peerNodeId)
+  return depPath == null ? undefined : { depPath, nodeId: peerNodeId }
 }
 
 interface ParentRefs {

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -2000,11 +2000,11 @@ describe('locked peer provider preferences', () => {
       previousDependenciesGraph: initial.dependenciesGraph,
       previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
     })
-    const peerfulConsumer = 'consumer/1.0.0(peer/1.0.0)' as DepPath
+    const consumerWithPeer = 'consumer/1.0.0(peer/1.0.0)' as DepPath
     const plainConsumer = 'consumer/1.0.0' as DepPath
     const holderWithConsumer = 'holder/1.0.0(consumer/1.0.0)' as DepPath
 
-    expect(initial.pathsByNodeId.get(injectedConsumerNodeId)).toBe(peerfulConsumer)
+    expect(initial.pathsByNodeId.get(injectedConsumerNodeId)).toBe(consumerWithPeer)
     expect(initial.pathsByNodeId.get(survivingConsumerNodeId)).toBe(plainConsumer)
     expect(cleaned.dependenciesByProjectId['']).toEqual(new Map([
       ['consumer', plainConsumer],

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -1,5 +1,8 @@
 /// <reference path="../../../__typings__/index.d.ts" />
-import { beforeAll, describe, expect, it, test } from '@jest/globals'
+import path from 'node:path'
+
+import { beforeAll, describe, expect, it, jest, test } from '@jest/globals'
+import { createPeerDepGraphHash } from '@pnpm/deps.path'
 import type {
   DepPath,
   PeerDependencyIssuesByProjects,
@@ -9,8 +12,8 @@ import type {
 } from '@pnpm/types'
 
 import type { NodeId } from '../lib/nextNodeId.js'
-import type { ChildrenMap, DependenciesTreeNode, PeerDependencies } from '../lib/resolveDependencies.js'
-import { type PartialResolvedPackage, resolvePeers } from '../lib/resolvePeers.js'
+import type { ChildrenMap, DependenciesTreeNode, LockedPeerContext, PeerDependencies } from '../lib/resolveDependencies.js'
+import { type PartialResolvedPackage, pickPeerCleanupWinner, type ProjectToResolve, resolvePeers } from '../lib/resolvePeers.js'
 
 test('resolve peer dependencies of cyclic dependencies', async () => {
   const fooPkg = {
@@ -766,6 +769,100 @@ test('resolve peer dependencies with npm aliases', async () => {
   ])
 })
 
+test('peer cleanup selects a compatible child superset', () => {
+  const subset = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childKeys: new Set(['foo\0foo/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  const superset = {
+    children: {
+      bar: 'bar/1.0.0' as DepPath,
+      foo: 'foo/1.0.0' as DepPath,
+    },
+    childKeys: new Set(['foo\0foo/1.0.0', 'bar\0bar/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-b/1.0.0)' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([subset, superset])).toBe(superset)
+})
+
+test('peer cleanup rejects incompatible children', () => {
+  const foo = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childKeys: new Set(['foo\0foo/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  const bar = {
+    children: { bar: 'bar/1.0.0' as DepPath },
+    childKeys: new Set(['bar\0bar/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-b/1.0.0)' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([foo, bar])).toBeUndefined()
+})
+
+test('peer cleanup rejects children assigned to different aliases', () => {
+  const first = {
+    children: { a: 'foo/1.0.0' as DepPath, b: 'bar/1.0.0' as DepPath },
+    childKeys: new Set(['a\0foo/1.0.0', 'b\0bar/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  const second = {
+    children: { a: 'bar/1.0.0' as DepPath, b: 'foo/1.0.0' as DepPath },
+    childKeys: new Set(['a\0bar/1.0.0', 'b\0foo/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-b/1.0.0)' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([first, second])).toBeUndefined()
+})
+
+test('peer cleanup breaks equal-child ties by depPath', () => {
+  const later = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childKeys: new Set(['foo\0foo/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-b/1.0.0)' as DepPath,
+  }
+  const earlier = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childKeys: new Set(['foo\0foo/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([later, earlier])).toBe(earlier)
+})
+
+test('peer cleanup prefers an existing target depPath', () => {
+  const remapped = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childKeys: new Set(['foo\0foo/1.0.0']),
+    depPath: 'consumer/1.0.0(peer-a/1.0.0)' as DepPath,
+  }
+  const existing = {
+    children: { foo: 'foo/1.0.0' as DepPath },
+    childKeys: new Set(['foo\0foo/1.0.0']),
+    depPath: 'consumer/1.0.0' as DepPath,
+  }
+  expect(pickPeerCleanupWinner([remapped, existing], existing.depPath)).toBe(existing)
+})
+
+test('peer cleanup preserves the fresh child context when normalized children tie', () => {
+  const normalizedStorybook = 'storybook/10.2.13' as DepPath
+  const freshStorybook = 'storybook/10.2.13(react/18.3.1)' as DepPath
+  const otherStorybook = 'storybook/10.2.13(react/19.2.7)' as DepPath
+  const remapped = {
+    children: { storybook: freshStorybook },
+    childKeys: new Set([`storybook\0${normalizedStorybook}`]),
+    depPath: 'consumer/1.0.0(supports-color/5.5.0)' as DepPath,
+  }
+  const existing = {
+    children: { storybook: otherStorybook },
+    childKeys: new Set([`storybook\0${normalizedStorybook}`]),
+    depPath: 'consumer/1.0.0' as DepPath,
+  }
+  expect(pickPeerCleanupWinner(
+    [existing, remapped],
+    existing.depPath,
+    { storybook: freshStorybook }
+  )).toBe(remapped)
+})
+
 describe('locked peer provider preferences', () => {
   const currentPeerNodeId = '>peer/1.0.0>' as NodeId
   const retainedPeerNodeId = '>retainer/1.0.0>peer/2.0.0>' as NodeId
@@ -886,6 +983,374 @@ describe('locked peer provider preferences', () => {
       workspaceProjectIds: new Set<string>(),
     }
   }
+
+  function resolvedPeerNamesByNodeId (
+    result: Awaited<ReturnType<typeof resolvePeers>>
+  ): Map<NodeId, Set<string>> {
+    const byNodeId = new Map<NodeId, Set<string>>()
+    for (const [nodeId, depPath] of result.pathsByNodeId.entries()) {
+      const node = result.dependenciesGraph[depPath]
+      if (node != null && node.resolvedPeerNames.size > 0) {
+        byNodeId.set(nodeId, node.resolvedPeerNames)
+      }
+    }
+    return byNodeId
+  }
+
+  function fixturePkg (
+    name: string,
+    peerDependencies: PeerDependencies = {}
+  ): PartialResolvedPackage {
+    return {
+      name,
+      pkgIdWithPatchHash: `${name}/1.0.0` as PkgIdWithPatchHash,
+      version: '1.0.0',
+      peerDependencies,
+      id: '' as PkgResolutionId,
+    }
+  }
+
+  function fixtureNode (
+    pkg: string | PartialResolvedPackage,
+    overrides: {
+      peerDependencies?: PeerDependencies
+      children?: DependenciesTreeNode<PartialResolvedPackage>['children']
+      depth?: number
+      installable?: boolean
+      previousDepPath?: DepPath
+      lockedPeerContext?: LockedPeerContext
+    } = {}
+  ): DependenciesTreeNode<PartialResolvedPackage> {
+    const resolvedPackage = typeof pkg === 'string' ? fixturePkg(pkg, overrides.peerDependencies) : pkg
+    return {
+      children: overrides.children ?? {},
+      installable: overrides.installable ?? true,
+      depth: overrides.depth ?? 0,
+      resolvedPackage,
+      ...(overrides.previousDepPath != null ? { previousDepPath: overrides.previousDepPath } : {}),
+      ...(overrides.lockedPeerContext != null ? { lockedPeerContext: overrides.lockedPeerContext } : {}),
+    }
+  }
+
+  function project (
+    id: string,
+    directNodeIdsByAlias: Map<string, NodeId>,
+    overrides: Partial<ProjectToResolve> = {}
+  ): ProjectToResolve {
+    return {
+      directNodeIdsByAlias,
+      topParents: [],
+      rootDir: '' as ProjectRootDir,
+      id,
+      ...overrides,
+    }
+  }
+
+  function baseResolveOpts () {
+    return {
+      resolvedImporters: {},
+      virtualStoreDir: '',
+      virtualStoreDirMaxLength: 120,
+      lockfileDir: '',
+      peersSuffixMaxLength: 1000,
+      workspaceProjectIds: new Set<string>(),
+    }
+  }
+
+  async function resolveWithCleanup (
+    resolutionOpts: Parameters<typeof resolvePeers>[0]
+  ) {
+    const initial = await resolvePeers({
+      ...resolutionOpts,
+      dedupePeerDependents: false,
+    })
+    const cleaned = await resolvePeers({
+      ...resolutionOpts,
+      dedupePeerDependents: true,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+      previousDependenciesGraph: initial.dependenciesGraph,
+      previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+    })
+    return { cleaned, initial }
+  }
+
+  test('cleanup preserves an own locked peer across occurrences sharing a depPath', async () => {
+    const xNodeId = '>retainer/1.0.0>x/1.0.0>' as NodeId
+    const shallowSharedNodeId = '>shared/1.0.0>' as NodeId
+    const propagatorNodeId = '>shared/1.0.0>propagator/1.0.0>' as NodeId
+    const deepSharedNodeId = '>wrapper/1.0.0>shared/1.0.0>' as NodeId
+    const xPeerDependencies: PeerDependencies = {
+      x: { version: '1.0.0', optional: true },
+    }
+    const sharedPkg = fixturePkg('shared', xPeerDependencies)
+    const resolutionOpts = options(
+      new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [retainerNodeId, fixtureNode(retainerPkg, { children: { x: xNodeId } })],
+        [xNodeId, fixtureNode('x', { depth: 1, previousDepPath: 'x/1.0.0' as DepPath })],
+        [shallowSharedNodeId, fixtureNode(sharedPkg, { children: { propagator: propagatorNodeId } })],
+        [propagatorNodeId, fixtureNode('propagator', {
+          peerDependencies: xPeerDependencies,
+          depth: 1,
+          lockedPeerContext: { x: 'x/1.0.0' as DepPath },
+        })],
+        [wrapperNodeId, fixtureNode(wrapperPkg, { children: { shared: deepSharedNodeId } })],
+        [deepSharedNodeId, fixtureNode(sharedPkg, { depth: 1, lockedPeerContext: { x: 'x/1.0.0' as DepPath } })],
+      ]),
+      new Map([
+        ['retainer', retainerNodeId],
+        ['shared', shallowSharedNodeId],
+        ['wrapper', wrapperNodeId],
+      ])
+    )
+    resolutionOpts.allPeerDepNames = new Set(['x'])
+    const { initial, cleaned } = await resolveWithCleanup(resolutionOpts)
+    const sharedWithX = 'shared/1.0.0(x/1.0.0)' as DepPath
+
+    expect(initial.pathsByNodeId.get(shallowSharedNodeId)).toBe('shared/1.0.0')
+    expect(initial.pathsByNodeId.get(deepSharedNodeId)).toBe('shared/1.0.0')
+    expect(cleaned.pathsByNodeId.get(shallowSharedNodeId)).toBe(sharedWithX)
+    expect(cleaned.pathsByNodeId.get(deepSharedNodeId)).toBe(sharedWithX)
+    expect(cleaned.dependenciesGraph[sharedWithX].children).toEqual({
+      propagator: 'propagator/1.0.0(x/1.0.0)',
+    })
+  })
+
+  test('cleanup preserves an own peer below a cache-pruned survivor after injected dedupe', async () => {
+    const ownerDepNodeId = '>retainer/1.0.0>dep/1.0.0>' as NodeId
+    const survivingRetainerNodeId = '>wrapper/1.0.0>retainer/1.0.0>' as NodeId
+    const survivingPeerNodeId = '>wrapper/1.0.0>retainer/1.0.0>peer/2.0.0>' as NodeId
+    const survivingDepNodeId = '>wrapper/1.0.0>retainer/1.0.0>dep/1.0.0>' as NodeId
+    const lazyChildren = jest.fn<() => ChildrenMap>(() => ({
+      peer: survivingPeerNodeId,
+      dep: survivingDepNodeId,
+    }))
+    const injectedRetainerPkg = {
+      ...retainerPkg,
+      id: 'file:workspace' as PkgResolutionId,
+    }
+    const depPkg = fixturePkg('dep', {
+      peer: { version: '>=1' },
+    })
+    const directNodeIdsByAlias = new Map([
+      ['injected', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ])
+    const resolutionOpts = options(
+      new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [retainerNodeId, fixtureNode(injectedRetainerPkg, {
+          children: { peer: retainedPeerNodeId, dep: ownerDepNodeId },
+        })],
+        [retainedPeerNodeId, fixtureNode(peer2Pkg, { depth: 1 })],
+        [ownerDepNodeId, fixtureNode(depPkg, { depth: 1 })],
+        [wrapperNodeId, fixtureNode(wrapperPkg, { children: { retainer: survivingRetainerNodeId } })],
+        [survivingRetainerNodeId, fixtureNode(injectedRetainerPkg, { children: lazyChildren, depth: 1 })],
+        [survivingPeerNodeId, fixtureNode(peer2Pkg, { depth: 2 })],
+        [survivingDepNodeId, fixtureNode(depPkg, { depth: 2 })],
+      ]),
+      directNodeIdsByAlias
+    )
+    const { cleaned } = await resolveWithCleanup({
+      ...resolutionOpts,
+      dedupeInjectedDeps: true,
+      resolvedImporters: {
+        '': {
+          directDependencies: [{
+            alias: 'injected',
+            pkgId: 'file:workspace' as PkgResolutionId,
+          } as Parameters<typeof resolvePeers>[0]['resolvedImporters'][string]['directDependencies'][number]],
+          directNodeIdsByAlias,
+          hoistedPeerProviderNodeIds: new Set<NodeId>(),
+          linkedDependencies: [],
+        },
+      },
+      workspaceProjectIds: new Set(['workspace']),
+    })
+    const depWithPeer = 'dep/1.0.0(peer/2.0.0)' as DepPath
+
+    expect(cleaned.dependenciesByProjectId[''].has('injected')).toBe(false)
+    expect(lazyChildren).not.toHaveBeenCalled()
+    expect(cleaned.dependenciesGraph['retainer/1.0.0'].children.dep).toBe(depWithPeer)
+    expect(cleaned.dependenciesGraph[depWithPeer].resolvedPeerNames).toEqual(new Set(['peer']))
+  })
+
+  test('cleanup accepts equivalent transitive provider contexts with dedupePeers', async () => {
+    const xPkg = fixturePkg('x')
+    const aPkg = fixturePkg('a', {
+      s: { version: '1.0.0', optional: true },
+    })
+    const bPkg = fixturePkg('b', {
+      t: { version: '1.0.0' },
+    })
+    const tPkg = fixturePkg('t', {
+      u: { version: '*' },
+    })
+    const plain = createContext('plain', '1.0.0')
+    const locked = createContext('locked', '2.0.0', true)
+    const sNodeId = '>plain>s>' as NodeId
+    plain.directNodeIdsByAlias.set('s', sNodeId)
+    const resolutionOpts = options(
+      new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        ...plain.nodes,
+        ...locked.nodes,
+        [sNodeId, fixtureNode('s', { previousDepPath: 's/1.0.0' as DepPath })],
+      ]),
+      plain.directNodeIdsByAlias
+    )
+    resolutionOpts.allPeerDepNames = new Set(['s', 't', 'u'])
+    resolutionOpts.projects[0].id = 'plain'
+    resolutionOpts.projects.push({
+      ...resolutionOpts.projects[0],
+      directNodeIdsByAlias: locked.directNodeIdsByAlias,
+      id: 'locked',
+    })
+    const { initial, cleaned } = await resolveWithCleanup({
+      ...resolutionOpts,
+      dedupePeers: true,
+    })
+    const xWithT = 'x/1.0.0(t@1.0.0)' as DepPath
+    const staleX = 'x/1.0.0(s@1.0.0)(t@1.0.0)' as DepPath
+
+    expect(initial.pathsByNodeId.get(plain.tNodeId))
+      .not.toBe(initial.pathsByNodeId.get(locked.tNodeId))
+    expect(initial.pathsByNodeId.get(locked.innerXNodeId)).toBe(xWithT)
+    expect(cleaned.pathsByNodeId.get(locked.innerXNodeId)).toBe(xWithT)
+    expect(cleaned.dependenciesGraph[staleX]).toBeUndefined()
+
+    function createContext (id: string, uVersion: string, reuseS = false) {
+      const outerXNodeId = `>${id}>x>` as NodeId
+      const innerXNodeId = `>${id}>x>x>` as NodeId
+      const aNodeId = `>${id}>x>x>a>` as NodeId
+      const bNodeId = `>${id}>x>x>b>` as NodeId
+      const tNodeId = `>${id}>x>t>` as NodeId
+      const uNodeId = `>${id}>u>` as NodeId
+      const nodes: Array<[NodeId, DependenciesTreeNode<PartialResolvedPackage>]> = [
+        [outerXNodeId, fixtureNode(xPkg, { children: { x: innerXNodeId, t: tNodeId } })],
+        [innerXNodeId, fixtureNode(xPkg, {
+          children: reuseS ? { a: aNodeId, b: bNodeId } : { b: bNodeId },
+          depth: 1,
+        })],
+        [bNodeId, fixtureNode(bPkg, { depth: 2 })],
+        [tNodeId, fixtureNode(tPkg, { depth: 1 })],
+        [uNodeId, fixtureNode({
+          ...fixturePkg('u'),
+          pkgIdWithPatchHash: `u/${uVersion}` as PkgIdWithPatchHash,
+          version: uVersion,
+        })],
+      ]
+      if (reuseS) {
+        nodes.push([aNodeId, fixtureNode(aPkg, { depth: 2, lockedPeerContext: { s: 's/1.0.0' as DepPath } })])
+      }
+      return {
+        directNodeIdsByAlias: new Map([
+          ['x', outerXNodeId],
+          ['u', uNodeId],
+        ]),
+        innerXNodeId,
+        nodes,
+        tNodeId,
+      }
+    }
+  })
+
+  test('cleanup preserves a fresh peer depPath when its provider is deduped', async () => {
+    const nNodeId = '>n>' as NodeId
+    const triggerNodeId = '>n>trigger>' as NodeId
+    const plainProvNodeId = '>prov>' as NodeId
+    const provWithOptNodeId = '>with-opt>prov>' as NodeId
+    const optNodeId = '>with-opt>opt>' as NodeId
+    const spurNodeId = '>with-opt>spur>' as NodeId
+    const provPkg = fixturePkg('prov', {
+      opt: { version: '1.0.0', optional: true },
+    })
+    const resolutionOpts = options(
+      new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [nNodeId, fixtureNode('n', { peerDependencies: { prov: { version: '1.0.0' } }, children: { trigger: triggerNodeId } })],
+        [triggerNodeId, fixtureNode('trigger', {
+          peerDependencies: { spur: { version: '1.0.0', optional: true } },
+          depth: 1,
+          lockedPeerContext: { spur: 'spur/1.0.0' as DepPath },
+        })],
+        [plainProvNodeId, fixtureNode(provPkg)],
+        [provWithOptNodeId, fixtureNode(provPkg)],
+        [optNodeId, fixtureNode('opt')],
+        [spurNodeId, fixtureNode('spur', { previousDepPath: 'spur/1.0.0' as DepPath })],
+      ]),
+      new Map([
+        ['n', nNodeId],
+        ['prov', plainProvNodeId],
+      ])
+    )
+    resolutionOpts.allPeerDepNames = new Set(['opt', 'prov', 'spur'])
+    resolutionOpts.projects[0].id = 'plain'
+    resolutionOpts.projects.push({
+      ...resolutionOpts.projects[0],
+      directNodeIdsByAlias: new Map([
+        ['prov', provWithOptNodeId],
+        ['opt', optNodeId],
+        ['spur', spurNodeId],
+      ]),
+      id: 'with-opt',
+    })
+    const { initial, cleaned } = await resolveWithCleanup(resolutionOpts)
+    const freshNDepPath = 'n/1.0.0(prov/1.0.0)' as DepPath
+
+    expect(initial.dependenciesByProjectId.plain.get('n')).toBe(freshNDepPath)
+    expect(cleaned.dependenciesByProjectId.plain.get('n')).toBe(freshNDepPath)
+    expect(cleaned.dependenciesGraph[freshNDepPath].children).toEqual({
+      trigger: 'trigger/1.0.0(spur/1.0.0)',
+      prov: 'prov/1.0.0(opt/1.0.0)',
+    })
+  })
+
+  test('cleanup follows a deduped provider referenced only by a peer hash', async () => {
+    const nNodeId = '>n>' as NodeId
+    const plainProvNodeId = '>prov>' as NodeId
+    const plainDepNodeId = '>prov>dep>' as NodeId
+    const qProvNodeId = '>with-q>prov>' as NodeId
+    const qDepNodeId = '>with-q>prov>dep>' as NodeId
+    const qNodeId = '>with-q>q>' as NodeId
+    const retainerNodeId = '>retainer>' as NodeId
+    const pNodeId = '>retainer>p>' as NodeId
+    const provPkg = fixturePkg('prov', {
+      q: { version: '1.0.0', optional: true },
+    })
+    const depPkg = fixturePkg('dep', {
+      p: { version: '1.0.0', optional: true },
+    })
+    const resolutionOpts = options(
+      new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [nNodeId, fixtureNode('n', { peerDependencies: { prov: { version: '1.0.0' } } })],
+        [plainProvNodeId, fixtureNode(provPkg, { children: { dep: plainDepNodeId } })],
+        [plainDepNodeId, fixtureNode(depPkg, { depth: 1, lockedPeerContext: { p: 'p/1.0.0' as DepPath } })],
+        [qProvNodeId, fixtureNode(provPkg, { children: { dep: qDepNodeId } })],
+        [qDepNodeId, fixtureNode(depPkg, { depth: 1, lockedPeerContext: { p: 'p/1.0.0' as DepPath } })],
+        [qNodeId, fixtureNode('q')],
+        [retainerNodeId, fixtureNode('retainer', { children: { p: pNodeId } })],
+        [pNodeId, fixtureNode('p', { depth: 1, previousDepPath: 'p/1.0.0' as DepPath })],
+      ]),
+      new Map([
+        ['n', nNodeId],
+        ['prov', plainProvNodeId],
+        ['retainer', retainerNodeId],
+      ])
+    )
+    resolutionOpts.allPeerDepNames = new Set(['p', 'prov', 'q'])
+    resolutionOpts.projects[0].id = 'plain'
+    resolutionOpts.projects.push({
+      ...resolutionOpts.projects[0],
+      directNodeIdsByAlias: new Map([
+        ['prov', qProvNodeId],
+        ['q', qNodeId],
+      ]),
+      id: 'with-q',
+    })
+    const { initial, cleaned } = await resolveWithCleanup(resolutionOpts)
+    const freshNDepPath = 'n/1.0.0(prov/1.0.0)' as DepPath
+
+    expect(initial.dependenciesByProjectId.plain.get('n')).toBe(freshNDepPath)
+    expect(cleaned.dependenciesByProjectId.plain.get('n')).toBe(freshNDepPath)
+    expect(cleaned.dependenciesGraph[freshNDepPath].children.prov).toBe('prov/1.0.0(q/1.0.0)')
+  })
 
   test('prefers a compatible locked provider that remains reachable in the current graph', async () => {
     const resolutionOpts = options(createTree(), new Map([
@@ -1111,6 +1576,444 @@ describe('locked peer provider preferences', () => {
 
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeTruthy()
     expect(preferred.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('drops a spuriously reused optional peer that the fresh pass left unresolved', async () => {
+    // Regression test for https://github.com/pnpm/pnpm/issues/12756. `dep` has an
+    // OPTIONAL peer whose only provider (peer@2.0.0) lives in an unrelated sibling
+    // subtree (under retainer), so a fresh resolution leaves it unbound. The
+    // locked-context reuse pass still binds it under `consumer`'s `dep` — that
+    // propagation is intentionally preserved so a shared provider can deduplicate.
+    // It bubbles `peer` up onto `consumer`, whose own optional peer stayed unresolved.
+    // The dropSpuriousReusePeers cleanup then removes that bubbled-up suffix from
+    // `consumer` because the fresh pass did not resolve `peer` for it, keeping a
+    // writable install aligned with `pnpm dedupe`.
+    const depNodeId = '>wrapper/1.0.0>consumer/1.0.0>dep/1.0.0>' as NodeId
+    const depPkg = fixturePkg('dep', {
+      peer: { version: '>=1', optional: true },
+    })
+    const consumerWithUnresolvedPeerPkg = {
+      ...consumerPkg,
+      peerDependencies: {
+        peer: { version: '>=1', optional: true },
+      },
+    }
+    const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [retainerNodeId, fixtureNode(retainerPkg, { children: { peer: retainedPeerNodeId } })],
+      [retainedPeerNodeId, fixtureNode(peer2Pkg, { depth: 1, previousDepPath: 'peer/2.0.0' as DepPath })],
+      [wrapperNodeId, fixtureNode(wrapperPkg, { children: { consumer: consumerNodeId } })],
+      [consumerNodeId, fixtureNode(consumerWithUnresolvedPeerPkg, { children: { dep: depNodeId }, depth: 1 })],
+      [depNodeId, fixtureNode(depPkg, { depth: 2, lockedPeerContext: { peer: 'peer/2.0.0' as DepPath } })],
+    ])
+    const resolutionOpts = options(dependenciesTree, new Map([
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers({
+      ...resolutionOpts,
+      dedupePeerDependents: false,
+    })
+
+    // Without the fresh-pass oracle the reuse pass still propagates the peer,
+    // bubbling the suffixed instance up onto consumer, which the cleanup removes.
+    const propagated = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+    })
+    expect(propagated.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
+
+    const cleaned = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+      dedupePeerDependents: true,
+      previousDependenciesGraph: initial.dependenciesGraph,
+      previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+    })
+    const cleanedConsumer = cleaned.dependenciesGraph['consumer/1.0.0' as DepPath]
+    expect(cleanedConsumer).toBeTruthy()
+    expect(cleanedConsumer.modules).toBe(path.join('consumer+1.0.0', 'node_modules'))
+    expect(cleanedConsumer.dir).toBe(path.join('consumer+1.0.0', 'node_modules', 'consumer'))
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('keeps a genuine reused peer context that the fresh pass also resolved', async () => {
+    // The consumer's peer is REQUIRED and a provider (peer@1.0.0) is in scope, so
+    // the fresh pass resolves the peer and the reuse pass re-binds it to the
+    // locked peer@2.0.0. Because the fresh pass also resolved `peer`, the cleanup
+    // treats the context as genuine and keeps it — the context preservation the
+    // reuse pass exists for is not undone.
+    const resolutionOpts = options(createTree(), new Map([
+      ['peer', currentPeerNodeId],
+      ['retainer', retainerNodeId],
+      ['wrapper', wrapperNodeId],
+    ]))
+    const initial = await resolvePeers({
+      ...resolutionOpts,
+      dedupePeerDependents: false,
+    })
+    const cleaned = await resolvePeers({
+      ...resolutionOpts,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+      dedupePeerDependents: true,
+      previousDependenciesGraph: initial.dependenciesGraph,
+      previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+    })
+
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/2.0.0)' as DepPath]).toBeTruthy()
+    expect(cleaned.dependenciesGraph['consumer/1.0.0(peer/1.0.0)' as DepPath]).toBeUndefined()
+  })
+
+  test('cleanup preserves a full peer depPath hashed after the provider broke a cycle elsewhere', async () => {
+    const mainNodeId = '>main/1.0.0>' as NodeId
+    const pluginNodeId = '>plugin/1.0.0>' as NodeId
+    const observerNodeId = '>observer/1.0.0>' as NodeId
+    const pNodeId = '>observer/1.0.0>p/1.0.0>' as NodeId
+    const containerNodeId = '>container/1.0.0>' as NodeId
+    const depNodeId = '>container/1.0.0>dep/1.0.0>' as NodeId
+    const resolutionOpts = {
+      ...baseResolveOpts(),
+      allPeerDepNames: new Set(['main', 'plugin', 'p']),
+      projects: [
+        project('.', new Map([['main', mainNodeId], ['plugin', pluginNodeId]])),
+        project('child', new Map([['observer', observerNodeId], ['container', containerNodeId]])),
+      ],
+      dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [mainNodeId, fixtureNode('main', { peerDependencies: { plugin: { version: '1.0.0' } } })],
+        [pluginNodeId, fixtureNode('plugin', { peerDependencies: { main: { version: '1.0.0' } } })],
+        [observerNodeId, fixtureNode('observer', { peerDependencies: { main: { version: '1.0.0' } }, children: { p: pNodeId } })],
+        [pNodeId, fixtureNode('p', { depth: 1, previousDepPath: 'p/1.0.0' as DepPath })],
+        [containerNodeId, fixtureNode('container', { children: { dep: depNodeId } })],
+        [depNodeId, fixtureNode('dep', {
+          peerDependencies: { p: { version: '1.0.0', optional: true } },
+          depth: 1,
+          lockedPeerContext: { p: 'p/1.0.0' as DepPath },
+        })],
+      ]),
+      resolvePeersFromWorkspaceRoot: true,
+    }
+    const { initial, cleaned } = await resolveWithCleanup(resolutionOpts)
+    const observerDepPath = 'observer/1.0.0(main/1.0.0(plugin@1.0.0))' as DepPath
+
+    expect(initial.dependenciesByProjectId.child.get('observer')).toBe(observerDepPath)
+    expect(cleaned.dependenciesByProjectId.child.get('observer')).toBe(observerDepPath)
+    expect(cleaned.dependenciesGraph[observerDepPath]).toBeTruthy()
+    expect(cleaned.dependenciesByProjectId.child.get('container')).toBe('container/1.0.0')
+  })
+
+  test('cleanup does not expand a peer cycle broken by the global fallback', async () => {
+    const mainNodeId = '>main@1.0.0>' as NodeId
+    const cyclePluginNodeId = '>plugin@1.0.0>' as NodeId
+    const plainPluginNodeId = '>provider>plugin@1.0.0>' as NodeId
+    const containerNodeId = '>container/1.0.0>' as NodeId
+    const depNodeId = '>container/1.0.0>dep/1.0.0>' as NodeId
+    const mainPkg = {
+      ...fixturePkg('main', {
+        plugin: { version: '1.0.0' },
+      }),
+      pkgIdWithPatchHash: 'main@1.0.0' as PkgIdWithPatchHash,
+    }
+    const pluginPkg = {
+      ...fixturePkg('plugin', {
+        main: { version: '1.0.0' },
+      }),
+      pkgIdWithPatchHash: 'plugin@1.0.0' as PkgIdWithPatchHash,
+    }
+    const { initial, cleaned } = await resolveWithCleanup({
+      ...baseResolveOpts(),
+      allPeerDepNames: new Set(['main', 'plugin']),
+      projects: [
+        project('.', new Map([['main', mainNodeId], ['plugin', cyclePluginNodeId]]), {
+          hoistedPeerProviderNodeIds: new Set([cyclePluginNodeId]),
+        }),
+        project('provider', new Map([['plugin', plainPluginNodeId]])),
+        project('consumer', new Map([['container', containerNodeId]])),
+      ],
+      dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [mainNodeId, fixtureNode(mainPkg)],
+        [cyclePluginNodeId, fixtureNode(pluginPkg, { depth: 1 })],
+        [plainPluginNodeId, fixtureNode(pluginPkg, { previousDepPath: 'plugin@1.0.0' as DepPath })],
+        [containerNodeId, fixtureNode('container', { children: { dep: depNodeId } })],
+        [depNodeId, fixtureNode('dep', {
+          peerDependencies: { plugin: { version: '1.0.0', optional: true } },
+          depth: 1,
+          lockedPeerContext: { plugin: 'plugin@1.0.0' as DepPath },
+        })],
+      ]),
+    })
+    const mainDepPath = 'main@1.0.0(plugin@1.0.0)' as DepPath
+
+    expect(initial.dependenciesByProjectId['.'].get('main')).toBe(mainDepPath)
+    expect(cleaned.dependenciesByProjectId['.'].get('main')).toBe(mainDepPath)
+  })
+
+  test('cleanup preserves cyclic peer hash provenance when a non-cycle peer is remapped', async () => {
+    const pNodeId = '>p>' as NodeId
+    const plainFNodeId = '>p>f>' as NodeId
+    const qNodeId = '>p>q>' as NodeId
+    const qDepNodeId = '>p>q>dep>' as NodeId
+    const eParentNodeId = '>p>x>' as NodeId
+    const eWithFNodeId = '>p>x>e>' as NodeId
+    const consumerNodeId = '>b>' as NodeId
+    const plainENodeId = '>b>e>' as NodeId
+    const fParentNodeId = '>b>y>' as NodeId
+    const fWithENodeId = '>b>y>f>' as NodeId
+    const sNodeId = '>b>s>' as NodeId
+    const ePkg = fixturePkg('e', {
+      f: { version: '1.0.0', optional: true },
+      q: { version: '1.0.0', optional: true },
+    })
+    const fPkg = fixturePkg('f', {
+      e: { version: '1.0.0', optional: true },
+    })
+    const { cleaned } = await resolveWithCleanup({
+      ...baseResolveOpts(),
+      allPeerDepNames: new Set(['e', 'f', 'p', 'q', 's']),
+      projects: [
+        project('p', new Map([['p', pNodeId]])),
+        project('b', new Map([['b', consumerNodeId], ['s', sNodeId]])),
+      ],
+      dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [pNodeId, fixtureNode('p', {
+          children: { f: plainFNodeId, q: qNodeId, x: eParentNodeId },
+          previousDepPath: 'p/1.0.0' as DepPath,
+        })],
+        [plainFNodeId, fixtureNode(fPkg, { depth: 1 })],
+        [qNodeId, fixtureNode('q', { children: { dep: qDepNodeId }, depth: 1 })],
+        [qDepNodeId, fixtureNode('dep', {
+          peerDependencies: { s: { version: '1.0.0', optional: true } },
+          depth: 2,
+          lockedPeerContext: { s: 's/1.0.0' as DepPath },
+        })],
+        [eParentNodeId, fixtureNode('x', { children: { e: eWithFNodeId }, depth: 1 })],
+        [eWithFNodeId, fixtureNode(ePkg, { depth: 2 })],
+        [consumerNodeId, fixtureNode('b', { children: { e: plainENodeId, y: fParentNodeId } })],
+        [sNodeId, fixtureNode('s', { previousDepPath: 's/1.0.0' as DepPath })],
+        [plainENodeId, fixtureNode(ePkg, { depth: 1 })],
+        [fParentNodeId, fixtureNode('y', {
+          peerDependencies: { p: { version: '1.0.0', optional: true } },
+          children: { f: fWithENodeId },
+          depth: 1,
+          lockedPeerContext: { p: 'p/1.0.0' as DepPath },
+        })],
+        [fWithENodeId, fixtureNode(fPkg, { depth: 2 })],
+      ]),
+    })
+
+    const qWithS = 'q/1.0.0(s/1.0.0)' as DepPath
+    const frozenE = 'e/1.0.0(f/1.0.0)(q/1.0.0(s/1.0.0))' as DepPath
+    const eNode = cleaned.dependenciesGraph[frozenE]
+    const peerIds = [...eNode.resolvedPeerIds!.values()].map((resolvedPeerId) =>
+      'depPath' in resolvedPeerId ? resolvedPeerId.depPath : resolvedPeerId.peerId
+    )
+
+    expect(cleaned.pathsByNodeId.get(qNodeId)).toBe('q/1.0.0')
+    expect(cleaned.pathsByNodeId.get(eWithFNodeId)).toBe(frozenE)
+    expect(cleaned.pathsByNodeId.get(fWithENodeId)).toBe('f/1.0.0(e/1.0.0)')
+    expect(eNode.resolvedPeerIds!.get('q')).toEqual({ depPath: qWithS, nodeId: qNodeId })
+    expect(eNode.pkgIdWithPatchHash + createPeerDepGraphHash(peerIds)).toBe(frozenE)
+  })
+
+  test('cleanup preserves metadata and nested edges across a partial dedupe', async () => {
+    const fooOneNodeId = '>one>foo/1.0.0>' as NodeId
+    const depOneNodeId = '>one>foo/1.0.0>dep/1.0.0>' as NodeId
+    const pNodeId = '>one>p/1.0.0>' as NodeId
+    const wrapperNodeId = '>one>wrapper/1.0.0>' as NodeId
+    const fooTwoNodeId = '>two>foo/1.0.0>' as NodeId
+    const depTwoNodeId = '>two>foo/1.0.0>dep/1.0.0>' as NodeId
+    const containerNodeId = '>two>foo/1.0.0>container/1.0.0>' as NodeId
+    const qNodeId = '>two>q/1.0.0>' as NodeId
+    const fooThreeNodeId = '>three>foo/1.0.0>' as NodeId
+    const depThreeNodeId = '>three>foo/1.0.0>dep/1.0.0>' as NodeId
+    const pThreeNodeId = '>three>p/1.0.0>' as NodeId
+    const rNodeId = '>three>r/1.0.0>' as NodeId
+    const fooPkg = fixturePkg('foo', {
+      q: { version: '1.0.0', optional: true },
+      r: { version: '1.0.0', optional: true },
+    })
+    const depPkg = fixturePkg('dep', {
+      p: { version: '1.0.0', optional: true },
+    })
+    const resolutionOpts = {
+      ...baseResolveOpts(),
+      allPeerDepNames: new Set(['p', 'q', 'r']),
+      projects: [
+        project('one', new Map([['foo', fooOneNodeId], ['p', pNodeId], ['wrapper', wrapperNodeId]])),
+        project('two', new Map([['foo', fooTwoNodeId], ['q', qNodeId]])),
+        project('three', new Map([['foo', fooThreeNodeId], ['p', pThreeNodeId], ['r', rNodeId]])),
+      ],
+      dependenciesTree: new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [fooOneNodeId, fixtureNode(fooPkg, { children: { dep: depOneNodeId, container: containerNodeId } })],
+        [depOneNodeId, fixtureNode(depPkg, { depth: 1 })],
+        [pNodeId, fixtureNode('p', { previousDepPath: 'p/1.0.0' as DepPath })],
+        [wrapperNodeId, fixtureNode('wrapper', { children: { foo: fooOneNodeId } })],
+        [fooTwoNodeId, fixtureNode(fooPkg, { children: { dep: depTwoNodeId, container: containerNodeId }, installable: false })],
+        [containerNodeId, fixtureNode('container', { children: { dep: depTwoNodeId }, depth: 1 })],
+        [depTwoNodeId, fixtureNode(depPkg, { depth: 1, lockedPeerContext: { p: 'p/1.0.0' as DepPath } })],
+        [qNodeId, fixtureNode('q')],
+        [fooThreeNodeId, fixtureNode(fooPkg, { children: { dep: depThreeNodeId }, installable: false })],
+        [depThreeNodeId, fixtureNode(depPkg, { depth: 1 })],
+        [pThreeNodeId, fixtureNode('p', { previousDepPath: 'p/1.0.0' as DepPath })],
+        [rNodeId, fixtureNode('r')],
+      ]),
+    }
+    const { initial, cleaned } = await resolveWithCleanup(resolutionOpts)
+    const fooWithP = 'foo/1.0.0(p/1.0.0)' as DepPath
+    const dedupedFoo = 'foo/1.0.0(p/1.0.0)(q/1.0.0)' as DepPath
+    const fooWithR = 'foo/1.0.0(p/1.0.0)(r/1.0.0)' as DepPath
+
+    expect(initial.pathsByNodeId.get(fooOneNodeId)).toBe(fooWithP)
+    expect(cleaned.dependenciesByProjectId.one.get('foo')).toBe(dedupedFoo)
+    expect(cleaned.dependenciesByProjectId.two.get('foo')).toBe(dedupedFoo)
+    expect(cleaned.dependenciesByProjectId.three.get('foo')).toBe(fooWithR)
+    const wrapperDepPath = cleaned.dependenciesByProjectId.one.get('wrapper')!
+    expect(cleaned.dependenciesGraph[wrapperDepPath].children.foo).toBe(fooWithP)
+    expect(cleaned.dependenciesGraph[dedupedFoo].installable).toBe(true)
+    expect(cleaned.dependenciesGraph[dedupedFoo].resolvedPeerNames).toEqual(new Set(['p', 'q']))
+    expect(cleaned.pathsByNodeId.get(fooOneNodeId)).toBe(fooWithP)
+    expect(cleaned.pathsByNodeId.get(fooTwoNodeId)).toBe(dedupedFoo)
+    for (const { children } of Object.values(cleaned.dependenciesGraph)) {
+      for (const childDepPath of Object.values<DepPath>(children)) {
+        expect(cleaned.dependenciesGraph[childDepPath]).toBeDefined()
+      }
+    }
+  })
+
+  test('cleanup retains an injected package referenced by a surviving peer hash', async () => {
+    const pNodeId = '>p>' as NodeId
+    const bNodeId = '>p>b>' as NodeId
+    const aNodeId = '>p>b>a>' as NodeId
+    const qNodeId = '>q>' as NodeId
+    const consumerNodeId = '>consumer>' as NodeId
+    const directNodeIdsByAlias = new Map([
+      ['p', pNodeId],
+      ['q', qNodeId],
+      ['consumer', consumerNodeId],
+    ])
+    const resolutionOpts = options(
+      new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+        [pNodeId, fixtureNode({ ...fixturePkg('p'), id: 'file:workspace' as PkgResolutionId }, { children: { b: bNodeId } })],
+        [bNodeId, fixtureNode('b', { children: { a: aNodeId }, depth: 1 })],
+        [aNodeId, fixtureNode('a', { peerDependencies: { q: { version: '1.0.0' } }, depth: 2 })],
+        [qNodeId, fixtureNode('q')],
+        [consumerNodeId, fixtureNode('consumer', { peerDependencies: { p: { version: '1.0.0' } } })],
+      ]),
+      directNodeIdsByAlias
+    )
+    resolutionOpts.allPeerDepNames = new Set(['p', 'q'])
+    resolutionOpts.projects.push({
+      ...resolutionOpts.projects[0],
+      directNodeIdsByAlias: new Map([
+        ['b', bNodeId],
+        ['q', qNodeId],
+      ]),
+      id: 'workspace',
+    })
+    const { initial, cleaned } = await resolveWithCleanup({
+      ...resolutionOpts,
+      dedupePeers: true,
+      dedupeInjectedDeps: true,
+      resolvedImporters: {
+        '': {
+          directDependencies: [{
+            alias: 'p',
+            pkgId: 'file:workspace' as PkgResolutionId,
+          } as Parameters<typeof resolvePeers>[0]['resolvedImporters'][string]['directDependencies'][number]],
+          directNodeIdsByAlias,
+          hoistedPeerProviderNodeIds: new Set<NodeId>(),
+          linkedDependencies: [],
+        },
+      },
+      workspaceProjectIds: new Set(['workspace']),
+    })
+    const pWithQ = 'p/1.0.0(q@1.0.0)' as DepPath
+    const bWithQ = 'b/1.0.0(q@1.0.0)' as DepPath
+    const consumerWithP = 'consumer/1.0.0(p@1.0.0)' as DepPath
+    const pPeerId = { peerId: { name: 'p', version: '1.0.0' }, nodeId: pNodeId }
+
+    expect(initial.dependenciesByProjectId[''].has('p')).toBe(false)
+    expect(initial.dependenciesGraph[consumerWithP].resolvedPeerIds!.get('p')).toEqual(pPeerId)
+    expect(cleaned.dependenciesByProjectId[''].get('consumer')).toBe(consumerWithP)
+    expect(cleaned.dependenciesGraph[consumerWithP].resolvedPeerIds!.get('p')).toEqual(pPeerId)
+    expect(cleaned.dependenciesGraph[pWithQ].children.b).toBe(bWithQ)
+    expect(cleaned.dependenciesGraph[bWithQ].resolvedPeerNames).toEqual(new Set(['q']))
+    expect(cleaned.dependenciesGraph[pWithQ].resolvedPeerNames).toEqual(new Set(['q']))
+  })
+
+  test('cleanup ignores peer contexts from an injected subtree deduped away', async () => {
+    const injectedNodeId = '>injected/1.0.0>' as NodeId
+    const peerNodeId = '>injected/1.0.0>peer/1.0.0>' as NodeId
+    const injectedConsumerNodeId = '>injected/1.0.0>consumer/1.0.0>' as NodeId
+    const injectedDepNodeId = '>injected/1.0.0>consumer/1.0.0>dep/1.0.0>' as NodeId
+    const survivingConsumerNodeId = '>consumer/1.0.0>' as NodeId
+    const survivingDepNodeId = '>consumer/1.0.0>dep/1.0.0>' as NodeId
+    const holderNodeId = '>holder/1.0.0>' as NodeId
+    const consumerPkg = fixturePkg('consumer')
+    const depPkg = fixturePkg('dep', {
+      peer: { version: '1.0.0', optional: true },
+    })
+    const directNodeIdsByAlias = new Map([
+      ['injected', injectedNodeId],
+      ['consumer', survivingConsumerNodeId],
+      ['holder', holderNodeId],
+    ])
+    const dependenciesTree = new Map<NodeId, DependenciesTreeNode<PartialResolvedPackage>>([
+      [injectedNodeId, fixtureNode({ ...fixturePkg('injected'), id: 'file:workspace' as PkgResolutionId }, {
+        children: { peer: peerNodeId, consumer: injectedConsumerNodeId },
+      })],
+      [peerNodeId, fixtureNode('peer', { depth: 1, previousDepPath: 'peer/1.0.0' as DepPath })],
+      [injectedConsumerNodeId, fixtureNode(consumerPkg, { children: { dep: injectedDepNodeId }, depth: 1 })],
+      [injectedDepNodeId, fixtureNode(depPkg, { depth: 2 })],
+      [survivingConsumerNodeId, fixtureNode(consumerPkg, { children: { dep: survivingDepNodeId } })],
+      [survivingDepNodeId, fixtureNode(depPkg, { depth: 1, lockedPeerContext: { peer: 'peer/1.0.0' as DepPath } })],
+      [holderNodeId, fixtureNode('holder', {
+        peerDependencies: {
+          consumer: { version: '1.0.0' },
+        },
+      })],
+    ])
+    const resolutionOpts = {
+      ...options(dependenciesTree, directNodeIdsByAlias),
+      resolvedImporters: {
+        '': {
+          directDependencies: [{
+            alias: 'injected',
+            pkgId: 'file:workspace' as PkgResolutionId,
+          } as Parameters<typeof resolvePeers>[0]['resolvedImporters'][string]['directDependencies'][number]],
+          directNodeIdsByAlias,
+          hoistedPeerProviderNodeIds: new Set<NodeId>(),
+          linkedDependencies: [],
+        },
+      },
+      workspaceProjectIds: new Set(['workspace']),
+    }
+    resolutionOpts.allPeerDepNames = new Set(['consumer', 'peer'])
+    const initial = await resolvePeers({
+      ...resolutionOpts,
+      dedupeInjectedDeps: false,
+      dedupePeerDependents: false,
+    })
+    const cleaned = await resolvePeers({
+      ...resolutionOpts,
+      dedupeInjectedDeps: true,
+      dedupePeerDependents: true,
+      resolvedPeerProviderPaths: initial.pathsByNodeId,
+      previousDependenciesGraph: initial.dependenciesGraph,
+      previousResolvedPeerNamesByNodeId: resolvedPeerNamesByNodeId(initial),
+    })
+    const peerfulConsumer = 'consumer/1.0.0(peer/1.0.0)' as DepPath
+    const plainConsumer = 'consumer/1.0.0' as DepPath
+    const holderWithConsumer = 'holder/1.0.0(consumer/1.0.0)' as DepPath
+
+    expect(initial.pathsByNodeId.get(injectedConsumerNodeId)).toBe(peerfulConsumer)
+    expect(initial.pathsByNodeId.get(survivingConsumerNodeId)).toBe(plainConsumer)
+    expect(cleaned.dependenciesByProjectId['']).toEqual(new Map([
+      ['consumer', plainConsumer],
+      ['holder', holderWithConsumer],
+    ]))
+    expect(cleaned.dependenciesGraph[holderWithConsumer].resolvedPeerIds!.get('consumer')).toEqual({
+      depPath: plainConsumer,
+      nodeId: survivingConsumerNodeId,
+    })
   })
 })
 

--- a/pnpm11/installing/deps-resolver/test/resolvePeers.ts
+++ b/pnpm11/installing/deps-resolver/test/resolvePeers.ts
@@ -1169,7 +1169,7 @@ describe('locked peer provider preferences', () => {
 
     expect(cleaned.dependenciesByProjectId[''].has('injected')).toBe(false)
     expect(lazyChildren).not.toHaveBeenCalled()
-    expect(cleaned.dependenciesGraph['retainer/1.0.0'].children.dep).toBe(depWithPeer)
+    expect(cleaned.dependenciesGraph['retainer/1.0.0' as DepPath].children.dep).toBe(depWithPeer)
     expect(cleaned.dependenciesGraph[depWithPeer].resolvedPeerNames).toEqual(new Set(['peer']))
   })
 


### PR DESCRIPTION
**Closed in favor of #13109**

<!-- A maintainer will only start reviewing once the automated code reviewers (CodeRabbit and Qodo) have approved and CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes [pnpm/pnpm#12756](https://github.com/pnpm/pnpm/issues/12756).

A writable install can reconstruct an optional peer context from the previous lockfile by locating the recorded provider anywhere in the dependency tree. The binding can be useful for deduplicating the package that owns the optional peer, but the resolved peer is also propagated through ancestors that did not resolve it during a fresh pass. Those ancestors receive peer suffixes that `pnpm dedupe` immediately removes.

The canonical minimal shape demonstrates the distinction this fix preserves: `debug@4.4.3(supports-color@5.5.0)` remains available as the deduplicated child of plain `agent-base@6.0.2`; `agent-base` records `supports-color` in `transitivePeerDependencies`, but does not receive its own `(supports-color@5.5.0)` suffix.

This PR keeps locked-context reuse and the deduplication opportunity raised in the review of [pnpm/pnpm#12830](https://github.com/pnpm/pnpm/pull/12830#pullrequestreview-4658728214). It allows reuse and `dedupePeerDependents` to complete, then removes only transitive peer contexts that are unsupported by every corresponding fresh occurrence.

## Implementation

The existing resolver already performs a fresh peer-resolution pass followed by a locked-context reuse pass. This PR changes the flow as follows:

1. When a reuse pass is needed, the fresh pass runs without `dedupeInjectedDeps` or `dedupePeerDependents` side effects. Its graph, per-NodeId paths, and resolved peer names are retained as the oracle describing current manifest visibility.
2. The locked-context pass runs normally. It may bind lateral providers and may create richer peer contexts that allow `dedupePeerDependents` to collapse compatible package instances.
3. After normal peer-dependent deduplication, `dropSpuriousReusePeers` examines only graph nodes reachable through importer roots, package children, or exact peer-hash provider references.
4. A resolved peer is removable only when it is not genuinely resolved as the package's own peer and no represented fresh occurrence resolved that peer name. Own locked peer contexts therefore remain available for deduplication.
5. Every graph node stores the exact `PeerId` used to create its suffix plus the provider NodeId. Cleanup can reproduce the original hash semantics for full depPaths, `dedupePeers` version-only IDs, links, local cycle fallbacks, and global cycle fallbacks instead of reconstructing them from the final tree.
6. Cleanup recomputes affected depPaths, remaps graph references, and rebuilds virtual-store `modules`/`dir`, minimum depth, and installability metadata.
7. When several old depPaths collapse onto one cleaned depPath, the winner must have an alias-aware compatible child superset. Fresh child context, an existing target depPath, dependency count, and lexical depPath order provide deterministic preferences.
8. If any collision group has incompatible children, cleanup aborts before mutating the graph. This deliberately prefers the pre-cleanup locked graph over emitting an invalid package snapshot.

The implementation also preserves provenance for cache-pruned occurrences and injected workspace dependencies, does not evaluate lazy dependency-tree children during cleanup, retains deduped-away providers that are still referenced by a peer hash, and treats cyclic peer-context nodes conservatively.

## Comparison with the previous PRs

The production-size counts below include only `src/index.ts` and `src/resolvePeers.ts`; tests and changesets are listed separately.

| PR | Strategy | Production diff | Test diff | Main advantage | Main limitation |
| --- | --- | ---: | ---: | --- | --- |
| [pnpm/pnpm#12830](https://github.com/pnpm/pnpm/pull/12830) | Skip an optional locked peer when no provider is visible in the current scope | +10/−0 | +58/−0 | By far the smallest and easiest to review | Fails the published short-circuit reproduction because the retained `peer-consumer(peer-p)(peer-q)` union is never created |
| [pnpm/pnpm#12998](https://github.com/pnpm/pnpm/pull/12998) | Propagate, dedupe, then remove reuse-only peers; require byte-identical children after a cleaned collision | +275/−0 | +118/−0 | Preserves the dedupe opportunity without changing resolution-time caches | The exact-child collision guard aborted cleanup on benign real-workspace collisions |
| [pnpm/pnpm#13069](https://github.com/pnpm/pnpm/pull/13069) | pnpm/pnpm#12998 plus compatible-superset collision selection | +332/−1 | +199/−1 | First attempt that passed the original, union, and 246-project reproductions together | Reconstructed peer hash inputs after resolution and did not cover several cycle, alias, injected, cache, and metadata invariants |
| [pnpm/pnpm#13083](https://github.com/pnpm/pnpm/pull/13083) | Filter child-propagated peers during the reuse pass using fresh per-node name sets | +162/−8 | +302/−1 | Much smaller production diff than graph cleanup | Independent probes found traversal-order dependence when `peersCache` pruned a different locked subtree, replay of the cache owner's propagated provider map, and same-depPath/different-child payloads when dedupe was disabled |
| This PR | Post-dedupe cleanup with exact hash and occurrence provenance | +500/−36, net +464 | +906/−3, net +903 | Strongest correctness coverage and explicit conservative fallbacks | Largest implementation and test diff; not the simplest option by line count |

### Correctness

pnpm/pnpm#12830 fixes the reported workspace but changes the package's own peer binding before deduplication, which demonstrably loses a valid union context. pnpm/pnpm#12998 and pnpm/pnpm#13069 have the correct high-level "propagate, dedupe, clean" ordering. This PR is based on that ordering, with additional provenance and consistency checks added after independent adversarial review.

The extra production code relative to pnpm/pnpm#13069 is primarily for exact per-calculation peer hash inputs, per-occurrence own-peer provenance, dedupe-source and peer-hash reachability, cycle preservation, alias-aware collision compatibility, lazy/cache-pruned subtrees, injected-link dedupe, and graph metadata reconstruction. Each of those paths has a focused regression test.

The resolver test file grew substantially because the review found failures that were not represented by the three original reproductions: local and cross-call cycles, mutually cyclic optional peers, chained and partial dedupe maps, deduped providers referenced only from peer hashes, version-only `dedupePeers` contexts, injected subtrees that should and should not contribute fresh evidence, cache-pruned survivors, shared depPaths with different own-peer provenance, alias-swapped children, stale virtual-store paths, and installability/depth loss. Small fixture builders reduce repeated setup while keeping the topologies explicit.

Correctness conclusion: this PR is more robust than the previous attempts and passes all known public, private, and adversarial reproductions. The improvement is not merely additional tests; the implementation carries information that the earlier cleanup approaches tried to reconstruct after it had already been lost.

### Speed and memory

The final implementation still performs two peer-resolution passes, exactly like current main and the other locked-context approaches. It does not add the third peer-resolution traversal that was previously measured at roughly 2.6× slower. Cleanup adds linear graph and occurrence-provenance walks after the second pass.

The following benchmark used the current 246-project Office workspace, removed the same two `@fluidx/localize-js` dependencies, restored the committed lockfile before each run, warmed every implementation first, and then ran three interleaved `install --lockfile-only --prefer-offline --ignore-scripts` measurements. The local PR bundles are based on different upstream commits, so differences of a few percent should be treated as noise rather than a ranking.

| Approach | Wall runs | Median wall | Median CPU | Median max RSS |
| --- | --- | ---: | ---: | ---: |
| pnpm/pnpm#12830 | 14.13, 14.47, 15.40 s | 14.47 s | 23.55 s | 4.297 GiB |
| pnpm/pnpm#12998 | 15.29, 14.92, 15.00 s | 15.00 s | 24.44 s | 4.493 GiB |
| pnpm/pnpm#13069 | 15.06, 15.14, 14.93 s | 15.06 s | 23.93 s | 4.440 GiB |
| pnpm/pnpm#13083 | 14.33, 15.19, 14.97 s | 14.97 s | 23.76 s | 4.287 GiB |
| This PR | 14.46, 14.92, 14.56 s | 14.56 s | 24.06 s | 4.390 GiB |

All five implementations are in the same performance range. This PR was 3.3% faster than pnpm/pnpm#13069 by median wall time in this sample, 0.5% higher in median CPU, and 1.1% lower in median RSS. Those differences are too small and too variable to claim a performance improvement. Speed conclusion: this PR is effectively tied with the previous approaches and has no measurable regression in the large workspace.

### Simplicity

This PR is not simpler than pnpm/pnpm#12830 or pnpm/pnpm#13083, and it is larger than pnpm/pnpm#13069. The additional code is the cost of keeping the post-resolution strategy while making its graph rewrite conservative across the edge cases found during review.

The argument for this version is therefore not "fewer lines." It is that the algorithm has explicit phases and explicit provenance rather than relying on implicit cache state or reconstructing hash inputs from a mutated graph. The core tradeoff is:

- pnpm/pnpm#12830 is simplest but knowingly loses deduplication.
- pnpm/pnpm#13083 is smaller but requires a substantially stronger cache-equivalence model to be sound.
- pnpm/pnpm#13069 is the closest design and is easier to review by size, but this PR adds correctness hardening for cases its representation could not distinguish.
- This PR has the largest review surface, but the strongest demonstrated correctness and comparable runtime.

This remains a draft because maintainers may reasonably prefer a smaller source-level redesign despite the additional cache and graph-identity proof obligations that design would carry.

## Validation

- Full `@pnpm/installing.deps-resolver` suite: 15 suites, 155 tests passed.
- The full pre-push hook passed TypeScript typechecking, bundled pnpm compilation, repository spellcheck and lint, Rust formatting, workspace Clippy with warnings denied, and Rust documentation with warnings denied. Optional local-only `cargo-dylint`, `typos`, and `taplo` checks were skipped because those binaries are not installed.
- Locked-context and `dedupePeers` pnpm e2e suites: 5 tests passed.
- Minimal pnpm/pnpm#12756 reproduction: install remains at 3 `supports-color` suffix positions, a repeated install is a fixed point, and install and dedupe lockfiles are byte-identical.
- Locked-union reproduction: install retains one `peer-consumer(peer-p)(peer-q)` instance, while fresh dedupe produces the expected two split contexts.
- 246-project Office lockfile-only reproduction: install and dedupe remain at 66 suffix positions, only the six intended importer lines are removed, and the lockfiles are byte-identical.
- 246-project Office full install: remains at 66 suffix positions and changes only the six intended importer lines.
- The changeset includes patch releases for `@pnpm/installing.deps-resolver` and `pnpm`.

## Rust parity

No Rust change is included. The regression depends on the TypeScript resolver's two-pass locked-context reuse path and does not reproduce in pacquet. The full Rust formatting, Clippy, and documentation checks pass with this branch.

## Squash Commit Body

```text
Fix lockfile drift caused by transitive peer contexts reused from unrelated
subtrees during writable installs.

Keep locked peer resolution and peer-dependent deduplication unchanged, then
remove only non-own peers that no corresponding fresh occurrence resolved.
Preserve exact peer hash and occurrence provenance while recomputing affected
depPaths, and reject incompatible graph collisions without mutation.

Fixes pnpm/pnpm#12756.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. No documentation change is needed for this lockfile-correctness fix.

---
Written by an agent (GitHub Copilot CLI, gpt-5.6-sol).
