### PR TITLE
fix(lockfile): hide content from parse errors

### DIFF
--- a/.changeset/safe-broken-lockfile-errors.md
+++ b/.changeset/safe-broken-lockfile-errors.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/lockfile.fs": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Prevent broken-lockfile errors from including snippets of the lockfile's contents.

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -116,8 +116,8 @@ impl EnvLockfile {
         let Some(env_doc) = extract_env_document(&content) else {
             return Ok(None);
         };
-        let mut env: EnvLockfile =
-            serde_saphyr::from_str(env_doc).map_err(LoadLockfileError::ParseYaml)?;
+        let mut env: EnvLockfile = serde_saphyr::from_str(env_doc)
+            .map_err(|source| LoadLockfileError::parse_yaml(&path, &source))?;
         env.root_importer_mut();
         Ok(Some(env))
     }

--- a/pnpm/crates/lockfile/src/load_lockfile.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile.rs
@@ -2,10 +2,11 @@ use crate::{Lockfile, extract_main_document};
 use derive_more::{Display, Error};
 use pacquet_diagnostics::miette::{self, Diagnostic};
 use pipe_trait::Pipe;
+use serde_saphyr::MessageFormatter;
 use std::{
     env, fs,
     io::{self, ErrorKind},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 /// Error when reading lockfile the filesystem.
@@ -20,9 +21,29 @@ pub enum LoadLockfileError {
     #[diagnostic(code(ERR_PNPM_LOCKFILE_READ_FILE))]
     ReadFile(io::Error),
 
-    #[display("Failed to parse lockfile content as YAML: {}", _0.without_snippet())]
-    #[diagnostic(code(ERR_PNPM_LOCKFILE_PARSE_YAML))]
-    ParseYaml(#[error(not(source))] serde_saphyr::Error),
+    #[display(
+        "The lockfile at \"{}\" is broken: {}",
+        path.display(),
+        reason
+    )]
+    #[diagnostic(code(ERR_PNPM_BROKEN_LOCKFILE))]
+    ParseYaml { path: PathBuf, reason: String },
+}
+
+impl LoadLockfileError {
+    pub(super) fn parse_yaml(path: &Path, source: &serde_saphyr::Error) -> Self {
+        Self::ParseYaml { path: path.to_path_buf(), reason: format_yaml_error(source) }
+    }
+}
+
+fn format_yaml_error(error: &serde_saphyr::Error) -> String {
+    let error = error.without_snippet();
+    let reason = serde_saphyr::DefaultMessageFormatter.format_message(error);
+    if let Some(location) = error.location() {
+        format!("{reason} ({}:{})", location.line(), location.column())
+    } else {
+        reason.into_owned()
+    }
 }
 
 impl Lockfile {
@@ -96,7 +117,7 @@ impl Lockfile {
                 lockfile.reconstruct_missing_directory_resolutions();
                 Some(lockfile)
             })
-            .map_err(LoadLockfileError::ParseYaml)
+            .map_err(|source| LoadLockfileError::parse_yaml(file_path, &source))
     }
 }
 

--- a/pnpm/crates/lockfile/src/load_lockfile.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile.rs
@@ -20,9 +20,9 @@ pub enum LoadLockfileError {
     #[diagnostic(code(ERR_PNPM_LOCKFILE_READ_FILE))]
     ReadFile(io::Error),
 
-    #[display("Failed to parse lockfile content as YAML: {_0}")]
+    #[display("Failed to parse lockfile content as YAML: {}", _0.without_snippet())]
     #[diagnostic(code(ERR_PNPM_LOCKFILE_PARSE_YAML))]
-    ParseYaml(serde_saphyr::Error),
+    ParseYaml(#[error(not(source))] serde_saphyr::Error),
 }
 
 impl Lockfile {

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -2,6 +2,7 @@ use crate::{
     DirectoryResolution, ImporterDepVersion, Lockfile, LockfileResolution, PackageKey, PkgName,
     SnapshotDepRef,
 };
+use pacquet_diagnostics::miette::Diagnostic;
 use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 use text_block_macros::text_block;
@@ -106,7 +107,15 @@ fn parse_error_does_not_include_lockfile_content() {
     let error = Lockfile::load_wanted_from_dir(dir.path()).expect_err("lockfile must be broken");
     let message = error.to_string();
 
-    assert!(message.contains("line 1, column 1"), "unexpected error: {message}");
+    assert_eq!(error.code().expect("diagnostic code").to_string(), "ERR_PNPM_BROKEN_LOCKFILE");
+    assert!(
+        message.starts_with(&format!(
+            r#"The lockfile at "{}" is broken: "#,
+            dir.path().join(Lockfile::FILE_NAME).display()
+        )),
+        "unexpected error: {message}",
+    );
+    assert!(message.contains("(1:1)"), "unexpected error: {message}");
     assert!(!message.contains(secret), "error included lockfile content: {message}");
     assert!(
         std::error::Error::source(&error).is_none(),

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -96,6 +96,26 @@ fn env_only_lockfile_loads_as_none() {
     assert!(result.is_none(), "expected None for env-only lockfile, got: {result:?}");
 }
 
+#[test]
+fn parse_error_does_not_include_lockfile_content() {
+    let dir = tempdir().expect("create tempdir");
+    let secret = "aws_secret_access_key = marker-secret";
+    std::fs::write(dir.path().join(Lockfile::FILE_NAME), format!("[default]\n{secret}\n"))
+        .expect("write broken lockfile");
+
+    let error = Lockfile::load_wanted_from_dir(dir.path()).expect_err("lockfile must be broken");
+    let message = error.to_string();
+
+    assert!(message.contains("line 1, column 1"), "unexpected error: {message}");
+    assert!(!message.contains(secret), "error included lockfile content: {message}");
+    assert!(
+        std::error::Error::source(&error).is_none(),
+        "parse error source could expose lockfile content",
+    );
+    let report = format!("{:?}", pacquet_diagnostics::miette::Report::new(error));
+    assert!(!report.contains(secret), "diagnostic included lockfile content: {report}");
+}
+
 /// Heuristic-boundary check: a dropped directory resolution is
 /// reconstructed for a pruned `file:` peer-variant, but never for a
 /// `file:` tarball.

--- a/pnpm11/lockfile/fs/src/read.ts
+++ b/pnpm11/lockfile/fs/src/read.ts
@@ -11,6 +11,7 @@ import { mergeLockfileChanges } from '@pnpm/lockfile.merger'
 import type { LockfileFile, LockfileObject } from '@pnpm/lockfile.types'
 import type { ProjectId } from '@pnpm/types'
 import { comverToSemver } from 'comver-to-semver'
+import type { YAMLException } from 'js-yaml'
 import yaml from 'js-yaml'
 import semver from 'semver'
 import stripBom from 'strip-bom'
@@ -141,7 +142,7 @@ async function _read (
     hadConflicts = false
   } catch (err: unknown) {
     if (!opts.autofixMergeConflicts || !isDiff(lockfileRawContent)) {
-      throw new PnpmError('BROKEN_LOCKFILE', `The lockfile at "${lockfilePath}" is broken: ${(err as Error).message}`)
+      throw new PnpmError('BROKEN_LOCKFILE', `The lockfile at "${lockfilePath}" is broken: ${formatLockfileError(err)}`)
     }
     hadConflicts = true
     lockfile = autofixMergeConflicts(lockfileRawContent)
@@ -180,6 +181,20 @@ async function _read (
     return { lockfile: null, lockfileFile: null, hadConflicts: false }
   }
   throw new LockfileBreakingChangeError(lockfilePath)
+}
+
+function formatLockfileError (err: unknown): string {
+  if (isYamlException(err)) {
+    const position = err.mark == null ? '' : ` (${err.mark.line + 1}:${err.mark.column + 1})`
+    return `${err.reason}${position}`
+  }
+  return util.types.isNativeError(err) ? err.message : String(err)
+}
+
+function isYamlException (err: unknown): err is YAMLException {
+  return typeof err === 'object' && err !== null &&
+    'name' in err && err.name === 'YAMLException' &&
+    'reason' in err && typeof err.reason === 'string'
 }
 
 export function createLockfileObject (

--- a/pnpm11/lockfile/fs/src/read.ts
+++ b/pnpm11/lockfile/fs/src/read.ts
@@ -11,7 +11,6 @@ import { mergeLockfileChanges } from '@pnpm/lockfile.merger'
 import type { LockfileFile, LockfileObject } from '@pnpm/lockfile.types'
 import type { ProjectId } from '@pnpm/types'
 import { comverToSemver } from 'comver-to-semver'
-import type { YAMLException } from 'js-yaml'
 import yaml from 'js-yaml'
 import semver from 'semver'
 import stripBom from 'strip-bom'
@@ -185,16 +184,30 @@ async function _read (
 
 function formatLockfileError (err: unknown): string {
   if (isYamlException(err)) {
-    const position = err.mark == null ? '' : ` (${err.mark.line + 1}:${err.mark.column + 1})`
-    return `${err.reason}${position}`
+    const reason = typeof err.reason === 'string' ? err.reason : 'Unable to parse YAML'
+    const line = err.mark?.line
+    const column = err.mark?.column
+    const position = typeof line === 'number' && Number.isFinite(line) &&
+      typeof column === 'number' && Number.isFinite(column)
+      ? ` (${line + 1}:${column + 1})`
+      : ''
+    return `${reason}${position}`
   }
   return util.types.isNativeError(err) ? err.message : String(err)
 }
 
-function isYamlException (err: unknown): err is YAMLException {
+function isYamlException (err: unknown): err is YamlExceptionLike {
   return typeof err === 'object' && err !== null &&
-    'name' in err && err.name === 'YAMLException' &&
-    'reason' in err && typeof err.reason === 'string'
+    'name' in err && err.name === 'YAMLException'
+}
+
+interface YamlExceptionLike {
+  name: 'YAMLException'
+  reason?: unknown
+  mark?: {
+    line?: unknown
+    column?: unknown
+  } | null
 }
 
 export function createLockfileObject (

--- a/pnpm11/lockfile/fs/test/read.test.ts
+++ b/pnpm11/lockfile/fs/test/read.test.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs'
+import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
 import { expect, jest, test } from '@jest/globals'
@@ -53,7 +53,7 @@ test('readWantedLockfile()', async () => {
 test('readWantedLockfile() does not include lockfile content in parse errors', async () => {
   const projectPath = temporaryDirectory()
   const secret = 'aws_secret_access_key = marker-secret'
-  fs.writeFileSync(path.join(projectPath, 'pnpm-lock.yaml'), `[default]\n${secret}\n`)
+  await writeFile(path.join(projectPath, 'pnpm-lock.yaml'), `[default]\n${secret}\n`)
 
   const error = await readWantedLockfile(projectPath, { ignoreIncompatible: false }).catch((err: unknown) => err)
 
@@ -68,7 +68,7 @@ test('readWantedLockfile() does not include lockfile content in parse errors', a
 test('readWantedLockfile() does not use a YAML exception message when its reason is missing', async () => {
   const projectPath = temporaryDirectory()
   const secret = 'aws_secret_access_key = marker-secret'
-  fs.writeFileSync(path.join(projectPath, 'pnpm-lock.yaml'), 'broken')
+  await writeFile(path.join(projectPath, 'pnpm-lock.yaml'), 'broken')
   jest.spyOn(yaml, 'load').mockImplementationOnce(() => {
     throw {
       name: 'YAMLException',

--- a/pnpm11/lockfile/fs/test/read.test.ts
+++ b/pnpm11/lockfile/fs/test/read.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { expect, jest, test } from '@jest/globals'
 import type { DepPath, ProjectId } from '@pnpm/types'
+import yaml from 'js-yaml'
 import { temporaryDirectory } from 'tempy'
 
 jest.unstable_mockModule('@pnpm/network.git-utils', () => ({ getCurrentBranch: jest.fn() }))
@@ -54,9 +55,31 @@ test('readWantedLockfile() does not include lockfile content in parse errors', a
   const secret = 'aws_secret_access_key = marker-secret'
   fs.writeFileSync(path.join(projectPath, 'pnpm-lock.yaml'), `[default]\n${secret}\n`)
 
+  const error = await readWantedLockfile(projectPath, { ignoreIncompatible: false }).catch((err: unknown) => err)
+
+  expect(error).toMatchObject({
+    code: 'ERR_PNPM_BROKEN_LOCKFILE',
+    message: expect.stringContaining(`The lockfile at "${path.join(projectPath, 'pnpm-lock.yaml')}" is broken:`),
+  })
+  expect(error).toMatchObject({ message: expect.stringContaining('(2:1)') })
+  expect(error).toMatchObject({ message: expect.not.stringContaining(secret) })
+})
+
+test('readWantedLockfile() does not use a YAML exception message when its reason is missing', async () => {
+  const projectPath = temporaryDirectory()
+  const secret = 'aws_secret_access_key = marker-secret'
+  fs.writeFileSync(path.join(projectPath, 'pnpm-lock.yaml'), 'broken')
+  jest.spyOn(yaml, 'load').mockImplementationOnce(() => {
+    throw {
+      name: 'YAMLException',
+      message: `Unable to parse YAML\n${secret}`,
+      mark: { line: 1, column: 2 },
+    }
+  })
+
   await expect(readWantedLockfile(projectPath, { ignoreIncompatible: false })).rejects.toMatchObject({
     code: 'ERR_PNPM_BROKEN_LOCKFILE',
-    message: `The lockfile at "${path.join(projectPath, 'pnpm-lock.yaml')}" is broken: end of the stream or a document separator is expected (2:1)`,
+    message: `The lockfile at "${path.join(projectPath, 'pnpm-lock.yaml')}" is broken: Unable to parse YAML (2:3)`,
   })
 })
 

--- a/pnpm11/lockfile/fs/test/read.test.ts
+++ b/pnpm11/lockfile/fs/test/read.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, jest, test } from '@jest/globals'
@@ -46,6 +47,17 @@ test('readWantedLockfile()', async () => {
       wantedVersions: ['3'],
     })
   ).rejects.toMatchObject({ code: 'ERR_PNPM_LOCKFILE_BREAKING_CHANGE' })
+})
+
+test('readWantedLockfile() does not include lockfile content in parse errors', async () => {
+  const projectPath = temporaryDirectory()
+  const secret = 'aws_secret_access_key = marker-secret'
+  fs.writeFileSync(path.join(projectPath, 'pnpm-lock.yaml'), `[default]\n${secret}\n`)
+
+  await expect(readWantedLockfile(projectPath, { ignoreIncompatible: false })).rejects.toMatchObject({
+    code: 'ERR_PNPM_BROKEN_LOCKFILE',
+    message: `The lockfile at "${path.join(projectPath, 'pnpm-lock.yaml')}" is broken: end of the stream or a document separator is expected (2:1)`,
+  })
 })
 
 test('readWantedLockfile() when lockfileVersion is a string', async () => {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13094.

Broken lockfile diagnostics now preserve the YAML reason and source position without including source snippets. The TypeScript CLI formats `js-yaml` exceptions from structured fields, while pacquet disables snippet rendering and cuts off the wrapped parser error as a diagnostic source.

## Squash Commit Body

```text
Broken lockfile errors rendered parser-provided source snippets. A repository can commit pnpm-lock.yaml as a symlink, so the snippet could quote content from a readable file outside the repository.

Format parse failures from their structured reason and location instead. Pacquet also stops exposing the snippet-bearing parser error through its diagnostic source chain.

Closes pnpm/pnpm#13094
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786882754&installation_id=145934176&pr_number=13101&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13101&signature=274a602f3a84d536ce36cf5f9f4379d0b02d0e871b832f11f07a04aa56bdbad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broken lockfile errors no longer include any snippets or contents from the lockfile.
  * YAML parse failures now produce clearer broken-lockfile messages, including the lockfile path and line/column location when available.
  * Improved consistency across different lockfile readers.
* **Tests**
  * Added regression tests ensuring broken-lockfile errors never leak lockfile content/secret markers and still report path plus parse location details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->