### PR TITLE
fix(default-reporter): render install stats once

### DIFF
--- a/.changeset/pacquet-render-stats-once.md
+++ b/.changeset/pacquet-render-stats-once.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed duplicate package statistics output during installs in non-interactive terminals.

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -488,20 +488,24 @@ impl ReporterState {
 
     fn on_stats(&mut self, message: &StatsMessage) {
         let prefix = match message {
-            StatsMessage::Added { prefix, added } => {
-                self.stats_added = Some(*added);
-                prefix.clone()
-            }
-            StatsMessage::Removed { prefix, removed } => {
-                self.stats_removed = Some(*removed);
-                prefix.clone()
-            }
+            StatsMessage::Added { prefix, .. } | StatsMessage::Removed { prefix, .. } => prefix,
         };
-        if prefix != self.cwd {
+        if prefix != &self.cwd {
             return;
         }
-        let added = self.stats_added.unwrap_or(0);
-        let removed = self.stats_removed.unwrap_or(0);
+        match message {
+            StatsMessage::Added { added, .. } => {
+                self.stats_added = Some(*added);
+            }
+            StatsMessage::Removed { removed, .. } => {
+                self.stats_removed = Some(*removed);
+            }
+        }
+        if self.stats_added.is_none() || self.stats_removed.is_none() {
+            return;
+        }
+        let added = self.stats_added.take().expect("added stats checked above");
+        let removed = self.stats_removed.take().expect("removed stats checked above");
         if added == 0 && removed == 0 {
             // The "Already up to date" line is emitted by pacquet as a
             // `pnpm` log; rendering it here too would duplicate it.

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -501,11 +501,14 @@ impl ReporterState {
                 self.stats_removed = Some(*removed);
             }
         }
-        if self.stats_added.is_none() || self.stats_removed.is_none() {
-            return;
+        if self.stats_added.is_some() && self.stats_removed.is_some() {
+            self.render_stats();
         }
-        let added = self.stats_added.take().expect("added stats checked above");
-        let removed = self.stats_removed.take().expect("removed stats checked above");
+    }
+
+    fn render_stats(&mut self) {
+        let added = self.stats_added.take().unwrap_or(0);
+        let removed = self.stats_removed.take().unwrap_or(0);
         if added == 0 && removed == 0 {
             // The "Already up to date" line is emitted by pacquet as a
             // `pnpm` log; rendering it here too would duplicate it.
@@ -613,6 +616,9 @@ impl ReporterState {
     }
 
     fn on_summary(&mut self) {
+        if self.stats_added.is_some() || self.stats_removed.is_some() {
+            self.render_stats();
+        }
         self.summary_seen = true;
         self.try_render_summary();
     }

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -323,7 +323,7 @@ impl ReporterState {
             LogEvent::Stats(log) => self.on_stats(&log.message),
             LogEvent::Root(log) => self.on_root(&log.message),
             LogEvent::PackageManifest(log) => self.on_manifest(&log.message),
-            LogEvent::Summary(_) => self.on_summary(),
+            LogEvent::Summary(log) => self.on_summary(&log.prefix),
             LogEvent::Lifecycle(log) => self.on_lifecycle(&log.message),
             LogEvent::IgnoredScripts(log) => self.on_ignored_scripts(log),
             LogEvent::SkippedOptionalDependency(log) => self.on_skipped_optional(log),
@@ -615,8 +615,8 @@ impl ReporterState {
         }
     }
 
-    fn on_summary(&mut self) {
-        if self.stats_added.is_some() || self.stats_removed.is_some() {
+    fn on_summary(&mut self, prefix: &str) {
+        if prefix == self.cwd && (self.stats_added.is_some() || self.stats_removed.is_some()) {
             self.render_stats();
         }
         self.summary_seen = true;

--- a/pnpm/crates/default-reporter/src/tests.rs
+++ b/pnpm/crates/default-reporter/src/tests.rs
@@ -26,7 +26,7 @@ fn progress_and_in_progress_downloads_coalesce() {
 }
 
 #[test]
-fn stats_renders_immediately() {
+fn stats_are_not_throttled() {
     let stats = LogEvent::Stats(StatsLog {
         level: LogLevel::Debug,
         message: StatsMessage::Added { prefix: "/repo".to_string(), added: 1 },

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -192,6 +192,22 @@ fn append_only_stats_render_once_after_both_events() {
 }
 
 #[test]
+fn append_only_stats_render_on_summary_when_pair_is_incomplete() {
+    let mut reporter = ReporterState::new(CWD.to_string(), 80, Colors { enabled: false }, true);
+    let added = reporter.handle(&LogEvent::Stats(StatsLog {
+        level: LogLevel::Debug,
+        message: StatsMessage::Added { prefix: CWD.to_string(), added: 5 },
+    }));
+    assert!(matches!(added, Output::None));
+
+    let summarized = reporter.handle(&summary());
+    match summarized {
+        Output::Lines(lines) => assert_eq!(lines, vec!["Packages: +5\n+++++"]),
+        _ => panic!("summary should flush incomplete stats"),
+    }
+}
+
+#[test]
 fn summary_groups_by_dependency_type_in_order() {
     let mut reporter = state(false);
     let frame = render(

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -158,12 +158,37 @@ fn stats_bar_is_colored_when_enabled() {
     let mut reporter = state(true);
     let frame = render(
         &mut reporter,
-        vec![LogEvent::Stats(StatsLog {
-            level: LogLevel::Debug,
-            message: StatsMessage::Added { prefix: CWD.to_string(), added: 1 },
-        })],
+        vec![
+            LogEvent::Stats(StatsLog {
+                level: LogLevel::Debug,
+                message: StatsMessage::Added { prefix: CWD.to_string(), added: 1 },
+            }),
+            LogEvent::Stats(StatsLog {
+                level: LogLevel::Debug,
+                message: StatsMessage::Removed { prefix: CWD.to_string(), removed: 0 },
+            }),
+        ],
     );
     assert_eq!(frame, "Packages: \u{1b}[32m+1\u{1b}[39m\n\u{1b}[32m+\u{1b}[39m");
+}
+
+#[test]
+fn append_only_stats_render_once_after_both_events() {
+    let mut reporter = ReporterState::new(CWD.to_string(), 80, Colors { enabled: false }, true);
+    let added = reporter.handle(&LogEvent::Stats(StatsLog {
+        level: LogLevel::Debug,
+        message: StatsMessage::Added { prefix: CWD.to_string(), added: 5 },
+    }));
+    assert!(matches!(added, Output::None));
+
+    let removed = reporter.handle(&LogEvent::Stats(StatsLog {
+        level: LogLevel::Debug,
+        message: StatsMessage::Removed { prefix: CWD.to_string(), removed: 0 },
+    }));
+    match removed {
+        Output::Lines(lines) => assert_eq!(lines, vec!["Packages: +5\n+++++"]),
+        _ => panic!("complete stats should emit Lines"),
+    }
 }
 
 #[test]
@@ -385,6 +410,10 @@ fn full_install_frame_orders_blocks_like_pnpm() {
             LogEvent::Stats(StatsLog {
                 level: LogLevel::Debug,
                 message: StatsMessage::Added { prefix: CWD.to_string(), added: 1 },
+            }),
+            LogEvent::Stats(StatsLog {
+                level: LogLevel::Debug,
+                message: StatsMessage::Removed { prefix: CWD.to_string(), removed: 0 },
             }),
             added_root("foo", "1.0.0", DependencyType::Prod),
             summary(),

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -106,7 +106,11 @@ fn package_manifest_updated_at(prefix: &str, value: serde_json::Value) -> LogEve
 }
 
 fn summary() -> LogEvent {
-    LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix: CWD.to_string() })
+    summary_at(CWD)
+}
+
+fn summary_at(prefix: &str) -> LogEvent {
+    LogEvent::Summary(SummaryLog { level: LogLevel::Debug, prefix: prefix.to_string() })
 }
 
 #[test]
@@ -199,6 +203,9 @@ fn append_only_stats_render_on_summary_when_pair_is_incomplete() {
         message: StatsMessage::Added { prefix: CWD.to_string(), added: 5 },
     }));
     assert!(matches!(added, Output::None));
+
+    let other_summary = reporter.handle(&summary_at("/repo/packages/other"));
+    assert!(matches!(other_summary, Output::None));
 
     let summarized = reporter.handle(&summary());
     match summarized {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Fix duplicate `Packages: +N` statistics output from Rust pnpm installs in
append-only and non-interactive terminals.

The installer emits separate added and removed statistics events. The
TypeScript reporter combines this pair, while the Rust reporter rendered after
each event and therefore printed the same block twice when the removed count
was zero. The Rust reporter now buffers the pair and renders the combined
statistics once. If the run ends with only one event, it flushes the partial
statistics at summary time, matching the TypeScript stream-completion fallback.
The TypeScript implementation already has the intended behavior, so it does not
need a matching code change.

Reproduction: https://github.com/pnpm/pnpm/actions/runs/29564581286/job/87834282836

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
The installer emits separate added and removed statistics events. The Rust
append-only reporter rendered both immediately, which printed the same package
statistics block twice when the removed count was zero.

Buffer both statistics events and render their combined result once, matching
the TypeScript reporter. Flush partial statistics when the run summary arrives
so a missing event cannot suppress the output. Add append-only regression tests
for both the normal pair and incomplete-pair fallback.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786883715&installation_id=145934176&pr_number=13103&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13103&signature=4f751eff7d1321a8c4ed0c28f49467377cfed568b75ef4e52293674f188d59fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate package statistics output during installs in non-interactive terminals.
  * Improved package statistics rendering so “added” and “removed” counts are displayed together, with correct timing, even when messages arrive separately.
  * Prevented premature or incorrect stats summaries from being shown for the wrong working directory.

* **Tests**
  * Expanded and renamed stats rendering tests to verify append-only behavior and summary flushing.

* **Release**
  * Included as a patch-level update for `pacquet`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
