### PR TITLE
ci(benchmark): threshold Bencher on the minimum latency (via BMF)

### DIFF
--- a/.github/workflows/pacquet-integrated-benchmark-comment.yml
+++ b/.github/workflows/pacquet-integrated-benchmark-comment.yml
@@ -176,7 +176,7 @@ jobs:
               --start-point-reset \
               --start-point-clone-thresholds \
               --err \
-              --adapter shell_hyperfine \
+              --adapter json \
               --file "$file" \
               --ci-number "$PR_NUMBER" \
               --github-actions "$GITHUB_TOKEN"

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -416,6 +416,8 @@ jobs:
             echo
             echo 'Each scenario reports direct installs and pnpr installs. Bencher consumes pacquet@HEAD and pnpr@HEAD.'
             echo
+            echo 'The tables below show mean ± σ; Bencher thresholds on the **minimum** latency, which is far less perturbed by shared-runner contention (noise only adds time).'
+            echo
             echo '### Scenario: Isolated linker: fresh restore, cold cache + cold store'
             echo
             cat bench-work-env/BENCHMARK_REPORT_ISOLATED_FRESH_RESTORE_COLD_CACHE_COLD_STORE.md
@@ -502,16 +504,33 @@ jobs:
           ) > bench-work-env/SUMMARY.md
 
       - name: Build Bencher-shaped report
-        # Combine the scenario JSONs into hyperfine-shaped files that
-        # Bencher's shell_hyperfine adapter accepts, one per testbed. For
-        # each, keep only the chosen target's result from each scenario
-        # and rename `.command` to the scenario name, so Bencher names the
-        # benchmark after the scenario. Both tools run every scenario,
-        # so the `pacquet` testbed gets `pacquet@HEAD` and the `pnpr`
-        # testbed gets `pnpr@HEAD`, each across the same scenario set.
+        # Convert the scenario JSONs into a Bencher Metric Format (BMF) file
+        # per testbed, keeping only the chosen target's result from each
+        # scenario and naming each benchmark after the scenario. Both tools run
+        # every scenario, so the `pacquet` testbed gets `pacquet@HEAD` and the
+        # `pnpr` testbed gets `pnpr@HEAD`, each across the same scenario set.
+        #
+        # We report each scenario's *minimum* latency as the metric value, so
+        # Bencher's threshold tracks the min rather than the mean. On a shared
+        # CI runner, contention only ever *adds* time, so the minimum is the run
+        # least perturbed by a noisy neighbour and the truest signal of a real
+        # code regression — the mean drifts run-to-run with whatever else the
+        # machine is doing (the latency-free offline scenario is pure CPU/disk
+        # and swung ~30% between runs, tripping a spurious alert on a control
+        # run whose HEAD and main binaries were byte-identical). Because the
+        # minimum only needs one uncontended run, hyperfine's default sampling
+        # suffices — no extra warmup or runs. The human-readable comment still
+        # reports mean ± σ; only the alerting signal moves to the min.
+        #
+        # BMF rather than the `shell_hyperfine` adapter with a doctored `mean`:
+        # this reports the min honestly as the value instead of relabelling it.
+        # `value` is in nanoseconds (`min` seconds × 1e9) to match the unit the
+        # `shell_hyperfine` adapter established for the `latency` measure, so
+        # the existing baseline stays comparable. The uploads that consume
+        # these files therefore use `--adapter json`.
         shell: bash
         run: |
-          # Build one bencher-results file: $1 = output path, $2 = the
+          # Build one BMF bencher-results file: $1 = output path, $2 = the
           # hyperfine command name to keep, $3.. = `FILE_TAG:scenario-name`
           # entries.
           build_bencher_file() {
@@ -525,11 +544,13 @@ jobs:
               src="bench-work-env/BENCHMARK_REPORT_${file_tag}.json"
               dst="bench-work-env/${name}-${command}-bencher.json"
               jq --arg s "$name" --arg c "$command" \
-                '.results |= [.[] | select(.command == $c) | .command = $s]' \
+                '(first(.results[] | select(.command == $c))
+                  // error("missing hyperfine result for \($c) in \($s)"))
+                  | {($s): {latency: {value: (.min * 1e9)}}}' \
                 "$src" > "$dst"
               inputs+=("$dst")
             done
-            jq -s '{results: map(.results) | add}' "${inputs[@]}" > "$out"
+            jq -s 'add' "${inputs[@]}" > "$out"
           }
 
           build_bencher_file bench-work-env/bencher-results.json pacquet@HEAD \
@@ -607,7 +628,7 @@ jobs:
             local args=(
               --project pnpm
               --testbed "$testbed"
-              --adapter shell_hyperfine
+              --adapter json
               --file "$file"
               --github-actions "$GITHUB_TOKEN"
             )


### PR DESCRIPTION
> [!WARNING]
> **The `Post benchmark comment` job (Upload PR results to Bencher) fails on this PR — this is expected and self-heals on merge. Merge through it.**
>
> `workflow_run`-triggered workflows always run from the **default branch**, so the comment workflow here runs `main`'s copy, which still uses `--adapter shell_hyperfine`. This PR emits results in **BMF** (`--adapter json`), which `shell_hyperfine` can't parse — hence the red upload step. Once this lands on `main`, `main`'s comment workflow uses `--adapter json` and the pipeline is consistent again. The **build** workflow's own upload (PR code, `--adapter json`) already succeeds, so Bencher does receive this PR's min-based data.
>
> **After merge:** confirm the first `Pacquet Integrated-Benchmark` run on `main` is green (build → BMF, comment → json, consistent).

## Summary

Make the integrated-benchmark's regression signal reliable on shared CI runners by having Bencher threshold on the **minimum** latency instead of the mean.

### The problem

The benchmark's timed work is CPU- and disk-bound, not network-bound. The simulated network latency only adds a *deterministic* floor, and the noisiest scenario — `fresh-resolve.hot-cache.offline` — runs `install --offline` with no network at all (pure mirror reads + packument parsing). So the run-to-run variance is host contention on a shared cloud VM (CPU steal, frequency scaling, disk I/O, page-cache pressure across the four sequentially-measured arms), which the mean tracks faithfully.

That surfaced as spurious alerts. This PR's own benchmark is the proof: because it only changes the workflow YAML, `pacquet@HEAD` and `pacquet@main` are **byte-identical binaries**, yet the mean-based threshold still swung the offline scenario ~30% and alerted. With identical binaries, that's 100% measurement noise.

### The fix

Report each scenario's **minimum** latency to Bencher. Contention only ever *adds* time, so the minimum is the run least perturbed by a noisy neighbour and the truest signal of a real code regression — the estimator the robust-benchmarking literature ([arXiv:1608.04295](https://arxiv.org/pdf/1608.04295)) and Julia's CI (`BenchmarkTools`) use for exactly this. The "noise is additive" property is universal, so this applies to every scenario.

Done **honestly via Bencher Metric Format (BMF)** rather than by doctoring hyperfine's `mean` field: `build_bencher_file` emits `{"<scenario>": {"latency": {"value": <min>}}}` and the integrated-benchmark uploads use `--adapter json`. `value` is nanoseconds (`min` seconds × 1e9), matching the unit the `shell_hyperfine` adapter established for the `latency` measure, so the existing baseline stays comparable. A missing/renamed target fails the step rather than silently dropping a scenario.

Because the minimum only needs *one* uncontended run to be stable, hyperfine's default sampling (1 warmup, ≥10 runs) suffices — no `--warmup`/`--min-runs` bump. The human-readable PR comment still reports mean ± σ; only the alerting signal moves to the min.

### Scope

- Only the two integrated-benchmark uploaders (`pacquet-integrated-benchmark.yml`, `pacquet-integrated-benchmark-comment.yml`) switch to `--adapter json`.
- The TypeScript test-duration and micro-benchmark uploaders (`ci-performance-bencher-upload.yml`, `benchmark.yml`) are untouched — they consume separate `ci-performance-*` artifacts, and their measurements are single-sample (`mean = min = max`), so min-based thresholding would be a no-op there anyway.

### Transition

Once this lands on `main`, the `main` baseline re-establishes on min values on its next run; PRs then compare min-vs-min. During the first PR run after merge, a PR's new min is compared against `main`'s old mean baseline (min ≤ mean), so the transition can only *under*-report a regression, never invent one.

## Squash Commit Body

```text
Report each scenario's minimum latency to Bencher instead of the mean, so the
threshold tracks the min. On shared CI runners the timed work is CPU/disk-bound
(the simulated latency only adds a deterministic floor, and the noisiest
scenario runs --offline with no network), so the mean drifts run-to-run with
host contention — byte-identical binaries differed ~30% on the offline scenario
and tripped a spurious alert.

Contention only ever adds time, so the minimum is the run least perturbed by a
noisy neighbour and the truest regression signal. Emit Bencher Metric Format
and upload the integrated benchmark with --adapter json, reporting the min
honestly as the value (nanoseconds, min seconds x 1e9, to match the latency
measure's unit) rather than relabelling hyperfine's mean field. The TS
test-duration and micro-benchmark uploads keep shell_hyperfine (single-sample,
so min equals mean there). Because the min only needs one uncontended run,
hyperfine's default sampling suffices. The human comment still shows mean +/- σ.

Note: the workflow_run-triggered comment workflow runs from the default branch,
so this PR's own benchmark-comment upload fails (main still uses
--adapter shell_hyperfine); it self-heals once this lands on main.
```

## Checklist

- [x] Added or updated tests. — N/A: CI benchmark-config change, no product code.
- [x] Updated the documentation if needed. — the workflow step comments explain the rationale.

<!-- No changeset: changes only CI workflows, no published package. -->
<!-- Not a TS/Rust parity change: it only changes how the pacquet integrated-benchmark result is thresholded. -->

---
Written by an agent (Claude Code, claude-opus-4-8).
