### PR TITLE
fix(deps-resolver): preserve workspace link: on re-resolution (fixes pnpm/pnpm#10433)

### DIFF
--- a/.changeset/preserve-workspace-link-on-partial-update.md
+++ b/.changeset/preserve-workspace-link-on-partial-update.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Preserve a workspace dependency's `link:` entry when an unrelated dependency is updated recursively (e.g. `pnpm update <pkg> --recursive`) with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.
+Preserve a workspace dependency's `link:` entry when an unrelated dependency is updated (e.g. `pnpm update <pkg>`) with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.

--- a/.changeset/preserve-workspace-link-on-partial-update.md
+++ b/.changeset/preserve-workspace-link-on-partial-update.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Preserve a workspace dependency's `link:` entry when an unrelated dependency is updated recursively (e.g. `pnpm update <pkg> --recursive`) with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.

--- a/.changeset/preserve-workspace-link-on-partial-update.md
+++ b/.changeset/preserve-workspace-link-on-partial-update.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/installing.deps-resolver": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 Preserve a workspace dependency's `link:` entry when a run does not target it — e.g. `pnpm update <other-pkg>` (with or without `--recursive`), or a plain install after a root/catalog dependency change — with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.

--- a/.changeset/preserve-workspace-link-on-partial-update.md
+++ b/.changeset/preserve-workspace-link-on-partial-update.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Preserve a workspace dependency's `link:` entry when an unrelated dependency is updated (e.g. `pnpm update <pkg>`) with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.
+Preserve a workspace dependency's `link:` entry when a run does not target it — e.g. `pnpm update <other-pkg>` (with or without `--recursive`), or a plain install after a root/catalog dependency change — with `injectWorkspacePackages`, instead of spuriously rewriting it to a peer-suffixed `file:` protocol. See pnpm/pnpm#10433.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,9 +709,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -121,8 +121,18 @@ pub struct GraphToLockfileOptions<'a> {
     /// `pacquet update` seed policy. Together with a spec change it
     /// decides whether an importer's workspace dependency is *targeted*
     /// by the run (and so may legitimately change its `link:`/`file:`
-    /// form) — see `build_importer`.
+    /// form) — see `build_importer`. This is the workspace-wide default;
+    /// [`Self::update_reuse_scopes_by_importer`] overrides it per importer.
     pub update_reuse_scope: UpdateReuseScope,
+    /// Per-importer update scopes, mirroring the resolver's
+    /// `update_reuse_scope_for`: a `pacquet update <name> --recursive`
+    /// lowers to a `ByImporter` policy whose workspace-wide scope is `All`
+    /// with the named packages recorded per importer here. The guard
+    /// resolves each importer's effective scope as: global when the global
+    /// is `None`, else this map's entry, else the global — so a recursive
+    /// update targets the named dependency in the importer that declares
+    /// it while leaving untouched importers' `link:` entries intact.
+    pub update_reuse_scopes_by_importer: BTreeMap<String, UpdateReuseScope>,
 }
 
 /// Error returned while converting a resolver graph into a lockfile.
@@ -193,6 +203,7 @@ pub fn dependencies_graph_to_lockfile(
         lockfile_include_tarball_url,
         previous_importers,
         update_reuse_scope,
+        update_reuse_scopes_by_importer,
     } = opts;
 
     let optional_overrides = compute_corrected_optional(&importer_inputs, graph);
@@ -207,6 +218,17 @@ pub fn dependencies_graph_to_lockfile(
         HashMap::with_capacity(importer_inputs.len());
     for (id, input) in &importer_inputs {
         let previous_importer = previous_importers.and_then(|imps| imps.get(id));
+        // Effective update scope for this importer, mirroring the resolver's
+        // `update_reuse_scope_for`: a global `None` (bare `update`) applies to
+        // every importer; otherwise the per-importer entry wins, falling back
+        // to the global. This is what lets a `pacquet update <name> --recursive`
+        // target the named dependency in the importer that declares it while
+        // leaving untouched importers on their global scope.
+        let effective_update_reuse_scope = if matches!(update_reuse_scope, UpdateReuseScope::None) {
+            &update_reuse_scope
+        } else {
+            update_reuse_scopes_by_importer.get(id).unwrap_or(&update_reuse_scope)
+        };
         importers.insert(
             id.clone(),
             build_importer(
@@ -214,7 +236,7 @@ pub fn dependencies_graph_to_lockfile(
                 graph,
                 &ImporterLockfileFlags { exclude_links_from_lockfile, auto_install_peers },
                 previous_importer,
-                &update_reuse_scope,
+                effective_update_reuse_scope,
             )?,
         );
     }
@@ -367,34 +389,19 @@ fn build_importer(
             && let ImporterDepVersion::Link(_) = &previous.version
         {
             // A workspace dependency the run doesn't target keeps its
-            // `link:`. It is targeted when the update scope names it (a
-            // `pacquet update <name>`, or a scope-wide `update` / forced
-            // re-resolve) or when its specifier changed (a new or edited
-            // manifest entry). `KeepAll` (plain install / add) never
-            // targets on its own, so an untouched workspace dep is
-            // preserved. Matches the TS resolver's `updateTargetedAliases`
-            // / `updateMatching` guard, where a plain install's blanket
-            // spec re-check must not count as targeting.
-            //
-            // Known parity gap with the TS side (`pnpm update <name>
-            // --recursive`): this reads the *global* update scope, not the
-            // per-importer scope from `update_reuse_scope_for`. A recursive
-            // update lowers to a `ByImporter` policy whose global scope is
-            // `All` (the named packages live in the per-importer map), so a
-            // workspace-link dep that the user named *and* whose peer
-            // context flips on re-resolve is preserved as `link:` here,
-            // whereas TS's per-importer `updateMatching(<name>)` would keep
-            // the fresh `file:`. Threading the per-importer scope instead is
-            // not a fix: `UpdateReuseScope` conflates "the user asked to
-            // update this importer" (`DropAll` -> `None`) with "re-resolve
-            // this importer as a side effect of a recursive update", and a
-            // non-target importer's `None` would re-target the untouched
-            // workspace edge and reintroduce pnpm/pnpm#10433. Expressing the
-            // narrower by-name targeting would need a separate signal (as TS
-            // keeps `update` and `updateMatching` distinct). The gap is
-            // limited to recursively updating a workspace-link dep by name
-            // that also diverges its peer context — where keeping `link:`
-            // for a workspace package is a defensible outcome anyway.
+            // `link:`. It is targeted when this importer's update scope names
+            // it (`pacquet update <name>`, including the per-importer scope of
+            // a `--recursive` run), when the scope is `None` (a scope-wide
+            // bare `update` / forced re-resolve), or when its specifier
+            // changed (a new or edited manifest entry). `KeepAll` (plain
+            // install / add) never targets on its own, so an untouched
+            // workspace dep is preserved. `update_reuse_scope` here is already
+            // resolved for this importer (see `update_reuse_scope_for` in the
+            // caller), so `pacquet update <name> --recursive` targets the
+            // named dep in the importer that declares it while untouched
+            // importers keep their `link:`. Matches the TS resolver's
+            // `updateTargetedAliases` / `updateMatching` guard, where a plain
+            // install's blanket spec re-check must not count as targeting.
             let targeted_by_update = match update_reuse_scope {
                 UpdateReuseScope::All => false,
                 UpdateReuseScope::None => true,

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -20,7 +20,9 @@ use pacquet_lockfile::{
     ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, VersionPart,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_resolving_deps_resolver::{DepPath, DependenciesGraph, DependenciesGraphNode};
+use pacquet_resolving_deps_resolver::{
+    DepPath, DependenciesGraph, DependenciesGraphNode, UpdateReuseScope,
+};
 use pacquet_resolving_resolver_base::ResolveResult;
 use serde_json::Value;
 
@@ -108,6 +110,19 @@ pub struct GraphToLockfileOptions<'a> {
     /// When `true`, registry tarball URLs are kept in the lockfile even when
     /// reconstructible (the `lockfileIncludeTarballUrl` setting).
     pub lockfile_include_tarball_url: bool,
+    /// The previous run's importer entries (the wanted lockfile's
+    /// `importers:` map), keyed by the same importer ids as
+    /// [`Self::importers`]. Used to preserve a workspace dependency's
+    /// prior `link:` entry when this install does not target it — see
+    /// [`build_importer`] and pnpm/pnpm#10433. `None` when there is no
+    /// previous lockfile (a first install).
+    pub previous_importers: Option<&'a HashMap<String, ProjectSnapshot>>,
+    /// How this install reuses the prior resolution, mapped from the
+    /// `pacquet update` seed policy. Together with a spec change it
+    /// decides whether an importer's workspace dependency is *targeted*
+    /// by the run (and so may legitimately change its `link:`/`file:`
+    /// form) — see [`build_importer`].
+    pub update_reuse_scope: UpdateReuseScope,
 }
 
 /// Error returned while converting a resolver graph into a lockfile.
@@ -176,6 +191,8 @@ pub fn dependencies_graph_to_lockfile(
         catalogs,
         registry,
         lockfile_include_tarball_url,
+        previous_importers,
+        update_reuse_scope,
     } = opts;
 
     let optional_overrides = compute_corrected_optional(&importer_inputs, graph);
@@ -189,12 +206,15 @@ pub fn dependencies_graph_to_lockfile(
     let mut importers: HashMap<String, ProjectSnapshot> =
         HashMap::with_capacity(importer_inputs.len());
     for (id, input) in &importer_inputs {
+        let previous_importer = previous_importers.and_then(|imps| imps.get(id));
         importers.insert(
             id.clone(),
             build_importer(
                 input,
                 graph,
                 &ImporterLockfileFlags { exclude_links_from_lockfile, auto_install_peers },
+                previous_importer,
+                &update_reuse_scope,
             )?,
         );
     }
@@ -285,6 +305,8 @@ fn build_importer(
     input: &ImporterLockfileInput<'_>,
     graph: &DependenciesGraph,
     flags: &ImporterLockfileFlags,
+    previous_importer: Option<&ProjectSnapshot>,
+    update_reuse_scope: &UpdateReuseScope,
 ) -> Result<ProjectSnapshot, DependenciesGraphToLockfileError> {
     let ImporterLockfileFlags { exclude_links_from_lockfile, auto_install_peers } = *flags;
     let manifest = input.manifest;
@@ -316,7 +338,7 @@ fn build_importer(
         // version directly from the `link:` depPath instead. Non-link
         // direct deps must be present in the graph — a missing entry
         // means the resolver dropped the edge, so skip.
-        let version = if let Some(target) = dep_path.as_str().strip_prefix("link:") {
+        let mut version = if let Some(target) = dep_path.as_str().strip_prefix("link:") {
             if exclude_links_from_lockfile && !specifier.starts_with("workspace:") {
                 continue;
             }
@@ -331,6 +353,41 @@ fn build_importer(
                 }
             })?
         };
+        // pnpm/pnpm#10433: a fresh-lockfile install re-resolves every
+        // importer, and an injected workspace dependency whose peer context
+        // genuinely diverges (or with `dedupeInjectedDeps` off) reaches
+        // `importer_dep_version`'s `file:` arm instead of deduping back to
+        // `link:`. When this install does not *target* that dependency, keep
+        // its previous `link:` importer entry rather than rewriting it to a
+        // peer-suffixed `file:`. `dedupe_injected_deps` runs earlier in the
+        // resolver and does not reach this finalization path.
+        if let ImporterDepVersion::File(_) = &version
+            && let Some(previous) =
+                previous_importer.and_then(|prev| previous_importer_dep(prev, &name_for_key))
+            && let ImporterDepVersion::Link(_) = &previous.version
+        {
+            // A workspace dependency the run doesn't target keeps its
+            // `link:`. It is targeted when the update scope names it (a
+            // `pacquet update <name>`, or a scope-wide `update` / forced
+            // re-resolve) or when its specifier changed (a new or edited
+            // manifest entry). `KeepAll` (plain install / add) never
+            // targets on its own, so an untouched workspace dep is
+            // preserved. Matches the TS resolver's `updateTargetedAliases`
+            // / `updateMatching` guard, where a plain install's blanket
+            // spec re-check must not count as targeting.
+            let targeted_by_update = match update_reuse_scope {
+                UpdateReuseScope::All => false,
+                UpdateReuseScope::None => true,
+                UpdateReuseScope::Except(names) => graph
+                    .get(dep_path)
+                    .and_then(node_pkg_name)
+                    .is_some_and(|name| names.contains(&name)),
+            };
+            let targeted_by_spec_change = previous.specifier != specifier;
+            if !targeted_by_update && !targeted_by_spec_change {
+                version = previous.version.clone();
+            }
+        }
         let spec = ResolvedDependencySpec { specifier: specifier.clone(), version };
         specifiers.insert(alias.clone(), specifier);
         let group = alias_to_group.get(alias).copied().unwrap_or(DependencyGroup::Prod);
@@ -473,6 +530,36 @@ fn self_aliased_file_ver<'a>(alias: &str, key: &'a PkgNameVerPeer) -> Option<&'a
     };
     (aliased_to_own_name && matches!(key.suffix.version(), VersionPart::File(_)))
         .then_some(&key.suffix)
+}
+
+/// The previous importer's recorded entry for `name`, searched across
+/// its `dependencies` / `optionalDependencies` / `devDependencies` maps
+/// (mirrors the lookup order in
+/// [`pacquet_resolving_deps_resolver`]'s `lockfile_reuse`). Used by the
+/// pnpm/pnpm#10433 guard in [`build_importer`] to recover a workspace
+/// dependency's prior `link:` entry.
+fn previous_importer_dep<'a>(
+    importer: &'a ProjectSnapshot,
+    name: &PkgName,
+) -> Option<&'a ResolvedDependencySpec> {
+    importer
+        .dependencies
+        .as_ref()
+        .and_then(|map| map.get(name))
+        .or_else(|| importer.optional_dependencies.as_ref().and_then(|map| map.get(name)))
+        .or_else(|| importer.dev_dependencies.as_ref().and_then(|map| map.get(name)))
+}
+
+/// The resolved package name for a graph node — the structured
+/// `name_ver` when the resolver produced one, otherwise the `name` from
+/// the fetched manifest (the case for a directory/workspace resolution,
+/// whose `name_ver` is unset). Used to match a workspace dependency
+/// against an `update <name>` scope in [`build_importer`].
+fn node_pkg_name(node: &DependenciesGraphNode) -> Option<String> {
+    if let Some(name_ver) = node.resolve_result.name_ver.as_ref() {
+        return Some(name_ver.name.to_string());
+    }
+    node.resolve_result.manifest.as_ref()?.get("name")?.as_str().map(str::to_string)
 }
 
 /// `Some(real_name)` when the resolver produced a structured name; `None`

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -375,6 +375,26 @@ fn build_importer(
             // preserved. Matches the TS resolver's `updateTargetedAliases`
             // / `updateMatching` guard, where a plain install's blanket
             // spec re-check must not count as targeting.
+            //
+            // Known parity gap with the TS side (`pnpm update <name>
+            // --recursive`): this reads the *global* update scope, not the
+            // per-importer scope from `update_reuse_scope_for`. A recursive
+            // update lowers to a `ByImporter` policy whose global scope is
+            // `All` (the named packages live in the per-importer map), so a
+            // workspace-link dep that the user named *and* whose peer
+            // context flips on re-resolve is preserved as `link:` here,
+            // whereas TS's per-importer `updateMatching(<name>)` would keep
+            // the fresh `file:`. Threading the per-importer scope instead is
+            // not a fix: `UpdateReuseScope` conflates "the user asked to
+            // update this importer" (`DropAll` -> `None`) with "re-resolve
+            // this importer as a side effect of a recursive update", and a
+            // non-target importer's `None` would re-target the untouched
+            // workspace edge and reintroduce pnpm/pnpm#10433. Expressing the
+            // narrower by-name targeting would need a separate signal (as TS
+            // keeps `update` and `updateMatching` distinct). The gap is
+            // limited to recursively updating a workspace-link dep by name
+            // that also diverges its peer context — where keeping `link:`
+            // for a workspace package is a defensible outcome anyway.
             let targeted_by_update = match update_reuse_scope {
                 UpdateReuseScope::All => false,
                 UpdateReuseScope::None => true,

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -114,14 +114,14 @@ pub struct GraphToLockfileOptions<'a> {
     /// `importers:` map), keyed by the same importer ids as
     /// [`Self::importers`]. Used to preserve a workspace dependency's
     /// prior `link:` entry when this install does not target it — see
-    /// [`build_importer`] and pnpm/pnpm#10433. `None` when there is no
+    /// `build_importer` and pnpm/pnpm#10433. `None` when there is no
     /// previous lockfile (a first install).
     pub previous_importers: Option<&'a HashMap<String, ProjectSnapshot>>,
     /// How this install reuses the prior resolution, mapped from the
     /// `pacquet update` seed policy. Together with a spec change it
     /// decides whether an importer's workspace dependency is *targeted*
     /// by the run (and so may legitimately change its `link:`/`file:`
-    /// form) — see [`build_importer`].
+    /// form) — see `build_importer`.
     pub update_reuse_scope: UpdateReuseScope,
 }
 

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -2497,3 +2497,75 @@ fn injected_workspace_dep_flips_to_file_when_specifier_changed() {
         entry.version,
     );
 }
+
+// Bare `pacquet update` (UpdateReuseScope::None) re-resolves the whole
+// graph, so every workspace dependency is targeted and its divergent
+// `file:` resolution stands — exercises the `None` arm of the guard.
+#[test]
+fn injected_workspace_dep_flips_to_file_on_scope_wide_update() {
+    let (_tmp, manifest, graph, direct) = injected_link_fixture();
+    let previous = previous_importers_with_link("n", "workspace:*", "../n");
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        previous_importers: Some(&previous),
+        update_reuse_scope: UpdateReuseScope::None,
+        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
+    });
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
+        .expect("n entry");
+    assert!(
+        matches!(&entry.version, ImporterDepVersion::File(_)),
+        "a scope-wide update must keep the fresh file: resolution, got {:?}",
+        entry.version,
+    );
+}
+
+// Same `pacquet update <name>` targeting as
+// `injected_workspace_dep_flips_to_file_when_update_targets_it`, but the
+// injected node carries a structured `name_ver` (rather than learning its
+// name from the manifest) — exercises the `name_ver` arm of
+// `node_pkg_name` used to match the update scope.
+#[test]
+fn injected_workspace_dep_flips_to_file_when_update_targets_named_node() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "consumer",
+        "version": "1.0.0",
+        "dependencies": { "n": "workspace:*" },
+    }));
+    // A file: injected node whose resolver produced a structured name.
+    let mut file_node = make_file_node("packages/n", json!({ "name": "n", "version": "1.0.0" }));
+    let resolve_result = ResolveResult {
+        name_ver: Some("n@1.0.0".parse().expect("parse PkgNameVer")),
+        ..(*file_node.resolve_result).clone()
+    };
+    file_node.resolve_result = std::sync::Arc::new(resolve_result);
+    let mut graph = DependenciesGraph::new();
+    graph.insert(file_node.dep_path.clone(), file_node.clone());
+    let mut direct = BTreeMap::new();
+    direct.insert("n".to_string(), file_node.dep_path);
+
+    let previous = previous_importers_with_link("n", "workspace:*", "../n");
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        previous_importers: Some(&previous),
+        update_reuse_scope: UpdateReuseScope::Except(HashSet::from(["n".to_string()])),
+        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
+    });
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
+        .expect("n entry");
+    assert!(
+        matches!(&entry.version, ImporterDepVersion::File(_)),
+        "an update targeting a name_ver-bearing node must keep file:, got {:?}",
+        entry.version,
+    );
+}

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -2325,43 +2325,6 @@ fn importer_records_a_peer_only_alias_only_under_auto_install_peers() {
     assert_eq!(entry.specifier, "^1.0.0");
 }
 
-/// Build a graph node for an injected workspace dependency that resolved
-/// to a `file:` dep path (the shape `dedupe_injected_deps` leaves behind
-/// when the injected copy's peer context genuinely diverges). `name_ver`
-/// is left `None` so the package name is read from the manifest, matching
-/// a real directory resolution.
-fn make_injected_file_node(target: &str, manifest: serde_json::Value) -> DependenciesGraphNode {
-    let id_text = format!("file:{target}");
-    let resolve_result = ResolveResult {
-        id: PkgResolutionId::from(id_text.clone()),
-        name_ver: None,
-        latest: None,
-        published_at: None,
-        manifest: Some(std::sync::Arc::new(manifest)),
-        resolution: LockfileResolution::Directory(DirectoryResolution {
-            directory: target.to_string(),
-        }),
-        resolved_via: "workspace".to_string(),
-        normalized_bare_specifier: None,
-        alias: None,
-        policy_violation: None,
-    };
-    DependenciesGraphNode {
-        dep_path: DepPath::from(id_text.clone()),
-        resolved_package_id: id_text,
-        resolve_result: std::sync::Arc::new(resolve_result),
-        children: BTreeMap::new(),
-        optional_children: HashSet::new(),
-        peer_dependencies: BTreeMap::new(),
-        transitive_peer_dependencies: HashSet::new(),
-        resolved_peer_names: HashSet::new(),
-        depth: 0,
-        installable: true,
-        is_pure: true,
-        optional: false,
-    }
-}
-
 /// A single-importer previous lockfile whose `alias` dependency was
 /// recorded as `link:<target>`.
 fn previous_importers_with_link(
@@ -2393,7 +2356,7 @@ fn injected_link_fixture()
         "version": "1.0.0",
         "dependencies": { "n": "workspace:*" },
     }));
-    let file_node = make_injected_file_node("packages/n", json!({ "name": "n", "version": "1.0.0" }));
+    let file_node = make_file_node("n", "packages/n");
     let mut graph = DependenciesGraph::new();
     graph.insert(file_node.dep_path.clone(), file_node.clone());
     let mut direct = BTreeMap::new();
@@ -2604,47 +2567,19 @@ fn injected_workspace_dep_flips_to_file_on_scope_wide_update() {
     );
 }
 
-// Same `pacquet update <name>` targeting as
-// `injected_workspace_dep_flips_to_file_when_update_targets_it`, but the
-// injected node carries a structured `name_ver` (rather than learning its
-// name from the manifest) — exercises the `name_ver` arm of
-// `node_pkg_name` used to match the update scope.
+// `node_pkg_name` (the guard's `update <name>` scope matcher) reads the
+// structured `name_ver` when the resolver produced one and falls back to
+// the fetched manifest's `name` for directory resolutions, whose
+// `name_ver` is unset.
 #[test]
-fn injected_workspace_dep_flips_to_file_when_update_targets_named_node() {
-    let (_tmp, manifest) = write_manifest(json!({
-        "name": "consumer",
-        "version": "1.0.0",
-        "dependencies": { "n": "workspace:*" },
-    }));
-    // A file: injected node whose resolver produced a structured name.
-    let mut file_node = make_file_node("packages/n", json!({ "name": "n", "version": "1.0.0" }));
+fn node_pkg_name_prefers_name_ver_and_falls_back_to_manifest() {
+    let mut node = make_file_node("n", "packages/n");
+    assert_eq!(super::node_pkg_name(&node), Some("n".to_string()));
+
     let resolve_result = ResolveResult {
-        name_ver: Some("n@1.0.0".parse().expect("parse PkgNameVer")),
-        ..(*file_node.resolve_result).clone()
+        name_ver: Some("renamed@1.0.0".parse().expect("parse PkgNameVer")),
+        ..(*node.resolve_result).clone()
     };
-    file_node.resolve_result = std::sync::Arc::new(resolve_result);
-    let mut graph = DependenciesGraph::new();
-    graph.insert(file_node.dep_path.clone(), file_node.clone());
-    let mut direct = BTreeMap::new();
-    direct.insert("n".to_string(), file_node.dep_path);
-
-    let previous = previous_importers_with_link("n", "workspace:*", "../n");
-
-    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
-        previous_importers: Some(&previous),
-        update_reuse_scope: UpdateReuseScope::Except(HashSet::from(["n".to_string()])),
-        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
-    });
-
-    let importer = lockfile.root_project().expect("root importer");
-    let entry = importer
-        .dependencies
-        .as_ref()
-        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
-        .expect("n entry");
-    assert!(
-        matches!(&entry.version, ImporterDepVersion::File(_)),
-        "an update targeting a name_ver-bearing node must keep file:, got {:?}",
-        entry.version,
-    );
+    node.resolve_result = std::sync::Arc::new(resolve_result);
+    assert_eq!(super::node_pkg_name(&node), Some("renamed".to_string()));
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -7,13 +7,14 @@ use indexmap::IndexMap;
 use pacquet_deps_path::DepPath;
 use pacquet_lockfile::{
     DirectoryResolution, GitResolution, ImporterDepVersion, LockfileResolution, PackageKey,
-    PkgName, PkgNameVer, RegistryResolution, SnapshotDepRef, TarballResolution,
-    VariationsResolution,
+    PkgName, PkgNameVer, ProjectSnapshot, RegistryResolution, ResolvedDependencyMap,
+    ResolvedDependencySpec, SnapshotDepRef, TarballResolution, VariationsResolution,
 };
 use pacquet_package_manifest::PackageManifest;
 use pacquet_resolving_deps_resolver::{
     ChildEdge, DependenciesGraph, DependenciesGraphNode, DependenciesTreeNode, DirectDep, NodeId,
-    PeerDep, ResolvePeersOptions, ResolvedPackage, ResolvedTree, TreeChildren, resolve_peers,
+    PeerDep, ResolvePeersOptions, ResolvedPackage, ResolvedTree, TreeChildren, UpdateReuseScope,
+    resolve_peers,
 };
 use pacquet_resolving_resolver_base::{PkgResolutionId, ResolveResult};
 use serde_json::json;
@@ -79,6 +80,8 @@ fn single_importer_opts<'a>(
         catalogs: &EMPTY_CATALOGS,
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
     }
 }
 
@@ -419,6 +422,8 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         catalogs: &EMPTY_CATALOGS,
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
     });
     let on_settings = on.settings.as_ref().expect("settings written");
     assert_eq!(on_settings.dedupe_peers, Some(true));
@@ -446,6 +451,8 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         catalogs: &EMPTY_CATALOGS,
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
     });
     let off_settings = off.settings.as_ref().expect("settings written");
     assert_eq!(off_settings.dedupe_peers, None);
@@ -527,6 +534,8 @@ fn patched_dependencies_flow_into_lockfile_and_empty_is_omitted() {
             catalogs: &EMPTY_CATALOGS,
             registry: "https://registry.npmjs.org",
             lockfile_include_tarball_url: false,
+            previous_importers: None,
+            update_reuse_scope: UpdateReuseScope::All,
         })
     };
 
@@ -681,6 +690,8 @@ fn aliased_catalog_dependency_records_catalog_snapshot() {
         catalogs: &catalogs,
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
     });
 
     let snapshots = lockfile.catalogs.as_ref().expect("catalogs snapshot present");
@@ -1734,6 +1745,8 @@ fn snapshot_link_uses_lockfile_root_while_importer_link_uses_project_root() {
         catalogs: &EMPTY_CATALOGS,
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
     });
 
     let importer = lockfile.importers.get("apps/nested/app").expect("nested importer");
@@ -1821,6 +1834,8 @@ fn multi_importer_workspace_writes_per_project_lockfile_entries() {
         catalogs: &EMPTY_CATALOGS,
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
     });
 
     let a_snap = lockfile.importers.get("packages/a").expect("importer a");
@@ -1926,6 +1941,8 @@ fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches
         catalogs: &EMPTY_CATALOGS,
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
     });
 
     let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
@@ -2057,6 +2074,8 @@ fn workspace_sibling_link_renders_per_importer_with_link_ref() {
         catalogs: &EMPTY_CATALOGS,
         registry: "https://registry.npmjs.org",
         lockfile_include_tarball_url: false,
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
     });
 
     let a_snap = lockfile.importers.get("packages/a").expect("importer a");
@@ -2295,4 +2314,186 @@ fn importer_records_a_peer_only_alias_only_under_auto_install_peers() {
         .and_then(|deps| deps.get(&peer_key))
         .expect("auto-installed peer entry");
     assert_eq!(entry.specifier, "^1.0.0");
+}
+
+/// Build a graph node for an injected workspace dependency that resolved
+/// to a `file:` dep path (the shape `dedupe_injected_deps` leaves behind
+/// when the injected copy's peer context genuinely diverges). `name_ver`
+/// is left `None` so the package name is read from the manifest, matching
+/// a real directory resolution.
+fn make_injected_file_node(target: &str, manifest: serde_json::Value) -> DependenciesGraphNode {
+    let id_text = format!("file:{target}");
+    let resolve_result = ResolveResult {
+        id: PkgResolutionId::from(id_text.clone()),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: Some(std::sync::Arc::new(manifest)),
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: target.to_string(),
+        }),
+        resolved_via: "workspace".to_string(),
+        normalized_bare_specifier: None,
+        alias: None,
+        policy_violation: None,
+    };
+    DependenciesGraphNode {
+        dep_path: DepPath::from(id_text.clone()),
+        resolved_package_id: id_text,
+        resolve_result: std::sync::Arc::new(resolve_result),
+        children: BTreeMap::new(),
+        optional_children: HashSet::new(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::new(),
+        resolved_peer_names: HashSet::new(),
+        depth: 0,
+        installable: true,
+        is_pure: true,
+        optional: false,
+    }
+}
+
+/// A single-importer previous lockfile whose `alias` dependency was
+/// recorded as `link:<target>`.
+fn previous_importers_with_link(
+    alias: &str,
+    specifier: &str,
+    target: &str,
+) -> HashMap<String, ProjectSnapshot> {
+    let mut deps = ResolvedDependencyMap::new();
+    deps.insert(
+        PkgName::parse(alias).unwrap(),
+        ResolvedDependencySpec {
+            specifier: specifier.to_string(),
+            version: ImporterDepVersion::Link(target.to_string()),
+        },
+    );
+    let snapshot = ProjectSnapshot { dependencies: Some(deps), ..Default::default() };
+    let mut importers = HashMap::new();
+    importers.insert(".".to_string(), snapshot);
+    importers
+}
+
+/// A `consumer -> n` edge whose fresh resolution is a divergent `file:`
+/// injection, with a previous lockfile that recorded it as `link:`.
+/// Shared by the guard tests below.
+fn injected_link_fixture()
+-> (TempDir, PackageManifest, DependenciesGraph, BTreeMap<String, DepPath>) {
+    let (tmp, manifest) = write_manifest(json!({
+        "name": "consumer",
+        "version": "1.0.0",
+        "dependencies": { "n": "workspace:*" },
+    }));
+    let file_node = make_injected_file_node("packages/n", json!({ "name": "n", "version": "1.0.0" }));
+    let mut graph = DependenciesGraph::new();
+    graph.insert(file_node.dep_path.clone(), file_node.clone());
+    let mut direct = BTreeMap::new();
+    direct.insert("n".to_string(), file_node.dep_path);
+    (tmp, manifest, graph, direct)
+}
+
+// pnpm/pnpm#10433: a plain install (UpdateReuseScope::All) that does not
+// target a workspace dependency must keep its prior `link:` importer
+// entry, even though the fresh resolution landed on a divergent `file:`.
+#[test]
+fn injected_workspace_dep_keeps_prior_link_on_untargeted_install() {
+    let (_tmp, manifest, graph, direct) = injected_link_fixture();
+    let previous = previous_importers_with_link("n", "workspace:*", "../n");
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        previous_importers: Some(&previous),
+        update_reuse_scope: UpdateReuseScope::All,
+        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
+    });
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
+        .expect("n entry");
+    match &entry.version {
+        ImporterDepVersion::Link(target) => assert_eq!(target, "../n"),
+        other => panic!("expected the prior Link(..) to be preserved, got {other:?}"),
+    }
+}
+
+// Without a previous `link:` to preserve (a first install), the divergent
+// `file:` resolution stands — the guard only preserves, never invents.
+#[test]
+fn injected_workspace_dep_renders_file_without_prior_link() {
+    let (_tmp, manifest, graph, direct) = injected_link_fixture();
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        previous_importers: None,
+        update_reuse_scope: UpdateReuseScope::All,
+        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
+    });
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
+        .expect("n entry");
+    assert!(
+        matches!(&entry.version, ImporterDepVersion::File(_)),
+        "expected File(..) with no prior link to preserve, got {:?}",
+        entry.version,
+    );
+}
+
+// A `pacquet update n` (UpdateReuseScope::Except containing the package
+// name) targets the dependency, so its divergent `file:` resolution is
+// kept rather than reverted to the prior `link:`.
+#[test]
+fn injected_workspace_dep_flips_to_file_when_update_targets_it() {
+    let (_tmp, manifest, graph, direct) = injected_link_fixture();
+    let previous = previous_importers_with_link("n", "workspace:*", "../n");
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        previous_importers: Some(&previous),
+        update_reuse_scope: UpdateReuseScope::Except(HashSet::from(["n".to_string()])),
+        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
+    });
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
+        .expect("n entry");
+    assert!(
+        matches!(&entry.version, ImporterDepVersion::File(_)),
+        "an update that targets n must keep the fresh file: resolution, got {:?}",
+        entry.version,
+    );
+}
+
+// A changed specifier (a new or edited manifest entry) targets the
+// dependency too, so the divergent `file:` stands.
+#[test]
+fn injected_workspace_dep_flips_to_file_when_specifier_changed() {
+    let (_tmp, manifest, graph, direct) = injected_link_fixture();
+    // Previous lockfile recorded a different specifier than the manifest
+    // now declares (`workspace:*`).
+    let previous = previous_importers_with_link("n", "workspace:^1.0.0", "../n");
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        previous_importers: Some(&previous),
+        update_reuse_scope: UpdateReuseScope::All,
+        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
+    });
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
+        .expect("n entry");
+    assert!(
+        matches!(&entry.version, ImporterDepVersion::File(_)),
+        "a spec change must keep the fresh file: resolution, got {:?}",
+        entry.version,
+    );
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -82,6 +82,7 @@ fn single_importer_opts<'a>(
         lockfile_include_tarball_url: false,
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
     }
 }
 
@@ -424,6 +425,7 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         lockfile_include_tarball_url: false,
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
     });
     let on_settings = on.settings.as_ref().expect("settings written");
     assert_eq!(on_settings.dedupe_peers, Some(true));
@@ -453,6 +455,7 @@ fn dedupe_peers_round_trips_through_lockfile_settings() {
         lockfile_include_tarball_url: false,
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
     });
     let off_settings = off.settings.as_ref().expect("settings written");
     assert_eq!(off_settings.dedupe_peers, None);
@@ -536,6 +539,7 @@ fn patched_dependencies_flow_into_lockfile_and_empty_is_omitted() {
             lockfile_include_tarball_url: false,
             previous_importers: None,
             update_reuse_scope: UpdateReuseScope::All,
+            update_reuse_scopes_by_importer: BTreeMap::new(),
         })
     };
 
@@ -692,6 +696,7 @@ fn aliased_catalog_dependency_records_catalog_snapshot() {
         lockfile_include_tarball_url: false,
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
     });
 
     let snapshots = lockfile.catalogs.as_ref().expect("catalogs snapshot present");
@@ -1747,6 +1752,7 @@ fn snapshot_link_uses_lockfile_root_while_importer_link_uses_project_root() {
         lockfile_include_tarball_url: false,
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
     });
 
     let importer = lockfile.importers.get("apps/nested/app").expect("nested importer");
@@ -1836,6 +1842,7 @@ fn multi_importer_workspace_writes_per_project_lockfile_entries() {
         lockfile_include_tarball_url: false,
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
     });
 
     let a_snap = lockfile.importers.get("packages/a").expect("importer a");
@@ -1943,6 +1950,7 @@ fn multi_importer_pruner_marks_shared_dep_non_optional_when_any_importer_reaches
         lockfile_include_tarball_url: false,
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
     });
 
     let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
@@ -2076,6 +2084,7 @@ fn workspace_sibling_link_renders_per_importer_with_link_ref() {
         lockfile_include_tarball_url: false,
         previous_importers: None,
         update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
     });
 
     let a_snap = lockfile.importers.get("packages/a").expect("importer a");
@@ -2496,6 +2505,76 @@ fn injected_workspace_dep_flips_to_file_when_specifier_changed() {
         "a spec change must keep the fresh file: resolution, got {:?}",
         entry.version,
     );
+}
+
+// `pacquet update n --recursive` lowers to a `ByImporter` policy whose
+// global scope is `All`, with the named package recorded per importer.
+// The guard resolves the effective per-importer scope, so `n` in the
+// importer that declares it is targeted and its divergent `file:` stands.
+#[test]
+fn injected_workspace_dep_flips_to_file_when_recursive_update_targets_it_per_importer() {
+    let (_tmp, manifest, graph, direct) = injected_link_fixture();
+    let previous = previous_importers_with_link("n", "workspace:*", "../n");
+    // Global All (recursive updates never withhold globally); the named
+    // package lives in the per-importer scope for the root importer (".").
+    let scopes_by_importer = BTreeMap::from([(
+        ".".to_string(),
+        UpdateReuseScope::Except(HashSet::from(["n".to_string()])),
+    )]);
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        previous_importers: Some(&previous),
+        update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: scopes_by_importer,
+        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
+    });
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
+        .expect("n entry");
+    assert!(
+        matches!(&entry.version, ImporterDepVersion::File(_)),
+        "a recursive update naming n must keep the fresh file: resolution, got {:?}",
+        entry.version,
+    );
+}
+
+// The #10433 scenario for the recursive path: `pacquet update <other>
+// --recursive` records `<other>` (not `n`) in the per-importer scope, so
+// `n` is untargeted and its `link:` must be preserved even though it
+// re-resolved to a divergent `file:`. Without honoring the per-importer
+// scope the guard would read the global `All` and (correctly, here) also
+// preserve — so to prove the per-importer scope is actually consulted, the
+// companion test above names `n` and asserts the opposite outcome.
+#[test]
+fn injected_workspace_dep_keeps_link_when_recursive_update_targets_other_pkg() {
+    let (_tmp, manifest, graph, direct) = injected_link_fixture();
+    let previous = previous_importers_with_link("n", "workspace:*", "../n");
+    let scopes_by_importer = BTreeMap::from([(
+        ".".to_string(),
+        UpdateReuseScope::Except(HashSet::from(["some-other-pkg".to_string()])),
+    )]);
+
+    let lockfile = dependencies_graph_to_lockfile(GraphToLockfileOptions {
+        previous_importers: Some(&previous),
+        update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: scopes_by_importer,
+        ..single_importer_opts(&manifest, &graph, direct, false, false, None, None)
+    });
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&PkgName::parse("n").unwrap()))
+        .expect("n entry");
+    match &entry.version {
+        ImporterDepVersion::Link(target) => assert_eq!(target, "../n"),
+        other => panic!("a recursive update of another package must keep n's link:, got {other:?}"),
+    }
 }
 
 // Bare `pacquet update` (UpdateReuseScope::None) re-resolves the whole

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -2542,7 +2542,7 @@ fn injected_workspace_dep_flips_to_file_when_recursive_update_targets_it_per_imp
     );
 }
 
-// The #10433 scenario for the recursive path: `pacquet update <other>
+// The pnpm/pnpm#10433 scenario for the recursive path: `pacquet update <other>
 // --recursive` records `<other>` (not `n`) in the per-importer scope, so
 // `n` is untargeted and its `link:` must be preserved even though it
 // re-resolved to a divergent `file:`. Without honoring the per-importer

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1455,6 +1455,15 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             None
         };
 
+        // Captured for the pnpm/pnpm#10433 guard in the fresh-lockfile
+        // builder (`build_importer`): it needs the previous run's importer
+        // entries and this run's final update scope, but `update_reuse_scope`
+        // is moved into the resolver options below and `wanted_lockfile` is
+        // later shadowed by the freshly built lockfile.
+        let guard_previous_importers: Option<&HashMap<String, pacquet_lockfile::ProjectSnapshot>> =
+            wanted_lockfile.map(|lockfile| &lockfile.importers);
+        let guard_update_reuse_scope = update_reuse_scope.clone();
+
         // Hand the resolver the prior lockfile so it can reuse
         // already-resolved subtrees instead of re-resolving from the
         // registry (see pnpm/plans/LOCKFILE_RESOLUTION_REUSE.md).
@@ -1742,6 +1751,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 catalogs: &catalogs,
                 pnpmfile_checksum: pnpmfile_checksum.as_deref(),
                 patched_dependency_hashes: patched_dependency_hashes.as_ref(),
+                previous_importers: guard_previous_importers,
+                update_reuse_scope: guard_update_reuse_scope.clone(),
             })
             .map_err(|error| {
                 InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
@@ -1906,6 +1917,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             catalogs: &catalogs,
             pnpmfile_checksum: pnpmfile_checksum.as_deref(),
             patched_dependency_hashes: patched_dependency_hashes.as_ref(),
+            previous_importers: guard_previous_importers,
+            update_reuse_scope: guard_update_reuse_scope.clone(),
         })
         .map_err(|error| {
             InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
@@ -2986,6 +2999,13 @@ struct FreshLockfileBuildOptions<'a> {
     catalogs: &'a pacquet_catalogs_types::Catalogs,
     pnpmfile_checksum: Option<&'a str>,
     patched_dependency_hashes: Option<&'a BTreeMap<String, String>>,
+    /// The previous run's lockfile importer entries, threaded into the
+    /// pnpm/pnpm#10433 guard so an untouched workspace dependency keeps
+    /// its prior `link:` entry. `None` on a first install.
+    previous_importers: Option<&'a HashMap<String, pacquet_lockfile::ProjectSnapshot>>,
+    /// How this install reuses the prior resolution (from the `pacquet
+    /// update` seed policy), also consumed by the pnpm/pnpm#10433 guard.
+    update_reuse_scope: pacquet_resolving_deps_resolver::UpdateReuseScope,
 }
 
 fn build_fresh_lockfile(
@@ -3000,6 +3020,8 @@ fn build_fresh_lockfile(
         catalogs,
         pnpmfile_checksum,
         patched_dependency_hashes,
+        previous_importers,
+        update_reuse_scope,
     } = opts;
     let mut importers = BTreeMap::new();
     for (id, manifest) in importer_manifests {
@@ -3027,6 +3049,8 @@ fn build_fresh_lockfile(
         catalogs,
         registry: &config.registry,
         lockfile_include_tarball_url: config.lockfile_include_tarball_url,
+        previous_importers,
+        update_reuse_scope,
     })
 }
 

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1463,6 +1463,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let guard_previous_importers: Option<&HashMap<String, pacquet_lockfile::ProjectSnapshot>> =
             wanted_lockfile.map(|lockfile| &lockfile.importers);
         let guard_update_reuse_scope = update_reuse_scope.clone();
+        let guard_update_reuse_scopes_by_importer = update_reuse_scopes_by_importer.clone();
 
         // Hand the resolver the prior lockfile so it can reuse
         // already-resolved subtrees instead of re-resolving from the
@@ -1753,6 +1754,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 patched_dependency_hashes: patched_dependency_hashes.as_ref(),
                 previous_importers: guard_previous_importers,
                 update_reuse_scope: guard_update_reuse_scope.clone(),
+                update_reuse_scopes_by_importer: guard_update_reuse_scopes_by_importer.clone(),
             })
             .map_err(|error| {
                 InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
@@ -1919,6 +1921,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             patched_dependency_hashes: patched_dependency_hashes.as_ref(),
             previous_importers: guard_previous_importers,
             update_reuse_scope: guard_update_reuse_scope.clone(),
+            update_reuse_scopes_by_importer: guard_update_reuse_scopes_by_importer.clone(),
         })
         .map_err(|error| {
             InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
@@ -3006,6 +3009,11 @@ struct FreshLockfileBuildOptions<'a> {
     /// How this install reuses the prior resolution (from the `pacquet
     /// update` seed policy), also consumed by the pnpm/pnpm#10433 guard.
     update_reuse_scope: pacquet_resolving_deps_resolver::UpdateReuseScope,
+    /// Per-importer update scopes (the `ByImporter` policy of a recursive
+    /// update), so the guard honors `pacquet update <name> --recursive`
+    /// targeting per importer rather than the workspace-wide default.
+    update_reuse_scopes_by_importer:
+        BTreeMap<String, pacquet_resolving_deps_resolver::UpdateReuseScope>,
 }
 
 fn build_fresh_lockfile(
@@ -3022,6 +3030,7 @@ fn build_fresh_lockfile(
         patched_dependency_hashes,
         previous_importers,
         update_reuse_scope,
+        update_reuse_scopes_by_importer,
     } = opts;
     let mut importers = BTreeMap::new();
     for (id, manifest) in importer_manifests {
@@ -3051,6 +3060,7 @@ fn build_fresh_lockfile(
         lockfile_include_tarball_url: config.lockfile_include_tarball_url,
         previous_importers,
         update_reuse_scope,
+        update_reuse_scopes_by_importer,
     })
 }
 

--- a/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
@@ -430,3 +430,89 @@ test('injected workspace dependency keeps link: when an unrelated dependency is 
   // The untouched workspace dependency must keep its link:.
   expect(lockfileAfterUpdate.importers.consumer.dependencies!.d.version).toBe('link:../d')
 })
+
+// Same protection on the plain `pnpm install` path (pnpm/pnpm#10433), for the
+// genuine peer-context divergence that dedupeInjectedDeps rightly refuses to
+// collapse. `q` peer-depends `@pnpm.e2e/foo`; `n` depends on `q` but does not
+// pin `foo` itself, so `q`'s peer is provided by an ancestor. Initially only
+// `foo@100.0.0` exists (via the root), so `q`'s peer resolves to it in both
+// `n`'s own context and `n`'s injected-under-consumer context — the occurrences
+// match and `consumer` -> `n` dedupes to `link:`.
+//
+// Then `foo@100.1.0` is added to the consumer and a plain install is run. Now
+// the injected `q` under the consumer resolves its `foo` peer to the consumer's
+// `100.1.0`, while `n`'s own context still resolves it to the root's `100.0.0`
+// — a real divergence, so dedupeInjectedDeps correctly keeps the injected copy
+// `file:`. The `consumer` -> `n` importer entry itself was not targeted by the
+// change and must be preserved as `link:` rather than rewritten to a
+// peer-suffixed `file:`.
+//
+// This is exactly the case the criterion depends on: a plain install marks
+// every consumer manifest dependency (including `n`) with `updateSpec: true`,
+// which must NOT count as targeting `n`.
+test('injected workspace dependency keeps link: on a plain install when a consumer change makes an ancestor-provided peer diverge', async () => {
+  const pkgQ = {
+    name: 'q',
+    version: '1.0.0',
+    peerDependencies: { '@pnpm.e2e/foo': '*' },
+  }
+  const pkgN = {
+    name: 'n',
+    version: '1.0.0',
+    dependencies: { 'q': 'workspace:^' },
+  }
+  const consumerManifest: { name: string, version: string, dependencies: Record<string, string> } = {
+    name: 'consumer',
+    version: '1.0.0',
+    dependencies: { 'n': 'workspace:*' },
+  }
+  const rootManifest = {
+    name: 'root',
+    version: '0.0.0',
+    dependencies: { '@pnpm.e2e/foo': '100.0.0' },
+  }
+
+  preparePackages([
+    { location: 'q', package: pkgQ },
+    { location: 'n', package: pkgN },
+    { location: 'consumer', package: consumerManifest },
+  ])
+  writeFileSync('package.json', `${JSON.stringify(rootManifest, null, 2)}\n`)
+
+  const allProjects: ProjectOptions[] = [
+    { buildIndex: 0, manifest: rootManifest, rootDir: path.resolve('.') as ProjectRootDir },
+    { buildIndex: 0, manifest: pkgQ, rootDir: path.resolve('q') as ProjectRootDir },
+    { buildIndex: 0, manifest: pkgN, rootDir: path.resolve('n') as ProjectRootDir },
+    { buildIndex: 0, manifest: consumerManifest, rootDir: path.resolve('consumer') as ProjectRootDir },
+  ]
+
+  const sharedOpts = {
+    allProjects,
+    injectWorkspacePackages: true,
+    linkWorkspacePackages: 'deep' as const,
+    preferWorkspacePackages: true,
+    dedupeInjectedDeps: true,
+    dedupePeerDependents: true,
+  }
+  const installMutations = allProjects.map(({ rootDir }) => ({ mutation: 'install' as const, rootDir }))
+
+  // Initial install: peers match at 100.0.0, so consumer -> n dedupes to link:.
+  await mutateModules(installMutations, testDefaults(sharedOpts))
+
+  const rootModules = assertProject(process.cwd())
+  expect(rootModules.readLockfile().importers.consumer.dependencies!.n.version).toBe('link:../n')
+
+  // Add a competing foo@100.1.0 to the consumer and run a plain install. n
+  // itself is untouched.
+  consumerManifest.dependencies['@pnpm.e2e/foo'] = '100.1.0'
+  const allProjectsAfter = allProjects.map((p) =>
+    p.rootDir === path.resolve('consumer') ? { ...p, manifest: consumerManifest } : p
+  )
+  await mutateModules(installMutations, testDefaults({ ...sharedOpts, allProjects: allProjectsAfter }))
+
+  const lockfileAfterInstall = rootModules.readLockfile()
+  // The consumer change itself must be reflected.
+  expect(lockfileAfterInstall.importers.consumer.dependencies!['@pnpm.e2e/foo'].version).toBe('100.1.0')
+  // The untouched workspace dependency must keep its link:.
+  expect(lockfileAfterInstall.importers.consumer.dependencies!.n.version).toBe('link:../n')
+})

--- a/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
@@ -513,6 +513,16 @@ test('injected workspace dependency keeps link: on a plain install when a consum
   const lockfileAfterInstall = rootModules.readLockfile()
   // The consumer change itself must be reflected.
   expect(lockfileAfterInstall.importers.consumer.dependencies!['@pnpm.e2e/foo'].version).toBe('100.1.0')
+  // The peer context genuinely diverged: both foo versions resolved — the
+  // consumer's direct 100.1.0 (what q's peer resolves to in n's injected
+  // context) and the root-provided 100.0.0 (what q's peer resolves to in n's
+  // own context). Without both present there would be no divergence for
+  // dedupeInjectedDeps to keep as file:, and the link: assertion below would
+  // pass vacuously.
+  const fooVersions = Object.keys(lockfileAfterInstall.packages ?? {})
+    .filter((key) => key.startsWith('@pnpm.e2e/foo@'))
+    .sort()
+  expect(fooVersions).toStrictEqual(['@pnpm.e2e/foo@100.0.0', '@pnpm.e2e/foo@100.1.0'])
   // The untouched workspace dependency must keep its link:.
   expect(lockfileAfterInstall.importers.consumer.dependencies!.n.version).toBe('link:../n')
 })

--- a/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
+++ b/pnpm11/installing/deps-installer/test/install/injectWorkspacePackagesPersistence.test.ts
@@ -1,8 +1,9 @@
+import { writeFileSync } from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { assertProject } from '@pnpm/assert-project'
-import { mutateModules, mutateModulesInSingleProject, type ProjectOptions } from '@pnpm/installing.deps-installer'
+import { type MutatedProject, mutateModules, mutateModulesInSingleProject, type ProjectOptions } from '@pnpm/installing.deps-installer'
 import { preparePackages } from '@pnpm/prepare'
 import type { ProjectRootDir } from '@pnpm/types'
 
@@ -312,4 +313,120 @@ test('peer-resolved workspace packages should keep their file: protocol after si
   // check, dedupeInjectedDeps would collapse the peer-resolved file: entry to link:../b
   // and lose the importer's peer context.
   expect(lockfileAfterRm.importers.a.dependencies!.b.version).toBe(initialVersion)
+})
+
+// Regression test for https://github.com/pnpm/pnpm/issues/10433: updating one
+// dependency must not rewrite an untouched workspace dependency's `link:` entry
+// to a peer-suffixed `file:`.
+//
+// `d` peer-depends on `a` and `b`; `b` has an optional `winston` peer. On the
+// initial install `consumer` -> `d` dedupes to `link:../d`. Updating the
+// unrelated `winston` re-resolves the untouched injected workspace deps on a
+// path dedupeInjectedDeps doesn't reach and, without the fix, flips
+// `consumer` -> `d` to `file:d(a@file:a)(b@file:b(a@file:a)(winston@3.19.0))`.
+//
+// The update is driven exactly like `pnpm update winston@3.19.0 --recursive`
+// lowers it (see installing/commands/src/recursive.ts): the importer whose
+// manifest has `winston` gets `installSome` with the selector, every other
+// importer gets `installSome` with no selectors and `update: true`.
+test('injected workspace dependency keeps link: when an unrelated dependency is updated', async () => {
+  const pkgA = { name: 'a', version: '1.0.0' }
+  const pkgB = {
+    name: 'b',
+    version: '1.0.0',
+    dependencies: { bluebird: '^3.7.2', 'c': 'workspace:^' },
+    peerDependencies: { winston: '^3' },
+    peerDependenciesMeta: { winston: { optional: true } },
+  }
+  const pkgC = {
+    name: 'c',
+    version: '1.0.0',
+    peerDependencies: { 'a': '>=1.0.0' },
+    dependencies: { debug: '^4.4.3' },
+  }
+  const pkgD = {
+    name: 'd',
+    version: '1.0.0',
+    peerDependencies: { 'a': '*', 'b': '^1.0.0' },
+    dependencies: { debug: '^4.4.3' },
+  }
+  const consumerManifest = {
+    name: 'consumer',
+    version: '1.0.0',
+    dependencies: { 'd': 'workspace:*', 'a': 'workspace:*' },
+  }
+  const rootManifest = {
+    name: 'root',
+    version: '0.0.0',
+    devDependencies: { winston: '3.17.0' },
+  }
+
+  preparePackages([
+    { location: 'a', package: pkgA },
+    { location: 'b', package: pkgB },
+    { location: 'c', package: pkgC },
+    { location: 'd', package: pkgD },
+    { location: 'consumer', package: consumerManifest },
+  ])
+  // The workspace root carries the dependency that will be updated.
+  writeFileSync('package.json', `${JSON.stringify(rootManifest, null, 2)}\n`)
+
+  const allProjects: ProjectOptions[] = [
+    { buildIndex: 0, manifest: rootManifest, rootDir: path.resolve('.') as ProjectRootDir },
+    { buildIndex: 0, manifest: pkgA, rootDir: path.resolve('a') as ProjectRootDir },
+    { buildIndex: 0, manifest: pkgB, rootDir: path.resolve('b') as ProjectRootDir },
+    { buildIndex: 0, manifest: pkgC, rootDir: path.resolve('c') as ProjectRootDir },
+    { buildIndex: 0, manifest: pkgD, rootDir: path.resolve('d') as ProjectRootDir },
+    { buildIndex: 0, manifest: consumerManifest, rootDir: path.resolve('consumer') as ProjectRootDir },
+  ]
+
+  const sharedOpts = {
+    allProjects,
+    injectWorkspacePackages: true,
+    linkWorkspacePackages: 'deep' as const,
+    preferWorkspacePackages: true,
+    dedupeInjectedDeps: true,
+    dedupePeerDependents: true,
+  }
+
+  // Initial install: `consumer` -> `d` dedupes to link:../d.
+  await mutateModules(
+    allProjects.map(({ rootDir }) => ({ mutation: 'install' as const, rootDir })),
+    testDefaults(sharedOpts)
+  )
+
+  const rootModules = assertProject(process.cwd())
+  expect(rootModules.readLockfile().importers.consumer.dependencies!.d.version).toBe('link:../d')
+
+  // `pnpm update winston@3.19.0 --recursive`, as lowered by
+  // installing/commands/src/recursive.ts.
+  const updateMutations: MutatedProject[] = allProjects.map(({ rootDir }) =>
+    rootDir === path.resolve('.')
+      ? {
+        allowNew: false,
+        dependencySelectors: ['winston@3.19.0'],
+        mutation: 'installSome' as const,
+        rootDir,
+        update: true,
+        updatePackageManifest: true,
+      } as MutatedProject
+      : {
+        allowNew: false,
+        dependencySelectors: [],
+        mutation: 'installSome' as const,
+        rootDir,
+        update: true,
+        updatePackageManifest: true,
+      } as MutatedProject
+  )
+  await mutateModules(updateMutations, testDefaults({
+    ...sharedOpts,
+    depth: Infinity,
+  }))
+
+  const lockfileAfterUpdate = rootModules.readLockfile()
+  // The update itself must still happen.
+  expect(lockfileAfterUpdate.importers['.'].devDependencies!.winston.version).toBe('3.19.0')
+  // The untouched workspace dependency must keep its link:.
+  expect(lockfileAfterUpdate.importers.consumer.dependencies!.d.version).toBe('link:../d')
 })

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -308,6 +308,30 @@ export async function resolveDependencies (
   await Promise.all(projectsToResolve.map(async (project, index) => {
     const resolvedImporter = resolvedImporters[project.id]
     linkedDependenciesByProjectId[project.id] = resolvedImporter.linkedDependencies
+    // Capture previous importer refs before the lockfile importer is rebuilt,
+    // so a partial update that doesn't actually change a workspace dependency
+    // does not rewrite its `link:` entry to a peer-suffixed `file:`. This is the
+    // `pnpm update --recursive` path of pnpm/pnpm#10433 that dedupeInjectedDeps
+    // does not reach.
+    const previousImporterSnapshot = opts.wantedLockfile.importers[project.id]
+    const previousDirectRefs: Record<string, string> = {
+      ...previousImporterSnapshot?.dependencies,
+      ...previousImporterSnapshot?.devDependencies,
+      ...previousImporterSnapshot?.optionalDependencies,
+    }
+    // Aliases this run actually targets (added, spec-changed, or matched by a
+    // `pnpm update <name>`). Only these may legitimately change their
+    // `link:`/`file:` form; the preserve-prior-link guard below is limited to
+    // dependencies outside this set.
+    const importer = importers[index]
+    const updateMatching = importer.updateMatching
+    const updateTargetedAliases = new Set(
+      project.wantedDependencies.flatMap(({ alias, bareSpecifier, isNew, prevSpecifier, updateSpec }) =>
+        alias != null && (isNew === true || updateSpec === true || (prevSpecifier != null && bareSpecifier !== prevSpecifier))
+          ? [alias]
+          : []
+      )
+    )
     let updatedManifest: ProjectManifest | undefined
     let updatedOriginalManifest: ProjectManifest | undefined
     if (project.updatePackageManifest) {
@@ -356,10 +380,23 @@ export async function resolveDependencies (
 
       const depNode = dependenciesGraph[depPath]
 
-      const ref = depPathToRef(depPath, {
+      let ref = depPathToRef(depPath, {
         alias,
         realName: depNode.name,
       })
+      // A workspace dependency resolved to `link:` has no version to update, so
+      // it should stay `link:` unless this run specifically targets it (a spec
+      // change or `pnpm update <name>`). Preserving it stops a partial update
+      // (e.g. `pnpm update <other-pkg> --recursive`) from re-resolving an
+      // untouched injected workspace dep and flipping its `link:` to a
+      // peer-suffixed `file:` on paths dedupeInjectedDeps doesn't reach. See
+      // pnpm/pnpm#10433.
+      const previousRef = previousDirectRefs[alias]
+      const targetedByUpdate = updateTargetedAliases.has(alias) ||
+        (updateMatching?.(depNode.name) ?? false)
+      if (!targetedByUpdate && ref.startsWith('file:') && previousRef?.startsWith('link:')) {
+        ref = previousRef
+      }
       if (projectSnapshot.dependencies?.[alias]) {
         projectSnapshot.dependencies[alias] = ref
       } else if (projectSnapshot.devDependencies?.[alias]) {

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -322,12 +322,14 @@ export async function resolveDependencies (
     // Aliases this run actually targets (added, spec-changed, or matched by a
     // `pnpm update <name>`). Only these may legitimately change their
     // `link:`/`file:` form; the preserve-prior-link guard below is limited to
-    // dependencies outside this set.
+    // dependencies outside this set. `updateSpec` is deliberately not
+    // consulted: a plain install marks every manifest dependency with it, so
+    // it signals "re-check the spec", not "the user targeted this dependency".
     const importer = importers[index]
     const updateMatching = importer.updateMatching
     const updateTargetedAliases = new Set(
-      project.wantedDependencies.flatMap(({ alias, bareSpecifier, isNew, prevSpecifier, updateSpec }) =>
-        alias != null && (isNew === true || updateSpec === true || (prevSpecifier != null && bareSpecifier !== prevSpecifier))
+      project.wantedDependencies.flatMap(({ alias, bareSpecifier, isNew, prevSpecifier }) =>
+        alias != null && (isNew === true || (prevSpecifier != null && bareSpecifier !== prevSpecifier))
           ? [alias]
           : []
       )

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -309,10 +309,10 @@ export async function resolveDependencies (
     const resolvedImporter = resolvedImporters[project.id]
     linkedDependenciesByProjectId[project.id] = resolvedImporter.linkedDependencies
     // Capture previous importer refs before the lockfile importer is rebuilt,
-    // so a partial update that doesn't actually change a workspace dependency
-    // does not rewrite its `link:` entry to a peer-suffixed `file:`. This is the
-    // `pnpm update --recursive` path of pnpm/pnpm#10433 that dedupeInjectedDeps
-    // does not reach.
+    // so an install that doesn't actually change a workspace dependency (e.g.
+    // updating an unrelated dependency) does not rewrite its `link:` entry to a
+    // peer-suffixed `file:`. These are the pnpm/pnpm#10433 re-resolution paths
+    // that dedupeInjectedDeps does not reach.
     const previousImporterSnapshot = opts.wantedLockfile.importers[project.id]
     const previousDirectRefs: Record<string, string> = {
       ...previousImporterSnapshot?.dependencies,
@@ -386,9 +386,9 @@ export async function resolveDependencies (
       })
       // A workspace dependency resolved to `link:` has no version to update, so
       // it should stay `link:` unless this run specifically targets it (a spec
-      // change or `pnpm update <name>`). Preserving it stops a partial update
-      // (e.g. `pnpm update <other-pkg> --recursive`) from re-resolving an
-      // untouched injected workspace dep and flipping its `link:` to a
+      // change or `pnpm update <name>`). Preserving it stops an update of an
+      // unrelated dependency (e.g. `pnpm update <other-pkg>`) from re-resolving
+      // an untouched injected workspace dep and flipping its `link:` to a
       // peer-suffixed `file:` on paths dedupeInjectedDeps doesn't reach. See
       // pnpm/pnpm#10433.
       const previousRef = previousDirectRefs[alias]


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#10433. #12800 (already merged) fixed the first mechanism; this PR closes the remaining re-resolution paths, so the reported corruption no longer reproduces.

The issue is a workspace `link:` that correctly deduped being **spuriously** rewritten to a peer-suffixed `file:`. There were two such mechanisms: a same-version peer-suffix decoration that `dedupeInjectedDeps` failed to collapse (fixed in #12800), and re-resolution of an **untargeted** workspace dependency on `pnpm update`/plain install (fixed here). With both landed, the reporter's exact repro produces zero corruptions (validated end-to-end below).

With `injectWorkspacePackages: true`, a workspace dependency that correctly deduped to `link:` on install can be spuriously rewritten to a peer-suffixed `file:` when an **unrelated** dependency changes — e.g. `pnpm update <pkg>` (with or without `--recursive`), a version bump of a root/catalog dependency, or a plain `pnpm install` after such a change. On a workspace where `consumer` → `pkg-d` resolved to `link:../pkg-d`, running:

```
pnpm add -D winston@3.17.0 -w
pnpm update winston@3.19.0 --recursive
```

flips it to `file:packages/pkg-d(@repro/pkg-a@…)(@repro/pkg-b@…(winston@3.19.0))` — even though `pkg-d` and everything it depends on is untouched by the change. Under `nodeLinker: hoisted` the `file:` entry copies a stale/unbuilt snapshot into `node_modules` instead of symlinking the live workspace source, which surfaces as build/e2e failures.

#12800 fixed the plain-install path where `dedupeInjectedDeps` collapses a peer-suffix decoration back to `link:`. The paths here re-resolve untouched injected workspace deps and either bypass that dedupe (the update-style runs) or land on a **genuine** peer-context divergence that dedupe correctly keeps as `file:` — so the importer entry is re-derived as `file:` even though the dependency wasn't touched.

Reproduction (still reproduces on 11.13.0, which already contains #12800): https://github.com/omril1/pnpm-workspace-link-corruption-repro — the `winston` add+update sequence above.

### Fix

When finalizing importer dependency refs in `resolveDependencies`, preserve the previous `link:` for a workspace dependency that this run does **not** target. A dependency is *targeted* when it is new, its specifier changed (`prevSpecifier !== bareSpecifier`), or it is matched by `updateMatching` (`pnpm update <name>`). A workspace dependency resolved to `link:` has no version to update, so a run that doesn't target it must not flip it to `file:`; a dependency the run actually targets still resolves freely.

`updateSpec` is deliberately **not** part of the targeting criterion: a plain `pnpm install` marks *every* manifest dependency with `updateSpec: true` (it means "re-check the spec", not "the user asked to change this"), so consulting it would treat every dependency as targeted and defeat the guard on the plain-install path. The guard is not specific to any one command — it applies to every mutation type that re-resolves importers (`install`, `installSome`, `uninstallSome`), covering the install, update, add, and remove entry points.

### Regression tests

`injectWorkspacePackagesPersistence.test.ts` gains two tests, both verified non-vacuous (they fail on `git checkout main -- installing/deps-resolver/src/index.ts` and pass with the fix):

1. **Update path** — drives the update **exactly as the CLI lowers `pnpm update winston@3.19.0 --recursive`** (see `installing/commands/src/recursive.ts`): the importer whose manifest has `winston` gets `mutation: 'installSome'` with the selector; every other importer gets `installSome` with no selectors and `update: true`. Without the fix it fails with `Received: "file:d(a@file:a)(b@file:b(a@file:a)(winston@3.19.0))"`; with it, `consumer → d` stays `link:../d` and `winston` still updates to `3.19.0`.
2. **Plain-install path** — a genuine peer-context divergence that `dedupeInjectedDeps` rightly keeps `file:`: `q` peer-depends `@pnpm.e2e/foo`, provided by the root at `100.0.0`, so the injected copy of `n` matches and dedupes to `link:` on install. Adding `foo@100.1.0` to the consumer and running a plain install makes the injected `q` diverge (`100.1.0`) from `n`'s own context (`100.0.0`); the untouched `consumer → n` entry must stay `link:`. This is the case that exercises the `updateSpec` criterion above.

Also validated end to end: built from this branch and run against the reproduction, `pkg-d` stays `link:`, `winston` updates, and `pnpm install --frozen-lockfile` accepts the result unchanged. The existing `injectWorkspacePackagesPersistence` and `dedupeInjectedDeps` suites still pass.

### Rust (`pnpm/`) port

The equivalent guard is ported to `pacquet-package-manager`'s fresh-lockfile builder (`dependencies_graph_to_lockfile::build_importer`): after computing an importer dependency's version cell, if it resolved to `file:`, the previous lockfile recorded it as `link:`, and the run doesn't target it, the prior `link:` is restored. Targeting is derived from the importer's **effective** update scope together with a specifier change — the same criterion as the TS side. The effective scope mirrors the resolver's `update_reuse_scope_for`: a global `None` (bare `update`) applies to every importer, otherwise the per-importer scope wins with the global as fallback. This is what lets `pacquet update <name> --recursive` (a `ByImporter` policy: global `All`, named packages recorded per importer) target the named dependency in the importer that declares it while leaving untouched importers' `link:` entries intact. Both the previous importer entries and the per-importer update scopes are threaded from `install_with_fresh_lockfile` into the builder. Adds unit tests for: preserve when untargeted; keep `file:` on a first install, on a single-project `update <name>`, on a scope-wide bare `update`, and on a specifier change; the recursive per-importer case (named dep flips to `file:`); and the #10433 recursive-protection case (a recursive update of *another* package preserves `n`'s `link:`) — the last verified non-vacuous by neutering the per-importer resolution.

## Squash Commit Body

```text
A workspace dependency that deduped to `link:` on install could be rewritten to
a peer-suffixed `file:` by any run that re-resolves it without deduping back to
`link:` — e.g. `pnpm update <other-pkg>` (with or without --recursive), a
root/catalog bump, or a plain install that hits a genuine peer-context
divergence.

When finalizing importer refs, keep the previous `link:` for a workspace
dependency the run doesn't target: not new, specifier unchanged, and not matched
by `pnpm update <name>`. `updateSpec` is intentionally excluded from the
criterion because a plain install marks every manifest dependency with it. A
workspace `link:` dependency has no version to update, so a run that doesn't
target it must not flip it to `file:`; targeted dependencies still resolve
freely.

Adds regression tests for the update-recursive and plain-install paths (both
fail without the fix) and ports the guard to the Rust package-manager crate.

Completes the fix for pnpm/pnpm#10433 — the first mechanism was fixed in #12800.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset.
- [x] Added or updated tests — regression tests on both paths verified to fail without the fix and pass with it, on both the TS and Rust sides.
- [ ] Updated the documentation if needed — not applicable.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing workspace `link:` dependency entries during partial installs and unrelated dependency updates.
  * Prevented untouched injected workspace dependencies from being rewritten into peer-suffixed `file:` entries.
  * Kept the correct `link:` form during lockfile rebuilds when the dependency isn’t targeted, while still switching to `file:` for truly targeted updates.

* **Tests**
  * Added regression coverage for partial updates, recursive updates, fresh-lockfile and lockfile-only flows, plus injected workspace persistence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->