### PR TITLE
fix(npm-resolver): apply the publishedBy cutoff to the held-back-update baseline

### DIFF
--- a/.changeset/held-back-warning-release-age.md
+++ b/.changeset/held-back-warning-release-age.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-The held-back-update warning printed by `pnpm update` no longer fires when `minimumReleaseAge` is the actual reason a newer version was not picked. The warning's baseline now applies the same maturity cutoff as the pick itself, so it no longer misattributes the hold-back to "your manifests and already installed dependencies" or recommends an override that would defeat the age gate. See pnpm/pnpm#13071.
+The held-back-update warning printed by `pnpm update` no longer fires when `minimumReleaseAge` is the actual reason a newer version was not picked. The warning's baseline now applies the same maturity cutoff as the pick itself, so it no longer wrongly attributes the hold-back to "your manifests and already installed dependencies" or recommends an override that would defeat the age gate. See pnpm/pnpm#13071.

--- a/.changeset/held-back-warning-release-age.md
+++ b/.changeset/held-back-warning-release-age.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+The held-back-update warning printed by `pnpm update` no longer fires when `minimumReleaseAge` is the actual reason a newer version was not picked. The warning's baseline now applies the same maturity cutoff as the pick itself, so it no longer misattributes the hold-back to "your manifests and already installed dependencies" or recommends an override that would defeat the age gate. See pnpm/pnpm#13071.

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -155,24 +155,12 @@ where
     // "Owned-after-filter" shape: when publishedBy is active and a
     // maturity filter applies, swap `meta` for the filtered view —
     // otherwise borrow the input through.
-    let filtered: Arc<Package>;
+    let view: PublishedByView;
     let meta_ref: &Package = match opts.published_by {
         Some(cutoff) => {
-            let exclude_result = opts
-                .published_by_exclude
-                .map_or(PolicyMatch::No, |policy| policy.matches(&meta.name));
-            if matches!(exclude_result, PolicyMatch::AnyVersion) {
-                meta
-            } else if meta.time.is_some() {
-                let trusted = match &exclude_result {
-                    PolicyMatch::ExactVersions(versions) => Some(versions.as_slice()),
-                    _ => None,
-                };
-                filtered = filter_pkg_metadata_by_publish_date(meta, cutoff, trusted);
-                filtered.as_ref()
-            } else {
-                // Abbreviated metadata has no per-version `time`. The
-                // missing-time error signals the orchestrator, which
+            view = apply_published_by_policy(meta, cutoff, opts.published_by_exclude);
+            if view.needs_full_metadata {
+                // The missing-time error signals the orchestrator, which
                 // then upgrades the fetch to full metadata.
                 //
                 // Cutoff is inclusive (`<=`) to match the per-version
@@ -189,6 +177,8 @@ where
                         });
                     }
                 }
+            } else {
+                view.filtered.as_deref().unwrap_or(meta)
             }
         }
         None => meta,
@@ -369,6 +359,54 @@ pub fn pick_lowest_version_by_version_range(
     min_satisfying(&all_versions, opts.version_range)
 }
 
+/// What the `publishedBy` cutoff leaves visible, as computed by
+/// [`apply_published_by_policy`].
+pub(crate) struct PublishedByView {
+    /// The narrowed packument, or `None` when the input is already the
+    /// view: the policy excludes the package wholesale, or the cutoff
+    /// could not be applied.
+    pub(crate) filtered: Option<Arc<Package>>,
+
+    /// The cutoff could not be applied: the metadata is abbreviated, so
+    /// there are no per-version timestamps to filter on. Whether that
+    /// is fatal is the caller's call — the pick needs full metadata to
+    /// honor the cutoff, while a caller reasoning about a pick that
+    /// already succeeded knows the versions cleared the cutoff some
+    /// other way.
+    pub(crate) needs_full_metadata: bool,
+}
+
+/// Narrow `meta` to the versions the `cutoff` admits, honoring the
+/// exclusion policy: a package the policy excludes wholesale keeps its
+/// unfiltered metadata, and versions the policy names explicitly stay
+/// in regardless of their age.
+///
+/// Every consumer of the cutoff goes through here so they agree on what
+/// the policy admits — a baseline that filters differently from the
+/// pick would misreport why a version was chosen.
+#[must_use]
+pub(crate) fn apply_published_by_policy(
+    meta: &Package,
+    cutoff: chrono::DateTime<chrono::Utc>,
+    exclude: Option<&PackageVersionPolicy>,
+) -> PublishedByView {
+    let exclude_result = exclude.map_or(PolicyMatch::No, |policy| policy.matches(&meta.name));
+    if matches!(exclude_result, PolicyMatch::AnyVersion) {
+        return PublishedByView { filtered: None, needs_full_metadata: false };
+    }
+    if meta.time.is_none() {
+        return PublishedByView { filtered: None, needs_full_metadata: true };
+    }
+    let trusted = match &exclude_result {
+        PolicyMatch::ExactVersions(versions) => Some(versions.as_slice()),
+        _ => None,
+    };
+    PublishedByView {
+        filtered: Some(filter_pkg_metadata_by_publish_date(meta, cutoff, trusted)),
+        needs_full_metadata: false,
+    }
+}
+
 /// Filter a packument to versions published at or before `cutoff`,
 /// then rewrite each `dist-tag` to the highest within-cutoff version
 /// that still belongs to the tag's original "family" (same major
@@ -381,10 +419,9 @@ pub fn pick_lowest_version_by_version_range(
 /// every caller of one cutoff and trusted-version list gets the same
 /// document, whose version manifests are the ones `meta` holds.
 ///
-/// Panics if `meta.time` is `None`: callers must check it first.
-/// Abbreviated metadata carries no per-version timestamps, so the
-/// publishedBy branch in [`pick_package_from_meta`] takes the
-/// `meta.modified` shortcut above instead of filtering.
+/// Panics if `meta.time` is `None`. Go through
+/// `apply_published_by_policy`, which reports abbreviated metadata as
+/// `needs_full_metadata` rather than filtering it.
 #[must_use]
 pub fn filter_pkg_metadata_by_publish_date(
     meta: &Package,

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -381,10 +381,10 @@ pub fn pick_lowest_version_by_version_range(
 /// every caller of one cutoff and trusted-version list gets the same
 /// document, whose version manifests are the ones `meta` holds.
 ///
-/// Panics if `meta.time` is `None` — the caller (the publishedBy
-/// branch in [`pick_package_from_meta`]) only invokes this with full
-/// metadata. The abbreviated-metadata path takes the `meta.modified`
-/// shortcut above and never reaches this function.
+/// Panics if `meta.time` is `None`: callers must check it first.
+/// Abbreviated metadata carries no per-version timestamps, so the
+/// publishedBy branch in [`pick_package_from_meta`] takes the
+/// `meta.modified` shortcut above instead of filtering.
 #[must_use]
 pub fn filter_pkg_metadata_by_publish_date(
     meta: &Package,

--- a/pnpm/crates/resolving-npm-resolver/src/preferred_overlay.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/preferred_overlay.rs
@@ -1,7 +1,8 @@
 use crate::pick_package_from_meta::{
     PickVersionByVersionRangeOptions, RegistryPackageSpec, RegistryPackageSpecType,
-    pick_version_by_version_range,
+    filter_pkg_metadata_by_publish_date, pick_version_by_version_range,
 };
+use pacquet_config::version_policy::PolicyMatch;
 use pacquet_registry::Package;
 use pacquet_resolving_resolver_base::{
     ResolveOptions, VersionSelectorEntry, VersionSelectorType, VersionSelectors,
@@ -49,6 +50,10 @@ static WARNED_HELD_BACK: std::sync::LazyLock<Mutex<indexmap::IndexSet<String>>> 
 /// selectors applied — `range`/`tag` selectors such as the
 /// `pnpm audit --fix` vulnerability penalties steer the baseline too,
 /// so the warning never recommends a version those selectors avoid.
+/// The baseline also honors the `published_by` maturity cutoff the
+/// actual pick applied: a version blocked by `minimumReleaseAge` is
+/// not an update the manifests held back, and recommending an
+/// override for it would defeat the age gate.
 ///
 /// The recommended override is scoped to the declared range being
 /// resolved (`name@<range>`), so applying it can never violate any
@@ -61,26 +66,9 @@ pub(crate) fn warn_once_on_held_back_update(
     meta: &Package,
     picked_version: &str,
 ) {
-    if !opts.update_requested || spec.spec_type != RegistryPackageSpecType::Range {
-        return;
-    }
-    let Some(selectors) = selectors else { return };
-    let non_pin_selectors: VersionSelectors = selectors
-        .iter()
-        .filter(|(_, entry)| entry.selector_type() != VersionSelectorType::Version)
-        .map(|(selector, entry)| (selector.clone(), entry.clone()))
-        .collect();
-    let Some(preferred) = pick_version_by_version_range(&PickVersionByVersionRangeOptions {
-        meta,
-        version_range: &spec.fetch_spec,
-        preferred_version_selectors: (!non_pin_selectors.is_empty()).then_some(&non_pin_selectors),
-        published_by: None,
-    }) else {
+    let Some(preferred) = held_back_preferred(opts, spec, selectors, meta, picked_version) else {
         return;
     };
-    if preferred == picked_version {
-        return;
-    }
     let key = format!("{}@{}:{picked_version}<{preferred}", spec.name, spec.fetch_spec);
     let mut warned = WARNED_HELD_BACK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     if warned.contains(&key) {
@@ -102,3 +90,58 @@ pub(crate) fn warn_once_on_held_back_update(
         spec.fetch_spec,
     );
 }
+
+/// The version [`warn_once_on_held_back_update`] would recommend, or
+/// `None` when the pick needs no warning because the baseline (see
+/// there) already agrees with it.
+fn held_back_preferred(
+    opts: &ResolveOptions,
+    spec: &RegistryPackageSpec,
+    selectors: Option<&VersionSelectors>,
+    meta: &Package,
+    picked_version: &str,
+) -> Option<String> {
+    if !opts.update_requested || spec.spec_type != RegistryPackageSpecType::Range {
+        return None;
+    }
+    let selectors = selectors?;
+    let non_pin_selectors: VersionSelectors = selectors
+        .iter()
+        .filter(|(_, entry)| entry.selector_type() != VersionSelectorType::Version)
+        .map(|(selector, entry)| (selector.clone(), entry.clone()))
+        .collect();
+    let filtered;
+    let baseline_meta: &Package = match opts.published_by {
+        Some(cutoff) => {
+            let exclude_result = opts
+                .published_by_exclude
+                .as_ref()
+                .map_or(PolicyMatch::No, |policy| policy.matches(&meta.name));
+            // Abbreviated metadata (no `time`) only passes the pick's
+            // maturity gate when every version predates the cutoff
+            // (see `pick_package_from_meta`), so there is nothing to
+            // filter out of the baseline.
+            if matches!(exclude_result, PolicyMatch::AnyVersion) || meta.time.is_none() {
+                meta
+            } else {
+                let trusted = match &exclude_result {
+                    PolicyMatch::ExactVersions(versions) => Some(versions.as_slice()),
+                    _ => None,
+                };
+                filtered = filter_pkg_metadata_by_publish_date(meta, cutoff, trusted);
+                &filtered
+            }
+        }
+        None => meta,
+    };
+    let preferred = pick_version_by_version_range(&PickVersionByVersionRangeOptions {
+        meta: baseline_meta,
+        version_range: &spec.fetch_spec,
+        preferred_version_selectors: (!non_pin_selectors.is_empty()).then_some(&non_pin_selectors),
+        published_by: opts.published_by,
+    })?;
+    (preferred != picked_version).then_some(preferred)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-npm-resolver/src/preferred_overlay.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/preferred_overlay.rs
@@ -1,8 +1,7 @@
 use crate::pick_package_from_meta::{
     PickVersionByVersionRangeOptions, RegistryPackageSpec, RegistryPackageSpecType,
-    filter_pkg_metadata_by_publish_date, pick_version_by_version_range,
+    apply_published_by_policy, pick_version_by_version_range,
 };
-use pacquet_config::version_policy::PolicyMatch;
 use pacquet_registry::Package;
 use pacquet_resolving_resolver_base::{
     ResolveOptions, VersionSelectorEntry, VersionSelectorType, VersionSelectors,
@@ -110,27 +109,15 @@ fn held_back_preferred(
         .filter(|(_, entry)| entry.selector_type() != VersionSelectorType::Version)
         .map(|(selector, entry)| (selector.clone(), entry.clone()))
         .collect();
-    let filtered;
+    let view;
+    // `needs_full_metadata` is not this caller's problem: the pick
+    // already succeeded on this metadata, which for an abbreviated
+    // packument means every version cleared the cutoff, so `meta` is
+    // the filtered view.
     let baseline_meta: &Package = match opts.published_by {
         Some(cutoff) => {
-            let exclude_result = opts
-                .published_by_exclude
-                .as_ref()
-                .map_or(PolicyMatch::No, |policy| policy.matches(&meta.name));
-            // Abbreviated metadata (no `time`) only passes the pick's
-            // maturity gate when every version predates the cutoff
-            // (see `pick_package_from_meta`), so there is nothing to
-            // filter out of the baseline.
-            if matches!(exclude_result, PolicyMatch::AnyVersion) || meta.time.is_none() {
-                meta
-            } else {
-                let trusted = match &exclude_result {
-                    PolicyMatch::ExactVersions(versions) => Some(versions.as_slice()),
-                    _ => None,
-                };
-                filtered = filter_pkg_metadata_by_publish_date(meta, cutoff, trusted);
-                &filtered
-            }
+            view = apply_published_by_policy(meta, cutoff, opts.published_by_exclude.as_ref());
+            view.filtered.as_deref().unwrap_or(meta)
         }
         None => meta,
     };

--- a/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
@@ -80,7 +80,7 @@ fn update_opts() -> ResolveOptions {
     ResolveOptions { update_requested: true, ..ResolveOptions::default() }
 }
 
-// https://github.com/pnpm/pnpm/issues/13071
+// <https://github.com/pnpm/pnpm/issues/13071>
 #[test]
 fn no_warning_when_minimum_release_age_is_the_reason_for_the_held_back_pick() {
     let opts = ResolveOptions {

--- a/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
@@ -1,0 +1,135 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use node_semver::Version;
+use pacquet_config::version_policy::create_package_version_policy;
+use pacquet_registry::{Package, PackageDistribution, PackageVersion};
+use pacquet_resolving_resolver_base::{
+    ResolveOptions, VersionSelectorEntry, VersionSelectorType, VersionSelectorWithWeight,
+    VersionSelectors,
+};
+use pretty_assertions::assert_eq;
+
+use super::held_back_preferred;
+use crate::pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType};
+
+fn parse_iso(input: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(input).expect("rfc3339").with_timezone(&Utc)
+}
+
+fn make_pkg_version(name: &str, version: &str) -> PackageVersion {
+    PackageVersion {
+        name: name.to_string(),
+        version: version.parse::<Version>().expect("parse semver"),
+        dist: PackageDistribution::default(),
+        dependencies: None,
+        dev_dependencies: None,
+        peer_dependencies: None,
+        optional_dependencies: None,
+        peer_dependencies_meta: None,
+        other: HashMap::default(),
+        npm_user: None,
+        deprecated: None,
+    }
+}
+
+/// `foo` with a mature `2.1.3` and a `2.1.4` published inside the
+/// `2026-07-01` cutoff used by the tests below.
+fn make_package() -> Package {
+    Package {
+        name: "foo".to_string(),
+        dist_tags: HashMap::from([("latest".to_string(), "2.1.4".to_string())]),
+        versions: ["2.1.3", "2.1.4"]
+            .into_iter()
+            .map(|version| (version.to_string(), make_pkg_version("foo", version)))
+            .collect(),
+        time: Some(HashMap::from([
+            (
+                "2.1.3".to_string(),
+                serde_json::Value::String("2026-01-01T00:00:00.000Z".to_string()),
+            ),
+            (
+                "2.1.4".to_string(),
+                serde_json::Value::String("2026-07-14T12:00:00.000Z".to_string()),
+            ),
+        ])),
+        modified: None,
+        etag: None,
+        homepage: None,
+        mutex: std::sync::Arc::default(),
+    }
+}
+
+fn range_spec() -> RegistryPackageSpec {
+    RegistryPackageSpec {
+        name: "foo".to_string(),
+        fetch_spec: ">=2.1.3 <3.0.0-0".to_string(),
+        spec_type: RegistryPackageSpecType::Range,
+        normalized_bare_specifier: None,
+    }
+}
+
+fn range_selectors() -> VersionSelectors {
+    VersionSelectors::from([(
+        ">=2.1.3 <3.0.0-0".to_string(),
+        VersionSelectorEntry::Plain(VersionSelectorType::Range),
+    )])
+}
+
+fn update_opts() -> ResolveOptions {
+    ResolveOptions { update_requested: true, ..ResolveOptions::default() }
+}
+
+// https://github.com/pnpm/pnpm/issues/13071
+#[test]
+fn no_warning_when_minimum_release_age_is_the_reason_for_the_held_back_pick() {
+    let opts = ResolveOptions {
+        published_by: Some(parse_iso("2026-07-01T00:00:00.000Z")),
+        ..update_opts()
+    };
+    let preferred = held_back_preferred(
+        &opts,
+        &range_spec(),
+        Some(&range_selectors()),
+        &make_package(),
+        "2.1.3",
+    );
+    assert_eq!(preferred, None);
+}
+
+#[test]
+fn warns_when_a_manifest_pin_is_the_reason_for_the_held_back_pick() {
+    let selectors = VersionSelectors::from([(
+        "2.1.3".to_string(),
+        VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
+            selector_type: VersionSelectorType::Version,
+            weight: 1000,
+        }),
+    )]);
+    let preferred = held_back_preferred(
+        &update_opts(),
+        &range_spec(),
+        Some(&selectors),
+        &make_package(),
+        "2.1.3",
+    );
+    assert_eq!(preferred, Some("2.1.4".to_string()));
+}
+
+#[test]
+fn excluded_package_keeps_the_unfiltered_baseline() {
+    let policy = create_package_version_policy(["foo"]).expect("policy");
+    let opts = ResolveOptions {
+        published_by: Some(parse_iso("2026-07-01T00:00:00.000Z")),
+        published_by_exclude: Some(policy),
+        ..update_opts()
+    };
+    let preferred = held_back_preferred(
+        &opts,
+        &range_spec(),
+        Some(&range_selectors()),
+        &make_package(),
+        "2.1.3",
+    );
+    assert_eq!(preferred, Some("2.1.4".to_string()));
+}

--- a/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
@@ -153,3 +153,21 @@ fn excluded_package_keeps_the_unfiltered_baseline() {
     );
     assert_eq!(preferred, Some("2.1.4".to_string()));
 }
+
+#[test]
+fn version_trusted_by_exact_version_stays_in_the_baseline() {
+    let policy = create_package_version_policy(["foo@2.1.4"]).expect("policy");
+    let opts = ResolveOptions {
+        published_by: Some(parse_iso("2026-07-01T00:00:00.000Z")),
+        published_by_exclude: Some(policy),
+        ..update_opts()
+    };
+    let preferred = held_back_preferred(
+        &opts,
+        &range_spec(),
+        Some(&range_selectors()),
+        &make_package(),
+        "2.1.3",
+    );
+    assert_eq!(preferred, Some("2.1.4".to_string()));
+}

--- a/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/preferred_overlay/tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use node_semver::Version;
 use pacquet_config::version_policy::create_package_version_policy;
-use pacquet_registry::{Package, PackageDistribution, PackageVersion};
+use pacquet_registry::{DerivedPackuments, Package, PackageDistribution, PackageVersion};
 use pacquet_resolving_resolver_base::{
     ResolveOptions, VersionSelectorEntry, VersionSelectorType, VersionSelectorWithWeight,
     VersionSelectors,
@@ -57,6 +57,8 @@ fn make_package() -> Package {
         etag: None,
         homepage: None,
         mutex: std::sync::Arc::default(),
+        release_age_upgrade_checked: false,
+        derived: DerivedPackuments::default(),
     }
 }
 
@@ -113,6 +115,24 @@ fn warns_when_a_manifest_pin_is_the_reason_for_the_held_back_pick() {
         &make_package(),
         "2.1.3",
     );
+    assert_eq!(preferred, Some("2.1.4".to_string()));
+}
+
+#[test]
+fn warns_when_the_newer_version_is_mature_under_the_cutoff() {
+    let selectors = VersionSelectors::from([(
+        "2.1.3".to_string(),
+        VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
+            selector_type: VersionSelectorType::Version,
+            weight: 1000,
+        }),
+    )]);
+    let opts = ResolveOptions {
+        published_by: Some(parse_iso("2026-08-01T00:00:00.000Z")),
+        ..update_opts()
+    };
+    let preferred =
+        held_back_preferred(&opts, &range_spec(), Some(&selectors), &make_package(), "2.1.3");
     assert_eq!(preferred, Some("2.1.4".to_string()));
 }
 

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -10,7 +10,6 @@ import type {
 } from '@pnpm/fetching.types'
 import { globalWarn } from '@pnpm/logger'
 import { rangeSpecGranularity, versionWithRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
-import { filterPkgMetadataByPublishDate } from '@pnpm/resolving.registry.pkg-metadata-filter'
 import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
 import type {
   DirectoryResolution,
@@ -68,7 +67,7 @@ import {
   pickPackage,
   type PickPackageOptions,
 } from './pickPackage.js'
-import { assertMetaHasTime, pickPackageFromMeta, pickVersionByVersionRange } from './pickPackageFromMeta.js'
+import { applyPublishedByPolicy, pickPackageFromMeta, pickVersionByVersionRange } from './pickPackageFromMeta.js'
 import { failIfTrustDowngraded } from './trustChecks.js'
 import { MINIMUM_RELEASE_AGE_VIOLATION_CODE } from './violationCodes.js'
 import { workspacePrefToNpm } from './workspacePrefToNpm.js'
@@ -390,18 +389,12 @@ function warnOnceOnHeldBackUpdate (
     nonPinSelectors ??= Object.create(null) as VersionSelectors
     nonPinSelectors[selector] = value
   }
-  let baselineMeta = meta
-  if (opts.publishedBy != null) {
-    const excludeResult = opts.publishedByExclude?.(meta.name) ?? false
-    // When the metadata is abbreviated (no `time` field), the pick only
-    // succeeded because every version predates the cutoff (see
-    // `pickPackageFromMeta`), so there is nothing to filter out.
-    if (excludeResult !== true && meta.time != null) {
-      assertMetaHasTime(meta)
-      const trustedVersions = Array.isArray(excludeResult) ? excludeResult : undefined
-      baselineMeta = filterPkgMetadataByPublishDate(meta, opts.publishedBy, trustedVersions)
-    }
-  }
+  // `needsFullMetadata` is not this caller's problem: the pick already
+  // succeeded on this metadata, which for an abbreviated packument means
+  // every version cleared the cutoff, so `meta` is the filtered view.
+  const baselineMeta = opts.publishedBy != null
+    ? applyPublishedByPolicy(meta, opts.publishedBy, opts.publishedByExclude).meta
+    : meta
   const preferred = pickVersionByVersionRange({
     meta: baselineMeta,
     versionRange: spec.fetchSpec,

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -10,6 +10,7 @@ import type {
 } from '@pnpm/fetching.types'
 import { globalWarn } from '@pnpm/logger'
 import { rangeSpecGranularity, versionWithRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
+import { filterPkgMetadataByPublishDate } from '@pnpm/resolving.registry.pkg-metadata-filter'
 import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
 import type {
   DirectoryResolution,
@@ -67,7 +68,7 @@ import {
   pickPackage,
   type PickPackageOptions,
 } from './pickPackage.js'
-import { pickPackageFromMeta, pickVersionByVersionRange } from './pickPackageFromMeta.js'
+import { assertMetaHasTime, pickPackageFromMeta, pickVersionByVersionRange } from './pickPackageFromMeta.js'
 import { failIfTrustDowngraded } from './trustChecks.js'
 import { MINIMUM_RELEASE_AGE_VIOLATION_CODE } from './violationCodes.js'
 import { workspacePrefToNpm } from './workspacePrefToNpm.js'
@@ -362,7 +363,10 @@ function stripLockfileVersionPins (selectors?: VersionSelectors): VersionSelecto
  * The baseline for "held back" is the pick with only the non-pin selectors
  * applied — `range`/`tag` selectors such as the `pnpm audit --fix`
  * vulnerability penalties steer the baseline too, so the warning never
- * recommends a version those selectors avoid.
+ * recommends a version those selectors avoid. The baseline also honors the
+ * `publishedBy` maturity cutoff the actual pick applied: a version blocked
+ * by `minimumReleaseAge` is not an update the manifests held back, and
+ * recommending an override for it would defeat the age gate.
  *
  * The recommended override is scoped to the declared range being resolved
  * (`name@<range>`), so applying it can never violate any consumer's range:
@@ -371,7 +375,7 @@ function stripLockfileVersionPins (selectors?: VersionSelectors): VersionSelecto
  */
 function warnOnceOnHeldBackUpdate (
   ctx: Pick<ResolveFromNpmContext, 'warnedHeldBackUpdates'>,
-  opts: Pick<ResolveFromNpmOptions, 'updateRequested' | 'preferredVersions'>,
+  opts: Pick<ResolveFromNpmOptions, 'updateRequested' | 'preferredVersions' | 'publishedBy' | 'publishedByExclude'>,
   spec: RegistryPackageSpec,
   meta: PackageMeta,
   pickedVersion: string
@@ -386,8 +390,20 @@ function warnOnceOnHeldBackUpdate (
     nonPinSelectors ??= Object.create(null) as VersionSelectors
     nonPinSelectors[selector] = value
   }
+  let baselineMeta = meta
+  if (opts.publishedBy != null) {
+    const excludeResult = opts.publishedByExclude?.(meta.name) ?? false
+    // When the metadata is abbreviated (no `time` field), the pick only
+    // succeeded because every version predates the cutoff (see
+    // `pickPackageFromMeta`), so there is nothing to filter out.
+    if (excludeResult !== true && meta.time != null) {
+      assertMetaHasTime(meta)
+      const trustedVersions = Array.isArray(excludeResult) ? excludeResult : undefined
+      baselineMeta = filterPkgMetadataByPublishDate(meta, opts.publishedBy, trustedVersions)
+    }
+  }
   const preferred = pickVersionByVersionRange({
-    meta,
+    meta: baselineMeta,
     versionRange: spec.fetchSpec,
     preferredVersionSelectors: nonPinSelectors,
   })

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -35,27 +35,20 @@ export function pickPackageFromMeta (
   spec: RegistryPackageSpec
 ): PackageInRegistry | null {
   if (publishedBy) {
-    const excludeResult = publishedByExclude?.(meta.name) ?? false
-    if (excludeResult !== true) {
-      if (meta.time != null) {
-        // Full metadata with per-version timestamps: filter normally
+    const view = applyPublishedByPolicy(meta, publishedBy, publishedByExclude)
+    meta = view.meta
+    if (view.needsFullMetadata) {
+      const modifiedDate = parseModifiedDate(meta.modified)
+      if (modifiedDate == null || modifiedDate > publishedBy) {
+        // The package was modified after the cutoff (or carries no usable
+        // `modified`), so which of its versions are mature is unknowable
+        // from abbreviated metadata. The error tells the caller to refetch.
         assertMetaHasTime(meta)
-        const trustedVersions = Array.isArray(excludeResult) ? excludeResult : undefined
-        meta = filterPkgMetadataByPublishDate(meta, publishedBy, trustedVersions)
-      } else {
-        const modifiedDate = parseModifiedDate(meta.modified)
-        if (modifiedDate == null || modifiedDate > publishedBy) {
-          // Abbreviated metadata without per-version timestamps, and the package
-          // was recently modified (or has no/invalid modified field). We cannot determine
-          // which individual versions are mature enough — need full metadata.
-          assertMetaHasTime(meta)
-        }
-        // else: meta.modified <= publishedBy — every version was published at or
-        // before the cutoff (modified is an upper bound on per-version time), so
-        // they all pass the per-version `<=` maturity filter and no filtering is
-        // needed. Inclusive at the boundary on purpose so this branch matches the
-        // per-version filter in `filterPkgMetadataByPublishDate`.
       }
+      // else: `modified` is an upper bound on every per-version timestamp, so
+      // `modified <= publishedBy` means they all pass the maturity filter and
+      // nothing would be dropped. Inclusive at the boundary on purpose, to
+      // match the per-version `<=` in `filterPkgMetadataByPublishDate`.
     }
   }
   if ((!meta.versions || Object.keys(meta.versions).length === 0) && !publishedBy) {
@@ -108,6 +101,45 @@ export function pickPackageFromMeta (
       `Received malformed metadata for "${spec.name}"`,
       { hint: 'This might mean that the package was unpublished from the registry', cause: err }
     )
+  }
+}
+
+export interface PublishedByView {
+  /** The metadata the cutoff leaves visible. `meta` itself when nothing is filtered out. */
+  meta: PackageMeta
+  /**
+   * The cutoff could not be applied: the metadata is abbreviated, so there
+   * are no per-version timestamps to filter on. Whether that is fatal is the
+   * caller's call — the pick needs full metadata to honor the cutoff, while a
+   * caller reasoning about a pick that already succeeded knows the versions
+   * cleared the cutoff some other way.
+   */
+  needsFullMetadata: boolean
+}
+
+/**
+ * Narrows `meta` to the versions the `publishedBy` cutoff admits, honoring
+ * `publishedByExclude`: a package the policy excludes wholesale keeps its
+ * unfiltered metadata, and versions the policy names explicitly stay in
+ * regardless of their age.
+ *
+ * Every consumer of the cutoff goes through here so they agree on what the
+ * policy admits — a baseline that filters differently from the pick would
+ * misreport why a version was chosen.
+ */
+export function applyPublishedByPolicy (
+  meta: PackageMeta,
+  publishedBy: Date,
+  publishedByExclude?: PackageVersionPolicy
+): PublishedByView {
+  const excludeResult = publishedByExclude?.(meta.name) ?? false
+  if (excludeResult === true) return { meta, needsFullMetadata: false }
+  if (meta.time == null) return { meta, needsFullMetadata: true }
+  assertMetaHasTime(meta)
+  const trustedVersions = Array.isArray(excludeResult) ? excludeResult : undefined
+  return {
+    meta: filterPkgMetadataByPublishDate(meta, publishedBy, trustedVersions),
+    needsFullMetadata: false,
   }
 }
 

--- a/pnpm11/resolving/npm-resolver/test/heldBackUpdateWarning.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/heldBackUpdateWarning.test.ts
@@ -111,3 +111,31 @@ test('still warns about a held-back update when a manifest pin is the reason the
   expect(heldBackWarnings).toHaveLength(1)
   expect(heldBackWarnings[0]).toContain('was updated to 2.1.3, not 2.1.4')
 })
+
+test('keeps the unfiltered baseline for a package excluded from the age gate via publishedByExclude', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/foo', method: 'GET' })
+    .reply(200, fooMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'foo', bareSpecifier: '^2.1.3' }, {
+    updateRequested: true,
+    publishedBy: new Date('2026-07-01T00:00:00.000Z'),
+    publishedByExclude: () => true,
+    preferredVersions: {
+      foo: { '2.1.3': { selectorType: 'version', weight: 1000 } },
+    },
+  })
+
+  // The pin holds the pick at 2.1.3, and the exclusion keeps 2.1.4 in the
+  // baseline despite the publishedBy cutoff, so the warning is printed.
+  expect(resolveResult!.id).toBe('foo@2.1.3')
+  const heldBackWarnings = collectedWarnings.filter(warning => warning.includes('was updated to'))
+  expect(heldBackWarnings).toHaveLength(1)
+  expect(heldBackWarnings[0]).toContain('was updated to 2.1.3, not 2.1.4')
+})

--- a/pnpm11/resolving/npm-resolver/test/heldBackUpdateWarning.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/heldBackUpdateWarning.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, expect, test } from '@jest/globals'
+import { type LogBase, streamParser } from '@pnpm/logger'
+import { createFetchFromRegistry } from '@pnpm/network.fetch'
+import { createNpmResolver } from '@pnpm/resolving.npm-resolver'
+import type { Registries } from '@pnpm/types'
+import { temporaryDirectory } from 'tempy'
+
+import { getMockAgent, setupMockAgent, teardownMockAgent } from './utils/index.js'
+
+const registries: Registries = {
+  default: 'https://registry.npmjs.org/',
+}
+
+const fetch = createFetchFromRegistry({})
+const getAuthHeader = () => undefined
+const createResolveFromNpm = createNpmResolver.bind(null, fetch, getAuthHeader)
+
+const fooMeta = {
+  name: 'foo',
+  'dist-tags': { latest: '2.1.4' },
+  versions: {
+    '2.1.3': {
+      name: 'foo',
+      version: '2.1.3',
+      dist: {
+        integrity: 'sha512-9Qa5b+9n69IEuxk4FiNcavXqkixb9lD03BLtdTeu2bbORnLZQrw+pR/exiSg7SoODeu08yxS47mdZa9ddodNwQ==',
+        tarball: 'https://registry.npmjs.org/foo/-/foo-2.1.3.tgz',
+      },
+    },
+    '2.1.4': {
+      name: 'foo',
+      version: '2.1.4',
+      dist: {
+        integrity: 'sha512-9Qa5b+9n69IEuxk4FiNcavXqkixb9lD03BLtdTeu2bbORnLZQrw+pR/exiSg7SoODeu08yxS47mdZa9ddodNwQ==',
+        tarball: 'https://registry.npmjs.org/foo/-/foo-2.1.4.tgz',
+      },
+    },
+  },
+  time: {
+    '2.1.3': '2026-01-01T00:00:00.000Z',
+    '2.1.4': '2026-07-14T12:00:00.000Z',
+  },
+}
+
+const collectedWarnings: string[] = []
+
+function collectWarnings (msg: LogBase & { message?: string }): void {
+  if (msg.level === 'warn' && typeof msg.message === 'string') {
+    collectedWarnings.push(msg.message)
+  }
+}
+
+beforeEach(async () => {
+  collectedWarnings.length = 0
+  streamParser.on('data', collectWarnings as (msg: LogBase) => void)
+  await setupMockAgent()
+})
+
+afterEach(async () => {
+  streamParser.removeListener('data', collectWarnings as (msg: LogBase) => void)
+  await teardownMockAgent()
+})
+
+// https://github.com/pnpm/pnpm/issues/13071
+test('does not warn about a held-back update when minimumReleaseAge is the reason the newer version was not picked', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/foo', method: 'GET' })
+    .reply(200, fooMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'foo', bareSpecifier: '^2.1.3' }, {
+    updateRequested: true,
+    publishedBy: new Date('2026-07-01T00:00:00.000Z'),
+    preferredVersions: {
+      foo: { '^2.1.3': 'range' },
+    },
+  })
+
+  // 2.1.4 is inside the minimumReleaseAge window, so 2.1.3 is picked.
+  expect(resolveResult!.id).toBe('foo@2.1.3')
+  // The pick is fully explained by the maturity cutoff, so no warning about
+  // manifests holding the update back should be printed.
+  expect(collectedWarnings.filter(warning => warning.includes('was updated to'))).toStrictEqual([])
+})
+
+test('still warns about a held-back update when a manifest pin is the reason the newer version was not picked', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/foo', method: 'GET' })
+    .reply(200, fooMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'foo', bareSpecifier: '^2.1.3' }, {
+    updateRequested: true,
+    preferredVersions: {
+      foo: { '2.1.3': { selectorType: 'version', weight: 1000 } },
+    },
+  })
+
+  expect(resolveResult!.id).toBe('foo@2.1.3')
+  const heldBackWarnings = collectedWarnings.filter(warning => warning.includes('was updated to'))
+  expect(heldBackWarnings).toHaveLength(1)
+  expect(heldBackWarnings[0]).toContain('was updated to 2.1.3, not 2.1.4')
+})

--- a/pnpm11/resolving/npm-resolver/test/heldBackUpdateWarning.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/heldBackUpdateWarning.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test } from '@jest/globals'
+import { createPackageVersionPolicy } from '@pnpm/config.version-policy'
 import { type LogBase, streamParser } from '@pnpm/logger'
 import { createFetchFromRegistry } from '@pnpm/network.fetch'
 import { createNpmResolver } from '@pnpm/resolving.npm-resolver'
@@ -10,6 +11,7 @@ import { getMockAgent, setupMockAgent, teardownMockAgent } from './utils/index.j
 const registries: Registries = {
   default: 'https://registry.npmjs.org/',
 }
+const registryOrigin = registries.default.slice(0, -1)
 
 const fetch = createFetchFromRegistry({})
 const getAuthHeader = () => undefined
@@ -44,12 +46,6 @@ const fooMeta = {
 
 const collectedWarnings: string[] = []
 
-function collectWarnings (msg: LogBase & { message?: string }): void {
-  if (msg.level === 'warn' && typeof msg.message === 'string') {
-    collectedWarnings.push(msg.message)
-  }
-}
-
 beforeEach(async () => {
   collectedWarnings.length = 0
   streamParser.on('data', collectWarnings as (msg: LogBase) => void)
@@ -61,9 +57,15 @@ afterEach(async () => {
   await teardownMockAgent()
 })
 
+function collectWarnings (msg: LogBase & { message?: string }): void {
+  if (msg.level === 'warn' && typeof msg.message === 'string') {
+    collectedWarnings.push(msg.message)
+  }
+}
+
 // https://github.com/pnpm/pnpm/issues/13071
 test('does not warn about a held-back update when minimumReleaseAge is the reason the newer version was not picked', async () => {
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
+  getMockAgent().get(registryOrigin)
     .intercept({ path: '/foo', method: 'GET' })
     .reply(200, fooMeta)
 
@@ -89,7 +91,7 @@ test('does not warn about a held-back update when minimumReleaseAge is the reaso
 })
 
 test('still warns about a held-back update when a manifest pin is the reason the newer version was not picked', async () => {
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
+  getMockAgent().get(registryOrigin)
     .intercept({ path: '/foo', method: 'GET' })
     .reply(200, fooMeta)
 
@@ -113,7 +115,7 @@ test('still warns about a held-back update when a manifest pin is the reason the
 })
 
 test('still warns about a held-back update when the newer version is mature under the publishedBy cutoff', async () => {
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
+  getMockAgent().get(registryOrigin)
     .intercept({ path: '/foo', method: 'GET' })
     .reply(200, fooMeta)
 
@@ -138,7 +140,7 @@ test('still warns about a held-back update when the newer version is mature unde
 })
 
 test('keeps the unfiltered baseline for a package excluded from the age gate via publishedByExclude', async () => {
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
+  getMockAgent().get(registryOrigin)
     .intercept({ path: '/foo', method: 'GET' })
     .reply(200, fooMeta)
 
@@ -159,6 +161,32 @@ test('keeps the unfiltered baseline for a package excluded from the age gate via
 
   // The pin holds the pick at 2.1.3, and the exclusion keeps 2.1.4 in the
   // baseline despite the publishedBy cutoff, so the warning is printed.
+  expect(resolveResult!.id).toBe('foo@2.1.3')
+  const heldBackWarnings = collectedWarnings.filter(warning => warning.includes('was updated to'))
+  expect(heldBackWarnings).toHaveLength(1)
+  expect(heldBackWarnings[0]).toContain('was updated to 2.1.3, not 2.1.4')
+})
+
+test('keeps a version the age gate trusts by exact version in the baseline', async () => {
+  getMockAgent().get(registryOrigin)
+    .intercept({ path: '/foo', method: 'GET' })
+    .reply(200, fooMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'foo', bareSpecifier: '^2.1.3' }, {
+    updateRequested: true,
+    publishedBy: new Date('2026-07-01T00:00:00.000Z'),
+    publishedByExclude: createPackageVersionPolicy(['foo@2.1.4']),
+    preferredVersions: {
+      foo: { '2.1.3': { selectorType: 'version', weight: 1000 } },
+    },
+  })
+
   expect(resolveResult!.id).toBe('foo@2.1.3')
   const heldBackWarnings = collectedWarnings.filter(warning => warning.includes('was updated to'))
   expect(heldBackWarnings).toHaveLength(1)

--- a/pnpm11/resolving/npm-resolver/test/heldBackUpdateWarning.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/heldBackUpdateWarning.test.ts
@@ -112,6 +112,31 @@ test('still warns about a held-back update when a manifest pin is the reason the
   expect(heldBackWarnings[0]).toContain('was updated to 2.1.3, not 2.1.4')
 })
 
+test('still warns about a held-back update when the newer version is mature under the publishedBy cutoff', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/foo', method: 'GET' })
+    .reply(200, fooMeta)
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'foo', bareSpecifier: '^2.1.3' }, {
+    updateRequested: true,
+    publishedBy: new Date('2026-08-01T00:00:00.000Z'),
+    preferredVersions: {
+      foo: { '2.1.3': { selectorType: 'version', weight: 1000 } },
+    },
+  })
+
+  expect(resolveResult!.id).toBe('foo@2.1.3')
+  const heldBackWarnings = collectedWarnings.filter(warning => warning.includes('was updated to'))
+  expect(heldBackWarnings).toHaveLength(1)
+  expect(heldBackWarnings[0]).toContain('was updated to 2.1.3, not 2.1.4')
+})
+
 test('keeps the unfiltered baseline for a package excluded from the age gate via publishedByExclude', async () => {
   getMockAgent().get(registries.default.replace(/\/$/, ''))
     .intercept({ path: '/foo', method: 'GET' })


### PR DESCRIPTION
## Summary

The held-back-update warning printed by `pnpm update` blamed "your manifests and already installed dependencies" (and recommended an override) even when `minimumReleaseAge` was the actual reason a newer version was not picked. The baseline pick that the warning compares against ran without the `publishedBy` / `minimumReleaseAge` filter, so any hold-back looked like a manifest constraint. Both stacks had the gap (the Rust side hardcoded `published_by: None`); both are fixed in this PR.

Closes pnpm/pnpm#13071

## Squash Commit Body

```text
The held-back-update warning compares the constrained pick against a
baseline "what would have been picked" resolution. That baseline ran
without applying the publishedBy cutoff, so when minimumReleaseAge was
the real reason a newer version was skipped, the warning wrongly
attributed the hold-back to manifests/installed dependencies and
recommended an override that would defeat the age gate.

TypeScript: the baseline pick in resolving/npm-resolver now filters
package metadata through filterPkgMetadataByPublishDate (honoring
publishedByExclude) before picking. Rust: preferred_overlay's baseline
logic is extracted into a testable held_back_preferred that applies the
same filter instead of hardcoding published_by: None.

Regression tests in both stacks pin the corrected warning behavior.

Closes pnpm/pnpm#13071
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset (`@pnpm/resolving.npm-resolver`, `pnpm`, `pacquet`).
- [x] Added or updated tests (TS `test/heldBackUpdateWarning.test.ts`; Rust `preferred_overlay/tests.rs` — TS npm-resolver suite 279 passing, Rust crate 294 + 3 passing, fmt/clippy clean).
- [ ] Updated the documentation if needed — n/a, corrects an inaccurate warning message path.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786935645&installation_id=145934176&pr_number=13115&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13115&signature=b0437434a7949c4a3b7553350ea013cd391111d116d55dccef1aace53f54feff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed misleading “held-back update” warnings when newer versions are blocked by `minimumReleaseAge`.
  - Prevented recommendations from suggesting overrides that bypass age-based protection.
  - Preserved accurate warnings for manifest-pinned versions and publish-date policy exclusions.

- **Tests**
  - Added coverage for age restrictions, manifest pinning, mature newer versions, and excluded versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->