### PR TITLE
fix(lockfile): fold auto-installed peers into the frozen-lockfile check

### DIFF
--- a/.changeset/pacquet-frozen-auto-install-peers.md
+++ b/.changeset/pacquet-frozen-auto-install-peers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm install --frozen-lockfile` incorrectly failing with `ERR_PNPM_OUTDATED_LOCKFILE` when a workspace project declares `peerDependencies` that `auto-install-peers` resolves. With `auto-install-peers` enabled (the default), pnpm records those missing peers in the lockfile importer's `dependencies`; the frozen-lockfile freshness check now folds `peerDependencies` into the comparison instead of reporting the materialized peers as removed.

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -190,6 +190,46 @@ fn fresh_resolve_walks_every_workspace_importer() {
     drop((root, mock_instance));
 }
 
+/// A workspace member that declares a `peerDependencies` entry gets
+/// that peer auto-installed (pnpm's default) and materialized into its
+/// lockfile importer `dependencies`. A subsequent `--frozen-lockfile`
+/// install must accept that lockfile instead of misreading the
+/// materialized peer as a removed dependency — the alpha.14
+/// workspace-importer freshness regression.
+#[test]
+fn frozen_install_accepts_auto_installed_workspace_peer() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } = two_project_workspace(
+        &serde_json::json!({
+            "name": "pkg-a",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/hello-world-js-bin": "1.0.0" },
+        }),
+        &serde_json::json!({ "name": "pkg-b", "version": "1.0.0" }),
+    );
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    // Fresh resolve auto-installs the unmet peer into pkg-a's importer
+    // `dependencies`.
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let a_section = lockfile
+        .split("  pkg-a:\n")
+        .nth(1)
+        .and_then(|tail| tail.split("\n  pkg-b:").next())
+        .expect("pnpm-lock.yaml missing pkg-a importer section");
+    assert!(
+        a_section.contains("hello-world-js-bin"),
+        "auto-installed peer not materialized into pkg-a; the test would not exercise the fix\n{lockfile}",
+    );
+
+    // The materialized peer must not read as lockfile drift.
+    pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn changed_workspace_importer_invalidates_lockfile() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } = two_project_workspace(

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -219,6 +219,7 @@ fn frozen_install_accepts_auto_installed_workspace_peer() {
         .nth(1)
         .and_then(|tail| tail.split("\n  pkg-b:").next())
         .expect("pnpm-lock.yaml missing pkg-a importer section");
+    eprintln!("pkg-a importer section:\n{a_section}");
     assert!(
         a_section.contains("hello-world-js-bin"),
         "auto-installed peer not materialized into pkg-a; the test would not exercise the fix\n{lockfile}",

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -386,8 +386,9 @@ fn all_catalogs_are_up_to_date(
 /// What is checked (in order, short-circuiting on the first failure):
 ///
 /// 1. Flat-record specifier diff against `devDependencies ∪
-///    dependencies ∪ optionalDependencies`. Catches added / removed /
-///    modified deps in one bucket.
+///    dependencies ∪ optionalDependencies` (∪ the auto-installed
+///    peers below). Catches added / removed / modified deps in one
+///    bucket.
 /// 2. `publishDirectory` vs `publishConfig.directory`.
 /// 3. `dependenciesMeta` equality.
 /// 4. Per-field name-set, per-dep specifier, and resolved-version
@@ -396,21 +397,31 @@ fn all_catalogs_are_up_to_date(
 ///    drift the flat-record diff doesn't see, plus broken lockfiles
 ///    whose resolved semver no longer satisfies the recorded range.
 ///
-/// Scoped to what pacquet supports today: no `auto-install-peers`
-/// pre-pass (pacquet has no separate auto-install-peers mode), no
-/// `excludeLinksFromLockfile` (`link:` resolutions aren't supported
-/// yet). Non-semver resolutions such as file and tarball dependencies
-/// are excluded from the resolved-version check.
+/// When `auto_install_peers` is set (pnpm's default), every peer
+/// dependency missing from the regular dependency fields is folded
+/// into `dependencies` for the comparison, matching how pnpm
+/// materializes those peers into the importer's `dependencies` in the
+/// lockfile. Without this, a peer-only dependency would be misread as
+/// a lockfile entry the manifest removed (see `auto_installed_peer_deps`).
+///
+/// Still unsupported: `excludeLinksFromLockfile` (`link:` resolutions
+/// aren't modeled yet). Non-semver resolutions such as file and
+/// tarball dependencies are excluded from the resolved-version check.
 pub fn satisfies_package_manifest(
     importer: &ProjectSnapshot,
     manifest: &PackageManifest,
+    auto_install_peers: bool,
     is_ignored_optional: &dyn Fn(&str) -> bool,
 ) -> Result<(), StalenessReason> {
+    let folded_peers = auto_installed_peer_deps(manifest, auto_install_peers);
+
     // Phase 1: flat-record diff against the manifest's union of
     // dependency fields. Compares the importer's specifiers to the
     // manifest's existing deps (devs + prod + optional flattened
-    // together).
-    let manifest_specs = flat_manifest_specs(manifest, is_ignored_optional);
+    // together, plus the auto-installed peers).
+    let mut manifest_specs = flat_manifest_specs(manifest, is_ignored_optional);
+    manifest_specs
+        .extend(folded_peers.iter().map(|(name, spec)| ((*name).to_string(), (*spec).to_string())));
     let importer_specs = flat_importer_specs(importer);
     let diff = diff_flat_records(&importer_specs, &manifest_specs);
     if !diff.is_empty() {
@@ -450,18 +461,22 @@ pub fn satisfies_package_manifest(
         });
     }
 
-    // Phase 4: per-field name-set + specifier match.
-    let manifest_prod: BTreeMap<&str, &str> = manifest
+    // Phase 4: per-field name-set + specifier match. The auto-installed
+    // peers join `dependencies`, so they count toward the prod name-set
+    // used for both the dev-field precedence filter and this field's
+    // own comparison.
+    let mut manifest_prod: BTreeMap<&str, &str> = manifest
         .dependencies([DependencyGroup::Prod])
         .filter(|(name, _)| !is_ignored_optional(name))
         .collect();
+    manifest_prod.extend(folded_peers.iter().map(|(name, spec)| (*name, *spec)));
     let manifest_optional: BTreeMap<&str, &str> = manifest
         .dependencies([DependencyGroup::Optional])
         .filter(|(name, _)| !is_ignored_optional(name))
         .collect();
     for field in [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional] {
         let field_name = <&'static str>::from(field);
-        let manifest_field: BTreeMap<&str, &str> = manifest
+        let mut manifest_field: BTreeMap<&str, &str> = manifest
             .dependencies([field])
             .filter(|(name, _)| {
                 !matches!(field, DependencyGroup::Prod | DependencyGroup::Optional)
@@ -475,6 +490,9 @@ pub fn satisfies_package_manifest(
                 DependencyGroup::Optional | DependencyGroup::Peer => true,
             })
             .collect();
+        if matches!(field, DependencyGroup::Prod) {
+            manifest_field.extend(folded_peers.iter().map(|(name, spec)| (*name, *spec)));
+        }
         let importer_field = importer.get_map_by_group(field);
 
         // Every manifest entry must have a matching importer entry
@@ -565,6 +583,33 @@ fn dependencies_meta_equal(
         (Some(a), Some(b)) => a == b,
         _ => false,
     }
+}
+
+/// Peer dependencies that `auto-install-peers` materializes into the
+/// importer's `dependencies`: every `peerDependencies` entry whose name
+/// isn't already declared in `dependencies`, `devDependencies`, or
+/// `optionalDependencies`. Empty when `auto_install_peers` is off, which
+/// restores the plain manifest-vs-lockfile comparison.
+///
+/// Mirrors pnpm's `omit(Object.keys(existingDeps), pkg.peerDependencies)`
+/// fold in `satisfiesPackageManifest`: peers already declared in a
+/// regular field keep that field's specifier, so only the peer-only
+/// entries are surfaced here.
+fn auto_installed_peer_deps(
+    manifest: &PackageManifest,
+    auto_install_peers: bool,
+) -> BTreeMap<&str, &str> {
+    if !auto_install_peers {
+        return BTreeMap::new();
+    }
+    let declared: BTreeSet<&str> = manifest
+        .dependencies([DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional])
+        .map(|(name, _)| name)
+        .collect();
+    manifest
+        .dependencies([DependencyGroup::Peer])
+        .filter(|(name, _)| !declared.contains(name))
+        .collect()
 }
 
 /// Build the manifest's `devDependencies ∪ dependencies ∪

--- a/pnpm/crates/lockfile/src/freshness/tests.rs
+++ b/pnpm/crates/lockfile/src/freshness/tests.rs
@@ -56,7 +56,7 @@ fn matching_manifest_and_lockfile_satisfies() {
         }
     }"#,
     );
-    assert!(satisfies_package_manifest(importer, &manifest, &|_: &str| false).is_ok());
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn equivalent_git_specifiers_satisfy_manifest() {
         }
     }"#,
     );
-    satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect("equivalent git specifiers must satisfy the manifest");
 }
 
@@ -112,7 +112,7 @@ fn different_git_specifiers_do_not_satisfy_manifest() {
             }}
         }}"#,
         ));
-        let error = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+        let error = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
             .expect_err("different git specifiers must leave the manifest stale");
         assert!(
             matches!(error, StalenessReason::SpecifiersDiffer(_)),
@@ -144,7 +144,7 @@ fn manifest_adds_dep_returns_specifier_diff() {
         }
     }"#,
     );
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("should be stale");
     let StalenessReason::SpecifiersDiffer(diff) = err else {
         panic!("expected SpecifiersDiffer, got {err:?}");
@@ -179,7 +179,7 @@ fn manifest_drops_dep_returns_specifier_diff() {
         }
     }"#,
     );
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("should be stale");
     let StalenessReason::SpecifiersDiffer(diff) = err else {
         panic!("expected SpecifiersDiffer, got {err:?}");
@@ -209,7 +209,7 @@ fn manifest_bumps_specifier_returns_specifier_diff() {
         }
     }"#,
     );
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("should be stale");
     let StalenessReason::SpecifiersDiffer(diff) = err else {
         panic!("expected SpecifiersDiffer, got {err:?}");
@@ -249,7 +249,7 @@ fn matching_across_all_three_dep_fields_satisfies() {
         "optionalDependencies": { "fsevents": "^2.0.0" }
     }"#,
     );
-    assert!(satisfies_package_manifest(importer, &manifest, &|_: &str| false).is_ok());
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
 }
 
 /// Lockfile has no `importers["."]` entry — even though pacquet's
@@ -292,7 +292,7 @@ fn dep_moves_between_fields_returns_dep_specifier_mismatch() {
         "dependencies": { "typescript": "^5.0.0" }
     }"#,
     );
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("should be stale");
     assert!(
         matches!(err, StalenessReason::DepSpecifierMismatch { .. }),
@@ -342,7 +342,7 @@ fn cross_field_swap_with_same_cardinalities_caught_by_per_field_check() {
         "devDependencies": { "react": "^17.0.2" }
     }"#,
     );
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("should be stale");
     assert!(
         matches!(err, StalenessReason::DepSpecifierMismatch { .. }),
@@ -374,7 +374,7 @@ fn publish_directory_mismatch_returns_publish_directory_mismatch() {
         "dependencies": { "react": "^17.0.2" }
     }"#,
     );
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("should be stale");
     assert!(
         matches!(err, StalenessReason::PublishDirectoryMismatch { .. }),
@@ -405,7 +405,7 @@ fn dependencies_meta_mismatch_returns_dependencies_meta_mismatch() {
         "dependencies": { "foo": "^1.0.0" }
     }"#,
     );
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("should be stale");
     assert!(
         matches!(err, StalenessReason::DependenciesMetaMismatch { .. }),
@@ -477,7 +477,7 @@ fn dependencies_meta_empty_object_equivalent_to_absent() {
         "dependenciesMeta": {}
     }"#,
     );
-    assert!(satisfies_package_manifest(importer, &manifest, &|_: &str| false).is_ok());
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
 }
 
 #[test]
@@ -502,7 +502,7 @@ fn publish_directory_match_satisfies() {
         "dependencies": { "foo": "1.0.0" }
     }"#,
     );
-    assert!(satisfies_package_manifest(importer, &manifest, &|_: &str| false).is_ok());
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
 }
 
 #[test]
@@ -527,7 +527,7 @@ fn same_dep_in_prod_and_dev_counts_under_prod() {
     }"#,
     );
     assert!(
-        satisfies_package_manifest(importer, &manifest, &|_: &str| false).is_ok(),
+        satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok(),
         "manifest listing foo in prod+dev must satisfy a lockfile that records it under prod only",
     );
 }
@@ -554,7 +554,7 @@ fn same_dep_in_prod_and_optional_counts_under_optional() {
     }"#,
     );
     assert!(
-        satisfies_package_manifest(importer, &manifest, &|_: &str| false).is_ok(),
+        satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok(),
         "manifest listing foo in prod+optional must satisfy a lockfile that records it under optional only",
     );
 }
@@ -580,7 +580,7 @@ fn importer_empty_dev_dependencies_equivalent_to_absent() {
         "dependencies": { "foo": "^1.0.0" }
     }"#,
     );
-    assert!(satisfies_package_manifest(importer, &manifest, &|_: &str| false).is_ok());
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
 }
 
 #[test]
@@ -604,7 +604,7 @@ fn resolved_version_outside_manifest_range_is_stale() {
     }"#,
     );
 
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("a broken direct resolution must be stale");
     assert_eq!(
         err,
@@ -614,6 +614,107 @@ fn resolved_version_outside_manifest_range_is_stale() {
             range: "3.3.7".to_string(),
         },
     );
+}
+
+// ---------------------------------------------------------------------------
+// `auto-install-peers` — peers materialized into the importer's
+// `dependencies` must not read as lockfile drift. Ports
+// `packages/lockfile/verification/test/satisfiesPackageManifest.ts`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn peer_only_dependency_is_satisfied_when_auto_install_peers() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      foo:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "      bar:"
+        "        specifier: ^1.0.0"
+        "        version: 1.0.0"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    let (_dir, manifest) = manifest_from_json(
+        r#"{
+        "name": "x",
+        "version": "1.0.0",
+        "dependencies": { "foo": "1.0.0" },
+        "peerDependencies": { "bar": "^1.0.0" }
+    }"#,
+    );
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
+}
+
+#[test]
+fn peers_also_declared_as_regular_deps_still_satisfy() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      qar:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "    optionalDependencies:"
+        "      bar:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "    devDependencies:"
+        "      foo:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    let (_dir, manifest) = manifest_from_json(
+        r#"{
+        "name": "x",
+        "version": "1.0.0",
+        "dependencies": { "qar": "1.0.0" },
+        "optionalDependencies": { "bar": "1.0.0" },
+        "devDependencies": { "foo": "1.0.0" },
+        "peerDependencies": { "foo": "^1.0.0", "bar": "^1.0.0", "qar": "^1.0.0" }
+    }"#,
+    );
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
+}
+
+#[test]
+fn peer_only_dependency_is_stale_without_auto_install_peers() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      foo:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+        "      bar:"
+        "        specifier: ^1.0.0"
+        "        version: 1.0.0"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    let (_dir, manifest) = manifest_from_json(
+        r#"{
+        "name": "x",
+        "version": "1.0.0",
+        "dependencies": { "foo": "1.0.0" },
+        "peerDependencies": { "bar": "^1.0.0" }
+    }"#,
+    );
+    let err = satisfies_package_manifest(importer, &manifest, false, &|_: &str| false)
+        .expect_err("without auto-install-peers, the materialized peer is unexplained drift");
+    let StalenessReason::SpecifiersDiffer(diff) = err else {
+        panic!("expected SpecifiersDiffer, got {err:?}");
+    };
+    assert_eq!(diff.removed, BTreeMap::from([("bar".to_string(), "^1.0.0".to_string())]));
+    assert!(diff.added.is_empty());
+    assert!(diff.modified.is_empty());
 }
 
 // ---------------------------------------------------------------------------
@@ -1413,7 +1514,7 @@ fn ignored_optional_filtered_out_of_manifest_diff() {
     }"#,
     );
     let is_ignored: &dyn Fn(&str) -> bool = &|name: &str| name == "foo";
-    assert!(satisfies_package_manifest(importer, &manifest, is_ignored).is_ok());
+    assert!(satisfies_package_manifest(importer, &manifest, true, is_ignored).is_ok());
 }
 
 /// Polarity: without the filter the same fixture must fail.
@@ -1440,7 +1541,7 @@ fn ignored_optional_without_filter_surfaces_as_drift() {
         "optionalDependencies": { "foo": "^1.0.0" }
     }"#,
     );
-    let err = satisfies_package_manifest(importer, &manifest, &|_: &str| false)
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
         .expect_err("without the filter the manifest's extra `foo` must surface as drift");
     assert!(
         matches!(err, StalenessReason::SpecifiersDiffer(_)),
@@ -1494,7 +1595,7 @@ fn ignored_optional_does_not_apply_to_dev_dependencies() {
     }"#,
     );
     let is_ignored: &dyn Fn(&str) -> bool = &|name: &str| name == "foo";
-    assert!(satisfies_package_manifest(importer, &manifest, is_ignored).is_ok());
+    assert!(satisfies_package_manifest(importer, &manifest, true, is_ignored).is_ok());
 }
 
 /// Pins the group gate: removing the `matches!(... Prod | Optional)`
@@ -1521,5 +1622,5 @@ fn ignored_optional_dev_only_lockfile_entry_kept() {
     }"#,
     );
     let is_ignored: &dyn Fn(&str) -> bool = &|name: &str| name == "foo";
-    assert!(satisfies_package_manifest(importer, &manifest, is_ignored).is_ok());
+    assert!(satisfies_package_manifest(importer, &manifest, true, is_ignored).is_ok());
 }

--- a/pnpm/crates/lockfile/src/freshness/tests.rs
+++ b/pnpm/crates/lockfile/src/freshness/tests.rs
@@ -616,6 +616,85 @@ fn resolved_version_outside_manifest_range_is_stale() {
     );
 }
 
+#[test]
+fn dev_only_dependency_match_satisfies() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    devDependencies:"
+        "      foo:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    let (_dir, manifest) = manifest_from_json(
+        r#"{
+        "name": "x",
+        "version": "1.0.0",
+        "devDependencies": { "foo": "1.0.0" }
+    }"#,
+    );
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
+}
+
+#[test]
+fn optional_only_dependency_match_satisfies() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    optionalDependencies:"
+        "      foo:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    let (_dir, manifest) = manifest_from_json(
+        r#"{
+        "name": "x",
+        "version": "1.0.0",
+        "optionalDependencies": { "foo": "1.0.0" }
+    }"#,
+    );
+    assert!(satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).is_ok());
+}
+
+/// A dependency the manifest lists only under `optionalDependencies`
+/// but the lockfile records under `dependencies` is drift: the flat
+/// diff agrees on the specifier, so the per-field check must catch the
+/// field move. Mirrors the `optionalDependencies` mismatch case in
+/// `satisfiesPackageManifest.ts`.
+#[test]
+fn manifest_optional_only_but_lockfile_records_prod_is_stale() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    dependencies:"
+        "      foo:"
+        "        specifier: 1.0.0"
+        "        version: 1.0.0"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    let (_dir, manifest) = manifest_from_json(
+        r#"{
+        "name": "x",
+        "version": "1.0.0",
+        "optionalDependencies": { "foo": "1.0.0" }
+    }"#,
+    );
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
+        .expect_err("a dep the manifest lists only as optional but the lockfile records under dependencies must be stale");
+    assert!(
+        matches!(err, StalenessReason::DepSpecifierMismatch { field: "dependencies", .. }),
+        "got: {err:?}",
+    );
+}
+
 // ---------------------------------------------------------------------------
 // `auto-install-peers` — peers materialized into the importer's
 // `dependencies` must not read as lockfile drift. Ports

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1837,6 +1837,7 @@ fn check_lockfile_freshness(
             lockfile,
             manifest,
             &importer_id,
+            config.auto_install_peers,
             &ignored_optional_matcher,
             parsed_overrides_opt.as_deref(),
         )?;
@@ -1905,6 +1906,7 @@ pub(crate) fn check_importer_satisfies(
     lockfile: &Lockfile,
     manifest: &PackageManifest,
     importer_id: &str,
+    auto_install_peers: bool,
     ignored_optional_matcher: &pacquet_config::matcher::Matcher,
     parsed_overrides: Option<&[pacquet_config_parse_overrides::VersionOverride]>,
 ) -> Result<(), FreshnessCheckError> {
@@ -1946,8 +1948,13 @@ pub(crate) fn check_importer_satisfies(
         ignored_optional_dependency_names(manifest_for_freshness, ignored_optional_matcher);
     let is_ignored_optional: &dyn Fn(&str) -> bool = &|name: &str| ignored_set.contains(name);
 
-    satisfies_package_manifest(importer, manifest_for_freshness, is_ignored_optional)
-        .map_err(FreshnessCheckError::Stale)
+    satisfies_package_manifest(
+        importer,
+        manifest_for_freshness,
+        auto_install_peers,
+        is_ignored_optional,
+    )
+    .map_err(FreshnessCheckError::Stale)
 }
 
 fn ignored_optional_dependency_names(

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -607,6 +607,7 @@ fn modified_manifests_match_lockfile(
             wanted,
             project.manifest,
             &importer_id,
+            config.auto_install_peers,
             &ignored_optional_matcher,
             parsed_overrides.as_deref(),
         ) {

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -37,6 +37,17 @@ Multi-importer parity coverage:
 
 Pacquet also keeps the issue-specific add-and-recover flow in `changed_workspace_importer_invalidates_lockfile`: adding a `workspace:*` dependency to a member makes a frozen install fail and a normal install refresh and link it.
 
+### `satisfiesPackageManifest` unit-level coverage
+
+`crates/lockfile/src/freshness.rs::satisfies_package_manifest` ports `lockfile/verification/src/satisfiesPackageManifest.ts`; unit tests live in `crates/lockfile/src/freshness/tests.rs`.
+
+- [x] `TypeScript repo: lockfile/verification/test/satisfiesPackageManifest.ts:255` / `:278` `autoInstallPeers` — peers auto-installed into the importer's `dependencies` (pnpm's default) must not read as drift — ported as `peer_only_dependency_is_satisfied_when_auto_install_peers`, `peers_also_declared_as_regular_deps_still_satisfy`, plus `frozen_install_accepts_auto_installed_workspace_peer` in `crates/cli/tests/workspace_install.rs`. Pacquet-only `peer_only_dependency_is_stale_without_auto_install_peers` pins the `auto_install_peers = false` branch.
+- [x] `TypeScript repo: lockfile/verification/test/satisfiesPackageManifest.ts:55` optional-only manifest vs prod-only lockfile → stale — ported as `manifest_optional_only_but_lockfile_records_prod_is_stale`.
+- [x] dev-only / optional-only field matches — `dev_only_dependency_match_satisfies`, `optional_only_dependency_match_satisfies`.
+- [ ] `TypeScript repo: lockfile/verification/test/satisfiesPackageManifest.ts:362` `excludeLinksFromLockfile: true` drops `link:`-protocol deps from both the flat diff and the per-field check — NOT IMPLEMENTED in the freshness check. Gated behind the non-default `exclude-links-from-lockfile: true`; `workspace:` deps are recorded regardless, so default installs and the pnpm monorepo are unaffected. The matching default-opts `link:`/`file:` tolerance (`countOfNonLinkedDeps`, `satisfiesPackageManifest.ts:191`) is likewise unmodeled. Follow-up.
+
+The v6/v7-shape scenarios (a top-level `importer.specifiers` map diverging from the dependency fields, `satisfiesPackageManifest.ts:103` / `:169`) are not representable in pacquet's inline-specifier v9 model; the equivalent v9 drift is covered by `manifest_adds_dep_returns_specifier_diff` / `manifest_drops_dep_returns_specifier_diff`. The `no importer` case (`:203`) is enforced at the caller (`check_importer_satisfies`) and covered by `missing_workspace_importer_is_not_accepted_by_frozen_install`.
+
 ## `.modules.yaml` Write And Verify
 
 Primary tests:

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -272,7 +272,9 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
     });
     std::fs::write(&manifest_path, serde_json::to_vec(&manifest_json).ok()?).ok()?;
     let manifest = PackageManifest::from_path(manifest_path).ok()?;
-    satisfies_package_manifest(importer, &manifest, &|_: &str| false).ok()?;
+    // The synthesized manifest carries no `peerDependencies`, so the
+    // auto-install-peers fold is a no-op; pass pnpm's default anyway.
+    satisfies_package_manifest(importer, &manifest, true, &|_: &str| false).ok()?;
 
     Some(lockfile.clone())
 }


### PR DESCRIPTION
## Summary

Fixes a false-positive `ERR_PNPM_OUTDATED_LOCKFILE` in the Rust pnpm (pacquet) `--frozen-lockfile` check, introduced in `12.0.0-alpha.14`.

pacquet's per-importer freshness check compared each lockfile importer's dependencies against only the manifest's `dependencies ∪ devDependencies ∪ optionalDependencies`. With `auto-install-peers` enabled (pnpm's default), pnpm materializes every missing non-optional peer dependency into the importer's `dependencies` in the lockfile. A workspace member that declares a dependency only under `peerDependencies` therefore had that materialized lockfile entry misread as a *removed* dependency, aborting the install.

This was latent until pnpm/pnpm#13081 (shipped in `12.0.0-alpha.14`) extended the check from the root importer to **every** workspace importer. It then broke the automated lockfile-bump PR pnpm/pnpm#13070, whose Rust CI runs `just install` (a `--frozen-lockfile` install) with the pinned pacquet binary:

```
ERR_PNPM_OUTDATED_LOCKFILE
* 2 dependencies were removed: @pnpm/logger@catalog:, @pnpm/worker@workspace:^
```

Importers such as `pnpm11/building/after-install` and `pnpm11/installing/env-installer` declare `@pnpm/logger` and `@pnpm/worker` only as peers. Verified against both stacks: `12.0.0-alpha.13` accepts the lockfile, `12.0.0-alpha.14` rejects it, and a binary built from this branch accepts it again.

The TypeScript CLI's `satisfiesPackageManifest` already folds peers into the comparison when `autoInstallPeers` is set, so this only brings pacquet back to parity — it is a Rust-only fix.

## Squash Commit Body

```text
pacquet's per-importer frozen-lockfile freshness check compared each
lockfile importer's dependencies against only the manifest's
dependencies/devDependencies/optionalDependencies. With auto-install-peers
enabled (pnpm's default), pnpm materializes every missing non-optional
peer dependency into the importer's `dependencies` in the lockfile, so a
workspace member that declares a dependency only under `peerDependencies`
had that materialized entry misread as a removed dependency, aborting a
`--frozen-lockfile` install with ERR_PNPM_OUTDATED_LOCKFILE.

This surfaced once pnpm/pnpm#13081 extended the check from the root
importer to every workspace importer (v12.0.0-alpha.14): importers such
as `pnpm11/building/after-install` declare `@pnpm/logger` and
`@pnpm/worker` only as peers.

`satisfies_package_manifest` now takes `auto_install_peers` and folds the
peer-only dependencies into both the flat-record diff and the per-field
`dependencies` comparison, mirroring the TypeScript
`satisfiesPackageManifest`. The TypeScript CLI already handled this, so
the fix is pacquet-only.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Rust-only: the TypeScript CLI's satisfiesPackageManifest already handles autoInstallPeers; this restores pacquet parity. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <!-- 6 freshness unit tests (autoInstallPeers + dev/optional field scenarios) ported from satisfiesPackageManifest.ts + a workspace_install integration test. -->

## Follow-up (out of scope)

One sibling parity gap remains, gated behind the **non-default** `exclude-links-from-lockfile: true`: the freshness check does not strip `link:`-protocol deps the way the TypeScript `satisfiesPackageManifest` does. It cannot affect default installs or this monorepo (`workspace:` deps are recorded regardless), and is tracked in `plans/TEST_PORTING.md`.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm install --frozen-lockfile` failing in workspaces where unmet peer dependencies are auto-installed.
  * Frozen lockfile checks now recognize auto-installed peers as valid/up-to-date importer state and keep repeat/optimistic installs consistent.
* **Tests**
  * Added a regression test for frozen installs in a workspace with auto-installed peer dependencies.
* **Documentation**
  * Updated test-porting notes to cover the refreshed lockfile freshness scenarios involving auto-installed peers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->