### PR TITLE
fix(peers): resolve optional peers implied by peerDependenciesMeta like declared ones

### DIFF
--- a/.changeset/meta-only-optional-peer-hoist.md
+++ b/.changeset/meta-only-optional-peer-hoist.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-resolver": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Optional peer dependencies declared only via `peerDependenciesMeta` (for example `debug`'s `supports-color` peer) are now resolved from a satisfying version already present in the dependency graph, the same way explicitly declared optional peer dependencies are. Previously such peers were only resolved this way when the package's metadata was read back from the lockfile, so an unrelated dependency change could rewrite peer resolutions across the whole lockfile.

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -268,7 +268,6 @@ fn peer_issues_to_json_derives_conflicts_and_intersections() {
         wanted_range: range.to_string(),
         raw_range: range.to_string(),
         optional,
-        meta_only: false,
         parents: vec![parent.clone()],
     };
     let mut issues = PeerDependencyIssues::default();

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -773,10 +773,8 @@ fn peer_suffixed_dep_path_splits_into_distinct_snapshot_and_package_keys() {
     let mut react_dom_children = BTreeMap::new();
     react_dom_children.insert("react".to_string(), DepPath::from("react@17.0.2".to_string()));
     let mut react_dom_peers = BTreeMap::new();
-    react_dom_peers.insert(
-        "react".to_string(),
-        PeerDep { version: "17.0.2".to_string(), optional: false, meta_only: false },
-    );
+    react_dom_peers
+        .insert("react".to_string(), PeerDep { version: "17.0.2".to_string(), optional: false });
     let react_dom_dep_path = DepPath::from("react-dom@17.0.2(react@17.0.2)".to_string());
     let react_dom = DependenciesGraphNode {
         dep_path: react_dom_dep_path.clone(),

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -1841,7 +1841,7 @@ async fn auto_install_peers_does_not_cascade_optional_peers() {
 /// Scenario: a warning is not reported when an optional peer
 /// dependency (specified by meta field only) cannot be resolved.
 #[tokio::test]
-async fn auto_install_peers_skips_meta_only_optional_peers() {
+async fn meta_only_optional_peers_absent_from_the_graph_are_not_installed() {
     let mock_instance = TestRegistry::start();
 
     let dir = tempdir().unwrap();
@@ -1906,9 +1906,10 @@ async fn auto_install_peers_skips_meta_only_optional_peers() {
         .collect();
 
     // peer-a is declared in `peerDependencies` so it stays required and
-    // gets auto-installed; peer-b and peer-c are declared *only* in
-    // `peerDependenciesMeta` with `optional: true` and stay out of the
-    // tree.
+    // gets auto-installed; peer-b and peer-c are implied optional peers
+    // (declared *only* in `peerDependenciesMeta`) — an optional peer is
+    // never fetched, only deduped onto a version already in the graph,
+    // and no version of either is in this graph.
     assert!(
         virtual_store_slots.iter().any(|name| name.starts_with("@pnpm.e2e+peer-a@")),
         "required peer `peer-a` must be auto-installed; \

--- a/pnpm/crates/resolving-deps-resolver/src/dependencies_graph.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dependencies_graph.rs
@@ -83,11 +83,6 @@ pub struct MissingPeer {
     /// source.
     pub raw_range: String,
     pub optional: bool,
-    /// `true` when the requiring package declares the peer only via
-    /// `peerDependenciesMeta`. The importer hoist loop uses it to keep
-    /// meta-only peers out of the optional-peer hoist, since the hoist
-    /// is fed from `peerDependencies` entries only.
-    pub meta_only: bool,
     /// Chain of `(name, version)` from the root importer down to the
     /// parent that declared the peer requirement.
     pub parents: Vec<ParentPackageRef>,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -2911,8 +2911,8 @@ fn render_parent(result: &pacquet_resolving_resolver_base::ResolveResult) -> Str
 /// peer-shadowed names from `dependencies`, so those peers survive
 /// here. A `peerDependenciesMeta` entry without a matching
 /// `peerDependencies` entry only counts when `optional: true` — it is
-/// treated as an optional `"*"` peer, and non-optional meta-only
-/// entries are ignored.
+/// treated as an optional `"*"` peer exactly like an explicitly
+/// declared one, and non-optional meta-only entries are ignored.
 fn extract_peer_dependencies(
     result: &pacquet_resolving_resolver_base::ResolveResult,
 ) -> BTreeMap<String, PeerDep> {
@@ -2941,7 +2941,7 @@ fn extract_peer_dependencies(
             if let Some(range_str) = range.as_str() {
                 peers.insert(
                     name.clone(),
-                    PeerDep { version: range_str.to_string(), optional: false, meta_only: false },
+                    PeerDep { version: range_str.to_string(), optional: false },
                 );
             }
         }
@@ -2954,9 +2954,10 @@ fn extract_peer_dependencies(
             {
                 continue;
             }
-            peers.entry(name.clone()).and_modify(|entry| entry.optional = true).or_insert_with(
-                || PeerDep { version: "*".to_string(), optional: true, meta_only: true },
-            );
+            peers
+                .entry(name.clone())
+                .and_modify(|entry| entry.optional = true)
+                .or_insert_with(|| PeerDep { version: "*".to_string(), optional: true });
         }
     }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -620,9 +620,6 @@ fn partition_missing_peers(
             let mut seen: BTreeSet<String> = BTreeSet::new();
             let mut ordered: Vec<String> = Vec::new();
             for entry in entries {
-                if entry.meta_only {
-                    continue;
-                }
                 if seen.insert(entry.wanted_range.clone()) {
                     ordered.push(entry.wanted_range.clone());
                 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -742,13 +742,16 @@ async fn optional_peer_with_real_entry_is_hoisted_from_resolved_tree() {
 
 /// A peer declared only via `peerDependenciesMeta` on a direct package
 /// (no `peerDependencies` entry — the `debug` / `supports-color`
-/// shape) is NOT hoisted even when a provider is resolved in the tree:
-/// the direct-package missing-peer scan feeds the hoist from
-/// `peerDependencies` entries only (verified against pnpm 11.6.0 —
-/// `debug` + `concurrently` leaves `debug@4.4.3` bare). For
-/// <https://github.com/pnpm/pnpm/issues/12266>.
+/// shape) is an implied optional `"*"` peer and joins the optional-peer
+/// hoist exactly like an explicitly declared optional peer: when a
+/// satisfying version is already in the graph, it is deduped onto that
+/// version and resolved for the requiring package. This keeps the
+/// outcome identical whether the peer came from the registry manifest
+/// or from a lockfile snapshot (which materializes implied peers into
+/// `peerDependencies`), so resolution does not drift across lockfile
+/// round-trips.
 #[tokio::test]
-async fn meta_only_optional_peer_is_not_hoisted() {
+async fn meta_only_optional_peer_is_hoisted_like_a_declared_optional_peer() {
     let mut table = HashMap::new();
     table.insert(
         ("needs-opt".to_string(), "1.0.0".to_string()),
@@ -790,10 +793,10 @@ async fn meta_only_optional_peer_is_not_hoisted() {
 
     let direct: Vec<&str> =
         result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
-    assert!(!direct.contains(&"opt"), "meta-only peer `opt` must not be hoisted: {direct:?}");
+    assert!(direct.contains(&"opt"), "meta-only peer `opt` must be hoisted: {direct:?}");
     assert_eq!(
         result.peers_result.direct_dependencies_by_alias.get("needs-opt"),
-        Some(&DepPath::from("needs-opt@1.0.0".to_string())),
+        Some(&DepPath::from("needs-opt@1.0.0(opt@1.0.0)".to_string())),
     );
 }
 
@@ -857,7 +860,7 @@ async fn real_peer_provider_from_direct_child_is_appended_as_hidden_direct_dep()
 }
 
 #[tokio::test]
-async fn meta_only_peer_provider_from_direct_child_is_not_appended_as_hidden_direct_dep() {
+async fn meta_only_peer_provider_from_direct_child_is_appended_as_hidden_direct_dep() {
     let mut table = HashMap::new();
     table.insert(
         ("host".to_string(), "1.0.0".to_string()),
@@ -901,18 +904,17 @@ async fn meta_only_peer_provider_from_direct_child_is_not_appended_as_hidden_dir
         .await
         .unwrap();
 
-    let direct: Vec<&str> =
-        result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
-    assert!(
-        !direct.contains(&"provider"),
-        "meta-only peers must not feed auto-installed hidden direct deps: {direct:?}",
+    assert_eq!(
+        result.peers_result.direct_dependencies_by_alias.get("provider"),
+        Some(&DepPath::from("provider@1.0.0".to_string())),
+        "a resolved meta-only peer feeds auto-installed hidden direct deps like a declared one",
     );
     assert!(
         result
             .peers_result
             .graph
             .contains_key(&DepPath::from("peer-user@1.0.0(provider@1.0.0)".to_string())),
-        "meta-only peers still resolve in the final peer graph when provider is in scope",
+        "meta-only peers resolve in the final peer graph when provider is in scope",
     );
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -611,8 +611,6 @@ struct MissingPeerInfo {
     range: String,
     #[allow(dead_code, reason = "future peersCache validation")]
     optional: bool,
-    /// See [`crate::dependencies_graph::MissingPeer::meta_only`].
-    meta_only: bool,
 }
 
 /// Output of [`Walker::resolve_node`] — the per-node result the parent
@@ -978,7 +976,6 @@ impl Walker<'_> {
                         wanted_range: get_peer_version_range(&info.range),
                         raw_range: info.range.clone(),
                         optional: info.optional,
-                        meta_only: info.meta_only,
                         parents: parents_from_chain(parent_chain_names, &pkg_name),
                     });
                 }
@@ -1054,9 +1051,7 @@ impl Walker<'_> {
                 &mut own_resolved_peers,
                 &mut own_missing_peers,
             );
-            if !peer_dep.meta_only
-                && let Some(peer_node_id) = own_resolved_peers.get(peer_name)
-            {
+            if let Some(peer_node_id) = own_resolved_peers.get(peer_name) {
                 auto_install_resolved_peers.insert(peer_name.clone(), peer_node_id.clone());
             }
         }
@@ -1275,13 +1270,12 @@ impl Walker<'_> {
         // named-registry/`npm:` bodies are extracted and opaque specs become `*`.
         let range_for_satisfies = get_peer_version_range(raw_range);
         let optional = peer_dep.optional;
-        let meta_only = peer_dep.meta_only;
 
         match parent_refs.get(peer_name) {
             None => {
                 missing.insert(
                     peer_name.to_string(),
-                    MissingPeerInfo { range: range_for_match.to_string(), optional, meta_only },
+                    MissingPeerInfo { range: range_for_match.to_string(), optional },
                 );
                 if !self.missing_issue_suppressed(ancestor_pkg_ids, peer_name) {
                     self.issues.missing.entry(peer_name.to_string()).or_default().push(
@@ -1289,7 +1283,6 @@ impl Walker<'_> {
                             wanted_range: range_for_satisfies,
                             raw_range: range_for_match.to_string(),
                             optional,
-                            meta_only,
                             parents: parents_from_chain(chain, pkg_name),
                         },
                     );

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1681,10 +1681,7 @@ fn package_with_peer_dependencies(
     let peer_dependencies = peer_dependencies
         .iter()
         .map(|(name, version, optional)| {
-            (
-                (*name).to_string(),
-                PeerDep { version: (*version).to_string(), optional: *optional, meta_only: false },
-            )
+            ((*name).to_string(), PeerDep { version: (*version).to_string(), optional: *optional })
         })
         .collect();
     ResolvedPackage {

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -141,12 +141,6 @@ pub struct PeerDep {
     /// is set — a missing peer with `optional` true is recorded as an
     /// issue but does not block resolution.
     pub optional: bool,
-    /// `true` when the peer exists only via `peerDependenciesMeta`
-    /// (no `peerDependencies` entry). The resolution-stage missing-peer
-    /// scan reads `peerDependencies` only, so a meta-only peer never
-    /// feeds the optional-peer hoist — it still resolves in the peer
-    /// pass when a provider is genuinely in scope.
-    pub meta_only: bool,
 }
 
 /// One per-occurrence node in the dependencies tree.

--- a/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
+++ b/pnpm11/installing/deps-installer/test/install/autoInstallPeers.ts
@@ -38,6 +38,28 @@ test('auto install non-optional peer dependencies', async () => {
   project.hasNot('@pnpm.e2e/peer-a')
 })
 
+test('resolve an optional peer dependency declared only via peerDependenciesMeta from a version present in the dependency graph', async () => {
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  const project = prepareEmpty()
+  await addDependenciesToPackage({}, [
+    '@pnpm.e2e/abc-optional-peers-meta-only@1.0.0',
+    '@pnpm.e2e/has-peer-c-in-deps@1.0.0',
+  ], testDefaults({ autoInstallPeers: true }))
+  const lockfile = project.readLockfile()
+  // peer-c is an implied optional peer (declared only in peerDependenciesMeta),
+  // so it is resolved from the version that has-peer-c-in-deps brings into the
+  // graph. peer-b is also an implied optional peer, but no version of it is in
+  // the graph, so it stays unresolved. peer-a is a required peer and gets
+  // auto-installed.
+  expect(Object.keys(lockfile.snapshots).sort()).toStrictEqual([
+    '@pnpm.e2e/abc-optional-peers-meta-only@1.0.0(@pnpm.e2e/peer-a@1.0.0)(@pnpm.e2e/peer-c@2.0.0)',
+    '@pnpm.e2e/has-peer-c-in-deps@1.0.0',
+    '@pnpm.e2e/peer-a@1.0.0',
+    '@pnpm.e2e/peer-c@2.0.0',
+  ])
+  project.hasNot('@pnpm.e2e/peer-c')
+})
+
 test('auto install the common peer dependency', async () => {
   await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.1', distTag: 'latest' })
   const project = prepareEmpty()

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -2201,7 +2201,7 @@ async function resolveDependency (
       childrenResolutionId: childrenResolution.id,
       pkgId: pkgResponse.body.id,
       rootDir,
-      missingPeers: getMissingPeers(pkg),
+      missingPeers: getMissingPeers(resolvedPkg.peerDependencies),
       optional: resolvedPkg.optional,
       version: resolvedPkg.version,
       saveCatalogName: wantedDependency.saveCatalogName,
@@ -2269,12 +2269,16 @@ export function getManifestFromResponse (
   }
 }
 
-function getMissingPeers (pkg: PackageManifest): MissingPeers {
+// The materialized peer set is used (not the manifest's raw peerDependencies)
+// so that peers implied by a peerDependenciesMeta-only declaration participate
+// in missing-peer collection — and therefore in optional-peer hoisting — the
+// same way explicitly declared peers do.
+function getMissingPeers (peerDependencies: PeerDependencies): MissingPeers {
   const missingPeers = {} as MissingPeers
-  for (const [peerName, peerVersion] of Object.entries(pkg.peerDependencies ?? {})) {
+  for (const [peerName, peerDep] of Object.entries(peerDependencies)) {
     missingPeers[peerName] = {
-      range: peerVersion,
-      optional: pkg.peerDependenciesMeta?.[peerName]?.optional === true,
+      range: peerDep.version,
+      optional: peerDep.optional === true,
     }
   }
   return missingPeers


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Bumping a single catalog entry in this repo rewrote ~1000 unrelated lockfile lines, adding `(supports-color@10.2.2)` peer suffixes across the whole graph. The trigger was harmless — any change that forces a peer-resolution recompute exposes the real bug: the two stacks (and pacquet's own fresh vs. incremental paths) disagree on *implied* optional peers, i.e. peers declared only via `peerDependenciesMeta` with no `peerDependencies` entry — the `debug` → `supports-color` shape.

Peer resolution and the lockfile writer already materialize such peers as optional `"*"` peers, but missing-peer collection excluded them from the optional-peer hoist: the TypeScript `getMissingPeers` read the raw manifest, and pacquet carried an explicit `meta_only` gate. pacquet's lockfile-reuse path, however, synthesizes manifests from lockfile snapshots, where the implied peer is already materialized into `peerDependencies` — so after a lockfile round-trip the distinction was lost and the hoist fired, resolving `debug@4.4.3(supports-color@10.2.2)` everywhere while a fresh resolve (in either stack) left `debug@4.4.3` bare.

This PR makes both stacks treat implied optional peers exactly like explicitly declared ones: when a satisfying version is already in the dependency graph, the optional peer is resolved from it — fresh and incremental installs now produce identical lockfiles, verified byte-identical between the two stacks on a `debug` + `supports-hyperlinks` repro. This also closes the npm-compat gap where `debug` could not see a `supports-color` present in the graph under pnpm's strict layout. Expect a one-time suffix churn in existing lockfiles on the next full re-resolve; the suffixed state is now the stable one.

The `meta_only` gate originally landed for pnpm/pnpm#12266 to mirror the TypeScript stack's fresh-install behavior; this change aligns both stacks on the hoisting side instead.

Changes:

- TypeScript: `getMissingPeers` reads the materialized `ResolvedPackage.peerDependencies` instead of the raw manifest (this also stops reporting peers satisfied by the package's own dependencies, matching pacquet's `extract_peer_dependencies`).
- pacquet: the `meta_only` flag is removed entirely — the optional-hoist gate in `partition_missing_peers`, the hidden-provider gate in `resolve_peers`, and all plumbing.
- Tests: the two pacquet tests asserting the old behavior are flipped to the new contract; a new TypeScript test (`abc-optional-peers-meta-only` + `has-peer-c-in-deps`) proves an implied optional peer resolves from a graph-present version while one absent from the graph stays unresolved and is never fetched.

## Squash Commit Body

```text
An optional peer declared only via peerDependenciesMeta (no peerDependencies
entry -- the debug -> supports-color shape) is an implied "*" peer. Peer
resolution and the lockfile writer already materialize it, but missing-peer
collection read the raw manifest in the TypeScript stack, and a meta_only flag
kept such peers out of the optional-peer hoist in pacquet, so on a fresh
resolve the implied peer was never deduped onto a version already in the
graph. pacquet's lockfile-reuse path, however, synthesizes manifests from
lockfile snapshots, where the implied peer is already materialized into
peerDependencies -- after a lockfile round-trip the distinction was lost and
the hoist fired. The stacks disagreed, and within pacquet a fresh install and
an incremental one produced different lockfiles: one unrelated catalog change
could rewrite peer suffixes across the whole lockfile.

Treat implied optional peers exactly like explicitly declared ones in both
stacks: the TypeScript getMissingPeers now reads the materialized
ResolvedPackage.peerDependencies (which also stops reporting peers satisfied
by the package's own dependencies, matching pacquet), and pacquet drops the
meta_only flag -- the hoist gate in partition_missing_peers, the
hidden-provider gate in resolve_peers, and all plumbing. Fresh and incremental
installs now produce identical lockfiles in both stacks, and a graph that
contains a satisfying version of the implied peer resolves it everywhere,
e.g. debug@4.4.3 gets its supports-color peer.

The meta_only gate originally landed for pnpm/pnpm#12266 to mirror the
TypeScript stack's fresh-install behavior; this change aligns both stacks on
the hoisting side instead, which also removes the npm-compat gap where debug
could not see a supports-color present in the graph.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786959251&installation_id=145934176&pr_number=13120&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13120&signature=bf2cc1f8f0627ef400a739dbd8364b102e3aa551e9a72c7838dbfb3ea3dfb903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resolution of optional peer dependencies declared only through metadata.
  - Existing compatible versions are now reused consistently during peer resolution and hoisting.
  - Prevented unnecessary top-level installation of optional peers while preserving required peer auto-installation.
- **Tests**
  - Added and updated coverage for meta-only optional peer resolution, hoisting, auto-installation, and lockfile output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->