### PR TITLE
fix(pacquet): send If-Modified-Since as an HTTP-date instead of ISO-8601

### DIFF
--- a/.changeset/if-modified-since-http-date.md
+++ b/.changeset/if-modified-since-http-date.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Conditional metadata requests send `If-Modified-Since` as an HTTP-date instead of the mirror's raw ISO-8601 `modified` value, so registries can answer `304 Not Modified` instead of re-serving the full packument [#13104](https://github.com/pnpm/pnpm/issues/13104).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,6 +4934,7 @@ dependencies = [
  "dashmap",
  "derive_more",
  "futures-util",
+ "httpdate",
  "indexmap 2.14.0",
  "miette 7.6.0",
  "mockito",

--- a/pnpm/crates/resolving-npm-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-npm-resolver/Cargo.toml
@@ -24,6 +24,7 @@ pacquet-workspace-spec                    = { workspace = true }
 chrono      = { workspace = true }
 dashmap     = { workspace = true }
 derive_more = { workspace = true }
+httpdate    = { workspace = true }
 indexmap    = { workspace = true }
 miette      = { workspace = true }
 node-semver = { workspace = true }

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -118,8 +118,11 @@ pub(crate) async fn send_metadata_request<'a>(
     opts: &MetadataRequestOptions<'a>,
 ) -> Result<(ThrottledClientGuard<'a>, Response), FetchMetadataError> {
     let etag = if opts.bypass_cache { None } else { opts.etag.filter(|value| !value.is_empty()) };
-    let modified =
-        if opts.bypass_cache { None } else { opts.modified.filter(|value| !value.is_empty()) };
+    let modified = if opts.bypass_cache {
+        None
+    } else {
+        opts.modified.filter(|value| !value.is_empty()).and_then(to_http_date)
+    };
     let has_validator = etag.is_some() || modified.is_some();
     let build_request = |client: &reqwest::Client, bypass_cache: bool| {
         let mut request = client.get(opts.url).header(header::ACCEPT, opts.accept);
@@ -129,7 +132,7 @@ pub(crate) async fn send_metadata_request<'a>(
         if let Some(etag) = etag {
             request = request.header(header::IF_NONE_MATCH, etag);
         }
-        if let Some(modified) = modified {
+        if let Some(modified) = modified.as_deref() {
             request = request.header(header::IF_MODIFIED_SINCE, modified);
         }
         if bypass_cache {
@@ -174,6 +177,19 @@ pub(crate) async fn send_metadata_request<'a>(
         });
     }
     Ok((client, response))
+}
+
+/// Convert a stored `modified` value — the packument's ISO-8601
+/// `time.modified` — to the HTTP-date form `If-Modified-Since` requires
+/// (RFC 9110 §8.8.3), the same conversion the TypeScript CLI applies with
+/// `toUTCString()`. A value already in HTTP-date form is kept. `None` when
+/// the value parses as neither, so it is dropped instead of sent — a
+/// recipient must ignore a malformed `If-Modified-Since` anyway.
+fn to_http_date(value: &str) -> Option<String> {
+    if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(value) {
+        return Some(httpdate::fmt_http_date(datetime.into()));
+    }
+    httpdate::parse_http_date(value).ok().map(httpdate::fmt_http_date)
 }
 
 /// Fetch the registry metadata document for `pkg_name`. The

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata/tests.rs
@@ -262,6 +262,113 @@ async fn fetch_full_metadata_retries_transient_status() {
     second.assert_async().await;
 }
 
+/// The mirror's `modified` value is the packument's ISO-8601
+/// `time.modified`, but `If-Modified-Since` must carry an HTTP-date
+/// (RFC 9110 §8.8.3) — the same conversion the TypeScript CLI does with
+/// `toUTCString()`, keeping the two stacks byte-identical on the wire.
+#[tokio::test]
+async fn fetch_full_metadata_sends_if_modified_since_as_http_date() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/acme")
+        .match_header("if-modified-since", "Wed, 15 Jan 2025 12:00:00 GMT")
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        full_metadata: true,
+        etag: None,
+        modified: Some("2025-01-15T12:00:00.000Z"),
+        retry_opts: no_retry_opts(),
+    };
+
+    let outcome = fetch_full_metadata("acme", &opts).await.expect("server returns 304");
+    assert!(
+        matches!(outcome, FetchFullMetadataOutcome::NotModified),
+        "expected NotModified outcome, got: {outcome:?}",
+    );
+    mock.assert_async().await;
+}
+
+/// A `modified` value that is neither ISO-8601 nor an HTTP-date cannot be
+/// turned into a valid header, so it is dropped rather than sent — and it
+/// must not count as a validator, or an unsolicited 304 would be
+/// misattributed to it instead of triggering the no-cache retry.
+#[tokio::test]
+async fn fetch_full_metadata_drops_unparsable_modified_value() {
+    let mut server = mockito::Server::new_async().await;
+    let body = r#"{
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": "https://registry/acme-1.0.0.tgz"
+                }
+            }
+        }
+    }"#;
+    let mock = server
+        .mock("GET", "/acme")
+        .match_header("if-modified-since", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let registry = format!("{}/", server.url());
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let opts = FetchFullMetadataOptions {
+        registry: &registry,
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        full_metadata: true,
+        etag: None,
+        modified: Some("not-a-date"),
+        retry_opts: no_retry_opts(),
+    };
+
+    let pkg =
+        expect_modified(fetch_full_metadata("acme", &opts).await.expect("server returns 200"));
+    assert_eq!(pkg.name, "acme");
+    mock.assert_async().await;
+}
+
+#[test]
+fn to_http_date_converts_iso_8601() {
+    assert_eq!(
+        super::to_http_date("2025-01-15T12:00:00.000Z").as_deref(),
+        Some("Wed, 15 Jan 2025 12:00:00 GMT"),
+    );
+}
+
+#[test]
+fn to_http_date_keeps_http_dates() {
+    assert_eq!(
+        super::to_http_date("Wed, 15 Jan 2025 12:00:00 GMT").as_deref(),
+        Some("Wed, 15 Jan 2025 12:00:00 GMT"),
+    );
+}
+
+#[test]
+fn to_http_date_rejects_unparsable_values() {
+    assert_eq!(super::to_http_date("not-a-date"), None);
+}
+
 /// A `Content-Encoding: gzip` header over a body that isn't gzip makes
 /// reqwest fail while *decoding the response body* — the same class of
 /// failure as a connection reset mid-transfer, surfacing as reqwest's

--- a/pnpm11/resolving/npm-resolver/test/ifModifiedSince.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/ifModifiedSince.test.ts
@@ -100,6 +100,44 @@ test('use local cache when registry returns 304 Not Modified', async () => {
   expect(resolveResult!.id).toBe('is-positive@3.1.0')
 })
 
+test('if-modified-since is sent as an HTTP-date derived from the stored ISO-8601 modified value', async () => {
+  const cacheDir = temporaryDirectory()
+  const metaDir = path.join(cacheDir, `${ABBREVIATED_META_DIR}/registry.npmjs.org`)
+  fs.mkdirSync(metaDir, { recursive: true })
+  // The mirror stores the packument's `time.modified`, which is ISO-8601. The
+  // wire header must be the HTTP-date form (RFC 9110 §8.8.3) — pinned here so
+  // the TypeScript CLI and pacquet stay byte-identical on the wire.
+  const headers = JSON.stringify({ modified: '2025-01-15T12:00:00.000Z' })
+  fs.writeFileSync(
+    path.join(metaDir, 'is-positive.jsonl'),
+    `${headers}\n${JSON.stringify(isPositiveMeta)}`,
+    'utf8'
+  )
+
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: {
+        'if-modified-since': 'Wed, 15 Jan 2025 12:00:00 GMT',
+      },
+    })
+    .reply(304, '')
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '^3.0.0' },
+    {}
+  )
+
+  expect(resolveResult!.resolvedVia).toBe('npm-registry')
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
+})
+
 test('a 304 Not Modified renews the metadata file mtime so the publishedBy freshness shortcut can fire again', async () => {
   const cacheDir = temporaryDirectory()
   const metaDir = path.join(cacheDir, `${ABBREVIATED_META_DIR}/registry.npmjs.org`)


### PR DESCRIPTION
## Summary

pacquet sent the stored ISO-8601 timestamp verbatim in the `If-Modified-Since` header, while the TypeScript CLI converts it to an HTTP-date before sending — registries that parse the header strictly never returned 304 to pacquet. Implements the fix exactly as specified in the issue: parse the stored value, format as HTTP-date, pass through values already in HTTP-date form, and drop unparseable values before they count toward `has_validator`. The TypeScript side was already correct; this PR pins its wire format with a test as the issue requested.

Closes pnpm/pnpm#13104

## Squash Commit Body

```text
The metadata cache stores the last-modified value as ISO-8601. The
TypeScript CLI converts it to an HTTP-date before sending
If-Modified-Since; pacquet sent the stored form verbatim, so strict
registries never matched and conditional requests always missed.

Add to_http_date() in fetch_full_metadata (chrono RFC3339 ->
httpdate::fmt_http_date, HTTP-date passthrough, unparseable values
dropped before has_validator), apply it in send_metadata_request, and
pin the TypeScript CLI's wire format with a counterpart test.

Closes pnpm/pnpm#13104
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port — Rust fix + tests; TS was already correct and now has a wire-format pinning test (added per the issue's request).
- [x] Added a changeset (`pacquet: patch` only, per the Rust-only changeset rule).
- [x] Added or updated tests — Rust crate 296+3 passing incl. mockito 304 header-match + drop tests; TS 12/12; clippy/fmt clean.
- [ ] Updated the documentation if needed — n/a, wire-format correctness fix.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786960292&installation_id=145934176&pr_number=13121&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13121&signature=157ee871cbd650610a8f416fd70c4fc062495f6b9ccfc47880fe013018201e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conditional package metadata requests now send `If-Modified-Since` in the correct HTTP-date format.
  * Registries can return `304 Not Modified`, avoiding unnecessary full metadata downloads.
  * Invalid modification timestamps are safely omitted instead of being sent as malformed headers.
  * Cached package resolution continues to work correctly when metadata is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->