### PR TITLE
fix(resolving-deps-resolver): keep synthesized reuse results out of the wanted-dep cache

### DIFF
--- a/.changeset/reuse-denied-edge-empty-snapshot.md
+++ b/.changeset/reuse-denied-edge-empty-snapshot.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed a lockfile corruption during non-frozen re-installs: when one workspace project reused a package's resolution from the lockfile and another project's edge to the same package was denied reuse (for example because it also depends on a direct dependency whose specifier changed), the denied edge could read the reused, dependency-less resolution from the shared wanted-dependency cache and record the package as a leaf. Its lockfile snapshot became empty (`{}`), its peer suffix was dropped, and none of its dependencies were linked, which later broke installs and builds consuming that lockfile [#13070](https://github.com/pnpm/pnpm/pull/13070).

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -151,6 +151,126 @@ fn a_reused_tree_is_structurally_identical_to_a_fresh_resolve() {
     drop((reused, fresh));
 }
 
+/// An edge denied subtree reuse re-resolves from the registry instead of
+/// reading another edge's reused resolution out of the wanted-dep cache.
+///
+/// The synthesized `ResolveResult` a reused node is built from carries a
+/// manifest without `dependencies` (a reused node's children come from
+/// the snapshot graph), so it must never satisfy a fresh-resolve cache
+/// lookup: a fresh edge walks children from the manifest, and the
+/// dependency-less manifest would make it record the package as a leaf.
+/// When that leaf occurrence sits at a shallower depth than the healthy
+/// reused occurrence it wins children ownership, so the package's
+/// snapshot collapses to `{}`, its peer suffix is dropped, and its
+/// dependents re-point at the bare instance
+/// (`'@yarnpkg/shell@4.0.0': {}` in the original report).
+///
+/// Scenario, driven by the `@pnpm.e2e/reuse-chain-*` fixtures
+/// (`grand → parent → target`, where `target` deps `@pnpm.e2e/abc` +
+/// `@pnpm.e2e/dep-of-pkg-with-1-dep`):
+///
+/// * `pkg-a` deps `grand`, so its unchanged walk reuses `target` at
+///   depth 2 and caches the synthesized resolution under the exact-pin
+///   wanted key.
+/// * `pkg-b` deps `parent` plus `dep-of-pkg-with-1-dep` directly. The
+///   test bumps that direct dep; `target`'s snapshot also depends on
+///   it, so pkg-b's transitive edge to `target` (depth 1) is denied
+///   reuse by the changed-direct-dep gate and resolves fresh — with
+///   the same wanted key pkg-a already cached.
+///
+/// Importers resolve in order, so pkg-a's cache entry exists when
+/// pkg-b's denied edge looks up; the depth-1 occurrence out-ranks the
+/// depth-2 one for children ownership, making the corruption (before
+/// the fix) deterministic rather than a race.
+///
+/// `target`'s dep `@pnpm.e2e/abc` wants peers nothing in the subtree
+/// provides, so auto-install-peers suffixes `target` — the corrupted
+/// instance is then visible as a distinct bare-key `{}` snapshot rather
+/// than colliding with the healthy suffixed one.
+#[test]
+fn an_edge_denied_reuse_keeps_the_subtree_instead_of_reading_the_synthesized_reuse_result() {
+    let fixture = CommandTempCwd::init().add_mocked_registry();
+    let workspace = &fixture.workspace;
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'pkg-a'\n  - 'pkg-b'\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    fs::create_dir(workspace.join("pkg-a")).expect("mkdir pkg-a");
+    fs::write(
+        workspace.join("pkg-a/package.json"),
+        serde_json::json!({
+            "name": "pkg-a",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/reuse-chain-grand": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write pkg-a/package.json");
+
+    let pkg_b_manifest = |dep_of_pkg_with_1_dep: &str| {
+        serde_json::json!({
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": {
+                "@pnpm.e2e/reuse-chain-parent": "1.0.0",
+                "@pnpm.e2e/dep-of-pkg-with-1-dep": dep_of_pkg_with_1_dep,
+            },
+        })
+        .to_string()
+    };
+    fs::create_dir(workspace.join("pkg-b")).expect("mkdir pkg-b");
+    let pkg_b_manifest_path = workspace.join("pkg-b/package.json");
+    fs::write(&pkg_b_manifest_path, pkg_b_manifest("100.0.0")).expect("write pkg-b/package.json");
+
+    pacquet_at(workspace).with_arg("install").assert().success();
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("'@pnpm.e2e/reuse-chain-target@1.0.0(@pnpm.e2e/peer-a@"),
+        "the fresh install must suffix the target with the auto-installed peers:\n{lockfile}",
+    );
+
+    // Bump `dep-of-pkg-with-1-dep` in pkg-b only: `target`'s snapshot
+    // depends on it, so pkg-b's edge to `target` is denied reuse while
+    // pkg-a's (already-walked) edge reused it.
+    fs::write(&pkg_b_manifest_path, pkg_b_manifest("100.1.0"))
+        .expect("bump dep-of-pkg-with-1-dep in pkg-b");
+    let future = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
+    fs::OpenOptions::new()
+        .write(true)
+        .open(&pkg_b_manifest_path)
+        .and_then(|file| file.set_times(std::fs::FileTimes::new().set_modified(future)))
+        .expect("bump manifest mtime");
+    pacquet_at(workspace).with_arg("install").assert().success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml after bump");
+    assert!(
+        !lockfile.contains("'@pnpm.e2e/reuse-chain-target@1.0.0': {}"),
+        "the denied edge must not record the target as an empty leaf:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("'@pnpm.e2e/reuse-chain-target@1.0.0(@pnpm.e2e/peer-a@"),
+        "the target must keep its peer-suffixed snapshot:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("'@pnpm.e2e/abc': 1.0.0("),
+        "the target's snapshot must keep its dependency on @pnpm.e2e/abc:\n{lockfile}",
+    );
+
+    drop(fixture);
+}
+
 /// Re-installing an unchanged manifest must leave `pnpm-lock.yaml`
 /// byte-identical: the lockfile maps are sorted at emit time, so the
 /// `importers` / `packages` / `snapshots` / dependency maps don't

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -2573,31 +2573,14 @@ where
     let ReusedNode { key, result } = reused;
     let result = Arc::new(result);
 
-    // A reused node carries the synthesized registry resolution into the
-    // same per-wanted cache bucket a fresh resolve would populate, so a
-    // later fresh-resolve of the identical wanted dep short-circuits to
-    // it without occupying an importer-independent bucket that normal
-    // workspace-mode semver specs must avoid.
-    let opts = ctx.opts_for_depth(depth);
-    let project_scope = project_relative_cache_scope(&wanted, opts);
-    let cache_key: WantedKey = (
-        wanted.alias.clone(),
-        wanted.bare_specifier.clone(),
-        wanted.optional,
-        wanted.injected,
-        opts.pick_lowest_version,
-        opts.published_by,
-        project_scope,
-        Some(key.clone()),
-        // Reused resolutions are exact pins — preference overlays
-        // can't change the pick, so the no-overlay bucket is right.
-        Vec::new(),
-        ctx.update_cache_scope(),
-        is_update_target(ctx.update_reuse_scope(), &wanted),
-    );
-    lock_recoverable(&ctx.workspace.resolved_by_wanted)
-        .entry(cache_key)
-        .or_insert_with(|| Arc::clone(&result));
+    // The synthesized result must stay out of `resolved_by_wanted`: its
+    // manifest deliberately omits `dependencies` (a reused node's
+    // children come from the snapshot graph), so if the fresh-resolve
+    // path ever read it back — e.g. an identical edge denied reuse by
+    // the changed-direct-dep gate or by `subtree_fully_reusable`'s
+    // provisional-`false` cycle guard — `extract_children` /
+    // `pkg_is_leaf` would misread the package as dependency-less and
+    // record it as a leaf, emptying its lockfile snapshot.
 
     let id = build_pkg_id_with_patch_hash(ctx, &result).await?;
 

--- a/pnpr/.fixtures/packages/@pnpm.e2e/reuse-chain-grand/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/reuse-chain-grand/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/reuse-chain-grand",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/reuse-chain-parent": "1.0.0"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/reuse-chain-parent/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/reuse-chain-parent/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/reuse-chain-parent",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/reuse-chain-target": "1.0.0"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/reuse-chain-target/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/reuse-chain-target/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@pnpm.e2e/reuse-chain-target",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/abc": "1.0.0",
+    "@pnpm.e2e/dep-of-pkg-with-1-dep": "100.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the resolver bug behind the `TS CI / Compile & Lint` failure on the pnpm@12.0.0-alpha.14 bump PR (related to pnpm/pnpm#13070, [failing run](https://github.com/pnpm/pnpm/actions/runs/29634476325/job/88054262347)).

During a non-frozen re-install, `resolve_reused_node` registered its synthesized `ResolveResult` in the workspace-shared `resolved_by_wanted` cache. That result's manifest deliberately omits `dependencies` (a reused node's children come from the snapshot graph), so when another edge with the identical wanted key was **denied** reuse — by the changed-direct-dep gate in a different importer, or by `subtree_fully_reusable`'s provisional-`false` guard racing a concurrent check — its fresh resolve read the dependency-less result back, classified the package as a leaf, and (when that occurrence won children ownership) recorded it with no children. The package's lockfile snapshot collapsed to `{}`, its peer suffix was dropped, its dependents were re-pointed at the bare instance, and none of its dependencies were linked.

On the bump PR this emptied the snapshots of `@yarnpkg/shell@4.0.0` and `normalize-package-data@3.0.3` (the alpha.14 per-importer freshness regression — since fixed by pnpm/pnpm#13117 — pushed CI's plain install onto the re-resolution path), which left `pnpm/dist` bundling unable to resolve `tslib`, `@yarnpkg/fslib`, `chalk`, and the rest of `@yarnpkg/shell`'s deps. The corruption itself predates alpha.14: it reproduces on alpha.13 by forcing a re-resolution with any manifest change.

The fix drops the cache insert — only the fresh-resolve path ever read it, and a denied edge must see the real registry manifest to walk its children. Verified end-to-end: with the fix, the forced re-resolution of the repo's own lockfile no longer produces any empty snapshot and the global-virtual-store links directory for `@yarnpkg/shell@4.0.0` contains all of its dependency links.

The regression test drives the deterministic cross-importer variant using new `@pnpm.e2e/reuse-chain-*` registry fixtures (an unchanged importer reuses the target at depth 2 and caches the synthesized result under the exact-pin wanted key; a later importer whose changed direct dep overlaps the target's snapshot is denied reuse at depth 1). The test fails on the previous code and passes with the fix.

Note: pnpm/pnpm#13070 stays red until a `next-12` release carries this fix together with pnpm/pnpm#13117, since its CI runs the released alpha.14 binary.

## Squash Commit Body

```text
During a non-frozen re-install, a node reused from the prior lockfile
registered its synthesized ResolveResult in the workspace-shared
resolved_by_wanted cache. That result's manifest deliberately omits
dependencies (a reused node's children come from the snapshot graph), so
when another edge with the identical wanted key was denied reuse - by
the changed-direct-dep gate in a different importer, or by
subtree_fully_reusable's provisional-false cycle guard racing a
concurrent check - its fresh resolve read the dependency-less result
back, classified the package as a leaf, and (when that occurrence was
shallow enough to win children ownership) recorded it with no children:
the package's lockfile snapshot collapsed to an empty map, its peer
suffix was dropped, its dependents were re-pointed at the bare instance,
and none of its dependencies were linked.

This is what broke the Compile & Lint job on the pnpm@12.0.0-alpha.14
bump PR (pnpm/pnpm#13070): the alpha.14 per-importer freshness check
regression (since fixed by pnpm/pnpm#13117) pushed CI's plain install
onto the re-resolution path, which then emptied the snapshots of
`@yarnpkg/shell@4.0.0` and `normalize-package-data@3.0.3`, leaving
`pnpm/dist` bundling unable to resolve their dependencies. The
corruption itself predates alpha.14 (reproducible on alpha.13 by
forcing a re-resolution with any manifest change).

Drop the cache insert: only the fresh-resolve path ever read it, and a
denied edge must see the real registry manifest to walk its children.
The regression test drives the deterministic cross-importer variant
using new reuse-chain-* registry fixtures: an unchanged importer reuses
the target at depth 2 (caching the synthesized result under the
exact-pin wanted key), then a later importer whose changed direct dep
overlaps the target's snapshot is denied reuse at depth 1 and must
re-resolve fresh.

The TypeScript CLI has no equivalent cache of synthesized reuse
results, so the fix is pacquet-only.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Pacquet-only: the TypeScript resolver has no equivalent cache of
  synthesized reuse results — verified pnpm 11.14.0 keeps the snapshots
  intact under the same forced re-resolution.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786962417&installation_id=145934176&pr_number=13122&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13122&signature=9633a7c0689c6d7f68644962bc5abdc6593fd4124ef4bbbb388b0b54bc997eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed lockfile corruption and missing dependency links during non-frozen reinstalls when subtree reuse is denied for a specific dependency path.
  - Ensured denied reuse no longer replaces packages with empty lockfile snapshots, preserving auto-installed peer-suffixed and dependency entries for correct later installs/builds.
- **Tests**
  - Added an end-to-end test covering denied subtree reuse in lockfile resolution, along with supporting fixture packages.
- **Chores**
  - Added a changeset for this patch release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->