### PR TITLE
fix(pkg-manifest): devDependencies/dependencies should win over peerDependencies when computing current specifiers

### DIFF
--- a/.changeset/peer-prefix-precedence-fix.md
+++ b/.changeset/peer-prefix-precedence-fix.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Fixed `pnpm add --save-exact`/`--save-prefix` and `pnpm update` writing a package's version with the `peerDependencies` range's prefix (e.g. `^19.2.7` instead of the requested `19.2.7`) whenever the same package also appeared in `peerDependencies`. `peerDependencies` is now merged in before `devDependencies`/`dependencies`/`optionalDependencies` when computing the current specifiers, so a real dependency entry always takes precedence over its own peer entry, matching how `getWantedDependencies` already treats peers elsewhere. See pnpm/pnpm#13108.
+Fixed `pnpm add --save-exact`/`--save-prefix` and `pnpm update` writing a package's version with the `peerDependencies` range's prefix (e.g. `^19.2.7` instead of the requested `19.2.7`) whenever the same package also appeared in `peerDependencies`. A real `dependencies`/`devDependencies`/`optionalDependencies` entry now takes precedence over a same-named `peerDependencies` entry when computing the current specifiers [#13108](https://github.com/pnpm/pnpm/issues/13108).

--- a/.changeset/peer-prefix-precedence-fix.md
+++ b/.changeset/peer-prefix-precedence-fix.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/pkg-manifest.utils": patch
+"pnpm": patch
+---
+
+Fixed `pnpm add --save-exact`/`--save-prefix` and `pnpm update` writing a package's version with the `peerDependencies` range's prefix (e.g. `^19.2.7` instead of the requested `19.2.7`) whenever the same package also appeared in `peerDependencies`. `peerDependencies` is now merged in before `devDependencies`/`dependencies`/`optionalDependencies` when computing the current specifiers, so a real dependency entry always takes precedence over its own peer entry, matching how `getWantedDependencies` already treats peers elsewhere. See pnpm/pnpm#13108.

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -422,6 +422,43 @@ fn add_existing_dependency_moves_it_to_the_target_group() {
     drop((root, npmrc_info)); // cleanup
 }
 
+/// A package declared in both a real group and `peerDependencies` takes
+/// its previous specifier from the real group — `peerDependencies` is
+/// last in the `findSpec` scan — so the peer range's caret must not
+/// replace the exact pin of the `devDependencies` entry being re-added
+/// (pnpm/pnpm#13108).
+#[test]
+fn add_existing_dependency_ignores_pin_from_peer_range() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{ "name": "p", "version": "1.0.0", "devDependencies": { "@pnpm.e2e/dep-of-pkg-with-1-dep": "100.0.0" }, "peerDependencies": { "@pnpm.e2e/dep-of-pkg-with-1-dep": "^100.0.0" } }"#,
+    )
+    .unwrap();
+
+    pacquet
+        .with_args([
+            "add",
+            "@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0",
+            "--save-dev",
+            "--lockfile-only",
+        ])
+        .assert()
+        .success();
+
+    let manifest = PackageManifest::from_path(workspace.join("package.json")).unwrap();
+    let group_spec = |group| {
+        manifest
+            .dependencies([group])
+            .find(|(key, _)| *key == "@pnpm.e2e/dep-of-pkg-with-1-dep")
+            .map(|(_, spec)| spec.to_string())
+    };
+    assert_eq!(group_spec(DependencyGroup::Dev).as_deref(), Some("100.1.0"));
+    assert_eq!(group_spec(DependencyGroup::Peer).as_deref(), Some("^100.0.0"));
+    drop((root, npmrc_info)); // cleanup
+}
+
 /// `add <pkg>@<range>` records the range resolved to a concrete version
 /// with the input's operator, matching pnpm. `^100.0.0` resolves to the
 /// highest in-range version (100.1.0; 101.0.0 is a different major), so the

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -422,11 +422,7 @@ fn add_existing_dependency_moves_it_to_the_target_group() {
     drop((root, npmrc_info)); // cleanup
 }
 
-/// A package declared in both a real group and `peerDependencies` takes
-/// its previous specifier from the real group — `peerDependencies` is
-/// last in the `findSpec` scan — so the peer range's caret must not
-/// replace the exact pin of the `devDependencies` entry being re-added
-/// (pnpm/pnpm#13108).
+// Regression test for pnpm/pnpm#13108
 #[test]
 fn add_existing_dependency_ignores_pin_from_peer_range() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm11/pkg-manifest/utils/src/getAllDependenciesFromManifest.ts
+++ b/pnpm11/pkg-manifest/utils/src/getAllDependenciesFromManifest.ts
@@ -1,13 +1,13 @@
-import type { Dependencies, DependenciesField, ProjectManifest } from '@pnpm/types'
+import type { Dependencies, DependenciesOrPeersField, ProjectManifest } from '@pnpm/types'
 
 export function getAllDependenciesFromManifest (
-  pkg: Pick<ProjectManifest, DependenciesField | 'peerDependencies'>,
+  manifest: Pick<ProjectManifest, DependenciesOrPeersField>,
   opts?: { autoInstallPeers?: boolean }
 ): Dependencies {
   return {
-    ...pkg.devDependencies,
-    ...pkg.dependencies,
-    ...pkg.optionalDependencies,
-    ...(opts?.autoInstallPeers ? pkg.peerDependencies : {}),
-  } as Dependencies
+    ...(opts?.autoInstallPeers ? manifest.peerDependencies : {}),
+    ...manifest.devDependencies,
+    ...manifest.dependencies,
+    ...manifest.optionalDependencies,
+  }
 }

--- a/pnpm11/pkg-manifest/utils/src/index.ts
+++ b/pnpm11/pkg-manifest/utils/src/index.ts
@@ -8,6 +8,7 @@ import { getAllUniqueSpecs } from './getAllUniqueSpecs.js'
 import { getSpecFromPackageManifest } from './getSpecFromPackageManifest.js'
 
 export * from './convertEnginesRuntimeToDependencies.js'
+export * from './getAllDependenciesFromManifest.js'
 export * from './getDependencyTypeFromManifest.js'
 export * from './updateProjectManifestObject.js'
 
@@ -21,17 +22,5 @@ export function filterDependenciesByType (
     ...(include.devDependencies ? manifest.devDependencies : {}),
     ...(include.dependencies ? manifest.dependencies : {}),
     ...(include.optionalDependencies ? manifest.optionalDependencies : {}),
-  }
-}
-
-export function getAllDependenciesFromManifest (
-  manifest: Pick<ProjectManifest, 'devDependencies' | 'dependencies' | 'optionalDependencies' | 'peerDependencies'>,
-  opts?: { autoInstallPeers?: boolean }
-): Dependencies {
-  return {
-    ...(opts?.autoInstallPeers ? manifest.peerDependencies : {}),
-    ...manifest.devDependencies,
-    ...manifest.dependencies,
-    ...manifest.optionalDependencies,
   }
 }

--- a/pnpm11/pkg-manifest/utils/src/index.ts
+++ b/pnpm11/pkg-manifest/utils/src/index.ts
@@ -29,9 +29,9 @@ export function getAllDependenciesFromManifest (
   opts?: { autoInstallPeers?: boolean }
 ): Dependencies {
   return {
+    ...(opts?.autoInstallPeers ? manifest.peerDependencies : {}),
     ...manifest.devDependencies,
     ...manifest.dependencies,
     ...manifest.optionalDependencies,
-    ...(opts?.autoInstallPeers ? manifest.peerDependencies : {}),
   }
 }

--- a/pnpm11/pkg-manifest/utils/test/getAllDependenciesFromManifest.test.ts
+++ b/pnpm11/pkg-manifest/utils/test/getAllDependenciesFromManifest.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@jest/globals'
+import { getAllDependenciesFromManifest } from '@pnpm/pkg-manifest.utils'
+
+test('getAllDependenciesFromManifest() lets devDependencies win over a same-named peerDependencies entry', () => {
+  expect(getAllDependenciesFromManifest({
+    devDependencies: { react: '19.0.0' },
+    peerDependencies: { react: '^19.0.0' },
+  }, { autoInstallPeers: true })).toStrictEqual({ react: '19.0.0' })
+})
+
+test('getAllDependenciesFromManifest() lets dependencies win over a same-named peerDependencies entry', () => {
+  expect(getAllDependenciesFromManifest({
+    dependencies: { react: '19.0.0' },
+    peerDependencies: { react: '^19.0.0' },
+  }, { autoInstallPeers: true })).toStrictEqual({ react: '19.0.0' })
+})
+
+test('getAllDependenciesFromManifest() still includes a peer-only dependency when autoInstallPeers is true', () => {
+  expect(getAllDependenciesFromManifest({
+    peerDependencies: { react: '^19.0.0' },
+  }, { autoInstallPeers: true })).toStrictEqual({ react: '^19.0.0' })
+})
+
+test('getAllDependenciesFromManifest() excludes peerDependencies when autoInstallPeers is false', () => {
+  expect(getAllDependenciesFromManifest({
+    devDependencies: { react: '19.0.0' },
+    peerDependencies: { react: '^19.0.0' },
+  }, { autoInstallPeers: false })).toStrictEqual({ react: '19.0.0' })
+})

--- a/pnpm11/pkg-manifest/utils/test/getAllDependenciesFromManifest.test.ts
+++ b/pnpm11/pkg-manifest/utils/test/getAllDependenciesFromManifest.test.ts
@@ -27,3 +27,11 @@ test('getAllDependenciesFromManifest() excludes peerDependencies when autoInstal
     peerDependencies: { react: '^19.0.0' },
   }, { autoInstallPeers: false })).toStrictEqual({ react: '19.0.0' })
 })
+
+test('getAllDependenciesFromManifest() lets optionalDependencies win over a same-named peerDependencies entry', () => {
+  expect(getAllDependenciesFromManifest({
+    optionalDependencies: { react: '~19.0.0' },
+    peerDependencies: { react: '^19.0.0' },
+  }, { autoInstallPeers: true })).toStrictEqual({ react: '~19.0.0' })
+})
+


### PR DESCRIPTION
Dependencies

when computing current specifiers

<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

`peerDependencies` was spread *last* in `getAllDependenciesFromManifest`, so a peer entry like `"react": "^19.0.0"` silently overwrote a real `devDependencies`/`dependencies`/`optionalDependencies` entry for the same package when computing "current specifiers" during `pnpm add`/`pnpm update`. That `^`-prefixed value then leaked into the resolver's pinned-version detection, overriding `--save-exact`/`--save-prefix` and writing `^19.2.7` instead of the requested `19.2.7`.

The sibling function `getWantedDependencies` already spreads `peerDependencies` first for exactly this reason — this function just had the order backwards.

Review follow-ups: the two same-named definitions of `getAllDependenciesFromManifest` (the dormant standalone copy kept the old peers-last order) are consolidated into a single module re-exported from the package index (0ef3520d67), and pacquet gained a regression test pinning the equivalent precedence in its `add` prev-specifier scan (bbeea26ee4).

Closes pnpm/pnpm#13108

## Squash Commit Body

```text
Fix pnpm add --save-exact/--save-prefix and pnpm update writing a
package's version with the peerDependencies range's prefix instead of
the requested exact version, whenever the same package also appeared
in peerDependencies.

getAllDependenciesFromManifest spread peerDependencies last when
merging a project's current specifiers, so a peerDependencies entry
(e.g. "react": "^19.0.0") silently overwrote a same-named
devDependencies/dependencies/optionalDependencies entry. The
resulting merged specifier was then read as prevSpecifier in
parseWantedDependencies, and whichVersionIsPinned saw the "^" prefix
and returned "major" instead of "patch", overriding the pinned-version
behavior requested by --save-exact.

getWantedDependencies already spreads peerDependencies first for this
same reason (so real dependency fields take precedence over a peer's
compatibility range). This change brings getAllDependenciesFromManifest
in line with that existing convention rather than introducing a new
pattern.

Two of the four new tests reproduce the bug's two reported scenarios
directly (pnpm add --save-exact, pnpm update --latest) and fail
against the unmodified function; the other two guard existing
behavior (a peer-only dependency is still included when
autoInstallPeers is true; peerDependencies is still excluded entirely
when autoInstallPeers is false), to confirm the reorder doesn't change
anything except precedence.

Review follow-ups: consolidate the duplicated
getAllDependenciesFromManifest definitions into a single module (the
dormant standalone copy kept the old peers-last order), and add a
pacquet regression test pinning the equivalent prev-specifier
precedence in add — pacquet already scanned peers last, so no Rust
behavior change was needed.

Closes pnpm/pnpm#13108
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.

  No Rust-side behavior change needed — pacquet already gives real dependency groups precedence over `peerDependencies` everywhere the TypeScript bug could occur: the `add` prev-specifier scan reads peers last (first match wins), `update` never reads peers and matches previous specifiers by name and group, and the resolver's wanted-deps merge spreads peers first. The pacquet regression test `add_existing_dependency_ignores_pin_from_peer_range` (bbeea26ee4) now pins the `add` scan's precedence; it was verified to fail when the scan order is flipped to peers-first.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Description edited by an agent (Claude Code, claude-fable-5): corrected the Rust parity note and recorded the review follow-up commits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786967834&installation_id=145934176&pr_number=13124&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13124&signature=ab10e35e7bf2c8765af3918b88b47404bcdb26c2cc99a62860d0d27b1e973062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed dependency spec precedence so matching `dependencies` / `devDependencies` / `optionalDependencies` correctly override `peerDependencies` when computing specifiers and when writing versions/prefixes (including `--save-exact`, `--save-prefix`, and `update`).

- **Tests**
  - Added regression coverage for `add` behavior with pinned non-peer entries vs peer ranges, and added Jest coverage for peer auto-install precedence and inclusion/exclusion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
