### PR TITLE
fix(releasing): round-trip ledger entries with no consumed intents

### DIFF
--- a/.changeset/ledger-empty-intents-roundtrip.md
+++ b/.changeset/ledger-empty-intents-roundtrip.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/releasing.versioning": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm version -r` no longer writes a versioning-ledger entry with no consumed intents as a bare `intents:` key, which the next run failed to read with `ERR_PNPM_INVALID_VERSIONING_LEDGER`. Empty intent lists are now written as `intents: []`, and the ledger reader accepts the bare form left by earlier releases.

--- a/.changeset/ledger.yaml
+++ b/.changeset/ledger.yaml
@@ -200,7 +200,7 @@ pacquet@12.0.0-alpha.12:
     - pacquet-symlink-dangling-junction-parent
 pacquet@12.0.0-alpha.13:
   dir: pnpm/npm/pnpm
-  intents:
+  intents: []
 pacquet@12.0.0-alpha.14:
   dir: pnpm/npm/pnpm
   intents:

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1357,7 +1357,7 @@ fn snapshot_link_uses_lockfile_root_while_importer_link_uses_project_root() {
         BTreeMap::from([("peer".to_string(), peer.dep_path.clone())]),
         BTreeMap::from([(
             "peer".to_string(),
-            PeerDep { version: "*".to_string(), optional: false, meta_only: false },
+            PeerDep { version: "*".to_string(), optional: false },
         )]),
         HashSet::new(),
     );

--- a/pnpm/crates/versioning/src/ledger.rs
+++ b/pnpm/crates/versioning/src/ledger.rs
@@ -33,9 +33,9 @@ pub enum LedgerEntry {
 /// `intents:` key parses as YAML null, and ledgers written before the
 /// serializers rendered empty lists as `[]` contain exactly that shape.
 impl<'de> Deserialize<'de> for LedgerEntry {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
     where
-        D: Deserializer<'de>,
+        De: Deserializer<'de>,
     {
         struct LedgerEntryVisitor;
 
@@ -44,23 +44,23 @@ impl<'de> Deserialize<'de> for LedgerEntry {
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter
-                    .write_str("a list of intent ids, or a mapping with \"dir\" and \"intents\"")
+                    .write_str(r#"a list of intent ids, or a mapping with "dir" and "intents""#)
             }
 
-            fn visit_unit<E>(self) -> Result<Self::Value, E> {
+            fn visit_unit<DeError>(self) -> Result<Self::Value, DeError> {
                 Ok(LedgerEntry::Ids(Vec::new()))
             }
 
-            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+            fn visit_seq<Seq>(self, seq: Seq) -> Result<Self::Value, Seq::Error>
             where
-                A: SeqAccess<'de>,
+                Seq: SeqAccess<'de>,
             {
                 Deserialize::deserialize(SeqAccessDeserializer::new(seq)).map(LedgerEntry::Ids)
             }
 
-            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            fn visit_map<Map>(self, map: Map) -> Result<Self::Value, Map::Error>
             where
-                A: MapAccess<'de>,
+                Map: MapAccess<'de>,
             {
                 #[derive(Deserialize)]
                 struct AttributedEntry {

--- a/pnpm/crates/versioning/src/ledger.rs
+++ b/pnpm/crates/versioning/src/ledger.rs
@@ -1,11 +1,17 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    fs,
+    fmt, fs,
     io::ErrorKind,
     path::Path,
 };
 
-use serde::Deserialize;
+use serde::{
+    Deserialize, Deserializer,
+    de::{
+        MapAccess, SeqAccess, Visitor,
+        value::{MapAccessDeserializer, SeqAccessDeserializer},
+    },
+};
 
 use crate::{error::VersioningError, intents::CHANGES_DIR};
 
@@ -17,11 +23,61 @@ pub const LEDGER_FILENAME: &str = "ledger.yaml";
 /// consumed. The bare id-list shape is accepted when read, for hand-written
 /// entries; its project is then resolved by the package name in the entry
 /// key, which must be unambiguous.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LedgerEntry {
     Ids(Vec<String>),
     Attributed { dir: String, intents: Vec<String> },
+}
+
+/// Null where a list belongs reads as an empty list: a bare `pkg@1.0.0:` or
+/// `intents:` key parses as YAML null, and ledgers written before the
+/// serializers rendered empty lists as `[]` contain exactly that shape.
+impl<'de> Deserialize<'de> for LedgerEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct LedgerEntryVisitor;
+
+        impl<'de> Visitor<'de> for LedgerEntryVisitor {
+            type Value = LedgerEntry;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter
+                    .write_str("a list of intent ids, or a mapping with \"dir\" and \"intents\"")
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E> {
+                Ok(LedgerEntry::Ids(Vec::new()))
+            }
+
+            fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                Deserialize::deserialize(SeqAccessDeserializer::new(seq)).map(LedgerEntry::Ids)
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                struct AttributedEntry {
+                    dir: String,
+                    intents: Option<Vec<String>>,
+                }
+                let entry: AttributedEntry =
+                    Deserialize::deserialize(MapAccessDeserializer::new(map))?;
+                Ok(LedgerEntry::Attributed {
+                    dir: entry.dir,
+                    intents: entry.intents.unwrap_or_default(),
+                })
+            }
+        }
+
+        deserializer.deserialize_any(LedgerEntryVisitor)
+    }
 }
 
 impl LedgerEntry {
@@ -88,21 +144,33 @@ pub fn append_to_ledger(
 /// Renders the ledger in the same YAML shape the TypeScript side's
 /// `yaml.stringify` produces: sorted `package@version` keys (quoted when the
 /// name is scoped, since a leading `@` is a YAML indicator), each with the
-/// released project directory and a two-space-indented id list.
+/// released project directory and a two-space-indented id list. An empty id
+/// list renders as `[]` — a bare key would read back as null, not a list.
 fn render_ledger(ledger: &Ledger) -> String {
     use std::fmt::Write as _;
     let mut output = String::new();
     for (key, entry) in ledger {
-        writeln!(output, "{}:", yaml_scalar(key)).expect("write to string");
-        if let LedgerEntry::Attributed { dir, .. } = entry {
-            writeln!(output, "  dir: {}", yaml_scalar(dir)).expect("write to string");
-            writeln!(output, "  intents:").expect("write to string");
-            for id in entry.intent_ids() {
-                writeln!(output, "    - {}", yaml_scalar(id)).expect("write to string");
+        match entry {
+            LedgerEntry::Attributed { dir, intents } => {
+                writeln!(output, "{}:", yaml_scalar(key)).expect("write to string");
+                writeln!(output, "  dir: {}", yaml_scalar(dir)).expect("write to string");
+                if intents.is_empty() {
+                    writeln!(output, "  intents: []").expect("write to string");
+                } else {
+                    writeln!(output, "  intents:").expect("write to string");
+                    for id in intents {
+                        writeln!(output, "    - {}", yaml_scalar(id)).expect("write to string");
+                    }
+                }
             }
-        } else {
-            for id in entry.intent_ids() {
-                writeln!(output, "  - {}", yaml_scalar(id)).expect("write to string");
+            LedgerEntry::Ids(ids) if ids.is_empty() => {
+                writeln!(output, "{}: []", yaml_scalar(key)).expect("write to string");
+            }
+            LedgerEntry::Ids(ids) => {
+                writeln!(output, "{}:", yaml_scalar(key)).expect("write to string");
+                for id in ids {
+                    writeln!(output, "  - {}", yaml_scalar(id)).expect("write to string");
+                }
             }
         }
     }

--- a/pnpm/crates/versioning/src/ledger.rs
+++ b/pnpm/crates/versioning/src/ledger.rs
@@ -30,8 +30,9 @@ pub enum LedgerEntry {
 }
 
 /// Null where a list belongs reads as an empty list: a bare `pkg@1.0.0:` or
-/// `intents:` key parses as YAML null, and ledgers written before the
-/// serializers rendered empty lists as `[]` contain exactly that shape.
+/// `intents:` key parses as YAML null, and a mapping entry may omit
+/// `intents` entirely. Committed ledgers contain such entries for releases
+/// that consumed no intents.
 impl<'de> Deserialize<'de> for LedgerEntry {
     fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
     where

--- a/pnpm/crates/versioning/src/ledger/tests.rs
+++ b/pnpm/crates/versioning/src/ledger/tests.rs
@@ -58,6 +58,37 @@ fn control_characters_are_escaped_and_round_trip() {
 }
 
 #[test]
+fn empty_intent_lists_render_as_flow_sequences_and_round_trip() {
+    let mut ledger = Ledger::new();
+    ledger.insert(
+        "pacquet@12.0.0-alpha.13".to_string(),
+        LedgerEntry::Attributed { dir: "pnpm/npm/pnpm".to_string(), intents: Vec::new() },
+    );
+    ledger.insert("pkg@1.0.0".to_string(), LedgerEntry::Ids(Vec::new()));
+    let rendered = render_ledger(&ledger);
+    assert_eq!(
+        rendered,
+        "pacquet@12.0.0-alpha.13:\n  dir: pnpm/npm/pnpm\n  intents: []\npkg@1.0.0: []\n",
+    );
+    let parsed: Ledger = serde_saphyr::from_str(&rendered).expect("render output parses back");
+    assert_eq!(parsed, ledger);
+}
+
+#[test]
+fn null_entries_and_null_intents_parse_as_empty_lists() {
+    // The shape ledgers written before empty lists rendered as `[]` contain.
+    let parsed: Ledger = serde_saphyr::from_str(
+        "pacquet@12.0.0-alpha.13:\n  dir: pnpm/npm/pnpm\n  intents:\npkg@1.0.0:\n",
+    )
+    .expect("bare keys parse");
+    assert_eq!(
+        parsed.get("pacquet@12.0.0-alpha.13"),
+        Some(&LedgerEntry::Attributed { dir: "pnpm/npm/pnpm".to_string(), intents: Vec::new() }),
+    );
+    assert_eq!(parsed.get("pkg@1.0.0"), Some(&LedgerEntry::Ids(Vec::new())));
+}
+
+#[test]
 fn yaml_scalar_quotes_only_when_needed() {
     assert_eq!(yaml_scalar("packages/util"), "packages/util");
     assert_eq!(yaml_scalar("pkg@1.0.0"), "pkg@1.0.0");

--- a/pnpm/crates/versioning/src/ledger/tests.rs
+++ b/pnpm/crates/versioning/src/ledger/tests.rs
@@ -75,17 +75,22 @@ fn empty_intent_lists_render_as_flow_sequences_and_round_trip() {
 }
 
 #[test]
-fn null_entries_and_null_intents_parse_as_empty_lists() {
-    // The shape ledgers written before empty lists rendered as `[]` contain.
-    let parsed: Ledger = serde_saphyr::from_str(
-        "pacquet@12.0.0-alpha.13:\n  dir: pnpm/npm/pnpm\n  intents:\npkg@1.0.0:\n",
-    )
-    .expect("bare keys parse");
+fn null_and_missing_intent_lists_parse_as_empty() {
+    let parsed: Ledger = serde_saphyr::from_str(concat!(
+        "pacquet@12.0.0-alpha.13:\n  dir: pnpm/npm/pnpm\n  intents:\n",
+        "pkg@1.0.0:\n",
+        "other@2.0.0:\n  dir: packages/other\n",
+    ))
+    .expect("bare and intents-less keys parse");
     assert_eq!(
         parsed.get("pacquet@12.0.0-alpha.13"),
         Some(&LedgerEntry::Attributed { dir: "pnpm/npm/pnpm".to_string(), intents: Vec::new() }),
     );
     assert_eq!(parsed.get("pkg@1.0.0"), Some(&LedgerEntry::Ids(Vec::new())));
+    assert_eq!(
+        parsed.get("other@2.0.0"),
+        Some(&LedgerEntry::Attributed { dir: "packages/other".to_string(), intents: Vec::new() }),
+    );
 }
 
 #[test]

--- a/pnpm11/releasing/versioning/src/ledger.ts
+++ b/pnpm11/releasing/versioning/src/ledger.ts
@@ -54,21 +54,32 @@ export async function readLedger (workspaceDir: string): Promise<Ledger> {
   // instead of mutating the prototype.
   const ledger: Ledger = Object.create(null) as Ledger
   for (const [key, entry] of Object.entries(parsed)) {
-    if (!isValidLedgerEntry(entry)) {
+    const normalized = normalizeLedgerEntry(entry)
+    if (normalized == null) {
       throw new PnpmError('INVALID_VERSIONING_LEDGER', `Invalid entry for ${key} in ${ledgerPath}. Expected a list of intent ids, or a mapping with "dir" and "intents"`)
     }
-    ledger[key] = entry as LedgerEntry
+    ledger[key] = normalized
   }
   return ledger
 }
 
-function isValidLedgerEntry (entry: unknown): boolean {
+/**
+ * Null where a list belongs reads as an empty list: a bare `pkg@1.0.0:` or
+ * `intents:` key parses as YAML null, and ledgers written before the
+ * serializers rendered empty lists as `[]` contain exactly that shape.
+ * Returns undefined for entries that are invalid in any shape.
+ */
+function normalizeLedgerEntry (entry: unknown): LedgerEntry | undefined {
+  if (entry == null) return []
   if (Array.isArray(entry)) {
-    return entry.every((id) => typeof id === 'string')
+    return entry.every((id) => typeof id === 'string') ? (entry as string[]) : undefined
   }
-  if (typeof entry !== 'object' || entry === null) return false
+  if (typeof entry !== 'object') return undefined
   const { dir, intents } = entry as { dir?: unknown, intents?: unknown }
-  return typeof dir === 'string' && Array.isArray(intents) && intents.every((id) => typeof id === 'string')
+  if (typeof dir !== 'string') return undefined
+  if (intents == null) return { dir, intents: [] }
+  if (!Array.isArray(intents) || !intents.every((id) => typeof id === 'string')) return undefined
+  return { dir, intents: intents as string[] }
 }
 
 export async function appendToLedger (

--- a/pnpm11/releasing/versioning/src/ledger.ts
+++ b/pnpm11/releasing/versioning/src/ledger.ts
@@ -65,9 +65,10 @@ export async function readLedger (workspaceDir: string): Promise<Ledger> {
 
 /**
  * Null where a list belongs reads as an empty list: a bare `pkg@1.0.0:` or
- * `intents:` key parses as YAML null, and ledgers written before the
- * serializers rendered empty lists as `[]` contain exactly that shape.
- * Returns undefined for entries that are invalid in any shape.
+ * `intents:` key parses as YAML null, and a mapping entry may omit
+ * `intents` entirely. Committed ledgers contain such entries for releases
+ * that consumed no intents. Returns undefined for entries that are invalid
+ * in any shape.
  */
 function normalizeLedgerEntry (entry: unknown): LedgerEntry | undefined {
   if (entry == null) return []

--- a/pnpm11/releasing/versioning/test/ledger.ts
+++ b/pnpm11/releasing/versioning/test/ledger.ts
@@ -14,12 +14,27 @@ test('empty intent lists render as flow sequences and round-trip', async () => {
   expect(ledger['pacquet@12.0.0-alpha.13']).toStrictEqual({ dir: 'pnpm/npm/pnpm', intents: [] })
 })
 
-test('null entries and null intents parse as empty lists', async () => {
-  // The shape ledgers written before empty lists rendered as `[]` contain.
+test('null and missing intent lists parse as empty', async () => {
   const workspaceDir = temporaryDirectory()
   await fs.mkdir(path.join(workspaceDir, '.changeset'))
-  await fs.writeFile(path.join(workspaceDir, '.changeset', 'ledger.yaml'), 'pacquet@12.0.0-alpha.13:\n  dir: pnpm/npm/pnpm\n  intents:\npkg@1.0.0:\n')
+  await fs.writeFile(path.join(workspaceDir, '.changeset', 'ledger.yaml'), [
+    'pacquet@12.0.0-alpha.13:\n  dir: pnpm/npm/pnpm\n  intents:\n',
+    'pkg@1.0.0:\n',
+    'other@2.0.0:\n  dir: packages/other\n',
+  ].join(''))
   const ledger = await readLedger(workspaceDir)
   expect(ledger['pacquet@12.0.0-alpha.13']).toStrictEqual({ dir: 'pnpm/npm/pnpm', intents: [] })
+  expect(ledger['pkg@1.0.0']).toStrictEqual([])
+  expect(ledger['other@2.0.0']).toStrictEqual({ dir: 'packages/other', intents: [] })
+})
+
+test('an id-list entry with no ids renders as [] when the ledger is rewritten', async () => {
+  const workspaceDir = temporaryDirectory()
+  await fs.mkdir(path.join(workspaceDir, '.changeset'))
+  await fs.writeFile(path.join(workspaceDir, '.changeset', 'ledger.yaml'), 'pkg@1.0.0: []\n')
+  await appendToLedger(workspaceDir, { 'other@2.0.0': { dir: 'packages/other', intents: ['some-intent'] } })
+  const rendered = await fs.readFile(path.join(workspaceDir, '.changeset', 'ledger.yaml'), 'utf8')
+  expect(rendered).toBe('other@2.0.0:\n  dir: packages/other\n  intents:\n    - some-intent\npkg@1.0.0: []\n')
+  const ledger = await readLedger(workspaceDir)
   expect(ledger['pkg@1.0.0']).toStrictEqual([])
 })

--- a/pnpm11/releasing/versioning/test/ledger.ts
+++ b/pnpm11/releasing/versioning/test/ledger.ts
@@ -1,0 +1,25 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { appendToLedger, readLedger } from '@pnpm/releasing.versioning'
+import { temporaryDirectory } from 'tempy'
+
+test('empty intent lists render as flow sequences and round-trip', async () => {
+  const workspaceDir = temporaryDirectory()
+  await appendToLedger(workspaceDir, { 'pacquet@12.0.0-alpha.13': { dir: 'pnpm/npm/pnpm', intents: [] } })
+  const rendered = await fs.readFile(path.join(workspaceDir, '.changeset', 'ledger.yaml'), 'utf8')
+  expect(rendered).toBe('pacquet@12.0.0-alpha.13:\n  dir: pnpm/npm/pnpm\n  intents: []\n')
+  const ledger = await readLedger(workspaceDir)
+  expect(ledger['pacquet@12.0.0-alpha.13']).toStrictEqual({ dir: 'pnpm/npm/pnpm', intents: [] })
+})
+
+test('null entries and null intents parse as empty lists', async () => {
+  // The shape ledgers written before empty lists rendered as `[]` contain.
+  const workspaceDir = temporaryDirectory()
+  await fs.mkdir(path.join(workspaceDir, '.changeset'))
+  await fs.writeFile(path.join(workspaceDir, '.changeset', 'ledger.yaml'), 'pacquet@12.0.0-alpha.13:\n  dir: pnpm/npm/pnpm\n  intents:\npkg@1.0.0:\n')
+  const ledger = await readLedger(workspaceDir)
+  expect(ledger['pacquet@12.0.0-alpha.13']).toStrictEqual({ dir: 'pnpm/npm/pnpm', intents: [] })
+  expect(ledger['pkg@1.0.0']).toStrictEqual([])
+})


### PR DESCRIPTION
## Summary

The "Create Release PR" workflow ([run 29642469010](https://github.com/pnpm/pnpm/actions/runs/29642469010/job/88075142776)) fails at the "Bump versions" step: `pnpm version -r` rejects `.changeset/ledger.yaml` with `ERR_PNPM_INVALID_VERSIONING_LEDGER`.

Root cause: pacquet's `render_ledger` writes a ledger entry with an empty intent list as a bare `intents:` key. YAML reads that back as null, which neither stack's ledger reader accepted. The `pacquet@12.0.0-alpha.13` entry legitimately has no consumed intents (a rebuild-only release, recorded by pnpm/pnpm#13049 as `intents: []`), and the 11.14.0 / 12.0.0-alpha.14 release run (pnpm/pnpm#13113) re-rendered the whole ledger through the Rust path, committing the unreadable bare form. Every `pnpm version -r` since then fails on read.

This PR, in both stacks:

- renders empty intent lists as `[]` (byte-identical between `render_ledger` and `yaml.stringify`), and
- accepts null where a list belongs when reading (bare entry key or bare `intents:` key → empty list), so ledgers written before this fix stay readable.

It also repairs the committed `.changeset/ledger.yaml` entry, which is what immediately unblocks the release workflow: verified locally that the pinned pacquet `12.0.0-alpha.13` binary parses the repaired file, and that a binary built from this branch parses the broken form.

One drive-by build fix: pnpm/pnpm#13030 added a test constructing `PeerDep` with the `meta_only` field while pnpm/pnpm#13120 (merged the same day) removed that field, leaving main's `--all-targets` build failing on E0560. Dropped the stale field from the fixture.

## Squash Commit Body

```text
The Rust render_ledger wrote an empty intent list as a bare 'intents:'
key, which parses as YAML null - a shape neither stack's ledger reader
accepted. The 11.14.0 / 12.0.0-alpha.14 release run (pnpm/pnpm#13113)
re-rendered the committed ledger through that path, turning the
pacquet@12.0.0-alpha.13 entry's 'intents: []' into the bare form, and
every 'pnpm version -r' after it failed with
ERR_PNPM_INVALID_VERSIONING_LEDGER.

- Render empty intent lists as '[]' in both ledger entry shapes,
  matching the TypeScript side's yaml.stringify byte for byte.
- Accept null where a list belongs when reading, in both stacks: a
  bare entry key or bare 'intents:' key now reads as an empty list,
  so ledgers written before this fix stay readable.
- Repair the committed .changeset/ledger.yaml entry.
- Drop the stale meta_only field from a package-manager PeerDep test
  fixture (pnpm/pnpm#13030 added it while pnpm/pnpm#13120 removed the
  field, breaking main's --all-targets build).
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786967978&installation_id=145934176&pr_number=13125&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13125&signature=9d18e8097ada35376465b650148c9d60b744c18185cbbd9e8d72cb2d1fab8842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved versioning ledger handling for packages with no intents.
  - Empty intent lists are now written consistently as `intents: []`.
  - Older ledger formats that used empty or omitted `intents` are still accepted, avoiding invalid-ledger errors on later runs.
  - Ledger entries now round-trip correctly between writing and reading, including entries with no intents.

- **Tests**
  - Added regression coverage for ledger parsing and rendering, including normalization and YAML round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->