### PR TITLE
feat(pacquet): implement install-test command

### DIFF
--- a/.changeset/pacquet-install-test.md
+++ b/.changeset/pacquet-install-test.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Implemented native `install-test` command.

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -27,6 +27,7 @@ pub mod global;
 pub mod ignored_builds;
 pub mod import;
 pub mod install;
+pub mod install_test;
 pub mod lane;
 pub mod licenses;
 pub mod link;

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -26,6 +26,7 @@ use super::{
     ignored_builds::IgnoredBuildsArgs,
     import::ImportArgs,
     install::InstallArgs,
+    install_test::InstallTestArgs,
     lane::LaneArgs,
     licenses::LicensesArgs,
     link::LinkArgs,
@@ -271,6 +272,9 @@ pub enum CliCommand {
     /// Install packages
     #[clap(visible_alias = "i")]
     Install(InstallArgs),
+    /// Runs a `pnpm install` followed immediately by a `pnpm test`. It takes exactly the same arguments as `pnpm install`.
+    #[clap(name = "install-test", visible_alias = "it")]
+    InstallTest(InstallTestArgs),
     /// Update packages to their newest version based on the specified range
     #[clap(visible_aliases = ["up", "upgrade"])]
     Update(UpdateArgs),

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -168,6 +168,7 @@ impl CliArgs {
                 | CliCommand::Update(_)
                 | CliCommand::Remove(_)
                 | CliCommand::Install(_)
+                | CliCommand::InstallTest(_)
                 | CliCommand::Dlx(_)
                 | CliCommand::Link(_)
                 | CliCommand::Import(_)
@@ -317,6 +318,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Init => dispatch_script::init(ctx),
         CliCommand::Add(args) => dispatch_install::add(ctx, args),
         CliCommand::Install(args) => dispatch_install::install(ctx, args),
+        CliCommand::InstallTest(args) => dispatch_install::install_test(ctx, args),
         CliCommand::Update(args) => dispatch_install::update(ctx, args),
         CliCommand::Outdated(args) => dispatch_query::outdated(ctx, args),
         CliCommand::Audit(args) => dispatch_query::audit(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -10,6 +10,7 @@ use super::{
     global,
     import::ImportArgs,
     install::InstallArgs,
+    install_test,
     link::LinkArgs,
     patch::PatchArgs,
     patch_commit::PatchCommitArgs,
@@ -223,6 +224,43 @@ pub(super) fn install<'a>(
                 }
             }
         }
+        Ok(())
+    }))
+}
+
+pub(super) fn install_test<'a>(
+    ctx: &RunCtx<'a>,
+    args: install_test::InstallTestArgs,
+) -> miette::Result<CommandFuture<'a>> {
+    let install_args = args.install_args;
+    let run_args = super::run::RunArgs {
+        command: Some("test".to_string()),
+        args: args.args,
+        if_present: ctx.if_present,
+        resume_from: ctx.recursive_resume_from.map(str::to_string),
+        report_summary: ctx.recursive_report_summary,
+        no_bail: ctx.recursive_no_bail,
+        sort: ctx.recursive_sort,
+        sequential: false,
+    };
+
+    let install_future = install(ctx, install_args)?;
+
+    let dir = ctx.dir;
+    let recursive = ctx.recursive;
+    let config = ctx.config;
+    let reporter = ctx.reporter;
+
+    Ok(Box::pin(async move {
+        install_future.await?;
+
+        let cfg = config()?;
+        if recursive {
+            run_args.run_recursive(cfg, dir)?;
+        } else {
+            run_args.run(dir, cfg, matches!(reporter, ReporterType::Silent))?;
+        }
+
         Ok(())
     }))
 }

--- a/pnpm/crates/cli/src/cli_args/install_test.rs
+++ b/pnpm/crates/cli/src/cli_args/install_test.rs
@@ -1,0 +1,12 @@
+use super::install::InstallArgs;
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct InstallTestArgs {
+    #[clap(flatten)]
+    pub install_args: InstallArgs,
+
+    /// Arguments passed to the script after the script name.
+    #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub args: Vec<String>,
+}

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -459,6 +459,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Init => "init",
         CliCommand::Add(_) => "add",
         CliCommand::Install(_) => "install",
+        CliCommand::InstallTest(_) => "install-test",
         CliCommand::Update(_) => "update",
         CliCommand::Outdated(_) => "outdated",
         CliCommand::Audit(_) => "audit",

--- a/pnpm/crates/cli/tests/completion.rs
+++ b/pnpm/crates/cli/tests/completion.rs
@@ -163,7 +163,7 @@ fn completion_server_filters_command_prefixes() {
         .expect("run pnpm completion-server");
     let reply = stdout(output);
 
-    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install"]);
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install", "install-test"]);
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/install_test.rs
+++ b/pnpm/crates/cli/tests/install_test.rs
@@ -27,10 +27,68 @@ fn install_test() {
     let output = pacquet.with_args(["install-test"]).assert().success().get_output().clone();
 
     let stdout = String::from_utf8_lossy(&output.stdout);
+    println!("stdout:\n{stdout}");
     assert!(stdout.contains("test ran successfully"), "stdout: {stdout}");
 
-    let is_positive_dir =
+    let hello_world_bin_dir =
         workspace.join("node_modules").join("@pnpm.e2e").join("hello-world-js-bin");
-    assert!(is_positive_dir.exists(), "dependency not installed");
+    println!("Checking if dependency directory exists: {}", hello_world_bin_dir.display());
+    assert!(hello_world_bin_dir.exists(), "dependency not installed");
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn install_test_failure_prevents_test() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{
+            "name": "test-install-test",
+            "scripts": {
+                "test": "node -e \"console.log('test ran successfully');\""
+            },
+            "dependencies": {
+                "does-not-exist-in-any-registry": "1.0.0"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let output = pacquet.with_args(["install-test"]).assert().failure().get_output().clone();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    println!("stdout:\n{stdout}");
+    assert!(
+        !stdout.contains("test ran successfully"),
+        "test script should not run on install failure"
+    );
+
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn it_alias() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{
+            "name": "test-it-alias",
+            "scripts": {
+                "test": "node -e \"console.log('it alias ran successfully');\""
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let output = pacquet.with_args(["it"]).assert().success().get_output().clone();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    println!("stdout:\n{stdout}");
+    assert!(stdout.contains("it alias ran successfully"), "stdout: {stdout}");
+
     drop((root, npmrc_info));
 }

--- a/pnpm/crates/cli/tests/install_test.rs
+++ b/pnpm/crates/cli/tests/install_test.rs
@@ -62,7 +62,7 @@ fn install_test_failure_prevents_test() {
     println!("stdout:\n{stdout}");
     assert!(
         !stdout.contains("test ran successfully"),
-        "test script should not run on install failure"
+        "test script should not run on install failure",
     );
 
     drop((root, npmrc_info));

--- a/pnpm/crates/cli/tests/install_test.rs
+++ b/pnpm/crates/cli/tests/install_test.rs
@@ -1,0 +1,36 @@
+pub mod _utils;
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+
+#[test]
+fn install_test() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    // Create a package.json with a test script and a dependency
+    std::fs::write(
+        workspace.join("package.json"),
+        r#"{
+            "name": "test-install-test",
+            "scripts": {
+                "test": "node -e \"console.log('test ran successfully');\""
+            },
+            "dependencies": {
+                "@pnpm.e2e/hello-world-js-bin": "1.0.0"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let output = pacquet.with_args(["install-test"]).assert().success().get_output().clone();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test ran successfully"), "stdout: {stdout}");
+
+    let is_positive_dir =
+        workspace.join("node_modules").join("@pnpm.e2e").join("hello-world-js-bin");
+    assert!(is_positive_dir.exists(), "dependency not installed");
+    drop((root, npmrc_info));
+}

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1357,7 +1357,7 @@ fn snapshot_link_uses_lockfile_root_while_importer_link_uses_project_root() {
         BTreeMap::from([("peer".to_string(), peer.dep_path.clone())]),
         BTreeMap::from([(
             "peer".to_string(),
-            PeerDep { version: "*".to_string(), optional: false, meta_only: false },
+            PeerDep { version: "*".to_string(), optional: false },
         )]),
         HashSet::new(),
     );


### PR DESCRIPTION
## Summary

Implement native install-test command in Rust for pacquet. 

Related to: pnpm/pnpm#11633.

## Squash Commit Body

```text
feat: implement native install-test command for pacquet

This implements the native `install-test` (and `it`) command in Rust.
The handler chains the install logic with the `run test` flow as expected by the parity requirements.
An integration test is provided in `crates/cli/tests/install_test.rs` to verify that installing and running tests simultaneously works.

Related to: #11633.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or -the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786969096&installation_id=145934176&pr_number=13127&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13127&signature=81bb1672269f38085e15573428087ea8d960320c299b52464bbf0176c958182a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary
- **New Features**
  - Added the native `pacquet install-test` command, with `it` as an alias.
  - Performs an install first, then immediately runs the project’s `test` script.
  - Supports the same options as install and can forward extra arguments to the test step.
- **Bug Fixes**
  - Updated CLI completion so the `inst` prefix now also suggests `install-test`.
- **Tests**
  - Added integration coverage for successful runs, ensures the test step doesn’t run when install fails, and verifies the `it` alias.
- **Chores**
  - Included a minor version bump for `pacquet` via a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->