### PR TITLE
fix(releasing): release each product only from its own version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,23 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - name: Assert the version tag points at this commit
+        # The plan job resumes any unpublished product from whichever tag's run
+        # survives the release concurrency queue, so this job's triggering tag
+        # is not necessarily v<ts_version> — but the commit it publishes from
+        # must be the one v<ts_version> names, both for the artifacts built
+        # below and for the GitHub release that lands on that tag. On a
+        # mismatch (the tags of two release commits ended up in one run's
+        # plan), rerun the release workflow from the v<ts_version> tag instead.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.plan.outputs.ts_version }}
+        run: |
+          tag_commit=$(gh api "repos/${GITHUB_REPOSITORY}/commits/v${VERSION}" --jq .sha)
+          if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+            echo "::error::Tag v${VERSION} points at ${tag_commit}, but this run would release commit ${GITHUB_SHA}. Rerun the release workflow from the v${VERSION} tag."
+            exit 1
+          fi
       - uses: garnet-org/action@2b7fc9d79b54f551b43358c27424a36064b3e078 # v2.0.2
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
@@ -377,6 +394,11 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
           draft: true
+          # Pinned because the triggering tag may belong to another product
+          # (see "Assert the version tag points at this commit" above); without
+          # tag_name the action falls back to github.ref.
+          tag_name: v${{ needs.plan.outputs.ts_version }}
+          name: pnpm ${{ needs.plan.outputs.ts_version }}
           files: dist/*
           body_path: RELEASE.md
       - name: Verify and publish release
@@ -773,6 +795,21 @@ jobs:
       - build-rust
       - publish-rust
     steps:
+      - name: Assert the version tag points at this commit
+        # Same tag↔commit invariant as the TypeScript release job's guard: the
+        # binaries below were built from this run's commit, and `target_commitish`
+        # cannot pin the release to it — GitHub ignores it whenever the tag
+        # already exists.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.plan.outputs.rust_version }}
+        run: |
+          tag_commit=$(gh api "repos/${GITHUB_REPOSITORY}/commits/v${VERSION}" --jq .sha)
+          if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+            echo "::error::Tag v${VERSION} points at ${tag_commit}, but this run built commit ${GITHUB_SHA}. Rerun the release workflow from the v${VERSION} tag."
+            exit 1
+          fi
+
       - name: Download Artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1274,3 +1274,49 @@ jobs:
             PNPR_SHA256_ARM64=${{ steps.stage.outputs.sha_arm64 }}
           provenance: mode=max
           sbom: true
+
+  github-release-pnpr:
+    name: Draft GitHub release for pnpr
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: write # create the draft release on the pnpr tag
+    needs:
+      - plan
+      - build-pnpr
+      - publish-pnpr
+    steps:
+      - name: Assert the version tag points at this commit
+        # Same tag↔commit invariant as the TypeScript release job's guard.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.plan.outputs.pnpr_version }}
+        run: |
+          tag_commit=$(gh api "repos/${GITHUB_REPOSITORY}/commits/pnpr@${VERSION}" --jq .sha)
+          if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+            echo "::error::Tag pnpr@${VERSION} points at ${tag_commit}, but this run built commit ${GITHUB_SHA}. Rerun the release workflow from the pnpr@${VERSION} tag."
+            exit 1
+          fi
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binaries-pnpr-*
+          merge-multiple: true
+
+      - name: Release
+        # The build job's archives carry a target-qualified `pnpr-<target>`
+        # binary and ship with its build-time checksum, so they're uploaded
+        # byte-for-byte as attested there. Draft so a maintainer publishes it
+        # deliberately; `make_latest: false` keeps a pnpr release off the
+        # repository's "Latest" badge, which tracks the stable pnpm CLI.
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
+        with:
+          draft: true
+          prerelease: ${{ contains(needs.plan.outputs.pnpr_version, '-') }}
+          make_latest: false
+          tag_name: pnpr@${{ needs.plan.outputs.pnpr_version }}
+          name: pnpr ${{ needs.plan.outputs.pnpr_version }}
+          files: |
+            pnpr-*.tar.gz
+            pnpr-*.zip
+            pnpr-*.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,10 @@ jobs:
         # sensitive and softprops/action-gh-release is widely battle-tested.
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
+          # Draft so a maintainer publishes it deliberately, like the Rust and
+          # pnpr releases: the repository uses immutable releases, so a
+          # published release cannot be corrected, only deleted — and deleting
+          # it burns its tag for releases forever.
           draft: true
           # Explicit so the release's identity comes from the plan job like
           # every other step here, never from the github.ref fallback.
@@ -430,7 +434,7 @@ jobs:
           name: pnpm ${{ needs.plan.outputs.ts_version }}
           files: dist/*
           body_path: RELEASE.md
-      - name: Verify and publish release
+      - name: Verify draft release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ID: ${{ steps.github-release.outputs.id }}
@@ -445,7 +449,6 @@ jobs:
           const expected = normalizeNewlines(fs.readFileSync('RELEASE.md', 'utf8'))
           if (actual !== expected) throw new Error('GitHub draft release body does not match RELEASE.md')
           NODE
-          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" -F draft=false > /dev/null
 
   build-rust:
     needs: plan
@@ -824,6 +827,11 @@ jobs:
       - build-rust
       - publish-rust
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Assert the version tag points at this commit
         # Same tag↔commit invariant as the TypeScript release job's guard: the
         # binaries below were built from this run's commit, and `target_commitish`
@@ -845,6 +853,23 @@ jobs:
           pattern: binaries-rust-*
           merge-multiple: true
 
+      - name: Generate release description
+        # The pending changelog written by `pnpm version -r` holds exactly this
+        # version's entry; its first line is a `## <version>` heading, redundant
+        # under the release title. A missing changelog only warns: the draft is
+        # still worth having for its artifacts, and a maintainer can fill in
+        # the description before publishing.
+        env:
+          VERSION: ${{ needs.plan.outputs.rust_version }}
+        run: |
+          changelog=".changeset/changelogs/pacquet@${VERSION}.md"
+          if [ -f "$changelog" ]; then
+            tail -n +2 "$changelog" | sed '/./,$!d' > RELEASE.md
+          else
+            echo "::warning::No pending changelog at ${changelog}; drafting the release with an empty description"
+            : > RELEASE.md
+          fi
+
       - name: Release
         # The build job's archives already carry the release layout (a `pnpm`
         # binary at the root of `pnpm-<target>.tar.gz` / `.zip`), so they're
@@ -861,6 +886,7 @@ jobs:
           tag_name: v${{ needs.plan.outputs.rust_version }}
           target_commitish: ${{ github.sha }}
           name: pnpm ${{ needs.plan.outputs.rust_version }}
+          body_path: RELEASE.md
           files: |
             pnpm-*.tar.gz
             pnpm-*.zip
@@ -1285,6 +1311,11 @@ jobs:
       - build-pnpr
       - publish-pnpr
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Assert the version tag points at this commit
         # Same tag↔commit invariant as the TypeScript release job's guard.
         env:
@@ -1303,6 +1334,20 @@ jobs:
           pattern: binaries-pnpr-*
           merge-multiple: true
 
+      - name: Generate release description
+        # Same shape as the Rust job's description step; pnpr's changelog file
+        # name carries the `@pnpm!` scope prefix (`!` escapes `/`).
+        env:
+          VERSION: ${{ needs.plan.outputs.pnpr_version }}
+        run: |
+          changelog=".changeset/changelogs/@pnpm!pnpr@${VERSION}.md"
+          if [ -f "$changelog" ]; then
+            tail -n +2 "$changelog" | sed '/./,$!d' > RELEASE.md
+          else
+            echo "::warning::No pending changelog at ${changelog}; drafting the release with an empty description"
+            : > RELEASE.md
+          fi
+
       - name: Release
         # The build job's archives carry a target-qualified `pnpr-<target>`
         # binary and ship with its build-time checksum, so they're uploaded
@@ -1316,6 +1361,7 @@ jobs:
           make_latest: false
           tag_name: pnpr@${{ needs.plan.outputs.pnpr_version }}
           name: pnpr ${{ needs.plan.outputs.pnpr_version }}
+          body_path: RELEASE.md
           files: |
             pnpr-*.tar.gz
             pnpr-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,11 @@ name: Release
 # TypeScript pnpm CLI (v11), the Rust pnpm CLI + NAPI addon (v12), and the
 # pnpr registry server. Versions are committed (bumped by `pnpm bump` via the
 # release PR that create-release-pr.yml opens); pushing a version tag runs the
-# `plan` job, which asks the npm registry which committed versions are not
-# published yet, and only those products' jobs run. Tagging e.g. a v12
-# prerelease therefore skips the TypeScript jobs whose version is already on
-# npm, and vice versa.
+# `plan` job, which releases exactly the product whose committed version the
+# tag names, so tags pushed together release their products in parallel runs.
+# The plan job also asks the npm registry whether that version is already
+# published: rerunning a tag resumes a partial release, and a completed one
+# skips every job.
 on:
   push:
     tags:
@@ -28,13 +29,15 @@ on:
         default: false
 
 # A release PR that bumps several products auto-tags each one (tag-release.yml),
-# so several version tags can land together and start a run apiece. Serialize
-# them: the plan job gates every publish on what npm reports as unpublished, so
-# once the first run publishes a product the rest skip it — but only if they
-# don't run concurrently and all read "unpublished" at once. Never cancel a
-# run mid-publish.
+# so several version tags can land together and start a run apiece. Each run
+# releases only the product its tag names (see the plan job), so simultaneous
+# runs publish disjoint packages and may proceed in parallel. The group is
+# scoped per ref because GitHub keeps at most one *pending* run per group and
+# cancels the rest — a shared group would silently drop one product's release
+# whenever several tags land together. Reruns of the same tag still serialize.
+# Never cancel a run mid-publish.
 concurrency:
-  group: release
+  group: release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -79,12 +82,15 @@ jobs:
 
       - name: Read committed versions and query the registry
         id: decide
-        # A product is released when its committed version is not on npm yet.
-        # `needs_release` treats only E404 as "not published"; any other npm
-        # failure aborts the plan so a registry outage can't be misread as a
-        # pending release. The gate packages are the ones each publish job
-        # publishes last (`pnpm` for both CLIs, `@pnpm/pnpr` for pnpr), so a
-        # rerun after a partial failure resumes instead of skipping.
+        # The tag names the product to release: the one whose committed
+        # version it matches. A tag matching no product's committed version
+        # is an error, never a fallback release. The matched product is then
+        # released only if its version is not on npm yet. `needs_release`
+        # treats only E404 as "not published"; any other npm failure aborts
+        # the plan so a registry outage can't be misread as a pending release.
+        # The gate packages are the ones each publish job publishes last
+        # (`pnpm` for both CLIs, `@pnpm/pnpr` for pnpr), so a rerun after a
+        # partial failure resumes instead of skipping.
         run: |
           set -eu
           needs_release() {
@@ -124,14 +130,40 @@ jobs:
             *) PNPR_TAG="latest" ;;
           esac
 
-          # Assign first so `set -e` aborts the plan on a `needs_release`
-          # failure. Inside `echo "$(needs_release …)"` the non-zero exit is
-          # the subshell's, discarded by echo, so a registry outage would
-          # otherwise be written out as an empty (falsy) value and silently
-          # skip the release.
-          TS_NEEDS=$(needs_release "pnpm@$TS_VERSION")
-          RUST_NEEDS=$(needs_release "pnpm@$RUST_VERSION")
-          PNPR_NEEDS=$(needs_release "@pnpm/pnpr@$PNPR_VERSION")
+          # `needs_release` results land in plain assignments so `set -e`
+          # aborts the plan on a failure. Inside `echo "$(needs_release …)"`
+          # the non-zero exit is the subshell's, discarded by echo, so a
+          # registry outage would otherwise be written out as an empty (falsy)
+          # value and silently skip the release.
+          TS_NEEDS=false
+          RUST_NEEDS=false
+          PNPR_NEEDS=false
+          case "$GITHUB_REF" in
+            refs/tags/pnpr@*)
+              TAG_VERSION="${GITHUB_REF#refs/tags/pnpr@}"
+              if [ "$TAG_VERSION" != "$PNPR_VERSION" ]; then
+                echo "::error::Tag pnpr@${TAG_VERSION} matches no product: the committed @pnpm/pnpr version is ${PNPR_VERSION}"
+                exit 1
+              fi
+              PNPR_NEEDS=$(needs_release "@pnpm/pnpr@$PNPR_VERSION")
+              ;;
+            refs/tags/v*)
+              TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+              if [ "$TAG_VERSION" = "$TS_VERSION" ]; then
+                TS_NEEDS=$(needs_release "pnpm@$TS_VERSION")
+              elif [ "$TAG_VERSION" = "$RUST_VERSION" ]; then
+                RUST_NEEDS=$(needs_release "pnpm@$RUST_VERSION")
+              else
+                echo "::error::Tag v${TAG_VERSION} matches no product: the committed TypeScript pnpm version is ${TS_VERSION} and the committed Rust pnpm version is ${RUST_VERSION}"
+                exit 1
+              fi
+              ;;
+            *)
+              # Only reachable via the verify_ts_release dispatch —
+              # validate-release-ref rejects every other non-tag ref. Nothing
+              # is released.
+              ;;
+          esac
 
           {
             echo "ts=$TS_NEEDS"
@@ -307,13 +339,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Assert the version tag points at this commit
-        # The plan job resumes any unpublished product from whichever tag's run
-        # survives the release concurrency queue, so this job's triggering tag
-        # is not necessarily v<ts_version> — but the commit it publishes from
-        # must be the one v<ts_version> names, both for the artifacts built
-        # below and for the GitHub release that lands on that tag. On a
-        # mismatch (the tags of two release commits ended up in one run's
-        # plan), rerun the release workflow from the v<ts_version> tag instead.
+        # The plan job dispatches on the tag's version string, which cannot
+        # prove the tag points at this commit — a retagged release, or another
+        # commit carrying the same committed version, would still dispatch.
+        # The artifacts built below and the GitHub release that lands on
+        # v<ts_version> must both come from the commit that tag names.
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.plan.outputs.ts_version }}
@@ -394,9 +424,8 @@ jobs:
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.0 # zizmor: ignore[superfluous-actions]
         with:
           draft: true
-          # Pinned because the triggering tag may belong to another product
-          # (see "Assert the version tag points at this commit" above); without
-          # tag_name the action falls back to github.ref.
+          # Explicit so the release's identity comes from the plan job like
+          # every other step here, never from the github.ref fallback.
           tag_name: v${{ needs.plan.outputs.ts_version }}
           name: pnpm ${{ needs.plan.outputs.ts_version }}
           files: dist/*


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

In [release run 29644133887](https://github.com/pnpm/pnpm/actions/runs/29644133887), the TypeScript 11.15.0 artifacts and release notes were published on the [v12.0.0-alpha.15 release page](https://github.com/pnpm/pnpm/releases/tag/v12.0.0-alpha.15), and no v11.15.0 GitHub release was created at all (since fixed up by hand). Two things combined to cause it: the three tags of the release PR shared the single `release` concurrency group — GitHub keeps at most one *pending* run per group, so the `v11.15.0` run was cancelled from the queue — and the surviving `v12.0.0-alpha.15` run resumed the unpublished TypeScript release, whose GitHub-release step passed no `tag_name` and fell back to `github.ref`, the v12 tag.

This PR replaces the "release whatever npm is missing" model with dispatch by tag:

- **The tag names the product.** The plan job releases exactly the product whose committed version the tag matches (`v<ts_version>` → TypeScript CLI, `v<rust_version>` → Rust CLI, `pnpr@<version>` → pnpr). A tag matching no product's committed version fails the plan loudly instead of falling back. The npm-registry check remains as an idempotency guard: rerunning a tag resumes a partial release, and rerunning a completed tag skips every job.
- **Per-ref concurrency.** Since each run now publishes a disjoint set of packages, simultaneous tag pushes run in parallel instead of sharing a queue that silently evicts pending runs. Reruns of the same tag still serialize, and nothing is cancelled mid-publish.
- **Pinned release identity.** The TypeScript GitHub-release step gets an explicit `tag_name`/`name` derived from the plan, mirroring `github-release-rust`, so no release step depends on the `github.ref` fallback.
- **Tag↔commit guards.** All GitHub-release jobs assert that the version tag points at the run's commit before creating the release — the dispatch matches version *strings*, which cannot prove the tag points at this commit (a retagged release, or a second commit carrying the same committed version, would still dispatch). The Rust job's `target_commitish` cannot enforce this because GitHub ignores it whenever the tag already exists.
- **pnpr gets a GitHub release page.** A new `github-release-pnpr` job mirrors `github-release-rust`: it drafts a release on the `pnpr@<version>` tag with the platform archives and their build-time checksums, prerelease-flagged for alpha versions and kept off the repository's "Latest" badge. This supersedes the still-relevant part of pnpm/pnpm#12963 (its other two parts — a pnpr tag namespace and the TypeScript `tag_name` pinning — landed as `pnpr@<version>` on main and in this PR, respectively).
- **Every product's release stays a draft until a maintainer publishes it.** The TypeScript job used to verify its draft's body and immediately publish it. The repository uses immutable releases, so publishing is irreversible — a wrong published release can only be deleted, and deletion burns its tag for releases forever (the alpha.15 incident had to be republished as `v12.0.0-alpha.15-1` for exactly this reason). All three products now get the same deliberate human publish gate.
- **Rust and pnpr drafts carry their changelogs.** Only the TypeScript release had generated notes; the Rust and pnpr drafts were empty. Each draft's body is now filled from the product's pending changelog written by `pnpm version -r` (`.changeset/changelogs/pacquet@<version>.md` / `` .changeset/changelogs/@pnpm!pnpr@<version>.md ``), with a warning fallback to an empty description if the file is missing.

The dispatch logic was exercised locally against the live registry for all six cases: the three current tags route to their own product (and skip, as all are published), `v9.9.9` / `pnpr@9.9.9` fail with a clear error, and a branch ref (the `verify_ts_release` dispatch path) releases nothing. Validated with `actionlint` (only pre-existing runner-label complaints) and `zizmor` (no findings).

## Squash Commit Body

```text
The plan job released every product whose committed version was missing
from npm, regardless of which tag triggered the run. Combined with the
shared release concurrency group - GitHub keeps at most one pending run
per group and cancels the rest - a multi-product release PR could get a
product's run evicted from the queue and its release performed under a
sibling product's tag. This published the v11.15.0 artifacts and notes
on the v12.0.0-alpha.15 release page
(https://github.com/pnpm/pnpm/actions/runs/29644133887).

Now the tag is the dispatch key: a run releases exactly the product
whose committed version the tag names, and a tag matching no product
fails the plan. The npm check remains as an idempotency guard, so
rerunning a tag resumes a partial release and a completed tag skips
every job. The concurrency group is scoped per ref so simultaneous tags
run in parallel instead of sharing a queue that evicts pending runs;
per-product runs publish disjoint packages, making parallelism safe.

The TypeScript GitHub-release step additionally pins tag_name and name
to the planned version, and both GitHub-release jobs assert that the
version tag points at the commit the run built, since the dispatch
matches version strings and cannot prove tag-commit identity. The Rust
job's target_commitish cannot enforce this - GitHub ignores it whenever
the tag already exists.
```

## Checklist

- [x] The change covers the release paths of both the TypeScript CLI and the Rust `pnpm/` port (workflow-only change; no product code affected).
- No changeset: no published package is affected.
- No tests: release workflow YAML; the dispatch script was exercised locally for all six ref cases, and the file passes `actionlint` and `zizmor`.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process Improvements**
  * Release workflows now run independently for each release tag.
  * Releases are created as drafts with explicit tags, names, release notes, and artifacts.
  * Added support for drafting pnpr releases.
  * Added safeguards to prevent releases when tags do not match the intended commit or product version.
  * Improved handling of unpublished package versions during release planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->