### PR TITLE
fix(pacquet): tolerate an already-removed cache mirror in metadata-fetch race tests

### DIFF
--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -425,7 +425,7 @@ async fn assert_cache_loss_after_304_recovers(
 fn remove_raced_mirror_tolerant(path: &std::path::Path) {
     match std::fs::remove_file(path) {
         Ok(()) => {}
-        Err(_) if !path.exists() => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => panic!("remove raced mirror: {error}"),
     }
 }

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -202,7 +202,7 @@ async fn cache_loss_after_304_stops_after_one_fallback() {
         .match_header("if-none-match", r#"W/"stale""#)
         .with_status(304)
         .with_body_from_request(move |_| {
-            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            remove_raced_mirror_tolerant(&raced_mirror);
             Vec::new()
         })
         .expect(1)
@@ -251,7 +251,7 @@ async fn cache_loss_after_304_body_retry_remains_bypassed() {
         .match_header("if-none-match", r#"W/"stale""#)
         .with_status(304)
         .with_body_from_request(move |_| {
-            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            remove_raced_mirror_tolerant(&raced_mirror);
             Vec::new()
         })
         .expect(1)
@@ -315,7 +315,7 @@ async fn cache_loss_after_304_registry_error_propagates() {
         .match_header("if-none-match", r#"W/"stale""#)
         .with_status(304)
         .with_body_from_request(move |_| {
-            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            remove_raced_mirror_tolerant(&raced_mirror);
             Vec::new()
         })
         .expect(1)
@@ -368,7 +368,7 @@ async fn assert_cache_loss_after_304_recovers(
         .match_header("if-none-match", r#"W/"stale""#)
         .with_status(304)
         .with_body_from_request(move |_| {
-            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            remove_raced_mirror_tolerant(&raced_mirror);
             Vec::new()
         })
         .expect(1)
@@ -414,6 +414,20 @@ async fn assert_cache_loss_after_304_recovers(
     assert_eq!(headers.etag.as_deref(), Some(r#"W/"fresh""#));
     first.assert_async().await;
     second.assert_async().await;
+}
+
+/// Removes the cache mirror at `path` if it exists.
+///
+/// This helper avoids panicking with a `NotFound` error if the file has already
+/// been deleted (e.g. on a subsequent unexpected request hit to the mock server),
+/// which would otherwise panic the mockito server thread and lead to process-aborting
+/// lock poisoning (see issue #13105).
+fn remove_raced_mirror_tolerant(path: &std::path::Path) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {}
+        Err(_) if !path.exists() => {}
+        Err(error) => panic!("remove raced mirror: {error}"),
+    }
 }
 
 fn write_stale_mirror(


### PR DESCRIPTION
Closes pnpm/pnpm#13105

<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

The cache-race tests in `fetch_full_metadata_cached/tests.rs` simulate a vanishing mirror from inside a mockito response closure, using `std::fs::remove_file(&raced_mirror).expect("remove raced mirror")`. The mock is declared `.expect(1)`, so on the happy path the closure runs once and this is fine.

But if the code under test regresses and the mock is hit a second time, the second `remove_file` call fails with `NotFound` and panics — on mockito's server thread, during `ServerGuard` cleanup. That panic occurs while unwinding through a `RwLock` guard drop in `Server::reset`, poisoning the lock and triggering a second panic — a panic during a panic, which Rust cannot unwind through, so the process aborts (`SIGABRT` on Linux, stack-buffer-overrun on Windows) instead of the test failing cleanly. `cargo nextest` then cancels any sibling tests still running.

This is a diagnostics-only issue — the regression is still caught (confirmed by mutating `fetch_full_metadata_cached.rs:123` to `bypass_cache: false` and observing the abort) — but the failure signal is far worse than a clean assertion.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Fix cache-race tests in fetch_full_metadata_cached aborting the test
process (SIGABRT / stack-buffer-overrun) instead of failing cleanly
when the code under test regresses.

Each of the four cache-race tests declared an identical
.with_body_from_request closure that called
std::fs::remove_file(&raced_mirror).expect("remove raced mirror") to
simulate a vanishing mirror. The mock is set to .expect(1), so this is
fine on the happy path. But if the mock is hit a second time (i.e. the
regression the test exists to catch), the second remove_file call
fails with NotFound and the .expect(...) panics on mockito's server
thread, during ServerGuard cleanup. That panic occurs while unwinding
through a RwLock guard drop in Server::reset, poisoning the lock and
triggering a second panic, a panic during a panic, which Rust cannot
unwind through, so the process aborts instead of the test failing.

Extracted a shared remove_raced_mirror_tolerant(path: &Path) helper
that only panics if removal fails for a reason other than the file
already being gone, and replaced all four duplicated closures to use
it. The mock's .expect(1) + assert_async() remains responsible for
actually reporting the unexpected extra request, this change only
removes the panic-during-panic failure mode, it does not change what
behavior is being tested.

Verified by re-simulating the regression (bypass_cache: false at
fetch_full_metadata_cached.rs:123): the previously-aborting test now
fails with a clean mockito expectation error instead of aborting the
process. Reverted that mutation and confirmed all 5 cache_loss tests
pass cleanly.

Closes pnpm/pnpm#13105
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.

  Rust-only change (test-file fix in `pacquet-resolving-npm-resolver`); no TypeScript equivalent exists for this test infrastructure.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.

  No changeset — this only touches test code, no published package behavior changes.
- [x] Added or updated tests.

  No new tests added; existing tests' failure-mode fixed. Verified via `cargo nextest run -p pacquet-resolving-npm-resolver cache_loss` (5/5 pass) and by re-simulating the original regression to confirm the fix produces a clean failure instead of an abort.
- [ ] Updated the documentation if needed.

  No doc update needed — internal test-infrastructure fix only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786991805&installation_id=145934176&pr_number=13130&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13130&signature=75959fb0e6bd7947036fe81d6e66028314ae5e148a956ad46c66b68c9eadc381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of package metadata retry and mirror-fallback handling.
  * Prevented intermittent test failures caused by cleanup attempting to remove a temporary mirror file that may already be gone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->