### PR TITLE
test(resolver): improve cache race failure diagnostics

### DIFF
--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -202,7 +202,7 @@ async fn cache_loss_after_304_stops_after_one_fallback() {
         .match_header("if-none-match", r#"W/"stale""#)
         .with_status(304)
         .with_body_from_request(move |_| {
-            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            remove_raced_mirror(&raced_mirror);
             Vec::new()
         })
         .expect(1)
@@ -251,7 +251,7 @@ async fn cache_loss_after_304_body_retry_remains_bypassed() {
         .match_header("if-none-match", r#"W/"stale""#)
         .with_status(304)
         .with_body_from_request(move |_| {
-            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            remove_raced_mirror(&raced_mirror);
             Vec::new()
         })
         .expect(1)
@@ -315,7 +315,7 @@ async fn cache_loss_after_304_registry_error_propagates() {
         .match_header("if-none-match", r#"W/"stale""#)
         .with_status(304)
         .with_body_from_request(move |_| {
-            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            remove_raced_mirror(&raced_mirror);
             Vec::new()
         })
         .expect(1)
@@ -368,7 +368,7 @@ async fn assert_cache_loss_after_304_recovers(
         .match_header("if-none-match", r#"W/"stale""#)
         .with_status(304)
         .with_body_from_request(move |_| {
-            std::fs::remove_file(&raced_mirror).expect("remove raced mirror");
+            remove_raced_mirror(&raced_mirror);
             Vec::new()
         })
         .expect(1)
@@ -425,6 +425,14 @@ fn write_stale_mirror(
     let meta = serde_json::from_str(PACKAGE_BODY).expect("package body");
     save_meta_indexed(&mirror_path, &meta, Some(r#"W/"stale""#)).expect("write stale mirror");
     mirror_path
+}
+
+fn remove_raced_mirror(mirror_path: &std::path::Path) {
+    match std::fs::remove_file(mirror_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => panic!("remove raced mirror: {error}"),
+    }
 }
 
 #[tokio::test]

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached/tests.rs
@@ -427,11 +427,21 @@ fn write_stale_mirror(
     mirror_path
 }
 
+#[test]
+fn raced_mirror_removal_is_idempotent() {
+    let cache = TempDir::new().expect("tempdir");
+    let mirror_path = cache.path().join("mirror.json");
+    std::fs::write(&mirror_path, "").expect("write mirror");
+
+    remove_raced_mirror(&mirror_path);
+    remove_raced_mirror(&mirror_path);
+}
+
 fn remove_raced_mirror(mirror_path: &std::path::Path) {
     match std::fs::remove_file(mirror_path) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => panic!("remove raced mirror: {error}"),
+        Err(error) => panic!("remove raced mirror at {}: {error}", mirror_path.display()),
     }
 }
 


### PR DESCRIPTION
## Summary

- Make cache-race mock mirror removal idempotent when the mirror is already missing.
- Let mockito report an extra request through its `.expect(1)` assertion instead of panicking on the server thread and aborting with SIGABRT.
- Continue failing immediately for filesystem errors other than `NotFound`.
- This is a Rust test-only change, so no TypeScript parity change or changeset is required.
- Closes pnpm/pnpm#13105.

## Squash Commit Body

```text
Make the metadata cache-race test cleanup tolerate a mirror that was already removed. This lets mockito report duplicate requests through its expectation failure instead of triggering a server-thread panic and SIGABRT.

Closes pnpm/pnpm#13105.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786996013&installation_id=145934176&pr_number=13131&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13131&signature=a2b267fa712c15e9889ebccb6b6b53e59ce1b811f2a120434af7eb95f682b87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary “raced” mirror files during metadata retry scenarios, tolerating cases where the file was already removed by another process.
  * Maintains strict error reporting for unexpected cleanup failures while avoiding unnecessary crashes.
* **Tests**
  * Added a unit test to verify raced mirror cleanup is idempotent (safe to run multiple times on the same path).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->