### PR TITLE
test(team): add team command tests for TS and Rust

### DIFF
--- a/pnpm/crates/cli/src/cli_args/team.rs
+++ b/pnpm/crates/cli/src/cli_args/team.rs
@@ -126,6 +126,10 @@ pub enum TeamError {
         body: String,
     },
 
+    #[display("Authentication required for registry access")]
+    #[diagnostic(code(ERR_PNPM_TEAM_MISSING_AUTH))]
+    MissingAuthToken,
+
     #[display("Organization or team not found. {body}")]
     #[diagnostic(code(ERR_PNPM_NOT_FOUND))]
     NotFound {
@@ -314,7 +318,7 @@ async fn team_create(context: &TeamContext<'_>, params: &[String]) -> miette::Re
     let team = st.team.as_deref().ok_or(TeamError::CreateNameRequired)?;
 
     let registry_url = registry_for_scope(context, &st.scope);
-    let auth_header = auth_header_for_registry(context, &st.scope);
+    let auth_header = auth_header_for_registry(context, &st.scope)?;
     let url = org_team_url(&registry_url, &st.scope);
     let body = serde_json::json!({ "name": team }).to_string();
 
@@ -322,7 +326,7 @@ async fn team_create(context: &TeamContext<'_>, params: &[String]) -> miette::Re
         send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
             let builder =
                 client.put(&url).header("content-type", "application/json").body(body.clone());
-            apply_auth_and_otp(builder, auth_header.as_deref(), context.otp.as_deref())
+            apply_auth_and_otp(builder, Some(&auth_header), context.otp.as_deref())
         })
         .await
         .map_err(|source| registry_operation_error("creating team", source))?;
@@ -340,13 +344,13 @@ async fn team_destroy(context: &TeamContext<'_>, params: &[String]) -> miette::R
     let team = st.team.as_deref().ok_or(TeamError::DestroyNameRequired)?;
 
     let registry_url = registry_for_scope(context, &st.scope);
-    let auth_header = auth_header_for_registry(context, &st.scope);
+    let auth_header = auth_header_for_registry(context, &st.scope)?;
     let url = team_url(&registry_url, &st.scope, team);
 
     let (_guard, response) =
         send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
             let builder = client.delete(&url);
-            apply_auth_and_otp(builder, auth_header.as_deref(), context.otp.as_deref())
+            apply_auth_and_otp(builder, Some(&auth_header), context.otp.as_deref())
         })
         .await
         .map_err(|source| registry_operation_error("destroying team", source))?;
@@ -367,7 +371,7 @@ async fn team_add(context: &TeamContext<'_>, params: &[String]) -> miette::Resul
     let username = &params[1];
 
     let registry_url = registry_for_scope(context, &st.scope);
-    let auth_header = auth_header_for_registry(context, &st.scope);
+    let auth_header = auth_header_for_registry(context, &st.scope)?;
     let url = team_user_url(&registry_url, &st.scope, team);
     let body = serde_json::json!({ "user": username }).to_string();
 
@@ -375,7 +379,7 @@ async fn team_add(context: &TeamContext<'_>, params: &[String]) -> miette::Resul
         send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
             let builder =
                 client.put(&url).header("content-type", "application/json").body(body.clone());
-            apply_auth_and_otp(builder, auth_header.as_deref(), context.otp.as_deref())
+            apply_auth_and_otp(builder, Some(&auth_header), context.otp.as_deref())
         })
         .await
         .map_err(|source| registry_operation_error("adding user to team", source))?;
@@ -399,7 +403,7 @@ async fn team_rm(context: &TeamContext<'_>, params: &[String]) -> miette::Result
     let username = &params[1];
 
     let registry_url = registry_for_scope(context, &st.scope);
-    let auth_header = auth_header_for_registry(context, &st.scope);
+    let auth_header = auth_header_for_registry(context, &st.scope)?;
     let url = team_user_url(&registry_url, &st.scope, team);
     let body = serde_json::json!({ "user": username }).to_string();
 
@@ -407,7 +411,7 @@ async fn team_rm(context: &TeamContext<'_>, params: &[String]) -> miette::Result
         send_with_retry(&context.http_client, &url, context.retry_opts, |client| {
             let builder =
                 client.delete(&url).header("content-type", "application/json").body(body.clone());
-            apply_auth_and_otp(builder, auth_header.as_deref(), context.otp.as_deref())
+            apply_auth_and_otp(builder, Some(&auth_header), context.otp.as_deref())
         })
         .await
         .map_err(|source| registry_operation_error("removing user from team", source))?;
@@ -426,13 +430,13 @@ async fn team_ls(context: &TeamContext<'_>, params: &[String]) -> miette::Result
     let spec = params.first().ok_or(TeamError::LsScopeRequired)?;
     let st = parse_scope_team(spec)?;
 
-    let auth_header = auth_header_for_registry(context, &st.scope);
+    let auth_header = auth_header_for_registry(context, &st.scope)?;
 
     if let Some(team) = &st.team {
-        let members = fetch_team_members(context, &st.scope, team, auth_header.as_deref()).await?;
+        let members = fetch_team_members(context, &st.scope, team, Some(&auth_header)).await?;
         render_members(&st.scope, team, &members, context.parseable, context.json)
     } else {
-        let teams = fetch_teams(context, &st.scope, auth_header.as_deref()).await?;
+        let teams = fetch_teams(context, &st.scope, Some(&auth_header)).await?;
         render_teams(&st.scope, &teams, context.parseable, context.json)
     }
 }
@@ -578,10 +582,14 @@ fn registry_for_scope(context: &TeamContext<'_>, scope: &str) -> String {
     pick_registry_for_package(&context.registries, &pkg_name, None)
 }
 
-fn auth_header_for_registry(context: &TeamContext<'_>, scope: &str) -> Option<String> {
+fn auth_header_for_registry(context: &TeamContext<'_>, scope: &str) -> miette::Result<String> {
     let registry_url = registry_for_scope(context, scope);
     let pkg_name = format!("@{scope}/_");
-    context.config.auth_headers.for_url_with_package(&registry_url, Some(&pkg_name))
+    context
+        .config
+        .auth_headers
+        .for_url_with_package(&registry_url, Some(&pkg_name))
+        .ok_or_else(|| TeamError::MissingAuthToken.into())
 }
 
 fn apply_auth_and_otp(

--- a/pnpm/crates/cli/tests/team.rs
+++ b/pnpm/crates/cli/tests/team.rs
@@ -40,14 +40,8 @@ fn run_team(
 #[test]
 fn fails_when_auth_is_missing() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let mut server = mockito::Server::new();
+    let server = mockito::Server::new();
     let registry = format!("{}/", server.url());
-
-    let _mock = server
-        .mock("GET", "/-/team/myscope/myteam/user")
-        .with_status(401)
-        .with_body("Unauthorized")
-        .create();
 
     let auth_file = empty_auth_file(root.path());
 
@@ -56,8 +50,8 @@ fn fails_when_auth_is_missing() {
     assert!(!output.status.success(), "team must fail when auth is missing");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("You must be logged in to"),
-        "stderr must contain auth error; got:\n{stderr}",
+        stderr.contains("Authentication required for registry access"),
+        "stderr must contain missing-auth error; got:\n{stderr}",
     );
     drop((root, server));
 }

--- a/pnpm/crates/cli/tests/team.rs
+++ b/pnpm/crates/cli/tests/team.rs
@@ -1,0 +1,94 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+fn empty_auth_file(root: &Path) -> PathBuf {
+    let auth_file = root.join("auth-npmrc");
+    fs::write(&auth_file, "").expect("write empty auth .npmrc");
+    auth_file
+}
+
+fn run_team(
+    workspace: &Path,
+    auth_file: &Path,
+    registry: &str,
+    args: &[&str],
+) -> std::process::Output {
+    let mut command = pacquet_at(workspace)
+        .with_arg("--npmrc-auth-file")
+        .with_arg(auth_file)
+        .with_arg("--registry")
+        .with_arg(registry)
+        .with_arg("team");
+
+    for arg in args {
+        command = command.with_arg(arg);
+    }
+
+    command.output().expect("spawn pacquet team")
+}
+
+#[test]
+fn fails_when_auth_is_missing() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+
+    let _mock = server
+        .mock("GET", "/-/team/myscope/myteam/user")
+        .with_status(401)
+        .with_body("Unauthorized")
+        .create();
+
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_team(&workspace, &auth_file, &registry, &["ls", "@myscope:myteam"]);
+
+    assert!(!output.status.success(), "team must fail when auth is missing");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Authentication required for registry access"),
+        "stderr must contain auth error; got:\n{stderr}",
+    );
+    drop((root, server));
+}
+
+#[test]
+fn team_create_succeeds_with_mock_registry() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+
+    let mock = server
+        .mock("PUT", "/-/org/myscope/team")
+        .match_header("authorization", "Bearer fake-token")
+        .with_status(201)
+        .create();
+
+    let auth_file = root.path().join("auth-npmrc");
+    let registry_no_scheme = server.url().replace("http://", "");
+    fs::write(&auth_file, format!("//{registry_no_scheme}/:_authToken=fake-token\n"))
+        .expect("write auth .npmrc");
+
+    let output = run_team(&workspace, &auth_file, &registry, &["create", "@myscope:myteam"]);
+
+    mock.assert();
+    assert!(
+        output.status.success(),
+        "team create must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("+myscope:myteam"));
+    drop((root, server));
+}

--- a/pnpm/crates/cli/tests/team.rs
+++ b/pnpm/crates/cli/tests/team.rs
@@ -56,7 +56,7 @@ fn fails_when_auth_is_missing() {
     assert!(!output.status.success(), "team must fail when auth is missing");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Authentication required for registry access"),
+        stderr.contains("You must be logged in to"),
         "stderr must contain auth error; got:\n{stderr}",
     );
     drop((root, server));

--- a/pnpm11/registry-access/commands/src/team.ts
+++ b/pnpm11/registry-access/commands/src/team.ts
@@ -416,6 +416,9 @@ function getRegistryAndAuthForOrg (
   const pkgName = `@${scope}/__pnpm_team__`
   const registryUrl = pickRegistryForPackage(opts.registries ?? { default: 'https://registry.npmjs.org/' }, pkgName)
   const authHeader = getAuthHeaderForRegistry(opts.configByUri, registryUrl, pkgName)
+  if (!authHeader) {
+    throw new PnpmError('TEAM_MISSING_AUTH', 'Authentication required for registry access')
+  }
   return { registryUrl, authHeader }
 }
 

--- a/pnpm11/registry-access/commands/test/team.ts
+++ b/pnpm11/registry-access/commands/test/team.ts
@@ -1,9 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals'
+import { PnpmError } from '@pnpm/error'
 import { getMockAgent, setupMockAgent, teardownMockAgent } from '@pnpm/testing.mock-agent'
 
 import { team } from '../src/index.js'
 
 const REGISTRY_URL = 'https://registry.npmjs.org/'
+
+const CONFIG_BY_URI = {
+  '//registry.npmjs.org/': {
+    '@': { authToken: 'test-token' },
+  },
+}
 
 describe('team command', () => {
   beforeEach(async () => {
@@ -47,6 +54,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['create', '@myorg:newteam'])
 
@@ -79,6 +87,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: { otp: '123456' },
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['create', '@myorg:newteam'])
 
@@ -94,6 +103,7 @@ describe('team command', () => {
       await expect(async () => {
         await team.handler({
           cliOptions: {},
+          configByUri: CONFIG_BY_URI,
           registries: { default: REGISTRY_URL },
         }, ['create', '@myorg:newteam'])
       }).rejects.toThrow('logged in')
@@ -108,6 +118,7 @@ describe('team command', () => {
       await expect(async () => {
         await team.handler({
           cliOptions: {},
+          configByUri: CONFIG_BY_URI,
           registries: { default: REGISTRY_URL },
         }, ['create', '@myorg:newteam'])
       }).rejects.toThrow('permission')
@@ -150,6 +161,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['destroy', '@myorg:oldteam'])
 
@@ -173,6 +185,51 @@ describe('team command', () => {
         }, ['destroy', '@myorg'])
       }).rejects.toThrow('Team name is required')
     })
+
+    it('should throw on 401 (unauthorized)', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'DELETE',
+        path: '/-/team/myorg/oldteam',
+      }).reply(401, { error: 'Unauthorized' })
+
+      await expect(async () => {
+        await team.handler({
+          cliOptions: {},
+          configByUri: CONFIG_BY_URI,
+          registries: { default: REGISTRY_URL },
+        }, ['destroy', '@myorg:oldteam'])
+      }).rejects.toThrow('logged in')
+    })
+
+    it('should throw on 403 (forbidden)', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'DELETE',
+        path: '/-/team/myorg/oldteam',
+      }).reply(403, { error: 'Forbidden' })
+
+      await expect(async () => {
+        await team.handler({
+          cliOptions: {},
+          configByUri: CONFIG_BY_URI,
+          registries: { default: REGISTRY_URL },
+        }, ['destroy', '@myorg:oldteam'])
+      }).rejects.toThrow('permission')
+    })
+
+    it('should pass otp header when provided', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'DELETE',
+        path: '/-/team/myorg/oldteam',
+      }).reply(200, { ok: true })
+
+      const result = await team.handler({
+        cliOptions: { otp: '654321' },
+        configByUri: CONFIG_BY_URI,
+        registries: { default: REGISTRY_URL },
+      }, ['destroy', '@myorg:oldteam'])
+
+      expect(result).toBe('-myorg:oldteam')
+    })
   })
 
   describe('add', () => {
@@ -185,6 +242,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['add', '@myorg:team1', 'alice'])
 
@@ -217,6 +275,51 @@ describe('team command', () => {
         }, ['add', '@myorg', 'alice'])
       }).rejects.toThrow('Team name is required')
     })
+
+    it('should throw on 401 (unauthorized)', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'PUT',
+        path: '/-/team/myorg/team1/user',
+      }).reply(401, { error: 'Unauthorized' })
+
+      await expect(async () => {
+        await team.handler({
+          cliOptions: {},
+          configByUri: CONFIG_BY_URI,
+          registries: { default: REGISTRY_URL },
+        }, ['add', '@myorg:team1', 'alice'])
+      }).rejects.toThrow('logged in')
+    })
+
+    it('should throw on 403 (forbidden)', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'PUT',
+        path: '/-/team/myorg/team1/user',
+      }).reply(403, { error: 'Forbidden' })
+
+      await expect(async () => {
+        await team.handler({
+          cliOptions: {},
+          configByUri: CONFIG_BY_URI,
+          registries: { default: REGISTRY_URL },
+        }, ['add', '@myorg:team1', 'alice'])
+      }).rejects.toThrow('permission')
+    })
+
+    it('should pass otp header when provided', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'PUT',
+        path: '/-/team/myorg/team1/user',
+      }).reply(200, { ok: true })
+
+      const result = await team.handler({
+        cliOptions: { otp: '123456' },
+        configByUri: CONFIG_BY_URI,
+        registries: { default: REGISTRY_URL },
+      }, ['add', '@myorg:team1', 'alice'])
+
+      expect(result).toBe('+alice added to @myorg:team1')
+    })
   })
 
   describe('rm', () => {
@@ -229,6 +332,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['rm', '@myorg:team1', 'bob'])
 
@@ -252,6 +356,51 @@ describe('team command', () => {
         }, ['rm', '@myorg:team1'])
       }).rejects.toThrow('Team scope and user are required')
     })
+
+    it('should throw on 401 (unauthorized)', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'DELETE',
+        path: '/-/team/myorg/team1/user',
+      }).reply(401, { error: 'Unauthorized' })
+
+      await expect(async () => {
+        await team.handler({
+          cliOptions: {},
+          configByUri: CONFIG_BY_URI,
+          registries: { default: REGISTRY_URL },
+        }, ['rm', '@myorg:team1', 'bob'])
+      }).rejects.toThrow('logged in')
+    })
+
+    it('should throw on 403 (forbidden)', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'DELETE',
+        path: '/-/team/myorg/team1/user',
+      }).reply(403, { error: 'Forbidden' })
+
+      await expect(async () => {
+        await team.handler({
+          cliOptions: {},
+          configByUri: CONFIG_BY_URI,
+          registries: { default: REGISTRY_URL },
+        }, ['rm', '@myorg:team1', 'bob'])
+      }).rejects.toThrow('permission')
+    })
+
+    it('should pass otp header when provided', async () => {
+      getMockAgent().get('https://registry.npmjs.org').intercept({
+        method: 'DELETE',
+        path: '/-/team/myorg/team1/user',
+      }).reply(200, { ok: true })
+
+      const result = await team.handler({
+        cliOptions: { otp: '123456' },
+        configByUri: CONFIG_BY_URI,
+        registries: { default: REGISTRY_URL },
+      }, ['rm', '@myorg:team1', 'bob'])
+
+      expect(result).toBe('-bob removed from @myorg:team1')
+    })
   })
 
   describe('ls', () => {
@@ -266,6 +415,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['ls', '@myorg'])
 
@@ -285,6 +435,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['ls', '@myorg:developers'])
 
@@ -304,6 +455,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: { parseable: true },
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['ls', '@myorg'])
 
@@ -321,6 +473,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: { json: true },
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['ls', '@myorg'])
 
@@ -336,6 +489,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['ls', '@myorg'])
 
@@ -350,6 +504,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['ls', '@myorg:empty-team'])
 
@@ -365,6 +520,7 @@ describe('team command', () => {
       await expect(async () => {
         await team.handler({
           cliOptions: {},
+          configByUri: CONFIG_BY_URI,
           registries: { default: REGISTRY_URL },
         }, ['ls', '@nonexistent'])
       }).rejects.toThrow('not found')
@@ -379,6 +535,7 @@ describe('team command', () => {
       await expect(async () => {
         await team.handler({
           cliOptions: {},
+          configByUri: CONFIG_BY_URI,
           registries: { default: REGISTRY_URL },
         }, ['ls', '@myorg:nonexistent'])
       }).rejects.toThrow('not found')
@@ -401,6 +558,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['list', '@myorg'])
 
@@ -417,6 +575,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['@myorg'])
 
@@ -431,6 +590,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: {},
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['@myorg:developers'])
 
@@ -457,6 +617,34 @@ describe('team command', () => {
       }).rejects.toThrow('Team spec must start with @scope')
     })
 
+    it('should throw missing-auth when no token is configured', async () => {
+      try {
+        await team.handler({
+          cliOptions: {},
+          configByUri: {},
+          registries: { default: REGISTRY_URL },
+        }, ['ls', '@myorg'])
+        throw new Error('Expected error to be thrown')
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(PnpmError)
+        expect((err as PnpmError).code).toBe('ERR_PNPM_TEAM_MISSING_AUTH')
+        expect((err as PnpmError).message).toContain('Authentication required')
+      }
+    })
+
+    it('should throw missing-auth when configByUri is absent', async () => {
+      try {
+        await team.handler({
+          cliOptions: {},
+          registries: { default: REGISTRY_URL },
+        }, ['ls', '@myorg'])
+        throw new Error('Expected error to be thrown')
+      } catch (err: unknown) {
+        expect(err).toBeInstanceOf(PnpmError)
+        expect((err as PnpmError).code).toBe('ERR_PNPM_TEAM_MISSING_AUTH')
+      }
+    })
+
     it('should throw on inappropriate parseable ls with just scope', async () => {
       getMockAgent().get('https://registry.npmjs.org').intercept({
         method: 'GET',
@@ -465,6 +653,7 @@ describe('team command', () => {
 
       const result = await team.handler({
         cliOptions: { parseable: true },
+        configByUri: CONFIG_BY_URI,
         registries: { default: REGISTRY_URL },
       }, ['ls', '@myorg'])
 


### PR DESCRIPTION
## Summary

Implement the `team` command tests tailored to the pnpm ecosystem for both the TypeScript CLI and the Rust port pacquet.

Related to: #11633 

## Squash Commit Body

```text
feat: implement team command for npm registry

This PR introduces the `team` command tests to manage organization teams and team memberships. 
The implementation handles network requests using `@pnpm/fetch` and `reqwest` respectively,
ensuring that the necessary auth tokens are passed and responses are formatted cleanly.

Related to: #11633 

```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787000179&installation_id=145934176&pr_number=13132&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13132&signature=e78af4fdf16d1a4818f6c9270c70ed785cc97bc8bf8821a4112d849d46b3e75b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI support for managing teams with create, list, destroy, add-member, and remove-member commands.
  * Added JSON output support for team operations.
  * Supports team and user references with optional scope notation.
* **Bug Fixes**
  * Team commands now clearly fail when registry authentication is missing or invalid.
  * Improved handling of invalid team references and unexpected registry responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->