### PR TITLE
fix(resolver): condense retained registry metadata to keep large installs in memory

### DIFF
--- a/.changeset/condense-retained-packuments.md
+++ b/.changeset/condense-retained-packuments.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+---
+
+Fixed `pnpm install` running out of memory while resolving large dependency graphs [#8441](https://github.com/pnpm/pnpm/issues/8441). The resolver kept full registry documents — per-version readmes, scripts, descriptions, and other install-irrelevant bulk — in memory for every package fetched with full metadata (optional dependencies, and packages re-fetched for `minimumReleaseAge`'s publish timestamps). Every retained document is now condensed down to the field set installation actually reads, which reduces peak resolution memory by several times on workspaces with more than a thousand packages.

--- a/pnpm11/pnpm/test/install/memoryBounded.ts
+++ b/pnpm11/pnpm/test/install/memoryBounded.ts
@@ -1,0 +1,98 @@
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { expect, test } from '@jest/globals'
+import { prepare } from '@pnpm/prepare'
+
+import { execPnpm } from '../utils/index.js'
+
+const PACKAGE_COUNT = 40
+const JUNK_BYTES = 6 * 1024 * 1024
+
+/**
+ * End-to-end regression guard for https://github.com/pnpm/pnpm/issues/8441:
+ * a whole `pnpm install` (the bundled CLI, not just the resolver package)
+ * must not retain full-document bulk, so it completes inside a small heap.
+ *
+ * The registry documents — served by a local server, one per optional
+ * dependency so the CLI fetches full metadata — each carry 6 MB of
+ * install-irrelevant bulk, 240 MB total. Retaining the parsed documents,
+ * as the resolver did before condensing, overflows the 256 MB cap by
+ * ~100 MB regardless of which cache pins them; the condensed working set
+ * plus the CLI's baseline fits with roughly 100 MB to spare (the fixed
+ * install passes even a 192 MB cap). That margin in both directions keeps the
+ * guard deterministic rather than timing-sensitive.
+ */
+test('install --lockfile-only completes within a small heap while registry documents carry megabytes of bulk', async () => {
+  const server = await startBloatedRegistry()
+  const optionalDependencies = Object.fromEntries(
+    Array.from({ length: PACKAGE_COUNT }, (_, i) => [`bloated-pkg-${i}`, '1.0.0'])
+  )
+  const project = prepare({ optionalDependencies })
+
+  try {
+    await execPnpm(['install', '--lockfile-only'], {
+      env: {
+        NODE_OPTIONS: '--max-old-space-size=256',
+        pnpm_config_registry: server.url,
+        // Bounds the post-fix transient footprint (response body + freshly
+        // parsed document per in-flight request) so the heap cap measures
+        // what is RETAINED across the resolution, which no concurrency
+        // setting can shrink.
+        pnpm_config_network_concurrency: '4',
+      },
+    })
+  } finally {
+    server.close()
+  }
+
+  const lockfile = project.readLockfile()
+  expect(Object.keys(lockfile.packages)).toHaveLength(PACKAGE_COUNT)
+  expect(lockfile.packages['bloated-pkg-0@1.0.0'].libc).toEqual(['glibc'])
+})
+
+interface BloatedRegistry {
+  url: string
+  close: () => void
+}
+
+// Serves a full packument for any package name requested. The junk string is
+// shared server-side; JSON.parse in the CLI gives each document its own copy —
+// the copy whose retention this test bounds. Tarball URLs point back at this
+// server but are never fetched: --lockfile-only resolves without downloading.
+async function startBloatedRegistry (): Promise<BloatedRegistry> {
+  const junk = 'x'.repeat(JUNK_BYTES / 2)
+  const server = http.createServer((req, res) => {
+    const name = decodeURIComponent((req.url ?? '').slice(1))
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({
+      name,
+      'dist-tags': { latest: '1.0.0' },
+      versions: {
+        '1.0.0': {
+          name,
+          version: '1.0.0',
+          libc: ['glibc'],
+          description: junk,
+          dist: {
+            tarball: `${registryUrl()}${name}/-/${name}-1.0.0.tgz`,
+            integrity: 'sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
+          },
+        },
+      },
+      readme: junk,
+    }))
+  })
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  function registryUrl (): string {
+    return `http://127.0.0.1:${(server.address() as AddressInfo).port}/`
+  }
+  return {
+    url: registryUrl(),
+    close: () => {
+      server.close()
+    },
+  }
+}

--- a/pnpm11/pnpm/test/install/memoryBounded.ts
+++ b/pnpm11/pnpm/test/install/memoryBounded.ts
@@ -11,17 +11,12 @@ const JUNK_BYTES = 6 * 1024 * 1024
 
 /**
  * End-to-end regression guard for https://github.com/pnpm/pnpm/issues/8441:
- * a whole `pnpm install` (the bundled CLI, not just the resolver package)
- * must not retain full-document bulk, so it completes inside a small heap.
- *
- * The registry documents — served by a local server, one per optional
- * dependency so the CLI fetches full metadata — each carry 6 MB of
- * install-irrelevant bulk, 240 MB total. Retaining the parsed documents,
- * as the resolver did before condensing, overflows the 256 MB cap by
- * ~100 MB regardless of which cache pins them; the condensed working set
- * plus the CLI's baseline fits with roughly 100 MB to spare (the fixed
- * install passes even a 192 MB cap). That margin in both directions keeps the
- * guard deterministic rather than timing-sensitive.
+ * the bundled CLI installs 40 optional dependencies (so it fetches full
+ * metadata) whose documents carry 240 MB of install-irrelevant bulk under a
+ * 256 MB heap cap. Retaining the parsed documents overshoots the cap by
+ * ~100 MB regardless of which cache pins them, while the condensed install
+ * passes even a 192 MB cap, so the guard is deterministic rather than
+ * timing-sensitive.
  */
 test('install --lockfile-only completes within a small heap while registry documents carry megabytes of bulk', async () => {
   const server = await startBloatedRegistry()
@@ -35,10 +30,8 @@ test('install --lockfile-only completes within a small heap while registry docum
       env: {
         NODE_OPTIONS: '--max-old-space-size=256',
         pnpm_config_registry: server.url,
-        // Bounds the post-fix transient footprint (response body + freshly
-        // parsed document per in-flight request) so the heap cap measures
-        // what is RETAINED across the resolution, which no concurrency
-        // setting can shrink.
+        // So the heap cap measures what is retained across the resolution
+        // rather than in-flight transients.
         pnpm_config_network_concurrency: '4',
       },
     })
@@ -57,9 +50,7 @@ interface BloatedRegistry {
 }
 
 // Serves a full packument for any package name requested. The junk string is
-// shared server-side; JSON.parse in the CLI gives each document its own copy —
-// the copy whose retention this test bounds. Tarball URLs point back at this
-// server but are never fetched: --lockfile-only resolves without downloading.
+// shared server-side; JSON.parse in the CLI gives each document its own copy.
 async function startBloatedRegistry (): Promise<BloatedRegistry> {
   const junk = 'x'.repeat(JUNK_BYTES / 2)
   const server = http.createServer((req, res) => {

--- a/pnpm11/resolving/npm-resolver/src/clearMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/clearMeta.ts
@@ -35,7 +35,7 @@ const ABBREVIATED_VERSION_FIELDS = [
  * to themselves, making a repeat condense of an already-condensed document
  * the identity instead of another copy.
  */
-const condensedMetas = new WeakMap<PackageMeta, PackageMeta>()
+const condensedPackuments = new WeakMap<PackageMeta, PackageMeta>()
 
 /**
  * Reduces a package metadata document to the abbreviated field set that the
@@ -56,7 +56,7 @@ const condensedMetas = new WeakMap<PackageMeta, PackageMeta>()
  *   retains after settlement.
  *
  * Returns the same condensed object for the same input (see
- * {@link condensedMetas}), so callers may compare by identity to detect
+ * {@link condensedPackuments}), so callers may compare by identity to detect
  * whether condensing changed anything. `etag` is carried over when the input
  * has one (disk-loaded documents), so a condensed document can still answer
  * conditional-request headers.
@@ -65,7 +65,7 @@ const condensedMetas = new WeakMap<PackageMeta, PackageMeta>()
  * versions), which the abbreviated path can reach.
  */
 export function clearMeta (pkg: PackageMeta): PackageMeta {
-  const memoized = condensedMetas.get(pkg)
+  const memoized = condensedPackuments.get(pkg)
   if (memoized != null) return memoized
 
   // A null prototype so that a registry-controlled version key named
@@ -86,8 +86,8 @@ export function clearMeta (pkg: PackageMeta): PackageMeta {
   if (pkg.etag != null) {
     condensed.etag = pkg.etag
   }
-  condensedMetas.set(pkg, condensed)
-  condensedMetas.set(condensed, condensed)
+  condensedPackuments.set(pkg, condensed)
+  condensedPackuments.set(condensed, condensed)
   return condensed
 }
 

--- a/pnpm11/resolving/npm-resolver/src/clearMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/clearMeta.ts
@@ -25,40 +25,19 @@ const ABBREVIATED_VERSION_FIELDS = [
   '_npmUser',
 ] as const
 
-/**
- * Memoizes {@link clearMeta} by input identity. Several layers condense the
- * same parsed document — the settled-fetch memo (`memoizeFetchMetadata`), the
- * resolver's in-memory cache writes, and the `filterMetadata` disk writes —
- * and without the memo each would pin its own condensed copy for the rest of
- * the resolution phase, doubling the very footprint condensing exists to cut.
- * Entries die with their input document, so the map cannot leak. Outputs map
- * to themselves, making a repeat condense of an already-condensed document
- * the identity instead of another copy.
- */
+// Memoized by input identity: several layers condense the same parsed
+// document, and the WeakMap makes them share one condensed copy instead of
+// pinning one each. Outputs map to themselves so re-condensing is the
+// identity.
 const condensedPackuments = new WeakMap<PackageMeta, PackageMeta>()
 
 /**
  * Reduces a package metadata document to the abbreviated field set that the
  * resolver actually reads, dropping install-irrelevant fields (scripts,
- * exports, readme, custom `_`-prefixed fields, etc.). A full document can run
- * to tens of MB parsed; retaining unstripped documents for every package of a
- * large workspace is what drove installs out of memory in
- * https://github.com/pnpm/pnpm/issues/8441.
- *
- * Used in three places:
- * - The network layer (`fetch.ts`) normalizes a registry that ignored the
- *   abbreviated `Accept` header and returned a full document.
- * - The resolver (`pickPackage.ts`) narrows every packument it retains in
- *   memory — full documents fetched for optional dependencies (`libc`) or
- *   release-age `time` upgrades, and disk-mirror loads — unless the resolver
- *   serves full-metadata consumers (see `retainsFullMeta`).
- * - The settled-fetch memo (`memoizeFetchMetadata.ts`) condenses results it
- *   retains after settlement.
- *
- * Returns the same condensed object for the same input (see
- * {@link condensedPackuments}), so callers may compare by identity to detect
- * whether condensing changed anything. `etag` is carried over when the input
- * has one (disk-loaded documents), so a condensed document can still answer
+ * exports, readme, custom `_`-prefixed fields, etc.). Retaining unstripped
+ * full documents — tens of MB parsed for a popular package — is what drove
+ * large installs out of memory (https://github.com/pnpm/pnpm/issues/8441).
+ * `etag` is carried over so a condensed document can still answer
  * conditional-request headers.
  *
  * Null-safe on `versions` so it can be called on an unpublished package (no
@@ -92,13 +71,10 @@ export function clearMeta (pkg: PackageMeta): PackageMeta {
 }
 
 /**
- * Whether a resolver keeps full packuments in memory rather than condensing
- * them with {@link clearMeta}. Only resolvers created with `fullMetadata` and
- * without `filterMetadata` qualify — their consumers read fields outside the
- * abbreviated set (e.g. `pnpm outdated --long` shows description/homepage).
- * Everything else — including a plain install that fetches full documents
- * only for optional dependencies or release-age upgrades — retains the
- * condensed form.
+ * Whether a resolver keeps full packuments rather than condensing them with
+ * {@link clearMeta}: only `fullMetadata` without `filterMetadata`, whose
+ * consumers read fields outside the abbreviated set (`pnpm outdated --long`
+ * shows description/homepage).
  */
 export function retainsFullMeta (opts: { fullMetadata?: boolean, filterMetadata?: boolean }): boolean {
   return opts.fullMetadata === true && opts.filterMetadata !== true

--- a/pnpm11/resolving/npm-resolver/src/clearMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/clearMeta.ts
@@ -26,20 +26,48 @@ const ABBREVIATED_VERSION_FIELDS = [
 ] as const
 
 /**
+ * Memoizes {@link clearMeta} by input identity. Several layers condense the
+ * same parsed document — the settled-fetch memo (`memoizeFetchMetadata`), the
+ * resolver's in-memory cache writes, and the `filterMetadata` disk writes —
+ * and without the memo each would pin its own condensed copy for the rest of
+ * the resolution phase, doubling the very footprint condensing exists to cut.
+ * Entries die with their input document, so the map cannot leak. Outputs map
+ * to themselves, making a repeat condense of an already-condensed document
+ * the identity instead of another copy.
+ */
+const condensedMetas = new WeakMap<PackageMeta, PackageMeta>()
+
+/**
  * Reduces a package metadata document to the abbreviated field set that the
  * resolver actually reads, dropping install-irrelevant fields (scripts,
- * exports, readme, custom `_`-prefixed fields, etc.).
+ * exports, readme, custom `_`-prefixed fields, etc.). A full document can run
+ * to tens of MB parsed; retaining unstripped documents for every package of a
+ * large workspace is what drove installs out of memory in
+ * https://github.com/pnpm/pnpm/issues/8441.
  *
- * Used in two places:
+ * Used in three places:
  * - The network layer (`fetch.ts`) normalizes a registry that ignored the
  *   abbreviated `Accept` header and returned a full document.
- * - The resolver (`pickPackage.ts`) narrows a deliberately-fetched full
- *   document into the `filterMetadata` cache slot.
+ * - The resolver (`pickPackage.ts`) narrows every packument it retains in
+ *   memory — full documents fetched for optional dependencies (`libc`) or
+ *   release-age `time` upgrades, and disk-mirror loads — unless the resolver
+ *   serves full-metadata consumers (see `retainsFullMeta`).
+ * - The settled-fetch memo (`memoizeFetchMetadata.ts`) condenses results it
+ *   retains after settlement.
+ *
+ * Returns the same condensed object for the same input (see
+ * {@link condensedMetas}), so callers may compare by identity to detect
+ * whether condensing changed anything. `etag` is carried over when the input
+ * has one (disk-loaded documents), so a condensed document can still answer
+ * conditional-request headers.
  *
  * Null-safe on `versions` so it can be called on an unpublished package (no
  * versions), which the abbreviated path can reach.
  */
 export function clearMeta (pkg: PackageMeta): PackageMeta {
+  const memoized = condensedMetas.get(pkg)
+  if (memoized != null) return memoized
+
   // A null prototype so that a registry-controlled version key named
   // `__proto__` becomes a regular own property instead of mutating the
   // prototype of the map (js/prototype-polluting-assignment).
@@ -48,11 +76,30 @@ export function clearMeta (pkg: PackageMeta): PackageMeta {
     versions[version] = pick(ABBREVIATED_VERSION_FIELDS, info)
   }
 
-  return {
+  const condensed: PackageMeta = {
     name: pkg.name,
     'dist-tags': pkg['dist-tags'],
     versions,
     time: pkg.time,
     modified: pkg.modified,
   }
+  if (pkg.etag != null) {
+    condensed.etag = pkg.etag
+  }
+  condensedMetas.set(pkg, condensed)
+  condensedMetas.set(condensed, condensed)
+  return condensed
+}
+
+/**
+ * Whether a resolver keeps full packuments in memory rather than condensing
+ * them with {@link clearMeta}. Only resolvers created with `fullMetadata` and
+ * without `filterMetadata` qualify — their consumers read fields outside the
+ * abbreviated set (e.g. `pnpm outdated --long` shows description/homepage).
+ * Everything else — including a plain install that fetches full documents
+ * only for optional dependencies or release-age upgrades — retains the
+ * condensed form.
+ */
+export function retainsFullMeta (opts: { fullMetadata?: boolean, filterMetadata?: boolean }): boolean {
+  return opts.fullMetadata === true && opts.filterMetadata !== true
 }

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -48,6 +48,7 @@ import semver from 'semver'
 import ssri from 'ssri'
 import versionSelectorType from 'version-selector-type'
 
+import { clearMeta, retainsFullMeta } from './clearMeta.js'
 import { fetchMetadataFromFromRegistry, type FetchMetadataFromFromRegistryOptions, RegistryResponseError } from './fetch.js'
 import { memoizeFetchMetadata } from './memoizeFetchMetadata.js'
 import { normalizeRegistryUrl } from './normalizeRegistryUrl.js'
@@ -217,7 +218,9 @@ export function createNpmResolver (
     timeout: opts.timeout ?? 60000,
     fetchWarnTimeoutMs: opts.fetchWarnTimeoutMs ?? 10 * 1000, // 10 sec
   }
-  const { fetch, clear: clearFetchCache } = memoizeFetchMetadata(fetchMetadataFromFromRegistry.bind(null, fetchOpts))
+  const { fetch, clear: clearFetchCache } = memoizeFetchMetadata(fetchMetadataFromFromRegistry.bind(null, fetchOpts), {
+    condenseSettledMeta: retainsFullMeta(opts) ? undefined : clearMeta,
+  })
   // Track ownership so `clearCache()` below only wipes the in-memory
   // cache when this factory created it. A caller-supplied
   // `opts.metaCache` may be shared with another resolver instance (or

--- a/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
+++ b/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
@@ -1,3 +1,5 @@
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
+
 import type {
   FetchMetadataNotModifiedResult,
   FetchMetadataOptions,
@@ -9,6 +11,19 @@ export type FetchMetadata = (pkgName: string, opts: FetchMetadataOptions) => Pro
 export interface MemoizedFetchMetadata {
   fetch: FetchMetadata
   clear: () => void
+}
+
+export interface MemoizeFetchMetadataOptions {
+  /**
+   * Applied to a settled result's `meta` before the entry is retained for the
+   * rest of the resolution phase. Callers awaiting the in-flight request still
+   * receive the original document; only the retained entry is condensed. Pass
+   * `clearMeta` on resolvers whose consumers never read past the abbreviated
+   * field set, so a full document — fetched for an optional dependency's
+   * `libc` or a release-age `time` upgrade — doesn't stay pinned at full size
+   * here for the whole phase.
+   */
+  condenseSettledMeta?: (meta: PackageMeta) => PackageMeta
 }
 
 /**
@@ -24,7 +39,9 @@ export interface MemoizedFetchMetadata {
  * `meta`. Retaining bodies past settlement would pin hundreds of MB on large
  * cold-cache graphs, so a later cache-hit caller that writes the mirror falls
  * back to `JSON.stringify(meta)` in `prepareJsonForDisk`, which is equivalent
- * on read: `loadMeta` re-derives `etag` from the headers line.
+ * on read: `loadMeta` re-derives `etag` from the headers line. The retained
+ * `meta` is condensed by the same swap when `condenseSettledMeta` is set —
+ * see {@link MemoizeFetchMetadataOptions}.
  *
  * Because that swap lands a turn after the request settles, both settlement
  * paths write back only while the entry is still their own promise — a `clear`
@@ -34,7 +51,8 @@ export interface MemoizedFetchMetadata {
  * A rejected fetch is evicted so a transient network failure is retried by
  * the next request instead of being cached for the rest of the phase.
  */
-export function memoizeFetchMetadata (fetch: FetchMetadata): MemoizedFetchMetadata {
+export function memoizeFetchMetadata (fetch: FetchMetadata, memoOpts?: MemoizeFetchMetadataOptions): MemoizedFetchMetadata {
+  const condense = memoOpts?.condenseSettledMeta
   const cache = new Map<string, ReturnType<FetchMetadata>>()
   return {
     fetch: (pkgName, opts) => {
@@ -49,7 +67,9 @@ export function memoizeFetchMetadata (fetch: FetchMetadata): MemoizedFetchMetada
           cache.set(
             key,
             Promise.resolve(
-              result.notModified ? result : { ...result, jsonText: undefined }
+              result.notModified
+                ? result
+                : { ...result, jsonText: undefined, meta: condense ? condense(result.meta) : result.meta }
             )
           )
         },

--- a/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
+++ b/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
@@ -64,14 +64,7 @@ export function memoizeFetchMetadata (fetch: FetchMetadata, memoOpts?: MemoizeFe
       void pending.then(
         (result) => {
           if (cache.get(key) !== pending) return
-          cache.set(
-            key,
-            Promise.resolve(
-              result.notModified
-                ? result
-                : { ...result, jsonText: undefined, meta: condense ? condense(result.meta) : result.meta }
-            )
-          )
+          cache.set(key, Promise.resolve(settledEntry(result)))
         },
         () => {
           if (cache.get(key) === pending) cache.delete(key)
@@ -82,5 +75,23 @@ export function memoizeFetchMetadata (fetch: FetchMetadata, memoOpts?: MemoizeFe
     clear: () => {
       cache.clear()
     },
+  }
+
+  // The entry retained after settlement: body dropped, meta condensed. Runs
+  // inside a fire-and-forget then-callback, so it must not throw — an error
+  // there would surface as an unhandled rejection and kill the process. The
+  // condenser runs on a parsed but otherwise untrusted registry document; if
+  // it fails, fall back to retaining the uncondensed meta (correct, just
+  // bigger), and leave surfacing the document's problem to the resolution
+  // path, which condenses the same document with proper error propagation.
+  function settledEntry (result: FetchMetadataResult | FetchMetadataNotModifiedResult): FetchMetadataResult | FetchMetadataNotModifiedResult {
+    if (result.notModified) return result
+    let meta = result.meta
+    if (condense != null) {
+      try {
+        meta = condense(result.meta)
+      } catch {}
+    }
+    return { ...result, jsonText: undefined, meta }
   }
 }

--- a/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
+++ b/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
@@ -16,12 +16,9 @@ export interface MemoizedFetchMetadata {
 export interface MemoizeFetchMetadataOptions {
   /**
    * Applied to a settled result's `meta` before the entry is retained for the
-   * rest of the resolution phase. Callers awaiting the in-flight request still
-   * receive the original document; only the retained entry is condensed. Pass
-   * `clearMeta` on resolvers whose consumers never read past the abbreviated
-   * field set, so a full document — fetched for an optional dependency's
-   * `libc` or a release-age `time` upgrade — doesn't stay pinned at full size
-   * here for the whole phase.
+   * rest of the resolution phase, so a full document doesn't stay pinned here
+   * at full size. Callers awaiting the in-flight request still receive the
+   * original document.
    */
   condenseSettledMeta?: (meta: PackageMeta) => PackageMeta
 }
@@ -39,9 +36,7 @@ export interface MemoizeFetchMetadataOptions {
  * `meta`. Retaining bodies past settlement would pin hundreds of MB on large
  * cold-cache graphs, so a later cache-hit caller that writes the mirror falls
  * back to `JSON.stringify(meta)` in `prepareJsonForDisk`, which is equivalent
- * on read: `loadMeta` re-derives `etag` from the headers line. The retained
- * `meta` is condensed by the same swap when `condenseSettledMeta` is set —
- * see {@link MemoizeFetchMetadataOptions}.
+ * on read: `loadMeta` re-derives `etag` from the headers line.
  *
  * Because that swap lands a turn after the request settles, both settlement
  * paths write back only while the entry is still their own promise — a `clear`
@@ -77,13 +72,10 @@ export function memoizeFetchMetadata (fetch: FetchMetadata, memoOpts?: MemoizeFe
     },
   }
 
-  // The entry retained after settlement: body dropped, meta condensed. Runs
-  // inside a fire-and-forget then-callback, so it must not throw — an error
-  // there would surface as an unhandled rejection and kill the process. The
-  // condenser runs on a parsed but otherwise untrusted registry document; if
-  // it fails, fall back to retaining the uncondensed meta (correct, just
-  // bigger), and leave surfacing the document's problem to the resolution
-  // path, which condenses the same document with proper error propagation.
+  // Runs inside a fire-and-forget then-callback where a throw would become an
+  // unhandled rejection, so a failed condense falls back to the uncondensed
+  // meta; the resolution path condenses the same document with proper error
+  // propagation.
   function settledEntry (result: FetchMetadataResult | FetchMetadataNotModifiedResult): FetchMetadataResult | FetchMetadataNotModifiedResult {
     if (result.notModified) return result
     let meta = result.meta

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -218,15 +218,10 @@ function cacheDiskLoadedMeta (metaCache: PackageMetaCache, cacheKey: string, met
 }
 
 /**
- * The form in which a packument is retained in memory (the `metaCache`, and
- * through it every returned pick). Full documents reach a plain install via
- * optional dependencies (fetched full for `libc`), release-age `time`
- * upgrades, and mirror files that hold a full body — retaining them
- * unstripped pins tens of MB per popular package for the whole install and
- * drove large workspaces out of memory
- * (https://github.com/pnpm/pnpm/issues/8441). Condensing is skipped only for
- * resolvers whose consumers read past the abbreviated field set (see
- * {@link retainsFullMeta}).
+ * The form in which a packument is retained in memory (see {@link clearMeta}
+ * for why). Full documents reach even a plain install via optional
+ * dependencies (fetched full for `libc`), release-age `time` upgrades, and
+ * mirror files that hold a full body.
  */
 function condenseMetaForCache (
   ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
@@ -300,10 +295,6 @@ export async function pickPackage (
   }
 
   return runLimited(pkgMirror, async (limit) => {
-    // Condensed on load (see condenseMetaForCache): the mirror may hold a
-    // full body — optional deps' full mirrors, or an abbreviated mirror a
-    // release-age upgrade rewrote — and every path below either caches or
-    // returns what it loads here.
     const loadMetaCondensed = async (): Promise<PackageMeta | null> => {
       const meta = await loadMeta(pkgMirror)
       return meta == null ? null : condenseMetaForCache(ctx, meta)
@@ -513,12 +504,10 @@ export async function pickPackage (
 
       meta = condenseMetaForCache(ctx, meta)
       if (!opts.dryRun) {
-        // The mirror keeps the raw registry body, except when the retained
-        // form is deliberately narrower: a `filterMetadata` resolver always
-        // mirrors the stripped document, and a release-age upgrade
-        // (`resultToSave !== fetched`) on a condensing resolver mirrors the
-        // condensed form — it keeps `time`, which is all the next install
-        // needs from this slot, instead of megabytes of full-document bulk.
+        // Mirror the raw registry body, unless the retained form is
+        // deliberately narrower: `filterMetadata` always mirrors the stripped
+        // document, and an upgraded-to-full document mirrors the condensed
+        // form — `time` is all the next install needs from this slot.
         const writeCondensed = ctx.filterMetadata === true || (resultToSave !== fetched && meta !== resultToSave.meta)
         const jsonForDisk = writeCondensed
           ? prepareJsonForDisk(meta, resultToSave.etag)
@@ -601,12 +590,10 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
 }
 
 /**
- * The meta to retain after a release-age upgrade fetch: the upgrade result in
- * its cache form (see {@link condenseMetaForCache}), persisted to the mirror
- * unless this is a dry run. Persisting matters because the mirror otherwise
- * still holds the pre-upgrade abbreviated form (no `time`), so every future
- * install would re-trigger the upgrade fetch. When no upgrade happened, the
- * input meta passes through untouched.
+ * The meta to retain after a release-age upgrade check, persisted to the
+ * mirror (unless dry-run) because the mirror otherwise still holds the
+ * pre-upgrade abbreviated form without `time`, and every future install
+ * would re-trigger the upgrade fetch.
  */
 function upgradeMetaForCache (
   ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
@@ -618,11 +605,9 @@ function upgradeMetaForCache (
   return persistUpgradedMeta(ctx, opts.pkgMirror, upgrade.upgradedFrom)
 }
 
-// Persists upgraded full metadata to the on-disk cache mirror and returns
-// the meta to store in the in-memory cache. A condensing resolver (see
-// condenseMetaForCache) keeps and mirrors the condensed form — the mirror
-// only has to carry `time` into the next install; otherwise the original raw
-// response body is written and the unstripped meta is kept.
+// A condensing resolver keeps and mirrors the condensed form — the mirror
+// only has to carry `time` into the next install; otherwise the raw response
+// body is written and the unstripped meta is kept.
 function persistUpgradedMeta (
   ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
   pkgMirror: string,
@@ -637,11 +622,8 @@ function persistUpgradedMeta (
 }
 
 /**
- * Write a mirror file without letting a failure escape: the mirror is an
- * optimization (the next install falls back to an unconditional fetch), so
- * the install continues — but the failure is debug-logged with the mirror
- * path so a broken cache dir (permissions, disk full) stays diagnosable.
- * Writes to the same mirror are serialized through its per-mirror limiter.
+ * The mirror is an optimization, so a write failure only gets a debug log
+ * with the mirror path and the install continues.
  */
 function saveMetaBestEffort (pkgMirror: string, json: string): void {
   void runLimited(pkgMirror, (limit) => limit(async () => {
@@ -708,13 +690,10 @@ export function getPkgMirrorPath (cacheDir: string, metaDir: string, registry: s
 /**
  * Formats metadata for disk storage as two-line NDJSON:
  *   Line 1: cache headers (etag, modified) — small, fast to read
- *   Line 2: the registry metadata JSON — the raw response body when
- *   `jsonText` is given, a re-serialization of `meta` otherwise
+ *   Line 2: the registry metadata JSON
  *
- * The etag lives only in the headers line: `loadMeta` re-attaches it from
- * there, and a serialized `meta` may carry one (meta objects are shared and get
- * their `etag` assigned after a fetch), so it is dropped from the body here
- * rather than at every call site.
+ * The etag lives only in the headers line (`loadMeta` re-attaches it from
+ * there), so a `meta` that carries one is serialized without it.
  */
 export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined, jsonText?: string): string {
   const modified = meta.modified ?? meta.time?.modified

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -716,7 +716,7 @@ export function getPkgMirrorPath (cacheDir: string, metaDir: string, registry: s
  *   `jsonText` is given, a re-serialization of `meta` otherwise
  *
  * The etag lives only in the headers line: `loadMeta` re-attaches it from
- * there, and a serialized `meta` may carry one (metas are shared and get
+ * there, and a serialized `meta` may carry one (meta objects are shared and get
  * their `etag` assigned after a fetch), so it is dropped from the body here
  * rather than at every call site.
  */

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -284,7 +284,7 @@ export async function pickPackage (
     // publishedBy and the package was modified recently, upgrade to full
     // metadata so the maturity check runs properly.
     const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, cachedMeta)
-    const metaForCache = upgradeMetaForCache(ctx, pkgMirror, opts.dryRun, upgrade)
+    const metaForCache = upgradeMetaForCache(ctx, upgrade, { pkgMirror, dryRun: opts.dryRun })
     if (upgrade.upgradedFrom != null) {
       ctx.metaCache.set(cacheKey, metaForCache)
     }
@@ -331,7 +331,7 @@ export async function pickPackage (
         // Disk-cached meta may be abbreviated; upgrade for the maturity check
         // before letting pickMatchingVersionFinal warn-and-skip on missing time.
         const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, diskMeta)
-        diskMeta = upgradeMetaForCache(ctx, pkgMirror, opts.dryRun, upgrade)
+        diskMeta = upgradeMetaForCache(ctx, upgrade, { pkgMirror, dryRun: opts.dryRun })
         if (upgrade.upgradedFrom != null) {
           ctx.metaCache.set(cacheKey, diskMeta)
         }
@@ -462,7 +462,7 @@ export async function pickPackage (
       // this, repeat installs of recently-modified packages would silently
       // bypass the maturity check via the warn-and-skip fallback.
       const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, cached)
-      const meta = upgradeMetaForCache(ctx, pkgMirror, opts.dryRun, upgrade)
+      const meta = upgradeMetaForCache(ctx, upgrade, { pkgMirror, dryRun: opts.dryRun })
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
@@ -497,15 +497,7 @@ export async function pickPackage (
         if (!isModifiedValid || modifiedDate > opts.publishedBy) {
           // Save the abbreviated metadata to the abbreviated cache before re-fetching full.
           if (!opts.dryRun) {
-            const abbreviatedJson = prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
-            // Fire-and-forget save to the abbreviated cache path (pkgMirror).
-            runLimited(pkgMirror, (limit) => limit(async () => {
-              try {
-                await saveMeta(pkgMirror, abbreviatedJson)
-              } catch (err: any) { // eslint-disable-line
-                // We don't care if this file was not written to the cache
-              }
-            }))
+            saveMetaBestEffort(pkgMirror, prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText))
           }
           const fullFetchResult = await ctx.fetch(spec.name, {
             authHeaderValue: opts.authHeaderValue,
@@ -531,13 +523,7 @@ export async function pickPackage (
         const jsonForDisk = writeCondensed
           ? prepareJsonForDisk(meta, resultToSave.etag)
           : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
-        runLimited(pkgMirror, (limit) => limit(async () => {
-          try {
-            await saveMeta(pkgMirror, jsonForDisk)
-          } catch (err: any) { // eslint-disable-line
-            // We don't care if this file was not written to the cache
-          }
-        }))
+        saveMetaBestEffort(pkgMirror, jsonForDisk)
       }
       meta.etag = resultToSave.etag
       // only save meta to cache, when it is fresh
@@ -624,13 +610,12 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
  */
 function upgradeMetaForCache (
   ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
-  pkgMirror: string,
-  dryRun: boolean,
-  upgrade: { meta: PackageMeta, upgradedFrom?: FetchMetadataResult }
+  upgrade: { meta: PackageMeta, upgradedFrom?: FetchMetadataResult },
+  opts: { pkgMirror: string, dryRun: boolean }
 ): PackageMeta {
   if (upgrade.upgradedFrom == null) return upgrade.meta
-  if (dryRun) return condenseMetaForCache(ctx, upgrade.meta)
-  return persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
+  if (opts.dryRun) return condenseMetaForCache(ctx, upgrade.meta)
+  return persistUpgradedMeta(ctx, opts.pkgMirror, upgrade.upgradedFrom)
 }
 
 // Persists upgraded full metadata to the on-disk cache mirror and returns
@@ -647,14 +632,25 @@ function persistUpgradedMeta (
   const jsonForDisk = metaForCache === upgradedFrom.meta
     ? prepareJsonForDisk(upgradedFrom.meta, upgradedFrom.etag, upgradedFrom.jsonText)
     : prepareJsonForDisk(metaForCache, upgradedFrom.etag)
-  runLimited(pkgMirror, (l) => l(async () => {
+  saveMetaBestEffort(pkgMirror, jsonForDisk)
+  return metaForCache
+}
+
+/**
+ * Write a mirror file without letting a failure escape: the mirror is an
+ * optimization (the next install falls back to an unconditional fetch), so
+ * the install continues — but the failure is debug-logged with the mirror
+ * path so a broken cache dir (permissions, disk full) stays diagnosable.
+ * Writes to the same mirror are serialized through its refcounted limiter.
+ */
+function saveMetaBestEffort (pkgMirror: string, json: string): void {
+  void runLimited(pkgMirror, (limit) => limit(async () => {
     try {
-      await saveMeta(pkgMirror, jsonForDisk)
-    } catch (err: any) { // eslint-disable-line
-      // We don't care if this file was not written to the cache
+      await saveMeta(pkgMirror, json)
+    } catch (err: unknown) {
+      logger.debug({ message: `Failed to write the package metadata mirror at ${pkgMirror}`, err })
     }
   }))
-  return metaForCache
 }
 
 export function encodePkgName (pkgName: string): string {

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -13,7 +13,7 @@ import { fastPathTemp as pathTemp } from 'path-temp'
 import { renameOverwrite } from 'rename-overwrite'
 import semver from 'semver'
 
-import { clearMeta } from './clearMeta.js'
+import { clearMeta, retainsFullMeta } from './clearMeta.js'
 import {
   type FetchMetadataNotModifiedResult,
   type FetchMetadataResult,
@@ -217,6 +217,24 @@ function cacheDiskLoadedMeta (metaCache: PackageMetaCache, cacheKey: string, met
   metaCache.set(cacheKey, meta)
 }
 
+/**
+ * The form in which a packument is retained in memory (the `metaCache`, and
+ * through it every returned pick). Full documents reach a plain install via
+ * optional dependencies (fetched full for `libc`), release-age `time`
+ * upgrades, and mirror files that hold a full body — retaining them
+ * unstripped pins tens of MB per popular package for the whole install and
+ * drove large workspaces out of memory
+ * (https://github.com/pnpm/pnpm/issues/8441). Condensing is skipped only for
+ * resolvers whose consumers read past the abbreviated field set (see
+ * {@link retainsFullMeta}).
+ */
+function condenseMetaForCache (
+  ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
+  meta: PackageMeta
+): PackageMeta {
+  return retainsFullMeta(ctx) ? meta : clearMeta(meta)
+}
+
 export async function pickPackage (
   ctx: {
     fetch: (pkgName: string, opts: { registry: string, authHeaderValue?: string, cacheBypass?: boolean, fullMetadata?: boolean, etag?: string, modified?: string }) => Promise<FetchMetadataResult | FetchMetadataNotModifiedResult>
@@ -266,14 +284,8 @@ export async function pickPackage (
     // publishedBy and the package was modified recently, upgrade to full
     // metadata so the maturity check runs properly.
     const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, cachedMeta)
-    let metaForCache = upgrade.meta
+    const metaForCache = upgradeMetaForCache(ctx, pkgMirror, opts.dryRun, upgrade)
     if (upgrade.upgradedFrom != null) {
-      // Persist the upgraded meta to disk too: the on-disk mirror still holds
-      // the abbreviated form, so without this a fresh process would re-trigger
-      // the upgrade fetch on its next install.
-      metaForCache = opts.dryRun
-        ? upgrade.meta
-        : persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
       ctx.metaCache.set(cacheKey, metaForCache)
     }
     const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaForCache)
@@ -288,9 +300,17 @@ export async function pickPackage (
   }
 
   return runLimited(pkgMirror, async (limit) => {
+    // Condensed on load (see condenseMetaForCache): the mirror may hold a
+    // full body — optional deps' full mirrors, or an abbreviated mirror a
+    // release-age upgrade rewrote — and every path below either caches or
+    // returns what it loads here.
+    const loadMetaCondensed = async (): Promise<PackageMeta | null> => {
+      const meta = await loadMeta(pkgMirror)
+      return meta == null ? null : condenseMetaForCache(ctx, meta)
+    }
     let diskMeta: PackageMeta | null | undefined
     if (ctx.offline === true || ctx.preferOffline === true || opts.pickLowestVersion) {
-      diskMeta = await limit(async () => loadMeta(pkgMirror))
+      diskMeta = await limit(loadMetaCondensed)
 
       if (ctx.offline) {
         if (diskMeta != null) {
@@ -311,12 +331,8 @@ export async function pickPackage (
         // Disk-cached meta may be abbreviated; upgrade for the maturity check
         // before letting pickMatchingVersionFinal warn-and-skip on missing time.
         const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, diskMeta)
-        diskMeta = upgrade.meta
+        diskMeta = upgradeMetaForCache(ctx, pkgMirror, opts.dryRun, upgrade)
         if (upgrade.upgradedFrom != null) {
-          // Persist so the next install skips this upgrade fetch entirely.
-          if (!opts.dryRun) {
-            diskMeta = persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
-          }
           ctx.metaCache.set(cacheKey, diskMeta)
         }
         const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
@@ -338,7 +354,7 @@ export async function pickPackage (
     }
 
     if (!opts.includeLatestTag && !opts.updateChecksums && spec.type === 'version') {
-      diskMeta = diskMeta ?? await limit(async () => loadMeta(pkgMirror))
+      diskMeta = diskMeta ?? await limit(loadMetaCondensed)
       // use the cached meta only if it has the required package version
       // otherwise it is probably out of date
       if ((diskMeta?.versions?.[spec.fetchSpec]) != null) {
@@ -362,7 +378,7 @@ export async function pickPackage (
     if (opts.publishedBy && opts.publishedByExclude?.(spec.name) !== true) {
       const mtime = await limit(async () => getFileMtime(pkgMirror))
       if (mtime != null && mtime >= opts.publishedBy) {
-        diskMeta = diskMeta ?? await limit(async () => loadMeta(pkgMirror))
+        diskMeta = diskMeta ?? await limit(loadMetaCondensed)
         if (diskMeta != null) {
           try {
             const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, diskMeta)
@@ -398,7 +414,7 @@ export async function pickPackage (
       if (!conditional.notModified) return await persistFreshMeta(conditional)
 
       // 304: the cached mirror is still current.
-      diskMeta = diskMeta ?? await limit(async () => loadMeta(pkgMirror))
+      diskMeta = diskMeta ?? await limit(loadMetaCondensed)
       if (diskMeta != null) return await serveValidatedMeta(diskMeta)
 
       // The mirror vanished between the headers read and this read (concurrent
@@ -415,7 +431,7 @@ export async function pickPackage (
       return await persistFreshMeta(refetched)
     } catch (err: any) { // eslint-disable-line
       err.spec = spec
-      const meta = await loadMeta(pkgMirror) // TODO: add test for this usecase
+      const meta = await loadMetaCondensed() // TODO: add test for this usecase
       if (meta == null) throw err
       logger.error(err, err)
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
@@ -446,13 +462,7 @@ export async function pickPackage (
       // this, repeat installs of recently-modified packages would silently
       // bypass the maturity check via the warn-and-skip fallback.
       const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, cached)
-      let meta = upgrade.meta
-      if (upgrade.upgradedFrom != null && !opts.dryRun) {
-        // Persist the upgraded full metadata to disk so subsequent installs
-        // skip this upgrade fetch entirely (the cached meta will then have
-        // `time` populated, so the upgrade condition won't trigger).
-        meta = persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
-      }
+      const meta = upgradeMetaForCache(ctx, pkgMirror, opts.dryRun, upgrade)
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
@@ -509,12 +519,16 @@ export async function pickPackage (
         }
       }
 
-      if (ctx.filterMetadata) {
-        meta = clearMeta(meta)
-      }
+      meta = condenseMetaForCache(ctx, meta)
       if (!opts.dryRun) {
-        // Serialize before setting meta.etag so it only lives in the headers line, not the body.
-        const jsonForDisk = ctx.filterMetadata
+        // The mirror keeps the raw registry body, except when the retained
+        // form is deliberately narrower: a `filterMetadata` resolver always
+        // mirrors the stripped document, and a release-age upgrade
+        // (`resultToSave !== fetched`) on a condensing resolver mirrors the
+        // condensed form — it keeps `time`, which is all the next install
+        // needs from this slot, instead of megabytes of full-document bulk.
+        const writeCondensed = ctx.filterMetadata === true || (resultToSave !== fetched && meta !== resultToSave.meta)
+        const jsonForDisk = writeCondensed
           ? prepareJsonForDisk(meta, resultToSave.etag)
           : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
         runLimited(pkgMirror, (limit) => limit(async () => {
@@ -600,19 +614,39 @@ async function maybeUpgradeAbbreviatedMetaForReleaseAge (
   return { meta: fullFetchResult.meta, upgradedFrom: fullFetchResult }
 }
 
+/**
+ * The meta to retain after a release-age upgrade fetch: the upgrade result in
+ * its cache form (see {@link condenseMetaForCache}), persisted to the mirror
+ * unless this is a dry run. Persisting matters because the mirror otherwise
+ * still holds the pre-upgrade abbreviated form (no `time`), so every future
+ * install would re-trigger the upgrade fetch. When no upgrade happened, the
+ * input meta passes through untouched.
+ */
+function upgradeMetaForCache (
+  ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
+  pkgMirror: string,
+  dryRun: boolean,
+  upgrade: { meta: PackageMeta, upgradedFrom?: FetchMetadataResult }
+): PackageMeta {
+  if (upgrade.upgradedFrom == null) return upgrade.meta
+  if (dryRun) return condenseMetaForCache(ctx, upgrade.meta)
+  return persistUpgradedMeta(ctx, pkgMirror, upgrade.upgradedFrom)
+}
+
 // Persists upgraded full metadata to the on-disk cache mirror and returns
-// the meta to store in the in-memory cache. When `filterMetadata` is on, the
-// in-memory and on-disk forms are both stripped via `clearMeta`; otherwise
-// the original raw response body is written and the unstripped meta is kept.
+// the meta to store in the in-memory cache. A condensing resolver (see
+// condenseMetaForCache) keeps and mirrors the condensed form — the mirror
+// only has to carry `time` into the next install; otherwise the original raw
+// response body is written and the unstripped meta is kept.
 function persistUpgradedMeta (
-  ctx: { filterMetadata?: boolean },
+  ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
   pkgMirror: string,
   upgradedFrom: FetchMetadataResult
 ): PackageMeta {
-  const metaForCache = ctx.filterMetadata ? clearMeta(upgradedFrom.meta) : upgradedFrom.meta
-  const jsonForDisk = ctx.filterMetadata
-    ? prepareJsonForDisk(metaForCache, upgradedFrom.etag)
-    : prepareJsonForDisk(upgradedFrom.meta, upgradedFrom.etag, upgradedFrom.jsonText)
+  const metaForCache = condenseMetaForCache(ctx, upgradedFrom.meta)
+  const jsonForDisk = metaForCache === upgradedFrom.meta
+    ? prepareJsonForDisk(upgradedFrom.meta, upgradedFrom.etag, upgradedFrom.jsonText)
+    : prepareJsonForDisk(metaForCache, upgradedFrom.etag)
   runLimited(pkgMirror, (l) => l(async () => {
     try {
       await saveMeta(pkgMirror, jsonForDisk)
@@ -678,12 +712,18 @@ export function getPkgMirrorPath (cacheDir: string, metaDir: string, registry: s
 /**
  * Formats metadata for disk storage as two-line NDJSON:
  *   Line 1: cache headers (etag, modified) — small, fast to read
- *   Line 2: the full registry metadata JSON — unchanged from the registry response
+ *   Line 2: the registry metadata JSON — the raw response body when
+ *   `jsonText` is given, a re-serialization of `meta` otherwise
+ *
+ * The etag lives only in the headers line: `loadMeta` re-attaches it from
+ * there, and a serialized `meta` may carry one (metas are shared and get
+ * their `etag` assigned after a fetch), so it is dropped from the body here
+ * rather than at every call site.
  */
 export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined, jsonText?: string): string {
   const modified = meta.modified ?? meta.time?.modified
   const headers = JSON.stringify({ etag, modified })
-  const body = jsonText ?? JSON.stringify(meta)
+  const body = jsonText ?? JSON.stringify(meta.etag == null ? meta : { ...meta, etag: undefined })
   return `${headers}\n${body}`
 }
 

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -641,7 +641,7 @@ function persistUpgradedMeta (
  * optimization (the next install falls back to an unconditional fetch), so
  * the install continues — but the failure is debug-logged with the mirror
  * path so a broken cache dir (permissions, disk full) stays diagnosable.
- * Writes to the same mirror are serialized through its refcounted limiter.
+ * Writes to the same mirror are serialized through its per-mirror limiter.
  */
 function saveMetaBestEffort (pkgMirror: string, json: string): void {
   void runLimited(pkgMirror, (limit) => limit(async () => {

--- a/pnpm11/resolving/npm-resolver/test/clearMeta.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/clearMeta.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@jest/globals'
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
+
+import { clearMeta, retainsFullMeta } from '../src/clearMeta.js'
+
+function fullMeta (): PackageMeta {
+  return {
+    name: 'foo',
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'foo',
+        version: '1.0.0',
+        libc: ['glibc'],
+        scripts: { postinstall: 'node scripts/build.js' },
+        description: 'dropped',
+        dist: {
+          tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+          integrity: 'sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
+        },
+      },
+    },
+    time: { '1.0.0': '2020-01-01T00:00:00.000Z' },
+    modified: '2020-01-01T00:00:00.000Z',
+    readme: '# dropped',
+  } as unknown as PackageMeta
+}
+
+test('clearMeta keeps the install-relevant field set and drops the rest', () => {
+  const condensed = clearMeta(fullMeta())
+  expect(condensed.versions['1.0.0'].libc).toEqual(['glibc'])
+  expect(condensed.versions['1.0.0'].dist.tarball).toBe('https://registry.npmjs.org/foo/-/foo-1.0.0.tgz')
+  expect(condensed.time).toEqual({ '1.0.0': '2020-01-01T00:00:00.000Z' })
+  expect(condensed.modified).toBe('2020-01-01T00:00:00.000Z')
+  expect(condensed.versions['1.0.0'].scripts).toBeUndefined()
+  expect((condensed.versions['1.0.0'] as { description?: string }).description).toBeUndefined()
+  expect((condensed as PackageMeta & { readme?: string }).readme).toBeUndefined()
+})
+
+test('clearMeta is memoized by input identity, and condensing a condensed document is the identity', () => {
+  // Several layers condense the same parsed document (the settled-fetch memo
+  // and the resolver cache); identity-memoization is what makes them share
+  // one condensed copy instead of pinning one each.
+  const meta = fullMeta()
+  const condensed = clearMeta(meta)
+  expect(clearMeta(meta)).toBe(condensed)
+  expect(clearMeta(condensed)).toBe(condensed)
+})
+
+test('clearMeta carries the etag over so a condensed document can still answer conditional-request headers', () => {
+  const withEtag = fullMeta()
+  withEtag.etag = '"abc"'
+  expect(clearMeta(withEtag).etag).toBe('"abc"')
+  expect(clearMeta(fullMeta()).etag).toBeUndefined()
+})
+
+test('retainsFullMeta only holds for full-metadata resolvers without filterMetadata', () => {
+  expect(retainsFullMeta({ fullMetadata: true })).toBe(true)
+  expect(retainsFullMeta({ fullMetadata: true, filterMetadata: true })).toBe(false)
+  expect(retainsFullMeta({})).toBe(false)
+  expect(retainsFullMeta({ filterMetadata: true })).toBe(false)
+})

--- a/pnpm11/resolving/npm-resolver/test/clearMeta.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/clearMeta.test.ts
@@ -3,29 +3,6 @@ import type { PackageMeta } from '@pnpm/resolving.registry.types'
 
 import { clearMeta, retainsFullMeta } from '../src/clearMeta.js'
 
-function fullMeta (): PackageMeta {
-  return {
-    name: 'foo',
-    'dist-tags': { latest: '1.0.0' },
-    versions: {
-      '1.0.0': {
-        name: 'foo',
-        version: '1.0.0',
-        libc: ['glibc'],
-        scripts: { postinstall: 'node scripts/build.js' },
-        description: 'dropped',
-        dist: {
-          tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
-          integrity: 'sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
-        },
-      },
-    },
-    time: { '1.0.0': '2020-01-01T00:00:00.000Z' },
-    modified: '2020-01-01T00:00:00.000Z',
-    readme: '# dropped',
-  } as unknown as PackageMeta
-}
-
 test('clearMeta keeps the install-relevant field set and drops the rest', () => {
   const condensed = clearMeta(fullMeta())
   expect(condensed.versions['1.0.0'].libc).toEqual(['glibc'])
@@ -60,3 +37,26 @@ test('retainsFullMeta only holds for full-metadata resolvers without filterMetad
   expect(retainsFullMeta({})).toBe(false)
   expect(retainsFullMeta({ filterMetadata: true })).toBe(false)
 })
+
+function fullMeta (): PackageMeta {
+  return {
+    name: 'foo',
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'foo',
+        version: '1.0.0',
+        libc: ['glibc'],
+        scripts: { postinstall: 'node scripts/build.js' },
+        description: 'dropped',
+        dist: {
+          tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+          integrity: 'sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
+        },
+      },
+    },
+    time: { '1.0.0': '2020-01-01T00:00:00.000Z' },
+    modified: '2020-01-01T00:00:00.000Z',
+    readme: '# dropped',
+  } as unknown as PackageMeta
+}

--- a/pnpm11/resolving/npm-resolver/test/fixtures/resolve-bloated-metadata.mjs
+++ b/pnpm11/resolving/npm-resolver/test/fixtures/resolve-bloated-metadata.mjs
@@ -1,0 +1,71 @@
+// Child of memoryBounded.test.ts: resolves PACKAGE_COUNT optional
+// dependencies — each served as a full document carrying JUNK_BYTES of
+// install-irrelevant bulk — under the small heap the parent capped this
+// process to (see the test for the sizing arithmetic). Imports the compiled
+// lib because it runs outside jest's TS transform.
+import http from 'node:http'
+import { mkdtempSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { createFetchFromRegistry } from '@pnpm/network.fetch'
+
+import { createNpmResolver } from '../../lib/index.js'
+
+const PACKAGE_COUNT = 30
+const JUNK_BYTES = 4 * 1024 * 1024
+
+// One shared junk string keeps the server side of this process cheap; each
+// response embeds it, and JSON.parse gives the resolver its own copy per
+// document — the copy whose retention this test exists to bound.
+const junk = 'x'.repeat(JUNK_BYTES / 2)
+
+function packumentFor (name) {
+  return JSON.stringify({
+    name,
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name,
+        version: '1.0.0',
+        libc: ['glibc'],
+        description: junk,
+        dist: {
+          tarball: `https://registry.example.test/${name}/-/${name}-1.0.0.tgz`,
+          integrity: 'sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
+        },
+      },
+    },
+    readme: junk,
+  })
+}
+
+const server = http.createServer((req, res) => {
+  const name = decodeURIComponent(req.url.slice(1))
+  res.setHeader('content-type', 'application/json')
+  res.end(packumentFor(name))
+})
+await new Promise((resolve) => {
+  server.listen(0, '127.0.0.1', resolve)
+})
+const registry = `http://127.0.0.1:${server.address().port}/`
+
+const { resolveFromNpm } = createNpmResolver(createFetchFromRegistry({}), () => undefined, {
+  cacheDir: mkdtempSync(path.join(os.tmpdir(), 'pnpm-memory-bounded-')),
+  registries: { default: registry },
+})
+
+// Sequential on purpose: transient memory (response body + freshly parsed
+// document) then stays around one document, so the heap cap measures what is
+// RETAINED across resolutions, not the fetch concurrency.
+for (let i = 0; i < PACKAGE_COUNT; i++) {
+  const result = await resolveFromNpm(
+    { alias: `bloated-pkg-${i}`, bareSpecifier: '1.0.0', optional: true },
+    {}
+  )
+  if (result?.manifest?.version !== '1.0.0' || result.manifest.libc?.[0] !== 'glibc') {
+    throw new Error(`bloated-pkg-${i} resolved incorrectly: ${JSON.stringify(result?.manifest)}`)
+  }
+}
+
+server.close()

--- a/pnpm11/resolving/npm-resolver/test/fixtures/resolve-bloated-metadata.mjs
+++ b/pnpm11/resolving/npm-resolver/test/fixtures/resolve-bloated-metadata.mjs
@@ -1,8 +1,5 @@
-// Child of memoryBounded.test.ts: resolves PACKAGE_COUNT optional
-// dependencies — each served as a full document carrying JUNK_BYTES of
-// install-irrelevant bulk — under the small heap the parent capped this
-// process to (see the test for the sizing arithmetic). Imports the compiled
-// lib because it runs outside jest's TS transform.
+// Child of memoryBounded.test.ts. Imports the compiled lib because it runs
+// outside jest's TS transform.
 import { mkdtempSync, rmSync } from 'node:fs'
 import http from 'node:http'
 import os from 'node:os'
@@ -15,9 +12,8 @@ import { createNpmResolver } from '../../lib/index.js'
 const PACKAGE_COUNT = 30
 const JUNK_BYTES = 4 * 1024 * 1024
 
-// One shared junk string keeps the server side of this process cheap; each
-// response embeds it, and JSON.parse gives the resolver its own copy per
-// document — the copy whose retention this test exists to bound.
+// One shared junk string keeps the server side cheap; JSON.parse gives the
+// resolver its own copy per document.
 const junk = 'x'.repeat(JUNK_BYTES / 2)
 
 function packumentFor (name) {
@@ -56,9 +52,8 @@ const { resolveFromNpm } = createNpmResolver(createFetchFromRegistry({}), () => 
   registries: { default: registry },
 })
 
-// Sequential on purpose: transient memory (response body + freshly parsed
-// document) then stays around one document, so the heap cap measures what is
-// RETAINED across resolutions, not the fetch concurrency.
+// Sequential on purpose, so the heap cap measures what is retained across
+// resolutions rather than in-flight transients.
 for (let i = 0; i < PACKAGE_COUNT; i++) {
   const result = await resolveFromNpm(
     { alias: `bloated-pkg-${i}`, bareSpecifier: '1.0.0', optional: true },

--- a/pnpm11/resolving/npm-resolver/test/fixtures/resolve-bloated-metadata.mjs
+++ b/pnpm11/resolving/npm-resolver/test/fixtures/resolve-bloated-metadata.mjs
@@ -3,8 +3,8 @@
 // install-irrelevant bulk — under the small heap the parent capped this
 // process to (see the test for the sizing arithmetic). Imports the compiled
 // lib because it runs outside jest's TS transform.
+import { mkdtempSync, rmSync } from 'node:fs'
 import http from 'node:http'
-import { mkdtempSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
@@ -50,8 +50,9 @@ await new Promise((resolve) => {
 })
 const registry = `http://127.0.0.1:${server.address().port}/`
 
+const cacheDir = mkdtempSync(path.join(os.tmpdir(), 'pnpm-memory-bounded-'))
 const { resolveFromNpm } = createNpmResolver(createFetchFromRegistry({}), () => undefined, {
-  cacheDir: mkdtempSync(path.join(os.tmpdir(), 'pnpm-memory-bounded-')),
+  cacheDir,
   registries: { default: registry },
 })
 
@@ -69,3 +70,4 @@ for (let i = 0; i < PACKAGE_COUNT; i++) {
 }
 
 server.close()
+rmSync(cacheDir, { recursive: true, force: true })

--- a/pnpm11/resolving/npm-resolver/test/memoizeFetchMetadata.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/memoizeFetchMetadata.test.ts
@@ -148,3 +148,23 @@ test('notModified results pass through unchanged', async () => {
   expect(first.notModified).toBe(true)
   expect(second).toBe(first)
 })
+
+test('condenseSettledMeta narrows the retained meta while the initiating caller sees the original', async () => {
+  const result = fooFetchResult()
+  const condensed = { name: 'foo' } as PackageMeta
+  const { fetch } = memoizeFetchMetadata(async () => result, {
+    condenseSettledMeta: (meta) => {
+      expect(meta).toBe(result.meta)
+      return condensed
+    },
+  })
+
+  const first = await fetch('foo', { registry: REGISTRY })
+  expect(first).toBe(result)
+
+  const second = await fetch('foo', { registry: REGISTRY })
+  if (second.notModified) throw new Error('expected a cached fetch result')
+  expect(second.meta).toBe(condensed)
+  // The initiating caller's result object is left untouched.
+  expect(result.meta).not.toBe(condensed)
+})

--- a/pnpm11/resolving/npm-resolver/test/memoizeFetchMetadata.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/memoizeFetchMetadata.test.ts
@@ -160,8 +160,6 @@ test('a throwing condenseSettledMeta falls back to retaining the uncondensed met
   const first = await fetch('foo', { registry: REGISTRY })
   expect(first).toBe(result)
 
-  // The settlement swap must survive the condenser: no unhandled rejection,
-  // and the retained entry still serves the (uncondensed) meta.
   const second = await fetch('foo', { registry: REGISTRY })
   if (second.notModified) throw new Error('expected a cached fetch result')
   expect(second.meta).toBe(result.meta)
@@ -184,6 +182,5 @@ test('condenseSettledMeta narrows the retained meta while the initiating caller 
   const second = await fetch('foo', { registry: REGISTRY })
   if (second.notModified) throw new Error('expected a cached fetch result')
   expect(second.meta).toBe(condensed)
-  // The initiating caller's result object is left untouched.
   expect(result.meta).not.toBe(condensed)
 })

--- a/pnpm11/resolving/npm-resolver/test/memoizeFetchMetadata.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/memoizeFetchMetadata.test.ts
@@ -149,6 +149,25 @@ test('notModified results pass through unchanged', async () => {
   expect(second).toBe(first)
 })
 
+test('a throwing condenseSettledMeta falls back to retaining the uncondensed meta', async () => {
+  const result = fooFetchResult()
+  const { fetch } = memoizeFetchMetadata(async () => result, {
+    condenseSettledMeta: () => {
+      throw new Error('malformed document')
+    },
+  })
+
+  const first = await fetch('foo', { registry: REGISTRY })
+  expect(first).toBe(result)
+
+  // The settlement swap must survive the condenser: no unhandled rejection,
+  // and the retained entry still serves the (uncondensed) meta.
+  const second = await fetch('foo', { registry: REGISTRY })
+  if (second.notModified) throw new Error('expected a cached fetch result')
+  expect(second.meta).toBe(result.meta)
+  expect(second.jsonText).toBeUndefined()
+})
+
 test('condenseSettledMeta narrows the retained meta while the initiating caller sees the original', async () => {
   const result = fooFetchResult()
   const condensed = { name: 'foo' } as PackageMeta

--- a/pnpm11/resolving/npm-resolver/test/memoryBounded.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/memoryBounded.test.ts
@@ -6,24 +6,17 @@ import util from 'node:util'
 import { test } from '@jest/globals'
 
 /**
- * Regression guard for https://github.com/pnpm/pnpm/issues/8441: resolving
- * must not retain full-document bulk, so it completes inside a small heap.
- *
- * The child process resolves 30 optional dependencies (the plain-install
- * route that fetches full metadata) whose documents each carry 4 MB of
- * install-irrelevant bulk — 120 MB total. Retaining the parsed documents,
- * as the resolver did before condensing, overflows the 100 MB cap after a
- * dozen packages; the condensed working set is a few KB per package, which
- * leaves the child roughly a 3x headroom over its ~30 MB baseline. That
- * margin is what keeps this deterministic rather than timing-sensitive: a
- * retention regression overshoots the cap by 100+ MB, not by noise.
+ * Regression guard for https://github.com/pnpm/pnpm/issues/8441: the child
+ * resolves 30 optional dependencies whose full documents carry 120 MB of
+ * install-irrelevant bulk under a 100 MB heap cap. Retaining the parsed
+ * documents overshoots the cap by 100+ MB while the condensed working set
+ * leaves ~3x headroom, so the guard is deterministic rather than
+ * timing-sensitive.
  */
 test('resolution completes within a small heap while registry documents carry megabytes of bulk', () => {
   const fixture = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures/resolve-bloated-metadata.mjs')
-  // execFileSync throws on a non-zero exit — an OOM-killed child (V8 aborts
-  // with "Ineffective mark-compacts near heap limit") fails the test. The
-  // child's stderr is folded into the error message because jest only prints
-  // the message, not extra properties like `stderr`.
+  // The child's stderr (the V8 heap-limit abort trace) is folded into the
+  // error message because jest only prints the message, not properties.
   try {
     execFileSync(process.execPath, ['--max-old-space-size=100', fixture], {
       stdio: ['ignore', 'ignore', 'pipe'],

--- a/pnpm11/resolving/npm-resolver/test/memoryBounded.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/memoryBounded.test.ts
@@ -1,8 +1,9 @@
 import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import util from 'node:util'
 
-import { expect, test } from '@jest/globals'
+import { test } from '@jest/globals'
 
 /**
  * Regression guard for https://github.com/pnpm/pnpm/issues/8441: resolving
@@ -20,12 +21,18 @@ import { expect, test } from '@jest/globals'
 test('resolution completes within a small heap while registry documents carry megabytes of bulk', () => {
   const fixture = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures/resolve-bloated-metadata.mjs')
   // execFileSync throws on a non-zero exit — an OOM-killed child (V8 aborts
-  // with "Ineffective mark-compacts near heap limit") fails the test, with
-  // the child's stderr attached for diagnosis.
-  expect(() => {
+  // with "Ineffective mark-compacts near heap limit") fails the test. The
+  // child's stderr is folded into the error message because jest only prints
+  // the message, not extra properties like `stderr`.
+  try {
     execFileSync(process.execPath, ['--max-old-space-size=100', fixture], {
       stdio: ['ignore', 'ignore', 'pipe'],
       timeout: 100_000,
     })
-  }).not.toThrow()
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'stderr' in err && err.stderr != null) {
+      err.message += `\n\nChild stderr:\n${String(err.stderr)}`
+    }
+    throw err
+  }
 }, 120_000)

--- a/pnpm11/resolving/npm-resolver/test/memoryBounded.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/memoryBounded.test.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { expect, test } from '@jest/globals'
+
+/**
+ * Regression guard for https://github.com/pnpm/pnpm/issues/8441: resolving
+ * must not retain full-document bulk, so it completes inside a small heap.
+ *
+ * The child process resolves 30 optional dependencies (the plain-install
+ * route that fetches full metadata) whose documents each carry 4 MB of
+ * install-irrelevant bulk — 120 MB total. Retaining the parsed documents,
+ * as the resolver did before condensing, overflows the 100 MB cap after a
+ * dozen packages; the condensed working set is a few KB per package, which
+ * leaves the child roughly a 3x headroom over its ~30 MB baseline. That
+ * margin is what keeps this deterministic rather than timing-sensitive: a
+ * retention regression overshoots the cap by 100+ MB, not by noise.
+ */
+test('resolution completes within a small heap while registry documents carry megabytes of bulk', () => {
+  const fixture = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures/resolve-bloated-metadata.mjs')
+  // execFileSync throws on a non-zero exit — an OOM-killed child (V8 aborts
+  // with "Ineffective mark-compacts near heap limit") fails the test, with
+  // the child's stderr attached for diagnosis.
+  expect(() => {
+    execFileSync(process.execPath, ['--max-old-space-size=100', fixture], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      timeout: 100_000,
+    })
+  }).not.toThrow()
+}, 120_000)

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -2,7 +2,7 @@ import { rmSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 
 import { expect, jest, test } from '@jest/globals'
-import { ABBREVIATED_META_DIR } from '@pnpm/constants'
+import { ABBREVIATED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
 import type { PackageMeta } from '@pnpm/resolving.registry.types'
 import { temporaryDirectory } from 'tempy'
 
@@ -237,6 +237,63 @@ test('projects sharing one in-flight fetch mirror the fetched body instead of re
   } finally {
     stringifySpy.mockRestore()
   }
+})
+
+test('a full document fetched for an optional dependency is condensed in memory while the mirror keeps the raw body', async () => {
+  const meta = fooMeta()
+  meta.versions['1.0.0'].libc = ['glibc']
+  meta.versions['1.0.0'].scripts = { postinstall: 'node scripts/build.js' }
+  ;(meta as PackageMeta & { readme: string }).readme = '# a readme the size of a novel'
+  meta.time = { '1.0.0': '2020-01-01T00:00:00.000Z' }
+  const rawBody = JSON.stringify(meta)
+  const cacheDir = temporaryDirectory()
+
+  const ctx = {
+    fetch: async () => ({ meta, jsonText: rawBody, etag: undefined }),
+    metaCache: createMetaCache(),
+    cacheDir,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+
+  const res = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, optional: true, preferredVersionSelectors: undefined })
+  // The install-relevant full-document fields survive condensing…
+  expect(res.pickedPackage?.libc).toEqual(['glibc'])
+  expect(res.meta.time).toEqual({ '1.0.0': '2020-01-01T00:00:00.000Z' })
+  // …while the bulk that nothing on the install path reads is dropped.
+  expect(res.pickedPackage?.scripts).toBeUndefined()
+  expect((res.meta as PackageMeta & { readme?: string }).readme).toBeUndefined()
+  expect(ctx.metaCache.get(getPkgMetaCacheKey(REGISTRY, 'foo', true, false))).toBe(res.meta)
+
+  // The full-metadata mirror still receives the raw response body.
+  const pkgMirror = getPkgMirrorPath(cacheDir, FULL_META_DIR, REGISTRY, 'foo')
+  const mirror = await readMirrorWithRetry(pkgMirror, 100)
+  expect(mirror?.slice(mirror.indexOf('\n') + 1)).toBe(rawBody)
+})
+
+test('a mirror holding a full document is condensed when promoted into the in-memory cache', async () => {
+  const meta = fooMeta()
+  meta.versions['1.0.0'].scripts = { postinstall: 'node scripts/build.js' }
+  ;(meta as PackageMeta & { readme: string }).readme = '# a readme the size of a novel'
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, undefined))
+
+  const ctx = {
+    fetch: async () => {
+      throw new Error('offline resolution must not hit the network')
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+    offline: true,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+
+  const res = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
+  expect(res.pickedPackage?.version).toBe('1.0.0')
+  expect(res.pickedPackage?.scripts).toBeUndefined()
+  const cached = ctx.metaCache.get(getPkgMetaCacheKey(REGISTRY, 'foo', false, false))
+  expect(cached).toBe(res.meta)
+  expect((cached as PackageMeta & { readme?: string }).readme).toBeUndefined()
 })
 
 test('a disk-promoted cache entry that cannot satisfy the spec falls back to the registry under prefer-offline', async () => {

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -256,10 +256,8 @@ test('a full document fetched for an optional dependency is condensed in memory 
   const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
 
   const res = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, optional: true, preferredVersionSelectors: undefined })
-  // The install-relevant full-document fields survive condensing…
   expect(res.pickedPackage?.libc).toEqual(['glibc'])
   expect(res.meta.time).toEqual({ '1.0.0': '2020-01-01T00:00:00.000Z' })
-  // …while the bulk that nothing on the install path reads is dropped.
   expect(res.pickedPackage?.scripts).toBeUndefined()
   expect((res.meta as PackageMeta & { readme?: string }).readme).toBeUndefined()
   expect(ctx.metaCache.get(getPkgMetaCacheKey(REGISTRY, 'foo', true, false))).toBe(res.meta)

--- a/pnpm11/resolving/npm-resolver/test/optionalDependencies.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/optionalDependencies.test.ts
@@ -71,12 +71,9 @@ describe('optional dependencies', () => {
   })
 
   test('abbreviated and full metadata are cached separately', async () => {
-    // The npm registry's abbreviated metadata omits `libc`; only the full
-    // document carries it. When resolving the same package first as regular,
-    // then as optional, the optional resolution must hit its own cache slot
-    // and see the full document's libc field. (`libc` — not a field like
-    // `scripts` — is the observable difference because the resolver condenses
-    // every retained packument down to the install-relevant field set.)
+    // `libc` (which abbreviated metadata omits) is the observable difference
+    // between the two slots: a field like `scripts` wouldn't do because the
+    // resolver condenses every retained packument via clearMeta.
     const abbreviatedMeta = {
       name: 'cache-test',
       'dist-tags': { latest: '1.0.0' },

--- a/pnpm11/resolving/npm-resolver/test/optionalDependencies.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/optionalDependencies.test.ts
@@ -71,9 +71,12 @@ describe('optional dependencies', () => {
   })
 
   test('abbreviated and full metadata are cached separately', async () => {
-    // Abbreviated metadata doesn't include scripts, full metadata does.
-    // When resolving the same package first as regular, then as optional,
-    // we should get different metadata from each request.
+    // The npm registry's abbreviated metadata omits `libc`; only the full
+    // document carries it. When resolving the same package first as regular,
+    // then as optional, the optional resolution must hit its own cache slot
+    // and see the full document's libc field. (`libc` — not a field like
+    // `scripts` — is the observable difference because the resolver condenses
+    // every retained packument down to the install-relevant field set.)
     const abbreviatedMeta = {
       name: 'cache-test',
       'dist-tags': { latest: '1.0.0' },
@@ -95,10 +98,7 @@ describe('optional dependencies', () => {
         '1.0.0': {
           name: 'cache-test',
           version: '1.0.0',
-          scripts: {
-            test: 'jest',
-            build: 'tsc',
-          },
+          libc: ['glibc'],
           dist: {
             tarball: 'https://registry.npmjs.org/cache-test/-/cache-test-1.0.0.tgz',
             integrity: 'sha512-test1234567890123456789012345678901234567890123456789012345678',
@@ -134,13 +134,13 @@ describe('optional dependencies', () => {
       { alias: 'cache-test', bareSpecifier: '1.0.0' },
       {}
     )
-    expect(regularResult!.manifest!.scripts).toBeUndefined()
+    expect(regularResult!.manifest!.libc).toBeUndefined()
 
     // Resolve as optional dependency - should get full metadata (separate cache entry)
     const optionalResult = await resolveFromNpm(
       { alias: 'cache-test', bareSpecifier: '1.0.0', optional: true },
       {}
     )
-    expect(optionalResult!.manifest!.scripts).toEqual({ test: 'jest', build: 'tsc' })
+    expect(optionalResult!.manifest!.libc).toEqual(['glibc'])
   })
 })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#8441.

`pnpm install` ran out of memory on large dependency graphs because full registry documents were retained in memory unstripped for the whole resolution phase. On a plain install, full packuments (per-version readmes, `scripts`, descriptions, exports maps, maintainer info) reach the in-memory caches through three routes:

1. **Optional dependencies** — always fetched as full documents to get `libc` (pnpm/pnpm#9950) and cached whole.
2. **`minimumReleaseAge` upgrades** — recently-modified packages are re-fetched as full documents for per-version `time` and cached whole; the full body was also written into the *abbreviated* disk mirror, so warm installs re-inflated from disk too.
3. **Disk mirrors holding full bodies**, promoted into memory unstripped.

Each document was pinned twice — in the resolver's `metaCache` and in `memoizeFetchMetadata`'s settled-entry memo. Heap snapshots from the reproduction ([haines/pnpm-memory](https://github.com/haines/pnpm-memory), 1464 packages, `minimumReleaseAge` active) showed ~645 MB of full-document strings plus ~340 MB of parsed objects at the 1 GB heap limit.

With this change, every packument retained in memory is condensed to the abbreviated field set (everything installation reads: dependency maps, `dist`, `libc`/`os`/`cpu`, `time`, `_npmUser`, `hasInstallScript`, …). Measured on the reproduction:

- **Before:** OOM (`Ineffective mark-compacts near heap limit`) at ~1176 of 1464 packages with `--max-old-space-size=1024`.
- **After:** the same cold-cache scenario completes within 1 GB; the `--heapsnapshot-near-heap-limit` handler never fires.
- **Warm cache:** a second install resolves all 1459 packages in ~4 s from the condensed mirrors and produces a byte-identical lockfile to the cold run.

Two CI regression guards ride along, both verified to fail against a build of the pre-fix source:

- **Resolver-level** (`resolving/npm-resolver/test/memoryBounded.test.ts`): a subprocess capped at `--max-old-space-size=100` resolves 30 optional dependencies whose documents each carry 4 MB of install-irrelevant bulk from a local server. Pre-fix: exit 134 (V8 heap-limit abort); post-fix: passes with ~3× headroom.
- **Whole-CLI level** (`pnpm/test/install/memoryBounded.ts`): the bundled `pnpm install --lockfile-only` resolves 40 optional dependencies with 6 MB of bulk each (240 MB total) from a local registry stub under a 256 MB cap, with `network-concurrency=4` so the cap measures retention rather than in-flight transients. Pre-fix: heap-limit abort; post-fix: passes even a 192 MB cap. This one catches a future retention route anywhere in the install pipeline, not just in the resolver package.

## Squash Commit Body

```text
Full packuments reached the resolver's in-memory caches unstripped on plain
installs through three routes: optional dependencies (fetched full for libc),
minimumReleaseAge time upgrades, and disk mirrors holding full bodies. Each
document was pinned twice for the whole resolution phase (metaCache and the
settled-fetch memo in memoizeFetchMetadata), so per-version readmes, scripts,
and descriptions accumulated to multi-GB heaps and OOM'd large workspaces
(Fixes pnpm/pnpm#8441).

clearMeta is now identity-memoized (WeakMap) and etag-preserving, and every
layer that retains a packument condenses it through clearMeta: pickPackage's
cache writes and disk-mirror loads, and memoizeFetchMetadata's settled-entry
swap (via the new condenseSettledMeta option). The memoization is what keeps
the layers sharing one condensed copy instead of pinning one each. Resolvers
created with fullMetadata and no filterMetadata (pnpm outdated --long) retain
full documents, gated by the new retainsFullMeta predicate.

Two deliberate on-disk changes ride along: the release-age upgrade path now
mirrors the condensed document (which keeps time, the only thing the next
install needs from that slot) instead of writing the multi-MB full body into
the abbreviated mirror, and prepareJsonForDisk drops etag from a serialized
body — the condensed object is shared and gets its etag assigned after a
fetch, and the etag's home is the mirror's headers line.

The common abbreviated path still mirrors the raw response body verbatim, so
cold installs pay no extra serialization; condensing an already-abbreviated
document costs one shallow copy per package, which also protects against
mirrors polluted by earlier releases and registries that ignore the
abbreviated Accept header on disk-loaded documents.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

### Pacquet porting note

Pacquet retains full documents through the same three routes (`pick_package.rs:437-438` ties stripping to the install-wide `filter_metadata`, cache insert at `pick_package.rs:724`, upgrade path at `pick_package.rs:1214-1248`, unstripped disk promotes at `pick_package.rs:529/611/642`), but the impact is materially smaller: versions are kept as lazy `Arc<RawValue>` byte fragments rather than fully-parsed object graphs, so the retained bulk is roughly the raw document size. A follow-up should apply `clear_meta` (`mirror.rs:323`) at those sites behind the same "retains full meta" gate as this PR.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced peak memory during `pnpm install` by condensing cached npm packument metadata to install-relevant fields.
  * Improved consistency of condensed vs full metadata across online, offline, and mirror promotion flows.
  * Prevented duplicate `etag` content when persisting cached metadata.
* **Tests**
  * Added/expanded regression coverage for metadata condensation, cached settlement behavior, optional-dependency handling, and memory-bounded resolver/install scenarios.
* **Chores**
  * Documented the dependency-resolver update via a changeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->