### PR TITLE
feat(releasing): finish native versioning

### DIFF
--- a/.changeset/finish-native-versioning.md
+++ b/.changeset/finish-native-versioning.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/releasing.commands": minor
+"@pnpm/releasing.exportable-manifest": minor
+"@pnpm/releasing.versioning": patch
+"@pnpm/workspace.projects-filter": minor
+"pacquet": minor
+"pnpm": minor
+---
+
+Completed native monorepo versioning with `pnpm change check`, catalog-aware change attribution, Changesets configuration migration, and in-memory recursive snapshot publishing [pnpm/pnpm#12952](https://github.com/pnpm/pnpm/issues/12952).

--- a/.changeset/registry-snapshot-lanes.md
+++ b/.changeset/registry-snapshot-lanes.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+Added registry lanes for snapshot releases, keeping lane versions out of default package metadata while allowing lane-specific reads through the `pnpm-lane` request header.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5130,10 +5130,13 @@ dependencies = [
  "derive_more",
  "indexmap 2.14.0",
  "miette 7.6.0",
+ "pacquet-catalogs-protocol-parser",
  "pacquet-config",
  "pacquet-testing-utils",
  "pacquet-workspace-projects-graph",
  "pathdiff",
+ "serde",
+ "serde-saphyr",
  "tempfile",
  "wax",
 ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ catalogs:
     '@babel/plugin-transform-explicit-resource-management':
       specifier: ^7.29.7
       version: 7.29.7
+    '@changesets/cli':
+      specifier: 2.31.1
+      version: 2.31.1(@types/node@26.1.1)
     '@commitlint/cli':
       specifier: ^21.0.2
       version: 21.2.1
@@ -8495,6 +8498,9 @@ importers:
         specifier: 'catalog:'
         version: 2.9.0
     devDependencies:
+      '@changesets/cli':
+        specifier: 'catalog:'
+        version: 2.31.1(@types/node@26.1.1)
       '@jest/globals':
         specifier: 'catalog:'
         version: 30.4.1
@@ -9752,6 +9758,9 @@ importers:
 
   pnpm11/workspace/projects-filter:
     dependencies:
+      '@pnpm/catalogs.protocol-parser':
+        specifier: workspace:*
+        version: link:../../catalogs/protocol-parser
       '@pnpm/config.matcher':
         specifier: workspace:*
         version: link:../../config/matcher
@@ -9782,6 +9791,9 @@ importers:
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -10293,6 +10305,61 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@changesets/apply-release-plan@7.1.1':
+    resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
+
+  '@changesets/assemble-release-plan@6.0.10':
+    resolution: {integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==}
+
+  '@changesets/changelog-git@0.2.1':
+    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
+    hasBin: true
+
+  '@changesets/config@3.1.4':
+    resolution: {integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==}
+
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+
+  '@changesets/get-dependents-graph@2.1.4':
+    resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
+
+  '@changesets/get-release-plan@4.0.16':
+    resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
+
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+
+  '@changesets/git@3.0.4':
+    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+
+  '@changesets/parse@0.4.3':
+    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
+
+  '@changesets/pre@2.0.2':
+    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+
+  '@changesets/read@0.6.7':
+    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
+
+  '@changesets/should-skip-package@0.1.2':
+    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
+
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+
+  '@changesets/types@6.1.0':
+    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+
+  '@changesets/write@0.4.0':
+    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
   '@commitlint/cli@21.2.1':
     resolution: {integrity: sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==}
@@ -11158,6 +11225,12 @@ packages:
 
   '@lazy-node/types-path@1.0.3':
     resolution: {integrity: sha512-5Bnl5s5jh7o14i0oa7gj+Y0fDLIlri3+KVZmv4gk0OFGuOrOEmWBBCI9ky3Syip5g/yPHZdfa+WO5BVJMUpMdw==}
+
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -12113,6 +12186,9 @@ packages:
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
@@ -13338,6 +13414,10 @@ packages:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
   detect-indent@7.0.2:
     resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
     engines: {node: '>=12.20'}
@@ -13685,6 +13765,9 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extendable-error@0.1.7:
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -13855,6 +13938,14 @@ packages:
 
   fs-extra@4.0.3:
     resolution: {integrity: sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
 
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
@@ -14814,6 +14905,9 @@ packages:
   lodash.kebabcase@4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
 
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
@@ -15125,6 +15219,10 @@ packages:
 
   module-not-found-error@1.0.1:
     resolution: {integrity: sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -15482,6 +15580,9 @@ packages:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
+  outdent@0.5.0:
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -15600,6 +15701,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -15765,6 +15869,11 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   pretty-bytes@4.0.2:
     resolution: {integrity: sha512-yJAF+AjbHKlxQ8eezMd/34Mnj/YTQ3i6kLzvVsH4l/BfIFtp444n0wVbnsn66JimZ9uBofv815aRp1zCppxlWw==}
     engines: {node: '>=4'}
@@ -15858,6 +15967,9 @@ packages:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -15930,6 +16042,10 @@ packages:
   read-pkg@9.0.1:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
     engines: {node: '>=18'}
+
+  read-yaml-file@1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
 
   read-yaml-file@2.1.0:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
@@ -16317,6 +16433,9 @@ packages:
   spawn-command@0.0.2-1:
     resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}
 
+  spawndamnit@3.0.1:
+    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
   spawno@2.1.2:
     resolution: {integrity: sha512-3QmgamuN/bF8zdy7hZaL+dzRYaakJh6UM6zfaS0hLEmVf77rmnFBIayikbLXrqLy8rIVsqKr3npm/14mGKBfOQ==}
 
@@ -16535,6 +16654,10 @@ packages:
   tempy@3.0.0:
     resolution: {integrity: sha512-B2I9X7+o2wOaW4r/CWMkpOO9mdiTRCxXNgob6iGvPmfPWgH/KyUD6Uy5crtWBxIBe3YrNZKR2lSzv1JJKWD4vA==}
     engines: {node: '>=14.16'}
+
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
 
   terminal-link@5.0.0:
     resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
@@ -17300,6 +17423,149 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@changesets/apply-release-plan@7.1.1':
+    dependencies:
+      '@changesets/config': 3.1.4
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.8.5
+
+  '@changesets/assemble-release-plan@6.0.10':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      semver: 7.8.5
+
+  '@changesets/changelog-git@0.2.1':
+    dependencies:
+      '@changesets/types': 6.1.0
+
+  '@changesets/cli@2.31.1(@types/node@26.1.1)':
+    dependencies:
+      '@changesets/apply-release-plan': 7.1.1
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.4
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/get-release-plan': 4.0.16
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@26.1.1)
+      '@manypkg/get-packages': 1.1.3
+      ansi-colors: 4.1.3
+      enquirer: 2.4.1
+      fs-extra: 7.0.1
+      mri: 1.2.0
+      package-manager-detector: 0.2.11
+      picocolors: 1.1.1
+      resolve-from: 5.0.0
+      semver: 7.8.5
+      spawndamnit: 3.0.1
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@changesets/config@3.1.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/logger': 0.1.1
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.8
+
+  '@changesets/errors@0.2.0':
+    dependencies:
+      extendable-error: 0.1.7
+
+  '@changesets/get-dependents-graph@2.1.4':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      picocolors: 1.1.1
+      semver: 7.8.5
+
+  '@changesets/get-release-plan@4.0.16':
+    dependencies:
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/config': 3.1.4
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/get-version-range-type@0.4.0': {}
+
+  '@changesets/git@3.0.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@manypkg/get-packages': 1.1.3
+      is-subdir: 1.2.0
+      micromatch: 4.0.8
+      spawndamnit: 3.0.1
+
+  '@changesets/logger@0.1.1':
+    dependencies:
+      picocolors: 1.1.1
+
+  '@changesets/parse@0.4.3':
+    dependencies:
+      '@changesets/types': 6.1.0
+      js-yaml: '@zkochan/js-yaml@0.0.11'
+
+  '@changesets/pre@2.0.2':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+
+  '@changesets/read@0.6.7':
+    dependencies:
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/parse': 0.4.3
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+      picocolors: 1.1.1
+
+  '@changesets/should-skip-package@0.1.2':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/types@4.1.0': {}
+
+  '@changesets/types@6.1.0': {}
+
+  '@changesets/write@0.4.0':
+    dependencies:
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      human-id: 4.2.0
+      prettier: 2.8.8
+
   '@commitlint/cli@21.2.1(@types/node@22.20.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-conventional': 21.2.0
@@ -17868,6 +18134,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.1
 
+  '@inquirer/external-editor@1.0.3(@types/node@26.1.1)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 26.1.1
+
   '@inquirer/external-editor@3.0.3(@types/node@26.1.1)':
     dependencies:
       chardet: 2.2.0
@@ -18182,6 +18455,22 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - ts-toolbelt
+
+  '@manypkg/find-root@1.1.0':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+
+  '@manypkg/get-packages@1.1.3':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      read-yaml-file: 1.1.0
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -19690,6 +19979,8 @@ snapshots:
       '@types/node': 26.1.1
       form-data: 4.0.6
 
+  '@types/node@12.20.55': {}
+
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
@@ -20997,6 +21288,8 @@ snapshots:
 
   destroy@1.2.0: {}
 
+  detect-indent@6.1.0: {}
+
   detect-indent@7.0.2: {}
 
   detect-libc@2.1.2: {}
@@ -21482,6 +21775,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extendable-error@0.1.7: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@6.0.2: {}
@@ -21654,6 +21949,18 @@ snapshots:
       universalify: 2.0.1
 
   fs-extra@4.0.3:
+    dependencies:
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
     dependencies:
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
       jsonfile: 4.0.0
@@ -22833,6 +23140,8 @@ snapshots:
 
   lodash.kebabcase@4.1.1: {}
 
+  lodash.startcase@4.4.0: {}
+
   lodash.throttle@4.1.1: {}
 
   lodash.truncate@4.4.2: {}
@@ -23254,6 +23563,8 @@ snapshots:
 
   module-not-found-error@1.0.1: {}
 
+  mri@1.2.0: {}
+
   ms@2.1.3: {}
 
   msgpackr-extract@3.0.4:
@@ -23543,6 +23854,8 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  outdent@0.5.0: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -23639,6 +23952,10 @@ snapshots:
   p-try@2.2.0: {}
 
   package-json-from-dist@1.0.1: {}
+
+  package-manager-detector@0.2.11:
+    dependencies:
+      quansync: 0.2.11
 
   parent-module@1.0.1:
     dependencies:
@@ -23769,6 +24086,8 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier@2.8.8: {}
+
   pretty-bytes@4.0.2: {}
 
   pretty-bytes@5.6.0: {}
@@ -23860,6 +24179,8 @@ snapshots:
       es-define-property: 1.0.1
       side-channel: 1.1.1
 
+  quansync@0.2.11: {}
+
   queue-microtask@1.2.3: {}
 
   quick-lru@4.0.1: {}
@@ -23932,6 +24253,13 @@ snapshots:
       parse-json: 8.3.0
       type-fest: 4.41.0
       unicorn-magic: 0.1.0
+
+  read-yaml-file@1.1.0:
+    dependencies:
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
+      js-yaml: 3.15.0
+      pify: 4.0.1
+      strip-bom: 3.0.0
 
   read-yaml-file@2.1.0:
     dependencies:
@@ -24374,6 +24702,11 @@ snapshots:
 
   spawn-command@0.0.2-1: {}
 
+  spawndamnit@3.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   spawno@2.1.2:
     dependencies:
       proc-output: 1.0.9
@@ -24629,6 +24962,8 @@ snapshots:
       temp-dir: 2.0.0
       type-fest: 2.19.0
       unique-string: 3.0.0
+
+  term-size@2.2.1: {}
 
   terminal-link@5.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,6 +104,7 @@ auditConfig:
 catalog:
   '@babel/core': ^7.29.7
   '@babel/plugin-transform-explicit-resource-management': ^7.29.7
+  '@changesets/cli': 2.31.1
   '@commitlint/cli': ^21.0.2
   '@commitlint/config-conventional': ^21.0.2
   '@commitlint/prompt-cli': ^21.0.2

--- a/pnpm/crates/cli/src/cli_args/change.rs
+++ b/pnpm/crates/cli/src/cli_args/change.rs
@@ -7,14 +7,18 @@ use node_semver::Version;
 use pacquet_config::Config;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_versioning::{
-    AssembleReleasePlanOptions, IntentBumpType, ManifestDependency, ReleasePlan,
-    VersioningSettings, WorkspaceProject, assemble_release_plan, index_project_refs,
-    read_change_intents, read_ledger, to_project_dir, write_change_intent,
+    AssembleReleasePlanOptions, ChangelogSettings, ChangelogStorage, IntentBumpType,
+    ManifestDependency, ReleasePlan, VersioningSettings, WorkspaceProject, assemble_release_plan,
+    build_consumption_index, index_project_refs, read_change_intents, read_ledger, to_project_dir,
+    write_change_intent,
 };
 use pacquet_workspace::Project;
-use pacquet_workspace_projects_filter::{GetChangedProjectsOptions, get_changed_projects};
+use pacquet_workspace_projects_filter::{
+    GetChangedProjectsOptions, collect_catalog_users, get_changed_projects,
+};
 use std::{
     collections::HashSet,
+    fs,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -26,8 +30,9 @@ use crate::cli_args::recursive::discover_workspace_projects;
 /// The intent file is written to `.changeset/` in the changesets format.
 #[derive(Debug, Args)]
 pub struct ChangeArgs {
-    /// `status` to print the pending intents and the release plan they
-    /// produce; otherwise the packages the change affects.
+    /// `status` prints the pending release plan; `check [since]` verifies
+    /// changed-package coverage; `migrate` imports Changesets configuration;
+    /// otherwise these are the packages the change affects.
     pub params: Vec<String>,
 
     /// Bump type for the named packages: none, patch, minor, major. "none"
@@ -66,6 +71,45 @@ enum ChangeError {
     #[display("Invalid bump type: {bump}. Expected one of none, patch, minor, major")]
     #[diagnostic(code(ERR_PNPM_VERSIONING_INVALID_BUMP))]
     InvalidBump { bump: String },
+
+    #[display("pnpm change check accepts at most one base revision")]
+    #[diagnostic(code(ERR_PNPM_VERSIONING_INVALID_CHECK_ARGS))]
+    InvalidCheckArgs,
+
+    #[display(
+        "Could not find a base revision for pnpm change check. Pass one explicitly, for example: pnpm change check origin/main"
+    )]
+    #[diagnostic(code(ERR_PNPM_VERSIONING_BASE_NOT_FOUND))]
+    BaseNotFound,
+
+    #[display(
+        "Changed packages are missing a pending change intent: {}. Record a bump or an explicit none decline with pnpm change.",
+        packages.join(", ")
+    )]
+    #[diagnostic(code(ERR_PNPM_VERSIONING_CHANGE_CHECK_FAILED))]
+    CheckFailed { packages: Vec<String> },
+
+    #[display("No Changesets config found at {}", path.display())]
+    #[diagnostic(code(ERR_PNPM_VERSIONING_CHANGESETS_CONFIG_NOT_FOUND))]
+    ChangesetsConfigNotFound { path: PathBuf },
+
+    #[display("Cannot parse {}: {message}", path.display())]
+    #[diagnostic(code(ERR_PNPM_VERSIONING_INVALID_CHANGESETS_CONFIG))]
+    InvalidChangesetsConfig { path: PathBuf, message: String },
+
+    #[display(
+        "Cannot migrate .changeset/config.json because linked groups are not supported. Convert them to fixed groups or remove them first."
+    )]
+    #[diagnostic(code(ERR_PNPM_VERSIONING_LINKED_UNSUPPORTED))]
+    LinkedUnsupported,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct ChangesetsConfig {
+    fixed: Option<Vec<Vec<String>>>,
+    ignore: Option<Vec<String>>,
+    linked: Option<Vec<Vec<String>>>,
 }
 
 impl ChangeArgs {
@@ -75,6 +119,35 @@ impl ChangeArgs {
         };
         let (projects, _) = discover_workspace_projects(&workspace_dir)?;
         let engine_projects = to_engine_projects(&projects);
+
+        if self.params.len() == 1
+            && self.params[0] == "migrate"
+            && self.bump.is_none()
+            && self.summary.is_none()
+        {
+            let repository_changelog =
+                migrate_changesets_config(&workspace_dir, &projects, &config.versioning)?;
+            println!(
+                "Migrated .changeset/config.json to pnpm-workspace.yaml{}.",
+                if repository_changelog { " with repository changelog storage" } else { "" },
+            );
+            return Ok(());
+        }
+
+        if self.params.first().is_some_and(|param| param == "check")
+            && self.bump.is_none()
+            && self.summary.is_none()
+        {
+            check_change_coverage(
+                &workspace_dir,
+                &projects,
+                &engine_projects,
+                config,
+                &self.params[1..],
+            )?;
+            println!("All changed packages are covered by change intents.");
+            return Ok(());
+        }
 
         // Only the exact no-option invocation is the status form, so a
         // package that happens to be named "status" stays recordable.
@@ -120,8 +193,13 @@ impl ChangeArgs {
         // each project under its directory reference, so the written intent
         // stays unambiguous without the contributor knowing the rule exists.
         let pkg_refs = if self.params.is_empty() {
-            let changed_dirs =
-                detect_changed_dirs(&releasable, &engine_projects, &workspace_dir, config);
+            let changed_dirs = detect_changed_dirs(
+                &releasable,
+                &projects,
+                &engine_projects,
+                &workspace_dir,
+                config,
+            );
             prompt_for_packages(&releasable, &changed_dirs)?
         } else {
             self.params.clone()
@@ -144,6 +222,50 @@ impl ChangeArgs {
         println!("Recorded change intent .changeset/{id}.md");
         Ok(())
     }
+}
+
+fn migrate_changesets_config(
+    workspace_dir: &Path,
+    projects: &[Project],
+    current: &VersioningSettings,
+) -> miette::Result<bool> {
+    let config_path = workspace_dir.join(".changeset/config.json");
+    let text = match fs::read_to_string(&config_path) {
+        Ok(text) => text,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Err(ChangeError::ChangesetsConfigNotFound { path: config_path }.into());
+        }
+        Err(err) => return Err(err).into_diagnostic(),
+    };
+    let legacy: ChangesetsConfig = serde_json::from_str(&text).map_err(|err| {
+        ChangeError::InvalidChangesetsConfig { path: config_path.clone(), message: err.to_string() }
+    })?;
+    if legacy.linked.as_ref().is_some_and(|groups| !groups.is_empty()) {
+        return Err(ChangeError::LinkedUnsupported.into());
+    }
+    let repository_changelog =
+        projects.iter().any(|project| project.root_dir.join("CHANGELOG.md").is_file());
+    let mut versioning = current.clone();
+    if let Some(fixed) = legacy.fixed {
+        versioning.fixed = fixed;
+    }
+    if let Some(ignore) = legacy.ignore {
+        versioning.ignore = ignore;
+    }
+    if repository_changelog {
+        versioning.changelog = Some(ChangelogSettings {
+            storage: Some(ChangelogStorage::Repository),
+            ..versioning.changelog.unwrap_or_default()
+        });
+    }
+    let value = serde_json::to_value(&versioning).into_diagnostic()?;
+    pacquet_workspace_manifest_writer::update_manifest_field(
+        &workspace_dir.join("pnpm-workspace.yaml"),
+        "versioning",
+        &value,
+    )?;
+    fs::remove_file(&config_path).into_diagnostic()?;
+    Ok(repository_changelog)
 }
 
 fn parse_bump(bump: &str) -> Option<IntentBumpType> {
@@ -203,6 +325,7 @@ fn prompt_for_packages(
 /// Returns an empty set on any failure so the picker degrades to a flat list.
 fn detect_changed_dirs(
     releasable: &[ReleasableProject],
+    projects: &[Project],
     engine_projects: &[WorkspaceProject],
     workspace_dir: &Path,
     config: &Config,
@@ -212,8 +335,11 @@ fn detect_changed_dirs(
     };
     let project_dirs: Vec<PathBuf> =
         engine_projects.iter().map(|project| project.root_dir.clone()).collect();
+    let catalog_users = collect_project_catalog_users(projects);
     let opts = GetChangedProjectsOptions {
         workspace_dir,
+        workspace_root: workspace_dir,
+        catalog_users: &catalog_users,
         test_pattern: &config.test_pattern,
         changed_files_ignore_pattern: &config.changed_files_ignore_pattern,
     };
@@ -230,9 +356,94 @@ fn detect_changed_dirs(
         .collect()
 }
 
+fn check_change_coverage(
+    workspace_dir: &Path,
+    projects: &[Project],
+    engine_projects: &[WorkspaceProject],
+    config: &Config,
+    params: &[String],
+) -> miette::Result<()> {
+    if params.len() > 1 {
+        return Err(ChangeError::InvalidCheckArgs.into());
+    }
+    let base_commit = match params.first() {
+        Some(commit) => commit.clone(),
+        None => detect_base_commit(workspace_dir).ok_or(ChangeError::BaseNotFound)?,
+    };
+    let releasable = releasable_projects(engine_projects, workspace_dir, &config.versioning);
+    let releasable_by_dir: std::collections::HashMap<&str, &ReleasableProject> =
+        releasable.iter().map(|project| (project.dir.as_str(), project)).collect();
+    let catalog_users = collect_project_catalog_users(projects.iter());
+    let changed = get_changed_projects(
+        projects.iter().map(|project| project.root_dir.clone()).collect(),
+        &base_commit,
+        &GetChangedProjectsOptions {
+            workspace_dir,
+            workspace_root: workspace_dir,
+            catalog_users: &catalog_users,
+            test_pattern: &config.test_pattern,
+            changed_files_ignore_pattern: &config.changed_files_ignore_pattern,
+        },
+    )?;
+    let touched: Vec<String> = changed
+        .changed_projects
+        .iter()
+        .map(|root_dir| to_project_dir(workspace_dir, root_dir))
+        .filter(|dir| releasable_by_dir.contains_key(dir.as_str()))
+        .collect();
+    if touched.is_empty() {
+        return Ok(());
+    }
+
+    let refs = index_project_refs(engine_projects, workspace_dir);
+    let intents = read_change_intents(workspace_dir)?;
+    let ledger = read_ledger(workspace_dir)?;
+    let consumption = build_consumption_index(&ledger, |name| refs.name_to_dirs(name))?;
+    let mut covered = HashSet::new();
+    for intent in &intents {
+        for reference in intent.releases.keys() {
+            for dir in refs.ref_to_dirs(reference) {
+                let already_consumed =
+                    consumption.get(&dir).is_some_and(|entry| entry.all_ids.contains(&intent.id));
+                if !already_consumed {
+                    covered.insert(dir);
+                }
+            }
+        }
+    }
+    let mut uncovered: Vec<String> = touched
+        .iter()
+        .filter(|dir| !covered.contains(*dir))
+        .map(|dir| releasable_by_dir[dir.as_str()].reference.clone())
+        .collect();
+    uncovered.sort();
+    if !uncovered.is_empty() {
+        return Err(ChangeError::CheckFailed { packages: uncovered }.into());
+    }
+    Ok(())
+}
+
+fn collect_project_catalog_users<'a>(
+    projects: impl IntoIterator<Item = &'a Project>,
+) -> pacquet_workspace_projects_filter::CatalogUsers {
+    collect_catalog_users(projects.into_iter().map(|project| {
+        let dependencies = project
+            .manifest
+            .dependencies([
+                DependencyGroup::Prod,
+                DependencyGroup::Dev,
+                DependencyGroup::Optional,
+                DependencyGroup::Peer,
+            ])
+            .map(|(name, specifier)| (name.to_string(), specifier.to_string()))
+            .collect();
+        (project.root_dir.clone(), dependencies)
+    }))
+}
+
 /// The merge-base of HEAD with the default branch, or `None`.
 fn detect_base_commit(cwd: &Path) -> Option<String> {
-    for branch in ["main", "master"] {
+    for branch in ["origin/main", "main", "origin/master", "master"] {
         let Ok(output) =
             Command::new("git").args(["merge-base", "HEAD", branch]).current_dir(cwd).output()
         else {

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -25,6 +25,7 @@ use pacquet_pack::{
 use pacquet_reporter::Reporter;
 use pacquet_workspace::read_workspace_manifest;
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -235,6 +236,7 @@ impl PackArgs {
         PackOptions {
             dir,
             catalogs,
+            workspace_versions: HashMap::new(),
             ignore_scripts: config.ignore_scripts,
             unsafe_perm: config.unsafe_perm,
             embed_readme: false,

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -92,6 +92,11 @@ pub struct PublishFlags {
     #[clap(long)]
     pub batch: bool,
 
+    /// Publish the pending release plan under in-memory snapshot versions.
+    /// With no value, the current branch names the snapshot.
+    #[clap(long, num_args = 0..=1, default_missing_value = "")]
+    pub snapshot: Option<String>,
+
     /// Recursive only: write a `pnpm-publish-summary.json` report listing the
     /// packages that were published.
     #[clap(long = "report-summary")]
@@ -163,6 +168,12 @@ impl PublishArgs {
                 "--batch can only be used together with --recursive",
             ));
         }
+        if self.flags.snapshot.is_some() && !recursive {
+            return Err(miette::miette!(
+                code = "ERR_PNPM_SNAPSHOT_PUBLISH_REQUIRES_RECURSIVE",
+                "--snapshot can only be used together with --recursive",
+            ));
+        }
 
         // Upstream gates on `opts.gitChecks !== false`, which folds together
         // the `git-checks` config setting and the `--no-git-checks` flag.
@@ -180,13 +191,14 @@ impl PublishArgs {
         let http_client = build_registry_client(config)?;
         let network = PublishNetwork { client: &http_client, auth_headers: &config.auth_headers };
 
-        let summary =
-            if let Some(package) = self.package.as_deref().filter(|path| is_tarball_path(path)) {
-                self.publish_tarball::<Reporter>(package, &opts, &network).await?
-            } else {
-                let project_dir = self.package.as_deref().map_or(dir, Path::new);
-                self.publish_directory::<Reporter>(project_dir, config, &opts, &network).await?
-            };
+        let summary = if let Some(package) =
+            self.package.as_deref().filter(|path| is_tarball_path(path))
+        {
+            self.publish_tarball::<Reporter>(package, &opts, &network).await?
+        } else {
+            let project_dir = self.package.as_deref().map_or(dir, Path::new);
+            self.publish_directory::<Reporter>(project_dir, config, &opts, &network, None).await?
+        };
         Ok(PublishedPackages::Single(Box::new(summary)))
     }
 
@@ -226,6 +238,7 @@ impl PublishArgs {
         config: &Config,
         opts: &PublishPackedPkgOptions,
         network: &PublishNetwork<'_>,
+        workspace_versions: Option<&HashMap<String, String>>,
     ) -> miette::Result<PublishSummary> {
         let manifest = pacquet_package_manifest::safe_read_package_json_from_dir(project_dir)
             .into_diagnostic()
@@ -248,8 +261,14 @@ impl PublishArgs {
         }
 
         let pack_destination = tempfile::tempdir().into_diagnostic().wrap_err("create temp dir")?;
-        let pack_result =
-            self.pack_for_publish::<Reporter>(project_dir, config, pack_destination.path()).await?;
+        let pack_result = self
+            .pack_for_publish::<Reporter>(
+                project_dir,
+                config,
+                pack_destination.path(),
+                workspace_versions,
+            )
+            .await?;
         let tarball_data = std::fs::read(&pack_result.tarball_path)
             .into_diagnostic()
             .wrap_err("read packed tarball")?;
@@ -294,6 +313,7 @@ impl PublishArgs {
         dir: &Path,
         config: &Config,
         pack_destination: &Path,
+        workspace_versions: Option<&HashMap<String, String>>,
     ) -> miette::Result<PackResult> {
         let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(dir);
         let before_packing_hooks =
@@ -301,6 +321,7 @@ impl PublishArgs {
         let mut options = PackOptions {
             dir: dir.to_path_buf(),
             catalogs: crate::cli_args::pack::pack_catalogs(config)?,
+            workspace_versions: workspace_versions.cloned().unwrap_or_default(),
             ignore_scripts: self.should_ignore_scripts(config),
             unsafe_perm: config.unsafe_perm,
             embed_readme: false,
@@ -317,7 +338,9 @@ impl PublishArgs {
             before_packing_hooks,
             injected_files: Vec::new(),
         };
-        crate::cli_args::pack::set_injected_changelog(&mut options, config, dir).await?;
+        if workspace_versions.is_none() {
+            crate::cli_args::pack::set_injected_changelog(&mut options, config, dir).await?;
+        }
         pack_api::<Reporter, PackHost>(&options)
             .await
             .map_err(miette::Report::new)
@@ -341,6 +364,7 @@ impl PublishArgs {
             provenance: self.flags.provenance.then_some(true),
             dry_run: self.flags.dry_run,
             stage,
+            lane: None,
             http: OidcHttpOptions {
                 fetch_retries: Some(config.fetch_retries),
                 fetch_retry_factor: Some(f64::from(config.fetch_retry_factor)),

--- a/pnpm/crates/cli/src/cli_args/publish/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/recursive.rs
@@ -6,7 +6,7 @@
 //! writing `pnpm-publish-summary.json`.
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -15,11 +15,16 @@ use miette::{Context, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_network::{RetryOpts, ThrottledClient};
 use pacquet_publish::{
-    Host, PublishNetwork, PublishSummary, find_registry_info, resolve_otp_from_env,
+    Host, PublishNetwork, PublishSummary, find_registry_info, get_current_branch,
+    resolve_otp_from_env,
 };
 use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pacquet_resolving_npm_resolver::{
     FetchFullMetadataOptions, FetchFullMetadataOutcome, fetch_full_metadata,
+};
+use pacquet_versioning::{
+    AssembleReleasePlanOptions, assemble_release_plan, read_change_intents, read_ledger,
+    to_project_dir,
 };
 use pipe_trait::Pipe;
 use serde_json::Value;
@@ -67,10 +72,20 @@ impl PublishArgs {
             return Ok(Vec::new());
         }
 
+        let snapshot_plan = self
+            .flags
+            .snapshot
+            .as_deref()
+            .map(|tag| build_snapshot_plan(tag, workspace_root, &projects, graph, config))
+            .transpose()?;
         let http_client = build_registry_client(config)?;
         let network = PublishNetwork { client: &http_client, auth_headers: &config.auth_headers };
         let otp = resolve_otp_from_env::<Host>(self.flags.otp.clone());
-        let opts = self.publish_options(config, otp, stage);
+        let mut opts = self.publish_options(config, otp, stage);
+        if let Some(snapshot) = &snapshot_plan {
+            opts.tag = snapshot.tag.clone();
+            opts.lane = Some(snapshot.tag.clone());
+        }
         let retry_opts = retry_opts_from_config(config);
 
         // Filter the selected graph: keep only packages that have a name and
@@ -79,11 +94,17 @@ impl PublishArgs {
         // reads, so run them concurrently rather than one round-trip at a time
         // (the `ThrottledClient` still bounds the actual in-flight fan-out).
         let http_client_ref = &http_client;
+        let is_snapshot = snapshot_plan.is_some();
         let probes = graph.iter().filter_map(|(root, node)| {
+            if snapshot_plan.as_ref().is_some_and(|snapshot| !snapshot.project_roots.contains(root))
+            {
+                return None;
+            }
             let manifest = node.package.project.manifest.value();
             let (name, version) = publish_eligible(manifest)?;
             Some(async move {
-                let already = !self.flags.force
+                let already = !is_snapshot
+                    && !self.flags.force
                     && is_already_published(
                         name,
                         version,
@@ -125,8 +146,15 @@ impl PublishArgs {
                 if !to_publish.contains(&root) {
                     continue;
                 }
-                let summary =
-                    self.publish_directory::<Reporter>(&root, config, &opts, &network).await?;
+                let summary = self
+                    .publish_directory::<Reporter>(
+                        &root,
+                        config,
+                        &opts,
+                        &network,
+                        snapshot_plan.as_ref().map(|snapshot| &snapshot.workspace_versions),
+                    )
+                    .await?;
                 published.push(summary);
             }
         }
@@ -136,6 +164,72 @@ impl PublishArgs {
         }
         Ok(published)
     }
+}
+
+struct SnapshotPlan {
+    project_roots: HashSet<PathBuf>,
+    tag: String,
+    workspace_versions: HashMap<String, String>,
+}
+
+fn build_snapshot_plan(
+    requested_tag: &str,
+    workspace_root: &Path,
+    projects: &[pacquet_workspace::Project],
+    selected: &pacquet_workspace_projects_graph::ProjectGraph<crate::cli_args::recursive::GraphPkg>,
+    config: &Config,
+) -> miette::Result<SnapshotPlan> {
+    let raw_tag = if requested_tag.is_empty() {
+        get_current_branch::<Host>(workspace_root).unwrap_or_else(|| "snapshot".to_string())
+    } else {
+        requested_tag.to_string()
+    };
+    let tag = normalize_snapshot_tag(&raw_tag)?;
+    let suffix = format!("{}-{}", tag, chrono::Utc::now().format("%Y%m%d%H%M%S"));
+    let engine_projects = crate::cli_args::change::to_engine_projects(projects);
+    let filter = (!config.filter.is_empty()).then(|| {
+        selected.keys().map(|root| to_project_dir(workspace_root, root)).collect::<HashSet<_>>()
+    });
+    let plan = assemble_release_plan(
+        &engine_projects,
+        workspace_root,
+        &read_change_intents(workspace_root)?,
+        &read_ledger(workspace_root)?,
+        Some(&config.versioning),
+        &AssembleReleasePlanOptions {
+            filter,
+            snapshot_suffix: Some(suffix),
+            enforce_workspace_protocol: true,
+        },
+    )?;
+    Ok(SnapshotPlan {
+        project_roots: plan.releases.iter().map(|release| release.root_dir.clone()).collect(),
+        workspace_versions: plan
+            .releases
+            .iter()
+            .map(|release| (release.name.clone(), release.new_version.clone()))
+            .collect(),
+        tag,
+    })
+}
+
+fn normalize_snapshot_tag(tag: &str) -> miette::Result<String> {
+    let mut normalized = String::new();
+    let mut last_was_dash = false;
+    for character in tag.chars() {
+        if character.is_ascii_alphanumeric() || character == '-' {
+            normalized.push(character);
+            last_was_dash = character == '-';
+        } else if !last_was_dash && !normalized.is_empty() {
+            normalized.push('-');
+            last_was_dash = true;
+        }
+    }
+    let normalized = normalized.trim_matches('-').to_string();
+    if normalized.is_empty() {
+        return Err(miette::miette!(r#"Cannot derive a snapshot tag from "{tag}""#));
+    }
+    Ok(normalized)
 }
 
 /// A package's `(name, version)` when it is eligible to be published, or `None`

--- a/pnpm/crates/cli/src/cli_args/publish/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/tests.rs
@@ -30,6 +30,7 @@ fn publish_flags() -> PublishFlags {
         no_git_checks: false,
         force: false,
         batch: false,
+        snapshot: None,
         report_summary: false,
     }
 }
@@ -84,7 +85,7 @@ async fn pack_for_publish_writes_a_tarball_and_returns_the_manifest() {
 
     let args = publish_args_with(PublishFlags { ignore_scripts: true, ..publish_flags() });
     let result = args
-        .pack_for_publish::<SilentReporter>(dir.path(), &Config::default(), dest.path())
+        .pack_for_publish::<SilentReporter>(dir.path(), &Config::default(), dest.path(), None)
         .await
         .expect("packing succeeds");
 
@@ -147,7 +148,7 @@ async fn publish_directory_errors_when_no_manifest_is_present() {
     let network = PublishNetwork { client: &client, auth_headers: &auth_headers };
 
     let err = args
-        .publish_directory::<SilentReporter>(dir.path(), &config, &opts, &network)
+        .publish_directory::<SilentReporter>(dir.path(), &config, &opts, &network, None)
         .await
         .expect_err("an empty directory has no package.json");
 

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -18,8 +18,8 @@ use pacquet_workspace::{
     workspace_package_patterns,
 };
 use pacquet_workspace_projects_filter::{
-    FilterWorkspaceProjectsOptions, ProjectSelector, filter_workspace_projects,
-    parse_project_selector,
+    FilterWorkspaceProjectsOptions, ProjectSelector, collect_catalog_users,
+    filter_workspace_projects, parse_project_selector,
 };
 use pacquet_workspace_projects_graph::{
     BaseProject, CreateProjectsGraphOptions, GraphProject, ProjectGraph, create_projects_graph,
@@ -330,6 +330,10 @@ pub fn select_recursive_projects<'a>(
     };
 
     let root_in_prod = !config.filter_prod.is_empty();
+    let catalog_users = collect_catalog_users(projects.iter().map(|project| {
+        let graph_project = GraphPkg { project };
+        (project.root_dir.clone(), graph_project.merged_dependencies(false))
+    }));
     let walk_opts = FilterWorkspaceProjectsOptions {
         // Glob dir filtering (the default, the inverse of
         // `legacyDirFiltering`) is load-bearing for the
@@ -340,6 +344,7 @@ pub fn select_recursive_projects<'a>(
         // stays at the default.
         use_glob_dir_filtering: true,
         workspace_dir: config.workspace_dir.as_deref().unwrap_or(prefix).to_path_buf(),
+        catalog_users,
         test_pattern: config.test_pattern.clone(),
         changed_files_ignore_pattern: config.changed_files_ignore_pattern.clone(),
     };

--- a/pnpm/crates/cli/tests/change.rs
+++ b/pnpm/crates/cli/tests/change.rs
@@ -118,6 +118,107 @@ fn change_records_an_intent_and_version_applies_the_release_plan() {
 }
 
 #[test]
+fn change_check_requires_a_pending_bump_or_none_intent_for_every_changed_package() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
+    write_workspace(&workspace);
+    add_pkg(&workspace, "lib", "1.0.0", "{}");
+    fs::write(workspace.join("packages/lib/index.js"), "module.exports = 0\n")
+        .expect("write initial file");
+    Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(&workspace)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.email", "x@y.z"])
+        .current_dir(&workspace)
+        .assert()
+        .success();
+    Command::new("git")
+        .args(["config", "user.name", "xyz"])
+        .current_dir(&workspace)
+        .assert()
+        .success();
+    Command::new("git").args(["add", "."]).current_dir(&workspace).assert().success();
+    Command::new("git")
+        .args(["commit", "-m", "initial", "--no-gpg-sign"])
+        .current_dir(&workspace)
+        .assert()
+        .success();
+    fs::write(workspace.join("packages/lib/index.js"), "module.exports = 1\n")
+        .expect("write changed file");
+
+    let uncovered = pnpm(&workspace)
+        .with_args(["change", "check", "HEAD"])
+        .output()
+        .expect("run pnpm change check");
+    assert!(!uncovered.status.success());
+    assert!(
+        String::from_utf8_lossy(&uncovered.stderr).contains("missing a pending change intent"),
+        "unexpected: {}",
+        String::from_utf8_lossy(&uncovered.stderr),
+    );
+    stdout_of(pnpm(&workspace).with_args([
+        "change",
+        "--bump",
+        "none",
+        "--summary",
+        "Internal refactor.",
+        "lib",
+    ]));
+    let covered = stdout_of(pnpm(&workspace).with_args(["change", "check", "HEAD"]));
+    assert!(covered.contains("All changed packages are covered"), "unexpected: {covered}");
+
+    drop(root);
+}
+
+#[test]
+fn change_migrate_translates_changesets_config_and_removes_it() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
+    write_workspace(&workspace);
+    add_pkg(&workspace, "lib", "1.0.0", "{}");
+    fs::write(workspace.join("packages/lib/CHANGELOG.md"), "# lib\n").expect("write changelog");
+    fs::create_dir(workspace.join(".changeset")).expect("create .changeset");
+    fs::write(
+        workspace.join(".changeset/config.json"),
+        r#"{"fixed":[["lib","cli"]],"ignore":["private-pkg"],"linked":[]}"#,
+    )
+    .expect("write Changesets config");
+
+    let output = stdout_of(pnpm(&workspace).with_args(["change", "migrate"]));
+    assert!(output.contains("repository changelog storage"), "unexpected: {output}");
+    let workspace_yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml");
+    assert!(workspace_yaml.contains("fixed:"), "unexpected: {workspace_yaml}");
+    assert!(workspace_yaml.contains("private-pkg"), "unexpected: {workspace_yaml}");
+    assert!(workspace_yaml.contains("storage: repository"), "unexpected: {workspace_yaml}");
+    assert!(!workspace.join(".changeset/config.json").exists());
+
+    drop(root);
+}
+
+#[test]
+fn change_migrate_rejects_linked_groups_without_removing_the_config() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
+    write_workspace(&workspace);
+    add_pkg(&workspace, "lib", "1.0.0", "{}");
+    fs::create_dir(workspace.join(".changeset")).expect("create .changeset");
+    let config_path = workspace.join(".changeset/config.json");
+    fs::write(&config_path, r#"{"linked":[["lib","cli"]]}"#).expect("write Changesets config");
+
+    let output = pnpm(&workspace).with_args(["change", "migrate"]).output().expect("run migration");
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("ERR_PNPM_VERSIONING_LINKED_UNSUPPORTED"),
+        "unexpected: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(config_path.exists());
+
+    drop(root);
+}
+
+#[test]
 fn lanes_are_entered_released_and_graduated() {
     let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
     write_workspace(&workspace);

--- a/pnpm/crates/cli/tests/publish_recursive.rs
+++ b/pnpm/crates/cli/tests/publish_recursive.rs
@@ -275,6 +275,68 @@ fn recursive_publish_empty_workspace_writes_no_summary() {
     drop(root);
 }
 
+#[test]
+fn recursive_snapshot_publish_uses_the_pending_plan_without_mutating_release_state() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("snapshot-core", public_pkg("snapshot-core")),
+            (
+                "snapshot-app",
+                json!({
+                    "name": "snapshot-app",
+                    "version": "1.0.0",
+                    "dependencies": { "snapshot-core": "workspace:^" },
+                }),
+            ),
+        ],
+    );
+    fs::create_dir(workspace.join(".changeset")).expect("create .changeset");
+    let intent = "---\n\"snapshot-core\": patch\n\"snapshot-app\": patch\n---\nSnapshot release.\n";
+    fs::write(workspace.join(".changeset/snapshot.md"), intent).expect("write intent");
+
+    clear_ci(pacquet)
+        .with_arg("publish")
+        .with_arg("-r")
+        .with_arg("--snapshot=pr-42")
+        .with_arg("--dry-run")
+        .with_arg("--report-summary")
+        .with_arg("--no-git-checks")
+        .assert()
+        .success();
+
+    let summary: Value = serde_json::from_str(
+        &fs::read_to_string(workspace.join("pnpm-publish-summary.json"))
+            .expect("read publish summary"),
+    )
+    .expect("parse publish summary");
+    let published = summary["publishedPackages"].as_array().expect("publishedPackages array");
+    assert_eq!(published.len(), 2);
+    for package in published {
+        let version = package["version"].as_str().expect("published version");
+        assert!(
+            version.starts_with("0.0.0-pr-42-") && version.len() == "0.0.0-pr-42-".len() + 14,
+            "unexpected snapshot version: {version}",
+        );
+    }
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &fs::read_to_string(workspace.join("snapshot-core/package.json"))
+                .expect("read core manifest"),
+        )
+        .expect("parse core manifest")["version"],
+        json!("1.0.0"),
+    );
+    assert_eq!(
+        fs::read_to_string(workspace.join(".changeset/snapshot.md")).expect("read intent"),
+        intent,
+    );
+    assert!(!workspace.join(".changeset/ledger.yaml").exists());
+
+    drop(root);
+}
+
 /// Each eligible workspace package is probed (a 404 means "not yet published")
 /// and then pushed with its own `PUT`.
 #[test]

--- a/pnpm/crates/exportable-manifest/src/create.rs
+++ b/pnpm/crates/exportable-manifest/src/create.rs
@@ -31,6 +31,7 @@ use crate::{
     replace::{
         ReplaceWorkspaceProtocolError, replace_workspace_protocol,
         replace_workspace_protocol_peer_dependency,
+        replace_workspace_protocol_with_snapshot_version,
     },
     transform::{TransformError, transform},
 };
@@ -42,7 +43,7 @@ use pacquet_catalogs_resolver::{
 use pacquet_catalogs_types::Catalogs;
 use pacquet_resolving_jsr_specifier_parser::{ParseJsrSpecifierError, parse_jsr_specifier};
 use serde_json::{Map, Value};
-use std::{fs, io, path::Path};
+use std::{collections::HashMap, fs, io, path::Path};
 
 /// Lifecycle scripts removed from the published manifest's `scripts`
 /// map during obfuscation, so they don't re-run when the package is
@@ -79,6 +80,8 @@ pub struct CreateExportableManifestOptions<'a> {
     /// Where workspace dependencies are installed. Defaults to
     /// `<dir>/node_modules` when `None`.
     pub modules_dir: Option<&'a Path>,
+    /// Planned in-memory workspace versions for snapshot publishing.
+    pub workspace_versions: Option<&'a HashMap<String, String>>,
     /// Keep `packageManager` and publish-lifecycle scripts in the
     /// packed manifest; only the `pnpm` field is stripped.
     pub skip_manifest_obfuscation: bool,
@@ -211,6 +214,17 @@ fn convert_dependency_for_publish(
     opts: &CreateExportableManifestOptions<'_>,
     kind: DependencyKind,
 ) -> Result<String, CreateExportableManifestError> {
+    if let Some(workspace_versions) = opts.workspace_versions
+        && let Some(snapshot) = replace_workspace_protocol_with_snapshot_version(
+            workspace_versions,
+            dep_name,
+            spec,
+            dir,
+        )
+        .map_err(CreateExportableManifestError::ReplaceWorkspaceProtocol)?
+    {
+        return Ok(snapshot);
+    }
     let after_workspace = match kind {
         DependencyKind::Regular => {
             replace_workspace_protocol(dep_name, spec, dir, opts.modules_dir)

--- a/pnpm/crates/exportable-manifest/src/create/tests.rs
+++ b/pnpm/crates/exportable-manifest/src/create/tests.rs
@@ -3,7 +3,11 @@ use super::{
 };
 use pacquet_catalogs_types::{Catalog, Catalogs};
 use serde_json::{Value, json};
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::Path,
+};
 use tempfile::tempdir;
 
 fn empty_catalogs() -> Catalogs {
@@ -18,6 +22,7 @@ fn default_opts(catalogs: &Catalogs) -> CreateExportableManifestOptions<'_> {
     CreateExportableManifestOptions {
         catalogs,
         modules_dir: None,
+        workspace_versions: None,
         skip_manifest_obfuscation: false,
         embed_readme: false,
     }
@@ -64,6 +69,7 @@ fn skip_obfuscation_keeps_scripts_and_package_manager() {
     let opts = CreateExportableManifestOptions {
         catalogs: &catalogs,
         modules_dir: None,
+        workspace_versions: None,
         skip_manifest_obfuscation: true,
         embed_readme: false,
     };
@@ -170,6 +176,38 @@ fn peer_workspace_protocol_dependency_is_rewritten() {
 }
 
 #[test]
+fn workspace_dependencies_use_in_memory_snapshot_versions() {
+    let dir = tempdir().unwrap();
+    let catalogs = empty_catalogs();
+    let workspace_versions =
+        HashMap::from([("core".to_string(), "0.0.0-preview-20260718000000".to_string())]);
+    let out = build(
+        dir.path(),
+        &json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": {
+                "core": "workspace:^",
+                "coreAlias": "workspace:core@*",
+            },
+            "peerDependencies": { "core": "workspace:^1.0.0" },
+        }),
+        &CreateExportableManifestOptions {
+            workspace_versions: Some(&workspace_versions),
+            ..default_opts(&catalogs)
+        },
+    );
+    assert_eq!(
+        out["dependencies"],
+        json!({
+            "core": "0.0.0-preview-20260718000000",
+            "coreAlias": "npm:core@0.0.0-preview-20260718000000",
+        }),
+    );
+    assert_eq!(out["peerDependencies"], json!({ "core": "0.0.0-preview-20260718000000" }));
+}
+
+#[test]
 fn publish_config_whitelisted_keys_are_hoisted() {
     let dir = tempdir().unwrap();
     let catalogs = empty_catalogs();
@@ -214,6 +252,7 @@ fn readme_is_embedded_when_requested() {
     let opts = CreateExportableManifestOptions {
         catalogs: &catalogs,
         modules_dir: None,
+        workspace_versions: None,
         skip_manifest_obfuscation: false,
         embed_readme: true,
     };
@@ -244,6 +283,7 @@ fn readme_symlink_is_not_embedded() {
     let opts = CreateExportableManifestOptions {
         catalogs: &catalogs,
         modules_dir: None,
+        workspace_versions: None,
         skip_manifest_obfuscation: false,
         embed_readme: true,
     };

--- a/pnpm/crates/exportable-manifest/src/lib.rs
+++ b/pnpm/crates/exportable-manifest/src/lib.rs
@@ -25,6 +25,6 @@ pub use create::{
 };
 pub use replace::{
     CannotResolveWorkspaceProtocolError, ReplaceWorkspaceProtocolError, replace_workspace_protocol,
-    replace_workspace_protocol_peer_dependency,
+    replace_workspace_protocol_peer_dependency, replace_workspace_protocol_with_snapshot_version,
 };
 pub use transform::TransformError;

--- a/pnpm/crates/exportable-manifest/src/replace.rs
+++ b/pnpm/crates/exportable-manifest/src/replace.rs
@@ -11,7 +11,10 @@
 //!   `workspace:` segment in place so a compound `a || workspace:>=`
 //!   round-trips correctly.
 
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -46,6 +49,35 @@ pub enum ReplaceWorkspaceProtocolError {
     /// error other than ENOENT, ...). Propagated so the caller can
     /// surface the underlying cause.
     ReadManifest(#[error(source)] PackageManifestError),
+}
+
+/// Materialize a workspace dependency to an exact in-memory snapshot version.
+/// `None` means either the specifier is not `workspace:` or its target is not
+/// part of the snapshot plan, so the ordinary publish conversion should run.
+pub fn replace_workspace_protocol_with_snapshot_version(
+    workspace_versions: &HashMap<String, String>,
+    dep_name: &str,
+    dep_spec: &str,
+    dir: &Path,
+) -> Result<Option<String>, ReplaceWorkspaceProtocolError> {
+    let Some(rest) = dep_spec.strip_prefix("workspace:") else {
+        return Ok(None);
+    };
+    let target_name = if let Some(relative) = strip_workspace_relative_prefix(dep_spec) {
+        read_and_check_manifest(dep_name, &dir.join(relative))?.name
+    } else if let Some(separator) = rest.rfind('@').filter(|&separator| separator > 0) {
+        rest[..separator].to_string()
+    } else {
+        dep_name.to_string()
+    };
+    let Some(version) = workspace_versions.get(&target_name) else {
+        return Ok(None);
+    };
+    Ok(Some(if target_name == dep_name {
+        version.clone()
+    } else {
+        format!("npm:{target_name}@{version}")
+    }))
 }
 
 /// Rewrites a single `dependencies` / `devDependencies` /

--- a/pnpm/crates/napi/src/pack.rs
+++ b/pnpm/crates/napi/src/pack.rs
@@ -59,6 +59,7 @@ pub async fn pack(options: PackOptions, on_log: Option<LogSink>) -> napi::Result
         // Bit does not use catalog: specifiers; workspace catalog loading is
         // deferred until a consumer needs it. See pnpm/plans/NAPI.md.
         catalogs: Catalogs::default(),
+        workspace_versions: HashMap::new(),
         ignore_scripts: options.ignore_scripts.unwrap_or(false),
         unsafe_perm: false,
         embed_readme: options.embed_readme.unwrap_or(false),

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -64,6 +64,8 @@ pub struct PackOptions {
     pub dir: PathBuf,
     /// Parsed workspace catalogs, for `catalog:` specifier rewriting.
     pub catalogs: Catalogs,
+    /// Planned versions used only while packing a snapshot release.
+    pub workspace_versions: HashMap<String, String>,
     /// Skip the `prepack` / `prepare` / `postpack` lifecycle scripts.
     pub ignore_scripts: bool,
     /// `--unsafe-perm`: run lifecycle scripts without dropping privileges.
@@ -284,6 +286,7 @@ where
         &CreateExportableManifestOptions {
             catalogs: &opts.catalogs,
             modules_dir: Some(&modules_dir),
+            workspace_versions: Some(&opts.workspace_versions),
             skip_manifest_obfuscation: opts.skip_manifest_obfuscation,
             embed_readme: opts.embed_readme,
         },
@@ -302,6 +305,12 @@ where
         &opts.before_packing_hooks,
     )
     .await?;
+
+    if let Some(snapshot_version) = opts.workspace_versions.get(name)
+        && let Some(object) = publish_manifest.as_object_mut()
+    {
+        object.insert("version".to_string(), Value::String(snapshot_version.clone()));
+    }
 
     // Strip semver build metadata (the `+<build>` segment) so the
     // tarball name, the packed manifest, and any registry metadata all

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -25,6 +25,7 @@ fn fixture(manifest: &Value) -> (TempDir, PackOptions) {
     let opts = PackOptions {
         dir: dir.path().to_path_buf(),
         catalogs: BTreeMap::new(),
+        workspace_versions: HashMap::new(),
         ignore_scripts: true,
         unsafe_perm: true,
         embed_readme: false,
@@ -365,6 +366,7 @@ fn workspace_license_is_injected_into_a_sub_package() {
     let opts = PackOptions {
         dir: pkg_dir.clone(),
         catalogs: BTreeMap::new(),
+        workspace_versions: HashMap::new(),
         ignore_scripts: true,
         unsafe_perm: true,
         embed_readme: false,
@@ -410,6 +412,7 @@ fn symlinked_workspace_license_is_not_injected() {
     let opts = PackOptions {
         dir: pkg_dir.clone(),
         catalogs: BTreeMap::new(),
+        workspace_versions: HashMap::new(),
         ignore_scripts: true,
         unsafe_perm: true,
         embed_readme: false,
@@ -450,6 +453,7 @@ fn workspace_root_gitignore_excludes_workspace_package_files() {
     let opts = PackOptions {
         dir: pkg_dir.clone(),
         catalogs: BTreeMap::new(),
+        workspace_versions: HashMap::new(),
         ignore_scripts: true,
         unsafe_perm: true,
         embed_readme: false,

--- a/pnpm/crates/publish/src/publish_packed_pkg.rs
+++ b/pnpm/crates/publish/src/publish_packed_pkg.rs
@@ -52,6 +52,9 @@ pub struct PublishPackedPkgOptions {
     pub provenance: Option<bool>,
     pub dry_run: bool,
     pub stage: bool,
+    /// Registry lane for snapshot versions. Stored as metadata on the
+    /// registry document, never in the packed package manifest.
+    pub lane: Option<String>,
     pub http: OidcHttpOptions,
 }
 
@@ -112,8 +115,14 @@ where
 
     // `summary` already hashed the tarball; reuse those digests for the
     // document's `dist` rather than hashing the bytes a second time.
+    let mut registry_manifest = pkg.published_manifest.clone();
+    if let Some(lane) = &opts.lane
+        && let Some(object) = registry_manifest.as_object_mut()
+    {
+        object.insert("_pnpmLane".to_string(), Value::String(lane.clone()));
+    }
     let mut document = build_publish_document(
-        pkg.published_manifest,
+        &registry_manifest,
         pkg.tarball_data,
         &registry,
         resolved.access,

--- a/pnpm/crates/publish/src/publish_packed_pkg/tests.rs
+++ b/pnpm/crates/publish/src/publish_packed_pkg/tests.rs
@@ -676,6 +676,7 @@ async fn publish_packed_pkg_dry_run_returns_the_summary_without_publishing() {
         provenance: None,
         dry_run: true,
         stage: false,
+        lane: None,
         http: OidcHttpOptions::default(),
     };
     let client = ThrottledClient::default();
@@ -769,12 +770,13 @@ async fn publish_packed_pkg_attaches_signed_provenance_to_the_document() {
         provenance: Some(true),
         dry_run: false,
         stage: false,
+        lane: Some("next".to_owned()),
         http: OidcHttpOptions::default(),
     };
     let mock = server
         .mock("PUT", "/pkg")
         .match_body(mockito::Matcher::PartialJsonString(
-            r#"{"_attachments":{"pkg-1.0.0.sigstore":{"content_type":"application/vnd.dev.sigstore.bundle.v0.3+json","data":"signed-bundle-json"}}}"#
+            r#"{"versions":{"1.0.0":{"_pnpmLane":"next"}},"_attachments":{"pkg-1.0.0.sigstore":{"content_type":"application/vnd.dev.sigstore.bundle.v0.3+json","data":"signed-bundle-json"}}}"#
                 .to_owned(),
         ))
         .with_status(200)

--- a/pnpm/crates/versioning/src/apply/tests.rs
+++ b/pnpm/crates/versioning/src/apply/tests.rs
@@ -130,7 +130,7 @@ fn apply_bumps_manifests_writes_changelogs_records_the_ledger_and_deletes_consum
 
     let cli_changelog = fs::read_to_string(cli_dir.join("CHANGELOG.md")).expect("read changelog");
     assert!(cli_changelog.contains("## 2.0.1"));
-    assert!(cli_changelog.contains("- Updated dependencies:"));
+    assert!(cli_changelog.contains("- Updated dependencies"));
     assert!(cli_changelog.contains("  - lib@1.1.0"));
 
     let ledger = read_ledger(workspace.dir.path()).expect("ledger reads");

--- a/pnpm/crates/versioning/src/changelog.rs
+++ b/pnpm/crates/versioning/src/changelog.rs
@@ -45,7 +45,7 @@ pub fn compose_changelog_section(release: &PlannedRelease) -> String {
             .iter()
             .map(|dep| format!("  - {}@{}", dep.name, dep.new_version))
             .collect();
-        entries_by_bump[2].1.push(format!("- Updated dependencies:\n{}", dep_lines.join("\n")));
+        entries_by_bump[2].1.push(format!("- Updated dependencies\n{}", dep_lines.join("\n")));
     }
 
     let mut parts = vec![format!("## {}", release.new_version)];
@@ -54,7 +54,7 @@ pub fn compose_changelog_section(release: &PlannedRelease) -> String {
             continue;
         }
         parts.push(format!("### {}", section_title(*bump_type)));
-        parts.push(entries.join("\n\n"));
+        parts.push(entries.join("\n"));
     }
     format!("{}\n", parts.join("\n\n"))
 }

--- a/pnpm/crates/workspace-projects-filter/Cargo.toml
+++ b/pnpm/crates/workspace-projects-filter/Cargo.toml
@@ -11,14 +11,17 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pacquet-catalogs-protocol-parser = { workspace = true }
 pacquet-config                   = { workspace = true }
 pacquet-workspace-projects-graph = { workspace = true }
 
-derive_more = { workspace = true }
-indexmap    = { workspace = true }
-miette      = { workspace = true }
-pathdiff    = { workspace = true }
-wax         = { workspace = true }
+derive_more  = { workspace = true }
+indexmap     = { workspace = true }
+miette       = { workspace = true }
+pathdiff     = { workspace = true }
+serde        = { workspace = true }
+serde-saphyr = { workspace = true }
+wax          = { workspace = true }
 
 [dev-dependencies]
 pacquet-testing-utils = { workspace = true }

--- a/pnpm/crates/workspace-projects-filter/src/filter.rs
+++ b/pnpm/crates/workspace-projects-filter/src/filter.rs
@@ -42,6 +42,7 @@ pub struct FilterWorkspaceProjectsOptions {
     /// Directory a `[<since>]` selector's git diff runs in when the
     /// selector has no `{dir}` part — normally the workspace root.
     pub workspace_dir: PathBuf,
+    pub catalog_users: crate::get_changed_projects::CatalogUsers,
     /// `testPattern`: glob patterns naming test files. A `[<since>]`
     /// selector selects a project whose changed files all match these
     /// patterns without the project's dependents.
@@ -171,6 +172,8 @@ where
                 diff,
                 &GetChangedProjectsOptions {
                     workspace_dir: selector.parent_dir.as_deref().unwrap_or(&opts.workspace_dir),
+                    workspace_root: &opts.workspace_dir,
+                    catalog_users: &opts.catalog_users,
                     test_pattern: &opts.test_pattern,
                     changed_files_ignore_pattern: &opts.changed_files_ignore_pattern,
                 },
@@ -414,11 +417,17 @@ pub fn filter_projects_by_selector_objects<Pkg>(
 where
     Pkg: GraphProject + Clone,
 {
+    let catalog_users = crate::get_changed_projects::collect_catalog_users(
+        projects
+            .iter()
+            .map(|project| (project.root_dir().to_path_buf(), project.merged_dependencies(false))),
+    );
     let (prod_selectors, all_selectors): (Vec<ProjectSelector>, Vec<ProjectSelector>) =
         selectors.iter().cloned().partition(|selector| selector.follow_prod_deps_only);
     let walk_opts = FilterWorkspaceProjectsOptions {
         use_glob_dir_filtering: opts.use_glob_dir_filtering,
         workspace_dir: opts.workspace_dir.clone(),
+        catalog_users,
         test_pattern: opts.test_pattern.clone(),
         changed_files_ignore_pattern: opts.changed_files_ignore_pattern.clone(),
     };

--- a/pnpm/crates/workspace-projects-filter/src/filter/tests.rs
+++ b/pnpm/crates/workspace-projects-filter/src/filter/tests.rs
@@ -415,7 +415,7 @@ mod changed_packages {
         parse_project_selector::ProjectSelector,
     };
     use indexmap::IndexMap;
-    use pacquet_workspace_projects_graph::ProjectGraph;
+    use pacquet_workspace_projects_graph::{GraphProject, ProjectGraph, ProjectGraphNode};
     use std::{fs, path::Path, process::Command};
     use tempfile::TempDir;
 
@@ -563,6 +563,72 @@ mod changed_packages {
                 },
             ),
             [path_of(&pkg_1_dir), path_of(&pkg_kor_dir)],
+        );
+    }
+
+    #[test]
+    fn changed_catalog_entry_selects_every_project_that_references_it() {
+        let workspace = TempDir::new().expect("create tempdir");
+        let workspace_dir = workspace.path();
+        init_repo(workspace_dir);
+        fs::write(
+            workspace_dir.join("pnpm-workspace.yaml"),
+            "packages:\n  - packages/*\ncatalog:\n  foo: ^1.0.0\n  bar: ^1.0.0\n",
+        )
+        .expect("write workspace manifest");
+        commit_all(workspace_dir);
+        fs::write(
+            workspace_dir.join("pnpm-workspace.yaml"),
+            "packages:\n  - packages/*\ncatalog:\n  foo: ^2.0.0\n  bar: ^1.0.0\n",
+        )
+        .expect("write workspace manifest");
+        commit_all(workspace_dir);
+
+        let foo_dir = workspace_dir.join("packages/foo");
+        let bar_dir = workspace_dir.join("packages/bar");
+        let mut graph: ProjectGraph<TestPkg> = IndexMap::new();
+        graph.insert(
+            foo_dir.clone(),
+            ProjectGraphNode {
+                package: TestPkg {
+                    root_dir: foo_dir.clone(),
+                    name: Some("foo".to_string()),
+                    version: Some("1.0.0".to_string()),
+                    deps: vec![("foo".to_string(), "catalog:".to_string())],
+                    dev_deps: Vec::new(),
+                },
+                dependencies: Vec::new(),
+            },
+        );
+        graph.insert(
+            bar_dir.clone(),
+            ProjectGraphNode {
+                package: TestPkg {
+                    root_dir: bar_dir,
+                    name: Some("bar".to_string()),
+                    version: Some("1.0.0".to_string()),
+                    deps: vec![("bar".to_string(), "catalog:".to_string())],
+                    dev_deps: Vec::new(),
+                },
+                dependencies: Vec::new(),
+            },
+        );
+        let catalog_users =
+            crate::get_changed_projects::collect_catalog_users(graph.values().map(|node| {
+                (node.package.root_dir.clone(), node.package.merged_dependencies(false))
+            }));
+
+        assert_eq!(
+            selected(
+                &graph,
+                &[diff_selector("HEAD~1")],
+                &FilterWorkspaceProjectsOptions {
+                    workspace_dir: workspace_dir.to_path_buf(),
+                    catalog_users,
+                    ..Default::default()
+                },
+            ),
+            [foo_dir.to_string_lossy().into_owned()],
         );
     }
 

--- a/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
+++ b/pnpm/crates/workspace-projects-filter/src/get_changed_projects.rs
@@ -2,8 +2,12 @@
 //! projects the git diff touches, upstream's `getChangedProjects`.
 
 use crate::filter::FilterError;
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
+use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
+use serde::Deserialize;
 use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -14,8 +18,30 @@ pub struct GetChangedProjectsOptions<'a> {
     /// Directory the `git diff` runs in and is path-restricted to: the
     /// selector's `{dir}` part when present, else the workspace root.
     pub workspace_dir: &'a Path,
+    pub workspace_root: &'a Path,
+    pub catalog_users: &'a CatalogUsers,
     pub test_pattern: &'a [String],
     pub changed_files_ignore_pattern: &'a [String],
+}
+
+pub type CatalogUsers = BTreeMap<(String, String), IndexSet<PathBuf>>;
+
+pub fn collect_catalog_users(
+    projects: impl IntoIterator<Item = (PathBuf, Vec<(String, String)>)>,
+) -> CatalogUsers {
+    let mut users = CatalogUsers::new();
+    for (project_dir, dependencies) in projects {
+        for (dependency_name, specifier) in dependencies {
+            let Some(catalog_name) = parse_catalog_protocol(&specifier) else {
+                continue;
+            };
+            users
+                .entry((catalog_name.to_string(), dependency_name))
+                .or_default()
+                .insert(project_dir.clone());
+        }
+    }
+    users
 }
 
 /// The two selection groups a `[<since>]` diff produces.
@@ -58,6 +84,9 @@ pub fn get_changed_projects(
             *entry = Some(change_type);
         }
     }
+    for project_dir in projects_using_changed_catalog_entries(commit, &repo_root, opts)? {
+        project_change_types.insert(project_dir, Some(ChangeType::Source));
+    }
 
     let mut changed_projects: Vec<PathBuf> = Vec::new();
     let mut ignore_dependent_for_projects: Vec<PathBuf> = Vec::new();
@@ -69,6 +98,91 @@ pub fn get_changed_projects(
         }
     }
     Ok(ChangedProjects { changed_projects, ignore_dependent_for_projects })
+}
+
+#[derive(Default, Deserialize)]
+struct CatalogManifest {
+    #[serde(default)]
+    catalog: Option<BTreeMap<String, String>>,
+    #[serde(default)]
+    catalogs: Option<BTreeMap<String, BTreeMap<String, String>>>,
+}
+
+fn projects_using_changed_catalog_entries(
+    commit: &str,
+    repo_root: &Path,
+    opts: &GetChangedProjectsOptions<'_>,
+) -> Result<IndexSet<PathBuf>, FilterError> {
+    let manifest_path = opts.workspace_root.join("pnpm-workspace.yaml");
+    let relative_manifest_path = manifest_path.strip_prefix(repo_root).unwrap_or(&manifest_path);
+    let before = read_catalogs_at_commit(repo_root, commit, relative_manifest_path);
+    let after = match fs::read_to_string(&manifest_path) {
+        Ok(source) => parse_catalogs(&source)?,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => BTreeMap::new(),
+        Err(err) => {
+            return Err(FilterError::FilterChanged {
+                stderr: format!("Failed to read {}: {err}", manifest_path.display()),
+            });
+        }
+    };
+    let changed = changed_catalog_entries(&before, &after);
+    let mut projects = IndexSet::new();
+    for key in changed {
+        if let Some(users) = opts.catalog_users.get(&key) {
+            projects.extend(users.iter().cloned());
+        }
+    }
+    Ok(projects)
+}
+
+fn read_catalogs_at_commit(
+    repo_root: &Path,
+    commit: &str,
+    relative_manifest_path: &Path,
+) -> BTreeMap<String, BTreeMap<String, String>> {
+    let revision = format!("{commit}:{}", relative_manifest_path.to_string_lossy());
+    let Ok(output) = Command::new("git").args(["show", &revision]).current_dir(repo_root).output()
+    else {
+        return BTreeMap::new();
+    };
+    if !output.status.success() {
+        return BTreeMap::new();
+    }
+    parse_catalogs(&String::from_utf8_lossy(&output.stdout)).unwrap_or_default()
+}
+
+fn parse_catalogs(source: &str) -> Result<BTreeMap<String, BTreeMap<String, String>>, FilterError> {
+    let manifest: CatalogManifest = serde_saphyr::from_str(source).map_err(|err| {
+        FilterError::FilterChanged { stderr: format!("Failed to parse pnpm-workspace.yaml: {err}") }
+    })?;
+    let mut catalogs = manifest.catalogs.unwrap_or_default();
+    if let Some(default) = manifest.catalog {
+        catalogs.insert("default".to_string(), default);
+    }
+    Ok(catalogs)
+}
+
+fn changed_catalog_entries(
+    before: &BTreeMap<String, BTreeMap<String, String>>,
+    after: &BTreeMap<String, BTreeMap<String, String>>,
+) -> BTreeSet<(String, String)> {
+    let mut changed = BTreeSet::new();
+    for catalog_name in before.keys().chain(after.keys()) {
+        let before_catalog = before.get(catalog_name);
+        let after_catalog = after.get(catalog_name);
+        let dependency_names = before_catalog
+            .into_iter()
+            .flat_map(|catalog| catalog.keys())
+            .chain(after_catalog.into_iter().flat_map(|catalog| catalog.keys()));
+        for dependency_name in dependency_names {
+            if before_catalog.and_then(|catalog| catalog.get(dependency_name))
+                != after_catalog.and_then(|catalog| catalog.get(dependency_name))
+            {
+                changed.insert((catalog_name.clone(), dependency_name.clone()));
+            }
+        }
+    }
+    changed
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/pnpm/crates/workspace-projects-filter/src/lib.rs
+++ b/pnpm/crates/workspace-projects-filter/src/lib.rs
@@ -16,7 +16,10 @@
 
 mod filter;
 mod get_changed_projects;
-pub use get_changed_projects::{ChangedProjects, GetChangedProjectsOptions, get_changed_projects};
+pub use get_changed_projects::{
+    CatalogUsers, ChangedProjects, GetChangedProjectsOptions, collect_catalog_users,
+    get_changed_projects,
+};
 mod glob;
 mod parse_project_selector;
 mod path_util;

--- a/pnpm11/releasing/commands/src/change/index.ts
+++ b/pnpm11/releasing/commands/src/change/index.ts
@@ -1,8 +1,12 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { checkbox, input, Separator } from '@inquirer/prompts'
 import type { Config } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
 import {
   assembleReleasePlan,
+  buildConsumptionIndex,
   BUMP_TYPES,
   type ChangeIntent,
   indexProjectRefs,
@@ -16,6 +20,7 @@ import {
 } from '@pnpm/releasing.versioning'
 import type { Project, VersioningSettings } from '@pnpm/types'
 import { getChangedProjects } from '@pnpm/workspace.projects-filter'
+import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writer'
 import { safeExeca as execa } from 'execa'
 import { renderHelp } from 'render-help'
 import { valid } from 'semver'
@@ -40,6 +45,8 @@ export function help (): string {
     usages: [
       'pnpm change [--bump <type>] [--summary <text>] [<pkg>...]',
       'pnpm change status',
+      'pnpm change check [<since>]',
+      'pnpm change migrate',
     ],
     descriptionLists: [
       {
@@ -81,7 +88,122 @@ export async function handler (opts: ChangeCommandOptions, params: string[]): Pr
   if (params.length === 1 && params[0] === 'status' && opts.bump == null && opts.summary == null) {
     return renderStatus(workspaceDir, opts)
   }
+  if (params[0] === 'check' && opts.bump == null && opts.summary == null) {
+    return checkChangeCoverage(workspaceDir, opts, params.slice(1))
+  }
+  if (params.length === 1 && params[0] === 'migrate' && opts.bump == null && opts.summary == null) {
+    return migrateChangesetsConfig(workspaceDir, opts)
+  }
   return recordChange(workspaceDir, opts, params)
+}
+
+interface ChangesetsConfig {
+  fixed?: unknown
+  ignore?: unknown
+  linked?: unknown
+}
+
+async function migrateChangesetsConfig (workspaceDir: string, opts: ChangeCommandOptions): Promise<string> {
+  const configPath = path.join(workspaceDir, '.changeset', 'config.json')
+  let config: ChangesetsConfig
+  try {
+    config = JSON.parse(await fs.promises.readFile(configPath, 'utf8')) as ChangesetsConfig
+  } catch (err: unknown) {
+    if (err instanceof SyntaxError) {
+      throw new PnpmError('VERSIONING_INVALID_CHANGESETS_CONFIG', `Cannot parse ${configPath}: ${err.message}`)
+    }
+    if (err != null && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
+      throw new PnpmError('VERSIONING_CHANGESETS_CONFIG_NOT_FOUND', `No Changesets config found at ${configPath}`)
+    }
+    throw err
+  }
+  const linked = parseStringGroups(config.linked, 'linked', configPath)
+  if (linked != null && linked.length > 0) {
+    throw new PnpmError('VERSIONING_LINKED_UNSUPPORTED', 'Cannot migrate .changeset/config.json because linked groups are not supported. Convert them to fixed groups or remove them first.')
+  }
+  const fixed = parseStringGroups(config.fixed, 'fixed', configPath)
+  const ignore = parseStringArray(config.ignore, 'ignore', configPath)
+  const hasCommittedChangelog = await anyProjectHasChangelog(opts.allProjects ?? [])
+  const versioning: VersioningSettings = {
+    ...opts.versioning,
+    ...(fixed == null ? {} : { fixed }),
+    ...(ignore == null ? {} : { ignore }),
+    ...(hasCommittedChangelog ? { changelog: { storage: 'repository' as const } } : {}),
+  }
+  await updateWorkspaceManifest(workspaceDir, { updatedFields: { versioning } })
+  await fs.promises.rm(configPath)
+  return `Migrated .changeset/config.json to pnpm-workspace.yaml${hasCommittedChangelog ? ' with repository changelog storage' : ''}.`
+}
+
+function parseStringGroups (value: unknown, field: string, configPath: string): string[][] | undefined {
+  if (value == null) return undefined
+  if (!Array.isArray(value) || value.some((group) => !Array.isArray(group) || group.some((item) => typeof item !== 'string'))) {
+    throw new PnpmError('VERSIONING_INVALID_CHANGESETS_CONFIG', `The "${field}" field in ${configPath} must be an array of string arrays`)
+  }
+  return value as string[][]
+}
+
+function parseStringArray (value: unknown, field: string, configPath: string): string[] | undefined {
+  if (value == null) return undefined
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new PnpmError('VERSIONING_INVALID_CHANGESETS_CONFIG', `The "${field}" field in ${configPath} must be an array of strings`)
+  }
+  return value as string[]
+}
+
+async function anyProjectHasChangelog (projects: Project[]): Promise<boolean> {
+  const results = await Promise.all(projects.map(async ({ rootDir }) => {
+    try {
+      return (await fs.promises.stat(path.join(rootDir, 'CHANGELOG.md'))).isFile()
+    } catch (err: unknown) {
+      if (err != null && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') return false
+      throw err
+    }
+  }))
+  return results.some(Boolean)
+}
+
+async function checkChangeCoverage (workspaceDir: string, opts: ChangeCommandOptions, params: string[]): Promise<string> {
+  if (params.length > 1) {
+    throw new PnpmError('VERSIONING_INVALID_CHECK_ARGS', 'pnpm change check accepts at most one base revision')
+  }
+  const baseCommit = params[0] ?? await detectBaseCommit(workspaceDir)
+  if (baseCommit == null) {
+    throw new PnpmError('VERSIONING_BASE_NOT_FOUND', 'Could not find a base revision for pnpm change check. Pass one explicitly, for example: pnpm change check origin/main')
+  }
+  const allProjects = opts.allProjects ?? []
+  const releasable = getReleasableProjects(allProjects, workspaceDir, opts.versioning)
+  const releasableByDir = new Map(releasable.map((project) => [project.dir, project]))
+  const [changedRootDirs] = await getChangedProjects(allProjects.map((project) => project.rootDir), baseCommit, {
+    workspaceDir,
+    workspaceRoot: workspaceDir,
+    projects: allProjects,
+    testPattern: opts.testPattern,
+    changedFilesIgnorePattern: opts.changedFilesIgnorePattern,
+  })
+  const touched = changedRootDirs
+    .map((rootDir) => toProjectDir(workspaceDir, rootDir))
+    .filter((dir) => releasableByDir.has(dir))
+  if (touched.length === 0) return 'All changed packages are covered by change intents.'
+
+  const refs = indexProjectRefs(allProjects, workspaceDir)
+  const intents = await readChangeIntents(workspaceDir)
+  const ledger = await readLedger(workspaceDir)
+  const consumptionFor = buildConsumptionIndex(ledger, refs.nameToDirs)
+  const covered = new Set<string>()
+  for (const intent of intents) {
+    for (const ref of Object.keys(intent.releases)) {
+      for (const dir of refs.refToDirs(ref)) {
+        if (!consumptionFor(dir).allIds.has(intent.id)) covered.add(dir)
+      }
+    }
+  }
+  const uncovered = touched.filter((dir) => !covered.has(dir))
+  if (uncovered.length > 0) {
+    const names = uncovered.map((dir) => releasableByDir.get(dir)!.ref).sort()
+    throw new PnpmError('VERSIONING_CHANGE_CHECK_FAILED', `Changed packages are missing a pending change intent: ${names.join(', ')}. Record a bump or an explicit none decline with pnpm change.`)
+  }
+  return 'All changed packages are covered by change intents.'
 }
 
 async function recordChange (workspaceDir: string, opts: ChangeCommandOptions, params: string[]): Promise<string> {
@@ -179,6 +301,8 @@ async function detectChangedDirs (
     const projectDirs = (opts.allProjects ?? []).map((project) => project.rootDir)
     const [changedRootDirs] = await getChangedProjects(projectDirs, baseCommit, {
       workspaceDir,
+      workspaceRoot: workspaceDir,
+      projects: opts.allProjects,
       testPattern: opts.testPattern,
       changedFilesIgnorePattern: opts.changedFilesIgnorePattern,
     })
@@ -195,7 +319,7 @@ async function detectChangedDirs (
 
 /** The merge-base of HEAD with the default branch, or `undefined`. */
 async function detectBaseCommit (cwd: string): Promise<string | undefined> {
-  for (const branch of ['main', 'master']) {
+  for (const branch of ['origin/main', 'main', 'origin/master', 'master']) {
     try {
       // eslint-disable-next-line no-await-in-loop
       const { stdout } = await execa('git', ['merge-base', 'HEAD', branch], { cwd })

--- a/pnpm11/releasing/commands/src/publish/batchPublish.ts
+++ b/pnpm11/releasing/commands/src/publish/batchPublish.ts
@@ -205,7 +205,7 @@ interface PublishDocument {
 function createPublishDocument (
   { publishedManifest, tarballData }: Pick<PackedPkg, 'publishedManifest' | 'tarballData'>,
   registry: string,
-  opts: Pick<BatchPublishOptions, 'access' | 'tag'>
+  opts: Pick<BatchPublishOptions, 'access' | 'lane' | 'tag'>
 ): PublishDocument {
   const name = publishedManifest.name as string
   const version = semver.clean(publishedManifest.version as string)
@@ -220,6 +220,7 @@ function createPublishDocument (
   const tarballName = `${name}-${version}.tgz`
   const manifest: ExportedManifest = {
     ...publishedManifest,
+    ...(opts.lane == null ? {} : { _pnpmLane: opts.lane }),
     _id: `${name}@${version}`,
     version,
     _nodeVersion: process.versions.node,

--- a/pnpm11/releasing/commands/src/publish/pack.ts
+++ b/pnpm11/releasing/commands/src/publish/pack.ts
@@ -148,6 +148,7 @@ export type PackOptions = Pick<UniversalOptions, 'dir'> & Pick<Config, 'catalogs
   out?: string
   json?: boolean
   unicode?: boolean
+  workspaceVersions?: Readonly<Record<string, string>>
 }
 
 export interface PackResultJson {
@@ -266,8 +267,12 @@ export async function api (opts: PackOptions): Promise<PackResult> {
     embedReadme: opts.embedReadme,
     catalogs: opts.catalogs ?? {},
     hooks: opts.hooks,
+    workspaceVersions: opts.workspaceVersions,
     skipManifestObfuscation: opts.skipManifestObfuscation,
   })
+  if (manifest.name in (opts.workspaceVersions ?? {})) {
+    publishManifest.version = opts.workspaceVersions![manifest.name]
+  }
   // Strip semver build metadata (the `+<build>` segment) from the published version so that
   // the tarball, the manifest packed inside it, and the metadata sent to the registry all agree.
   // libnpmpublish runs `semver.clean()` on `manifest.version` before computing the provenance
@@ -315,7 +320,9 @@ export async function api (opts: PackOptions): Promise<PackResult> {
   // composed here on top of the previously published version's changelog and
   // packed in. A composed entry supersedes any stale committed CHANGELOG.md.
   const injectedEntries: Record<string, string> = {}
-  const composedChangelog = await composeRegistryChangelog(opts, manifest.name, manifest.version)
+  const composedChangelog = opts.workspaceVersions == null
+    ? await composeRegistryChangelog(opts, manifest.name, manifest.version)
+    : undefined
   if (composedChangelog != null) {
     delete filesMap['package/CHANGELOG.md']
     injectedEntries['package/CHANGELOG.md'] = composedChangelog
@@ -493,14 +500,16 @@ async function createPublishManifest (opts: {
   manifest: ProjectManifest
   catalogs: Catalogs
   hooks?: Hooks
+  workspaceVersions?: Readonly<Record<string, string>>
   skipManifestObfuscation?: boolean
 }): Promise<ExportedManifest> {
-  const { projectDir, embedReadme, modulesDir, manifest, catalogs, hooks, skipManifestObfuscation } = opts
+  const { projectDir, embedReadme, modulesDir, manifest, catalogs, hooks, workspaceVersions, skipManifestObfuscation } = opts
   return createExportableManifest(projectDir, manifest, {
     catalogs,
     hooks,
     embedReadme,
     modulesDir,
+    workspaceVersions,
     skipManifestObfuscation,
   })
 }

--- a/pnpm11/releasing/commands/src/publish/publish.ts
+++ b/pnpm11/releasing/commands/src/publish/publish.ts
@@ -48,6 +48,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
     otp: String,
     recursive: Boolean,
     'report-summary': Boolean,
+    snapshot: [String, Boolean],
   }
 }
 
@@ -114,6 +115,10 @@ export function help (): string {
             description: 'Send all packages to the registry in a single request instead of one request per package. Requires --recursive and a registry that implements the "/-/pnpm/v1/publish" endpoint (for example, pnpr)',
             name: '--batch',
           },
+          {
+            description: 'Publish the pending release plan under in-memory 0.0.0 snapshot versions. An optional tag controls the prerelease identifier and defaults to the current branch',
+            name: '--snapshot [tag]',
+          },
         ],
       },
       FILTERING,
@@ -179,6 +184,9 @@ export async function publish (
     throw new PnpmError('BATCH_PUBLISH_REQUIRES_RECURSIVE', '--batch can only be used together with --recursive', {
       hint: 'Run "pnpm publish -r --batch" to publish all workspace packages in a single request.',
     })
+  }
+  if (opts.snapshot && !opts.recursive) {
+    throw new PnpmError('SNAPSHOT_PUBLISH_REQUIRES_RECURSIVE', '--snapshot can only be used together with --recursive')
   }
   if (opts.gitChecks !== false && await isGitRepo()) {
     if (!(await isWorkingTreeClean())) {

--- a/pnpm11/releasing/commands/src/publish/publishPackedPkg.ts
+++ b/pnpm11/releasing/commands/src/publish/publishPackedPkg.ts
@@ -49,6 +49,7 @@ export type PublishPackedPkgOptions = Pick<Config,
   provenance?: boolean
   provenanceFile?: string // NOTE: This field is currently not supported
   stage?: boolean
+  lane?: string
 }
 
 export async function publishPackedPkg (
@@ -69,9 +70,12 @@ export async function publishPackedPkg (
     return summary
   }
   const context = createPublishContext(opts)
+  const registryManifest = opts.lane == null
+    ? publishedManifest
+    : { ...publishedManifest, _pnpmLane: opts.lane } as ExportedManifest
   const response = await publishWithOtpHandling({
     context,
-    manifest: publishedManifest,
+    manifest: registryManifest,
     publishOptions,
     tarballData,
   })

--- a/pnpm11/releasing/commands/src/publish/recursivePublish.ts
+++ b/pnpm11/releasing/commands/src/publish/recursivePublish.ts
@@ -4,6 +4,8 @@ import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
 import { createResolver } from '@pnpm/installing.client'
 import { logger } from '@pnpm/logger'
+import { getCurrentBranch } from '@pnpm/network.git-utils'
+import { assembleReleasePlan, readChangeIntents, readLedger, toProjectDir } from '@pnpm/releasing.versioning'
 import type { ResolveFunction } from '@pnpm/resolving.resolver-base'
 import type { ProjectRootDir, Registries } from '@pnpm/types'
 import { sortFilteredProjects } from '@pnpm/workspace.projects-sorter'
@@ -54,12 +56,14 @@ Partial<Pick<Config,
 | 'userAgent'
 | 'verifyStoreIntegrity'
 | 'versioning'
+| 'filter'
 >> &
 Partial<Pick<ConfigContext,
 | 'selectedProjectsGraph'
 | 'allProjectsGraph'
 | 'prodAllProjectsGraph'
 | 'prodOnlySelectedProjectDirs'
+| 'allProjects'
 >> & {
   access?: 'public' | 'restricted'
   argv: {
@@ -67,6 +71,8 @@ Partial<Pick<ConfigContext,
   }
   batch?: boolean
   reportSummary?: boolean
+  snapshot?: string | boolean
+  workspaceVersions?: Readonly<Record<string, string>>
 } & PublishPackedPkgOptions
 
 export type RecursivePublishedPackage = PublishSummary | { name?: string, version?: string }
@@ -74,7 +80,16 @@ export type RecursivePublishedPackage = PublishSummary | { name?: string, versio
 export async function recursivePublish (
   opts: PublishRecursiveOpts & Required<Pick<ConfigContext, 'selectedProjectsGraph'>>
 ): Promise<{ exitCode: number, publishedPackages: RecursivePublishedPackage[] }> {
-  const pkgs = Object.values(opts.selectedProjectsGraph).map((wsPkg) => wsPkg.package)
+  let pkgs = Object.values(opts.selectedProjectsGraph).map((wsPkg) => wsPkg.package)
+  let workspaceVersions = opts.workspaceVersions
+  let snapshotTag: string | undefined
+  if (opts.snapshot) {
+    const snapshot = await createSnapshotPlan(opts)
+    workspaceVersions = snapshot.workspaceVersions
+    snapshotTag = snapshot.tag
+    const plannedDirs = new Set(snapshot.projectDirs)
+    pkgs = pkgs.filter((pkg) => plannedDirs.has(pkg.rootDir))
+  }
   const { resolve } = createResolver({
     ...opts,
     configByUri: opts.configByUri,
@@ -88,6 +103,7 @@ export async function recursivePublish (
   })
   const pkgsToPublish = await pFilter(pkgs, async (pkg) => {
     if (!pkg.manifest.name || !pkg.manifest.version || pkg.manifest.private) return false
+    if (workspaceVersions != null) return true
     if (opts.force) return true
     return !(await isAlreadyPublished({
       dir: pkg.rootDir,
@@ -118,13 +134,13 @@ export async function recursivePublish (
       appendedArgs.push(`--otp=${opts.cliOptions['otp'] as string}`)
     }
     const chunks = sortFilteredProjects(opts)
-    const tag = opts.tag ?? 'latest'
+    const tag = snapshotTag ?? opts.tag ?? 'latest'
     if (opts.batch) {
       const sortedPkgs = chunks
         .flat()
         .filter((pkgDir) => publishedPkgDirs.has(pkgDir))
         .map((pkgDir) => opts.selectedProjectsGraph[pkgDir].package)
-      publishedPackages.push(...await batchPublishPackages(sortedPkgs, { ...opts, tag }))
+      publishedPackages.push(...await batchPublishPackages(sortedPkgs, { ...opts, tag, workspaceVersions, lane: snapshotTag ?? opts.lane }))
     } else {
       const commandArgs = opts.stage ? ['stage', 'publish'] : ['publish']
       for (const chunk of chunks) {
@@ -152,6 +168,9 @@ export async function recursivePublish (
             },
             gitChecks: false,
             recursive: false,
+            snapshot: false,
+            workspaceVersions,
+            lane: snapshotTag ?? opts.lane,
           }, [pkg.rootDir])
           if (publishResult?.publishSummary != null) {
             publishedPackages.push(publishResult.publishSummary)
@@ -173,6 +192,50 @@ export async function recursivePublish (
     await writeJsonFile(path.join(opts.lockfileDir ?? opts.dir, 'pnpm-publish-summary.json'), { publishedPackages })
   }
   return { exitCode: 0, publishedPackages }
+}
+
+async function createSnapshotPlan (
+  opts: PublishRecursiveOpts & Required<Pick<ConfigContext, 'selectedProjectsGraph'>>
+): Promise<{ projectDirs: string[], tag: string, workspaceVersions: Record<string, string> }> {
+  const projects = opts.allProjects ?? []
+  if (projects.length === 0) {
+    throw new Error('Cannot assemble a snapshot release plan without workspace projects')
+  }
+  const requestedTag = typeof opts.snapshot === 'string'
+    ? opts.snapshot
+    : await getCurrentBranch() ?? 'snapshot'
+  const tag = normalizeSnapshotTag(requestedTag)
+  const plan = assembleReleasePlan({
+    workspaceDir: opts.workspaceDir,
+    projects: projects.map(({ rootDir, manifest }) => ({ rootDir, manifest })),
+    intents: await readChangeIntents(opts.workspaceDir),
+    ledger: await readLedger(opts.workspaceDir),
+    versioning: opts.versioning,
+    filter: (opts.filter ?? []).length > 0
+      ? new Set(Object.keys(opts.selectedProjectsGraph).map((rootDir) => toProjectDir(opts.workspaceDir, rootDir)))
+      : undefined,
+    snapshotSuffix: createSnapshotSuffix(tag),
+    enforceWorkspaceProtocol: true,
+  })
+  return {
+    projectDirs: plan.releases.map((release) => release.rootDir),
+    tag,
+    workspaceVersions: Object.fromEntries(plan.releases.map((release) => [release.name, release.newVersion])),
+  }
+}
+
+export function createSnapshotSuffix (tag: string, now = new Date()): string {
+  return `${tag}-${now.toISOString().replace(/[-:TZ.]/g, '').slice(0, 14)}`
+}
+
+function normalizeSnapshotTag (tag: string): string {
+  const normalized = tag
+    .replace(/[^0-9a-z-]+/gi, '-')
+    .replace(/^-+|-+$/g, '')
+  if (normalized.length === 0) {
+    throw new Error(`Cannot derive a snapshot tag from "${tag}"`)
+  }
+  return normalized
 }
 
 async function isAlreadyPublished (

--- a/pnpm11/releasing/commands/test/change/index.test.ts
+++ b/pnpm11/releasing/commands/test/change/index.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals'
+import { safeExeca as execa } from 'execa'
 
 import { change, lane, version } from '../../src/index.js'
 
@@ -59,11 +60,60 @@ describe('change command and intent-consuming version -r', () => {
     expect(status).toContain('cli: 2.0.0 → 2.0.1')
   })
 
+  it('change check requires a pending bump or explicit none intent for every changed package', async () => {
+    const lib = addPkg({ name: 'lib', version: '1.0.0' })
+    const opts = baseOpts([lib])
+    fs.writeFileSync(path.join(lib.rootDir, 'index.js'), 'module.exports = 0\n')
+    await execa('git', ['init', '--initial-branch=main'], { cwd: tempDir })
+    await execa('git', ['config', 'user.email', 'x@y.z'], { cwd: tempDir })
+    await execa('git', ['config', 'user.name', 'xyz'], { cwd: tempDir })
+    await execa('git', ['add', '.'], { cwd: tempDir })
+    await execa('git', ['commit', '-m', 'initial', '--no-gpg-sign'], { cwd: tempDir })
+    fs.writeFileSync(path.join(lib.rootDir, 'index.js'), 'module.exports = 1\n')
+
+    await expect(change.handler(opts as any, ['check', 'HEAD'])).rejects.toMatchObject({ // eslint-disable-line @typescript-eslint/no-explicit-any
+      code: 'ERR_PNPM_VERSIONING_CHANGE_CHECK_FAILED',
+    })
+    await change.handler({ ...opts, bump: 'none', summary: 'Internal refactor.' } as any, ['lib']) // eslint-disable-line @typescript-eslint/no-explicit-any
+    await expect(change.handler(opts as any, ['check', 'HEAD'])).resolves.toBe('All changed packages are covered by change intents.') // eslint-disable-line @typescript-eslint/no-explicit-any
+  })
+
   it('rejects an unknown package name', async () => {
     const lib = addPkg({ name: 'lib', version: '1.0.0' })
     await expect(
       change.handler({ ...baseOpts([lib]), bump: 'patch', summary: 'x' } as any, ['ghost']) // eslint-disable-line @typescript-eslint/no-explicit-any
     ).rejects.toMatchObject({ code: 'ERR_PNPM_VERSIONING_UNKNOWN_PACKAGE' })
+  })
+
+  it('migrates Changesets fixed and ignore config and selects repository changelogs', async () => {
+    const lib = addPkg({ name: 'lib', version: '1.0.0' })
+    fs.writeFileSync(path.join(lib.rootDir, 'CHANGELOG.md'), '# lib\n')
+    fs.mkdirSync(path.join(tempDir, '.changeset'))
+    fs.writeFileSync(path.join(tempDir, '.changeset', 'config.json'), JSON.stringify({
+      fixed: [['lib', 'cli']],
+      ignore: ['private-pkg'],
+      linked: [],
+    }))
+
+    await expect(change.handler(baseOpts([lib]) as any, ['migrate'])) // eslint-disable-line @typescript-eslint/no-explicit-any
+      .resolves.toContain('repository changelog storage')
+    const workspaceManifest = fs.readFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'utf8')
+    expect(workspaceManifest).toContain('versioning:')
+    expect(workspaceManifest).toContain('storage: repository')
+    expect(workspaceManifest).toContain('private-pkg')
+    expect(fs.existsSync(path.join(tempDir, '.changeset', 'config.json'))).toBe(false)
+  })
+
+  it('refuses to migrate Changesets linked groups', async () => {
+    const lib = addPkg({ name: 'lib', version: '1.0.0' })
+    fs.mkdirSync(path.join(tempDir, '.changeset'))
+    const configPath = path.join(tempDir, '.changeset', 'config.json')
+    fs.writeFileSync(configPath, JSON.stringify({ linked: [['lib', 'cli']] }))
+
+    await expect(change.handler(baseOpts([lib]) as any, ['migrate'])).rejects.toMatchObject({ // eslint-disable-line @typescript-eslint/no-explicit-any
+      code: 'ERR_PNPM_VERSIONING_LINKED_UNSUPPORTED',
+    })
+    expect(fs.existsSync(configPath)).toBe(true)
   })
 
   it('bare version -r applies the release plan and cleans up the intent', async () => {

--- a/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
+++ b/pnpm11/releasing/commands/test/publish/batchPublish.test.ts
@@ -118,6 +118,7 @@ test('batch publish sends all packages in a single batch publish request', async
   await publish.handler({
     ...batchPublishOpts(),
     ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+    lane: 'next',
     tag: 'next',
   }, [])
 
@@ -130,7 +131,7 @@ test('batch publish sends all packages in a single batch publish request', async
       _id: string
       name: string
       'dist-tags': Record<string, string>
-      versions: Record<string, { dist: { integrity: string, shasum: string, tarball: string } }>
+      versions: Record<string, { _pnpmLane?: string, dist: { integrity: string, shasum: string, tarball: string } }>
       _attachments: Record<string, { content_type: string, data: string, length: number }>
     }>
   }
@@ -147,6 +148,7 @@ test('batch publish sends all packages in a single batch publish request', async
   const tarballData = Buffer.from(attachment.data, 'base64')
   expect(attachment).toHaveLength(tarballData.length)
   const { dist } = scopedPkg.versions['1.0.0']
+  expect(scopedPkg.versions['1.0.0']._pnpmLane).toBe('next')
   expect(dist.integrity).toBe(`sha512-${createHash('sha512').update(tarballData).digest('base64')}`)
   expect(dist.shasum).toBe(createHash('sha1').update(tarballData).digest('hex'))
   expect(dist.tarball).toBe(`${registry.url}@pnpmtest/batch-pkg-1/-/@pnpmtest/batch-pkg-1-1.0.0.tgz`)

--- a/pnpm11/releasing/commands/test/publish/recursivePublish.ts
+++ b/pnpm11/releasing/commands/test/publish/recursivePublish.ts
@@ -79,6 +79,7 @@ test('recursive publish', async () => {
     configByUri: CONFIG_BY_URI,
     dir: process.cwd(),
     dryRun: true,
+    gitChecks: false,
     recursive: true,
   }, [])
 
@@ -117,6 +118,55 @@ test('recursive publish', async () => {
     const { stdout } = await execa('pnpm', ['dist-tag', 'ls', pkg1.name, '--registry', `http://localhost:${REGISTRY_MOCK_PORT}`])
     expect(stdout?.toString()).toContain('next: 2.0.0')
   }
+})
+
+test('recursive snapshot publish uses the pending plan without mutating release state', async () => {
+  preparePackages([
+    {
+      name: 'snapshot-core',
+      version: '1.0.0',
+    },
+    {
+      name: 'snapshot-app',
+      version: '1.0.0',
+      dependencies: {
+        'snapshot-core': 'workspace:^',
+      },
+    },
+  ])
+  fs.mkdirSync('.changeset')
+  const intent = `---
+"snapshot-core": patch
+"snapshot-app": patch
+---
+Snapshot release.
+`
+  fs.writeFileSync('.changeset/snapshot.md', intent)
+  const context = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [])
+
+  await publish.handler({
+    ...DEFAULT_OPTS,
+    ...context,
+    allProjects: Object.values(context.allProjectsGraph).map((node) => node.package),
+    configByUri: CONFIG_BY_URI,
+    dir: process.cwd(),
+    dryRun: true,
+    gitChecks: false,
+    recursive: true,
+    reportSummary: true,
+    snapshot: 'pr-42',
+  }, [])
+
+  const summary = loadJsonFileSync<{ publishedPackages: Array<{ name: string, version: string }> }>('pnpm-publish-summary.json')
+  expect(summary.publishedPackages).toHaveLength(2)
+  expect(summary.publishedPackages.map(({ version }) => version)).toEqual([
+    expect.stringMatching(/^0\.0\.0-pr-42-\d{14}$/),
+    expect.stringMatching(/^0\.0\.0-pr-42-\d{14}$/),
+  ])
+  expect(loadJsonFileSync<ProjectManifest>('snapshot-core/package.json').version).toBe('1.0.0')
+  expect(loadJsonFileSync<ProjectManifest>('snapshot-app/package.json').version).toBe('1.0.0')
+  expect(fs.readFileSync('.changeset/snapshot.md', 'utf8')).toBe(intent)
+  expect(fs.existsSync('.changeset/ledger.yaml')).toBe(false)
 })
 
 test('print info when no packages are published', async () => {

--- a/pnpm11/releasing/exportable-manifest/src/index.ts
+++ b/pnpm11/releasing/exportable-manifest/src/index.ts
@@ -30,6 +30,7 @@ export interface MakePublishManifestOptions {
   catalogs: Catalogs
   hooks?: Hooks
   modulesDir?: string
+  workspaceVersions?: Readonly<Record<string, string>>
   skipManifestObfuscation?: boolean
   embedReadme?: boolean
 }
@@ -52,7 +53,8 @@ export async function createExportableManifest (
   const catalogResolver = resolveFromCatalog.bind(null, opts.catalogs)
   const replaceCatalogProtocol = resolveCatalogProtocol.bind(null, catalogResolver)
 
-  const convertDependencyForPublish = combineConverters(replaceWorkspaceProtocol, replaceCatalogProtocol, replaceJsrProtocol)
+  const replaceSnapshotWorkspaceProtocol = replaceWorkspaceProtocolWithSnapshotVersion.bind(null, opts.workspaceVersions)
+  const convertDependencyForPublish = combineConverters(replaceSnapshotWorkspaceProtocol, replaceWorkspaceProtocol, replaceCatalogProtocol, replaceJsrProtocol)
   await Promise.all((['dependencies', 'devDependencies', 'optionalDependencies'] as const).map(async (depsField) => {
     const deps = await makePublishDependencies(dir, originalManifest[depsField], {
       modulesDir: opts?.modulesDir,
@@ -65,7 +67,7 @@ export async function createExportableManifest (
 
   const peerDependencies = originalManifest.peerDependencies
   if (peerDependencies) {
-    const convertPeersForPublish = combineConverters(replaceWorkspaceProtocolPeerDependency, replaceCatalogProtocol, replaceJsrProtocol)
+    const convertPeersForPublish = combineConverters(replaceSnapshotWorkspaceProtocol, replaceWorkspaceProtocolPeerDependency, replaceCatalogProtocol, replaceJsrProtocol)
     publishManifest.peerDependencies = await makePublishDependencies(dir, peerDependencies, {
       modulesDir: opts?.modulesDir,
       convertDependencyForPublish: convertPeersForPublish,
@@ -160,6 +162,29 @@ async function readAndCheckManifest (depName: string, dependencyDir: string): Pr
     )
   }
   return manifest
+}
+
+async function replaceWorkspaceProtocolWithSnapshotVersion (
+  workspaceVersions: Readonly<Record<string, string>> | undefined,
+  depName: string,
+  depSpec: string,
+  dir: string,
+  _modulesDir?: string
+): Promise<string> {
+  if (workspaceVersions == null || !depSpec.startsWith('workspace:')) return depSpec
+
+  let targetName = depName
+  if (depSpec.startsWith('workspace:./') || depSpec.startsWith('workspace:../')) {
+    const manifest = await readAndCheckManifest(depName, path.join(dir, depSpec.slice(10)))
+    targetName = manifest.name!
+  } else {
+    const workspaceSpec = depSpec.slice('workspace:'.length)
+    const aliasSeparator = workspaceSpec.lastIndexOf('@')
+    if (aliasSeparator > 0) targetName = workspaceSpec.slice(0, aliasSeparator)
+  }
+  const version = workspaceVersions[targetName]
+  if (version == null) return depSpec
+  return targetName === depName ? version : `npm:${targetName}@${version}`
 }
 
 function resolveCatalogProtocol (catalogResolver: CatalogResolver, alias: string, bareSpecifier: string): string {

--- a/pnpm11/releasing/exportable-manifest/test/index.test.ts
+++ b/pnpm11/releasing/exportable-manifest/test/index.test.ts
@@ -296,6 +296,35 @@ test('workspace deps are replaced', async () => {
   })
 })
 
+test('workspace deps use in-memory sibling snapshot versions', async () => {
+  expect(await createExportableManifest(process.cwd(), {
+    name: 'app',
+    version: '1.0.0',
+    dependencies: {
+      core: 'workspace:^',
+      coreAlias: 'workspace:core@*',
+    },
+    peerDependencies: {
+      core: 'workspace:^1.0.0',
+    },
+  }, {
+    catalogs: {},
+    workspaceVersions: {
+      core: '0.0.0-preview-20260718000000',
+    },
+  })).toStrictEqual({
+    name: 'app',
+    version: '1.0.0',
+    dependencies: {
+      core: '0.0.0-preview-20260718000000',
+      coreAlias: 'npm:core@0.0.0-preview-20260718000000',
+    },
+    peerDependencies: {
+      core: '0.0.0-preview-20260718000000',
+    },
+  })
+})
+
 test('catalog deps are replaced', async () => {
   const manifest: ProjectManifest = {
     name: 'catalog-protocol-package',

--- a/pnpm11/releasing/versioning/package.json
+++ b/pnpm11/releasing/versioning/package.json
@@ -40,6 +40,7 @@
     "yaml": "catalog:"
   },
   "devDependencies": {
+    "@changesets/cli": "catalog:",
     "@jest/globals": "catalog:",
     "@pnpm/releasing.versioning": "workspace:*",
     "@types/semver": "catalog:",

--- a/pnpm11/releasing/versioning/src/changelog.ts
+++ b/pnpm11/releasing/versioning/src/changelog.ts
@@ -21,14 +21,14 @@ export function composeChangelogSection (release: PlannedRelease): string {
   }
   if (release.dependencyUpdates.length > 0) {
     const depLines = release.dependencyUpdates.map((dep) => `  - ${dep.name}@${dep.newVersion}`)
-    entriesByBump.patch.push(`- Updated dependencies:\n${depLines.join('\n')}`)
+    entriesByBump.patch.push(`- Updated dependencies\n${depLines.join('\n')}`)
   }
 
   const parts: string[] = [`## ${release.newVersion}`]
   for (const bumpType of ['major', 'minor', 'patch'] as const) {
     if (entriesByBump[bumpType].length === 0) continue
     parts.push(`### ${SECTION_TITLES[bumpType]}`)
-    parts.push(entriesByBump[bumpType].join('\n\n'))
+    parts.push(entriesByBump[bumpType].join('\n'))
   }
   return `${parts.join('\n\n')}\n`
 }

--- a/pnpm11/releasing/versioning/test/differentialChangesets.test.ts
+++ b/pnpm11/releasing/versioning/test/differentialChangesets.test.ts
@@ -1,0 +1,117 @@
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import util from 'node:util'
+
+import { expect, test } from '@jest/globals'
+import {
+  applyReleasePlan,
+  assembleReleasePlan,
+  readChangeIntents,
+  readLedger,
+  type WorkspaceProject,
+} from '@pnpm/releasing.versioning'
+import { temporaryDirectory } from 'tempy'
+
+const execFileAsync = util.promisify(execFile)
+const changesetBin = path.join(import.meta.dirname, '..', 'node_modules', '.bin', 'changeset')
+
+const packageNames = ['a', 'b', 'c', 'd']
+
+test('native direct bumps and fixed groups match Changesets manifests and changelogs', async () => {
+  const nativeDir = temporaryDirectory()
+  const changesetsDir = temporaryDirectory()
+  writeFixture(nativeDir)
+  writeFixture(changesetsDir)
+
+  const projects = readProjects(nativeDir)
+  const intents = await readChangeIntents(nativeDir)
+  const versioning = {
+    fixed: [['c', 'd']],
+    changelog: { storage: 'repository' as const },
+  }
+  const plan = assembleReleasePlan({
+    workspaceDir: nativeDir,
+    projects,
+    intents,
+    ledger: await readLedger(nativeDir),
+    versioning,
+    enforceWorkspaceProtocol: true,
+  })
+  await applyReleasePlan(plan, {
+    workspaceDir: nativeDir,
+    projects,
+    allIntents: intents,
+    versioning,
+  })
+
+  await execFileAsync(changesetBin, ['version'], { cwd: changesetsDir })
+
+  for (const name of packageNames) {
+    const nativeManifest = readJson(path.join(nativeDir, 'packages', name, 'package.json'))
+    const changesetsManifest = readJson(path.join(changesetsDir, 'packages', name, 'package.json'))
+    expect(nativeManifest).toEqual(changesetsManifest)
+    expect(readNormalized(path.join(nativeDir, 'packages', name, 'CHANGELOG.md')))
+      .toBe(readNormalized(path.join(changesetsDir, 'packages', name, 'CHANGELOG.md')))
+  }
+})
+
+function writeFixture (workspaceDir: string): void {
+  fs.mkdirSync(path.join(workspaceDir, '.changeset'), { recursive: true })
+  fs.writeFileSync(path.join(workspaceDir, 'package.json'), JSON.stringify({
+    name: 'differential-root',
+    private: true,
+  }, null, 2))
+  fs.writeFileSync(path.join(workspaceDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\n')
+  fs.writeFileSync(path.join(workspaceDir, '.changeset', 'config.json'), JSON.stringify({
+    changelog: '@changesets/cli/changelog',
+    commit: false,
+    fixed: [['c', 'd']],
+    linked: [],
+    access: 'restricted',
+    baseBranch: 'main',
+    updateInternalDependencies: 'patch',
+    ignore: [],
+  }, null, 2))
+  fs.writeFileSync(path.join(workspaceDir, '.changeset', 'parity.md'), `---
+"a": minor
+"b": patch
+"c": minor
+---
+Added the parity fixture.
+`)
+  writePackage(workspaceDir, 'a', '1.0.0')
+  writePackage(workspaceDir, 'b', '1.0.0', { a: 'workspace:' })
+  writePackage(workspaceDir, 'c', '2.0.0')
+  writePackage(workspaceDir, 'd', '2.0.0')
+}
+
+function writePackage (
+  workspaceDir: string,
+  name: string,
+  version: string,
+  dependencies?: Record<string, string>
+): void {
+  const dir = path.join(workspaceDir, 'packages', name)
+  fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
+    name,
+    version,
+    ...(dependencies == null ? {} : { dependencies }),
+  }, null, 2))
+}
+
+function readProjects (workspaceDir: string): WorkspaceProject[] {
+  return packageNames.map((name) => ({
+    rootDir: path.join(workspaceDir, 'packages', name),
+    manifest: readJson(path.join(workspaceDir, 'packages', name, 'package.json')),
+  }))
+}
+
+function readJson (filePath: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>
+}
+
+function readNormalized (filePath: string): string {
+  return fs.readFileSync(filePath, 'utf8').replaceAll('\r\n', '\n').trim()
+}

--- a/pnpm11/releasing/versioning/test/lifecycle.ts
+++ b/pnpm11/releasing/versioning/test/lifecycle.ts
@@ -102,7 +102,7 @@ test('applyReleasePlan bumps manifests, writes changelogs, records the ledger, a
 
   const cliChangelog = await fs.readFile(path.join(cliDir, 'CHANGELOG.md'), 'utf8')
   expect(cliChangelog).toContain('## 2.0.1')
-  expect(cliChangelog).toContain('- Updated dependencies:')
+  expect(cliChangelog).toContain('- Updated dependencies')
   expect(cliChangelog).toContain('  - lib@1.1.0')
 
   const ledger = await readLedger(workspaceDir)

--- a/pnpm11/workspace/projects-filter/package.json
+++ b/pnpm11/workspace/projects-filter/package.json
@@ -31,6 +31,7 @@
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
+    "@pnpm/catalogs.protocol-parser": "workspace:*",
     "@pnpm/config.matcher": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/workspace.projects-graph": "workspace:*",
@@ -40,7 +41,8 @@
     "execa": "catalog:",
     "is-subdir": "catalog:",
     "micromatch": "catalog:",
-    "ramda": "catalog:"
+    "ramda": "catalog:",
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",

--- a/pnpm11/workspace/projects-filter/src/getChangedProjects.ts
+++ b/pnpm11/workspace/projects-filter/src/getChangedProjects.ts
@@ -1,12 +1,15 @@
 import assert from 'node:assert'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import util from 'node:util'
 
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
 import { PnpmError } from '@pnpm/error'
-import type { ProjectRootDir } from '@pnpm/types'
+import type { BaseManifest, ProjectRootDir } from '@pnpm/types'
 import * as find from 'empathic/find'
 import { safeExeca as execa } from 'execa'
 import * as micromatch from 'micromatch'
+import * as yaml from 'yaml'
 
 type ChangeType = 'source' | 'test'
 
@@ -17,7 +20,13 @@ interface ChangedDir {
 export async function getChangedProjects (
   projectDirs: ProjectRootDir[],
   commit: string,
-  opts: { workspaceDir: string, testPattern?: string[], changedFilesIgnorePattern?: string[] }
+  opts: {
+    workspaceDir: string
+    workspaceRoot?: string
+    projects?: Array<{ rootDir: ProjectRootDir, manifest: BaseManifest }>
+    testPattern?: string[]
+    changedFilesIgnorePattern?: string[]
+  }
 ): Promise<[ProjectRootDir[], ProjectRootDir[]]> {
 
   // .git is a directory in regular repos, but a file in worktrees. The
@@ -44,6 +53,17 @@ export async function getChangedProjects (
     if (projectChangeTypes.get(currentDir as ProjectRootDir) === 'source') continue
     projectChangeTypes.set(currentDir as ProjectRootDir, changedDir.changeType)
   }
+  if (opts.projects != null) {
+    const catalogChangedProjects = await getProjectsUsingChangedCatalogEntries(
+      commit,
+      repoRoot,
+      opts.workspaceRoot ?? opts.workspaceDir,
+      opts.projects
+    )
+    for (const projectDir of catalogChangedProjects) {
+      projectChangeTypes.set(projectDir, 'source')
+    }
+  }
 
   const changedProjects = [] as ProjectRootDir[]
   const ignoreDependentForPkgs = [] as ProjectRootDir[]
@@ -58,6 +78,87 @@ export async function getChangedProjects (
     }
   }
   return [changedProjects, ignoreDependentForPkgs]
+}
+
+interface WorkspaceCatalogsManifest {
+  catalog?: Record<string, string>
+  catalogs?: Record<string, Record<string, string>>
+}
+
+async function getProjectsUsingChangedCatalogEntries (
+  commit: string,
+  repoRoot: string,
+  workspaceRoot: string,
+  projects: Array<{ rootDir: ProjectRootDir, manifest: BaseManifest }>
+): Promise<ProjectRootDir[]> {
+  const manifestPath = path.join(workspaceRoot, 'pnpm-workspace.yaml')
+  const relativeManifestPath = path.relative(repoRoot, manifestPath).split(path.sep).join('/')
+  const [before, after] = await Promise.all([
+    readWorkspaceCatalogsAtCommit(repoRoot, commit, relativeManifestPath),
+    readWorkspaceCatalogs(manifestPath),
+  ])
+  const changedEntries = changedCatalogEntries(before, after)
+  if (changedEntries.size === 0) return []
+
+  const changedProjects = new Set<ProjectRootDir>()
+  for (const project of projects) {
+    for (const dependencyField of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const) {
+      for (const [dependencyName, specifier] of Object.entries(project.manifest[dependencyField] ?? {})) {
+        const catalogName = parseCatalogProtocol(specifier)
+        if (catalogName != null && changedEntries.has(`${catalogName}\0${dependencyName}`)) {
+          changedProjects.add(project.rootDir)
+        }
+      }
+    }
+  }
+  return [...changedProjects]
+}
+
+async function readWorkspaceCatalogsAtCommit (
+  repoRoot: string,
+  commit: string,
+  relativeManifestPath: string
+): Promise<Record<string, Record<string, string>>> {
+  try {
+    const { stdout } = await execa('git', ['show', `${commit}:${relativeManifestPath}`], { cwd: repoRoot })
+    return parseWorkspaceCatalogs(stdout as string)
+  } catch {
+    return {}
+  }
+}
+
+async function readWorkspaceCatalogs (manifestPath: string): Promise<Record<string, Record<string, string>>> {
+  try {
+    return parseWorkspaceCatalogs(await fs.readFile(manifestPath, 'utf8'))
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return {}
+    throw err
+  }
+}
+
+function parseWorkspaceCatalogs (source: string): Record<string, Record<string, string>> {
+  const manifest = (yaml.parse(source) ?? {}) as WorkspaceCatalogsManifest
+  return {
+    ...(manifest.catalog != null ? { default: manifest.catalog } : {}),
+    ...(manifest.catalogs ?? {}),
+  }
+}
+
+function changedCatalogEntries (
+  before: Record<string, Record<string, string>>,
+  after: Record<string, Record<string, string>>
+): Set<string> {
+  const changed = new Set<string>()
+  for (const catalogName of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    const beforeCatalog = before[catalogName] ?? {}
+    const afterCatalog = after[catalogName] ?? {}
+    for (const dependencyName of new Set([...Object.keys(beforeCatalog), ...Object.keys(afterCatalog)])) {
+      if (beforeCatalog[dependencyName] !== afterCatalog[dependencyName]) {
+        changed.add(`${catalogName}\0${dependencyName}`)
+      }
+    }
+  }
+  return changed
 }
 
 async function getChangedDirsSinceCommit (commit: string, workingDir: string, testPattern: string[], changedFilesIgnorePattern: string[]): Promise<ChangedDir[]> {

--- a/pnpm11/workspace/projects-filter/src/index.ts
+++ b/pnpm11/workspace/projects-filter/src/index.ts
@@ -234,8 +234,10 @@ async function _filterGraph<Pkg extends BaseProject> (
         selector.diff,
         {
           changedFilesIgnorePattern: opts.changedFilesIgnorePattern,
+          projects: Object.values(projectsGraph).map(({ package: project }) => project),
           testPattern: opts.testPattern,
           workspaceDir: selector.parentDir ?? opts.workspaceDir,
+          workspaceRoot: opts.workspaceDir,
         }
       )
       selectEntries({

--- a/pnpm11/workspace/projects-filter/test/index.ts
+++ b/pnpm11/workspace/projects-filter/test/index.ts
@@ -518,6 +518,35 @@ test('select changed packages', async () => {
   }
 })
 
+test('a changed catalog entry selects every project that references it', async () => {
+  const workspaceDir = temporaryDirectory()
+  await execa('git', ['init', '--initial-branch=main'], { cwd: workspaceDir })
+  await execa('git', ['config', 'user.email', 'x@y.z'], { cwd: workspaceDir })
+  await execa('git', ['config', 'user.name', 'xyz'], { cwd: workspaceDir })
+  fs.writeFileSync(path.join(workspaceDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\ncatalog:\n  foo: ^1.0.0\n  bar: ^1.0.0\n')
+  await execa('git', ['add', '.'], { cwd: workspaceDir })
+  await execa('git', ['commit', '-m', 'initial', '--no-gpg-sign'], { cwd: workspaceDir })
+  fs.writeFileSync(path.join(workspaceDir, 'pnpm-workspace.yaml'), 'packages:\n  - packages/*\ncatalog:\n  foo: ^2.0.0\n  bar: ^1.0.0\n')
+  await execa('git', ['add', '.'], { cwd: workspaceDir })
+  await execa('git', ['commit', '-m', 'catalog', '--no-gpg-sign'], { cwd: workspaceDir })
+
+  const fooDir = path.join(workspaceDir, 'packages/foo') as ProjectRootDir
+  const barDir = path.join(workspaceDir, 'packages/bar') as ProjectRootDir
+  const projectsGraph: ProjectGraph<BaseProject> = {
+    [fooDir]: {
+      dependencies: [],
+      package: { rootDir: fooDir, manifest: { name: 'foo', version: '1.0.0', dependencies: { foo: 'catalog:' } } },
+    },
+    [barDir]: {
+      dependencies: [],
+      package: { rootDir: barDir, manifest: { name: 'bar', version: '1.0.0', dependencies: { bar: 'catalog:' } } },
+    },
+  }
+
+  const { selectedProjectsGraph } = await filterWorkspaceProjects(projectsGraph, [{ diff: 'HEAD~1' }], { workspaceDir })
+  expect(Object.keys(selectedProjectsGraph)).toStrictEqual([fooDir])
+})
+
 test('select changed packages when operating under a git worktree', async () => {
   if (isCI && isWindows()) {
     return

--- a/pnpm11/workspace/projects-filter/tsconfig.json
+++ b/pnpm11/workspace/projects-filter/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../catalogs/protocol-parser"
+    },
+    {
       "path": "../../config/matcher"
     },
     {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1650,6 +1650,7 @@ async fn serve_packument_via_upstream(
         tarball_base,
         state.inner.osv_index.as_ref(),
         wants_abbreviated(headers),
+        None,
     ) {
         Ok(response) => response,
         Err(err) => error_response(&err),
@@ -2096,6 +2097,7 @@ async fn serve_hosted_packument(
             tarball_base,
             state.inner.osv_index.as_ref(),
             wants_abbreviated(headers),
+            requested_lane(headers),
         ) {
             Ok(response) => response,
             Err(err) => error_response(&err),
@@ -2916,7 +2918,7 @@ async fn stage_publish(
     now_iso: &str,
     org: Option<&str>,
 ) -> Result<StagedPublish, RegistryError> {
-    let ValidatedPublish { name, incoming, prepared } = doc;
+    let ValidatedPublish { name, mut incoming, prepared } = doc;
     let storage = hosted_storage(state, org);
 
     let hosted_packument = storage.read_hosted_packument_for_update(&name).await?;
@@ -2977,6 +2979,8 @@ async fn stage_publish(
             }
         }
     }
+
+    strip_registry_lane_dist_tags(&mut incoming);
 
     // A hosted registry has no upstream, so a publish seeds the merge only from
     // the org's own hosted packument; a brand-new package starts from `None`.
@@ -4187,8 +4191,10 @@ fn packument_response(
     tarball_base: &str,
     osv_index: Option<&Arc<crate::resolver::OsvIndex>>,
     abbreviated: bool,
+    lane: Option<&str>,
 ) -> Result<Response, RegistryError> {
     let mut doc: Value = serde_json::from_slice(bytes)?;
+    filter_registry_lane(&mut doc, lane);
     filter_osv_vulnerable_versions(&mut doc, name, osv_index);
     rewrite_tarball_urls(&mut doc, name, tarball_base);
     let (body, content_type) = if abbreviated {
@@ -4198,6 +4204,65 @@ fn packument_response(
         (serde_json::to_vec(&doc)?, "application/json")
     };
     Ok(packument_bytes_response(body, content_type))
+}
+
+fn requested_lane(headers: &HeaderMap) -> Option<&str> {
+    headers.get("pnpm-lane").and_then(|value| value.to_str().ok()).filter(|lane| !lane.is_empty())
+}
+
+fn strip_registry_lane_dist_tags(packument: &mut Value) {
+    let lane_versions: HashSet<String> = packument
+        .get("versions")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|versions| versions.iter())
+        .filter(|(_, manifest)| manifest.get("_pnpmLane").and_then(Value::as_str).is_some())
+        .map(|(version, _)| version.clone())
+        .collect();
+    if !lane_versions.is_empty()
+        && let Some(tags) = packument.get_mut("dist-tags").and_then(Value::as_object_mut)
+    {
+        tags.retain(|_, version| {
+            version.as_str().is_none_or(|version| !lane_versions.contains(version))
+        });
+    }
+}
+
+fn filter_registry_lane(packument: &mut Value, requested_lane: Option<&str>) {
+    let mut removed = HashSet::new();
+    let mut matching = Vec::new();
+    if let Some(versions) = packument.get_mut("versions").and_then(Value::as_object_mut) {
+        versions.retain(|version, manifest| {
+            let lane = manifest.get("_pnpmLane").and_then(Value::as_str);
+            let keep = match (requested_lane, lane) {
+                (_, None) => true,
+                (Some(requested), Some(actual)) if requested == actual => {
+                    matching.push(version.clone());
+                    true
+                }
+                _ => false,
+            };
+            if keep {
+                if let Some(manifest) = manifest.as_object_mut() {
+                    manifest.remove("_pnpmLane");
+                }
+            } else {
+                removed.insert(version.clone());
+            }
+            keep
+        });
+    }
+    if let Some(tags) = packument.get_mut("dist-tags").and_then(Value::as_object_mut) {
+        tags.retain(|_, version| version.as_str().is_none_or(|version| !removed.contains(version)));
+        if let Some(lane) = requested_lane
+            && let Some(version) = matching.into_iter().max()
+        {
+            tags.insert(lane.to_string(), Value::String(version));
+        }
+    }
+    if let Some(time) = packument.get_mut("time").and_then(Value::as_object_mut) {
+        time.retain(|version, _| !removed.contains(version));
+    }
 }
 
 fn filter_osv_vulnerable_versions(

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     ConnectInfo, PeerAddr, bearer_credentials, canonical_ip, cidr_contains, cidr_whitelist_allows,
-    is_write_method, router_with_auth, token_timestamp_millis,
+    filter_registry_lane, is_write_method, router_with_auth, strip_registry_lane_dist_tags,
+    token_timestamp_millis,
 };
 use crate::{
     auth::{AuthState, TokenBackend, TokenRecord, UserStore},
@@ -19,6 +20,76 @@ use std::{
 };
 use tempfile::TempDir;
 use tower::ServiceExt;
+
+#[test]
+fn registry_lanes_are_hidden_unless_requested() {
+    let source = serde_json::json!({
+        "dist-tags": {
+            "latest": "1.0.0",
+            "next": "0.0.0-next-20260718120000",
+            "other": "0.0.0-other-20260718120000"
+        },
+        "versions": {
+            "1.0.0": { "name": "example", "version": "1.0.0" },
+            "0.0.0-next-20260718120000": {
+                "name": "example",
+                "version": "0.0.0-next-20260718120000",
+                "_pnpmLane": "next"
+            },
+            "0.0.0-other-20260718120000": {
+                "name": "example",
+                "version": "0.0.0-other-20260718120000",
+                "_pnpmLane": "other"
+            }
+        },
+        "time": {
+            "1.0.0": "2026-07-18T10:00:00Z",
+            "0.0.0-next-20260718120000": "2026-07-18T12:00:00Z",
+            "0.0.0-other-20260718120000": "2026-07-18T12:00:00Z"
+        }
+    });
+
+    let mut default_packument = source.clone();
+    filter_registry_lane(&mut default_packument, None);
+    assert_eq!(
+        default_packument["versions"].as_object().unwrap().keys().collect::<Vec<_>>(),
+        vec!["1.0.0"],
+    );
+    assert_eq!(default_packument["dist-tags"], serde_json::json!({ "latest": "1.0.0" }));
+    assert_eq!(default_packument["time"], serde_json::json!({ "1.0.0": "2026-07-18T10:00:00Z" }));
+
+    let mut next_packument = source;
+    filter_registry_lane(&mut next_packument, Some("next"));
+    assert_eq!(
+        next_packument["versions"].as_object().unwrap().keys().collect::<Vec<_>>(),
+        vec!["1.0.0", "0.0.0-next-20260718120000"],
+    );
+    assert_eq!(
+        next_packument["dist-tags"],
+        serde_json::json!({
+            "latest": "1.0.0",
+            "next": "0.0.0-next-20260718120000"
+        }),
+    );
+    assert!(next_packument["versions"]["0.0.0-next-20260718120000"].get("_pnpmLane").is_none());
+}
+
+#[test]
+fn registry_lane_publish_does_not_update_a_default_dist_tag() {
+    let mut incoming = serde_json::json!({
+        "dist-tags": { "next": "0.0.0-next-20260718120000" },
+        "versions": {
+            "0.0.0-next-20260718120000": {
+                "version": "0.0.0-next-20260718120000",
+                "_pnpmLane": "next"
+            }
+        }
+    });
+
+    strip_registry_lane_dist_tags(&mut incoming);
+
+    assert_eq!(incoming["dist-tags"], serde_json::json!({}));
+}
 
 #[test]
 fn token_timestamp_millis_saturates_before_i64_conversion() {

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -243,6 +243,52 @@ async fn authenticated_publish_writes_manifest_and_tarball() {
 }
 
 #[tokio::test]
+async fn snapshot_lane_versions_are_hidden_from_default_packuments() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let (app, token) = add_user_and_get_token(app, "alice", "secret").await;
+
+    for (version, lane) in [("1.0.0", None), ("0.0.0-pr-42-20260718120000", Some("pr-42"))] {
+        let mut body = sample_publish_body("lane-pkg", version, version.as_bytes());
+        if let Some(lane) = lane {
+            body["versions"][version]["_pnpmLane"] = json!(lane);
+        }
+        let request = Request::put("/lane-pkg")
+            .header("content-type", "application/json")
+            .header("Authorization", format!("Bearer {token}"))
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap();
+        assert_eq!(app.clone().oneshot(request).await.unwrap().status(), StatusCode::CREATED);
+    }
+
+    let default_response =
+        app.clone().oneshot(Request::get("/lane-pkg").body(Body::empty()).unwrap()).await.unwrap();
+    let default_packument = body_json(default_response.into_body()).await;
+    assert_eq!(
+        default_packument["versions"].as_object().unwrap().keys().collect::<Vec<_>>(),
+        vec!["1.0.0"],
+    );
+    assert_eq!(default_packument["dist-tags"], json!({ "latest": "1.0.0" }));
+
+    let lane_response = app
+        .oneshot(
+            Request::get("/lane-pkg").header("pnpm-lane", "pr-42").body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+    let lane_packument = body_json(lane_response.into_body()).await;
+    assert_eq!(lane_packument["versions"].as_object().unwrap().len(), 2);
+    assert_eq!(
+        lane_packument["dist-tags"],
+        json!({
+            "latest": "1.0.0",
+            "pr-42": "0.0.0-pr-42-20260718120000"
+        }),
+    );
+    assert!(lane_packument["versions"]["0.0.0-pr-42-20260718120000"].get("_pnpmLane").is_none());
+}
+
+#[tokio::test]
 async fn republishing_an_existing_version_is_rejected_with_conflict() {
     let tmp = TempDir::new().unwrap();
     let storage = tmp.path().to_path_buf();


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Completes the implementation gaps tracked by pnpm/pnpm#12952 across the TypeScript CLI, pacquet, and pnpr:

- adds `pnpm change check [since]`, including catalog-aware changed-package attribution shared with `[<since>]` filters;
- adds `pnpm change migrate` for `.changeset/config.json`, preserving native settings, selecting repository changelogs when committed changelogs exist, and rejecting linked groups;
- adds `pnpm publish -r --snapshot [tag]`, deriving and packing snapshot versions entirely in memory without consuming intents or updating the ledger;
- adds pnpr registry lanes: snapshot versions are hidden from default packuments and exposed only when the `pnpm-lane` request header selects their lane;
- adds a Changesets differential oracle for manifests and repository changelogs, and aligns native changelog formatting with Changesets.

The snapshot lane name is both the prerelease identifier and publish tag. pnpr strips that tag from stored default metadata and synthesizes it only for lane-aware reads. Snapshot publishing also works with the existing batch endpoint.

The command and release-management documentation lives in `pnpm/pnpm.io`; the new `check`, `migrate`, and snapshot/lane details will need a docs follow-up before this draft is made ready for review.

## Squash Commit Body

```text
Finish the native monorepo versioning implementation plan across both CLI stacks and pnpr.

Add CI coverage checks with catalog-aware attribution, migrate Changesets configuration into native workspace settings, and publish release-plan snapshots without mutating release state. Mark snapshots in registry-only manifests so pnpr can isolate them from ordinary packuments and reveal a selected branch lane on demand. Add a differential Changesets oracle to keep common manifest and changelog behavior aligned.

Closes pnpm/pnpm#12952.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787007420&installation_id=145934176&pr_number=13134&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13134&signature=bb06e671b4bdfe34ce052ff39ba4ecc15a899a96a5b7966795560fb38c5d39bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->