### PR TITLE
feat(resolver): emit pnpm:deprecation events for deprecated packages

### DIFF
--- a/.changeset/pacquet-deprecation-warnings.md
+++ b/.changeset/pacquet-deprecation-warnings.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Deprecated packages are reported during installation: a directly depended-on deprecated package gets an immediate warning, and deprecated subdependencies are summarized in a single `<N> deprecated subdependencies found` line. Versions matched by `pnpm.allowedDeprecatedVersions` are not warned about [#11633](https://github.com/pnpm/pnpm/issues/11633).

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -1078,19 +1078,26 @@ impl ReporterState {
     /// `resolution_done` summary.
     fn on_deprecation(&mut self, log: &DeprecationLog) {
         if log.depth == 0 {
-            let msg = format!(
-                "{} {} {}@{}: {}",
-                self.colors.warn_label(),
-                self.colors.red("deprecated"),
-                log.pkg_name,
-                log.pkg_version,
-                log.deprecated,
-            );
             if log.prefix.is_empty() || log.prefix == self.cwd {
-                self.push_block(msg);
+                self.push_block(format!(
+                    "{} {} {}@{}: {}",
+                    self.colors.warn_label(),
+                    self.colors.red("deprecated"),
+                    log.pkg_name,
+                    log.pkg_version,
+                    log.deprecated,
+                ));
             } else {
-                let zoomed = zoom_out(&self.cwd, &log.prefix, &msg);
-                self.push_block(zoomed);
+                // The zoomed line drops the deprecation text, as
+                // `reportDeprecations.ts` does.
+                let msg = format!(
+                    "{} {} {}@{}",
+                    self.colors.warn_label(),
+                    self.colors.red("deprecated"),
+                    log.pkg_name,
+                    log.pkg_version,
+                );
+                self.push_block(zoom_out(&self.cwd, &log.prefix, &msg));
             }
         } else {
             self.deprecated_subdeps.push(log.clone());

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -241,8 +241,6 @@ pub struct ReporterState {
     warnings_counter: usize,
     collapsed_warn_slot: BlockSlot,
 
-    /// Buffered transitive-deprecation events, accumulated until
-    /// `resolution_done` fires and rendered as a single summary line.
     deprecated_subdeps: Vec<DeprecationLog>,
     deprecated_slot: BlockSlot,
 }
@@ -1075,9 +1073,9 @@ impl ReporterState {
         ));
     }
 
-    /// Handle a `pnpm:deprecation` event. Direct dependencies
-    /// (`depth == 0`) are rendered immediately; transitive ones are
-    /// buffered and summarized at `resolution_done`.
+    /// Matches pnpm's `reportDeprecations.ts`: only direct-dependency
+    /// deprecations render immediately; transitive ones wait for the
+    /// `resolution_done` summary.
     fn on_deprecation(&mut self, log: &DeprecationLog) {
         if log.depth == 0 {
             let msg = format!(
@@ -1099,9 +1097,6 @@ impl ReporterState {
         }
     }
 
-    /// Flush buffered transitive-deprecation events into a single
-    /// summary line, matching pnpm's `reportDeprecations.ts` behavior:
-    /// `<N> deprecated subdependencies found: <list>`.
     fn flush_deprecated_subdeps(&mut self) {
         if self.deprecated_subdeps.is_empty() {
             return;

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -11,11 +11,11 @@ use std::{
 };
 
 use pacquet_reporter::{
-    AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, FetchingProgressMessage, HookLog,
-    IgnoredScriptsLog, InstallingConfigDepsLog, InstallingConfigDepsStatus, LifecycleMessage,
-    LifecycleStdio, LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod,
-    PackageManifestMessage, ProgressMessage, RemovedRoot, RequestRetryLog,
-    SkippedOptionalDependencyLog, SkippedOptionalPackage, Stage, StatsMessage,
+    AddedRoot, ContextLog, DependencyType, DeprecationLog, ExecutionTimeLog,
+    FetchingProgressMessage, HookLog, IgnoredScriptsLog, InstallingConfigDepsLog,
+    InstallingConfigDepsStatus, LifecycleMessage, LifecycleStdio, LockfileVerificationMessage,
+    LogEvent, LogLevel, PackageImportMethod, PackageManifestMessage, ProgressMessage, RemovedRoot,
+    RequestRetryLog, SkippedOptionalDependencyLog, SkippedOptionalPackage, Stage, StatsMessage,
 };
 use serde_json::Value;
 
@@ -240,6 +240,11 @@ pub struct ReporterState {
 
     warnings_counter: usize,
     collapsed_warn_slot: BlockSlot,
+
+    /// Buffered transitive-deprecation events, accumulated until
+    /// `resolution_done` fires and rendered as a single summary line.
+    deprecated_subdeps: Vec<DeprecationLog>,
+    deprecated_slot: BlockSlot,
 }
 
 const MAX_SHOWN_WARNINGS: usize = 5;
@@ -305,6 +310,8 @@ impl ReporterState {
             exec_slot: BlockSlot::default(),
             warnings_counter: 0,
             collapsed_warn_slot: BlockSlot::default(),
+            deprecated_subdeps: Vec::new(),
+            deprecated_slot: BlockSlot::default(),
         }
     }
 
@@ -337,6 +344,7 @@ impl ReporterState {
             LogEvent::Global(log) => self.on_pnpm(log.level, &log.message, ""),
             LogEvent::ExecutionTime(log) => self.on_execution_time(log),
             LogEvent::Hook(log) => self.on_hook(log),
+            LogEvent::Deprecation(log) => self.on_deprecation(log),
             // Debug-only / non-rendered channels in pnpm's default reporter.
             LogEvent::BrokenModules(_) => {}
         }
@@ -435,16 +443,21 @@ impl ReporterState {
     }
 
     fn on_stage(&mut self, prefix: &str, stage: Stage) {
-        if stage != Stage::ImportingDone {
-            return;
+        match stage {
+            Stage::ResolutionDone => {
+                self.flush_deprecated_subdeps();
+            }
+            Stage::ImportingDone => {
+                if !self.progress.contains_key(prefix) {
+                    return;
+                }
+                let msg = self.progress_message(prefix, true);
+                let mut slot = std::mem::take(&mut self.progress.get_mut(prefix).unwrap().slot);
+                self.frame.emit(&mut slot, msg, false);
+                self.progress.get_mut(prefix).unwrap().slot = slot;
+            }
+            _ => {}
         }
-        if !self.progress.contains_key(prefix) {
-            return;
-        }
-        let msg = self.progress_message(prefix, true);
-        let mut slot = std::mem::take(&mut self.progress.get_mut(prefix).unwrap().slot);
-        self.frame.emit(&mut slot, msg, false);
-        self.progress.get_mut(prefix).unwrap().slot = slot;
     }
 
     // --- big tarballs -----------------------------------------------------
@@ -1060,6 +1073,55 @@ impl ReporterState {
         self.push_block(format!(
             "info: {pkg} is an optional dependency and failed compatibility check. Excluding it from installation.",
         ));
+    }
+
+    /// Handle a `pnpm:deprecation` event. Direct dependencies
+    /// (`depth == 0`) are rendered immediately; transitive ones are
+    /// buffered and summarized at `resolution_done`.
+    fn on_deprecation(&mut self, log: &DeprecationLog) {
+        if log.depth == 0 {
+            let msg = format!(
+                "{} {} {}@{}: {}",
+                self.colors.warn_label(),
+                self.colors.red("deprecated"),
+                log.pkg_name,
+                log.pkg_version,
+                log.deprecated,
+            );
+            if log.prefix.is_empty() || log.prefix == self.cwd {
+                self.push_block(msg);
+            } else {
+                let zoomed = zoom_out(&self.cwd, &log.prefix, &msg);
+                self.push_block(zoomed);
+            }
+        } else {
+            self.deprecated_subdeps.push(log.clone());
+        }
+    }
+
+    /// Flush buffered transitive-deprecation events into a single
+    /// summary line, matching pnpm's `reportDeprecations.ts` behavior:
+    /// `<N> deprecated subdependencies found: <list>`.
+    fn flush_deprecated_subdeps(&mut self) {
+        if self.deprecated_subdeps.is_empty() {
+            return;
+        }
+        let mut names: Vec<String> = self
+            .deprecated_subdeps
+            .iter()
+            .map(|log| format!("{}@{}", log.pkg_name, log.pkg_version))
+            .collect();
+        names.sort();
+        names.dedup();
+        let count = names.len();
+        let msg = format!(
+            "{} {} {}",
+            self.colors.warn_label(),
+            self.colors.red(&format!("{count} deprecated subdependencies found:")),
+            names.join(", "),
+        );
+        self.frame.emit(&mut self.deprecated_slot, msg, false);
+        self.deprecated_subdeps.clear();
     }
 
     /// Renders a `pnpm:hook` event as `hook: message`, matching pnpm's

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -662,7 +662,7 @@ fn transitive_deprecations_flush_as_a_summary_at_resolution_done() {
     );
     assert!(
         frame.is_empty(),
-        "transitive deprecations must buffer until resolution_done: {frame:?}"
+        "transitive deprecations must buffer until resolution_done: {frame:?}",
     );
 
     let frame = render(&mut reporter, vec![resolution_done()]);

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -9,8 +9,8 @@ use pacquet_default_reporter::{
     state::{Output, ReporterState},
 };
 use pacquet_reporter::{
-    AddedRoot, ContextLog, DependencyType, ExecutionTimeLog, GlobalLog, HookLog, LifecycleLog,
-    LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, PackageImportMethod,
+    AddedRoot, ContextLog, DependencyType, DeprecationLog, ExecutionTimeLog, GlobalLog, HookLog,
+    LifecycleLog, LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, PackageImportMethod,
     PackageImportMethodLog, PackageManifestLog, PackageManifestMessage, PnpmLog, ProgressLog,
     ProgressMessage, RootLog, RootMessage, SkippedOptionalDependencyLog, SkippedOptionalPackage,
     SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage,
@@ -607,4 +607,64 @@ fn hook_log_renders_with_magenta_hook_name() {
         })],
     );
     assert_eq!(frame, "preResolution: Starting resolution");
+}
+
+fn deprecation(name: &str, version: &str, depth: i32, prefix: &str) -> LogEvent {
+    LogEvent::Deprecation(DeprecationLog {
+        level: LogLevel::Debug,
+        pkg_name: name.to_string(),
+        pkg_version: version.to_string(),
+        pkg_id: format!("{name}@{version}"),
+        prefix: prefix.to_string(),
+        deprecated: "no longer supported".to_string(),
+        depth,
+    })
+}
+
+fn resolution_done() -> LogEvent {
+    LogEvent::Stage(StageLog {
+        level: LogLevel::Debug,
+        prefix: CWD.to_string(),
+        stage: Stage::ResolutionDone,
+    })
+}
+
+#[test]
+fn direct_deprecation_renders_immediately_with_the_message() {
+    let mut reporter = state(false);
+    let frame = render(&mut reporter, vec![deprecation("express", "0.14.1", 0, CWD)]);
+    assert_eq!(frame, "[WARN] deprecated express@0.14.1: no longer supported");
+}
+
+/// Upstream's zoomed variant carries only `deprecated name@version` — the
+/// deprecation text is dropped.
+#[test]
+fn zoomed_direct_deprecation_omits_the_message() {
+    let mut reporter = state(false);
+    let frame =
+        render(&mut reporter, vec![deprecation("express", "0.14.1", 0, "/repo/packages/app")]);
+    assert_eq!(
+        frame,
+        pacquet_default_reporter::format::zoom_out(
+            CWD,
+            "/repo/packages/app",
+            "[WARN] deprecated express@0.14.1",
+        ),
+    );
+}
+
+#[test]
+fn transitive_deprecations_flush_as_a_summary_at_resolution_done() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![deprecation("uuid", "3.4.0", 2, CWD), deprecation("request", "2.88.2", 3, CWD)],
+    );
+    assert!(
+        frame.is_empty(),
+        "transitive deprecations must buffer until resolution_done: {frame:?}"
+    );
+
+    let frame = render(&mut reporter, vec![resolution_done()]);
+    assert_eq!(frame, "[WARN] 2 deprecated subdependencies found: request@2.88.2, uuid@3.4.0");
 }

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1308,6 +1308,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             || std::ffi::OsString::from("node_modules"),
             std::ffi::OsStr::to_os_string,
         );
+        Reporter::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: lockfile_dir.display().to_string(),
+            stage: Stage::ResolutionStarted,
+        }));
         let workspace_result = pacquet_resolving_deps_resolver::resolve_workspace(
             &*resolver,
             &workspace_importers,
@@ -1472,6 +1477,14 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         drop(meta_cache);
         drop(fetch_locker);
         drop(picked_manifest_cache);
+
+        // Must come after every `pnpm:deprecation` emit — the default
+        // reporter flushes its transitive-deprecation buffer on this event.
+        Reporter::emit(&LogEvent::Stage(StageLog {
+            level: LogLevel::Debug,
+            prefix: lockfile_dir.display().to_string(),
+            stage: Stage::ResolutionDone,
+        }));
 
         // Compute the `pnpmfileChecksum` once for both lockfile-build
         // paths below: the hash of the project's `.pnpmfile.{cjs,mjs}`

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -23,8 +23,8 @@ use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{
-    HookLog, LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog, SkippedOptionalPackage,
-    SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog,
+    DeprecationLog, HookLog, LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog,
+    SkippedOptionalPackage, SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog,
 };
 use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_deps_resolver::{
@@ -1301,6 +1301,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             update_reuse_scopes_by_importer,
             auto_install_peers: config.auto_install_peers,
             registries,
+            allowed_deprecated_versions: config.allowed_deprecated_versions.clone(),
+            deprecation_log: Some(deprecation_log_fn::<Reporter>()),
         };
         let modules_basename = config.modules_dir.file_name().map_or_else(
             || std::ffi::OsString::from("node_modules"),
@@ -2507,6 +2509,24 @@ fn skipped_optional_log_fn<Reporter: self::Reporter>()
             ),
             prefix: skipped.prefix,
             reason: SkippedOptionalReason::ResolutionFailure,
+        }));
+    })
+}
+
+/// Build the resolver's deprecation sink: each notification emits a
+/// `pnpm:deprecation` debug event through the install's reporter,
+/// matching pnpm's `deprecationLogger.debug` payload.
+fn deprecation_log_fn<Reporter: self::Reporter>()
+-> pacquet_resolving_deps_resolver::DeprecationLogFn {
+    Arc::new(|deprecation: pacquet_resolving_deps_resolver::Deprecation| {
+        Reporter::emit(&LogEvent::Deprecation(DeprecationLog {
+            level: LogLevel::Debug,
+            pkg_name: deprecation.pkg_name,
+            pkg_version: deprecation.pkg_version,
+            pkg_id: deprecation.pkg_id,
+            prefix: deprecation.prefix,
+            deprecated: deprecation.deprecated,
+            depth: deprecation.depth,
         }));
     })
 }

--- a/pnpm/crates/reporter/src/lib.rs
+++ b/pnpm/crates/reporter/src/lib.rs
@@ -182,6 +182,15 @@ pub enum LogEvent {
     /// it as the `Done in <time> using <pkg> v<version>` footer.
     #[serde(rename = "pnpm:execution-time")]
     ExecutionTime(ExecutionTimeLog),
+
+    /// Deprecated-package warning (`pnpm:deprecation`). Emitted once per
+    /// newly-resolved package whose registry manifest carries a `deprecated`
+    /// field and whose name/version is not covered by
+    /// `allowedDeprecatedVersions`. Direct dependencies (`depth == 0`) are
+    /// rendered immediately; transitive ones are buffered and summarized at
+    /// `pnpm:stage` time.
+    #[serde(rename = "pnpm:deprecation")]
+    Deprecation(DeprecationLog),
 }
 
 /// `pnpm:context` payload.
@@ -806,6 +815,25 @@ pub struct ExecutionTimeLog {
     pub level: LogLevel,
     pub started_at: u128,
     pub ended_at: u128,
+}
+
+/// `pnpm:deprecation` payload. Emitted once per newly-resolved package
+/// whose registry manifest carries a `deprecated` field and whose
+/// name/version is not covered by `allowedDeprecatedVersions`. Field
+/// names match pnpm's [`DeprecationMessage`] wire shape so
+/// `@pnpm/cli.default-reporter` dispatches on them unchanged.
+///
+/// [`DeprecationMessage`]: https://github.com/pnpm/pnpm/blob/main/core/core-loggers/src/deprecationLogger.ts
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeprecationLog {
+    pub level: LogLevel,
+    pub pkg_name: String,
+    pub pkg_version: String,
+    pub pkg_id: String,
+    pub prefix: String,
+    pub deprecated: String,
+    pub depth: i32,
 }
 
 /// Severity level on the [bunyan]-shaped envelope.

--- a/pnpm/crates/reporter/src/lib.rs
+++ b/pnpm/crates/reporter/src/lib.rs
@@ -817,11 +817,9 @@ pub struct ExecutionTimeLog {
     pub ended_at: u128,
 }
 
-/// `pnpm:deprecation` payload. Emitted once per newly-resolved package
-/// whose registry manifest carries a `deprecated` field and whose
-/// name/version is not covered by `allowedDeprecatedVersions`. Field
-/// names match pnpm's [`DeprecationMessage`] wire shape so
-/// `@pnpm/cli.default-reporter` dispatches on them unchanged.
+/// `pnpm:deprecation` payload. Field names match pnpm's
+/// [`DeprecationMessage`] wire shape so `@pnpm/cli.default-reporter`
+/// dispatches on them unchanged.
 ///
 /// [`DeprecationMessage`]: https://github.com/pnpm/pnpm/blob/main/core/core-loggers/src/deprecationLogger.ts
 #[derive(Debug, Clone, Serialize)]

--- a/pnpm/crates/reporter/src/tests.rs
+++ b/pnpm/crates/reporter/src/tests.rs
@@ -5,9 +5,9 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 
 use crate::{
-    AddedRoot, BrokenModulesLog, ContextLog, DependencyType, Envelope, FetchingProgressLog,
-    FetchingProgressMessage, GetHostName, GlobalLog, HookLog, Host, IgnoredScriptsLog,
-    LifecycleLog, LifecycleMessage, LifecycleStdio, LockfileVerificationLog,
+    AddedRoot, BrokenModulesLog, ContextLog, DependencyType, DeprecationLog, Envelope,
+    FetchingProgressLog, FetchingProgressMessage, GetHostName, GlobalLog, HookLog, Host,
+    IgnoredScriptsLog, LifecycleLog, LifecycleMessage, LifecycleStdio, LockfileVerificationLog,
     LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog,
     PackageManifestLog, PackageManifestMessage, PnpmLog, ProgressLog, ProgressMessage,
     PromptAction, PromptLog, RemovedRoot, Reporter, RequestRetryError, RequestRetryLog, RootLog,
@@ -1078,4 +1078,57 @@ fn host_returns_a_non_empty_host_name() {
     let host = Host::get_host_name();
     eprintln!("Host::get_host_name() = {host:?}");
     assert!(!host.is_empty());
+}
+
+/// `pnpm:deprecation` event serializes to the same JSON shape
+/// pnpm's `@pnpm/cli.default-reporter` expects.
+#[test]
+fn deprecation_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::Deprecation(DeprecationLog {
+        level: LogLevel::Debug,
+        pkg_name: "express".to_string(),
+        pkg_version: "0.14.1".to_string(),
+        pkg_id: "express@0.14.1".to_string(),
+        prefix: "/projects/x".to_string(),
+        deprecated: "express 0.x series is deprecated".to_string(),
+        depth: 0,
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    dbg!(&json);
+    assert_eq!(json["name"], "pnpm:deprecation");
+    assert_eq!(json["level"], "debug");
+    assert_eq!(json["pkgName"], "express");
+    assert_eq!(json["pkgVersion"], "0.14.1");
+    assert_eq!(json["pkgId"], "express@0.14.1");
+    assert_eq!(json["prefix"], "/projects/x");
+    assert_eq!(json["deprecated"], "express 0.x series is deprecated");
+    assert_eq!(json["depth"], 0);
+}
+
+/// Transitive deprecation events (`depth > 0`) also match the wire shape.
+#[test]
+fn deprecation_event_transitive_matches_pnpm_wire_shape() {
+    let event = LogEvent::Deprecation(DeprecationLog {
+        level: LogLevel::Debug,
+        pkg_name: "request".to_string(),
+        pkg_version: "2.88.2".to_string(),
+        pkg_id: "request@2.88.2".to_string(),
+        prefix: "/projects/x".to_string(),
+        deprecated: "request has been deprecated".to_string(),
+        depth: 3,
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+    assert_eq!(json["name"], "pnpm:deprecation");
+    assert_eq!(json["pkgName"], "request");
+    assert_eq!(json["depth"], 3);
 }

--- a/pnpm/crates/resolving-deps-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lib.rs
@@ -85,9 +85,10 @@ pub use hoist_peers::{
 pub use node_id::NodeId;
 pub use pacquet_deps_path::DepPath;
 pub use resolve_dependency_tree::{
-    ManifestHook, ResolveDependencyTreeError, ResolveDependencyTreeOptions,
-    SkippedOptionalDependency, SkippedOptionalDependencyParent, SkippedOptionalLogFn, TreeCtx,
-    UpdateReuseScope, WorkspaceTreeCtx, extend_tree, resolve_dependency_tree,
+    Deprecation, DeprecationLogFn, ManifestHook, ResolveDependencyTreeError,
+    ResolveDependencyTreeOptions, SkippedOptionalDependency, SkippedOptionalDependencyParent,
+    SkippedOptionalLogFn, TreeCtx, UpdateReuseScope, WorkspaceTreeCtx, extend_tree,
+    resolve_dependency_tree,
 };
 pub use resolve_importer::{
     ResolveImporterError, ResolveImporterOptions, ResolveImporterResult, resolve_importer,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1656,30 +1656,28 @@ where
     let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    {
-        let mut packages = lock_recoverable(&ctx.workspace.packages);
-        if let Some(existing) = packages.get_mut(&id) {
-            existing.optional = existing.optional && current_is_optional;
-        } else {
-            let peer_dependencies =
-                if is_link { BTreeMap::new() } else { extract_peer_dependencies(&result) };
-            {
-                let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
-                for name in peer_dependencies.keys() {
-                    all_peers.insert(name.clone());
-                }
+    let mut packages = lock_recoverable(&ctx.workspace.packages);
+    if let Some(existing) = packages.get_mut(&id) {
+        existing.optional = existing.optional && current_is_optional;
+    } else {
+        let peer_dependencies =
+            if is_link { BTreeMap::new() } else { extract_peer_dependencies(&result) };
+        {
+            let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
+            for name in peer_dependencies.keys() {
+                all_peers.insert(name.clone());
             }
-            packages.insert(
-                id.clone(),
-                ResolvedPackage {
-                    id: id.clone(),
-                    result: Arc::clone(&result),
-                    peer_dependencies,
-                    optional: current_is_optional,
-                    is_leaf,
-                },
-            );
         }
+        packages.insert(
+            id.clone(),
+            ResolvedPackage {
+                id: id.clone(),
+                result: Arc::clone(&result),
+                peer_dependencies,
+                optional: current_is_optional,
+                is_leaf,
+            },
+        );
     }
 
     emit_deprecation_if_needed(ctx, &result, &id, depth);
@@ -2688,7 +2686,7 @@ where
                 },
             );
         }
-    };
+    }
 
     emit_deprecation_if_needed(ctx, &result, &id, depth);
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1681,34 +1681,8 @@ where
         }
     };
 
-    // Matches the TS deprecation warning at
-    // `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2119`;
-    // runs outside the `packages` lock to keep the semver check and the
-    // emit out of the critical section.
-    if package_is_new
-        && let Some(deprecated) = extract_deprecated_from_manifest(result.manifest.as_deref())
-        && !deprecated.is_empty()
-    {
-        let pkg_name =
-            result.name_ver.as_ref().map_or_else(|| alias.clone(), |nv| nv.name.to_string());
-        let pkg_version =
-            result.name_ver.as_ref().map(|nv| nv.suffix.to_string()).unwrap_or_default();
-
-        if !is_deprecation_allowed(
-            &pkg_name,
-            &pkg_version,
-            &ctx.workspace.allowed_deprecated_versions,
-        ) && let Some(log) = ctx.workspace.deprecation_log.as_ref()
-        {
-            log(Deprecation {
-                pkg_name,
-                pkg_version,
-                pkg_id: id.clone(),
-                prefix: ctx.base_opts.project_dir.display().to_string(),
-                deprecated,
-                depth,
-            });
-        }
+    if package_is_new {
+        emit_deprecation_if_needed(ctx, &result, &id, depth);
     }
 
     let next_ancestors: Vec<String> =
@@ -2693,10 +2667,11 @@ where
     let is_leaf = child_refs.is_empty() && peer_dependencies.is_empty();
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    {
+    let package_is_new = {
         let mut packages = lock_recoverable(&ctx.workspace.packages);
         if let Some(existing) = packages.get_mut(&id) {
             existing.optional = existing.optional && current_is_optional;
+            false
         } else {
             {
                 let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
@@ -2714,7 +2689,16 @@ where
                     is_leaf,
                 },
             );
+            true
         }
+    };
+
+    // The synthesized manifest round-trips the lockfile's `deprecated`
+    // metadata so reused entries keep warning on warm installs, the
+    // same way pnpm's requester serves cached manifests to its
+    // deprecation check.
+    if package_is_new {
+        emit_deprecation_if_needed(ctx, &result, &id, depth);
     }
 
     let next_ancestors: Vec<String> =
@@ -3149,10 +3133,67 @@ fn is_empty_or_absent(value: Option<&Value>) -> bool {
     value.and_then(Value::as_object).is_none_or(serde_json::Map::is_empty)
 }
 
+/// Emits one [`Deprecation`] notification when a newly-recorded
+/// package's manifest carries a non-empty `deprecated` field not
+/// covered by `allowedDeprecatedVersions`. Matches the TS warning at
+/// `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2119`,
+/// which fires once per package id per install — both call sites gate
+/// on the first `packages`-map insert and run outside its lock to keep
+/// the semver check and the emit out of the critical section.
+fn emit_deprecation_if_needed(
+    ctx: &TreeCtx,
+    result: &pacquet_resolving_resolver_base::ResolveResult,
+    id: &str,
+    depth: i32,
+) {
+    let Some(deprecated) = extract_deprecated_from_manifest(result.manifest.as_deref()) else {
+        return;
+    };
+    if deprecated.is_empty() {
+        return;
+    }
+    let Some((pkg_name, pkg_version)) = deprecated_pkg_name_ver(result) else {
+        return;
+    };
+    if is_deprecation_allowed(&pkg_name, &pkg_version, &ctx.workspace.allowed_deprecated_versions) {
+        return;
+    }
+    let Some(log) = ctx.workspace.deprecation_log.as_ref() else {
+        return;
+    };
+    log(Deprecation {
+        pkg_name,
+        pkg_version,
+        pkg_id: id.to_string(),
+        prefix: ctx.base_opts.project_dir.display().to_string(),
+        deprecated,
+        depth,
+    });
+}
+
 /// A missing manifest, an absent `deprecated` field, and a non-string
 /// one all count as not deprecated.
 fn extract_deprecated_from_manifest(manifest: Option<&Value>) -> Option<String> {
     manifest?.get("deprecated")?.as_str().map(str::to_string)
+}
+
+/// The name/version a `pnpm:deprecation` payload reports:
+/// [`ResolveResult::name_ver`] when the resolver filled it, otherwise
+/// the manifest's `name`/`version` — the canonical source for non-npm
+/// resolutions (see the `name_ver` field doc). `None`, suppressing the
+/// warning, when neither carries both fields.
+///
+/// [`ResolveResult::name_ver`]: pacquet_resolving_resolver_base::ResolveResult::name_ver
+fn deprecated_pkg_name_ver(
+    result: &pacquet_resolving_resolver_base::ResolveResult,
+) -> Option<(String, String)> {
+    if let Some(nv) = result.name_ver.as_ref() {
+        return Some((nv.name.to_string(), nv.suffix.to_string()));
+    }
+    let manifest = result.manifest.as_deref()?;
+    let name = manifest.get("name")?.as_str()?;
+    let version = manifest.get("version")?.as_str()?;
+    Some((name.to_string(), version.to_string()))
 }
 
 /// Whether `pkg_name@pkg_version` satisfies its entry in the

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1651,10 +1651,11 @@ where
     let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    {
+    let package_is_new = {
         let mut packages = lock_recoverable(&ctx.workspace.packages);
         if let Some(existing) = packages.get_mut(&id) {
             existing.optional = existing.optional && current_is_optional;
+            false
         } else {
             let peer_dependencies =
                 if is_link { BTreeMap::new() } else { extract_peer_dependencies(&result) };
@@ -1676,35 +1677,37 @@ where
                     is_leaf,
                 },
             );
+            true
+        }
+    };
 
-            // Matches the TS deprecation warning at
-            // `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2119`.
-            if let Some(deprecated) = extract_deprecated_from_manifest(result.manifest.as_deref())
-                && !deprecated.is_empty()
-            {
-                let pkg_name = result
-                    .name_ver
-                    .as_ref()
-                    .map_or_else(|| alias.clone(), |nv| nv.name.to_string());
-                let pkg_version =
-                    result.name_ver.as_ref().map(|nv| nv.suffix.to_string()).unwrap_or_default();
+    // Matches the TS deprecation warning at
+    // `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2119`;
+    // runs outside the `packages` lock to keep the semver check and the
+    // emit out of the critical section.
+    if package_is_new
+        && let Some(deprecated) = extract_deprecated_from_manifest(result.manifest.as_deref())
+        && !deprecated.is_empty()
+    {
+        let pkg_name =
+            result.name_ver.as_ref().map_or_else(|| alias.clone(), |nv| nv.name.to_string());
+        let pkg_version =
+            result.name_ver.as_ref().map(|nv| nv.suffix.to_string()).unwrap_or_default();
 
-                if !is_deprecation_allowed(
-                    &pkg_name,
-                    &pkg_version,
-                    &ctx.workspace.allowed_deprecated_versions,
-                ) && let Some(log) = ctx.workspace.deprecation_log.as_ref()
-                {
-                    log(Deprecation {
-                        pkg_name,
-                        pkg_version,
-                        pkg_id: id.clone(),
-                        prefix: ctx.base_opts.project_dir.display().to_string(),
-                        deprecated,
-                        depth,
-                    });
-                }
-            }
+        if !is_deprecation_allowed(
+            &pkg_name,
+            &pkg_version,
+            &ctx.workspace.allowed_deprecated_versions,
+        ) && let Some(log) = ctx.workspace.deprecation_log.as_ref()
+        {
+            log(Deprecation {
+                pkg_name,
+                pkg_version,
+                pkg_id: id.clone(),
+                prefix: ctx.base_opts.project_dir.display().to_string(),
+                deprecated,
+                depth,
+            });
         }
     }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -650,6 +650,10 @@ pub struct WorkspaceTreeCtx {
     /// deprecation check but drops the notification. See
     /// [`DeprecationLogFn`].
     deprecation_log: Option<DeprecationLogFn>,
+    /// Per-package shallowest depth at which a deprecation was emitted.
+    /// Re-emits when the same package appears at a shallower depth so a
+    /// direct dependency is never misclassified as transitive.
+    deprecation_depths: Mutex<HashMap<String, i32>>,
     /// The install's `autoInstallPeers` setting. When `true`,
     /// [`fn@resolve_node`] drops a resolved package's `dependencies`
     /// entries that are shadowed by its own `peerDependencies`, so the
@@ -727,6 +731,7 @@ impl Default for WorkspaceTreeCtx {
             read_package_log: None,
             skipped_optional_log: None,
             allowed_deprecated_versions: BTreeMap::new(),
+            deprecation_depths: Mutex::new(HashMap::new()),
             deprecation_log: None,
             auto_install_peers: false,
             registries: HashMap::new(),
@@ -1651,16 +1656,13 @@ where
     let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    let package_is_new = {
+    {
         let mut packages = lock_recoverable(&ctx.workspace.packages);
         if let Some(existing) = packages.get_mut(&id) {
             existing.optional = existing.optional && current_is_optional;
-            false
         } else {
             let peer_dependencies =
                 if is_link { BTreeMap::new() } else { extract_peer_dependencies(&result) };
-            // Collect peer names for the peer-resolution stage's
-            // `parentPkgs` filter (only peers count as parents).
             {
                 let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
                 for name in peer_dependencies.keys() {
@@ -1677,13 +1679,10 @@ where
                     is_leaf,
                 },
             );
-            true
         }
-    };
-
-    if package_is_new {
-        emit_deprecation_if_needed(ctx, &result, &id, depth);
     }
+
+    emit_deprecation_if_needed(ctx, &result, &id, depth);
 
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
@@ -2667,11 +2666,10 @@ where
     let is_leaf = child_refs.is_empty() && peer_dependencies.is_empty();
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    let package_is_new = {
+    {
         let mut packages = lock_recoverable(&ctx.workspace.packages);
         if let Some(existing) = packages.get_mut(&id) {
             existing.optional = existing.optional && current_is_optional;
-            false
         } else {
             {
                 let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
@@ -2689,17 +2687,10 @@ where
                     is_leaf,
                 },
             );
-            true
         }
     };
 
-    // The synthesized manifest round-trips the lockfile's `deprecated`
-    // metadata so reused entries keep warning on warm installs, the
-    // same way pnpm's requester serves cached manifests to its
-    // deprecation check.
-    if package_is_new {
-        emit_deprecation_if_needed(ctx, &result, &id, depth);
-    }
+    emit_deprecation_if_needed(ctx, &result, &id, depth);
 
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
@@ -3133,13 +3124,10 @@ fn is_empty_or_absent(value: Option<&Value>) -> bool {
     value.and_then(Value::as_object).is_none_or(serde_json::Map::is_empty)
 }
 
-/// Emits one [`Deprecation`] notification when a newly-recorded
-/// package's manifest carries a non-empty `deprecated` field not
-/// covered by `allowedDeprecatedVersions`. Matches the TS warning at
-/// `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2119`,
-/// which fires once per package id per install — both call sites gate
-/// on the first `packages`-map insert and run outside its lock to keep
-/// the semver check and the emit out of the critical section.
+/// Emits a [`Deprecation`] when the manifest carries a non-empty
+/// `deprecated` field not covered by `allowedDeprecatedVersions`.
+/// Re-emits at a shallower depth so a direct dependency is never
+/// misclassified as transitive.
 fn emit_deprecation_if_needed(
     ctx: &TreeCtx,
     result: &pacquet_resolving_resolver_base::ResolveResult,
@@ -3157,6 +3145,15 @@ fn emit_deprecation_if_needed(
     };
     if is_deprecation_allowed(&pkg_name, &pkg_version, &ctx.workspace.allowed_deprecated_versions) {
         return;
+    }
+    {
+        let mut depths = lock_recoverable(&ctx.workspace.deprecation_depths);
+        if let Some(prev) = depths.get(id)
+            && depth >= *prev
+        {
+            return;
+        }
+        depths.insert(id.to_string(), depth);
     }
     let Some(log) = ctx.workspace.deprecation_log.as_ref() else {
         return;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -205,6 +205,26 @@ pub struct SkippedOptionalDependencyParent {
 /// [`crate::WorkspaceResolveOptions::skipped_optional_log`].
 pub type SkippedOptionalLogFn = Arc<dyn Fn(SkippedOptionalDependency) + Send + Sync>;
 
+/// One deprecation notification from the tree walker: a newly-resolved
+/// package carries a non-empty `deprecated` field in its registry
+/// manifest and is not covered by `allowedDeprecatedVersions`. Mirrors
+/// the package payload of the `pnpm:deprecation` debug log so the
+/// install layer can forward it to the reporter wire.
+#[derive(Debug, Clone)]
+pub struct Deprecation {
+    pub pkg_name: String,
+    pub pkg_version: String,
+    pub pkg_id: String,
+    pub prefix: String,
+    pub deprecated: String,
+    pub depth: i32,
+}
+
+/// Sink for [`Deprecation`] notifications, pre-bound to the install's
+/// reporter so the resolver stays reporter-agnostic. See
+/// [`crate::WorkspaceResolveOptions::deprecation_log`].
+pub type DeprecationLogFn = Arc<dyn Fn(Deprecation) + Send + Sync>;
+
 /// Error envelope returned by the tree walker.
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum ResolveDependencyTreeError {
@@ -623,6 +643,16 @@ pub struct WorkspaceTreeCtx {
     /// keeps the skip behavior but drops the notification. See
     /// [`SkippedOptionalLogFn`].
     skipped_optional_log: Option<SkippedOptionalLogFn>,
+    /// Package-name → semver-range map from the
+    /// `pnpm.allowedDeprecatedVersions` setting. When a newly-resolved
+    /// package is deprecated and its `name@version` satisfies an entry
+    /// here, the deprecation warning is suppressed. See
+    /// [`WorkspaceTreeCtx::with_allowed_deprecated_versions`].
+    allowed_deprecated_versions: BTreeMap<String, String>,
+    /// Sink for deprecation notifications. `None` keeps the
+    /// deprecation check but drops the notification. See
+    /// [`DeprecationLogFn`].
+    deprecation_log: Option<DeprecationLogFn>,
     /// The install's `autoInstallPeers` setting. When `true`,
     /// [`fn@resolve_node`] drops a resolved package's `dependencies`
     /// entries that are shadowed by its own `peerDependencies`, so the
@@ -699,6 +729,8 @@ impl Default for WorkspaceTreeCtx {
             pnpmfile_hook: None,
             read_package_log: None,
             skipped_optional_log: None,
+            allowed_deprecated_versions: BTreeMap::new(),
+            deprecation_log: None,
             auto_install_peers: false,
             registries: HashMap::new(),
             first_importer_by_pkg: Mutex::new(HashMap::new()),
@@ -855,6 +887,26 @@ impl WorkspaceTreeCtx {
         skipped_optional_log: Option<SkippedOptionalLogFn>,
     ) -> Self {
         self.skipped_optional_log = skipped_optional_log;
+        self
+    }
+
+    /// Attach the `pnpm.allowedDeprecatedVersions` map. When a
+    /// newly-resolved package is deprecated and its `name@version`
+    /// satisfies an entry here, the deprecation warning is suppressed.
+    #[must_use]
+    pub fn with_allowed_deprecated_versions(
+        mut self,
+        allowed_deprecated_versions: BTreeMap<String, String>,
+    ) -> Self {
+        self.allowed_deprecated_versions = allowed_deprecated_versions;
+        self
+    }
+
+    /// Attach the sink deprecation notifications are forwarded to.
+    /// See [`DeprecationLogFn`].
+    #[must_use]
+    pub fn with_deprecation_log(mut self, deprecation_log: Option<DeprecationLogFn>) -> Self {
+        self.deprecation_log = deprecation_log;
         self
     }
 
@@ -1628,6 +1680,38 @@ where
                     is_leaf,
                 },
             );
+
+            // Deprecation check: emit `pnpm:deprecation` for newly-resolved
+            // packages whose registry manifest carries a non-empty `deprecated`
+            // field, unless the package name+version is covered by
+            // `allowedDeprecatedVersions`. Matches the TS implementation at
+            // `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2119`.
+            if let Some(deprecated) = extract_deprecated_from_manifest(result.manifest.as_deref())
+                && !deprecated.is_empty()
+            {
+                let pkg_name = result
+                    .name_ver
+                    .as_ref()
+                    .map_or_else(|| alias.clone(), |nv| nv.name.to_string());
+                let pkg_version =
+                    result.name_ver.as_ref().map(|nv| nv.suffix.to_string()).unwrap_or_default();
+
+                if !is_deprecation_allowed(
+                    &pkg_name,
+                    &pkg_version,
+                    &ctx.workspace.allowed_deprecated_versions,
+                ) && let Some(log) = ctx.workspace.deprecation_log.as_ref()
+                {
+                    log(Deprecation {
+                        pkg_name,
+                        pkg_version,
+                        pkg_id: id.clone(),
+                        prefix: ctx.base_opts.project_dir.display().to_string(),
+                        deprecated,
+                        depth,
+                    });
+                }
+            }
         }
     }
 
@@ -3067,6 +3151,39 @@ fn pkg_is_leaf(result: &pacquet_resolving_resolver_base::ResolveResult) -> bool 
 
 fn is_empty_or_absent(value: Option<&Value>) -> bool {
     value.and_then(Value::as_object).is_none_or(serde_json::Map::is_empty)
+}
+
+/// Extract the `deprecated` string from a registry manifest `Value`.
+///
+/// Returns `None` when the manifest is absent or the field is missing
+/// or not a string — both cases mean "not deprecated" and the caller
+/// skips the deprecation check.
+fn extract_deprecated_from_manifest(manifest: Option<&Value>) -> Option<String> {
+    manifest?.get("deprecated")?.as_str().map(str::to_string)
+}
+
+/// Check whether a deprecated package is covered by the
+/// `pnpm.allowedDeprecatedVersions` setting.
+///
+/// Returns `true` when `allowed_deprecated_versions` contains an entry
+/// for `pkg_name` whose semver range satisfies `pkg_version`. The
+/// deprecation warning is suppressed in that case. Matches the TS
+/// check at `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2122`.
+fn is_deprecation_allowed(
+    pkg_name: &str,
+    pkg_version: &str,
+    allowed_deprecated_versions: &BTreeMap<String, String>,
+) -> bool {
+    let Some(range_str) = allowed_deprecated_versions.get(pkg_name) else {
+        return false;
+    };
+    let Ok(range) = range_str.parse::<node_semver::Range>() else {
+        return false;
+    };
+    let Ok(version) = pkg_version.parse::<node_semver::Version>() else {
+        return false;
+    };
+    range.satisfies(&version)
 }
 
 /// Provenance tags that count as non-exotic for `blockExoticSubdeps`.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -643,11 +643,8 @@ pub struct WorkspaceTreeCtx {
     /// keeps the skip behavior but drops the notification. See
     /// [`SkippedOptionalLogFn`].
     skipped_optional_log: Option<SkippedOptionalLogFn>,
-    /// Package-name → semver-range map from the
-    /// `pnpm.allowedDeprecatedVersions` setting. When a newly-resolved
-    /// package is deprecated and its `name@version` satisfies an entry
-    /// here, the deprecation warning is suppressed. See
-    /// [`WorkspaceTreeCtx::with_allowed_deprecated_versions`].
+    /// The `pnpm.allowedDeprecatedVersions` map. See
+    /// [`crate::WorkspaceResolveOptions::allowed_deprecated_versions`].
     allowed_deprecated_versions: BTreeMap<String, String>,
     /// Sink for deprecation notifications. `None` keeps the
     /// deprecation check but drops the notification. See
@@ -890,9 +887,8 @@ impl WorkspaceTreeCtx {
         self
     }
 
-    /// Attach the `pnpm.allowedDeprecatedVersions` map. When a
-    /// newly-resolved package is deprecated and its `name@version`
-    /// satisfies an entry here, the deprecation warning is suppressed.
+    /// Attach the `pnpm.allowedDeprecatedVersions` map. See
+    /// [`crate::WorkspaceResolveOptions::allowed_deprecated_versions`].
     #[must_use]
     pub fn with_allowed_deprecated_versions(
         mut self,
@@ -1681,10 +1677,7 @@ where
                 },
             );
 
-            // Deprecation check: emit `pnpm:deprecation` for newly-resolved
-            // packages whose registry manifest carries a non-empty `deprecated`
-            // field, unless the package name+version is covered by
-            // `allowedDeprecatedVersions`. Matches the TS implementation at
+            // Matches the TS deprecation warning at
             // `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2119`.
             if let Some(deprecated) = extract_deprecated_from_manifest(result.manifest.as_deref())
                 && !deprecated.is_empty()
@@ -3153,22 +3146,15 @@ fn is_empty_or_absent(value: Option<&Value>) -> bool {
     value.and_then(Value::as_object).is_none_or(serde_json::Map::is_empty)
 }
 
-/// Extract the `deprecated` string from a registry manifest `Value`.
-///
-/// Returns `None` when the manifest is absent or the field is missing
-/// or not a string — both cases mean "not deprecated" and the caller
-/// skips the deprecation check.
+/// A missing manifest, an absent `deprecated` field, and a non-string
+/// one all count as not deprecated.
 fn extract_deprecated_from_manifest(manifest: Option<&Value>) -> Option<String> {
     manifest?.get("deprecated")?.as_str().map(str::to_string)
 }
 
-/// Check whether a deprecated package is covered by the
-/// `pnpm.allowedDeprecatedVersions` setting.
-///
-/// Returns `true` when `allowed_deprecated_versions` contains an entry
-/// for `pkg_name` whose semver range satisfies `pkg_version`. The
-/// deprecation warning is suppressed in that case. Matches the TS
-/// check at `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2122`.
+/// Whether `pkg_name@pkg_version` satisfies its entry in the
+/// `pnpm.allowedDeprecatedVersions` map, matching the TS check at
+/// `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2122`.
 fn is_deprecation_allowed(
     pkg_name: &str,
     pkg_version: &str,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -461,3 +461,36 @@ mod is_update_target {
         assert!(!is_update_target(&except(&["foo"]), &wanted_with(None, None),));
     }
 }
+
+/// With `name_ver` unset (git / tarball / local resolutions), the
+/// deprecation payload's name and version come from the manifest, and a
+/// manifest missing either field suppresses the warning instead of
+/// emitting a malformed `name@` payload.
+#[test]
+fn deprecated_pkg_name_ver_falls_back_to_the_manifest() {
+    let result = |manifest: serde_json::Value| ResolveResult {
+        id: PkgResolutionId::from("git-pkg@https://example.com/repo.tgz"),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: Some(std::sync::Arc::new(manifest)),
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: ".".to_string(),
+        }),
+        resolved_via: "git-repository".to_string(),
+        normalized_bare_specifier: None,
+        alias: Some("git-pkg".to_string()),
+        policy_violation: None,
+    };
+
+    assert_eq!(
+        super::deprecated_pkg_name_ver(&result(
+            serde_json::json!({ "name": "git-pkg", "version": "2.0.0" })
+        )),
+        Some(("git-pkg".to_string(), "2.0.0".to_string())),
+    );
+    assert_eq!(
+        super::deprecated_pkg_name_ver(&result(serde_json::json!({ "name": "git-pkg" }))),
+        None,
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -116,6 +116,18 @@ pub struct WorkspaceResolveOptions {
     /// log). `None` keeps the skip behavior but drops the notification.
     pub skipped_optional_log: Option<crate::SkippedOptionalLogFn>,
 
+    /// Package-name → semver-range map from the
+    /// `pnpm.allowedDeprecatedVersions` setting. When a newly-resolved
+    /// package is deprecated and its `name@version` satisfies an entry
+    /// here, the deprecation warning is suppressed.
+    pub allowed_deprecated_versions: BTreeMap<String, String>,
+
+    /// Sink for deprecation notifications, pre-bound to the install's
+    /// reporter (the install layer forwards each one as a
+    /// `pnpm:deprecation` debug log). `None` keeps the deprecation
+    /// check but drops the notification.
+    pub deprecation_log: Option<crate::DeprecationLogFn>,
+
     /// The install's `autoInstallPeers` setting, threaded onto the
     /// shared [`WorkspaceTreeCtx`] so the tree walk drops
     /// peer-shadowed `dependencies` entries. Also overrides every
@@ -170,6 +182,8 @@ where
         pnpmfile_hook,
         read_package_log,
         skipped_optional_log,
+        allowed_deprecated_versions,
+        deprecation_log,
         pick_lowest_direct,
         time_based,
         wanted_lockfile,
@@ -187,6 +201,8 @@ where
             .with_pnpmfile_hook(pnpmfile_hook)
             .with_read_package_log(read_package_log)
             .with_skipped_optional_log(skipped_optional_log)
+            .with_allowed_deprecated_versions(allowed_deprecated_versions)
+            .with_deprecation_log(deprecation_log)
             .with_auto_install_peers(auto_install_peers)
             .with_registries(registries),
     );

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -202,6 +202,8 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         pnpmfile_hook: None,
         read_package_log: None,
         skipped_optional_log: None,
+        allowed_deprecated_versions: BTreeMap::new(),
+        deprecation_log: None,
         pick_lowest_direct,
         time_based,
         wanted_lockfile: None,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1217,3 +1217,108 @@ async fn skips_an_optional_dependency_when_the_locked_entry_does_not_satisfy_the
     let direct = &result.peers.direct_dependencies_by_importer["."];
     assert!(!direct.contains_key("broken"), "the failing optional edge is dropped: {direct:?}");
 }
+
+/// A newly-resolved package whose manifest carries `deprecated` is
+/// forwarded to the deprecation sink once, and an
+/// `allowedDeprecatedVersions` entry satisfied by the resolved version
+/// suppresses the notification.
+#[tokio::test]
+async fn deprecated_manifests_notify_the_deprecation_sink_unless_allowed() {
+    for (allowed_range, expect_notification) in
+        [(None, true), (Some("^1.0.0"), false), (Some("^2.0.0"), true)]
+    {
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "old": "^1.0.0" }));
+        let importers = [WorkspaceImporter { id: "root".to_string(), manifest: &manifest }];
+        let resolver = RecordingResolver {
+            table: HashMap::from([(
+                ("old".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "old",
+                    "1.2.0",
+                    None,
+                    serde_json::json!({
+                        "name": "old",
+                        "version": "1.2.0",
+                        "deprecated": "use new instead",
+                    }),
+                ),
+            )]),
+            seen: Mutex::new(HashMap::new()),
+        };
+        let notifications = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&notifications);
+        let mut opts = workspace_opts(false, false);
+        if let Some(range) = allowed_range {
+            opts.allowed_deprecated_versions =
+                BTreeMap::from([("old".to_string(), range.to_string())]);
+        }
+        opts.deprecation_log = Some(std::sync::Arc::new(move |deprecation: crate::Deprecation| {
+            sink.lock().unwrap().push(deprecation);
+        }));
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+        })
+        .await
+        .expect("resolve workspace with a deprecated dependency");
+
+        let notifications = notifications.lock().unwrap();
+        if expect_notification {
+            let [deprecation] = notifications.as_slice() else {
+                panic!("expected one deprecation for range {allowed_range:?}: {notifications:?}");
+            };
+            assert_eq!(deprecation.pkg_name, "old");
+            assert_eq!(deprecation.pkg_version, "1.2.0");
+            assert_eq!(deprecation.deprecated, "use new instead");
+            assert_eq!(deprecation.depth, 0);
+            assert_eq!(
+                deprecation.prefix,
+                std::path::PathBuf::from("/repo").join("root").display().to_string(),
+            );
+        } else {
+            assert!(
+                notifications.is_empty(),
+                "range {allowed_range:?} must suppress the warning: {notifications:?}",
+            );
+        }
+    }
+}
+
+/// A dependency reused from the wanted lockfile still notifies the
+/// deprecation sink: the synthesized manifest round-trips the
+/// lockfile's `deprecated` metadata precisely so warm installs keep
+/// warning, matching pnpm's repeat-install behavior.
+#[tokio::test]
+async fn reused_lockfile_entries_still_notify_the_deprecation_sink() {
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({ "old": "^1.0.0" }));
+    let importers = [WorkspaceImporter { id: "root".to_string(), manifest: &manifest }];
+    let resolver = RecordingResolver { table: HashMap::new(), seen: Mutex::new(HashMap::new()) };
+    let mut lockfile = importer_scoped_update_lockfile(&["root"], "old", "^1.0.0", "1.2.0", None);
+    lockfile
+        .packages
+        .as_mut()
+        .expect("lockfile carries packages")
+        .get_mut(&"old@1.2.0".parse::<pacquet_lockfile::PkgNameVerPeer>().expect("parse key"))
+        .expect("direct entry")
+        .deprecated = Some("use new instead".to_string());
+    let notifications = std::sync::Arc::new(Mutex::new(Vec::new()));
+    let sink = std::sync::Arc::clone(&notifications);
+    let mut opts = workspace_opts(false, false);
+    opts.wanted_lockfile = Some(std::sync::Arc::new(lockfile));
+    opts.deprecation_log = Some(std::sync::Arc::new(move |deprecation: crate::Deprecation| {
+        sink.lock().unwrap().push(deprecation);
+    }));
+    resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+        importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+    })
+    .await
+    .expect("resolve workspace reusing the lockfile");
+
+    let notifications = notifications.lock().unwrap();
+    let [deprecation] = notifications.as_slice() else {
+        panic!("expected one deprecation from the reused entry: {notifications:?}");
+    };
+    assert_eq!(deprecation.pkg_name, "old");
+    assert_eq!(deprecation.pkg_version, "1.2.0");
+    assert_eq!(deprecation.deprecated, "use new instead");
+    assert_eq!(deprecation.depth, 0);
+}


### PR DESCRIPTION
## Summary

Implements native Rust deprecation warning emission for pacquet. When a package's registry manifest carries a `deprecated` field and its name+version is not covered by `pnpm.allowedDeprecatedVersions`, the resolver now emits a `pnpm:deprecation` NDJSON event through the reporter — matching the legacy TypeScript implementation at `pnpm11/installing/deps-resolver/src/resolveDependencies.ts:2119`.

The default reporter renders direct-dependency deprecations immediately and buffers transitive ones into a single summary line at `resolution_done`, matching `@pnpm/cli.default-reporter`'s `reportDeprecations.ts`.

Related to #11633

## Squash Commit Body

```text
feat(resolver): emit pnpm:deprecation events for deprecated packages

Detect deprecated package versions during resolution and emit
pnpm:deprecation NDJSON events, matching the TypeScript CLI's
deprecationLogger behavior.

The deprecation check runs once per newly-resolved package (on first
dedup-map insert). It extracts the `deprecated` field from the registry
manifest, checks it against `pnpm.allowedDeprecatedVersions` using
node-semver range satisfaction, and forwards the notification to the
install layer via a DeprecationLogFn callback (same pattern as the
existing SkippedOptionalLogFn).

The default reporter renders direct-dep deprecations immediately and
buffers transitive ones into a summary line at resolution_done.

Related to #11633
```

## Checklist

- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787008372&installation_id=145934176&pr_number=13135&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13135&signature=8127761f1c214744e210850c58e3b69ddf844ab6d93c0c5083b13092d1f2210e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `pnpm:deprecation` NDJSON log events when deprecated packages are detected during dependency resolution.
  * Reporter now renders deprecations as red warning lines: direct deprecations show immediately, while subdependency deprecations are buffered and emitted as a single aggregated summary at resolution completion (with zoomed deprecations omitting extra detail when the prefix differs).
  * Added workspace-level suppression to hide deprecations for configured `name@version` semver ranges.
* **Tests**
  * Expanded NDJSON wire-serialization and rendering tests for direct vs transitive deprecations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->