### PR TITLE
fix(auth): normalize subpath registry URLs with a trailing slash

### DIFF
--- a/.changeset/login-subpath-registry.md
+++ b/.changeset/login-subpath-registry.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fixed `pnpm login`, `pnpm adduser`, and `pnpm logout` against a registry hosted under a URL subpath (e.g. `https://example.com/npm/registry`) when the configured URL has no trailing slash. Such URLs were left unnormalized, so the last path segment was dropped when building the login and token endpoints and the auth token was stored under a truncated key. Registry URLs with a path now always get a trailing slash appended during normalization, matching how root-level registry URLs are handled.

--- a/__patches__/normalize-registry-url@2.0.1.patch
+++ b/__patches__/normalize-registry-url@2.0.1.patch
@@ -1,0 +1,15 @@
+diff --git a/index.js b/index.js
+index e03373cdeaff3d2d09f7dcf48beab0c5b7e221ac..7ce6d0616bf40aea1d8b9e4ec387bcff6e91281a 100644
+--- a/index.js
++++ b/index.js
+@@ -8,9 +8,6 @@ module.exports = function (registry) {
+     // Remove default ports (80 for HTTP, 443 for HTTPS) to ensure consistency
+     registry = new URL(registry).toString()
+   } catch {}
+-  if (
+-    registry.endsWith('/') ||
+-    registry.indexOf('/', registry.indexOf('//') + 2) != -1
+-  ) return registry
++  if (registry.endsWith('/')) return registry
+   return `${registry}/`
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,6 +915,7 @@ pnpmfileChecksum: sha256-C2XY6+pe0kqyHiBBFj5dX5DnhJzLAwdcic3kR7l3o5w=
 
 patchedDependencies:
   graceful-fs@4.2.11: 68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1
+  normalize-registry-url@2.0.1: e80227ac379f28c9f982c0588f5dfbcd517912bdd3a5c77a75e944c328fd8932
 
 importers:
 
@@ -1412,7 +1413,7 @@ importers:
         version: link:../../registry-access/client
       normalize-registry-url:
         specifier: 'catalog:'
-        version: 2.0.1
+        version: 2.0.1(patch_hash=e80227ac379f28c9f982c0588f5dfbcd517912bdd3a5c77a75e944c328fd8932)
       read-ini-file:
         specifier: 'catalog:'
         version: 5.0.0
@@ -2372,7 +2373,7 @@ importers:
         version: link:../../core/types
       normalize-registry-url:
         specifier: 'catalog:'
-        version: 2.0.1
+        version: 2.0.1(patch_hash=e80227ac379f28c9f982c0588f5dfbcd517912bdd3a5c77a75e944c328fd8932)
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
@@ -2541,7 +2542,7 @@ importers:
         version: 4.1.1
       normalize-registry-url:
         specifier: 'catalog:'
-        version: 2.0.1
+        version: 2.0.1(patch_hash=e80227ac379f28c9f982c0588f5dfbcd517912bdd3a5c77a75e944c328fd8932)
       path-absolute:
         specifier: 'catalog:'
         version: 2.0.0
@@ -8293,7 +8294,7 @@ importers:
         version: 3.0.0
       normalize-registry-url:
         specifier: 'catalog:'
-        version: 2.0.1
+        version: 2.0.1(patch_hash=e80227ac379f28c9f982c0588f5dfbcd517912bdd3a5c77a75e944c328fd8932)
       npm-registry-fetch:
         specifier: 'catalog:'
         version: 19.1.1(supports-color@10.2.2)
@@ -18413,7 +18414,7 @@ snapshots:
       is-subdir: 1.2.0
       is-windows: 1.0.2
       lodash.kebabcase: 4.1.1
-      normalize-registry-url: 2.0.1
+      normalize-registry-url: 2.0.1(patch_hash=e80227ac379f28c9f982c0588f5dfbcd517912bdd3a5c77a75e944c328fd8932)
       path-absolute: 1.0.1
       path-name: 1.0.0
       ramda: '@pnpm/ramda@0.28.1'
@@ -23402,7 +23403,7 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
-  normalize-registry-url@2.0.1: {}
+  normalize-registry-url@2.0.1(patch_hash=e80227ac379f28c9f982c0588f5dfbcd517912bdd3a5c77a75e944c328fd8932): {}
 
   normalize-url@6.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -518,6 +518,7 @@ packageExtensions:
 
 patchedDependencies:
   graceful-fs@4.2.11: __patches__/graceful-fs@4.2.11.patch
+  normalize-registry-url@2.0.1: __patches__/normalize-registry-url@2.0.1.patch
 
 patchesDir: __patches__
 

--- a/pnpm/crates/auth-commands/src/login/test_classic_login.rs
+++ b/pnpm/crates/auth-commands/src/login/test_classic_login.rs
@@ -63,6 +63,45 @@ async fn should_fall_back_to_classic_login_when_web_login_returns_404() {
 }
 
 #[tokio::test]
+async fn should_fall_back_to_classic_login_on_a_subpath_registry_without_a_trailing_slash() {
+    web_auth_fake!();
+    login_fake!(FakeHost, set_prompt_input, set_prompt_password, login_writes);
+    reset();
+    reset_login();
+    set_prompt_input(credential_prompts("john", "john@example.com"));
+    set_prompt_password(Box::new(|_| Ok("secret".to_owned())));
+
+    let mut server = mockito::Server::new_async().await;
+    let login_mock = server
+        .mock("POST", "/npm/registry/-/v1/login")
+        .with_status(404)
+        .with_body("Not Found")
+        .create_async()
+        .await;
+    let add_user_mock = server
+        .mock("PUT", "/npm/registry/-/user/org.couchdb.user:john")
+        .with_status(201)
+        .with_body(json!({"ok": true, "token": "subpath-classic-token"}).to_string())
+        .create_async()
+        .await;
+    let registry = format!("{}/npm/registry", server.url());
+    let config_dir = Path::new("/mock/config");
+
+    let result = login::<FakeHost, RecordingReporter>(&client(), opts(&registry, config_dir))
+        .await
+        .expect("classic login succeeds on a subpath registry");
+
+    login_mock.assert_async().await;
+    add_user_mock.assert_async().await;
+    assert_eq!(result, format!("Logged in on {registry}/"));
+
+    let writes = login_writes();
+    let token_key = format!("{}:_authToken", nerf_dart(&format!("{registry}/")));
+    assert_eq!(written_settings(&writes).get(&token_key), Some("subpath-classic-token"));
+    assert_eq!(infos(), ["Logged in as john"]);
+}
+
+#[tokio::test]
 async fn should_fall_back_to_classic_login_when_web_login_returns_405() {
     web_auth_fake!();
     login_fake!(FakeHost, set_prompt_input, set_prompt_password, login_writes);

--- a/pnpm/crates/auth-commands/src/login/test_web_login.rs
+++ b/pnpm/crates/auth-commands/src/login/test_web_login.rs
@@ -58,6 +58,36 @@ async fn should_use_web_login_when_registry_supports_it() {
 }
 
 #[tokio::test]
+async fn should_log_in_to_a_registry_under_a_subpath_without_a_trailing_slash() {
+    web_auth_fake!();
+    login_fake!(FakeHost, login_writes);
+    reset();
+    reset_login();
+    set_fetch(Box::new(|| Ok(ok_token("subpath-token"))));
+
+    let mut server = mockito::Server::new_async().await;
+    let login_mock = server
+        .mock("POST", "/npm/registry/-/v1/login")
+        .with_status(200)
+        .with_body(json!({"loginUrl": "https://example.com/auth/login", "doneUrl": "https://example.com/auth/done"}).to_string())
+        .create_async()
+        .await;
+    let registry = format!("{}/npm/registry", server.url());
+    let config_dir = Path::new("/mock/config");
+
+    let result = login::<FakeHost, RecordingReporter>(&client(), opts(&registry, config_dir))
+        .await
+        .expect("web login succeeds on a subpath registry");
+
+    login_mock.assert_async().await;
+    assert_eq!(result, format!("Logged in on {registry}/"));
+
+    let writes = login_writes();
+    let token_key = format!("{}:_authToken", nerf_dart(&format!("{registry}/")));
+    assert_eq!(written_settings(&writes).get(&token_key), Some("subpath-token"));
+}
+
+#[tokio::test]
 async fn should_succeed_when_config_file_does_not_exist() {
     web_auth_fake!();
     login_fake!(FakeHost, set_ini_read, login_writes);

--- a/pnpm/crates/auth-commands/src/logout/tests.rs
+++ b/pnpm/crates/auth-commands/src/logout/tests.rs
@@ -509,6 +509,38 @@ async fn handles_registry_with_a_path() {
 }
 
 #[tokio::test]
+async fn handles_registry_under_a_subpath_without_a_trailing_slash() {
+    recording_reporter!(Rep, EVENTS);
+    sys_fake!(
+        Sys,
+        writes = WRITES,
+        revokes = REVOKES,
+        read = { Ok("//example.com/npm/registry/:_authToken=subpath-token\n".to_string()) },
+        revoke = RevokeOutcome::Revoked,
+    );
+    let auth = auth_config(&[("//example.com/npm/registry/:_authToken", "subpath-token")]);
+    let result = logout::<Sys, Rep>(
+        &unused_client(),
+        LogoutOptions {
+            registry: Some("https://example.com/npm/registry"),
+            auth_config: &auth,
+            config_dir: Path::new("/config"),
+            retry: no_retry(),
+            prefix: "/mock",
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(result, "Logged out of https://example.com/npm/registry/");
+    assert_eq!(
+        REVOKES.lock().unwrap()[0].0,
+        "https://example.com/npm/registry/-/user/token/subpath-token"
+    );
+    assert_eq!(WRITES.lock().unwrap()[0].1, "");
+}
+
+#[tokio::test]
 async fn propagates_auth_ini_write_errors() {
     recording_reporter!(Rep, EVENTS);
     // `sys_fake!`'s write always succeeds, so this branch needs a

--- a/pnpm/crates/auth-commands/src/logout/tests.rs
+++ b/pnpm/crates/auth-commands/src/logout/tests.rs
@@ -535,7 +535,7 @@ async fn handles_registry_under_a_subpath_without_a_trailing_slash() {
     assert_eq!(result, "Logged out of https://example.com/npm/registry/");
     assert_eq!(
         REVOKES.lock().unwrap()[0].0,
-        "https://example.com/npm/registry/-/user/token/subpath-token"
+        "https://example.com/npm/registry/-/user/token/subpath-token",
     );
     assert_eq!(WRITES.lock().unwrap()[0].1, "");
 }

--- a/pnpm11/auth/commands/test/login.test.ts
+++ b/pnpm11/auth/commands/test/login.test.ts
@@ -143,6 +143,97 @@ describe('login', () => {
     ])
   })
 
+  it('should log in to a registry under a subpath when the URL has no trailing slash', async () => {
+    const fetchedUrls: string[] = []
+    let savedSettings: Record<string, unknown> = {}
+    const context = createMockContext({
+      globalInfo: jest.fn(),
+      readIniFile: async () => ({}),
+      writeIniFile: async (_configPath, settings) => {
+        savedSettings = settings
+      },
+      fetch: async url => {
+        fetchedUrls.push(url)
+        if (url === 'https://example.com/npm/registry/-/v1/login') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: {
+              loginUrl: 'https://example.com/auth/login',
+              doneUrl: 'https://example.com/auth/done',
+            },
+          })
+        }
+        if (url === 'https://example.com/auth/done') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: { token: 'subpath-token' },
+          })
+        }
+        throw new Error(`Unexpected call to fetch: ${url}`)
+      },
+    })
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://example.com/npm/registry' }
+    const result = await login({ context, opts })
+    expect(result).toBe('Logged in on https://example.com/npm/registry/')
+    expect(fetchedUrls[0]).toBe('https://example.com/npm/registry/-/v1/login')
+    expect(savedSettings).toMatchObject({
+      '//example.com/npm/registry/:_authToken': 'subpath-token',
+    })
+  })
+
+  it('should fall back to classic login on a registry under a subpath when the URL has no trailing slash', async () => {
+    const fetchedUrls: string[] = []
+    let savedSettings: Record<string, unknown> = {}
+    const context = createMockContext({
+      globalInfo: jest.fn(),
+      readIniFile: async () => ({}),
+      writeIniFile: async (_configPath, settings) => {
+        savedSettings = settings
+      },
+      fetch: async url => {
+        fetchedUrls.push(url)
+        if (url === 'https://example.com/npm/registry/-/v1/login') {
+          return createMockResponse({
+            ok: false,
+            status: 404,
+            text: 'Not Found',
+          })
+        }
+        if (url === 'https://example.com/npm/registry/-/user/org.couchdb.user:john') {
+          return createMockResponse({
+            ok: true,
+            status: 201,
+            json: { ok: true, token: 'subpath-classic-token' },
+          })
+        }
+        throw new Error(`Unexpected call to fetch: ${url}`)
+      },
+      enquirer: {
+        input: async (opts: { message: string }): Promise<string> => {
+          if (opts.message === 'Username:') return 'john'
+          if (opts.message === 'Email (this IS public):') return 'john@example.com'
+          throw new Error(`Unexpected call to enquirer.input: ${opts.message}`)
+        },
+        password: async (opts: { message: string }): Promise<string> => {
+          if (opts.message === 'Password:') return 'secret'
+          throw new Error(`Unexpected call to enquirer.password: ${opts.message}`)
+        },
+      },
+    })
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://example.com/npm/registry' }
+    const result = await login({ context, opts })
+    expect(result).toBe('Logged in on https://example.com/npm/registry/')
+    expect(fetchedUrls).toEqual([
+      'https://example.com/npm/registry/-/v1/login',
+      'https://example.com/npm/registry/-/user/org.couchdb.user:john',
+    ])
+    expect(savedSettings).toMatchObject({
+      '//example.com/npm/registry/:_authToken': 'subpath-classic-token',
+    })
+  })
+
   it('should persist a scoped auth token and scope registry mapping when --scope is provided', async () => {
     let savedSettings: Record<string, unknown> = {}
     const context = createMockContext({

--- a/pnpm11/auth/commands/test/logout.test.ts
+++ b/pnpm11/auth/commands/test/logout.test.ts
@@ -406,4 +406,37 @@ describe('logout', () => {
     )
     expect(savedSettings).not.toHaveProperty(['//example.com/npm/:_authToken'])
   })
+
+  it('should handle a registry under a subpath when the URL has no trailing slash', async () => {
+    const fetch = jest.fn<LogoutContext['fetch']>(async () => createMockResponse({ ok: true, status: 200 }))
+    let savedSettings: Record<string, unknown> = {}
+
+    const context = createMockContext({
+      fetch,
+      readIniFile: async () => ({
+        '//example.com/npm/registry/:_authToken': 'subpath-token',
+      }),
+      writeIniFile: async (_configPath, settings) => {
+        savedSettings = settings
+      },
+    })
+
+    const opts = {
+      configDir: '/config',
+      dir: '/mock',
+      authConfig: {
+        '//example.com/npm/registry/:_authToken': 'subpath-token',
+      },
+      registry: 'https://example.com/npm/registry',
+    }
+
+    const result = await logout({ context, opts })
+
+    expect(result).toBe('Logged out of https://example.com/npm/registry/')
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com/npm/registry/-/user/token/subpath-token',
+      expect.anything()
+    )
+    expect(savedSettings).not.toHaveProperty(['//example.com/npm/registry/:_authToken'])
+  })
 })

--- a/pnpm11/config/reader/test/getNetworkConfigs.test.ts
+++ b/pnpm11/config/reader/test/getNetworkConfigs.test.ts
@@ -14,7 +14,7 @@ test('without files', () => {
     '@foo:registry': 'https://example.com/foo',
   })).toStrictEqual({
     registries: {
-      '@foo': 'https://example.com/foo',
+      '@foo': 'https://example.com/foo/',
     },
   } as NetworkConfigs)
 
@@ -46,7 +46,7 @@ test('without files', () => {
     '//example.com/foo:cert': 'some-cert',
   })).toStrictEqual({
     registries: {
-      '@foo': 'https://example.com/foo',
+      '@foo': 'https://example.com/foo/',
     },
     configByUri: {
       '//example.com/foo': {
@@ -68,7 +68,7 @@ test('with files', () => {
     '//example.com/foo:certfile': 'certfile',
   })).toStrictEqual({
     registries: {
-      '@foo': 'https://example.com/foo',
+      '@foo': 'https://example.com/foo/',
     },
     configByUri: {
       '//example.com/foo': {
@@ -84,7 +84,7 @@ test('auth and tls combined', () => {
     '//example.com/foo:_authToken': 'example auth token',
   })).toStrictEqual({
     registries: {
-      '@foo': 'https://example.com/foo',
+      '@foo': 'https://example.com/foo/',
     },
     configByUri: {
       '//example.com/foo': {
@@ -98,7 +98,7 @@ test('auth and tls combined', () => {
     '//example.com/foo:_auth': btoa('foo:bar'),
   })).toStrictEqual({
     registries: {
-      '@foo': 'https://example.com/foo',
+      '@foo': 'https://example.com/foo/',
     },
     configByUri: {
       '//example.com/foo': {
@@ -118,7 +118,7 @@ test('auth and tls combined', () => {
     '//example.com/foo:_password': btoa('bar'),
   })).toStrictEqual({
     registries: {
-      '@foo': 'https://example.com/foo',
+      '@foo': 'https://example.com/foo/',
     },
     configByUri: {
       '//example.com/foo': {
@@ -137,7 +137,7 @@ test('auth and tls combined', () => {
     '//example.com/foo:tokenHelper': 'node ./my-token-helper.cjs',
   })).toStrictEqual({
     registries: {
-      '@foo': 'https://example.com/foo',
+      '@foo': 'https://example.com/foo/',
     },
     configByUri: {
       '//example.com/foo': {
@@ -211,7 +211,7 @@ test('unsupported key', () => {
     '//example.com/foo:someUnsupportedKey': 'hello world',
   })).toStrictEqual({
     registries: {
-      '@foo': 'https://example.com/foo',
+      '@foo': 'https://example.com/foo/',
     },
   } as NetworkConfigs)
 })

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -682,7 +682,7 @@ test('registries of scoped packages are read and normalized', async () => {
     '@jsr': 'https://npm.jsr.io/',
     '@foo': 'https://foo.com/',
     '@bar': 'https://bar.com/',
-    '@qar': 'https://qar.com/qar',
+    '@qar': 'https://qar.com/qar/',
   })
 })
 
@@ -706,7 +706,7 @@ test('registries in current directory\'s .npmrc have bigger priority then global
     '@jsr': 'https://npm.jsr.io/',
     '@foo': 'https://foo.com/',
     '@bar': 'https://bar.com/',
-    '@qar': 'https://qar.com/qar',
+    '@qar': 'https://qar.com/qar/',
   })
   expect(config.packageManagerRegistries?.default).toBe('https://default.com/')
 })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

`pnpm login` (and `adduser` / `logout`) failed against a registry hosted under a URL subpath (e.g. `https://example.com/npm/registry`) whenever the configured URL had no trailing slash. `normalize-registry-url@2.0.1` returns URLs that already contain a path unchanged instead of appending the trailing slash, and the WHATWG relative resolution used to build the `-/v1/login`, couchdb-user, and token-revocation endpoints then drops the last path segment — the CLI contacted `https://example.com/npm/-/v1/login` instead of `https://example.com/npm/registry/-/v1/login` and stored the auth token under a truncated key. Root-level registries and subpath URLs written *with* a trailing slash were unaffected.

The fix patches `normalize-registry-url` through `patchedDependencies` (the same mechanism as the existing `graceful-fs` patch) so the trailing slash is always appended. That repairs every consumer at once: the config reader, login, logout, and the publish registry keys. The resulting endpoints match what the npm CLI produces for the same configuration (npm joins registry and path by stripping/re-adding the slash at request time, so it never had this bug).

The Rust CLI already normalizes correctly (`registry_url.rs` appends the slash unconditionally), so it gains only the mirrored subpath-without-trailing-slash tests for web login, classic login, and logout — no behavior change, hence the changeset targets only `pnpm`.

The lockfile diff is limited to the patch hashes. A full install also wanted to re-resolve unrelated `@types/node` jest peer contexts from 22.x to 26.x (against the catalog's documented 22.x pin); that churn was deliberately kept out, and the resulting lockfile was verified with both a full and a `--frozen-lockfile` install.

Follow-up (out of scope here): publishing a fixed `normalize-registry-url` 2.0.2 upstream would let us drop the patch on the next dependency bump and would also fix external consumers of the published `@pnpm/*` v11 library packages, which resolve the unpatched 2.0.1 from npm.

## Squash Commit Body

```text
pnpm login, pnpm adduser, and pnpm logout dropped the last path segment
of a registry hosted under a URL subpath when the configured URL had no
trailing slash: normalize-registry-url 2.0.1 returns URLs that already
contain a path unchanged instead of appending the slash, and the WHATWG
relative resolution used to build the -/v1/login, couchdb-user, and
token-revocation endpoints then resolves against the truncated parent
path. The auth token was likewise stored under a truncated key.
Registries at a domain root were unaffected, and so were subpath URLs
written with a trailing slash.

Fix the package once for every consumer (config reader, login, logout,
publish registry keys) with a patchedDependencies patch that always
appends the trailing slash, matching the Rust CLI, whose normalization
was already correct. The lockfile diff is limited to the patch hashes;
the unrelated peer-context re-resolution a full install wanted to make
was reverted deliberately.

The config-reader test expectations that encoded the old truncating
behavior are updated to expect the trailing slash. The Rust side gains
the mirrored subpath-without-trailing-slash tests for web login, classic
login, and logout; its behavior is unchanged.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787039937&installation_id=145934176&pr_number=13137&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13137&signature=3922ef79dad6f9c35b9a3636d6789199d4bd7989d15015f164fc30a51ccd1e1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm login`, `adduser`, and `logout` for registries hosted under URL subpaths without trailing slashes.
  * Preserved registry subpaths when creating authentication and token-revocation endpoints.
  * Ensured authentication tokens are stored and removed using the correct normalized registry URL.
  * Standardized normalized registry URLs to include a trailing slash. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->