### PR TITLE
fix(pacquet): do not narrow a partial add's install to its save-target group

### DIFF
--- a/.changeset/add-keeps-all-dependency-groups.md
+++ b/.changeset/add-keeps-all-dependency-groups.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm add` no longer narrows the install to the dependency group it saves into. Previously the group leaked into the install as an include filter, so `pnpm add` of a package with `optionalDependencies` swept the just-installed optional packages from the virtual store, leaving dangling symlinks — `pnpm add -g @openai/codex` produced a broken `codex` bin that failed with "Missing optional dependency `@openai/codex-darwin-arm64`" — and a production `pnpm add` dropped the project's `devDependencies` from `pnpm-lock.yaml` and `node_modules`.

--- a/.changeset/add-keeps-all-dependency-groups.md
+++ b/.changeset/add-keeps-all-dependency-groups.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm add` no longer narrows the install to the dependency group it saves into. Previously the group leaked into the install as an include filter, so `pnpm add` of a package with `optionalDependencies` swept the just-installed optional packages from the virtual store, leaving dangling symlinks — `pnpm add -g @openai/codex` produced a broken `codex` bin that failed with "Missing optional dependency `@openai/codex-darwin-arm64`" — and a production `pnpm add` dropped the project's `devDependencies` from `pnpm-lock.yaml` and `node_modules`.
+`pnpm add` no longer drops the other dependency groups from the install: adding a package with `optionalDependencies` no longer leaves dangling optional-dependency symlinks in the virtual store (`pnpm add -g @openai/codex` produced a `codex` bin that failed with "Missing optional dependency `@openai/codex-darwin-arm64`"), and a production `pnpm add` no longer removes the project's `devDependencies` from `pnpm-lock.yaml` and `node_modules`.

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -601,9 +601,11 @@ fn add_without_version_respects_minimum_release_age() {
 }
 
 /// `add` saves into one dependency group, but its install must keep every
-/// group: the transitive optionals of the added package have to be
-/// materialized (not swept as surplus right after linking, which left the
-/// alias symlink dangling — the `pnpm add -g @openai/codex` failure).
+/// group: the added package's transitive optionals must be materialized in
+/// the virtual store and recorded in the current lockfile, and the alias
+/// symlink inside the dependent package must resolve. A missing slot here
+/// is what breaks a globally installed bin at runtime with "Missing
+/// optional dependency" (e.g. `@openai/codex`'s platform binary).
 #[test]
 fn add_materializes_transitive_optional_dependencies() {
     let (root, workspace, anchor) =
@@ -632,8 +634,8 @@ fn add_materializes_transitive_optional_dependencies() {
 }
 
 /// `add` into one dependency group must leave the other groups' entries in
-/// the wanted lockfile and `node_modules` — a prod `add` used to erase the
-/// project's devDependencies from both.
+/// the wanted lockfile and `node_modules`: a prod `add` must not erase the
+/// project's devDependencies from either.
 #[test]
 fn add_keeps_entries_of_other_dependency_groups() {
     let (root, workspace, anchor) =

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -599,3 +599,63 @@ fn add_without_version_respects_minimum_release_age() {
 
     drop((root, npmrc_info)); // cleanup
 }
+
+/// `add` saves into one dependency group, but its install must keep every
+/// group: the transitive optionals of the added package have to be
+/// materialized (not swept as surplus right after linking, which left the
+/// alias symlink dangling — the `pnpm add -g @openai/codex` failure).
+#[test]
+fn add_materializes_transitive_optional_dependencies() {
+    let (root, workspace, anchor) =
+        exec_pacquet_in_temp_cwd(["add", "@pnpm.e2e/pkg-with-good-optional"]);
+
+    let virtual_store = workspace.join("node_modules").join(".pnpm");
+    assert!(
+        virtual_store.join("is-positive@1.0.0").exists(),
+        "the transitive optional dependency must be materialized",
+    );
+    assert!(
+        virtual_store
+            .join("@pnpm.e2e+pkg-with-good-optional@1.0.0/node_modules/is-positive/package.json")
+            .exists(),
+        "the optional dependency alias symlink must resolve",
+    );
+
+    let current_lockfile = std::fs::read_to_string(virtual_store.join("lock.yaml"))
+        .expect("read the current lockfile");
+    assert!(
+        current_lockfile.contains("is-positive@1.0.0"),
+        "the current lockfile must record the materialized optional:\n{current_lockfile}",
+    );
+
+    drop((root, anchor)); // cleanup
+}
+
+/// `add` into one dependency group must leave the other groups' entries in
+/// the wanted lockfile and `node_modules` — a prod `add` used to erase the
+/// project's devDependencies from both.
+#[test]
+fn add_keeps_entries_of_other_dependency_groups() {
+    let (root, workspace, anchor) =
+        exec_pacquet_in_temp_cwd(["add", "--save-dev", "@pnpm.e2e/hello-world-js-bin"]);
+
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["add", "@pnpm.e2e/hello-world-js-bin-parent"])
+        .assert()
+        .success();
+
+    let lockfile = std::fs::read_to_string(workspace.join("pnpm-lock.yaml"))
+        .expect("read the wanted lockfile");
+    assert!(
+        lockfile.contains("devDependencies"),
+        "the wanted lockfile must keep the dev dependency after a prod add:\n{lockfile}",
+    );
+    assert!(
+        workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin/package.json").exists(),
+        "the dev dependency's node_modules link must survive a prod add",
+    );
+
+    drop((root, anchor)); // cleanup
+}

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -125,6 +125,48 @@ fn global_add_list_remove_round_trip() {
     drop(root);
 }
 
+/// A global add must materialize the added package's transitive
+/// `optionalDependencies` in the group's virtual store. They used to be
+/// swept as surplus right after linking, leaving a dangling alias symlink —
+/// the `pnpm add -g @openai/codex` "missing optional dependency
+/// `@openai/codex-darwin-arm64`" failure.
+#[cfg(unix)]
+#[test]
+fn global_add_materializes_transitive_optional_dependencies() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_pkg_dir = pnpm_home.join("global").join("v11");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["add", "-g", "@pnpm.e2e/pkg-with-good-optional"])
+        .assert()
+        .success();
+
+    let links = symlink_entries(&global_pkg_dir);
+    assert_eq!(links.len(), 1, "exactly one cache-keyed hash symlink should exist: {links:?}");
+    // The hash symlink's target is relative to the global packages dir.
+    let install_dir = global_pkg_dir.join(fs::read_link(&links[0]).expect("read the hash symlink"));
+    let virtual_store = install_dir.join("node_modules").join(".pnpm");
+    assert!(
+        virtual_store.join("is-positive@1.0.0").exists(),
+        "the transitive optional dependency must be materialized",
+    );
+    assert!(
+        virtual_store
+            .join("@pnpm.e2e+pkg-with-good-optional@1.0.0/node_modules/is-positive/package.json")
+            .exists(),
+        "the optional dependency alias symlink must resolve",
+    );
+
+    drop(npmrc_info);
+    drop(root);
+}
+
 /// `pnpm setup` installs the standalone executable through this exact
 /// command shape. The local directory's package name must be inferred
 /// without treating the `file:` selector as a registry package.

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -126,10 +126,10 @@ fn global_add_list_remove_round_trip() {
 }
 
 /// A global add must materialize the added package's transitive
-/// `optionalDependencies` in the group's virtual store. They used to be
-/// swept as surplus right after linking, leaving a dangling alias symlink —
-/// the `pnpm add -g @openai/codex` "missing optional dependency
-/// `@openai/codex-darwin-arm64`" failure.
+/// `optionalDependencies` in the group's virtual store: a missing slot
+/// dangles the alias symlink, and the globally installed bin then fails at
+/// runtime with "Missing optional dependency" (e.g. `@openai/codex`'s
+/// platform binary).
 #[cfg(unix)]
 #[test]
 fn global_add_materializes_transitive_optional_dependencies() {

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -1,7 +1,7 @@
 use crate::{
-    CatalogDecision, CatalogModeDep, CatalogVersionMismatchError, Install, InstallError,
-    ResolvedPackages, UpdateSeedPolicy, WorkspaceInstallSelection, decide_catalog_outcome,
-    emit_initial_package_manifest, package_manifest_prefix,
+    CatalogDecision, CatalogModeDep, CatalogVersionMismatchError, DIRECT_GROUPS, Install,
+    InstallError, ResolvedPackages, UpdateSeedPolicy, WorkspaceInstallSelection,
+    decide_catalog_outcome, emit_initial_package_manifest, package_manifest_prefix,
     resolution_policy::{PickPolicy, pick_package_context},
     resolve_latest::LatestPicker,
     selected_project_indices,
@@ -195,7 +195,12 @@ where
             emit_initial_manifest: false,
             lockfile: MaybeLazyLockfile::Loaded(lockfile),
             lockfile_path,
-            dependency_groups,
+            // `dependency_groups` names the manifest group the new
+            // package is saved into (`prepare_manifest` above), not an
+            // include filter: like `remove`, the re-resolve walks every
+            // dependency group so the other groups' entries stay in the
+            // lockfile, the virtual store, and `node_modules`.
+            dependency_groups: DIRECT_GROUPS,
             frozen_lockfile: false,
             // `pacquet add` mutates the manifest, so the lockfile is
             // necessarily stale by the time the install dispatch
@@ -296,7 +301,10 @@ where
                 emit_initial_manifest: false,
                 lockfile: MaybeLazyLockfile::Loaded(lockfile),
                 lockfile_path,
-                dependency_groups,
+                // See the `dependency_groups` comment in [`Self::run`]:
+                // the save target must not narrow the install's include
+                // set.
+                dependency_groups: DIRECT_GROUPS,
                 frozen_lockfile: false,
                 prefer_frozen_lockfile: Some(false),
                 ignore_manifest_check: false,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -176,9 +176,8 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     /// A full workspace install versus a partial one (`pacquet add` and the
     /// package installs built on it — `dlx`, global add, the engine install).
     /// See [`crate::Install::is_full_install`]. Gates the `--no-optional`
-    /// exclusion: a partial add's `dependency_groups` names the manifest
-    /// group to save into, not a `--no-optional` intent, so it must not
-    /// drop the added package's transitive optionals.
+    /// exclusion: only a full install's `dependency_groups` carries that
+    /// intent, so a partial run must not drop transitive optionals.
     pub is_full_install: bool,
     /// Which lockfile pins to withhold from the preferred-versions seed
     /// so the affected names re-resolve to the highest version
@@ -1843,11 +1842,12 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // it out of materialization and `.modules.yaml.skipped` yet leaves it
         // in the lockfile, so a later install without the flag restores it.
         //
-        // Gated on `is_full_install`: for a partial `add` (and the package
-        // installs built on it — `dlx`, global add, the engine install)
-        // `dependency_groups` names the manifest group to save into, not a
-        // `--no-optional` intent, so those must keep their transitive
-        // optionals (e.g. `@pnpm/exe`'s platform binary).
+        // Gated on `is_full_install`: only a full install's
+        // `dependency_groups` carries a `--no-optional` intent. Partial
+        // runs either pass every direct group (`add`, `remove`, `update`)
+        // or narrow the groups for reasons of their own (`fetch --dev`,
+        // `rebuild`), and must keep their transitive optionals (e.g.
+        // `@pnpm/exe`'s platform binary on the engine install).
         if is_full_install
             && !dependency_groups.contains(&DependencyGroup::Optional)
             && let Some(snapshots) = initial_materialization_lockfile.snapshots.as_ref()

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -110,6 +110,19 @@ pub use validate_lockfile_paths::*;
 pub use version_policy::*;
 pub use virtual_store_layout::*;
 
+/// The dependency groups a project installs directly — `dependencies`,
+/// `devDependencies`, `optionalDependencies` — in the order pnpm's
+/// `updateProjectManifest` walks them. This is also the install `include`
+/// set for runs whose `dependency_groups` carries no user filter intent
+/// (`add`, `remove`, `update`): those mutations pick a manifest group to
+/// save into separately, and the install itself must keep resolving and
+/// materializing every group.
+pub(crate) const DIRECT_GROUPS: [pacquet_package_manifest::DependencyGroup; 3] = [
+    pacquet_package_manifest::DependencyGroup::Prod,
+    pacquet_package_manifest::DependencyGroup::Dev,
+    pacquet_package_manifest::DependencyGroup::Optional,
+];
+
 pub(crate) fn package_manifest_prefix(
     manifest: &pacquet_package_manifest::PackageManifest,
 ) -> String {

--- a/pnpm/crates/package-manager/src/remove.rs
+++ b/pnpm/crates/package-manager/src/remove.rs
@@ -1,6 +1,7 @@
 use crate::{
-    Install, InstallError, ResolvedPackages, UpdateSeedPolicy, WorkspaceInstallSelection,
-    emit_initial_package_manifest, package_manifest_prefix, selected_project_indices,
+    DIRECT_GROUPS, Install, InstallError, ResolvedPackages, UpdateSeedPolicy,
+    WorkspaceInstallSelection, emit_initial_package_manifest, package_manifest_prefix,
+    selected_project_indices,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -224,9 +225,6 @@ impl Remove<'_> {
         Ok(())
     }
 }
-
-const DIRECT_GROUPS: [DependencyGroup; 3] =
-    [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
 
 fn validate_selected_remove(package_names: &[String]) -> Result<(), RemoveValidationError> {
     if package_names.is_empty() {

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -1,8 +1,9 @@
 use crate::{
-    CatalogDecision, CatalogModeDep, CatalogVersionMismatchError, ImporterUpdateSeedPolicy,
-    Install, InstallError, ResolvedPackages, UpdateSeedPolicy, WorkspaceInstallSelection,
-    decide_catalog, emit_initial_package_manifest, package_manifest_prefix,
-    resolution_policy::PickPolicy, resolve_latest::LatestPicker, selected_project_indices,
+    CatalogDecision, CatalogModeDep, CatalogVersionMismatchError, DIRECT_GROUPS,
+    ImporterUpdateSeedPolicy, Install, InstallError, ResolvedPackages, UpdateSeedPolicy,
+    WorkspaceInstallSelection, decide_catalog, emit_initial_package_manifest,
+    package_manifest_prefix, resolution_policy::PickPolicy, resolve_latest::LatestPicker,
+    selected_project_indices,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -25,11 +26,6 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-
-/// The three dependency groups `pacquet update` considers as "direct"
-/// targets, in the order pnpm's `updateProjectManifest` walks them.
-const DIRECT_GROUPS: [DependencyGroup; 3] =
-    [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
 
 /// Everything `pacquet update` (alias `up` / `upgrade`) does.
 ///


### PR DESCRIPTION
## Summary

`pnpm add -g @openai/codex` (pnpm v12.0.0-alpha.15) produced a broken global bin: the platform binary `@openai/codex-darwin-arm64` was resolved, downloaded, and linked, but its virtual-store directory was swept as surplus right after linking, leaving a dangling alias symlink and a `codex` bin that fails at runtime with "Missing optional dependency `@openai/codex-darwin-arm64`".

Root cause: `Add` passed the manifest group the new package is saved into (`[Prod]` for a plain `pnpm add`) into `Install.dependency_groups`, which the install pipeline treats as the *include filter* (the meaning it has for `install --prod` / `fetch --dev`). Beyond the global-install symptom, this made a prod `pnpm add` erase the project's `devDependencies` from `pnpm-lock.yaml` and `node_modules` (and vice versa for `add -D`), and recorded a narrowed `included` set in `.modules.yaml`. The bug is only visible in the classic `.pnpm` virtual-store layout (global installs always use it; `enableGlobalVirtualStore` masks it) and only in the fresh-lockfile path (the frozen path was always correct).

The fix passes the full direct-group set (`Prod`, `Dev`, `Optional`) from `Add` to `Install`, exactly as `remove` and `update` already do; the save-target group keeps driving only the manifest mutation. The previously duplicated `DIRECT_GROUPS` const is hoisted into the crate root now that it has three consumers.

Regression tests: two in `tests/add.rs` (transitive optionals survive the sweep; other groups' entries survive a prod add) and one global e2e in `tests/global.rs` mirroring the original report. All three fail with the fix reverted.

## Squash Commit Body

```text
`Add` passed the manifest group the new package is saved into (e.g.
`Prod` for a plain `pnpm add`) straight into `Install.dependency_groups`,
which the install pipeline treats as the include filter — the meaning it
has for `install --prod` or `fetch --dev`. In the fresh-lockfile path
this caused:

- The resolver walked only the save-target group, so a prod add erased
  the project's devDependencies from `pnpm-lock.yaml` and unlinked them
  from `node_modules` (and vice versa for `add -D`).
- The narrowed include set filtered transitive optionals out of the
  current `lock.yaml`, so the virtual-store sweep removed the freshly
  linked optional packages right after linking, leaving dangling alias
  symlinks. Running `pnpm add -g` for `@openai/codex` produced a broken
  global bin failing with "Missing optional dependency
  `@openai/codex-darwin-arm64`" — global installs always hit this
  because they force the classic virtual-store layout.
- `.modules.yaml` recorded the narrowed `included` set, poisoning later
  installs' up-to-date checks.

Pass `DIRECT_GROUPS` (Prod, Dev, Optional) to `Install` from `Add`, as
`remove` and `update` already do; the save-target keeps driving only
`prepare_manifest`. The const is hoisted into the crate root now that it
has three consumers. Keying off `is_full_install` instead would be
wrong: `fetch --dev` and `rebuild` are partial installs whose groups
carry genuine filter intent.

The frozen-lockfile path was never affected, and the TypeScript CLI
derives its include set from config rather than the target field, so no
TS-side change is needed.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only:
  the TypeScript CLI derives its include set from config, not the save-target
  field, and was verified unaffected — nothing to port.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787040227&installation_id=145934176&pr_number=13138&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13138&signature=c31bcf5a7737dfb725cf35100cb7c9b04decb2ca0aaa90a089c0f69aa07098ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm add` to preserve dependency groups when saving into a specific group.
  * Ensured transitive `optionalDependencies` are materialized, correctly linked in `node_modules`, and recorded in the lockfile.
  * Fixed global installs to avoid broken binaries caused by missing optional dependencies.
* **Tests**
  * Added integration and end-to-end coverage for dependency-group preservation and transitive optional dependencies (including global installs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->