### PR TITLE
feat(patching): wire verify_patches into the fresh-lockfile install path

### DIFF
--- a/.changeset/verify-unused-patches-on-install.md
+++ b/.changeset/verify-unused-patches-on-install.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+`pnpm install` now fails with `ERR_PNPM_UNUSED_PATCH` when an entry in `patchedDependencies` doesn't match any installed package. Set `allowUnusedPatches: true` in `pnpm-workspace.yaml` to get a warning instead, matching pnpm 11 [#11633](https://github.com/pnpm/pnpm/issues/11633).

--- a/pnpm/crates/cli/tests/patch.rs
+++ b/pnpm/crates/cli/tests/patch.rs
@@ -1120,6 +1120,12 @@ fn unused_patch_warns_when_allow_unused_patches_is_set() {
         stdout = String::from_utf8_lossy(&output.stdout),
         stderr = String::from_utf8_lossy(&output.stderr),
     );
+    assert!(
+        combined.contains("is-negative@1.0.0"),
+        "warning should mention the unused patch key: stdout={stdout}, stderr={stderr}",
+        stdout = String::from_utf8_lossy(&output.stdout),
+        stderr = String::from_utf8_lossy(&output.stderr),
+    );
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/patch.rs
+++ b/pnpm/crates/cli/tests/patch.rs
@@ -1129,3 +1129,57 @@ fn unused_patch_warns_when_allow_unused_patches_is_set() {
 
     drop((root, mock_instance));
 }
+
+/// pnpm only verifies patch usage when every workspace importer was part
+/// of the resolution, so a filtered install must not fail on an unused
+/// patch.
+#[test]
+fn unused_patch_is_not_checked_on_a_filtered_install() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    fs::write(workspace.join("package.json"), serde_json::json!({}).to_string())
+        .expect("write root package.json");
+    let project = workspace.join("packages").join("pkg-a");
+    fs::create_dir_all(&project).expect("create pkg-a dir");
+    fs::write(
+        project.join("package.json"),
+        serde_json::json!({
+            "name": "pkg-a",
+            "dependencies": {
+                "is-positive": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write pkg-a package.json");
+    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
+    fs::write(workspace.join("patches").join("is-positive@1.0.0.patch"), IS_POSITIVE_PATCH)
+        .expect("write patch file");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str(concat!(
+        "packages:\n",
+        "  - 'packages/*'\n",
+        "patchedDependencies:\n",
+        "  is-positive@1.0.0: patches/is-positive@1.0.0.patch\n",
+        "  is-negative@1.0.0: patches/is-positive@1.0.0.patch\n",
+    ));
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let output =
+        pacquet(&workspace, ["install", "--filter", "pkg-a"]).output().expect("run install");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "filtered install should succeed: {stderr}");
+    assert!(
+        !stderr.contains("ERR_PNPM_UNUSED_PATCH"),
+        "filtered install should not run the unused-patch check: {stderr}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/cli/tests/patch.rs
+++ b/pnpm/crates/cli/tests/patch.rs
@@ -1028,3 +1028,98 @@ fn patch_remove_unlinks_final_symlink_without_touching_target() {
 
     drop((root, mock_instance));
 }
+
+fn setup_configured_patch_with_allow_unused(
+    entries: &[(&str, &str)],
+    allow_unused: bool,
+) -> (TempDir, std::path::PathBuf, AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "is-positive": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
+    for (_key, file_name) in entries {
+        fs::write(workspace.join("patches").join(file_name), IS_POSITIVE_PATCH)
+            .expect("write patch file");
+    }
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("patchedDependencies:\n");
+    for (key, file_name) in entries {
+        writeln!(&mut workspace_yaml, "  {key}: patches/{file_name}")
+            .expect("append patchedDependencies entry");
+    }
+    if allow_unused {
+        workspace_yaml.push_str("allowUnusedPatches: true\n");
+    }
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+    (root, workspace, npmrc_info)
+}
+
+#[test]
+fn unused_patch_fails_with_err_pnpm_unused_patch() {
+    let (root, workspace, npmrc_info) = setup_configured_patch_with_allow_unused(
+        &[
+            ("is-positive@1.0.0", "is-positive@1.0.0.patch"),
+            ("is-negative@1.0.0", "is-positive@1.0.0.patch"),
+        ],
+        false,
+    );
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let output = pacquet(&workspace, ["install"]).output().expect("run install");
+
+    assert!(!output.status.success(), "install with unused patch should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_UNUSED_PATCH"),
+        "stderr should contain ERR_PNPM_UNUSED_PATCH: {stderr}",
+    );
+    assert!(
+        stderr.contains("is-negative@1.0.0"),
+        "stderr should mention the unused patch key: {stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn unused_patch_warns_when_allow_unused_patches_is_set() {
+    let (root, workspace, npmrc_info) = setup_configured_patch_with_allow_unused(
+        &[
+            ("is-positive@1.0.0", "is-positive@1.0.0.patch"),
+            ("is-negative@1.0.0", "is-positive@1.0.0.patch"),
+        ],
+        true,
+    );
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let output = pacquet(&workspace, ["install"]).output().expect("run install");
+
+    assert!(output.status.success(), "install should succeed with allowUnusedPatches");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        combined.contains("not used"),
+        "output should warn about unused patches: stdout={stdout}, stderr={stderr}",
+        stdout = String::from_utf8_lossy(&output.stdout),
+        stderr = String::from_utf8_lossy(&output.stderr),
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1155,6 +1155,13 @@ pub struct Config {
     /// (`patches`) applies.
     pub patches_dir: Option<String>,
 
+    /// `allowUnusedPatches` from `pnpm-workspace.yaml`. When `true`,
+    /// configured patches that don't match any installed dependency
+    /// produce a warning instead of failing the install with
+    /// `ERR_PNPM_UNUSED_PATCH`. Default `false` — unused patches are
+    /// an error.
+    pub allow_unused_patches: bool,
+
     /// Raw `configDependencies` from `pnpm-workspace.yaml`: package
     /// name → version-with-integrity spec. Recorded verbatim in the
     /// workspace-state file so pnpm's `checkDepsStatus` sees the same

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -653,6 +653,7 @@ impl WorkspaceSettings {
         self.package_extensions = None;
         self.test_pattern = None;
         self.changed_files_ignore_pattern = None;
+        self.allow_unused_patches = None;
     }
 
     /// Walk up from `start_dir` looking for a readable `pnpm-workspace.yaml`.

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -203,9 +203,7 @@ pub struct WorkspaceSettings {
 
     pub patches_dir: Option<String>,
 
-    /// `allowUnusedPatches` from `pnpm-workspace.yaml`. When `true`,
-    /// patches that don't match any installed dependency produce a
-    /// warning instead of failing the install. Default `false`.
+    /// `allowUnusedPatches` from `pnpm-workspace.yaml`. Default `false`.
     pub allow_unused_patches: Option<bool>,
 
     /// `configDependencies` from `pnpm-workspace.yaml`: package name →

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -203,6 +203,11 @@ pub struct WorkspaceSettings {
 
     pub patches_dir: Option<String>,
 
+    /// `allowUnusedPatches` from `pnpm-workspace.yaml`. When `true`,
+    /// patches that don't match any installed dependency produce a
+    /// warning instead of failing the install. Default `false`.
+    pub allow_unused_patches: Option<bool>,
+
     /// `configDependencies` from `pnpm-workspace.yaml`: package name →
     /// version-with-integrity spec. pnpm records this verbatim in the
     /// workspace-state file so that `checkDepsStatus` can detect when a
@@ -784,6 +789,7 @@ impl WorkspaceSettings {
             resolution_mode, catalog_mode, registry_supports_time_field,
             allowed_deprecated_versions, update_config, peer_dependency_rules,
             enable_pre_post_scripts, dlx_cache_max_age,
+            allow_unused_patches,
         }
 
         if let Some(inner) = self.hoist_pattern {

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -98,6 +98,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         workspace_dir: None,
         patched_dependencies: None,
         patches_dir: None,
+        allow_unused_patches: false,
         config_dependencies: None,
         allow_builds: Default::default(),
         dangerously_allow_all_builds: false,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1396,8 +1396,13 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         )
         .await
         .map_err(InstallWithFreshLockfileError::MinimumReleaseAge)?;
-        // Only in the fresh-lockfile path — frozen lockfile trusts recorded patches.
-        if let Some(ref deps) = patched_dependencies {
+        // Only in the fresh-lockfile path — frozen lockfile trusts recorded
+        // patches. Skipped for a filtered install (`--filter`), matching
+        // pnpm's importer-count gate: pnpm only verifies patches when every
+        // workspace importer was part of the resolution.
+        if let Some(ref deps) = patched_dependencies
+            && !is_partial_workspace_selection(real_importer_ids, selected_importer_ids)
+        {
             match pacquet_patching::verify_patches(
                 deps,
                 &workspace_result.merged_tree.applied_patches,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1396,9 +1396,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         )
         .await
         .map_err(InstallWithFreshLockfileError::MinimumReleaseAge)?;
-        // Verify that every configured patch was applied at least once.
-        // Only checked during full resolution (fresh lockfile path) — the
-        // frozen lockfile path trusts the lockfile's recorded patches.
+        // Only in the fresh-lockfile path — frozen lockfile trusts recorded patches.
         if let Some(ref deps) = patched_dependencies {
             match pacquet_patching::verify_patches(
                 deps,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1409,10 +1409,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 Ok(Some(warning)) => {
                     Reporter::emit(&LogEvent::Global(GlobalLog {
                         level: LogLevel::Warn,
-                        message: format!(
-                            "The following patches were not used: {}",
-                            warning.unused_patches.join(", ")
-                        ),
+                        message: warning.to_string(),
                     }));
                 }
                 Err(err) => {

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -23,7 +23,7 @@ use pacquet_modules_yaml::IncludedDependencies;
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_reporter::{
-    DeprecationLog, HookLog, LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog,
+    DeprecationLog, GlobalLog, HookLog, LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog,
     SkippedOptionalPackage, SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog,
 };
 use pacquet_resolving_default_resolver::DefaultResolver;
@@ -404,6 +404,12 @@ pub enum InstallWithFreshLockfileError {
     /// lockfile's top-level `patchedDependencies` block.
     #[diagnostic(transparent)]
     CalcPatchHashes(#[error(source)] pacquet_patching::CalcPatchHashError),
+
+    /// One or more configured patches were never applied because no
+    /// package matched their key. Surfaced as `ERR_PNPM_UNUSED_PATCH`
+    /// unless `allowUnusedPatches` is `true`.
+    #[diagnostic(transparent)]
+    UnusedPatch(#[error(source)] pacquet_patching::UnusedPatchError),
 
     /// A user-defined `namedRegistries` entry mapped an alias to a
     /// non-http(s) URL. Surfaced at resolver construction so the
@@ -1390,6 +1396,30 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         )
         .await
         .map_err(InstallWithFreshLockfileError::MinimumReleaseAge)?;
+        // Verify that every configured patch was applied at least once.
+        // Only checked during full resolution (fresh lockfile path) — the
+        // frozen lockfile path trusts the lockfile's recorded patches.
+        if let Some(ref deps) = patched_dependencies {
+            match pacquet_patching::verify_patches(
+                deps,
+                &workspace_result.merged_tree.applied_patches,
+                config.allow_unused_patches,
+            ) {
+                Ok(None) => {}
+                Ok(Some(warning)) => {
+                    Reporter::emit(&LogEvent::Global(GlobalLog {
+                        level: LogLevel::Warn,
+                        message: format!(
+                            "The following patches were not used: {}",
+                            warning.unused_patches.join(", ")
+                        ),
+                    }));
+                }
+                Err(err) => {
+                    return Err(InstallWithFreshLockfileError::UnusedPatch(err));
+                }
+            }
+        }
         let total_nodes = workspace_result.peers.graph.len();
         // Hand the per-importer issues to the programmatic caller
         // before the graph is consumed below.

--- a/pnpm/crates/patching/src/verify.rs
+++ b/pnpm/crates/patching/src/verify.rs
@@ -31,7 +31,8 @@ pub struct UnusedPatchError {
 
 /// Result of [`verify_patches`] when `allow_unused_patches` is true:
 /// the caller emits a warning instead of failing.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Display, Clone, PartialEq, Eq)]
+#[display("The following patches were not used: {}", unused_patches.join(", "))]
 pub struct UnusedPatches {
     pub unused_patches: Vec<String>,
 }

--- a/pnpm/crates/patching/src/verify.rs
+++ b/pnpm/crates/patching/src/verify.rs
@@ -29,8 +29,7 @@ pub struct UnusedPatchError {
     pub unused_patches: Vec<String>,
 }
 
-/// Result of [`verify_patches`] when `allow_unused_patches` is true:
-/// the caller emits a warning instead of failing.
+/// Warning payload when `allow_unused_patches` is true.
 #[derive(Debug, Display, Clone, PartialEq, Eq)]
 #[display("The following patches were not used: {}", unused_patches.join(", "))]
 pub struct UnusedPatches {

--- a/pnpm/crates/patching/src/verify.rs
+++ b/pnpm/crates/patching/src/verify.rs
@@ -29,7 +29,6 @@ pub struct UnusedPatchError {
     pub unused_patches: Vec<String>,
 }
 
-/// Warning payload when `allow_unused_patches` is true.
 #[derive(Debug, Display, Clone, PartialEq, Eq)]
 #[display("The following patches were not used: {}", unused_patches.join(", "))]
 pub struct UnusedPatches {

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -194,8 +194,8 @@ Primary frozen/headless tests:
 Supporting tests:
 
 - [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:848` `installing with no modules directory and a patched dependency` covers headless patched dependency behavior when `enableModulesDir: false`.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/patch.ts:216` `patch package reports warning if not all patches are applied and allowUnusedPatches is set`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/patch.ts:246` `patch package throws an exception if not all patches are applied`
+- [x] `TypeScript repo: installing/deps-installer/test/install/patch.ts:216` `patch package reports warning if not all patches are applied and allowUnusedPatches is set`
+- [x] `TypeScript repo: installing/deps-installer/test/install/patch.ts:246` `patch package throws an exception if not all patches are applied`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/patch.ts:269` `the patched package is updated if the patch is modified`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/patch.ts:475` `patch package when the patched package has no dependencies and appears multiple times`
 - [ ] `TypeScript repo: installing/deps-installer/test/install/patch.ts:508` `patch package should fail when the exact version patch fails to apply`
@@ -206,6 +206,7 @@ Rust port notes:
 
 - The primary tests are enough for the frozen installer milestone.
 - The supporting tests belong with patch parser/application correctness and should be ported when Rust has a patching subsystem.
+- Ported `allowUnusedPatches` warning test and `ERR_PNPM_UNUSED_PATCH` error test in `crates/cli/tests/patch.rs` as part of the `allow_unused_patches` config wiring.
 
 ## Support Building Dependencies
 


### PR DESCRIPTION
## Summary

The verify_patches utility in crates/patching already existed with full test coverage, and the resolver already populated applied_patches during resolution. The gap was: (a) the allowUnusedPatches workspace setting was not parsed from pnpm-workspace.yaml, and (b) verify_patches was never called in the install flow. Both are now addressed.

The allow_unused_patches option was added to WorkspaceSettings in workspace_yaml.rs and wired through the apply! macro into Config. An UnusedPatch error variant was added to InstallWithFreshLockfileError. In install_with_fresh_lockfile.rs, after resolution completes, pacquet_patching::verify_patches is called against the lockfile packages and applied patches map. If verification fails and allow_unused_patches is true, a warning is emitted via Reporter::emit instead of failing. Two integration tests in crates/cli/tests/patch.rs cover both the default failure path and the allowed-warning path.

No verification runs on the frozen lockfile path, which trusts the lockfile entirely and has no applied_patches map. Verification is also skipped for filtered installs (`--filter`), matching the TypeScript CLI, which only verifies patches when every workspace importer was part of the resolution. A changeset targeting `pacquet` is included.

Related to: #11633 

## Squash Commit Body

```text
Wire pacquet_patching::verify_patches into the fresh-lockfile install path
so that unused patches are caught and reported, matching the TypeScript CLI. 
Add allow_unused_patches to WorkspaceSettings and Config. 
Return UnusedPatch error when verification fails. 
Emit a warning instead of failing when allow_unused_patches is true.
Add Display to UnusedPatches to keep warning format in sync with UnusedPatchError. 
Add allow_unused_patches to clear_workspace_only_fields so global config cannot override it. 
Add two integration tests for the allow_unused_patches config option.
Skip the unused-patch check on filtered installs, matching pnpm's
importer-count gate, and cover it with an e2e test.
Add a changeset targeting pacquet.

Related to: #11633 
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `allowUnusedPatches` to workspace configuration to control whether unmatched configured patches fail the install or only produce a warning.
* **Bug Fixes**
  * Installs now fail by default with `ERR_PNPM_UNUSED_PATCH` when unused patches are detected.
  * When `allowUnusedPatches: true`, installs succeed and emit a warning listing the unused patch keys.
  * Fresh-lockfile installs now verify configured patches were applied, aborting on unused patches when applicable.
* **Tests**
  * Added end-to-end coverage for both the failure (error) and success (warning) flows, validating the surfaced unused patch keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
