### PR TITLE
fix(lockfile): omit empty bundled dependencies

### DIFF
--- a/.changeset/normalize-empty-bundled-dependencies.md
+++ b/.changeset/normalize-empty-bundled-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Fixed empty `bundledDependencies` and `bundleDependencies` arrays causing nondeterministic lockfile changes. See pnpm/pnpm#13123.

--- a/.changeset/normalize-empty-bundled-dependencies.md
+++ b/.changeset/normalize-empty-bundled-dependencies.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/installing.deps-resolver": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 Fixed empty `bundledDependencies` and `bundleDependencies` arrays causing nondeterministic lockfile changes. See pnpm/pnpm#13123.

--- a/pnpm/crates/lockfile/src/package_metadata.rs
+++ b/pnpm/crates/lockfile/src/package_metadata.rs
@@ -65,21 +65,26 @@ pub enum BundledDependencies {
 }
 
 impl BundledDependencies {
-    /// Read the declaration off a package manifest. Only a list or `true` is
-    /// recorded; anything else (including `false`) falls through to the legacy
-    /// `bundleDependencies` spelling and then to `None`, because a package that
-    /// bundles nothing must not look like one that does.
+    /// Read the declaration off a package manifest. Only a nonempty list or
+    /// `true` is recorded; anything else (including `false` and an empty list)
+    /// falls through to the legacy `bundleDependencies` spelling and then to
+    /// `None`, because a package that bundles nothing must not look like one
+    /// that does. Tarball manifests can carry an empty list where registry
+    /// metadata omits the field, so recording it would make the lockfile
+    /// depend on the manifest source.
     #[must_use]
     pub fn from_manifest(manifest: Option<&serde_json::Value>) -> Option<Self> {
         ["bundledDependencies", "bundleDependencies"].into_iter().find_map(|key| {
             match manifest?.get(key)? {
-                serde_json::Value::Array(items) => Some(BundledDependencies::Names(
-                    items
-                        .iter()
-                        .filter_map(serde_json::Value::as_str)
-                        .map(ToString::to_string)
-                        .collect(),
-                )),
+                serde_json::Value::Array(items) if !items.is_empty() => {
+                    Some(BundledDependencies::Names(
+                        items
+                            .iter()
+                            .filter_map(serde_json::Value::as_str)
+                            .map(ToString::to_string)
+                            .collect(),
+                    ))
+                }
                 serde_json::Value::Bool(true) => Some(BundledDependencies::Boolean(true)),
                 _ => None,
             }

--- a/pnpm/crates/lockfile/src/package_metadata/tests.rs
+++ b/pnpm/crates/lockfile/src/package_metadata/tests.rs
@@ -70,9 +70,9 @@ fn bundled_dependencies_from_the_legacy_spelling() {
     );
 }
 
-// Upstream writes whichever of the two keys holds a list or `true`, preferring
-// `bundledDependencies` — so a `false` under the preferred key does not veto
-// the legacy one.
+// Upstream writes whichever of the two keys holds a nonempty list or `true`,
+// preferring `bundledDependencies` — so a `false` or empty list under the
+// preferred key does not veto the legacy one.
 #[test]
 fn bundled_dependencies_falls_through_a_false_to_the_legacy_spelling() {
     let manifest = serde_json::json!({ "bundledDependencies": false, "bundleDependencies": ["a"] });
@@ -97,16 +97,18 @@ fn bundled_dependencies_false_is_dropped() {
     assert_eq!(BundledDependencies::from_manifest(Some(&manifest)), None);
 }
 
-// pnpm records an empty list verbatim (`Array.isArray([])` passes its gate),
-// and `pnpm install` on a package declaring `"bundledDependencies": []` writes
-// `bundledDependencies: []` into `pnpm-lock.yaml`. Dropping it here would make
-// pacquet's lockfile differ from pnpm's for that package.
 #[test]
-fn bundled_dependencies_keeps_an_empty_list() {
+fn bundled_dependencies_drops_an_empty_list() {
     let manifest = serde_json::json!({ "bundledDependencies": [] });
+    assert_eq!(BundledDependencies::from_manifest(Some(&manifest)), None);
+}
+
+#[test]
+fn bundled_dependencies_falls_through_an_empty_list_to_the_legacy_spelling() {
+    let manifest = serde_json::json!({ "bundledDependencies": [], "bundleDependencies": ["a"] });
     assert_eq!(
         BundledDependencies::from_manifest(Some(&manifest)),
-        Some(BundledDependencies::Names(Vec::new())),
+        Some(BundledDependencies::Names(vec!["a".to_string()])),
     );
 }
 

--- a/pnpm11/installing/deps-resolver/src/updateLockfile.ts
+++ b/pnpm11/installing/deps-resolver/src/updateLockfile.ts
@@ -150,12 +150,12 @@ function toLockfileDependency (
     result['libc'] = pkg.additionalInfo.libc
   }
   if (
-    Array.isArray(pkg.additionalInfo.bundledDependencies) ||
+    (Array.isArray(pkg.additionalInfo.bundledDependencies) && pkg.additionalInfo.bundledDependencies.length > 0) ||
     pkg.additionalInfo.bundledDependencies === true
   ) {
     result['bundledDependencies'] = pkg.additionalInfo.bundledDependencies
   } else if (
-    Array.isArray(pkg.additionalInfo.bundleDependencies) ||
+    (Array.isArray(pkg.additionalInfo.bundleDependencies) && pkg.additionalInfo.bundleDependencies.length > 0) ||
     pkg.additionalInfo.bundleDependencies === true
   ) {
     result['bundledDependencies'] = pkg.additionalInfo.bundleDependencies
@@ -193,4 +193,3 @@ function updateResolvedDeps (
       })
   )
 }
-

--- a/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
+++ b/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
@@ -15,8 +15,8 @@ const REGISTRIES: Registries = { default: 'https://registry.npmjs.org/' }
 function tarballGraph (
   resolution: { tarball: string, integrity?: string },
   additionalInfo: {
-    bundledDependencies?: string[] | boolean
-    bundleDependencies?: string[] | boolean
+    bundledDependencies?: readonly string[] | boolean
+    bundleDependencies?: readonly string[] | boolean
   } = {}
 ): DependenciesGraph {
   return {

--- a/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
+++ b/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
@@ -12,7 +12,13 @@ const DEP_PATH = `xlsx@${TARBALL_URL}` as DepPath
 const INTEGRITY = 'sha512-AaaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaAaA=='
 const REGISTRIES: Registries = { default: 'https://registry.npmjs.org/' }
 
-function tarballGraph (resolution: { tarball: string, integrity?: string }): DependenciesGraph {
+function tarballGraph (
+  resolution: { tarball: string, integrity?: string },
+  additionalInfo: {
+    bundledDependencies?: string[] | boolean
+    bundleDependencies?: string[] | boolean
+  } = {}
+): DependenciesGraph {
   return {
     [DEP_PATH]: {
       name: 'xlsx',
@@ -23,7 +29,7 @@ function tarballGraph (resolution: { tarball: string, integrity?: string }): Dep
       optionalDependencies: new Set<string>(),
       peerDependencies: {},
       transitivePeerDependencies: new Set<string>(),
-      additionalInfo: {},
+      additionalInfo,
       hasBin: false,
     },
   } as unknown as DependenciesGraph
@@ -84,4 +90,26 @@ test('a stale integrity is not attached when the tarball URL changed', () => {
     registries: REGISTRIES,
   })
   expect(lockfile.packages![newDepPath].resolution).toStrictEqual({ tarball: newUrl })
+})
+
+test.each([
+  [{ bundledDependencies: [] }, undefined],
+  [{ bundleDependencies: [] }, undefined],
+  [{ bundledDependencies: ['bundled'] }, ['bundled']],
+  [{ bundleDependencies: ['bundle'] }, ['bundle']],
+  [{ bundledDependencies: true }, true],
+  [{ bundleDependencies: true }, true],
+  [{ bundledDependencies: ['bundled'], bundleDependencies: ['bundle'] }, ['bundled']],
+  [{ bundledDependencies: ['bundled'], bundleDependencies: true }, ['bundled']],
+  [{ bundledDependencies: true, bundleDependencies: ['bundle'] }, true],
+  [{ bundledDependencies: [], bundleDependencies: ['bundle'] }, ['bundle']],
+  [{ bundledDependencies: [], bundleDependencies: true }, true],
+] as const)('normalizes bundled dependencies from %p to %p', (additionalInfo, expected) => {
+  const lockfile = updateLockfile({
+    dependenciesGraph: tarballGraph({ tarball: TARBALL_URL }, additionalInfo),
+    lockfile: lockfileWith({ resolution: { tarball: TARBALL_URL } }),
+    prefix: '.',
+    registries: REGISTRIES,
+  })
+  expect(lockfile.packages![DEP_PATH].bundledDependencies).toEqual(expected)
 })


### PR DESCRIPTION
## Summary

Treat empty `bundledDependencies` and `bundleDependencies` arrays as absent when generating package lockfile entries.

Tarball-derived manifests can retain an empty array while registry metadata omits the field. Serializing that array made the resulting lockfile depend on which manifest source was used. Nonempty arrays and `true` remain preserved, `bundledDependencies` keeps precedence when meaningful, and an empty preferred value can fall back to meaningful `bundleDependencies`.

Pacquet is updated to match: `BundledDependencies::from_manifest` previously recorded an empty list (deliberately mirroring the old TypeScript gate); it now skips empty lists and falls through to the legacy spelling, and the changeset targets `pacquet` as well.

Closes pnpm/pnpm#13123.

## Squash Commit Body

```text
Tarball manifests can contain an empty bundledDependencies array while registry
metadata for the same package omits the field. Treat empty arrays as absent so
lockfile generation does not depend on the manifest source used during
resolution.

Preserve nonempty arrays and true for both field spellings. Continue preferring
bundledDependencies when meaningful, but allow an empty value to fall back to
a meaningful bundleDependencies value.

Mirror the change in pacquet: BundledDependencies::from_manifest no longer
records an empty list and falls through to the legacy spelling instead.

Closes pnpm/pnpm#13123.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.

## Verification

- Focused resolver test: 14 passed
- Resolver TypeScript build and ESLint
- Changeset validation
- Full pre-push TypeScript compile, pnpm bundle, cspell, metadata validation, and ESLint
- Rust: `cargo test -p pacquet-lockfile` (including the new empty-list tests), `cargo fmt --check`, clippy, and the workspace dylint pass

## AI disclosure

OpenCode using `myself/gpt-5.6-sol` assisted with issue investigation, implementation, and test preparation. I reviewed the source changes, parity behavior, and verification results.

---
Written by an agent (OpenCode, myself/gpt-5.6-sol).
Pacquet parity commit and description update by an agent (Claude Code, claude-fable-5).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty bundled dependency lists from being unnecessarily written to lockfiles.
  * Improved lockfile consistency by avoiding nondeterministic updates for packages without bundled dependencies.

* **Tests**
  * Added coverage for bundled dependency metadata, including supported aliases and value formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->