### PR TITLE
test(pacquet): port the Stage 2 workspace subset and multi-importer suites

### DIFF
--- a/.changeset/hungry-donkeys-repeat.md
+++ b/.changeset/hungry-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` now announces `Lockfile is up to date, resolution step is skipped` whenever the headless installer runs — including installs that materialize a cold `node_modules` from an up-to-date lockfile and `--filter` subset installs — matching the TypeScript CLI. `pnpm fetch` prints `Importing packages to virtual store` on that path instead.

--- a/pnpm/crates/cli/tests/_utils.rs
+++ b/pnpm/crates/cli/tests/_utils.rs
@@ -1,5 +1,23 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, SnapshotEntry};
+use pacquet_modules_yaml::{Host as ModulesHost, Modules, read_modules_manifest};
 use pacquet_store_dir::{CafsFileInfo, StoreDir, StoreIndex};
-use std::{collections::BTreeMap, fmt::Write as _, fs, path::Path};
+use pacquet_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fs::is_symlink_or_junction,
+};
+use pacquet_workspace_state::WorkspaceState;
+use serde_json::{Map, Value, json};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::OsStr,
+    fmt::Write as _,
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+use tempfile::TempDir;
 
 /// Flip the `enableGlobalVirtualStore` key in the `pnpm-workspace.yaml`
 /// that [`pacquet_testing_utils::bin::CommandTempCwd::add_mocked_registry`]
@@ -98,4 +116,374 @@ pub fn read_current_lockfile(workspace: &Path) -> pacquet_lockfile::Lockfile {
     let text = fs::read_to_string(workspace.join("node_modules/.pnpm/lock.yaml"))
         .expect("read the current lockfile");
     serde_saphyr::from_str(&text).expect("parse the current lockfile")
+}
+
+/// Dependency groups for [`write_project_manifest`] /
+/// [`WorkspaceFixture::project`].
+#[derive(Default, Clone, Copy)]
+pub struct ManifestDeps<'a> {
+    pub prod: &'a [(&'a str, &'a str)],
+    pub dev: &'a [(&'a str, &'a str)],
+    pub optional: &'a [(&'a str, &'a str)],
+    pub peer: &'a [(&'a str, &'a str)],
+}
+
+/// A `packages/*` workspace against the mocked registry: project
+/// scaffolding, CLI invocation with NDJSON capture, and readers for
+/// the lockfiles and install-state files.
+pub struct WorkspaceFixture {
+    /// RAII guard for the temporary directory the workspace lives in.
+    _root: TempDir,
+    pub workspace: PathBuf,
+    pub registry: AddMockedRegistry,
+}
+
+impl WorkspaceFixture {
+    #[must_use]
+    pub fn new() -> Self {
+        let CommandTempCwd { root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let fixture = Self { _root: root, workspace, registry: npmrc_info };
+        fixture.append_workspace_yaml("packages:\n  - 'packages/*'\n");
+        fixture
+    }
+
+    pub fn append_workspace_yaml(&self, text: &str) {
+        let path = self.workspace.join("pnpm-workspace.yaml");
+        let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+        if !yaml.ends_with('\n') {
+            yaml.push('\n');
+        }
+        yaml.push_str(text);
+        fs::write(path, yaml).expect("write pnpm-workspace.yaml");
+    }
+
+    pub fn write_root_manifest(&self, name: &str, deps: ManifestDeps<'_>) {
+        write_project_manifest(&self.workspace, name, deps);
+    }
+
+    #[expect(
+        clippy::must_use_candidate,
+        reason = "many callers scaffold a project for its side effect and never need the returned path"
+    )]
+    pub fn project(&self, dir: &str, name: &str, deps: ManifestDeps<'_>) -> PathBuf {
+        let project = self.workspace.join("packages").join(dir);
+        write_project_manifest(&project, name, deps);
+        project
+    }
+
+    pub fn command_at<Args, Arg>(&self, cwd: &Path, args: Args) -> Output
+    where
+        Args: IntoIterator<Item = Arg>,
+        Arg: AsRef<OsStr>,
+    {
+        Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(cwd)
+            .env("PNPM_CONFIG_REGISTRY", self.registry.mock_instance.url())
+            .arg("--reporter=ndjson")
+            .args(args)
+            .output()
+            .expect("run pacquet")
+    }
+
+    pub fn run<Args, Arg>(&self, args: Args) -> Vec<Value>
+    where
+        Args: IntoIterator<Item = Arg>,
+        Arg: AsRef<OsStr>,
+    {
+        self.run_at(&self.workspace, args)
+    }
+
+    pub fn run_at<Args, Arg>(&self, cwd: &Path, args: Args) -> Vec<Value>
+    where
+        Args: IntoIterator<Item = Arg>,
+        Arg: AsRef<OsStr>,
+    {
+        let output = self.command_at(cwd, args);
+        assert_success(&output);
+        ndjson_records(&output)
+    }
+
+    #[must_use]
+    pub fn wanted(&self) -> Lockfile {
+        read_lockfile(&self.workspace.join("pnpm-lock.yaml"))
+    }
+
+    #[must_use]
+    pub fn current(&self) -> Lockfile {
+        read_lockfile(&self.workspace.join("node_modules/.pnpm/lock.yaml"))
+    }
+
+    #[must_use]
+    pub fn modules(&self) -> Modules {
+        read_modules_manifest::<ModulesHost>(&self.workspace.join("node_modules"))
+            .expect("read .modules.yaml")
+            .expect(".modules.yaml exists")
+    }
+
+    pub fn write_modules(&self, modules: Modules) {
+        pacquet_modules_yaml::write_modules_manifest::<ModulesHost>(
+            &self.workspace.join("node_modules"),
+            modules,
+        )
+        .expect("write .modules.yaml");
+    }
+
+    #[must_use]
+    pub fn state(&self) -> WorkspaceState {
+        let path = self.workspace.join("node_modules/.pnpm-workspace-state-v1.json");
+        serde_json::from_str(&fs::read_to_string(path).expect("read workspace state"))
+            .expect("parse workspace state")
+    }
+
+    #[must_use]
+    pub fn package_map(&self) -> Value {
+        let path = self.workspace.join("node_modules/.package-map.json");
+        serde_json::from_str(&fs::read_to_string(path).expect("read package map"))
+            .expect("parse package map")
+    }
+
+    #[must_use]
+    pub fn slot(&self, name: &str, version: &str) -> PathBuf {
+        self.workspace
+            .join("node_modules/.pnpm")
+            .join(format!("{}@{version}", name.replace('/', "+")))
+    }
+}
+
+impl Default for WorkspaceFixture {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn write_project_manifest(project: &Path, name: &str, deps: ManifestDeps<'_>) {
+    fs::create_dir_all(project).expect("create project directory");
+    let mut manifest = Map::from_iter([
+        ("name".to_string(), Value::String(name.to_string())),
+        ("version".to_string(), Value::String("1.0.0".to_string())),
+        ("private".to_string(), Value::Bool(true)),
+    ]);
+    insert_dependency_group(&mut manifest, "dependencies", deps.prod);
+    insert_dependency_group(&mut manifest, "devDependencies", deps.dev);
+    insert_dependency_group(&mut manifest, "optionalDependencies", deps.optional);
+    insert_dependency_group(&mut manifest, "peerDependencies", deps.peer);
+    fs::write(
+        project.join("package.json"),
+        serde_json::to_string_pretty(&Value::Object(manifest)).expect("serialize package.json"),
+    )
+    .expect("write package.json");
+}
+
+fn insert_dependency_group(manifest: &mut Map<String, Value>, group: &str, deps: &[(&str, &str)]) {
+    if deps.is_empty() {
+        return;
+    }
+    manifest.insert(
+        group.to_string(),
+        Value::Object(
+            deps.iter()
+                .map(|(name, spec)| (name.to_string(), Value::String(spec.to_string())))
+                .collect(),
+        ),
+    );
+}
+
+#[must_use]
+pub fn read_manifest(project: &Path) -> Value {
+    serde_json::from_str(
+        &fs::read_to_string(project.join("package.json")).expect("read package.json"),
+    )
+    .expect("parse package.json")
+}
+
+pub fn write_manifest_value(project: &Path, manifest: &Value) {
+    fs::write(
+        project.join("package.json"),
+        serde_json::to_string_pretty(manifest).expect("serialize package.json"),
+    )
+    .expect("write package.json");
+}
+
+pub fn set_dependency(project: &Path, group: &str, name: &str, spec: &str) {
+    let mut manifest = read_manifest(project);
+    let object = manifest.as_object_mut().expect("manifest is an object");
+    let dependencies = object.entry(group).or_insert_with(|| json!({}));
+    dependencies
+        .as_object_mut()
+        .expect("dependency group is an object")
+        .insert(name.to_string(), Value::String(spec.to_string()));
+    write_manifest_value(project, &manifest);
+}
+
+pub fn set_version(project: &Path, version: &str) {
+    let mut manifest = read_manifest(project);
+    manifest["version"] = Value::String(version.to_string());
+    write_manifest_value(project, &manifest);
+}
+
+pub fn replace_dependencies(project: &Path, deps: &[(&str, &str)]) {
+    let mut manifest = read_manifest(project);
+    manifest["dependencies"] = Value::Object(
+        deps.iter()
+            .map(|(name, spec)| (name.to_string(), Value::String(spec.to_string())))
+            .collect(),
+    );
+    write_manifest_value(project, &manifest);
+}
+
+#[must_use]
+pub fn dependency_spec(project: &Path, group: &str, name: &str) -> Option<String> {
+    read_manifest(project)
+        .get(group)
+        .and_then(Value::as_object)
+        .and_then(|dependencies| dependencies.get(name))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+#[must_use]
+pub fn read_lockfile(path: &Path) -> Lockfile {
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read lockfile {}: {error}", path.display()));
+    serde_saphyr::from_str(&contents)
+        .unwrap_or_else(|error| panic!("parse lockfile {}: {error}\n{contents}", path.display()))
+}
+
+pub fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[must_use]
+pub fn ndjson_records(output: &Output) -> Vec<Value> {
+    [&output.stderr[..], &output.stdout[..]]
+        .into_iter()
+        .flat_map(|stream| {
+            String::from_utf8_lossy(stream).lines().map(str::to_string).collect::<Vec<_>>()
+        })
+        .filter_map(|line| serde_json::from_str(&line).ok())
+        .collect()
+}
+
+/// The `name: "pnpm" / level: "info"` log pnpm's headless installer
+/// emits when it is entered with an up-to-date lockfile.
+#[must_use]
+pub fn has_up_to_date_log(records: &[Value]) -> bool {
+    records.iter().any(|record| {
+        record.get("name").and_then(Value::as_str) == Some("pnpm")
+            && record.get("level").and_then(Value::as_str) == Some("info")
+            && record.get("message").and_then(Value::as_str)
+                == Some("Lockfile is up to date, resolution step is skipped")
+    })
+}
+
+#[must_use]
+pub fn importer<'a>(lockfile: &'a Lockfile, id: &str) -> &'a ProjectSnapshot {
+    lockfile
+        .importers
+        .get(id)
+        .unwrap_or_else(|| panic!("missing importer {id:?}: {:?}", lockfile.importers.keys()))
+}
+
+#[must_use]
+pub fn importer_version(lockfile: &Lockfile, id: &str, name: &str) -> String {
+    let name: PkgName = name.parse().expect("parse package name");
+    let snapshot = importer(lockfile, id);
+    snapshot
+        .dependencies
+        .as_ref()
+        .and_then(|dependencies| dependencies.get(&name))
+        .or_else(|| {
+            snapshot.dev_dependencies.as_ref().and_then(|dependencies| dependencies.get(&name))
+        })
+        .or_else(|| {
+            snapshot.optional_dependencies.as_ref().and_then(|dependencies| dependencies.get(&name))
+        })
+        .unwrap_or_else(|| panic!("missing dependency {name} in importer {id}"))
+        .version
+        .to_string()
+}
+
+#[must_use]
+pub fn importer_specifier(lockfile: &Lockfile, id: &str, name: &str) -> String {
+    let name: PkgName = name.parse().expect("parse package name");
+    importer(lockfile, id)
+        .dependencies
+        .as_ref()
+        .and_then(|dependencies| dependencies.get(&name))
+        .unwrap_or_else(|| panic!("missing dependency {name} in importer {id}"))
+        .specifier
+        .clone()
+}
+
+#[must_use]
+pub fn importer_ids(lockfile: &Lockfile) -> BTreeSet<String> {
+    lockfile.importers.keys().cloned().collect()
+}
+
+#[must_use]
+pub fn snapshot_entries(lockfile: &Lockfile, name: &str) -> Vec<(String, SnapshotEntry)> {
+    lockfile
+        .snapshots
+        .as_ref()
+        .into_iter()
+        .flatten()
+        .filter(|(key, _)| key.to_string().starts_with(&format!("{name}@")))
+        .map(|(key, snapshot)| (key.to_string(), snapshot.clone()))
+        .collect()
+}
+
+#[must_use]
+pub fn has_snapshot(lockfile: &Lockfile, name: &str, version: &str) -> bool {
+    lockfile.snapshots.as_ref().is_some_and(|snapshots| {
+        snapshots.keys().any(|key| {
+            let key = key.to_string();
+            key == format!("{name}@{version}") || key.starts_with(&format!("{name}@{version}("))
+        })
+    })
+}
+
+#[must_use]
+pub fn has_link(project: &Path, name: &str) -> bool {
+    is_symlink_or_junction(&project.join("node_modules").join(name)).unwrap_or(false)
+}
+
+#[must_use]
+pub fn canonical_path(path: &Path) -> String {
+    dunce::canonicalize(path)
+        .unwrap_or_else(|error| panic!("canonicalize {}: {error}", path.display()))
+        .to_string_lossy()
+        .into_owned()
+}
+
+pub fn assert_full_wanted(lockfile: &Lockfile, ids: &[&str]) {
+    assert_eq!(
+        importer_ids(lockfile),
+        ids.iter().map(ToString::to_string).collect(),
+        "wanted lockfile must retain every real importer",
+    );
+}
+
+#[must_use]
+pub fn importer_has_group_dependency(
+    lockfile: &Lockfile,
+    id: &str,
+    group: &str,
+    dependency: &str,
+) -> bool {
+    let name: PkgName = dependency.parse().expect("parse package name");
+    let importer = importer(lockfile, id);
+    match group {
+        "dependencies" => importer.dependencies.as_ref(),
+        "devDependencies" => importer.dev_dependencies.as_ref(),
+        "optionalDependencies" => importer.optional_dependencies.as_ref(),
+        _ => panic!("unsupported dependency group {group}"),
+    }
+    .is_some_and(|dependencies| dependencies.contains_key(&name))
 }

--- a/pnpm/crates/cli/tests/_utils/mod.rs
+++ b/pnpm/crates/cli/tests/_utils/mod.rs
@@ -351,6 +351,36 @@ pub fn read_lockfile(path: &Path) -> Lockfile {
         .unwrap_or_else(|error| panic!("parse lockfile {}: {error}\n{contents}", path.display()))
 }
 
+/// Rewrite one snapshot's dependency pin in the lockfile at
+/// `lockfile_path` — the structured stand-in for the hand-written
+/// lockfiles the upstream tests use to stage wanted/current divergence.
+/// `new_ref` takes any `snapshots:` dependency shape (`100.0.0`,
+/// `link:packages/foo`, ...).
+pub fn repin_snapshot_dependency(
+    lockfile_path: &Path,
+    snapshot_key: &str,
+    dependency: &str,
+    new_ref: &str,
+) {
+    let mut lockfile = read_lockfile(lockfile_path);
+    let snapshots = lockfile.snapshots.as_mut().expect("lockfile has snapshots");
+    let key = snapshots
+        .keys()
+        .find(|key| key.to_string() == snapshot_key)
+        .cloned()
+        .unwrap_or_else(|| panic!("missing snapshot {snapshot_key}"));
+    let pin = snapshots
+        .get_mut(&key)
+        .expect("snapshot entry exists")
+        .dependencies
+        .as_mut()
+        .expect("snapshot has dependencies")
+        .get_mut(&dependency.parse().expect("parse the dependency name"))
+        .unwrap_or_else(|| panic!("snapshot {snapshot_key} does not pin {dependency}"));
+    *pin = serde_saphyr::from_str(new_ref).expect("parse the new dependency ref");
+    lockfile.save_to_path(lockfile_path).expect("write the rewritten lockfile");
+}
+
 pub fn assert_success(output: &Output) {
     assert!(
         output.status.success(),

--- a/pnpm/crates/cli/tests/hoist.rs
+++ b/pnpm/crates/cli/tests/hoist.rs
@@ -700,24 +700,12 @@ fn workspace_hoist_only_in_selected_projects_with_subdeps() {
     );
     fixture.run(["install", "--lockfile-only"]);
 
-    let lockfile_path = fixture.workspace.join("pnpm-lock.yaml");
-    let mut wanted = read_lockfile(&lockfile_path);
-    let snapshots = wanted.snapshots.as_mut().expect("lockfile has snapshots");
-    let unselected_parent = snapshots
-        .keys()
-        .find(|key| key.to_string() == format!("{PARENT}@100.0.0"))
-        .cloned()
-        .expect("the unselected parent has a snapshot");
-    let subdependency = snapshots
-        .get_mut(&unselected_parent)
-        .expect("snapshot entry exists")
-        .dependencies
-        .as_mut()
-        .expect("the parent snapshot has dependencies")
-        .get_mut(&DEP.parse().expect("parse the subdependency name"))
-        .expect("the parent snapshot pins the subdependency");
-    *subdependency = serde_saphyr::from_str("101.0.0").expect("parse the repinned version");
-    wanted.save_to_path(&lockfile_path).expect("write the repinned lockfile");
+    repin_snapshot_dependency(
+        &fixture.workspace.join("pnpm-lock.yaml"),
+        &format!("{PARENT}@100.0.0"),
+        DEP,
+        "101.0.0",
+    );
 
     fixture.run(["--filter", "root", "--filter", "project-2", "install"]);
 

--- a/pnpm/crates/cli/tests/hoist.rs
+++ b/pnpm/crates/cli/tests/hoist.rs
@@ -642,6 +642,98 @@ fn fresh_install_hoisted_node_linker_lands_real_directories() {
     drop((root, mock_instance));
 }
 
+/// TS: `hoist packages which is in the dependencies tree of the
+/// selected projects` (`hoist.ts:587`): with `hoistPattern: '*'` and a
+/// lockfile that pins a different `@pnpm.e2e/foo` per project, a subset
+/// install of the root plus project-2 must hoist project-2's version —
+/// not the unselected project-1's, which sorts first among importers.
+#[test]
+fn workspace_hoist_packages_in_selected_projects_tree() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("hoistPattern:\n  - '*'\n");
+    fixture.write_root_manifest("root", ManifestDeps::default());
+    fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps { prod: &[("@pnpm.e2e/foo", "1.0.0")], ..Default::default() },
+    );
+    fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[("@pnpm.e2e/foo", "2.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+
+    fixture.run(["--filter", "root", "--filter", "project-2", "install"]);
+
+    let hoisted = fixture.workspace.join("node_modules/.pnpm/node_modules/@pnpm.e2e/foo");
+    let manifest: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(hoisted.join("package.json")).expect("read the hoisted manifest"),
+    )
+    .expect("parse the hoisted manifest");
+    assert_eq!(manifest["version"], "2.0.0", "the selected project's version must win the hoist");
+}
+
+/// TS: `only hoist packages which is in the dependencies tree of the
+/// selected projects with sub dependencies` (`hoist.ts:682`): the
+/// hoisted transitives must come from the selected project's tree too.
+/// The upstream test hand-writes a lockfile whose two parent versions
+/// pin different subdependency versions; the port gets the same shape
+/// by locking a third `dep-of-pkg-with-1-dep` version through a direct
+/// dependency and repinning the unselected parent's edge to it.
+#[test]
+fn workspace_hoist_only_in_selected_projects_with_subdeps() {
+    const PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
+    const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("hoistPattern:\n  - '*'\n");
+    fixture.write_root_manifest("root", ManifestDeps::default());
+    fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps { prod: &[(PARENT, "100.0.0"), (DEP, "101.0.0")], ..Default::default() },
+    );
+    fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[(PARENT, "100.1.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+
+    let lockfile_path = fixture.workspace.join("pnpm-lock.yaml");
+    let mut wanted = read_lockfile(&lockfile_path);
+    let snapshots = wanted.snapshots.as_mut().expect("lockfile has snapshots");
+    let unselected_parent = snapshots
+        .keys()
+        .find(|key| key.to_string() == format!("{PARENT}@100.0.0"))
+        .cloned()
+        .expect("the unselected parent has a snapshot");
+    let subdependency = snapshots
+        .get_mut(&unselected_parent)
+        .expect("snapshot entry exists")
+        .dependencies
+        .as_mut()
+        .expect("the parent snapshot has dependencies")
+        .get_mut(&DEP.parse().expect("parse the subdependency name"))
+        .expect("the parent snapshot pins the subdependency");
+    *subdependency = serde_saphyr::from_str("101.0.0").expect("parse the repinned version");
+    wanted.save_to_path(&lockfile_path).expect("write the repinned lockfile");
+
+    fixture.run(["--filter", "root", "--filter", "project-2", "install"]);
+
+    for (name, version) in [(PARENT, "100.1.0"), (DEP, "100.1.0")] {
+        let hoisted = fixture.workspace.join("node_modules/.pnpm/node_modules").join(name);
+        let manifest: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(hoisted.join("package.json")).expect("read the hoisted manifest"),
+        )
+        .expect("parse the hoisted manifest");
+        assert_eq!(
+            manifest["version"], version,
+            "{name} must be hoisted from the selected project's tree",
+        );
+    }
+}
+
 mod known_failures {
     //! Hoist cases blocked on features pacquet hasn't built yet. Each
     //! entry stubs the not-yet-built subject under test through
@@ -655,8 +747,6 @@ mod known_failures {
     //! - **`pnpm add` / `pnpm remove`**: re-running install after
     //!   adding or removing a dep requires the manifest-mutation
     //!   path pacquet doesn't expose yet.
-    //! - **`--filter` selected-projects install**: pacquet doesn't
-    //!   yet implement the workspace-projects-filter selection.
     //! - **`hoistWorkspacePackages`**: links workspace projects
     //!   themselves into the hoist tree (separate from snapshot
     //!   hoisting); pacquet doesn't model the
@@ -694,16 +784,6 @@ mod known_failures {
             "Pacquet doesn't yet implement `pnpm add` / `pnpm remove` \
              manifest mutation. Upstream tests that mutate the manifest \
              between installs aren't directly portable until that lands.",
-        ))
-    }
-
-    fn workspace_filter_selection() -> KnownResult<()> {
-        Err(KnownFailure::new(
-            "Pacquet doesn't yet implement `--filter` selected-projects \
-             installs. Workspace install (pnpm/pacquet#431) landed in \
-             #443 but only as the unfiltered \"install all importers\" \
-             flow; selecting a subset of workspace projects is a \
-             follow-up.",
         ))
     }
 
@@ -848,20 +928,6 @@ mod known_failures {
     #[test]
     fn hoisted_packages_dont_override_direct_dep_bins() {
         allow_known_failure!(direct_dep_bin_precedence());
-    }
-
-    /// Installs a subset of workspace projects by selected project
-    /// dirs. Pacquet doesn't yet implement `--filter` selected-projects
-    /// installs.
-    #[test]
-    fn workspace_hoist_packages_in_selected_projects_tree() {
-        allow_known_failure!(workspace_filter_selection());
-    }
-
-    /// Same selected-project-dirs shape as above.
-    #[test]
-    fn workspace_hoist_only_in_selected_projects_with_subdeps() {
-        allow_known_failure!(workspace_filter_selection());
     }
 
     #[test]

--- a/pnpm/crates/cli/tests/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/hoisted_node_linker.rs
@@ -475,6 +475,94 @@ fn node_major() -> u32 {
         .expect("node major is numeric")
 }
 
+/// TS: `install only the dependencies of the specified importer, when
+/// node-linker is hoisted` (`multipleImporters.ts:87`). The subset
+/// install lands the selected project's dependency at the workspace
+/// root, and the wanted lockfile keeps the unselected importer's
+/// entries. (Upstream leaves "the unselected dependency is absent" as a
+/// TODO — the hoisted linker materializes the full shared graph — so
+/// only the positive assertions are pinned, matching upstream.)
+#[test]
+fn install_only_dependencies_of_specified_importer_with_hoisted_linker() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("nodeLinker: hoisted\n");
+    fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps { prod: &[("@pnpm.e2e/foo", "1.0.0")], ..Default::default() },
+    );
+    fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[("@foo/no-deps", "1.0.0")], ..Default::default() },
+    );
+
+    fixture.run(["--filter", "project-1", "install"]);
+
+    assert!(
+        is_real_dir(&fixture.workspace, "node_modules/@pnpm.e2e/foo"),
+        "the selected project's dependency must be hoisted to the workspace root",
+    );
+    let wanted = fixture.wanted();
+    assert_eq!(importer_version(&wanted, "packages/project-2", "@foo/no-deps"), "1.0.0");
+}
+
+/// TS: `run pre/postinstall scripts in a workspace that uses
+/// node-linker=hoisted` (`lifecycleScripts.ts:718`). Two projects pin
+/// `@pnpm.e2e/pre-and-postinstall-scripts-example@1` and two pin `@2`;
+/// the hoisted layout keeps one version at the workspace root and
+/// nests the other under its consumers, and the build step must run
+/// the scripts at every materialized copy. Driven through the frozen
+/// path — lifecycle scripts on the fresh hoisted path are still
+/// blocked on pnpm/pnpm#11870 (see [`known_failures`]).
+#[test]
+fn run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker() {
+    const SCRIPTS: &str = "@pnpm.e2e/pre-and-postinstall-scripts-example";
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml(&format!(
+        "nodeLinker: hoisted\nallowBuilds:\n  '{SCRIPTS}': true\n"
+    ));
+    let mut projects = Vec::new();
+    for (dir, spec) in
+        [("project-1", "1"), ("project-2", "1"), ("project-3", "2"), ("project-4", "2")]
+    {
+        projects.push(fixture.project(
+            dir,
+            dir,
+            ManifestDeps { prod: &[(SCRIPTS, spec)], ..Default::default() },
+        ));
+    }
+    fixture.run(["install", "--lockfile-only"]);
+
+    fixture.run(["install", "--frozen-lockfile"]);
+
+    assert_eq!(
+        read_pkg_version(
+            &fixture.workspace,
+            "node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example"
+        ),
+        "1.0.0",
+        "the majority-tie version must win the workspace-root slot, matching upstream",
+    );
+    for generated in ["generated-by-preinstall.js", "generated-by-postinstall.js"] {
+        assert!(
+            fixture.workspace.join("node_modules").join(SCRIPTS).join(generated).exists(),
+            "the hoisted root copy must be built ({generated})",
+        );
+        // Pacquet's hoisted linker materializes each project's direct
+        // dep under the project as well — upstream nests a copy only
+        // for the version that lost the root slot (see
+        // `known_failures::hoisted_workspace_layout_does_not_duplicate_root_version`).
+        // Every copy that is materialized must be built.
+        for project in &projects {
+            assert!(
+                project.join("node_modules").join(SCRIPTS).join(generated).exists(),
+                "every materialized copy must be built ({generated})",
+            );
+        }
+    }
+}
+
 mod known_failures {
     //! Hoisted-node-linker cases blocked on features pacquet hasn't
     //! built yet. Each stubs the not-yet-built subject through
@@ -493,6 +581,27 @@ mod known_failures {
              bump a dist-tag, then reinstall). Partial install / re-hoist \
              across runs is tracked by pnpm/pacquet#433.",
         ))
+    }
+
+    fn hoisted_workspace_duplicate_materialization() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "Pacquet's hoisted linker materializes each workspace \
+             project's direct dependency under the project's own \
+             `node_modules` even when the same version already won the \
+             workspace-root slot. Upstream nests a copy only for \
+             versions that lost the root slot \
+             (`lifecycleScripts.ts:718` asserts the hoisted-version \
+             consumers have no nested copy).",
+        ))
+    }
+
+    /// The layout tail of TS `run pre/postinstall scripts in a
+    /// workspace that uses node-linker=hoisted`
+    /// (`lifecycleScripts.ts:718`); the script-execution half is the
+    /// real [`super::run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker`].
+    #[test]
+    fn hoisted_workspace_layout_does_not_duplicate_root_version() {
+        allow_known_failure!(hoisted_workspace_duplicate_materialization());
     }
 
     fn lifecycle_scripts_on_fresh_path() -> KnownResult<()> {

--- a/pnpm/crates/cli/tests/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/hoisted_node_linker.rs
@@ -520,7 +520,7 @@ fn run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker() {
     const SCRIPTS: &str = "@pnpm.e2e/pre-and-postinstall-scripts-example";
     let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml(&format!(
-        "nodeLinker: hoisted\nallowBuilds:\n  '{SCRIPTS}': true\n"
+        "nodeLinker: hoisted\nallowBuilds:\n  '{SCRIPTS}': true\n",
     ));
     let mut projects = Vec::new();
     for (dir, spec) in

--- a/pnpm/crates/cli/tests/install_filters.rs
+++ b/pnpm/crates/cli/tests/install_filters.rs
@@ -1,22 +1,14 @@
-use assert_cmd::prelude::*;
-use command_extra::CommandExtra;
-use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, SnapshotEntry};
-use pacquet_modules_yaml::{Host, Modules, read_modules_manifest, write_modules_manifest};
-use pacquet_testing_utils::{
-    bin::{AddMockedRegistry, CommandTempCwd},
-    fs::is_symlink_or_junction,
-};
-use pacquet_workspace_state::WorkspaceState;
+pub mod _utils;
+pub use _utils::*;
+
+use pacquet_lockfile::{PkgName, SnapshotEntry};
 use pretty_assertions::assert_eq;
-use serde_json::{Map, Value, json};
+use serde_json::{Value, json};
 use std::{
     collections::{BTreeSet, HashMap},
-    ffi::OsStr,
     fs,
-    path::{Path, PathBuf},
-    process::{Command, Output},
+    path::Path,
 };
-use tempfile::TempDir;
 
 const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
 const CATALOG_FOO: &str = "@pnpm.e2e/foo";
@@ -24,233 +16,6 @@ const HELLO: &str = "@pnpm.e2e/hello-world-js-bin";
 const HELLO_PARENT: &str = "@pnpm.e2e/hello-world-js-bin-parent";
 const NO_DEPS: &str = "@foo/no-deps";
 const PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
-
-#[derive(Default, Clone, Copy)]
-struct ManifestDeps<'a> {
-    prod: &'a [(&'a str, &'a str)],
-    dev: &'a [(&'a str, &'a str)],
-    optional: &'a [(&'a str, &'a str)],
-    peer: &'a [(&'a str, &'a str)],
-}
-
-struct FilteredWorkspace {
-    _root: TempDir,
-    workspace: PathBuf,
-    registry: AddMockedRegistry,
-}
-
-impl FilteredWorkspace {
-    fn new() -> Self {
-        let CommandTempCwd { root, workspace, npmrc_info, .. } =
-            CommandTempCwd::init().add_mocked_registry();
-        let fixture = Self { _root: root, workspace, registry: npmrc_info };
-        fixture.append_workspace_yaml("packages:\n  - 'packages/*'\n");
-        fixture
-    }
-
-    fn append_workspace_yaml(&self, text: &str) {
-        let path = self.workspace.join("pnpm-workspace.yaml");
-        let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
-        if !yaml.ends_with('\n') {
-            yaml.push('\n');
-        }
-        yaml.push_str(text);
-        fs::write(path, yaml).expect("write pnpm-workspace.yaml");
-    }
-
-    fn write_root_manifest(&self, name: &str, deps: ManifestDeps<'_>) {
-        write_manifest(&self.workspace, name, deps);
-    }
-
-    fn project(&self, dir: &str, name: &str, deps: ManifestDeps<'_>) -> PathBuf {
-        let project = self.workspace.join("packages").join(dir);
-        write_manifest(&project, name, deps);
-        project
-    }
-
-    fn command_at<Args, Arg>(&self, cwd: &Path, args: Args) -> Output
-    where
-        Args: IntoIterator<Item = Arg>,
-        Arg: AsRef<OsStr>,
-    {
-        Command::cargo_bin("pnpm")
-            .expect("find the pnpm binary")
-            .with_current_dir(cwd)
-            .env("PNPM_CONFIG_REGISTRY", self.registry.mock_instance.url())
-            .arg("--reporter=ndjson")
-            .args(args)
-            .output()
-            .expect("run pacquet")
-    }
-
-    fn run<Args, Arg>(&self, args: Args) -> Vec<Value>
-    where
-        Args: IntoIterator<Item = Arg>,
-        Arg: AsRef<OsStr>,
-    {
-        self.run_at(&self.workspace, args)
-    }
-
-    fn run_at<Args, Arg>(&self, cwd: &Path, args: Args) -> Vec<Value>
-    where
-        Args: IntoIterator<Item = Arg>,
-        Arg: AsRef<OsStr>,
-    {
-        let output = self.command_at(cwd, args);
-        assert_success(&output);
-        ndjson_records(&output)
-    }
-
-    fn wanted(&self) -> Lockfile {
-        read_lockfile(&self.workspace.join("pnpm-lock.yaml"))
-    }
-
-    fn current(&self) -> Lockfile {
-        read_lockfile(&self.workspace.join("node_modules/.pnpm/lock.yaml"))
-    }
-
-    fn modules(&self) -> Modules {
-        read_modules_manifest::<Host>(&self.workspace.join("node_modules"))
-            .expect("read .modules.yaml")
-            .expect(".modules.yaml exists")
-    }
-
-    fn write_modules(&self, modules: Modules) {
-        write_modules_manifest::<Host>(&self.workspace.join("node_modules"), modules)
-            .expect("write .modules.yaml");
-    }
-
-    fn state(&self) -> WorkspaceState {
-        let path = self.workspace.join("node_modules/.pnpm-workspace-state-v1.json");
-        serde_json::from_str(&fs::read_to_string(path).expect("read workspace state"))
-            .expect("parse workspace state")
-    }
-
-    fn package_map(&self) -> Value {
-        let path = self.workspace.join("node_modules/.package-map.json");
-        serde_json::from_str(&fs::read_to_string(path).expect("read package map"))
-            .expect("parse package map")
-    }
-
-    fn slot(&self, name: &str, version: &str) -> PathBuf {
-        self.workspace
-            .join("node_modules/.pnpm")
-            .join(format!("{}@{version}", name.replace('/', "+")))
-    }
-}
-
-fn write_manifest(project: &Path, name: &str, deps: ManifestDeps<'_>) {
-    fs::create_dir_all(project).expect("create project directory");
-    let mut manifest = Map::from_iter([
-        ("name".to_string(), Value::String(name.to_string())),
-        ("version".to_string(), Value::String("1.0.0".to_string())),
-        ("private".to_string(), Value::Bool(true)),
-    ]);
-    insert_dependency_group(&mut manifest, "dependencies", deps.prod);
-    insert_dependency_group(&mut manifest, "devDependencies", deps.dev);
-    insert_dependency_group(&mut manifest, "optionalDependencies", deps.optional);
-    insert_dependency_group(&mut manifest, "peerDependencies", deps.peer);
-    fs::write(
-        project.join("package.json"),
-        serde_json::to_string_pretty(&Value::Object(manifest)).expect("serialize package.json"),
-    )
-    .expect("write package.json");
-}
-
-fn insert_dependency_group(manifest: &mut Map<String, Value>, group: &str, deps: &[(&str, &str)]) {
-    if deps.is_empty() {
-        return;
-    }
-    manifest.insert(
-        group.to_string(),
-        Value::Object(
-            deps.iter()
-                .map(|(name, spec)| (name.to_string(), Value::String(spec.to_string())))
-                .collect(),
-        ),
-    );
-}
-
-fn read_manifest(project: &Path) -> Value {
-    serde_json::from_str(
-        &fs::read_to_string(project.join("package.json")).expect("read package.json"),
-    )
-    .expect("parse package.json")
-}
-
-fn write_manifest_value(project: &Path, manifest: &Value) {
-    fs::write(
-        project.join("package.json"),
-        serde_json::to_string_pretty(manifest).expect("serialize package.json"),
-    )
-    .expect("write package.json");
-}
-
-fn set_dependency(project: &Path, group: &str, name: &str, spec: &str) {
-    let mut manifest = read_manifest(project);
-    let object = manifest.as_object_mut().expect("manifest is an object");
-    let dependencies = object.entry(group).or_insert_with(|| json!({}));
-    dependencies
-        .as_object_mut()
-        .expect("dependency group is an object")
-        .insert(name.to_string(), Value::String(spec.to_string()));
-    write_manifest_value(project, &manifest);
-}
-
-fn set_version(project: &Path, version: &str) {
-    let path = project.join("package.json");
-    let mut manifest: Value =
-        serde_json::from_str(&fs::read_to_string(&path).expect("read package.json"))
-            .expect("parse package.json");
-    manifest["version"] = Value::String(version.to_string());
-    fs::write(path, serde_json::to_string_pretty(&manifest).expect("serialize package.json"))
-        .expect("write package.json");
-}
-
-fn replace_dependencies(project: &Path, deps: &[(&str, &str)]) {
-    let mut manifest = read_manifest(project);
-    manifest["dependencies"] = Value::Object(
-        deps.iter()
-            .map(|(name, spec)| (name.to_string(), Value::String(spec.to_string())))
-            .collect(),
-    );
-    write_manifest_value(project, &manifest);
-}
-
-fn dependency_spec(project: &Path, group: &str, name: &str) -> Option<String> {
-    read_manifest(project)
-        .get(group)
-        .and_then(Value::as_object)
-        .and_then(|dependencies| dependencies.get(name))
-        .and_then(Value::as_str)
-        .map(str::to_string)
-}
-
-fn read_lockfile(path: &Path) -> Lockfile {
-    let contents = fs::read_to_string(path)
-        .unwrap_or_else(|error| panic!("read lockfile {}: {error}", path.display()));
-    serde_saphyr::from_str(&contents)
-        .unwrap_or_else(|error| panic!("parse lockfile {}: {error}\n{contents}", path.display()))
-}
-
-fn assert_success(output: &Output) {
-    assert!(
-        output.status.success(),
-        "command failed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr),
-    );
-}
-
-fn ndjson_records(output: &Output) -> Vec<Value> {
-    [&output.stderr[..], &output.stdout[..]]
-        .into_iter()
-        .flat_map(|stream| {
-            String::from_utf8_lossy(stream).lines().map(str::to_string).collect::<Vec<_>>()
-        })
-        .filter_map(|line| serde_json::from_str(&line).ok())
-        .collect()
-}
 
 fn importing_started_count(records: &[Value]) -> usize {
     records
@@ -273,92 +38,13 @@ fn initial_manifest_prefixes(records: &[Value]) -> Vec<String> {
         .collect()
 }
 
-fn importer<'a>(lockfile: &'a Lockfile, id: &str) -> &'a ProjectSnapshot {
-    lockfile
-        .importers
-        .get(id)
-        .unwrap_or_else(|| panic!("missing importer {id:?}: {:?}", lockfile.importers.keys()))
-}
-
-fn importer_version(lockfile: &Lockfile, id: &str, name: &str) -> String {
-    let name: PkgName = name.parse().expect("parse package name");
-    let snapshot = importer(lockfile, id);
-    snapshot
-        .dependencies
-        .as_ref()
-        .and_then(|dependencies| dependencies.get(&name))
-        .or_else(|| {
-            snapshot.dev_dependencies.as_ref().and_then(|dependencies| dependencies.get(&name))
-        })
-        .or_else(|| {
-            snapshot.optional_dependencies.as_ref().and_then(|dependencies| dependencies.get(&name))
-        })
-        .unwrap_or_else(|| panic!("missing dependency {name} in importer {id}"))
-        .version
-        .to_string()
-}
-
-fn importer_specifier(lockfile: &Lockfile, id: &str, name: &str) -> String {
-    let name: PkgName = name.parse().expect("parse package name");
-    importer(lockfile, id)
-        .dependencies
-        .as_ref()
-        .and_then(|dependencies| dependencies.get(&name))
-        .unwrap_or_else(|| panic!("missing dependency {name} in importer {id}"))
-        .specifier
-        .clone()
-}
-
-fn importer_ids(lockfile: &Lockfile) -> BTreeSet<String> {
-    lockfile.importers.keys().cloned().collect()
-}
-
-fn snapshot_entries(lockfile: &Lockfile, name: &str) -> Vec<(String, SnapshotEntry)> {
-    lockfile
-        .snapshots
-        .as_ref()
-        .into_iter()
-        .flatten()
-        .filter(|(key, _)| key.to_string().starts_with(&format!("{name}@")))
-        .map(|(key, snapshot)| (key.to_string(), snapshot.clone()))
-        .collect()
-}
-
-fn has_snapshot(lockfile: &Lockfile, name: &str, version: &str) -> bool {
-    lockfile.snapshots.as_ref().is_some_and(|snapshots| {
-        snapshots.keys().any(|key| {
-            let key = key.to_string();
-            key == format!("{name}@{version}") || key.starts_with(&format!("{name}@{version}("))
-        })
-    })
-}
-
-fn has_link(project: &Path, name: &str) -> bool {
-    is_symlink_or_junction(&project.join("node_modules").join(name)).unwrap_or(false)
-}
-
-fn canonical_path(path: &Path) -> String {
-    dunce::canonicalize(path)
-        .unwrap_or_else(|error| panic!("canonicalize {}: {error}", path.display()))
-        .to_string_lossy()
-        .into_owned()
-}
-
 fn assert_stage_once(records: &[Value]) {
     assert_eq!(importing_started_count(records), 1, "one install pipeline must import once");
 }
 
-fn assert_full_wanted(lockfile: &Lockfile, ids: &[&str]) {
-    assert_eq!(
-        importer_ids(lockfile),
-        ids.iter().map(ToString::to_string).collect(),
-        "wanted lockfile must retain every real importer",
-    );
-}
-
 #[test]
 fn full_recursive_install_keeps_the_unfiltered_up_to_date_path() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.project("app", "app", ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() });
     fixture.project(
         "lib",
@@ -386,7 +72,7 @@ fn full_recursive_install_keeps_the_unfiltered_up_to_date_path() {
 
 #[test]
 fn filtered_add_mutates_only_selected_importers() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected_a = fixture.project("selected-a", "selected-a", ManifestDeps::default());
     let selected_b = fixture.project("selected-b", "selected-b", ManifestDeps::default());
     let unselected = fixture.project(
@@ -424,7 +110,7 @@ fn filtered_add_mutates_only_selected_importers() {
 
 #[test]
 fn filtered_update_mutates_only_selected_importers() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected_a = fixture.project(
         "selected-a",
         "selected-a",
@@ -475,7 +161,7 @@ fn filtered_update_mutates_only_selected_importers() {
 
 #[test]
 fn filtered_remove_mutates_only_selected_importers() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected_a = fixture.project(
         "selected-a",
         "selected-a",
@@ -522,7 +208,7 @@ fn filtered_remove_mutates_only_selected_importers() {
 
 #[test]
 fn filtered_update_from_selected_child_uses_discovered_manifest_as_source_of_truth() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -549,7 +235,7 @@ fn filtered_update_from_selected_child_uses_discovered_manifest_as_source_of_tru
 
 #[test]
 fn filtered_update_preserves_prior_importer_when_unselected_manifest_changed_externally() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -583,7 +269,7 @@ fn filtered_update_preserves_prior_importer_when_unselected_manifest_changed_ext
 }
 
 fn compatible_update_scenario(selected_dir: &str, unselected_dir: &str) {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         selected_dir,
         "selected",
@@ -617,7 +303,7 @@ fn filtered_compatible_update_does_not_cross_importer_cache_boundaries() {
 
 #[test]
 fn filtered_compatible_update_keeps_workspace_manifest_preferences() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -647,7 +333,7 @@ fn transitive_update_scenario(
     selected_dir: &str,
     unselected_dir: &str,
 ) -> (HashMap<pacquet_lockfile::PackageKey, SnapshotEntry>, String) {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let deps = || ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() };
     let selected = fixture.project(selected_dir, "selected", deps());
     let unselected = fixture.project(unselected_dir, "unselected", deps());
@@ -695,7 +381,7 @@ fn filtered_transitive_update_keeps_one_canonical_shared_snapshot() {
 }
 
 fn assert_selected_isolated_closure(
-    fixture: &FilteredWorkspace,
+    fixture: &WorkspaceFixture,
     selected: &Path,
     unselected: &Path,
 ) {
@@ -722,7 +408,7 @@ fn assert_selected_isolated_closure(
 
 #[test]
 fn filtered_fresh_install_materializes_only_selected_isolated_closure() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -739,7 +425,7 @@ fn filtered_fresh_install_materializes_only_selected_isolated_closure() {
 
 #[test]
 fn filtered_frozen_install_materializes_only_selected_isolated_closure() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -757,7 +443,7 @@ fn filtered_frozen_install_materializes_only_selected_isolated_closure() {
 
 #[test]
 fn unfiltered_install_after_filtered_install_restores_all_projects() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -782,7 +468,7 @@ fn unfiltered_install_after_filtered_install_restores_all_projects() {
 
 #[test]
 fn filtered_frozen_install_checks_only_selected_manifest_specifiers() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -839,7 +525,7 @@ fn map_contains(value: &Value, needle: &str) -> bool {
 
 #[test]
 fn filtered_install_after_full_install_preserves_unselected_materialization() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml(
         "nodeExperimentalPackageMap: true\nhoistPattern:\n  - '*'\nmodulesCacheMaxAge: 0\n",
     );
@@ -922,26 +608,9 @@ fn filtered_install_after_full_install_preserves_unselected_materialization() {
     assert_eq!(importer_version(&after_current, "packages/selected", NO_DEPS), "1.0.0");
 }
 
-fn importer_has_group_dependency(
-    lockfile: &Lockfile,
-    id: &str,
-    group: &str,
-    dependency: &str,
-) -> bool {
-    let name: PkgName = dependency.parse().expect("parse package name");
-    let importer = importer(lockfile, id);
-    match group {
-        "dependencies" => importer.dependencies.as_ref(),
-        "devDependencies" => importer.dev_dependencies.as_ref(),
-        "optionalDependencies" => importer.optional_dependencies.as_ref(),
-        _ => panic!("unsupported dependency group {group}"),
-    }
-    .is_some_and(|dependencies| dependencies.contains_key(&name))
-}
-
 #[test]
 fn filtered_prod_install_prunes_direct_links_only_in_selected_projects() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let deps = || ManifestDeps {
         prod: &[(HELLO, "1.0.0")],
         dev: &[(NO_DEPS, "1.0.0")],
@@ -974,7 +643,7 @@ fn filtered_prod_install_prunes_direct_links_only_in_selected_projects() {
 
 #[test]
 fn sequential_filtered_prod_installs_prune_each_selected_project() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let deps = || ManifestDeps {
         prod: &[(HELLO, "1.0.0")],
         dev: &[(NO_DEPS, "1.0.0")],
@@ -996,7 +665,7 @@ fn sequential_filtered_prod_installs_prune_each_selected_project() {
 
 #[test]
 fn filtered_prod_install_prunes_workspace_link_closure_projects() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml("linkWorkspacePackages: true\n");
     let selected = fixture.project(
         "selected",
@@ -1024,7 +693,7 @@ fn filtered_prod_install_prunes_workspace_link_closure_projects() {
 
 #[test]
 fn filtered_install_keeps_full_cleanup_for_shared_layout_drift() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -1065,7 +734,7 @@ fn filtered_install_keeps_full_cleanup_for_shared_layout_drift() {
 
 #[test]
 fn filtered_hoisted_install_materializes_full_shared_graph_but_links_only_selected_projects() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml("nodeLinker: hoisted\nnodeExperimentalPackageMap: true\n");
     let selected = fixture.project(
         "selected",
@@ -1101,7 +770,7 @@ fn filtered_hoisted_install_materializes_full_shared_graph_but_links_only_select
 
 #[test]
 fn filtered_isolated_install_expands_workspace_link_closure() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml("linkWorkspacePackages: deep\n");
     let selected = fixture.project(
         "selected",
@@ -1140,7 +809,7 @@ fn filtered_isolated_install_expands_workspace_link_closure() {
 
 #[test]
 fn filtered_pnp_install_uses_isolated_placeholder_scope() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml("nodeLinker: pnp\n");
     let selected = fixture.project(
         "selected",
@@ -1165,7 +834,7 @@ fn filtered_pnp_install_uses_isolated_placeholder_scope() {
 
 #[test]
 fn install_selection_uses_post_update_config_workspace_graph() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let app = fixture.project(
         "app",
         "app",
@@ -1187,7 +856,7 @@ fn install_selection_uses_post_update_config_workspace_graph() {
 }
 
 fn recursive_add_prefixes(no_sort: bool) -> (Vec<String>, String, String) {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let app = fixture.project(
         "app",
         "app",
@@ -1213,7 +882,7 @@ fn recursive_no_sort_preserves_selector_discovery_order() {
 
 #[test]
 fn workspace_without_root_manifest_does_not_create_root_importer() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let selected = fixture.project(
         "selected",
         "selected",
@@ -1240,7 +909,7 @@ fn workspace_without_root_manifest_does_not_create_root_importer() {
 
 #[test]
 fn workspace_non_project_subdirectory_does_not_create_active_importer() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.write_root_manifest("workspace-root", ManifestDeps::default());
     let selected = fixture.project(
         "selected",
@@ -1273,7 +942,7 @@ fn workspace_non_project_subdirectory_does_not_create_active_importer() {
 
 #[test]
 fn filtered_install_rejects_per_project_workspace_lockfiles() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml("sharedWorkspaceLockfile: false\n");
     fixture.project("app", "app", ManifestDeps::default());
 
@@ -1292,7 +961,7 @@ fn filtered_install_rejects_per_project_workspace_lockfiles() {
 
 #[test]
 fn recursive_add_auto_excludes_workspace_root() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.write_root_manifest("workspace-root", ManifestDeps::default());
     let member_a = fixture.project("member-a", "member-a", ManifestDeps::default());
     let member_b = fixture.project("member-b", "member-b", ManifestDeps::default());
@@ -1309,7 +978,7 @@ fn recursive_add_auto_excludes_workspace_root() {
 
 #[test]
 fn filter_matching_every_real_project_is_not_partial() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let member_a = fixture.project(
         "member-a",
         "member-a",
@@ -1336,7 +1005,7 @@ fn filter_matching_every_real_project_is_not_partial() {
 
 #[test]
 fn filtered_install_refreshes_unselected_catalog_importers_when_catalog_changes() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml(&format!("catalog:\n  '{CATALOG_FOO}': 1.0.0\n"));
     fixture.project("app", "app", ManifestDeps::default());
     fixture.project(
@@ -1374,14 +1043,14 @@ fn filtered_install_refreshes_unselected_catalog_importers_when_catalog_changes(
 
 #[test]
 fn active_manifest_outside_workspace_patterns_keeps_install_filtered() {
-    let fixture = FilteredWorkspace::new();
+    let fixture = WorkspaceFixture::new();
     let member = fixture.project(
         "member",
         "member",
         ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
     );
     let local = fixture.workspace.join("tools/local");
-    write_manifest(
+    write_project_manifest(
         &local,
         "local",
         ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },

--- a/pnpm/crates/cli/tests/multiple_importers.rs
+++ b/pnpm/crates/cli/tests/multiple_importers.rs
@@ -1,0 +1,599 @@
+//! Ports of the upstream multi-importer install suites — the
+//! workspace-subset (`--filter`) and shared-lockfile scenarios from
+//! `installing/deps-installer/test/install/multipleImporters.ts`, the
+//! workspace cases of `installing/deps-restorer/test/index.ts`, and the
+//! CLI-level `pnpm/test/monorepo/index.ts` items. See
+//! `plans/TEST_PORTING.md` § "Support Workspaces".
+//!
+//! Upstream drives subset installs through `mutateModules` /
+//! `mutateModulesInSingleProject` with a shared lockfile dir; the CLI
+//! equivalent is `pnpm --filter <project> install` in a
+//! `pnpm-workspace.yaml` workspace.
+
+#![cfg(unix)] // pnpm CLI: 'program not found' on Windows runners.
+
+pub mod _utils;
+pub use _utils::*;
+
+use pacquet_testing_utils::fs::is_path_executable;
+use serde_json::json;
+use std::fs;
+
+const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+const FOO: &str = "@pnpm.e2e/foo";
+const FOOBAR: &str = "@pnpm.e2e/foobar";
+const HELLO: &str = "@pnpm.e2e/hello-world-js-bin";
+const NO_DEPS: &str = "@foo/no-deps";
+const PARENT: &str = "@pnpm.e2e/pkg-with-1-dep";
+const QAR: &str = "@pnpm.e2e/qar";
+
+/// TS: `dependencies of other importers are not pruned when (headless)
+/// installing for a subset of importers` (`multipleImporters.ts:438`).
+/// After bumping a selected project's dependency lockfile-only, the
+/// frozen subset install must replace only the selected project's old
+/// slot; the unselected project's materialization stays.
+#[test]
+fn deps_of_other_importers_are_not_pruned_when_headless_installing_a_subset() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("modulesCacheMaxAge: 0\n");
+    let project_1 = fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps { prod: &[(FOO, "1.0.0")], ..Default::default() },
+    );
+    let project_2 = fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[(NO_DEPS, "1.0.0")], ..Default::default() },
+    );
+    fixture.run(["install"]);
+    assert!(fixture.slot(FOO, "1.0.0").exists());
+
+    fixture.run(["--filter", "project-1", "add", &format!("{FOO}@2.0.0"), "--lockfile-only"]);
+    fixture.run(["--filter", "project-1", "install", "--frozen-lockfile"]);
+
+    assert!(has_link(&project_1, FOO));
+    assert!(has_link(&project_2, NO_DEPS));
+    assert!(fixture.slot(FOO, "2.0.0").exists());
+    assert!(!fixture.slot(FOO, "1.0.0").exists(), "the replaced slot must be pruned");
+    assert!(
+        fixture.slot(NO_DEPS, "1.0.0").exists(),
+        "the unselected project's slot must survive the subset install",
+    );
+}
+
+/// TS: `install only the dependencies of the specified importer. The
+/// current lockfile has importers that do not exist anymore`
+/// (`multipleImporters.ts:208`). A project leaves the workspace while
+/// its materialization stays on disk; a later subset install must keep
+/// the stale importer (and its packages) in the current lockfile.
+#[test]
+fn stale_current_lockfile_importers_are_retained_on_subset_install() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("hoistPattern:\n  - '*'\n");
+    fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps { prod: &[(FOO, "1.0.0")], ..Default::default() },
+    );
+    fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[(NO_DEPS, "1.0.0")], ..Default::default() },
+    );
+    let project_3 = fixture.project(
+        "project-3",
+        "project-3",
+        ManifestDeps { prod: &[(FOOBAR, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install"]);
+    let before = fixture.current();
+    assert!(before.importers.contains_key("packages/project-3"));
+
+    fs::remove_file(project_3.join("package.json")).expect("drop project-3 from the workspace");
+    fixture.run(["install", "--lockfile-only", "--no-prefer-frozen-lockfile"]);
+    assert!(
+        !fixture.wanted().importers.contains_key("packages/project-3"),
+        "the wanted lockfile must drop the removed importer",
+    );
+
+    fixture.run(["--filter", "project-1", "add", PARENT]);
+
+    let current = fixture.current();
+    assert!(
+        current.importers.contains_key("packages/project-3"),
+        "the still-materialized stale importer must stay in the current lockfile",
+    );
+    assert!(has_snapshot(&current, FOOBAR, "100.0.0"));
+}
+
+/// TS: `current lockfile contains only installed dependencies when
+/// adding a new importer to workspace with shared lockfile`
+/// (`multipleImporters.ts:730`).
+#[test]
+fn current_lockfile_contains_only_installed_dependencies() {
+    let fixture = WorkspaceFixture::new();
+    fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps { prod: &[(FOO, "1.0.0")], ..Default::default() },
+    );
+    fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[(NO_DEPS, "1.0.0")], ..Default::default() },
+    );
+    fixture.run(["--filter", "project-1", "install", "--lockfile-only"]);
+    fixture.run(["--filter", "project-2", "install"]);
+
+    let current = fixture.current();
+    let package_keys: Vec<String> =
+        current.packages.iter().flatten().map(|(key, _)| key.to_string()).collect();
+    assert_eq!(package_keys, [format!("{NO_DEPS}@1.0.0")]);
+}
+
+/// TS: `headless install is used when package linked to another package
+/// in the workspace` (`multipleImporters.ts:540`). The subset install
+/// after a lockfile-only resolve must go headless (it announces
+/// "Lockfile is up to date, resolution step is skipped").
+///
+/// Upstream additionally asserts the unselected link target's own
+/// dependencies are *not* installed; pacquet expands the subset closure
+/// through importer-level links, so that tail lives in
+/// [`known_failures::subset_install_does_not_install_unselected_link_targets_dependencies`].
+#[test]
+fn headless_install_is_used_when_package_is_linked_to_another_workspace_package() {
+    let fixture = WorkspaceFixture::new();
+    let project_1 = fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps {
+            prod: &[(FOO, "1.0.0"), ("project-2", "link:../project-2")],
+            ..Default::default()
+        },
+    );
+    fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[(NO_DEPS, "1.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+
+    let records = fixture.run(["--filter", "project-1", "install"]);
+
+    assert!(has_up_to_date_log(&records), "the subset install must go headless: {records:#?}");
+    assert!(has_link(&project_1, FOO));
+    assert!(has_link(&project_1, "project-2"));
+}
+
+/// TS: `headless install is used with an up-to-date lockfile when
+/// package references another package via workspace: protocol`
+/// (`multipleImporters.ts:598`).
+#[test]
+fn headless_install_is_used_with_workspace_protocol_references() {
+    let fixture = WorkspaceFixture::new();
+    let project_1 = fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps {
+            prod: &[(FOO, "1.0.0"), ("project-2", "workspace:1.0.0")],
+            ..Default::default()
+        },
+    );
+    let project_2 = fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[(NO_DEPS, "1.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+
+    let records = fixture.run(["install"]);
+
+    assert!(has_up_to_date_log(&records), "the install must go headless: {records:#?}");
+    assert!(has_link(&project_1, FOO));
+    assert!(has_link(&project_1, "project-2"));
+    assert!(has_link(&project_2, NO_DEPS));
+}
+
+/// TS: `headless install is used when packages are not linked from the
+/// workspace (unless workspace ranges are used)`
+/// (`multipleImporters.ts:656`). With `linkWorkspacePackages: false`, a
+/// `workspace:*` range still links while a plain semver range resolves
+/// from the registry — and the resulting mixed lockfile still passes
+/// the freshness gate, so the reinstall goes headless.
+#[test]
+fn headless_install_is_used_when_packages_are_not_linked_from_the_workspace() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("linkWorkspacePackages: false\n");
+    let foo_project = fixture.project(
+        "foo",
+        FOO,
+        ManifestDeps { prod: &[(QAR, "workspace:*")], ..Default::default() },
+    );
+    let bar_project = fixture.project(
+        "bar",
+        "@pnpm.e2e/bar",
+        ManifestDeps { prod: &[(QAR, "100.0.0")], ..Default::default() },
+    );
+    let qar_project = fixture.project("qar", QAR, ManifestDeps::default());
+    set_version(&qar_project, "100.0.0");
+    fixture.run(["install", "--lockfile-only"]);
+
+    let records = fixture.run(["install"]);
+
+    assert!(has_up_to_date_log(&records), "the install must go headless: {records:#?}");
+    let foo_qar = fs::canonicalize(foo_project.join("node_modules").join(QAR))
+        .expect("foo's workspace-range dependency is linked");
+    assert_eq!(foo_qar, fs::canonicalize(&qar_project).expect("canonicalize the qar project"));
+    let bar_qar = fs::canonicalize(bar_project.join("node_modules").join(QAR))
+        .expect("bar's registry dependency is materialized");
+    assert!(
+        bar_qar.starts_with(fs::canonicalize(fixture.slot(QAR, "100.0.0")).expect("qar slot")),
+        "a plain semver range must resolve from the registry when linking is off, got {bar_qar:?}",
+    );
+}
+
+/// TS: `partial installation in a monorepo does not remove dependencies
+/// of other workspace projects when lockfile is frozen`
+/// (`multipleImporters.ts:865`). The wanted lockfile is edited so the
+/// unselected project's transitive pin points elsewhere; the frozen
+/// subset install must still not remove the previously-materialized
+/// slots of the unselected project.
+#[test]
+fn partial_frozen_install_does_not_remove_dependencies_of_other_workspace_projects() {
+    let fixture = WorkspaceFixture::new();
+    // Project-1 pins 101.0.0 directly — outside project-2's transitive
+    // `^100.0.0` range, so the resolver cannot converge the transitive
+    // onto it and both versions get locked and materialized.
+    fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps { prod: &[(FOO, "1.0.0"), (DEP, "101.0.0")], ..Default::default() },
+    );
+    fixture.project(
+        "project-2",
+        "project-2",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install"]);
+    assert!(fixture.slot(DEP, "100.1.0").exists());
+
+    // Repin the unselected project's transitive from 100.1.0 (what the
+    // resolver picked for `^100.0.0`) to the 101.0.0 entry that
+    // project-1's direct dependency already locked — the upstream test
+    // rewrites the lockfile to the same effect, leaving the 100.1.0
+    // materialization orphaned.
+    let lockfile_path = fixture.workspace.join("pnpm-lock.yaml");
+    let lockfile_text = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    let repinned =
+        lockfile_text.replace(&format!("'{DEP}': 100.1.0"), &format!("'{DEP}': 101.0.0"));
+    assert_ne!(repinned, lockfile_text, "expected the transitive pin in the snapshots section");
+    fs::write(&lockfile_path, repinned).expect("write pnpm-lock.yaml");
+
+    fixture.run(["--filter", "project-1", "install", "--frozen-lockfile"]);
+
+    assert!(fixture.slot(FOO, "1.0.0").exists());
+    assert!(
+        fixture.slot(PARENT, "100.0.0").exists(),
+        "the unselected project's direct dependency must not be removed",
+    );
+    assert!(
+        fixture.slot(DEP, "100.1.0").exists(),
+        "the unselected project's previously-materialized transitive must not be removed",
+    );
+}
+
+/// TS: `resolve a subdependency from the workspace`
+/// (`multipleImporters.ts:1427`). With `linkWorkspacePackages: deep`, a
+/// transitive resolves to the workspace project as a `link:`, and the
+/// headless reinstall does not fail on links in subdeps.
+#[test]
+fn resolve_a_subdependency_from_the_workspace() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("linkWorkspacePackages: deep\n");
+    fixture.project(
+        "project",
+        "project",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    let dep_project = fixture.project("dep", DEP, ManifestDeps::default());
+    set_version(&dep_project, "100.1.0");
+    fixture.run(["install"]);
+
+    let wanted = fixture.wanted();
+    let parent_snapshots = snapshot_entries(&wanted, PARENT);
+    assert_eq!(parent_snapshots.len(), 1);
+    let subdependency = parent_snapshots[0]
+        .1
+        .dependencies
+        .as_ref()
+        .and_then(|dependencies| dependencies.get(&DEP.parse().expect("parse package name")))
+        .expect("parent snapshot records the subdependency")
+        .to_string();
+    assert_eq!(subdependency, "link:packages/dep");
+
+    fs::remove_dir_all(fixture.workspace.join("node_modules")).expect("remove node_modules");
+    fixture.run(["install", "--frozen-lockfile"]);
+}
+
+/// TS: `resolve a subdependency from the workspace, when it uses the
+/// workspace protocol` (`multipleImporters.ts:1563`). The `workspace:*`
+/// pin arrives through an override while `linkWorkspacePackages` is
+/// off.
+#[test]
+fn resolve_a_subdependency_from_the_workspace_via_workspace_protocol_override() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml(&format!(
+        "linkWorkspacePackages: false\noverrides:\n  '{DEP}': 'workspace:*'\n"
+    ));
+    fixture.project(
+        "project",
+        "project",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+    let dep_project = fixture.project("dep", DEP, ManifestDeps::default());
+    set_version(&dep_project, "100.1.0");
+    fixture.run(["install"]);
+
+    let wanted = fixture.wanted();
+    let parent_snapshots = snapshot_entries(&wanted, PARENT);
+    assert_eq!(parent_snapshots.len(), 1);
+    let subdependency = parent_snapshots[0]
+        .1
+        .dependencies
+        .as_ref()
+        .and_then(|dependencies| dependencies.get(&DEP.parse().expect("parse package name")))
+        .expect("parent snapshot records the subdependency")
+        .to_string();
+    assert_eq!(subdependency, "link:packages/dep");
+
+    fs::remove_dir_all(fixture.workspace.join("node_modules")).expect("remove node_modules");
+    fixture.run(["install", "--frozen-lockfile"]);
+}
+
+/// TS: `installing in a workspace` (`deps-restorer/test/index.ts:789`).
+/// A subset headless install keeps the other project's packages in the
+/// current lockfile.
+#[test]
+fn subset_headless_install_keeps_other_projects_packages_in_current_lockfile() {
+    let fixture = WorkspaceFixture::new();
+    let foo_project = fixture.project(
+        "foo",
+        "foo",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let bar_project = fixture.project(
+        "bar",
+        "bar",
+        ManifestDeps { prod: &[("foo", "workspace:*"), (NO_DEPS, "1.0.0")], ..Default::default() },
+    );
+    fixture.run(["install"]);
+    assert!(has_link(&bar_project, "foo"));
+
+    fixture.run(["--filter", "foo", "install", "--frozen-lockfile"]);
+
+    assert!(has_link(&foo_project, HELLO));
+    assert!(has_link(&bar_project, "foo"));
+    let current = fixture.current();
+    assert!(has_snapshot(&current, HELLO, "1.0.0"));
+    assert!(
+        has_snapshot(&current, NO_DEPS, "1.0.0"),
+        "the other project's package must stay in the current lockfile",
+    );
+}
+
+/// TS: `installing a package deeply installs all required dependencies`
+/// (`deps-restorer/test/index.ts:897`). The selected project depends on
+/// an external registry package whose own dependency resolves to a
+/// workspace project (`link:packages/f` in its snapshot); the frozen
+/// subset install must materialize that linked project's own
+/// dependencies too.
+#[test]
+fn subset_headless_install_deeply_materializes_workspace_linked_dependencies() {
+    let fixture = WorkspaceFixture::new();
+    let f_project = fixture.project(
+        "f",
+        "@pnpm.e2e/internal-f",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let g_project = fixture.project(
+        "g",
+        "@pnpm.e2e/internal-g",
+        ManifestDeps {
+            prod: &[("@pnpm.e2e/external-depend-on-internal-dep", "1.0.0")],
+            ..Default::default()
+        },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    // Pacquet's resolver records the external manifest's
+    // `link:packages/f` relative to the dependent importer
+    // (`link:packages/g/packages/f`); the upstream fixture lockfile
+    // records it relative to the lockfile dir. Rewrite the snapshot to
+    // the upstream (lockfile-relative) shape — the subject under test
+    // is the headless materialization of snapshot-level links, and
+    // upstream drives it from a hand-authored lockfile too.
+    let lockfile_path = fixture.workspace.join("pnpm-lock.yaml");
+    let lockfile_text = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    let rewritten = lockfile_text.replace("link:packages/g/packages/f", "link:packages/f");
+    assert_ne!(
+        rewritten, lockfile_text,
+        "expected the external package's snapshot to record the workspace link",
+    );
+    fs::write(&lockfile_path, rewritten).expect("write pnpm-lock.yaml");
+
+    fixture.run(["--filter", "@pnpm.e2e/internal-g", "install", "--frozen-lockfile"]);
+
+    assert!(has_link(&g_project, "@pnpm.e2e/external-depend-on-internal-dep"));
+    assert!(
+        has_link(&f_project, HELLO),
+        "the snapshot-linked workspace project's own dependencies must be materialized",
+    );
+    assert!(fixture.slot(HELLO, "1.0.0").exists());
+}
+
+/// TS: `linking the package's bin to another workspace package in a
+/// monorepo` (`pnpm/test/monorepo/index.ts:1317`), including the frozen
+/// reinstall after wiping every `node_modules`.
+#[test]
+fn links_workspace_package_bin_into_dependent_project() {
+    let fixture = WorkspaceFixture::new();
+    let hello_project = fixture.workspace.join("packages/hello");
+    fs::create_dir_all(&hello_project).expect("create the hello project");
+    fs::write(
+        hello_project.join("package.json"),
+        json!({ "name": "hello", "version": "1.0.0", "bin": "index.js" }).to_string(),
+    )
+    .expect("write hello's package.json");
+    fs::write(hello_project.join("index.js"), "#!/usr/bin/env node\n").expect("write hello's bin");
+    let main_project = fixture.project(
+        "main",
+        "main",
+        ManifestDeps { prod: &[("hello", "workspace:*")], ..Default::default() },
+    );
+
+    fixture.run(["install"]);
+    let bin_path = main_project.join("node_modules/.bin/hello");
+    assert!(is_path_executable(&bin_path), "expected an executable bin at {bin_path:?}");
+
+    fs::remove_dir_all(main_project.join("node_modules")).expect("remove main's node_modules");
+    fs::remove_dir_all(fixture.workspace.join("node_modules")).expect("remove root node_modules");
+    fixture.run(["install", "--frozen-lockfile"]);
+
+    assert!(is_path_executable(&bin_path), "the frozen reinstall must re-link the bin");
+}
+
+/// TS: `custom virtual store directory in a workspace with shared
+/// lockfile` (`pnpm/test/monorepo/index.ts:1514`). `.modules.yaml`
+/// records the resolved custom `virtualStoreDir`, on the fresh install
+/// and again after a frozen reinstall from a wiped state.
+#[test]
+fn custom_virtual_store_directory_in_a_workspace_with_shared_lockfile() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("virtualStoreDir: virtual-store\n");
+    fixture.project(
+        "project-1",
+        "project-1",
+        ManifestDeps { prod: &[(FOO, "1.0.0")], ..Default::default() },
+    );
+
+    let expected = fixture.workspace.join("virtual-store");
+    let assert_recorded_virtual_store = |phase: &str| {
+        let modules = fixture.modules();
+        assert_eq!(
+            dunce::canonicalize(&modules.virtual_store_dir)
+                .unwrap_or_else(|_| modules.virtual_store_dir.clone().into()),
+            dunce::canonicalize(&expected).expect("canonicalize the custom virtual store"),
+            "[{phase}] .modules.yaml must record the custom virtualStoreDir",
+        );
+    };
+
+    fixture.run(["install"]);
+    assert_recorded_virtual_store("fresh");
+
+    fs::remove_dir_all(&expected).expect("remove the virtual store");
+    fs::remove_dir_all(fixture.workspace.join("node_modules")).expect("remove node_modules");
+    fixture.run(["install", "--frozen-lockfile"]);
+    assert_recorded_virtual_store("frozen");
+}
+
+mod known_failures {
+    //! Multi-importer cases blocked on features pacquet hasn't built
+    //! yet. Each entry stubs the not-yet-built subject under test
+    //! through [`pacquet_testing_utils::allow_known_failure`] so the
+    //! test exits early rather than masking a real bug.
+
+    use pacquet_testing_utils::{
+        allow_known_failure,
+        known_failure::{KnownFailure, KnownResult},
+    };
+
+    fn publish_config_directory_linking() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "Pacquet reads `publishConfig.directory` for the lockfile's \
+             `publishDirectory` field, freshness drift, and `pnpm pack`, \
+             but the install path never links a workspace package from \
+             that directory (`publishConfig.linkDirectory`).",
+        ))
+    }
+
+    fn build_index_ordered_project_scripts() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "Pacquet runs workspace projects' own lifecycle scripts \
+             root-first, not in `buildIndex` (workspace-topological) \
+             order, and does not re-link project bins between build \
+             groups — see the follow-up note on \
+             `run_projects_lifecycle_scripts` in \
+             `crates/package-manager/src/install.rs`.",
+        ))
+    }
+
+    fn per_project_workspace_lockfiles() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "`sharedWorkspaceLockfile: false` is not supported by \
+             pacquet's install family \
+             (`ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED`).",
+        ))
+    }
+
+    fn importer_level_link_closure_divergence() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "Pacquet's subset-install materialization closure follows \
+             importer-level `link:` / workspace-linked dependencies of \
+             the selected projects and installs the link targets' own \
+             dependencies (`materialization_closure` in \
+             `crates/package-manager/src/current_lockfile.rs`). The \
+             TypeScript CLI keeps those targets shallow — only \
+             `--filter <project>...` widens the selection — so the two \
+             stacks need a shared decision before this can be pinned.",
+        ))
+    }
+
+    /// TS: `symlink local package from the location described in its
+    /// publishConfig.directory when linkDirectory is true`
+    /// (`multipleImporters.ts:1768`).
+    #[test]
+    fn symlink_local_package_from_publish_config_directory() {
+        allow_known_failure!(publish_config_directory_linking());
+    }
+
+    /// TS: `link the bin file of a workspace project that is created by
+    /// a lifecycle script` (`multipleImporters.ts:1902`). Needs
+    /// `buildIndex` ordering plus bin re-linking between groups so a
+    /// dependent project's `prepare` can call the freshly-created bin.
+    #[test]
+    fn link_bin_of_workspace_project_created_by_lifecycle_script() {
+        allow_known_failure!(build_index_ordered_project_scripts());
+    }
+
+    /// TS: `recursive install with shared-workspace-lockfile builds
+    /// workspace projects in correct order`
+    /// (`pnpm/test/monorepo/index.ts:734`).
+    #[test]
+    fn recursive_install_builds_workspace_projects_in_correct_order() {
+        allow_known_failure!(build_index_ordered_project_scripts());
+    }
+
+    /// TS: `dependencies of workspace projects are built during
+    /// headless installation` (`pnpm/test/monorepo/index.ts:1281`) —
+    /// the upstream fixture turns off `sharedWorkspaceLockfile`.
+    #[test]
+    fn workspace_project_dependencies_built_during_headless_install_with_dedicated_lockfiles() {
+        allow_known_failure!(per_project_workspace_lockfiles());
+    }
+
+    /// TS: `custom virtual store directory in a workspace with not
+    /// shared lockfile` (`pnpm/test/monorepo/index.ts:1467`).
+    #[test]
+    fn custom_virtual_store_directory_with_dedicated_lockfiles() {
+        allow_known_failure!(per_project_workspace_lockfiles());
+    }
+
+    /// The tail of TS `headless install is used when package linked to
+    /// another package in the workspace` (`multipleImporters.ts:540`):
+    /// the unselected `link:` target's own dependencies must not be
+    /// installed by the subset install.
+    #[test]
+    fn subset_install_does_not_install_unselected_link_targets_dependencies() {
+        allow_known_failure!(importer_level_link_closure_divergence());
+    }
+}

--- a/pnpm/crates/cli/tests/multiple_importers.rs
+++ b/pnpm/crates/cli/tests/multiple_importers.rs
@@ -324,7 +324,7 @@ fn resolve_a_subdependency_from_the_workspace() {
 fn resolve_a_subdependency_from_the_workspace_via_workspace_protocol_override() {
     let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml(&format!(
-        "linkWorkspacePackages: false\noverrides:\n  '{DEP}': 'workspace:*'\n"
+        "linkWorkspacePackages: false\noverrides:\n  '{DEP}': 'workspace:*'\n",
     ));
     fixture.project(
         "project",

--- a/pnpm/crates/cli/tests/multiple_importers.rs
+++ b/pnpm/crates/cli/tests/multiple_importers.rs
@@ -263,12 +263,12 @@ fn partial_frozen_install_does_not_remove_dependencies_of_other_workspace_projec
     // project-1's direct dependency already locked — the upstream test
     // rewrites the lockfile to the same effect, leaving the 100.1.0
     // materialization orphaned.
-    let lockfile_path = fixture.workspace.join("pnpm-lock.yaml");
-    let lockfile_text = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
-    let repinned =
-        lockfile_text.replace(&format!("'{DEP}': 100.1.0"), &format!("'{DEP}': 101.0.0"));
-    assert_ne!(repinned, lockfile_text, "expected the transitive pin in the snapshots section");
-    fs::write(&lockfile_path, repinned).expect("write pnpm-lock.yaml");
+    repin_snapshot_dependency(
+        &fixture.workspace.join("pnpm-lock.yaml"),
+        &format!("{PARENT}@100.0.0"),
+        DEP,
+        "101.0.0",
+    );
 
     fixture.run(["--filter", "project-1", "install", "--frozen-lockfile"]);
 
@@ -412,14 +412,12 @@ fn subset_headless_install_deeply_materializes_workspace_linked_dependencies() {
     // the upstream (lockfile-relative) shape — the subject under test
     // is the headless materialization of snapshot-level links, and
     // upstream drives it from a hand-authored lockfile too.
-    let lockfile_path = fixture.workspace.join("pnpm-lock.yaml");
-    let lockfile_text = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
-    let rewritten = lockfile_text.replace("link:packages/g/packages/f", "link:packages/f");
-    assert_ne!(
-        rewritten, lockfile_text,
-        "expected the external package's snapshot to record the workspace link",
+    repin_snapshot_dependency(
+        &fixture.workspace.join("pnpm-lock.yaml"),
+        "@pnpm.e2e/external-depend-on-internal-dep@1.0.0",
+        "@pnpm.e2e/internal-f",
+        "link:packages/f",
     );
-    fs::write(&lockfile_path, rewritten).expect("write pnpm-lock.yaml");
 
     fixture.run(["--filter", "@pnpm.e2e/internal-g", "install", "--frozen-lockfile"]);
 

--- a/pnpm/crates/cli/tests/optional_dependencies.rs
+++ b/pnpm/crates/cli/tests/optional_dependencies.rs
@@ -260,24 +260,37 @@ mod known_failures {
     fn fail_on_unsupported_dependency_of_optional_dependency() {
         allow_known_failure!(edge_aware_engine_strict());
     }
+}
 
-    fn workspace_filter_selection() -> KnownResult<()> {
-        Err(KnownFailure::new(
-            "Pacquet doesn't yet implement `--filter` selected-projects \
-             installs, so installing a subset of workspace projects \
-             (the shape upstream drives through \
-             `mutateModulesInSingleProject` with a shared lockfile dir) \
-             can't be expressed end to end.",
-        ))
-    }
+/// TS: `skip optional dependency that does not support the current OS,
+/// when doing install on a subset of workspace projects`
+/// (`optionalDependencies.ts:644`). The subset resolve-path install
+/// records the skipped optional subtree in the workspace root's
+/// `.modules.yaml`.
+#[test]
+fn skip_unsupported_optional_when_installing_a_workspace_subset() {
+    let fixture = WorkspaceFixture::new();
+    fixture.project(
+        "project1",
+        "project1",
+        ManifestDeps {
+            optional: &[("@pnpm.e2e/not-compatible-with-any-os", "*")],
+            ..Default::default()
+        },
+    );
+    fixture.project(
+        "project2",
+        "project2",
+        ManifestDeps { prod: &[("@pnpm.e2e/pkg-with-1-dep", "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
 
-    /// TS: `skip optional dependency that does not support the current
-    /// OS, when doing install on a subset of workspace projects`
-    /// (`optionalDependencies.ts:470`).
-    #[test]
-    fn skip_unsupported_optional_when_installing_a_workspace_subset() {
-        allow_known_failure!(workspace_filter_selection());
-    }
+    fixture.run(["--filter", "project1", "install", "--no-prefer-frozen-lockfile"]);
+
+    assert_eq!(
+        read_skipped(&fixture.workspace),
+        ["@pnpm.e2e/dep-of-optional-pkg@1.0.0", "@pnpm.e2e/not-compatible-with-any-os@1.0.0"],
+    );
 }
 
 /// TS: `skip optional dependency that does not support the current OS`

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1533,6 +1533,26 @@ where
             Option<Lockfile>,
         ) = if take_frozen_path {
             let lockfile = lockfile.expect("dispatch verified lockfile is present");
+            // pnpm's headless installer announces itself whenever it is
+            // entered — also on a cold `node_modules` and on subset
+            // (`--filter`) installs — not only when nothing needs to be
+            // materialized. `pnpm fetch` (`ignore_manifest_check`) gets
+            // the ignorePackageManifest wording instead. Upstream's
+            // headless entry returns before the announcement for an
+            // empty lockfile (`isEmptyLockfile`), and an explicit
+            // `pnpm rebuild` is not an install, so both stay silent.
+            if rebuild.is_none() && !lockfile.is_empty() {
+                let message = if ignore_manifest_check {
+                    "Importing packages to virtual store"
+                } else {
+                    "Lockfile is up to date, resolution step is skipped"
+                };
+                Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+                    level: LogLevel::Info,
+                    message: message.to_string(),
+                    prefix: prefix.clone(),
+                }));
+            }
             let initial_materialization_ids = requested_importer_ids.as_ref().map(|selected| {
                 if matches!(node_linker, NodeLinker::Hoisted) {
                     lockfile.importers.keys().cloned().collect()

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1536,13 +1536,17 @@ where
             // pnpm's headless installer announces itself whenever it is
             // entered — also on a cold `node_modules` and on subset
             // (`--filter`) installs — not only when nothing needs to be
-            // materialized. `pnpm fetch` (`ignore_manifest_check`) gets
-            // the ignorePackageManifest wording instead. Upstream's
-            // headless entry returns before the announcement for an
-            // empty lockfile (`isEmptyLockfile`), and an explicit
+            // materialized. `pnpm fetch` gets upstream's
+            // ignorePackageManifest wording instead; it is the one
+            // caller combining `ignore_manifest_check` with a non-full
+            // install, and the flag alone can't identify it because
+            // `install --ignore-manifest-check` is a user-facing way to
+            // skip the frozen freshness gate on a full install.
+            // Upstream's headless entry returns before the announcement
+            // for an empty lockfile (`isEmptyLockfile`), and an explicit
             // `pnpm rebuild` is not an install, so both stay silent.
             if rebuild.is_none() && !lockfile.is_empty() {
-                let message = if ignore_manifest_check {
+                let message = if ignore_manifest_check && !is_full_install {
                     "Importing packages to virtual store"
                 } else {
                     "Lockfile is up to date, resolution step is skipped"

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -69,8 +69,8 @@ Frozen/headless install coverage:
 - [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:74` `skip optional dependency that does not support the current OS` verifies `skipped` survives frozen reinstall — ported as `skip_optional_dependency_that_does_not_support_the_current_os` in `crates/cli/tests/optional_dependencies.rs`.
 - [ ] `TypeScript repo: installing/deps-installer/test/lockfile.ts:614` `pendingBuilds gets updated if install removes packages` verifies `.modules.yaml.pendingBuilds` is rewritten after pruning.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:205` `GVS re-links when allowBuilds changes` verifies GVS-related `allowBuilds` state is updated in `.modules.yaml`. Adjacent non-GVS coverage exists (`rebuild_after_allow_builds_changes` in `crates/cli/tests/lifecycle_scripts.rs`), but nothing asserts the GVS `.modules.yaml` state.
-- [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:1467` `custom virtual store directory in a workspace with not shared lockfile` verifies frozen reinstall preserves custom `virtualStoreDir` serialization.
-- [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:1514` `custom virtual store directory in a workspace with shared lockfile` verifies frozen reinstall preserves root `virtualStoreDir` serialization.
+- [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:1467` `custom virtual store directory in a workspace with not shared lockfile` verifies frozen reinstall preserves custom `virtualStoreDir` serialization — stubbed in `known_failures::custom_virtual_store_directory_with_dedicated_lockfiles` (`crates/cli/tests/multiple_importers.rs`; needs `sharedWorkspaceLockfile: false`).
+- [x] `TypeScript repo: pnpm/test/monorepo/index.ts:1514` `custom virtual store directory in a workspace with shared lockfile` verifies frozen reinstall preserves root `virtualStoreDir` serialization — ported as `custom_virtual_store_directory_in_a_workspace_with_shared_lockfile` in `crates/cli/tests/multiple_importers.rs`.
 
 Rust port notes:
 
@@ -106,7 +106,7 @@ Supporting tests:
 - [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:391` `not installing optional dependencies when optional is false` — ported as `not_installing_optional_dependencies_when_optional_is_false` in `crates/cli/tests/optional_dependencies.rs`.
 - [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:419` `optional dependency has bigger priority than regular dependency` — ported as `optional_dependency_has_bigger_priority_than_regular_dependency` in `crates/cli/tests/optional_dependencies.rs`.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:436` `only skip optional dependencies` — deferred: the scenario needs `firebase-tools` + `@google-cloud/functions-emulator` scale dependency graphs (upstream carries a TODO to shrink them); a fixture-scale equivalent still needs designing.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:470` `skip optional dependency that does not support the current OS, when doing install on a subset of workspace projects` — `known_failures` stub in `crates/cli/tests/optional_dependencies.rs` until `--filter` selected-project installs land.
+- [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:470` `skip optional dependency that does not support the current OS, when doing install on a subset of workspace projects` — ported as the real `skip_unsupported_optional_when_installing_a_workspace_subset` in `crates/cli/tests/optional_dependencies.rs` (previously a `known_failures` stub; `--filter` selected-projects installs landed in pnpm/pnpm#13030).
 - [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:540` `do not fail on unsupported dependency of optional dependency` — ported as `do_not_fail_on_unsupported_dependency_of_optional_dependency` in `crates/cli/tests/optional_dependencies.rs`.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:552` `fail on unsupported dependency of optional dependency` — `known_failures` stub in `crates/cli/tests/optional_dependencies.rs`: pacquet's `engineStrict` keys on snapshot-level optionality where upstream evaluates per edge (pnpm/pnpm#13143).
 - [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:563` `do not fail on an optional dependency that has a non-optional dependency with a failing postinstall script` — ported as `do_not_fail_on_optional_dependency_with_failing_non_optional_postinstall` in `crates/cli/tests/optional_dependencies.rs`.
@@ -165,8 +165,8 @@ Primary tests:
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:514` `should recreate node_modules with hoisting`. Stubbed (#433).
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:540` `hoisting should not create a broken symlink to a skipped optional dependency` covers hoisting with skipped optional packages. Ported as the real `hoisting_skips_broken_symlink_for_skipped_optional` in `crates/cli/tests/hoist.rs` (previously a `known_failures` stub).
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:567` `the hoisted packages should not override the bin files of the direct dependencies` covers public hoist bin precedence after frozen reinstall. Stubbed in `known_failures::hoisted_packages_dont_override_direct_dep_bins` — bin-conflict resolution rules not implemented.
-- [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:587` `hoist packages which is in the dependencies tree of the selected projects`. Stubbed in `known_failures::workspace_hoist_packages_in_selected_projects_tree` — needs `--filter` selected-projects install, which workspace install (#443) didn't implement.
-- [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:682` `only hoist packages which is in the dependencies tree of the selected projects with sub dependencies`. Stubbed (`--filter` selected-projects install).
+- [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:587` `hoist packages which is in the dependencies tree of the selected projects`. Ported as the real `workspace_hoist_packages_in_selected_projects_tree` in `crates/cli/tests/hoist.rs` (previously a `known_failures` stub — `--filter` selected-projects installs landed in pnpm/pnpm#13030).
+- [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:682` `only hoist packages which is in the dependencies tree of the selected projects with sub dependencies`. Ported as the real `workspace_hoist_only_in_selected_projects_with_subdeps` in `crates/cli/tests/hoist.rs` (the divergent per-parent subdependency pins are produced by repinning the generated lockfile, standing in for upstream's hand-written one).
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:790` `should add extra node paths to command shims`. Stubbed in `known_failures::should_add_extra_node_paths_to_command_shims` — `extendNodePath` not implemented.
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:799` `should not add extra node paths to command shims, when extend-node-path is set to false`. Stubbed (extendNodePath).
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:813` `hoistWorkspacePackages should hoist all workspace projects` covers workspace package hoisting and frozen reinstall. Ported as `hoist_workspace_packages_links_projects_by_name` in `crates/cli/tests/hoist.rs` (loops `hoistWorkspacePackages` on/off and asserts the name-links into `.pnpm/node_modules`); the frozen-reinstall preservation tail still needs partial install (pnpm/pacquet#433).
@@ -223,7 +223,7 @@ Primary frozen/headless tests:
 - [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:504` `selectively allow scripts in some dependencies by allowBuilds using exact versions` covers exact-version allow list — ported as `selectively_allow_scripts_by_allow_builds_exact_versions` in `crates/cli/tests/lifecycle_scripts.rs`.
 - [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:552` `lifecycle scripts run after linking root dependencies` verifies builds can require root dependencies during frozen install — ported as `lifecycle_scripts_run_after_linking_root_deps` in `crates/cli/tests/lifecycle_scripts.rs`.
 - [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:724` `build dependencies that were not previously built after allowBuilds changes` covers rebuilding newly allowed dependencies with frozen install — ported as `rebuild_after_allow_builds_changes` in `crates/cli/tests/lifecycle_scripts.rs`.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1902` `link the bin file of a workspace project that is created by a lifecycle script` covers workspace build-created bin behavior and frozen reinstall.
+- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1902` `link the bin file of a workspace project that is created by a lifecycle script` covers workspace build-created bin behavior and frozen reinstall — stubbed in `known_failures::link_bin_of_workspace_project_created_by_lifecycle_script` (`crates/cli/tests/multiple_importers.rs`; needs `buildIndex`-ordered project scripts plus bin re-linking between build groups).
 
 Supporting tests:
 
@@ -270,38 +270,38 @@ Rust port notes:
 
 Primary frozen/headless tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:438` `dependencies of other importers are not pruned when (headless) installing for a subset of importers`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:208` `install only the dependencies of the specified importer. The current lockfile has importers that do not exist anymore` covers stale importer entries in the current lockfile.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:730` `current lockfile contains only installed dependencies when adding a new importer to workspace with shared lockfile` asserts filtered current lockfile contents.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:540` `headless install is used when package linked to another package in the workspace`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:598` `headless install is used with an up-to-date lockfile when package references another package via workspace: protocol`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:656` `headless install is used when packages are not linked from the workspace (unless workspace ranges are used)`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:865` `partial installation in a monorepo does not remove dependencies of other workspace projects when lockfile is frozen`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1427` `resolve a subdependency from the workspace` includes frozen reinstall.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1563` `resolve a subdependency from the workspace, when it uses the workspace protocol` includes frozen reinstall.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1768` `symlink local package from the location described in its publishConfig.directory when linkDirectory is true` includes frozen reinstall.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1902` `link the bin file of a workspace project that is created by a lifecycle script` includes frozen reinstall.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:438` `dependencies of other importers are not pruned when (headless) installing for a subset of importers` — ported as `deps_of_other_importers_are_not_pruned_when_headless_installing_a_subset` in `crates/cli/tests/multiple_importers.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:208` `install only the dependencies of the specified importer. The current lockfile has importers that do not exist anymore` — ported as `stale_current_lockfile_importers_are_retained_on_subset_install` in `crates/cli/tests/multiple_importers.rs` (the project leaves the workspace on disk; upstream shrinks the mutated-importer set instead).
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:730` `current lockfile contains only installed dependencies when adding a new importer to workspace with shared lockfile` — ported as `current_lockfile_contains_only_installed_dependencies` in `crates/cli/tests/multiple_importers.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:540` `headless install is used when package linked to another package in the workspace` — ported as `headless_install_is_used_when_package_is_linked_to_another_workspace_package` in `crates/cli/tests/multiple_importers.rs`. The upstream tail (the unselected link target's own deps stay uninstalled) is stubbed in `known_failures::subset_install_does_not_install_unselected_link_targets_dependencies`: pacquet's subset closure deep-installs importer-level link targets, upstream keeps them shallow — a cross-stack decision is needed.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:598` `headless install is used with an up-to-date lockfile when package references another package via workspace: protocol` — ported as `headless_install_is_used_with_workspace_protocol_references` in `crates/cli/tests/multiple_importers.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:656` `headless install is used when packages are not linked from the workspace (unless workspace ranges are used)` — ported as `headless_install_is_used_when_packages_are_not_linked_from_the_workspace` in `crates/cli/tests/multiple_importers.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:865` `partial installation in a monorepo does not remove dependencies of other workspace projects when lockfile is frozen` — ported as `partial_frozen_install_does_not_remove_dependencies_of_other_workspace_projects` in `crates/cli/tests/multiple_importers.rs` (the divergent transitive pin is produced by repinning the generated lockfile rather than hand-writing one).
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1427` `resolve a subdependency from the workspace` — ported as `resolve_a_subdependency_from_the_workspace` in `crates/cli/tests/multiple_importers.rs` (snapshot `link:` + frozen reinstall).
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1563` `resolve a subdependency from the workspace, when it uses the workspace protocol` — ported as `resolve_a_subdependency_from_the_workspace_via_workspace_protocol_override` in `crates/cli/tests/multiple_importers.rs` (the `workspace:*` pin arrives through `overrides`).
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1768` `symlink local package from the location described in its publishConfig.directory when linkDirectory is true` — stubbed in `known_failures::symlink_local_package_from_publish_config_directory` (`crates/cli/tests/multiple_importers.rs`): install-time `publishConfig.directory` linking is not implemented.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1902` `link the bin file of a workspace project that is created by a lifecycle script` — stubbed in `known_failures::link_bin_of_workspace_project_created_by_lifecycle_script` (`crates/cli/tests/multiple_importers.rs`): needs `buildIndex`-ordered project lifecycle scripts plus bin re-linking between build groups.
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:341` `hoist-pattern: hoist all dependencies to the virtual store node_modules` covers workspace hoisting and frozen reinstall — basic shape ported as `workspace_hoist_walks_every_importer`; the reinstall-preservation tail is stubbed (see the Hoisting section).
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:813` `hoistWorkspacePackages should hoist all workspace projects` covers workspace package hoisting and frozen reinstall — ported as `hoist_workspace_packages_links_projects_by_name` in `crates/cli/tests/hoist.rs` (frozen-reinstall preservation still stubbed; see the Hoisting section).
 
 Headless restorer tests:
 
-- [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:789` `installing in a workspace`
+- [x] `TypeScript repo: installing/deps-restorer/test/index.ts:789` `installing in a workspace` — ported as `subset_headless_install_keeps_other_projects_packages_in_current_lockfile` in `crates/cli/tests/multiple_importers.rs`.
 - [x] `TypeScript repo: installing/deps-restorer/test/index.ts:873` `installing in a workspace with node-linker=hoisted` — ported as `installing_in_a_workspace_with_hoisted_node_linker_frozen` in `crates/cli/tests/hoisted_node_linker.rs`.
-- [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:897` `installing a package deeply installs all required dependencies`
+- [x] `TypeScript repo: installing/deps-restorer/test/index.ts:897` `installing a package deeply installs all required dependencies` — ported as `subset_headless_install_deeply_materializes_workspace_linked_dependencies` in `crates/cli/tests/multiple_importers.rs`. The snapshot-level `link:` is rewritten to upstream's lockfile-relative shape before the frozen install: pacquet's resolver records a registry manifest's `link:` dep relative to the dependent importer, upstream's fixture records it relative to the lockfile dir.
 
 CLI-level frozen workspace tests:
 
-- [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:734` `recursive install with shared-workspace-lockfile builds workspace projects in correct order` includes recursive frozen reinstall.
-- [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:1281` `dependencies of workspace projects are built during headless installation` runs CLI `install --frozen-lockfile` after lockfile-only generation.
-- [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:1317` `linking the package's bin to another workspace package in a monorepo` deletes workspace `node_modules` and runs frozen reinstall.
-- [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:1467` `custom virtual store directory in a workspace with not shared lockfile` verifies workspace-local custom virtual store on frozen reinstall.
-- [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:1514` `custom virtual store directory in a workspace with shared lockfile` verifies root custom virtual store on frozen reinstall.
+- [x] `TypeScript repo: pnpm/test/monorepo/index.ts:734` `recursive install with shared-workspace-lockfile builds workspace projects in correct order` — stubbed in `known_failures::recursive_install_builds_workspace_projects_in_correct_order` (`crates/cli/tests/multiple_importers.rs`): project lifecycle scripts run root-first, not in `buildIndex` order.
+- [x] `TypeScript repo: pnpm/test/monorepo/index.ts:1281` `dependencies of workspace projects are built during headless installation` — stubbed in `known_failures::workspace_project_dependencies_built_during_headless_install_with_dedicated_lockfiles` (`crates/cli/tests/multiple_importers.rs`): the upstream fixture requires `sharedWorkspaceLockfile: false`, which pacquet's install family rejects.
+- [x] `TypeScript repo: pnpm/test/monorepo/index.ts:1317` `linking the package's bin to another workspace package in a monorepo` — ported as `links_workspace_package_bin_into_dependent_project` in `crates/cli/tests/multiple_importers.rs`.
+- [x] `TypeScript repo: pnpm/test/monorepo/index.ts:1467` `custom virtual store directory in a workspace with not shared lockfile` — stubbed in `known_failures::custom_virtual_store_directory_with_dedicated_lockfiles` (`crates/cli/tests/multiple_importers.rs`): needs `sharedWorkspaceLockfile: false`.
+- [x] `TypeScript repo: pnpm/test/monorepo/index.ts:1514` `custom virtual store directory in a workspace with shared lockfile` — ported as `custom_virtual_store_directory_in_a_workspace_with_shared_lockfile` in `crates/cli/tests/multiple_importers.rs`.
 
 Rust port notes:
 
-- Start with single root workspace lockfile and direct workspace links.
-- Add subset/partial install tests only after Rust has project selection semantics.
+- Subset (`--filter`) install tests live in `crates/cli/tests/multiple_importers.rs` and drive the CLI selection that upstream expresses through `mutateModules` subsets.
+- Pacquet's subset closure deep-installs importer-level link targets where upstream keeps them shallow (only `--filter <project>...` widens the selection upstream); the divergence is pinned by the `known_failures` stub on the `multipleImporters.ts:540` tail and needs a cross-stack decision.
 
 ## Workspace Script `PATH` (`extraBinPaths`)
 
@@ -314,11 +314,13 @@ Ported into the new `pacquet-workspace-projects-filter` and
 `pacquet-workspace-projects-graph` crates (the Rust ports of
 `@pnpm/workspace.projects-filter` and `@pnpm/workspace.projects-graph`).
 The CLI `--filter` / `--filter-prod` flags are parsed into
-`Config::filter` / `Config::filter_prod`. Recursive `run` / `exec` now
+`Config::filter` / `Config::filter_prod`. Recursive `run` / `exec`
 narrow their selected set through these selectors (via
-`cli_args::recursive::select_recursive_projects`); narrowing the install
-to the selected projects is still a follow-up (the install fan-out is
-unfiltered, so the two `known_failures` hoist stubs below stay).
+`cli_args::recursive::select_recursive_projects`), and the install
+family honors the selection too (pnpm/pnpm#13030): subset installs are
+covered end to end in `crates/cli/tests/install_filters.rs` and
+`crates/cli/tests/multiple_importers.rs`, and the formerly stubbed
+selected-projects hoist / optional-dependency cases are real tests now.
 
 `parseProjectSelector` (ported as `parse_project_selector::tests`):
 
@@ -380,7 +382,7 @@ Primary tests:
 - [x] `TypeScript repo: installing/deps-installer/test/hoistedNodeLinker/install.ts:264` `linking bins of local projects when node-linker is set to hoisted`. Stubbed in `known_failures::linking_bins_of_local_projects` (#11870 — bin linking on the fresh path).
 - [x] `TypeScript repo: installing/deps-installer/test/hoistedNodeLinker/install.ts:314` `peerDependencies should be installed when autoInstallPeers is set to true and nodeLinker is set to hoisted`. Ported as `peer_dependencies_installed_with_auto_install_peers`.
 - [x] `TypeScript repo: installing/deps-installer/test/hoistedNodeLinker/install.ts:329` `installing with hoisted node-linker a package that is a peer dependency of itself`. Stubbed in `known_failures::package_that_is_peer_dependency_of_itself` — needs `pnpm add --save` + lockfile `peerDependencies` introspection (#433).
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:87` `install only the dependencies of the specified importer, when node-linker is hoisted` is workspace subset coverage for hoisted linker.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:87` `install only the dependencies of the specified importer, when node-linker is hoisted` — ported as `install_only_dependencies_of_specified_importer_with_hoisted_linker` in `crates/cli/tests/hoisted_node_linker.rs` (matching upstream, only the positive assertions are pinned — upstream's "unselected dependency is absent" tail is a TODO there too).
 
 Frozen/headless cross-coverage:
 
@@ -391,7 +393,7 @@ Frozen/headless cross-coverage:
 - [x] `TypeScript repo: installing/deps-installer/test/install/patch.ts:386` `patch package when the package is not in allowBuilds list` includes frozen hoisted reinstall — same coverage.
 
 Pacquet also keeps `hoisted_patch_reaches_every_nested_copy_of_a_package` in `crates/cli/tests/patch.rs`: a package the walker nests under several consumers must be patched at every one of them, on both the fresh and the cache-warm frozen path. See the Rust port note under Support `patchedDependencies` for the bug it pins.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:579` `run pre/postinstall scripts in a workspace that uses node-linker=hoisted`
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:579` `run pre/postinstall scripts in a workspace that uses node-linker=hoisted` — ported as `run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker` in `crates/cli/tests/hoisted_node_linker.rs`, driven through the frozen path (fresh-path scripts are still pnpm/pnpm#11870). The layout tail — no nested copy for consumers of the version that won the root slot — is stubbed in `known_failures::hoisted_workspace_layout_does_not_duplicate_root_version`: pacquet materializes every project's direct dep under the project as well.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:686` `run pre/postinstall scripts in a project that uses node-linker=hoisted. Should not fail on repeat install`
 - [x] `TypeScript repo: installing/deps-restorer/test/index.ts:859` `installing with node-linker=hoisted`. Ported as `installing_with_hoisted_node_linker_frozen` in `crates/cli/tests/hoisted_node_linker.rs` — seeds the lockfile with a fresh install, tears down `node_modules`, then replays via `--frozen-lockfile` and asserts the real-dir + version-conflict-nesting layout.
 - [x] `TypeScript repo: installing/deps-restorer/test/index.ts:873` `installing in a workspace with node-linker=hoisted`. Ported as `installing_in_a_workspace_with_hoisted_node_linker_frozen` — a frozen workspace replay where the root importer's `ms@2.1.3` wins the top-level slot and a project's conflicting `ms@2.0.0` nests under the project (the root-deps-rank-first preference landed in `real-hoist`).
@@ -442,7 +444,7 @@ Primary frozen/headless tests:
 - [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:331` `lifecycle scripts run before linking bins` verifies generated bins after frozen reinstall — ported as `lifecycle_scripts_run_before_linking_bins` in `crates/cli/tests/lifecycle_scripts.rs`.
 - [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:372` `bins are linked even if lifecycle scripts are ignored` — ported as `bins_linked_even_if_scripts_ignored` in `crates/cli/tests/lifecycle_scripts.rs` (single fresh install; the frozen-reinstall tail is still missing).
 - [x] `TypeScript repo: installing/deps-installer/test/install/hoist.ts:567` `the hoisted packages should not override the bin files of the direct dependencies` verifies public hoist bin precedence after frozen reinstall. Stubbed in `known_failures::hoisted_packages_dont_override_direct_dep_bins` (see the Hoisting section).
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1902` `link the bin file of a workspace project that is created by a lifecycle script` verifies workspace bin link after frozen reinstall.
+- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:1902` `link the bin file of a workspace project that is created by a lifecycle script` verifies workspace bin link after frozen reinstall — stubbed in `known_failures::link_bin_of_workspace_project_created_by_lifecycle_script` (`crates/cli/tests/multiple_importers.rs`). The pre-existing-bin variant is covered by `links_workspace_package_bin_into_dependent_project` there.
 
 Supporting tests:
 
@@ -489,8 +491,8 @@ Primary tests:
 - [x] `TypeScript repo: installing/deps-installer/test/install/packageExtensions.ts:16` `manifests are extended with fields specified by packageExtensions` — split into pacquet's `install::tests::fresh_install_applies_package_extensions_to_dependency_manifest` (verifies the extension lands in the lockfile's `packages` block AND `packageExtensionsChecksum` is written) and `install::tests::frozen_lockfile_errors_when_package_extensions_drift_from_lockfile` (frozen-install drift gate). Current-lockfile round-trip parity is covered by `current_lockfile`'s clone of `package_extensions_checksum`.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:408` `dependency should not be added to current lockfile if it was not built successfully during headless install` verifies failed build does not update current lockfile.
 - [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:74` `skip optional dependency that does not support the current OS` verifies current lockfile package set matches wanted lockfile while skipped packages are tracked — covered by `skip_optional_dependency_that_does_not_support_the_current_os` in `crates/cli/tests/optional_dependencies.rs`, which asserts both the current-lockfile package set and the skip set.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:208` `install only the dependencies of the specified importer. The current lockfile has importers that do not exist anymore` covers stale current-lockfile importers.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:730` `current lockfile contains only installed dependencies when adding a new importer to workspace with shared lockfile` verifies filtered current lockfile content.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:208` `install only the dependencies of the specified importer. The current lockfile has importers that do not exist anymore` — ported as `stale_current_lockfile_importers_are_retained_on_subset_install` in `crates/cli/tests/multiple_importers.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/multipleImporters.ts:730` `current lockfile contains only installed dependencies when adding a new importer to workspace with shared lockfile` — ported as `current_lockfile_contains_only_installed_dependencies` in `crates/cli/tests/multiple_importers.rs`.
 - [ ] `TypeScript repo: installing/deps-installer/test/packageImportMethods.ts:31` `packages are updated in node_modules, when packageImportMethod is set to copy and modules manifest and current lockfile are incorrect` covers incorrect current lockfile repair.
 - [ ] `TypeScript repo: installing/deps-installer/test/lockfile.ts:368` `subdeps are updated on repeat install if outer pnpm-lock.yaml does not match the inner one` tests wanted/current lockfile divergence.
 - [ ] `TypeScript repo: installing/deps-installer/test/lockfile.ts:547` `repeat install with no inner lockfile should not rewrite packages in node_modules` covers missing current lockfile on repeat install.
@@ -504,7 +506,7 @@ Supporting tests:
 - [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:165` `installing with package manifest ignored` verifies filtered current lockfile package contents.
 - [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:189` `installing only prod package with package manifest ignored` verifies filtered current lockfile package contents.
 - [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:213` `installing only dev package with package manifest ignored` verifies filtered current lockfile package contents.
-- [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:789` `installing in a workspace` verifies current lockfile is filtered after subset workspace headless install.
+- [x] `TypeScript repo: installing/deps-restorer/test/index.ts:789` `installing in a workspace` verifies current lockfile is filtered after subset workspace headless install — covered by `subset_headless_install_keeps_other_projects_packages_in_current_lockfile` in `crates/cli/tests/multiple_importers.rs`.
 
 Rust port notes:
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Stage 2 of the TEST_PORTING plan — workspace subset installs (`--filter`) and multi-importer coverage. Related to pnpm/pnpm#13146.

**New ports** (all "tested the test" by temporarily breaking the implementation path they pin):

- New `crates/cli/tests/multiple_importers.rs` suite covering the open `Support Workspaces` items: subset preservation of other importers' materialization (`multipleImporters.ts:438`, `:865`), stale current-lockfile importers (`:208`), filtered current-lockfile contents (`:730`), headless-vs-resolve decisions with `link:` / `workspace:` / unlinked workspace packages (`:540`, `:598`, `:656`), subdependency-from-workspace with `linkWorkspacePackages: deep` and via a `workspace:*` override (`:1427`, `:1563`), the deps-restorer workspace cases (`index.ts:789`, `:897`), workspace bin links (`monorepo/index.ts:1317`), and the shared-lockfile custom `virtualStoreDir` round-trip (`monorepo/index.ts:1514`).
- Promoted the three stale `--filter` `known_failures` stubs to real tests — filtered installs landed in pnpm/pnpm#13030, so `workspace_hoist_packages_in_selected_projects_tree` + `workspace_hoist_only_in_selected_projects_with_subdeps` (`hoist.ts:587` / `:682`) and `skip_unsupported_optional_when_installing_a_workspace_subset` (`optionalDependencies.ts:470`) now run for real.
- Ported the hoisted-linker workspace-subset item (`multipleImporters.ts:87`) and the hoisted workspace lifecycle-scripts case (`lifecycleScripts.ts:579`, driven through the frozen path while fresh-path scripts remain blocked on pnpm/pnpm#11870).

**Parity fix** (changeset included): pacquet only announced `Lockfile is up to date, resolution step is skipped` on the no-op short-circuit. The TypeScript CLI emits it whenever the headless installer is entered — including cold materialization and `--filter` subset installs — and emits `Importing packages to virtual store` under `ignorePackageManifest` (`pnpm fetch`). The frozen materialization branch now emits the same logs (`crates/package-manager/src/install.rs`); the `multipleImporters.ts:540/:598/:656` ports pin it.

**New `known_failures` stubs** at not-yet-implemented boundaries: install-time `publishConfig.directory` linking (`:1768`), `buildIndex`-ordered project lifecycle scripts + inter-group bin relinking (`:1902`, `monorepo:734`), and `sharedWorkspaceLockfile: false` (`monorepo:1281`, `:1467`).

**Divergences surfaced by the port** — each is pinned by a `known_failures` stub naming the divergence, and needs a cross-stack decision rather than a unilateral "fix":

1. **Subset closure over importer-level links.** `pnpm --filter project-1 install` where project-1 has a `link:`/workspace-linked sibling: pacquet deep-installs the link target's own dependencies (deliberately pinned by `install_filters.rs` since pnpm/pnpm#13030); the TypeScript CLI keeps importer-level link targets shallow — only `--filter project-1...` widens the selection. Snapshot-level links (subdependency-from-workspace) deep-install in both stacks.
2. **Hoisted-linker workspace duplication.** In a hoisted-linker workspace, pacquet materializes every project's direct dep under the project's own `node_modules` even when the same version won the workspace-root slot; upstream nests a copy only for versions that lost the root slot.
3. **Registry-manifest `link:` deps** (minor, noted in the plan): pacquet's resolver records them relative to the dependent importer; upstream's fixture lockfile records them relative to the lockfile dir. The headless materialization handles the upstream shape, which the port pins.

Also extracted the `FilteredWorkspace` fixture from `install_filters.rs` into the shared `tests/_utils/mod.rs` (renamed `WorkspaceFixture`) so the new suite reuses it instead of copy-pasting ~350 lines.

**Post-review updates:** rebased over `main` (resolving the `TEST_PORTING.md` overlap with pnpm/pnpm#13149), scoped the fetch-specific log wording to non-full installs so `install --ignore-manifest-check` keeps the up-to-date message, replaced the raw-string lockfile edits with a structured `repin_snapshot_dependency` helper, and moved `tests/_utils.rs` to `tests/_utils/mod.rs` so it is no longer an auto-discovered test target.

## Squash Commit Body

```text
Stage 2 of pnpm/plans/TEST_PORTING.md (pnpm/pnpm#13146): port the workspace
subset install (--filter) and multi-importer suites.

Add crates/cli/tests/multiple_importers.rs covering the open "Support
Workspaces" items (subset preservation, stale current-lockfile importers,
filtered current-lockfile contents, headless-vs-resolve decisions,
subdependency-from-workspace, workspace bin links, custom virtualStoreDir),
promote the three --filter known_failures stubs in hoist.rs and
optional_dependencies.rs to real tests now that filtered installs exist
(pnpm/pnpm#13030), and port the hoisted-linker workspace-subset and
workspace lifecycle-script cases.

Fix a reporter parity gap the ports exposed: the TypeScript CLI announces
"Lockfile is up to date, resolution step is skipped" whenever the headless
installer is entered (cold materialization and subset installs included) and
"Importing packages to virtual store" under ignorePackageManifest; pacquet
only announced the no-op short-circuit. The frozen materialization branch
now emits the same logs.

Record two behavioral divergences the ports surfaced as known_failures
stubs pending a cross-stack decision: pacquet's subset closure deep-installs
importer-level link targets where upstream keeps them shallow, and pacquet's
hoisted workspace layout duplicates the root-winning version under consumer
projects. Not-yet-implemented boundaries (publishConfig.directory linking,
buildIndex-ordered project scripts, sharedWorkspaceLockfile: false) are
stubbed too.

The FilteredWorkspace fixture moves from install_filters.rs into the shared
tests/_utils/mod.rs as WorkspaceFixture so the new suite reuses it.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (Test
  porting is pacquet-only by design; the reporter fix aligns pacquet to the
  TypeScript CLI's existing behavior, so no TypeScript change is needed.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).