### PR TITLE
fix: normalize empty bundledDependencies array in lockfile

### DIFF
--- a/.changeset/bundled-dependencies-empty-array.md
+++ b/.changeset/bundled-dependencies-empty-array.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pnpm": patch
+---
+
+Normalize empty `bundledDependencies` and `bundleDependencies` arrays to prevent them from being serialized in the lockfile, resolving non-deterministic lockfile changes.

--- a/pnpm11/installing/deps-resolver/src/updateLockfile.ts
+++ b/pnpm11/installing/deps-resolver/src/updateLockfile.ts
@@ -150,12 +150,14 @@ function toLockfileDependency (
     result['libc'] = pkg.additionalInfo.libc
   }
   if (
-    Array.isArray(pkg.additionalInfo.bundledDependencies) ||
+    (Array.isArray(pkg.additionalInfo.bundledDependencies) &&
+      pkg.additionalInfo.bundledDependencies.length > 0) ||
     pkg.additionalInfo.bundledDependencies === true
   ) {
     result['bundledDependencies'] = pkg.additionalInfo.bundledDependencies
   } else if (
-    Array.isArray(pkg.additionalInfo.bundleDependencies) ||
+    (Array.isArray(pkg.additionalInfo.bundleDependencies) &&
+      pkg.additionalInfo.bundleDependencies.length > 0) ||
     pkg.additionalInfo.bundleDependencies === true
   ) {
     result['bundledDependencies'] = pkg.additionalInfo.bundleDependencies

--- a/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
+++ b/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
@@ -85,3 +85,39 @@ test('a stale integrity is not attached when the tarball URL changed', () => {
   })
   expect(lockfile.packages![newDepPath].resolution).toStrictEqual({ tarball: newUrl })
 })
+
+test('empty bundledDependencies or bundleDependencies arrays are normalized away and not written to the lockfile packages list', () => {
+  const lockfile = updateLockfile({
+    dependenciesGraph: {
+      [DEP_PATH]: {
+        ...tarballGraph({ tarball: TARBALL_URL })[DEP_PATH],
+        additionalInfo: {
+          bundledDependencies: [],
+          bundleDependencies: [],
+        },
+      },
+    } as unknown as DependenciesGraph,
+    lockfile: lockfileWith({ resolution: { tarball: TARBALL_URL, integrity: INTEGRITY } }),
+    prefix: '.',
+    registries: REGISTRIES,
+  })
+  expect(lockfile.packages![DEP_PATH].bundledDependencies).toBeUndefined()
+})
+
+test('non-empty bundledDependencies array or boolean bundledDependencies is kept in the lockfile', () => {
+  const lockfile = updateLockfile({
+    dependenciesGraph: {
+      [DEP_PATH]: {
+        ...tarballGraph({ tarball: TARBALL_URL })[DEP_PATH],
+        additionalInfo: {
+          bundledDependencies: ['some-dep'],
+        },
+      },
+    } as unknown as DependenciesGraph,
+    lockfile: lockfileWith({ resolution: { tarball: TARBALL_URL, integrity: INTEGRITY } }),
+    prefix: '.',
+    registries: REGISTRIES,
+  })
+  expect(lockfile.packages![DEP_PATH].bundledDependencies).toStrictEqual(['some-dep'])
+})
+

--- a/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
+++ b/pnpm11/installing/deps-resolver/test/updateLockfile.test.ts
@@ -104,7 +104,7 @@ test('empty bundledDependencies or bundleDependencies arrays are normalized away
   expect(lockfile.packages![DEP_PATH].bundledDependencies).toBeUndefined()
 })
 
-test('non-empty bundledDependencies array or boolean bundledDependencies is kept in the lockfile', () => {
+test('non-empty bundledDependencies array is kept in the lockfile', () => {
   const lockfile = updateLockfile({
     dependenciesGraph: {
       [DEP_PATH]: {
@@ -119,5 +119,22 @@ test('non-empty bundledDependencies array or boolean bundledDependencies is kept
     registries: REGISTRIES,
   })
   expect(lockfile.packages![DEP_PATH].bundledDependencies).toStrictEqual(['some-dep'])
+})
+
+test('boolean true bundledDependencies is kept in the lockfile', () => {
+  const lockfile = updateLockfile({
+    dependenciesGraph: {
+      [DEP_PATH]: {
+        ...tarballGraph({ tarball: TARBALL_URL })[DEP_PATH],
+        additionalInfo: {
+          bundledDependencies: true,
+        },
+      },
+    } as unknown as DependenciesGraph,
+    lockfile: lockfileWith({ resolution: { tarball: TARBALL_URL, integrity: INTEGRITY } }),
+    prefix: '.',
+    registries: REGISTRIES,
+  })
+  expect(lockfile.packages![DEP_PATH].bundledDependencies).toBe(true)
 })
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Resolves non-deterministic addition/removal of `bundledDependencies: []` in
`pnpm-lock.yaml` (the empty-array variant of pnpm/pnpm#7576).

Some packages (e.g. `constructs@10.0.0`) publish a tarball `package.json`
containing `"bundledDependencies": []`, while the registry version metadata
for the same version omits the field entirely. Depending on which manifest
source pnpm resolves from (store-derived vs. registry metadata), the
lockfile serializer would write the empty array in one case and omit it in
the other — causing lockfile churn with no actual dependency changes.

This PR normalizes empty `bundledDependencies` / `bundleDependencies` arrays
so they are never serialized, since an empty array carries no information
(equivalent to the field being absent).

Fixes pnpm/pnpm#13123

## Squash Commit Body

```text
fix: normalize empty bundledDependencies array in lockfile

Some packages publish a tarball package.json containing
"bundledDependencies": [] while the registry version metadata for the
same version omits the field. Depending on which manifest source pnpm
resolves from (store-derived vs. registry metadata), the lockfile
serializer wrote the empty array in one case and omitted it in the
other, causing non-deterministic lockfile churn across machines/caches
with no real dependency changes.

Add a length check before serializing bundledDependencies and
bundleDependencies so empty arrays are normalized away, matching how
`bundledDependencies: false` was already handled (pnpm/pnpm#7580).
An empty array carries no information and should be treated as
equivalent to the field being absent.

The Rust pnpm/ port already discards empty arrays via
(!out.is_empty()).then_some(out) in read_string_list, so no parity
change is needed there.

Fixes pnpm/pnpm#13123
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust port already immune — see commit body.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787079332&installation_id=145934176&pr_number=13154&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13154&signature=a2bc3ce7c975ef2b3f303c274c44b4c50d35527b1deadcec8a8ba2d712001f4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty `bundledDependencies` / `bundleDependencies` from being written to lockfiles, reducing non-deterministic lockfile diffs.
  * Preserved bundled dependency information when non-empty lists (and `true`) are present during lockfile updates.
* **Tests**
  * Added coverage to verify correct lockfile output for empty, non-empty, and boolean `true` bundled dependency settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->