### PR TITLE
test(pacquet): complete progress reporting port (stage 7)

### DIFF
--- a/.changeset/pacquet-progress-reporting-parity.md
+++ b/.changeset/pacquet-progress-reporting-parity.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Aligned large-download progress byte formatting with pnpm.

--- a/pnpm/crates/default-reporter/src/format.rs
+++ b/pnpm/crates/default-reporter/src/format.rs
@@ -12,14 +12,16 @@ pub const PREFIX_MAX_LENGTH: usize = 40;
 #[must_use]
 pub fn pretty_bytes(n: u64) -> String {
     const UNITS: [&str; 9] = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
-    let mut value = n as f64;
+    let n = u128::from(n);
+    let mut divisor = 1;
     let mut idx = 0;
-    while value >= 1000.0 && idx < UNITS.len() - 1 {
-        value /= 1000.0;
+    while n >= divisor * 1000 && idx < UNITS.len() - 1 {
+        divisor *= 1000;
         idx += 1;
     }
-    value = (value * 100.0).floor() / 100.0;
-    format!("{value:.2} {}", UNITS[idx])
+    let whole = n / divisor;
+    let fraction = (n % divisor) * 100 / divisor;
+    format!("{whole}.{fraction:02} {}", UNITS[idx])
 }
 
 /// Port of `pretty-ms` for the magnitudes the reporter renders (sub-second

--- a/pnpm/crates/default-reporter/src/format.rs
+++ b/pnpm/crates/default-reporter/src/format.rs
@@ -7,19 +7,18 @@ pub const PREFIX_MAX_LENGTH: usize = 40;
 
 /// Port of `pretty-bytes` with `{ minimumFractionDigits: 2,
 /// maximumFractionDigits: 2 }` — base-1000 units, always two decimals, a
-/// space before the unit. `0` short-circuits to `"0 B"` like the library.
+/// space before the unit. pnpm's pinned version truncates at two fractional
+/// digits for these progress values.
 #[must_use]
 pub fn pretty_bytes(n: u64) -> String {
     const UNITS: [&str; 9] = ["B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
-    if n == 0 {
-        return "0 B".to_string();
-    }
     let mut value = n as f64;
     let mut idx = 0;
     while value >= 1000.0 && idx < UNITS.len() - 1 {
         value /= 1000.0;
         idx += 1;
     }
+    value = (value * 100.0).floor() / 100.0;
     format!("{value:.2} {}", UNITS[idx])
 }
 

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -38,6 +38,30 @@ pub enum Output {
     Lines(Vec<String>),
 }
 
+/// Rendering settings that cannot be recovered from the event stream.
+#[derive(Debug, Clone, Copy)]
+pub struct ReporterOptions {
+    /// Emit each update as a new line instead of replacing the current frame.
+    pub append_only: bool,
+    /// Omit the `added` counter from dependency progress lines.
+    pub hide_added_pkgs_progress: bool,
+    /// Omit the workspace-project prefix from progress lines.
+    pub hide_progress_prefix: bool,
+    /// Select which project prefixes contribute to the package summary.
+    pub summary_scope: SummaryScope,
+}
+
+impl Default for ReporterOptions {
+    fn default() -> Self {
+        Self {
+            append_only: false,
+            hide_added_pkgs_progress: false,
+            hide_progress_prefix: false,
+            summary_scope: SummaryScope::CurrentPrefix,
+        }
+    }
+}
+
 /// Lazily-assigned block indices for one logical output stream — its
 /// non-fixed (`block`) and fixed (`fixed`) slots in the frame — the
 /// per-stream `currentBlockNo` / `currentFixedBlockNo` pair.
@@ -206,6 +230,8 @@ pub struct ReporterState {
     width: usize,
     colors: Colors,
     append_only: bool,
+    hide_added_pkgs_progress: bool,
+    hide_progress_prefix: bool,
     frame: Frame,
     last_frame: Option<String>,
 
@@ -262,7 +288,12 @@ const COLOR_WHEEL: [fn(&Colors, &str) -> String; 6] = [
 impl ReporterState {
     #[must_use]
     pub fn new(cwd: String, width: usize, colors: Colors, append_only: bool) -> Self {
-        Self::new_with_summary_scope(cwd, width, colors, append_only, SummaryScope::CurrentPrefix)
+        Self::new_with_options(
+            cwd,
+            width,
+            colors,
+            ReporterOptions { append_only, ..ReporterOptions::default() },
+        )
     }
 
     #[must_use]
@@ -273,6 +304,27 @@ impl ReporterState {
         append_only: bool,
         summary_scope: SummaryScope,
     ) -> Self {
+        Self::new_with_options(
+            cwd,
+            width,
+            colors,
+            ReporterOptions { append_only, summary_scope, ..ReporterOptions::default() },
+        )
+    }
+
+    #[must_use]
+    pub fn new_with_options(
+        cwd: String,
+        width: usize,
+        colors: Colors,
+        options: ReporterOptions,
+    ) -> Self {
+        let ReporterOptions {
+            append_only,
+            hide_added_pkgs_progress,
+            hide_progress_prefix,
+            summary_scope,
+        } = options;
         let mut diff = HashMap::new();
         for kind in SUMMARY_ORDER {
             diff.insert(diff_key(kind), HashMap::new());
@@ -282,6 +334,8 @@ impl ReporterState {
             width,
             colors,
             append_only,
+            hide_added_pkgs_progress,
+            hide_progress_prefix,
             frame: Frame::new(append_only),
             last_frame: None,
             progress: HashMap::new(),
@@ -425,16 +479,19 @@ impl ReporterState {
         let stats = self.progress.get(requester).map(|entry| entry.stats).unwrap_or_default();
         let hl = |count: u64| self.colors.cyan_bright(&count.to_string());
         let mut msg = format!(
-            "Progress: resolved {}, reused {}, downloaded {}, added {}",
+            "Progress: resolved {}, reused {}, downloaded {}",
             hl(stats.resolved),
             hl(stats.reused),
             hl(stats.fetched),
-            hl(stats.imported),
         );
+        if !self.hide_added_pkgs_progress {
+            msg.push_str(", added ");
+            msg.push_str(&hl(stats.imported));
+        }
         if done {
             msg.push_str(", done");
         }
-        if requester != self.cwd {
+        if !self.hide_progress_prefix && requester != self.cwd {
             msg = zoom_out(&self.cwd, requester, &msg);
         }
         msg

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -6,21 +6,25 @@
 use pacquet_default_reporter::{
     SummaryScope,
     colors::Colors,
-    state::{Output, ReporterState},
+    state::{Output, ReporterOptions, ReporterState},
 };
 use pacquet_reporter::{
-    AddedRoot, ContextLog, DependencyType, DeprecationLog, ExecutionTimeLog, GlobalLog, HookLog,
-    LifecycleLog, LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, PackageImportMethod,
-    PackageImportMethodLog, PackageManifestLog, PackageManifestMessage, PnpmLog, ProgressLog,
-    ProgressMessage, RootLog, RootMessage, SkippedOptionalDependencyLog, SkippedOptionalPackage,
-    SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage,
-    SummaryLog,
+    AddedRoot, ContextLog, DependencyType, DeprecationLog, ExecutionTimeLog, FetchingProgressLog,
+    FetchingProgressMessage, GlobalLog, HookLog, LifecycleLog, LifecycleMessage, LifecycleStdio,
+    LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog, PackageManifestLog,
+    PackageManifestMessage, PnpmLog, ProgressLog, ProgressMessage, RootLog, RootMessage,
+    SkippedOptionalDependencyLog, SkippedOptionalPackage, SkippedOptionalParent,
+    SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
 };
 
 const CWD: &str = "/repo";
 
 fn state(colors: bool) -> ReporterState {
     ReporterState::new(CWD.to_string(), 80, Colors { enabled: colors }, false)
+}
+
+fn state_with_options(options: ReporterOptions) -> ReporterState {
+    ReporterState::new_with_options(CWD.to_string(), 80, Colors { enabled: false }, options)
 }
 
 fn state_without_summary_prefix_filter() -> ReporterState {
@@ -45,7 +49,11 @@ fn render(state: &mut ReporterState, events: Vec<LogEvent>) -> String {
 }
 
 fn progress(status: &str) -> LogEvent {
-    let requester = CWD.to_string();
+    progress_at(CWD, status)
+}
+
+fn progress_at(requester: &str, status: &str) -> LogEvent {
+    let requester = requester.to_string();
     let package_id = "registry.npmjs.org/foo/1.0.0".to_string();
     let message = match status {
         "resolved" => ProgressMessage::Resolved { package_id, requester },
@@ -59,6 +67,31 @@ fn progress(status: &str) -> LogEvent {
         other => panic!("unknown status {other}"),
     };
     LogEvent::Progress(ProgressLog { level: LogLevel::Debug, message })
+}
+
+fn stage_at(prefix: &str, stage: Stage) -> LogEvent {
+    LogEvent::Stage(StageLog { level: LogLevel::Debug, prefix: prefix.to_string(), stage })
+}
+
+fn fetching_started(package_id: &str, size: u64, attempt: u32) -> LogEvent {
+    LogEvent::FetchingProgress(FetchingProgressLog {
+        level: LogLevel::Debug,
+        message: FetchingProgressMessage::Started {
+            attempt,
+            package_id: package_id.to_string(),
+            size: Some(size),
+        },
+    })
+}
+
+fn fetching_in_progress(package_id: &str, downloaded: u64) -> LogEvent {
+    LogEvent::FetchingProgress(FetchingProgressLog {
+        level: LogLevel::Debug,
+        message: FetchingProgressMessage::InProgress {
+            downloaded,
+            package_id: package_id.to_string(),
+        },
+    })
 }
 
 fn importing_done() -> LogEvent {
@@ -128,6 +161,190 @@ fn progress_line_counts_each_status() {
         ],
     );
     assert_eq!(frame, "Progress: resolved 3, reused 2, downloaded 0, added 1");
+}
+
+#[test]
+fn prints_progress_beginning() {
+    let mut reporter = state(false);
+    let frame =
+        render(&mut reporter, vec![stage_at(CWD, Stage::ResolutionStarted), progress("resolved")]);
+    assert_eq!(frame, "Progress: resolved 1, reused 0, downloaded 0, added 0");
+}
+
+#[test]
+fn prints_progress_without_added_packages_stats() {
+    let mut reporter = state_with_options(ReporterOptions {
+        hide_added_pkgs_progress: true,
+        ..ReporterOptions::default()
+    });
+    let frame =
+        render(&mut reporter, vec![stage_at(CWD, Stage::ResolutionStarted), progress("resolved")]);
+    assert_eq!(frame, "Progress: resolved 1, reused 0, downloaded 0");
+}
+
+#[test]
+fn prints_all_progress_stats() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            stage_at(CWD, Stage::ResolutionStarted),
+            progress("resolved"),
+            progress("fetched"),
+            progress("found_in_store"),
+            progress("imported"),
+        ],
+    );
+    assert_eq!(frame, "Progress: resolved 1, reused 1, downloaded 1, added 1");
+}
+
+#[test]
+fn prints_progress_beginning_for_node_modules_outside_cwd() {
+    let requester = "/repo/foo";
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![stage_at(requester, Stage::ResolutionStarted), progress_at(requester, "resolved")],
+    );
+    assert_eq!(
+        frame,
+        "foo                                      | Progress: resolved 1, reused 0, downloaded 0, added 0",
+    );
+}
+
+#[test]
+fn hides_progress_prefix_for_node_modules_outside_cwd() {
+    let requester = "/repo/foo";
+    let mut reporter = state_with_options(ReporterOptions {
+        hide_progress_prefix: true,
+        ..ReporterOptions::default()
+    });
+    let frame = render(
+        &mut reporter,
+        vec![stage_at(requester, Stage::ResolutionStarted), progress_at(requester, "resolved")],
+    );
+    assert_eq!(frame, "Progress: resolved 1, reused 0, downloaded 0, added 0");
+}
+
+#[test]
+fn prints_progress_beginning_in_append_only_mode() {
+    let mut reporter =
+        state_with_options(ReporterOptions { append_only: true, ..ReporterOptions::default() });
+    assert!(matches!(reporter.handle(&stage_at(CWD, Stage::ResolutionStarted)), Output::None,));
+    let Output::Lines(lines) = reporter.handle(&progress("resolved")) else {
+        panic!("append-only progress must emit a line");
+    };
+    assert_eq!(lines, vec!["Progress: resolved 1, reused 0, downloaded 0, added 0"]);
+}
+
+#[test]
+fn prints_progress_beginning_during_recursive_install() {
+    let mut reporter = state(false);
+    let frame =
+        render(&mut reporter, vec![stage_at(CWD, Stage::ResolutionStarted), progress("resolved")]);
+    assert_eq!(frame, "Progress: resolved 1, reused 0, downloaded 0, added 0");
+}
+
+#[test]
+fn prints_progress_on_first_download() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![stage_at(CWD, Stage::ResolutionStarted), progress("resolved"), progress("fetched")],
+    );
+    assert_eq!(frame, "Progress: resolved 1, reused 0, downloaded 1, added 0");
+}
+
+#[test]
+fn moves_fixed_progress_line_to_the_end() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            stage_at(CWD, Stage::ResolutionStarted),
+            progress("resolved"),
+            progress("fetched"),
+            LogEvent::Pnpm(PnpmLog {
+                level: LogLevel::Warn,
+                message: "foo".to_string(),
+                prefix: CWD.to_string(),
+            }),
+            stage_at(CWD, Stage::ResolutionDone),
+            stage_at(CWD, Stage::ImportingDone),
+        ],
+    );
+    assert_eq!(frame, "[WARN] foo\nProgress: resolved 1, reused 0, downloaded 1, added 0, done");
+}
+
+#[test]
+fn prints_progress_of_big_files_download() {
+    const MIB: u64 = 1024 * 1024;
+    let pkg_1 = "registry.npmjs.org/foo/1.0.0";
+    let pkg_3 = "registry.npmjs.org/qar/3.0.0";
+    let mut reporter = state(false);
+    let events = vec![
+        stage_at(CWD, Stage::ResolutionStarted),
+        progress("resolved"),
+        fetching_started(pkg_1, 10 * MIB, 1),
+        fetching_in_progress(pkg_1, 11 * MIB / 2),
+        progress_at(CWD, "resolved"),
+        fetching_started(pkg_1, 10, 1),
+        fetching_in_progress(pkg_1, 7 * MIB),
+        progress_at(CWD, "resolved"),
+        fetching_started(pkg_3, 20 * MIB, 1),
+        fetching_in_progress(pkg_3, 19 * MIB),
+        fetching_in_progress(pkg_1, 10 * MIB),
+    ];
+    let mut frames = Vec::new();
+    for event in events {
+        if let Output::Frame(frame) = reporter.handle(&event)
+            && !frame.is_empty()
+        {
+            frames.push(frame);
+        }
+    }
+
+    assert_eq!(
+        frames,
+        vec![
+            "Progress: resolved 1, reused 0, downloaded 0, added 0".to_string(),
+            format!(
+                "Progress: resolved 1, reused 0, downloaded 0, added 0\n\
+                 Downloading {pkg_1}: 0.00 B/10.48 MB",
+            ),
+            format!(
+                "Progress: resolved 1, reused 0, downloaded 0, added 0\n\
+                 Downloading {pkg_1}: 5.76 MB/10.48 MB",
+            ),
+            format!(
+                "Progress: resolved 2, reused 0, downloaded 0, added 0\n\
+                 Downloading {pkg_1}: 5.76 MB/10.48 MB",
+            ),
+            format!(
+                "Progress: resolved 2, reused 0, downloaded 0, added 0\n\
+                 Downloading {pkg_1}: 7.34 MB/10.48 MB",
+            ),
+            format!(
+                "Progress: resolved 3, reused 0, downloaded 0, added 0\n\
+                 Downloading {pkg_1}: 7.34 MB/10.48 MB",
+            ),
+            format!(
+                "Progress: resolved 3, reused 0, downloaded 0, added 0\n\
+                 Downloading {pkg_1}: 7.34 MB/10.48 MB\n\
+                 Downloading {pkg_3}: 0.00 B/20.97 MB",
+            ),
+            format!(
+                "Progress: resolved 3, reused 0, downloaded 0, added 0\n\
+                 Downloading {pkg_1}: 7.34 MB/10.48 MB\n\
+                 Downloading {pkg_3}: 19.92 MB/20.97 MB",
+            ),
+            format!(
+                "Downloading {pkg_1}: 10.48 MB/10.48 MB, done\n\
+                 Progress: resolved 3, reused 0, downloaded 0, added 0\n\
+                 Downloading {pkg_3}: 19.92 MB/20.97 MB",
+            ),
+        ],
+    );
 }
 
 #[test]

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -6,6 +6,7 @@
 use pacquet_default_reporter::{
     SummaryScope,
     colors::Colors,
+    format::pretty_bytes,
     state::{Output, ReporterOptions, ReporterState},
 };
 use pacquet_reporter::{
@@ -18,6 +19,12 @@ use pacquet_reporter::{
 };
 
 const CWD: &str = "/repo";
+
+#[test]
+fn pretty_bytes_truncates_without_floating_point_drift() {
+    assert_eq!(pretty_bytes(1_130), "1.13 kB");
+    assert_eq!(pretty_bytes(1_130_000), "1.13 MB");
+}
 
 fn state(colors: bool) -> ReporterState {
     ReporterState::new(CWD.to_string(), 80, Colors { enabled: colors }, false)

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -239,10 +239,22 @@ fn prints_progress_beginning_in_append_only_mode() {
 
 #[test]
 fn prints_progress_beginning_during_recursive_install() {
+    let first_requester = "/repo/foo";
+    let second_requester = "/repo/bar";
     let mut reporter = state(false);
-    let frame =
-        render(&mut reporter, vec![stage_at(CWD, Stage::ResolutionStarted), progress("resolved")]);
-    assert_eq!(frame, "Progress: resolved 1, reused 0, downloaded 0, added 0");
+    let frame = render(
+        &mut reporter,
+        vec![
+            stage_at(first_requester, Stage::ResolutionStarted),
+            progress_at(first_requester, "resolved"),
+            stage_at(second_requester, Stage::ResolutionStarted),
+            progress_at(second_requester, "resolved"),
+        ],
+    );
+    assert_eq!(
+        frame,
+        "foo                                      | Progress: resolved 1, reused 0, downloaded 0, added 0\nbar                                      | Progress: resolved 1, reused 0, downloaded 0, added 0",
+    );
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -174,6 +174,16 @@ fn package_map_writer_is_gated_to_supported_pacquet_mode() {
 
 #[tokio::test]
 async fn should_install_dependencies() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
     let mock_instance = TestRegistry::start();
 
     let dir = tempdir().unwrap();
@@ -230,9 +240,57 @@ async fn should_install_dependencies() {
         pnpmfile_hook_override: None,
         workspace_projects_override: None,
     }
-    .run::<SilentReporter>()
+    .run::<RecordingReporter>()
     .await
     .expect("install should succeed");
+
+    let captured = EVENTS.lock().unwrap();
+    let expected_manifest = manifest.value();
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            LogEvent::PackageManifest(PackageManifestLog {
+                message: PackageManifestMessage::Initial { initial, .. },
+                ..
+            }) if initial == expected_manifest
+        )),
+        "install must report the input package manifest; events={captured:#?}",
+    );
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            LogEvent::Stats(StatsLog {
+                message: StatsMessage::Added { added, .. },
+                ..
+            }) if *added > 0
+        )),
+        "install must report a positive added count; events={captured:#?}",
+    );
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            LogEvent::Stats(StatsLog { message: StatsMessage::Removed { removed: 0, .. }, .. })
+        )),
+        "install must report that it removed no packages; events={captured:#?}",
+    );
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. })
+        )),
+        "install must close the importing stage; events={captured:#?}",
+    );
+    assert!(
+        captured.iter().any(|event| matches!(
+            event,
+            LogEvent::Progress(ProgressLog {
+                message: ProgressMessage::Resolved { package_id, .. },
+                ..
+            }) if package_id == "@pnpm.e2e/hello-world-js-bin@1.0.0"
+        )),
+        "install must report the resolved direct dependency; events={captured:#?}",
+    );
+    drop(captured);
 
     let path = project_root.join("node_modules/@pnpm.e2e/hello-world-js-bin");
     eprintln!("path={path:?} symlink_or_junction={:?}", is_symlink_or_junction(&path));

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -246,15 +246,24 @@ async fn should_install_dependencies() {
 
     let captured = EVENTS.lock().unwrap();
     let expected_manifest = manifest.value();
-    assert!(
-        captured.iter().any(|event| matches!(
-            event,
-            LogEvent::PackageManifest(PackageManifestLog {
-                message: PackageManifestMessage::Initial { initial, .. },
-                ..
-            }) if initial == expected_manifest
-        )),
-        "install must report the input package manifest; events={captured:#?}",
+    let manifest_indices: Vec<_> = captured
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| {
+            matches!(
+                event,
+                LogEvent::PackageManifest(PackageManifestLog {
+                    message: PackageManifestMessage::Initial { initial, .. },
+                    ..
+                }) if initial == expected_manifest,
+            )
+            .then_some(index)
+        })
+        .collect();
+    assert_eq!(
+        manifest_indices.len(),
+        1,
+        "install must report the input package manifest exactly once; events={captured:#?}",
     );
     assert!(
         captured.iter().any(|event| matches!(
@@ -273,22 +282,42 @@ async fn should_install_dependencies() {
         )),
         "install must report that it removed no packages; events={captured:#?}",
     );
-    assert!(
-        captured.iter().any(|event| matches!(
-            event,
-            LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. })
-        )),
-        "install must close the importing stage; events={captured:#?}",
+    let importing_done_indices: Vec<_> = captured
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| {
+            matches!(event, LogEvent::Stage(StageLog { stage: Stage::ImportingDone, .. }))
+                .then_some(index)
+        })
+        .collect();
+    assert_eq!(
+        importing_done_indices.len(),
+        1,
+        "install must close the importing stage exactly once; events={captured:#?}",
+    );
+    let resolved_indices: Vec<_> = captured
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| {
+            matches!(
+                event,
+                LogEvent::Progress(ProgressLog {
+                    message: ProgressMessage::Resolved { package_id, .. },
+                    ..
+                }) if package_id == "@pnpm.e2e/hello-world-js-bin@1.0.0",
+            )
+            .then_some(index)
+        })
+        .collect();
+    assert_eq!(
+        resolved_indices.len(),
+        1,
+        "install must report the resolved direct dependency exactly once; events={captured:#?}",
     );
     assert!(
-        captured.iter().any(|event| matches!(
-            event,
-            LogEvent::Progress(ProgressLog {
-                message: ProgressMessage::Resolved { package_id, .. },
-                ..
-            }) if package_id == "@pnpm.e2e/hello-world-js-bin@1.0.0"
-        )),
-        "install must report the resolved direct dependency; events={captured:#?}",
+        manifest_indices[0] < resolved_indices[0]
+            && resolved_indices[0] < importing_done_indices[0],
+        "install events must report the manifest, resolve the dependency, then close importing; events={captured:#?}",
     );
     drop(captured);
 

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -180,7 +180,7 @@ async fn should_install_dependencies() {
     struct RecordingReporter;
     impl Reporter for RecordingReporter {
         fn emit(event: &LogEvent) {
-            EVENTS.lock().unwrap().push(event.clone());
+            EVENTS.lock().unwrap_or_else(std::sync::PoisonError::into_inner).push(event.clone());
         }
     }
 

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -514,21 +514,21 @@ Rust port notes:
 
 Reporter unit tests:
 
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:25` `prints progress beginning`
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:50` `prints progress without added packages stats`
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:78` `prints all progress stats`
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:119` `prints progress beginning of node_modules from not cwd`
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:144` `prints progress beginning of node_modules from not cwd, when progress prefix is hidden`
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:172` `prints progress beginning when appendOnly is true`
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:200` `prints progress beginning during recursive install`
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:228` `prints progress on first download`
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:262` `moves fixed line to the end`
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:25` `prints progress beginning` — ported as `prints_progress_beginning` in `crates/default-reporter/tests/render.rs`.
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:50` `prints progress without added packages stats` — ported as `prints_progress_without_added_packages_stats` in `crates/default-reporter/tests/render.rs`.
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:78` `prints all progress stats` — ported as `prints_all_progress_stats` in `crates/default-reporter/tests/render.rs`.
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:119` `prints progress beginning of node_modules from not cwd` — ported as `prints_progress_beginning_for_node_modules_outside_cwd` in `crates/default-reporter/tests/render.rs`.
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:144` `prints progress beginning of node_modules from not cwd, when progress prefix is hidden` — ported as `hides_progress_prefix_for_node_modules_outside_cwd` in `crates/default-reporter/tests/render.rs`.
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:172` `prints progress beginning when appendOnly is true` — ported as `prints_progress_beginning_in_append_only_mode` in `crates/default-reporter/tests/render.rs`.
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:200` `prints progress beginning during recursive install` — ported as `prints_progress_beginning_during_recursive_install` in `crates/default-reporter/tests/render.rs`.
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:228` `prints progress on first download` — ported as `prints_progress_on_first_download` in `crates/default-reporter/tests/render.rs`.
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:262` `moves fixed line to the end` — ported as `moves_fixed_progress_line_to_the_end` in `crates/default-reporter/tests/render.rs`.
 - [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:307` `prints "Already up to date"` — ported as `already_up_to_date_pnpm_log_renders` in `crates/default-reporter/tests/render.rs`.
-- [ ] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:324` `prints progress of big files download`
+- [x] `TypeScript repo: cli/default-reporter/test/reportingProgress.ts:324` `prints progress of big files download` — ported as `prints_progress_of_big_files_download` in `crates/default-reporter/tests/render.rs`.
 
 Install reporter coverage:
 
-- [ ] `TypeScript repo: installing/deps-restorer/test/index.ts:54` `installing a simple project` asserts headless reporter events: stats, stage, package-manifest, and resolved logs.
+- [x] `TypeScript repo: installing/deps-restorer/test/index.ts:54` `installing a simple project` asserts headless reporter events: stats, stage, package-manifest, and resolved logs — ported in `crates/package-manager/src/install/tests.rs::should_install_dependencies`.
 
 Rust port notes:
 


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13146.

- Port all stage 7 progress-reporting scenarios from the TypeScript reporter to pacquet, including recursive, append-only, hidden-prefix, hidden-added, download, and fixed-line rendering.
- Align pacquet's large-download byte formatting with pnpm by truncating fractional values to two decimal places.
- Assert the real install reporter event sequence and mark every stage 7 entry complete in the test-porting plan.
- Add a `pacquet` patch changeset for the user-visible formatting parity fix.

The TypeScript implementation and tests already define the behavior; this PR ports that existing behavior to the Rust CLI.

Validation:

- Deliberately broke the progress counters and verified the new renderer tests failed.
- Deliberately removed the real install's resolved event and verified the new install assertion failed.
- `just ready` (6,413 tests passed, 3 skipped; workspace clippy clean).
- Full pre-push TypeScript build, bundle, spellcheck, metadata checks, Rust format/clippy/docs, dylint, typos, and TOML formatting checks.

## Squash Commit Body

```text
Port the stage 7 default-reporter progress scenarios to pacquet and cover the
real install reporter event stream. Add renderer options for append-only,
hidden-added, and hidden-prefix behavior so the Rust tests exercise the same
surface as pnpm's reporter tests.

Match pnpm's byte formatting by truncating fractional values to two decimal
places, then record the user-visible parity fix in a pacquet changeset.

Related to pnpm/pnpm#13146.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787080287&installation_id=145934176&pr_number=13155&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13155&signature=67a2773c1c1cb73d45710bb09db2bd40e78aecc7dc233d1ebe0d94296d8134cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Aligned large-download progress byte formatting with pnpm, including zero-byte output formatting.
  - Improved progress rendering behavior: conditional “added packages” visibility, refined progress prefix handling (including work outside the current directory) and correct behavior in append-only mode.
- **Tests**
  - Expanded reporter progress rendering coverage with more granular stage/progress/fetching scenarios.
  - Strengthened installation event assertions by recording and validating emitted telemetry and ordering.
- **Documentation**
  - Updated progress-reporting parity porting status in the test plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->