### PR TITLE
test(pacquet): port the global virtual store suites (stage 5)

### DIFF
--- a/.changeset/gvs-build-failure-cleanup.md
+++ b/.changeset/gvs-build-failure-cleanup.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/building.during-install": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+When a dependency's build script fails under `enableGlobalVirtualStore`, the global virtual store directory it was being built in is now removed for scoped packages too. Previously the cleanup resolved one directory level short of the hash directory for a scoped name, leaving a half-built directory behind that later installs would reuse.

--- a/.changeset/pacquet-gvs-slot-state.md
+++ b/.changeset/pacquet-gvs-slot-state.md
@@ -1,0 +1,7 @@
+---
+"pacquet": patch
+---
+
+Fixed two global-virtual-store correctness gaps. A failed build now discards the hash directory it was building in, so the next install re-fetches instead of reusing a half-built directory shared by every project with the same dependency graph. The removal only ever touches a slot strictly inside the store, so a crafted package name cannot make it escape. And a side-effects-cache hit no longer assumes the store slot still holds the cached build: when the slot has been re-imported pristine, the build output is materialized rather than skipped, which previously left the package without its build artifacts.
+
+`.modules.yaml` now records the `allowBuilds` set the install ran under, matching pnpm.

--- a/.changeset/pacquet-virtual-store-only.md
+++ b/.changeset/pacquet-virtual-store-only.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added the `virtualStoreOnly` setting, which populates the virtual store without any post-import linking — no importer symlinks, no `.bin` entries, no hoisting, and no project lifecycle scripts. Combining it with `enableModulesDir: false` fails with `ERR_PNPM_CONFIG_CONFLICT_VIRTUAL_STORE_ONLY_WITH_NO_MODULES_DIR` unless `enableGlobalVirtualStore` is on, since the standard virtual store lives inside `node_modules`. A subsequent ordinary install completes the linking instead of treating the partially-populated directory as up-to-date. `enableModulesDir` is now read from `pnpm-workspace.yaml` as well.

--- a/pnpm/crates/cli/tests/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/global_virtual_store.rs
@@ -1,0 +1,1103 @@
+//! Ports of the upstream global-virtual-store suites — the primary
+//! `installing/deps-installer/test/install/globalVirtualStore.ts` and the
+//! CLI-level `pnpm/test/install/globalVirtualStore.ts`.
+//!
+//! Upstream drives these through the programmatic `install()` API and can
+//! monkey-patch `storeController.fetchPackage` to count fetches. Pacquet's
+//! equivalent surface is the CLI, so the ports assert the same on-disk
+//! contract — slot layout, hash-directory identity across `allowBuilds`
+//! changes, build artifacts, and `.modules.yaml` state — instead of the
+//! call counts. Where that loses a signal it is called out on the test.
+//!
+//! `known_failures` at the bottom holds the one case whose subject under
+//! test pacquet has not built yet.
+#![cfg(unix)] // the GVS slot assertions read symlinks
+
+pub mod _utils;
+pub use _utils::*;
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_store_dir::STORE_VERSION;
+use pacquet_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fs::is_symlink_or_junction,
+};
+use std::{
+    fmt::Write as _,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// `<store_dir>/v11/links` — the root every GVS slot hangs off.
+fn gvs_root(store_dir: &Path) -> PathBuf {
+    store_dir.join(STORE_VERSION).join("links")
+}
+
+/// The `<gvs>/<scope>/<name>/<version>` directory whose children are the
+/// per-dependency-graph hash directories.
+fn pkg_version_dir(store_dir: &Path, name: &str, version: &str) -> PathBuf {
+    gvs_root(store_dir).join(name).join(version)
+}
+
+/// Sorted hash-directory names under a `<name>/<version>` directory.
+///
+/// Upstream reads these with `fs.readdirSync` and asserts on the count and
+/// on identity across installs; sorting keeps the comparison stable.
+fn hash_dirs(pkg_version_dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = fs::read_dir(pkg_version_dir)
+        .unwrap_or_else(|err| panic!("read hash dirs under {pkg_version_dir:?}: {err}"))
+        .map(|entry| entry.expect("read hash dir entry").file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    names
+}
+
+/// The single hash directory under `<name>/<version>`, asserting there is
+/// exactly one — upstream's `expect(files).toHaveLength(1)`.
+fn sole_hash_dir(pkg_version_dir: &Path) -> PathBuf {
+    let hashes = hash_dirs(pkg_version_dir);
+    assert_eq!(
+        hashes.len(),
+        1,
+        "expected exactly one hash directory under {pkg_version_dir:?}, got {hashes:?}",
+    );
+    pkg_version_dir.join(&hashes[0])
+}
+
+/// `<hash>/node_modules/<name>` — where the package's files actually live.
+fn pkg_in_slot(hash_dir: &Path, name: &str) -> PathBuf {
+    hash_dir.join("node_modules").join(name)
+}
+
+/// Rewrite `pnpm-workspace.yaml` as the harness's `storeDir` / `cacheDir`
+/// plus `enableGlobalVirtualStore: true` and `extra_yaml`.
+///
+/// [`enable_gvs_in_workspace_yaml`] asserts it is flipping the harness's
+/// `enableGlobalVirtualStore: false` line, so it can only be called once.
+/// These tests re-set `allowBuilds` between installs, so they need a form
+/// that is idempotent.
+fn set_gvs_workspace_yaml(workspace: &Path, extra_yaml: &str) {
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let existing = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    let mut yaml: String = existing
+        .lines()
+        .filter(|line| line.starts_with("storeDir:") || line.starts_with("cacheDir:"))
+        .fold(String::new(), |mut acc, line| {
+            acc.push_str(line);
+            acc.push('\n');
+            acc
+        });
+    assert!(
+        !yaml.is_empty(),
+        "expected the `storeDir` / `cacheDir` keys written by \
+         `CommandTempCwd::add_mocked_registry` — has the helper changed?",
+    );
+    yaml.push_str("enableGlobalVirtualStore: true\n");
+    yaml.push_str(extra_yaml);
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+}
+
+fn write_manifest(workspace: &Path, deps: &serde_json::Value) {
+    let manifest = serde_json::json!({ "dependencies": deps });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+}
+
+/// A fresh `Command` for the pacquet binary — `assert_cmd`'s `Command` is
+/// single-use, so every sequential install needs its own.
+fn pacquet(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+fn read_modules_manifest(workspace: &Path) -> pacquet_modules_yaml::Modules {
+    pacquet_modules_yaml::read_modules_manifest::<pacquet_modules_yaml::Host>(
+        &workspace.join("node_modules"),
+    )
+    .expect("read .modules.yaml")
+    .expect(".modules.yaml must exist after an install")
+}
+
+/// Render an `allowBuilds:` block for [`set_gvs_workspace_yaml`]'s
+/// `extra_yaml`. An empty slice yields `allowBuilds: {}` — upstream's
+/// `allowBuilds: {}`, which is materially different from omitting the key
+/// because it pins "nothing may build" rather than "no opinion".
+fn allow_builds_yaml(entries: &[(&str, bool)]) -> String {
+    if entries.is_empty() {
+        return "allowBuilds: {}\n".to_string();
+    }
+    let mut yaml = String::from("allowBuilds:\n");
+    for (spec, value) in entries {
+        writeln!(yaml, "  '{spec}': {value}").expect("format an allowBuilds entry");
+    }
+    yaml
+}
+
+/// TS: `using a global virtual store` (`globalVirtualStore.ts:21`), which
+/// is also the CLI-level `pnpm/test/install/globalVirtualStore.ts:11`.
+/// Both halves of the upstream test: a fresh install populates the GVS and
+/// the private hoist, then wiping `node_modules` *and* the GVS and
+/// reinstalling frozen rebuilds the identical layout.
+#[test]
+fn using_a_global_virtual_store() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    set_gvs_workspace_yaml(&workspace, "privateHoistPattern:\n  - '*'\n");
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+    let assert_layout = |phase: &str| {
+        assert!(
+            workspace
+                .join(
+                    "node_modules/.pnpm/node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep/package.json"
+                )
+                .exists(),
+            "{phase}: the transitive dep must be privately hoisted",
+        );
+        assert!(
+            workspace.join("node_modules/.pnpm/lock.yaml").exists(),
+            "{phase}: the current lockfile must be written",
+        );
+        let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+        let hash_dir = sole_hash_dir(&version_dir);
+        assert!(
+            pkg_in_slot(&hash_dir, "@pnpm.e2e/pkg-with-1-dep").join("package.json").exists(),
+            "{phase}: the package must be materialized in its GVS slot",
+        );
+        assert!(
+            pkg_in_slot(&hash_dir, "@pnpm.e2e/dep-of-pkg-with-1-dep").join("package.json").exists(),
+            "{phase}: the slot's own node_modules must carry the transitive dep",
+        );
+    };
+
+    eprintln!("Fresh install with GVS enabled...");
+    pacquet(&workspace).with_arg("install").assert().success();
+    assert_layout("fresh install");
+
+    eprintln!("Wiping node_modules and the whole GVS, then reinstalling frozen...");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    fs::remove_dir_all(gvs_root(&store_dir)).expect("remove the GVS root");
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert_layout("frozen reinstall from a cold GVS");
+
+    drop((root, mock_instance));
+}
+
+/// TS: `reinstall from warm global virtual store after deleting
+/// node_modules` (`globalVirtualStore.ts:63`) and the CLI-level `warm GVS
+/// reinstall skips internal linking` (`pnpm/test/install/globalVirtualStore.ts:80`).
+///
+/// Upstream additionally wraps `storeController.fetchPackage` to assert it
+/// is never called. Pacquet's CLI exposes no such seam, so the port
+/// asserts the observable consequence instead: the warm slot is reused
+/// rather than rebuilt beside a second hash directory, and the project
+/// tree — including `.bin` — is fully restored from it.
+#[test]
+fn reinstall_from_warm_global_virtual_store_after_deleting_node_modules() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    set_gvs_workspace_yaml(&workspace, "privateHoistPattern:\n  - '*'\n");
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "@pnpm.e2e/hello-world-js-bin": "1.0.0",
+            "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+        }),
+    );
+
+    eprintln!("First install — warms the GVS...");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let hashes_before = hash_dirs(&version_dir);
+
+    eprintln!("Deleting node_modules only — the GVS stays warm...");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    assert!(gvs_root(&store_dir).is_dir(), "the GVS must survive the node_modules wipe");
+
+    eprintln!("Frozen reinstall — must reattach from the warm GVS...");
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    assert_eq!(
+        hash_dirs(&version_dir),
+        hashes_before,
+        "a warm reinstall must reuse the existing slot, not materialize a second one",
+    );
+    assert!(
+        workspace.join("node_modules/@pnpm.e2e/pkg-with-1-dep/package.json").exists(),
+        "the direct dep must be relinked into the project",
+    );
+    assert!(
+        workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin/package.json").exists(),
+        "every direct dep must be relinked, not just the first",
+    );
+    assert!(
+        workspace
+            .join("node_modules/.pnpm/node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep")
+            .try_exists()
+            .expect("stat the hoisted dep"),
+        "the private hoist must be rebuilt from the warm GVS",
+    );
+    assert!(
+        workspace.join("node_modules/.bin/hello-world-js-bin").exists(),
+        "bins must be relinked after a warm reinstall",
+    );
+    assert!(
+        workspace.join("node_modules/.pnpm/lock.yaml").exists(),
+        "the current lockfile must be rewritten",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `modules are correctly updated when using a global virtual store`
+/// (`globalVirtualStore.ts:107`). Bumping one dependency's version must
+/// materialize a slot for the new version.
+#[test]
+fn modules_are_correctly_updated_when_using_a_global_virtual_store() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    set_gvs_workspace_yaml(&workspace, "");
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            "@pnpm.e2e/peer-c": "1.0.0",
+        }),
+    );
+
+    eprintln!("Installing with peer-c 1.0.0...");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    eprintln!("Bumping peer-c to 2.0.0 and reinstalling...");
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            "@pnpm.e2e/peer-c": "2.0.0",
+        }),
+    );
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    assert!(
+        workspace.join("node_modules/.pnpm/lock.yaml").exists(),
+        "the current lockfile must be rewritten",
+    );
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/peer-c", "2.0.0");
+    let hash_dir = sole_hash_dir(&version_dir);
+    assert!(
+        pkg_in_slot(&hash_dir, "@pnpm.e2e/peer-c").join("package.json").exists(),
+        "the newly-resolved version must be materialized in its own GVS slot",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `GVS hashes are engine-agnostic for packages not in allowBuilds`
+/// (`globalVirtualStore.ts:132`).
+///
+/// The hash of a package covers the engine only when the package — or
+/// something in its dependency closure — is allowed to build. Allowing
+/// the *transitive* dep therefore has to change the *parent's* hash.
+#[test]
+fn gvs_hashes_are_engine_agnostic_for_packages_not_in_allow_builds() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+    eprintln!("Scenario 1: nothing may build — hashes must omit the engine...");
+    set_gvs_workspace_yaml(&workspace, &allow_builds_yaml(&[]));
+    pacquet(&workspace).with_arg("install").assert().success();
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let hash_no_builds = sole_hash_dir(&version_dir);
+
+    eprintln!("Scenario 2: the transitive dep may build — the parent hash must change...");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    set_gvs_workspace_yaml(
+        &workspace,
+        &allow_builds_yaml(&[("@pnpm.e2e/dep-of-pkg-with-1-dep", true)]),
+    );
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    let hashes_after = hash_dirs(&version_dir);
+    let hash_no_builds_name =
+        hash_no_builds.file_name().expect("hash dir name").to_string_lossy().into_owned();
+    let hash_with_builds = hashes_after
+        .iter()
+        .find(|hash| *hash != &hash_no_builds_name)
+        .expect("allowing a transitive dep to build must produce a new, engine-specific hash");
+
+    assert_ne!(
+        hash_with_builds, &hash_no_builds_name,
+        "the engine-agnostic and engine-specific hashes must differ",
+    );
+    assert!(
+        pkg_in_slot(&hash_no_builds, "@pnpm.e2e/pkg-with-1-dep").join("package.json").exists(),
+        "the engine-agnostic slot must still be a valid layout",
+    );
+    assert!(
+        pkg_in_slot(&version_dir.join(hash_with_builds), "@pnpm.e2e/pkg-with-1-dep")
+            .join("package.json")
+            .exists(),
+        "the engine-specific slot must be a valid layout too",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `GVS hashes are stable when allowBuilds targets an unrelated
+/// package` (`globalVirtualStore.ts:172`). The complement of the previous
+/// test: an `allowBuilds` entry outside the dependency closure must not
+/// perturb any hash.
+#[test]
+fn gvs_hashes_are_stable_when_allow_builds_targets_an_unrelated_package() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+    eprintln!("Scenario 1: nothing may build...");
+    set_gvs_workspace_yaml(&workspace, &allow_builds_yaml(&[]));
+    pacquet(&workspace).with_arg("install").assert().success();
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let hashes_before = hash_dirs(&version_dir);
+
+    eprintln!("Scenario 2: an unrelated package may build...");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    set_gvs_workspace_yaml(&workspace, &allow_builds_yaml(&[("some-unrelated-package", true)]));
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    assert_eq!(
+        hash_dirs(&version_dir),
+        hashes_before,
+        "an allowBuilds entry outside the dependency closure must not change any hash",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `GVS re-links when allowBuilds changes` (`globalVirtualStore.ts:205`),
+/// which is also the `.modules.yaml` half listed under the
+/// "`.modules.yaml` Write And Verify" section of the porting plan: the
+/// approval set the install ran under has to round-trip through
+/// `.modules.yaml`.
+#[test]
+fn gvs_relinks_when_allow_builds_changes() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+    eprintln!("Installing with nothing allowed to build...");
+    set_gvs_workspace_yaml(&workspace, &allow_builds_yaml(&[]));
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let hash_before = sole_hash_dir(&version_dir)
+        .file_name()
+        .expect("hash dir name")
+        .to_string_lossy()
+        .into_owned();
+
+    assert_eq!(
+        read_modules_manifest(&workspace).allow_builds,
+        Some(std::collections::BTreeMap::new()),
+        "an empty allowBuilds must round-trip as an empty map, not as an absent key",
+    );
+
+    eprintln!("Reinstalling with the transitive dep allowed to build...");
+    set_gvs_workspace_yaml(
+        &workspace,
+        &allow_builds_yaml(&[("@pnpm.e2e/dep-of-pkg-with-1-dep", true)]),
+    );
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let hash_after = hash_dirs(&version_dir)
+        .into_iter()
+        .find(|hash| hash != &hash_before)
+        .expect("an allowBuilds change must produce a new hash directory");
+    assert!(
+        pkg_in_slot(&version_dir.join(&hash_after), "@pnpm.e2e/pkg-with-1-dep")
+            .join("package.json")
+            .exists(),
+        "the re-linked slot must be a valid layout",
+    );
+
+    let expected = std::collections::BTreeMap::from([(
+        "@pnpm.e2e/dep-of-pkg-with-1-dep".to_string(),
+        pacquet_modules_yaml::AllowBuildValue::Bool(true),
+    )]);
+    assert_eq!(
+        read_modules_manifest(&workspace).allow_builds,
+        Some(expected),
+        ".modules.yaml must record the allowBuilds set the install ran under",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `GVS successful build creates package directory with build
+/// artifacts` (`globalVirtualStore.ts:250`).
+#[test]
+fn gvs_successful_build_creates_package_directory_with_build_artifacts() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" }),
+    );
+    set_gvs_workspace_yaml(
+        &workspace,
+        &allow_builds_yaml(&[("@pnpm.e2e/pre-and-postinstall-scripts-example", true)]),
+    );
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir =
+        pkg_version_dir(&store_dir, "@pnpm.e2e/pre-and-postinstall-scripts-example", "1.0.0");
+    let pkg =
+        pkg_in_slot(&sole_hash_dir(&version_dir), "@pnpm.e2e/pre-and-postinstall-scripts-example");
+
+    assert!(pkg.join("package.json").exists(), "the built package must be in its GVS slot");
+    assert!(
+        pkg.join("generated-by-preinstall.js").exists(),
+        "the preinstall artifact must be written into the GVS slot",
+    );
+    assert!(
+        pkg.join("generated-by-postinstall.js").exists(),
+        "the postinstall artifact must be written into the GVS slot",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `GVS: approve-builds scenario — install with no builds, then
+/// reinstall with allowBuilds` (`globalVirtualStore.ts:290`). The
+/// hash-directory move is what makes approval safe: the unbuilt slot stays
+/// intact and the built one is a sibling.
+#[test]
+fn gvs_approve_builds_scenario_moves_artifacts_to_a_new_hash_dir() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" }),
+    );
+
+    eprintln!("Installing with builds NOT approved...");
+    set_gvs_workspace_yaml(
+        &workspace,
+        &format!("strictDepBuilds: false\n{}", allow_builds_yaml(&[])),
+    );
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir =
+        pkg_version_dir(&store_dir, "@pnpm.e2e/pre-and-postinstall-scripts-example", "1.0.0");
+    let hash_before = sole_hash_dir(&version_dir)
+        .file_name()
+        .expect("hash dir name")
+        .to_string_lossy()
+        .into_owned();
+    assert!(
+        !workspace
+            .join("node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js")
+            .exists(),
+        "an unapproved package must not have run its postinstall",
+    );
+
+    eprintln!("Reinstalling with the build approved...");
+    set_gvs_workspace_yaml(
+        &workspace,
+        &allow_builds_yaml(&[("@pnpm.e2e/pre-and-postinstall-scripts-example", true)]),
+    );
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let hash_after = hash_dirs(&version_dir)
+        .into_iter()
+        .find(|hash| hash != &hash_before)
+        .expect("approving a build must produce a new hash directory");
+    let pkg = pkg_in_slot(
+        &version_dir.join(&hash_after),
+        "@pnpm.e2e/pre-and-postinstall-scripts-example",
+    );
+    assert!(
+        pkg.join("generated-by-preinstall.js").exists(),
+        "the preinstall artifact must land in the new hash directory",
+    );
+    assert!(
+        pkg.join("generated-by-postinstall.js").exists(),
+        "the postinstall artifact must land in the new hash directory",
+    );
+
+    eprintln!("Artifacts must be reachable through node_modules...");
+    let linked = workspace.join("node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example");
+    assert!(is_symlink_or_junction(&linked).expect("stat the direct dep link"));
+    assert!(
+        linked.join("generated-by-preinstall.js").exists(),
+        "the project link must resolve to the built slot",
+    );
+    assert!(
+        linked.join("generated-by-postinstall.js").exists(),
+        "the project link must resolve to the built slot",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `GVS build failure cleans up broken package directory`
+/// (`globalVirtualStore.ts:338`).
+///
+/// A GVS hash directory is shared by every project whose dependency graph
+/// hashes to it, so a half-built one must not survive a failed build — the
+/// next install would take the warm path into broken files.
+#[test]
+fn gvs_build_failure_cleans_up_broken_package_directory() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/failing-postinstall": "1.0.0" }));
+    set_gvs_workspace_yaml(
+        &workspace,
+        &allow_builds_yaml(&[("@pnpm.e2e/failing-postinstall", true)]),
+    );
+
+    eprintln!("Installing a package whose postinstall exits non-zero...");
+    pacquet(&workspace).with_arg("install").assert().failure();
+
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/failing-postinstall", "1.0.0");
+    if version_dir.exists() {
+        for hash in hash_dirs(&version_dir) {
+            let pkg = pkg_in_slot(&version_dir.join(&hash), "@pnpm.e2e/failing-postinstall");
+            assert!(
+                !pkg.exists(),
+                "the failed build's slot must be removed so the next install re-fetches; \
+                 {pkg:?} survived",
+            );
+        }
+    }
+
+    drop((root, mock_instance));
+}
+
+/// TS: `GVS rebuilds successfully after simulated build failure cleanup`
+/// (`globalVirtualStore.ts:367`). With the hash directory gone the warm
+/// fast path must not fire — the install re-fetches, re-imports and
+/// re-builds into a fresh slot.
+#[test]
+fn gvs_rebuilds_successfully_after_simulated_build_failure_cleanup() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" }),
+    );
+    set_gvs_workspace_yaml(
+        &workspace,
+        &allow_builds_yaml(&[("@pnpm.e2e/pre-and-postinstall-scripts-example", true)]),
+    );
+
+    eprintln!("First install, with the build approved...");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir =
+        pkg_version_dir(&store_dir, "@pnpm.e2e/pre-and-postinstall-scripts-example", "1.0.0");
+    let hash_dir = sole_hash_dir(&version_dir);
+    assert!(
+        pkg_in_slot(&hash_dir, "@pnpm.e2e/pre-and-postinstall-scripts-example")
+            .join("generated-by-postinstall.js")
+            .exists(),
+    );
+
+    eprintln!("Simulating a previous build failure by removing the hash directory...");
+    fs::remove_dir_all(&hash_dir).expect("remove the GVS hash dir");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    eprintln!("Frozen reinstall must rebuild the slot from scratch...");
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    let rebuilt = sole_hash_dir(&version_dir);
+    assert!(
+        pkg_in_slot(&rebuilt, "@pnpm.e2e/pre-and-postinstall-scripts-example")
+            .join("generated-by-postinstall.js")
+            .exists(),
+        "the rebuilt slot must carry the build artifacts again",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `injected local packages work with global virtual store`
+/// (`globalVirtualStore.ts:461`).
+///
+/// The materialization half is already pinned by
+/// `injected_workspace_dep_with_dedupe_off_materialises_under_gvs` in
+/// `dedupe_injected_deps.rs`; this port covers the half that one does not
+/// — `.modules.yaml.injectedDeps` pointing into the GVS.
+#[test]
+fn injected_local_packages_work_with_global_virtual_store() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+    set_gvs_workspace_yaml(&workspace, "packages:\n  - 'project-*'\ndedupeInjectedDeps: false\n");
+
+    fs::create_dir_all(workspace.join("project-1")).expect("mkdir project-1");
+    fs::write(
+        workspace.join("project-1/package.json"),
+        serde_json::json!({
+            "name": "project-1",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/dep-of-pkg-with-1-dep": "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write project-1/package.json");
+    fs::write(workspace.join("project-1/foo.js"), "").expect("write project-1/foo.js");
+
+    fs::create_dir_all(workspace.join("project-2")).expect("mkdir project-2");
+    fs::write(
+        workspace.join("project-2/package.json"),
+        serde_json::json!({
+            "name": "project-2",
+            "version": "1.0.0",
+            "dependencies": { "project-1": "workspace:1.0.0" },
+            "dependenciesMeta": { "project-1": { "injected": true } },
+        })
+        .to_string(),
+    )
+    .expect("write project-2/package.json");
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    assert!(
+        workspace.join("project-2/node_modules/project-1").exists(),
+        "project-2 must have the injected workspace package installed",
+    );
+
+    let injected_deps = read_modules_manifest(&workspace)
+        .injected_deps
+        .expect(".modules.yaml must record injectedDeps under GVS");
+    let locations =
+        injected_deps.get("project-1").expect("injectedDeps must have an entry for project-1");
+    assert!(!locations.is_empty(), "the injectedDeps entry must list at least one location");
+
+    let gvs_root = gvs_root(&store_dir);
+    let location = Path::new(&locations[0]);
+    // `.modules.yaml` stores injected-dep locations relative to the
+    // project root, matching pnpm — upstream's assertion joins the
+    // recorded value straight onto the test's cwd.
+    let resolved =
+        if location.is_absolute() { location.to_path_buf() } else { workspace.join(location) };
+    let resolved = dunce::canonicalize(&resolved)
+        .unwrap_or_else(|err| panic!("canonicalize injected dep location {resolved:?}: {err}"));
+    let gvs_root = dunce::canonicalize(&gvs_root).expect("canonicalize the GVS root");
+    assert!(
+        resolved.starts_with(&gvs_root),
+        "the injected dep must be materialized inside the GVS ({gvs_root:?}), got {resolved:?}",
+    );
+    assert!(
+        resolved.join("foo.js").exists(),
+        "the injected copy must carry the source project's files",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `virtualStoreOnly populates standard virtual store without importer
+/// symlinks` (`globalVirtualStore.ts:539`).
+#[test]
+fn virtual_store_only_populates_standard_virtual_store_without_importer_symlinks() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+    append_workspace_yaml_key(&workspace, "virtualStoreOnly", true);
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    assert!(
+        workspace
+            .join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0/node_modules/@pnpm.e2e/pkg-with-1-dep/package.json")
+            .exists(),
+        "the standard virtual store must still be populated",
+    );
+    assert!(
+        !workspace.join("node_modules/@pnpm.e2e/pkg-with-1-dep").exists(),
+        "importer-level symlinks must not be created",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `virtualStoreOnly with enableModulesDir=false throws config error
+/// (standard virtual store)` (`globalVirtualStore.ts:559`). Without a
+/// global virtual store there is nowhere to put the packages, because the
+/// standard one lives inside `node_modules`.
+#[test]
+fn virtual_store_only_with_no_modules_dir_is_a_config_conflict() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({}));
+    append_workspace_yaml_key(&workspace, "virtualStoreOnly", true);
+    append_workspace_yaml_key(&workspace, "enableModulesDir", false);
+
+    let output = pacquet(&workspace).with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    assert!(
+        stderr.contains("ERR_PNPM_CONFIG_CONFLICT_VIRTUAL_STORE_ONLY_WITH_NO_MODULES_DIR"),
+        "the conflict must surface pnpm's error code; got: {stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `virtualStoreOnly with enableModulesDir=false works when GVS is
+/// enabled` (`globalVirtualStore.ts:571`). The global virtual store lives
+/// outside `node_modules`, so the same combination becomes legal.
+#[test]
+fn virtual_store_only_with_no_modules_dir_works_when_gvs_is_enabled() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+    eprintln!("First install with the modules dir enabled, to produce a lockfile...");
+    set_gvs_workspace_yaml(&workspace, "");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    fs::remove_dir_all(gvs_root(&store_dir)).expect("remove the GVS root");
+
+    eprintln!("Now virtualStoreOnly + enableModulesDir=false + GVS — must not throw...");
+    set_gvs_workspace_yaml(&workspace, "virtualStoreOnly: true\nenableModulesDir: false\n");
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let hash_dir = sole_hash_dir(&version_dir);
+    assert!(
+        pkg_in_slot(&hash_dir, "@pnpm.e2e/pkg-with-1-dep").join("package.json").exists(),
+        "the GVS must be populated even with no modules dir",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `virtualStoreOnly with GVS populates global virtual store without
+/// importer links` (`globalVirtualStore.ts:605`).
+#[test]
+fn virtual_store_only_with_gvs_populates_the_store_without_importer_links() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+    set_gvs_workspace_yaml(&workspace, "virtualStoreOnly: true\n");
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let hash_dir = sole_hash_dir(&version_dir);
+    assert!(
+        pkg_in_slot(&hash_dir, "@pnpm.e2e/pkg-with-1-dep").join("package.json").exists(),
+        "the GVS must be populated",
+    );
+    assert!(
+        pkg_in_slot(&hash_dir, "@pnpm.e2e/dep-of-pkg-with-1-dep").join("package.json").exists(),
+        "the transitive dep must be materialized in the slot too",
+    );
+
+    assert_no_post_import_linking(&workspace);
+
+    drop((root, mock_instance));
+}
+
+/// TS: `virtualStoreOnly with frozenLockfile populates virtual store
+/// without importer symlinks` (`globalVirtualStore.ts:635`).
+#[test]
+fn virtual_store_only_with_frozen_lockfile_populates_the_gvs_without_importer_symlinks() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+    eprintln!("First install to produce a lockfile...");
+    set_gvs_workspace_yaml(&workspace, "");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    fs::remove_dir_all(gvs_root(&store_dir)).expect("remove the GVS root");
+
+    eprintln!("Frozen reinstall with virtualStoreOnly...");
+    set_gvs_workspace_yaml(&workspace, "virtualStoreOnly: true\n");
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    let version_dir = pkg_version_dir(&store_dir, "@pnpm.e2e/pkg-with-1-dep", "100.0.0");
+    let hash_dir = sole_hash_dir(&version_dir);
+    assert!(
+        pkg_in_slot(&hash_dir, "@pnpm.e2e/pkg-with-1-dep").join("package.json").exists(),
+        "the GVS must be populated",
+    );
+    assert!(
+        pkg_in_slot(&hash_dir, "@pnpm.e2e/dep-of-pkg-with-1-dep").join("package.json").exists(),
+        "the transitive dep must be materialized in the slot too",
+    );
+
+    assert_no_post_import_linking(&workspace);
+
+    drop((root, mock_instance));
+}
+
+/// TS: `virtualStoreOnly with frozenLockfile populates standard virtual
+/// store without importer symlinks` (`globalVirtualStore.ts:677`).
+#[test]
+fn virtual_store_only_with_frozen_lockfile_populates_the_standard_store() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+
+    eprintln!("First install to produce a lockfile...");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    eprintln!("Frozen reinstall with virtualStoreOnly...");
+    append_workspace_yaml_key(&workspace, "virtualStoreOnly", true);
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    assert!(
+        workspace
+            .join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0/node_modules/@pnpm.e2e/pkg-with-1-dep/package.json")
+            .exists(),
+        "the standard virtual store must be populated",
+    );
+
+    assert_no_post_import_linking(&workspace);
+
+    drop((root, mock_instance));
+}
+
+/// TS: `virtualStoreOnly suppresses hoisting even with explicit
+/// hoistPattern` (`globalVirtualStore.ts:708`). The flag wins over an
+/// explicit opt-in on both hoist patterns.
+#[test]
+fn virtual_store_only_suppresses_hoisting_even_with_explicit_hoist_pattern() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+    append_workspace_yaml_key(&workspace, "virtualStoreOnly", true);
+    append_workspace_yaml_key(&workspace, "hoistPattern", "['*']");
+    append_workspace_yaml_key(&workspace, "publicHoistPattern", "['*']");
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    assert!(
+        workspace
+            .join("node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0/node_modules/@pnpm.e2e/pkg-with-1-dep/package.json")
+            .exists(),
+        "the virtual store must still be populated",
+    );
+
+    assert_no_post_import_linking(&workspace);
+
+    drop((root, mock_instance));
+}
+
+/// The three negatives every `virtualStoreOnly` install shares: no
+/// importer symlinks, no hoisted packages, no `.bin`.
+fn assert_no_post_import_linking(workspace: &Path) {
+    assert!(
+        !workspace.join("node_modules/@pnpm.e2e/pkg-with-1-dep").exists(),
+        "importer-level symlinks must not be created",
+    );
+    assert!(
+        !workspace.join("node_modules/.pnpm/node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep").exists(),
+        "nothing must be hoisted",
+    );
+    assert!(!workspace.join("node_modules/.bin").exists(), "no bins must be linked");
+}
+
+/// A `virtualStoreOnly` install must leave the project in a state a
+/// following ordinary install completes rather than purges — the empty
+/// hoist patterns it records are deliberate, not drift.
+///
+/// Pacquet-only: upstream encodes this as the `!modules.virtualStoreOnly`
+/// guards inside `validateModules.ts`, which has no test of its own.
+#[test]
+fn ordinary_install_after_virtual_store_only_completes_the_linking() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+    append_workspace_yaml_key(&workspace, "virtualStoreOnly", true);
+    append_workspace_yaml_key(&workspace, "hoistPattern", "['*']");
+
+    eprintln!("virtualStoreOnly install...");
+    pacquet(&workspace).with_arg("install").assert().success();
+    assert_eq!(
+        read_modules_manifest(&workspace).virtual_store_only,
+        Some(true),
+        ".modules.yaml must record that this install was virtualStoreOnly",
+    );
+
+    eprintln!("Ordinary install with the same hoistPattern must complete the linking...");
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&yaml_path, yaml.replace("virtualStoreOnly: true\n", ""))
+        .expect("write pnpm-workspace.yaml");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    assert!(
+        workspace.join("node_modules/@pnpm.e2e/pkg-with-1-dep/package.json").exists(),
+        "the follow-up install must create the importer symlinks",
+    );
+    assert_eq!(
+        read_modules_manifest(&workspace).virtual_store_only,
+        None,
+        "the flag must be cleared once an ordinary install has completed the linking",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// TS: `approve-builds updates GVS symlinks and runs builds at correct
+/// hash directory` (`pnpm/test/install/globalVirtualStore.ts:34`).
+///
+/// The CLI-level counterpart of
+/// [`gvs_approve_builds_scenario_moves_artifacts_to_a_new_hash_dir`]:
+/// the same hash move, but driven by the real `approve-builds` command,
+/// which also has to persist the approval into `pnpm-workspace.yaml`.
+#[test]
+fn approve_builds_updates_gvs_symlinks_and_runs_builds_at_the_new_hash_dir() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" }),
+    );
+    set_gvs_workspace_yaml(&workspace, "strictDepBuilds: false\n");
+
+    eprintln!("Install with the build unapproved...");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir =
+        pkg_version_dir(&store_dir, "@pnpm.e2e/pre-and-postinstall-scripts-example", "1.0.0");
+    let hash_before = sole_hash_dir(&version_dir)
+        .file_name()
+        .expect("hash dir name")
+        .to_string_lossy()
+        .into_owned();
+    assert!(
+        !workspace
+            .join("node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example/generated-by-postinstall.js")
+            .exists(),
+        "the build must not have run before approval",
+    );
+
+    eprintln!("Running approve-builds --all...");
+    pacquet(&workspace).with_args(["approve-builds", "--all"]).assert().success();
+
+    let hash_after = hash_dirs(&version_dir)
+        .into_iter()
+        .find(|hash| hash != &hash_before)
+        .expect("approve-builds must move the package to a new, engine-specific hash directory");
+    let pkg = pkg_in_slot(
+        &version_dir.join(&hash_after),
+        "@pnpm.e2e/pre-and-postinstall-scripts-example",
+    );
+    assert!(pkg.join("generated-by-preinstall.js").exists());
+    assert!(pkg.join("generated-by-postinstall.js").exists());
+
+    eprintln!("The artifacts must be reachable through node_modules...");
+    let linked = workspace.join("node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example");
+    assert!(
+        linked.join("generated-by-postinstall.js").exists(),
+        "approve-builds must repoint the project link at the built slot",
+    );
+
+    eprintln!("The approval must be persisted into pnpm-workspace.yaml...");
+    let yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml"))
+        .expect("read pnpm-workspace.yaml");
+    assert!(
+        yaml.contains("@pnpm.e2e/pre-and-postinstall-scripts-example"),
+        "approve-builds must record the approval in pnpm-workspace.yaml; got:\n{yaml}",
+    );
+
+    drop((root, mock_instance));
+}
+
+mod known_failures {
+    //! Global-virtual-store cases whose subject under test pacquet has
+    //! not built yet. Each stubs the boundary through
+    //! [`pacquet_testing_utils::allow_known_failure`] so the test exits
+    //! early rather than masking a real bug.
+
+    use pacquet_testing_utils::{
+        allow_known_failure,
+        known_failure::{KnownFailure, KnownResult},
+    };
+
+    fn needs_build_marker() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "Pacquet does not implement the `.pnpm-needs-build` marker. \
+             pnpm writes the file into a GVS slot between import and \
+             build, removes it on success, and treats its presence on a \
+             later install as \"this slot is half-built, re-fetch and \
+             re-build\". Pacquet's import pipeline never writes it, the \
+             warm-slot fast path never looks for it, and the \
+             side-effects upload does not exclude it — so an interrupted \
+             build leaves a slot the next install trusts. Porting it \
+             means all three: the write site, the detect sites, and the \
+             upload exclusion.",
+        ))
+    }
+
+    /// TS: `GVS .pnpm-needs-build marker triggers re-import on next
+    /// install` (`globalVirtualStore.ts:411`).
+    #[test]
+    fn needs_build_marker_triggers_reimport_on_next_install() {
+        allow_known_failure!(needs_build_marker());
+    }
+
+    /// The tail of TS `GVS successful build creates package directory
+    /// with build artifacts` (`globalVirtualStore.ts:250`): the marker
+    /// must never reach the side-effects cache diff, or every cache hit
+    /// would re-materialize a file that forces a rebuild forever.
+    #[test]
+    fn needs_build_marker_is_not_uploaded_to_the_side_effects_cache() {
+        allow_known_failure!(needs_build_marker());
+    }
+}

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -620,6 +620,32 @@ pub struct Config {
     #[default(_code = "default_virtual_store_dir()")]
     pub global_virtual_store_dir: PathBuf,
 
+    /// `virtualStoreOnly`: populate the virtual store but perform no
+    /// post-import linking — no importer symlinks, no `.bin` entries,
+    /// no hoisting, and no project lifecycle scripts. `pnpm fetch` is
+    /// the canonical consumer.
+    ///
+    /// [`Self::apply_virtual_store_only_derivation`] clears both hoist
+    /// patterns when this is set. Combining it with
+    /// `enable_modules_dir: false` while the global virtual store is
+    /// off is a config conflict, rejected by
+    /// `pacquet_package_manager::Install::run`.
+    pub virtual_store_only: bool,
+
+    /// `enableModulesDir`: pnpm's setting for suppressing the
+    /// `node_modules` directory entirely. Default `true`.
+    ///
+    /// Only partially wired in pacquet: it gates the
+    /// [`virtual_store_only`] config conflict (a store-only install with
+    /// no modules dir needs the global virtual store to have anywhere to
+    /// put packages). The standalone "create no `node_modules` at all"
+    /// behavior is not implemented yet — a `false` value on its own does
+    /// not suppress materialization.
+    ///
+    /// [`virtual_store_only`]: Self::virtual_store_only
+    #[default(true)]
+    pub enable_modules_dir: bool,
+
     /// User override for the global packages root (`global-dir` setting /
     /// `PNPM_CONFIG_GLOBAL_DIR`). When unset, [`Config::current`] derives
     /// the root from the pnpm home directory.
@@ -1828,6 +1854,22 @@ impl Config {
             };
     }
 
+    /// Clear both hoist patterns when [`virtual_store_only`] is set.
+    ///
+    /// A `virtualStoreOnly` install does no hoisting, so the patterns it
+    /// records in `.modules.yaml` must be empty — that is how the next
+    /// ordinary install learns hoisting still has to be done from
+    /// scratch rather than reading a pattern it never applied.
+    ///
+    /// [`virtual_store_only`]: Self::virtual_store_only
+    pub fn apply_virtual_store_only_derivation(&mut self) {
+        if !self.virtual_store_only {
+            return;
+        }
+        self.hoist_pattern = Some(Vec::new());
+        self.public_hoist_pattern = Some(Vec::new());
+    }
+
     /// Restore the smart default store after a higher-precedence config
     /// source explicitly clears `storeDir`.
     pub fn reset_store_dir_to_default<Sys>(&mut self, start_dir: &Path)
@@ -2337,6 +2379,8 @@ impl Config {
             virtual_store_dir_explicit,
             global_virtual_store_dir_explicit,
         );
+
+        self.apply_virtual_store_only_derivation();
 
         // Resolve the global install directories:
         // `globalPkgDir = (globalDir ?? <pnpm-home>/global)/v11` and

--- a/pnpm/crates/config/src/pnpm_default_parity.rs
+++ b/pnpm/crates/config/src/pnpm_default_parity.rs
@@ -69,7 +69,6 @@ const NOT_PORTED: &[&str] = &[
     "color",
     "disallow-workspace-cycles",
     "embed-readme",
-    "enable-modules-dir",
     "extend-node-path",
     "fail-if-no-match",
     "fetch-min-speed-ki-bps",
@@ -91,7 +90,6 @@ const NOT_PORTED: &[&str] = &[
     "sort",
     "strict-store-pkg-content-check",
     "use-beta-cli",
-    "virtual-store-only",
     "workspace-prefix",
 ];
 
@@ -106,6 +104,8 @@ fn mapped_rows(cfg: &Config) -> Vec<(&'static str, Scalar)> {
         ("block-exotic-subdeps", Bool(cfg.block_exotic_subdeps)),
         ("dangerously-allow-all-builds", Bool(cfg.dangerously_allow_all_builds)),
         ("strict-dep-builds", Bool(cfg.strict_dep_builds)),
+        ("virtual-store-only", Bool(cfg.virtual_store_only)),
+        ("enable-modules-dir", Bool(cfg.enable_modules_dir)),
         ("dedupe-direct-deps", Bool(cfg.dedupe_direct_deps)),
         ("dedupe-injected-deps", Bool(cfg.dedupe_injected_deps)),
         ("dedupe-peer-dependents", Bool(cfg.dedupe_peer_dependents)),

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -85,6 +85,12 @@ pub struct WorkspaceSettings {
     /// has no `--global` flow). See
     /// [`Config::enable_global_virtual_store`].
     pub enable_global_virtual_store: Option<bool>,
+    /// `virtualStoreOnly` from `pnpm-workspace.yaml`. See
+    /// [`Config::virtual_store_only`].
+    pub virtual_store_only: Option<bool>,
+    /// `enableModulesDir` from `pnpm-workspace.yaml`. See
+    /// [`Config::enable_modules_dir`].
+    pub enable_modules_dir: Option<bool>,
     /// `globalVirtualStoreDir` from `pnpm-workspace.yaml`. Resolved
     /// against the workspace dir like the other path-valued fields.
     /// When set, overrides the derived `<store_dir>/links` path.
@@ -783,6 +789,7 @@ impl WorkspaceSettings {
             fetch_retry_mintimeout, fetch_retry_maxtimeout,
             network_concurrency, fetch_timeout, user_agent,
             enable_global_virtual_store,
+            virtual_store_only, enable_modules_dir,
             git_shallow_hosts,
             test_pattern, changed_files_ignore_pattern,
             resolution_mode, catalog_mode, registry_supports_time_field,

--- a/pnpm/crates/modules-yaml/src/lib.rs
+++ b/pnpm/crates/modules-yaml/src/lib.rs
@@ -209,6 +209,15 @@ pub struct Modules {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_builds: Option<BTreeMap<String, AllowBuildValue>>,
+
+    /// `true` when this modules directory was populated by a
+    /// `virtualStoreOnly` install (`pnpm fetch`). Such an install
+    /// records empty hoist patterns because it did no hoisting, so the
+    /// next ordinary install must finish the linking rather than read
+    /// the pattern mismatch as drift and purge. Omitted when false,
+    /// matching pnpm's delete-when-falsy encoding.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub virtual_store_only: Option<bool>,
 }
 
 /// A lightweight version of [`Modules`] that skips deserializing the potentially
@@ -253,6 +262,10 @@ pub struct ModulesLayout {
     pub virtual_store_dir_max_length: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allow_builds: Option<BTreeMap<String, AllowBuildValue>>,
+    /// See [`Modules::virtual_store_only`]. Read by the layout-drift
+    /// check, which skips the hoist-pattern comparison when it is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub virtual_store_only: Option<bool>,
 }
 
 /// Which dependency groups the install pipeline included.

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -921,7 +921,23 @@ fn build_one_snapshot<Reporter: self::Reporter>(
         // missing after a failed materialization, skip an optional
         // dependency (as for any optional build failure) and surface a
         // hard error otherwise.
-        let satisfied_by_cache = if layout.enable_global_virtual_store() {
+        //
+        // Under the global virtual store the slot usually *is* the seeded
+        // build — it persists inside the store across installs — so the
+        // overlay is already on disk and re-linking it would be pure
+        // overhead. That only holds while the slot survives, though: a
+        // failed build discards it
+        // ([`discard_failed_global_virtual_store_slot`]), and a prune or a
+        // manual removal can too. The store index keeps the side-effects
+        // row either way, so the next install re-imports the slot pristine
+        // and still hits the cache. Trusting the hit there would skip the
+        // build and leave the package unbuilt, so the slot has to be
+        // checked rather than assumed.
+        let gvs_slot_already_seeded = layout.enable_global_virtual_store()
+            && pkg_root_for_key(layout, pkg_roots_by_key, snapshot_key)
+                .is_some_and(|pkg_dir| slot_carries_overlay(&pkg_dir, overlay));
+
+        let satisfied_by_cache = if gvs_slot_already_seeded {
             true
         } else {
             // The overlay carries the patched / built contents, so it
@@ -1060,6 +1076,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
                 continue;
             }
             apply_patch_to_dir(&patched_dir, patch_file_path)
+                .inspect_err(|_| discard_failed_global_virtual_store_slot(layout, snapshot_key))
                 .map_err(BuildModulesError::PatchApply)?;
         }
         true
@@ -1089,6 +1106,9 @@ fn build_one_snapshot<Reporter: self::Reporter>(
         match result {
             Ok(ran) => ran,
             Err(err) => {
+                // Before the optional-skip return, so a failed optional
+                // build leaves no half-built slot behind either.
+                discard_failed_global_virtual_store_slot(layout, snapshot_key);
                 if optional {
                     Reporter::emit(&LogEvent::SkippedOptionalDependency(
                         SkippedOptionalDependencyLog {
@@ -1188,6 +1208,85 @@ fn virtual_store_dir_for_key(layout: &crate::VirtualStoreLayout, key: &PackageKe
     let name = &name_version[..at_idx];
 
     layout.slot_dir(key).join("node_modules").join(name)
+}
+
+/// Whether `pkg_dir` already holds every file of a side-effects-cache
+/// overlay — i.e. the cached build is on disk rather than merely recorded
+/// in the store index.
+///
+/// The overlay is the resolved post-build file set, so a slot still
+/// carrying only the pristine tarball is missing whatever the build
+/// added and fails the check. A build that *only deleted* files is
+/// indistinguishable from an unbuilt slot here and reads as seeded;
+/// pnpm's `.pnpm-needs-build` marker is what closes that gap, and
+/// pacquet has not ported it yet.
+///
+/// Only reached for packages that both pass the build-allow policy and
+/// have a cache entry — a handful per install, not the whole tree.
+fn slot_carries_overlay(pkg_dir: &Path, overlay: &HashMap<String, PathBuf>) -> bool {
+    pkg_dir.is_dir() && overlay.keys().all(|relative| pkg_dir.join(relative).exists())
+}
+
+/// Whether `slot_dir` is a strict descendant of `root` reached only
+/// through `..`-free path components.
+///
+/// The gate for [`discard_failed_global_virtual_store_slot`]'s recursive
+/// delete: `slot_dir` is derived from a lockfile-controlled package
+/// name, so a crafted `..` segment must not let the delete escape the
+/// store root.
+fn is_contained_descendant(root: &Path, slot_dir: &Path) -> bool {
+    slot_dir.strip_prefix(root).is_ok_and(|suffix| {
+        let mut components = suffix.components().peekable();
+        components.peek().is_some()
+            && components.all(|component| matches!(component, std::path::Component::Normal(_)))
+    })
+}
+
+/// Remove a snapshot's whole global-virtual-store hash directory after
+/// its patch application or build script failed.
+///
+/// The hash directory is shared across every project that resolves to
+/// the same dependency graph, so leaving a half-built one behind would
+/// serve broken files to all of them: the next install finds the
+/// directory present, takes the warm fast path, and never re-fetches.
+/// Removing it restores the cold path.
+///
+/// No-op when the global virtual store is off — a project-local
+/// `node_modules/.pnpm` slot is rebuilt from scratch by the next
+/// install anyway. Removal failures are logged and swallowed; the build
+/// error the caller is already returning is the one worth surfacing.
+fn discard_failed_global_virtual_store_slot(layout: &crate::VirtualStoreLayout, key: &PackageKey) {
+    if !layout.enable_global_virtual_store() {
+        return;
+    }
+    let slot_dir = layout.slot_dir(key);
+    // Defense-in-depth: the slot path is built from a lockfile-controlled
+    // package name, which is not validated against `..` segments. Refuse
+    // to recurse-delete anything that isn't a plain descendant of the GVS
+    // root, so a crafted name can't turn cleanup into a path traversal
+    // that removes directories outside the store.
+    let root = layout.package_store_dir();
+    if !is_contained_descendant(root, &slot_dir) {
+        tracing::warn!(
+            target: "pacquet::build",
+            dep_path = %key,
+            slot_dir = %slot_dir.display(),
+            store_root = %root.display(),
+            "refusing to remove a build slot outside the store root",
+        );
+        return;
+    }
+    if let Err(err) = std::fs::remove_dir_all(&slot_dir)
+        && err.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            target: "pacquet::build",
+            ?err,
+            dep_path = %key,
+            slot_dir = %slot_dir.display(),
+            "failed to remove the global virtual store slot of a failed build",
+        );
+    }
 }
 
 /// Resolve the canonical on-disk package directory for a snapshot — the

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    AllowBuildPolicy, BuildModules, allow_build_key_from_ignored_build, parse_name_version_from_key,
+    AllowBuildPolicy, BuildModules, allow_build_key_from_ignored_build, is_contained_descendant,
+    parse_name_version_from_key,
 };
 // Only the `#[cfg(unix)]` rebuild-selection test uses this; importing it
 // unconditionally would be an unused import on Windows.
@@ -2723,4 +2724,28 @@ fn rebuild_selection_runs_only_selected_scripts() {
         !zzz_dir.join("built-marker").exists(),
         "the non-selected package's script must not run",
     );
+}
+
+/// The GVS build-failure cleanup only recurse-deletes a slot that sits
+/// strictly inside the store root through `..`-free components, so a
+/// crafted package name cannot turn the cleanup into a path traversal.
+#[test]
+fn is_contained_descendant_rejects_traversal_and_escapes() {
+    let root = Path::new("/store/v11/links");
+
+    // A normal GVS slot suffix is accepted.
+    assert!(is_contained_descendant(root, &root.join("@pnpm.e2e/foo/1.0.0/deadbeef")));
+    assert!(is_contained_descendant(root, &root.join("foo/1.0.0/deadbeef")));
+
+    // A `..` segment that climbs out of the root is rejected even though
+    // the path still textually starts with the root.
+    assert!(!is_contained_descendant(root, &root.join("../../../etc/passwd")));
+    assert!(!is_contained_descendant(root, &root.join("foo/../../../escape")));
+
+    // The root itself is not a descendant — deleting it wholesale is not
+    // a per-slot cleanup.
+    assert!(!is_contained_descendant(root, root));
+
+    // A sibling that merely shares a name prefix is not contained.
+    assert!(!is_contained_descendant(root, Path::new("/store/v11/links-evil/foo")));
 }

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -568,6 +568,18 @@ pub enum InstallError {
     )]
     #[diagnostic(code(ERR_PNPM_CONFIG_CONFLICT_FROZEN_STORE_WITH_FORCE))]
     ConfigConflictFrozenStoreWithForce,
+
+    /// `virtualStoreOnly` was requested with `enableModulesDir: false`
+    /// while the global virtual store is off. The standard virtual
+    /// store lives at `node_modules/.pnpm`, so suppressing
+    /// `node_modules` leaves nowhere to populate. The global virtual
+    /// store lives outside the project, which is why enabling it makes
+    /// the same combination legal.
+    #[display(
+        "Cannot use virtualStoreOnly when enableModulesDir is false (the standard virtual store requires node_modules/.pnpm)"
+    )]
+    #[diagnostic(code(ERR_PNPM_CONFIG_CONFLICT_VIRTUAL_STORE_ONLY_WITH_NO_MODULES_DIR))]
+    ConfigConflictVirtualStoreOnlyWithNoModulesDir,
 }
 
 #[derive(Default)]
@@ -736,6 +748,13 @@ where
 
         if config.frozen_store && config.force {
             return Err(InstallError::ConfigConflictFrozenStoreWithForce);
+        }
+
+        if config.virtual_store_only
+            && !config.enable_modules_dir
+            && !config.enable_global_virtual_store
+        {
+            return Err(InstallError::ConfigConflictVirtualStoreOnlyWithNoModulesDir);
         }
 
         // Resolve the effective `preferFrozenLockfile` for the
@@ -2009,17 +2028,24 @@ where
         // regardless. Aliases the wanted lockfile *does* track are
         // skipped — those belong to the lockfile passes (and their
         // dedupe decisions). See [`crate::link_manifest_link_deps`].
-        crate::link_manifest_link_deps::<Reporter>(
-            &workspace_root,
-            &materialized_project_manifests,
-            fresh_lockfile.as_ref().or(lockfile).and_then(|lockfile| {
-                (!lockfile.importers.is_empty()).then_some(&lockfile.importers)
-            }),
-            // Honor a `modulesDir` override the same way the
-            // lockfile-driven symlink pass does.
-            config.modules_dir.file_name().unwrap_or_else(|| std::ffi::OsStr::new("node_modules")),
-        )
-        .map_err(InstallError::LinkManifestLinkDeps)?;
+        // These are importer symlinks like any other, so
+        // `virtualStoreOnly` skips them too.
+        if !config.virtual_store_only {
+            crate::link_manifest_link_deps::<Reporter>(
+                &workspace_root,
+                &materialized_project_manifests,
+                fresh_lockfile.as_ref().or(lockfile).and_then(|lockfile| {
+                    (!lockfile.importers.is_empty()).then_some(&lockfile.importers)
+                }),
+                // Honor a `modulesDir` override the same way the
+                // lockfile-driven symlink pass does.
+                config
+                    .modules_dir
+                    .file_name()
+                    .unwrap_or_else(|| std::ffi::OsStr::new("node_modules")),
+            )
+            .map_err(InstallError::LinkManifestLinkDeps)?;
+        }
 
         // `Stage::ImportingDone` is emitted inside the install paths
         // (`InstallFrozenLockfile` between symlink and build, and
@@ -2188,7 +2214,10 @@ where
         // Also skipped under `--ignore-scripts`: pnpm suppresses the
         // project's own lifecycle scripts alongside dependency build
         // scripts when `ignoreScripts` is set.
-        if is_full_install && !config.ignore_scripts {
+        //
+        // And under `virtualStoreOnly`, which stops before any linking
+        // the project's scripts would expect to find in place.
+        if is_full_install && !config.ignore_scripts && !config.virtual_store_only {
             run_projects_lifecycle_scripts::<Reporter>(
                 &materialized_project_manifests,
                 config,
@@ -2534,6 +2563,14 @@ fn modules_consistent_with(
     node_linker: NodeLinker,
     included: IncludedDependencies,
 ) -> bool {
+    // A `virtualStoreOnly` install populates the virtual store and stops,
+    // so the modules directory it leaves behind has no importer symlinks,
+    // bins, or hoisted packages. It can never satisfy an ordinary
+    // install, however well its recorded settings line up — the no-op
+    // short-circuit would leave the linking permanently undone.
+    if modules.virtual_store_only == Some(true) && !config.virtual_store_only {
+        return false;
+    }
     modules.included == included && modules_layout_consistent_with(modules, config, node_linker)
 }
 
@@ -2668,17 +2705,27 @@ fn modules_layout_consistent_with(
     config: &Config,
     node_linker: NodeLinker,
 ) -> bool {
+    // A `virtualStoreOnly` install (`pnpm fetch`) records empty hoist
+    // patterns because it deliberately did no hoisting. Diffing those
+    // against the follow-up install's real patterns would read as drift
+    // and purge the directory the fetch just populated, so the
+    // comparison is skipped and the follow-up completes the linking
+    // instead.
+    // Patterns compare normalized (upstream's `?? []`): `None` and an
+    // empty list are the same disabled state, so the pair must not read
+    // as layout drift — a purge every install for `hoistPattern: []`
+    // projects, and a spurious `*_DIFF` error for `add` / `remove`. A
+    // `virtualStoreOnly` install records empty patterns deliberately, so
+    // it skips the comparison entirely and lets the follow-up install
+    // complete the linking instead of purging.
+    let hoist_patterns_match = modules.virtual_store_only == Some(true)
+        || (normalized_pattern(modules.hoist_pattern.as_deref())
+            == normalized_pattern(config.hoist_pattern.as_deref())
+            && normalized_pattern(modules.public_hoist_pattern.as_deref())
+                == normalized_pattern(config.public_hoist_pattern.as_deref()));
     modules.layout_version == Some(LayoutVersion)
         && modules.node_linker == Some(map_node_linker(node_linker))
-        // Patterns compare normalized (upstream's `?? []`): `None` and
-        // an empty list are the same disabled state, so the pair must
-        // not read as layout drift — a purge every install for
-        // `hoistPattern: []` projects, and a spurious `*_DIFF` error
-        // for `add` / `remove`.
-        && normalized_pattern(modules.hoist_pattern.as_deref())
-            == normalized_pattern(config.hoist_pattern.as_deref())
-        && normalized_pattern(modules.public_hoist_pattern.as_deref())
-            == normalized_pattern(config.public_hoist_pattern.as_deref())
+        && hoist_patterns_match
         && modules.virtual_store_dir_max_length == config.virtual_store_dir_max_length
         && modules.store_dir == config.store_dir.display().to_string()
         && modules.virtual_store_dir
@@ -2747,8 +2794,8 @@ fn unapproved_recorded_ignored_builds(
 
 /// Assemble the [`Modules`] payload for [`write_modules_manifest`].
 ///
-/// Fields pacquet does not populate yet (`pendingBuilds`,
-/// `allowBuilds`) default to empty / unset.
+/// Fields pacquet does not populate yet (`pendingBuilds`) default to
+/// empty / unset.
 ///
 /// `hoistedDependencies` is produced by the isolated-linker hoist
 /// pass in [`crate::InstallFrozenLockfile::run`] and threaded in
@@ -2833,6 +2880,20 @@ fn build_modules_manifest(
         store_dir: config.store_dir.display().to_string(),
         virtual_store_dir: config.effective_virtual_store_dir().to_string_lossy().into_owned(),
         virtual_store_dir_max_length: config.virtual_store_dir_max_length,
+        // The build-approval set this install ran under. A GVS install
+        // hashes engine-specific slots for allowed builders, so the
+        // recorded set is what a later install diffs against to decide
+        // whether its slots need re-linking.
+        allow_builds: Some(
+            config
+                .allow_builds
+                .iter()
+                .map(|(spec, allowed)| {
+                    (spec.clone(), pacquet_modules_yaml::AllowBuildValue::Bool(*allowed))
+                })
+                .collect(),
+        ),
+        virtual_store_only: config.virtual_store_only.then_some(true),
         ..Default::default()
     }
 }
@@ -3423,8 +3484,8 @@ fn build_workspace_packages_map(
     Some(map)
 }
 
-pub(crate) fn should_write_package_map(_config: &Config, node_linker: NodeLinker) -> bool {
-    node_linker == NodeLinker::Isolated
+pub(crate) fn should_write_package_map(config: &Config, node_linker: NodeLinker) -> bool {
+    node_linker == NodeLinker::Isolated && !config.virtual_store_only
 }
 
 /// Build the `projects` map for [`WorkspaceState`] from the

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -534,6 +534,13 @@ pub(crate) fn run_build_phase<Reporter: self::Reporter>(
         strict_dep_builds: config.strict_dep_builds,
     }));
 
+    // `virtual_store_only` links no bins at all, so there is nothing for
+    // the pass below to re-resolve. Dependency *build* scripts still ran
+    // above — only the linking stops, matching `pnpm fetch`.
+    if config.virtual_store_only {
+        return Ok(ignored_builds);
+    }
+
     // Post-`BuildModules` per-importer top-level bin link
     // (pnpm/pacquet#342). Resolves direct-over-hoisted precedence and
     // shims lifecycle-script-created bins that didn't exist at extract
@@ -1100,7 +1107,11 @@ where
         // [`crate::link_hoisted_modules()`]); on the isolated linker
         // the event fires here, so every install carries exactly one,
         // pairing the `added` emitted in `CreateVirtualStore`.
-        if !is_hoisted {
+        //
+        // `virtual_store_only` skips reconciliation for the same reason
+        // it skips linking below: it never creates importer or hoist
+        // links, so there is nothing of its own to reconcile.
+        if !is_hoisted && !config.virtual_store_only {
             let removed_count = match current_lockfile {
                 Some(current) => crate::PruneStaleModules {
                     config,
@@ -1124,7 +1135,10 @@ where
             }));
         }
 
-        if !is_hoisted {
+        // `virtual_store_only` stops here: the virtual store is
+        // populated, but nothing downstream of it — importer symlinks,
+        // per-slot bins, root components — gets linked.
+        if !is_hoisted && !config.virtual_store_only {
             // Importer ids backed by the install's own declared
             // projects. These may legitimately live outside the
             // lockfile dir (Bit's capsule installs pass such
@@ -1231,31 +1245,32 @@ where
         // [`crate::BuildModules::pkg_roots_by_key`] for why a snapshot
         // can map to more than one directory and which writes have to
         // reach all of them.
-        let HoistedLinkerOutput { hoisted_locations, hoisted_pkg_roots_by_key } = if is_hoisted {
-            run_hoisted_linker::<Reporter>(
-                HoistedLinkerInputs {
-                    config,
-                    lockfile,
-                    current_lockfile,
-                    layout: &layout,
-                    importers,
-                    dependency_groups: &dependency_groups,
-                    project_manifests,
-                    package_map_project_manifests,
-                    walker_lockfile_dir: workspace_root,
-                    symlink_workspace_root: workspace_root,
-                    host_node: host_node.as_ref(),
-                    supported_architectures,
-                    cas_paths_by_pkg_id,
-                    logged_methods,
-                    requester,
-                },
-                &mut skipped,
-            )
-            .map_err(InstallFrozenLockfileError::from)?
-        } else {
-            HoistedLinkerOutput::default()
-        };
+        let HoistedLinkerOutput { hoisted_locations, hoisted_pkg_roots_by_key } =
+            if is_hoisted && !config.virtual_store_only {
+                run_hoisted_linker::<Reporter>(
+                    HoistedLinkerInputs {
+                        config,
+                        lockfile,
+                        current_lockfile,
+                        layout: &layout,
+                        importers,
+                        dependency_groups: &dependency_groups,
+                        project_manifests,
+                        package_map_project_manifests,
+                        walker_lockfile_dir: workspace_root,
+                        symlink_workspace_root: workspace_root,
+                        host_node: host_node.as_ref(),
+                        supported_architectures,
+                        cas_paths_by_pkg_id,
+                        logged_methods,
+                        requester,
+                    },
+                    &mut skipped,
+                )
+                .map_err(InstallFrozenLockfileError::from)?
+            } else {
+                HoistedLinkerOutput::default()
+            };
 
         // Hoist transitive deps into `<virtual_store>/node_modules`
         // (private hoist) and/or `<root>/node_modules` (public hoist).
@@ -1916,6 +1931,13 @@ pub(crate) fn compute_hoist_plan(
     hoisted_workspace_packages: Option<&std::collections::BTreeMap<String, PathBuf>>,
 ) -> Option<HoistPlan> {
     if is_hoisted {
+        return None;
+    }
+    // Independent of the empty patterns
+    // [`Config::apply_virtual_store_only_derivation`] leaves behind, so a
+    // caller that sets the flag without going through `Config::current`
+    // still gets no hoisting.
+    if config.virtual_store_only {
         return None;
     }
     if config.hoist_pattern.is_none() && config.public_hoist_pattern.is_none() {

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -39,6 +39,8 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         symlink: false,
         virtual_store_dir: virtual_store_dir.to_path_buf(),
         enable_global_virtual_store: false,
+        virtual_store_only: false,
+        enable_modules_dir: true,
         global_virtual_store_dir: virtual_store_dir.to_path_buf(),
         global_dir: None,
         global_bin_dir: None,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -2089,7 +2089,11 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // [`crate::link_hoisted_modules()`]); on the isolated linker
         // the event fires here, so every install carries exactly one,
         // pairing the `added` emitted in `CreateVirtualStore`.
-        if !is_hoisted {
+        //
+        // `virtual_store_only` skips reconciliation for the same reason
+        // it skips linking below: it never creates importer or hoist
+        // links, so there is nothing of its own to reconcile.
+        if !is_hoisted && !config.virtual_store_only {
             let removed_count = match current_lockfile {
                 Some(current) => crate::PruneStaleModules {
                     config,
@@ -2113,7 +2117,12 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             }));
         }
 
-        let (hoisted_dependencies, hoisted_locations) = if is_hoisted {
+        // `virtual_store_only` stops after the virtual store is
+        // populated: neither linker arm runs, so nothing is hoisted and
+        // no importer symlinks or bins are created.
+        let (hoisted_dependencies, hoisted_locations) = if config.virtual_store_only {
+            (HoistedDependencies::new(), BTreeMap::new())
+        } else if is_hoisted {
             let project_manifests = importer_manifests
                 .iter()
                 .filter(|(id, _)| project_anchor_importer_ids.contains(id.as_str()))

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -68,7 +68,7 @@ Frozen/headless install coverage:
 - [ ] `TypeScript repo: installing/deps-installer/test/install/modulesCache.ts:52` `the modules cache is pruned when it expires and headless install is used` verifies `prunedAt` is read, rewritten, and honored by headless install.
 - [x] `TypeScript repo: installing/deps-installer/test/install/optionalDependencies.ts:74` `skip optional dependency that does not support the current OS` verifies `skipped` survives frozen reinstall — ported as `skip_optional_dependency_that_does_not_support_the_current_os` in `crates/cli/tests/optional_dependencies.rs`.
 - [ ] `TypeScript repo: installing/deps-installer/test/lockfile.ts:614` `pendingBuilds gets updated if install removes packages` verifies `.modules.yaml.pendingBuilds` is rewritten after pruning.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:205` `GVS re-links when allowBuilds changes` verifies GVS-related `allowBuilds` state is updated in `.modules.yaml`. Adjacent non-GVS coverage exists (`rebuild_after_allow_builds_changes` in `crates/cli/tests/lifecycle_scripts.rs`), but nothing asserts the GVS `.modules.yaml` state.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:205` `GVS re-links when allowBuilds changes` verifies GVS-related `allowBuilds` state is updated in `.modules.yaml` — ported as `gvs_relinks_when_allow_builds_changes` in `crates/cli/tests/global_virtual_store.rs`, which also drove populating `Modules::allow_builds` (previously always unset). Adjacent non-GVS coverage is `rebuild_after_allow_builds_changes` in `crates/cli/tests/lifecycle_scripts.rs`.
 - [ ] `TypeScript repo: pnpm/test/monorepo/index.ts:1467` `custom virtual store directory in a workspace with not shared lockfile` verifies frozen reinstall preserves custom `virtualStoreDir` serialization — stubbed in `known_failures::custom_virtual_store_directory_with_dedicated_lockfiles` (`crates/cli/tests/multiple_importers.rs`; needs `sharedWorkspaceLockfile: false`).
 - [x] `TypeScript repo: pnpm/test/monorepo/index.ts:1514` `custom virtual store directory in a workspace with shared lockfile` verifies frozen reinstall preserves root `virtualStoreDir` serialization — ported as `custom_virtual_store_directory_in_a_workspace_with_shared_lockfile` in `crates/cli/tests/multiple_importers.rs`.
 
@@ -404,38 +404,51 @@ Rust port notes:
 
 ## Support The Global Virtual Store Dir
 
+Ported in `crates/cli/tests/global_virtual_store.rs`. Upstream drives the
+primary suite through the programmatic `install()` API; pacquet's
+equivalent surface is the CLI, so the ports assert the same on-disk
+contract instead of the call counts upstream can reach by patching
+`storeController.fetchPackage`.
+
 Primary tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:21` `using a global virtual store` includes reinstall with `frozenLockfile: true`.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:63` `reinstall from warm global virtual store after deleting node_modules` deletes `node_modules`, keeps GVS warm, and reinstalls frozen.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:107` `modules are correctly updated when using a global virtual store`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:132` `GVS hashes are engine-agnostic for packages not in allowBuilds`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:172` `GVS hashes are stable when allowBuilds targets an unrelated package`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:205` `GVS re-links when allowBuilds changes`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:250` `GVS successful build creates package directory with build artifacts`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:290` `GVS: approve-builds scenario — install with no builds, then reinstall with allowBuilds`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:338` `GVS build failure cleans up broken package directory`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:367` `GVS rebuilds successfully after simulated build failure cleanup`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:411` `GVS .pnpm-needs-build marker triggers re-import on next install`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:461` `injected local packages work with global virtual store`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:539` `virtualStoreOnly populates standard virtual store without importer symlinks` is the standard-store counterpart for virtual-store-only behavior.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:559` `virtualStoreOnly with enableModulesDir=false throws config error (standard virtual store)` is the negative counterpart to GVS behavior.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:571` `virtualStoreOnly with enableModulesDir=false works when GVS is enabled`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:605` `virtualStoreOnly with GVS populates global virtual store without importer links`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:635` `virtualStoreOnly with frozenLockfile populates virtual store without importer symlinks`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:677` `virtualStoreOnly with frozenLockfile populates standard virtual store without importer symlinks`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:708` `virtualStoreOnly suppresses hoisting even with explicit hoistPattern`
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:21` `using a global virtual store` includes reinstall with `frozenLockfile: true` — ported as `using_a_global_virtual_store` (covers the CLI-level `:11` case too).
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:63` `reinstall from warm global virtual store after deleting node_modules` deletes `node_modules`, keeps GVS warm, and reinstalls frozen — ported as `reinstall_from_warm_global_virtual_store_after_deleting_node_modules`. Upstream's `fetchPackage` spy has no CLI equivalent; the port asserts the observable consequence instead (the warm slot is reused rather than materialized beside a second hash directory, and the whole project tree including `.bin` is restored from it).
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:107` `modules are correctly updated when using a global virtual store` — ported as `modules_are_correctly_updated_when_using_a_global_virtual_store`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:132` `GVS hashes are engine-agnostic for packages not in allowBuilds` — ported as `gvs_hashes_are_engine_agnostic_for_packages_not_in_allow_builds`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:172` `GVS hashes are stable when allowBuilds targets an unrelated package` — ported as `gvs_hashes_are_stable_when_allow_builds_targets_an_unrelated_package`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:205` `GVS re-links when allowBuilds changes` — ported as `gvs_relinks_when_allow_builds_changes`, including the `.modules.yaml` half (pacquet now persists `allowBuilds`, which it previously left unset).
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:250` `GVS successful build creates package directory with build artifacts` — ported as `gvs_successful_build_creates_package_directory_with_build_artifacts`. The `.pnpm-needs-build` tail is a `known_failures` stub (see `:411`).
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:290` `GVS: approve-builds scenario — install with no builds, then reinstall with allowBuilds` — ported as `gvs_approve_builds_scenario_moves_artifacts_to_a_new_hash_dir`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:338` `GVS build failure cleans up broken package directory` — ported as `gvs_build_failure_cleans_up_broken_package_directory`; the cleanup itself is new in pacquet (`discard_failed_global_virtual_store_slot`).
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:367` `GVS rebuilds successfully after simulated build failure cleanup` — ported as `gvs_rebuilds_successfully_after_simulated_build_failure_cleanup`.
+- [ ] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:411` `GVS .pnpm-needs-build marker triggers re-import on next install` — `known_failures` stub: pacquet does not implement the marker at all. pnpm writes it into a GVS slot between import and build, removes it on success, and treats its presence on a later install as "half-built, re-fetch and re-build"; pacquet's import pipeline never writes it, the warm-slot fast path never looks for it, and the side-effects upload does not exclude it. Porting it means all three sites at once.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:461` `injected local packages work with global virtual store` — ported as `injected_local_packages_work_with_global_virtual_store` (the `.modules.yaml.injectedDeps` half; the materialization half is `injected_workspace_dep_with_dedupe_off_materialises_under_gvs` in `crates/cli/tests/dedupe_injected_deps.rs`).
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:539` `virtualStoreOnly populates standard virtual store without importer symlinks` — ported as `virtual_store_only_populates_standard_virtual_store_without_importer_symlinks`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:559` `virtualStoreOnly with enableModulesDir=false throws config error (standard virtual store)` — ported as `virtual_store_only_with_no_modules_dir_is_a_config_conflict`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:571` `virtualStoreOnly with enableModulesDir=false works when GVS is enabled` — ported as `virtual_store_only_with_no_modules_dir_works_when_gvs_is_enabled`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:605` `virtualStoreOnly with GVS populates global virtual store without importer links` — ported as `virtual_store_only_with_gvs_populates_the_store_without_importer_links`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:635` `virtualStoreOnly with frozenLockfile populates virtual store without importer symlinks` — ported as `virtual_store_only_with_frozen_lockfile_populates_the_gvs_without_importer_symlinks`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:677` `virtualStoreOnly with frozenLockfile populates standard virtual store without importer symlinks` — ported as `virtual_store_only_with_frozen_lockfile_populates_the_standard_store`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/globalVirtualStore.ts:708` `virtualStoreOnly suppresses hoisting even with explicit hoistPattern` — ported as `virtual_store_only_suppresses_hoisting_even_with_explicit_hoist_pattern`.
+
+The seven `virtualStoreOnly` items required implementing the setting: it
+had no `Config` field before (nor did `enableModulesDir`), so none of the
+behavior was reachable end to end. Pacquet-only
+`ordinary_install_after_virtual_store_only_completes_the_linking` pins the
+follow-up contract upstream encodes as the `!modules.virtualStoreOnly`
+guards in `validateModules.ts` and has no test for.
 
 CLI-level tests:
 
-- [ ] `TypeScript repo: pnpm/test/install/globalVirtualStore.ts:11` `using a global virtual store`
-- [ ] `TypeScript repo: pnpm/test/install/globalVirtualStore.ts:34` `approve-builds updates GVS symlinks and runs builds at correct hash directory`
-- [ ] `TypeScript repo: pnpm/test/install/globalVirtualStore.ts:80` `warm GVS reinstall skips internal linking`
+- [x] `TypeScript repo: pnpm/test/install/globalVirtualStore.ts:11` `using a global virtual store` — same scenario as the primary `:21`; covered by `using_a_global_virtual_store`.
+- [x] `TypeScript repo: pnpm/test/install/globalVirtualStore.ts:34` `approve-builds updates GVS symlinks and runs builds at correct hash directory` — ported as `approve_builds_updates_gvs_symlinks_and_runs_builds_at_the_new_hash_dir`, driving the real `approve-builds` command.
+- [x] `TypeScript repo: pnpm/test/install/globalVirtualStore.ts:80` `warm GVS reinstall skips internal linking` — same scenario as the primary `:63`; covered by `reinstall_from_warm_global_virtual_store_after_deleting_node_modules`.
 
-Rust port notes:
-
-- Separate GVS path layout from build/allowBuilds behavior.
-- The first frozen target should be warm GVS reinstall after deleting `node_modules`.
+The two remaining upstream CLI cases (`switching from non-GVS to GVS
+replaces stale hoisted symlinks`, `the post-install build step preserves
+the global virtual store directory of a workspace package`) are not listed
+above and remain unported.
 
 ## Link Dependency Binaries
 

--- a/pnpm11/building/during-install/src/buildSequence.ts
+++ b/pnpm11/building/during-install/src/buildSequence.ts
@@ -11,6 +11,8 @@ export interface DependenciesGraphNode<T extends string> {
   name: string
   version: string
   dir: string
+  /** The `node_modules` directory `dir` sits in. */
+  modules: string
   fetching?: () => Promise<PkgRequestFetchResult>
   filesIndexFile?: string
   hasBin: boolean

--- a/pnpm11/building/during-install/src/index.ts
+++ b/pnpm11/building/during-install/src/index.ts
@@ -296,7 +296,11 @@ async function buildDependency<T extends string> (
     // In GVS mode, remove the entire hash directory so the next install
     // sees the directory is absent, re-fetches, and re-builds.
     if (opts.enableGlobalVirtualStore) {
-      const hashDir = path.resolve(depNode.dir, '../..')
+      // `depNode.modules` is `<hashDir>/node_modules`, so its parent is the
+      // hash directory for scoped and unscoped names alike. Deriving it from
+      // `depNode.dir` instead would land on `node_modules` for a scoped name,
+      // whose extra path segment makes `../..` one level short.
+      const hashDir = path.dirname(depNode.modules)
       await fs.rm(hashDir, { recursive: true, force: true })
     }
     if (depNode.optional) {


### PR DESCRIPTION
## Summary

Stage 5 of pnpm/pnpm#13146 — all 22 items of the **Support The Global Virtual Store Dir** section, ported into `pnpm/crates/cli/tests/global_virtual_store.rs`.

21 land as real tests. The `.pnpm-needs-build` marker case (`globalVirtualStore.ts:411`) stays a `known_failures` stub: pacquet implements none of its three sites (the write between import and build, the detect sites in the warm-slot fast path, the side-effects upload exclusion), and porting it means all three at once.

Upstream drives the primary suite through the programmatic `install()` API and counts fetches by patching `storeController.fetchPackage`. Pacquet's equivalent surface is the CLI, so the ports assert the same on-disk contract instead — slot layout, hash-directory identity across `allowBuilds` changes, build artifacts, and `.modules.yaml` state. Where that loses a signal it is called out on the test.

**Three of the items needed the subject under test built first.**

*`virtualStoreOnly` (7 items)* had no `Config` field at all, so none of the behavior was reachable end to end. This adds it alongside `enableModulesDir`, with the conflict error, the hoist-pattern reset, and guards at every post-import linking site in both install paths. `.modules.yaml` gains the matching `virtualStoreOnly` flag so the layout-drift check knows the empty hoist patterns are deliberate and a follow-up install completes the linking rather than purging. The up-to-date fast path also had to reject such a modules directory, or the linking would never happen — pinned by the pacquet-only `ordinary_install_after_virtual_store_only_completes_the_linking`. The setting is already documented on pnpm.io, so this is pacquet reaching parity, not new surface.

*GVS build-failure cleanup* was absent: a failed build left a half-built hash directory — shared by every project with the same dependency graph — that the next install trusted. Added `discard_failed_global_virtual_store_slot`, running before the optional-skip return so a failed optional build is cleaned up too.

*A second gap that fix exposed:* with slots now removable, a side-effects-cache hit can describe a build no longer on disk. The GVS branch assumed the slot was authoritative and skipped both the build and the overlay materialization, leaving the package unbuilt. The hit is now checked against the slot rather than assumed.

**TypeScript side.** The same cleanup resolved one directory level short for scoped names: `path.resolve(depNode.dir, '../..')` lands on `node_modules`, not the hash directory its own comment describes, because a scoped name is two path segments. It now derives the hash directory from `depNode.modules`, correct for both shapes.

Each ported test was verified by breaking the implementation it covers and confirming it failed for the expected reason.

**Known follow-up, not addressed here:** pacquet's `fetch` still does its own post-import linking, while pnpm's `fetch` sets `virtualStoreOnly` internally (`installing/commands/src/fetch.ts`). `crates/cli/tests/fetch.rs` currently asserts the importer symlinks that pnpm's `fetch` deliberately does not create. Wiring pacquet's `fetch` to the new setting is a user-visible change to that command and needs those tests rewritten, so it is left out of this PR.

## Squash Commit Body

```text
Stage 5 of pnpm/pnpm#13146: all 22 items of the "Support The Global
Virtual Store Dir" section, ported into
crates/cli/tests/global_virtual_store.rs. 21 land as real tests; the
`.pnpm-needs-build` marker case stays a known_failures stub because
pacquet implements none of its three sites (write, detect, upload
exclusion).

Upstream drives the primary suite through the programmatic install()
API and counts fetches by patching storeController.fetchPackage.
Pacquet's equivalent surface is the CLI, so the ports assert the same
on-disk contract instead: slot layout, hash-directory identity across
allowBuilds changes, build artifacts, and .modules.yaml state.

Three of the items needed the subject under test built first.

virtualStoreOnly (7 items) had no Config field at all, so none of the
behavior was reachable. Added it alongside enableModulesDir, with the
conflict error, the hoist-pattern reset, and guards at every
post-import linking site in both install paths. `.modules.yaml` gains
the matching virtualStoreOnly flag so the layout-drift check knows the
empty hoist patterns are deliberate and the follow-up install completes
the linking rather than purging. The up-to-date fast path also has to
reject such a modules directory, or the linking would never happen --
pinned by the pacquet-only
ordinary_install_after_virtual_store_only_completes_the_linking.

GVS build-failure cleanup was absent: a failed build left a half-built
hash directory that the next install trusted. Added
discard_failed_global_virtual_store_slot, which runs before the
optional-skip return so a failed optional build is cleaned up too.

That fix exposed a second gap. With slots now removable, a
side-effects-cache hit could describe a build no longer on disk: the
GVS branch assumed the slot was authoritative and skipped both the
build and the overlay materialization, leaving the package unbuilt.
The hit is now checked against the slot rather than assumed.

On the TypeScript side, the same cleanup resolved one directory level
short for scoped names -- path.resolve(depNode.dir, '../..') lands on
node_modules, not the hash directory its comment describes, because a
scoped name is two path segments. It now derives the hash directory
from depNode.modules, which is correct for both shapes.

Each ported test was verified by breaking the implementation it covers
and confirming it failed for the expected reason.

Not addressed here: pacquet's `fetch` still does its own post-import
linking, while pnpm's `fetch` sets virtualStoreOnly internally. Wiring
pacquet's `fetch` to the new setting is a user-visible change to that
command and needs its tests rewritten, so it is left as a follow-up.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (`virtualStoreOnly` and `enableModulesDir` are already documented on pnpm.io; this brings pacquet to parity with the documented behavior.)

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787081242&installation_id=145934176&pr_number=13156&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13156&signature=f7acaa6b502e57819ef52be957502c166fa382b2764a9920abcaf1d349a346e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `virtualStoreOnly` mode to populate the virtual store without creating importer links, hoisting, or running lifecycle scripts.
  - Added `enableModulesDir` and pnpm-workspace.yaml support, with install-state tracking for virtual-store-only and build approvals.

- **Bug Fixes**
  - Improved global virtual store correctness: failed builds now discard partially built slots (including scoped cases) and prevent stale/half-built reuse.
  - Fixed side-effects cache-hit detection so builds aren’t incorrectly skipped, and corrected cleanup behavior.

- **Tests**
  - Added extensive end-to-end CLI and unit coverage for global virtual store and virtual-store-only scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->