### PR TITLE
feat(pacquet): complete runtime installation parity

### DIFF
--- a/.changeset/complete-runtime-installation-port.md
+++ b/.changeset/complete-runtime-installation-port.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Completed pnpm runtime installation parity for Node.js, Deno, and Bun, including runtime failure policy, target architecture selection, and dependency runtime engines.

--- a/.changeset/complete-runtime-installation-port.md
+++ b/.changeset/complete-runtime-installation-port.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/pkg-manifest.utils": patch
 "pacquet": minor
+"pnpm": patch
 ---
 
-Completed pnpm runtime installation parity for Node.js, Deno, and Bun, including runtime failure policy, target architecture selection, and dependency runtime engines.
+Completed pnpm runtime installation parity for Node.js, Deno, and Bun, including runtime failure policy, target architecture selection, and dependency runtime engines. Runtime failure overrides now preserve explicit runtime dependencies without matching engine entries.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,6 +3976,8 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
+ "sha2",
+ "ssri",
  "tabled",
  "tar",
  "tempfile",
@@ -3987,6 +3989,7 @@ dependencies = [
  "wax",
  "which 8.0.4",
  "windows-sys 0.61.2",
+ "zip",
 ]
 
 [[package]]
@@ -4694,6 +4697,7 @@ dependencies = [
  "derive_more",
  "insta",
  "miette 7.6.0",
+ "node-semver",
  "pipe-trait",
  "pretty_assertions",
  "serde",

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -108,8 +108,11 @@ insta             = { workspace = true }
 mockito           = { workspace = true }
 pretty_assertions = { workspace = true }
 serde-saphyr      = { workspace = true }
+sha2              = { workspace = true }
+ssri              = { workspace = true }
 text-block-macros = { workspace = true }
 walkdir           = { workspace = true }
+zip               = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -48,7 +48,15 @@ fn select_install_family_projects(
     }
 
     let workspace_root = cfg.workspace_dir.as_deref().unwrap_or(prefix).to_path_buf();
-    let (projects, workspace_patterns) = discover_workspace_projects(&workspace_root)?;
+    let (mut projects, workspace_patterns) = discover_workspace_projects(&workspace_root)?;
+    if let Some(runtime_on_fail) = cfg.runtime_on_fail {
+        for project in &mut projects {
+            pacquet_package_manifest::apply_runtime_on_fail_override(
+                project.manifest.value_mut(),
+                runtime_on_fail.as_str(),
+            );
+        }
+    }
     let (ordered_dirs, selected_dirs) = {
         let selection = select_recursive_projects(
             &projects,

--- a/pnpm/crates/cli/src/state.rs
+++ b/pnpm/crates/cli/src/state.rs
@@ -145,13 +145,29 @@ fn load_or_create_manifest(
         if let Some((_, manifest)) = pacquet_workspace::try_read_project_manifest(project_dir)
             .map_err(InitStateError::ManifestRead)?
         {
-            return Ok(manifest);
+            return Ok(apply_runtime_on_fail(manifest, config));
         }
         if config.workspace_dir.is_some() {
-            return Ok(PackageManifest::from_value(manifest_path, serde_json::json!({})));
+            return Ok(apply_runtime_on_fail(
+                PackageManifest::from_value(manifest_path, serde_json::json!({})),
+                config,
+            ));
         }
     }
-    manifest_path.pipe(PackageManifest::create_if_needed).map_err(InitStateError::Manifest)
+    manifest_path
+        .pipe(PackageManifest::create_if_needed)
+        .map(|manifest| apply_runtime_on_fail(manifest, config))
+        .map_err(InitStateError::Manifest)
+}
+
+fn apply_runtime_on_fail(mut manifest: PackageManifest, config: &Config) -> PackageManifest {
+    if let Some(runtime_on_fail) = config.runtime_on_fail {
+        pacquet_package_manifest::apply_runtime_on_fail_override(
+            manifest.value_mut(),
+            runtime_on_fail.as_str(),
+        );
+    }
+    manifest
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/tests/install_runtimes.rs
+++ b/pnpm/crates/cli/tests/install_runtimes.rs
@@ -170,7 +170,7 @@ fn installs_node_runtime_declared_by_a_dependency_engine() {
     let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
     assert!(
         lockfile.contains(format!("node@runtime:{version}").as_str()),
-        "lockfile was:\n{lockfile}"
+        "lockfile was:\n{lockfile}",
     );
 }
 
@@ -300,7 +300,7 @@ fn prepare_workspace(root: &TempDir, extra_yaml: &str) -> PathBuf {
     fs::write(
         workspace.join("pnpm-workspace.yaml"),
         format!(
-            "storeDir: ../store\ncacheDir: ../cache\nenableGlobalVirtualStore: false\n{extra_yaml}"
+            "storeDir: ../store\ncacheDir: ../cache\nenableGlobalVirtualStore: false\n{extra_yaml}",
         ),
     )
     .unwrap();

--- a/pnpm/crates/cli/tests/install_runtimes.rs
+++ b/pnpm/crates/cli/tests/install_runtimes.rs
@@ -1,0 +1,548 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_graph_hasher::{host_arch, host_platform};
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+use std::{
+    fs,
+    io::{Cursor, Write},
+    path::{Path, PathBuf},
+    process::Command,
+};
+use tempfile::TempDir;
+
+struct RuntimeFixture {
+    name: &'static str,
+    version: &'static str,
+    archive_mock: mockito::Mock,
+    resolution: Value,
+}
+
+#[test]
+fn installs_node_deno_and_bun_then_reinstalls_them_offline() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "");
+    let mut server = mockito::Server::new();
+    let fixtures = [
+        runtime_fixture(&mut server, "node", "22.0.0", host_platform(), host_arch()),
+        runtime_fixture(&mut server, "deno", "2.4.2", host_platform(), host_arch()),
+        runtime_fixture(&mut server, "bun", "1.2.19", host_platform(), host_arch()),
+    ];
+    write_runtime_manifest(&workspace, &fixtures);
+    write_runtime_lockfile(&workspace, &fixtures);
+
+    command(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert_installed(&workspace, &fixtures);
+    let node_root = workspace.join("node_modules/node");
+    let node_extras = if host_platform() == "win32" {
+        [
+            "node_modules/npm/package.json",
+            "node_modules/corepack/package.json",
+            "npm.cmd",
+            "npx.cmd",
+            "corepack.cmd",
+        ]
+    } else {
+        [
+            "lib/node_modules/npm/package.json",
+            "lib/node_modules/corepack/package.json",
+            "bin/npm",
+            "bin/npx",
+            "bin/corepack",
+        ]
+    };
+    for relative in node_extras {
+        assert!(!node_root.join(relative).exists(), "Node extra was not stripped: {relative}");
+    }
+
+    fs::remove_dir_all(workspace.join("node_modules")).unwrap();
+    command(&workspace).with_args(["install", "--frozen-lockfile", "--offline"]).assert().success();
+    assert_installed(&workspace, &fixtures);
+    for fixture in &fixtures {
+        fixture.archive_mock.assert();
+    }
+}
+
+#[test]
+fn node_runtime_fails_when_missing_offline() {
+    assert_runtime_missing_offline("node", "22.0.0");
+}
+
+#[test]
+fn deno_runtime_fails_when_missing_offline() {
+    assert_runtime_missing_offline("deno", "2.4.2");
+}
+
+#[test]
+fn bun_runtime_fails_when_missing_offline() {
+    assert_runtime_missing_offline("bun", "1.2.19");
+}
+
+#[test]
+fn node_runtime_fails_on_bad_integrity() {
+    assert_runtime_bad_integrity("node", "22.0.0");
+}
+
+#[test]
+fn deno_runtime_fails_on_bad_integrity() {
+    assert_runtime_bad_integrity("deno", "2.4.2");
+}
+
+#[test]
+fn bun_runtime_fails_on_bad_integrity() {
+    assert_runtime_bad_integrity("bun", "1.2.19");
+}
+
+#[test]
+fn installs_node_runtime_for_the_requested_target_architecture() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "");
+    let mut server = mockito::Server::new();
+    let target_os = if host_platform() == "win32" { "linux" } else { "win32" };
+    let fixture = runtime_fixture(&mut server, "node", "22.0.0", target_os, "x64");
+    write_runtime_manifest(&workspace, std::slice::from_ref(&fixture));
+    write_runtime_lockfile(&workspace, std::slice::from_ref(&fixture));
+
+    command(&workspace)
+        .with_args(["install", "--frozen-lockfile", "--os", target_os, "--cpu", "x64"])
+        .assert()
+        .success();
+    let expected_bin = if target_os == "win32" { "node.exe" } else { "bin/node" };
+    assert!(workspace.join("node_modules/node").join(expected_bin).exists());
+}
+
+#[test]
+fn installs_node_runtime_from_the_rc_channel() {
+    let root = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new();
+    let version = "24.0.0-rc.4";
+    let _mocks = mock_node_release(&mut server, version);
+    let workspace = prepare_workspace(
+        &root,
+        format!("nodeDownloadMirrors:\n  rc: '{}/'\n", server.url()).as_str(),
+    );
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "dependencies": { "node": format!("runtime:{version}") } }).to_string(),
+    )
+    .unwrap();
+
+    command(&workspace).with_arg("install").assert().success();
+    assert!(workspace.join("node_modules/node/package.json").exists());
+    assert!(fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap().contains(version));
+}
+
+#[test]
+fn installs_node_runtime_declared_by_a_dependency_engine() {
+    let root = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new();
+    let version = "22.19.0-rc.1";
+    let _mocks = mock_node_release(&mut server, version);
+    let workspace = prepare_workspace(
+        &root,
+        format!("nodeDownloadMirrors:\n  rc: '{}/'\n", server.url()).as_str(),
+    );
+    let dependency = workspace.join("dependency");
+    fs::create_dir(&dependency).unwrap();
+    fs::write(
+        dependency.join("package.json"),
+        json!({
+            "name": "dependency",
+            "version": "1.0.0",
+            "engines": {
+                "runtime": {
+                    "name": "node",
+                    "version": version,
+                    "onFail": "download",
+                },
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "dependencies": { "dependency": "file:dependency" } }).to_string(),
+    )
+    .unwrap();
+
+    command(&workspace).with_arg("install").assert().success();
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
+    assert!(
+        lockfile.contains(format!("node@runtime:{version}").as_str()),
+        "lockfile was:\n{lockfile}"
+    );
+}
+
+#[test]
+fn runtime_on_fail_download_reifies_the_manifest_runtime() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "runtimeOnFail: download\n");
+    let mut server = mockito::Server::new();
+    let fixture = runtime_fixture(&mut server, "node", "24.0.0", host_platform(), host_arch());
+    write_devengines_manifest(&workspace, fixture.version, None);
+    write_runtime_lockfile_for_group(&workspace, std::slice::from_ref(&fixture), "devDependencies");
+
+    command(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert_installed(&workspace, std::slice::from_ref(&fixture));
+}
+
+#[test]
+fn devengines_runtime_with_download_is_installed() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "");
+    let mut server = mockito::Server::new();
+    let fixture = runtime_fixture(&mut server, "node", "24.0.0", host_platform(), host_arch());
+    write_devengines_manifest(&workspace, fixture.version, Some("download"));
+    write_runtime_lockfile_for_group(&workspace, std::slice::from_ref(&fixture), "devDependencies");
+
+    command(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert_installed(&workspace, std::slice::from_ref(&fixture));
+}
+
+#[test]
+fn devengines_runtime_without_download_is_not_installed() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "");
+    write_devengines_manifest(&workspace, "24.0.0", None);
+
+    command(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
+    assert!(!lockfile.contains("node@runtime:"), "lockfile was:\n{lockfile}");
+}
+
+#[test]
+fn runtime_on_fail_ignore_removes_the_synthesized_runtime_dependency() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "runtimeOnFail: ignore\n");
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "devEngines": {
+                "runtime": {
+                    "name": "node",
+                    "version": "24.0.0",
+                    "onFail": "download",
+                },
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    command(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap();
+    assert!(!lockfile.contains("node@runtime:"), "lockfile was:\n{lockfile}");
+}
+
+#[test]
+fn explicit_node_version_takes_priority_over_the_manifest_runtime() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "engineStrict: true\nnodeVersion: 20.0.0\n");
+    let dependency = workspace.join("dependency");
+    fs::create_dir(&dependency).unwrap();
+    fs::write(
+        dependency.join("package.json"),
+        json!({ "name": "dependency", "version": "1.0.0", "engines": { "node": "<21" } })
+            .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "dependencies": { "dependency": "file:dependency" },
+            "devEngines": {
+                "runtime": { "name": "node", "version": "^22.0.0", "onFail": "ignore" },
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    command(&workspace).with_arg("install").assert().success();
+}
+
+fn assert_runtime_missing_offline(name: &'static str, version: &'static str) {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "");
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "dependencies": { name: format!("runtime:{version}") } }).to_string(),
+    )
+    .unwrap();
+    let output = command(&workspace).with_args(["install", "--offline"]).assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(
+        stderr.to_ascii_lowercase().contains(name),
+        "stderr did not identify the missing {name} runtime:\n{stderr}",
+    );
+}
+
+fn assert_runtime_bad_integrity(name: &'static str, version: &'static str) {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = prepare_workspace(&root, "");
+    let mut server = mockito::Server::new();
+    let mut fixture = runtime_fixture(&mut server, name, version, host_platform(), host_arch());
+    let bad_integrity = ssri::IntegrityOpts::new()
+        .algorithm(ssri::Algorithm::Sha512)
+        .chain(b"different runtime archive")
+        .result()
+        .to_string();
+    fixture.resolution["variants"][0]["resolution"]["integrity"] = Value::String(bad_integrity);
+    write_runtime_manifest(&workspace, std::slice::from_ref(&fixture));
+    write_runtime_lockfile(&workspace, std::slice::from_ref(&fixture));
+    let output = command(&workspace).with_args(["install", "--frozen-lockfile"]).assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("Integrity check failed"), "stderr was:\n{stderr}");
+}
+
+fn prepare_workspace(root: &TempDir, extra_yaml: &str) -> PathBuf {
+    let workspace = root.path().join("workspace");
+    fs::create_dir(&workspace).unwrap();
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!(
+            "storeDir: ../store\ncacheDir: ../cache\nenableGlobalVirtualStore: false\n{extra_yaml}"
+        ),
+    )
+    .unwrap();
+    workspace
+}
+
+fn runtime_fixture(
+    server: &mut mockito::Server,
+    name: &'static str,
+    version: &'static str,
+    target_os: &str,
+    target_cpu: &str,
+) -> RuntimeFixture {
+    let is_zip = name != "node" || target_os == "win32";
+    let bin_path = runtime_bin_path(name, target_os);
+    let prefix = (name == "bun" || (name == "node" && is_zip)).then(|| format!("{name}-fixture"));
+    let bytes = if is_zip {
+        build_zip(name, target_os, prefix.as_deref(), name == "node")
+    } else {
+        build_tarball(name, version, name == "node")
+    };
+    let archive_path = format!("/{name}-{target_os}-{target_cpu}.archive");
+    let archive_mock = server
+        .mock("GET", archive_path.as_str())
+        .with_status(200)
+        .with_body(bytes.clone())
+        .expect(1)
+        .create();
+    let integrity = ssri::IntegrityOpts::new()
+        .algorithm(ssri::Algorithm::Sha512)
+        .chain(&bytes)
+        .result()
+        .to_string();
+    let mut resolution = json!({
+        "type": "binary",
+        "archive": if is_zip { "zip" } else { "tarball" },
+        "url": format!("{}{archive_path}", server.url()),
+        "integrity": integrity,
+        "bin": if name == "node" { json!({ "node": bin_path }) } else { json!(bin_path) },
+    });
+    if let Some(prefix) = prefix {
+        resolution["prefix"] = Value::String(prefix);
+    }
+    RuntimeFixture {
+        name,
+        version,
+        archive_mock,
+        resolution: json!({
+            "type": "variations",
+            "variants": [{
+                "targets": [{ "os": target_os, "cpu": target_cpu }],
+                "resolution": resolution,
+            }],
+        }),
+    }
+}
+
+fn write_runtime_manifest(workspace: &Path, fixtures: &[RuntimeFixture]) {
+    let dependencies = fixtures
+        .iter()
+        .map(|fixture| {
+            (fixture.name.to_string(), Value::String(format!("runtime:{}", fixture.version)))
+        })
+        .collect::<Map<_, _>>();
+    fs::write(workspace.join("package.json"), json!({ "dependencies": dependencies }).to_string())
+        .unwrap();
+}
+
+fn write_runtime_lockfile(workspace: &Path, fixtures: &[RuntimeFixture]) {
+    write_runtime_lockfile_for_group(workspace, fixtures, "dependencies");
+}
+
+fn write_runtime_lockfile_for_group(
+    workspace: &Path,
+    fixtures: &[RuntimeFixture],
+    dependency_group: &str,
+) {
+    let mut importer_dependencies = Map::new();
+    let mut packages = Map::new();
+    let mut snapshots = Map::new();
+    for fixture in fixtures {
+        let version = format!("runtime:{}", fixture.version);
+        let key = format!("{}@{version}", fixture.name);
+        importer_dependencies
+            .insert(fixture.name.to_string(), json!({ "specifier": version, "version": version }));
+        packages.insert(
+            key.clone(),
+            json!({
+                "hasBin": true,
+                "resolution": fixture.resolution,
+                "version": fixture.version,
+            }),
+        );
+        snapshots.insert(key, json!({}));
+    }
+    let mut importer = Map::new();
+    importer.insert(dependency_group.to_string(), Value::Object(importer_dependencies));
+    let lockfile = json!({
+        "lockfileVersion": "9.0",
+        "importers": { ".": importer },
+        "packages": packages,
+        "snapshots": snapshots,
+    });
+    fs::write(workspace.join("pnpm-lock.yaml"), serde_saphyr::to_string(&lockfile).unwrap())
+        .unwrap();
+}
+
+fn write_devengines_manifest(workspace: &Path, version: &str, on_fail: Option<&str>) {
+    let mut runtime = json!({ "name": "node", "version": version });
+    if let Some(on_fail) = on_fail {
+        runtime["onFail"] = Value::String(on_fail.to_string());
+    }
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "devEngines": { "runtime": runtime } }).to_string(),
+    )
+    .unwrap();
+}
+
+fn assert_installed(workspace: &Path, fixtures: &[RuntimeFixture]) {
+    for fixture in fixtures {
+        assert!(workspace.join("node_modules").join(fixture.name).join("package.json").exists());
+        let bin_dir = workspace.join("node_modules/.bin");
+        assert!(
+            [
+                bin_dir.join(fixture.name),
+                bin_dir.join(format!("{}.exe", fixture.name)),
+                bin_dir.join(format!("{}.cmd", fixture.name)),
+            ]
+            .iter()
+            .any(|path| path.exists()),
+            "runtime bin was not linked for {}",
+            fixture.name,
+        );
+    }
+}
+
+fn runtime_bin_path(name: &str, target_os: &str) -> String {
+    if target_os == "win32" {
+        format!("{name}.exe")
+    } else if name == "node" {
+        "bin/node".to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+fn build_tarball(name: &str, version: &str, node_extras: bool) -> Vec<u8> {
+    let prefix = format!("{name}-v{version}-fixture");
+    let mut tar = tar::Builder::new(Vec::new());
+    append_tar(
+        &mut tar,
+        format!("{prefix}/{}", runtime_bin_path(name, "linux")).as_str(),
+        b"#!/bin/sh\nexit 0\n",
+        0o755,
+    );
+    if node_extras {
+        for path in [
+            "lib/node_modules/npm/package.json",
+            "lib/node_modules/corepack/package.json",
+            "bin/npm",
+            "bin/npx",
+            "bin/corepack",
+        ] {
+            append_tar(&mut tar, format!("{prefix}/{path}").as_str(), b"extra", 0o755);
+        }
+    }
+    let tar = tar.into_inner().unwrap();
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&tar).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn append_tar(tar: &mut tar::Builder<Vec<u8>>, path: &str, body: &[u8], mode: u32) {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(body.len() as u64);
+    header.set_mode(mode);
+    tar.append_data(&mut header, path, body).unwrap();
+}
+
+fn build_zip(name: &str, target_os: &str, prefix: Option<&str>, node_extras: bool) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    {
+        let mut writer = zip::ZipWriter::new(Cursor::new(&mut bytes));
+        let options: zip::write::FileOptions<()> = zip::write::FileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored)
+            .unix_permissions(0o100755);
+        let path = |relative: &str| {
+            prefix.map_or_else(|| relative.to_string(), |p| format!("{p}/{relative}"))
+        };
+        writer.start_file(path(runtime_bin_path(name, target_os).as_str()), options).unwrap();
+        writer.write_all(b"runtime fixture").unwrap();
+        if node_extras {
+            for relative in [
+                "node_modules/npm/package.json",
+                "node_modules/corepack/package.json",
+                "npm.cmd",
+                "npx.cmd",
+                "corepack.cmd",
+            ] {
+                writer.start_file(path(relative), options).unwrap();
+                writer.write_all(b"extra").unwrap();
+            }
+        }
+        writer.finish().unwrap();
+    }
+    bytes
+}
+
+fn node_archive_name(version: &str, platform: &str, arch: &str) -> String {
+    let platform = if platform == "win32" { "win" } else { platform };
+    let extension = if platform == "win" { "zip" } else { "tar.gz" };
+    format!("node-v{version}-{platform}-{arch}.{extension}")
+}
+
+fn mock_node_release(server: &mut mockito::Server, version: &str) -> [mockito::Mock; 3] {
+    let archive_name = node_archive_name(version, host_platform(), host_arch());
+    let archive = if host_platform() == "win32" {
+        let prefix = archive_name.strip_suffix(".zip").unwrap();
+        build_zip("node", "win32", Some(prefix), true)
+    } else {
+        build_tarball("node", version, true)
+    };
+    let digest = format!("{:x}", Sha256::digest(&archive));
+    let index = server
+        .mock("GET", "/index.json")
+        .with_status(200)
+        .with_body(format!(r#"[{{"version":"v{version}","lts":false}}]"#))
+        .create();
+    let shasums = server
+        .mock("GET", format!("/v{version}/SHASUMS256.txt").as_str())
+        .with_status(200)
+        .with_body(format!("{digest}  {archive_name}\n"))
+        .create();
+    let archive = server
+        .mock("GET", format!("/v{version}/{archive_name}").as_str())
+        .with_status(200)
+        .with_body(archive)
+        .create();
+    [index, shasums, archive]
+}
+
+fn command(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").unwrap().with_current_dir(workspace)
+}

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -13,8 +13,8 @@
 
 use crate::{
     AuditLevel, CatalogMode, HoistingLimits, NodeLinker, NodePackageMapType, PackageImportMethod,
-    PmOnFail, ResolutionMode, ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun,
-    WorkspaceSettings, api::EnvVar,
+    PmOnFail, ResolutionMode, RuntimeOnFail, ScriptsPrependNodePath, TrustPolicy,
+    VerifyDepsBeforeRun, WorkspaceSettings, api::EnvVar,
 };
 use serde::de::DeserializeOwned;
 
@@ -178,6 +178,8 @@ impl WorkspaceSettings {
         json_field!(git_checks, "GIT_CHECKS");
         json_field!(engine_strict, "ENGINE_STRICT");
         string_field!(node_version, "NODE_VERSION");
+        enum_field!(runtime_on_fail, "RUNTIME_ON_FAIL", RuntimeOnFail);
+        json_field!(node_download_mirrors, "NODE_DOWNLOAD_MIRRORS");
         enum_field!(scripts_prepend_node_path, "SCRIPTS_PREPEND_NODE_PATH", ScriptsPrependNodePath);
         json_field!(enable_pre_post_scripts, "ENABLE_PRE_POST_SCRIPTS");
         tri_string_field!(script_shell, "SCRIPT_SHELL");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -139,6 +139,33 @@ pub enum PmOnFail {
     Ignore,
 }
 
+/// What to do when a runtime declared through `devEngines.runtime` or
+/// `engines.runtime` does not match the current process.
+///
+/// The `runtimeOnFail` setting overrides the manifest-level `onFail` value.
+/// `download` reifies the runtime as a dependency; the other modes leave it
+/// as an engine constraint only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RuntimeOnFail {
+    Download,
+    Error,
+    Warn,
+    Ignore,
+}
+
+impl RuntimeOnFail {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Download => "download",
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Ignore => "ignore",
+        }
+    }
+}
+
 /// What `pnpm run` / `pnpm exec` do when `node_modules` is out of sync
 /// with the lockfile before running a script.
 ///
@@ -742,6 +769,14 @@ pub struct Config {
     /// `node` is found). An explicit value is treated as authoritative — no
     /// `node --version` probe runs.
     pub node_version: Option<String>,
+
+    /// Override for `devEngines.runtime.onFail` / `engines.runtime.onFail`.
+    /// Unset by default so each manifest keeps its own policy.
+    pub runtime_on_fail: Option<RuntimeOnFail>,
+
+    /// Per-release-channel Node.js download mirrors. Keys are `release`,
+    /// `rc`, `nightly`, `test`, or `v8-canary`.
+    pub node_download_mirrors: HashMap<String, String>,
 
     /// Copy every project file during `pnpm deploy` instead of the publish
     /// packlist. The `deployAllFiles` setting; default `false`.

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2080,6 +2080,14 @@ pub fn engine_strict_node_version_and_max_sockets_from_workspace_yaml() {
 }
 
 #[test]
+pub fn runtime_on_fail_from_workspace_yaml() {
+    let dir = tempdir().unwrap();
+    std::fs::write(dir.path().join("pnpm-workspace.yaml"), "runtimeOnFail: download\n").unwrap();
+    let config = Config::default().current::<Host>(dir.path()).unwrap();
+    assert_eq!(config.runtime_on_fail, Some(crate::RuntimeOnFail::Download));
+}
+
+#[test]
 pub fn virtual_store_dir_max_length_env_var_overrides_yaml() {
     let tmp = tempdir().unwrap();
     fs::write(tmp.path().join("pnpm-workspace.yaml"), "virtualStoreDirMaxLength: 90\n")

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1,6 +1,6 @@
 use crate::{
     AuditConfig, AuditLevel, CatalogMode, Config, HoistingLimits, LinkWorkspacePackages,
-    NodeLinker, NodePackageMapType, PackageImportMethod, PmOnFail, ResolutionMode,
+    NodeLinker, NodePackageMapType, PackageImportMethod, PmOnFail, ResolutionMode, RuntimeOnFail,
     ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun, api::EnvVar,
     resolve_child_concurrency,
 };
@@ -256,6 +256,12 @@ pub struct WorkspaceSettings {
     /// `nodeVersion` from `pnpm-workspace.yaml` / global `config.yaml`.
     /// See [`Config::node_version`]. Default unset (auto-detect).
     pub node_version: Option<String>,
+
+    /// `runtimeOnFail` from `pnpm-workspace.yaml` / global `config.yaml`.
+    pub runtime_on_fail: Option<RuntimeOnFail>,
+
+    /// Per-release-channel Node.js download mirrors.
+    pub node_download_mirrors: Option<HashMap<String, String>>,
 
     /// `scriptsPrependNodePath` from `pnpm-workspace.yaml`. Tri-state
     /// — yaml accepts `true` / `false` / `"warn-only"`. Custom serde
@@ -869,6 +875,12 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.node_version {
             config.node_version = Some(v);
+        }
+        if let Some(v) = self.runtime_on_fail {
+            config.runtime_on_fail = Some(v);
+        }
+        if let Some(v) = self.node_download_mirrors {
+            config.node_download_mirrors = v;
         }
         if let Some(v) = self.max_sockets {
             config.max_sockets = Some(v);

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -643,6 +643,7 @@ async fn resolve_added_dependency<'a>(
     let bare_specifier =
         if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
             let mut node_resolver = NodeResolver::new(std::sync::Arc::clone(http_client_arc));
+            node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
             node_resolver.offline = config.offline;
             node_resolver
                 .resolve_save_specifier(version_spec, prev_specifier.as_deref())

--- a/pnpm/crates/package-manager/src/create_virtual_store.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store.rs
@@ -1,6 +1,6 @@
 use crate::{
     CasPathsByPkgId, InstallPackageBySnapshot, InstallPackageBySnapshotError, SkippedSnapshots,
-    install_package_by_snapshot::host_platform_selector, store_init::init_store_dir_best_effort,
+    install_package_by_snapshot::runtime_platform_selector, store_init::init_store_dir_best_effort,
 };
 use derive_more::{Display, Error};
 use futures_util::future;
@@ -10,7 +10,7 @@ use pacquet_deps_path::get_pkg_id_with_patch_hash;
 use pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker;
 use pacquet_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgName, PkgNameVerPeer,
-    SnapshotEntry, select_platform_variant,
+    PlatformSelector, SnapshotEntry, select_platform_variant,
 };
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{files_include_install_scripts, manifest_requires_build};
@@ -144,6 +144,7 @@ pub struct CreateVirtualStore<'a> {
     /// are likewise omitted: only non-skipped snapshots are
     /// materialized into the graph passed to the build phase.
     pub skipped: &'a SkippedSnapshots,
+    pub supported_architectures: Option<&'a pacquet_package_is_installable::SupportedArchitectures>,
     /// Lockfile / workspace root (`lockfileDir`). Threaded into the
     /// per-snapshot
     /// [`InstallPackageBySnapshot`] so the directory fetcher can
@@ -223,6 +224,7 @@ impl CreateVirtualStore<'_> {
             store_index_writer,
             allow_build_policy,
             skipped,
+            supported_architectures,
             workspace_root,
             node_linker,
             progress_reported,
@@ -233,6 +235,7 @@ impl CreateVirtualStore<'_> {
         } = self;
 
         let is_hoisted = matches!(node_linker, NodeLinker::Hoisted);
+        let runtime_platform_selector = runtime_platform_selector(supported_architectures);
 
         let Some(snapshots) = snapshots else {
             // No snapshots to install. If the lockfile also has no project deps
@@ -460,8 +463,13 @@ impl CreateVirtualStore<'_> {
         type SnapshotWithCacheKey<'a> = (&'a PackageKey, &'a SnapshotEntry, Option<String>);
         let snapshot_entries: Vec<SnapshotWithCacheKey<'_>> = survivors
             .map(|(snapshot_key, snapshot)| {
-                snapshot_cache_key(snapshot_key, packages, config.ignore_scripts)
-                    .map(|key| (snapshot_key, snapshot, key))
+                snapshot_cache_key(
+                    snapshot_key,
+                    packages,
+                    config.ignore_scripts,
+                    &runtime_platform_selector,
+                )
+                .map(|key| (snapshot_key, snapshot, key))
             })
             .collect::<Result<_, _>>()?;
 
@@ -487,9 +495,14 @@ impl CreateVirtualStore<'_> {
             // here.
             .filter(|(snapshot_key, _)| !skipped.contains(snapshot_key))
             .map(|(snapshot_key, snapshot)| {
-                let cache_key = snapshot_cache_key(snapshot_key, packages, config.ignore_scripts)
-                    .ok()
-                    .flatten();
+                let cache_key = snapshot_cache_key(
+                    snapshot_key,
+                    packages,
+                    config.ignore_scripts,
+                    &runtime_platform_selector,
+                )
+                .ok()
+                .flatten();
                 (snapshot_key, snapshot, cache_key)
             })
             .collect();
@@ -773,6 +786,7 @@ impl CreateVirtualStore<'_> {
         if !cold.is_empty() {
             let prefetched_ref = Some(&prefetched);
             let verified_files_cache_ref = &verified_files_cache;
+            let runtime_platform_selector_ref = &runtime_platform_selector;
             type ColdOutcome<'a> = (
                 Option<PackageKey>,
                 Option<(&'a PackageKey, &'a SnapshotEntry, HashMap<String, PathBuf>, bool)>,
@@ -804,6 +818,7 @@ impl CreateVirtualStore<'_> {
                         snapshot,
                         allow_build_policy,
                         skipped,
+                        runtime_platform_selector: runtime_platform_selector_ref,
                         workspace_root,
                         node_linker,
                         custom_fetcher_picker,
@@ -1124,6 +1139,7 @@ fn snapshot_cache_key(
     snapshot_key: &PackageKey,
     packages: &HashMap<PackageKey, PackageMetadata>,
     ignore_scripts: bool,
+    runtime_platform_selector: &PlatformSelector,
 ) -> Result<Option<String>, CreateVirtualStoreError> {
     let metadata_key = snapshot_key.without_peer();
     let metadata = packages.get(&metadata_key).ok_or_else(|| {
@@ -1207,8 +1223,9 @@ fn snapshot_cache_key(
         // is best-effort and the cold path is where errors are
         // raised).
         LockfileResolution::Variations(variations) => {
-            let selector = host_platform_selector();
-            let Some(variant) = select_platform_variant(&variations.variants, &selector) else {
+            let Some(variant) =
+                select_platform_variant(&variations.variants, runtime_platform_selector)
+            else {
                 return Ok(None);
             };
             match &variant.resolution {

--- a/pnpm/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store/tests.rs
@@ -3,6 +3,7 @@ use super::{
     emit_warm_snapshot_progress, integrity_equal, removed_child_aliases, snapshot_cache_key,
     snapshot_deps_equal,
 };
+use crate::install_package_by_snapshot::host_platform_selector;
 use pacquet_lockfile::{
     GitResolution, LockfileResolution, PackageKey, PackageMetadata, PkgName, PkgVerPeer,
     RegistryResolution, SnapshotDepRef, SnapshotEntry, TarballResolution,
@@ -181,6 +182,7 @@ async fn cold_batch_links_slots_in_parallel() {
         store_index_writer: &store_index_writer,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
+        supported_architectures: None,
         workspace_root: &workspace_root,
         node_linker: NodeLinker::Isolated,
         progress_reported: &progress_reported,
@@ -428,8 +430,8 @@ fn snapshot_cache_key_for_git_resolution_uses_git_hosted_key() {
     let pkg = key("ts-pipe-compose", "0.2.1");
     let packages = HashMap::from([(pkg.clone(), git_metadata())]);
 
-    let received =
-        snapshot_cache_key(&pkg, &packages, false).expect("snapshot_cache_key must not error");
+    let received = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
+        .expect("snapshot_cache_key must not error");
     assert_eq!(
         received,
         Some(format!("{pkg}\tbuilt")),
@@ -442,8 +444,8 @@ fn snapshot_cache_key_for_git_hosted_tarball_uses_git_hosted_key() {
     let pkg = key("foo", "1.0.0");
     let packages = HashMap::from([(pkg.clone(), git_hosted_tarball_metadata())]);
 
-    let received =
-        snapshot_cache_key(&pkg, &packages, false).expect("snapshot_cache_key must not error");
+    let received = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
+        .expect("snapshot_cache_key must not error");
     assert_eq!(
         received,
         Some(format!("{pkg}\tbuilt")),
@@ -460,7 +462,7 @@ fn snapshot_cache_key_rejects_tarball_without_integrity() {
     let pkg = key("foo", "1.0.0");
     let packages = HashMap::from([(pkg.clone(), tarball_metadata_without_integrity())]);
 
-    let err = snapshot_cache_key(&pkg, &packages, false)
+    let err = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
         .expect_err("missing integrity must reject upfront");
     assert!(
         matches!(

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -29,7 +29,9 @@ use pacquet_modules_yaml::{
     ReadModulesError, WriteModulesError, write_modules_manifest,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient};
-use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_package_manifest::{
+    DependencyGroup, PackageManifest, node_version_from_engines_runtime,
+};
 use pacquet_reporter::{
     ContextLog, LogEvent, LogLevel, PnpmLog, Reporter, Stage, StageLog, SummaryLog,
 };
@@ -1526,6 +1528,10 @@ where
         // deps, for `.modules.yaml`'s `injectedDeps`; assigned by
         // whichever path runs. See [`crate::collect_injected_deps`].
         let injected_deps: BTreeMap<String, Vec<String>>;
+        let effective_node_version = config
+            .node_version
+            .clone()
+            .or_else(|| node_version_from_engines_runtime(manifest.value()));
         let (hoisted_dependencies, hoisted_locations, install_skipped, fresh_lockfile): (
             HoistedDependencies,
             BTreeMap<String, Vec<String>>,
@@ -1619,6 +1625,7 @@ where
                 requester: &prefix,
                 supported_architectures: supported_architectures.as_ref(),
                 skip_runtimes,
+                node_version: effective_node_version.clone(),
                 node_linker,
                 tarball_mem_cache: Some(&tarball_mem_cache),
                 seed_skipped: modules_manifest.map(|manifest| manifest.skipped.clone()),
@@ -1734,6 +1741,7 @@ where
                 // entries keep their pins on rewrite (the `update: false`
                 // mode). State 4 (no lockfile) passes `None`.
                 wanted_lockfile: lockfile,
+                node_version: effective_node_version,
                 node_linker,
                 supported_architectures: supported_architectures.as_ref(),
                 lockfile_only: resolve_only,

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -149,6 +149,10 @@ where
     /// `config.skip_runtimes || --no-runtime`.
     pub skip_runtimes: bool,
 
+    /// Effective `nodeVersion`: an explicit config value, otherwise the
+    /// minimum version declared by the root manifest's runtime engine.
+    pub node_version: Option<String>,
+
     /// `nodeLinker` value to honor for *this* invocation. Threaded
     /// from the [`crate::Install`] caller (which has already
     /// applied any `--node-linker` CLI override on top of
@@ -591,6 +595,7 @@ where
             requester,
             supported_architectures,
             skip_runtimes,
+            node_version,
             node_linker,
             tarball_mem_cache,
             seed_skipped,
@@ -697,7 +702,7 @@ where
         // the reactor thread.
         let (mut skipped, host_node) = if needs_installability_check {
             let engine_strict = config.engine_strict;
-            let mut host = match config.node_version.clone() {
+            let mut host = match node_version {
                 // An explicit `nodeVersion` needs no `node --version` probe, so
                 // build the host directly off the reactor thread.
                 node_version @ Some(_) => {
@@ -989,6 +994,7 @@ where
                 store_index_writer: &store_index_writer,
                 allow_build_policy: &allow_build_policy,
                 skipped: &skipped,
+                supported_architectures,
                 workspace_root,
                 node_linker,
                 progress_reported: &progress_reported,

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -103,6 +103,9 @@ pub struct InstallPackageBySnapshot<'a> {
     /// exclusion, or swallowed optional fetch failure). See
     /// [`crate::SkippedSnapshots`] for how it is built.
     pub skipped: &'a crate::SkippedSnapshots,
+    /// Platform triple used to select a runtime archive. This is the host
+    /// triple unless `supportedArchitectures` targets another platform.
+    pub runtime_platform_selector: &'a PlatformSelector,
     /// Selects between the isolated and hoisted install layouts.
     /// `Isolated` runs [`CreateVirtualDirBySnapshot`] at the end of
     /// the per-snapshot fetch to populate the virtual-store slot;
@@ -187,20 +190,18 @@ pub enum InstallPackageBySnapshotError {
     UnsupportedResolutionType { resolution_type: String },
 
     /// No variant in a [`LockfileResolution::Variations`] matches the
-    /// host triple `(os, cpu, libc?)`. Surfaces with the host triple
+    /// selected triple `(os, cpu, libc?)`. Surfaces with that triple
     /// plus the list of advertised target triples so the user can see
     /// at a glance whether they're running on an unsupported platform
     /// or whether the lockfile was generated without the host's
     /// architecture in mind.
     #[display(
-        "Package `{package_key}` is a runtime dependency, but none of its declared variants matches the host triple (os = `{host_os}`, cpu = `{host_cpu}`, libc = `{host_libc:?}`). Available variants: {available_targets}"
+        "Package `{package_key}` is a runtime dependency, but none of its declared variants matches the selected triple ({selected_target}). Available variants: {available_targets}"
     )]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_NO_MATCHING_PLATFORM_VARIANT))]
     NoMatchingPlatformVariant {
         package_key: String,
-        host_os: &'static str,
-        host_cpu: &'static str,
-        host_libc: Option<&'static str>,
+        selected_target: String,
         /// Pre-rendered list of the lockfile's advertised target
         /// triples, formatted as `os/cpu[+libc]`. Lives in the error
         /// payload rather than the lockfile (which is borrowed from
@@ -275,6 +276,7 @@ impl InstallPackageBySnapshot<'_> {
             snapshot,
             allow_build_policy,
             skipped,
+            runtime_platform_selector,
             workspace_root,
             node_linker,
             custom_fetcher_picker,
@@ -502,16 +504,17 @@ impl InstallPackageBySnapshot<'_> {
                 .await?
             }
             LockfileResolution::Variations(variations) => {
-                let selector = host_platform_selector();
-                let Some(variant) = select_platform_variant(&variations.variants, &selector) else {
+                let Some(variant) =
+                    select_platform_variant(&variations.variants, runtime_platform_selector)
+                else {
                     return Err(InstallPackageBySnapshotError::NoMatchingPlatformVariant {
                         package_key: package_key.to_string(),
-                        host_os: host_platform(),
-                        host_cpu: host_arch(),
-                        host_libc: match host_libc() {
-                            "unknown" => None,
-                            other => Some(other),
-                        },
+                        selected_target: format!(
+                            "os = `{}`, cpu = `{}`, libc = `{:?}`",
+                            runtime_platform_selector.os,
+                            runtime_platform_selector.cpu,
+                            runtime_platform_selector.libc,
+                        ),
                         available_targets: render_variant_targets(&variations.variants),
                     });
                 };
@@ -727,6 +730,35 @@ pub(crate) fn host_platform_selector() -> PlatformSelector {
         other => Some(other.to_string()),
     };
     PlatformSelector { os: host_platform().to_string(), cpu: host_arch().to_string(), libc }
+}
+
+/// Resolve the runtime archive selector from `supportedArchitectures`, using
+/// the first requested value on each axis and expanding `current` to the host.
+#[must_use]
+pub(crate) fn runtime_platform_selector(
+    supported: Option<&pacquet_package_is_installable::SupportedArchitectures>,
+) -> PlatformSelector {
+    let host = host_platform_selector();
+    let pick = |values: Option<&Vec<String>>, current: &str| {
+        values.and_then(|values| values.first()).map_or_else(
+            || current.to_string(),
+            |value| {
+                if value == "current" { current.to_string() } else { value.clone() }
+            },
+        )
+    };
+    PlatformSelector {
+        os: pick(supported.and_then(|value| value.os.as_ref()), &host.os),
+        cpu: pick(supported.and_then(|value| value.cpu.as_ref()), &host.cpu),
+        libc: match supported
+            .and_then(|value| value.libc.as_ref())
+            .and_then(|values| values.first())
+        {
+            None => host.libc,
+            Some(value) if value == "current" => host.libc,
+            Some(value) => Some(value.clone()),
+        },
+    }
 }
 
 /// Hand-coded matcher for the

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -1,8 +1,8 @@
 use super::{
     InstallPackageBySnapshotError, archive_filter_for, emit_progress_resolved,
     fetch_directory_resolution, host_platform_selector, local_file_tarball_install_url,
-    node_extras_filter, render_variant_targets, synthesize_runtime_manifest_bytes,
-    tarball_url_and_integrity,
+    node_extras_filter, render_variant_targets, runtime_platform_selector,
+    synthesize_runtime_manifest_bytes, tarball_url_and_integrity,
 };
 use pacquet_config::Config;
 use pacquet_directory_fetcher::DirectoryFetcherError;
@@ -11,6 +11,7 @@ use pacquet_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, LockfileResolution,
     PackageKey, PlatformAssetResolution, PlatformAssetTarget, RegistryResolution,
 };
+use pacquet_package_is_installable::SupportedArchitectures;
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
 use pretty_assertions::assert_eq;
 use std::{borrow::Cow, sync::Mutex};
@@ -125,6 +126,21 @@ fn host_platform_selector_omits_libc_on_non_linux_hosts() {
     if libc_known {
         assert_eq!(selector.libc.as_deref(), Some(host_libc()));
     }
+}
+
+#[test]
+fn runtime_platform_selector_uses_the_first_configured_target() {
+    let supported = SupportedArchitectures {
+        os: Some(vec!["win32".to_string(), "linux".to_string()]),
+        cpu: Some(vec!["x64".to_string(), "arm64".to_string()]),
+        libc: Some(vec!["current".to_string(), "musl".to_string()]),
+    };
+
+    let selector = runtime_platform_selector(Some(&supported));
+
+    assert_eq!(selector.os, "win32");
+    assert_eq!(selector.cpu, "x64");
+    assert_eq!(selector.libc, host_platform_selector().libc);
 }
 
 #[test]
@@ -417,6 +433,7 @@ async fn cold_batch_reuses_in_flight_prefetch_from_mem_cache() {
         snapshot: &snapshot,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
+        runtime_platform_selector: &host_platform_selector(),
         workspace_root: store_tmp.path(),
         // Hoisted skips slot materialization, so the test exercises
         // only the download-coordination branch and gets the CAS map
@@ -494,6 +511,7 @@ async fn without_mem_cache_skips_coordination_and_downloads() {
         snapshot: &snapshot,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
+        runtime_platform_selector: &host_platform_selector(),
         workspace_root: store_tmp.path(),
         node_linker: pacquet_config::NodeLinker::Hoisted,
         custom_fetcher_picker: None,
@@ -568,6 +586,7 @@ async fn cold_batch_falls_back_when_prefetch_failed() {
         snapshot: &snapshot,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
+        runtime_platform_selector: &host_platform_selector(),
         workspace_root: store_tmp.path(),
         node_linker: pacquet_config::NodeLinker::Hoisted,
         custom_fetcher_picker: None,
@@ -667,6 +686,7 @@ async fn run_snapshot_install_with_picker(
         snapshot: &snapshot,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
+        runtime_platform_selector: &host_platform_selector(),
         workspace_root,
         node_linker: pacquet_config::NodeLinker::Hoisted,
         custom_fetcher_picker: Some(picker),
@@ -995,6 +1015,7 @@ async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_i
         snapshot: &snapshot,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
+        runtime_platform_selector: &host_platform_selector(),
         workspace_root: store_tmp.path(),
         node_linker: pacquet_config::NodeLinker::Hoisted,
         custom_fetcher_picker: None,
@@ -1053,6 +1074,7 @@ async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_i
         snapshot: &snapshot,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
+        runtime_platform_selector: &host_platform_selector(),
         workspace_root: store_tmp.path(),
         node_linker: pacquet_config::NodeLinker::Hoisted,
         custom_fetcher_picker: None,

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -54,6 +54,8 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         skip_runtimes: false,
         engine_strict: false,
         node_version: None,
+        runtime_on_fail: None,
+        node_download_mirrors: Default::default(),
         deploy_all_files: false,
         force_legacy_deploy: false,
         shared_workspace_lockfile: true,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -140,6 +140,9 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     /// pins. `None` on the no-lockfile path. Corresponds to the
     /// `update: false` resolver mode.
     pub wanted_lockfile: Option<&'a Lockfile>,
+    /// Effective `nodeVersion`: an explicit config value, otherwise the
+    /// minimum version declared by the root manifest's runtime engine.
+    pub node_version: Option<String>,
     /// Per-install packument cache shared with the lockfile-verifier
     /// constructed in [`Install::run`](crate::Install::run). The
     /// resolver writes to it during `pick_package`; the verifier reads
@@ -587,6 +590,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             workspace_packages,
             update_checksums,
             wanted_lockfile,
+            node_version,
             meta_cache,
             node_linker,
             supported_architectures,
@@ -834,6 +838,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let local_scheme_resolver = LocalSchemeResolver::new(local_ctx);
         let local_path_resolver = LocalPathResolver::new(local_ctx);
         let mut node_resolver = NodeResolver::new(Arc::clone(&http_client_arc));
+        node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
         node_resolver.offline = config.offline;
         let deno_resolver =
             DenoResolver::new(Arc::clone(&http_client_arc), Arc::clone(&npm_resolver));
@@ -1762,7 +1767,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             });
         let installability_host = if needs_installability_check {
             let engine_strict = config.engine_strict;
-            let mut host = match config.node_version.clone() {
+            let mut host = match node_version {
                 // An explicit `nodeVersion` needs no `node --version` probe, so
                 // build the host directly off the reactor thread.
                 node_version @ Some(_) => {
@@ -1980,6 +1985,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             store_index_writer: &store_index_writer,
             allow_build_policy: &allow_build_policy,
             skipped: &skipped,
+            supported_architectures,
             workspace_root: lockfile_dir,
             node_linker,
             progress_reported: &progress_reported,

--- a/pnpm/crates/package-manifest/Cargo.toml
+++ b/pnpm/crates/package-manifest/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace  = true
 [dependencies]
 derive_more = { workspace = true }
 miette      = { workspace = true }
+node-semver = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }
 strum       = { workspace = true }

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -477,14 +477,35 @@ pub fn convert_engines_runtime_to_dependencies(
     engines_field: &str,
     deps_field: &str,
 ) {
-    // Collect first, mutate after — avoids a simultaneous shared+mutable
-    // borrow of the manifest while reading `engines_field` and writing
-    // `deps_field`.
-    let mut to_insert: Vec<(&'static str, String)> = Vec::new();
+    let to_insert = engines_runtime_dependencies(manifest, engines_field, deps_field);
+    if to_insert.is_empty() {
+        return;
+    }
+    let Some(manifest_obj) = manifest.as_object_mut() else {
+        return;
+    };
+    let deps =
+        manifest_obj.entry(deps_field.to_string()).or_insert_with(|| Value::Object(Map::new()));
+    let Some(deps_obj) = deps.as_object_mut() else {
+        return;
+    };
+    for (name, spec) in to_insert {
+        deps_obj.insert(name.to_string(), Value::String(spec));
+    }
+}
+
+/// Return runtime dependency edges synthesized from an engines field.
+#[must_use]
+pub fn engines_runtime_dependencies(
+    manifest: &Value,
+    engines_field: &str,
+    deps_field: &str,
+) -> Vec<(&'static str, String)> {
+    let mut dependencies = Vec::new();
     let Some(runtime_entry) =
         manifest.get(engines_field).and_then(|engines| engines.get("runtime"))
     else {
-        return;
+        return dependencies;
     };
     for runtime_name in RUNTIME_NAMES {
         if manifest.get(deps_field).and_then(|deps| deps.get(runtime_name)).is_some() {
@@ -507,29 +528,16 @@ pub fn convert_engines_runtime_to_dependencies(
         let Some(version) = runtime.get("version").and_then(Value::as_str) else {
             continue;
         };
-        to_insert.push((runtime_name, format!("runtime:{}", version.trim())));
+        dependencies.push((runtime_name, format!("runtime:{}", version.trim())));
     }
-    if to_insert.is_empty() {
-        return;
-    }
-    let Some(manifest_obj) = manifest.as_object_mut() else {
-        return;
-    };
-    let deps =
-        manifest_obj.entry(deps_field.to_string()).or_insert_with(|| Value::Object(Map::new()));
-    let Some(deps_obj) = deps.as_object_mut() else {
-        return;
-    };
-    for (name, spec) in to_insert {
-        deps_obj.insert(name.to_string(), Value::String(spec));
-    }
+    dependencies
 }
 
 /// Apply the configured runtime failure policy to both engine fields.
 ///
-/// A non-download policy removes only dependency entries synthesized from a
-/// `runtime:` specifier; an explicit ordinary dependency with the same name is
-/// preserved. `download` re-runs the normal engine-to-dependency conversion.
+/// A non-download policy removes `runtime:` dependency entries only for names
+/// managed by the corresponding engines field. `download` re-runs the normal
+/// engine-to-dependency conversion.
 pub fn apply_runtime_on_fail_override(manifest: &mut Value, on_fail_override: &str) {
     for (engines_field, deps_field) in
         [("devEngines", "devDependencies"), ("engines", "dependencies")]
@@ -539,6 +547,18 @@ pub fn apply_runtime_on_fail_override(manifest: &mut Value, on_fail_override: &s
         else {
             continue;
         };
+        let managed_runtime_names: Vec<_> = RUNTIME_NAMES
+            .into_iter()
+            .filter(|runtime_name| match &*runtime_entry {
+                Value::Array(runtimes) => runtimes.iter().any(|runtime| {
+                    runtime.get("name").and_then(Value::as_str) == Some(*runtime_name)
+                }),
+                Value::Object(runtime) => {
+                    runtime.get("name").and_then(Value::as_str) == Some(*runtime_name)
+                }
+                _ => false,
+            })
+            .collect();
         match runtime_entry {
             Value::Array(runtimes) => {
                 for runtime in runtimes {
@@ -562,7 +582,7 @@ pub fn apply_runtime_on_fail_override(manifest: &mut Value, on_fail_override: &s
         let Some(deps) = manifest.get_mut(deps_field).and_then(Value::as_object_mut) else {
             continue;
         };
-        for runtime_name in RUNTIME_NAMES {
+        for runtime_name in managed_runtime_names {
             if deps
                 .get(runtime_name)
                 .and_then(Value::as_str)
@@ -596,7 +616,7 @@ pub fn node_version_from_engines_runtime(manifest: &Value) -> Option<String> {
         }) else {
             continue;
         };
-        if let Ok(range) = Range::parse(version)
+        if let Ok(range) = Range::parse(version.trim())
             && let Some(version) = range.min_version()
         {
             return Some(version.to_string());

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
 
 use derive_more::{Display, Error, From};
 use miette::Diagnostic;
+use node_semver::Range;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use strum::IntoStaticStr;
@@ -506,7 +507,7 @@ pub fn convert_engines_runtime_to_dependencies(
         let Some(version) = runtime.get("version").and_then(Value::as_str) else {
             continue;
         };
-        to_insert.push((runtime_name, format!("runtime:{version}")));
+        to_insert.push((runtime_name, format!("runtime:{}", version.trim())));
     }
     if to_insert.is_empty() {
         return;
@@ -522,6 +523,86 @@ pub fn convert_engines_runtime_to_dependencies(
     for (name, spec) in to_insert {
         deps_obj.insert(name.to_string(), Value::String(spec));
     }
+}
+
+/// Apply the configured runtime failure policy to both engine fields.
+///
+/// A non-download policy removes only dependency entries synthesized from a
+/// `runtime:` specifier; an explicit ordinary dependency with the same name is
+/// preserved. `download` re-runs the normal engine-to-dependency conversion.
+pub fn apply_runtime_on_fail_override(manifest: &mut Value, on_fail_override: &str) {
+    for (engines_field, deps_field) in
+        [("devEngines", "devDependencies"), ("engines", "dependencies")]
+    {
+        let Some(runtime_entry) =
+            manifest.get_mut(engines_field).and_then(|engines| engines.get_mut("runtime"))
+        else {
+            continue;
+        };
+        match runtime_entry {
+            Value::Array(runtimes) => {
+                for runtime in runtimes {
+                    if let Some(runtime) = runtime.as_object_mut() {
+                        runtime.insert(
+                            "onFail".to_string(),
+                            Value::String(on_fail_override.to_string()),
+                        );
+                    }
+                }
+            }
+            Value::Object(runtime) => {
+                runtime.insert("onFail".to_string(), Value::String(on_fail_override.to_string()));
+            }
+            _ => continue,
+        }
+        if on_fail_override == "download" {
+            convert_engines_runtime_to_dependencies(manifest, engines_field, deps_field);
+            continue;
+        }
+        let Some(deps) = manifest.get_mut(deps_field).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        for runtime_name in RUNTIME_NAMES {
+            if deps
+                .get(runtime_name)
+                .and_then(Value::as_str)
+                .is_some_and(|specifier| specifier.starts_with("runtime:"))
+            {
+                deps.remove(runtime_name);
+            }
+        }
+    }
+}
+
+/// Return the minimum Node.js version declared by `devEngines.runtime` or
+/// `engines.runtime`, in that precedence order.
+#[must_use]
+pub fn node_version_from_engines_runtime(manifest: &Value) -> Option<String> {
+    for engines_field in ["devEngines", "engines"] {
+        let Some(runtime_entry) =
+            manifest.get(engines_field).and_then(|value| value.get("runtime"))
+        else {
+            continue;
+        };
+        let runtimes = match runtime_entry {
+            Value::Array(runtimes) => runtimes.as_slice(),
+            runtime @ Value::Object(_) => std::slice::from_ref(runtime),
+            _ => continue,
+        };
+        let Some(version) = runtimes.iter().find_map(|runtime| {
+            (runtime.get("name").and_then(Value::as_str) == Some("node"))
+                .then(|| runtime.get("version").and_then(Value::as_str))
+                .flatten()
+        }) else {
+            continue;
+        };
+        if let Ok(range) = Range::parse(version)
+            && let Some(version) = range.min_version()
+        {
+            return Some(version.to_string());
+        }
+    }
+    None
 }
 
 /// pnpm's on-write manifest normalization: within each dependency field,

--- a/pnpm/crates/package-manifest/src/tests.rs
+++ b/pnpm/crates/package-manifest/src/tests.rs
@@ -8,8 +8,9 @@ use tempfile::{NamedTempFile, tempdir};
 #[cfg(unix)]
 use super::safe_read_package_json_from_dir;
 use super::{
-    BundleDependencies, PackageManifest, PackageManifestError,
+    BundleDependencies, PackageManifest, PackageManifestError, apply_runtime_on_fail_override,
     convert_dependencies_to_engines_runtime, convert_engines_runtime_to_dependencies,
+    node_version_from_engines_runtime,
 };
 use crate::DependencyGroup;
 use serde_json::json;
@@ -297,6 +298,93 @@ fn convert_engines_runtime_only_reifies_onfail_download() {
             "onFail={on_fail} should not reify; manifest: {manifest}",
         );
     }
+}
+
+#[test]
+fn convert_engines_runtime_trims_the_version() {
+    for (version, expected) in [("", "runtime:"), ("  ", "runtime:"), (" 22 ", "runtime:22")] {
+        let mut manifest = json!({
+            "devEngines": {
+                "runtime": {
+                    "name": "node",
+                    "version": version,
+                    "onFail": "download",
+                },
+            },
+        });
+        convert_engines_runtime_to_dependencies(&mut manifest, "devEngines", "devDependencies");
+        assert_eq!(
+            manifest.get("devDependencies").and_then(|d| d.get("node")).and_then(|v| v.as_str()),
+            Some(expected),
+        );
+    }
+}
+
+#[test]
+fn runtime_on_fail_download_reifies_runtime_dependencies() {
+    let mut manifest = json!({
+        "devEngines": {
+            "runtime": { "name": "node", "version": "22.20.0" },
+        },
+    });
+    apply_runtime_on_fail_override(&mut manifest, "download");
+    assert_eq!(
+        manifest.get("devEngines").and_then(|v| v.get("runtime")).and_then(|v| v.get("onFail")),
+        Some(&json!("download")),
+    );
+    assert_eq!(
+        manifest.get("devDependencies").and_then(|v| v.get("node")),
+        Some(&json!("runtime:22.20.0")),
+    );
+}
+
+#[test]
+fn runtime_on_fail_ignore_removes_only_synthesized_runtime_dependencies() {
+    let mut manifest = json!({
+        "devEngines": {
+            "runtime": { "name": "node", "version": "22.20.0", "onFail": "download" },
+        },
+        "devDependencies": {
+            "node": "runtime:22.20.0",
+            "bun": "1.2.0",
+        },
+    });
+    apply_runtime_on_fail_override(&mut manifest, "ignore");
+    assert_eq!(
+        manifest.get("devEngines").and_then(|v| v.get("runtime")).and_then(|v| v.get("onFail")),
+        Some(&json!("ignore")),
+    );
+    assert!(manifest.get("devDependencies").and_then(|v| v.get("node")).is_none());
+    assert_eq!(manifest.get("devDependencies").and_then(|v| v.get("bun")), Some(&json!("1.2.0")),);
+}
+
+#[test]
+fn node_version_uses_devengines_then_engines_and_returns_the_range_minimum() {
+    assert_eq!(
+        node_version_from_engines_runtime(&json!({
+            "devEngines": {
+                "runtime": { "name": "node", "version": "^22.0.0" },
+            },
+            "engines": {
+                "runtime": { "name": "node", "version": "20.0.0" },
+            },
+        })),
+        Some("22.0.0".to_string()),
+    );
+    assert_eq!(
+        node_version_from_engines_runtime(&json!({
+            "devEngines": {
+                "runtime": { "name": "bun", "version": "1.2.0" },
+            },
+            "engines": {
+                "runtime": [
+                    { "name": "deno", "version": "2.0.0" },
+                    { "name": "node", "version": "22.20.0" },
+                ],
+            },
+        })),
+        Some("22.20.0".to_string()),
+    );
 }
 
 #[test]

--- a/pnpm/crates/package-manifest/src/tests.rs
+++ b/pnpm/crates/package-manifest/src/tests.rs
@@ -359,6 +359,23 @@ fn runtime_on_fail_ignore_removes_only_synthesized_runtime_dependencies() {
 }
 
 #[test]
+fn runtime_on_fail_ignore_preserves_explicit_runtime_dependencies() {
+    let mut manifest = json!({
+        "devEngines": {
+            "runtime": { "name": "bun", "version": "1.2.0", "onFail": "download" },
+        },
+        "devDependencies": {
+            "node": "runtime:22.20.0",
+        },
+    });
+    apply_runtime_on_fail_override(&mut manifest, "ignore");
+    assert_eq!(
+        manifest.get("devDependencies").and_then(|value| value.get("node")),
+        Some(&json!("runtime:22.20.0")),
+    );
+}
+
+#[test]
 fn node_version_uses_devengines_then_engines_and_returns_the_range_minimum() {
     assert_eq!(
         node_version_from_engines_runtime(&json!({
@@ -384,6 +401,14 @@ fn node_version_uses_devengines_then_engines_and_returns_the_range_minimum() {
             },
         })),
         Some("22.20.0".to_string()),
+    );
+    assert_eq!(
+        node_version_from_engines_runtime(&json!({
+            "engines": {
+                "runtime": { "name": "node", "version": " 24.6.0 " },
+            },
+        })),
+        Some("24.6.0".to_string()),
     );
 }
 

--- a/pnpm/crates/package-manifest/src/tests.rs
+++ b/pnpm/crates/package-manifest/src/tests.rs
@@ -355,7 +355,7 @@ fn runtime_on_fail_ignore_removes_only_synthesized_runtime_dependencies() {
         Some(&json!("ignore")),
     );
     assert!(manifest.get("devDependencies").and_then(|v| v.get("node")).is_none());
-    assert_eq!(manifest.get("devDependencies").and_then(|v| v.get("bun")), Some(&json!("1.2.0")),);
+    assert_eq!(manifest.get("devDependencies").and_then(|v| v.get("bun")), Some(&json!("1.2.0")));
 }
 
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -9,7 +9,9 @@ use pacquet_catalogs_resolver::{
 };
 use pacquet_catalogs_types::Catalogs;
 use pacquet_hooks::PnpmfileHooks;
-use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_package_manifest::{
+    DependencyGroup, PackageManifest, convert_engines_runtime_to_dependencies,
+};
 use pacquet_patching::{PatchGroupRecord, PatchKeyConflictError, get_patch_info};
 use pacquet_resolving_resolver_base::{
     PreferredVersionsOverlay, ResolveError, ResolveOptions, Resolver, WantedDependency,
@@ -2977,8 +2979,15 @@ fn extract_children(
     let Some(manifest) = result.manifest.as_ref() else { return Ok(Vec::new()) };
     let parent = render_parent(result);
     let mut out = Vec::new();
-    collect_deps(manifest, "dependencies", false, &parent, &mut out)?;
-    collect_deps(manifest, "optionalDependencies", true, &parent, &mut out)?;
+    if manifest.get("engines").and_then(|engines| engines.get("runtime")).is_some() {
+        let mut manifest = (**manifest).clone();
+        convert_engines_runtime_to_dependencies(&mut manifest, "engines", "dependencies");
+        collect_deps(&manifest, "dependencies", false, &parent, &mut out)?;
+        collect_deps(&manifest, "optionalDependencies", true, &parent, &mut out)?;
+    } else {
+        collect_deps(manifest, "dependencies", false, &parent, &mut out)?;
+        collect_deps(manifest, "optionalDependencies", true, &parent, &mut out)?;
+    }
     Ok(out)
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -9,9 +9,7 @@ use pacquet_catalogs_resolver::{
 };
 use pacquet_catalogs_types::Catalogs;
 use pacquet_hooks::PnpmfileHooks;
-use pacquet_package_manifest::{
-    DependencyGroup, PackageManifest, convert_engines_runtime_to_dependencies,
-};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest, engines_runtime_dependencies};
 use pacquet_patching::{PatchGroupRecord, PatchKeyConflictError, get_patch_info};
 use pacquet_resolving_resolver_base::{
     PreferredVersionsOverlay, ResolveError, ResolveOptions, Resolver, WantedDependency,
@@ -2979,14 +2977,10 @@ fn extract_children(
     let Some(manifest) = result.manifest.as_ref() else { return Ok(Vec::new()) };
     let parent = render_parent(result);
     let mut out = Vec::new();
-    if manifest.get("engines").and_then(|engines| engines.get("runtime")).is_some() {
-        let mut manifest = (**manifest).clone();
-        convert_engines_runtime_to_dependencies(&mut manifest, "engines", "dependencies");
-        collect_deps(&manifest, "dependencies", false, &parent, &mut out)?;
-        collect_deps(&manifest, "optionalDependencies", true, &parent, &mut out)?;
-    } else {
-        collect_deps(manifest, "dependencies", false, &parent, &mut out)?;
-        collect_deps(manifest, "optionalDependencies", true, &parent, &mut out)?;
+    collect_deps(manifest, "dependencies", false, &parent, &mut out)?;
+    collect_deps(manifest, "optionalDependencies", true, &parent, &mut out)?;
+    for (name, specifier) in engines_runtime_dependencies(manifest, "engines", "dependencies") {
+        out.push((name.to_string(), specifier, false));
     }
     Ok(out)
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -5,7 +5,41 @@ use pacquet_resolving_resolver_base::{
     ResolveResult, Resolver, WantedDependency,
 };
 
-use super::{ResolveDependencyTreeOptions, landed_on_prior_entry, resolve_dependency_tree};
+use super::{
+    ResolveDependencyTreeOptions, extract_children, landed_on_prior_entry, resolve_dependency_tree,
+};
+
+#[test]
+fn dependency_engines_runtime_is_walked_as_a_runtime_dependency() {
+    let result = ResolveResult {
+        id: PkgResolutionId::from("parent@1.0.0"),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: Some(std::sync::Arc::new(serde_json::json!({
+            "name": "parent",
+            "version": "1.0.0",
+            "engines": {
+                "runtime": {
+                    "name": "node",
+                    "version": "22.19.0",
+                    "onFail": "download",
+                },
+            },
+        }))),
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: "parent".to_string(),
+        }),
+        resolved_via: "npm-registry".to_string(),
+        normalized_bare_specifier: None,
+        alias: Some("parent".to_string()),
+        policy_violation: None,
+    };
+    assert_eq!(
+        extract_children(&result).unwrap(),
+        vec![("node".to_string(), "runtime:22.19.0".to_string(), false)],
+    );
+}
 
 fn key(raw: &str) -> PkgNameVerPeer {
     raw.parse().expect("parse snapshot key")

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -630,57 +630,51 @@ The runtime lockfile *format* (importer `version: runtime:<ver>`, the
 `variants[].resolution.bin: { node: … }` map asserted in
 `nodeRuntime.ts:236-269`) is covered at pacquet's adapter/resolver layer by
 `dependencies_graph_to_lockfile::tests::runtime_dependency_strips_importer_prefix_and_records_package_version`
-and `node_resolver::tests::bin_spec_is_a_named_map`. The full
-install-and-reinstall integration tests below are still unported end-to-end
-against a real mirror (they download real runtime artifacts), but the
-*cold-install → wipe → offline-reinstall* regression at their core — a
-runtime archive ships no `package.json`, so the synthesized manifest must
-be baked into the persisted store-index row for the warm reinstall to
-re-materialize it (pnpm/pnpm#12811) — is covered without the network by
-`install_package_by_snapshot::tests::installing_a_runtime_persists_the_synthesized_manifest_into_the_store_index_row`
-(drives `InstallPackageBySnapshot` on a `Binary` resolution pointing at a
-local `file:` runtime-archive fixture).
+and `node_resolver::tests::bin_spec_is_a_named_map`. The command-level ports
+use local HTTP runtime archives so they exercise fetching, integrity checks,
+runtime manifest synthesis, bin linking, and frozen/offline reinstall without
+depending on external release services.
 
 Node runtime tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:209` `installing Node.js runtime` includes frozen/offline reinstall after deleting `node_modules`. _(Regression core — the offline reinstall re-materializing the synthesized `package.json` — is covered by `installing_a_runtime_persists_the_synthesized_manifest_into_the_store_index_row`; the real-download lockfile-shape / musl-variant / npm+corepack-filter assertions remain unported.)_
-- [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:332` `installing node.js runtime fails if offline mode is used and node.js not found locally` — the offline-fail error (`ERR_PNPM_NO_OFFLINE_NODEJS_RESOLUTION`) is pinned at resolver level by `offline_raises_no_offline_nodejs_resolution` in `crates/engine-runtime-node-resolver/src/node_resolver/tests.rs`; the install-level flow is unported.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:339` `installing Node.js runtime from RC channel`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:346` `installing Node.js runtime fails if integrity check fails` verifies frozen integrity failure.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:400` `installing Node.js runtime for the given supported architecture` includes frozen reinstall for target architecture.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:422` `installing Node.js runtime, when it is set via the engines field of a dependency`
+- [x] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:209` `installing Node.js runtime` includes frozen/offline reinstall after deleting `node_modules`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:332` `installing node.js runtime fails if offline mode is used and node.js not found locally`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:339` `installing Node.js runtime from RC channel`
+- [x] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:346` `installing Node.js runtime fails if integrity check fails` verifies frozen integrity failure.
+- [x] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:400` `installing Node.js runtime for the given supported architecture` includes frozen reinstall for target architecture.
+- [x] `TypeScript repo: installing/deps-installer/test/install/nodeRuntime.ts:422` `installing Node.js runtime, when it is set via the engines field of a dependency`
 
 Deno runtime tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/denoRuntime.ts:111` `installing Deno runtime` includes frozen/offline reinstall.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/denoRuntime.ts:217` `installing Deno runtime fails if offline mode is used and Deno not found locally`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/denoRuntime.ts:224` `installing Deno runtime fails if integrity check fails`
+- [x] `TypeScript repo: installing/deps-installer/test/install/denoRuntime.ts:111` `installing Deno runtime` includes frozen/offline reinstall.
+- [x] `TypeScript repo: installing/deps-installer/test/install/denoRuntime.ts:217` `installing Deno runtime fails if offline mode is used and Deno not found locally`
+- [x] `TypeScript repo: installing/deps-installer/test/install/denoRuntime.ts:224` `installing Deno runtime fails if integrity check fails`
 
 Bun runtime tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/bunRuntime.ts:128` `installing Bun runtime` includes frozen/offline reinstall.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/bunRuntime.ts:215` `installing Bun runtime fails if offline mode is used and Bun not found locally`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/bunRuntime.ts:222` `installing Bun runtime fails if integrity check fails`
+- [x] `TypeScript repo: installing/deps-installer/test/install/bunRuntime.ts:128` `installing Bun runtime` includes frozen/offline reinstall.
+- [x] `TypeScript repo: installing/deps-installer/test/install/bunRuntime.ts:215` `installing Bun runtime fails if offline mode is used and Bun not found locally`
+- [x] `TypeScript repo: installing/deps-installer/test/install/bunRuntime.ts:222` `installing Bun runtime fails if integrity check fails`
 
 Command-level tests:
 
-- [ ] `TypeScript repo: installing/commands/test/install.ts:124` `install Node.js when devEngines runtime is set with onFail=download` — the `onFail=download` reification gate is pinned at helper level by `convert_engines_runtime_only_reifies_onfail_download` in `crates/package-manifest/src/tests.rs`; the command-level flow is unported.
-- [ ] `TypeScript repo: installing/commands/test/install.ts:160` `do not install Node.js when devEngines runtime is not set to onFail=download`
-- [ ] `TypeScript repo: pnpm/test/install/runtimeOnFail.ts:8` `runtimeOnFail=download causes Node.js to be downloaded even when the manifest does not set onFail`
-- [ ] `TypeScript repo: pnpm/test/install/runtimeOnFail.ts:31` `runtimeOnFail=ignore prevents Node.js download even when manifest sets onFail=download`
+- [x] `TypeScript repo: installing/commands/test/install.ts:124` `install Node.js when devEngines runtime is set with onFail=download`
+- [x] `TypeScript repo: installing/commands/test/install.ts:160` `do not install Node.js when devEngines runtime is not set to onFail=download`
+- [x] `TypeScript repo: pnpm/test/install/runtimeOnFail.ts:8` `runtimeOnFail=download causes Node.js to be downloaded even when the manifest does not set onFail`
+- [x] `TypeScript repo: pnpm/test/install/runtimeOnFail.ts:31` `runtimeOnFail=ignore prevents Node.js download even when manifest sets onFail=download`
 
 Runtime manifest/config conversion tests:
 
-- [ ] `TypeScript repo: config/reader/test/index.ts:85` `nodeVersion from config takes priority over devEngines.runtime`
-- [ ] `TypeScript repo: config/reader/test/index.ts:109` `runtimeOnFail=download overrides devEngines.runtime.onFail and adds node to devDependencies`
-- [ ] `TypeScript repo: config/reader/test/index.ts:138` `runtimeOnFail=ignore overrides an existing onFail=download and removes node from devDependencies`
+- [x] `TypeScript repo: config/reader/test/index.ts:85` `nodeVersion from config takes priority over devEngines.runtime`
+- [x] `TypeScript repo: config/reader/test/index.ts:109` `runtimeOnFail=download overrides devEngines.runtime.onFail and adds node to devDependencies`
+- [x] `TypeScript repo: config/reader/test/index.ts:138` `runtimeOnFail=ignore overrides an existing onFail=download and removes node from devDependencies`
 - [x] `TypeScript repo: workspace/project-manifest-reader/test/index.ts:37` `readProjectManifest() converts devEngines runtime to devDependencies` — ported as `from_path_applies_convert_engines_runtime` (read path) and `convert_engines_runtime_lifts_devengines_runtime_into_devdependencies` (helper) in `crates/package-manifest/src/tests.rs`.
 - [x] `TypeScript repo: workspace/project-manifest-reader/test/index.ts:68` `readProjectManifest() converts engines runtime to dependencies` — covered at helper level by `convert_engines_runtime_targets_dependencies_for_engines_field` in `crates/package-manifest/src/tests.rs` (the `from_path` read-path test asserts only the `devEngines` direction).
 
 Rust port notes:
 
-- Treat Node, Deno, and Bun as separate subfeatures.
-- Frozen/offline reinstall is the most relevant Stage 1 assertion.
+- Ported in `crates/cli/tests/install_runtimes.rs`, with conversion and resolver
+  details pinned by the focused unit tests named above.
 
 ## Installation Of Git-Hosted Packages
 

--- a/pnpm11/pkg-manifest/utils/src/convertEnginesRuntimeToDependencies.ts
+++ b/pnpm11/pkg-manifest/utils/src/convertEnginesRuntimeToDependencies.ts
@@ -62,7 +62,11 @@ export function applyRuntimeOnFailOverride (
       const deps = manifest[dependenciesFieldName]
       if (deps) {
         for (const runtimeName of RUNTIME_NAMES) {
-          if (typeof deps[runtimeName] === 'string' && deps[runtimeName].startsWith('runtime:')) {
+          if (
+            runtimes.some(runtime => runtime.name === runtimeName) &&
+            typeof deps[runtimeName] === 'string' &&
+            deps[runtimeName].startsWith('runtime:')
+          ) {
             delete deps[runtimeName]
           }
         }

--- a/pnpm11/pkg-manifest/utils/test/convertEnginesRuntimeToDependencies.test.ts
+++ b/pnpm11/pkg-manifest/utils/test/convertEnginesRuntimeToDependencies.test.ts
@@ -54,3 +54,22 @@ test('applyRuntimeOnFailOverride(download) skips runtime entries without a versi
   expect(manifest.devEngines?.runtime).toMatchObject({ name: 'node', onFail: 'download' })
   expect(manifest.devDependencies).toBeUndefined()
 })
+
+test('applyRuntimeOnFailOverride(ignore) preserves explicit runtime dependencies', () => {
+  const manifest: ProjectManifest = {
+    devEngines: {
+      runtime: {
+        name: 'bun',
+        version: '1.2.0',
+        onFail: 'download',
+      },
+    },
+    devDependencies: {
+      node: 'runtime:22.20.0',
+    },
+  }
+
+  applyRuntimeOnFailOverride(manifest, 'ignore')
+
+  expect(manifest.devDependencies?.node).toBe('runtime:22.20.0')
+})


### PR DESCRIPTION
## Summary

Completes Stage 8 of pnpm/pnpm#13146 by bringing pacquet's runtime installation behavior into parity with the TypeScript CLI.

- threads `runtimeOnFail`, `nodeDownloadMirrors`, runtime-derived Node versions, and dependency `engines.runtime` declarations through resolution and installation
- selects runtime archive variants from `supportedArchitectures` and preserves the selected target through virtual-store installation
- adds hermetic local-HTTP coverage for Node.js, Deno, and Bun cold/offline installs, integrity failures, release channels, target architectures, dependency runtimes, and failure policies
- preserves explicit runtime dependencies for unmatched engine entries in both the TypeScript and Rust implementations
- synthesizes transitive runtime edges without cloning full dependency manifests in the resolver hot path

The TypeScript implementation already provides the Stage 8 behaviors; this PR implements the corresponding Rust pacquet behavior and keeps the shared override behavior aligned across both stacks.

Related to pnpm/pnpm#13146.

## Squash Commit Body

```text
Complete pacquet runtime installation parity for Node.js, Deno, and Bun.

Thread runtime failure policy, Node download mirrors, and runtime-derived Node versions through configuration and installation. Select runtime archive variants from supportedArchitectures and resolve engines.runtime declarations on dependency manifests without cloning full manifests in the resolver hot path.

Preserve explicit runtime dependencies for unmatched engine entries in both the TypeScript and Rust implementations. Add hermetic local-HTTP coverage for cold and offline reinstall, integrity failures, release channels, target architectures, dependency runtimes, and runtimeOnFail flows.

Completes Stage 8 of pnpm/pnpm#13146.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).
