### PR TITLE
fix(pacquet): complete auth and proxy parity

### DIFF
--- a/.changeset/tidy-wolves-proxy.md
+++ b/.changeset/tidy-wolves-proxy.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed proxy settings from the global `config.yaml` and command-line options in pnpm.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5063,9 +5063,13 @@ version = "0.0.0"
 dependencies = [
  "assert_cmd",
  "command-extra",
+ "flate2",
  "junction",
  "pnpr",
  "pnpr-fixtures",
+ "serde_json",
+ "ssri",
+ "tar",
  "tempfile",
  "text-block-macros",
  "tokio",

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -124,6 +124,18 @@ pub struct CliArgs {
     #[clap(long = "npmrc-auth-file", visible_alias = "userconfig", global = true)]
     pub npmrc_auth_file: Option<PathBuf>,
 
+    /// Proxy for HTTPS registry and tarball requests.
+    #[clap(long = "https-proxy", global = true)]
+    pub https_proxy: Option<String>,
+
+    /// Proxy for HTTP registry and tarball requests.
+    #[clap(long = "http-proxy", global = true)]
+    pub http_proxy: Option<String>,
+
+    /// Hosts that bypass configured proxies.
+    #[clap(long = "no-proxy", global = true)]
+    pub no_proxy: Option<String>,
+
     /// Run the command for every project in the workspace instead of only
     /// the project in `--dir`.
     #[clap(short = 'r', long, global = true)]

--- a/pnpm/crates/cli/src/cli_args/config/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/config/tests.rs
@@ -219,6 +219,48 @@ fn set_global_https_proxy_writes_config_yaml_not_auth_ini() {
 }
 
 #[test]
+fn set_global_http_proxy_writes_config_yaml() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(true, None, false),
+        "httpProxy",
+        Some("http://proxy.example.com:8080".into()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_yaml(&config_dir.join("config.yaml")).unwrap(),
+        json!({ "httpProxy": "http://proxy.example.com:8080" }),
+    );
+}
+
+#[test]
+fn set_global_no_proxy_writes_config_yaml() {
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("global-config");
+    let config = config_with_dir(&config_dir);
+
+    config_set(
+        &config,
+        tmp.path(),
+        flags(true, None, false),
+        "no-proxy",
+        Some("localhost,127.0.0.1".into()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        read_yaml(&config_dir.join("config.yaml")).unwrap(),
+        json!({ "noProxy": "localhost,127.0.0.1" }),
+    );
+}
+
+#[test]
 fn set_key_equals_value_form() {
     let tmp = TempDir::new().unwrap();
     let config = config_with_dir(&tmp.path().join("global-config"));

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -91,6 +91,11 @@ impl CliArgs {
             return false;
         };
         config_overrides.apply(&mut config);
+        config.apply_proxy_cli_overrides(
+            self.https_proxy.as_deref(),
+            self.http_proxy.as_deref(),
+            self.no_proxy.as_deref(),
+        );
         if let Some(store_dir) = self.store_dir.as_deref()
             && apply_store_dir_override::<Host>(&mut config, store_dir, &dir).is_err()
         {
@@ -128,6 +133,9 @@ impl CliArgs {
             dir,
             store_dir,
             npmrc_auth_file,
+            https_proxy,
+            http_proxy,
+            no_proxy,
             recursive,
             reporter,
             filter,
@@ -204,6 +212,11 @@ impl CliArgs {
                 .wrap_err("load configuration")
                 .and_then(|mut cfg| {
                     config_overrides.apply(&mut cfg);
+                    cfg.apply_proxy_cli_overrides(
+                        https_proxy.as_deref(),
+                        http_proxy.as_deref(),
+                        no_proxy.as_deref(),
+                    );
                     if let Some(store_dir) = store_dir.as_deref() {
                         apply_store_dir_override::<Host>(&mut cfg, store_dir, anchor)?;
                     }

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -42,6 +42,24 @@ fn store_dir_accepts_an_explicit_empty_value() {
 }
 
 #[test]
+fn proxy_flags_are_global_and_parse_on_either_side_of_the_subcommand() {
+    let before =
+        CliArgs::try_parse_from(["pacquet", "--https-proxy=http://proxy.example:8443", "install"])
+            .expect("parse HTTPS proxy before subcommand");
+    assert_eq!(before.https_proxy.as_deref(), Some("http://proxy.example:8443"));
+
+    let after = CliArgs::try_parse_from([
+        "pacquet",
+        "install",
+        "--http-proxy=http://proxy.example:8080",
+        "--no-proxy=localhost,127.0.0.1",
+    ])
+    .expect("parse proxy settings after subcommand");
+    assert_eq!(after.http_proxy.as_deref(), Some("http://proxy.example:8080"));
+    assert_eq!(after.no_proxy.as_deref(), Some("localhost,127.0.0.1"));
+}
+
+#[test]
 fn recursive_default_is_false() {
     let parsed = CliArgs::try_parse_from(["pacquet", "install"]).expect("parses");
     assert!(!parsed.recursive, "flag absent → false");

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -87,6 +87,9 @@ pub struct ConfigOverrides {
     node_linker: Option<NodeLinker>,
     shared_workspace_lockfile: Option<bool>,
     verify_deps_before_run: Option<VerifyDepsBeforeRun>,
+    https_proxy: Option<String>,
+    http_proxy: Option<String>,
+    no_proxy: Option<String>,
 }
 
 impl ConfigOverrides {
@@ -123,6 +126,18 @@ impl ConfigOverrides {
             self.registry = Some(normalize_registry_url(value));
             return;
         }
+        if key == "https-proxy" {
+            self.https_proxy = Some(value.to_string());
+            return;
+        }
+        if key == "http-proxy" {
+            self.http_proxy = Some(value.to_string());
+            return;
+        }
+        if key == "no-proxy" {
+            self.no_proxy = Some(value.to_string());
+            return;
+        }
         if key == "deploy-all-files" {
             self.deploy_all_files = parse_bool(value);
             return;
@@ -157,6 +172,11 @@ impl ConfigOverrides {
     /// been built from defaults, `.npmrc`, and `pnpm-workspace.yaml`.
     /// Mirrors pnpm 11's "CLI > yaml > .npmrc > defaults" precedence.
     pub fn apply(&self, config: &mut Config) {
+        config.apply_proxy_cli_overrides(
+            self.https_proxy.as_deref(),
+            self.http_proxy.as_deref(),
+            self.no_proxy.as_deref(),
+        );
         if let Some(registry) = &self.registry {
             config.registry.clone_from(registry);
             config.registries.insert("default".to_string(), registry.clone());
@@ -251,6 +271,9 @@ fn global_option_width(arg: &str) -> Option<usize> {
         "dir"
             | "filter"
             | "filter-prod"
+            | "http-proxy"
+            | "https-proxy"
+            | "no-proxy"
             | "npmrc-auth-file"
             | "reporter"
             | "store-dir"

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -155,6 +155,33 @@ fn last_value_wins_for_repeated_keys() {
 }
 
 #[test]
+fn dotted_proxy_overrides_apply_to_network_config() {
+    let (overrides, _) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--config.https-proxy=http://proxy.example:8443",
+        "--config.http-proxy=http://proxy.example:8080",
+        "--config.no-proxy=localhost,127.0.0.1",
+    ]));
+    let mut config = Config::default();
+    config.proxy.https_proxy = Some("http://yaml.example:9443".to_string());
+    config.proxy.http_proxy = Some("http://yaml.example:9080".to_string());
+    config.package_manager_bootstrap.proxy = config.proxy.clone();
+    overrides.apply(&mut config);
+
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://proxy.example:8443"));
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://proxy.example:8080"));
+    assert_eq!(
+        config.proxy.no_proxy,
+        Some(pacquet_network::NoProxySetting::List(vec![
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+        ])),
+    );
+    assert_eq!(config.package_manager_bootstrap.proxy, config.proxy);
+}
+
+#[test]
 fn apply_is_a_noop_when_no_overrides_set() {
     let (overrides, _) = ConfigOverrides::extract(argv(["pacquet", "install"]));
     let default_registry = Config::default().registry;

--- a/pnpm/crates/cli/tests/auth.rs
+++ b/pnpm/crates/cli/tests/auth.rs
@@ -1,0 +1,230 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::{
+    bin::CommandTempCwd,
+    fixtures::{minimal_tarball, sha512_integrity},
+};
+use std::{fs, path::Path, process::Command};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+fn write_project_config(root: &Path, workspace: &Path, registry: &str, credentials: &str) {
+    fs::write(workspace.join(".npmrc"), format!("registry={registry}/\n{credentials}"))
+        .expect("write .npmrc");
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "storeDir: ../store\ncacheDir: ../cache\nenableGlobalVirtualStore: false\nfetchRetries: 0\n",
+    )
+    .expect("write workspace config");
+    fs::create_dir_all(root.join("xdg")).expect("create isolated config home");
+}
+
+fn install_command(workspace: &Path, root: &Path) -> Command {
+    pacquet_at(workspace)
+        .with_env("XDG_CONFIG_HOME", root.join("xdg"))
+        .with_env("NO_PROXY", "127.0.0.1,localhost")
+        .with_env("no_proxy", "127.0.0.1,localhost")
+}
+
+fn assert_authenticated_install(
+    package: &str,
+    credentials: impl FnOnce(&str) -> String,
+    expected_header: &str,
+    frozen_reinstall: bool,
+) {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let registry_url = registry.url();
+    let authority = registry_url.strip_prefix("http://").expect("mock registry is HTTP");
+    write_project_config(root.path(), &workspace, &registry_url, &credentials(authority));
+
+    let tarball = minimal_tarball(package, "1.0.0");
+    let integrity = sha512_integrity(&tarball);
+    let tarball_path = "/private-pkg-1.0.0.tgz";
+    let packument_path = format!("/{}", package.replace('/', "%2F"));
+    let packument = serde_json::json!({
+        "name": package,
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": package,
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": integrity,
+                    "tarball": format!("{registry_url}{tarball_path}"),
+                },
+            },
+        },
+    });
+    let metadata = registry
+        .mock("GET", packument_path.as_str())
+        .match_header("authorization", expected_header)
+        .with_status(200)
+        .with_header("content-type", "application/vnd.npm.install-v1+json")
+        .with_body(packument.to_string())
+        .expect_at_least(1)
+        .create();
+    let tarballs = registry
+        .mock("GET", tarball_path)
+        .match_header("authorization", expected_header)
+        .with_status(200)
+        .with_body(tarball)
+        .expect_at_least(if frozen_reinstall { 2 } else { 1 })
+        .create();
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { (package): "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+
+    install_command(&workspace, root.path()).with_arg("install").assert().success();
+    assert!(workspace.join("node_modules").join(package).exists());
+
+    if frozen_reinstall {
+        fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+        fs::remove_dir_all(root.path().join("store")).expect("remove cold store");
+        install_command(&workspace, root.path())
+            .with_args(["install", "--frozen-lockfile"])
+            .assert()
+            .success();
+        assert!(workspace.join("node_modules").join(package).exists());
+    }
+
+    metadata.assert();
+    tarballs.assert();
+}
+
+#[test]
+fn bearer_auth_is_used_for_metadata_tarballs_and_cold_frozen_reinstall() {
+    assert_authenticated_install(
+        "private-pkg",
+        |authority| format!("//{authority}/:_authToken=secret-token\n"),
+        "Bearer secret-token",
+        true,
+    );
+}
+
+#[test]
+fn username_and_password_authenticates_install() {
+    assert_authenticated_install(
+        "private-pkg",
+        |authority| format!("//{authority}/:username=foo\n//{authority}/:_password=YmFy\n"),
+        "Basic Zm9vOmJhcg==",
+        false,
+    );
+}
+
+#[test]
+fn legacy_basic_auth_authenticates_install() {
+    assert_authenticated_install(
+        "private-pkg",
+        |authority| format!("//{authority}/:_auth=Zm9vOmJhcg==\n"),
+        "Basic Zm9vOmJhcg==",
+        false,
+    );
+}
+
+#[test]
+fn package_scope_bearer_auth_wins_for_scoped_install() {
+    assert_authenticated_install(
+        "@private/foo",
+        |authority| {
+            format!(
+                "//{authority}/:_authToken=wrong-token\n\
+                 //{authority}/:@private:_authToken=scoped-token\n",
+            )
+        },
+        "Bearer scoped-token",
+        true,
+    );
+}
+
+#[test]
+fn package_scope_legacy_auth_wins_for_scoped_install() {
+    assert_authenticated_install(
+        "@private/foo",
+        |authority| {
+            format!(
+                "//{authority}/:_authToken=wrong-token\n\
+                 //{authority}/:@private:_auth=Zm9vOmJhcg==\n",
+            )
+        },
+        "Basic Zm9vOmJhcg==",
+        true,
+    );
+}
+
+#[test]
+fn metadata_authorization_failure_is_reported() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    write_project_config(root.path(), &workspace, &registry.url(), "");
+    let forbidden = registry
+        .mock("GET", "/private-pkg")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(403)
+        .with_body("Forbidden")
+        .expect(1)
+        .create();
+    fs::write(workspace.join("package.json"), r#"{"dependencies":{"private-pkg":"1.0.0"}}"#)
+        .expect("write package.json");
+
+    let output = install_command(&workspace, root.path()).with_arg("install").output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("403 Forbidden"), "got {stderr}");
+
+    forbidden.assert();
+}
+
+#[test]
+fn tarball_authorization_failure_is_reported() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let registry_url = registry.url();
+    write_project_config(root.path(), &workspace, &registry_url, "");
+    let tarball = minimal_tarball("private-pkg", "1.0.0");
+    let integrity = sha512_integrity(&tarball);
+    let metadata = registry
+        .mock("GET", "/private-pkg")
+        .with_status(200)
+        .with_header("content-type", "application/vnd.npm.install-v1+json")
+        .with_body(
+            serde_json::json!({
+                "name": "private-pkg",
+                "dist-tags": { "latest": "1.0.0" },
+                "versions": {
+                    "1.0.0": {
+                        "name": "private-pkg",
+                        "version": "1.0.0",
+                        "dist": {
+                            "integrity": integrity,
+                            "tarball": format!("{registry_url}/private-pkg-1.0.0.tgz"),
+                        },
+                    },
+                },
+            })
+            .to_string(),
+        )
+        .expect_at_least(1)
+        .create();
+    let forbidden = registry
+        .mock("GET", "/private-pkg-1.0.0.tgz")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(403)
+        .with_body("Forbidden")
+        .expect_at_least(1)
+        .create();
+    fs::write(workspace.join("package.json"), r#"{"dependencies":{"private-pkg":"1.0.0"}}"#)
+        .expect("write package.json");
+
+    let output = install_command(&workspace, root.path()).with_arg("install").output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("HTTP 403"), "got {stderr}");
+
+    metadata.assert();
+    forbidden.assert();
+}

--- a/pnpm/crates/cli/tests/tarball_url_dependency.rs
+++ b/pnpm/crates/cli/tests/tarball_url_dependency.rs
@@ -37,7 +37,10 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use pacquet_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fixtures::minimal_tarball,
+};
 use std::{fs, path::Path, process::Command, thread::sleep, time::Duration};
 
 fn pacquet_at(workspace: &Path) -> Command {
@@ -158,29 +161,6 @@ fn remote_tarball_integrity_survives_unrelated_install() {
     pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, mock_instance));
-}
-
-/// Build a minimal gzipped npm tarball carrying just a `package.json`
-/// under the conventional top-level `package/` directory (which the
-/// extractor strips). Enough for the resolver to learn the package's
-/// name/version + compute an integrity, without a real registry.
-fn minimal_tarball(name: &str, version: &str) -> Vec<u8> {
-    use std::io::Write;
-    let manifest = serde_json::json!({ "name": name, "version": version }).to_string();
-    let manifest = manifest.as_bytes();
-
-    let mut builder = tar::Builder::new(Vec::new());
-    let mut header = tar::Header::new_gnu();
-    header.set_path("package/package.json").expect("set tar entry path");
-    header.set_size(manifest.len() as u64);
-    header.set_mode(0o644);
-    header.set_cksum();
-    builder.append(&header, manifest).expect("append package.json to tar");
-    let tar_bytes = builder.into_inner().expect("finish tar");
-
-    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-    encoder.write_all(&tar_bytes).expect("gzip tar");
-    encoder.finish().expect("finish gzip")
 }
 
 /// On re-resolution, a remote tarball already recorded in the lockfile is

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -143,6 +143,15 @@ impl WorkspaceSettings {
         json_field!(lockfile_include_tarball_url, "LOCKFILE_INCLUDE_TARBALL_URL");
         string_field!(registry, "REGISTRY");
         string_field!(pnpr_server, "PNPR_SERVER");
+        string_field!(https_proxy, "HTTPS_PROXY");
+        string_field!(http_proxy, "HTTP_PROXY");
+        string_field!(proxy, "PROXY");
+        if let Some(value) = read_env::<Sys>("NO_PROXY") {
+            settings.no_proxy = Some(serde_json::Value::String(value));
+        }
+        if let Some(value) = read_env::<Sys>("NOPROXY") {
+            settings.noproxy = Some(serde_json::Value::String(value));
+        }
         json_field!(auto_install_peers, "AUTO_INSTALL_PEERS");
         json_field!(auto_install_peers_from_highest_match, "AUTO_INSTALL_PEERS_FROM_HIGHEST_MATCH");
         json_field!(exclude_links_from_lockfile, "EXCLUDE_LINKS_FROM_LOCKFILE");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -819,6 +819,10 @@ pub struct Config {
     /// Default is empty (`None` for every field) — i.e. no proxy.
     pub proxy: pacquet_network::ProxyConfig,
 
+    /// Whether `http_proxy` came from a non-empty `http-proxy` setting,
+    /// rather than falling back to the resolved HTTPS proxy.
+    pub http_proxy_is_explicit: bool,
+
     /// Resolved TLS + `local-address` configuration — `ca`, `cafile`,
     /// `cert`, `key`, `strict-ssl`, `local-address` from `.npmrc`. The
     /// type lives in `pacquet-network` for the same reason as
@@ -1652,6 +1656,9 @@ pub struct PackageManagerBootstrap {
     /// Scoped registry routes (keyed by `@scope`), excluding `default`.
     pub registries: BTreeMap<String, String>,
     pub proxy: pacquet_network::ProxyConfig,
+    /// Whether `proxy.http_proxy` came from a non-empty trusted
+    /// `http-proxy` setting rather than the HTTPS-proxy fallback.
+    pub http_proxy_is_explicit: bool,
     pub tls: pacquet_network::TlsConfig,
     pub tls_by_uri: pacquet_network::PerRegistryTls,
     pub auth_headers: std::sync::Arc<pacquet_network::AuthHeaders>,
@@ -1683,12 +1690,16 @@ impl Config {
         http_proxy: Option<&str>,
         no_proxy: Option<&str>,
     ) {
-        let has_explicit_http_proxy = self.explicit_settings.contains_key("httpProxy")
-            || self.raw_auth_config.contains_key("http-proxy");
-        for proxy in [&mut self.proxy, &mut self.package_manager_bootstrap.proxy] {
+        for (proxy, http_proxy_is_explicit) in [
+            (&mut self.proxy, self.http_proxy_is_explicit),
+            (
+                &mut self.package_manager_bootstrap.proxy,
+                self.package_manager_bootstrap.http_proxy_is_explicit,
+            ),
+        ] {
             if let Some(value) = https_proxy {
                 proxy.https_proxy = Some(value.to_string());
-                if http_proxy.is_none() && !has_explicit_http_proxy {
+                if http_proxy.is_none() && !http_proxy_is_explicit {
                     proxy.http_proxy = Some(value.to_string());
                 }
             }
@@ -2168,6 +2179,7 @@ impl Config {
         for lower in sources {
             npmrc_auth.merge_under(lower);
         }
+        self.http_proxy_is_explicit = has_nonempty_string(npmrc_auth.http_proxy.as_deref());
         // Retain the merged raw `.npmrc` / `auth.ini` config keys for
         // `pnpm config get` / `pnpm config list` before the structured fields
         // are consumed below.
@@ -2187,6 +2199,8 @@ impl Config {
 
         self.package_manager_bootstrap = build_package_manager_bootstrap::<Sys>(trusted_auth)?;
         if let Some(global_settings) = global_settings.as_ref() {
+            self.package_manager_bootstrap.http_proxy_is_explicit |=
+                has_nonempty_string(global_settings.http_proxy.as_deref());
             global_settings.apply_proxy_to(&mut self.package_manager_bootstrap.proxy);
         }
 
@@ -2232,6 +2246,8 @@ impl Config {
         // path. See [`crate::store_path::resolve_store_dir`].
         let mut store_dir_explicit = false;
         if let Some(global_settings) = global_settings {
+            self.http_proxy_is_explicit |=
+                has_nonempty_string(global_settings.http_proxy.as_deref());
             virtual_store_dir_explicit |= global_settings.virtual_store_dir.is_some();
             global_virtual_store_dir_explicit |= global_settings.global_virtual_store_dir.is_some();
             store_dir_explicit |= global_settings.store_dir.is_some();
@@ -2290,6 +2306,7 @@ impl Config {
                 global_virtual_store_dir_explicit |= settings.global_virtual_store_dir.is_some();
                 store_dir_explicit |= settings.store_dir.is_some();
                 settings.substitute_env_untrusted::<Sys>();
+                self.http_proxy_is_explicit |= has_nonempty_string(settings.http_proxy.as_deref());
                 collect_explicit_settings(&mut self.explicit_settings, &settings);
                 settings.apply_to(&mut self, &base_dir);
             }
@@ -2322,6 +2339,9 @@ impl Config {
         // `PNPM_CONFIG_REGISTRY` comes from the environment, not the
         // repository, so it overrides the bootstrap default registry too.
         let env_registry_override = env_settings.registry.clone();
+        let env_http_proxy_is_explicit = has_nonempty_string(env_settings.http_proxy.as_deref());
+        self.http_proxy_is_explicit |= env_http_proxy_is_explicit;
+        self.package_manager_bootstrap.http_proxy_is_explicit |= env_http_proxy_is_explicit;
         collect_explicit_settings(&mut self.explicit_settings, &env_settings);
         env_settings.apply_proxy_to(&mut self.package_manager_bootstrap.proxy);
         let saved_workspace_dir = self.workspace_dir.clone();
@@ -2431,6 +2451,10 @@ fn collect_explicit_settings(
     }
 }
 
+fn has_nonempty_string(value: Option<&str>) -> bool {
+    value.is_some_and(|value| !value.is_empty())
+}
+
 /// Build the [`PackageManagerBootstrap`] from the already-folded trusted
 /// sources, running them through the same registry/proxy/TLS/auth steps the
 /// full config uses so the bootstrap cascade matches the project cascade
@@ -2441,6 +2465,7 @@ fn build_package_manager_bootstrap<Sys: EnvVar>(
     // The full-config fold already surfaced these sources' `${VAR}` warnings;
     // drop the duplicates this second pass would log.
     trusted_auth.warnings.clear();
+    let http_proxy_is_explicit = has_nonempty_string(trusted_auth.http_proxy.as_deref());
     let mut config = Config::default();
     trusted_auth.apply_registry_and_warn(&mut config);
     trusted_auth.apply_json_env_registries(&mut config);
@@ -2451,6 +2476,7 @@ fn build_package_manager_bootstrap<Sys: EnvVar>(
         registry: config.registry,
         registries: config.registries,
         proxy: config.proxy,
+        http_proxy_is_explicit,
         tls: config.tls,
         tls_by_uri: config.tls_by_uri,
         auth_headers: config.auth_headers,

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1674,6 +1674,33 @@ impl Config {
         Self::default()
     }
 
+    /// Overlays proxy options after file and environment settings have been
+    /// resolved. An HTTPS proxy also serves HTTP unless a lower-priority source
+    /// explicitly configured the HTTP proxy.
+    pub fn apply_proxy_cli_overrides(
+        &mut self,
+        https_proxy: Option<&str>,
+        http_proxy: Option<&str>,
+        no_proxy: Option<&str>,
+    ) {
+        let has_explicit_http_proxy = self.explicit_settings.contains_key("httpProxy")
+            || self.raw_auth_config.contains_key("http-proxy");
+        for proxy in [&mut self.proxy, &mut self.package_manager_bootstrap.proxy] {
+            if let Some(value) = https_proxy {
+                proxy.https_proxy = Some(value.to_string());
+                if http_proxy.is_none() && !has_explicit_http_proxy {
+                    proxy.http_proxy = Some(value.to_string());
+                }
+            }
+            if let Some(value) = http_proxy {
+                proxy.http_proxy = Some(value.to_string());
+            }
+            if let Some(value) = no_proxy {
+                proxy.no_proxy = Some(crate::npmrc_auth::parse_no_proxy(value));
+            }
+        }
+    }
+
     /// Effective value of [`Self::minimum_release_age_strict`].
     /// Returns the user-supplied value when set, else `false`.
     ///
@@ -2159,6 +2186,9 @@ impl Config {
         crate::npmrc_auth::enforce_token_helper_trust(&npmrc_auth, &trusted_auth)?;
 
         self.package_manager_bootstrap = build_package_manager_bootstrap::<Sys>(trusted_auth)?;
+        if let Some(global_settings) = global_settings.as_ref() {
+            global_settings.apply_proxy_to(&mut self.package_manager_bootstrap.proxy);
+        }
 
         npmrc_auth.apply_registry_and_warn(&mut self);
         // Proxy cascade fires unconditionally — even when no `.npmrc`
@@ -2293,6 +2323,7 @@ impl Config {
         // repository, so it overrides the bootstrap default registry too.
         let env_registry_override = env_settings.registry.clone();
         collect_explicit_settings(&mut self.explicit_settings, &env_settings);
+        env_settings.apply_proxy_to(&mut self.package_manager_bootstrap.proxy);
         let saved_workspace_dir = self.workspace_dir.clone();
         env_settings.apply_to(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2201,7 +2201,9 @@ impl Config {
         if let Some(global_settings) = global_settings.as_ref() {
             self.package_manager_bootstrap.http_proxy_is_explicit |=
                 has_nonempty_string(global_settings.http_proxy.as_deref());
-            global_settings.apply_proxy_to(&mut self.package_manager_bootstrap.proxy);
+            let http_proxy_is_explicit = self.package_manager_bootstrap.http_proxy_is_explicit;
+            global_settings
+                .apply_proxy_to(&mut self.package_manager_bootstrap.proxy, http_proxy_is_explicit);
         }
 
         npmrc_auth.apply_registry_and_warn(&mut self);
@@ -2343,7 +2345,12 @@ impl Config {
         self.http_proxy_is_explicit |= env_http_proxy_is_explicit;
         self.package_manager_bootstrap.http_proxy_is_explicit |= env_http_proxy_is_explicit;
         collect_explicit_settings(&mut self.explicit_settings, &env_settings);
-        env_settings.apply_proxy_to(&mut self.package_manager_bootstrap.proxy);
+        let bootstrap_http_proxy_is_explicit =
+            self.package_manager_bootstrap.http_proxy_is_explicit;
+        env_settings.apply_proxy_to(
+            &mut self.package_manager_bootstrap.proxy,
+            bootstrap_http_proxy_is_explicit,
+        );
         let saved_workspace_dir = self.workspace_dir.clone();
         env_settings.apply_to(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -897,7 +897,7 @@ fn load_cafile(path: &Path) -> Vec<String> {
 ///
 /// `"true"` (after trimming) means "bypass every proxy". Anything else is
 /// comma-split, trimmed, empties dropped.
-fn parse_no_proxy(raw: &str) -> NoProxySetting {
+pub(crate) fn parse_no_proxy(raw: &str) -> NoProxySetting {
     if raw.trim() == "true" {
         return NoProxySetting::Bypass;
     }

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -1092,6 +1092,36 @@ pub fn global_config_yaml_proxy_overrides_project_npmrc() {
 }
 
 #[test]
+pub fn workspace_yaml_proxy_is_not_trusted_for_package_manager_bootstrap() {
+    let project = tempdir().expect("project tempdir");
+    fs::write(
+        project.path().join("pnpm-workspace.yaml"),
+        "httpsProxy: http://workspace-proxy.example.com:9090\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+    let xdg = tempdir().expect("config tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create global config dir");
+    fs::write(
+        config_dir.join("config.yaml"),
+        "httpsProxy: http://trusted-proxy.example.com:8080\n",
+    )
+    .expect("write global config.yaml");
+
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.proxy.https_proxy.as_deref(),
+        Some("http://workspace-proxy.example.com:9090"),
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.proxy.https_proxy.as_deref(),
+        Some("http://trusted-proxy.example.com:8080"),
+    );
+}
+
+#[test]
 pub fn pnpm_config_proxy_overrides_global_config_yaml() {
     let project = tempdir().expect("project tempdir");
     let xdg = tempdir().expect("config tempdir");

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -1133,6 +1133,60 @@ pub fn project_npmrc_proxy_settings_are_preserved() {
     );
 }
 
+#[test]
+pub fn cli_https_proxy_preserves_project_npmrc_http_proxy_only_for_project_requests() {
+    let project = tempdir().expect("project tempdir");
+    fs::write(
+        project.path().join(".npmrc"),
+        "http-proxy=http://project-http-proxy.example.com:8080\n",
+    )
+    .expect("write project .npmrc");
+    set_fake_env(&[]);
+
+    let mut config = load_with_fake_env(project.path());
+    config.apply_proxy_cli_overrides(Some("http://cli-https-proxy.example.com:8443"), None, None);
+
+    assert_eq!(
+        config.proxy.http_proxy.as_deref(),
+        Some("http://project-http-proxy.example.com:8080"),
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.proxy.http_proxy.as_deref(),
+        Some("http://cli-https-proxy.example.com:8443"),
+    );
+}
+
+#[test]
+pub fn cli_https_proxy_preserves_trusted_npmrc_http_proxy_for_bootstrap_requests() {
+    let project = tempdir().expect("project tempdir");
+    let auth = tempdir().expect("auth tempdir");
+    let user_file = auth.path().join("user-npmrc");
+    write_file(&user_file, "http-proxy=http://user-http-proxy.example.com:8080\n");
+
+    let mut config = Config { npmrc_auth_file: Some(user_file), ..Config::default() }
+        .current::<HostNoHome>(project.path())
+        .expect("load config");
+    config.apply_proxy_cli_overrides(Some("http://cli-https-proxy.example.com:8443"), None, None);
+
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://user-http-proxy.example.com:8080"));
+    assert_eq!(
+        config.package_manager_bootstrap.proxy.http_proxy.as_deref(),
+        Some("http://user-http-proxy.example.com:8080"),
+    );
+}
+
+#[test]
+pub fn cli_https_proxy_precedes_standard_http_proxy_environment_fallback() {
+    let project = tempdir().expect("project tempdir");
+    set_fake_env(&[("HTTP_PROXY", "http://environment-http-proxy.example.com:8080")]);
+
+    let mut config = load_with_fake_env(project.path());
+    config.apply_proxy_cli_overrides(Some("http://cli-https-proxy.example.com:8443"), None, None);
+
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://cli-https-proxy.example.com:8443"));
+    assert_eq!(config.package_manager_bootstrap.proxy, config.proxy);
+}
+
 /// Explicitly URL-scoped credentials pass through unchanged — they
 /// are never rescoped, so they stay on exactly the registry the user
 /// wrote, regardless of a workspace registry override.

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -1023,6 +1023,116 @@ pub fn workspace_unscoped_creds_pin_to_workspace_registry() {
     );
 }
 
+#[test]
+pub fn workspace_npmrc_overrides_global_auth_file() {
+    let project = tempdir().expect("project tempdir");
+    fs::write(project.path().join(".npmrc"), "//registry.npmjs.org/:_authToken=workspace-token\n")
+        .expect("write workspace .npmrc");
+
+    let xdg = tempdir().expect("config tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create global config dir");
+    fs::write(config_dir.join("auth.ini"), "//registry.npmjs.org/:_authToken=global-token\n")
+        .expect("write global auth file");
+
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.auth_headers.for_url("https://registry.npmjs.org/pkg").as_deref(),
+        Some("Bearer workspace-token"),
+    );
+}
+
+#[test]
+pub fn global_config_yaml_supplies_proxy_settings() {
+    let project = tempdir().expect("project tempdir");
+    let xdg = tempdir().expect("config tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create global config dir");
+    fs::write(
+        config_dir.join("config.yaml"),
+        "httpProxy: http://proxy.example.com:8080\n\
+         httpsProxy: http://proxy.example.com:8443\n\
+         noProxy: localhost,127.0.0.1\n",
+    )
+    .expect("write global config.yaml");
+
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://proxy.example.com:8080"));
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://proxy.example.com:8443"));
+    assert_eq!(
+        config.proxy.no_proxy,
+        Some(pacquet_network::NoProxySetting::List(vec![
+            "localhost".to_string(),
+            "127.0.0.1".to_string(),
+        ])),
+    );
+    assert_eq!(config.package_manager_bootstrap.proxy, config.proxy);
+}
+
+#[test]
+pub fn global_config_yaml_proxy_overrides_project_npmrc() {
+    let project = tempdir().expect("project tempdir");
+    fs::write(project.path().join(".npmrc"), "https-proxy=http://npmrc-proxy.example.com:8080\n")
+        .expect("write project .npmrc");
+    let xdg = tempdir().expect("config tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create global config dir");
+    fs::write(config_dir.join("config.yaml"), "httpsProxy: http://yaml-proxy.example.com:9090\n")
+        .expect("write global config.yaml");
+
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://yaml-proxy.example.com:9090"));
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://yaml-proxy.example.com:9090"));
+}
+
+#[test]
+pub fn pnpm_config_proxy_overrides_global_config_yaml() {
+    let project = tempdir().expect("project tempdir");
+    let xdg = tempdir().expect("config tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create global config dir");
+    fs::write(config_dir.join("config.yaml"), "httpsProxy: http://yaml-proxy.example.com:9090\n")
+        .expect("write global config.yaml");
+
+    set_fake_env(&[
+        ("XDG_CONFIG_HOME", xdg.path().to_str().unwrap()),
+        ("PNPM_CONFIG_HTTPS_PROXY", "http://cli-proxy.example.com:7070"),
+    ]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://cli-proxy.example.com:7070"));
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://cli-proxy.example.com:7070"));
+    assert_eq!(config.package_manager_bootstrap.proxy, config.proxy);
+}
+
+#[test]
+pub fn project_npmrc_proxy_settings_are_preserved() {
+    let project = tempdir().expect("project tempdir");
+    fs::write(
+        project.path().join(".npmrc"),
+        "https-proxy=http://npmrc-proxy.example.com:8080\n\
+         proxy=http://npmrc-http-proxy.example.com:3128\n\
+         no-proxy=internal.example.com\n",
+    )
+    .expect("write project .npmrc");
+    set_fake_env(&[]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://npmrc-proxy.example.com:8080"));
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://npmrc-proxy.example.com:8080"));
+    assert_eq!(
+        config.proxy.no_proxy,
+        Some(pacquet_network::NoProxySetting::List(vec!["internal.example.com".to_string()])),
+    );
+}
+
 /// Explicitly URL-scoped credentials pass through unchanged — they
 /// are never rescoped, so they stay on exactly the registry the user
 /// wrote, regardless of a workspace registry override.

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -1092,6 +1092,34 @@ pub fn global_config_yaml_proxy_overrides_project_npmrc() {
 }
 
 #[test]
+pub fn global_config_yaml_https_proxy_preserves_project_npmrc_http_proxy() {
+    let project = tempdir().expect("project tempdir");
+    fs::write(
+        project.path().join(".npmrc"),
+        "http-proxy=http://project-http-proxy.example.com:8080\n",
+    )
+    .expect("write project .npmrc");
+    let xdg = tempdir().expect("config tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create global config dir");
+    fs::write(config_dir.join("config.yaml"), "httpsProxy: http://yaml-proxy.example.com:9090\n")
+        .expect("write global config.yaml");
+
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://yaml-proxy.example.com:9090"));
+    assert_eq!(
+        config.proxy.http_proxy.as_deref(),
+        Some("http://project-http-proxy.example.com:8080"),
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.proxy.http_proxy.as_deref(),
+        Some("http://yaml-proxy.example.com:9090"),
+    );
+}
+
+#[test]
 pub fn workspace_yaml_proxy_is_not_trusted_for_package_manager_bootstrap() {
     let project = tempdir().expect("project tempdir");
     fs::write(
@@ -1104,7 +1132,8 @@ pub fn workspace_yaml_proxy_is_not_trusted_for_package_manager_bootstrap() {
     fs::create_dir_all(&config_dir).expect("create global config dir");
     fs::write(
         config_dir.join("config.yaml"),
-        "httpsProxy: http://trusted-proxy.example.com:8080\n",
+        "httpsProxy: http://trusted-proxy.example.com:8080\n\
+         httpProxy: http://trusted-http-proxy.example.com:8080\n",
     )
     .expect("write global config.yaml");
 
@@ -1116,19 +1145,31 @@ pub fn workspace_yaml_proxy_is_not_trusted_for_package_manager_bootstrap() {
         Some("http://workspace-proxy.example.com:9090"),
     );
     assert_eq!(
+        config.proxy.http_proxy.as_deref(),
+        Some("http://trusted-http-proxy.example.com:8080"),
+    );
+    assert_eq!(
         config.package_manager_bootstrap.proxy.https_proxy.as_deref(),
         Some("http://trusted-proxy.example.com:8080"),
+    );
+    assert_eq!(
+        config.package_manager_bootstrap.proxy.http_proxy.as_deref(),
+        Some("http://trusted-http-proxy.example.com:8080"),
     );
 }
 
 #[test]
-pub fn pnpm_config_proxy_overrides_global_config_yaml() {
+pub fn pnpm_config_https_proxy_preserves_global_http_proxy() {
     let project = tempdir().expect("project tempdir");
     let xdg = tempdir().expect("config tempdir");
     let config_dir = xdg.path().join("pnpm");
     fs::create_dir_all(&config_dir).expect("create global config dir");
-    fs::write(config_dir.join("config.yaml"), "httpsProxy: http://yaml-proxy.example.com:9090\n")
-        .expect("write global config.yaml");
+    fs::write(
+        config_dir.join("config.yaml"),
+        "httpsProxy: http://yaml-proxy.example.com:9090\n\
+         httpProxy: http://yaml-http-proxy.example.com:8080\n",
+    )
+    .expect("write global config.yaml");
 
     set_fake_env(&[
         ("XDG_CONFIG_HOME", xdg.path().to_str().unwrap()),
@@ -1137,7 +1178,7 @@ pub fn pnpm_config_proxy_overrides_global_config_yaml() {
     let config = load_with_fake_env(project.path());
 
     assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://cli-proxy.example.com:7070"));
-    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://cli-proxy.example.com:7070"));
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://yaml-http-proxy.example.com:8080"));
     assert_eq!(config.package_manager_bootstrap.proxy, config.proxy);
 }
 

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2,7 +2,7 @@ use crate::{
     AuditConfig, AuditLevel, CatalogMode, Config, HoistingLimits, LinkWorkspacePackages,
     NodeLinker, NodePackageMapType, PackageImportMethod, PmOnFail, ResolutionMode,
     ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun, api::EnvVar,
-    resolve_child_concurrency,
+    npmrc_auth::parse_no_proxy, resolve_child_concurrency,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -104,6 +104,11 @@ pub struct WorkspaceSettings {
     pub registry: Option<String>,
     pub registries: Option<BTreeMap<String, String>>,
     pub pnpr_server: Option<String>,
+    pub https_proxy: Option<String>,
+    pub http_proxy: Option<String>,
+    pub no_proxy: Option<serde_json::Value>,
+    pub proxy: Option<String>,
+    pub noproxy: Option<serde_json::Value>,
 
     /// User-defined named-registry aliases. Outer key is the alias
     /// name (`gh`, `work`, ...); inner string is the registry URL the
@@ -698,6 +703,11 @@ impl WorkspaceSettings {
         self.substitute_env_scalars::<Sys>();
         substitute_optional_string::<Sys>(&mut self.pnpr_server);
         substitute_optional_string::<Sys>(&mut self.registry);
+        substitute_optional_string::<Sys>(&mut self.https_proxy);
+        substitute_optional_string::<Sys>(&mut self.http_proxy);
+        substitute_optional_string::<Sys>(&mut self.proxy);
+        substitute_json_string::<Sys>(&mut self.no_proxy);
+        substitute_json_string::<Sys>(&mut self.noproxy);
         substitute_optional_string_map::<Sys>(&mut self.registries);
         substitute_optional_string_map::<Sys>(&mut self.named_registries);
     }
@@ -726,6 +736,20 @@ impl WorkspaceSettings {
         if self.pnpr_server.as_deref().is_some_and(has_env_placeholder) {
             self.pnpr_server = None;
         }
+        for proxy in [&mut self.https_proxy, &mut self.http_proxy, &mut self.proxy] {
+            if proxy.as_deref().is_some_and(has_env_placeholder) {
+                *proxy = None;
+            }
+        }
+        for no_proxy in [&mut self.no_proxy, &mut self.noproxy] {
+            if no_proxy
+                .as_ref()
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(has_env_placeholder)
+            {
+                *no_proxy = None;
+            }
+        }
     }
 
     fn substitute_env_scalars<Sys: EnvVar>(&mut self) {
@@ -747,6 +771,8 @@ impl WorkspaceSettings {
     /// are resolved against `base_dir` if relative — anchored at the
     /// workspace root where the yaml was found, matching pnpm.
     pub fn apply_to(self, config: &mut Config, base_dir: &Path) {
+        self.apply_proxy_to(&mut config.proxy);
+
         macro_rules! apply {
             ($($field:ident),* $(,)?) => {$(
                 if let Some(v) = self.$field {
@@ -949,6 +975,25 @@ impl WorkspaceSettings {
             config.trust_policy_ignore_after = Some(v);
         }
     }
+
+    pub(crate) fn apply_proxy_to(&self, proxy_config: &mut pacquet_network::ProxyConfig) {
+        if let Some(value) = self.https_proxy.as_ref().or(self.proxy.as_ref()) {
+            proxy_config.https_proxy = Some(value.clone());
+        }
+        if let Some(value) = &self.http_proxy {
+            proxy_config.http_proxy = Some(value.clone());
+        } else if self.https_proxy.is_some() || self.proxy.is_some() {
+            proxy_config.http_proxy.clone_from(&proxy_config.https_proxy);
+        }
+        if let Some(value) = self.no_proxy.as_ref().or(self.noproxy.as_ref()) {
+            proxy_config.no_proxy = match value {
+                serde_json::Value::Bool(true) => Some(pacquet_network::NoProxySetting::Bypass),
+                serde_json::Value::Bool(false) | serde_json::Value::Null => None,
+                serde_json::Value::String(value) => Some(parse_no_proxy(value)),
+                _ => None,
+            };
+        }
+    }
 }
 
 fn has_env_placeholder(value: &str) -> bool {
@@ -959,6 +1004,13 @@ fn has_env_placeholder(value: &str) -> bool {
 
 fn substitute_optional_string<Sys: EnvVar>(value: &mut Option<String>) {
     if let Some(value) = value {
+        let (substituted, _) = env_replace_lossy::<Sys>(value);
+        *value = substituted;
+    }
+}
+
+fn substitute_json_string<Sys: EnvVar>(value: &mut Option<serde_json::Value>) {
+    if let Some(serde_json::Value::String(value)) = value {
         let (substituted, _) = env_replace_lossy::<Sys>(value);
         *value = substituted;
     }

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -771,7 +771,8 @@ impl WorkspaceSettings {
     /// are resolved against `base_dir` if relative — anchored at the
     /// workspace root where the yaml was found, matching pnpm.
     pub fn apply_to(self, config: &mut Config, base_dir: &Path) {
-        self.apply_proxy_to(&mut config.proxy);
+        let http_proxy_is_explicit = config.http_proxy_is_explicit;
+        self.apply_proxy_to(&mut config.proxy, http_proxy_is_explicit);
 
         macro_rules! apply {
             ($($field:ident),* $(,)?) => {$(
@@ -976,13 +977,17 @@ impl WorkspaceSettings {
         }
     }
 
-    pub(crate) fn apply_proxy_to(&self, proxy_config: &mut pacquet_network::ProxyConfig) {
+    pub(crate) fn apply_proxy_to(
+        &self,
+        proxy_config: &mut pacquet_network::ProxyConfig,
+        http_proxy_is_explicit: bool,
+    ) {
         if let Some(value) = self.https_proxy.as_ref().or(self.proxy.as_ref()) {
             proxy_config.https_proxy = Some(value.clone());
         }
         if let Some(value) = &self.http_proxy {
             proxy_config.http_proxy = Some(value.clone());
-        } else if self.https_proxy.is_some() || self.proxy.is_some() {
+        } else if (self.https_proxy.is_some() || self.proxy.is_some()) && !http_proxy_is_explicit {
             proxy_config.http_proxy.clone_from(&proxy_config.https_proxy);
         }
         if let Some(value) = self.no_proxy.as_ref().or(self.noproxy.as_ref()) {

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -251,6 +251,11 @@ fn ignores_env_vars_inside_workspace_request_destination_values() {
     let yaml = r"
 pnprServer: https://${WORK_HOST}/pnpr/
 registry: https://${WORK_HOST}/npm/
+httpsProxy: http://${WORK_HOST}:8080/
+httpProxy: http://${WORK_HOST}:8081/
+noProxy: ${WORK_HOST}
+proxy: http://${WORK_HOST}:8082/
+noproxy: ${WORK_HOST}
 registries:
   '@safe': https://safe.example.com/npm/
   '@work': https://${WORK_HOST}/scope/
@@ -265,6 +270,7 @@ namedRegistries:
     settings.apply_to(&mut config, Path::new("/irrelevant"));
     assert_eq!(config.pnpr_server, None);
     assert_eq!(config.registry, "https://registry.npmjs.org/");
+    assert_eq!(config.proxy, pacquet_network::ProxyConfig::default());
     assert_eq!(
         config.registries.get("@safe").map(String::as_str),
         Some("https://safe.example.com/npm/"),
@@ -330,6 +336,9 @@ fn trusted_settings_expand_env_vars_inside_request_destination_values() {
     let yaml = r"
 pnprServer: https://${WORK_HOST}/pnpr/
 registry: https://${WORK_HOST}/npm/
+httpsProxy: http://${WORK_HOST}:8080/
+httpProxy: http://${WORK_HOST}:8081/
+noProxy: ${WORK_HOST}
 namedRegistries:
   stable: https://registry.example.com/npm/
   work: https://${WORK_HOST}/work/
@@ -340,6 +349,12 @@ namedRegistries:
     settings.apply_to(&mut config, Path::new("/irrelevant"));
     assert_eq!(config.pnpr_server.as_deref(), Some("https://internal.example.com/pnpr/"));
     assert_eq!(config.registry, "https://internal.example.com/npm/");
+    assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://internal.example.com:8080/"));
+    assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://internal.example.com:8081/"));
+    assert_eq!(
+        config.proxy.no_proxy,
+        Some(pacquet_network::NoProxySetting::List(vec!["internal.example.com".to_string()])),
+    );
     assert_eq!(
         config.named_registries.get("stable").map(String::as_str),
         Some("https://registry.example.com/npm/"),

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -30,7 +30,10 @@ use std::{
     },
     time::Duration,
 };
-use tokio::sync::Semaphore;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Semaphore,
+};
 
 struct RecordingResolver {
     active: Arc<AtomicUsize>,
@@ -389,6 +392,201 @@ async fn mockito_integration_no_proxy_bypasses_proxy() {
     assert_eq!(resp.text().await.expect("body"), "direct");
     proxy_mock.assert_async().await;
     target_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn authorization_is_removed_on_cross_origin_redirect() {
+    let mut target = mockito::Server::new_async().await;
+    let target_mock = target
+        .mock("GET", "/final")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body("ok")
+        .expect(1)
+        .create_async()
+        .await;
+    let mut registry = mockito::Server::new_async().await;
+    let registry_mock = registry
+        .mock("GET", "/start")
+        .match_header("authorization", "Bearer 123")
+        .with_status(302)
+        .with_header("location", &format!("{}/final", target.url()))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = ThrottledClient::default();
+    let response = client
+        .acquire()
+        .await
+        .get(format!("{}/start", registry.url()))
+        .header("authorization", "Bearer 123")
+        .send()
+        .await
+        .expect("follow cross-origin redirect");
+
+    assert_eq!(response.status(), 200);
+    registry_mock.assert_async().await;
+    target_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn authorization_is_retained_on_same_origin_redirect() {
+    let mut registry = mockito::Server::new_async().await;
+    let start_mock = registry
+        .mock("GET", "/start")
+        .match_header("authorization", "Bearer 123")
+        .with_status(302)
+        .with_header("location", "/final")
+        .expect(1)
+        .create_async()
+        .await;
+    let final_mock = registry
+        .mock("GET", "/final")
+        .match_header("authorization", "Bearer 123")
+        .with_status(200)
+        .with_body("ok")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = ThrottledClient::default();
+    let response = client
+        .acquire()
+        .await
+        .get(format!("{}/start", registry.url()))
+        .header("authorization", "Bearer 123")
+        .send()
+        .await
+        .expect("follow same-origin redirect");
+
+    assert_eq!(response.status(), 200);
+    start_mock.assert_async().await;
+    final_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn https_target_uses_configured_proxy() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind proxy");
+    let proxy_addr = listener.local_addr().expect("proxy address");
+    let proxy = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept proxy connection");
+        let mut request = vec![0; 1024];
+        let size = stream.read(&mut request).await.expect("read CONNECT request");
+        stream
+            .write_all(b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n")
+            .await
+            .expect("reject tunnel after recording it");
+        String::from_utf8(request[..size].to_vec()).expect("CONNECT request is ASCII")
+    });
+    let config = ProxyConfig {
+        https_proxy: Some(format!("http://{proxy_addr}")),
+        http_proxy: None,
+        no_proxy: None,
+    };
+    let client = ThrottledClient::for_installs(
+        &config,
+        &TlsConfig::default(),
+        &PerRegistryTls::default(),
+        &NetworkSettings::default(),
+    )
+    .expect("build HTTPS proxy client");
+
+    client
+        .acquire()
+        .await
+        .get("https://target.example/package")
+        .send()
+        .await
+        .expect_err("the recording proxy rejects the tunnel");
+    let connect = proxy.await.expect("proxy task");
+
+    assert!(connect.starts_with("CONNECT target.example:443 HTTP/1.1\r\n"), "got {connect:?}");
+}
+
+#[tokio::test]
+async fn socks5_proxy_connects_to_real_target() {
+    let target_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind target");
+    let target_addr = target_listener.local_addr().expect("target address");
+    let target = tokio::spawn(async move {
+        let (mut stream, _) = target_listener.accept().await.expect("accept target connection");
+        let mut request = vec![0; 1024];
+        let size = stream.read(&mut request).await.expect("read target request");
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .await
+            .expect("write target response");
+        String::from_utf8(request[..size].to_vec()).expect("HTTP request is ASCII")
+    });
+
+    let socks_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind SOCKS5");
+    let socks_addr = socks_listener.local_addr().expect("SOCKS5 address");
+    let socks = tokio::spawn(async move {
+        let (mut inbound, _) = socks_listener.accept().await.expect("accept SOCKS5 connection");
+        let mut greeting = [0; 2];
+        inbound.read_exact(&mut greeting).await.expect("read SOCKS5 greeting");
+        assert_eq!(greeting[0], 5);
+        let mut methods = vec![0; usize::from(greeting[1])];
+        inbound.read_exact(&mut methods).await.expect("read SOCKS5 methods");
+        inbound.write_all(&[5, 0]).await.expect("accept no-auth method");
+
+        let mut request = [0; 4];
+        inbound.read_exact(&mut request).await.expect("read SOCKS5 request");
+        assert_eq!(&request[..3], &[5, 1, 0]);
+        match request[3] {
+            1 => {
+                let mut address = [0; 4];
+                inbound.read_exact(&mut address).await.expect("read IPv4 target");
+            }
+            3 => {
+                let length = inbound.read_u8().await.expect("read domain length");
+                let mut address = vec![0; usize::from(length)];
+                inbound.read_exact(&mut address).await.expect("read domain target");
+            }
+            4 => {
+                let mut address = [0; 16];
+                inbound.read_exact(&mut address).await.expect("read IPv6 target");
+            }
+            atyp => panic!("unsupported SOCKS5 address type {atyp}"),
+        }
+        let port = inbound.read_u16().await.expect("read target port");
+        assert_eq!(port, target_addr.port());
+        let mut outbound =
+            tokio::net::TcpStream::connect(target_addr).await.expect("connect target");
+        inbound
+            .write_all(&[5, 0, 0, 1, 127, 0, 0, 1, (port >> 8) as u8, port as u8])
+            .await
+            .expect("accept SOCKS5 connect");
+        tokio::io::copy_bidirectional(&mut inbound, &mut outbound)
+            .await
+            .expect("forward SOCKS5 traffic");
+    });
+
+    let config = ProxyConfig {
+        https_proxy: None,
+        http_proxy: Some(format!("socks5://{socks_addr}")),
+        no_proxy: None,
+    };
+    let client = ThrottledClient::for_installs(
+        &config,
+        &TlsConfig::default(),
+        &PerRegistryTls::default(),
+        &NetworkSettings::default(),
+    )
+    .expect("build SOCKS5 client");
+    let response = client
+        .acquire()
+        .await
+        .get(format!("http://{target_addr}/package"))
+        .send()
+        .await
+        .expect("request through SOCKS5");
+
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.text().await.expect("target body"), "ok");
+    let request = target.await.expect("target task");
+    assert!(request.starts_with("GET /package HTTP/1.1\r\n"), "got {request:?}");
+    socks.await.expect("SOCKS5 task");
 }
 
 // --- TLS / local-address tests ---

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -149,6 +149,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         auth_headers: Default::default(),
         auth_tokens_by_uri: Default::default(),
         proxy: Default::default(),
+        http_proxy_is_explicit: false,
         tls: Default::default(),
         tls_by_uri: Default::default(),
         package_manager_bootstrap: Default::default(),

--- a/pnpm/crates/testing-utils/Cargo.toml
+++ b/pnpm/crates/testing-utils/Cargo.toml
@@ -13,7 +13,11 @@ repository.workspace = true
 [dependencies]
 assert_cmd        = { workspace = true }
 command-extra     = { workspace = true }
+flate2            = { workspace = true }
 pnpr              = { workspace = true }
+serde_json        = { workspace = true }
+ssri              = { workspace = true }
+tar               = { workspace = true }
 tempfile          = { workspace = true }
 tokio             = { workspace = true }
 walkdir           = { workspace = true }

--- a/pnpm/crates/testing-utils/src/fixtures.rs
+++ b/pnpm/crates/testing-utils/src/fixtures.rs
@@ -1,2 +1,27 @@
 pub const BIG_MANIFEST: &str = include_str!("fixtures/big/package.json");
 pub const BIG_LOCKFILE: &str = include_str!("fixtures/big/pnpm-lock.yaml");
+
+#[must_use]
+pub fn minimal_tarball(name: &str, version: &str) -> Vec<u8> {
+    use std::io::Write;
+
+    let manifest = serde_json::json!({ "name": name, "version": version }).to_string();
+    let manifest = manifest.as_bytes();
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    header.set_path("package/package.json").expect("set tar entry path");
+    header.set_size(manifest.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append(&header, manifest).expect("append package.json to tar");
+    let tar_bytes = builder.into_inner().expect("finish tar");
+
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&tar_bytes).expect("gzip tar");
+    encoder.finish().expect("finish gzip")
+}
+
+#[must_use]
+pub fn sha512_integrity(bytes: &[u8]) -> String {
+    ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512).chain(bytes).result().to_string()
+}

--- a/pnpm/crates/testing-utils/src/fixtures.rs
+++ b/pnpm/crates/testing-utils/src/fixtures.rs
@@ -1,6 +1,7 @@
 pub const BIG_MANIFEST: &str = include_str!("fixtures/big/package.json");
 pub const BIG_LOCKFILE: &str = include_str!("fixtures/big/pnpm-lock.yaml");
 
+/// Returns a gzipped package tarball containing a manifest with the given identity.
 #[must_use]
 pub fn minimal_tarball(name: &str, version: &str) -> Vec<u8> {
     use std::io::Write;
@@ -21,6 +22,7 @@ pub fn minimal_tarball(name: &str, version: &str) -> Vec<u8> {
     encoder.finish().expect("finish gzip")
 }
 
+/// Returns the SHA-512 SSRI string for `bytes`.
 #[must_use]
 pub fn sha512_integrity(bytes: &[u8]) -> String {
     ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512).chain(bytes).result().to_string()

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -540,13 +540,13 @@ Rust port notes:
 
 Install tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/auth.ts:14` `a package that need authentication`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/auth.ts:52` `installing a package that need authentication, using password`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/auth.ts:73` `a package that need authentication, legacy way`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/auth.ts:94` `a scoped package that need authentication specific to scope`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/auth.ts:142` `a scoped package that need legacy authentication specific to scope`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/auth.ts:190` `a package that need authentication reuses authorization tokens for tarball fetching`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/auth.ts:216` `a package that need authentication reuses authorization tokens for tarball fetching when meta info is cached`
+- [x] `TypeScript repo: installing/deps-installer/test/install/auth.ts:14` `a package that need authentication` — `bearer_auth_is_used_for_metadata_tarballs_and_cold_frozen_reinstall` in `crates/cli/tests/auth.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/auth.ts:52` `installing a package that need authentication, using password` — `username_and_password_authenticates_install` in `crates/cli/tests/auth.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/auth.ts:73` `a package that need authentication, legacy way` — `legacy_basic_auth_authenticates_install` in `crates/cli/tests/auth.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/auth.ts:94` `a scoped package that need authentication specific to scope` — `package_scope_bearer_auth_wins_for_scoped_install` in `crates/cli/tests/auth.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/auth.ts:142` `a scoped package that need legacy authentication specific to scope` — `package_scope_legacy_auth_wins_for_scoped_install` in `crates/cli/tests/auth.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/auth.ts:190` `a package that need authentication reuses authorization tokens for tarball fetching` — the authenticated tarball assertion in `bearer_auth_is_used_for_metadata_tarballs_and_cold_frozen_reinstall`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/auth.ts:216` `a package that need authentication reuses authorization tokens for tarball fetching when meta info is cached` — the cold-store frozen reinstall in `bearer_auth_is_used_for_metadata_tarballs_and_cold_frozen_reinstall`.
 
 Auth header tests:
 
@@ -568,7 +568,7 @@ Auth header tests:
 Auth config parsing and precedence tests:
 
 - [x] `TypeScript repo: config/reader/test/index.ts:481` `auth tokens from pnpm auth file override ~/.npmrc` — ported as `npmrc_auth_file_outranks_userconfig` (plus `npmrc_auth_file_override_supplies_auth` and `user_auth_token_pins_to_its_own_file_registry`) in `crates/config/src/tests.rs`.
-- [ ] `TypeScript repo: config/reader/test/index.ts:523` `workspace .npmrc overrides pnpm auth file`
+- [x] `TypeScript repo: config/reader/test/index.ts:523` `workspace .npmrc overrides pnpm auth file` — `workspace_npmrc_overrides_global_auth_file` in `crates/config/src/tests.rs`.
 - [x] `TypeScript repo: config/reader/test/parseCreds.test.ts:15` `authToken`
 - [x] `TypeScript repo: config/reader/test/parseCreds.test.ts:23` `authPairBase64`
 - [x] `TypeScript repo: config/reader/test/parseCreds.test.ts:49` `authUsername and authPassword`
@@ -576,31 +576,31 @@ Auth config parsing and precedence tests:
 
 Fetcher tests:
 
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:349` `throw error when accessing private package w/o authorization`
-- [ ] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:409` `accessing private packages`
-- [ ] `TypeScript repo: network/fetch/test/fetchFromRegistry.test.ts:62` `authorization headers are removed before redirection if the target is on a different host`
-- [ ] `TypeScript repo: network/fetch/test/fetchFromRegistry.test.ts:90` `authorization headers are not removed before redirection if the target is on the same host`
-- [ ] `TypeScript repo: resolving/npm-resolver/test/index.ts:934` `error is thrown when package needs authorization`
+- [x] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:349` `throw error when accessing private package w/o authorization` — `tarball_authorization_failure_is_reported` in `crates/cli/tests/auth.rs`.
+- [x] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:409` `accessing private packages` — the authenticated tarball assertions in `crates/cli/tests/auth.rs`.
+- [x] `TypeScript repo: network/fetch/test/fetchFromRegistry.test.ts:62` `authorization headers are removed before redirection if the target is on a different host` — `authorization_is_removed_on_cross_origin_redirect` in `crates/network/src/tests.rs`.
+- [x] `TypeScript repo: network/fetch/test/fetchFromRegistry.test.ts:90` `authorization headers are not removed before redirection if the target is on the same host` — `authorization_is_retained_on_same_origin_redirect` in `crates/network/src/tests.rs`.
+- [x] `TypeScript repo: resolving/npm-resolver/test/index.ts:934` `error is thrown when package needs authorization` — `metadata_authorization_failure_is_reported` in `crates/cli/tests/auth.rs`.
 
 Rust port notes:
 
-- Frozen install still fetches tarballs when the store is cold, so auth applies even without resolution.
-- Header matching and token helper behavior should be ported below install-level tests.
+- Frozen install still fetches tarballs when the store is cold, so auth applies even without resolution; `bearer_auth_is_used_for_metadata_tarballs_and_cold_frozen_reinstall` exercises that path.
+- Header matching, token helpers, install authentication, and fetch failures are covered at their corresponding layers.
 
 ## Support pnpm Proxy Settings
 
 Proxy dispatcher tests:
 
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:62` `returns ProxyAgent for httpProxy with http target` — behavioral equivalent `mockito_integration_http_proxy_forwards_request_with_basic_auth` in `crates/network/src/tests.rs` (proves the http proxy actually carries the request; undici's Agent/ProxyAgent split has no Rust analog).
-- [ ] `TypeScript repo: network/fetch/test/dispatcher.test.ts:69` `returns ProxyAgent for httpsProxy with https target` — no https-target integration test yet.
+- [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:69` `returns ProxyAgent for httpsProxy with https target` — `https_target_uses_configured_proxy` in `crates/network/src/tests.rs` proves the HTTPS target reaches the configured proxy with CONNECT.
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:76` `adds protocol prefix when proxy URL has none` — `parse_proxy_url_auto_prefixes_missing_scheme` in `crates/network/src/tests.rs`.
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:84` `throws PnpmError for invalid proxy URL` — `parse_proxy_url_invalid_returns_invalid_proxy_error` plus `for_installs_with_invalid_proxy_url_errors` in `crates/network/src/tests.rs`.
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:92` `proxy with authentication credentials` — `strip_userinfo_decodes_user_and_password` plus `mockito_integration_http_proxy_forwards_request_with_basic_auth` in `crates/network/src/tests.rs`.
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:101` `returns Agent (not ProxyAgent) for socks5 proxy` — behavioral equivalents `parse_proxy_url_socks_schemes_pass_through` and `for_installs_with_socks_proxy_url_builds` in `crates/network/src/tests.rs` (the Agent/ProxyAgent distinction has no Rust analog).
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:111` `returns Agent for socks4 proxy` — same coverage as the socks5 entry.
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:119` `returns Agent for socks proxy with https target` — same coverage as the socks5 entry.
-- [ ] `TypeScript repo: network/fetch/test/dispatcher.test.ts:127` `SOCKS proxy dispatchers are cached`
-- [ ] `TypeScript repo: network/fetch/test/dispatcher.test.ts:134` `SOCKS proxy can connect through a real SOCKS5 server`
+- [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:127` `SOCKS proxy dispatchers are cached` — pacquet builds the proxy dispatcher once inside the `reqwest::Client` retained by `ThrottledClient`, so there is no separate dispatcher-cache identity to test.
+- [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:134` `SOCKS proxy can connect through a real SOCKS5 server` — `socks5_proxy_connects_to_real_target` in `crates/network/src/tests.rs`.
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:192` `bypasses proxy when noProxy matches hostname` — `no_proxy_matcher_reverse_dot_match` in `crates/network/src/tests.rs` (exact-host probe).
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:202` `bypasses proxy when noProxy matches domain suffix` — `no_proxy_matcher_reverse_dot_match` (subdomain probes).
 - [x] `TypeScript repo: network/fetch/test/dispatcher.test.ts:211` `does not bypass proxy when noProxy does not match` — negative probes in `no_proxy_matcher_reverse_dot_match` and `no_proxy_matcher_multiple_entries`.
@@ -610,13 +610,13 @@ Proxy dispatcher tests:
 Config tests:
 
 - [x] `TypeScript repo: config/reader/test/index.ts:978` `getConfig() converts noproxy to noProxy` — covered by `no_proxy_and_noproxy_aliases_last_wins` in `crates/config/src/npmrc_auth/tests.rs`.
-- [ ] `TypeScript repo: config/reader/test/index.ts:1514` `reads proxy settings from global config.yaml`
-- [ ] `TypeScript repo: config/reader/test/index.ts:1540` `proxy settings from global config.yaml override .npmrc`
-- [ ] `TypeScript repo: config/reader/test/index.ts:1567` `CLI flags override proxy settings from global config.yaml`
-- [ ] `TypeScript repo: config/reader/test/index.ts:1592` `proxy settings are still read from .npmrc`
+- [x] `TypeScript repo: config/reader/test/index.ts:1514` `reads proxy settings from global config.yaml` — `global_config_yaml_supplies_proxy_settings` in `crates/config/src/tests.rs`.
+- [x] `TypeScript repo: config/reader/test/index.ts:1540` `proxy settings from global config.yaml override .npmrc` — `global_config_yaml_proxy_overrides_project_npmrc` in `crates/config/src/tests.rs`.
+- [x] `TypeScript repo: config/reader/test/index.ts:1567` `CLI flags override proxy settings from global config.yaml` — `pnpm_config_proxy_overrides_global_config_yaml` in `crates/config/src/tests.rs`, plus plain and dotted flag coverage in `crates/cli/src`.
+- [x] `TypeScript repo: config/reader/test/index.ts:1592` `proxy settings are still read from .npmrc` — `project_npmrc_proxy_settings_are_preserved` in `crates/config/src/tests.rs`.
 - [x] `TypeScript repo: config/commands/test/configSet.test.ts:875` `config set --global https-proxy writes to config.yaml, not auth.ini` — ported as `set_global_https_proxy_writes_config_yaml_not_auth_ini` in `crates/cli/src/cli_args/config/tests.rs`.
-- [ ] `TypeScript repo: config/commands/test/configSet.test.ts:902` `config set --global httpProxy writes to config.yaml`
-- [ ] `TypeScript repo: config/commands/test/configSet.test.ts:928` `config set --global no-proxy writes to config.yaml`
+- [x] `TypeScript repo: config/commands/test/configSet.test.ts:902` `config set --global httpProxy writes to config.yaml` — `set_global_http_proxy_writes_config_yaml` in `crates/cli/src/cli_args/config/tests.rs`.
+- [x] `TypeScript repo: config/commands/test/configSet.test.ts:928` `config set --global no-proxy writes to config.yaml` — `set_global_no_proxy_writes_config_yaml` in `crates/cli/src/cli_args/config/tests.rs`.
 
 Rust port notes:
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Complete the auth and proxy test-porting work in Stage 6 of pnpm/pnpm#13146.
- Add hermetic install coverage for bearer, basic, legacy, scoped, metadata-failure, and tarball-failure authentication paths.
- Bring pacquet's proxy configuration precedence in line with pnpm for global YAML, environment, npmrc, workspace YAML, and CLI overrides.
- Cover HTTPS CONNECT proxies, SOCKS5 tunneling, redirect credential handling, proxy config commands, and update the porting plan.

Related to pnpm/pnpm#13146.

## Squash Commit Body

```text
Port the remaining Stage 6 auth and proxy scenarios to pacquet with hermetic
registry, HTTPS proxy, and SOCKS5 fixtures.

Apply proxy settings from global and workspace YAML, PNPM_CONFIG environment
variables, npmrc, and CLI flags with pnpm-compatible precedence. Ensure proxy
CLI overrides also reach bootstrap requests, including optimistic installs.

Share minimal tarball fixtures across CLI integration tests and record the
completed coverage in the test-porting plan.

Related to pnpm/pnpm#13146.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787082523&installation_id=145934176&pr_number=13158&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13158&signature=c6699f229249b37048a2027768c977f7b82b63916571e78a95b56e803a71a9c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added global CLI options: `--http-proxy`, `--https-proxy`, and `--no-proxy`.
  * Proxy settings are now sourced consistently from global configuration, workspace settings, environment variables, and CLI overrides.
  * Expanded proxy routing support (including HTTPS tunneling and SOCKS5 proxying).
* **Bug Fixes**
  * Fixed proxy updates to persist to the global `config.yaml` when using global configuration commands.
  * Improved proxy precedence and preservation for different request types (HTTP vs HTTPS).  
* **Tests**
  * Added/expanded coverage for proxy precedence, parsing, and network/auth behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->