### PR TITLE
test(pacquet): port the git-hosted install suite (stage 9)

### DIFF
--- a/.changeset/git-dep-importer-version.md
+++ b/.changeset/git-dep-importer-version.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A git-hosted dependency with no host archive (an ssh, self-hosted, or `git+file:` repo) whose package name matches the dependency's alias now records the bare `git+<repo>#<commit>` reference in the lockfile's importer entry, matching pnpm's `pnpm-lock.yaml` output instead of prefixing it with `<name>@`.

--- a/.changeset/git-private-repo-keeps-auth-url.md
+++ b/.changeset/git-private-repo-keeps-auth-url.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A private git-hosted dependency resolved over HTTPS with an embedded auth token (`git+https://<token>@github.com/owner/repo.git`) is now recorded as a `type: git` resolution against the authenticated remote, instead of being rewritten to the host's public archive URL (a `codeload.github.com` tarball) that carries none of those credentials and so could not be fetched.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5067,6 +5067,7 @@ version = "0.0.0"
 dependencies = [
  "assert_cmd",
  "command-extra",
+ "dunce",
  "flate2",
  "junction",
  "pnpr",
@@ -5077,6 +5078,7 @@ dependencies = [
  "tempfile",
  "text-block-macros",
  "tokio",
+ "url",
  "walkdir",
 ]
 

--- a/pnpm/crates/cli/tests/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/git_hosted_install.rs
@@ -124,8 +124,8 @@ fn install_from_a_git_repo() {
     assert_eq!(resolution.commit, commit);
     assert_eq!(resolution.repo, repo.file_url());
     assert_eq!(resolution.path, None);
-    // A non-host git dep with no alias records the bare `git+…#<commit>`
-    // ref in the importer, not `is-negative@git+…` — byte-for-byte what
+    // A non-host git dep with no alias records the bare `git+...#<commit>`
+    // ref in the importer, not `is-negative@git+...` — byte-for-byte what
     // pnpm 11 writes.
     assert_eq!(importer_version(&lockfile, ".", "is-negative"), repo.git_url_at(&commit));
 

--- a/pnpm/crates/cli/tests/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/git_hosted_install.rs
@@ -1,0 +1,569 @@
+//! Installing a dependency hosted in a git repository.
+//!
+//! Ports the install half of
+//! `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts`
+//! plus the git-hosted `prepare` case from `lifecycleScripts.ts:311`.
+//!
+//! Upstream points these at real repositories on github.com. Here each
+//! test builds its own repo on disk and installs it over `git+file://`
+//! ([`GitRepoFixture`]), so the git install path runs end to end without
+//! reaching the network — the same technique upstream's own
+//! `createGitPreparePackage` uses. What that trades away is the *host*
+//! identity: a `github:`/`gitlab:`/`bitbucket:` spec resolves to the
+//! host's archive URL (a `gitHosted: true` tarball resolution), while a
+//! `file:` repo has no archive endpoint and resolves to `type: git`.
+//! The host-archive shape is pinned at the resolver level in
+//! `pacquet-resolving-git-resolver`.
+
+pub mod _utils;
+
+use std::{fmt::Write as _, path::Path, process::Command};
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_lockfile::{Lockfile, LockfileResolution};
+use pacquet_testing_utils::{bin::CommandTempCwd, git_repo::GitRepoFixture};
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+
+use _utils::{
+    assert_success, importer_specifier, importer_version, ndjson_records, read_lockfile,
+    read_manifest, write_manifest_value,
+};
+
+/// The `hi` package upstream installs under the `say-hi` alias. Two bin
+/// names under one script make bin linking observable, and the package
+/// name differs from every alias the tests give it.
+fn say_hi_repo(root: &Path) -> (GitRepoFixture, String) {
+    let repo = GitRepoFixture::init(root, "hi");
+    repo.write_file(
+        "package.json",
+        r#"{"name":"hi","version":"1.0.0","main":"index.js","bin":{"hi":"index.js","szia":"index.js"}}"#,
+    );
+    repo.write_file("index.js", "#!/usr/bin/env node\nmodule.exports = 'Hi'\n");
+    let commit = repo.commit("init");
+    (repo, commit)
+}
+
+/// A single-package repo named after `name`, at `version`.
+fn simple_repo(root: &Path, name: &str, version: &str) -> (GitRepoFixture, String) {
+    let repo = GitRepoFixture::init(root, name);
+    repo.write_file(
+        "package.json",
+        &format!(r#"{{"name":"{name}","version":"{version}","main":"index.js"}}"#),
+    );
+    repo.write_file("index.js", "module.exports = true\n");
+    let commit = repo.commit("init");
+    (repo, commit)
+}
+
+/// A fresh `pnpm` invocation in `workspace`.
+///
+/// [`CommandTempCwd`] hands out one prepared `Command`; follow-up runs
+/// against the same project build their own. The registry, store, and
+/// cache all come from the config files the harness already wrote into
+/// the workspace, so nothing else has to be re-threaded.
+fn pnpm_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+/// Write `project/package.json` with `dependencies` set to `deps`.
+fn write_dependencies(project: &Path, deps: &[(&str, &str)]) {
+    let dependencies: serde_json::Map<String, Value> =
+        deps.iter().map(|(name, spec)| ((*name).to_string(), json!(spec))).collect();
+    write_manifest_value(
+        project,
+        &json!({ "name": "project", "version": "1.0.0", "dependencies": dependencies }),
+    );
+}
+
+/// The lone `packages:` entry whose key names `name`, as a
+/// `(package_key, metadata)` pair.
+fn sole_package<'a>(
+    lockfile: &'a Lockfile,
+    name: &str,
+) -> (String, &'a pacquet_lockfile::PackageMetadata) {
+    let prefix = format!("{name}@");
+    let mut matches = lockfile
+        .packages
+        .as_ref()
+        .expect("lockfile has packages")
+        .iter()
+        .filter(|(key, _)| key.to_string().starts_with(&prefix))
+        .map(|(key, metadata)| (key.to_string(), metadata));
+    let found = matches.next().unwrap_or_else(|| panic!("no packages entry for {name}"));
+    assert!(matches.next().is_none(), "expected exactly one packages entry for {name}");
+    found
+}
+
+/// The `type: git` resolution of the lone `packages:` entry for `name`.
+fn git_resolution<'a>(lockfile: &'a Lockfile, name: &str) -> &'a pacquet_lockfile::GitResolution {
+    match &sole_package(lockfile, name).1.resolution {
+        LockfileResolution::Git(git) => git,
+        other => panic!("expected a git resolution for {name}, got {other:?}"),
+    }
+}
+
+/// TS: `from a git repo` (`fromRepo.ts:174`).
+///
+/// Upstream reaches github over `git+ssh://` and skips itself on CI;
+/// the `file:` repo here resolves through the same non-host branch
+/// (`LockfileResolution::Git`) without needing an SSH agent.
+#[test]
+fn install_from_a_git_repo() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let (repo, commit) = simple_repo(root.path(), "is-negative", "1.0.0");
+    write_dependencies(&workspace, &[("is-negative", &repo.git_url_at(&commit))]);
+
+    pacquet.with_args(["install"]).assert().success();
+
+    assert!(workspace.join("node_modules/is-negative/package.json").exists());
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    let resolution = git_resolution(&lockfile, "is-negative");
+    assert_eq!(resolution.commit, commit);
+    assert_eq!(resolution.repo, repo.file_url());
+    assert_eq!(resolution.path, None);
+    // A non-host git dep with no alias records the bare `git+…#<commit>`
+    // ref in the importer, not `is-negative@git+…` — byte-for-byte what
+    // pnpm 11 writes.
+    assert_eq!(importer_version(&lockfile, ".", "is-negative"), repo.git_url_at(&commit));
+
+    drop((root, npmrc_info));
+}
+
+/// TS: `from a github repo with different name via named installation`
+/// (`fromRepo.ts:61`).
+///
+/// The alias is the point: the manifest and the importer entry key on
+/// `say-hi`, while the package resolves to `hi` — so the importer's
+/// version keeps the `hi@` prefix, the `pnpm:root` event reports both
+/// names, and both of the package's bins are linked under their own
+/// names rather than the alias.
+#[test]
+fn install_from_a_git_repo_with_a_different_name_via_named_installation() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let (repo, commit) = say_hi_repo(root.path());
+    let spec = repo.git_url_at(&commit);
+
+    let output = pacquet
+        .with_args(["add", &format!("say-hi@{spec}"), "--reporter=ndjson"])
+        .output()
+        .expect("run pnpm add");
+    assert_success(&output);
+
+    assert_eq!(
+        read_manifest(&workspace)["dependencies"],
+        json!({ "say-hi": spec }),
+        "the git specifier is saved verbatim under the alias",
+    );
+
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    assert_eq!(importer_specifier(&lockfile, ".", "say-hi"), spec);
+    assert_eq!(importer_version(&lockfile, ".", "say-hi"), format!("hi@{spec}"));
+
+    let added = ndjson_records(&output)
+        .into_iter()
+        .filter_map(|record| {
+            (record.get("name").and_then(Value::as_str) == Some("pnpm:root"))
+                .then(|| record.get("added").cloned())
+                .flatten()
+        })
+        .find(|added| added.get("name").and_then(Value::as_str) == Some("say-hi"))
+        .expect("a pnpm:root `added` record for say-hi");
+    assert_eq!(added["realName"], "hi");
+    assert_eq!(added["dependencyType"], "prod");
+
+    for bin in ["hi", "szia"] {
+        assert!(
+            workspace.join("node_modules/.bin").join(bin).exists(),
+            "{bin} should be linked into node_modules/.bin",
+        );
+    }
+
+    drop((root, npmrc_info));
+}
+
+/// TS: `from a github repo with different name` (`fromRepo.ts:105`).
+///
+/// Same shape as the named-installation case, reached through a
+/// manifest that already declares the alias rather than through `add` —
+/// upstream keeps both because the two entered the installer by
+/// different routes.
+#[test]
+fn install_from_a_git_repo_with_a_different_name() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let (repo, commit) = say_hi_repo(root.path());
+    let spec = repo.git_url_at(&commit);
+    write_dependencies(&workspace, &[("say-hi", &spec)]);
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    assert_eq!(importer_specifier(&lockfile, ".", "say-hi"), spec);
+    assert_eq!(importer_version(&lockfile, ".", "say-hi"), format!("hi@{spec}"));
+    assert_eq!(sole_package(&lockfile, "hi").1.version.as_deref(), Some("1.0.0"));
+
+    let linked = workspace.join("node_modules/say-hi/package.json");
+    let manifest: Value =
+        serde_json::from_str(&std::fs::read_to_string(&linked).expect("read the linked manifest"))
+            .expect("parse the linked manifest");
+    assert_eq!(manifest["name"], "hi", "the alias directory holds the real package");
+
+    drop((root, npmrc_info));
+}
+
+/// TS: `re-adding a git repo with a different tag` (`fromRepo.ts:276`).
+///
+/// Each tag is a distinct commit, so re-adding must re-resolve to the
+/// second one and leave exactly one `packages:` entry behind — a stale
+/// entry for the first tag would mean the old commit is still installed.
+#[test]
+fn re_adding_a_git_repo_with_a_different_tag() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "is-negative");
+    repo.write_file("package.json", r#"{"name":"is-negative","version":"1.0.0"}"#);
+    let first_commit = repo.commit("1.0.0");
+    repo.tag("1.0.0");
+    repo.write_file("package.json", r#"{"name":"is-negative","version":"1.0.1"}"#);
+    let second_commit = repo.commit("1.0.1");
+    repo.tag("1.0.1");
+    assert_ne!(first_commit, second_commit);
+
+    let installed_version = |workspace: &Path| -> String {
+        let manifest: Value = serde_json::from_str(
+            &std::fs::read_to_string(workspace.join("node_modules/is-negative/package.json"))
+                .expect("read the installed manifest"),
+        )
+        .expect("parse the installed manifest");
+        manifest["version"].as_str().expect("version is a string").to_string()
+    };
+
+    write_dependencies(&workspace, &[("is-negative", &repo.git_url_at("1.0.0"))]);
+    pacquet.with_args(["install"]).assert().success();
+
+    assert_eq!(installed_version(&workspace), "1.0.0");
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    assert_eq!(git_resolution(&lockfile, "is-negative").commit, first_commit);
+
+    write_dependencies(&workspace, &[("is-negative", &repo.git_url_at("1.0.1"))]);
+    pnpm_at(&workspace).with_args(["install"]).assert().success();
+
+    assert_eq!(installed_version(&workspace), "1.0.1");
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    assert_eq!(git_resolution(&lockfile, "is-negative").commit, second_commit);
+    assert_eq!(
+        importer_specifier(&lockfile, ".", "is-negative"),
+        repo.git_url_at("1.0.1"),
+        "the tag the user wrote is preserved, not the commit it resolved to",
+    );
+
+    drop((root, npmrc_info));
+}
+
+/// TS: `git-hosted repository is not added to the store if it fails to
+/// be built` (`fromRepo.ts:354`).
+///
+/// The second install is the assertion: a package whose `prepare`
+/// failed must not have been indexed, or the retry would find a
+/// half-built package in the store and succeed.
+#[test]
+fn git_hosted_repository_is_not_added_to_the_store_if_it_fails_to_be_built() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "prepare-script-fails");
+    repo.write_file(
+        "package.json",
+        r#"{"name":"prepare-script-fails","version":"1.0.0","main":"index.js","scripts":{"prepare":"node -e \"process.exit(1)\""}}"#,
+    );
+    repo.write_file("index.js", "module.exports = true\n");
+    let commit = repo.commit("init");
+    let spec = repo.git_url_at(&commit);
+
+    write_dependencies(&workspace, &[("prepare-script-fails", &spec)]);
+    allow_builds(&workspace, &[&format!("prepare-script-fails@{spec}")]);
+
+    pacquet.with_args(["install"]).assert().failure();
+    pnpm_at(&workspace).with_args(["install"]).assert().failure();
+
+    drop((root, npmrc_info));
+}
+
+/// TS: `from subdirectories of a git repo` (`fromRepo.ts:366`).
+///
+/// Two packages out of one repo: each `#path:` selects its own
+/// subdirectory, and the two must not collide even though they share a
+/// repo and a commit.
+#[test]
+fn install_from_subdirectories_of_a_git_repo() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "test-git-subfolder-fetch");
+    repo.write_file("package.json", r#"{"name":"monorepo-root","version":"0.0.0"}"#);
+    for name in ["simple-react-app", "simple-express-server"] {
+        repo.write_file(
+            &format!("packages/{name}/package.json"),
+            &format!(r#"{{"name":"@my-namespace/{name}","version":"1.0.0","main":"index.js"}}"#),
+        );
+        repo.write_file(&format!("packages/{name}/index.js"), "module.exports = true\n");
+    }
+    let commit = repo.commit("init");
+
+    let react_spec = format!("{}&path:/packages/simple-react-app", repo.git_url_at(&commit));
+    let express_spec = format!("{}&path:/packages/simple-express-server", repo.git_url_at(&commit));
+    write_dependencies(
+        &workspace,
+        &[
+            ("@my-namespace/simple-react-app", &react_spec),
+            ("@my-namespace/simple-express-server", &express_spec),
+        ],
+    );
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    for name in ["simple-react-app", "simple-express-server"] {
+        let package = format!("@my-namespace/{name}");
+        assert!(
+            workspace.join("node_modules").join(&package).join("package.json").exists(),
+            "{package} should be installed",
+        );
+        let resolution = git_resolution(&lockfile, &package);
+        assert_eq!(resolution.commit, commit);
+        assert_eq!(resolution.path.as_deref(), Some(format!("/packages/{name}").as_str()));
+    }
+
+    drop((root, npmrc_info));
+}
+
+/// TS: `no hash character for github subdirectory install`
+/// (`fromRepo.ts:389`).
+///
+/// `#path:/&<ref>` puts the ref *after* the `path:` parameter with no
+/// second `#`, so the whole fragment has to be split on `&` rather than
+/// read as "everything after the hash is the committish".
+#[test]
+fn no_hash_character_for_subdirectory_install() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "only-allow");
+    repo.write_file("package.json", r#"{"name":"only-allow","version":"1.2.1","main":"index.js"}"#);
+    repo.write_file("index.js", "module.exports = true\n");
+    let commit = repo.commit("init");
+    repo.tag("v1.2.1");
+
+    write_dependencies(
+        &workspace,
+        &[("only-allow", &format!("git+{}#path:/&v1.2.1", repo.file_url()))],
+    );
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    let resolution = git_resolution(&lockfile, "only-allow");
+    assert_eq!(resolution.commit, commit, "`v1.2.1` after the `&` is the committish");
+    assert_eq!(resolution.path.as_deref(), Some("/"), "`path:/` is the repo root");
+
+    drop((root, npmrc_info));
+}
+
+/// TS: `run prepare script for git-hosted dependencies`
+/// (`lifecycleScripts.ts:311`).
+///
+/// A git dependency has no published tarball, so pnpm builds it on the
+/// way in: the install lifecycle runs once for the checkout, `prepare`
+/// packs it, and the lifecycle runs again for the installed package.
+#[test]
+fn run_prepare_script_for_git_hosted_dependencies() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "test-git-fetch");
+    repo.write_file(
+        "append.js",
+        "const fs = require('fs')\n\
+         const file = 'output.json'\n\
+         let scripts = []\n\
+         try { scripts = JSON.parse(fs.readFileSync(file, 'utf8')) } catch {}\n\
+         scripts.push(process.argv[2])\n\
+         fs.writeFileSync(file, JSON.stringify(scripts))\n",
+    );
+    repo.write_file("index.js", "module.exports = 'ok'\n");
+    repo.write_file(
+        "package.json",
+        r#"{"name":"test-git-fetch","version":"1.0.0","main":"index.js","scripts":{"prepare":"node append prepare","preinstall":"node append preinstall","install":"node append install","postinstall":"node append postinstall"}}"#,
+    );
+    let commit = repo.commit("init");
+    let spec = repo.git_url_at(&commit);
+
+    write_dependencies(&workspace, &[("test-git-fetch", &spec)]);
+    allow_builds(&workspace, &[&format!("test-git-fetch@{spec}")]);
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let output: Value = serde_json::from_str(
+        &std::fs::read_to_string(workspace.join("node_modules/test-git-fetch/output.json"))
+            .expect("read the script log the package wrote"),
+    )
+    .expect("parse the script log");
+    assert_eq!(
+        output,
+        json!([
+            "preinstall",
+            "install",
+            "postinstall",
+            "prepare",
+            "preinstall",
+            "install",
+            "postinstall",
+        ]),
+    );
+
+    drop((root, npmrc_info));
+}
+
+/// Append an `allowBuilds` block to the `pnpm-workspace.yaml` the
+/// harness wrote, opting the listed `<name>@<specifier>` keys into
+/// running lifecycle scripts.
+fn allow_builds(workspace: &Path, keys: &[&str]) {
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = std::fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+    assert!(
+        !yaml.contains("allowBuilds:"),
+        "pnpm-workspace.yaml already has an `allowBuilds:` key — update this helper",
+    );
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("allowBuilds:\n");
+    for key in keys {
+        // The keys are URLs, so they carry `:` and must be quoted to
+        // stay a single YAML scalar.
+        writeln!(yaml, "  {key:?}: true").expect("format allowBuilds entry");
+    }
+    std::fs::write(&path, yaml).expect("write pnpm-workspace.yaml");
+}
+
+mod known_failures {
+    //! Git-hosted install cases blocked on behavior pacquet hasn't
+    //! built or reconciled yet. Each stubs the not-yet-implemented
+    //! subject under test through
+    //! [`pacquet_testing_utils::allow_known_failure`] so the test exits
+    //! early rather than masking a real bug.
+
+    use pacquet_testing_utils::{
+        allow_known_failure,
+        known_failure::{KnownFailure, KnownResult},
+    };
+
+    fn alias_less_git_add() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "`pnpm add <git-specifier>` without an explicit `<alias>@` \
+             prefix is not supported. `add`'s `split_name_spec` treats \
+             the whole argument as a package name, so \
+             `pnpm add kevva/is-negative` / \
+             `pnpm add https://github.com/kevva/is-negative` ask the \
+             registry for a package literally named by the specifier \
+             and fail with ERR_PNPM_INVALID_PACKAGE_NAME. Upstream \
+             resolves the repo first and takes the name from the \
+             fetched manifest. The aliased form \
+             (`pnpm add say-hi@github:zkochan/hi`) and every \
+             manifest-declared git dependency already work — see the \
+             real tests in this file.",
+        ))
+    }
+
+    fn git_dep_version_in_root_log() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "The `pnpm:root` `added` event reports a git dependency's \
+             `version` as the specifier's version slot — the \
+             `git+<repo>#<commit>` URL — where upstream reports the \
+             package's own version (`1.0.0`), which the default \
+             reporter renders as `+ hi 1.0.0`. Pacquet prints \
+             `+ hi git+file:///...#<commit>`. The version lives in the \
+             lockfile's `packages:` entry, which \
+             `symlink_direct_dependencies` does not receive.",
+        ))
+    }
+
+    fn git_ref_relocked_on_every_resolution() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "A git dependency's locked commit is not reused from the \
+             wanted lockfile: every resolution pass re-runs \
+             `git ls-remote` and relocks whatever the ref points at \
+             now. For a moving ref (`#main`, a floating tag) an \
+             unrelated `pnpm add` therefore bumps the git dependency's \
+             commit, which upstream's test pins as the thing that must \
+             not happen — verified against pnpm 11.13.1, which keeps \
+             the locked commit after the branch moves. The reuse map \
+             built in `install_with_fresh_lockfile` keys on integrity, \
+             so git resolutions never enter it.",
+        ))
+    }
+
+    fn git_dependency_of_a_registry_fixture() -> KnownResult<()> {
+        Err(KnownFailure::new(
+            "Needs a registry fixture that declares a git dependency. A \
+             fixture's `package.json` is static, so its git specifier \
+             would have to name a repository that exists at test time — \
+             i.e. a real forge URL, which would make the suite depend \
+             on github.com being reachable. The install-level git tests \
+             in this file build a repo per test and reference it by \
+             `git+file://`, a URL no committed fixture can know. \
+             Unblocking this needs the fixture builder in \
+             `pnpr-fixtures` to support substituting a per-run repo URL \
+             into a fixture manifest.",
+        ))
+    }
+
+    /// TS: `from a github repo` (`fromRepo.ts:31`) — `pnpm add
+    /// kevva/is-negative`, whose saved specifier is `github:kevva/is-negative`.
+    #[test]
+    fn add_from_a_github_repo_shorthand() {
+        allow_known_failure!(alias_less_git_add());
+    }
+
+    /// TS: `from a github repo through URL` (`fromRepo.ts:48`) — `pnpm add
+    /// https://github.com/kevva/is-negative`.
+    #[test]
+    fn add_from_a_github_repo_through_url() {
+        allow_known_failure!(alias_less_git_add());
+    }
+
+    /// The `pnpm:root` `added.version` half of TS `from a github repo
+    /// with different name via named installation` (`fromRepo.ts:61`),
+    /// which expects `version: '1.0.0'`. The alias half — `name`,
+    /// `realName`, `dependencyType` — is asserted by the real test.
+    #[test]
+    fn root_log_reports_the_package_version_for_a_git_dependency() {
+        allow_known_failure!(git_dep_version_in_root_log());
+    }
+
+    /// TS: `should not update when adding unrelated dependency`
+    /// (`fromRepo.ts:323`). Adding an unrelated registry dependency
+    /// must leave a branch-pinned git dependency on its locked commit.
+    #[test]
+    fn should_not_update_when_adding_unrelated_dependency() {
+        allow_known_failure!(git_ref_relocked_on_every_resolution());
+    }
+
+    /// TS: `a subdependency is from a github repo with different name`
+    /// (`fromRepo.ts:150`), which installs
+    /// `@pnpm.e2e/has-aliased-git-dependency` — a registry package whose
+    /// own `dependencies` alias a github repo.
+    #[test]
+    fn a_subdependency_is_from_a_git_repo_with_a_different_name() {
+        allow_known_failure!(git_dependency_of_a_registry_fixture());
+    }
+
+    /// TS: `updating package that has a github-hosted dependency`
+    /// (`lockfile.ts:600`), which re-adds `@pnpm.e2e/has-github-dep` at
+    /// a second version to prove the range-comparison path tolerates a
+    /// non-semver pin among the dependency's own deps.
+    #[test]
+    fn updating_package_that_has_a_git_hosted_dependency() {
+        allow_known_failure!(git_dependency_of_a_registry_fixture());
+    }
+}

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -441,13 +441,16 @@ fn real_name(result: &ResolveResult) -> Option<String> {
     //   (`<name>@<tarball-url>` -> `version: <url>`), which a git-hosted
     //   dep's host archive URL also is,
     // - a runtime dep (`<name>@runtime:<ver>`, a Variations resolution ->
-    //   `version: runtime:<ver>`).
+    //   `version: runtime:<ver>`),
+    // - a git dep with no host archive (`<name>@git+<repo>#<commit>` ->
+    //   `version: git+<repo>#<commit>`), the shape every non-host repo
+    //   resolves to (ssh, self-hosted, `file:`).
     // `file:` resolutions are deliberately left to the `None` path so
     // their importer entries keep pacquet's current prefixed shape —
     // bringing those in line is separate from
     // <https://github.com/pnpm/pnpm/issues/12053>.
     let reads_name_from_manifest = match &result.resolution {
-        LockfileResolution::Variations(_) => true,
+        LockfileResolution::Variations(_) | LockfileResolution::Git(_) => true,
         LockfileResolution::Tarball(tarball) => is_remote_http_tarball(&tarball.tarball),
         _ => false,
     };

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -5,8 +5,9 @@ use super::{
 use indexmap::IndexMap;
 use pacquet_deps_path::DepPath;
 use pacquet_lockfile::{
-    DirectoryResolution, ImporterDepVersion, LockfileResolution, PackageKey, PkgName, PkgNameVer,
-    RegistryResolution, SnapshotDepRef, TarballResolution, VariationsResolution,
+    DirectoryResolution, GitResolution, ImporterDepVersion, LockfileResolution, PackageKey,
+    PkgName, PkgNameVer, RegistryResolution, SnapshotDepRef, TarballResolution,
+    VariationsResolution,
 };
 use pacquet_package_manifest::PackageManifest;
 use pacquet_resolving_deps_resolver::{
@@ -714,6 +715,90 @@ fn aliased_git_hosted_dependency_keeps_package_name_in_importer_ref() {
     let package_key: PackageKey = format!("is-negative@{GIT_TARBALL_URL}").parse().unwrap();
     assert!(lockfile.packages.as_ref().expect("packages").contains_key(&package_key));
     assert!(lockfile.snapshots.as_ref().expect("snapshots").contains_key(&package_key));
+}
+
+/// A non-host git dep (ssh / self-hosted / `git+file:`) resolves to a
+/// `type: git` snapshot whose id *is* its depPath, and whose name lives
+/// only in the fetched manifest. When the manifest alias matches that
+/// name, the importer entry drops the `<name>@` prefix and records the
+/// bare `git+<repo>#<commit>` ref — the shape pnpm v11 writes, verified
+/// byte-for-byte against pnpm 11.13.1.
+#[test]
+fn non_host_git_dependency_records_bare_git_url_in_importer() {
+    const GIT_REF: &str =
+        "git+ssh://git@example.com/org/is-negative.git#0123456789012345678901234567890123456789";
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "is-negative": GIT_REF },
+    }));
+
+    // The install pipeline keys a git dep's depPath by `<name>@<ref>`
+    // once the name is read from the fetched manifest, so the `<name>@`
+    // prefix is present here — the exact shape `real_name` has to strip
+    // back off for the importer entry.
+    let dep_path = DepPath::from(format!("is-negative@{GIT_REF}"));
+    let resolve_result = ResolveResult {
+        id: PkgResolutionId::from(GIT_REF),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: Some(Arc::new(json!({ "name": "is-negative", "version": "1.0.0" }))),
+        resolution: LockfileResolution::Git(GitResolution {
+            repo: "ssh://git@example.com/org/is-negative.git".to_string(),
+            commit: "0123456789012345678901234567890123456789".to_string(),
+            path: None,
+        }),
+        resolved_via: "git-repository".to_string(),
+        normalized_bare_specifier: Some(GIT_REF.to_string()),
+        alias: Some("is-negative".to_string()),
+        policy_violation: None,
+    };
+    let node = DependenciesGraphNode {
+        dep_path: dep_path.clone(),
+        resolved_package_id: dep_path.to_string(),
+        resolve_result: Arc::new(resolve_result),
+        children: BTreeMap::new(),
+        optional_children: HashSet::new(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::new(),
+        resolved_peer_names: HashSet::new(),
+        depth: 1,
+        installable: true,
+        is_pure: true,
+        optional: false,
+    };
+    let mut graph = DependenciesGraph::new();
+    graph.insert(dep_path.clone(), node);
+    let direct = BTreeMap::from([("is-negative".to_string(), dep_path)]);
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    let importer = lockfile.root_project().expect("root importer");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .expect("dependencies")
+        .get(&PkgName::parse("is-negative").unwrap())
+        .expect("git dependency");
+    match &entry.version {
+        // The `is-negative@` prefix is stripped: the bare git ref, not
+        // `is-negative@git+...`.
+        ImporterDepVersion::Regular(version) => assert_eq!(version.to_string(), GIT_REF),
+        other => panic!("expected Regular({GIT_REF}), got {other:?}"),
+    }
+
+    let packages = lockfile.packages.as_ref().expect("packages");
+    let (package_key, metadata) =
+        packages.iter().find(|(key, _)| key.to_string().contains("is-negative")).expect("package");
+    assert!(matches!(metadata.resolution, LockfileResolution::Git(_)));
+    assert_eq!(metadata.version.as_deref(), Some("1.0.0"));
+    assert!(
+        lockfile.snapshots.as_ref().expect("snapshots").contains_key(package_key),
+        "the snapshot is keyed by the same depPath",
+    );
 }
 
 #[test]

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
@@ -296,7 +296,7 @@ async fn private_https_repo_with_an_auth_token_keeps_the_authenticated_url() {
     assert_eq!(result.resolved_via, "git-repository");
     assert_eq!(
         result.normalized_bare_specifier.as_deref(),
-        Some(format!("git+{AUTH_URL}").as_str())
+        Some(format!("git+{AUTH_URL}").as_str()),
     );
     match &result.resolution {
         LockfileResolution::Git(git) => {

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
@@ -4,7 +4,7 @@ use crate::{
     resolve_ref::{GitCommandRunner, GitRunError},
 };
 use pacquet_lockfile::LockfileResolution;
-use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
+use pacquet_resolving_resolver_base::{ResolveOptions, ResolveResult, Resolver, WantedDependency};
 use std::{
     future::Future,
     pin::Pin,
@@ -14,14 +14,39 @@ use std::{
 struct FakeProbe {
     head_ok: bool,
     ls_ok: bool,
+    /// When non-empty, `ls-remote --exit-code` succeeds only for these
+    /// URLs and `ls_ok` is ignored. Models a repo that is reachable
+    /// over exactly one of the candidate transports — which is what
+    /// decides the fetch spec for a private repo.
+    ls_ok_only_for: Vec<String>,
 }
+
+impl FakeProbe {
+    /// A public repo: both probes succeed for every URL.
+    fn public() -> Self {
+        Self { head_ok: true, ls_ok: true, ls_ok_only_for: Vec::new() }
+    }
+
+    /// A private repo — the HTTPS HEAD that detects a public repo comes
+    /// back non-2xx — reachable only over `url`. Upstream's
+    /// `mockFetchAsPrivate` plus a `git` mock that throws for every
+    /// other remote.
+    fn private_reachable_over(url: &str) -> Self {
+        Self { head_ok: false, ls_ok: false, ls_ok_only_for: vec![url.to_string()] }
+    }
+}
+
 impl GitProbe for FakeProbe {
     fn https_head_ok<'a>(&'a self, _url: &'a str) -> ProbeFuture<'a> {
         let enabled = self.head_ok;
         Box::pin(async move { enabled })
     }
-    fn ls_remote_exit_code<'a>(&'a self, _repo: &'a str) -> ProbeFuture<'a> {
-        let enabled = self.ls_ok;
+    fn ls_remote_exit_code<'a>(&'a self, repo: &'a str) -> ProbeFuture<'a> {
+        let enabled = if self.ls_ok_only_for.is_empty() {
+            self.ls_ok
+        } else {
+            self.ls_ok_only_for.iter().any(|allowed| allowed == repo)
+        };
         Box::pin(async move { enabled })
     }
 }
@@ -44,9 +69,33 @@ impl GitCommandRunner for FakeRunner {
 
 fn resolver(head_ok: bool, ls_ok: bool, stdout: &str) -> GitResolver<FakeProbe, FakeRunner> {
     GitResolver::new(
-        Arc::new(FakeProbe { head_ok, ls_ok }),
-        Arc::new(FakeRunner { stdout: stdout.to_string(), calls: Mutex::new(Vec::new()) }),
+        Arc::new(FakeProbe { head_ok, ls_ok, ls_ok_only_for: Vec::new() }),
+        Arc::new(runner(stdout)),
     )
+}
+
+fn runner(stdout: &str) -> FakeRunner {
+    FakeRunner { stdout: stdout.to_string(), calls: Mutex::new(Vec::new()) }
+}
+
+/// Resolve `bare_specifier`, returning the result alongside the runner
+/// so a test can assert which remote `ls-remote` was pointed at — for a
+/// private repo that choice *is* the behavior under test.
+async fn resolve_with(
+    probe: FakeProbe,
+    stdout: &str,
+    bare_specifier: &str,
+) -> (ResolveResult, Arc<FakeRunner>) {
+    let runner = Arc::new(runner(stdout));
+    let resolver = GitResolver::new(Arc::new(probe), Arc::clone(&runner));
+    let wanted = WantedDependency {
+        alias: None,
+        bare_specifier: Some(bare_specifier.to_string()),
+        ..WantedDependency::default()
+    };
+    let result =
+        resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().expect("claimed");
+    (result, runner)
 }
 
 #[tokio::test]
@@ -137,4 +186,129 @@ async fn path_suffix_appended_to_id_and_resolution() {
         other => panic!("expected Tarball, got {other:?}"),
     }
     assert!(result.id.as_str().ends_with("#path:/packages/simple-react-app"));
+}
+
+/// TS: `resolveFromGit() with both sub folder and branch`
+/// (`resolving/git-resolver/test/index.ts:211`).
+///
+/// `#beta&path:/packages/simple-react-app` carries a branch *and* a
+/// subdirectory in one fragment: the branch decides the commit the
+/// archive URL pins, while the path rides along into the resolution and
+/// the id, so two subdirectories of one repo stay distinct packages.
+#[tokio::test]
+async fn sub_folder_and_branch_resolve_to_a_tarball_carrying_the_path() {
+    const BETA_COMMIT: &str = "777e8a3e78cc89bbf41fb3fd9f6cf922d5463313";
+    let (result, runner) = resolve_with(
+        FakeProbe::public(),
+        &format!("{BETA_COMMIT}\trefs/heads/beta\n"),
+        "github:RexSkz/test-git-subfolder-fetch.git#beta&path:/packages/simple-react-app",
+    )
+    .await;
+
+    assert_eq!(result.resolved_via, "git-repository");
+    assert_eq!(
+        result.normalized_bare_specifier.as_deref(),
+        Some("github:RexSkz/test-git-subfolder-fetch#beta&path:/packages/simple-react-app"),
+    );
+    match &result.resolution {
+        LockfileResolution::Tarball(tarball) => {
+            assert_eq!(
+                tarball.tarball,
+                format!(
+                    "https://codeload.github.com/RexSkz/test-git-subfolder-fetch/tar.gz/{BETA_COMMIT}"
+                ),
+            );
+            assert_eq!(tarball.path.as_deref(), Some("/packages/simple-react-app"));
+            assert_eq!(tarball.git_hosted, Some(true));
+        }
+        other => panic!("expected Tarball, got {other:?}"),
+    }
+    assert_eq!(
+        result.id.as_str(),
+        format!(
+            "https://codeload.github.com/RexSkz/test-git-subfolder-fetch/tar.gz/{BETA_COMMIT}#path:/packages/simple-react-app"
+        ),
+    );
+    assert_eq!(
+        runner.calls.lock().unwrap().as_slice(),
+        [(
+            "https://github.com/RexSkz/test-git-subfolder-fetch.git".to_string(),
+            Some("beta".to_string())
+        )],
+        "the branch, not HEAD, is what ls-remote is asked to resolve",
+    );
+}
+
+/// TS: `resolve a private repository using the HTTPS protocol without
+/// auth token` (`resolving/git-resolver/test/index.ts:482`).
+///
+/// The HTTPS HEAD that detects a public repo fails and the anonymous
+/// HTTPS remote is unreachable, so the only transport left is SSH —
+/// and an SSH fetch spec must not resolve to the host's public archive
+/// URL.
+#[tokio::test]
+async fn private_https_repo_without_auth_falls_back_to_the_ssh_url() {
+    const SSH_URL: &str = "git+ssh://git@github.com/foo/bar.git";
+    const COMMIT: &str = "0000000000000000000000000000000000000000";
+    let (result, runner) = resolve_with(
+        FakeProbe::private_reachable_over(SSH_URL),
+        &format!("{COMMIT}\tHEAD\n"),
+        "git+https://github.com/foo/bar.git",
+    )
+    .await;
+
+    assert_eq!(result.resolved_via, "git-repository");
+    assert_eq!(result.normalized_bare_specifier.as_deref(), Some("github:foo/bar"));
+    match &result.resolution {
+        LockfileResolution::Git(git) => {
+            assert_eq!(git.repo, SSH_URL);
+            assert_eq!(git.commit, COMMIT);
+            assert_eq!(git.path, None);
+        }
+        other => panic!("expected Git, got {other:?}"),
+    }
+    assert_eq!(result.id.as_str(), format!("{SSH_URL}#{COMMIT}"));
+    assert_eq!(
+        runner.calls.lock().unwrap().as_slice(),
+        [(SSH_URL.to_string(), Some("HEAD".to_string()))],
+    );
+}
+
+/// TS: `resolve a private repository using the HTTPS protocol and an
+/// auth token` (`resolving/git-resolver/test/index.ts:526`).
+///
+/// The credentials in the URL are what make the repo reachable, and a
+/// host's archive endpoint does not carry them — so this must stay a
+/// `type: git` resolution against the authenticated remote rather than
+/// collapsing to a `codeload` URL nothing could fetch.
+#[tokio::test]
+async fn private_https_repo_with_an_auth_token_keeps_the_authenticated_url() {
+    const COMMIT: &str = "0000000000000000000000000000000000000000";
+    const AUTH_URL: &str =
+        "https://0000000000000000000000000000000000000000:x-oauth-basic@github.com/foo/bar.git";
+    let (result, runner) = resolve_with(
+        FakeProbe::private_reachable_over(AUTH_URL),
+        &format!("{COMMIT}\tHEAD\n"),
+        "git+https://0000000000000000000000000000000000000000:x-oauth-basic@github.com/foo/bar.git",
+    )
+    .await;
+
+    assert_eq!(result.resolved_via, "git-repository");
+    assert_eq!(
+        result.normalized_bare_specifier.as_deref(),
+        Some(format!("git+{AUTH_URL}").as_str())
+    );
+    match &result.resolution {
+        LockfileResolution::Git(git) => {
+            assert_eq!(git.repo, AUTH_URL);
+            assert_eq!(git.commit, COMMIT);
+            assert_eq!(git.path, None);
+        }
+        other => panic!("expected Git, got {other:?}"),
+    }
+    assert_eq!(result.id.as_str(), format!("git+{AUTH_URL}#{COMMIT}"));
+    assert_eq!(
+        runner.calls.lock().unwrap().as_slice(),
+        [(AUTH_URL.to_string(), Some("HEAD".to_string()))],
+    );
 }

--- a/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-git-resolver/src/parse_bare_specifier.rs
@@ -258,7 +258,15 @@ async fn from_hosted_git<Probe: GitProbe + ?Sized>(
             let params = parse_git_params(hosted.committish.as_deref());
             return HostedPackageSpec {
                 fetch_spec: https_url.clone(),
-                hosted: Some(strip_committish(hosted)),
+                // `hosted: None` drops the host-archive option, so the
+                // resolution stays `type: git` against the URL that
+                // just probed reachable. A host's archive endpoint
+                // carries none of this URL's credentials, so a private
+                // repo resolved to its `codeload`-style archive would
+                // record a URL nothing can fetch. Mirrors upstream
+                // returning `hosted: { ...hosted, tarball: undefined }`
+                // here.
+                hosted: None,
                 normalized_bare_specifier: format!("git+{https_url}"),
                 git_committish: params.git_committish,
                 git_range: params.git_range,
@@ -293,11 +301,6 @@ async fn from_hosted_git<Probe: GitProbe + ?Sized>(
         git_range: params.git_range,
         path: params.path,
     }
-}
-
-fn strip_committish(mut hosted: HostedGit) -> HostedGit {
-    hosted.committish = None;
-    hosted
 }
 
 fn percent_decode_str(input: &str) -> String {

--- a/pnpm/crates/testing-utils/Cargo.toml
+++ b/pnpm/crates/testing-utils/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 [dependencies]
 assert_cmd        = { workspace = true }
 command-extra     = { workspace = true }
+dunce             = { workspace = true }
 flate2            = { workspace = true }
 pnpr              = { workspace = true }
 serde_json        = { workspace = true }
@@ -20,6 +21,7 @@ ssri              = { workspace = true }
 tar               = { workspace = true }
 tempfile          = { workspace = true }
 tokio             = { workspace = true }
+url               = { workspace = true }
 walkdir           = { workspace = true }
 text-block-macros = { workspace = true }
 pnpr-fixtures     = { workspace = true }

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -1,6 +1,6 @@
 //! Local git repositories for tests that install a git-hosted dependency.
 //!
-//! A test points its manifest at a repo on disk (`git+file://…`) rather
+//! A test points its manifest at a repo on disk (`git+file://...`) rather
 //! than a real forge, so the whole git install path — `ls-remote`
 //! resolution, clone, `prepare`, packlist, link — runs without network
 //! access. The TypeScript suite uses the same technique for its
@@ -97,7 +97,7 @@ impl GitRepoFixture {
     /// specifier, and the `repo` field a `type: git` resolution records.
     #[must_use]
     pub fn file_url(&self) -> String {
-        // `dunce` keeps Windows paths in their `C:\…` form rather than
+        // `dunce` keeps Windows paths in their `C:\...` form rather than
         // the `\\?\` UNC prefix, which `Url::from_file_path` would
         // otherwise carry into the URL and `git` would reject.
         let canonical = dunce::canonicalize(&self.bare).expect("canonicalize bare repo path");
@@ -106,7 +106,7 @@ impl GitRepoFixture {
             .to_string()
     }
 
-    /// The `git+file://…#<committish>` specifier a manifest declares to
+    /// The `git+file://...#<committish>` specifier a manifest declares to
     /// install this repo at `committish` (a SHA, tag, or branch).
     #[must_use]
     pub fn git_url_at(&self, committish: &str) -> String {

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -1,0 +1,136 @@
+//! Local git repositories for tests that install a git-hosted dependency.
+//!
+//! A test points its manifest at a repo on disk (`git+file://…`) rather
+//! than a real forge, so the whole git install path — `ls-remote`
+//! resolution, clone, `prepare`, packlist, link — runs without network
+//! access. The TypeScript suite uses the same technique for its
+//! `prepare`-script coverage (`createGitPreparePackage` in
+//! `installing/deps-installer/test/install/lifecycleScripts.ts`).
+//!
+//! Repos that need a *host* identity (a `codeload.github.com` archive
+//! URL, `gitHosted: true`) can't be modeled this way — those resolve to
+//! a tarball and are covered at the resolver level instead.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use url::Url;
+
+/// A git work tree plus the bare clone a test's manifest points at.
+///
+/// Every [`Self::commit`] and [`Self::tag`] mirrors the work tree into
+/// the bare repo, so the URL accessors always describe current history.
+pub struct GitRepoFixture {
+    work: PathBuf,
+    bare: PathBuf,
+}
+
+impl GitRepoFixture {
+    /// Create an empty repo under `root`, as a work tree at
+    /// `<root>/<name>-src` and a bare clone at `<root>/<name>.git`.
+    ///
+    /// Put `root` outside the project being installed into — a git repo
+    /// nested inside the workspace would be picked up as part of it.
+    #[must_use]
+    pub fn init(root: &Path, name: &str) -> Self {
+        let work = root.join(format!("{name}-src"));
+        let bare = root.join(format!("{name}.git"));
+        fs::create_dir_all(&work).expect("create git work tree");
+        fs::create_dir_all(&bare).expect("create bare repo directory");
+
+        git(&bare, &["init", "-q", "--bare"]);
+        git(&work, &["init", "-q", "-b", "main"]);
+        git(&work, &["config", "user.email", "test@example.invalid"]);
+        git(&work, &["config", "user.name", "Test"]);
+        // Neutralise a user-global `gpgsign = true`, which would
+        // otherwise demand a real signing key for every commit and tag.
+        git(&work, &["config", "commit.gpgsign", "false"]);
+        git(&work, &["config", "tag.gpgsign", "false"]);
+        git(&work, &["remote", "add", "origin", &bare.to_string_lossy()]);
+
+        Self { work, bare }
+    }
+
+    /// Write `contents` to `relative_path` in the work tree, creating
+    /// parent directories. Not committed until [`Self::commit`] runs.
+    pub fn write_file(&self, relative_path: &str, contents: &str) {
+        let path = self.work.join(relative_path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent directory");
+        }
+        fs::write(&path, contents).unwrap_or_else(|err| panic!("write {}: {err}", path.display()));
+    }
+
+    /// Stage every change, commit it, mirror to the bare repo, and
+    /// return the new commit's SHA.
+    #[must_use]
+    pub fn commit(&self, message: &str) -> String {
+        git(&self.work, &["add", "-A"]);
+        git(&self.work, &["commit", "-q", "-m", message]);
+        self.mirror();
+        self.head()
+    }
+
+    /// Create an annotated tag on `HEAD` and mirror it to the bare repo.
+    pub fn tag(&self, name: &str) {
+        git(&self.work, &["tag", "-a", name, "-m", name]);
+        self.mirror();
+    }
+
+    /// Force-push every branch and tag into the bare repo, so what a
+    /// test resolves against always matches the work tree.
+    fn mirror(&self) {
+        git(&self.work, &["push", "-q", "--force", "origin", "--all"]);
+        git(&self.work, &["push", "-q", "--force", "origin", "--tags"]);
+    }
+
+    /// SHA of the work tree's current `HEAD`.
+    #[must_use]
+    pub fn head(&self) -> String {
+        git(&self.work, &["rev-parse", "HEAD"]).trim().to_string()
+    }
+
+    /// `file://` URL of the bare repo — the transport half of a git
+    /// specifier, and the `repo` field a `type: git` resolution records.
+    #[must_use]
+    pub fn file_url(&self) -> String {
+        // `dunce` keeps Windows paths in their `C:\…` form rather than
+        // the `\\?\` UNC prefix, which `Url::from_file_path` would
+        // otherwise carry into the URL and `git` would reject.
+        let canonical = dunce::canonicalize(&self.bare).expect("canonicalize bare repo path");
+        Url::from_file_path(&canonical)
+            .unwrap_or_else(|()| panic!("build a file:// URL for {}", canonical.display()))
+            .to_string()
+    }
+
+    /// The `git+file://…#<committish>` specifier a manifest declares to
+    /// install this repo at `committish` (a SHA, tag, or branch).
+    #[must_use]
+    pub fn git_url_at(&self, committish: &str) -> String {
+        format!("git+{}#{committish}", self.file_url())
+    }
+}
+
+/// Run `git` with `args` in `cwd` and return its stdout.
+///
+/// Panics when `git` is missing or the command fails — per
+/// `pnpm/AGENTS.md`, a test must not tolerate an under-provisioned
+/// environment by skipping.
+fn git(cwd: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|err| panic!("run `git {}`: {err}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "`git {}` failed in {}:\n{}",
+        args.join(" "),
+        cwd.display(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("git stdout is UTF-8")
+}

--- a/pnpm/crates/testing-utils/src/lib.rs
+++ b/pnpm/crates/testing-utils/src/lib.rs
@@ -5,5 +5,6 @@ pub mod bin;
 pub mod env_guard;
 pub mod fixtures;
 pub mod fs;
+pub mod git_repo;
 pub mod known_failure;
 pub mod registry;

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -695,19 +695,21 @@ Rust port notes:
 
 Install tests:
 
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:31` `from a github repo`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:48` `from a github repo through URL`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:61` `from a github repo with different name via named installation`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:105` `from a github repo with different name`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:150` `a subdependency is from a github repo with different name`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:174` `from a git repo`
+The install-level ports build a local repo per test and reference it over `git+file://` (`GitRepoFixture` in `pacquet-testing-utils`), so the whole git install path runs without network access — the same technique upstream's `createGitPreparePackage` uses. That trades away the *host* archive identity (`gitHosted: true` tarball resolution), which is pinned separately at the resolver level; a `file:` repo resolves to `type: git`. They live in `crates/cli/tests/git_hosted_install.rs`.
+
+- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:31` `from a github repo` — `pnpm add <shorthand>` (no alias) is a `known_failures` stub (`add_from_a_github_repo_shorthand`): `add`'s `split_name_spec` treats the whole argument as a package name, so an alias-less git specifier is sent to the registry as a package name. The aliased and manifest-declared forms work.
+- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:48` `from a github repo through URL` — same alias-less `pnpm add` gap, stubbed as `add_from_a_github_repo_through_url`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:61` `from a github repo with different name via named installation` — ported as `install_from_a_git_repo_with_a_different_name_via_named_installation`. Asserts the alias/`realName`/`dependencyType` on the `pnpm:root` event and both linked bins; the `added.version` half (upstream expects `1.0.0`) is the `known_failures` stub `root_log_reports_the_package_version_for_a_git_dependency`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:105` `from a github repo with different name` — ported as `install_from_a_git_repo_with_a_different_name`.
+- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:150` `a subdependency is from a github repo with different name` — `known_failures` stub `a_subdependency_is_from_a_git_repo_with_a_different_name`: needs a registry fixture whose manifest declares a git dependency, but a committed fixture cannot name a per-run `git+file://` repo. Unblocking needs the `pnpr-fixtures` builder to substitute a per-run repo URL.
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:174` `from a git repo` — ported as `install_from_a_git_repo` (upstream reaches github over `git+ssh://` and self-skips on CI; the `file:` repo exercises the same non-host `type: git` branch). Also pins the bare-`git+…#<commit>` importer ref against pnpm 11.
 - [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:206` `from a github repo that has no package.json file` — covered at fetcher level by `crates/git-fetcher/src/fetcher/tests.rs::fetcher_handles_repo_without_package_json`. Full install-level test deferred until a non-resolver lockfile fixture lands.
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:276` `re-adding a git repo with a different tag`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:323` `should not update when adding unrelated dependency`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:354` `git-hosted repository is not added to the store if it fails to be built`
-- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:366` `from subdirectories of a git repo` — covered at fetcher level by `fetcher_packs_subfolder_when_path_set`. Full install-level test deferred (Stage 2 resolver dependency).
-- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:389` `no hash character for github subdirectory install`
-- [ ] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:311` `run prepare script for git-hosted dependencies`
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:276` `re-adding a git repo with a different tag` — ported as `re_adding_a_git_repo_with_a_different_tag`.
+- [ ] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:323` `should not update when adding unrelated dependency` — `known_failures` stub `should_not_update_when_adding_unrelated_dependency`: a git dependency's locked commit is not reused from the wanted lockfile — every resolution re-runs `git ls-remote`, so an unrelated `pnpm add` relocks a moving ref (verified against pnpm 11.13.1, which keeps the commit). The reuse map keys on integrity, which git resolutions lack.
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:354` `git-hosted repository is not added to the store if it fails to be built` — ported as `git_hosted_repository_is_not_added_to_the_store_if_it_fails_to_be_built`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:366` `from subdirectories of a git repo` — ported as the install-level `install_from_subdirectories_of_a_git_repo` (two `#path:` subdirectories of one repo); the fetcher-level `fetcher_packs_subfolder_when_path_set` remains.
+- [x] `TypeScript repo: installing/deps-installer/test/install/fromRepo.ts:389` `no hash character for github subdirectory install` — ported as `no_hash_character_for_subdirectory_install` (`#path:/&<ref>` splits the ref out of the `path:` fragment).
+- [x] `TypeScript repo: installing/deps-installer/test/install/lifecycleScripts.ts:311` `run prepare script for git-hosted dependencies` — ported as `run_prepare_script_for_git_hosted_dependencies` (asserts the full `preinstall,install,postinstall,prepare,preinstall,install,postinstall` order).
 
 Fetcher/resolver/store tests:
 
@@ -733,12 +735,12 @@ Fetcher/resolver/store tests:
 - [x] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:610` `prevent directory traversal attack when path is present` — `tarball_path_traversal_attack_is_rejected`.
 - [x] `TypeScript repo: fetching/tarball-fetcher/test/fetch.ts:637` `fail when path is not exists` — `tarball_path_to_missing_subdir_is_rejected`.
 - [x] `TypeScript repo: resolving/git-resolver/test/index.ts:188` `resolveFromGit() with sub folder` — ported as `path_suffix_appended_to_id_and_resolution` in `crates/resolving-git-resolver/src/git_resolver/tests.rs`.
-- [ ] `TypeScript repo: resolving/git-resolver/test/index.ts:211` `resolveFromGit() with both sub folder and branch`
-- [ ] `TypeScript repo: resolving/git-resolver/test/index.ts:482` `resolve a private repository using the HTTPS protocol without auth token`
-- [ ] `TypeScript repo: resolving/git-resolver/test/index.ts:526` `resolve a private repository using the HTTPS protocol and an auth token`
+- [x] `TypeScript repo: resolving/git-resolver/test/index.ts:211` `resolveFromGit() with both sub folder and branch` — ported as `sub_folder_and_branch_resolve_to_a_tarball_carrying_the_path` in `crates/resolving-git-resolver/src/git_resolver/tests.rs`.
+- [x] `TypeScript repo: resolving/git-resolver/test/index.ts:482` `resolve a private repository using the HTTPS protocol without auth token` — ported as `private_https_repo_without_auth_falls_back_to_the_ssh_url` (the `FakeProbe::private_reachable_over` seam makes exactly one transport reachable).
+- [x] `TypeScript repo: resolving/git-resolver/test/index.ts:526` `resolve a private repository using the HTTPS protocol and an auth token` — ported as `private_https_repo_with_an_auth_token_keeps_the_authenticated_url`. Fixing this found a divergence: pacquet resolved an auth-bearing private repo to the host's public `codeload` archive URL (`gitHosted: true` tarball) — a URL that carries none of the URL's credentials. Now `hosted: None` in the private-repo branch of `from_hosted_git` keeps it a `type: git` resolution against the authenticated remote, matching upstream's `tarball: undefined`.
 - [x] `TypeScript repo: installing/package-requester/test/index.ts:884` `fetch a git package without a package.json` — covered alongside `fetching/git-fetcher/test/index.ts:150` via `fetcher_handles_repo_without_package_json`.
 - [ ] `TypeScript repo: installing/deps-installer/test/install/peerDependencies.ts:30` `don't fail when peer dependency is fetched from GitHub`
-- [ ] `TypeScript repo: installing/deps-installer/test/lockfile.ts:600` `updating package that has a github-hosted dependency`
+- [ ] `TypeScript repo: installing/deps-installer/test/lockfile.ts:600` `updating package that has a github-hosted dependency` — `known_failures` stub `updating_package_that_has_a_git_hosted_dependency` in `crates/cli/tests/git_hosted_install.rs`: same registry-fixture-with-a-git-dependency blocker as `fromRepo.ts:150`.
 - [x] `TypeScript repo: store/pkg-finder/test/readPackageFileMap.test.ts:67` `should resolve git-hosted tarball packages (no type, has tarball)` — write side covered by `tarball_fetcher::tests::writes_index_row_when_writer_provided`; read side reuses the existing tarball-warm prefetch (no git-specific code path).
 - [x] `TypeScript repo: store/pkg-finder/test/readPackageFileMap.test.ts:84` `should resolve git dependencies with type "git" and return readable file paths` — same coverage: the write side produces a `gitHostedStoreIndexKey` row at `pkg_id\tbuilt` (see `create_virtual_store::tests::snapshot_cache_key_for_git_resolution_uses_git_hosted_key` for the read-side key shape pin).
 


### PR DESCRIPTION
## Summary

Stage 9 of pnpm/pnpm#13146 — porting the **Installation Of Git-Hosted Packages** suite to pacquet.

Ports the install half of `installing/deps-installer/test/install/fromRepo.ts`, the git-hosted `prepare` case from `lifecycleScripts.ts:311`, and the three open git-resolver unit tests (`resolveFromGit() with both sub folder and branch`, and the two private-HTTPS-repo cases).

The install-level tests build a local repository per test and install it over `git+file://` (new `GitRepoFixture` in `pacquet-testing-utils`), so the entire git install path — `ls-remote` resolution, clone, `prepare`, packlist, link — runs without network access. This is the same technique upstream's own `createGitPreparePackage` uses. The trade-off is the *host* archive identity (`gitHosted: true` tarball resolution), which can't be modeled with a local repo; that shape is pinned separately at the resolver level. A `file:` repo resolves to `type: git`.

Porting these surfaced **two cross-stack divergences**, both fixed in pacquet (the TypeScript CLI is already correct — verified byte-for-byte against pnpm 11.13.1):

1. **Importer version for a non-host git dep.** A git dep with no host archive (ssh / self-hosted / `git+file:`) whose package name matched its alias recorded `<name>@git+<repo>#<commit>` in the importer entry, where pnpm writes the bare `git+<repo>#<commit>` ref. `real_name` now reads the fetched manifest name for a `Git` resolution the same way it already did for a remote tarball.
2. **Auth-bearing private HTTPS repo.** Such a repo resolved to the host's public `codeload` archive URL — a URL carrying none of the credentials that made the repo reachable. The private-repo branch of `from_hosted_git` now drops the host-archive option (`hosted: None`), matching upstream's `tarball: undefined`, so it stays a `type: git` resolution against the authenticated remote.

Three behaviors are tracked as `known_failures` stubs (each with a doc comment citing the upstream test and a reason string): alias-less `pnpm add <git-spec>`, the `pnpm:root` `added.version` value for a git dep, and reuse of a git dep's locked commit across resolutions (a moving ref is currently relocked on an unrelated `pnpm add`).

Each ported test was verified to catch its regression by temporarily breaking the implementation, per the plan's "test the tests" rule; `TEST_PORTING.md` checkboxes are updated in the same PR.

Related to pnpm/pnpm#13146.

## Squash Commit Body

```text
test(pacquet): port the git-hosted install suite (stage 9)

Port the install half of `fromRepo.ts`, the git-hosted `prepare` case,
and the three open git-resolver unit tests, per stage 9 of
pnpm/pnpm#13146.

The install-level tests build a local repo per test and install it over
`git+file://` (new `GitRepoFixture` in `pacquet-testing-utils`), so the
whole git install path runs without network access. That trades away the
host archive identity (`gitHosted: true` tarball), which the resolver
tests pin separately; a `file:` repo resolves to `type: git`.

Two cross-stack divergences surfaced and are fixed in pacquet (the
TypeScript CLI is already correct, verified byte-for-byte against pnpm
11.13.1):

- A non-host git dep whose package name matches its alias recorded
  `<name>@git+<repo>#<commit>` in the importer entry instead of the bare
  `git+<repo>#<commit>` ref. `real_name` now reads the manifest name for
  a `Git` resolution the same way it does for a remote tarball.
- An auth-bearing private HTTPS repo resolved to the host's public
  `codeload` archive URL, which carries none of the URL's credentials.
  The private-repo branch of `from_hosted_git` now drops the host
  archive option, matching upstream's `tarball: undefined`.

Three behaviors are tracked as known_failures stubs: alias-less
`pnpm add <git-spec>`, the `pnpm:root` added.version for a git dep, and
reuse of a git dep's locked commit across resolutions.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. *(The two behavior fixes bring pacquet in line with the already-correct TypeScript CLI; no TS change needed. This is otherwise a pacquet-only test port.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787084135&installation_id=145934176&pr_number=13160&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13160&signature=7717860046c89fe6da364da7cd8385c63b9f207866a048e35ba2b7913df1a99e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Private Git dependencies over HTTPS with embedded authentication are now preserved as authenticated Git sources (no fallback to credential-less archive URLs).
  - Lockfiles/importers for non-hosted Git refs now record the bare `git+<repo>#<commit>` form (removing the previous `<name>@`-prefixed behavior).
  - Git dependency name/version resolution is more consistent across alias, tag, and subdirectory fragment installs.
- **Documentation**
  - Updated release/porting guidance to reflect the corrected lockfile importer and Git resolution behaviors.
- **Tests**
  - Expanded offline Git install/resolver coverage, including `prepare`/lifecycle execution order, `#path:` handling, alias/tag updates, multi-path resolution, and build-failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->