### PR TITLE
chore: update lockfile, Node.js, and pnpm versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "shx": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@12.0.0-alpha.15",
+  "packageManager": "pnpm@12.0.0-alpha.16",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "12.0.0-alpha.15",
+      "version": "12.0.0-alpha.16",
       "onFail": "download"
     },
     "runtime": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,115 +7,115 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 12.0.0-alpha.15
-        version: 12.0.0-alpha.15
+        specifier: 12.0.0-alpha.16
+        version: 12.0.0-alpha.16
       pnpm:
-        specifier: 12.0.0-alpha.15
-        version: 12.0.0-alpha.15
+        specifier: 12.0.0-alpha.16
+        version: 12.0.0-alpha.16
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.15':
-    resolution: {integrity: sha512-JpjZNRq1BYvVjM/bpWqq1T9Hm+kcutbkr5YL/VhOdbwaGITUCYMa6gMeoXL1E5iRU3+rfGX0g1UfMHfg4WM0Qw==}
+  '@pnpm/exe.darwin-arm64@12.0.0-alpha.16':
+    resolution: {integrity: sha512-3/hMVxWHfT29/8quF5DbsPAVb+ZOJrG4LcQDDcZzFVn4RYv2Ll+a0mu+ERtJaaf8UouvJKEkANyZ2BH69jc5NA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.15':
-    resolution: {integrity: sha512-dGL+0+8J7GFAsGJ/cAgpnwYVbCY6awzBN6f63wyGXiDsUf4YqCFh7i8aOtIOcIwqE6eFfMGbthc5npa+vILHqA==}
+  '@pnpm/exe.darwin-x64@12.0.0-alpha.16':
+    resolution: {integrity: sha512-4b0t6i4fdd4GSxQ75X95ZKDzdq7bzgVkXFhynwqWuLpTZGxljFyoOJwNNmMPsxLXcZPyVkAIMDJFtQY+sioWdw==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.15':
-    resolution: {integrity: sha512-nGNuJtjrobLOF8/oPvpvqU+YmxbKujuYrRBq9CMtTBoA4zC0nXPZp2r2A/YZK2jB+65/vnT+NBdfNFUkb5z7kw==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.16':
+    resolution: {integrity: sha512-0/mEjuOCgjuYiR4K2lhbGVWATXNVtKvb6jRa6AqTCYXNccLsxqZoOhs/ueC4dUp/6iW8njPrTPupJRsrkLv5nA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.15':
-    resolution: {integrity: sha512-8RmCrWMm0gBAS7QngUjrv40Iw16sCshb7T463riZWqvEOsm6LFpQBZ4gFwrXHciTKZhklIJYmnf+GZ1WTlHj2Q==}
+  '@pnpm/exe.linux-arm64@12.0.0-alpha.16':
+    resolution: {integrity: sha512-PcefktUnvX9p1lTnJYIx78YNnsXNqMF3NrBo3ajcJEn0yKnp5h0VJlzXeftD00u4wgZnL7WNzop6JdPoN5QTwg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.15':
-    resolution: {integrity: sha512-xSnBHhFnhuvngFrK7mbU7mJHClTTpKvUbE67BxOIwur2ED58rvpmu8NP9TsmqktupQxXi61EbzTN4depiKsA6Q==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.16':
+    resolution: {integrity: sha512-HlPRuLEkxC4Ymf856sGucd1RnjGXO9yvfmZ3jdk/MwkCa96j4KrA/RxqyeneT2bmvw/EOO1Q8HSTGZxcwFGkmw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-alpha.15':
-    resolution: {integrity: sha512-cXrLlNXf5RnbX1OFE8LHs3irquZcG9Fktd0S3i/S40dfOGGE2qwhaGPwEzJtJhTjt89yda68H3r9/eo5GKUAlQ==}
+  '@pnpm/exe.linux-x64@12.0.0-alpha.16':
+    resolution: {integrity: sha512-MxRRABWXnlutujhv7NBPUtsGveJdgtIOZFmf7n4eI8RZ1/UpNL98hCYsd++6zJcdw2h1FEExAlwl7ewD8Zim3g==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.15':
-    resolution: {integrity: sha512-5ZNHbaBpyvv3z0NCoDTYSB8sV56sNbQz3Qj1uHUc2iwZJ/zXH7+l74B1ZNhuEPqsNkyljR+EBAAxTe4VJjpzwA==}
+  '@pnpm/exe.win32-arm64@12.0.0-alpha.16':
+    resolution: {integrity: sha512-gUPZx39UrpHl/tjSrL74y2wn7O+1C2ZvMhMLu1PytirULhGrW0Qxwx7i2ohu68FYxvBlhNl7Q+xjfI5OVLi9+g==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-alpha.15':
-    resolution: {integrity: sha512-mrzDYxizd1oQHLMbn5GEcMh4eAJSQCN91HA4OEChm2ynZe9mJH2+X8FeJodaHLsMq0YsimyJeffAaZsGHCW7fA==}
+  '@pnpm/exe.win32-x64@12.0.0-alpha.16':
+    resolution: {integrity: sha512-Ll05GkqFKyBU4FShG98amINgOvYuiZSoh7rcne7hFvWXisvOYRFqV2jVKcuSW7T4OJBAOoYnfQieUoHM2w5dCw==}
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0-alpha.15':
-    resolution: {integrity: sha512-N6j0fHgSeRgpT0NZBk8P0zoalgQDnk63xuatfosEJ2FXNqN33Z5G0mkdvu+b2HMEhgrci0CFMKMkizURIb3hRg==}
+  '@pnpm/exe@12.0.0-alpha.16':
+    resolution: {integrity: sha512-ZqKZLuUwYj2gGYumlPGOKi+Nb8G1GxflaYzVbciN+70X7yoh4Fmrx2L8I8t8633+AQe1HrN187VsI6vCcDL8+A==}
     engines: {node: '>=18.*'}
     hasBin: true
 
-  pnpm@12.0.0-alpha.15:
-    resolution: {integrity: sha512-LUOrkRXFFCsrFvlFtW9/r38apbegjcGJoCTBo2ntNjjc2kq+cSYj8/wos7ta8q0Ep85T+yxylYE/oNOQSapxzA==}
+  pnpm@12.0.0-alpha.16:
+    resolution: {integrity: sha512-htjhs7/nHkXz4uy6PCKu8XDauE5rsWkL1EXWX6lcZuSLsUep1vhinL3ZbQlNnpAwK01x0ZH6vpKffRyzlHtvOw==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.15':
+  '@pnpm/exe.darwin-arm64@12.0.0-alpha.16':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.15':
+  '@pnpm/exe.darwin-x64@12.0.0-alpha.16':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.15':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.16':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.15':
+  '@pnpm/exe.linux-arm64@12.0.0-alpha.16':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.15':
+  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.16':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-alpha.15':
+  '@pnpm/exe.linux-x64@12.0.0-alpha.16':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.15':
+  '@pnpm/exe.win32-arm64@12.0.0-alpha.16':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-alpha.15':
+  '@pnpm/exe.win32-x64@12.0.0-alpha.16':
     optional: true
 
-  '@pnpm/exe@12.0.0-alpha.15':
+  '@pnpm/exe@12.0.0-alpha.16':
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.15
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.15
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.15
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.15
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.15
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.15
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.15
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.15
+      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.16
+      '@pnpm/exe.darwin-x64': 12.0.0-alpha.16
+      '@pnpm/exe.linux-arm64': 12.0.0-alpha.16
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.16
+      '@pnpm/exe.linux-x64': 12.0.0-alpha.16
+      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.16
+      '@pnpm/exe.win32-arm64': 12.0.0-alpha.16
+      '@pnpm/exe.win32-x64': 12.0.0-alpha.16
 
-  pnpm@12.0.0-alpha.15:
+  pnpm@12.0.0-alpha.16:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.15
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.15
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.15
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.15
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.15
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.15
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.15
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.15
+      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.16
+      '@pnpm/exe.darwin-x64': 12.0.0-alpha.16
+      '@pnpm/exe.linux-arm64': 12.0.0-alpha.16
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.16
+      '@pnpm/exe.linux-x64': 12.0.0-alpha.16
+      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.16
+      '@pnpm/exe.win32-arm64': 12.0.0-alpha.16
+      '@pnpm/exe.win32-x64': 12.0.0-alpha.16
 
 ---
 lockfileVersion: '9.0'
@@ -15741,8 +15741,8 @@ packages:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
 
-  pnpm@11.15.0:
-    resolution: {integrity: sha512-Jm+JV6MNK+bpRo5eZrze3TWnlBdfcbBnuoUE1obM4dDA9CmzPDI8PFaa1IkeZnV0pJ/3HRuJoizGbxPGWBjFeA==}
+  pnpm@11.15.1:
+    resolution: {integrity: sha512-gTULB+U8lTigLx8jA7QpD6LXvgTlbiqXDEzEtBfcdh3hlu2r1J1Vx9yVgNuBAHxEFD5OPX5GKzAA0jwlUSLQZQ==}
     engines: {node: '>=22.13'}
     hasBin: true
 
@@ -18564,7 +18564,7 @@ snapshots:
     dependencies:
       command-exists: 1.2.9
       cross-spawn: 7.0.6
-      pnpm: 11.15.0
+      pnpm: 11.15.1
 
   '@pnpm/fetch@1001.0.0(@pnpm/logger@1001.0.1)(supports-color@10.2.2)':
     dependencies:
@@ -23749,7 +23749,7 @@ snapshots:
     dependencies:
       find-up: 5.0.0
 
-  pnpm@11.15.0: {}
+  pnpm@11.15.1: {}
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
This automated PR refreshes the project's pinned versions:

- Updates the lockfile to the latest compatible versions of dependencies.
- Bumps Node.js to the latest 26.x release, propagated into the CI, release, and benchmark workflows via the meta-updater.
- Bumps pnpm to the latest `next-12` release (`packageManager` and `devEngines.packageManager`).

Created by the update-lockfile workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787123466&installation_id=145934176&pr_number=13165&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13165&signature=7fb12a09f20831912cfbd9fecbfceca5c7fccb7ed8c81c8f14f7ed5d835b2db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package manager version to pnpm 12.0.0-alpha.16.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->