### PR TITLE
fix(tarball): fix a lost-wakeup hang in the tarball mem cache

### DIFF
--- a/.changeset/tarball-mem-cache-lost-wakeup.md
+++ b/.changeset/tarball-mem-cache-lost-wakeup.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed a rare hang where `pnpm install` or `pnpm add` could wait forever: when two tasks fetched the same tarball concurrently, the waiting task could miss the downloader's completion notification and never wake up.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,17 @@
+# Workspace-wide cargo-nextest configuration (pacquet and pnpr).
+
+[profile.default]
+# Terminate a test that stops making progress. Without `terminate-after`,
+# nextest only *marks* a test SLOW every `period` and waits forever — a
+# single hung test binary then wedges the entire run until the CI job is
+# killed from outside, with no output from the offender. With it, the
+# test is SIGTERM'd (then SIGKILL'd after the grace period), reported as
+# TIMEOUT with its captured output, and the rest of the run completes.
+#
+# The threshold must clear the suite's legitimately slow tests: the
+# fetch-timeout retry-ladder tests (install_runtimes bad-integrity,
+# lockfile_verification trust-lockfile, and the package-manager
+# fresh-resolve pair) run a designed 60s timeout + 10s retry, ~70s on
+# Linux/Windows and ~85s on macOS. 5 × 60s = 300s keeps ~3.5× headroom
+# over the slowest of them.
+slow-timeout = { period = "60s", terminate-after = 5 }

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -100,6 +100,12 @@ jobs:
           - os: blacksmith-12vcpu-macos-latest
             os_label: macos
     runs-on: ${{ matrix.os }}
+    # Backstop for hangs outside nextest's per-test terminate-after
+    # (stuck cargo build, stuck tool download): warm-cache runs finish
+    # in ~5 minutes, cold-cache rebuilds of the full workspace need the
+    # rest of the hour. Without this, a wedged job runs on the default
+    # 360-minute limit.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -2219,7 +2219,8 @@ impl<'a> DownloadTarballToStore<'a> {
                 // Checking first and registering after loses that
                 // wakeup and parks this task forever (nothing ever
                 // notifies the slot again once it is terminal).
-                let mut notified = std::pin::pin!(notify.notified());
+                let notified = notify.notified();
+                let mut notified = std::pin::pin!(notified);
                 notified.as_mut().enable();
                 match &*cache_lock.read().await {
                     CacheValue::Available(cas_paths) => {

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -2209,23 +2209,42 @@ impl<'a> DownloadTarballToStore<'a> {
             };
 
             tracing::info!(target: "pacquet::download", ?package_url, "Wait for cache");
-            notify.notified().await;
-            match &*cache_lock.read().await {
-                CacheValue::Available(cas_paths) => {
-                    // Same rationale as the pre-notify `Available`
-                    // branch above.
-                    emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
-                    Ok(Arc::clone(cas_paths))
+            loop {
+                // Register with the `Notify` *before* re-checking the
+                // slot. `notify_waiters` stores no permit — it wakes
+                // only `Notified` futures already registered at that
+                // instant — and the read guard from the `InProgress`
+                // observation above is released before this point, so
+                // the owner's flip-and-notify can land in between.
+                // Checking first and registering after loses that
+                // wakeup and parks this task forever (nothing ever
+                // notifies the slot again once it is terminal).
+                let mut notified = std::pin::pin!(notify.notified());
+                notified.as_mut().enable();
+                match &*cache_lock.read().await {
+                    CacheValue::Available(cas_paths) => {
+                        // Same rationale as the pre-wait `Available`
+                        // branch above.
+                        emit_progress_found_in_store::<Reporter>(
+                            package_id,
+                            requester,
+                            progress_key,
+                        );
+                        return Ok(Arc::clone(cas_paths));
+                    }
+                    CacheValue::Failed => {
+                        return Err(TarballError::SiblingFetchFailed {
+                            url: package_url.to_string(),
+                        });
+                    }
+                    // The owner notifies only after flipping the slot
+                    // to `Available` or `Failed`, so a wake with the
+                    // slot still `InProgress` cannot happen — but a
+                    // stale registration completing early is harmless
+                    // either way: re-register and park again.
+                    CacheValue::InProgress(_) => {}
                 }
-                CacheValue::Failed => {
-                    Err(TarballError::SiblingFetchFailed { url: package_url.to_string() })
-                }
-                // The owner only flips us to `Available` or `Failed`
-                // before notifying. Hitting this is a programmer
-                // error in the owner branch below.
-                CacheValue::InProgress(_) => unreachable!(
-                    "owner notified waiters but left the cache in InProgress for {package_url:?}",
-                ),
+                notified.await;
             }
         } else {
             let notify = Arc::new(Notify::new());


### PR DESCRIPTION
## Summary

The Rust CI job for the 11.15.1 release commit hung for 62 minutes until it was cancelled: https://github.com/pnpm/pnpm/actions/runs/29705938247/job/88242852400. The last test of the run, `pacquet-cli::add save_prefix_empty_writes_exact_version` (normally 0.2s), never finished — the spawned pacquet process was still alive when the job died.

Root cause: a lost wakeup in `DownloadTarballToStore::run_with_mem_cache`. A task that finds the per-URL cache slot `InProgress` released the `RwLock` read guard and only then polled `Notify::notified()`. `notify_waiters()` stores no permit — it wakes only futures registered at that instant — so if the owning fetch flips the slot to `Available`/`Failed` and notifies inside that window, the waiter parks forever (nothing ever notifies the slot again). The window requires the owner to complete its flip on another worker thread while the waiter is preempted mid-poll, which is why it surfaced only once, on an oversubscribed CI runner. The waiter path is exercised on every cold `add`/`install`: the resolve-time prefetcher owns the fetch and the install pass waits on the same slot (or vice versa — a parked detached prefetch task pins the store-index writer channel and hangs the final `writer_task.await` instead).

The fix follows the documented tokio pattern: pin the `Notified` future and `enable()` it to register interest *before* re-checking the slot, awaiting only if the slot is still `InProgress`, in a loop.

Two CI guardrails ride along so any similar hang can never wedge a job again:

- A workspace `.config/nextest.toml` with `slow-timeout = { period = "60s", terminate-after = 5 }`: a test stuck past 300s is killed and reported as TIMEOUT with its captured output, and the rest of the run completes. 300s keeps ~3.5× headroom over the suite's slowest legitimate tests (the fetch-timeout retry-ladder tests: ~70s on Linux/Windows, ~85s on macOS).
- `timeout-minutes: 60` on the Rust CI test job as a backstop for hangs outside nextest (warm-cache runs finish in ~5 minutes; cold-cache rebuilds get the rest of the hour).

Rust-only: the TypeScript CLI dedupes concurrent tarball fetches through shared promises, which cannot lose a completion, so there is nothing to port.

## Squash Commit Body

```text
A task that found the per-URL tarball mem-cache slot InProgress released
the RwLock read guard and only then polled Notify::notified().
notify_waiters() stores no permit - it wakes only futures already
registered at that instant - so an owner that flipped the slot to
Available/Failed and notified inside that window left the waiter parked
forever. The window needs the owner to complete its flip on another
worker thread while the waiter is preempted between the guard drop and
its first poll, which is why it surfaced only as a rare hang on an
oversubscribed CI runner: pacquet-cli::add
save_prefix_empty_writes_exact_version (a 0.2s test) hung for over an
hour and wedged the Rust CI job at
https://github.com/pnpm/pnpm/actions/runs/29705938247.

The waiter path runs on every cold add/install: the resolve-time
prefetcher owns the fetch and the install pass waits on the same slot.
A detached prefetch task losing the same race instead pinned the
store-index writer channel open and hung the final writer_task.await -
same root cause, either direction.

Fix per the documented tokio pattern: pin the Notified future and
enable() it to register interest before re-checking the slot state,
awaiting only while the slot is still InProgress, in a loop.

The exact interleaving cannot be reproduced deterministically without
loom (it requires preempting the waiter mid-poll), so no regression
test accompanies the fix. Instead, CI gains guardrails so a recurrence
is a visible failure, not a wedged job: a workspace .config/nextest.toml
sets slow-timeout terminate-after = 5 (a test stuck past 300s is killed
and reported as TIMEOUT with output; ~3.5x headroom over the slowest
legitimate retry-ladder tests), and the Rust CI test job is capped at
timeout-minutes: 60 as a backstop for non-test hangs.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests — the lost wakeup needs the waiter preempted
  mid-poll between two specific instructions, which cannot be scheduled
  deterministically without loom; the existing waiter-path tests cover the new
  loop, and the nextest terminate-after guardrail turns any recurrence into a
  5-minute TIMEOUT failure with output.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787128962&installation_id=145934176&pr_number=13166&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13166&signature=53858844022f71b27e32a14279d848db0a95b76ffe04fc2c0ce0c1910694a581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare hang that could occur during package installation or addition when concurrent operations fetched the same tarball.
  * Improved reliability when waiting for shared package downloads to complete or fail.

* **Tests**
  * Added safeguards to detect stalled tests and prevent CI jobs from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->