### PR TITLE
fix(exec): revert script ordering change for `pnpm run --sequential /regex/`

### DIFF
--- a/.changeset/some-games-smash.md
+++ b/.changeset/some-games-smash.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.commands": patch
+"pnpm": patch
+---
+
+Revert script ordering change for `pnpm run --sequential /regex/`

--- a/pnpm11/exec/commands/src/runRecursive.ts
+++ b/pnpm11/exec/commands/src/runRecursive.ts
@@ -245,10 +245,7 @@ export function getSpecifiedScripts (scripts: PackageScripts, scriptName: string
 
   // if scriptName which a user passes is RegExp (like /build:.*/), multiple scripts to execute will be selected with RegExp
   if (scriptSelector) {
-    const scriptKeys = Object.keys(scripts)
-    return scriptKeys
-      .filter(script => script.match(scriptSelector))
-      .sort()
+    return Object.keys(scripts).filter(script => script.match(scriptSelector))
   }
 
   return []

--- a/pnpm11/exec/commands/test/index.ts
+++ b/pnpm11/exec/commands/test/index.ts
@@ -801,7 +801,7 @@ test('cliOptionsTypes exposes sequential as Boolean flag', () => {
   expect(options.sequential).toBe(Boolean)
 })
 
-test('RegExp script matching executes multiple scripts in lexicographically sorted order when sequential is enabled', async () => {
+test('RegExp script matching executes multiple scripts in package.json order when sequential is enabled', async () => {
   prepare({
     scripts: {
       'build:z': 'node -e "require(\'fs\').appendFileSync(\'./order.log\', \'z\')"',
@@ -822,7 +822,7 @@ test('RegExp script matching executes multiple scripts in lexicographically sort
   }, ['/^build:.*/'])
 
   const outputLog = fs.readFileSync(path.join(process.cwd(), 'order.log'), 'utf-8')
-  expect(outputLog).toBe('amz')
+  expect(outputLog).toBe('zam')
 })
 
 test('passing --sequential option sets effective workspaceConcurrency to 1 for matched scripts without timing flakes', async () => {
@@ -851,4 +851,3 @@ test('passing --sequential option sets effective workspaceConcurrency to 1 for m
 test('shorthands maps -s to --sequential and --workspace-concurrency=1', () => {
   expect(run.shorthands.s).toEqual(['--sequential', '--workspace-concurrency=1'])
 })
-


### PR DESCRIPTION
## Summary

Reverts the lexicographical sorting of scripts introduced in #13074, as this was a breaking change in behaviour. When using `pnpm run --sequential /regex/`, scripts will now be executed in the order they are listed in `package.json`, giving developers control over the order without needing odd script prefixes. Fixes #13174.

I'm unfortunately not familiar enough with Rust to confidently port this to the new implementation (and didn't want to set an agent on it without being able to review what it did myself). This may be a case where the Rust version introduces a breaking change to this behaviour when released (though I would very much prefer to have it also match the `package.json` order so developers have more control).

## Squash Commit Body

```text
Reverts the lexicographical sorting of scripts introduced in pnpm/pnpm#13074, as this was a breaking change in behaviour. When using `pnpm run --sequential /regex/`, scripts will now be executed in the order they are listed in `package.json`, giving developers control over the order without needing odd script prefixes. Fixes pnpm/pnpm#13174.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787143568&installation_id=145934176&pr_number=13175&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13175&signature=c18e8849be8879bae23fcc6048b0e82d3a540ec7146e0aa789f8ed0d6ae44e0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored `pnpm run --sequential` RegExp-based script selection to execute in the same order scripts appear in `package.json`, rather than alphabetical order.
* **Tests**
  * Updated RegExp `--sequential` coverage to assert the new execution order, including corresponding expected output changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->