### PR TITLE
feat(pacquet): make list and why feature complete with the TypeScript CLI

### DIFF
--- a/.changeset/list-why-parity.md
+++ b/.changeset/list-why-parity.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+`pnpm list` and `pnpm why` are now feature complete and behaviorally identical to the TypeScript CLI. `pnpm list` gained `--only-projects`, `--find-by` (finders declared in `.pnpmfile.cjs`), search by version range (`pnpm ls "foo@^2"`), subtree deduplication with `[deduped]` markers, peer/skipped annotations, the package-count summary, `--long` manifest details, resolved tarball URLs and absolute paths in `--json`/`--parseable` output, and `--depth` support for globally installed packages. `pnpm why` gained `--json`, `--parseable`, `--long`, `--prod`/`--dev`/`--no-optional`, `--find-by`, workspace project names in the reverse tree, dependency-field annotations, `[circular]`/`[deduped]` markers, peer-variant hashes, and the `Found N versions` summary.

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -16,6 +16,7 @@ pub mod create;
 pub mod dedupe;
 pub mod deploy;
 pub mod deprecate;
+pub(crate) mod deps_tree;
 pub mod dist_tag;
 pub mod dlx;
 pub mod docs;

--- a/pnpm/crates/cli/src/cli_args/deps_tree.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree.rs
@@ -1,0 +1,96 @@
+//! Dependency-tree building shared by `pnpm list` and `pnpm why`.
+//!
+//! Rust counterpart of the TypeScript `@pnpm/deps.inspection.tree-builder`
+//! package: a lockfile-backed dependency graph ([`graph`]), a
+//! materializer that turns it into renderable [`DependencyNode`] trees
+//! with deduplication and circular-reference marking ([`get_tree`]),
+//! per-node metadata resolution ([`pkg_info`]), dev/prod classification
+//! ([`dep_types`]), package search ([`search`]), and the reverse
+//! (dependents) tree used by `pnpm why` ([`dependents`]).
+
+pub(crate) mod build;
+pub(crate) mod dep_types;
+pub(crate) mod dependents;
+pub(crate) mod finders;
+pub(crate) mod get_tree;
+pub(crate) mod graph;
+pub(crate) mod pkg_info;
+pub(crate) mod render;
+pub(crate) mod search;
+
+use pacquet_lockfile::PkgNameVerPeer;
+
+/// Identity of a node in the dependency graph: a workspace project
+/// (importer) or an external package addressed by its depPath.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum TreeNodeId {
+    Importer(String),
+    Package(PkgNameVerPeer),
+}
+
+impl TreeNodeId {
+    /// Stable serialization used for deterministic tie-break ordering.
+    /// Byte-identical to the TypeScript `serializeTreeNodeId` so the
+    /// two stacks order same-name parents the same way.
+    pub(crate) fn serialize(&self) -> String {
+        match self {
+            TreeNodeId::Importer(importer_id) => {
+                format!(
+                    r#"{{"type":"importer","importerId":{}}}"#,
+                    serde_json::to_string(importer_id).expect("serialize importer id")
+                )
+            }
+            TreeNodeId::Package(dep_path) => {
+                format!(
+                    r#"{{"type":"package","depPath":{}}}"#,
+                    serde_json::to_string(&dep_path.to_string()).expect("serialize depPath")
+                )
+            }
+        }
+    }
+}
+
+/// One materialized node of the forward dependency tree — the shape the
+/// `list` renderers consume. Counterpart of the TypeScript
+/// `DependencyNode`.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DependencyNode {
+    pub alias: String,
+    pub name: String,
+    pub version: String,
+    /// Absolute filesystem path of the package.
+    pub path: String,
+    /// Tarball URL the package was resolved from, when reconstructible.
+    pub resolved: Option<String>,
+    pub is_peer: bool,
+    pub is_skipped: bool,
+    /// `Some(true)` when the package is only reachable through
+    /// `devDependencies`, `Some(false)` when only through production
+    /// dependencies, `None` when reachable through both.
+    pub dev: Option<bool>,
+    pub optional: bool,
+    pub circular: bool,
+    pub deduped: bool,
+    /// When `deduped`, the number of transitive dependencies elided
+    /// because this subtree was already expanded elsewhere.
+    pub deduped_dependencies_count: Option<u64>,
+    /// Short hash distinguishing peer-dependency variants of the same
+    /// `name@version`.
+    pub peers_suffix_hash: Option<String>,
+    pub searched: bool,
+    pub search_message: Option<String>,
+    pub dependencies: Vec<DependencyNode>,
+}
+
+/// Short hash of a depPath's peer-dependency suffix, used to
+/// distinguish deduped instances of the same package resolved against
+/// different peers. `None` when the depPath carries no peer suffix.
+pub(crate) fn peers_suffix_hash(dep_path: &PkgNameVerPeer) -> Option<String> {
+    let peer = dep_path.suffix.peer();
+    if peer.is_empty() {
+        return None;
+    }
+    let mut hex = pacquet_crypto_hash::create_hex_hash(peer);
+    hex.truncate(4);
+    Some(hex)
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree.rs
@@ -37,13 +37,13 @@ impl TreeNodeId {
             TreeNodeId::Importer(importer_id) => {
                 format!(
                     r#"{{"type":"importer","importerId":{}}}"#,
-                    serde_json::to_string(importer_id).expect("serialize importer id")
+                    serde_json::to_string(importer_id).expect("serialize importer id"),
                 )
             }
             TreeNodeId::Package(dep_path) => {
                 format!(
                     r#"{{"type":"package","depPath":{}}}"#,
-                    serde_json::to_string(&dep_path.to_string()).expect("serialize depPath")
+                    serde_json::to_string(&dep_path.to_string()).expect("serialize depPath"),
                 )
             }
         }
@@ -52,8 +52,8 @@ impl TreeNodeId {
 
 /// One materialized node of the forward dependency tree — the shape the
 /// `list` renderers consume. Counterpart of the TypeScript
-/// `DependencyNode`.
-#[derive(Debug, Clone, Default)]
+/// [`DependencyNode`].
+#[derive(Debug, Default, Clone)]
 pub(crate) struct DependencyNode {
     pub alias: String,
     pub name: String,

--- a/pnpm/crates/cli/src/cli_args/deps_tree.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree.rs
@@ -20,6 +20,13 @@ pub(crate) mod search;
 
 use pacquet_lockfile::PkgNameVerPeer;
 
+/// Cap on every recursive walk over the dependency graph. The cycle
+/// guards bound the *output*, not the recursion depth, so a hostile
+/// lockfile with an absurdly long acyclic chain could otherwise
+/// overflow the stack (worker threads get 2 MiB). Real dependency
+/// chains stay far below this.
+pub(crate) const MAX_WALK_DEPTH: usize = 256;
+
 /// Identity of a node in the dependency graph: a workspace project
 /// (importer) or an external package addressed by its depPath.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
@@ -21,7 +21,7 @@ use super::{
     DependencyNode, TreeNodeId,
     dep_types::detect_dep_types,
     get_tree::{GetTreeOptions, MaterializationCache, MaxDepth, get_tree},
-    graph::{BuildGraphOptions, DependencyGraph, build_dependency_graph},
+    graph::DependencyGraph,
     pkg_info::PkgInfoEnv,
     search::Searcher,
 };
@@ -152,37 +152,39 @@ pub(crate) struct BuildTreeOptions<'a> {
     pub modules_dir_opt: Option<&'a Path>,
 }
 
-/// Build the dependency hierarchy of every project in `project_dirs`,
-/// sharing one graph and one materialization cache so identical
-/// subtrees are only expanded once across projects.
-pub(crate) fn build_dependencies_tree(
-    state: &LoadedState,
-    env: &PkgInfoEnv<'_>,
+/// The importer root ids of `project_dirs` that exist in the lockfile.
+pub(crate) fn importer_root_ids(
+    lockfile: &Lockfile,
+    lockfile_dir: &Path,
     project_dirs: &[PathBuf],
-    opts: &BuildTreeOptions<'_>,
-) -> miette::Result<Vec<(PathBuf, DependenciesHierarchy)>> {
-    let lockfile = env.current_lockfile;
-
-    let root_ids: Vec<TreeNodeId> = project_dirs
+) -> Vec<TreeNodeId> {
+    project_dirs
         .iter()
-        .map(|dir| TreeNodeId::Importer(importer_id_for(opts.lockfile_dir, dir)))
+        .map(|dir| TreeNodeId::Importer(importer_id_for(lockfile_dir, dir)))
         .filter(|id| match id {
             TreeNodeId::Importer(importer_id) => {
                 lockfile.importers.contains_key(importer_id.as_str())
             }
             TreeNodeId::Package(_) => false,
         })
-        .collect();
+        .collect()
+}
 
-    let graph = build_dependency_graph(
-        &root_ids,
-        &BuildGraphOptions { lockfile, include: opts.include, only_projects: opts.only_projects },
-    );
+/// Build the dependency hierarchy of every project in `project_dirs`
+/// over a prebuilt `graph`, sharing one materialization cache so
+/// identical subtrees are only expanded once across projects.
+pub(crate) fn build_dependencies_tree(
+    state: &LoadedState,
+    env: &PkgInfoEnv<'_>,
+    graph: &DependencyGraph,
+    project_dirs: &[PathBuf],
+    opts: &BuildTreeOptions<'_>,
+) -> miette::Result<Vec<(PathBuf, DependenciesHierarchy)>> {
     let mut cache: MaterializationCache = MaterializationCache::new();
 
     let mut result = Vec::with_capacity(project_dirs.len());
     for project_dir in project_dirs {
-        let hierarchy = hierarchy_for_project(state, env, &graph, &mut cache, project_dir, opts)?;
+        let hierarchy = hierarchy_for_project(state, env, graph, &mut cache, project_dir, opts)?;
         result.push((project_dir.clone(), hierarchy));
     }
     Ok(result)

--- a/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
@@ -300,6 +300,14 @@ pub(crate) fn importer_id_for(lockfile_dir: &Path, project_dir: &Path) -> String
     pacquet_workspace::importer_id_from_root_dir(lockfile_dir, project_dir)
 }
 
+/// The on-disk directory of a lockfile importer key, or `None` for a
+/// key that cannot be safely joined (absolute, drive-prefixed, or
+/// `..`-traversing — a malformed or hostile lockfile).
+pub(crate) fn safe_importer_dir(lockfile_dir: &Path, importer_id: &str) -> Option<PathBuf> {
+    pacquet_package_manager::validate_importer_id(importer_id).ok()?;
+    Some(pacquet_package_manager::importer_root_dir(lockfile_dir, importer_id))
+}
+
 /// Resolve symlinks in the deepest existing ancestor of `path`,
 /// re-appending the missing tail (counterpart of the `realpath-missing`
 /// package).

--- a/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
@@ -88,7 +88,8 @@ impl LoadedState {
         let lockfile = self.lockfile_to_use()?;
         let mut registries = HashMap::new();
         registries.insert("default".to_string(), DEFAULT_REGISTRY.to_string());
-        if let Some(modules_registries) = self.modules.as_ref().and_then(|m| m.registries.as_ref())
+        if let Some(modules_registries) =
+            self.modules.as_ref().and_then(|modules| modules.registries.as_ref())
         {
             for (key, url) in modules_registries {
                 registries.insert(key.clone(), url.clone());

--- a/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
@@ -1,0 +1,476 @@
+//! Assemble the tree-build environment from the lockfiles and modules
+//! manifest, and build per-project dependency hierarchies. Rust
+//! counterpart of the TypeScript tree-builder's
+//! `buildDependenciesTree`.
+
+use std::{
+    collections::{HashMap, HashSet},
+    io,
+    path::{Path, PathBuf},
+};
+
+use miette::{Context, IntoDiagnostic};
+use pacquet_fs::lexical_normalize;
+use pacquet_lockfile::{Lockfile, ProjectSnapshot};
+use pacquet_modules_yaml::{
+    DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH, Host, IncludedDependencies, Modules,
+    read_modules_manifest,
+};
+
+use super::{
+    DependencyNode, TreeNodeId,
+    dep_types::detect_dep_types,
+    get_tree::{GetTreeOptions, MaterializationCache, MaxDepth, get_tree},
+    graph::{BuildGraphOptions, DependencyGraph, build_dependency_graph},
+    pkg_info::PkgInfoEnv,
+    search::Searcher,
+};
+
+pub(crate) const DEFAULT_REGISTRY: &str = "https://registry.npmjs.org/";
+
+/// The lockfiles and modules-manifest state one tree build runs
+/// against. Owns the loaded lockfiles; [`TreeBuild::env`] borrows them.
+pub(crate) struct LoadedState {
+    pub modules_dir: PathBuf,
+    pub modules: Option<Modules>,
+    pub current_lockfile: Option<Lockfile>,
+    pub wanted_lockfile: Option<Lockfile>,
+    pub check_wanted_lockfile_only: bool,
+}
+
+impl LoadedState {
+    pub(crate) fn load(
+        lockfile_dir: &Path,
+        modules_dir_opt: Option<&Path>,
+        check_wanted_lockfile_only: bool,
+    ) -> miette::Result<LoadedState> {
+        let modules_dir_raw = match modules_dir_opt {
+            Some(dir) if dir.is_absolute() => dir.to_path_buf(),
+            Some(dir) => lockfile_dir.join(dir),
+            None => lockfile_dir.join("node_modules"),
+        };
+        let modules_dir = realpath_missing(&modules_dir_raw);
+        let modules = read_modules_manifest::<Host>(&modules_dir)
+            .into_diagnostic()
+            .wrap_err("read the modules manifest")?;
+        let current_lockfile =
+            Lockfile::load_current_from_virtual_store_dir(&modules_dir.join(".pnpm"))
+                .into_diagnostic()
+                .wrap_err("load the current lockfile")?;
+        let wanted_lockfile = Lockfile::load_wanted_from_dir(lockfile_dir)
+            .into_diagnostic()
+            .wrap_err("load the wanted lockfile")?;
+        Ok(LoadedState {
+            modules_dir,
+            modules,
+            current_lockfile,
+            wanted_lockfile,
+            check_wanted_lockfile_only,
+        })
+    }
+
+    /// The lockfile the tree is built from: the wanted lockfile under
+    /// `--lockfile-only`, otherwise the current lockfile with the
+    /// wanted one as fallback.
+    pub(crate) fn lockfile_to_use(&self) -> Option<&Lockfile> {
+        if self.check_wanted_lockfile_only {
+            self.wanted_lockfile.as_ref()
+        } else {
+            self.current_lockfile.as_ref().or(self.wanted_lockfile.as_ref())
+        }
+    }
+
+    pub(crate) fn env<'a>(
+        &'a self,
+        lockfile_dir: &Path,
+        virtual_store_dir_max_length: usize,
+    ) -> Option<PkgInfoEnv<'a>> {
+        let lockfile = self.lockfile_to_use()?;
+        let mut registries = HashMap::new();
+        registries.insert("default".to_string(), DEFAULT_REGISTRY.to_string());
+        if let Some(modules_registries) = self.modules.as_ref().and_then(|m| m.registries.as_ref())
+        {
+            for (key, url) in modules_registries {
+                registries.insert(key.clone(), url.clone());
+            }
+        }
+        let virtual_store_dir = match &self.modules {
+            Some(modules) if !modules.virtual_store_dir.is_empty() => {
+                let dir = PathBuf::from(&modules.virtual_store_dir);
+                if dir.is_absolute() { dir } else { self.modules_dir.join(dir) }
+            }
+            _ => self.modules_dir.join(".pnpm"),
+        };
+        Some(PkgInfoEnv {
+            lockfile_dir: lockfile_dir.to_path_buf(),
+            modules_dir: self.modules_dir.clone(),
+            virtual_store_dir,
+            virtual_store_dir_max_length: self.modules.as_ref().map_or(
+                virtual_store_dir_max_length,
+                |modules| {
+                    usize::try_from(modules.virtual_store_dir_max_length)
+                        .unwrap_or(DEFAULT_VIRTUAL_STORE_DIR_MAX_LENGTH as usize)
+                },
+            ),
+            registries,
+            skipped: self
+                .modules
+                .as_ref()
+                .map(|modules| modules.skipped.iter().cloned().collect::<HashSet<_>>())
+                .unwrap_or_default(),
+            store_dir: self
+                .modules
+                .as_ref()
+                .map(|modules| PathBuf::from(&modules.store_dir))
+                .filter(|dir| !dir.as_os_str().is_empty()),
+            current_lockfile: lockfile,
+            wanted_lockfile: self.wanted_lockfile.as_ref(),
+            dep_types: detect_dep_types(lockfile),
+        })
+    }
+}
+
+/// One project's categorized dependency hierarchy — the input of the
+/// `list` renderers.
+#[derive(Debug, Default)]
+pub(crate) struct DependenciesHierarchy {
+    pub dependencies: Vec<DependencyNode>,
+    pub dev_dependencies: Vec<DependencyNode>,
+    pub optional_dependencies: Vec<DependencyNode>,
+    pub unsaved_dependencies: Vec<DependencyNode>,
+}
+
+pub(crate) struct BuildTreeOptions<'a> {
+    pub lockfile_dir: &'a Path,
+    pub depth: MaxDepth,
+    pub include: IncludedDependencies,
+    pub exclude_peer_dependencies: bool,
+    pub only_projects: bool,
+    pub search: Option<&'a Searcher>,
+    pub show_deduped_search_matches: bool,
+    pub modules_dir_opt: Option<&'a Path>,
+}
+
+/// Build the dependency hierarchy of every project in `project_dirs`,
+/// sharing one graph and one materialization cache so identical
+/// subtrees are only expanded once across projects.
+pub(crate) fn build_dependencies_tree(
+    state: &LoadedState,
+    env: &PkgInfoEnv<'_>,
+    project_dirs: &[PathBuf],
+    opts: &BuildTreeOptions<'_>,
+) -> miette::Result<Vec<(PathBuf, DependenciesHierarchy)>> {
+    let lockfile = env.current_lockfile;
+
+    let root_ids: Vec<TreeNodeId> = project_dirs
+        .iter()
+        .map(|dir| TreeNodeId::Importer(importer_id_for(opts.lockfile_dir, dir)))
+        .filter(|id| match id {
+            TreeNodeId::Importer(importer_id) => {
+                lockfile.importers.contains_key(importer_id.as_str())
+            }
+            TreeNodeId::Package(_) => false,
+        })
+        .collect();
+
+    let graph = build_dependency_graph(
+        &root_ids,
+        &BuildGraphOptions { lockfile, include: opts.include, only_projects: opts.only_projects },
+    );
+    let mut cache: MaterializationCache = MaterializationCache::new();
+
+    let mut result = Vec::with_capacity(project_dirs.len());
+    for project_dir in project_dirs {
+        let hierarchy = hierarchy_for_project(state, env, &graph, &mut cache, project_dir, opts)?;
+        result.push((project_dir.clone(), hierarchy));
+    }
+    Ok(result)
+}
+
+fn hierarchy_for_project(
+    state: &LoadedState,
+    env: &PkgInfoEnv<'_>,
+    graph: &DependencyGraph,
+    cache: &mut MaterializationCache,
+    project_dir: &Path,
+    opts: &BuildTreeOptions<'_>,
+) -> miette::Result<DependenciesHierarchy> {
+    let importer_id = importer_id_for(opts.lockfile_dir, project_dir);
+    let Some(importer) = env.current_lockfile.importers.get(importer_id.as_str()) else {
+        return Ok(DependenciesHierarchy::default());
+    };
+
+    let project_modules_dir = match opts.modules_dir_opt {
+        Some(dir) if dir.is_absolute() => dir.to_path_buf(),
+        Some(dir) => project_dir.join(dir),
+        None => project_dir.join("node_modules"),
+    };
+
+    let mut hierarchy = DependenciesHierarchy::default();
+
+    let get_tree_opts = GetTreeOptions {
+        env,
+        graph,
+        exclude_peer_dependencies: opts.exclude_peer_dependencies,
+        only_projects: opts.only_projects,
+        search: opts.search,
+        show_deduped_search_matches: opts.show_deduped_search_matches,
+        rewrite_link_version_dir: project_dir.to_path_buf(),
+    };
+    // The importer itself is one level: `opts.depth` counts levels
+    // below the direct dependencies.
+    let max_depth = match opts.depth {
+        MaxDepth::Finite(depth) => MaxDepth::Finite(depth.saturating_add(1)),
+        MaxDepth::Unlimited => MaxDepth::Unlimited,
+    };
+    let nodes = get_tree(
+        &get_tree_opts,
+        cache,
+        &TreeNodeId::Importer(importer_id.clone()),
+        max_depth,
+        None,
+    );
+
+    let field_of = field_map(importer, opts.include);
+    for node in nodes {
+        match field_of.get(node.alias.as_str()) {
+            Some(DependenciesField::Dependencies) => hierarchy.dependencies.push(node),
+            Some(DependenciesField::DevDependencies) => hierarchy.dev_dependencies.push(node),
+            Some(DependenciesField::OptionalDependencies) => {
+                hierarchy.optional_dependencies.push(node);
+            }
+            None => {}
+        }
+    }
+
+    // Unsaved (extraneous) dependencies: packages present in the
+    // project's modules dir but absent from its lockfile entry. They
+    // are irrelevant while searching — they are not in the lockfile
+    // graph and cannot contain paths to the search target.
+    if opts.search.is_none() {
+        hierarchy.unsaved_dependencies =
+            read_unsaved_dependencies(importer, project_dir, &project_modules_dir)?;
+    }
+
+    let _ = state;
+    Ok(hierarchy)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DependenciesField {
+    Dependencies,
+    DevDependencies,
+    OptionalDependencies,
+}
+
+fn field_map(
+    importer: &ProjectSnapshot,
+    include: IncludedDependencies,
+) -> HashMap<String, DependenciesField> {
+    let mut map = HashMap::new();
+    let groups: [(bool, Option<&pacquet_lockfile::ResolvedDependencyMap>, DependenciesField); 3] = [
+        (include.dependencies, importer.dependencies.as_ref(), DependenciesField::Dependencies),
+        (
+            include.dev_dependencies,
+            importer.dev_dependencies.as_ref(),
+            DependenciesField::DevDependencies,
+        ),
+        (
+            include.optional_dependencies,
+            importer.optional_dependencies.as_ref(),
+            DependenciesField::OptionalDependencies,
+        ),
+    ];
+    for (included, group, field) in groups {
+        if !included {
+            continue;
+        }
+        for alias in group.into_iter().flatten().map(|(alias, _)| alias) {
+            map.insert(alias.to_string(), field);
+        }
+    }
+    map
+}
+
+/// The importer id of `project_dir` relative to the lockfile root.
+pub(crate) fn importer_id_for(lockfile_dir: &Path, project_dir: &Path) -> String {
+    pacquet_workspace::importer_id_from_root_dir(lockfile_dir, project_dir)
+}
+
+/// Resolve symlinks in the deepest existing ancestor of `path`,
+/// re-appending the missing tail (counterpart of the `realpath-missing`
+/// package).
+pub(crate) fn realpath_missing(path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    loop {
+        match dunce::canonicalize(&current) {
+            Ok(mut real) => {
+                for component in tail.iter().rev() {
+                    real.push(component);
+                }
+                return real;
+            }
+            Err(_) => match (current.parent(), current.file_name()) {
+                (Some(parent), Some(name)) => {
+                    tail.push(name.to_os_string());
+                    current = parent.to_path_buf();
+                }
+                _ => return lexical_normalize(path),
+            },
+        }
+    }
+}
+
+/// Scan the project's modules dir for packages absent from its
+/// lockfile entry (npm's "extraneous" dependencies), building a leaf
+/// [`DependencyNode`] for each.
+fn read_unsaved_dependencies(
+    importer: &ProjectSnapshot,
+    project_dir: &Path,
+    modules_dir: &Path,
+) -> miette::Result<Vec<DependencyNode>> {
+    let saved = saved_direct_dep_names(importer);
+    let unsaved: Vec<DependencyNode> = read_modules_dir_names(modules_dir)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to read {}", modules_dir.display()))?
+        .into_iter()
+        .filter(|name| !saved.contains(name))
+        .map(|name| build_unsaved_node(&name, modules_dir, project_dir))
+        .collect();
+    Ok(unsaved)
+}
+
+/// The alias keys of an importer's `dependencies`, `devDependencies`,
+/// and `optionalDependencies` — always spanning all three groups
+/// regardless of the include filter, matching the TypeScript CLI's
+/// `getAllDirectDependencies`.
+fn saved_direct_dep_names(importer: &ProjectSnapshot) -> HashSet<String> {
+    let mut names = HashSet::new();
+    let groups =
+        [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies];
+    for group in groups.into_iter().flatten() {
+        for name in group.keys() {
+            names.insert(name.to_string());
+        }
+    }
+    names
+}
+
+/// The package directory names directly under `modules_dir`, following
+/// the same enumeration rules as the TypeScript CLI's `readModulesDir`.
+/// A missing `modules_dir` is not an error; any other read failure is.
+fn read_modules_dir_names(modules_dir: &Path) -> io::Result<Vec<String>> {
+    let mut names = Vec::new();
+    collect_module_names(modules_dir, None, &mut names)?;
+    Ok(names)
+}
+
+fn collect_module_names(
+    modules_dir: &Path,
+    scope: Option<&str>,
+    names: &mut Vec<String>,
+) -> io::Result<()> {
+    let parent_dir = match scope {
+        Some(scope) => modules_dir.join(scope),
+        None => modules_dir.to_path_buf(),
+    };
+    let entries = match std::fs::read_dir(&parent_dir) {
+        Ok(entries) => entries,
+        // A missing directory is "no packages"; every other error is
+        // surfaced, matching `readModulesDir`, which only swallows ENOENT.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if name.starts_with('.') {
+            continue;
+        }
+        if entry.file_type().is_ok_and(|file_type| file_type.is_file()) {
+            continue;
+        }
+        if scope.is_none() && name.starts_with('@') {
+            collect_module_names(modules_dir, Some(name), names)?;
+            continue;
+        }
+        match scope {
+            Some(scope) => names.push(format!("{scope}/{name}")),
+            None => names.push(name.to_string()),
+        }
+    }
+    Ok(())
+}
+
+/// Build the leaf [`DependencyNode`] for one extraneous package, taking
+/// its version and path from the symlink target for a `link:`
+/// dependency or from `package.json` for a regular directory.
+fn build_unsaved_node(name: &str, modules_dir: &Path, project_dir: &Path) -> DependencyNode {
+    let entry_path = modules_dir.join(name);
+    let (path, version) = if let Some(target) = resolve_link_target(&entry_path) {
+        let relative = pathdiff::diff_paths(&target, project_dir).unwrap_or_else(|| target.clone());
+        let version = format!("link:{}", relative.to_string_lossy().replace('\\', "/"));
+        (target.to_string_lossy().into_owned(), version)
+    } else {
+        let version = read_package_version(&entry_path).unwrap_or_else(|| "undefined".to_string());
+        (entry_path.to_string_lossy().into_owned(), version)
+    };
+    DependencyNode {
+        alias: name.to_string(),
+        name: name.to_string(),
+        version,
+        path,
+        ..DependencyNode::default()
+    }
+}
+
+/// Resolve a symlink to the absolute path of its immediate target,
+/// lexically (without requiring the target to exist), matching the
+/// TypeScript CLI's `resolveLinkTarget`. `None` when `link` is not a
+/// symlink.
+fn resolve_link_target(link: &Path) -> Option<PathBuf> {
+    let target = std::fs::read_link(link).ok()?;
+    let joined = if target.is_absolute() {
+        target
+    } else {
+        match link.parent() {
+            Some(parent) => parent.join(target),
+            None => target,
+        }
+    };
+    Some(lexical_normalize(&joined))
+}
+
+fn read_package_version(pkg_dir: &Path) -> Option<String> {
+    let bytes = std::fs::read(pkg_dir.join("package.json")).ok()?;
+    let manifest: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    manifest.get("version").and_then(serde_json::Value::as_str).map(str::to_string)
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ProjectManifestSummary {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub private: bool,
+}
+
+/// Read `name` / `version` / `private` from a project manifest,
+/// treating an unreadable manifest as empty (mirroring the TypeScript
+/// `safeReadProjectManifestOnly`).
+pub(crate) fn read_project_manifest(project_dir: &Path) -> ProjectManifestSummary {
+    let Ok(bytes) = std::fs::read(project_dir.join("package.json")) else {
+        return ProjectManifestSummary::default();
+    };
+    let Ok(manifest) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return ProjectManifestSummary::default();
+    };
+    ProjectManifestSummary {
+        name: manifest.get("name").and_then(serde_json::Value::as_str).map(str::to_string),
+        version: manifest.get("version").and_then(serde_json::Value::as_str).map(str::to_string),
+        private: manifest.get("private").and_then(serde_json::Value::as_bool).unwrap_or(false),
+    }
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/build.rs
@@ -29,7 +29,7 @@ use super::{
 pub(crate) const DEFAULT_REGISTRY: &str = "https://registry.npmjs.org/";
 
 /// The lockfiles and modules-manifest state one tree build runs
-/// against. Owns the loaded lockfiles; [`TreeBuild::env`] borrows them.
+/// against. Owns the loaded lockfiles; [`LoadedState::env`] borrows them.
 pub(crate) struct LoadedState {
     pub modules_dir: PathBuf,
     pub modules: Option<Modules>,

--- a/pnpm/crates/cli/src/cli_args/deps_tree/dep_types.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/dep_types.rs
@@ -1,0 +1,82 @@
+//! Classify every depPath in a lockfile as dev-only, prod-only, or
+//! both. Rust counterpart of `@pnpm/lockfile.detect-dep-types`.
+
+use std::collections::{HashMap, HashSet};
+
+use pacquet_lockfile::{Lockfile, PkgNameVerPeer};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DepType {
+    DevOnly,
+    DevAndProd,
+    ProdOnly,
+}
+
+pub(crate) type DepTypes = HashMap<PkgNameVerPeer, DepType>;
+
+pub(crate) fn detect_dep_types(lockfile: &Lockfile) -> DepTypes {
+    let mut ctx = Ctx {
+        lockfile,
+        walked: HashSet::new(),
+        not_prod_only: HashSet::new(),
+        dep_types: HashMap::new(),
+    };
+
+    let group_dep_paths = |group: fn(
+        &pacquet_lockfile::ProjectSnapshot,
+    ) -> Option<&pacquet_lockfile::ResolvedDependencyMap>| {
+        lockfile
+            .importers
+            .values()
+            .filter_map(group)
+            .flat_map(|deps| {
+                deps.iter().filter_map(|(alias, spec)| spec.version.resolved_key(alias))
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let dev_dep_paths = group_dep_paths(|importer| importer.dev_dependencies.as_ref());
+    let optional_dep_paths = group_dep_paths(|importer| importer.optional_dependencies.as_ref());
+    let prod_dep_paths = group_dep_paths(|importer| importer.dependencies.as_ref());
+
+    detect_in_subgraph(&mut ctx, &dev_dep_paths, true);
+    detect_in_subgraph(&mut ctx, &optional_dep_paths, false);
+    detect_in_subgraph(&mut ctx, &prod_dep_paths, false);
+    ctx.dep_types
+}
+
+struct Ctx<'a> {
+    lockfile: &'a Lockfile,
+    walked: HashSet<(PkgNameVerPeer, bool)>,
+    not_prod_only: HashSet<PkgNameVerPeer>,
+    dep_types: DepTypes,
+}
+
+fn detect_in_subgraph(ctx: &mut Ctx<'_>, dep_paths: &[PkgNameVerPeer], dev: bool) {
+    for dep_path in dep_paths {
+        if !ctx.walked.insert((dep_path.clone(), dev)) {
+            continue;
+        }
+        let Some(snapshot) =
+            ctx.lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(dep_path))
+        else {
+            continue;
+        };
+        if dev {
+            ctx.not_prod_only.insert(dep_path.clone());
+            ctx.dep_types.insert(dep_path.clone(), DepType::DevOnly);
+        } else if ctx.dep_types.get(dep_path) == Some(&DepType::DevOnly) {
+            ctx.dep_types.insert(dep_path.clone(), DepType::DevAndProd);
+        } else if !ctx.dep_types.contains_key(dep_path) && !ctx.not_prod_only.contains(dep_path) {
+            ctx.dep_types.insert(dep_path.clone(), DepType::ProdOnly);
+        }
+        for group in [&snapshot.dependencies, &snapshot.optional_dependencies] {
+            let child_paths: Vec<PkgNameVerPeer> = group
+                .iter()
+                .flatten()
+                .filter_map(|(alias, dep_ref)| dep_ref.resolve(alias))
+                .collect();
+            detect_in_subgraph(ctx, &child_paths, dev);
+        }
+    }
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/dep_types.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/dep_types.rs
@@ -53,6 +53,13 @@ struct Ctx<'a> {
 }
 
 fn detect_in_subgraph(ctx: &mut Ctx<'_>, dep_paths: &[PkgNameVerPeer], dev: bool) {
+    detect_in_subgraph_at(ctx, dep_paths, dev, 0);
+}
+
+fn detect_in_subgraph_at(ctx: &mut Ctx<'_>, dep_paths: &[PkgNameVerPeer], dev: bool, depth: usize) {
+    if depth >= super::MAX_WALK_DEPTH {
+        return;
+    }
     for dep_path in dep_paths {
         if !ctx.walked.insert((dep_path.clone(), dev)) {
             continue;
@@ -76,7 +83,7 @@ fn detect_in_subgraph(ctx: &mut Ctx<'_>, dep_paths: &[PkgNameVerPeer], dev: bool
                 .flatten()
                 .filter_map(|(alias, dep_ref)| dep_ref.resolve(alias))
                 .collect();
-            detect_in_subgraph(ctx, &child_paths, dev);
+            detect_in_subgraph_at(ctx, &child_paths, dev, depth + 1);
         }
     }
 }

--- a/pnpm/crates/cli/src/cli_args/deps_tree/dependents.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/dependents.rs
@@ -407,9 +407,9 @@ pub(crate) fn name_ver_from_dep_path(
 
 /// `semver.compare` when both versions parse as semver, lexicographic
 /// otherwise — the tree ordering the TypeScript CLI uses.
-pub(crate) fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
-    match (node_semver::Version::parse(a), node_semver::Version::parse(b)) {
-        (Ok(a), Ok(b)) => a.cmp(&b),
-        _ => a.cmp(b),
+pub(crate) fn compare_versions(left: &str, right: &str) -> std::cmp::Ordering {
+    match (node_semver::Version::parse(left), node_semver::Version::parse(right)) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
     }
 }

--- a/pnpm/crates/cli/src/cli_args/deps_tree/dependents.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/dependents.rs
@@ -167,7 +167,7 @@ pub(crate) fn build_dependents_tree(opts: &BuildDependentsOptions<'_>) -> Vec<De
             visited: HashSet::from([node_id.clone()]),
             expanded: HashSet::new(),
         };
-        let dependents = walk_reverse(&mut ctx, node_id);
+        let dependents = walk_reverse(&mut ctx, node_id, 0);
 
         trees.push(DependentsTree {
             name,
@@ -207,7 +207,11 @@ pub(crate) fn resolve_package_nodes(
         resolved: &mut HashMap<TreeNodeId, ManifestSource>,
         node_id: &TreeNodeId,
         parent_dir: Option<&Path>,
+        depth: usize,
     ) {
+        if depth >= super::MAX_WALK_DEPTH {
+            return;
+        }
         let Some(node) = graph.nodes.get(node_id) else {
             return;
         };
@@ -227,13 +231,13 @@ pub(crate) fn resolve_package_nodes(
             let (_, manifest_source) = get_pkg_info(env, edge, &edge_ctx);
             let target_path = manifest_source.path.clone();
             resolved.insert(target.clone(), manifest_source);
-            walk(env, graph, resolved, target, Some(&target_path));
+            walk(env, graph, resolved, target, Some(&target_path), depth + 1);
         }
     }
 
     for node_id in graph.nodes.keys() {
         if matches!(node_id, TreeNodeId::Importer(_)) {
-            walk(env, graph, &mut resolved, node_id, None);
+            walk(env, graph, &mut resolved, node_id, None, 0);
         }
     }
     resolved
@@ -255,7 +259,10 @@ fn invert_graph(graph: &DependencyGraph) -> HashMap<TreeNodeId, Vec<ReverseEdge>
     reverse
 }
 
-fn walk_reverse(ctx: &mut WalkCtx<'_>, node_id: &TreeNodeId) -> Vec<DependentNode> {
+fn walk_reverse(ctx: &mut WalkCtx<'_>, node_id: &TreeNodeId, depth: usize) -> Vec<DependentNode> {
+    if depth >= super::MAX_WALK_DEPTH {
+        return Vec::new();
+    }
     let Some(reverse_edges) = ctx.reverse_map.get(node_id) else {
         return Vec::new();
     };
@@ -337,7 +344,7 @@ fn walk_reverse(ctx: &mut WalkCtx<'_>, node_id: &TreeNodeId) -> Vec<DependentNod
 
                 ctx.visited.insert(edge.parent.clone());
                 ctx.expanded.insert(edge.parent.clone());
-                let child_dependents = walk_reverse(ctx, &edge.parent);
+                let child_dependents = walk_reverse(ctx, &edge.parent, depth + 1);
                 ctx.visited.remove(&edge.parent);
 
                 let mut node = DependentNode::leaf(name, version);

--- a/pnpm/crates/cli/src/cli_args/deps_tree/dependents.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/dependents.rs
@@ -1,0 +1,415 @@
+//! Reverse (dependents) tree for `pnpm why`. Rust counterpart of the
+//! TypeScript tree-builder's `buildDependentsTree`.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
+
+use pacquet_lockfile::{Lockfile, PkgNameVerPeer, ProjectSnapshot};
+
+use super::{
+    TreeNodeId,
+    graph::DependencyGraph,
+    peers_suffix_hash,
+    pkg_info::{EdgeContext, ManifestSource, PkgInfoEnv, get_pkg_info},
+    search::Searcher,
+};
+
+/// One node of the reverse tree: a package or workspace project that
+/// depends (directly or transitively) on the searched package.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DependentNode {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    pub version: String,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub circular: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peers_suffix_hash: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub deduped: bool,
+    /// For importer leaf nodes: the dependency field the searched
+    /// package (or the chain leading to it) is declared in.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dep_field: Option<DepField>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependents: Option<Vec<DependentNode>>,
+}
+
+impl DependentNode {
+    fn leaf(name: String, version: String) -> DependentNode {
+        DependentNode {
+            name,
+            display_name: None,
+            version,
+            circular: false,
+            peers_suffix_hash: None,
+            deduped: false,
+            dep_field: None,
+            dependents: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub(crate) enum DepField {
+    #[serde(rename = "dependencies")]
+    Dependencies,
+    #[serde(rename = "devDependencies")]
+    DevDependencies,
+    #[serde(rename = "optionalDependencies")]
+    OptionalDependencies,
+}
+
+impl DepField {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            DepField::Dependencies => "dependencies",
+            DepField::DevDependencies => "devDependencies",
+            DepField::OptionalDependencies => "optionalDependencies",
+        }
+    }
+}
+
+/// One matched package and everything that depends on it.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DependentsTree {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peers_suffix_hash: Option<String>,
+    pub dependents: Vec<DependentNode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search_message: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ImporterInfo {
+    pub name: String,
+    pub version: String,
+}
+
+pub(crate) struct BuildDependentsOptions<'a> {
+    pub env: &'a PkgInfoEnv<'a>,
+    pub graph: &'a DependencyGraph,
+    pub search: &'a Searcher,
+    pub importer_info: &'a HashMap<String, ImporterInfo>,
+}
+
+struct ReverseEdge {
+    parent: TreeNodeId,
+    alias: String,
+}
+
+struct WalkCtx<'a> {
+    reverse_map: &'a HashMap<TreeNodeId, Vec<ReverseEdge>>,
+    lockfile: &'a Lockfile,
+    importer_info: &'a HashMap<String, ImporterInfo>,
+    /// Nodes on the current path, for cycle detection.
+    visited: HashSet<TreeNodeId>,
+    /// Nodes already fully expanded, for deduplication across branches.
+    expanded: HashSet<TreeNodeId>,
+}
+
+/// Scan every package node of the graph for search matches and build
+/// the reverse tree of each match. Each distinct depPath (peer-variant)
+/// is a separate result.
+pub(crate) fn build_dependents_tree(opts: &BuildDependentsOptions<'_>) -> Vec<DependentsTree> {
+    let lockfile = opts.env.current_lockfile;
+    let reverse_map = invert_graph(opts.graph);
+    let resolved_nodes = resolve_package_nodes(opts.env, opts.graph);
+
+    let mut trees: Vec<DependentsTree> = Vec::new();
+
+    for node_id in opts.graph.nodes.keys() {
+        let TreeNodeId::Package(dep_path) = node_id else {
+            continue;
+        };
+        if !lockfile.snapshots.as_ref().is_some_and(|snapshots| snapshots.contains_key(dep_path)) {
+            continue;
+        }
+        let (name, version) = name_ver_from_dep_path(lockfile, dep_path);
+        let Some(resolved) = resolved_nodes.get(node_id) else {
+            continue;
+        };
+
+        // Canonical name first, then aliases from incoming edges
+        // (npm: protocol aliases).
+        let mut matched = opts.search.matches(&name, &name, &version, Some(node_id));
+        if !matched.is_match()
+            && let Some(incoming) = reverse_map.get(node_id)
+        {
+            for edge in incoming {
+                if edge.alias != name {
+                    matched = opts.search.matches(&edge.alias, &name, &version, Some(node_id));
+                    if matched.is_match() {
+                        break;
+                    }
+                }
+            }
+        }
+        if !matched.is_match() {
+            continue;
+        }
+
+        let mut ctx = WalkCtx {
+            reverse_map: &reverse_map,
+            lockfile,
+            importer_info: opts.importer_info,
+            visited: HashSet::from([node_id.clone()]),
+            expanded: HashSet::new(),
+        };
+        let dependents = walk_reverse(&mut ctx, node_id);
+
+        trees.push(DependentsTree {
+            name,
+            display_name: None,
+            version,
+            path: Some(resolved.path.to_string_lossy().into_owned()),
+            peers_suffix_hash: peers_suffix_hash(dep_path),
+            dependents,
+            search_message: matched.message().map(str::to_string),
+        });
+    }
+
+    trees.sort_by(|a, b| {
+        a.name.cmp(&b.name).then_with(|| compare_versions(&a.version, &b.version)).then_with(|| {
+            a.peers_suffix_hash
+                .as_deref()
+                .unwrap_or("")
+                .cmp(b.peers_suffix_hash.as_deref().unwrap_or(""))
+        })
+    });
+    trees
+}
+
+/// The resolved filesystem location (and manifest source) of every
+/// package node, found by walking the graph top-down from importers —
+/// with a global virtual store the correct path is only reachable by
+/// following symlinks through each parent's `node_modules`.
+pub(crate) fn resolve_package_nodes(
+    env: &PkgInfoEnv<'_>,
+    graph: &DependencyGraph,
+) -> HashMap<TreeNodeId, ManifestSource> {
+    let mut resolved: HashMap<TreeNodeId, ManifestSource> = HashMap::new();
+
+    fn walk(
+        env: &PkgInfoEnv<'_>,
+        graph: &DependencyGraph,
+        resolved: &mut HashMap<TreeNodeId, ManifestSource>,
+        node_id: &TreeNodeId,
+        parent_dir: Option<&Path>,
+    ) {
+        let Some(node) = graph.nodes.get(node_id) else {
+            return;
+        };
+        for edge in &node.edges {
+            let Some(target) = &edge.target else {
+                continue;
+            };
+            if resolved.contains_key(target) || !matches!(target, TreeNodeId::Package(_)) {
+                continue;
+            }
+            let edge_ctx = EdgeContext {
+                peers: None,
+                linked_path_base_dir: env.modules_dir.clone(),
+                rewrite_link_version_dir: None,
+                parent_dir: parent_dir.map(Path::to_path_buf),
+            };
+            let (_, manifest_source) = get_pkg_info(env, edge, &edge_ctx);
+            let target_path = manifest_source.path.clone();
+            resolved.insert(target.clone(), manifest_source);
+            walk(env, graph, resolved, target, Some(&target_path));
+        }
+    }
+
+    for node_id in graph.nodes.keys() {
+        if matches!(node_id, TreeNodeId::Importer(_)) {
+            walk(env, graph, &mut resolved, node_id, None);
+        }
+    }
+    resolved
+}
+
+fn invert_graph(graph: &DependencyGraph) -> HashMap<TreeNodeId, Vec<ReverseEdge>> {
+    let mut reverse: HashMap<TreeNodeId, Vec<ReverseEdge>> = HashMap::new();
+    for (parent_id, node) in &graph.nodes {
+        for edge in &node.edges {
+            let Some(target) = &edge.target else {
+                continue;
+            };
+            reverse
+                .entry(target.clone())
+                .or_default()
+                .push(ReverseEdge { parent: parent_id.clone(), alias: edge.alias.clone() });
+        }
+    }
+    reverse
+}
+
+fn walk_reverse(ctx: &mut WalkCtx<'_>, node_id: &TreeNodeId) -> Vec<DependentNode> {
+    let Some(reverse_edges) = ctx.reverse_map.get(node_id) else {
+        return Vec::new();
+    };
+
+    // Sort by parent name (serialized id as tiebreaker) so
+    // deduplication is deterministic: the first parent always gets
+    // fully expanded.
+    let mut sorted_edges: Vec<&ReverseEdge> = reverse_edges.iter().collect();
+    sorted_edges.sort_by(|a, b| {
+        resolve_parent_name(ctx, &a.parent)
+            .cmp(&resolve_parent_name(ctx, &b.parent))
+            .then_with(|| a.parent.serialize().cmp(&b.parent.serialize()))
+    });
+
+    let mut dependents: Vec<DependentNode> = Vec::new();
+
+    for edge in sorted_edges {
+        if ctx.visited.contains(&edge.parent) {
+            match &edge.parent {
+                TreeNodeId::Importer(importer_id) => {
+                    if let Some(info) = ctx.importer_info.get(importer_id) {
+                        let mut node = DependentNode::leaf(info.name.clone(), info.version.clone());
+                        node.circular = true;
+                        dependents.push(node);
+                    }
+                }
+                TreeNodeId::Package(dep_path) => {
+                    if ctx
+                        .lockfile
+                        .snapshots
+                        .as_ref()
+                        .is_some_and(|snapshots| snapshots.contains_key(dep_path))
+                    {
+                        let (name, version) = name_ver_from_dep_path(ctx.lockfile, dep_path);
+                        let mut node = DependentNode::leaf(name, version);
+                        node.circular = true;
+                        dependents.push(node);
+                    }
+                }
+            }
+            continue;
+        }
+
+        match &edge.parent {
+            TreeNodeId::Importer(importer_id) => {
+                let (name, version) = match ctx.importer_info.get(importer_id) {
+                    Some(info) => (info.name.clone(), info.version.clone()),
+                    None => (importer_id.clone(), String::new()),
+                };
+                let mut node = DependentNode::leaf(name, version);
+                node.dep_field = ctx
+                    .lockfile
+                    .importers
+                    .get(importer_id.as_str())
+                    .and_then(|importer| dep_field_for_alias(&edge.alias, importer));
+                dependents.push(node);
+            }
+            TreeNodeId::Package(dep_path) => {
+                if !ctx
+                    .lockfile
+                    .snapshots
+                    .as_ref()
+                    .is_some_and(|snapshots| snapshots.contains_key(dep_path))
+                {
+                    continue;
+                }
+                let (name, version) = name_ver_from_dep_path(ctx.lockfile, dep_path);
+                let hash = peers_suffix_hash(dep_path);
+
+                if ctx.expanded.contains(&edge.parent) {
+                    // Already expanded elsewhere in the tree — show as
+                    // a leaf to keep the output bounded.
+                    let mut node = DependentNode::leaf(name, version);
+                    node.peers_suffix_hash = hash;
+                    node.deduped = true;
+                    dependents.push(node);
+                    continue;
+                }
+
+                ctx.visited.insert(edge.parent.clone());
+                ctx.expanded.insert(edge.parent.clone());
+                let child_dependents = walk_reverse(ctx, &edge.parent);
+                ctx.visited.remove(&edge.parent);
+
+                let mut node = DependentNode::leaf(name, version);
+                node.peers_suffix_hash = hash;
+                node.dependents =
+                    if child_dependents.is_empty() { None } else { Some(child_dependents) };
+                dependents.push(node);
+            }
+        }
+    }
+
+    dependents
+}
+
+fn resolve_parent_name(ctx: &WalkCtx<'_>, parent: &TreeNodeId) -> String {
+    match parent {
+        TreeNodeId::Importer(importer_id) => ctx
+            .importer_info
+            .get(importer_id)
+            .map_or_else(|| importer_id.clone(), |info| info.name.clone()),
+        TreeNodeId::Package(dep_path) => {
+            if ctx
+                .lockfile
+                .snapshots
+                .as_ref()
+                .is_some_and(|snapshots| snapshots.contains_key(dep_path))
+            {
+                dep_path.name.to_string()
+            } else {
+                String::new()
+            }
+        }
+    }
+}
+
+fn dep_field_for_alias(alias: &str, importer: &ProjectSnapshot) -> Option<DepField> {
+    let has = |group: Option<&pacquet_lockfile::ResolvedDependencyMap>| {
+        group.is_some_and(|deps| deps.keys().any(|key| key.to_string() == alias))
+    };
+    if has(importer.dev_dependencies.as_ref()) {
+        return Some(DepField::DevDependencies);
+    }
+    if has(importer.optional_dependencies.as_ref()) {
+        return Some(DepField::OptionalDependencies);
+    }
+    if has(importer.dependencies.as_ref()) {
+        return Some(DepField::Dependencies);
+    }
+    None
+}
+
+/// Name and display version of a depPath, preferring the `version:`
+/// recorded in the `packages:` entry (git/tarball deps) over the
+/// version encoded in the depPath.
+pub(crate) fn name_ver_from_dep_path(
+    lockfile: &Lockfile,
+    dep_path: &PkgNameVerPeer,
+) -> (String, String) {
+    let version = lockfile
+        .packages
+        .as_ref()
+        .and_then(|packages| packages.get(&dep_path.without_peer()))
+        .and_then(|metadata| metadata.version.clone())
+        .unwrap_or_else(|| dep_path.suffix.version().to_string());
+    (dep_path.name.to_string(), version)
+}
+
+/// `semver.compare` when both versions parse as semver, lexicographic
+/// otherwise — the tree ordering the TypeScript CLI uses.
+pub(crate) fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    match (node_semver::Version::parse(a), node_semver::Version::parse(b)) {
+        (Ok(a), Ok(b)) => a.cmp(&b),
+        _ => a.cmp(b),
+    }
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/finders.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/finders.rs
@@ -80,7 +80,14 @@ pub(crate) fn finder_candidates(
     for (node_id, source) in &resolved {
         push(source.name.clone(), Some(node_id), source.clone());
     }
-    for node in graph.nodes.values() {
+    for (parent_id, node) in &graph.nodes {
+        // Unresolvable `link:` edges resolve against the same base the
+        // tree materialization uses: the parent importer's directory
+        // for importer parents, the lockfile root otherwise.
+        let linked_path_base_dir = match parent_id {
+            TreeNodeId::Importer(importer_id) => env.lockfile_dir.join(importer_id),
+            TreeNodeId::Package(_) => env.lockfile_dir.clone(),
+        };
         for edge in &node.edges {
             match &edge.target {
                 Some(target @ TreeNodeId::Package(_)) => {
@@ -107,7 +114,7 @@ pub(crate) fn finder_candidates(
                         None,
                         ManifestSource {
                             path: pacquet_fs::lexical_normalize(
-                                &env.lockfile_dir.join(link_target),
+                                &linked_path_base_dir.join(link_target),
                             ),
                             integrity: None,
                             name: edge.alias.clone(),

--- a/pnpm/crates/cli/src/cli_args/deps_tree/finders.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/finders.rs
@@ -85,7 +85,10 @@ pub(crate) fn finder_candidates(
         // tree materialization uses: the parent importer's directory
         // for importer parents, the lockfile root otherwise.
         let linked_path_base_dir = match parent_id {
-            TreeNodeId::Importer(importer_id) => env.lockfile_dir.join(importer_id),
+            TreeNodeId::Importer(importer_id) => {
+                super::build::safe_importer_dir(&env.lockfile_dir, importer_id)
+                    .unwrap_or_else(|| env.lockfile_dir.clone())
+            }
             TreeNodeId::Package(_) => env.lockfile_dir.clone(),
         };
         for edge in &node.edges {
@@ -96,11 +99,16 @@ pub(crate) fn finder_candidates(
                     }
                 }
                 Some(target @ TreeNodeId::Importer(importer_id)) => {
+                    let Some(importer_dir) =
+                        super::build::safe_importer_dir(&env.lockfile_dir, importer_id)
+                    else {
+                        continue;
+                    };
                     push(
                         edge.alias.clone(),
                         Some(target),
                         ManifestSource {
-                            path: env.lockfile_dir.join(importer_id),
+                            path: importer_dir,
                             integrity: None,
                             name: edge.alias.clone(),
                             version: edge.ref_display.clone(),

--- a/pnpm/crates/cli/src/cli_args/deps_tree/finders.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/finders.rs
@@ -1,0 +1,217 @@
+//! `--find-by` finder support: resolve finder callbacks from the
+//! loaded pnpmfiles and pre-evaluate them for every package the tree
+//! walk can encounter. Finders are JavaScript functions running in the
+//! pnpmfile Node worker, so their verdicts are gathered up front and
+//! the synchronous tree walk consults the recorded results.
+
+use std::{collections::HashMap, path::Path, sync::Arc};
+
+use pacquet_config::Config;
+use pacquet_hooks::PnpmfileHooks;
+use pacquet_store_dir::{StoreDir, StoreIndex, store_index_key};
+
+use super::{
+    TreeNodeId,
+    dependents::resolve_package_nodes,
+    graph::DependencyGraph,
+    pkg_info::{ManifestSource, PkgInfoEnv},
+    search::SearchMatch,
+};
+
+/// One resolved finder: the name it was requested by and the pnpmfile
+/// hook set that exports it.
+pub(crate) struct FinderHandle {
+    name: String,
+    hooks: Arc<dyn PnpmfileHooks>,
+}
+
+/// Resolve every `--find-by` name against the finders exported by the
+/// project's pnpmfiles (the later pnpmfile wins on a name collision,
+/// matching the TypeScript hook merger).
+pub(crate) async fn resolve_finders(
+    config: &Config,
+    lockfile_dir: &Path,
+    find_by: &[String],
+) -> miette::Result<Vec<FinderHandle>> {
+    if find_by.is_empty() {
+        return Ok(Vec::new());
+    }
+    let pnpmfiles = crate::config_deps::load_before_packing_hooks(config, lockfile_dir);
+    let mut finders_by_name: HashMap<String, Arc<dyn PnpmfileHooks>> = HashMap::new();
+    for hooks in pnpmfiles {
+        let names = hooks
+            .get_finder_names()
+            .await
+            .map_err(|err| miette::miette!("loading finders from a pnpmfile: {err}"))?;
+        for name in names {
+            finders_by_name.insert(name, Arc::clone(&hooks));
+        }
+    }
+    find_by
+        .iter()
+        .map(|name| match finders_by_name.get(name) {
+            Some(hooks) => Ok(FinderHandle { name: name.clone(), hooks: Arc::clone(hooks) }),
+            None => Err(miette::miette!(
+                code = "ERR_PNPM_FINDER_NOT_FOUND",
+                "No finder with name {name} is found"
+            )),
+        })
+        .collect()
+}
+
+/// Every `(alias, node)` pair a finder must be evaluated for: the
+/// canonical name of every resolved package node, plus each edge's
+/// alias — including edges to workspace projects and unresolvable
+/// link edges, which the search also visits.
+pub(crate) fn finder_candidates(
+    env: &PkgInfoEnv<'_>,
+    graph: &DependencyGraph,
+) -> Vec<(String, Option<TreeNodeId>, ManifestSource)> {
+    let resolved = resolve_package_nodes(env, graph);
+    let mut seen: std::collections::HashSet<(String, Option<TreeNodeId>)> =
+        std::collections::HashSet::new();
+    let mut candidates: Vec<(String, Option<TreeNodeId>, ManifestSource)> = Vec::new();
+    let mut push = |alias: String, node_id: Option<&TreeNodeId>, source: ManifestSource| {
+        if seen.insert((alias.clone(), node_id.cloned())) {
+            candidates.push((alias, node_id.cloned(), source));
+        }
+    };
+
+    for (node_id, source) in &resolved {
+        push(source.name.clone(), Some(node_id), source.clone());
+    }
+    for node in graph.nodes.values() {
+        for edge in &node.edges {
+            match &edge.target {
+                Some(target @ TreeNodeId::Package(_)) => {
+                    if let Some(source) = resolved.get(target) {
+                        push(edge.alias.clone(), Some(target), source.clone());
+                    }
+                }
+                Some(target @ TreeNodeId::Importer(importer_id)) => {
+                    push(
+                        edge.alias.clone(),
+                        Some(target),
+                        ManifestSource {
+                            path: env.lockfile_dir.join(importer_id),
+                            integrity: None,
+                            name: edge.alias.clone(),
+                            version: edge.ref_display.clone(),
+                        },
+                    );
+                }
+                None => {
+                    let link_target = edge.link_target.clone().unwrap_or_default();
+                    push(
+                        edge.alias.clone(),
+                        None,
+                        ManifestSource {
+                            path: pacquet_fs::lexical_normalize(
+                                &env.lockfile_dir.join(link_target),
+                            ),
+                            integrity: None,
+                            name: edge.alias.clone(),
+                            version: edge.ref_display.clone(),
+                        },
+                    );
+                }
+            }
+        }
+    }
+    candidates
+}
+
+/// Run every requested finder over `candidates` and record the
+/// verdicts. String results become messages (joined with `\n` when
+/// several finders return one), truthy results a plain match.
+pub(crate) async fn evaluate_finders(
+    env: &PkgInfoEnv<'_>,
+    finders: &[FinderHandle],
+    candidates: Vec<(String, Option<TreeNodeId>, ManifestSource)>,
+) -> miette::Result<HashMap<(String, Option<TreeNodeId>), SearchMatch>> {
+    let store_index =
+        env.store_dir.as_ref().and_then(|store_dir| StoreIndex::open_readonly(store_dir).ok());
+
+    let mut results = HashMap::new();
+    for (alias, node_id, source) in candidates {
+        let manifest = read_manifest(env, store_index.as_ref(), &source);
+        let ctx = serde_json::json!({
+            "alias": alias,
+            "name": source.name,
+            "version": source.version,
+            "manifest": manifest,
+        });
+        let mut messages: Vec<String> = Vec::new();
+        let mut found = false;
+        for finder in finders {
+            let verdict = finder
+                .hooks
+                .run_finder(&finder.name, ctx.clone())
+                .await
+                .map_err(|err| miette::miette!("running finder {}: {err}", finder.name))?;
+            match verdict {
+                serde_json::Value::String(message) => {
+                    found = true;
+                    messages.push(message);
+                }
+                other => {
+                    if truthy(&other) {
+                        found = true;
+                    }
+                }
+            }
+        }
+        let verdict = if !messages.is_empty() {
+            SearchMatch::Message(messages.join("\n"))
+        } else if found {
+            SearchMatch::Yes
+        } else {
+            continue;
+        };
+        results.insert((alias, node_id), verdict);
+    }
+    Ok(results)
+}
+
+fn truthy(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Null => false,
+        serde_json::Value::Bool(value) => *value,
+        serde_json::Value::Number(number) => number.as_f64().is_some_and(|n| n != 0.0),
+        serde_json::Value::String(text) => !text.is_empty(),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => true,
+    }
+}
+
+/// Read a package manifest, preferring the content-addressable store
+/// (available even when `node_modules` was never materialized) and
+/// falling back to the package directory.
+fn read_manifest(
+    env: &PkgInfoEnv<'_>,
+    store_index: Option<&StoreIndex>,
+    source: &ManifestSource,
+) -> serde_json::Value {
+    if let Some(manifest) = read_manifest_from_cafs(env, store_index, source) {
+        return manifest;
+    }
+    std::fs::read(source.path.join("package.json"))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .unwrap_or(serde_json::Value::Null)
+}
+
+fn read_manifest_from_cafs(
+    env: &PkgInfoEnv<'_>,
+    store_index: Option<&StoreIndex>,
+    source: &ManifestSource,
+) -> Option<serde_json::Value> {
+    let store_index = store_index?;
+    let integrity = source.integrity.as_deref()?;
+    let store_dir = StoreDir::new(env.store_dir.as_ref()?.clone());
+    let pkg_id = format!("{}@{}", source.name, source.version);
+    let index = store_index.get(&store_index_key(integrity, &pkg_id)).ok()??;
+    let manifest_entry = index.files.get("package.json")?;
+    let manifest_path =
+        store_dir.cas_file_path_by_mode(&manifest_entry.digest, manifest_entry.mode)?;
+    std::fs::read(manifest_path).ok().and_then(|bytes| serde_json::from_slice(&bytes).ok())
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/get_tree.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/get_tree.rs
@@ -1,0 +1,319 @@
+//! Materialize the dependency graph into renderable [`DependencyNode`]
+//! trees, with subtree deduplication, depth limiting, search pruning,
+//! and circular-reference marking. Rust counterpart of the TypeScript
+//! tree-builder's `getTree` / `materializeChildren` / `fixCircularRefs`.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
+
+use super::{
+    DependencyNode, TreeNodeId,
+    graph::DependencyGraph,
+    pkg_info::{EdgeContext, PkgInfoEnv, get_pkg_info},
+    search::Searcher,
+};
+
+/// Remaining tree depth. `Unlimited` corresponds to the TypeScript
+/// `Infinity` depth, which the materialization cache keys differently
+/// from any finite depth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum MaxDepth {
+    Finite(u64),
+    Unlimited,
+}
+
+impl MaxDepth {
+    fn is_exhausted(self) -> bool {
+        matches!(self, MaxDepth::Finite(0))
+    }
+
+    fn decrement(self) -> MaxDepth {
+        match self {
+            MaxDepth::Finite(depth) => MaxDepth::Finite(depth.saturating_sub(1)),
+            MaxDepth::Unlimited => MaxDepth::Unlimited,
+        }
+    }
+
+    fn cache_depth(self) -> Option<u64> {
+        match self {
+            MaxDepth::Finite(depth) => Some(depth),
+            MaxDepth::Unlimited => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedSubtree {
+    count: u64,
+    has_search_match: bool,
+    search_messages: Vec<String>,
+}
+
+/// Caches already-materialized subtrees keyed by `(node, remaining
+/// depth)`. A cache hit elides the subtree (the node is marked
+/// `deduped`), bounding the total output to `O(N)` nodes.
+pub(crate) type MaterializationCache = HashMap<(TreeNodeId, Option<u64>), CachedSubtreeOpaque>;
+
+/// Opaque wrapper so the cache type can be shared without exposing the
+/// bookkeeping fields.
+#[derive(Debug, Clone)]
+pub(crate) struct CachedSubtreeOpaque(CachedSubtree);
+
+pub(crate) struct GetTreeOptions<'a> {
+    pub env: &'a PkgInfoEnv<'a>,
+    pub graph: &'a DependencyGraph,
+    pub exclude_peer_dependencies: bool,
+    pub only_projects: bool,
+    pub search: Option<&'a Searcher>,
+    pub show_deduped_search_matches: bool,
+    /// Directory `link:` versions are rewritten relative to.
+    pub rewrite_link_version_dir: PathBuf,
+}
+
+struct MaterializationResult {
+    nodes: Vec<DependencyNode>,
+    count: u64,
+    has_search_match: bool,
+    search_messages: Vec<String>,
+}
+
+pub(crate) fn get_tree(
+    opts: &GetTreeOptions<'_>,
+    cache: &mut MaterializationCache,
+    parent_id: &TreeNodeId,
+    max_depth: MaxDepth,
+    parent_dir: Option<&Path>,
+) -> Vec<DependencyNode> {
+    let mut ancestors = HashSet::new();
+    ancestors.insert(parent_id.clone());
+
+    let result =
+        materialize_children(opts, cache, &mut ancestors, parent_id, max_depth, parent_dir);
+
+    // Circular back-edges are marked in a post-pass: materialization
+    // truncates dependencies at cycle boundaries but leaves cached
+    // subtrees free of context-dependent circular flags.
+    let mut circular_ancestors = HashSet::new();
+    if let Some(parent_dir) = parent_dir {
+        circular_ancestors.insert(parent_dir.to_string_lossy().into_owned());
+    }
+    fix_circular_refs(result.nodes, &mut circular_ancestors)
+}
+
+fn materialize_children(
+    opts: &GetTreeOptions<'_>,
+    cache: &mut MaterializationCache,
+    ancestors: &mut HashSet<TreeNodeId>,
+    parent_id: &TreeNodeId,
+    max_depth: MaxDepth,
+    parent_dir: Option<&Path>,
+) -> MaterializationResult {
+    let empty = || MaterializationResult {
+        nodes: Vec::new(),
+        count: 0,
+        has_search_match: false,
+        search_messages: Vec::new(),
+    };
+    if max_depth.is_exhausted() {
+        return empty();
+    }
+    let Some(graph_node) = opts.graph.nodes.get(parent_id) else {
+        return empty();
+    };
+
+    let child_tree_max_depth = max_depth.decrement();
+    let linked_path_base_dir = match parent_id {
+        TreeNodeId::Importer(importer_id) => opts.env.lockfile_dir.join(importer_id),
+        TreeNodeId::Package(_) => opts.env.lockfile_dir.clone(),
+    };
+
+    let mut result_dependencies: Vec<DependencyNode> = Vec::new();
+    let mut result_count: u64 = 0;
+    let mut result_has_search_match = false;
+    let mut result_search_messages: Vec<String> = Vec::new();
+
+    // Sort edges by alias so that deduplication is deterministic: the
+    // alphabetically-first dependency always gets fully expanded.
+    let mut sorted_edges: Vec<_> = graph_node.edges.iter().collect();
+    sorted_edges.sort_by(|a, b| a.alias.cmp(&b.alias));
+
+    for edge in sorted_edges {
+        if opts.only_projects && !matches!(edge.target, Some(TreeNodeId::Importer(_))) {
+            continue;
+        }
+
+        let edge_ctx = EdgeContext {
+            peers: Some(&graph_node.peers),
+            linked_path_base_dir: linked_path_base_dir.clone(),
+            rewrite_link_version_dir: Some(opts.rewrite_link_version_dir.clone()),
+            parent_dir: parent_dir.map(Path::to_path_buf),
+        };
+        let (package_info, _manifest) = get_pkg_info(opts.env, edge, &edge_ctx);
+
+        let search_match = opts.search.map(|search| {
+            search.matches(
+                &edge.alias,
+                &package_info.name,
+                &package_info.version,
+                edge.target.as_ref(),
+            )
+        });
+        let searching = opts.search.is_some();
+        let matched = search_match.as_ref().is_some_and(super::search::SearchMatch::is_match);
+
+        let mut new_entry: DependencyNode;
+        let mut child_count: u64 = 0;
+        let mut deduped_has_search_match = false;
+        let mut deduped_search_messages: Vec<String> = Vec::new();
+
+        match &edge.target {
+            None => {
+                // External link or unresolvable — no traversal possible.
+                if !searching || matched {
+                    new_entry = package_info;
+                } else {
+                    continue;
+                }
+            }
+            Some(target) => {
+                let mut dependencies: Vec<DependencyNode>;
+                let mut deduped_count: Option<u64> = None;
+                let circular = ancestors.contains(target);
+
+                if circular {
+                    dependencies = Vec::new();
+                } else {
+                    let cache_key = (target.clone(), child_tree_max_depth.cache_depth());
+                    if let Some(CachedSubtreeOpaque(cached)) = cache.get(&cache_key) {
+                        // Subtree already emitted elsewhere in the
+                        // output — elide it to avoid repeating nodes.
+                        dependencies = Vec::new();
+                        if cached.count > 0 {
+                            deduped_count = Some(cached.count);
+                        }
+                        if opts.show_deduped_search_matches {
+                            deduped_has_search_match = cached.has_search_match;
+                            deduped_search_messages.clone_from(&cached.search_messages);
+                        }
+                    } else {
+                        ancestors.insert(target.clone());
+                        let child_result = materialize_children(
+                            opts,
+                            cache,
+                            ancestors,
+                            target,
+                            child_tree_max_depth,
+                            Some(Path::new(&package_info.path)),
+                        );
+                        ancestors.remove(target);
+
+                        dependencies = child_result.nodes;
+                        child_count = child_result.count;
+
+                        cache.insert(
+                            cache_key,
+                            CachedSubtreeOpaque(CachedSubtree {
+                                count: child_count,
+                                has_search_match: child_result.has_search_match,
+                                search_messages: child_result.search_messages.clone(),
+                            }),
+                        );
+                        if child_result.has_search_match {
+                            result_has_search_match = true;
+                        }
+                        if opts.show_deduped_search_matches {
+                            result_search_messages.extend(child_result.search_messages);
+                        }
+                    }
+                    if deduped_has_search_match {
+                        result_has_search_match = true;
+                        result_search_messages.extend(deduped_search_messages.iter().cloned());
+                    }
+                }
+
+                if !dependencies.is_empty() {
+                    new_entry = package_info;
+                    new_entry.dependencies = std::mem::take(&mut dependencies);
+                } else if !searching || matched || deduped_has_search_match {
+                    new_entry = package_info;
+                } else {
+                    continue;
+                }
+
+                if let Some(count) = deduped_count {
+                    new_entry.deduped = true;
+                    new_entry.deduped_dependencies_count = Some(count);
+                }
+            }
+        }
+
+        match &search_match {
+            Some(search_match) if search_match.is_match() => {
+                new_entry.searched = true;
+                result_has_search_match = true;
+                if let Some(message) = search_match.message() {
+                    new_entry.search_message = Some(message.to_string());
+                    result_search_messages.push(message.to_string());
+                }
+            }
+            _ => {
+                if deduped_has_search_match {
+                    new_entry.searched = true;
+                    if !deduped_search_messages.is_empty() {
+                        new_entry.search_message = Some(deduped_search_messages.join("\n"));
+                    }
+                }
+            }
+        }
+
+        if !new_entry.is_peer
+            || !opts.exclude_peer_dependencies
+            || !new_entry.dependencies.is_empty()
+        {
+            let has_children = !new_entry.dependencies.is_empty();
+            result_count += 1 + if has_children { child_count } else { 0 };
+            result_dependencies.push(new_entry);
+        }
+    }
+
+    MaterializationResult {
+        nodes: result_dependencies,
+        count: result_count,
+        has_search_match: result_has_search_match,
+        search_messages: result_search_messages,
+    }
+}
+
+/// Mark circular back-edges: a node whose `path` matches an ancestor's
+/// gets `circular` and its dependencies (and dedup bookkeeping)
+/// stripped.
+fn fix_circular_refs(
+    nodes: Vec<DependencyNode>,
+    ancestors: &mut HashSet<String>,
+) -> Vec<DependencyNode> {
+    nodes
+        .into_iter()
+        .map(|mut node| {
+            if !node.path.is_empty() && ancestors.contains(&node.path) {
+                node.circular = true;
+                node.dependencies = Vec::new();
+                node.deduped = false;
+                node.deduped_dependencies_count = None;
+                return node;
+            }
+            if node.dependencies.is_empty() {
+                return node;
+            }
+            ancestors.insert(node.path.clone());
+            node.dependencies =
+                fix_circular_refs(std::mem::take(&mut node.dependencies), ancestors);
+            ancestors.remove(&node.path);
+            node
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/deps_tree/get_tree.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/get_tree.rs
@@ -126,7 +126,10 @@ fn materialize_children(
 
     let child_tree_max_depth = max_depth.decrement();
     let linked_path_base_dir = match parent_id {
-        TreeNodeId::Importer(importer_id) => opts.env.lockfile_dir.join(importer_id),
+        TreeNodeId::Importer(importer_id) => {
+            super::build::safe_importer_dir(&opts.env.lockfile_dir, importer_id)
+                .unwrap_or_else(|| opts.env.lockfile_dir.clone())
+        }
         TreeNodeId::Package(_) => opts.env.lockfile_dir.clone(),
     };
 

--- a/pnpm/crates/cli/src/cli_args/deps_tree/get_tree.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/get_tree.rs
@@ -90,7 +90,7 @@ pub(crate) fn get_tree(
     ancestors.insert(parent_id.clone());
 
     let result =
-        materialize_children(opts, cache, &mut ancestors, parent_id, max_depth, parent_dir);
+        materialize_children(opts, cache, &mut ancestors, parent_id, max_depth, parent_dir, 0);
 
     // Circular back-edges are marked in a post-pass: materialization
     // truncates dependencies at cycle boundaries but leaves cached
@@ -109,6 +109,7 @@ fn materialize_children(
     parent_id: &TreeNodeId,
     max_depth: MaxDepth,
     parent_dir: Option<&Path>,
+    guard_depth: usize,
 ) -> MaterializationResult {
     let empty = || MaterializationResult {
         nodes: Vec::new(),
@@ -116,7 +117,7 @@ fn materialize_children(
         has_search_match: false,
         search_messages: Vec::new(),
     };
-    if max_depth.is_exhausted() {
+    if max_depth.is_exhausted() || guard_depth >= super::MAX_WALK_DEPTH {
         return empty();
     }
     let Some(graph_node) = opts.graph.nodes.get(parent_id) else {
@@ -206,6 +207,7 @@ fn materialize_children(
                             target,
                             child_tree_max_depth,
                             Some(Path::new(&package_info.path)),
+                            guard_depth + 1,
                         );
                         ancestors.remove(target);
 

--- a/pnpm/crates/cli/src/cli_args/deps_tree/get_tree/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/get_tree/tests.rs
@@ -56,7 +56,7 @@ fn load_lockfile(dir: &Path, yaml: &str) -> Lockfile {
 fn mock_lockfile(dir: &Path, packages: &[(&str, &[&str])]) -> Lockfile {
     let yaml = format!(
         "lockfileVersion: '9.0'\n\nimporters:\n  .: {{}}\n\n{}",
-        mock_packages_yaml(packages)
+        mock_packages_yaml(packages),
     );
     load_lockfile(dir, &yaml)
 }
@@ -385,7 +385,7 @@ importers:
         version: 1.0.0
 
 {}",
-        mock_packages_yaml(&[("regular-dep", &["transitive"])])
+        mock_packages_yaml(&[("regular-dep", &["transitive"])]),
     );
     let lockfile = load_lockfile(dir.path(), &yaml);
     let env = mock_env(dir.path(), &lockfile);
@@ -416,7 +416,7 @@ importers:
         version: 1.0.0
 
 {}",
-        mock_packages_yaml(&[("leaf", &[])])
+        mock_packages_yaml(&[("leaf", &[])]),
     );
     let lockfile = load_lockfile(dir.path(), &yaml);
     let env = mock_env(dir.path(), &lockfile);
@@ -528,7 +528,7 @@ importers:
         version: 1.0.0
 
 {}",
-        mock_packages_yaml(&[("a", &["shared"]), ("b", &["unique-to-b"]), ("shared", &["deep"])])
+        mock_packages_yaml(&[("a", &["shared"]), ("b", &["unique-to-b"]), ("shared", &["deep"])]),
     );
     let lockfile = load_lockfile(dir.path(), &yaml);
     let root_a = TreeNodeId::Importer("project-a".to_string());
@@ -711,7 +711,7 @@ snapshots:
       bar: 1.0.0
   peer2@1.0.0: {{}}
   qar@1.0.0: {{}}
-"
+",
     );
     let lockfile = load_lockfile(dir.path(), &yaml);
     let env = mock_env(dir.path(), &lockfile);

--- a/pnpm/crates/cli/src/cli_args/deps_tree/get_tree/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/get_tree/tests.rs
@@ -733,3 +733,60 @@ snapshots:
     // peer1 stays because it has dependencies of its own; peer2 is excluded.
     assert_eq!(shape(&result), "peer1(bar),qar");
 }
+
+// A pathologically deep (acyclic) chain must not overflow the stack:
+// the walks stop at MAX_WALK_DEPTH instead of recursing without bound.
+#[test]
+fn absurdly_deep_chain_is_capped_instead_of_overflowing_the_stack() {
+    let chain_len = crate::cli_args::deps_tree::MAX_WALK_DEPTH * 3;
+    let names: Vec<String> = (0..chain_len).map(|i| format!("chain-{i}")).collect();
+
+    let mut yaml = String::from("lockfileVersion: '9.0'\n\nimporters:\n  .: {}\n\npackages:\n");
+    for name in &names {
+        writeln!(yaml, "  {name}@1.0.0:\n    resolution: {{integrity: {MOCK_INTEGRITY}}}").unwrap();
+    }
+    yaml.push_str("\nsnapshots:\n");
+    for (i, name) in names.iter().enumerate() {
+        match names.get(i + 1) {
+            Some(next) => {
+                writeln!(yaml, "  {name}@1.0.0:\n    dependencies:\n      {next}: 1.0.0").unwrap();
+            }
+            None => writeln!(yaml, "  {name}@1.0.0: {{}}").unwrap(),
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = load_lockfile(dir.path(), &yaml);
+    let env = mock_env(dir.path(), &lockfile);
+    let root_id = TreeNodeId::Package("chain-0@1.0.0".parse().unwrap());
+    let graph = build_dependency_graph(
+        std::slice::from_ref(&root_id),
+        &BuildGraphOptions {
+            lockfile: &lockfile,
+            include: include_no_optional(),
+            only_projects: false,
+        },
+    );
+    let mut cache = MaterializationCache::new();
+    let opts = GetTreeOptions {
+        env: &env,
+        graph: &graph,
+        exclude_peer_dependencies: false,
+        only_projects: false,
+        search: None,
+        show_deduped_search_matches: false,
+        rewrite_link_version_dir: dir.path().to_path_buf(),
+    };
+
+    let result = get_tree(&opts, &mut cache, &root_id, MaxDepth::Unlimited, None);
+
+    let mut depth = 0;
+    let mut nodes = &result;
+    while let Some(node) = nodes.first() {
+        depth += 1;
+        nodes = &node.dependencies;
+    }
+    eprintln!("materialized chain depth: {depth}");
+    assert!(depth <= crate::cli_args::deps_tree::MAX_WALK_DEPTH);
+    assert!(depth >= crate::cli_args::deps_tree::MAX_WALK_DEPTH - 1);
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/get_tree/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/get_tree/tests.rs
@@ -1,0 +1,735 @@
+//! Ports of the upstream `getTree` tests
+//! (deps/inspection/tree-builder/test/getTree.test.ts).
+
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    fmt::Write,
+    path::Path,
+};
+
+use pacquet_lockfile::Lockfile;
+use pacquet_modules_yaml::IncludedDependencies;
+use pretty_assertions::assert_eq;
+
+use super::{GetTreeOptions, MaterializationCache, MaxDepth, get_tree};
+use crate::cli_args::deps_tree::{
+    DependencyNode, TreeNodeId,
+    graph::{BuildGraphOptions, DependencyGraph, build_dependency_graph},
+    pkg_info::PkgInfoEnv,
+    search::{SearchMatch, Searcher},
+};
+
+const MOCK_INTEGRITY: &str = "sha512-TIE61hcgbI/SlJh/0c1sT1SZbBlpg7WiZcs65WPJhoIZQPhH1SCpcGA7LgrVXT15lwN3HV4GQM/MJ9aKEn3Qfg==";
+
+/// Counterpart of the upstream test helper `generateMockCurrentPackages`:
+/// every package gets version `1.0.0`, and every dependency name that is
+/// mentioned but not declared gets its own empty entry.
+fn mock_packages_yaml(packages: &[(&str, &[&str])]) -> String {
+    let mut names: BTreeSet<&str> = packages.iter().map(|(name, _)| *name).collect();
+    names.extend(packages.iter().flat_map(|(_, deps)| deps.iter().copied()));
+    let deps_of: HashMap<&str, &[&str]> = packages.iter().copied().collect();
+
+    let mut yaml = String::from("packages:\n");
+    for name in &names {
+        writeln!(yaml, "  {name}@1.0.0:\n    resolution: {{integrity: {MOCK_INTEGRITY}}}").unwrap();
+    }
+    yaml.push_str("\nsnapshots:\n");
+    for name in &names {
+        match deps_of.get(name).copied().unwrap_or_default() {
+            [] => writeln!(yaml, "  {name}@1.0.0: {{}}").unwrap(),
+            deps => {
+                writeln!(yaml, "  {name}@1.0.0:\n    dependencies:").unwrap();
+                for dep in deps {
+                    writeln!(yaml, "      {dep}: 1.0.0").unwrap();
+                }
+            }
+        }
+    }
+    yaml
+}
+
+fn load_lockfile(dir: &Path, yaml: &str) -> Lockfile {
+    std::fs::write(dir.join("pnpm-lock.yaml"), yaml).unwrap();
+    Lockfile::load_wanted_from_dir(dir).unwrap().unwrap()
+}
+
+fn mock_lockfile(dir: &Path, packages: &[(&str, &[&str])]) -> Lockfile {
+    let yaml = format!(
+        "lockfileVersion: '9.0'\n\nimporters:\n  .: {{}}\n\n{}",
+        mock_packages_yaml(packages)
+    );
+    load_lockfile(dir, &yaml)
+}
+
+fn mock_env<'a>(dir: &Path, lockfile: &'a Lockfile) -> PkgInfoEnv<'a> {
+    PkgInfoEnv {
+        lockfile_dir: dir.to_path_buf(),
+        modules_dir: dir.join("node_modules"),
+        virtual_store_dir: dir.join("node_modules/.pnpm"),
+        virtual_store_dir_max_length: 120,
+        registries: HashMap::from([(
+            "default".to_string(),
+            "https://mock-registry-for-testing.example/".to_string(),
+        )]),
+        skipped: HashSet::new(),
+        store_dir: None,
+        current_lockfile: lockfile,
+        wanted_lockfile: Some(lockfile),
+        dep_types: HashMap::new(),
+    }
+}
+
+/// The `include` filter the upstream tests pass: `{ optionalDependencies: false }`.
+fn include_no_optional() -> IncludedDependencies {
+    IncludedDependencies {
+        dependencies: true,
+        dev_dependencies: true,
+        optional_dependencies: false,
+    }
+}
+
+fn graph_for(lockfile: &Lockfile, roots: &[TreeNodeId]) -> DependencyGraph {
+    build_dependency_graph(
+        roots,
+        &BuildGraphOptions { lockfile, include: include_no_optional(), only_projects: false },
+    )
+}
+
+fn pkg_root(name: &str) -> TreeNodeId {
+    TreeNodeId::Package(format!("{name}@1.0.0").parse().unwrap())
+}
+
+/// Counterpart of the upstream test helper `getTreeWithGraph`.
+fn tree_with_graph(
+    env: &PkgInfoEnv<'_>,
+    root: &TreeNodeId,
+    max_depth: MaxDepth,
+) -> Vec<DependencyNode> {
+    let graph = graph_for(env.current_lockfile, std::slice::from_ref(root));
+    let opts = GetTreeOptions {
+        env,
+        graph: &graph,
+        exclude_peer_dependencies: false,
+        only_projects: false,
+        search: None,
+        show_deduped_search_matches: false,
+        rewrite_link_version_dir: env.lockfile_dir.clone(),
+    };
+    get_tree(&opts, &mut MaterializationCache::new(), root, max_depth, None)
+}
+
+fn tree_with_search(
+    env: &PkgInfoEnv<'_>,
+    root: &TreeNodeId,
+    search: &Searcher,
+    show_deduped_search_matches: bool,
+) -> Vec<DependencyNode> {
+    let graph = graph_for(env.current_lockfile, std::slice::from_ref(root));
+    let opts = GetTreeOptions {
+        env,
+        graph: &graph,
+        exclude_peer_dependencies: false,
+        only_projects: false,
+        search: Some(search),
+        show_deduped_search_matches,
+        rewrite_link_version_dir: env.lockfile_dir.clone(),
+    };
+    get_tree(&opts, &mut MaterializationCache::new(), root, MaxDepth::Unlimited, None)
+}
+
+fn query_searcher(query: &str) -> Searcher {
+    Searcher::from_queries(&[query.to_string()]).unwrap()
+}
+
+/// A message-returning `--find-by` finder, pre-evaluated the way the CLI
+/// seeds finder verdicts: keyed by `(alias, node)`.
+fn finder_searcher(alias: &str, dep_path: &str, message: &str) -> Searcher {
+    let mut searcher = Searcher::from_queries(&[]).unwrap();
+    searcher.set_finder_results(HashMap::from([(
+        (alias.to_string(), Some(TreeNodeId::Package(dep_path.parse().unwrap()))),
+        SearchMatch::Message(message.to_string()),
+    )]));
+    searcher
+}
+
+/// Renders the alias nesting of a materialized tree, e.g. `b1(c1(d1)),b2,b3`.
+/// Children come out sorted by alias, so the rendering is deterministic.
+fn shape(nodes: &[DependencyNode]) -> String {
+    nodes
+        .iter()
+        .map(|node| {
+            if node.dependencies.is_empty() {
+                node.alias.clone()
+            } else {
+                format!("{}({})", node.alias, shape(&node.dependencies))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn find<'a>(nodes: &'a [DependencyNode], alias_path: &[&str]) -> &'a DependencyNode {
+    let (first, rest) = alias_path.split_first().expect("alias path must be non-empty");
+    let node = nodes
+        .iter()
+        .find(|node| node.alias == *first)
+        .unwrap_or_else(|| panic!("no node with alias {first}"));
+    if rest.is_empty() { node } else { find(&node.dependencies, rest) }
+}
+
+// Port of upstream's 'full test case to print when max depth is large' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn full_test_case_to_print_when_max_depth_is_large() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile =
+        mock_lockfile(dir.path(), &[("a", &["b1", "b2", "b3"]), ("b1", &["c1"]), ("c1", &["d1"])]);
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("a"), MaxDepth::Finite(9999));
+
+    assert_eq!(shape(&result), "b1(c1(d1)),b2,b3");
+}
+
+// Port of upstream's 'no result when current depth exceeds max depth' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn no_result_when_current_depth_exceeds_max_depth() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile =
+        mock_lockfile(dir.path(), &[("a", &["b1", "b2", "b3"]), ("b1", &["c1"]), ("c1", &["d1"])]);
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("a"), MaxDepth::Finite(0));
+
+    assert_eq!(shape(&result), "");
+}
+
+// Port of upstream's 'max depth of 1 to print flat dependencies' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn max_depth_of_1_to_print_flat_dependencies() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile =
+        mock_lockfile(dir.path(), &[("a", &["b1", "b2", "b3"]), ("b1", &["c1"]), ("c1", &["d1"])]);
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("a"), MaxDepth::Finite(1));
+
+    assert_eq!(shape(&result), "b1,b2,b3");
+}
+
+// Port of upstream's 'max depth of 2 to print a1 -> b1 -> c1, but not d1' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn max_depth_of_2_to_print_a1_to_b1_to_c1_but_not_d1() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile =
+        mock_lockfile(dir.path(), &[("a", &["b1", "b2", "b3"]), ("b1", &["c1"]), ("c1", &["d1"])]);
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("a"), MaxDepth::Finite(2));
+
+    assert_eq!(shape(&result), "b1(c1),b2,b3");
+}
+
+// Port of upstream's 'revisiting package at lower depth prints dependencies not previously printed' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn revisiting_package_at_lower_depth_prints_dependencies_not_previously_printed() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[
+            ("root", &["glob"]),
+            ("glob", &["inflight", "once"]),
+            ("inflight", &["once"]),
+            ("once", &["wrappy"]),
+        ],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("root"), MaxDepth::Finite(3));
+
+    assert_eq!(shape(&result), "glob(inflight(once),once(wrappy))");
+}
+
+// Port of upstream's 'revisiting package at higher depth does not print extra dependencies' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn revisiting_package_at_higher_depth_does_not_print_extra_dependencies() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[("root", &["a"]), ("a", &["b", "d"]), ("b", &["c"]), ("d", &["b"])],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("root"), MaxDepth::Finite(3));
+
+    assert_eq!(shape(&result), "a(b(c),d(b))");
+}
+
+// Port of upstream's 'height < requestedDepth' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn height_less_than_requested_depth() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile =
+        mock_lockfile(dir.path(), &[("root", &["a", "b"]), ("a", &["b"]), ("b", &["c"])]);
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("root"), MaxDepth::Finite(4));
+
+    assert_eq!(shape(&result), "a(b(c)),b(c)");
+}
+
+// Port of upstream's 'height === requestedDepth' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn height_equals_requested_depth() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[("root", &["a", "c"]), ("a", &["b"]), ("c", &["d"]), ("d", &["a"])],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("root"), MaxDepth::Finite(4));
+
+    assert_eq!(shape(&result), "a(b),c(d(a(b)))");
+}
+
+// Port of upstream's 'height === requestedDepth + 1' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn height_equals_requested_depth_plus_1() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[("root", &["a", "c"]), ("a", &["b"]), ("c", &["d"]), ("d", &["a"])],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("root"), MaxDepth::Finite(3));
+
+    assert_eq!(shape(&result), "a(b),c(d(a))");
+}
+
+// Port of upstream's 'height > requestedDepth' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn height_greater_than_requested_depth() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[
+            ("root", &["a", "e"]),
+            ("a", &["b"]),
+            ("b", &["c"]),
+            ("c", &["d"]),
+            ("e", &["f"]),
+            ("f", &["g"]),
+            ("g", &["a"]),
+        ],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("root"), MaxDepth::Finite(5));
+
+    assert_eq!(shape(&result), "a(b(c(d))),e(f(g(a(b))))");
+}
+
+// Port of upstream's 'marks back-edge as circular in a simple cycle' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn marks_back_edge_as_circular_in_a_simple_cycle() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(dir.path(), &[("root", &["a"]), ("a", &["b"]), ("b", &["a"])]);
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("root"), MaxDepth::Unlimited);
+
+    assert_eq!(shape(&result), "a(b(a))");
+    let back_edge = find(&result, &["a", "b", "a"]);
+    dbg!(back_edge);
+    assert!(back_edge.circular);
+}
+
+// Port of upstream's 'does not mark a node as circular when reached from a non-cyclic path' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn does_not_mark_a_node_as_circular_when_reached_from_a_non_cyclic_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[("root", &["a", "c"]), ("a", &["b"]), ("b", &["a"]), ("c", &["b"])],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &pkg_root("root"), MaxDepth::Unlimited);
+
+    assert_eq!(shape(&result), "a(b(a)),c(b)");
+    let back_edge = find(&result, &["a", "b", "a"]);
+    let b_under_c = find(&result, &["c", "b"]);
+    dbg!(back_edge, b_under_c);
+    assert!(back_edge.circular);
+    // b under c is deduped (already expanded under a), not circular.
+    assert!(!b_under_c.circular);
+    assert!(b_under_c.deduped);
+}
+
+// Port of upstream's 'link outside workspace appears as leaf node' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn link_outside_workspace_appears_as_leaf_node() {
+    let dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      my-link:
+        specifier: link:../external-pkg
+        version: link:../external-pkg
+      regular-dep:
+        specifier: 1.0.0
+        version: 1.0.0
+
+{}",
+        mock_packages_yaml(&[("regular-dep", &["transitive"])])
+    );
+    let lockfile = load_lockfile(dir.path(), &yaml);
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &TreeNodeId::Importer(".".to_string()), MaxDepth::Unlimited);
+
+    assert_eq!(shape(&result), "my-link,regular-dep(transitive)");
+    assert_eq!(find(&result, &["my-link"]).version, "link:../external-pkg");
+}
+
+// Port of upstream's 'link inside workspace resolves to importer and is traversed' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn link_inside_workspace_resolves_to_importer_and_is_traversed() {
+    let dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "lockfileVersion: '9.0'
+
+importers:
+  .:
+    dependencies:
+      workspace-pkg:
+        specifier: link:packages/workspace-pkg
+        version: link:packages/workspace-pkg
+  packages/workspace-pkg:
+    dependencies:
+      leaf:
+        specifier: 1.0.0
+        version: 1.0.0
+
+{}",
+        mock_packages_yaml(&[("leaf", &[])])
+    );
+    let lockfile = load_lockfile(dir.path(), &yaml);
+    let env = mock_env(dir.path(), &lockfile);
+
+    let result = tree_with_graph(&env, &TreeNodeId::Importer(".".to_string()), MaxDepth::Unlimited);
+
+    assert_eq!(shape(&result), "workspace-pkg(leaf)");
+    assert_eq!(find(&result, &["workspace-pkg"]).version, "link:packages/workspace-pkg");
+}
+
+// Port of upstream's 'deduped subtree containing a search match still appears in output' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn deduped_subtree_containing_a_search_match_still_appears_in_output() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[("root", &["a", "c"]), ("a", &["b"]), ("b", &["target"]), ("c", &["b"])],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+    let search = query_searcher("target");
+
+    let result = tree_with_search(&env, &pkg_root("root"), &search, true);
+
+    assert_eq!(shape(&result), "a(b(target)),c(b)");
+    let matched = find(&result, &["a", "b", "target"]);
+    let b_under_c = find(&result, &["c", "b"]);
+    dbg!(matched, b_under_c);
+    assert!(matched.searched);
+    assert!(b_under_c.deduped);
+    assert!(b_under_c.searched);
+}
+
+// Port of upstream's 'deduped subtree propagates string search messages to the deduped node' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn deduped_subtree_propagates_string_search_messages_to_the_deduped_node() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[("root", &["a", "c"]), ("a", &["b"]), ("b", &["target"]), ("c", &["b"])],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+    let search = finder_searcher("target", "target@1.0.0", "depends on target");
+
+    let result = tree_with_search(&env, &pkg_root("root"), &search, true);
+
+    assert_eq!(shape(&result), "a(b(target)),c(b)");
+    let matched = find(&result, &["a", "b", "target"]);
+    let b_under_c = find(&result, &["c", "b"]);
+    dbg!(matched, b_under_c);
+    assert!(matched.searched);
+    assert_eq!(matched.search_message.as_deref(), Some("depends on target"));
+    // The deduped b under c carries the search message from target.
+    assert!(b_under_c.deduped);
+    assert!(b_under_c.searched);
+    assert_eq!(b_under_c.search_message.as_deref(), Some("depends on target"));
+}
+
+// Port of upstream's 'deduped subtree with search match is hidden by default' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn deduped_subtree_with_search_match_is_hidden_by_default() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[("root", &["a", "c"]), ("a", &["b"]), ("b", &["target"]), ("c", &["b"])],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+    let search = query_searcher("target");
+
+    let result = tree_with_search(&env, &pkg_root("root"), &search, false);
+
+    // Only a -> b -> target appears; c is excluded because its only child b
+    // is deduped and does not directly match.
+    assert_eq!(shape(&result), "a(b(target))");
+}
+
+// Port of upstream's 'deduped subtree without search match is excluded when search is active' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn deduped_subtree_without_search_match_is_excluded_when_search_is_active() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(
+        dir.path(),
+        &[("root", &["a", "c"]), ("a", &["b"]), ("b", &["leaf"]), ("c", &["b"])],
+    );
+    let env = mock_env(dir.path(), &lockfile);
+    let search = query_searcher("target");
+
+    let result = tree_with_search(&env, &pkg_root("root"), &search, false);
+
+    assert_eq!(shape(&result), "");
+}
+
+// Port of upstream's 'graph includes nodes reachable from all specified root IDs' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn graph_includes_nodes_reachable_from_all_specified_root_ids() {
+    let dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "lockfileVersion: '9.0'
+
+importers:
+  project-a:
+    dependencies:
+      a:
+        specifier: 1.0.0
+        version: 1.0.0
+  project-b:
+    dependencies:
+      b:
+        specifier: 1.0.0
+        version: 1.0.0
+
+{}",
+        mock_packages_yaml(&[("a", &["shared"]), ("b", &["unique-to-b"]), ("shared", &["deep"])])
+    );
+    let lockfile = load_lockfile(dir.path(), &yaml);
+    let root_a = TreeNodeId::Importer("project-a".to_string());
+    let root_b = TreeNodeId::Importer("project-b".to_string());
+
+    let multi = graph_for(&lockfile, &[root_a.clone(), root_b.clone()]);
+    let graph_a = graph_for(&lockfile, std::slice::from_ref(&root_a));
+    let graph_b = graph_for(&lockfile, std::slice::from_ref(&root_b));
+
+    dbg!(multi.nodes.keys().collect::<Vec<_>>());
+    for key in graph_a.nodes.keys().chain(graph_b.nodes.keys()) {
+        assert!(multi.nodes.contains_key(key), "multi-root graph is missing {key:?}");
+    }
+    for name in ["unique-to-b", "shared", "deep"] {
+        let id = pkg_root(name);
+        assert!(multi.nodes.contains_key(&id), "multi-root graph is missing {id:?}");
+    }
+}
+
+// Port of upstream's 'second getTree call for same node returns deduped children' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn second_get_tree_call_for_same_node_returns_deduped_children() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(dir.path(), &[("root", &["a"]), ("a", &["b"]), ("b", &["c"])]);
+    let env = mock_env(dir.path(), &lockfile);
+    let root = pkg_root("root");
+    let graph = graph_for(&lockfile, std::slice::from_ref(&root));
+    let opts = GetTreeOptions {
+        env: &env,
+        graph: &graph,
+        exclude_peer_dependencies: false,
+        only_projects: false,
+        search: None,
+        show_deduped_search_matches: false,
+        rewrite_link_version_dir: dir.path().to_path_buf(),
+    };
+    let mut cache = MaterializationCache::new();
+
+    let result1 = get_tree(&opts, &mut cache, &root, MaxDepth::Unlimited, None);
+    assert_eq!(shape(&result1), "a(b(c))");
+
+    let result2 = get_tree(&opts, &mut cache, &root, MaxDepth::Unlimited, None);
+    assert_eq!(shape(&result2), "a");
+    let deduped_a = &result2[0];
+    dbg!(deduped_a);
+    assert!(deduped_a.deduped);
+    assert!(deduped_a.deduped_dependencies_count.unwrap() > 0);
+}
+
+// Port of upstream's 'deduped result preserves search match metadata' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn deduped_result_preserves_search_match_metadata() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(dir.path(), &[("root", &["a"]), ("a", &["target"])]);
+    let env = mock_env(dir.path(), &lockfile);
+    let root = pkg_root("root");
+    let graph = graph_for(&lockfile, std::slice::from_ref(&root));
+    let search = finder_searcher("target", "target@1.0.0", "found target");
+    let opts = GetTreeOptions {
+        env: &env,
+        graph: &graph,
+        exclude_peer_dependencies: false,
+        only_projects: false,
+        search: Some(&search),
+        show_deduped_search_matches: true,
+        rewrite_link_version_dir: dir.path().to_path_buf(),
+    };
+    let mut cache = MaterializationCache::new();
+
+    let result1 = get_tree(&opts, &mut cache, &root, MaxDepth::Unlimited, None);
+    assert_eq!(shape(&result1), "a(target)");
+    let matched = find(&result1, &["a", "target"]);
+    dbg!(matched);
+    assert!(matched.searched);
+    assert_eq!(matched.search_message.as_deref(), Some("found target"));
+
+    // The second call dedupes a but carries the search metadata from the cache.
+    let result2 = get_tree(&opts, &mut cache, &root, MaxDepth::Unlimited, None);
+    assert_eq!(shape(&result2), "a");
+    let deduped_a = &result2[0];
+    dbg!(deduped_a);
+    assert!(deduped_a.deduped);
+    assert!(deduped_a.searched);
+    assert_eq!(deduped_a.search_message.as_deref(), Some("found target"));
+}
+
+// Port of upstream's 'dedupedDependenciesCount correctly reflects subtree size' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn deduped_dependencies_count_correctly_reflects_subtree_size() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(dir.path(), &[("root", &["a"]), ("a", &["b", "c"])]);
+    let env = mock_env(dir.path(), &lockfile);
+    let root = pkg_root("root");
+    let graph = graph_for(&lockfile, std::slice::from_ref(&root));
+    let opts = GetTreeOptions {
+        env: &env,
+        graph: &graph,
+        exclude_peer_dependencies: false,
+        only_projects: false,
+        search: None,
+        show_deduped_search_matches: false,
+        rewrite_link_version_dir: dir.path().to_path_buf(),
+    };
+    let mut cache = MaterializationCache::new();
+
+    let result1 = get_tree(&opts, &mut cache, &root, MaxDepth::Unlimited, None);
+    assert_eq!(shape(&result1), "a(b,c)");
+
+    let result2 = get_tree(&opts, &mut cache, &root, MaxDepth::Unlimited, None);
+    assert_eq!(shape(&result2), "a");
+    let deduped_a = &result2[0];
+    dbg!(deduped_a);
+    assert!(deduped_a.deduped);
+    // a's subtree had 2 nodes (b and c).
+    assert_eq!(deduped_a.deduped_dependencies_count, Some(2));
+}
+
+// Port of upstream's 'different maxDepth values are cached independently' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn different_max_depth_values_are_cached_independently() {
+    let dir = tempfile::tempdir().unwrap();
+    let lockfile = mock_lockfile(dir.path(), &[("root", &["a"]), ("a", &["b"]), ("b", &["c"])]);
+    let env = mock_env(dir.path(), &lockfile);
+    let root = pkg_root("root");
+    let graph = graph_for(&lockfile, std::slice::from_ref(&root));
+    let opts = GetTreeOptions {
+        env: &env,
+        graph: &graph,
+        exclude_peer_dependencies: false,
+        only_projects: false,
+        search: None,
+        show_deduped_search_matches: false,
+        rewrite_link_version_dir: dir.path().to_path_buf(),
+    };
+    let mut cache = MaterializationCache::new();
+
+    // Depth 1 only shows a without children.
+    let shallow = get_tree(&opts, &mut cache, &root, MaxDepth::Finite(1), None);
+    assert_eq!(shape(&shallow), "a");
+
+    // Unlimited depth shows the full tree, unaffected by the depth-1 cache.
+    let deep = get_tree(&opts, &mut cache, &root, MaxDepth::Unlimited, None);
+    assert_eq!(shape(&deep), "a(b(c))");
+}
+
+// Port of upstream's 'exclude peers' (deps/inspection/tree-builder/test/getTree.test.ts).
+#[test]
+fn exclude_peers() {
+    let dir = tempfile::tempdir().unwrap();
+    let yaml = format!(
+        "lockfileVersion: '9.0'
+
+importers:
+  .: {{}}
+
+packages:
+  bar@1.0.0:
+    resolution: {{integrity: {MOCK_INTEGRITY}}}
+  foo@1.0.0:
+    resolution: {{integrity: {MOCK_INTEGRITY}}}
+    peerDependencies:
+      peer1: ^1.0.0
+      peer2: ^1.0.0
+  peer1@1.0.0:
+    resolution: {{integrity: {MOCK_INTEGRITY}}}
+  peer2@1.0.0:
+    resolution: {{integrity: {MOCK_INTEGRITY}}}
+  qar@1.0.0:
+    resolution: {{integrity: {MOCK_INTEGRITY}}}
+
+snapshots:
+  bar@1.0.0: {{}}
+  foo@1.0.0:
+    dependencies:
+      peer1: 1.0.0
+      peer2: 1.0.0
+      qar: 1.0.0
+  peer1@1.0.0:
+    dependencies:
+      bar: 1.0.0
+  peer2@1.0.0: {{}}
+  qar@1.0.0: {{}}
+"
+    );
+    let lockfile = load_lockfile(dir.path(), &yaml);
+    let env = mock_env(dir.path(), &lockfile);
+    let root = pkg_root("foo");
+    let graph = graph_for(&lockfile, std::slice::from_ref(&root));
+    let opts = GetTreeOptions {
+        env: &env,
+        graph: &graph,
+        exclude_peer_dependencies: true,
+        only_projects: false,
+        search: None,
+        show_deduped_search_matches: false,
+        rewrite_link_version_dir: dir.path().to_path_buf(),
+    };
+
+    let result =
+        get_tree(&opts, &mut MaterializationCache::new(), &root, MaxDepth::Finite(9999), None);
+
+    // peer1 stays because it has dependencies of its own; peer2 is excluded.
+    assert_eq!(shape(&result), "peer1(bar),qar");
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/graph.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/graph.rs
@@ -1,0 +1,225 @@
+//! Lockfile-backed dependency graph shared by the forward (`list`) and
+//! reverse (`why`) tree builders.
+
+use std::collections::{HashMap, HashSet};
+
+use pacquet_lockfile::{Lockfile, PkgName, PkgNameVerPeer, ProjectSnapshot, SnapshotEntry};
+use pacquet_modules_yaml::IncludedDependencies;
+
+use super::TreeNodeId;
+
+/// One outgoing dependency edge of a graph node.
+#[derive(Debug, Clone)]
+pub(crate) struct GraphEdge {
+    pub alias: String,
+    /// The raw `version:` reference, used as the display version when
+    /// the target cannot be resolved (mirrors the TypeScript
+    /// `version = opts.ref` fallback).
+    pub ref_display: String,
+    /// The `snapshots:`/`packages:` key this edge resolves to, when the
+    /// reference addresses the virtual store.
+    pub dep_path: Option<PkgNameVerPeer>,
+    /// The path portion of a `link:` reference, scheme stripped.
+    pub link_target: Option<String>,
+    /// The graph node this edge leads to. `None` for edges that cannot
+    /// be traversed (links outside the workspace, links from external
+    /// packages).
+    pub target: Option<TreeNodeId>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct GraphNode {
+    pub edges: Vec<GraphEdge>,
+    /// Names declared in this package's `peerDependencies` — a child
+    /// edge whose alias is in this set is a peer dependency.
+    pub peers: HashSet<String>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct DependencyGraph {
+    pub nodes: HashMap<TreeNodeId, GraphNode>,
+}
+
+pub(crate) struct BuildGraphOptions<'a> {
+    pub lockfile: &'a Lockfile,
+    pub include: IncludedDependencies,
+    pub only_projects: bool,
+}
+
+/// Breadth-first walk from `root_ids`, recording every reachable node
+/// and its outgoing edges. Mirrors the TypeScript `buildDependencyGraph`.
+pub(crate) fn build_dependency_graph(
+    root_ids: &[TreeNodeId],
+    opts: &BuildGraphOptions<'_>,
+) -> DependencyGraph {
+    let mut graph = DependencyGraph::default();
+    let mut queue: Vec<TreeNodeId> = root_ids.to_vec();
+    let mut queue_idx = 0;
+    let mut visited: HashSet<TreeNodeId> = HashSet::new();
+
+    while queue_idx < queue.len() {
+        let node_id = queue[queue_idx].clone();
+        queue_idx += 1;
+        if !visited.insert(node_id.clone()) {
+            continue;
+        }
+
+        let edges = match &node_id {
+            TreeNodeId::Importer(importer_id) => {
+                match opts.lockfile.importers.get(importer_id.as_str()) {
+                    Some(importer) => importer_edges(importer, importer_id, opts),
+                    None => Vec::new(),
+                }
+            }
+            TreeNodeId::Package(dep_path) => {
+                match opts.lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(dep_path))
+                {
+                    Some(snapshot) => package_edges(snapshot, opts),
+                    None => Vec::new(),
+                }
+            }
+        };
+
+        let peers = match &node_id {
+            TreeNodeId::Package(dep_path) => peer_names(opts.lockfile, dep_path),
+            TreeNodeId::Importer(_) => HashSet::new(),
+        };
+
+        for edge in &edges {
+            if let Some(target) = &edge.target
+                && !visited.contains(target)
+            {
+                queue.push(target.clone());
+            }
+        }
+
+        graph.nodes.insert(node_id, GraphNode { edges, peers });
+    }
+
+    graph
+}
+
+/// Names declared in `peerDependencies` of the `packages:` entry for
+/// `dep_path` (looked up by its peer-stripped key).
+pub(crate) fn peer_names(lockfile: &Lockfile, dep_path: &PkgNameVerPeer) -> HashSet<String> {
+    lockfile
+        .packages
+        .as_ref()
+        .and_then(|packages| packages.get(&dep_path.without_peer()))
+        .and_then(|metadata| metadata.peer_dependencies.as_ref())
+        .map(|peers| peers.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+fn importer_edges(
+    importer: &ProjectSnapshot,
+    importer_id: &str,
+    opts: &BuildGraphOptions<'_>,
+) -> Vec<GraphEdge> {
+    let mut edges = Vec::new();
+    let groups: [(bool, Option<&pacquet_lockfile::ResolvedDependencyMap>); 3] = [
+        (opts.include.dependencies, importer.dependencies.as_ref()),
+        (opts.include.dev_dependencies, importer.dev_dependencies.as_ref()),
+        (opts.include.optional_dependencies, importer.optional_dependencies.as_ref()),
+    ];
+    for (included, group) in groups {
+        if !included {
+            continue;
+        }
+        for (alias, spec) in group.into_iter().flatten() {
+            let dep_path = spec.version.resolved_key(alias);
+            let link_target = spec.version.as_link_target().map(str::to_string);
+            let target = edge_target(
+                dep_path.as_ref(),
+                link_target.as_deref(),
+                Some(importer_id),
+                opts.lockfile,
+            );
+            if opts.only_projects && !matches!(target, Some(TreeNodeId::Importer(_))) {
+                continue;
+            }
+            edges.push(GraphEdge {
+                alias: alias.to_string(),
+                ref_display: spec.version.to_string(),
+                dep_path,
+                link_target,
+                target,
+            });
+        }
+    }
+    edges
+}
+
+fn package_edges(snapshot: &SnapshotEntry, opts: &BuildGraphOptions<'_>) -> Vec<GraphEdge> {
+    let mut edges = Vec::new();
+    let groups: [(bool, Option<&HashMap<PkgName, pacquet_lockfile::SnapshotDepRef>>); 2] = [
+        (true, snapshot.dependencies.as_ref()),
+        (opts.include.optional_dependencies, snapshot.optional_dependencies.as_ref()),
+    ];
+    for (included, group) in groups {
+        if !included {
+            continue;
+        }
+        for (alias, dep_ref) in group.into_iter().flatten() {
+            let dep_path = dep_ref.resolve(alias);
+            let link_target = dep_ref.as_link_target().map(str::to_string);
+            // Links from external packages are not traversed (the
+            // TypeScript `getTreeNodeChildId` returns undefined for
+            // package parents), so no importer id is passed here.
+            let target =
+                edge_target(dep_path.as_ref(), link_target.as_deref(), None, opts.lockfile);
+            if opts.only_projects && !matches!(target, Some(TreeNodeId::Importer(_))) {
+                continue;
+            }
+            edges.push(GraphEdge {
+                alias: alias.to_string(),
+                ref_display: dep_ref.to_string(),
+                dep_path,
+                link_target,
+                target,
+            });
+        }
+    }
+    edges
+}
+
+/// The node an edge leads to. A resolvable depPath is a package node; a
+/// `link:` from an importer resolves to a sibling importer when the
+/// linked path is itself a workspace project; anything else is a leaf
+/// edge (`None`).
+fn edge_target(
+    dep_path: Option<&PkgNameVerPeer>,
+    link_target: Option<&str>,
+    parent_importer_id: Option<&str>,
+    lockfile: &Lockfile,
+) -> Option<TreeNodeId> {
+    if let Some(dep_path) = dep_path {
+        return Some(TreeNodeId::Package(dep_path.clone()));
+    }
+    let link_target = link_target?;
+    let parent_importer_id = parent_importer_id?;
+    let importer_id = normalize_importer_path(parent_importer_id, link_target)?;
+    lockfile
+        .importers
+        .contains_key(importer_id.as_str())
+        .then_some(TreeNodeId::Importer(importer_id))
+}
+
+/// Lexically resolve `relative` against the importer id `base`,
+/// producing another importer id (`.` for the workspace root). `None`
+/// when the path escapes the workspace root.
+pub(crate) fn normalize_importer_path(base: &str, relative: &str) -> Option<String> {
+    let mut parts: Vec<&str> =
+        base.split('/').filter(|segment| !segment.is_empty() && *segment != ".").collect();
+    let normalized = relative.replace('\\', "/");
+    for part in normalized.split('/') {
+        match part {
+            "" | "." => continue,
+            ".." => {
+                parts.pop()?;
+            }
+            other => parts.push(other),
+        }
+    }
+    if parts.is_empty() { Some(".".to_string()) } else { Some(parts.join("/")) }
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
@@ -203,10 +203,18 @@ fn resolved_tarball_url(
     }
 }
 
+/// A lockfile-derived path component that could escape the directory
+/// it is joined under — the same guard `pnpm licenses` applies before
+/// dereferencing store paths built from lockfile keys.
+fn is_unsafe_path_component(component: &str) -> bool {
+    component.contains("..") || Path::new(component).is_absolute()
+}
+
 /// Filesystem path of a package addressed by `dep_path`. For a local
 /// virtual store the path is constructed directly; for a global
 /// virtual store the symlink through the parent's `node_modules` is
-/// resolved instead.
+/// resolved instead. A name that could traverse outside the virtual
+/// store is never joined or dereferenced.
 pub(crate) fn resolve_package_path(
     env: &PkgInfoEnv<'_>,
     dep_path: &PkgNameVerPeer,
@@ -214,13 +222,13 @@ pub(crate) fn resolve_package_path(
     alias: &str,
     ctx: &EdgeContext<'_>,
 ) -> PathBuf {
-    let constructed = env
-        .virtual_store_dir
-        .join(dep_path.to_virtual_store_name(env.virtual_store_dir_max_length))
-        .join("node_modules")
-        .join(name);
+    let store_name = dep_path.to_virtual_store_name(env.virtual_store_dir_max_length);
+    if is_unsafe_path_component(&store_name) || is_unsafe_path_component(name) {
+        return env.virtual_store_dir.clone();
+    }
+    let constructed = env.virtual_store_dir.join(store_name).join("node_modules").join(name);
 
-    if !env.is_global_virtual_store() {
+    if !env.is_global_virtual_store() || is_unsafe_path_component(alias) {
         return constructed;
     }
 

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
@@ -185,8 +185,8 @@ fn lookup_dep<'l>(
 
 /// The tarball URL recorded in (or reconstructible from) a lockfile
 /// resolution. `None` for resolutions that have no tarball (git,
-/// directory, binary, …), matching the TypeScript CLI, which drops the
-/// `resolved` field for those.
+/// directory, binary, and so on), matching the TypeScript CLI, which
+/// drops the `resolved` field for those.
 fn resolved_tarball_url(
     env: &PkgInfoEnv<'_>,
     resolution: &LockfileResolution,

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
@@ -1,0 +1,244 @@
+//! Per-edge node materialization: name, version, filesystem path,
+//! resolved tarball URL, and dev/optional/peer/skipped/missing flags.
+//! Rust counterpart of the TypeScript tree-builder's `getPkgInfo` and
+//! `resolvePackagePath`.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
+
+use pacquet_fs::{is_subdir, lexical_normalize};
+use pacquet_lockfile::{
+    Lockfile, LockfileResolution, PkgNameVerPeer, npm_tarball_url, pick_registry_for_package,
+};
+
+use super::{
+    DependencyNode,
+    dep_types::{DepType, DepTypes},
+    graph::GraphEdge,
+    peers_suffix_hash,
+};
+
+/// Everything that stays constant while resolving node metadata across
+/// one tree build.
+pub(crate) struct PkgInfoEnv<'a> {
+    pub lockfile_dir: PathBuf,
+    /// Absolute, symlink-resolved `node_modules` of the lockfile root.
+    pub modules_dir: PathBuf,
+    /// Absolute virtual store directory (`<modules_dir>/.pnpm` unless
+    /// the modules manifest points elsewhere, e.g. a global store).
+    pub virtual_store_dir: PathBuf,
+    pub virtual_store_dir_max_length: usize,
+    /// Registry URLs keyed by `default` / `@scope`.
+    pub registries: HashMap<String, String>,
+    /// depPaths of packages skipped by the installer (unsupported
+    /// platform optional deps).
+    pub skipped: HashSet<String>,
+    pub store_dir: Option<PathBuf>,
+    pub current_lockfile: &'a Lockfile,
+    pub wanted_lockfile: Option<&'a Lockfile>,
+    pub dep_types: DepTypes,
+}
+
+impl PkgInfoEnv<'_> {
+    /// Whether the virtual store lives outside the project's
+    /// `node_modules` (global virtual store), in which case package
+    /// paths must be resolved through symlinks.
+    fn is_global_virtual_store(&self) -> bool {
+        !is_subdir(&self.modules_dir, &self.virtual_store_dir)
+            && self.virtual_store_dir != self.modules_dir
+    }
+}
+
+/// Where a node's manifest can be read from, for `--long` output and
+/// finder callbacks. The store is preferred (it has the manifest even
+/// when `node_modules` was never materialized), the package directory
+/// is the fallback.
+#[derive(Debug, Clone)]
+pub(crate) struct ManifestSource {
+    pub path: PathBuf,
+    pub integrity: Option<String>,
+    pub name: String,
+    pub version: String,
+}
+
+pub(crate) struct EdgeContext<'a> {
+    /// Names in the parent's `peerDependencies`.
+    pub peers: Option<&'a HashSet<String>>,
+    /// Base directory for resolving `link:` paths of this edge.
+    pub linked_path_base_dir: PathBuf,
+    /// Directory `link:` versions are rewritten relative to.
+    pub rewrite_link_version_dir: Option<PathBuf>,
+    /// Resolved path of the parent package (used by the global virtual
+    /// store to resolve through the parent's `node_modules`).
+    pub parent_dir: Option<PathBuf>,
+}
+
+pub(crate) fn get_pkg_info(
+    env: &PkgInfoEnv<'_>,
+    edge: &GraphEdge,
+    ctx: &EdgeContext<'_>,
+) -> (DependencyNode, ManifestSource) {
+    let name;
+    let mut version;
+    let mut resolved = None;
+    let mut integrity = None;
+    let mut optional = false;
+    let mut is_skipped = false;
+    let mut dev = None;
+
+    let full_package_path: PathBuf;
+
+    if let Some(dep_path) = &edge.dep_path {
+        let metadata_key = dep_path.without_peer();
+
+        let (in_current, current_snapshot, current_metadata) =
+            lookup_dep(env.current_lockfile, dep_path, &metadata_key);
+        let (known, snapshot, metadata) = if in_current {
+            (true, current_snapshot, current_metadata)
+        } else {
+            // The package is missing from the current lockfile — it was
+            // never materialized (e.g. skipped platform-specific
+            // optional deps).
+            is_skipped = env.skipped.contains(&dep_path.to_string());
+            match env.wanted_lockfile {
+                Some(wanted) => lookup_dep(wanted, dep_path, &metadata_key),
+                None => (false, None, None),
+            }
+        };
+
+        if known {
+            name = dep_path.name.to_string();
+            version = metadata
+                .and_then(|metadata| metadata.version.clone())
+                .unwrap_or_else(|| dep_path.suffix.version().to_string());
+            optional = snapshot.is_some_and(|snapshot| snapshot.optional);
+            if let Some(metadata) = metadata {
+                integrity = metadata.resolution.integrity().map(ToString::to_string);
+                resolved = resolved_tarball_url(env, &metadata.resolution, &name, &version);
+            }
+        } else {
+            name = edge.alias.clone();
+            version = edge.ref_display.clone();
+        }
+        dev = match env.dep_types.get(dep_path) {
+            Some(DepType::DevOnly) => Some(true),
+            Some(DepType::ProdOnly) => Some(false),
+            Some(DepType::DevAndProd) | None => None,
+        };
+        full_package_path = resolve_package_path(env, dep_path, &name, &edge.alias, ctx);
+    } else {
+        name = edge.alias.clone();
+        version = edge.ref_display.clone();
+        let link_target = edge.link_target.as_deref().unwrap_or("");
+        full_package_path = lexical_normalize(&ctx.linked_path_base_dir.join(link_target));
+    }
+
+    if version.is_empty() {
+        version = edge.ref_display.clone();
+    }
+    if version.starts_with("link:")
+        && let Some(rewrite_dir) = &ctx.rewrite_link_version_dir
+    {
+        let relative = pathdiff::diff_paths(&full_package_path, rewrite_dir)
+            .unwrap_or_else(|| full_package_path.clone());
+        version = format!("link:{}", relative.to_string_lossy().replace('\\', "/"));
+    }
+
+    let path = full_package_path.to_string_lossy().into_owned();
+    let manifest_source = ManifestSource {
+        path: full_package_path,
+        integrity,
+        name: name.clone(),
+        version: version.clone(),
+    };
+    let node = DependencyNode {
+        alias: edge.alias.clone(),
+        name,
+        version,
+        path,
+        resolved,
+        is_peer: ctx.peers.is_some_and(|peers| peers.contains(&edge.alias)),
+        is_skipped,
+        dev,
+        optional,
+        peers_suffix_hash: edge.dep_path.as_ref().and_then(peers_suffix_hash),
+        ..DependencyNode::default()
+    };
+    (node, manifest_source)
+}
+
+fn lookup_dep<'l>(
+    lockfile: &'l Lockfile,
+    dep_path: &PkgNameVerPeer,
+    metadata_key: &PkgNameVerPeer,
+) -> (
+    bool,
+    Option<&'l pacquet_lockfile::SnapshotEntry>,
+    Option<&'l pacquet_lockfile::PackageMetadata>,
+) {
+    let snapshot = lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(dep_path));
+    let metadata = lockfile.packages.as_ref().and_then(|packages| packages.get(metadata_key));
+    (snapshot.is_some() || metadata.is_some(), snapshot, metadata)
+}
+
+/// The tarball URL recorded in (or reconstructible from) a lockfile
+/// resolution. `None` for resolutions that have no tarball (git,
+/// directory, binary, …), matching the TypeScript CLI, which drops the
+/// `resolved` field for those.
+fn resolved_tarball_url(
+    env: &PkgInfoEnv<'_>,
+    resolution: &LockfileResolution,
+    name: &str,
+    version: &str,
+) -> Option<String> {
+    match resolution {
+        LockfileResolution::Tarball(tarball) => Some(tarball.tarball.clone()),
+        LockfileResolution::Registry(_) => {
+            let registry = pick_registry_for_package(&env.registries, name, None);
+            Some(npm_tarball_url(name, version, &registry))
+        }
+        _ => None,
+    }
+}
+
+/// Filesystem path of a package addressed by `dep_path`. For a local
+/// virtual store the path is constructed directly; for a global
+/// virtual store the symlink through the parent's `node_modules` is
+/// resolved instead.
+pub(crate) fn resolve_package_path(
+    env: &PkgInfoEnv<'_>,
+    dep_path: &PkgNameVerPeer,
+    name: &str,
+    alias: &str,
+    ctx: &EdgeContext<'_>,
+) -> PathBuf {
+    let constructed = env
+        .virtual_store_dir
+        .join(dep_path.to_virtual_store_name(env.virtual_store_dir_max_length))
+        .join("node_modules")
+        .join(name);
+
+    if !env.is_global_virtual_store() {
+        return constructed;
+    }
+
+    let node_modules_dir = match &ctx.parent_dir {
+        Some(parent_dir) => {
+            let mut dir = parent_dir.parent().map(Path::to_path_buf).unwrap_or_default();
+            // Scoped parents live one level deeper (`node_modules/@scope/pkg`).
+            if dir.file_name().is_some_and(|component| component.to_string_lossy().starts_with('@'))
+                && let Some(grandparent) = dir.parent()
+            {
+                dir = grandparent.to_path_buf();
+            }
+            dir
+        }
+        None => env.modules_dir.clone(),
+    };
+    dunce::canonicalize(node_modules_dir.join(alias)).unwrap_or(constructed)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
@@ -205,9 +205,15 @@ fn resolved_tarball_url(
 
 /// A lockfile-derived path component that could escape the directory
 /// it is joined under — the same guard `pnpm licenses` applies before
-/// dereferencing store paths built from lockfile keys.
+/// dereferencing store paths built from lockfile keys. Rooted and
+/// prefixed components are rejected by shape, not `is_absolute()`:
+/// on Windows a rooted-but-prefixless `\escape` (or a prefix-only
+/// `C:evil`) is not "absolute" yet still replaces the join base.
 fn is_unsafe_path_component(component: &str) -> bool {
-    component.contains("..") || Path::new(component).is_absolute()
+    component.contains("..")
+        || Path::new(component).components().any(|part| {
+            matches!(part, std::path::Component::RootDir | std::path::Component::Prefix(_))
+        })
 }
 
 /// Filesystem path of a package addressed by `dep_path`. For a local

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
@@ -78,3 +78,45 @@ fn get_pkg_info_handles_missing_pkg_snapshot_without_crashing() {
     assert!(!node.is_skipped);
     assert!(!node.optional);
 }
+
+// A lockfile-derived name with traversal segments is never joined into
+// the package path (the same guard `pnpm licenses` applies to
+// store paths built from lockfile keys).
+#[test]
+fn resolve_package_path_rejects_traversal_in_lockfile_derived_names() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("pnpm-lock.yaml"),
+        "lockfileVersion: '9.0'\n\nimporters:\n  .: {}\n",
+    )
+    .unwrap();
+    let lockfile = Lockfile::load_wanted_from_dir(dir.path()).unwrap().unwrap();
+
+    let virtual_store_dir = dir.path().join("node_modules").join(".pnpm");
+    let env = PkgInfoEnv {
+        lockfile_dir: dir.path().to_path_buf(),
+        modules_dir: dir.path().join("node_modules"),
+        virtual_store_dir: virtual_store_dir.clone(),
+        virtual_store_dir_max_length: 120,
+        registries: HashMap::from([(
+            "default".to_string(),
+            "https://registry.npmjs.org/".to_string(),
+        )]),
+        skipped: HashSet::new(),
+        store_dir: None,
+        current_lockfile: &lockfile,
+        wanted_lockfile: Some(&lockfile),
+        dep_types: HashMap::new(),
+    };
+    let ctx = EdgeContext {
+        peers: None,
+        linked_path_base_dir: PathBuf::new(),
+        rewrite_link_version_dir: None,
+        parent_dir: None,
+    };
+
+    let dep_path = "..@1.0.0".parse().unwrap();
+    let path = super::resolve_package_path(&env, &dep_path, "../../../../escape", "alias", &ctx);
+
+    assert_eq!(path, virtual_store_dir);
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
@@ -1,0 +1,80 @@
+//! Ports of the upstream `getPkgInfo` tests
+//! (deps/inspection/tree-builder/test/getPkgInfo.test.ts).
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+};
+
+use pacquet_lockfile::Lockfile;
+use pretty_assertions::assert_eq;
+
+use super::{EdgeContext, PkgInfoEnv, get_pkg_info};
+use crate::cli_args::deps_tree::graph::GraphEdge;
+
+// Port of upstream's 'getPkgInfo handles missing pkgSnapshot without crashing'
+// (deps/inspection/tree-builder/test/getPkgInfo.test.ts). Upstream asserts
+// `isMissing: true`; `DependencyNode` has no such field, so this port asserts
+// the observable fallbacks instead: `name` falls back to the alias and
+// `version` to the raw reference.
+#[test]
+fn get_pkg_info_handles_missing_pkg_snapshot_without_crashing() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("pnpm-lock.yaml"),
+        "lockfileVersion: '9.0'\n\nimporters:\n  .: {}\n",
+    )
+    .unwrap();
+    let lockfile = Lockfile::load_wanted_from_dir(dir.path()).unwrap().unwrap();
+
+    let env = PkgInfoEnv {
+        lockfile_dir: PathBuf::new(),
+        modules_dir: PathBuf::new(),
+        virtual_store_dir: PathBuf::from(".pnpm"),
+        virtual_store_dir_max_length: 120,
+        registries: HashMap::from([(
+            "default".to_string(),
+            "https://registry.npmjs.org/".to_string(),
+        )]),
+        skipped: HashSet::new(),
+        store_dir: None,
+        current_lockfile: &lockfile,
+        wanted_lockfile: Some(&lockfile),
+        dep_types: HashMap::new(),
+    };
+    let edge = GraphEdge {
+        alias: "missing-pkg".to_string(),
+        ref_display: "missing-pkg@1.0.0".to_string(),
+        dep_path: Some("missing-pkg@1.0.0".parse().unwrap()),
+        link_target: None,
+        target: None,
+    };
+    let ctx = EdgeContext {
+        peers: None,
+        linked_path_base_dir: PathBuf::new(),
+        rewrite_link_version_dir: None,
+        parent_dir: None,
+    };
+
+    let (node, _manifest) = get_pkg_info(&env, &edge, &ctx);
+
+    dbg!(&node);
+    assert_eq!(node.alias, "missing-pkg");
+    assert_eq!(node.name, "missing-pkg");
+    assert_eq!(node.version, "missing-pkg@1.0.0");
+    assert_eq!(
+        node.path,
+        Path::new(".pnpm")
+            .join("missing-pkg@1.0.0")
+            .join("node_modules")
+            .join("missing-pkg")
+            .to_string_lossy()
+            .into_owned()
+    );
+    assert_eq!(node.resolved, None);
+    assert_eq!(node.dev, None);
+    assert_eq!(node.peers_suffix_hash, None);
+    assert!(!node.is_peer);
+    assert!(!node.is_skipped);
+    assert!(!node.optional);
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
@@ -69,7 +69,7 @@ fn get_pkg_info_handles_missing_pkg_snapshot_without_crashing() {
             .join("node_modules")
             .join("missing-pkg")
             .to_string_lossy()
-            .into_owned()
+            .into_owned(),
     );
     assert_eq!(node.resolved, None);
     assert_eq!(node.dev, None);

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
@@ -120,3 +120,19 @@ fn resolve_package_path_rejects_traversal_in_lockfile_derived_names() {
 
     assert_eq!(path, virtual_store_dir);
 }
+
+#[test]
+fn unsafe_path_components_are_detected_by_shape() {
+    assert!(super::is_unsafe_path_component(".."));
+    assert!(super::is_unsafe_path_component("../../escape"));
+    assert!(super::is_unsafe_path_component("/etc"));
+    assert!(!super::is_unsafe_path_component("lodash"));
+    assert!(!super::is_unsafe_path_component("@scope/pkg"));
+    // Rooted-but-prefixless and prefix-only components replace the
+    // join base on Windows without being `is_absolute()`.
+    #[cfg(windows)]
+    {
+        assert!(super::is_unsafe_path_component("\\escape"));
+        assert!(super::is_unsafe_path_component("C:evil"));
+    }
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
@@ -132,7 +132,7 @@ fn unsafe_path_components_are_detected_by_shape() {
     // join base on Windows without being `is_absolute()`.
     #[cfg(windows)]
     {
-        assert!(super::is_unsafe_path_component("\\escape"));
+        assert!(super::is_unsafe_path_component(r"\escape"));
         assert!(super::is_unsafe_path_component("C:evil"));
     }
 }

--- a/pnpm/crates/cli/src/cli_args/deps_tree/render.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/render.rs
@@ -1,0 +1,230 @@
+//! Rendering helpers shared by the `list` and `why` output formats:
+//! the archy-style tree renderer, color helpers, label formatting, and
+//! peer-variant bookkeeping.
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
+
+use owo_colors::{OwoColorize, Stream};
+
+use crate::cli_args::sanitize::sanitize;
+
+pub(crate) struct TreeNode {
+    pub label: String,
+    pub groups: Vec<TreeNodeGroup>,
+}
+
+pub(crate) struct TreeNodeGroup {
+    pub group: String,
+    pub nodes: Vec<TreeNode>,
+}
+
+impl TreeNode {
+    /// A node whose children carry no group header.
+    pub(crate) fn with_children(label: String, nodes: Vec<TreeNode>) -> TreeNode {
+        let groups = if nodes.is_empty() {
+            Vec::new()
+        } else {
+            vec![TreeNodeGroup { group: String::new(), nodes }]
+        };
+        TreeNode { label, groups }
+    }
+}
+
+/// Archy-style tree renderer with dimmed tree-drawing characters,
+/// matching the TypeScript `@pnpm/text.tree-renderer` output.
+pub(crate) fn render_archy(node: &TreeNode) -> String {
+    let mut out = String::new();
+    render_archy_node(node, "", "", &mut out);
+    out
+}
+
+fn render_archy_node(node: &TreeNode, connector: &str, prefix: &str, out: &mut String) {
+    let lines: Vec<&str> = node.label.split('\n').collect();
+    if !connector.is_empty() {
+        out.push_str(&dim(connector));
+    }
+    out.push_str(lines[0]);
+    out.push('\n');
+
+    struct Item<'a> {
+        node: &'a TreeNode,
+        group: &'a str,
+    }
+
+    let mut items: Vec<Item<'_>> = Vec::new();
+    for group in &node.groups {
+        for group_node in &group.nodes {
+            items.push(Item { node: group_node, group: group.group.as_str() });
+        }
+    }
+
+    let continuation = if items.is_empty() { "  " } else { "\u{2502} " };
+    for line in &lines[1..] {
+        out.push_str(&dim(&format!("{prefix}{continuation}")));
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    let mut current_group: Option<&str> = None;
+    let count = items.len();
+    for (i, item) in items.into_iter().enumerate() {
+        let last = i == count - 1;
+
+        if current_group != Some(item.group) {
+            current_group = Some(item.group);
+            if !item.group.is_empty() {
+                out.push_str(&dim(&format!("{prefix}\u{2502}")));
+                out.push('\n');
+                out.push_str(&dim(&format!("{prefix}\u{2502}   ")));
+                out.push_str(item.group);
+                out.push('\n');
+            }
+        }
+
+        let more = item.node.groups.iter().any(|group| !group.nodes.is_empty());
+        let branch = if last { "\u{2514}" } else { "\u{251c}" };
+        let stem = if more { "\u{252c}" } else { "\u{2500}" };
+        let child_connector = format!("{prefix}{branch}\u{2500}{stem} ");
+        let child_prefix = if last { format!("{prefix}  ") } else { format!("{prefix}\u{2502} ") };
+        render_archy_node(item.node, &child_connector, &child_prefix, out);
+    }
+}
+
+/// A terminal-styling function (identity when colors are off).
+pub(crate) type ColorFn = fn(&str) -> String;
+
+/// `name` followed by the gray `@version` suffix (no suffix when the
+/// version is empty). `color` styles the name only.
+pub(crate) fn name_at_version(name: &str, version: &str, color: ColorFn) -> String {
+    let name = sanitize(name);
+    let version = sanitize(version);
+    if version.is_empty() {
+        color(&name)
+    } else {
+        format!("{}{}", color(&name), gray(&format!("@{version}")))
+    }
+}
+
+pub(crate) fn deduped_label() -> String {
+    dim(" [deduped]")
+}
+
+pub(crate) fn circular_label() -> String {
+    dim(" [circular]")
+}
+
+/// Track how many distinct peer-variant hashes each `name@version`
+/// appears with; only packages with more than one variant get the
+/// `peer#<hash>` suffix in the output.
+#[derive(Debug, Default)]
+pub(crate) struct PeerVariants {
+    hashes_per_pkg: HashMap<String, HashSet<String>>,
+}
+
+impl PeerVariants {
+    pub(crate) fn collect(&mut self, name: &str, version: &str, hash: Option<&str>) {
+        let Some(hash) = hash else { return };
+        self.hashes_per_pkg
+            .entry(format!("{name}@{version}"))
+            .or_default()
+            .insert(hash.to_string());
+    }
+
+    pub(crate) fn into_multi_variant_counts(self) -> HashMap<String, usize> {
+        self.hashes_per_pkg
+            .into_iter()
+            .filter(|(_, hashes)| hashes.len() > 1)
+            .map(|(key, hashes)| (key, hashes.len()))
+            .collect()
+    }
+}
+
+pub(crate) fn peer_hash_suffix(
+    multi_peer_pkgs: &HashMap<String, usize>,
+    name: &str,
+    version: &str,
+    hash: Option<&str>,
+) -> String {
+    let Some(hash) = hash else { return String::new() };
+    let Some(count) = multi_peer_pkgs.get(&format!("{name}@{version}")) else {
+        return String::new();
+    };
+    let plural = if *count == 1 { "" } else { "s" };
+    red(&format!(" peer#{hash} ({count} variation{plural})"))
+}
+
+/// Extra manifest details shown by `--long`.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct LongPkgInfo {
+    pub description: Option<String>,
+    pub license: Option<serde_json::Value>,
+    pub author: Option<serde_json::Value>,
+    pub homepage: Option<String>,
+    pub repository: Option<String>,
+}
+
+/// Read the `--long` manifest details from `<pkg_dir>/package.json`.
+/// Unreadable manifests degrade to a placeholder description, matching
+/// the TypeScript CLI.
+pub(crate) fn read_long_pkg_info(pkg_dir: &Path) -> LongPkgInfo {
+    let manifest: Option<serde_json::Value> = std::fs::read(pkg_dir.join("package.json"))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok());
+    let Some(manifest) = manifest else {
+        return LongPkgInfo {
+            description: Some("[Could not find additional info about this dependency]".to_string()),
+            ..LongPkgInfo::default()
+        };
+    };
+    LongPkgInfo {
+        description: manifest
+            .get("description")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string),
+        license: manifest.get("license").cloned(),
+        author: manifest.get("author").cloned(),
+        homepage: manifest.get("homepage").and_then(serde_json::Value::as_str).map(str::to_string),
+        repository: match manifest.get("repository") {
+            Some(serde_json::Value::String(url)) => Some(url.clone()),
+            Some(serde_json::Value::Object(map)) => {
+                map.get("url").and_then(serde_json::Value::as_str).map(str::to_string)
+            }
+            _ => None,
+        },
+    }
+}
+
+pub(crate) fn plain(text: &str) -> String {
+    sanitize(text).into_owned()
+}
+
+pub(crate) fn dim(text: &str) -> String {
+    sanitize(text).if_supports_color(Stream::Stdout, |t| t.dimmed()).to_string()
+}
+
+pub(crate) fn bold(text: &str) -> String {
+    sanitize(text).if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
+}
+
+pub(crate) fn cyan_bright(text: &str) -> String {
+    sanitize(text).if_supports_color(Stream::Stdout, |t| t.bright_cyan()).to_string()
+}
+
+pub(crate) fn gray(text: &str) -> String {
+    sanitize(text).if_supports_color(Stream::Stdout, |t| t.bright_black()).to_string()
+}
+
+pub(crate) fn yellow(text: &str) -> String {
+    sanitize(text).if_supports_color(Stream::Stdout, |t| t.yellow()).to_string()
+}
+
+pub(crate) fn blue(text: &str) -> String {
+    sanitize(text).if_supports_color(Stream::Stdout, |t| t.blue()).to_string()
+}
+
+pub(crate) fn red(text: &str) -> String {
+    sanitize(text).if_supports_color(Stream::Stdout, |t| t.red()).to_string()
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/search.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/search.rs
@@ -1,0 +1,130 @@
+//! Package search used by `pnpm list <pkg>` / `pnpm why <pkg>` and the
+//! `--find-by` finder hooks. Rust counterpart of the TypeScript
+//! tree-builder's `createPackagesSearcher`.
+
+use std::collections::HashMap;
+
+use node_semver::{Range, Version};
+use pacquet_config::matcher::{Matcher, create_matcher};
+
+use super::TreeNodeId;
+
+/// Result of matching one package: no match, a plain match, or a match
+/// with a message returned by a finder.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum SearchMatch {
+    No,
+    Yes,
+    Message(String),
+}
+
+impl SearchMatch {
+    pub(crate) fn is_match(&self) -> bool {
+        !matches!(self, SearchMatch::No)
+    }
+
+    pub(crate) fn message(&self) -> Option<&str> {
+        match self {
+            SearchMatch::Message(message) => Some(message),
+            SearchMatch::No | SearchMatch::Yes => None,
+        }
+    }
+}
+
+struct ParsedQuery {
+    match_name: Matcher,
+    match_version: Option<Range>,
+}
+
+/// A compiled search: positional `<pkg>` queries evaluated inline, plus
+/// finder verdicts pre-computed per `(alias, node)` pair (finders are
+/// JavaScript callbacks running in the pnpmfile worker, so their
+/// results are gathered before the synchronous tree walk).
+pub(crate) struct Searcher {
+    queries: Vec<ParsedQuery>,
+    finder_results: HashMap<(String, Option<TreeNodeId>), SearchMatch>,
+    has_finders: bool,
+}
+
+impl Searcher {
+    pub(crate) fn from_queries(queries: &[String]) -> miette::Result<Self> {
+        Ok(Searcher {
+            queries: queries
+                .iter()
+                .map(|query| parse_search_query(query))
+                .collect::<miette::Result<_>>()?,
+            finder_results: HashMap::new(),
+            has_finders: false,
+        })
+    }
+
+    /// Record the verdicts of the `--find-by` finder callbacks,
+    /// evaluated ahead of the tree walk. The key is the alias the
+    /// package is referred to by and the node it resolves to (`None`
+    /// for unresolvable leaf edges, keyed by alias only).
+    pub(crate) fn set_finder_results(
+        &mut self,
+        results: HashMap<(String, Option<TreeNodeId>), SearchMatch>,
+    ) {
+        self.finder_results = results;
+        self.has_finders = true;
+    }
+
+    pub(crate) fn matches(
+        &self,
+        alias: &str,
+        name: &str,
+        version: &str,
+        node: Option<&TreeNodeId>,
+    ) -> SearchMatch {
+        for query in &self.queries {
+            if !query.match_name.matches(name) && !query.match_name.matches(alias) {
+                continue;
+            }
+            match &query.match_version {
+                None => return SearchMatch::Yes,
+                Some(range) => {
+                    if !version.starts_with("link:")
+                        && Version::parse(version).is_ok_and(|version| range.satisfies(&version))
+                    {
+                        return SearchMatch::Yes;
+                    }
+                }
+            }
+        }
+        if self.has_finders {
+            let key = (alias.to_string(), node.cloned());
+            if let Some(verdict) = self.finder_results.get(&key) {
+                return verdict.clone();
+            }
+        }
+        SearchMatch::No
+    }
+}
+
+fn parse_search_query(query: &str) -> miette::Result<ParsedQuery> {
+    let (name, spec) = split_query(query);
+    let match_name = create_matcher(std::slice::from_ref(&name.to_string()));
+    let match_version = match spec {
+        None => None,
+        Some(spec) => Some(spec.parse::<Range>().map_err(|_| {
+            miette::miette!("Invalid query - {query}. List can search only by version or range")
+        })?),
+    };
+    Ok(ParsedQuery { match_name, match_version })
+}
+
+/// Split `<name>[@<spec>]`, honoring the `@scope/` prefix.
+fn split_query(query: &str) -> (&str, Option<&str>) {
+    let search_start = usize::from(query.starts_with('@'));
+    match query[search_start..].find('@') {
+        Some(at) => {
+            let idx = search_start + at;
+            (&query[..idx], Some(&query[idx + 1..]))
+        }
+        None => (query, None),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/deps_tree/search/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/search/tests.rs
@@ -1,0 +1,85 @@
+//! Ports of the upstream `createPackagesSearcher` tests
+//! (deps/inspection/tree-builder/test/createPackagesSearcher.spec.ts).
+
+use std::collections::HashMap;
+
+use pretty_assertions::assert_eq;
+
+use super::{SearchMatch, Searcher};
+use crate::cli_args::deps_tree::TreeNodeId;
+
+fn searcher(queries: &[&str]) -> Searcher {
+    let queries: Vec<String> = queries.iter().copied().map(str::to_string).collect();
+    Searcher::from_queries(&queries).unwrap()
+}
+
+// Port of upstream's 'packages searcher' (deps/inspection/tree-builder/test/createPackagesSearcher.spec.ts).
+#[test]
+fn packages_searcher() {
+    let search = searcher(&["rimraf@*"]);
+    assert_eq!(search.matches("rimraf", "rimraf", "1.0.0", None), SearchMatch::Yes);
+    assert_eq!(search.matches("express", "express", "1.0.0", None), SearchMatch::No);
+
+    let search = searcher(&["rim*"]);
+    assert_eq!(search.matches("rimraf", "rimraf", "1.0.0", None), SearchMatch::Yes);
+    assert_eq!(search.matches("express", "express", "1.0.0", None), SearchMatch::No);
+
+    let search = searcher(&["rim*@2"]);
+    assert_eq!(search.matches("rimraf", "rimraf", "2.0.0", None), SearchMatch::Yes);
+    assert_eq!(search.matches("rimraf", "rimraf", "1.0.0", None), SearchMatch::No);
+
+    let search = searcher(&["minimatch", "once@1.4"]);
+    assert_eq!(search.matches("minimatch", "minimatch", "2.0.0", None), SearchMatch::Yes);
+    assert_eq!(search.matches("once", "once", "1.4.1", None), SearchMatch::Yes);
+    assert_eq!(search.matches("rimraf", "rimraf", "1.0.0", None), SearchMatch::No);
+}
+
+// Rust counterpart of upstream's 'package searcher with 2 finders'
+// (deps/inspection/tree-builder/test/createPackagesSearcher.spec.ts).
+// Finders are JavaScript callbacks evaluated in the pnpmfile worker, so the
+// searcher consumes pre-computed verdicts keyed by `(alias, node)`; several
+// message-returning finders arrive already combined into one newline-joined
+// message.
+#[test]
+fn finder_results_are_consulted_by_alias_and_node() {
+    let once = TreeNodeId::Package("once@1.4.1".parse().unwrap());
+    let rimraf = TreeNodeId::Package("rimraf@1.0.0".parse().unwrap());
+    let minimatch = TreeNodeId::Package("minimatch@2.0.0".parse().unwrap());
+
+    let mut search = Searcher::from_queries(&[]).unwrap();
+    search.set_finder_results(HashMap::from([
+        (("once".to_string(), Some(once.clone())), SearchMatch::Yes),
+        (
+            ("rimraf".to_string(), Some(rimraf.clone())),
+            SearchMatch::Message("found by finder one\nfound by finder two".to_string()),
+        ),
+    ]));
+
+    assert_eq!(
+        search.matches("minimatch", "minimatch", "2.0.0", Some(&minimatch)),
+        SearchMatch::No
+    );
+    assert_eq!(search.matches("once", "once", "1.4.1", Some(&once)), SearchMatch::Yes);
+    assert_eq!(
+        search.matches("rimraf", "rimraf", "1.0.0", Some(&rimraf)),
+        SearchMatch::Message("found by finder one\nfound by finder two".to_string())
+    );
+    // A verdict recorded for one node does not apply to the same alias
+    // resolved to a different node.
+    assert_eq!(search.matches("once", "once", "1.4.1", Some(&minimatch)), SearchMatch::No);
+}
+
+// Positional queries are checked before finder verdicts, mirroring the
+// upstream searcher, which returns a plain `true` for a query match without
+// consulting the finders.
+#[test]
+fn queries_are_checked_before_finder_results() {
+    let once = TreeNodeId::Package("once@1.4.1".parse().unwrap());
+    let mut search = searcher(&["once"]);
+    search.set_finder_results(HashMap::from([(
+        ("once".to_string(), Some(once.clone())),
+        SearchMatch::Message("finder message".to_string()),
+    )]));
+
+    assert_eq!(search.matches("once", "once", "1.4.1", Some(&once)), SearchMatch::Yes);
+}

--- a/pnpm/crates/cli/src/cli_args/deps_tree/search/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/search/tests.rs
@@ -57,12 +57,12 @@ fn finder_results_are_consulted_by_alias_and_node() {
 
     assert_eq!(
         search.matches("minimatch", "minimatch", "2.0.0", Some(&minimatch)),
-        SearchMatch::No
+        SearchMatch::No,
     );
     assert_eq!(search.matches("once", "once", "1.4.1", Some(&once)), SearchMatch::Yes);
     assert_eq!(
         search.matches("rimraf", "rimraf", "1.0.0", Some(&rimraf)),
-        SearchMatch::Message("found by finder one\nfound by finder two".to_string())
+        SearchMatch::Message("found by finder one\nfound by finder two".to_string()),
     );
     // A verdict recorded for one node does not apply to the same alias
     // resolved to a different node.

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -119,14 +119,18 @@ pub(super) fn audit<'a>(ctx: &RunCtx<'a>, args: AuditArgs) -> miette::Result<Com
 }
 
 pub(super) fn list<'a>(ctx: &RunCtx<'a>, args: ListArgs) -> miette::Result<CommandFuture<'a>> {
-    args.run((ctx.config)()?, ctx.dir, ctx.recursive)?;
-    Ok(Box::pin(std::future::ready(Ok(()))))
+    let config = (ctx.config)()?;
+    let dir = ctx.dir;
+    let recursive = ctx.recursive;
+    Ok(Box::pin(async move { args.run(config, dir, recursive).await }))
 }
 
 pub(super) fn ll<'a>(ctx: &RunCtx<'a>, mut args: ListArgs) -> miette::Result<CommandFuture<'a>> {
     args.long = true;
-    args.run((ctx.config)()?, ctx.dir, ctx.recursive)?;
-    Ok(Box::pin(std::future::ready(Ok(()))))
+    let config = (ctx.config)()?;
+    let dir = ctx.dir;
+    let recursive = ctx.recursive;
+    Ok(Box::pin(async move { args.run(config, dir, recursive).await }))
 }
 
 pub(super) fn licenses<'a>(

--- a/pnpm/crates/cli/src/cli_args/list.rs
+++ b/pnpm/crates/cli/src/cli_args/list.rs
@@ -10,7 +10,10 @@ use pacquet_modules_yaml::IncludedDependencies;
 
 use crate::cli_args::{
     deps_tree::{
-        build::{BuildTreeOptions, DependenciesHierarchy, LoadedState, build_dependencies_tree},
+        build::{
+            BuildTreeOptions, DependenciesHierarchy, LoadedState, build_dependencies_tree,
+            importer_root_ids,
+        },
         finders::{evaluate_finders, finder_candidates, resolve_finders},
         get_tree::MaxDepth,
         graph::{BuildGraphOptions, build_dependency_graph},
@@ -280,29 +283,20 @@ impl ListArgs {
                 hierarchies.push((project_dir.clone(), DependenciesHierarchy::default()));
             }
         } else if let Some(env) = &env {
+            let root_ids = importer_root_ids(env.current_lockfile, lockfile_dir, project_dirs);
+            let graph = build_dependency_graph(
+                &root_ids,
+                &BuildGraphOptions {
+                    lockfile: env.current_lockfile,
+                    include,
+                    only_projects: self.only_projects,
+                },
+            );
+
             let searcher = if searching {
                 let mut searcher = Searcher::from_queries(params)?;
                 if !self.find_by.is_empty() {
                     let finders = resolve_finders(config, lockfile_dir, &self.find_by).await?;
-                    let graph_root_ids: Vec<_> = project_dirs
-                        .iter()
-                        .map(|dir| {
-                            crate::cli_args::deps_tree::TreeNodeId::Importer(
-                                crate::cli_args::deps_tree::build::importer_id_for(
-                                    lockfile_dir,
-                                    dir,
-                                ),
-                            )
-                        })
-                        .collect();
-                    let graph = build_dependency_graph(
-                        &graph_root_ids,
-                        &BuildGraphOptions {
-                            lockfile: env.current_lockfile,
-                            include,
-                            only_projects: self.only_projects,
-                        },
-                    );
                     let candidates = finder_candidates(env, &graph);
                     let results = evaluate_finders(env, &finders, candidates).await?;
                     searcher.set_finder_results(results);
@@ -315,6 +309,7 @@ impl ListArgs {
             hierarchies = build_dependencies_tree(
                 &state,
                 env,
+                &graph,
                 project_dirs,
                 &BuildTreeOptions {
                     lockfile_dir,

--- a/pnpm/crates/cli/src/cli_args/list.rs
+++ b/pnpm/crates/cli/src/cli_args/list.rs
@@ -1,24 +1,27 @@
-use std::{
-    collections::{HashMap, HashSet},
-    ffi::OsStr,
-    io,
-    path::{Path, PathBuf},
-};
+//! `pnpm list` / `ls` / `ll` / `la` — list installed packages.
+
+use std::path::{Path, PathBuf};
 
 use clap::Args;
-use miette::{Context, IntoDiagnostic};
-use owo_colors::{OwoColorize, Stream};
+use miette::IntoDiagnostic;
 use pacquet_config::Config;
-use pacquet_fs::lexical_normalize;
-use pacquet_global::{ListReportAs, list_global_packages};
-pub(crate) use pacquet_lockfile::PkgNameVerPeer;
-use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, SnapshotEntry};
-use serde_json::{Map, Value, json};
+use pacquet_global::{ListReportAs, find_global_install_dirs, list_global_packages};
+use pacquet_modules_yaml::IncludedDependencies;
 
 use crate::cli_args::{
+    deps_tree::{
+        build::{BuildTreeOptions, DependenciesHierarchy, LoadedState, build_dependencies_tree},
+        finders::{evaluate_finders, finder_candidates, resolve_finders},
+        get_tree::MaxDepth,
+        graph::{BuildGraphOptions, build_dependency_graph},
+        search::Searcher,
+    },
     recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
-    sanitize::sanitize,
 };
+
+pub(crate) mod render;
+
+use render::{ProjectHierarchy, RenderParseableOptions, RenderTreeOptions};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum RecursionLimit {
@@ -41,6 +44,16 @@ fn parse_depth(text: &str) -> Result<RecursionLimit, String> {
     Ok(RecursionLimit::Levels(n))
 }
 
+impl RecursionLimit {
+    fn max_depth(self) -> MaxDepth {
+        match self {
+            RecursionLimit::ProjectsOnly => MaxDepth::Finite(0),
+            RecursionLimit::Levels(levels) => MaxDepth::Finite(u64::from(levels)),
+            RecursionLimit::Unlimited => MaxDepth::Unlimited,
+        }
+    }
+}
+
 #[derive(Debug, Args)]
 pub struct ListArgs {
     pub packages: Vec<String>,
@@ -48,46 +61,71 @@ pub struct ListArgs {
     #[clap(short = 'g', long)]
     pub global: bool,
 
+    /// Show extended information.
     #[clap(long)]
     pub long: bool,
 
+    /// Show information in JSON format.
     #[clap(long)]
     pub json: bool,
 
+    /// Show parseable output instead of tree view.
     #[clap(long)]
     pub parseable: bool,
 
+    /// Max display depth of the dependency tree. `0` lists direct
+    /// dependencies only; `-1` lists projects only.
     #[clap(long, default_value = "0", value_parser = parse_depth, allow_hyphen_values = true)]
     pub depth: RecursionLimit,
 
+    /// Display only the dependency graph for packages in `dependencies`
+    /// and `optionalDependencies`.
     #[clap(short = 'P', long = "prod")]
     pub production: bool,
 
+    /// Display only the dependency graph for packages in `devDependencies`.
     #[clap(short = 'D', long)]
     pub dev: bool,
 
+    /// Don't display packages from `optionalDependencies`.
     #[clap(long)]
     pub no_optional: bool,
 
+    /// Exclude peer dependencies.
     #[clap(long)]
     pub exclude_peers: bool,
 
+    /// Display only dependencies that are also projects within the
+    /// workspace.
+    #[clap(long)]
+    pub only_projects: bool,
+
+    /// List packages from the lockfile only, without checking
+    /// `node_modules`.
     #[clap(long)]
     pub lockfile_only: bool,
+
+    /// Search by a finder function declared in `.pnpmfile.cjs`.
+    #[clap(long = "find-by")]
+    pub find_by: Vec<String>,
 }
 
 impl ListArgs {
-    pub fn run(self, config: &Config, dir: &Path, recursive: bool) -> miette::Result<()> {
-        if self.global {
-            return self.run_global(config);
-        }
-        if recursive {
-            return self.run_recursive(config, dir);
-        }
-        self.run_local(config, dir)
+    pub async fn run(self, config: &Config, dir: &Path, recursive: bool) -> miette::Result<()> {
+        let output = if self.global {
+            self.run_global(config).await?
+        } else if recursive {
+            self.run_recursive(config, dir).await?
+        } else {
+            let lockfile_dir = local_lockfile_dir(config, dir);
+            self.render_projects(config, &[dir.to_path_buf()], &self.packages, &lockfile_dir, true)
+                .await?
+        };
+        print_output(&output);
+        Ok(())
     }
 
-    fn run_global(&self, config: &Config) -> miette::Result<()> {
+    async fn run_global(&self, config: &Config) -> miette::Result<String> {
         let global_pkg_dir = config.global_pkg_dir.clone().ok_or_else(|| {
             miette::miette!(
                 code = "ERR_PNPM_NO_GLOBAL_BIN_DIR",
@@ -95,1003 +133,274 @@ impl ListArgs {
             )
         })?;
 
-        let report_as = if self.json {
-            ListReportAs::Json
-        } else if self.parseable {
-            ListReportAs::Parseable
-        } else {
-            ListReportAs::Tree
-        };
+        if matches!(self.depth, RecursionLimit::Levels(n) if n > 0)
+            || self.depth == RecursionLimit::Unlimited
+        {
+            let all_install_dirs =
+                find_global_install_dirs(&global_pkg_dir, &[]).into_diagnostic()?;
+            if all_install_dirs.len() == 1 {
+                // Single global install: keep params so the search can
+                // cover the whole tree, matching regular `pnpm ls`.
+                let install_dir = all_install_dirs[0].clone();
+                return self
+                    .render_projects(
+                        config,
+                        std::slice::from_ref(&install_dir),
+                        &self.packages,
+                        &install_dir,
+                        true,
+                    )
+                    .await;
+            }
+            // Multiple installs — try to narrow to a single one via
+            // params, matching against top-level aliases of each
+            // install group.
+            let matching_install_dirs =
+                find_global_install_dirs(&global_pkg_dir, &self.packages).into_diagnostic()?;
+            if matching_install_dirs.len() > 1
+                || (matching_install_dirs.is_empty() && !all_install_dirs.is_empty())
+            {
+                return Err(miette::miette!(
+                    code = "ERR_PNPM_GLOBAL_LS_DEPTH_NOT_SUPPORTED",
+                    "Cannot list a merged dependency tree across multiple global packages. \
+                     Each global package is installed in an isolated directory with its own lockfile, \
+                     so transitive dependencies cannot be coherently merged. \
+                     Filter to a single global package by its top-level name, or omit --depth."
+                ));
+            }
+            if let [install_dir] = matching_install_dirs.as_slice() {
+                // Params served their purpose of narrowing to a single
+                // install group; passing them on would activate search
+                // semantics, which prune the matched package's children.
+                let install_dir = install_dir.clone();
+                return self
+                    .render_projects(
+                        config,
+                        std::slice::from_ref(&install_dir),
+                        &[],
+                        &install_dir,
+                        true,
+                    )
+                    .await;
+            }
+        }
 
-        let output = list_global_packages(&global_pkg_dir, &self.packages, report_as, self.long)
-            .into_diagnostic()
-            .wrap_err("list global packages")?;
-        println!("{output}");
-        Ok(())
+        let report_as = self.report_as();
+        list_global_packages(
+            &global_pkg_dir,
+            &self.packages,
+            global_report_as(report_as),
+            self.long,
+        )
+        .into_diagnostic()
     }
 
-    fn run_recursive(&self, config: &Config, dir: &Path) -> miette::Result<()> {
-        let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
-        let (projects, _) = discover_workspace_projects(workspace_root)?;
+    async fn run_recursive(&self, config: &Config, dir: &Path) -> miette::Result<String> {
+        let workspace_root = config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+        let (projects, _) = discover_workspace_projects(&workspace_root)?;
         let selection =
             select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
+        let project_dirs: Vec<PathBuf> = selection.selected.keys().cloned().collect();
 
-        let roots = if self.depth == RecursionLimit::ProjectsOnly {
-            selection
-                .selected
-                .values()
-                .map(|node| project_only_root(node.package.project))
-                .collect::<Vec<_>>()
-        } else {
-            let mut roots = Vec::new();
-            for project_dir in selection.selected.keys() {
-                if let LocalRootResult::Root(root) = self.local_root(config, project_dir)? {
-                    roots.push(root);
-                }
-            }
-            roots
-        };
+        let always_print_root_package = self.depth == RecursionLimit::ProjectsOnly;
 
-        self.print_roots(&roots);
-        Ok(())
-    }
-
-    fn run_local(&self, config: &Config, dir: &Path) -> miette::Result<()> {
-        match self.local_root(config, dir)? {
-            LocalRootResult::Root(root) => self.print_roots(&[root]),
-            LocalRootResult::NoLockfile { lockfile_dir } => {
-                if self.packages.is_empty() {
-                    println!("No lockfile found in {}", lockfile_dir.display());
-                } else {
-                    println!("No matching packages found");
-                }
-            }
-            LocalRootResult::NoPackages => {
-                if self.packages.is_empty() {
-                    println!("No packages found");
-                } else {
-                    println!("No matching packages found");
-                }
-            }
-            LocalRootResult::NoMatchingPackages => println!("No matching packages found"),
+        if config.shared_workspace_lockfile {
+            return self
+                .render_projects(
+                    config,
+                    &project_dirs,
+                    &self.packages,
+                    &workspace_root,
+                    always_print_root_package,
+                )
+                .await;
         }
-        Ok(())
+
+        // Per-project lockfiles: each project renders independently
+        // (with its own legend and summary).
+        let mut outputs = Vec::new();
+        for project_dir in project_dirs {
+            let output = self
+                .render_projects(
+                    config,
+                    std::slice::from_ref(&project_dir),
+                    &self.packages,
+                    &project_dir,
+                    always_print_root_package,
+                )
+                .await?;
+            if !output.is_empty() {
+                outputs.push(output);
+            }
+        }
+        let joiner = if self.depth == RecursionLimit::ProjectsOnly { "\n" } else { "\n\n" };
+        Ok(outputs.join(joiner))
     }
 
-    fn local_root(&self, config: &Config, dir: &Path) -> miette::Result<LocalRootResult> {
-        let lockfile_dir = config.workspace_dir.as_deref().unwrap_or(dir);
-        let lockfile_result = if self.lockfile_only {
-            Lockfile::load_wanted_from_dir(lockfile_dir)
+    fn report_as(&self) -> ReportAs {
+        if self.parseable {
+            ReportAs::Parseable
+        } else if self.json {
+            ReportAs::Json
         } else {
-            match Lockfile::load_current_from_virtual_store_dir(&config.virtual_store_dir) {
-                Ok(Some(lf)) => Ok(Some(lf)),
-                Ok(None) => Lockfile::load_wanted_from_dir(lockfile_dir),
-                Err(e) => Err(e),
-            }
-        };
-        let Some(lockfile) = lockfile_result.into_diagnostic().wrap_err("load lockfile")? else {
-            return Ok(LocalRootResult::NoLockfile { lockfile_dir: lockfile_dir.to_path_buf() });
-        };
+            ReportAs::Tree
+        }
+    }
 
-        let importer_id: String = if dir == lockfile_dir {
-            ".".into()
-        } else {
-            dir.strip_prefix(lockfile_dir)
-                .ok()
-                .map(|rel| rel.to_string_lossy().replace('\\', "/"))
-                .filter(|id| !id.is_empty())
-                .unwrap_or_else(|| ".".to_string())
-        };
-        let Some(importer) =
-            lockfile.importers.get(&importer_id).or_else(|| lockfile.root_project())
-        else {
-            return Ok(LocalRootResult::NoPackages);
-        };
-
-        let manifest_path = dir.join("package.json");
-        let (root_name, root_version, root_private) = read_root_manifest(&manifest_path)?;
-
+    fn include(&self) -> IncludedDependencies {
         let has_both = self.production == self.dev;
-        let include_prod = has_both || self.production;
-        let include_dev = has_both || self.dev;
-        let include_optional = !self.no_optional;
-
-        let ctx = BuildContext {
-            snapshots: lockfile.snapshots.as_ref(),
-            packages: lockfile.packages.as_ref(),
-            depth: self.depth,
-            exclude_peers: self.exclude_peers,
-            include_optional,
-            virtual_store_dir_max_length: config.virtual_store_dir_max_length as usize,
-        };
-
-        let mut tree =
-            build_local_tree(importer, &ctx, include_prod, include_dev, include_optional);
-
-        if !self.packages.is_empty() {
-            let matches = |dep: &DepNode| dep_or_subtree_matches(dep, &self.packages);
-            tree.dependencies.retain(|dep| matches(dep));
-            tree.dev_dependencies.retain(|dep| matches(dep));
-            tree.optional_dependencies.retain(|dep| matches(dep));
-
-            if tree.dependencies.is_empty()
-                && tree.dev_dependencies.is_empty()
-                && tree.optional_dependencies.is_empty()
-            {
-                return Ok(LocalRootResult::NoMatchingPackages);
-            }
-        }
-
-        // Only the `--json`/`--parseable` renderers surface extraneous
-        // packages (the tree view omits them), so the `node_modules` scan
-        // is skipped for the default tree output. It is also suppressed
-        // when searching by name and for `--depth -1` (project-only
-        // output) — the same gates the TypeScript CLI applies before it
-        // scans `node_modules`.
-        let unsaved = if (self.json || self.parseable)
-            && self.packages.is_empty()
-            && self.depth != RecursionLimit::ProjectsOnly
-        {
-            read_unsaved_dependencies(importer, dir, config)?
-        } else {
-            Vec::new()
-        };
-
-        let root = LocalTreeRoot {
-            name: root_name,
-            version: root_version,
-            private: root_private,
-            path: dir.to_string_lossy().into_owned(),
-            dependencies: tree.dependencies,
-            dev_dependencies: tree.dev_dependencies,
-            optional_dependencies: tree.optional_dependencies,
-            unsaved,
-        };
-
-        Ok(LocalRootResult::Root(root))
-    }
-
-    fn print_roots(&self, roots: &[LocalTreeRoot]) {
-        if self.json {
-            let output = match roots {
-                [root] => render_local_json(root),
-                _ => render_local_roots_json(roots),
-            };
-            println!("{output}");
-        } else if self.parseable {
-            let output = roots
-                .iter()
-                .map(|root| render_local_parseable(root, self.long))
-                .filter(|output| !output.is_empty())
-                .collect::<Vec<_>>()
-                .join("\n");
-            if !output.is_empty() {
-                println!("{output}");
-            }
-        } else {
-            let joiner = if self.depth == RecursionLimit::ProjectsOnly { "\n" } else { "\n\n" };
-            let output = roots
-                .iter()
-                .map(|root| render_local_tree(root, self.long))
-                .filter(|output| !output.is_empty())
-                .collect::<Vec<_>>()
-                .join(joiner);
-            if !output.is_empty() {
-                println!("{output}");
-            }
-        }
-    }
-}
-
-enum LocalRootResult {
-    Root(LocalTreeRoot),
-    NoLockfile { lockfile_dir: PathBuf },
-    NoPackages,
-    NoMatchingPackages,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct DepNode {
-    pub(crate) alias: String,
-    pub(crate) name: String,
-    pub(crate) version: String,
-    pub(crate) path: String,
-    pub(crate) is_peer: bool,
-    pub(crate) is_dev: bool,
-    pub(crate) is_optional: bool,
-    pub(crate) dependencies: Vec<DepNode>,
-}
-
-#[derive(Debug)]
-pub(crate) struct LocalTreeRoot {
-    pub(crate) name: Option<String>,
-    pub(crate) version: Option<String>,
-    pub(crate) private: Option<bool>,
-    pub(crate) path: String,
-    pub(crate) dependencies: Vec<DepNode>,
-    pub(crate) dev_dependencies: Vec<DepNode>,
-    pub(crate) optional_dependencies: Vec<DepNode>,
-    /// Packages present in the importer's `node_modules` but absent from
-    /// its lockfile entry (npm calls these "extraneous"). Surfaced by
-    /// `--json` and `--parseable` only; the tree view omits them, matching
-    /// the TypeScript CLI, which hardcodes `showExtraneous: false`.
-    pub(crate) unsaved: Vec<DepNode>,
-}
-
-fn project_only_root(project: &pacquet_workspace::Project) -> LocalTreeRoot {
-    let manifest = project.manifest.value();
-    LocalTreeRoot {
-        name: manifest.get("name").and_then(Value::as_str).map(str::to_string),
-        version: manifest.get("version").and_then(Value::as_str).map(str::to_string),
-        private: manifest.get("private").and_then(Value::as_bool),
-        path: project.root_dir.to_string_lossy().into_owned(),
-        dependencies: Vec::new(),
-        dev_dependencies: Vec::new(),
-        optional_dependencies: Vec::new(),
-        unsaved: Vec::new(),
-    }
-}
-
-struct BuiltTree {
-    dependencies: Vec<DepNode>,
-    dev_dependencies: Vec<DepNode>,
-    optional_dependencies: Vec<DepNode>,
-}
-
-struct BuildContext<'a> {
-    snapshots: Option<&'a HashMap<PkgNameVerPeer, SnapshotEntry>>,
-    packages: Option<&'a HashMap<PkgNameVerPeer, pacquet_lockfile::PackageMetadata>>,
-    depth: RecursionLimit,
-    exclude_peers: bool,
-    include_optional: bool,
-    virtual_store_dir_max_length: usize,
-}
-
-fn build_local_tree(
-    importer: &ProjectSnapshot,
-    ctx: &BuildContext,
-    include_prod: bool,
-    include_dev: bool,
-    include_optional: bool,
-) -> BuiltTree {
-    if ctx.depth == RecursionLimit::ProjectsOnly {
-        return BuiltTree {
-            dependencies: Vec::new(),
-            dev_dependencies: Vec::new(),
-            optional_dependencies: Vec::new(),
-        };
-    }
-
-    let mut deps = Vec::new();
-    let mut dev_deps = Vec::new();
-    let mut opt_deps = Vec::new();
-
-    if include_prod && let Some(dep_map) = &importer.dependencies {
-        for (name, spec) in dep_map {
-            if let Some(node) = resolve_importer_dep(name, spec, ctx, 0) {
-                deps.push(node);
-            }
+        IncludedDependencies {
+            dependencies: has_both || self.production,
+            dev_dependencies: has_both || self.dev,
+            optional_dependencies: !self.no_optional,
         }
     }
 
-    if include_dev && let Some(dep_map) = &importer.dev_dependencies {
-        for (name, spec) in dep_map {
-            let mut node = resolve_importer_dep(name, spec, ctx, 0);
-            if let Some(ref mut n) = node {
-                n.is_dev = true;
+    async fn render_projects(
+        &self,
+        config: &Config,
+        project_dirs: &[PathBuf],
+        params: &[String],
+        lockfile_dir: &Path,
+        always_print_root_package: bool,
+    ) -> miette::Result<String> {
+        let include = self.include();
+        let searching = !params.is_empty() || !self.find_by.is_empty();
+
+        let state = LoadedState::load(
+            lockfile_dir,
+            Some(config.modules_dir.as_path()),
+            self.lockfile_only,
+        )?;
+        let env = state.env(lockfile_dir, config.virtual_store_dir_max_length as usize);
+
+        let mut hierarchies: Vec<(PathBuf, DependenciesHierarchy)> = Vec::new();
+        if self.depth == RecursionLimit::ProjectsOnly || env.is_none() {
+            for project_dir in project_dirs {
+                hierarchies.push((project_dir.clone(), DependenciesHierarchy::default()));
             }
-            if let Some(n) = node {
-                dev_deps.push(n);
-            }
-        }
-    }
-
-    if include_optional && let Some(dep_map) = &importer.optional_dependencies {
-        for (name, spec) in dep_map {
-            let mut node = resolve_importer_dep(name, spec, ctx, 0);
-            if let Some(ref mut n) = node {
-                n.is_optional = true;
-            }
-            if let Some(n) = node {
-                opt_deps.push(n);
-            }
-        }
-    }
-
-    sort_deps(&mut deps);
-    sort_deps(&mut dev_deps);
-    sort_deps(&mut opt_deps);
-
-    BuiltTree { dependencies: deps, dev_dependencies: dev_deps, optional_dependencies: opt_deps }
-}
-
-fn resolve_importer_dep(
-    name: &PkgName,
-    spec: &pacquet_lockfile::ResolvedDependencySpec,
-    ctx: &BuildContext,
-    current_depth: i32,
-) -> Option<DepNode> {
-    let alias = name.to_string();
-    let version_str = spec.version.to_string();
-    let snapshot_key = spec.version.resolved_key(name);
-
-    let (resolved_name, resolved_version, is_peer, child_deps) = match &snapshot_key {
-        Some(key) => {
-            let dep_name = key.name.to_string();
-            let dep_version = key.suffix.version().to_string();
-
-            let peer = ctx.exclude_peers
-                && ctx.packages.is_some_and(|pkgs| {
-                    let base_key = key.without_peer();
-                    pkgs.get(&base_key)
-                        .and_then(|meta| meta.peer_dependencies.as_ref())
-                        .is_some_and(|peers| peers.contains_key(&name.to_string()))
-                });
-
-            let children = match ctx.depth {
-                RecursionLimit::Unlimited => resolve_snapshot_children(key, ctx, current_depth + 1),
-                RecursionLimit::Levels(n) if (current_depth as u32) < n => {
-                    resolve_snapshot_children(key, ctx, current_depth + 1)
+        } else if let Some(env) = &env {
+            let searcher = if searching {
+                let mut searcher = Searcher::from_queries(params)?;
+                if !self.find_by.is_empty() {
+                    let finders = resolve_finders(config, lockfile_dir, &self.find_by).await?;
+                    let graph_root_ids: Vec<_> = project_dirs
+                        .iter()
+                        .map(|dir| {
+                            crate::cli_args::deps_tree::TreeNodeId::Importer(
+                                crate::cli_args::deps_tree::build::importer_id_for(
+                                    lockfile_dir,
+                                    dir,
+                                ),
+                            )
+                        })
+                        .collect();
+                    let graph = build_dependency_graph(
+                        &graph_root_ids,
+                        &BuildGraphOptions {
+                            lockfile: env.current_lockfile,
+                            include,
+                            only_projects: self.only_projects,
+                        },
+                    );
+                    let candidates = finder_candidates(env, &graph);
+                    let results = evaluate_finders(env, &finders, candidates).await?;
+                    searcher.set_finder_results(results);
                 }
-                _ => Vec::new(),
+                Some(searcher)
+            } else {
+                None
             };
 
-            (dep_name, dep_version, peer, children)
-        }
-        None => (alias.clone(), version_str, false, Vec::new()),
-    };
-
-    let pkg_path = if let Some(key) = &snapshot_key {
-        let vsn = key.to_virtual_store_name(ctx.virtual_store_dir_max_length);
-        format!(".pnpm/{vsn}/node_modules/{resolved_name}")
-    } else if let Some(link_target) = spec.version.as_link_target() {
-        format!("link:{link_target}")
-    } else {
-        String::new()
-    };
-
-    Some(DepNode {
-        alias,
-        name: resolved_name,
-        version: resolved_version,
-        path: pkg_path,
-        is_peer,
-        is_dev: false,
-        is_optional: false,
-        dependencies: child_deps,
-    })
-}
-
-fn resolve_snapshot_children(
-    key: &PkgNameVerPeer,
-    ctx: &BuildContext,
-    current_depth: i32,
-) -> Vec<DepNode> {
-    let Some(snapshots) = ctx.snapshots else { return Vec::new() };
-    let Some(entry) = snapshots.get(key) else { return Vec::new() };
-
-    let peer_set = get_peer_set(key, ctx.packages);
-
-    let mut children = Vec::new();
-
-    let mut push_child = |dep_alias: &PkgName, dep_ref: &pacquet_lockfile::SnapshotDepRef| {
-        let child_key = dep_ref.resolve(dep_alias);
-        let alias_str = dep_alias.to_string();
-
-        let is_peer = ctx.exclude_peers && peer_set.contains(&alias_str);
-        if is_peer {
-            return;
+            hierarchies = build_dependencies_tree(
+                &state,
+                env,
+                project_dirs,
+                &BuildTreeOptions {
+                    lockfile_dir,
+                    depth: self.depth.max_depth(),
+                    include,
+                    exclude_peer_dependencies: self.exclude_peers,
+                    only_projects: self.only_projects,
+                    search: searcher.as_ref(),
+                    show_deduped_search_matches: searcher.is_some(),
+                    modules_dir_opt: Some(config.modules_dir.as_path()),
+                },
+            )?;
         }
 
-        let (child_name, child_version) = match &child_key {
-            Some(ck) => (ck.name.to_string(), ck.suffix.version().to_string()),
-            None => (alias_str.clone(), dep_ref.to_string()),
-        };
-
-        let grandchildren = match ctx.depth {
-            RecursionLimit::Unlimited => child_key
-                .as_ref()
-                .map_or(Vec::new(), |ck| resolve_snapshot_children(ck, ctx, current_depth + 1)),
-            RecursionLimit::Levels(n) if (current_depth as u32) < n => child_key
-                .as_ref()
-                .map_or(Vec::new(), |ck| resolve_snapshot_children(ck, ctx, current_depth + 1)),
-            _ => Vec::new(),
-        };
-
-        let pkg_path = if let Some(ck) = &child_key {
-            let vsn = ck.to_virtual_store_name(ctx.virtual_store_dir_max_length);
-            format!(".pnpm/{vsn}/node_modules/{child_name}")
-        } else if let Some(link_target) = dep_ref.as_link_target() {
-            format!("link:{link_target}")
-        } else {
-            String::new()
-        };
-
-        children.push(DepNode {
-            alias: alias_str,
-            name: child_name,
-            version: child_version,
-            path: pkg_path,
-            is_peer,
-            is_dev: false,
-            is_optional: false,
-            dependencies: grandchildren,
-        });
-    };
-
-    if let Some(deps) = &entry.dependencies {
-        for (dep_alias, dep_ref) in deps {
-            push_child(dep_alias, dep_ref);
-        }
-    }
-
-    if ctx.include_optional
-        && let Some(opt_deps) = &entry.optional_dependencies
-    {
-        for (dep_alias, dep_ref) in opt_deps {
-            push_child(dep_alias, dep_ref);
-        }
-    }
-
-    sort_deps(&mut children);
-    children
-}
-
-pub(crate) fn get_peer_set(
-    key: &PkgNameVerPeer,
-    packages: Option<&HashMap<PkgNameVerPeer, pacquet_lockfile::PackageMetadata>>,
-) -> HashSet<String> {
-    let Some(packages) = packages else { return HashSet::new() };
-    let base_key = key.without_peer();
-    packages
-        .get(&base_key)
-        .and_then(|meta| meta.peer_dependencies.as_ref())
-        .map(|peers| peers.keys().cloned().collect())
-        .unwrap_or_default()
-}
-
-pub(crate) fn sort_deps(deps: &mut [DepNode]) {
-    deps.sort_by(|a, b| a.name.cmp(&b.name));
-    for dep in deps.iter_mut() {
-        sort_deps(&mut dep.dependencies);
-    }
-}
-
-pub(crate) fn matches_params(params: &[String], alias: &str) -> bool {
-    if params.is_empty() {
-        return true;
-    }
-    params.iter().any(|pattern| glob_match(pattern, alias))
-}
-
-pub(crate) fn dep_or_subtree_matches(dep: &DepNode, params: &[String]) -> bool {
-    if params.is_empty() {
-        return true;
-    }
-    if matches_params(params, &dep.alias) || matches_params(params, &dep.name) {
-        return true;
-    }
-    dep.dependencies.iter().any(|child| dep_or_subtree_matches(child, params))
-}
-
-pub(crate) fn glob_match(pattern: &str, value: &str) -> bool {
-    if !pattern.contains('*') {
-        return pattern == value;
-    }
-    let segments: Vec<&str> = pattern.split('*').collect();
-    let mut rest = value;
-    for (i, segment) in segments.iter().enumerate() {
-        if segment.is_empty() {
-            continue;
-        }
-        if i == 0 {
-            let Some(stripped) = rest.strip_prefix(segment) else { return false };
-            rest = stripped;
-        } else if i == segments.len() - 1 {
-            return rest.ends_with(segment);
-        } else if let Some(pos) = rest.find(segment) {
-            rest = &rest[pos + segment.len()..];
-        } else {
-            return false;
-        }
-    }
-    true
-}
-
-pub(crate) fn read_root_manifest(
-    manifest_path: &Path,
-) -> miette::Result<(Option<String>, Option<String>, Option<bool>)> {
-    let content = std::fs::read_to_string(manifest_path)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to read {}", manifest_path.display()))?;
-    let parsed: Value = serde_json::from_str(&content)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to parse {}", manifest_path.display()))?;
-    let name = parsed.get("name").and_then(Value::as_str).map(str::to_string);
-    let version = parsed.get("version").and_then(Value::as_str).map(str::to_string);
-    let private = parsed.get("private").and_then(Value::as_bool);
-    Ok((name, version, private))
-}
-
-/// Scan `project_dir`'s `node_modules` for packages that are installed on
-/// disk but not recorded in `importer` (npm's "extraneous" dependencies),
-/// building a leaf [`DepNode`] for each. Mirrors the unsaved-dependency
-/// handling of the TypeScript CLI's `buildDependenciesTree`.
-fn read_unsaved_dependencies(
-    importer: &ProjectSnapshot,
-    project_dir: &Path,
-    config: &Config,
-) -> miette::Result<Vec<DepNode>> {
-    // Same per-importer modules-dir suffix the linker uses: the final
-    // component of `modules_dir` (default `node_modules`) under the
-    // project root.
-    let modules_dir_name =
-        config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
-    let modules_dir = project_dir.join(modules_dir_name);
-
-    let saved = saved_direct_dep_names(importer);
-    let mut unsaved: Vec<DepNode> = read_modules_dir_names(&modules_dir)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("failed to read {}", modules_dir.display()))?
-        .into_iter()
-        .filter(|name| !saved.contains(name))
-        .map(|name| build_unsaved_node(&name, &modules_dir, project_dir))
-        .collect();
-    sort_deps(&mut unsaved);
-    Ok(unsaved)
-}
-
-/// The alias keys of an importer's `dependencies`, `devDependencies`, and
-/// `optionalDependencies` — the directory names a saved dependency owns
-/// under `node_modules`. Always spans all three groups regardless of
-/// `--prod`/`--dev`/`--optional`, matching the TypeScript CLI's
-/// `getAllDirectDependencies`.
-fn saved_direct_dep_names(importer: &ProjectSnapshot) -> HashSet<String> {
-    let mut names = HashSet::new();
-    let groups =
-        [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies];
-    for group in groups.into_iter().flatten() {
-        for name in group.keys() {
-            names.insert(name.to_string());
-        }
-    }
-    names
-}
-
-/// The package directory names directly under `modules_dir`, following
-/// the same enumeration rules as the TypeScript CLI's `readModulesDir`. A
-/// missing `modules_dir` is not an error; any other read failure is.
-fn read_modules_dir_names(modules_dir: &Path) -> io::Result<Vec<String>> {
-    let mut names = Vec::new();
-    collect_module_names(modules_dir, None, &mut names)?;
-    Ok(names)
-}
-
-fn collect_module_names(
-    modules_dir: &Path,
-    scope: Option<&str>,
-    names: &mut Vec<String>,
-) -> io::Result<()> {
-    let parent_dir = match scope {
-        Some(scope) => modules_dir.join(scope),
-        None => modules_dir.to_path_buf(),
-    };
-    let entries = match std::fs::read_dir(&parent_dir) {
-        Ok(entries) => entries,
-        // A missing directory is "no packages"; every other error is
-        // surfaced, matching `readModulesDir`, which only swallows ENOENT.
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => return Err(error),
-    };
-    for entry in entries {
-        let entry = entry?;
-        let file_name = entry.file_name();
-        let Some(name) = file_name.to_str() else {
-            continue;
-        };
-        if name.starts_with('.') {
-            continue;
-        }
-        if entry.file_type().is_ok_and(|file_type| file_type.is_file()) {
-            continue;
-        }
-        if scope.is_none() && name.starts_with('@') {
-            collect_module_names(modules_dir, Some(name), names)?;
-            continue;
-        }
-        match scope {
-            Some(scope) => names.push(format!("{scope}/{name}")),
-            None => names.push(name.to_string()),
-        }
-    }
-    Ok(())
-}
-
-/// Build the leaf [`DepNode`] for one extraneous package, taking its
-/// version and path from the symlink target for a `link:` dependency or
-/// from `package.json` for a regular directory.
-fn build_unsaved_node(name: &str, modules_dir: &Path, project_dir: &Path) -> DepNode {
-    let entry_path = modules_dir.join(name);
-    let (path, version) = if let Some(target) = resolve_link_target(&entry_path) {
-        let relative = pathdiff::diff_paths(&target, project_dir).unwrap_or_else(|| target.clone());
-        let version = format!("link:{}", relative.display().to_string().replace('\\', "/"));
-        (target.to_string_lossy().into_owned(), version)
-    } else {
-        let version = read_package_version(&entry_path).unwrap_or_else(|| "undefined".to_string());
-        (entry_path.to_string_lossy().into_owned(), version)
-    };
-    DepNode {
-        alias: name.to_string(),
-        name: name.to_string(),
-        version,
-        path,
-        is_peer: false,
-        is_dev: false,
-        is_optional: false,
-        dependencies: Vec::new(),
-    }
-}
-
-/// Resolve a symlink to the absolute path of its immediate target,
-/// lexically (without requiring the target to exist), matching the
-/// TypeScript CLI's `resolveLinkTarget`. `None` when `link` is not a
-/// symlink.
-fn resolve_link_target(link: &Path) -> Option<PathBuf> {
-    let target = std::fs::read_link(link).ok()?;
-    let joined = if target.is_absolute() {
-        target
-    } else {
-        match link.parent() {
-            Some(parent) => parent.join(target),
-            None => target,
-        }
-    };
-    Some(lexical_normalize(&joined))
-}
-
-fn read_package_version(pkg_dir: &Path) -> Option<String> {
-    let bytes = std::fs::read(pkg_dir.join("package.json")).ok()?;
-    let manifest: Value = serde_json::from_slice(&bytes).ok()?;
-    manifest.get("version").and_then(Value::as_str).map(str::to_string)
-}
-
-const LEGEND: &str = "Legend: production dependency, optional only, dev only\n\n";
-
-struct TreeNode {
-    label: String,
-    groups: Vec<TreeNodeGroup>,
-}
-
-struct TreeNodeGroup {
-    group: String,
-    nodes: Vec<TreeNode>,
-}
-
-pub(crate) fn render_local_tree(root: &LocalTreeRoot, long: bool) -> String {
-    let mut root_label = String::new();
-    if let Some(ref name) = root.name {
-        use std::fmt::Write;
-        let _ = write!(
-            root_label,
-            "{} {}",
-            name_at_version(name, root.version.as_deref().unwrap_or("")),
-            dim(&root.path),
-        );
-    } else {
-        root_label.push_str(&dim(&root.path));
-    }
-    if root.private == Some(true) {
-        root_label.push_str(&dim(" (PRIVATE)"));
-    }
-
-    let mut groups: Vec<TreeNodeGroup> = Vec::new();
-
-    if !root.dependencies.is_empty() {
-        let nodes = deps_to_tree_nodes(&root.dependencies, long);
-        groups.push(TreeNodeGroup { group: cyan_bright("dependencies:"), nodes });
-    }
-
-    if !root.dev_dependencies.is_empty() {
-        let nodes = deps_to_tree_nodes_colored(&root.dev_dependencies, long, true, false);
-        groups.push(TreeNodeGroup { group: cyan_bright("devDependencies:"), nodes });
-    }
-
-    if !root.optional_dependencies.is_empty() {
-        let nodes = deps_to_tree_nodes_colored(&root.optional_dependencies, long, false, true);
-        groups.push(TreeNodeGroup { group: cyan_bright("optionalDependencies:"), nodes });
-    }
-
-    if groups.is_empty() {
-        return root_label;
-    }
-
-    let root_node = TreeNode { label: bold(&root_label), groups };
-    let mut output = String::new();
-    render_archy(&root_node, "", "", &mut output);
-    let body = output.trim_end().to_string();
-
-    if body.is_empty() {
-        return String::new();
-    }
-
-    format!("{LEGEND}{body}")
-}
-
-fn deps_to_tree_nodes(deps: &[DepNode], long: bool) -> Vec<TreeNode> {
-    deps_to_tree_nodes_colored(deps, long, false, false)
-}
-
-fn deps_to_tree_nodes_colored(
-    deps: &[DepNode],
-    long: bool,
-    is_dev: bool,
-    is_optional: bool,
-) -> Vec<TreeNode> {
-    deps.iter().map(|dep| dep_to_tree_node(dep, long, is_dev, is_optional)).collect()
-}
-
-fn dep_to_tree_node(dep: &DepNode, long: bool, is_dev: bool, is_optional: bool) -> TreeNode {
-    let color: fn(&str) -> String = if is_optional {
-        |text| text.if_supports_color(Stream::Stdout, |text| text.blue()).to_string()
-    } else if is_dev {
-        |text| text.if_supports_color(Stream::Stdout, |text| text.yellow()).to_string()
-    } else {
-        |text| text.to_string()
-    };
-
-    let mut label = print_label(dep, &color);
-
-    if long && !dep.path.is_empty() {
-        label.push('\n');
-        label.push_str(&dim(&dep.path));
-    }
-
-    let mut groups = Vec::new();
-    if !dep.dependencies.is_empty() && !dep.is_peer {
-        let children: Vec<TreeNode> = dep
-            .dependencies
-            .iter()
-            .map(|child| dep_to_tree_node(child, long, child.is_dev, child.is_optional))
+        let projects: Vec<ProjectHierarchy> = hierarchies
+            .into_iter()
+            .map(|(project_dir, hierarchy)| {
+                let manifest =
+                    crate::cli_args::deps_tree::build::read_project_manifest(&project_dir);
+                ProjectHierarchy {
+                    name: manifest.name,
+                    version: manifest.version,
+                    private: manifest.private,
+                    path: project_dir.to_string_lossy().into_owned(),
+                    hierarchy,
+                }
+            })
             .collect();
-        groups.push(TreeNodeGroup { group: String::new(), nodes: children });
-    }
 
-    TreeNode { label, groups }
+        Ok(match self.report_as() {
+            ReportAs::Tree => render::render_tree(
+                &projects,
+                &RenderTreeOptions {
+                    always_print_root_package,
+                    depth_above_projects_only: self.depth != RecursionLimit::ProjectsOnly,
+                    long: self.long,
+                    show_extraneous: false,
+                    show_summary: true,
+                },
+            ),
+            ReportAs::Parseable => render::render_parseable(
+                &projects,
+                &RenderParseableOptions { long: self.long, always_print_root_package },
+            ),
+            ReportAs::Json => render::render_json(&projects, self.long),
+        })
+    }
 }
 
-pub(crate) fn print_label(dep: &DepNode, color: &dyn Fn(&str) -> String) -> String {
-    let alias = sanitize(&dep.alias);
-    let name = sanitize(&dep.name);
-    let version = sanitize(&dep.version);
-    if alias == name {
-        format!("{}{}", color(&name), gray(&format!("@{version}")))
-    } else if version.contains('@') {
-        format!("{}{}", color(&alias), gray(&format!("@{version}")))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReportAs {
+    Tree,
+    Json,
+    Parseable,
+}
+
+fn global_report_as(report_as: ReportAs) -> ListReportAs {
+    match report_as {
+        ReportAs::Tree => ListReportAs::Tree,
+        ReportAs::Json => ListReportAs::Json,
+        ReportAs::Parseable => ListReportAs::Parseable,
+    }
+}
+
+/// The directory the lockfile is read from for a non-recursive `list`:
+/// the workspace root under a shared workspace lockfile, the project
+/// itself otherwise.
+pub(crate) fn local_lockfile_dir(config: &Config, dir: &Path) -> PathBuf {
+    if config.shared_workspace_lockfile {
+        config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf())
     } else {
-        format!("{}{}", color(&alias), gray(&format!("@npm:{name}@{version}")))
+        dir.to_path_buf()
     }
 }
 
-pub(crate) fn name_at_version(name: &str, version: &str) -> String {
-    let name = sanitize(name);
-    if version.is_empty() {
-        name.into_owned()
-    } else {
-        format!("{}{}", name, gray(&format!("@{version}")))
-    }
-}
-
-fn render_archy(node: &TreeNode, connector: &str, prefix: &str, out: &mut String) {
-    let lines: Vec<&str> = node.label.split('\n').collect();
-    if !connector.is_empty() {
-        out.push_str(&dim(connector));
-    }
-    out.push_str(lines[0]);
-    out.push('\n');
-
-    struct Item<'a> {
-        node: &'a TreeNode,
-        group_header: Option<&'a str>,
-    }
-
-    let mut items: Vec<Item> = Vec::new();
-    for group in &node.groups {
-        for (i, gn) in group.nodes.iter().enumerate() {
-            items.push(Item { node: gn, group_header: (i == 0).then_some(group.group.as_str()) });
-        }
-    }
-
-    let continuation = if items.is_empty() { "  " } else { "\u{2502} " };
-    for line in &lines[1..] {
-        out.push_str(&dim(&format!("{prefix}{continuation}")));
-        out.push_str(line);
-        out.push('\n');
-    }
-
-    let count = items.len();
-    for (i, item) in items.into_iter().enumerate() {
-        let last = i == count - 1;
-
-        if let Some(header) = item.group_header
-            && !header.is_empty()
-        {
-            out.push_str(&dim(&format!("{prefix}\u{2502}")));
-            out.push('\n');
-            out.push_str(&dim(&format!("{prefix}\u{2502}   ")));
-            out.push_str(header);
-            out.push('\n');
-        }
-
-        let more = !item.node.groups.is_empty();
-        let branch = if last { "\u{2514}" } else { "\u{251c}" };
-        let stem = if more { "\u{252c}" } else { "\u{2500}" };
-        let child_connector = format!("{prefix}{branch}\u{2500}{stem} ");
-        let child_prefix = if last { format!("{prefix}  ") } else { format!("{prefix}\u{2502} ") };
-        render_archy(item.node, &child_connector, &child_prefix, out);
-    }
-}
-
-pub(crate) fn render_local_json(root: &LocalTreeRoot) -> String {
-    render_local_roots_json(std::slice::from_ref(root))
-}
-
-fn render_local_roots_json(roots: &[LocalTreeRoot]) -> String {
-    let root_objs = roots.iter().map(local_root_to_json).collect::<Vec<_>>();
-    serde_json::to_string_pretty(&root_objs).expect("serialize local list")
-}
-
-fn local_root_to_json(root: &LocalTreeRoot) -> Value {
-    let mut deps_map = Map::new();
-    for dep in &root.dependencies {
-        deps_map.insert(dep.alias.clone(), dep_to_json(dep));
-    }
-    let mut dev_map = Map::new();
-    for dep in &root.dev_dependencies {
-        dev_map.insert(dep.alias.clone(), dep_to_json(dep));
-    }
-    let mut opt_map = Map::new();
-    for dep in &root.optional_dependencies {
-        opt_map.insert(dep.alias.clone(), dep_to_json(dep));
-    }
-
-    let mut root_obj = Map::new();
-    if let Some(ref name) = root.name {
-        root_obj.insert("name".to_string(), json!(name));
-    }
-    if let Some(ref version) = root.version {
-        root_obj.insert("version".to_string(), json!(version));
-    }
-    root_obj.insert("path".to_string(), json!(root.path));
-    root_obj.insert("private".to_string(), json!(root.private.unwrap_or(false)));
-
-    if !deps_map.is_empty() {
-        root_obj.insert("dependencies".to_string(), Value::Object(deps_map));
-    }
-    if !dev_map.is_empty() {
-        root_obj.insert("devDependencies".to_string(), Value::Object(dev_map));
-    }
-    if !opt_map.is_empty() {
-        root_obj.insert("optionalDependencies".to_string(), Value::Object(opt_map));
-    }
-
-    if !root.unsaved.is_empty() {
-        let mut unsaved_map = Map::new();
-        for dep in &root.unsaved {
-            unsaved_map.insert(dep.alias.clone(), dep_to_json(dep));
-        }
-        root_obj.insert("unsavedDependencies".to_string(), Value::Object(unsaved_map));
-    }
-
-    Value::Object(root_obj)
-}
-
-pub(crate) fn dep_to_json(dep: &DepNode) -> Value {
-    let mut obj = Map::new();
-    obj.insert("from".to_string(), json!(dep.name));
-    obj.insert("version".to_string(), json!(dep.version));
-    obj.insert("path".to_string(), json!(dep.path));
-
-    if !dep.dependencies.is_empty() {
-        let mut child_deps = Map::new();
-        for child in &dep.dependencies {
-            child_deps.insert(child.alias.clone(), dep_to_json(child));
-        }
-        obj.insert("dependencies".to_string(), Value::Object(child_deps));
-    }
-
-    Value::Object(obj)
-}
-
-pub(crate) fn render_local_parseable(root: &LocalTreeRoot, long: bool) -> String {
-    let mut lines = Vec::new();
-
-    let root_line = if long {
-        let mut line = sanitize(&root.path).to_string();
-        if let Some(ref name) = root.name {
-            line.push(':');
-            line.push_str(&sanitize(name));
-            if let Some(ref version) = root.version {
-                line.push('@');
-                line.push_str(&sanitize(version));
-            }
-            if root.private == Some(true) {
-                line.push_str(":PRIVATE");
-            }
-        }
-        line
-    } else {
-        sanitize(&root.path).to_string()
-    };
-    lines.push(root_line);
-
-    let mut seen = HashSet::new();
-    seen.insert(sanitize(&root.path).to_string());
-
-    for dep in &root.dependencies {
-        flatten_parseable(dep, &mut lines, &mut seen, long);
-    }
-    for dep in &root.dev_dependencies {
-        flatten_parseable(dep, &mut lines, &mut seen, long);
-    }
-    for dep in &root.optional_dependencies {
-        flatten_parseable(dep, &mut lines, &mut seen, long);
-    }
-    for dep in &root.unsaved {
-        flatten_parseable(dep, &mut lines, &mut seen, long);
-    }
-
-    lines.join("\n")
-}
-
-fn flatten_parseable(
-    dep: &DepNode,
-    lines: &mut Vec<String>,
-    seen: &mut HashSet<String>,
-    long: bool,
-) {
-    let path = sanitize(&dep.path);
-    if !seen.insert(path.to_string()) && !path.is_empty() {
+/// Print command output the way the TypeScript CLI does: nothing for an
+/// empty string, exactly one trailing newline otherwise.
+pub(crate) fn print_output(output: &str) {
+    if output.is_empty() {
         return;
     }
-
-    if long {
-        let alias = sanitize(&dep.alias);
-        let name = sanitize(&dep.name);
-        let version = sanitize(&dep.version);
-        if alias != name {
-            if version.contains('@') {
-                lines.push(format!("{path}:{alias} {version}"));
-            } else {
-                lines.push(format!("{path}:{alias} npm:{name}@{version}"));
-            }
-        } else if version.contains('@') {
-            lines.push(format!("{path}:{version}"));
-        } else {
-            lines.push(format!("{path}:{name}@{version}"));
-        }
+    if output.ends_with('\n') {
+        print!("{output}");
     } else {
-        lines.push(path.to_string());
+        println!("{output}");
     }
-
-    for child in &dep.dependencies {
-        flatten_parseable(child, lines, seen, long);
-    }
-}
-
-fn dim(text: &str) -> String {
-    sanitize(text).if_supports_color(Stream::Stdout, |t| t.dimmed()).to_string()
-}
-
-fn bold(text: &str) -> String {
-    sanitize(text).if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
-}
-
-fn cyan_bright(text: &str) -> String {
-    sanitize(text).if_supports_color(Stream::Stdout, |t| t.bright_cyan()).to_string()
-}
-
-fn gray(text: &str) -> String {
-    sanitize(text).if_supports_color(Stream::Stdout, |t| t.bright_black()).to_string()
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/list/render.rs
+++ b/pnpm/crates/cli/src/cli_args/list/render.rs
@@ -1,8 +1,10 @@
 //! `pnpm list` output renderers (tree / parseable / JSON), mirroring
 //! the TypeScript `@pnpm/deps.inspection.list` renderers byte for byte.
 
-use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
 
 use serde_json::{Map, Value, json};
 
@@ -192,14 +194,14 @@ fn print_label(
         name_at_version(&node.name, &node.version, color)
     } else {
         // An npm: protocol alias displays as `alias@npm:name@version`,
-        // unless the version already carries an `@` (file:, link:, …).
+        // unless the version already carries an `@` (file:, link:, ...).
         if node.version.contains('@') {
             format!("{}{}", color(&node.alias), gray(&format!("@{}", node.version)))
         } else {
             format!(
                 "{}{}",
                 color(&node.alias),
-                gray(&format!("@npm:{}@{}", node.name, node.version))
+                gray(&format!("@npm:{}@{}", node.name, node.version)),
             )
         }
     };

--- a/pnpm/crates/cli/src/cli_args/list/render.rs
+++ b/pnpm/crates/cli/src/cli_args/list/render.rs
@@ -1,0 +1,438 @@
+//! `pnpm list` output renderers (tree / parseable / JSON), mirroring
+//! the TypeScript `@pnpm/deps.inspection.list` renderers byte for byte.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use serde_json::{Map, Value, json};
+
+use crate::cli_args::deps_tree::{
+    DependencyNode,
+    build::DependenciesHierarchy,
+    render::{
+        ColorFn, LongPkgInfo, PeerVariants, TreeNode, TreeNodeGroup, blue, bold, cyan_bright,
+        deduped_label, dim, gray, name_at_version, peer_hash_suffix, plain, read_long_pkg_info,
+        red, render_archy, yellow,
+    },
+};
+
+/// One project (importer) with its categorized dependency hierarchy —
+/// the unit the renderers consume.
+#[derive(Debug)]
+pub(crate) struct ProjectHierarchy {
+    pub name: Option<String>,
+    pub version: Option<String>,
+    pub private: bool,
+    pub path: String,
+    pub hierarchy: DependenciesHierarchy,
+}
+
+impl ProjectHierarchy {
+    fn groups(&self) -> [(&'static str, &Vec<DependencyNode>); 3] {
+        [
+            ("dependencies", &self.hierarchy.dependencies),
+            ("devDependencies", &self.hierarchy.dev_dependencies),
+            ("optionalDependencies", &self.hierarchy.optional_dependencies),
+        ]
+    }
+}
+
+pub(crate) struct RenderTreeOptions {
+    pub always_print_root_package: bool,
+    /// `false` when `--depth -1` printed project roots only (which
+    /// suppresses the legend and summary).
+    pub depth_above_projects_only: bool,
+    pub long: bool,
+    pub show_extraneous: bool,
+    pub show_summary: bool,
+}
+
+fn legend() -> String {
+    format!(
+        "Legend: {}, {}, {}\n\n",
+        plain("production dependency"),
+        blue("optional only"),
+        yellow("dev only"),
+    )
+}
+
+pub(crate) fn render_tree(projects: &[ProjectHierarchy], opts: &RenderTreeOptions) -> String {
+    let multi_peer_pkgs = find_multi_peer_packages(projects);
+    let output = projects
+        .iter()
+        .filter_map(|project| render_tree_for_project(project, opts, &multi_peer_pkgs))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let legend =
+        if opts.depth_above_projects_only && !output.is_empty() { legend() } else { String::new() };
+    let summary = if opts.show_summary && opts.depth_above_projects_only && !output.is_empty() {
+        format!("\n\n{}", list_summary(projects))
+    } else {
+        String::new()
+    };
+    format!("{legend}{output}{summary}")
+}
+
+fn render_tree_for_project(
+    project: &ProjectHierarchy,
+    opts: &RenderTreeOptions,
+    multi_peer_pkgs: &HashMap<String, usize>,
+) -> Option<String> {
+    let has_deps = project.groups().iter().any(|(_, nodes)| !nodes.is_empty())
+        || (opts.show_extraneous && !project.hierarchy.unsaved_dependencies.is_empty());
+    if !opts.always_print_root_package && !has_deps {
+        return None;
+    }
+
+    let mut label = String::new();
+    if let Some(name) = &project.name {
+        label.push_str(&name_at_version(name, project.version.as_deref().unwrap_or(""), plain));
+        label.push(' ');
+    }
+    label.push_str(&dim(&project.path));
+    if project.private {
+        label.push_str(&dim(" (PRIVATE)"));
+    }
+
+    let mut groups: Vec<TreeNodeGroup> = Vec::new();
+    for (field, nodes) in project.groups() {
+        if nodes.is_empty() {
+            continue;
+        }
+        groups.push(TreeNodeGroup {
+            group: cyan_bright(&format!("{field}:")),
+            nodes: to_archy_nodes(get_pkg_color, nodes, opts.long, multi_peer_pkgs),
+        });
+    }
+    if opts.show_extraneous && !project.hierarchy.unsaved_dependencies.is_empty() {
+        groups.push(TreeNodeGroup {
+            group: cyan_bright(
+                "not saved (you should add these dependencies to package.json if you need them):",
+            ),
+            nodes: to_archy_nodes(
+                unsaved_color,
+                &project.hierarchy.unsaved_dependencies,
+                opts.long,
+                multi_peer_pkgs,
+            ),
+        });
+    }
+
+    let root_label = bold(&label);
+    if groups.is_empty() {
+        return Some(root_label);
+    }
+    let tree = TreeNode { label: root_label, groups };
+    Some(render_archy(&tree).trim_end().to_string())
+}
+
+type PkgColor = fn(&DependencyNode) -> ColorFn;
+
+fn get_pkg_color(node: &DependencyNode) -> ColorFn {
+    if node.dev == Some(true) {
+        yellow
+    } else if node.optional {
+        blue
+    } else {
+        plain
+    }
+}
+
+fn unsaved_color(_node: &DependencyNode) -> ColorFn {
+    red
+}
+
+fn to_archy_nodes(
+    get_color: PkgColor,
+    nodes: &[DependencyNode],
+    long: bool,
+    multi_peer_pkgs: &HashMap<String, usize>,
+) -> Vec<TreeNode> {
+    let mut sorted: Vec<&DependencyNode> = nodes.iter().collect();
+    sorted.sort_by(|a, b| a.name.cmp(&b.name));
+    sorted
+        .iter()
+        .map(|node| {
+            let children = if node.deduped {
+                Vec::new()
+            } else {
+                to_archy_nodes(get_color, &node.dependencies, long, multi_peer_pkgs)
+            };
+            let mut label_lines = vec![print_label(get_color, Some(multi_peer_pkgs), node)];
+            if let Some(message) = &node.search_message {
+                label_lines.push(plain(message));
+            }
+            if long {
+                let info = read_long_pkg_info(Path::new(&node.path));
+                if let Some(description) = info.description {
+                    label_lines.push(plain(&description));
+                }
+                if let Some(repository) = info.repository {
+                    label_lines.push(plain(&repository));
+                }
+                if let Some(homepage) = info.homepage {
+                    label_lines.push(plain(&homepage));
+                }
+                if !node.path.is_empty() {
+                    label_lines.push(plain(&node.path));
+                }
+            }
+            TreeNode::with_children(label_lines.join("\n"), children)
+        })
+        .collect()
+}
+
+fn print_label(
+    get_color: PkgColor,
+    multi_peer_pkgs: Option<&HashMap<String, usize>>,
+    node: &DependencyNode,
+) -> String {
+    let color = get_color(node);
+    let mut label = if node.alias == node.name {
+        name_at_version(&node.name, &node.version, color)
+    } else {
+        // An npm: protocol alias displays as `alias@npm:name@version`,
+        // unless the version already carries an `@` (file:, link:, …).
+        if node.version.contains('@') {
+            format!("{}{}", color(&node.alias), gray(&format!("@{}", node.version)))
+        } else {
+            format!(
+                "{}{}",
+                color(&node.alias),
+                gray(&format!("@npm:{}@{}", node.name, node.version))
+            )
+        }
+    };
+    if node.is_peer {
+        label.push_str(" peer");
+    }
+    if node.is_skipped {
+        label.push_str(" skipped");
+    }
+    if let Some(multi_peer_pkgs) = multi_peer_pkgs {
+        label.push_str(&peer_hash_suffix(
+            multi_peer_pkgs,
+            &node.name,
+            &node.version,
+            node.peers_suffix_hash.as_deref(),
+        ));
+    }
+    if node.deduped {
+        label.push_str(&deduped_label());
+    }
+    if node.searched { bold(&label) } else { label }
+}
+
+fn find_multi_peer_packages(projects: &[ProjectHierarchy]) -> HashMap<String, usize> {
+    let mut variants = PeerVariants::default();
+    fn walk(variants: &mut PeerVariants, nodes: &[DependencyNode]) {
+        for node in nodes {
+            variants.collect(&node.name, &node.version, node.peers_suffix_hash.as_deref());
+            walk(variants, &node.dependencies);
+        }
+    }
+    for project in projects {
+        for (_, nodes) in project.groups() {
+            walk(&mut variants, nodes);
+        }
+    }
+    variants.into_multi_variant_counts()
+}
+
+fn list_summary(projects: &[ProjectHierarchy]) -> String {
+    fn count(nodes: &[DependencyNode]) -> u64 {
+        nodes.iter().map(|node| 1 + count(&node.dependencies)).sum()
+    }
+    let total: u64 = projects
+        .iter()
+        .map(|project| project.groups().iter().map(|(_, nodes)| count(nodes)).sum::<u64>())
+        .sum();
+    let mut parts = vec![format!("{total} package{}", if total == 1 { "" } else { "s" })];
+    if projects.len() > 1 {
+        parts.push(format!("{} projects", projects.len()));
+    }
+    dim(&parts.join(" in "))
+}
+
+// --- parseable ---------------------------------------------------------------
+
+pub(crate) struct RenderParseableOptions {
+    pub long: bool,
+    pub always_print_root_package: bool,
+}
+
+pub(crate) fn render_parseable(
+    projects: &[ProjectHierarchy],
+    opts: &RenderParseableOptions,
+) -> String {
+    let mut dep_paths: HashSet<String> = HashSet::new();
+    projects
+        .iter()
+        .map(|project| render_parseable_for_project(&mut dep_paths, project, opts))
+        .filter(|out| !out.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn render_parseable_for_project(
+    dep_paths: &mut HashSet<String>,
+    project: &ProjectHierarchy,
+    opts: &RenderParseableOptions,
+) -> String {
+    let root_already_seen = dep_paths.contains(&project.path);
+    dep_paths.insert(project.path.clone());
+    let all_deps: Vec<&DependencyNode> = project
+        .hierarchy
+        .optional_dependencies
+        .iter()
+        .chain(&project.hierarchy.dependencies)
+        .chain(&project.hierarchy.dev_dependencies)
+        .chain(&project.hierarchy.unsaved_dependencies)
+        .collect();
+    let mut flattened = flatten(dep_paths, &all_deps);
+    flattened.sort_by(|a, b| a.name.cmp(&b.name));
+    if root_already_seen && flattened.is_empty() {
+        return String::new();
+    }
+    if !opts.always_print_root_package && flattened.is_empty() && all_deps.is_empty() {
+        return String::new();
+    }
+
+    let mut lines: Vec<String> = Vec::new();
+    if !root_already_seen {
+        let mut first_line = plain(&project.path);
+        if opts.long
+            && let Some(name) = &project.name
+        {
+            first_line.push(':');
+            first_line.push_str(&plain(name));
+            if let Some(version) = &project.version {
+                first_line.push('@');
+                first_line.push_str(&plain(version));
+            }
+            if project.private {
+                first_line.push_str(":PRIVATE");
+            }
+        }
+        lines.push(first_line);
+    }
+    for node in flattened {
+        if opts.long {
+            let path = plain(&node.path);
+            let alias = plain(&node.alias);
+            let name = plain(&node.name);
+            let version = plain(&node.version);
+            if alias != name {
+                if version.contains('@') {
+                    lines.push(format!("{path}:{alias} {version}"));
+                } else {
+                    lines.push(format!("{path}:{alias} npm:{name}@{version}"));
+                }
+            } else if version.contains('@') {
+                lines.push(format!("{path}:{version}"));
+            } else {
+                lines.push(format!("{path}:{name}@{version}"));
+            }
+        } else {
+            lines.push(plain(&node.path));
+        }
+    }
+    lines.join("\n")
+}
+
+fn flatten<'a>(
+    dep_paths: &mut HashSet<String>,
+    nodes: &[&'a DependencyNode],
+) -> Vec<&'a DependencyNode> {
+    let mut packages: Vec<&'a DependencyNode> = Vec::new();
+    for node in nodes {
+        // Parseable output is flat, so packages that several parents
+        // depend on are printed once.
+        if !dep_paths.contains(&node.path) {
+            dep_paths.insert(node.path.clone());
+            packages.push(node);
+        }
+        if !node.dependencies.is_empty() {
+            let children: Vec<&DependencyNode> = node.dependencies.iter().collect();
+            packages.extend(flatten(dep_paths, &children));
+        }
+    }
+    packages
+}
+
+// --- JSON --------------------------------------------------------------------
+
+pub(crate) fn render_json(projects: &[ProjectHierarchy], long: bool) -> String {
+    let arr: Vec<Value> = projects
+        .iter()
+        .map(|project| {
+            let mut obj = Map::new();
+            if let Some(name) = &project.name {
+                obj.insert("name".to_string(), json!(name));
+            }
+            if let Some(version) = &project.version {
+                obj.insert("version".to_string(), json!(version));
+            }
+            obj.insert("path".to_string(), json!(project.path));
+            obj.insert("private".to_string(), json!(project.private));
+            let fields: [(&str, &Vec<DependencyNode>); 4] = [
+                ("dependencies", &project.hierarchy.dependencies),
+                ("devDependencies", &project.hierarchy.dev_dependencies),
+                ("optionalDependencies", &project.hierarchy.optional_dependencies),
+                ("unsavedDependencies", &project.hierarchy.unsaved_dependencies),
+            ];
+            for (field, nodes) in fields {
+                if !nodes.is_empty() {
+                    obj.insert(field.to_string(), Value::Object(to_json_result(nodes, long)));
+                }
+            }
+            Value::Object(obj)
+        })
+        .collect();
+    serde_json::to_string_pretty(&arr).expect("serialize list JSON")
+}
+
+fn to_json_result(nodes: &[DependencyNode], long: bool) -> Map<String, Value> {
+    let mut sorted: Vec<&DependencyNode> = nodes.iter().collect();
+    sorted.sort_by(|a, b| a.alias.cmp(&b.alias));
+    let mut result = Map::new();
+    for node in sorted {
+        let sub_dependencies = to_json_result(&node.dependencies, long);
+        let mut dep = Map::new();
+        dep.insert("from".to_string(), json!(node.name));
+        dep.insert("version".to_string(), json!(node.version));
+        if let Some(resolved) = &node.resolved {
+            dep.insert("resolved".to_string(), json!(resolved));
+        }
+        if long {
+            let info: LongPkgInfo = read_long_pkg_info(Path::new(&node.path));
+            if let Some(description) = info.description {
+                dep.insert("description".to_string(), json!(description));
+            }
+            if let Some(license) = info.license {
+                dep.insert("license".to_string(), license);
+            }
+            if let Some(author) = info.author {
+                dep.insert("author".to_string(), author);
+            }
+            if let Some(homepage) = info.homepage {
+                dep.insert("homepage".to_string(), json!(homepage));
+            }
+            if let Some(repository) = info.repository {
+                dep.insert("repository".to_string(), json!(repository));
+            }
+        }
+        dep.insert("path".to_string(), json!(node.path));
+        if !sub_dependencies.is_empty() {
+            dep.insert("dependencies".to_string(), Value::Object(sub_dependencies));
+        }
+        if node.deduped {
+            dep.insert("deduped".to_string(), json!(true));
+            if let Some(count) = node.deduped_dependencies_count {
+                dep.insert("dedupedDependenciesCount".to_string(), json!(count));
+            }
+        }
+        result.insert(node.alias.clone(), Value::Object(dep));
+    }
+    result
+}

--- a/pnpm/crates/cli/src/cli_args/list/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/list/tests.rs
@@ -65,7 +65,7 @@ fn print_empty() {
     let output = render_tree(&projects, &tree_opts(true, false));
     assert_eq!(
         output,
-        "Legend: production dependency, optional only, dev only\n\nempty@1.0.0 /empty"
+        "Legend: production dependency, optional only, dev only\n\nempty@1.0.0 /empty",
     );
 }
 
@@ -101,7 +101,7 @@ fn unsaved_dependencies_are_marked() {
             "│"
             "│   not saved (you should add these dependencies to package.json if you need them):"
             "└── foo@1.0.0"
-        }
+        },
     );
 }
 
@@ -141,7 +141,7 @@ fn list_with_many_dependencies() {
             "├── i@1.0.0"
             "├── k@1.0.0"
             "└── l@1.0.0"
-        }
+        },
     );
 }
 
@@ -173,7 +173,7 @@ fn sort_list_items() {
             "└─┬ foo@1.0.0"
             "  ├── bar@1.0.0"
             "  └── qar@1.0.0"
-        }
+        },
     );
 }
 
@@ -383,6 +383,6 @@ fn render_parseable_search_long_shared_dep_across_packages_is_not_duplicated() {
     assert!(lines.contains(&"/workspace/packages/pkg-b:pkg-b@1.0.0"));
     assert_eq!(
         lines.iter().filter(|line| line.starts_with("/workspace/packages/shared")).count(),
-        1
+        1,
     );
 }

--- a/pnpm/crates/cli/src/cli_args/list/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/list/tests.rs
@@ -1,585 +1,388 @@
-use std::{collections::HashMap, fs};
-
-use pacquet_config::Config;
-use pacquet_lockfile::{ImporterDepVersion, ProjectSnapshot, ResolvedDependencySpec};
 use pretty_assertions::assert_eq;
-use serde_json::Value;
-use tempfile::TempDir;
+use text_block_macros::text_block;
 
 use super::{
-    DepNode, LocalTreeRoot, PkgNameVerPeer, build_unsaved_node, dep_to_json, get_peer_set,
-    glob_match, matches_params, name_at_version, print_label, read_modules_dir_names,
-    read_root_manifest, read_unsaved_dependencies, render_local_json, render_local_parseable,
-    render_local_tree, sort_deps,
+    RecursionLimit, parse_depth,
+    render::{
+        ProjectHierarchy, RenderParseableOptions, RenderTreeOptions, render_parseable, render_tree,
+    },
 };
+use crate::cli_args::deps_tree::{DependencyNode, build::DependenciesHierarchy};
 
 #[test]
-fn glob_match_exact() {
-    assert!(glob_match("foo", "foo"));
-    assert!(!glob_match("foo", "bar"));
+fn parse_depth_accepts_infinity_and_minus_one() {
+    assert_eq!(parse_depth("Infinity").unwrap(), RecursionLimit::Unlimited);
+    assert_eq!(parse_depth("-1").unwrap(), RecursionLimit::ProjectsOnly);
+    assert_eq!(parse_depth("0").unwrap(), RecursionLimit::Levels(0));
+    assert_eq!(parse_depth("3").unwrap(), RecursionLimit::Levels(3));
+    assert!(parse_depth("-2").is_err());
 }
 
-#[test]
-fn glob_match_wildcard_suffix() {
-    assert!(glob_match("foo*", "foobar"));
-    assert!(glob_match("foo*", "foo"));
-    assert!(!glob_match("foo*", "f"));
-}
-
-#[test]
-fn glob_match_wildcard_prefix() {
-    assert!(glob_match("*bar", "foobar"));
-    assert!(glob_match("*bar", "bar"));
-    assert!(!glob_match("*bar", "barbaz"));
-}
-
-#[test]
-fn glob_match_wildcard_infix() {
-    assert!(glob_match("f*o", "foo"));
-    assert!(glob_match("f*o", "f_o"));
-    assert!(glob_match("f*o", "fooo"));
-    assert!(!glob_match("f*o", "far"));
-}
-
-#[test]
-fn glob_match_scoped_package() {
-    assert!(glob_match("@scope/*", "@scope/foo"));
-    assert!(!glob_match("@scope/*", "@other/foo"));
-}
-
-#[test]
-fn matches_params_empty() {
-    assert!(matches_params(&[], "anything"));
-}
-
-#[test]
-fn matches_params_with_patterns() {
-    assert!(matches_params(&["foo".to_string()], "foo"));
-    assert!(!matches_params(&["foo".to_string()], "bar"));
-    assert!(matches_params(&["foo*".to_string()], "foobar"));
-}
-
-#[test]
-fn matches_params_multiple_patterns() {
-    assert!(matches_params(&["foo".to_string(), "bar".to_string()], "bar"));
-    assert!(!matches_params(&["foo".to_string(), "bar".to_string()], "baz"));
-}
-
-#[test]
-fn sort_deps_by_name() {
-    let mut deps = vec![
-        DepNode {
-            alias: "z-pkg".into(),
-            name: "z-pkg".into(),
-            version: "1.0.0".into(),
-            path: String::new(),
-            is_peer: false,
-            is_dev: false,
-            is_optional: false,
-            dependencies: vec![],
-        },
-        DepNode {
-            alias: "a-pkg".into(),
-            name: "a-pkg".into(),
-            version: "2.0.0".into(),
-            path: String::new(),
-            is_peer: false,
-            is_dev: false,
-            is_optional: false,
-            dependencies: vec![],
-        },
-    ];
-    sort_deps(&mut deps);
-    assert_eq!(deps[0].name, "a-pkg");
-    assert_eq!(deps[1].name, "z-pkg");
-}
-
-#[test]
-fn sort_deps_recursive() {
-    let mut deps = vec![DepNode {
-        alias: "outer".into(),
-        name: "outer".into(),
-        version: "1.0.0".into(),
-        path: String::new(),
-        is_peer: false,
-        is_dev: false,
-        is_optional: false,
-        dependencies: vec![
-            DepNode {
-                alias: "z-inner".into(),
-                name: "z-inner".into(),
-                version: "0.1.0".into(),
-                path: String::new(),
-                is_peer: false,
-                is_dev: false,
-                is_optional: false,
-                dependencies: vec![],
-            },
-            DepNode {
-                alias: "a-inner".into(),
-                name: "a-inner".into(),
-                version: "0.2.0".into(),
-                path: String::new(),
-                is_peer: false,
-                is_dev: false,
-                is_optional: false,
-                dependencies: vec![],
-            },
-        ],
-    }];
-    sort_deps(&mut deps);
-    assert_eq!(deps[0].dependencies[0].name, "a-inner");
-    assert_eq!(deps[0].dependencies[1].name, "z-inner");
-}
-
-#[test]
-fn read_root_manifest_with_all_fields() {
-    let dir = tempfile::TempDir::new().expect("temp dir");
-    let manifest = dir.path().join("package.json");
-    std::fs::write(&manifest, r#"{"name":"test-pkg","version":"1.0.0","private":true}"#)
-        .expect("write manifest");
-    let (name, version, private) = read_root_manifest(&manifest).unwrap();
-    assert_eq!(name, Some("test-pkg".into()));
-    assert_eq!(version, Some("1.0.0".into()));
-    assert_eq!(private, Some(true));
-}
-
-#[test]
-fn read_root_manifest_missing_file() {
-    let dir = tempfile::TempDir::new().expect("temp dir");
-    let manifest = dir.path().join("nonexistent.json");
-    let err = read_root_manifest(&manifest).unwrap_err();
-    assert!(err.to_string().contains("failed to read"));
-}
-
-#[test]
-fn read_root_manifest_invalid_json() {
-    let dir = tempfile::TempDir::new().expect("temp dir");
-    let manifest = dir.path().join("package.json");
-    std::fs::write(&manifest, "not json").expect("write manifest");
-    let err = read_root_manifest(&manifest).unwrap_err();
-    assert!(err.to_string().contains("failed to parse"));
-}
-
-#[test]
-fn render_local_tree_shows_root_with_name() {
-    let root = LocalTreeRoot {
-        name: Some("my-pkg".into()),
-        version: Some("1.0.0".into()),
-        private: Some(false),
-        path: "/tmp/project".into(),
-        dependencies: vec![],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_tree(&root, false);
-    assert!(output.contains("my-pkg"));
-}
-
-#[test]
-fn render_local_tree_shows_private() {
-    let root = LocalTreeRoot {
-        name: Some("my-pkg".into()),
-        version: Some("1.0.0".into()),
-        private: Some(true),
-        path: "/tmp/project".into(),
-        dependencies: vec![],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_tree(&root, false);
-    assert!(output.contains("PRIVATE"));
-}
-
-#[test]
-fn render_local_tree_with_deps() {
-    let root = LocalTreeRoot {
-        name: Some("root".into()),
-        version: Some("0.0.0".into()),
-        private: Some(false),
-        path: "/project".into(),
-        dependencies: vec![DepNode {
-            alias: "foo".into(),
-            name: "foo".into(),
-            version: "1.0.0".into(),
-            path: ".pnpm/foo@1.0.0/node_modules/foo".into(),
-            is_peer: false,
-            is_dev: false,
-            is_optional: false,
-            dependencies: vec![],
-        }],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_tree(&root, false);
-    assert!(output.contains("foo"));
-    assert!(output.contains("1.0.0"));
-}
-
-#[test]
-fn render_local_tree_empty_returns_root_line() {
-    let root = LocalTreeRoot {
-        name: Some("lone".into()),
-        version: Some("0.0.0".into()),
-        private: Some(false),
-        path: "/nowhere".into(),
-        dependencies: vec![],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_tree(&root, false);
-    assert!(output.contains("lone"));
-    assert!(output.contains("nowhere"));
-}
-
-#[test]
-fn render_local_tree_sanitizes_root_name_without_deps() {
-    let root = LocalTreeRoot {
-        name: Some("bad\u{1b}[31m-name".into()),
-        version: Some("0.0.0".into()),
-        private: Some(false),
-        path: "/nowhere".into(),
-        dependencies: vec![],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_tree(&root, false);
-    assert!(!output.contains('\u{1b}'));
-    assert!(output.contains("bad[31m-name"));
-}
-
-#[test]
-fn render_local_json_basic() {
-    let root = LocalTreeRoot {
-        name: Some("pkg".into()),
-        version: Some("2.0.0".into()),
-        private: Some(false),
-        path: "/p".into(),
-        dependencies: vec![DepNode {
-            alias: "dep".into(),
-            name: "dep".into(),
-            version: "1.0.0".into(),
-            path: ".pnpm/dep@1.0.0/node_modules/dep".into(),
-            is_peer: false,
-            is_dev: false,
-            is_optional: false,
-            dependencies: vec![],
-        }],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_json(&root);
-    assert!(output.contains("pkg"));
-    assert!(output.contains("2.0.0"));
-    assert!(output.contains("dep"));
-    let parsed: Value = serde_json::from_str(&output).expect("valid json");
-    assert!(parsed.is_array());
-    assert_eq!(parsed[0]["name"], "pkg");
-}
-
-#[test]
-fn render_local_json_private() {
-    let root = LocalTreeRoot {
-        name: Some("secret".into()),
-        version: None,
-        private: Some(true),
-        path: "/hidden".into(),
-        dependencies: vec![],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_json(&root);
-    let parsed: Value = serde_json::from_str(&output).expect("valid json");
-    assert_eq!(parsed[0]["private"], true);
-}
-
-#[test]
-fn render_local_parseable_flat() {
-    let root = LocalTreeRoot {
-        name: Some("root".into()),
-        version: Some("1.0.0".into()),
-        private: Some(false),
-        path: "/r".into(),
-        dependencies: vec![DepNode {
-            alias: "a".into(),
-            name: "a".into(),
-            version: "0.1.0".into(),
-            path: ".pnpm/a@0.1.0/node_modules/a".into(),
-            is_peer: false,
-            is_dev: false,
-            is_optional: false,
-            dependencies: vec![],
-        }],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_parseable(&root, false);
-    let lines: Vec<&str> = output.lines().collect();
-    assert_eq!(lines[0], "/r");
-    assert!(lines[1].contains(".pnpm/a@0.1.0"));
-}
-
-#[test]
-fn render_local_parseable_long() {
-    let root = LocalTreeRoot {
-        name: Some("test".into()),
-        version: Some("3.0.0".into()),
-        private: Some(false),
-        path: "/t".into(),
-        dependencies: vec![DepNode {
-            alias: "b".into(),
-            name: "b".into(),
-            version: "2.0.0".into(),
-            path: ".pnpm/b@2.0.0/node_modules/b".into(),
-            is_peer: false,
-            is_dev: false,
-            is_optional: false,
-            dependencies: vec![],
-        }],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![],
-    };
-    let output = render_local_parseable(&root, true);
-    assert!(output.contains(":test@3.0.0"));
-    assert!(output.contains("b@2.0.0"));
-}
-
-#[test]
-fn dep_to_json_nested() {
-    let dep = DepNode {
-        alias: "parent".into(),
-        name: "parent".into(),
-        version: "1.0.0".into(),
-        path: ".pnpm/parent@1.0.0/node_modules/parent".into(),
-        is_peer: false,
-        is_dev: false,
-        is_optional: false,
-        dependencies: vec![DepNode {
-            alias: "child".into(),
-            name: "child".into(),
-            version: "0.1.0".into(),
-            path: ".pnpm/child@0.1.0/node_modules/child".into(),
-            is_peer: false,
-            is_dev: false,
-            is_optional: false,
-            dependencies: vec![],
-        }],
-    };
-    let json = dep_to_json(&dep);
-    assert_eq!(json["from"], "parent");
-    assert_eq!(json["version"], "1.0.0");
-    assert!(json.get("dependencies").is_some());
-}
-
-#[test]
-fn get_peer_set_empty_when_no_packages() {
-    let key = "pkg@1.0.0".parse::<PkgNameVerPeer>().expect("parse pkg@1.0.0");
-    let set = get_peer_set(&key, None);
-    assert!(set.is_empty());
-}
-
-#[test]
-fn name_at_version_with_and_without() {
-    assert_eq!(name_at_version("pkg", ""), "pkg");
-    let with_v = name_at_version("pkg", "1.0.0");
-    assert!(with_v.starts_with("pkg"));
-}
-
-#[test]
-fn print_label_alias_match() {
-    let dep = DepNode {
-        alias: "mypkg".into(),
-        name: "mypkg".into(),
-        version: "1.0.0".into(),
-        path: String::new(),
-        is_peer: false,
-        is_dev: false,
-        is_optional: false,
-        dependencies: vec![],
-    };
-    let label = print_label(&dep, &|text| text.to_string());
-    assert!(label.starts_with("mypkg"));
-    assert!(label.contains("1.0.0"));
-}
-
-#[test]
-fn print_label_alias_different() {
-    let dep = DepNode {
-        alias: "my-alias".into(),
-        name: "real-name".into(),
-        version: "2.0.0".into(),
-        path: String::new(),
-        is_peer: false,
-        is_dev: false,
-        is_optional: false,
-        dependencies: vec![],
-    };
-    let label = print_label(&dep, &|text| text.to_string());
-    assert!(label.starts_with("my-alias"));
-    assert!(label.contains("real-name"));
-}
-
-#[test]
-fn print_label_alias_with_version_containing_at() {
-    let dep = DepNode {
-        alias: "aliased".into(),
-        name: "target".into(),
-        version: "npm:@scope/pkg@1.0.0".into(),
-        path: String::new(),
-        is_peer: false,
-        is_dev: false,
-        is_optional: false,
-        dependencies: vec![],
-    };
-    let label = print_label(&dep, &|text| text.to_string());
-    assert!(label.starts_with("aliased"));
-    assert!(label.contains("npm:@scope/pkg@1.0.0"));
-}
-
-fn write_package(modules_dir: &std::path::Path, name: &str, version: &str) {
-    let pkg = modules_dir.join(name);
-    fs::create_dir_all(&pkg).expect("create package dir");
-    fs::write(pkg.join("package.json"), format!(r#"{{"name":"{name}","version":"{version}"}}"#))
-        .expect("write package.json");
-}
-
-#[test]
-fn read_modules_dir_names_skips_dot_entries_and_files_and_descends_scopes() {
-    let dir = TempDir::new().expect("temp dir");
-    let modules = dir.path().join("node_modules");
-    fs::create_dir_all(modules.join("foo")).expect("create foo");
-    fs::create_dir_all(modules.join(".pnpm")).expect("create .pnpm");
-    fs::create_dir_all(modules.join(".bin")).expect("create .bin");
-    fs::create_dir_all(modules.join("@scope").join("bar")).expect("create @scope/bar");
-    fs::write(modules.join("a-file"), "x").expect("write file");
-
-    let mut names = read_modules_dir_names(&modules).expect("read node_modules");
-    names.sort();
-    assert_eq!(names, vec!["@scope/bar".to_string(), "foo".to_string()]);
-}
-
-#[test]
-fn read_modules_dir_names_of_missing_dir_is_empty() {
-    let dir = TempDir::new().expect("temp dir");
-    assert!(read_modules_dir_names(&dir.path().join("node_modules")).expect("read").is_empty());
-}
-
-#[test]
-fn build_unsaved_node_reads_regular_package_version() {
-    let project = TempDir::new().expect("temp dir");
-    let modules = project.path().join("node_modules");
-    write_package(&modules, "foo", "1.2.3");
-
-    let node = build_unsaved_node("foo", &modules, project.path());
-    assert_eq!(node.alias, "foo");
-    assert_eq!(node.name, "foo");
-    assert_eq!(node.version, "1.2.3");
-    assert_eq!(node.path, modules.join("foo").to_string_lossy());
-    assert!(!node.is_peer && !node.is_dev && !node.is_optional);
-    assert!(node.dependencies.is_empty());
-}
-
-#[test]
-fn build_unsaved_node_without_version_is_undefined() {
-    let project = TempDir::new().expect("temp dir");
-    let modules = project.path().join("node_modules");
-    fs::create_dir_all(modules.join("foo")).expect("create foo");
-
-    let node = build_unsaved_node("foo", &modules, project.path());
-    assert_eq!(node.version, "undefined");
-}
-
-#[cfg(unix)]
-#[test]
-fn build_unsaved_node_symlink_gets_relative_link_version() {
-    let root = TempDir::new().expect("temp dir");
-    let project = root.path().join("project");
-    let sibling = root.path().join("sibling");
-    let modules = project.join("node_modules");
-    fs::create_dir_all(&modules).expect("create node_modules");
-    fs::create_dir_all(&sibling).expect("create sibling");
-    // A relative symlink, as the linker writes for workspace/link: deps.
-    std::os::unix::fs::symlink("../../sibling", modules.join("sibling")).expect("create symlink");
-
-    let node = build_unsaved_node("sibling", &modules, &project);
-    assert_eq!(node.version, "link:../sibling");
-    assert_eq!(node.path, sibling.to_string_lossy());
-}
-
-#[test]
-fn read_unsaved_dependencies_excludes_saved_and_lists_extraneous() {
-    let project = TempDir::new().expect("temp dir");
-    let modules = project.path().join("node_modules");
-    write_package(&modules, "saved-dep", "1.0.0");
-    write_package(&modules, "extraneous", "9.9.9");
-    fs::create_dir_all(modules.join(".pnpm")).expect("create .pnpm");
-
-    let mut deps: HashMap<_, _> = HashMap::new();
-    deps.insert(
-        "saved-dep".parse().expect("parse pkg name"),
-        ResolvedDependencySpec {
-            specifier: "1.0.0".into(),
-            version: ImporterDepVersion::Link("ignored".into()),
-        },
-    );
-    let importer = ProjectSnapshot { dependencies: Some(deps), ..Default::default() };
-
-    let unsaved = read_unsaved_dependencies(&importer, project.path(), &Config::default())
-        .expect("scan node_modules");
-    assert_eq!(unsaved.len(), 1);
-    assert_eq!(unsaved[0].name, "extraneous");
-    assert_eq!(unsaved[0].version, "9.9.9");
-}
-
-fn root_with_one_unsaved() -> LocalTreeRoot {
-    LocalTreeRoot {
-        name: Some("pkg".into()),
-        version: Some("1.0.0".into()),
-        private: Some(false),
-        path: "/p".into(),
-        dependencies: vec![],
-        dev_dependencies: vec![],
-        optional_dependencies: vec![],
-        unsaved: vec![DepNode {
-            alias: "foo".into(),
-            name: "foo".into(),
-            version: "1.0.0".into(),
-            path: "/p/node_modules/foo".into(),
-            is_peer: false,
-            is_dev: false,
-            is_optional: false,
-            dependencies: vec![],
-        }],
+fn dep(alias: &str, name: &str, version: &str, path: &str) -> DependencyNode {
+    DependencyNode {
+        alias: alias.to_string(),
+        name: name.to_string(),
+        version: version.to_string(),
+        path: path.to_string(),
+        ..DependencyNode::default()
     }
 }
 
-#[test]
-fn render_local_json_includes_unsaved_dependencies() {
-    let parsed: Value =
-        serde_json::from_str(&render_local_json(&root_with_one_unsaved())).expect("valid json");
-    let unsaved = &parsed[0]["unsavedDependencies"]["foo"];
-    assert_eq!(unsaved["from"], "foo");
-    assert_eq!(unsaved["version"], "1.0.0");
-    assert_eq!(unsaved["path"], "/p/node_modules/foo");
+fn project(
+    name: &str,
+    version: &str,
+    path: &str,
+    hierarchy: DependenciesHierarchy,
+) -> ProjectHierarchy {
+    ProjectHierarchy {
+        name: Some(name.to_string()),
+        version: Some(version.to_string()),
+        private: false,
+        path: path.to_string(),
+        hierarchy,
+    }
 }
 
-#[test]
-fn render_local_parseable_includes_unsaved_dependency_path() {
-    let output = render_local_parseable(&root_with_one_unsaved(), false);
-    assert!(output.lines().any(|line| line == "/p/node_modules/foo"), "output was:\n{output}");
+fn tree_opts(always_print_root_package: bool, show_extraneous: bool) -> RenderTreeOptions {
+    RenderTreeOptions {
+        always_print_root_package,
+        depth_above_projects_only: true,
+        long: false,
+        show_extraneous,
+        show_summary: false,
+    }
 }
 
+fn parseable_opts(long: bool) -> RenderParseableOptions {
+    RenderParseableOptions { long, always_print_root_package: false }
+}
+
+// Port of upstream's 'print empty' (deps/inspection/list/test/index.ts).
 #[test]
-fn render_local_tree_omits_unsaved_dependencies() {
-    let output = render_local_tree(&root_with_one_unsaved(), false);
-    assert!(!output.contains("foo"), "tree must not show extraneous deps:\n{output}");
+fn print_empty() {
+    let projects = vec![project("empty", "1.0.0", "/empty", DependenciesHierarchy::default())];
+
+    let output = render_tree(&projects, &tree_opts(true, false));
+    assert_eq!(
+        output,
+        "Legend: production dependency, optional only, dev only\n\nempty@1.0.0 /empty"
+    );
+}
+
+// Port of upstream's "don't print empty" (deps/inspection/list/test/index.ts).
+#[test]
+fn dont_print_empty() {
+    let projects = vec![project("empty", "1.0.0", "/empty", DependenciesHierarchy::default())];
+
+    let output = render_tree(&projects, &tree_opts(false, false));
+    assert_eq!(output, "");
+}
+
+// Port of upstream's 'unsaved dependencies are marked' (deps/inspection/list/test/index.ts).
+#[test]
+fn unsaved_dependencies_are_marked() {
+    let projects = vec![project(
+        "fixture",
+        "1.0.0",
+        "/fixture",
+        DependenciesHierarchy {
+            unsaved_dependencies: vec![dep("foo", "foo", "1.0.0", "")],
+            ..DependenciesHierarchy::default()
+        },
+    )];
+
+    let output = render_tree(&projects, &tree_opts(false, true));
+    assert_eq!(
+        output,
+        text_block! {
+            "Legend: production dependency, optional only, dev only"
+            ""
+            "fixture@1.0.0 /fixture"
+            "│"
+            "│   not saved (you should add these dependencies to package.json if you need them):"
+            "└── foo@1.0.0"
+        }
+    );
+}
+
+// Port of upstream's 'list with many dependencies' (deps/inspection/list/test/index.ts).
+#[test]
+fn list_with_many_dependencies() {
+    let projects = vec![project(
+        "fixture",
+        "1.0.0",
+        "/fixture",
+        DependenciesHierarchy {
+            dependencies: ["a", "b", "c", "d", "e", "f", "g", "h", "i", "k", "l"]
+                .iter()
+                .map(|name| dep(name, name, "1.0.0", ""))
+                .collect(),
+            ..DependenciesHierarchy::default()
+        },
+    )];
+
+    let output = render_tree(&projects, &tree_opts(false, false));
+    assert_eq!(
+        output,
+        text_block! {
+            "Legend: production dependency, optional only, dev only"
+            ""
+            "fixture@1.0.0 /fixture"
+            "│"
+            "│   dependencies:"
+            "├── a@1.0.0"
+            "├── b@1.0.0"
+            "├── c@1.0.0"
+            "├── d@1.0.0"
+            "├── e@1.0.0"
+            "├── f@1.0.0"
+            "├── g@1.0.0"
+            "├── h@1.0.0"
+            "├── i@1.0.0"
+            "├── k@1.0.0"
+            "└── l@1.0.0"
+        }
+    );
+}
+
+// Port of upstream's 'sort list items' (deps/inspection/list/test/index.ts).
+#[test]
+fn sort_list_items() {
+    let projects = vec![project(
+        "fixture",
+        "1.0.0",
+        "/fixture",
+        DependenciesHierarchy {
+            dependencies: vec![DependencyNode {
+                dependencies: vec![dep("qar", "qar", "1.0.0", ""), dep("bar", "bar", "1.0.0", "")],
+                ..dep("foo", "foo", "1.0.0", "")
+            }],
+            ..DependenciesHierarchy::default()
+        },
+    )];
+
+    let output = render_tree(&projects, &tree_opts(false, false));
+    assert_eq!(
+        output,
+        text_block! {
+            "Legend: production dependency, optional only, dev only"
+            ""
+            "fixture@1.0.0 /fixture"
+            "│"
+            "│   dependencies:"
+            "└─┬ foo@1.0.0"
+            "  ├── bar@1.0.0"
+            "  └── qar@1.0.0"
+        }
+    );
+}
+
+// Port of upstream's 'renderTree displays npm: protocol for aliased packages' (deps/inspection/list/test/index.ts).
+#[test]
+fn render_tree_displays_npm_protocol_for_aliased_packages() {
+    let projects = vec![project(
+        "test-project",
+        "1.0.0",
+        "/test/path",
+        DependenciesHierarchy {
+            dependencies: vec![dep(
+                "foo",
+                "@pnpm.e2e/pkg-with-1-dep",
+                "100.0.0",
+                "/test/path/node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0/node_modules/@pnpm.e2e/pkg-with-1-dep",
+            )],
+            ..DependenciesHierarchy::default()
+        },
+    )];
+
+    let output = render_tree(&projects, &tree_opts(false, false));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("foo"));
+    assert!(output.contains("npm:@pnpm.e2e/pkg-with-1-dep@100.0.0"));
+}
+
+// Port of upstream's 'renderTree displays file: protocol correctly for aliased packages' (deps/inspection/list/test/index.ts).
+#[test]
+fn render_tree_displays_file_protocol_correctly_for_aliased_packages() {
+    let projects = vec![project(
+        "test-project",
+        "1.0.0",
+        "/test/path",
+        DependenciesHierarchy {
+            dependencies: vec![dep(
+                "my-alias",
+                "my-local-pkg",
+                "my-local-pkg@file:local-pkg",
+                "/test/path/local-pkg",
+            )],
+            ..DependenciesHierarchy::default()
+        },
+    )];
+
+    let output = render_tree(&projects, &tree_opts(false, false));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("my-alias"));
+    assert!(output.contains("my-local-pkg@file:local-pkg"));
+}
+
+// Port of upstream's 'renderParseable displays npm: protocol for aliased packages' (deps/inspection/list/test/index.ts).
+#[test]
+fn render_parseable_displays_npm_protocol_for_aliased_packages() {
+    let projects = vec![project(
+        "test-project",
+        "1.0.0",
+        "/test/path",
+        DependenciesHierarchy {
+            dependencies: vec![dep(
+                "foo",
+                "@pnpm.e2e/pkg-with-1-dep",
+                "100.0.0",
+                "/test/path/node_modules/.pnpm/@pnpm.e2e+pkg-with-1-dep@100.0.0/node_modules/@pnpm.e2e/pkg-with-1-dep",
+            )],
+            ..DependenciesHierarchy::default()
+        },
+    )];
+
+    let output = render_parseable(&projects, &parseable_opts(true));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("foo npm:@pnpm.e2e/pkg-with-1-dep@100.0.0"));
+}
+
+// Port of upstream's 'renderParseable displays file: protocol correctly for aliased packages' (deps/inspection/list/test/index.ts).
+#[test]
+fn render_parseable_displays_file_protocol_correctly_for_aliased_packages() {
+    let projects = vec![project(
+        "test-project",
+        "1.0.0",
+        "/test/path",
+        DependenciesHierarchy {
+            dependencies: vec![dep(
+                "my-alias",
+                "my-local-pkg",
+                "my-local-pkg@file:local-pkg",
+                "/test/path/local-pkg",
+            )],
+            ..DependenciesHierarchy::default()
+        },
+    )];
+
+    let output = render_parseable(&projects, &parseable_opts(true));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("my-alias my-local-pkg@file:local-pkg"));
+}
+
+// Port of upstream's 'renderParseable search: shared dep across packages is not duplicated' (deps/inspection/list/test/index.ts).
+#[test]
+fn render_parseable_search_shared_dep_across_packages_is_not_duplicated() {
+    let shared_dep = || dep("@org/shared", "@org/shared", "1.0.0", "/workspace/packages/shared");
+    let projects = vec![
+        project(
+            "pkg-a",
+            "1.0.0",
+            "/workspace/packages/pkg-a",
+            DependenciesHierarchy {
+                dependencies: vec![shared_dep()],
+                ..DependenciesHierarchy::default()
+            },
+        ),
+        project(
+            "pkg-b",
+            "1.0.0",
+            "/workspace/packages/pkg-b",
+            DependenciesHierarchy {
+                dependencies: vec![shared_dep()],
+                ..DependenciesHierarchy::default()
+            },
+        ),
+        project(
+            "@org/shared",
+            "1.0.0",
+            "/workspace/packages/shared",
+            DependenciesHierarchy::default(),
+        ),
+    ];
+
+    let output = render_parseable(&projects, &parseable_opts(false));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    eprintln!("output:\n{output}");
+    assert!(lines.contains(&"/workspace/packages/pkg-a"));
+    assert!(lines.contains(&"/workspace/packages/pkg-b"));
+    assert!(lines.contains(&"/workspace/packages/shared"));
+    assert_eq!(lines.iter().filter(|line| **line == "/workspace/packages/shared").count(), 1);
+}
+
+// Port of upstream's 'renderParseable search: packages unrelated to search are excluded' (deps/inspection/list/test/index.ts).
+#[test]
+fn render_parseable_search_packages_unrelated_to_search_are_excluded() {
+    let projects = vec![
+        project("root", "1.0.0", "/workspace", DependenciesHierarchy::default()),
+        project(
+            "pkg-a",
+            "1.0.0",
+            "/workspace/packages/pkg-a",
+            DependenciesHierarchy {
+                dependencies: vec![dep(
+                    "@org/shared",
+                    "@org/shared",
+                    "1.0.0",
+                    "/workspace/packages/shared",
+                )],
+                ..DependenciesHierarchy::default()
+            },
+        ),
+        project(
+            "unrelated",
+            "1.0.0",
+            "/workspace/packages/unrelated",
+            DependenciesHierarchy::default(),
+        ),
+    ];
+
+    let output = render_parseable(&projects, &parseable_opts(false));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    eprintln!("output:\n{output}");
+    assert!(lines.contains(&"/workspace/packages/pkg-a"));
+    assert!(lines.contains(&"/workspace/packages/shared"));
+    assert!(!lines.contains(&"/workspace"));
+    assert!(!lines.contains(&"/workspace/packages/unrelated"));
+}
+
+// Port of upstream's 'renderParseable search long: shared dep across packages is not duplicated' (deps/inspection/list/test/index.ts).
+#[test]
+fn render_parseable_search_long_shared_dep_across_packages_is_not_duplicated() {
+    let shared_dep =
+        || dep("@org/shared", "@org/shared", "link:../shared", "/workspace/packages/shared");
+    let projects = vec![
+        project(
+            "pkg-a",
+            "1.0.0",
+            "/workspace/packages/pkg-a",
+            DependenciesHierarchy {
+                dependencies: vec![shared_dep()],
+                ..DependenciesHierarchy::default()
+            },
+        ),
+        project(
+            "pkg-b",
+            "1.0.0",
+            "/workspace/packages/pkg-b",
+            DependenciesHierarchy {
+                dependencies: vec![shared_dep()],
+                ..DependenciesHierarchy::default()
+            },
+        ),
+    ];
+
+    let output = render_parseable(&projects, &parseable_opts(true));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    eprintln!("output:\n{output}");
+    assert!(lines.contains(&"/workspace/packages/pkg-a:pkg-a@1.0.0"));
+    assert!(lines.contains(&"/workspace/packages/pkg-b:pkg-b@1.0.0"));
+    assert_eq!(
+        lines.iter().filter(|line| line.starts_with("/workspace/packages/shared")).count(),
+        1
+    );
 }

--- a/pnpm/crates/cli/src/cli_args/why.rs
+++ b/pnpm/crates/cli/src/cli_args/why.rs
@@ -1,90 +1,84 @@
 //! `pnpm why` — show the packages that depend on `<pkg>`.
 
+use std::{collections::HashMap, path::PathBuf};
+
+use clap::Args;
+use pacquet_modules_yaml::IncludedDependencies;
+
 use crate::{
     State,
     cli_args::{
+        deps_tree::{
+            TreeNodeId,
+            build::{LoadedState, importer_id_for, read_project_manifest},
+            dependents::{BuildDependentsOptions, ImporterInfo, build_dependents_tree},
+            finders::{evaluate_finders, finder_candidates, resolve_finders},
+            graph::{BuildGraphOptions, build_dependency_graph},
+            search::Searcher,
+        },
+        list::print_output,
         recursive::{
             AutoExcludeRoot, RecursiveSharedLockfileUnsupported, discover_workspace_projects,
             select_recursive_projects,
         },
-        sanitize::sanitize,
     },
 };
-use clap::Args;
-use owo_colors::{OwoColorize, Stream};
-use pacquet_config::matcher::{Matcher, create_matcher};
-use pacquet_lockfile::{Lockfile, PackageKey, PackageMetadata, PkgNameVerPeer};
-use pacquet_modules_yaml::IncludedDependencies;
-use pacquet_package_manager::{SkippedSnapshots, materialization_closure};
-use pacquet_package_manifest::DependencyGroup;
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    io::Write,
+
+mod render;
+
+use render::{
+    RenderDependentsOptions, render_dependents_json, render_dependents_parseable,
+    render_dependents_tree,
 };
-
-#[derive(Debug, Clone)]
-struct DependentNode {
-    name: String,
-    version: String,
-    dep_field: Option<DependencyGroup>,
-    dependents: Vec<DependentNode>,
-}
-
-#[derive(Debug)]
-struct WhyResult {
-    name: String,
-    version: String,
-    dependents: Vec<DependentNode>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum ParentNode {
-    Package(PkgNameVerPeer),
-    Importer(String),
-}
-
-impl fmt::Display for ParentNode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ParentNode::Package(key) => write!(f, "{key}"),
-            ParentNode::Importer(id) => write!(f, "{id}"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum ReverseKey {
-    Package(PkgNameVerPeer),
-    Importer(String),
-}
-
-#[derive(Debug)]
-struct ImporterInfo {
-    name: String,
-    version: String,
-}
-
-struct WalkCtx<'a> {
-    reverse_map: &'a HashMap<ReverseKey, Vec<(ParentNode, String)>>,
-    importer_info: &'a HashMap<String, ImporterInfo>,
-    packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
-}
 
 #[derive(Debug, Args)]
 pub struct WhyArgs {
     pub packages: Vec<String>,
 
+    /// Max display depth of the reverse dependency tree.
     #[clap(long)]
     pub depth: Option<usize>,
+
+    /// Show extended information.
+    #[clap(long)]
+    pub long: bool,
+
+    /// Show information in JSON format.
+    #[clap(long)]
+    pub json: bool,
+
+    /// Show parseable output instead of tree view.
+    #[clap(long)]
+    pub parseable: bool,
+
+    /// Display only the dependency graph for packages in `dependencies`
+    /// and `optionalDependencies`.
+    #[clap(short = 'P', long = "prod")]
+    pub production: bool,
+
+    /// Display only the dependency graph for packages in `devDependencies`.
+    #[clap(short = 'D', long)]
+    pub dev: bool,
+
+    /// Don't display packages from `optionalDependencies`.
+    #[clap(long)]
+    pub no_optional: bool,
+
+    /// Exclude peer dependencies.
+    #[clap(long)]
+    pub exclude_peers: bool,
+
+    /// Search by a finder function declared in `.pnpmfile.cjs`.
+    #[clap(long = "find-by")]
+    pub find_by: Vec<String>,
 }
 
 impl WhyArgs {
     pub async fn run(self, state: State) -> miette::Result<()> {
-        if self.packages.is_empty() {
+        if self.packages.is_empty() && self.find_by.is_empty() {
             return Err(miette::miette!(
                 code = "ERR_PNPM_MISSING_PACKAGE_NAME",
-                "`pnpm why` requires a package name or pattern"
+                "`pnpm why` requires the package name or --find-by=<finder-name>"
             ));
         }
         if state.config.recursive && !state.config.shared_workspace_lockfile {
@@ -94,441 +88,105 @@ impl WhyArgs {
             .into());
         }
 
-        let active_importer_id = state.active_importer_id();
-        let lockfile = state
-            .lockfile
-            .get()
-            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+        let lockfile_dir = state.lockfile_dir().to_path_buf();
+        let project_dir = state
+            .manifest
+            .path()
+            .parent()
+            .expect("manifest path always has a parent dir")
+            .to_path_buf();
 
-        let Some(lockfile) = lockfile else {
-            return Ok(());
-        };
-        let initial_importer_ids = if state.config.recursive
-            && (!state.config.filter.is_empty() || !state.config.filter_prod.is_empty())
-        {
-            let workspace_root = state.lockfile_dir();
-            let (projects, _) = discover_workspace_projects(workspace_root)?;
-            let prefix =
-                state.manifest.path().parent().expect("manifest path always has a parent dir");
-            select_recursive_projects(&projects, state.config, prefix, AutoExcludeRoot::Disabled)?
-                .selected
-                .keys()
-                .map(|project_dir| {
-                    pacquet_workspace::importer_id_from_root_dir(workspace_root, project_dir)
-                })
-                .collect()
-        } else if state.config.recursive {
-            lockfile.importers.keys().cloned().collect()
+        let project_dirs: Vec<PathBuf> = if state.config.recursive {
+            let (projects, _) = discover_workspace_projects(&lockfile_dir)?;
+            select_recursive_projects(
+                &projects,
+                state.config,
+                &project_dir,
+                AutoExcludeRoot::Disabled,
+            )?
+            .selected
+            .keys()
+            .cloned()
+            .collect()
         } else {
-            HashSet::from([active_importer_id.clone()])
+            vec![project_dir]
         };
-        let lockfile = materialization_closure(
-            lockfile,
-            state.lockfile_dir(),
-            &initial_importer_ids,
-            IncludedDependencies {
-                dependencies: true,
-                dev_dependencies: true,
-                optional_dependencies: true,
-            },
-            &SkippedSnapshots::new(),
-        )
-        .lockfile;
 
-        let matcher = create_matcher(&self.packages);
-
-        let manifest_value = state.manifest.value();
-        let root_name = manifest_value
-            .get("name")
-            .and_then(|v| v.as_str())
-            .unwrap_or("the root project")
-            .to_string();
-        let root_version =
-            manifest_value.get("version").and_then(|v| v.as_str()).unwrap_or("").to_string();
-
-        let mut importer_info = HashMap::new();
-        for importer_id in lockfile.importers.keys() {
-            if importer_id == &active_importer_id {
-                importer_info.insert(
-                    importer_id.clone(),
-                    ImporterInfo { name: root_name.clone(), version: root_version.clone() },
-                );
-            } else {
-                importer_info.insert(
-                    importer_id.clone(),
-                    ImporterInfo { name: importer_id.clone(), version: String::new() },
-                );
-            }
-        }
-
-        let results = build_dependents_tree(&lockfile, &matcher, &importer_info, self.depth);
-
-        if results.is_empty() {
+        let loaded =
+            LoadedState::load(&lockfile_dir, Some(state.config.modules_dir.as_path()), false)?;
+        let Some(env) =
+            loaded.env(&lockfile_dir, state.config.virtual_store_dir_max_length as usize)
+        else {
             return Ok(());
+        };
+        let lockfile = env.current_lockfile;
+
+        let mut importer_info: HashMap<String, ImporterInfo> = HashMap::new();
+        for importer_id in lockfile.importers.keys() {
+            let manifest = read_project_manifest(&lockfile_dir.join(importer_id.as_str()));
+            let name = manifest.name.unwrap_or_else(|| {
+                if importer_id == "." {
+                    "the root project".to_string()
+                } else {
+                    importer_id.clone()
+                }
+            });
+            importer_info.insert(
+                importer_id.clone(),
+                ImporterInfo { name, version: manifest.version.unwrap_or_default() },
+            );
         }
 
-        let output = render_tree(&results, self.depth);
-        let mut stdout = std::io::stdout();
-        let _ = write!(stdout, "{output}");
-        let _ = stdout.flush();
-
-        Ok(())
-    }
-}
-
-const MAX_REVERSE_WALK_DEPTH: usize = 64;
-
-fn display_version(
-    key: &PkgNameVerPeer,
-    packages: Option<&HashMap<PackageKey, PackageMetadata>>,
-) -> String {
-    let metadata_key = key.without_peer();
-    packages
-        .and_then(|pkg_map| pkg_map.get(&metadata_key))
-        .and_then(|meta| meta.version.clone())
-        .unwrap_or_else(|| key.suffix.version().to_string())
-}
-
-fn resolve_link_to_importer(
-    parent_importer_id: &str,
-    link_target: &str,
-    importer_ids: &HashMap<String, impl std::any::Any>,
-) -> Option<String> {
-    let resolved = normalize_path(parent_importer_id, link_target)?;
-    importer_ids.contains_key(&resolved).then_some(resolved)
-}
-
-fn normalize_path(base: &str, relative: &str) -> Option<String> {
-    let mut parts: Vec<&str> = Vec::new();
-    for part in base.split('/').filter(|segment| !segment.is_empty()) {
-        parts.push(part);
-    }
-    for part in relative.split('/') {
-        match part {
-            "" | "." => continue,
-            ".." => {
-                parts.pop()?;
+        let include = {
+            let has_both = self.production == self.dev;
+            IncludedDependencies {
+                dependencies: has_both || self.production,
+                dev_dependencies: has_both || self.dev,
+                optional_dependencies: !self.no_optional,
             }
-            other => parts.push(other),
-        }
-    }
-    Some(parts.join("/"))
-}
-
-fn build_dependents_tree(
-    lockfile: &Lockfile,
-    matcher: &Matcher,
-    importer_info: &HashMap<String, ImporterInfo>,
-    max_depth: Option<usize>,
-) -> Vec<WhyResult> {
-    let packages = lockfile.packages.as_ref();
-    let snapshots = lockfile.snapshots.as_ref();
-
-    let mut forward_edges: HashMap<PkgNameVerPeer, Vec<(String, Option<PkgNameVerPeer>)>> =
-        HashMap::new();
-
-    let node_keys: Vec<PackageKey> = if let Some(pkgs) = packages {
-        pkgs.keys().cloned().collect()
-    } else if let Some(snapshot_map) = snapshots {
-        snapshot_map.keys().cloned().collect()
-    } else {
-        return vec![];
-    };
-
-    for key in &node_keys {
-        let Some(snapshot) = snapshots.and_then(|s| s.get(key)) else {
-            continue;
         };
 
-        let mut edges: Vec<(String, Option<PkgNameVerPeer>)> = Vec::new();
-
-        if let Some(deps) = &snapshot.dependencies {
-            for (alias, dep_ref) in deps {
-                edges.push((alias.to_string(), dep_ref.resolve(alias)));
-            }
-        }
-
-        if let Some(optional_deps) = &snapshot.optional_dependencies {
-            for (alias, dep_ref) in optional_deps {
-                edges.push((alias.to_string(), dep_ref.resolve(alias)));
-            }
-        }
-
-        forward_edges.insert(key.clone(), edges);
-    }
-
-    let mut reverse_map: HashMap<ReverseKey, Vec<(ParentNode, String)>> = HashMap::new();
-
-    let groups = [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
-    for importer_id in importer_info.keys() {
-        let Some(importer) = lockfile.importers.get(importer_id.as_str()) else {
-            continue;
-        };
-        for group in groups {
-            if let Some(deps) = importer.get_map_by_group(group) {
-                for (alias, spec) in deps {
-                    if let Some(target_key) = spec.version.resolved_key(alias) {
-                        reverse_map
-                            .entry(ReverseKey::Package(target_key))
-                            .or_default()
-                            .push((ParentNode::Importer(importer_id.clone()), alias.to_string()));
-                    } else if let Some(link_target) = spec.version.as_link_target()
-                        && let Some(resolved_id) =
-                            resolve_link_to_importer(importer_id, link_target, &lockfile.importers)
-                    {
-                        reverse_map
-                            .entry(ReverseKey::Importer(resolved_id))
-                            .or_default()
-                            .push((ParentNode::Importer(importer_id.clone()), alias.to_string()));
-                    }
+        let root_ids: Vec<TreeNodeId> = project_dirs
+            .iter()
+            .map(|dir| TreeNodeId::Importer(importer_id_for(&lockfile_dir, dir)))
+            .filter(|id| match id {
+                TreeNodeId::Importer(importer_id) => {
+                    lockfile.importers.contains_key(importer_id.as_str())
                 }
-            }
-        }
-    }
-
-    for (parent_key, edges) in &forward_edges {
-        for (alias, target) in edges {
-            if let Some(target_key) = target {
-                reverse_map
-                    .entry(ReverseKey::Package(target_key.clone()))
-                    .or_default()
-                    .push((ParentNode::Package(parent_key.clone()), alias.clone()));
-            }
-        }
-    }
-
-    for edges in reverse_map.values_mut() {
-        edges.sort_by_cached_key(|entry| entry.0.to_string());
-    }
-
-    let ctx = WalkCtx { reverse_map: &reverse_map, importer_info, packages };
-
-    let mut matched_roots: Vec<(String, String, ReverseKey)> = Vec::new();
-
-    for key in &node_keys {
-        let name = key.name.to_string();
-        let version = display_version(key, packages);
-
-        let matched = matcher.matches(&name)
-            || reverse_map
-                .get(&ReverseKey::Package(key.clone()))
-                .is_some_and(|edges| edges.iter().any(|(_parent, alias)| matcher.matches(alias)));
-
-        if matched {
-            matched_roots.push((name, version, ReverseKey::Package(key.clone())));
-        }
-    }
-
-    for importer_id in importer_info.keys() {
-        let info = importer_info.get(importer_id.as_str());
-        let name = info.map_or_else(|| importer_id.clone(), |i| i.name.clone());
-
-        let matched = matcher.matches(&name)
-            || reverse_map
-                .get(&ReverseKey::Importer(importer_id.clone()))
-                .is_some_and(|edges| edges.iter().any(|(_parent, alias)| matcher.matches(alias)));
-
-        if matched {
-            let version = info.map_or_else(String::new, |i| i.version.clone());
-            matched_roots.push((name, version, ReverseKey::Importer(importer_id.clone())));
-        }
-    }
-
-    let mut memo: HashMap<(ReverseKey, usize), Vec<DependentNode>> = HashMap::new();
-    let mut results: Vec<WhyResult> = Vec::new();
-
-    for (name, version, root_key) in &matched_roots {
-        let mut visited = HashSet::new();
-        match root_key {
-            ReverseKey::Package(key) => {
-                visited.insert(ParentNode::Package(key.clone()));
-            }
-            ReverseKey::Importer(id) => {
-                visited.insert(ParentNode::Importer(id.clone()));
-            }
-        }
-        let mut expanded = HashSet::new();
-        let dependents =
-            walk_reverse(root_key, &ctx, &mut visited, &mut expanded, &mut memo, 0, max_depth);
-
-        results.push(WhyResult { name: name.clone(), version: version.clone(), dependents });
-    }
-
-    results
-        .sort_by(|left, right| left.name.cmp(&right.name).then(left.version.cmp(&right.version)));
-
-    results
-}
-
-fn walk_reverse(
-    node_key: &ReverseKey,
-    ctx: &WalkCtx<'_>,
-    visited: &mut HashSet<ParentNode>,
-    expanded: &mut HashSet<ParentNode>,
-    memo: &mut HashMap<(ReverseKey, usize), Vec<DependentNode>>,
-    depth: usize,
-    max_depth: Option<usize>,
-) -> Vec<DependentNode> {
-    if depth >= MAX_REVERSE_WALK_DEPTH || max_depth.is_some_and(|max| depth >= max) {
-        return vec![];
-    }
-
-    let Some(edges) = ctx.reverse_map.get(node_key) else {
-        return vec![];
-    };
-
-    let memo_key = (node_key.clone(), depth);
-    if let Some(cached) = memo.get(&memo_key) {
-        return cached.clone();
-    }
-
-    let mut dependents = Vec::new();
-
-    for (parent_node, _alias) in edges {
-        match parent_node {
-            ParentNode::Importer(importer_id) => {
-                let info = ctx.importer_info.get(importer_id.as_str());
-                dependents.push(DependentNode {
-                    name: info.map_or_else(|| importer_id.clone(), |i| i.name.clone()),
-                    version: info.map_or_else(String::new, |i| i.version.clone()),
-                    dep_field: None,
-                    dependents: vec![],
-                });
-            }
-            ParentNode::Package(parent_key) => {
-                if visited.contains(parent_node) {
-                    dependents.push(DependentNode {
-                        name: parent_key.name.to_string(),
-                        version: display_version(parent_key, ctx.packages),
-                        dep_field: None,
-                        dependents: vec![],
-                    });
-                    continue;
-                }
-
-                if expanded.contains(parent_node) {
-                    dependents.push(DependentNode {
-                        name: parent_key.name.to_string(),
-                        version: display_version(parent_key, ctx.packages),
-                        dep_field: None,
-                        dependents: vec![],
-                    });
-                    continue;
-                }
-
-                visited.insert(parent_node.clone());
-                expanded.insert(parent_node.clone());
-
-                let parent_name = parent_key.name.to_string();
-                let parent_version = display_version(parent_key, ctx.packages);
-
-                let child_dependents = walk_reverse(
-                    &ReverseKey::Package(parent_key.clone()),
-                    ctx,
-                    visited,
-                    expanded,
-                    memo,
-                    depth + 1,
-                    max_depth,
-                );
-
-                visited.remove(parent_node);
-
-                dependents.push(DependentNode {
-                    name: parent_name,
-                    version: parent_version,
-                    dep_field: None,
-                    dependents: child_dependents,
-                });
-            }
-        }
-    }
-
-    dependents
-        .sort_by(|left, right| left.name.cmp(&right.name).then(left.version.cmp(&right.version)));
-
-    memo.insert(memo_key, dependents.clone());
-    dependents
-}
-
-fn render_tree(results: &[WhyResult], max_depth: Option<usize>) -> String {
-    let mut output = String::new();
-
-    for (i, result) in results.iter().enumerate() {
-        if i > 0 {
-            output.push_str("\n\n");
-        }
-
-        let root_label = format!("{}{}", bold(&result.name), dim(&format!("@{}", result.version)));
-        output.push_str(&root_label);
-
-        if result.dependents.is_empty() {
-            continue;
-        }
-
-        output.push('\n');
-        render_dependents(&mut output, &result.dependents, "", max_depth, 0);
-    }
-
-    output
-}
-
-fn render_dependents(
-    output: &mut String,
-    dependents: &[DependentNode],
-    prefix: &str,
-    max_depth: Option<usize>,
-    current_depth: usize,
-) {
-    if let Some(max) = max_depth
-        && current_depth >= max
-    {
-        return;
-    }
-
-    for (i, dep) in dependents.iter().enumerate() {
-        let is_last = i == dependents.len() - 1;
-        let connector = if is_last { "└── " } else { "├── " };
-        let child_prefix = if is_last { "    " } else { "│   " };
-
-        let label = format!(
-            "{}{}{}",
-            bold(&dep.name),
-            dim(&format!("@{}", dep.version)),
-            dep.dep_field
-                .map(|field| format!(" {}", dim(&format!("({})", dep_field_name(field)))))
-                .unwrap_or_default(),
+                TreeNodeId::Package(_) => false,
+            })
+            .collect();
+        let graph = build_dependency_graph(
+            &root_ids,
+            &BuildGraphOptions { lockfile, include, only_projects: false },
         );
 
-        output.push_str(prefix);
-        output.push_str(connector);
-        output.push_str(&label);
-        output.push('\n');
-
-        if !dep.dependents.is_empty() {
-            let new_prefix = format!("{prefix}{child_prefix}");
-            render_dependents(output, &dep.dependents, &new_prefix, max_depth, current_depth + 1);
+        let mut searcher = Searcher::from_queries(&self.packages)?;
+        if !self.find_by.is_empty() {
+            let finders = resolve_finders(state.config, &lockfile_dir, &self.find_by).await?;
+            let candidates = finder_candidates(&env, &graph);
+            let results = evaluate_finders(&env, &finders, candidates).await?;
+            searcher.set_finder_results(results);
         }
+
+        let trees = build_dependents_tree(&BuildDependentsOptions {
+            env: &env,
+            graph: &graph,
+            search: &searcher,
+            importer_info: &importer_info,
+        });
+
+        let render_opts = RenderDependentsOptions { long: self.long, depth: self.depth };
+        let output = if self.parseable {
+            render_dependents_parseable(&trees, &render_opts)
+        } else if self.json {
+            render_dependents_json(&trees, &render_opts)
+        } else {
+            render_dependents_tree(&trees, &render_opts)
+        };
+        print_output(&output);
+        Ok(())
     }
-}
-
-fn dep_field_name(field: DependencyGroup) -> &'static str {
-    match field {
-        DependencyGroup::Prod => "dependencies",
-        DependencyGroup::Dev => "devDependencies",
-        DependencyGroup::Optional => "optionalDependencies",
-        DependencyGroup::Peer => "peerDependencies",
-    }
-}
-
-fn bold(text: &str) -> String {
-    let cleaned = sanitize(text);
-    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
-}
-
-fn dim(text: &str) -> String {
-    let cleaned = sanitize(text);
-    cleaned.as_ref().if_supports_color(Stream::Stdout, |t| t.dimmed()).to_string()
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/why.rs
+++ b/pnpm/crates/cli/src/cli_args/why.rs
@@ -9,7 +9,7 @@ use crate::{
     State,
     cli_args::{
         deps_tree::{
-            build::{LoadedState, importer_root_ids, read_project_manifest},
+            build::{LoadedState, importer_root_ids, read_project_manifest, safe_importer_dir},
             dependents::{BuildDependentsOptions, ImporterInfo, build_dependents_tree},
             finders::{evaluate_finders, finder_candidates, resolve_finders},
             graph::{BuildGraphOptions, build_dependency_graph},
@@ -64,6 +64,10 @@ pub struct WhyArgs {
     pub no_optional: bool,
 
     /// Exclude peer dependencies.
+    ///
+    /// Accepted but not applied, matching the TypeScript CLI: its `why`
+    /// command declares the flag without forwarding it to the
+    /// dependents-tree builder.
     #[clap(long)]
     pub exclude_peers: bool,
 
@@ -122,7 +126,12 @@ impl WhyArgs {
 
         let mut importer_info: HashMap<String, ImporterInfo> = HashMap::new();
         for importer_id in lockfile.importers.keys() {
-            let manifest = read_project_manifest(&lockfile_dir.join(importer_id.as_str()));
+            // A key that cannot be safely joined (a malformed or
+            // hostile lockfile) is never dereferenced; the raw key
+            // still names the importer in the output.
+            let manifest = safe_importer_dir(&lockfile_dir, importer_id)
+                .map(|importer_dir| read_project_manifest(&importer_dir))
+                .unwrap_or_default();
             let name = manifest.name.unwrap_or_else(|| {
                 if importer_id == "." {
                     "the root project".to_string()

--- a/pnpm/crates/cli/src/cli_args/why.rs
+++ b/pnpm/crates/cli/src/cli_args/why.rs
@@ -9,8 +9,7 @@ use crate::{
     State,
     cli_args::{
         deps_tree::{
-            TreeNodeId,
-            build::{LoadedState, importer_id_for, read_project_manifest},
+            build::{LoadedState, importer_root_ids, read_project_manifest},
             dependents::{BuildDependentsOptions, ImporterInfo, build_dependents_tree},
             finders::{evaluate_finders, finder_candidates, resolve_finders},
             graph::{BuildGraphOptions, build_dependency_graph},
@@ -146,16 +145,7 @@ impl WhyArgs {
             }
         };
 
-        let root_ids: Vec<TreeNodeId> = project_dirs
-            .iter()
-            .map(|dir| TreeNodeId::Importer(importer_id_for(&lockfile_dir, dir)))
-            .filter(|id| match id {
-                TreeNodeId::Importer(importer_id) => {
-                    lockfile.importers.contains_key(importer_id.as_str())
-                }
-                TreeNodeId::Package(_) => false,
-            })
-            .collect();
+        let root_ids = importer_root_ids(lockfile, &lockfile_dir, &project_dirs);
         let graph = build_dependency_graph(
             &root_ids,
             &BuildGraphOptions { lockfile, include, only_projects: false },

--- a/pnpm/crates/cli/src/cli_args/why/render.rs
+++ b/pnpm/crates/cli/src/cli_args/why/render.rs
@@ -1,0 +1,287 @@
+//! `pnpm why` output renderers (tree / parseable / JSON), mirroring the
+//! TypeScript `renderDependentsTree` / `renderDependentsJson` /
+//! `renderDependentsParseable`.
+
+use std::{collections::HashMap, path::Path};
+
+use crate::cli_args::deps_tree::{
+    dependents::{DependentNode, DependentsTree},
+    render::{
+        PeerVariants, TreeNode, bold, circular_label, deduped_label, dim, name_at_version,
+        peer_hash_suffix, plain, read_long_pkg_info, render_archy,
+    },
+};
+
+pub(crate) struct RenderDependentsOptions {
+    pub long: bool,
+    pub depth: Option<usize>,
+}
+
+pub(crate) fn render_dependents_tree(
+    trees: &[DependentsTree],
+    opts: &RenderDependentsOptions,
+) -> String {
+    if trees.is_empty() {
+        return String::new();
+    }
+
+    let multi_peer_pkgs = find_multi_peer_packages(trees);
+
+    let output = trees
+        .iter()
+        .map(|tree| {
+            let displayed_name = tree.display_name.as_deref().unwrap_or(&tree.name);
+            let mut root_label_parts = vec![format!(
+                "{}{}",
+                bold(&name_at_version_plain(displayed_name, &tree.version)),
+                peer_hash_suffix(
+                    &multi_peer_pkgs,
+                    &tree.name,
+                    &tree.version,
+                    tree.peers_suffix_hash.as_deref(),
+                ),
+            )];
+            if let Some(message) = &tree.search_message {
+                root_label_parts.push(plain(message));
+            }
+            if opts.long
+                && let Some(path) = &tree.path
+            {
+                let info = read_long_pkg_info(Path::new(path));
+                if let Some(description) = info.description {
+                    root_label_parts.push(plain(&description));
+                }
+                if let Some(repository) = info.repository {
+                    root_label_parts.push(plain(&repository));
+                }
+                if let Some(homepage) = info.homepage {
+                    root_label_parts.push(plain(&homepage));
+                }
+                root_label_parts.push(plain(path));
+            }
+            let root_label = root_label_parts.join("\n");
+            if tree.dependents.is_empty() {
+                return root_label;
+            }
+            let child_nodes =
+                dependents_to_tree_nodes(&tree.dependents, &multi_peer_pkgs, 0, opts.depth);
+            let archy = render_archy(&TreeNode::with_children(root_label, child_nodes));
+            archy.trim_end_matches('\n').to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let summary = why_summary(trees);
+    if summary.is_empty() { output } else { format!("{output}\n\n{summary}") }
+}
+
+fn name_at_version_plain(name: &str, version: &str) -> String {
+    name_at_version(name, version, plain)
+}
+
+fn why_summary(trees: &[DependentsTree]) -> String {
+    if trees.is_empty() {
+        return String::new();
+    }
+
+    struct Entry {
+        versions: Vec<String>,
+        count: usize,
+    }
+    let mut order: Vec<String> = Vec::new();
+    let mut by_name: HashMap<String, Entry> = HashMap::new();
+    for tree in trees {
+        let displayed_name = tree.display_name.clone().unwrap_or_else(|| tree.name.clone());
+        let entry = by_name.entry(displayed_name.clone()).or_insert_with(|| {
+            order.push(displayed_name);
+            Entry { versions: Vec::new(), count: 0 }
+        });
+        if !entry.versions.contains(&tree.version) {
+            entry.versions.push(tree.version.clone());
+        }
+        entry.count += 1;
+    }
+
+    let lines: Vec<String> = order
+        .iter()
+        .map(|name| {
+            let entry = &by_name[name];
+            let versions = entry.versions.len();
+            let mut parts =
+                vec![format!("{versions} version{}", if versions == 1 { "" } else { "s" })];
+            if entry.count > versions {
+                parts.push(format!("{} instances", entry.count));
+            }
+            format!("Found {} of {name}", parts.join(", "))
+        })
+        .collect();
+    dim(&lines.join("\n"))
+}
+
+fn find_multi_peer_packages(trees: &[DependentsTree]) -> HashMap<String, usize> {
+    let mut variants = PeerVariants::default();
+    fn walk(variants: &mut PeerVariants, dependents: &[DependentNode]) {
+        for dep in dependents {
+            variants.collect(&dep.name, &dep.version, dep.peers_suffix_hash.as_deref());
+            if let Some(children) = &dep.dependents {
+                walk(variants, children);
+            }
+        }
+    }
+    for tree in trees {
+        variants.collect(&tree.name, &tree.version, tree.peers_suffix_hash.as_deref());
+        walk(&mut variants, &tree.dependents);
+    }
+    variants.into_multi_variant_counts()
+}
+
+fn dependents_to_tree_nodes(
+    dependents: &[DependentNode],
+    multi_peer_pkgs: &HashMap<String, usize>,
+    current_depth: usize,
+    max_depth: Option<usize>,
+) -> Vec<TreeNode> {
+    dependents
+        .iter()
+        .map(|dep| {
+            let displayed_name = dep.display_name.as_deref().unwrap_or(&dep.name);
+            let mut label = if let Some(dep_field) = dep.dep_field {
+                // An importer (leaf node).
+                format!(
+                    "{} {}",
+                    bold(&name_at_version_plain(displayed_name, &dep.version)),
+                    dim(&format!("({})", dep_field.as_str())),
+                )
+            } else {
+                format!(
+                    "{}{}",
+                    name_at_version_plain(displayed_name, &dep.version),
+                    peer_hash_suffix(
+                        multi_peer_pkgs,
+                        &dep.name,
+                        &dep.version,
+                        dep.peers_suffix_hash.as_deref(),
+                    ),
+                )
+            };
+            if dep.circular {
+                label.push_str(&circular_label());
+            }
+            if dep.deduped {
+                label.push_str(&deduped_label());
+            }
+
+            let at_depth_limit = max_depth.is_some_and(|max_depth| current_depth + 1 >= max_depth);
+            let nodes = match &dep.dependents {
+                Some(children) if !at_depth_limit => dependents_to_tree_nodes(
+                    children,
+                    multi_peer_pkgs,
+                    current_depth + 1,
+                    max_depth,
+                ),
+                _ => Vec::new(),
+            };
+            TreeNode::with_children(label, nodes)
+        })
+        .collect()
+}
+
+pub(crate) fn render_dependents_json(
+    trees: &[DependentsTree],
+    opts: &RenderDependentsOptions,
+) -> String {
+    let values: Vec<serde_json::Value> = trees
+        .iter()
+        .map(|tree| {
+            let mut tree = tree.clone();
+            if let Some(max_depth) = opts.depth {
+                tree.dependents = truncate_dependents(tree.dependents, 0, max_depth);
+            }
+            let mut value = serde_json::to_value(&tree).expect("serialize dependents tree");
+            if opts.long
+                && let Some(path) = &tree.path
+                && let Some(object) = value.as_object_mut()
+            {
+                let info = read_long_pkg_info(Path::new(path));
+                if let Some(description) = info.description {
+                    object.insert("description".to_string(), serde_json::json!(description));
+                }
+                if let Some(repository) = info.repository {
+                    object.insert("repository".to_string(), serde_json::json!(repository));
+                }
+                if let Some(homepage) = info.homepage {
+                    object.insert("homepage".to_string(), serde_json::json!(homepage));
+                }
+            }
+            value
+        })
+        .collect();
+    serde_json::to_string_pretty(&values).expect("serialize dependents trees")
+}
+
+fn truncate_dependents(
+    dependents: Vec<DependentNode>,
+    current_depth: usize,
+    max_depth: usize,
+) -> Vec<DependentNode> {
+    dependents
+        .into_iter()
+        .map(|mut dep| {
+            dep.dependents = match dep.dependents {
+                Some(children) if current_depth + 1 < max_depth => {
+                    Some(truncate_dependents(children, current_depth + 1, max_depth))
+                }
+                _ => None,
+            };
+            dep
+        })
+        .collect()
+}
+
+pub(crate) fn render_dependents_parseable(
+    trees: &[DependentsTree],
+    opts: &RenderDependentsOptions,
+) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    for tree in trees {
+        let displayed_name = tree.display_name.as_deref().unwrap_or(&tree.name);
+        let root_segment = match (&tree.path, opts.long) {
+            (Some(path), true) => {
+                format!("{path}:{}", plain_name_at_version(displayed_name, &tree.version))
+            }
+            _ => plain_name_at_version(displayed_name, &tree.version),
+        };
+        collect_paths(&tree.dependents, &[root_segment], &mut lines, 0, opts.depth);
+    }
+    lines.join("\n")
+}
+
+fn collect_paths(
+    dependents: &[DependentNode],
+    current_path: &[String],
+    lines: &mut Vec<String>,
+    current_depth: usize,
+    max_depth: Option<usize>,
+) {
+    for dep in dependents {
+        let displayed_name = dep.display_name.as_deref().unwrap_or(&dep.name);
+        let mut new_path = current_path.to_vec();
+        new_path.push(plain_name_at_version(displayed_name, &dep.version));
+        let at_depth_limit = max_depth.is_some_and(|max_depth| current_depth + 1 >= max_depth);
+        match &dep.dependents {
+            Some(children) if !children.is_empty() && !at_depth_limit => {
+                collect_paths(children, &new_path, lines, current_depth + 1, max_depth);
+            }
+            _ => {
+                // Leaf (importer or depth-limited) — reversed so the
+                // importer comes first.
+                new_path.reverse();
+                lines.push(new_path.join(" > "));
+            }
+        }
+    }
+}
+
+fn plain_name_at_version(name: &str, version: &str) -> String {
+    if version.is_empty() { plain(name) } else { plain(&format!("{name}@{version}")) }
+}

--- a/pnpm/crates/cli/src/cli_args/why/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/why/tests.rs
@@ -1,98 +1,412 @@
-use super::{
-    DependencyGroup, DependentNode, WhyResult, dep_field_name, normalize_path, render_tree,
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+
+use super::render::{
+    RenderDependentsOptions, render_dependents_json, render_dependents_parseable,
+    render_dependents_tree,
 };
+use crate::cli_args::deps_tree::dependents::{DepField, DependentNode, DependentsTree};
 
-#[test]
-fn test_dep_field_name() {
-    assert_eq!(dep_field_name(DependencyGroup::Prod), "dependencies");
-    assert_eq!(dep_field_name(DependencyGroup::Dev), "devDependencies");
-    assert_eq!(dep_field_name(DependencyGroup::Optional), "optionalDependencies");
-    assert_eq!(dep_field_name(DependencyGroup::Peer), "peerDependencies");
+fn tree(name: &str, version: &str, dependents: Vec<DependentNode>) -> DependentsTree {
+    DependentsTree {
+        name: name.to_string(),
+        display_name: None,
+        version: version.to_string(),
+        path: None,
+        peers_suffix_hash: None,
+        dependents,
+        search_message: None,
+    }
 }
 
-#[test]
-fn test_render_tree_empty() {
-    let results: Vec<WhyResult> = vec![];
-    assert_eq!(render_tree(&results, None), "");
+fn importer(name: &str, version: &str, dep_field: DepField) -> DependentNode {
+    DependentNode {
+        name: name.to_string(),
+        display_name: None,
+        version: version.to_string(),
+        circular: false,
+        peers_suffix_hash: None,
+        deduped: false,
+        dep_field: Some(dep_field),
+        dependents: None,
+    }
 }
 
+fn package(name: &str, version: &str, dependents: Vec<DependentNode>) -> DependentNode {
+    DependentNode {
+        dep_field: None,
+        dependents: Some(dependents),
+        ..importer(name, version, DepField::Dependencies)
+    }
+}
+
+/// Shared fixture: target ← mid-a ← root-project (2 levels of dependents).
+fn deep_tree() -> Vec<DependentsTree> {
+    vec![tree(
+        "target",
+        "1.0.0",
+        vec![
+            package(
+                "mid-a",
+                "2.0.0",
+                vec![importer("root-project", "0.0.0", DepField::Dependencies)],
+            ),
+            importer("root-project", "0.0.0", DepField::DevDependencies),
+        ],
+    )]
+}
+
+fn opts(depth: Option<usize>) -> RenderDependentsOptions {
+    RenderDependentsOptions { long: false, depth }
+}
+
+// Port of upstream's 'renders searchMessage below the root label' (deps/inspection/list/test/renderDependentsTree.test.ts).
 #[test]
-fn test_render_tree_no_dependents() {
-    let results = vec![WhyResult {
-        name: "lodash".to_string(),
-        version: "4.17.21".to_string(),
-        dependents: vec![],
+fn renders_search_message_below_the_root_label() {
+    let results = vec![DependentsTree {
+        search_message: Some("Matched by custom finder".to_string()),
+        ..tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])
     }];
-    let output = render_tree(&results, None);
-    assert!(output.contains("lodash@4.17.21"));
+
+    let output = render_dependents_tree(&results, &opts(None));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    eprintln!("output:\n{output}");
+    assert!(lines[0].contains("foo@1.0.0"));
+    assert!(lines.iter().any(|line| line.contains("Matched by custom finder")));
+    assert!(lines.iter().any(|line| line.contains("my-project@0.0.0")));
 }
 
+// Port of upstream's 'does not render extra line when searchMessage is undefined' (deps/inspection/list/test/renderDependentsTree.test.ts).
 #[test]
-fn test_render_tree_with_dependents() {
-    let results = vec![WhyResult {
-        name: "lodash".to_string(),
-        version: "4.17.21".to_string(),
-        dependents: vec![DependentNode {
-            name: "express".to_string(),
-            version: "4.18.2".to_string(),
-            dep_field: None,
-            dependents: vec![DependentNode {
-                name: "project".to_string(),
-                version: "0.0.0".to_string(),
-                dep_field: None,
-                dependents: vec![],
+fn does_not_render_extra_line_when_search_message_is_undefined() {
+    let results =
+        vec![tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])];
+
+    let output = render_dependents_tree(&results, &opts(None));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    eprintln!("output:\n{output}");
+    assert_eq!(lines[0], "foo@1.0.0");
+    // Second line should be part of the tree, not a message.
+    assert_ne!(lines[1], "");
+    assert!(lines[1].contains("my-project"));
+}
+
+// Port of upstream's 'depth limits how deep the tree is rendered' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn depth_limits_how_deep_the_tree_is_rendered() {
+    let with_depth = render_dependents_tree(&deep_tree(), &opts(Some(1)));
+    let without_depth = render_dependents_tree(&deep_tree(), &opts(None));
+
+    eprintln!("with depth:\n{with_depth}\n\nwithout depth:\n{without_depth}");
+
+    // Without depth, root-project appears twice: once nested under
+    // mid-a, once as direct dependent.
+    let full_occurrences =
+        without_depth.lines().filter(|line| line.contains("root-project@0.0.0")).count();
+    assert_eq!(full_occurrences, 2);
+
+    // With depth 1, mid-a's children are not expanded, so root-project
+    // appears only once (as direct dependent).
+    let limited_occurrences =
+        with_depth.lines().filter(|line| line.contains("root-project@0.0.0")).count();
+    assert_eq!(limited_occurrences, 1);
+    assert!(with_depth.contains("mid-a@2.0.0"));
+}
+
+// Port of upstream's 'renders displayName instead of name when provided' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn renders_display_name_instead_of_name_when_provided() {
+    let results = vec![DependentsTree {
+        display_name: Some("my-component".to_string()),
+        ..tree(
+            "foo",
+            "1.0.0",
+            vec![DependentNode {
+                display_name: Some("other-component".to_string()),
+                ..package(
+                    "bar",
+                    "2.0.0",
+                    vec![importer("my-project", "0.0.0", DepField::Dependencies)],
+                )
             }],
-        }],
+        )
     }];
-    let output = render_tree(&results, None);
-    assert!(output.contains("lodash@4.17.21"));
-    assert!(output.contains("express@4.18.2"));
-    assert!(output.contains("project@0.0.0"));
+
+    let output = render_dependents_tree(&results, &opts(None));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("my-component@1.0.0"));
+    assert!(!output.contains("foo@1.0.0"));
+    assert!(output.contains("other-component@2.0.0"));
+    assert!(!output.contains("bar@2.0.0"));
+    // Importer without displayName should still render its name.
+    assert!(output.contains("my-project@0.0.0"));
 }
 
+// Port of upstream's 'falls back to name when displayName is undefined' (deps/inspection/list/test/renderDependentsTree.test.ts).
 #[test]
-fn test_render_tree_respects_depth() {
-    let results = vec![WhyResult {
-        name: "lodash".to_string(),
-        version: "4.17.21".to_string(),
-        dependents: vec![DependentNode {
-            name: "express".to_string(),
-            version: "4.18.2".to_string(),
-            dep_field: None,
-            dependents: vec![DependentNode {
-                name: "project".to_string(),
-                version: "0.0.0".to_string(),
-                dep_field: None,
-                dependents: vec![],
+fn falls_back_to_name_when_display_name_is_undefined() {
+    let results =
+        vec![tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])];
+
+    let output = render_dependents_tree(&results, &opts(None));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("foo@1.0.0"));
+}
+
+// Port of upstream's 'renders package with no dependents and a searchMessage' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn renders_package_with_no_dependents_and_a_search_message() {
+    let results = vec![DependentsTree {
+        search_message: Some("Found via license check".to_string()),
+        ..tree("bar", "2.0.0", vec![])
+    }];
+
+    let output = render_dependents_tree(&results, &opts(None));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    assert_eq!(lines[0], "bar@2.0.0");
+    assert_eq!(lines[1], "Found via license check");
+}
+
+// Port of upstream's 'whySummary > single package, single version' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn why_summary_single_package_single_version() {
+    let results =
+        vec![tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])];
+
+    let output = render_dependents_tree(&results, &opts(None));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("Found 1 version of foo"));
+    assert!(!output.contains("instances"));
+}
+
+// Port of upstream's 'whySummary > single package, multiple versions' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn why_summary_single_package_multiple_versions() {
+    let results = vec![
+        tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)]),
+        tree("foo", "2.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)]),
+    ];
+
+    let output = render_dependents_tree(&results, &opts(None));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("Found 2 versions of foo"));
+    assert!(!output.contains("instances"));
+}
+
+// Port of upstream's 'whySummary > single package, same version with multiple peer variants shows instance count' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn why_summary_single_package_same_version_with_multiple_peer_variants_shows_instance_count() {
+    let results = vec![
+        DependentsTree {
+            peers_suffix_hash: Some("aaaa".to_string()),
+            ..tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])
+        },
+        DependentsTree {
+            peers_suffix_hash: Some("bbbb".to_string()),
+            ..tree("foo", "1.0.0", vec![importer("other", "0.0.0", DepField::Dependencies)])
+        },
+    ];
+
+    let output = render_dependents_tree(&results, &opts(None));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("Found 1 version, 2 instances of foo"));
+}
+
+// Port of upstream's 'whySummary > multiple different packages each get their own summary line' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn why_summary_multiple_different_packages_each_get_their_own_summary_line() {
+    let results = vec![
+        tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)]),
+        tree("bar", "2.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)]),
+        tree("bar", "3.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)]),
+    ];
+
+    let output = render_dependents_tree(&results, &opts(None));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("Found 1 version of foo"));
+    assert!(output.contains("Found 2 versions of bar"));
+}
+
+// Port of upstream's 'whySummary > summary uses displayName when provided' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn why_summary_uses_display_name_when_provided() {
+    let results = vec![
+        DependentsTree {
+            display_name: Some("my-component".to_string()),
+            ..tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])
+        },
+        DependentsTree {
+            display_name: Some("my-component".to_string()),
+            ..tree("foo", "2.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])
+        },
+    ];
+
+    let output = render_dependents_tree(&results, &opts(None));
+    eprintln!("output:\n{output}");
+    assert!(output.contains("Found 2 versions of my-component"));
+    assert!(!output.contains("Found 2 versions of foo"));
+}
+
+// Port of upstream's 'whySummary > empty results produce no summary' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn empty_results_produce_no_summary() {
+    let output = render_dependents_tree(&[], &opts(None));
+    assert_eq!(output, "");
+}
+
+// Port of upstream's 'renderDependentsJson > includes searchMessage in JSON output' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn includes_search_message_in_json_output() {
+    let results = vec![DependentsTree {
+        search_message: Some("Matched by custom finder".to_string()),
+        ..tree("foo", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])
+    }];
+
+    let parsed: Value =
+        serde_json::from_str(&render_dependents_json(&results, &opts(None))).expect("valid JSON");
+    let trees = parsed.as_array().expect("JSON array");
+    assert_eq!(trees.len(), 1);
+    assert_eq!(trees[0]["searchMessage"], "Matched by custom finder");
+}
+
+// Port of upstream's 'renderDependentsJson > depth truncates dependents in JSON output' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn depth_truncates_dependents_in_json_output() {
+    let parsed: Value = serde_json::from_str(&render_dependents_json(&deep_tree(), &opts(Some(1))))
+        .expect("valid JSON");
+    let trees = parsed.as_array().expect("JSON array");
+    assert_eq!(trees.len(), 1);
+    // Direct dependents (depth 0) should be present.
+    let dependents = trees[0]["dependents"].as_array().expect("dependents array");
+    assert_eq!(dependents.len(), 2);
+    // mid-a should have its dependents stripped (depth 1 is beyond the limit).
+    let mid_a = dependents.iter().find(|dep| dep["name"] == "mid-a").expect("mid-a present");
+    dbg!(mid_a);
+    assert!(mid_a.get("dependents").is_none());
+    // root-project (direct dependent) should still be present.
+    assert!(dependents.iter().any(|dep| dep["name"] == "root-project"));
+}
+
+// Port of upstream's 'renderDependentsJson > no depth option preserves full dependents in JSON output' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn no_depth_option_preserves_full_dependents_in_json_output() {
+    let parsed: Value = serde_json::from_str(&render_dependents_json(&deep_tree(), &opts(None)))
+        .expect("valid JSON");
+    let dependents = parsed[0]["dependents"].as_array().expect("dependents array");
+    let mid_a = dependents.iter().find(|dep| dep["name"] == "mid-a").expect("mid-a present");
+    let mid_a_dependents = mid_a["dependents"].as_array().expect("mid-a dependents array");
+    assert_eq!(mid_a_dependents.len(), 1);
+    assert_eq!(mid_a_dependents[0]["name"], "root-project");
+}
+
+// Port of upstream's 'renderDependentsJson > includes displayName in JSON output' (deps/inspection/list/test/renderDependentsTree.test.ts).
+#[test]
+fn includes_display_name_in_json_output() {
+    let results = vec![DependentsTree {
+        display_name: Some("my-component".to_string()),
+        ..tree(
+            "foo",
+            "1.0.0",
+            vec![DependentNode {
+                display_name: Some("other-component".to_string()),
+                ..package(
+                    "bar",
+                    "2.0.0",
+                    vec![importer("my-project", "0.0.0", DepField::Dependencies)],
+                )
             }],
-        }],
+        )
     }];
-    let output = render_tree(&results, Some(1));
-    assert!(output.contains("express@4.18.2"));
-    assert!(!output.contains("project@0.0.0"));
+
+    let parsed: Value =
+        serde_json::from_str(&render_dependents_json(&results, &opts(None))).expect("valid JSON");
+    assert_eq!(parsed[0]["name"], "foo");
+    assert_eq!(parsed[0]["displayName"], "my-component");
+    assert_eq!(parsed[0]["dependents"][0]["name"], "bar");
+    assert_eq!(parsed[0]["dependents"][0]["displayName"], "other-component");
+    // Nodes without displayName should not have the field.
+    let importer_node = &parsed[0]["dependents"][0]["dependents"][0];
+    dbg!(importer_node);
+    assert!(importer_node.get("displayName").is_none());
 }
 
+// Port of upstream's 'renderDependentsJson > does not include searchMessage when undefined' (deps/inspection/list/test/renderDependentsTree.test.ts).
 #[test]
-fn test_normalize_path_simple() {
-    assert_eq!(normalize_path("packages/a", "../b"), Some("packages/b".to_string()));
+fn does_not_include_search_message_when_undefined() {
+    let results = vec![tree("foo", "1.0.0", vec![])];
+
+    let parsed: Value =
+        serde_json::from_str(&render_dependents_json(&results, &opts(None))).expect("valid JSON");
+    dbg!(&parsed);
+    assert!(parsed[0].get("searchMessage").is_none());
 }
 
+// Port of upstream's 'renderDependentsParseable > depth limits parseable output depth' (deps/inspection/list/test/renderDependentsTree.test.ts).
 #[test]
-fn test_normalize_path_nested() {
-    assert_eq!(normalize_path("packages/a", "../../other"), Some("other".to_string()));
+fn depth_limits_parseable_output_depth() {
+    let output = render_dependents_parseable(&deep_tree(), &opts(Some(1)));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    eprintln!("output:\n{output}");
+    // With depth 1, mid-a cannot recurse further — it becomes a leaf.
+    assert_eq!(lines.len(), 2);
+    assert!(lines.contains(&"mid-a@2.0.0 > target@1.0.0"));
+    assert!(lines.contains(&"root-project@0.0.0 > target@1.0.0"));
 }
 
+// Port of upstream's 'renderDependentsParseable > no depth option renders full paths in parseable output' (deps/inspection/list/test/renderDependentsTree.test.ts).
 #[test]
-fn test_normalize_path_dot() {
-    assert_eq!(normalize_path("packages/a", "./sibling"), Some("packages/a/sibling".to_string()));
+fn no_depth_option_renders_full_paths_in_parseable_output() {
+    let output = render_dependents_parseable(&deep_tree(), &opts(None));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    eprintln!("output:\n{output}");
+    // Without depth limit, mid-a is expanded to root-project.
+    assert_eq!(lines.len(), 2);
+    assert!(lines.contains(&"root-project@0.0.0 > mid-a@2.0.0 > target@1.0.0"));
+    assert!(lines.contains(&"root-project@0.0.0 > target@1.0.0"));
 }
 
+// Port of upstream's 'renderDependentsParseable > uses displayName in parseable output' (deps/inspection/list/test/renderDependentsTree.test.ts).
 #[test]
-fn test_normalize_path_empty() {
-    assert_eq!(normalize_path("packages/a", ""), Some("packages/a".to_string()));
+fn uses_display_name_in_parseable_output() {
+    let results = vec![DependentsTree {
+        display_name: Some("my-component".to_string()),
+        ..tree(
+            "foo",
+            "1.0.0",
+            vec![DependentNode {
+                display_name: Some("other-component".to_string()),
+                ..package(
+                    "bar",
+                    "2.0.0",
+                    vec![importer("my-project", "0.0.0", DepField::Dependencies)],
+                )
+            }],
+        )
+    }];
+
+    let output = render_dependents_parseable(&results, &opts(None));
+    assert_eq!(output, "my-project@0.0.0 > other-component@2.0.0 > my-component@1.0.0");
 }
 
+// Port of upstream's 'renderDependentsParseable > renders parseable output with searchMessage result' (deps/inspection/list/test/renderDependentsTree.test.ts).
 #[test]
-fn test_normalize_path_too_many_parents() {
-    assert_eq!(normalize_path("a", "../../b"), None);
+fn renders_parseable_output_with_search_message_result() {
+    let results = vec![DependentsTree {
+        search_message: Some("Found via custom check".to_string()),
+        ..tree("dep-a", "1.0.0", vec![importer("my-project", "0.0.0", DepField::Dependencies)])
+    }];
+
+    let output = render_dependents_parseable(&results, &opts(None));
+    let lines: Vec<&str> = output.split('\n').collect();
+
+    eprintln!("output:\n{output}");
+    // Parseable output should still contain the path.
+    assert_eq!(lines.len(), 1);
+    assert!(lines[0].contains("dep-a@1.0.0"));
+    assert!(lines[0].contains("my-project@0.0.0"));
 }

--- a/pnpm/crates/cli/tests/list.rs
+++ b/pnpm/crates/cli/tests/list.rs
@@ -308,3 +308,565 @@ fn list_json_with_package_arg_omits_unsaved_dependencies() {
 
     drop(root);
 }
+
+// --- ports of the TypeScript listing command tests ---------------------------
+//
+// Sources: pnpm11/deps/inspection/commands/test/listing/{index.ts,json.ts,
+// recursive.ts} and pnpm11/pnpm/test/list.ts.
+
+const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+const HELLO: &str = "@pnpm.e2e/hello-world-js-bin";
+const PKG: &str = "@pnpm.e2e/pkg-with-1-dep";
+
+const LEGEND: &str = "Legend: production dependency, optional only, dev only";
+
+fn setup_registry()
+-> (tempfile::TempDir, std::path::PathBuf, pacquet_testing_utils::bin::AddMockedRegistry) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    (root, workspace, npmrc_info)
+}
+
+fn pacquet_in(dir: &Path, args: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>) -> Command {
+    let mut command = Command::cargo_bin("pnpm").expect("find the pnpm binary");
+    command.current_dir(dir);
+    command.args(args);
+    command
+}
+
+fn run_ok(dir: &Path, args: &[&str]) -> String {
+    let output = pacquet_in(dir, args).output().expect("run pacquet");
+    assert!(
+        output.status.success(),
+        "`pnpm {}` should succeed:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn canonical(dir: &Path) -> String {
+    dunce::canonicalize(dir).expect("canonicalize dir").to_string_lossy().into_owned()
+}
+
+/// Port of upstream's `listing packages`
+/// (`deps/inspection/commands/test/listing/index.ts`).
+#[test]
+fn listing_packages_prints_tree_with_legend_and_summary() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "dependencies": { PKG: "100.0.0" },
+            "devDependencies": { HELLO: "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    run_ok(&workspace, &["install"]);
+    let dir = canonical(&workspace);
+
+    let prod_only = run_ok(&workspace, &["list", "--prod"]);
+    assert_eq!(
+        prod_only,
+        format!(
+            "{LEGEND}\n\nproject@0.0.0 {dir}\n\u{2502}\n\u{2502}   dependencies:\n\u{2514}\u{2500}\u{2500} {PKG}@100.0.0\n\n1 package\n"
+        ),
+    );
+
+    let dev_only = run_ok(&workspace, &["list", "--dev"]);
+    assert_eq!(
+        dev_only,
+        format!(
+            "{LEGEND}\n\nproject@0.0.0 {dir}\n\u{2502}\n\u{2502}   devDependencies:\n\u{2514}\u{2500}\u{2500} {HELLO}@1.0.0\n\n1 package\n"
+        ),
+    );
+
+    let both = run_ok(&workspace, &["list"]);
+    assert_eq!(
+        both,
+        format!(
+            "{LEGEND}\n\nproject@0.0.0 {dir}\n\u{2502}\n\u{2502}   dependencies:\n\u{251c}\u{2500}\u{2500} {PKG}@100.0.0\n\u{2502}\n\u{2502}   devDependencies:\n\u{2514}\u{2500}\u{2500} {HELLO}@1.0.0\n\n2 packages\n"
+        ),
+    );
+}
+
+/// Port of upstream's `listing packages of a project that has an
+/// external pnpm-lock.yaml`
+/// (`deps/inspection/commands/test/listing/index.ts`).
+#[test]
+fn listing_packages_of_a_project_with_an_external_lockfile() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - pkg\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "root", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write root package.json");
+    let pkg = workspace.join("pkg");
+    fs::create_dir_all(&pkg).expect("create pkg");
+    fs::write(
+        pkg.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "dependencies": { PKG: "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write pkg package.json");
+    run_ok(&workspace, &["install"]);
+
+    let output = run_ok(&pkg, &["list"]);
+    let dir = canonical(&pkg);
+    assert_eq!(
+        output,
+        format!(
+            "{LEGEND}\n\npkg@1.0.0 {dir}\n\u{2502}\n\u{2502}   dependencies:\n\u{2514}\u{2500}\u{2500} {PKG}@100.0.0\n\n1 package\n"
+        ),
+    );
+}
+
+/// Port of upstream's `listing packages should not fail on package that
+/// has local file directory in dependencies`
+/// (`deps/inspection/commands/test/listing/index.ts`, pnpm/pnpm#6873).
+#[test]
+fn listing_packages_with_local_file_directory_dependency() {
+    let (_root, workspace, _registry) = setup_registry();
+    // The upstream scenario is a standalone project (no workspace), so
+    // the `file:` path stays relative to the project itself.
+    fs::remove_file(workspace.join("pnpm-workspace.yaml")).expect("remove pnpm-workspace.yaml");
+    let dep = workspace.join("dep");
+    let pkg = workspace.join("pkg");
+    fs::create_dir_all(&dep).expect("create dep");
+    fs::create_dir_all(&pkg).expect("create pkg");
+    fs::write(dep.join("package.json"), json!({ "name": "dep", "version": "1.0.0" }).to_string())
+        .expect("write dep package.json");
+    fs::write(
+        pkg.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "dependencies": { "dep": "file:../dep" },
+        })
+        .to_string(),
+    )
+    .expect("write pkg package.json");
+    run_ok(&pkg, &["install"]);
+
+    let output = run_ok(&pkg, &["list", "--prod"]);
+    let dir = canonical(&pkg);
+    assert_eq!(
+        output,
+        format!(
+            "{LEGEND}\n\npkg@1.0.0 {dir}\n\u{2502}\n\u{2502}   dependencies:\n\u{2514}\u{2500}\u{2500} dep@file:../dep\n\n1 package\n"
+        ),
+    );
+}
+
+/// Port of upstream's `listing packages with --lockfile-only`
+/// (`deps/inspection/commands/test/listing/index.ts`).
+#[test]
+fn listing_packages_with_lockfile_only() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "dependencies": { PKG: "100.0.0" },
+            "devDependencies": { HELLO: "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    run_ok(&workspace, &["install", "--lockfile-only"]);
+    let dir = canonical(&workspace);
+
+    let prod_only = run_ok(&workspace, &["list", "--lockfile-only", "--prod"]);
+    assert_eq!(
+        prod_only,
+        format!(
+            "{LEGEND}\n\nproject@0.0.0 {dir}\n\u{2502}\n\u{2502}   dependencies:\n\u{2514}\u{2500}\u{2500} {PKG}@100.0.0\n\n1 package\n"
+        ),
+    );
+
+    let dev_only = run_ok(&workspace, &["list", "--lockfile-only", "--dev"]);
+    assert_eq!(
+        dev_only,
+        format!(
+            "{LEGEND}\n\nproject@0.0.0 {dir}\n\u{2502}\n\u{2502}   devDependencies:\n\u{2514}\u{2500}\u{2500} {HELLO}@1.0.0\n\n1 package\n"
+        ),
+    );
+
+    let both = run_ok(&workspace, &["list", "--lockfile-only"]);
+    assert_eq!(
+        both,
+        format!(
+            "{LEGEND}\n\nproject@0.0.0 {dir}\n\u{2502}\n\u{2502}   dependencies:\n\u{251c}\u{2500}\u{2500} {PKG}@100.0.0\n\u{2502}\n\u{2502}   devDependencies:\n\u{2514}\u{2500}\u{2500} {HELLO}@1.0.0\n\n2 packages\n"
+        ),
+    );
+}
+
+/// Port of upstream's `listing packages with --lockfile-only in JSON
+/// format` (`deps/inspection/commands/test/listing/index.ts`).
+#[test]
+fn listing_packages_with_lockfile_only_in_json_format() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "dependencies": { PKG: "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    run_ok(&workspace, &["install", "--lockfile-only"]);
+
+    let output = run_ok(&workspace, &["list", "--json", "--lockfile-only"]);
+    let parsed: Vec<Value> = serde_json::from_str(&output).expect("parse list JSON");
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0]["name"], "project");
+    assert_eq!(parsed[0]["dependencies"][PKG]["version"], "100.0.0");
+}
+
+/// Port of upstream's `listing specific package with --lockfile-only`
+/// (`deps/inspection/commands/test/listing/index.ts`).
+#[test]
+fn listing_specific_package_with_lockfile_only() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "dependencies": { PKG: "100.0.0", HELLO: "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    run_ok(&workspace, &["install", "--lockfile-only"]);
+
+    let output = run_ok(&workspace, &["list", "--lockfile-only", PKG]);
+    let dir = canonical(&workspace);
+    assert_eq!(
+        output,
+        format!(
+            "{LEGEND}\n\nproject@0.0.0 {dir}\n\u{2502}\n\u{2502}   dependencies:\n\u{2514}\u{2500}\u{2500} {PKG}@100.0.0\n\n1 package\n"
+        ),
+    );
+}
+
+/// Port of upstream's `correctly report the value of the private field
+/// when arguments are provided`
+/// (`deps/inspection/commands/test/listing/json.ts`, pnpm/pnpm#8519).
+#[test]
+fn list_json_reports_private_field_when_arguments_are_provided() {
+    for (private_field, expected) in [(None, false), (Some(false), false), (Some(true), true)] {
+        let (_root, workspace, _registry) = setup_registry();
+        let mut manifest = json!({ "name": "root", "version": "0.0.0" });
+        if let Some(private) = private_field {
+            manifest["private"] = json!(private);
+        }
+        fs::write(workspace.join("package.json"), manifest.to_string())
+            .expect("write package.json");
+        run_ok(&workspace, &["install"]);
+
+        let output = run_ok(&workspace, &["list", "--json", "root"]);
+        let parsed: Vec<Value> = serde_json::from_str(&output).expect("parse list JSON");
+        assert_eq!(parsed.len(), 1, "private_field={private_field:?}");
+        assert_eq!(parsed[0]["name"], "root");
+        assert_eq!(parsed[0]["private"], json!(expected), "private_field={private_field:?}");
+        assert!(parsed[0]["path"].is_string());
+    }
+}
+
+/// Port of upstream's `recursive list with sharedWorkspaceLockfile`
+/// (`deps/inspection/commands/test/listing/recursive.ts`). With a
+/// shared workspace lockfile the projects render in one pass: one
+/// legend, one combined summary.
+#[test]
+fn recursive_list_renders_workspace_projects_in_one_pass() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "root", "version": "1.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+    let mut yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml");
+    yaml.push_str("packages:\n  - project-*\n");
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write workspace yaml");
+
+    let manifests = [
+        (
+            "project-1",
+            json!({ "name": "project-1", "version": "1.0.0", "dependencies": { PKG: "100.0.0" } }),
+        ),
+        (
+            "project-2",
+            json!({ "name": "project-2", "version": "1.0.0", "dependencies": { HELLO: "1.0.0" } }),
+        ),
+        ("project-3", json!({ "name": "project-3", "version": "1.0.0" })),
+    ];
+    for (name, manifest) in &manifests {
+        let dir = workspace.join(name);
+        fs::create_dir_all(&dir).expect("create project dir");
+        fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
+    }
+    run_ok(&workspace, &["install"]);
+
+    let output = run_ok(&workspace, &["-r", "list", "--depth", "2"]);
+    let project_1 = canonical(&workspace.join("project-1"));
+    let project_2 = canonical(&workspace.join("project-2"));
+    assert_eq!(
+        output,
+        format!(
+            "{LEGEND}\n\n\
+             project-1@1.0.0 {project_1}\n\
+             \u{2502}\n\
+             \u{2502}   dependencies:\n\
+             \u{2514}\u{2500}\u{252c} {PKG}@100.0.0\n\
+             \x20\x20\u{2514}\u{2500}\u{2500} {DEP}@100.1.0\n\
+             \n\
+             project-2@1.0.0 {project_2}\n\
+             \u{2502}\n\
+             \u{2502}   dependencies:\n\
+             \u{2514}\u{2500}\u{2500} {HELLO}@1.0.0\n\
+             \n\
+             3 packages in 4 projects\n"
+        ),
+    );
+}
+
+/// Port of upstream's `ls --filter=not-exist --json should prints an
+/// empty array` (`pnpm/test/list.ts`, pnpm/pnpm#9672).
+#[test]
+fn ls_filter_not_exist_json_prints_an_empty_array() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "root", "version": "1.0.0", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+    let mut yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml");
+    yaml.push_str("packages:\n  - packages/*\n");
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write workspace yaml");
+    let foo = workspace.join("packages/foo");
+    fs::create_dir_all(&foo).expect("create packages/foo");
+    fs::write(
+        foo.join("package.json"),
+        json!({ "name": "foo", "version": "0.0.0", "private": true }).to_string(),
+    )
+    .expect("write foo package.json");
+    run_ok(&workspace, &["install"]);
+
+    let output = run_ok(&workspace, &["ls", "--filter=project-that-does-not-exist", "--json"]);
+    assert_eq!(output.trim_end(), "[]");
+}
+
+/// Port of upstream's `ls should load a finder from .pnpmfile.cjs`
+/// (`pnpm/test/list.ts`).
+#[test]
+fn ls_loads_a_finder_from_pnpmfile() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r"
+module.exports = { finders: { hasPeerA } }
+function hasPeerA (context) {
+  const manifest = context.readManifest()
+  if (manifest?.peerDependencies?.['@pnpm.e2e/peer-a'] == null) {
+    return false
+  }
+  return `@pnpm.e2e/peer-a@${manifest.peerDependencies['@pnpm.e2e/peer-a']}`
+}
+",
+    )
+    .expect("write .pnpmfile.cjs");
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "dependencies": { HELLO: "1.0.0", "@pnpm.e2e/abc": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    run_ok(&workspace, &["install"]);
+
+    let output = run_ok(&workspace, &["list", "--find-by=hasPeerA"]);
+    assert!(output.contains("@pnpm.e2e/abc@1.0.0"), "finder match missing: {output}");
+    assert!(output.contains("@pnpm.e2e/peer-a@^1.0.0"), "finder message missing: {output}");
+    assert!(
+        !output.contains(&format!("{HELLO}@1.0.0")),
+        "packages the finder rejected must be pruned: {output}",
+    );
+}
+
+/// An unknown `--find-by` name fails with the same error code as the
+/// TypeScript CLI (`resolveFinders` in
+/// `deps/inspection/commands/src/listing/common.ts`).
+#[test]
+fn ls_with_unknown_finder_fails() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "project", "version": "0.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+    run_ok(&workspace, &["install"]);
+
+    let output = pacquet_in(&workspace, ["list", "--find-by=no-such-finder"])
+        .output()
+        .expect("run pacquet list");
+    assert!(!output.status.success(), "unknown finder should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("No finder with name no-such-finder is found"), "stderr: {stderr}");
+}
+
+/// Port of upstream's `pnpm list returns correct paths with global
+/// virtual store` (`pnpm/test/list.ts`).
+#[test]
+fn list_returns_correct_paths_with_global_virtual_store() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "dependencies": { PKG: "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let mut yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml");
+    yaml = yaml.replace("enableGlobalVirtualStore: false", "enableGlobalVirtualStore: true");
+    yaml.push_str("privateHoistPattern: '*'\n");
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write workspace yaml");
+    run_ok(&workspace, &["install"]);
+
+    let output = run_ok(&workspace, &["list", "--json", "--depth=Infinity"]);
+    let parsed: Vec<Value> = serde_json::from_str(&output).expect("parse list JSON");
+
+    let pkg_path = parsed[0]["dependencies"][PKG]["path"].as_str().expect("pkg path");
+    let real = dunce::canonicalize(workspace.join("node_modules").join(PKG))
+        .expect("resolve the symlink of the installed package");
+    assert_eq!(Path::new(pkg_path), real.as_path());
+
+    let sub_dep_path =
+        parsed[0]["dependencies"][PKG]["dependencies"][DEP]["path"].as_str().expect("subdep path");
+    assert!(Path::new(sub_dep_path).exists(), "subdep path should exist: {sub_dep_path}");
+    assert!(
+        Path::new(sub_dep_path).join("package.json").exists(),
+        "subdep package.json should exist: {sub_dep_path}",
+    );
+}
+
+/// Port of upstream's `--only-projects shows only projects`
+/// (`deps/inspection/list/test/index.ts`): dependencies that are not
+/// workspace projects are pruned from the tree.
+#[test]
+fn list_only_projects_shows_only_projects() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "root",
+            "version": "1.0.0",
+            "dependencies": { "@scope/a": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+    let mut yaml =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace yaml");
+    yaml.push_str("packages:\n  - packages/*\n");
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write workspace yaml");
+
+    let packages = [
+        (
+            "a",
+            json!({ "name": "@scope/a", "version": "1.0.0", "dependencies": { "@scope/b": "workspace:*" } }),
+        ),
+        (
+            "b",
+            json!({ "name": "@scope/b", "version": "1.0.0", "dependencies": { "@scope/c": "workspace:*", HELLO: "1.0.0" } }),
+        ),
+        ("c", json!({ "name": "@scope/c", "version": "1.0.0" })),
+    ];
+    for (dir_name, manifest) in &packages {
+        let dir = workspace.join("packages").join(dir_name);
+        fs::create_dir_all(&dir).expect("create package dir");
+        fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
+    }
+    run_ok(&workspace, &["install"]);
+
+    let output = run_ok(&workspace, &["list", "--depth", "999", "--only-projects"]);
+    let dir = canonical(&workspace);
+    assert_eq!(
+        output,
+        format!(
+            "{LEGEND}\n\n\
+             root@1.0.0 {dir}\n\
+             \u{2502}\n\
+             \u{2502}   dependencies:\n\
+             \u{2514}\u{2500}\u{252c} @scope/a@link:packages/a\n\
+             \x20\x20\u{2514}\u{2500}\u{252c} @scope/b@link:packages/b\n\
+             \x20\x20\x20\x20\u{2514}\u{2500}\u{2500} @scope/c@link:packages/c\n\
+             \n\
+             3 packages\n"
+        ),
+    );
+}
+
+/// Port of upstream's `list in long format`
+/// (`deps/inspection/list/test/index.ts`): `--long` appends the
+/// description, repository, and filesystem path under each node.
+#[test]
+fn list_in_long_format_appends_manifest_details() {
+    let (_root, workspace, _registry) = setup_registry();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "project",
+            "version": "0.0.0",
+            "dependencies": { HELLO: "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    run_ok(&workspace, &["install"]);
+
+    let output = run_ok(&workspace, &["list", "--long"]);
+    assert!(output.contains(&format!("{HELLO}@1.0.0")), "long output: {output}");
+    assert!(
+        output.contains("A package with a hello world js bin"),
+        "description line missing: {output}",
+    );
+    assert!(
+        output.contains(
+            "https://github.com/pnpm/pnpm/tree/master/test/packages/hello-world-js-bin@1.0.0"
+        ),
+        "repository line missing: {output}",
+    );
+    assert!(
+        output.contains(&format!(
+            "node_modules/.pnpm/{}@1.0.0/node_modules/{HELLO}",
+            HELLO.replace('/', "+")
+        )),
+        "package path line missing: {output}",
+    );
+
+    // `ll` is `list --long`.
+    let ll_output = run_ok(&workspace, &["ll"]);
+    assert_eq!(ll_output, output);
+}

--- a/pnpm/crates/cli/tests/list.rs
+++ b/pnpm/crates/cli/tests/list.rs
@@ -858,11 +858,10 @@ fn list_in_long_format_appends_manifest_details() {
         ),
         "repository line missing: {output}",
     );
+    // The virtual-store dirname identifies the path line without
+    // assuming the platform's path separators.
     assert!(
-        output.contains(&format!(
-            "node_modules/.pnpm/{}@1.0.0/node_modules/{HELLO}",
-            HELLO.replace('/', "+")
-        )),
+        output.contains(&format!("{}@1.0.0", HELLO.replace('/', "+"))),
         "package path line missing: {output}",
     );
 

--- a/pnpm/crates/cli/tests/why.rs
+++ b/pnpm/crates/cli/tests/why.rs
@@ -285,7 +285,7 @@ fn why_shows_reverse_dependency_tree_for_a_non_direct_dependency() {
     fs::write(
         workspace.join("package.json"),
         format!(
-            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "{DEP}": "100.0.0", "{PKG}": "100.0.0" }} }}"#
+            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "{DEP}": "100.0.0", "{PKG}": "100.0.0" }} }}"#,
         ),
     )
     .expect("write package.json");
@@ -314,7 +314,7 @@ fn why_finds_packages_by_alias_name_when_using_npm_protocol() {
     fs::write(
         workspace.join("package.json"),
         format!(
-            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "foo": "npm:{PKG}@100.0.0" }} }}"#
+            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "foo": "npm:{PKG}@100.0.0" }} }}"#,
         ),
     )
     .expect("write package.json");
@@ -339,7 +339,7 @@ fn why_finds_packages_by_actual_name_when_using_npm_protocol() {
     fs::write(
         workspace.join("package.json"),
         format!(
-            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "foo": "npm:{PKG}@100.0.0" }} }}"#
+            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "foo": "npm:{PKG}@100.0.0" }} }}"#,
         ),
     )
     .expect("write package.json");
@@ -363,7 +363,7 @@ fn why_displays_parseable_output() {
     fs::write(
         workspace.join("package.json"),
         format!(
-            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "{DEP}": "100.0.0", "{PKG}": "100.0.0" }} }}"#
+            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "{DEP}": "100.0.0", "{PKG}": "100.0.0" }} }}"#,
         ),
     )
     .expect("write package.json");
@@ -441,7 +441,7 @@ module.exports = {{ finders: {{ 'manifest-reader': (ctx) => {{
   }}
   return false
 }} }} }}
-"
+",
         ),
     )
     .expect("write .pnpmfile.cjs");
@@ -499,7 +499,7 @@ fn why_marks_importer_dep_field_and_prints_summary() {
     fs::write(
         workspace.join("package.json"),
         format!(
-            r#"{{ "name": "project", "version": "0.0.0", "devDependencies": {{ "{PKG}": "100.0.0" }} }}"#
+            r#"{{ "name": "project", "version": "0.0.0", "devDependencies": {{ "{PKG}": "100.0.0" }} }}"#,
         ),
     )
     .expect("write package.json");
@@ -527,7 +527,7 @@ module.exports = {{ finders: {{ 'test-finder': (ctx) => {{
   }}
   return false
 }} }} }}
-"
+",
         ),
     )
     .expect("write .pnpmfile.cjs");

--- a/pnpm/crates/cli/tests/why.rs
+++ b/pnpm/crates/cli/tests/why.rs
@@ -38,9 +38,10 @@ fn why_fails_without_package_name() {
     assert!(!output.status.success(), "why without args should fail");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("requires a package name"),
+        stderr.contains("requires the package name or --find-by=<finder-name>"),
         "should show error about missing package name: {stderr}",
     );
+    assert!(stderr.contains("ERR_PNPM_MISSING_PACKAGE_NAME"), "stderr: {stderr}");
 }
 
 #[test]
@@ -189,7 +190,7 @@ fn why_from_workspace_member_stays_within_forward_workspace_link_closure() {
     let linked_stdout = String::from_utf8_lossy(&linked_output.stdout);
     assert!(linked_stdout.contains(PKG), "linked dependency should be reported: {linked_stdout}");
     assert!(
-        linked_stdout.contains("packages/linked"),
+        linked_stdout.contains("linked@1.0.0"),
         "the forward workspace-link closure should be retained: {linked_stdout}",
     );
 }
@@ -267,7 +268,267 @@ fn recursive_why_includes_all_workspace_projects() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains(HELLO), "recursive why should include sibling dependencies: {stdout}");
     assert!(
-        stdout.contains("packages/sibling"),
+        stdout.contains("sibling@1.0.0"),
         "recursive why should include the sibling importer: {stdout}",
     );
+}
+
+// --- ports of the TypeScript why command tests --------------------------------
+//
+// Source: pnpm11/deps/inspection/commands/test/listing/why.ts.
+
+/// Port of upstream's `"why" should show reverse dependency tree for a
+/// non-direct dependency`.
+#[test]
+fn why_shows_reverse_dependency_tree_for_a_non_direct_dependency() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "{DEP}": "100.0.0", "{PKG}": "100.0.0" }} }}"#
+        ),
+    )
+    .expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["why", "--prod", DEP]).output().expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines[0], format!("{DEP}@100.0.0"), "root is the searched package: {stdout}");
+    assert!(
+        lines.iter().any(|line| line.contains("project@0.0.0")),
+        "shows project as a direct dependent: {stdout}",
+    );
+    assert!(
+        lines.iter().any(|line| line.contains(&format!("{PKG}@100.0.0"))),
+        "shows the transitive path: {stdout}",
+    );
+}
+
+/// Port of upstream's `"why" should find packages by alias name when
+/// using npm: protocol`.
+#[test]
+fn why_finds_packages_by_alias_name_when_using_npm_protocol() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "foo": "npm:{PKG}@100.0.0" }} }}"#
+        ),
+    )
+    .expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["why", "--prod", "foo"]).output().expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines[0], format!("{PKG}@100.0.0"), "root shows the canonical name: {stdout}");
+    assert!(
+        lines.iter().any(|line| line.contains("project@0.0.0")),
+        "shows the project as dependent: {stdout}",
+    );
+}
+
+/// Port of upstream's `"why" should find packages by actual package
+/// name when using npm: protocol`.
+#[test]
+fn why_finds_packages_by_actual_name_when_using_npm_protocol() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "foo": "npm:{PKG}@100.0.0" }} }}"#
+        ),
+    )
+    .expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["why", "--prod", PKG]).output().expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines[0], format!("{PKG}@100.0.0"), "root shows the canonical name: {stdout}");
+    assert!(
+        lines.iter().any(|line| line.contains("project@0.0.0")),
+        "shows the project as dependent: {stdout}",
+    );
+}
+
+/// Port of upstream's `"why" should display parseable output`.
+#[test]
+fn why_displays_parseable_output() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{ "name": "project", "version": "0.0.0", "dependencies": {{ "{DEP}": "100.0.0", "{PKG}": "100.0.0" }} }}"#
+        ),
+    )
+    .expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["why", "--parseable", "--prod", DEP])
+        .output()
+        .expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(
+        lines.contains(&format!("project@0.0.0 > {DEP}@100.0.0").as_str()),
+        "direct path is importer-first: {stdout}",
+    );
+    assert!(
+        lines.contains(&format!("project@0.0.0 > {PKG}@100.0.0 > {DEP}@100.0.0").as_str()),
+        "transitive path is importer-first: {stdout}",
+    );
+}
+
+/// Port of upstream's `"why" should display finder message in tree
+/// output`.
+#[test]
+fn why_displays_finder_message_in_tree_output() {
+    let (_root, workspace, _anchor) = setup();
+    write_finder_pnpmfile(&workspace, "'Found: has 1 dep'");
+    write_manifest(&workspace, &format!(r#"{{ "{PKG}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output =
+        pacquet(&workspace, ["why", "--find-by=test-finder"]).output().expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines[0], format!("{PKG}@100.0.0"), "stdout: {stdout}");
+    assert_eq!(lines[1], "\u{2502} Found: has 1 dep", "stdout: {stdout}");
+}
+
+/// Port of upstream's `"why" should display finder message in JSON
+/// output`.
+#[test]
+fn why_displays_finder_message_in_json_output() {
+    let (_root, workspace, _anchor) = setup();
+    write_finder_pnpmfile(&workspace, "'custom message'");
+    write_manifest(&workspace, &format!(r#"{{ "{PKG}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["why", "--json", "--find-by=test-finder"])
+        .output()
+        .expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).expect("parse why JSON");
+    let matched = parsed
+        .as_array()
+        .expect("array output")
+        .iter()
+        .find(|result| result["name"] == PKG)
+        .expect("the finder-matched package is present");
+    assert_eq!(matched["searchMessage"], "custom message");
+}
+
+/// Port of upstream's `"why" finder can read manifest from store`.
+#[test]
+fn why_finder_can_read_manifest_from_store() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        format!(
+            r"
+module.exports = {{ finders: {{ 'manifest-reader': (ctx) => {{
+  const manifest = ctx.readManifest()
+  if (manifest && manifest.name === '{PKG}') {{
+    return 'description: ' + (manifest.description ?? 'none')
+  }}
+  return false
+}} }} }}
+"
+        ),
+    )
+    .expect("write .pnpmfile.cjs");
+    write_manifest(&workspace, &format!(r#"{{ "{PKG}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["why", "--json", "--find-by=manifest-reader"])
+        .output()
+        .expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).expect("parse why JSON");
+    let matched = parsed
+        .as_array()
+        .expect("array output")
+        .iter()
+        .find(|result| result["name"] == PKG)
+        .expect("the finder-matched package is present");
+    let message = matched["searchMessage"].as_str().expect("searchMessage string");
+    assert!(message.starts_with("description: "), "searchMessage: {message}");
+}
+
+/// Port of upstream's `"why" should find file: protocol local packages`.
+#[test]
+fn why_finds_file_protocol_local_packages() {
+    let (_root, workspace, _anchor) = setup();
+    let local_pkg = workspace.join("local-pkg");
+    fs::create_dir_all(&local_pkg).expect("create local-pkg");
+    fs::write(local_pkg.join("package.json"), r#"{ "name": "my-local-pkg", "version": "1.0.0" }"#)
+        .expect("write local-pkg package.json");
+    fs::write(
+        workspace.join("package.json"),
+        r#"{ "name": "project", "version": "0.0.0", "dependencies": { "my-alias": "file:./local-pkg" } }"#,
+    )
+    .expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output =
+        pacquet(&workspace, ["why", "--prod", "my-local-pkg"]).output().expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert!(lines[0].contains("my-local-pkg"), "finds the local package: {stdout}");
+    assert!(
+        lines.iter().any(|line| line.contains("project@0.0.0")),
+        "shows the project as dependent: {stdout}",
+    );
+}
+
+/// The importer leaf carries the dependency field it declares the chain
+/// in, and the output ends with the `Found …` summary (mirrors the
+/// `renderDependentsTree` contract exercised end to end).
+#[test]
+fn why_marks_importer_dep_field_and_prints_summary() {
+    let (_root, workspace, _anchor) = setup();
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{ "name": "project", "version": "0.0.0", "devDependencies": {{ "{PKG}": "100.0.0" }} }}"#
+        ),
+    )
+    .expect("write package.json");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["why", PKG]).output().expect("run pacquet why");
+    assert!(output.status.success(), "why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout,
+        format!(
+            "{PKG}@100.0.0\n\u{2514}\u{2500}\u{2500} project@0.0.0 (devDependencies)\n\nFound 1 version of {PKG}\n"
+        ),
+    );
+}
+
+fn write_finder_pnpmfile(workspace: &Path, message_expr: &str) {
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        format!(
+            r"
+module.exports = {{ finders: {{ 'test-finder': (ctx) => {{
+  if (ctx.name === '{PKG}') {{
+    return {message_expr}
+  }}
+  return false
+}} }} }}
+"
+        ),
+    )
+    .expect("write .pnpmfile.cjs");
 }

--- a/pnpm/crates/global/src/lib.rs
+++ b/pnpm/crates/global/src/lib.rs
@@ -22,7 +22,7 @@ pub use check_bin_conflicts::{
     CheckGlobalBinConflictsError, GlobalBinConflictError, check_global_bin_conflicts,
 };
 pub use global_package_dir::{create_install_dir, get_hash_link, resolve_install_dir};
-pub use list::{ListReportAs, list_global_packages};
+pub use list::{ListReportAs, find_global_install_dirs, list_global_packages};
 pub use scan::{
     GlobalPackageInfo, InstalledGlobalPackage, clean_orphaned_install_dirs, find_global_package,
     get_global_package_details, get_installed_bin_names, read_direct_dependency_aliases,

--- a/pnpm/crates/global/src/list.rs
+++ b/pnpm/crates/global/src/list.rs
@@ -29,9 +29,11 @@ struct ListedDep {
     path: String,
 }
 
-/// The install directories whose direct-dependency aliases match
-/// `params` (all install directories when `params` is empty). Used by
-/// `pnpm ls -g --depth <n>` to narrow the listing to one install group.
+/// The install directories with a direct-dependency alias matching
+/// `params` (any alias when `params` is empty — a group with no
+/// dependencies never matches, mirroring the TypeScript
+/// `findGlobalInstallDirs`). Used by `pnpm ls -g --depth <n>` to narrow
+/// the listing to one install group.
 pub fn find_global_install_dirs(
     global_dir: &Path,
     params: &[String],

--- a/pnpm/crates/global/src/list.rs
+++ b/pnpm/crates/global/src/list.rs
@@ -29,6 +29,24 @@ struct ListedDep {
     path: String,
 }
 
+/// The install directories whose direct-dependency aliases match
+/// `params` (all install directories when `params` is empty). Used by
+/// `pnpm ls -g --depth <n>` to narrow the listing to one install group.
+pub fn find_global_install_dirs(
+    global_dir: &Path,
+    params: &[String],
+) -> std::io::Result<Vec<PathBuf>> {
+    let packages = scan_global_packages(global_dir)?;
+    let mut install_dirs: Vec<PathBuf> = Vec::new();
+    for pkg in packages {
+        let matched = pkg.dependencies.iter().any(|(alias, _)| matches_params(params, alias));
+        if matched && !install_dirs.contains(&pkg.install_dir) {
+            install_dirs.push(pkg.install_dir);
+        }
+    }
+    Ok(install_dirs)
+}
+
 /// Render the globally installed packages matching `params` (all when
 /// empty) in the requested format.
 pub fn list_global_packages(

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -155,6 +155,23 @@ pub trait PnpmfileHooks: Send + Sync {
     async fn get_custom_fetchers(&self) -> Result<Vec<Arc<dyn CustomFetcher>>, HookError> {
         Ok(vec![])
     }
+
+    /// The names of the finders exported from the pnpmfile's top-level
+    /// `finders` object (consumed by `pnpm list --find-by` /
+    /// `pnpm why --find-by`).
+    async fn get_finder_names(&self) -> Result<Vec<String>, HookError> {
+        Ok(vec![])
+    }
+
+    /// Run the finder named `finder_name` against one package. `ctx`
+    /// carries `alias`, `name`, `version`, and the package's `manifest`
+    /// (exposed to the JavaScript finder as its `readManifest()`
+    /// callback). Returns the finder's verdict: a boolean or a message
+    /// string.
+    async fn run_finder(&self, finder_name: &str, ctx: Value) -> Result<Value, HookError> {
+        let _ = (finder_name, ctx);
+        Ok(Value::Bool(false))
+    }
 }
 
 /// A custom fetcher exported from a pnpmfile's `fetchers` array.

--- a/pnpm/crates/hooks/src/node_runtime.rs
+++ b/pnpm/crates/hooks/src/node_runtime.rs
@@ -363,6 +363,14 @@ impl crate::PnpmfileHooks for NodeJsHooks {
             })
             .collect())
     }
+
+    async fn get_finder_names(&self) -> Result<Vec<String>, HookError> {
+        self.worker().await?.get_finder_names().await
+    }
+
+    async fn run_finder(&self, finder_name: &str, ctx: Value) -> Result<Value, HookError> {
+        self.worker().await?.call_finder(finder_name, ctx).await
+    }
 }
 
 pub struct NodeJsCustomResolver {

--- a/pnpm/crates/hooks/src/worker.rs
+++ b/pnpm/crates/hooks/src/worker.rs
@@ -248,6 +248,28 @@ impl NodeWorker {
         serde_json::from_value(value).map_err(|err| self.exec_err(err.to_string()))
     }
 
+    /// The names of the finders exported by the pnpmfile's `finders`
+    /// object.
+    pub async fn get_finder_names(&self) -> Result<Vec<String>, HookError> {
+        let value = self
+            .request("finders", serde_json::json!({ "target": "finders" }), Arc::new(|_| {}))
+            .await?;
+        serde_json::from_value(value).map_err(|err| self.exec_err(err.to_string()))
+    }
+
+    /// Call the finder named `name` with a context of `alias`, `name`,
+    /// `version`, and `manifest` (exposed to the finder as a
+    /// `readManifest()` callback). Returns the finder's verdict:
+    /// `false`/`true` or a message string.
+    pub async fn call_finder(&self, name: &str, ctx: Value) -> Result<Value, HookError> {
+        self.request(
+            "finder",
+            serde_json::json!({ "target": "finder", "name": name, "ctx": ctx }),
+            Arc::new(|_| {}),
+        )
+        .await
+    }
+
     /// Send one request `body` (an object the worker dispatches on) and
     /// await its reply, stamping in the request id and routing any
     /// `context.log(...)` lines to `log`. `label` names the request in a
@@ -357,6 +379,30 @@ async function handle(line) {{
         canFetch: f != null && typeof f.canFetch === 'function',
         fetch: f != null && typeof f.fetch === 'function',
       }})) : []) }});
+      return;
+    }}
+    if (req.target === 'finders') {{
+      const finders = mod && mod.finders;
+      send({{ ok: (finders != null && typeof finders === 'object')
+        ? Object.keys(finders).filter((name) => typeof finders[name] === 'function')
+        : [] }});
+      return;
+    }}
+    if (req.target === 'finder') {{
+      const finders = mod && mod.finders;
+      const finder = (finders != null && typeof finders === 'object') ? finders[req.name] : null;
+      if (typeof finder !== 'function') {{
+        send({{ ok: false }});
+        return;
+      }}
+      const ctx = req.ctx || {{}};
+      const res = await finder({{
+        alias: ctx.alias,
+        name: ctx.name,
+        version: ctx.version,
+        readManifest: () => ctx.manifest,
+      }});
+      send({{ ok: res === undefined ? false : res }});
       return;
     }}
     if (req.target === 'fetcher') {{

--- a/pnpm/crates/hooks/src/worker.rs
+++ b/pnpm/crates/hooks/src/worker.rs
@@ -248,8 +248,6 @@ impl NodeWorker {
         serde_json::from_value(value).map_err(|err| self.exec_err(err.to_string()))
     }
 
-    /// The names of the finders exported by the pnpmfile's `finders`
-    /// object.
     pub async fn get_finder_names(&self) -> Result<Vec<String>, HookError> {
         let value = self
             .request("finders", serde_json::json!({ "target": "finders" }), Arc::new(|_| {}))
@@ -257,10 +255,9 @@ impl NodeWorker {
         serde_json::from_value(value).map_err(|err| self.exec_err(err.to_string()))
     }
 
-    /// Call the finder named `name` with a context of `alias`, `name`,
-    /// `version`, and `manifest` (exposed to the finder as a
-    /// `readManifest()` callback). Returns the finder's verdict:
-    /// `false`/`true` or a message string.
+    /// `ctx.manifest` is passed pre-read because a JavaScript callback
+    /// cannot call back over the pipe: the runner wraps it as the
+    /// `readManifest()` the finder contract expects.
     pub async fn call_finder(&self, name: &str, ctx: Value) -> Result<Value, HookError> {
         self.request(
             "finder",

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -1001,3 +1001,49 @@ Pacquet's port lives in `pacquet-auth-commands` (`login` module) with the CLI ad
 - [x] `TypeScript repo: pnpm11/auth/commands/test/login.test.ts:635` `should not trigger OTP for 401 without www-authenticate otp header` — `login::tests::should_not_trigger_otp_for_401_without_www_authenticate_otp_header`.
 - [x] `TypeScript repo: pnpm11/auth/commands/test/login.test.ts:673` `should succeed when config file does not exist (ENOENT)` — `login::tests::should_succeed_when_config_file_does_not_exist`.
 - [x] `TypeScript repo: pnpm11/auth/commands/test/login.test.ts:711` `should propagate non-ENOENT errors from readIniFile` — `login::tests::should_propagate_non_enoent_errors_from_reading_auth_ini`.
+
+## `pnpm list` / `pnpm why` (deps/inspection)
+
+The `list`/`why` parity port. TypeScript sources live under
+`pnpm11/deps/inspection/{commands,list,tree-builder}` plus the CLI-level
+`pnpm11/pnpm/test/list.ts`.
+
+CLI-level ports (`crates/cli/tests/list.rs`, `crates/cli/tests/why.rs`):
+
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/index.ts:14` `listing packages` — `listing_packages_prints_tree_with_legend_and_summary`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/index.ts:82` `listing packages of a project that has an external pnpm-lock.yaml` — `listing_packages_of_a_project_with_an_external_lockfile`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/index.ts:176` `listing packages should not fail on package that has local file directory in dependencies` — `listing_packages_with_local_file_directory_dependency`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/index.ts:212` `listing packages with --lockfile-only` — `listing_packages_with_lockfile_only`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/index.ts:283` `listing packages with --lockfile-only in JSON format` — `listing_packages_with_lockfile_only_in_json_format`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/index.ts:306` `listing specific package with --lockfile-only` — `listing_specific_package_with_lockfile_only`.
+- [ ] `TypeScript repo: deps/inspection/commands/test/listing/index.ts:121` `list on a project with skipped optional dependencies` — upstream keeps this `test.skip`-ped; not ported.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/json.ts:8` `correctly report the value of the private field when arguments are provided` — `list_json_reports_private_field_when_arguments_are_provided`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/recursive.ts:77` `recursive list with sharedWorkspaceLockfile` — `recursive_list_renders_workspace_projects_in_one_pass` (the real CLI takes the shared-lockfile single-render path, so the port pins one legend and one combined summary).
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/recursive.ts:265` `pnpm recursive why should fail if no package name was provided` — covered by `why_fails_without_package_name` (same handler-level gate).
+- [x] `TypeScript repo: deps/inspection/list/test/index.ts:826` `--only-projects shows only projects` — `list_only_projects_shows_only_projects` (end-to-end).
+- [x] `TypeScript repo: deps/inspection/list/test/index.ts:237` `list in long format` — `list_in_long_format_appends_manifest_details` (also pins `ll` ≡ `list --long`).
+- [x] `TypeScript repo: pnpm/test/list.ts:10` `ls --filter=not-exist --json should prints an empty array` — `ls_filter_not_exist_json_prints_an_empty_array`.
+- [x] `TypeScript repo: pnpm/test/list.ts:30` `ls should load a finder from .pnpmfile.cjs` — `ls_loads_a_finder_from_pnpmfile` (plus the pacquet-only `ls_with_unknown_finder_fails` pinning `ERR_PNPM_FINDER_NOT_FOUND`).
+- [x] `TypeScript repo: pnpm/test/list.ts:49` `pnpm list returns correct paths with global virtual store` — `list_returns_correct_paths_with_global_virtual_store`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:14` `pnpm why should fail if no package name was provided` — `why_fails_without_package_name`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:31` `"why" should show reverse dependency tree for a non-direct dependency` — `why_shows_reverse_dependency_tree_for_a_non_direct_dependency`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:57` `"why" should find packages by alias name when using npm: protocol` — `why_finds_packages_by_alias_name_when_using_npm_protocol`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:79` `"why" should find packages by actual package name when using npm: protocol` — `why_finds_packages_by_actual_name_when_using_npm_protocol`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:100` `"why" should display parseable output` — `why_displays_parseable_output`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:124` `"why" should display finder message in tree output` — `why_displays_finder_message_in_tree_output`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:152` `"why" should display finder message in JSON output` — `why_displays_finder_message_in_json_output`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:182` `"why" finder can read manifest from store` — `why_finder_can_read_manifest_from_store`.
+- [x] `TypeScript repo: deps/inspection/commands/test/listing/why.ts:215` `"why" should find file: protocol local packages` — `why_finds_file_protocol_local_packages`.
+
+Renderer-level ports (`crates/cli/src/cli_args/why/tests.rs`, `crates/cli/src/cli_args/list/tests.rs`):
+
+- [x] `TypeScript repo: deps/inspection/list/test/renderDependentsTree.test.ts` — all 21 tests (renderDependentsTree 6, whySummary 6, renderDependentsJson 5, renderDependentsParseable 4) ported one-to-one into `why::tests`.
+- [x] `TypeScript repo: deps/inspection/list/test/index.ts` renderer-level tests — `print empty`, `don't print empty`, `unsaved dependencies are marked`, `list with many dependencies`, `sort list items`, the four npm:/file: alias-label tests, and the three parseable-search dedup tests ported into `list::tests`.
+
+Tree-builder ports (`crates/cli/src/cli_args/deps_tree/{get_tree,search,pkg_info}/tests.rs`):
+
+- [x] `TypeScript repo: deps/inspection/tree-builder/test/getTree.test.ts` — all 24 tests (depth, cache regression, fully-visited cache, circular detection, linked dependencies, search-with-dedup, multi-root graph, cross-call dedup, exclude peers) ported one-to-one.
+- [x] `TypeScript repo: deps/inspection/tree-builder/test/createPackagesSearcher.spec.ts:` `packages searcher` — ported as `packages_searcher`; the `2 finders` case is covered by the Rust-only `finder_results_are_consulted_by_alias_and_node` + `queries_are_checked_before_finder_results` (finders are JS callbacks pre-evaluated through the pnpmfile worker; end-to-end finder coverage lives in the CLI-level ports above).
+- [x] `TypeScript repo: deps/inspection/tree-builder/test/getPkgInfo.test.ts:` `getPkgInfo handles missing pkgSnapshot without crashing` — ported as `get_pkg_info_handles_missing_pkg_snapshot_without_crashing` (asserts the alias/ref fallbacks; pacquet models "missing" through them rather than an `isMissing` field).
+- [ ] `TypeScript repo: deps/inspection/tree-builder/test/buildDependentsTree.test.ts` `nameFormatter` group (3 tests) — not ported: no pnpm command passes a `nameFormatter`, so pacquet's `build_dependents_tree` has no formatter parameter; the `displayName` rendering it feeds is covered by the renderDependentsTree ports.
+- [ ] `TypeScript repo: deps/inspection/list/test/manyDeps.ts` `list all deps in a project with many dependencies without failing with an OOM error` — the guard it exercises is the materialization dedup cache, pinned directly by the cross-call dedup ports.


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Makes pacquet's `pnpm list` (`ls`/`ll`/`la`) and `pnpm why` feature complete and behaviorally identical to the TypeScript CLI. The TypeScript side is untouched — it is the source of truth here; this PR closes the Rust side of the gap and ports the corresponding test suites.

**New shared tree-builder.** A new `cli_args/deps_tree` module ports `@pnpm/deps.inspection.tree-builder`: a lockfile-backed dependency graph (importer + package nodes, workspace-link resolution, `--only-projects` edge filtering), a materializer with per-`(node, depth)` subtree deduplication (`[deduped]` markers and `dedupedDependenciesCount`, bounding output to O(N)), a circular-reference post-pass, dev/prod dep-type detection (port of `@pnpm/lockfile.detect-dep-types`), and per-node metadata resolution: absolute filesystem paths (global-virtual-store aware, resolving through parent `node_modules` symlinks), reconstructed registry tarball URLs for `resolved`, peer/skipped flags, `link:` version rewriting, and peer-variant hashes.

**`pnpm list`.** Rewritten on the tree-builder with byte-identical renderers: the legend, cyan group headers, the `N packages[ in M projects]` summary, ` peer`/` skipped` annotations, red `peer#hash (N variations)` suffixes, bold search matches with subtree pruning, `--long` manifest details (description/repository/homepage/path; JSON adds license/author), sorted JSON keyed by alias with `from`/`version`/`resolved`/`path`, and flat deduplicated parseable output. New surface matching TS: `--only-projects`, `--find-by` (finders exported by `.pnpmfile.cjs`, evaluated through the pnpmfile Node worker via a new finder protocol), version-range search queries (`pnpm ls "foo@^2"`), `--depth` for globally installed packages (with the `ERR_PNPM_GLOBAL_LS_DEPTH_NOT_SUPPORTED` guard and install-group narrowing), and shared-lockfile recursive rendering in a single pass (one legend, cross-project dedup, combined summary). The pacquet-only "No lockfile found" messages are gone — a lockfile-less project renders the root header like TS does.

**`pnpm why`.** Rebuilt on the same graph: `--json`/`--parseable`/`--long` output, `-P`/`-D`/`--no-optional` include filters, `--find-by`, workspace project names/versions read from importer manifests, `(dependencies)`-style dependency-field annotations on importer leaves, `[circular]`/`[deduped]` markers, peer-variant hashes, semver-ordered results, the `Found N versions[, M instances] of <pkg>` summary, archy-style tree rendering, and current-lockfile preference. Error message/code now match TS (`ERR_PNPM_MISSING_PACKAGE_NAME`: `` `pnpm why` requires the package name or --find-by=<finder-name> ``). Search roots are now package nodes only, matching TS.

**Tests.** Ported one-to-one and enumerated in `pnpm/plans/TEST_PORTING.md` (new "`pnpm list` / `pnpm why` (deps/inspection)" section): the 24 `getTree` materialization tests, the packages-searcher and `getPkgInfo` tests, all 21 `renderDependentsTree` renderer tests, the renderer-level `list` tests, and the CLI-level `listing`/`why`/`list.ts` suites — exact tree output including legend and summary, `--lockfile-only`, the JSON `private` field, `file:` deps, recursive rendering, finders end to end (including finder manifest reads from the content-addressable store), and global-virtual-store paths. 62 unit + 38 integration tests pass; regression checks were done per the "test the tests" convention (breaking dedup, the missing-package fallback, version-range matching, and the summary each made the corresponding tests fail).

Not ported, with reasons recorded in the plan: the upstream `test.skip`-ped skipped-optional-deps listing test, the `nameFormatter` group of `buildDependentsTree.test.ts` (no pnpm command passes a `nameFormatter`; the `displayName` rendering it feeds is covered), and `manyDeps.ts` (its OOM guard is the dedup cache, pinned directly).

## Squash Commit Body

```text
Rebuild pacquet's list/why on a shared deps_tree module that ports the
TypeScript deps.inspection tree-builder: a lockfile-backed dependency
graph, materialization with subtree deduplication and circular-reference
marking, dev/prod dep-type detection, absolute package paths (global
virtual store aware), reconstructed tarball URLs, peer/skipped flags,
and peer-variant hashes. The renderers now match the TypeScript output
byte for byte: legend, cyan group headers, package-count summary, long
manifest details, JSON field order, and parseable dedup.

New command surface, matching the TypeScript CLI: list gains
--only-projects, --find-by (finders exported by .pnpmfile.cjs, evaluated
through the pnpmfile Node worker via a new finder protocol), search by
version range, --depth for globally installed packages (with the
GLOBAL_LS_DEPTH_NOT_SUPPORTED guard), and shared-lockfile single-pass
recursive rendering. why gains --json/--parseable/--long, the
prod/dev/no-optional include filters, --find-by, workspace project
names read from importer manifests, dependency-field annotations,
circular/deduped markers, peer-variant hashes, semver-ordered results,
and the Found-N-versions summary. why now prefers the current lockfile
over the wanted one, and error codes/messages match the TypeScript CLI
(MISSING_PACKAGE_NAME, FINDER_NOT_FOUND).

Ported the upstream test suites: the 24 getTree materialization tests,
the packages-searcher and getPkgInfo tests, all 21 renderDependentsTree
renderer tests, the renderer-level list tests, and the CLI-level
listing/why/list.ts suites (exact tree output, lockfile-only, private
JSON field, file: deps, recursive rendering, finders end to end, finder
manifest reads from the store, and global-virtual-store paths). The
ported coverage is enumerated in pnpm/plans/TEST_PORTING.md.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only by design: the TypeScript CLI already has all of this
  behavior and is unchanged.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (No docs changes: the flags and
  output formats are already documented for the TypeScript CLI.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787154625&installation_model_id=426870&pr_number=13178&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13178&signature=ec4ce0695ea30fa14bc51d6fdf65585ee5f660fbf69a8187ab96e2702d6bbfba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm list` and `pnpm why` are now more feature-complete and behaviorally aligned, including `--only-projects` and `--find-by` finder support with version-range searching.
  - Expanded output across tree/JSON/parseable and `--long`, with richer peer, deduped, and circular annotations plus “Found …” summaries.
- **Bug Fixes**
  - Improved consistency for global installs and recursive workspace rendering, and clearer `pnpm why` validation messaging.
- **Tests**
  - Added extensive integration and unit test coverage for search, rendering, depth/caching, and finder results.
- **Documentation**
  - Updated porting notes for `pnpm list` / `pnpm why`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->