### PR TITLE
feat(pacquet-cli): implement the pnpm view command

### DIFF
--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -78,6 +78,7 @@ pub mod unstar;
 pub mod update;
 pub mod update_interactive;
 pub mod version;
+pub mod view;
 pub mod whoami;
 pub mod why;
 pub mod with;

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -70,6 +70,7 @@ use super::{
     unstar::UnstarArgs,
     update::UpdateArgs,
     version::VersionArgs,
+    view::ViewArgs,
     why::WhyArgs,
     with::WithArgs,
 };
@@ -318,6 +319,9 @@ pub enum CliCommand {
     Licenses(LicensesArgs),
     /// Shows the packages that depend on `pkg`
     Why(WhyArgs),
+    /// View registry information about a package.
+    #[clap(visible_aliases = ["info", "show", "v"])]
+    View(ViewArgs),
     /// Generate a Software Bill of Materials (SBOM).
     Sbom(SbomArgs),
     /// Displays your pnpm username.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -344,6 +344,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Ll(args) => dispatch_query::ll(ctx, args),
         CliCommand::Licenses(args) => dispatch_query::licenses(ctx, args),
         CliCommand::Why(args) => dispatch_query::why(ctx, args),
+        CliCommand::View(args) => dispatch_query::view(ctx, args),
         CliCommand::Sbom(args) => dispatch_query::sbom(ctx, args),
         CliCommand::Whoami => dispatch_query::whoami(ctx),
         CliCommand::Star(args) => dispatch_query::star(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -44,6 +44,7 @@ use super::{
     undeprecate::UndeprecateArgs,
     unstar::UnstarArgs,
     version::VersionArgs,
+    view::ViewArgs,
     why::WhyArgs,
     with::WithArgs,
 };
@@ -327,6 +328,25 @@ pub(super) fn ping<'a>(ctx: &RunCtx<'a>, args: PingArgs) -> miette::Result<Comma
     Ok(Box::pin(async move {
         let report = args.run(cfg).await?;
         println!("{report}");
+        Ok(())
+    }))
+}
+
+// `view` is a read-only registry query: it resolves the package metadata
+// (and, when the package name is omitted, the nearest manifest's name from
+// `ctx.dir`), then prints the requested fields, a JSON dump, or the formatted
+// summary its handler returns. No lockfile or install pipeline, so it
+// dispatches off `config()` like the other read-only registry commands.
+pub(super) fn view<'a>(ctx: &RunCtx<'a>, args: ViewArgs) -> miette::Result<CommandFuture<'a>> {
+    let cfg: &Config = (ctx.config)()?;
+    let dir = ctx.dir;
+    Ok(Box::pin(async move {
+        let output = args.run(cfg, dir).await?;
+        // A field selection for an absent field renders as an empty string;
+        // skip the print so it emits no output, matching `pnpm view`.
+        if !output.is_empty() {
+            println!("{output}");
+        }
         Ok(())
     }))
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -342,8 +342,11 @@ pub(super) fn view<'a>(ctx: &RunCtx<'a>, args: ViewArgs) -> miette::Result<Comma
     let dir = ctx.dir;
     Ok(Box::pin(async move {
         let output = args.run(cfg, dir).await?;
-        // A field selection for an absent field renders as an empty string;
-        // skip the print so it emits no output, matching `pnpm view`.
+        // A single-field selection of an absent field renders as an empty
+        // string; skip the print so it emits no output. A multi-field `--json`
+        // selection of absent fields renders as `{}` and is printed. Both
+        // match `pnpm view`, which prints whatever truthy string the handler
+        // returns.
         if !output.is_empty() {
             println!("{output}");
         }

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -472,6 +472,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Ll(_) => "ll",
         CliCommand::Licenses(_) => "licenses",
         CliCommand::Why(_) => "why",
+        CliCommand::View(_) => "view",
         CliCommand::Sbom(_) => "sbom",
         CliCommand::Whoami => "whoami",
         CliCommand::Deprecate(_) => "deprecate",

--- a/pnpm/crates/cli/src/cli_args/view.rs
+++ b/pnpm/crates/cli/src/cli_args/view.rs
@@ -1,0 +1,609 @@
+//! `pacquet view` (aliases `info`, `show`, `v`) — print package metadata
+//! from the registry.
+//!
+//! When the package name is omitted, the nearest project manifest's `name`
+//! is used (searching upward from `--dir`). With one or more trailing
+//! field arguments, only those fields are printed; otherwise a formatted
+//! summary (or, with `--json`, the whole assembled info object) is shown.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic, IntoDiagnostic};
+use owo_colors::{OwoColorize, Stream, Style};
+use pacquet_config::Config;
+use pacquet_network::{NetworkSettings, RetryOpts, ThrottledClient};
+use pacquet_resolving_npm_resolver::{
+    FetchFullMetadataOptions, FetchFullMetadataOutcome, PickPackageFromMetaOptions,
+    fetch_full_metadata, parse_bare_specifier, pick_package_from_meta, pick_registry_for_package,
+    pick_version_by_version_range,
+};
+use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
+use pacquet_workspace::try_read_project_manifest;
+use serde_json::{Map, Value};
+
+/// Errors from `pacquet view`. The codes are the `ERR_PNPM_*` codes pnpm
+/// defines for these failures.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum ViewError {
+    #[display("Package name is required. Usage: pnpm view [<package-name>]")]
+    #[diagnostic(code(ERR_PNPM_MISSING_PACKAGE_NAME))]
+    MissingPackageName,
+
+    #[display("Invalid package name: \"{spec}\". This command only supports registry packages.")]
+    #[diagnostic(code(ERR_PNPM_INVALID_PACKAGE_NAME))]
+    InvalidPackageName {
+        #[error(not(source))]
+        spec: String,
+    },
+
+    #[display("{message}")]
+    #[diagnostic(code(ERR_PNPM_INVALID_PACKAGE_JSON))]
+    InvalidPackageJson {
+        #[error(not(source))]
+        message: String,
+    },
+
+    #[display("No matching version found for {name}@{spec}")]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_NOT_FOUND))]
+    PackageNotFound {
+        #[error(not(source))]
+        name: String,
+        spec: String,
+    },
+
+    #[display("GET {url}: Not Found - 404")]
+    #[diagnostic(code(ERR_PNPM_FETCH_404))]
+    Fetch404 {
+        #[error(not(source))]
+        url: String,
+    },
+}
+
+#[derive(Debug, Args)]
+pub struct ViewArgs {
+    /// `<package-name>[@<version>]` followed by optional fields to print
+    /// (e.g. `view foo dist.tarball version`). When the package name is
+    /// omitted, the nearest project manifest's name is used.
+    pub params: Vec<String>,
+
+    /// Show information in JSON format.
+    #[clap(long)]
+    pub json: bool,
+}
+
+impl ViewArgs {
+    /// Resolve the package spec (the first positional, or the nearest
+    /// manifest's name when omitted), fetch its registry metadata, pick the
+    /// matching version, and render the requested fields, a JSON dump, or the
+    /// formatted summary.
+    pub async fn run(self, config: &Config, dir: &Path) -> miette::Result<String> {
+        let package_spec = match self.params.first() {
+            Some(spec) => spec.clone(),
+            None => nearest_manifest_name(dir)?,
+        };
+        let fields = self.params.get(1..).unwrap_or(&[]);
+
+        let info = fetch_package_info(config, &package_spec).await?;
+
+        if !fields.is_empty() {
+            return Ok(render_fields(&info, fields, self.json));
+        }
+        if self.json {
+            return Ok(to_pretty(&info));
+        }
+        Ok(render_summary(&info))
+    }
+}
+
+/// Find the nearest project manifest's `name`, searching upward from
+/// `start_dir`. A missing manifest is [`ViewError::MissingPackageName`]; a
+/// present-but-invalid manifest (parse error, non-object body, or no `name`)
+/// is [`ViewError::InvalidPackageJson`].
+fn nearest_manifest_name(start_dir: &Path) -> Result<String, ViewError> {
+    let mut dir = start_dir;
+    loop {
+        let manifest_path = dir.join("package.json");
+        if manifest_path.is_file() {
+            let manifest =
+                try_read_project_manifest(dir).map_err(|err| ViewError::InvalidPackageJson {
+                    message: format!(
+                        r#"Failed to read or parse project manifest in "{dir}": {err}"#,
+                        dir = dir.display(),
+                    ),
+                })?;
+            let value = manifest.map_or(Value::Null, |(_, manifest)| manifest.value().clone());
+            if !value.is_object() {
+                return Err(invalid_manifest(dir));
+            }
+            return match value.get("name").and_then(Value::as_str).filter(|name| !name.is_empty()) {
+                Some(name) => Ok(name.to_string()),
+                None => Err(invalid_manifest(dir)),
+            };
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return Err(ViewError::MissingPackageName),
+        }
+    }
+}
+
+/// The `ERR_PNPM_INVALID_PACKAGE_JSON` raised when a found manifest is not a
+/// usable object or lacks a non-empty `name`.
+fn invalid_manifest(dir: &Path) -> ViewError {
+    ViewError::InvalidPackageJson {
+        message: format!(
+            r#"Invalid package.json at "{}". The "name" field is required and must be a non-empty string."#,
+            dir.display(),
+        ),
+    }
+}
+
+/// Fetch and assemble the registry info object for `package_spec`: parse the
+/// spec (rejecting non-registry protocols), fetch full metadata, pick the
+/// version satisfying the spec, then extend that version's manifest with the
+/// packument-level `versions`, `dist-tags`, and `time` fields the renderers
+/// read.
+async fn fetch_package_info(config: &Config, package_spec: &str) -> miette::Result<Value> {
+    let parsed = parse_wanted_dependency(package_spec);
+    let alias = parsed.alias.as_deref();
+    let bare = parsed.bare_specifier.as_deref().unwrap_or("latest");
+    let name_hint = alias.unwrap_or(package_spec);
+
+    let registries: std::collections::HashMap<String, String> =
+        config.resolved_registries().into_iter().collect();
+    let registry = pick_registry_for_package(&registries, name_hint, Some(bare));
+
+    let spec = parse_bare_specifier(bare, alias, "latest", &registry)
+        .ok_or_else(|| ViewError::InvalidPackageName { spec: package_spec.to_string() })?;
+
+    let http_client = ThrottledClient::for_installs(
+        &config.proxy,
+        &config.tls,
+        &config.tls_by_uri,
+        &NetworkSettings {
+            network_concurrency: config.network_concurrency,
+            fetch_timeout: std::time::Duration::from_millis(config.fetch_timeout),
+            user_agent: config.user_agent.clone(),
+        },
+    )
+    .into_diagnostic()
+    .wrap_err("create the network client for view")?;
+
+    let outcome = fetch_full_metadata(
+        &spec.name,
+        &FetchFullMetadataOptions {
+            registry: &registry,
+            http_client: &http_client,
+            auth_headers: &config.auth_headers,
+            full_metadata: true,
+            etag: None,
+            modified: None,
+            retry_opts: RetryOpts::default(),
+        },
+    )
+    .await
+    .map_err(|error| map_fetch_error(error, &registry, &spec.name))?;
+
+    let meta = match outcome {
+        FetchFullMetadataOutcome::Modified(meta) => *meta,
+        FetchFullMetadataOutcome::NotModified => {
+            miette::bail!("registry returned 304 Not Modified unexpectedly for {}", spec.name)
+        }
+    };
+
+    let picked = pick_package_from_meta(
+        pick_version_by_version_range,
+        &PickPackageFromMetaOptions::default(),
+        &meta,
+        &spec,
+    )?
+    .ok_or_else(|| ViewError::PackageNotFound {
+        name: spec.name.clone(),
+        spec: spec.fetch_spec.clone(),
+    })?;
+
+    Ok(assemble_info(&meta, &picked))
+}
+
+/// Build the info object the renderers consume from the picked version's
+/// manifest and the packument-level fields. The picked version's raw JSON
+/// fragment is reused so registry key order is preserved in `--json` output,
+/// and the extra fields are appended in place.
+fn assemble_info(
+    meta: &pacquet_registry::Package,
+    picked: &pacquet_registry::PackageVersion,
+) -> Value {
+    let version_key = picked.version.to_string();
+    let data = meta
+        .versions
+        .fragments()
+        .find(|(version, _)| version.as_str() == version_key)
+        .and_then(|(_, json)| serde_json::from_str::<Value>(&json).ok())
+        .unwrap_or_else(|| serde_json::to_value(picked).unwrap_or(Value::Null));
+
+    let mut info = match data {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    };
+
+    // An object author collapses to its `name` (dropped entirely when it has
+    // none); a string author is left untouched.
+    if let Some(Value::Object(author)) = info.get("author") {
+        match author.get("name").cloned() {
+            Some(name) => {
+                info.insert("author".to_string(), name);
+            }
+            None => {
+                info.shift_remove("author");
+            }
+        }
+    }
+
+    let versions: Vec<&String> = meta.versions.keys().collect();
+    let versions_count = versions.len();
+    let deps_count = picked.dependencies.as_ref().map_or(0, std::collections::HashMap::len);
+
+    info.insert("versions".to_string(), serde_json::to_value(&versions).unwrap_or(Value::Null));
+    if versions_count > 0 {
+        info.insert("versionsCount".to_string(), serde_json::json!(versions_count));
+    }
+    if deps_count > 0 {
+        info.insert("depsCount".to_string(), serde_json::json!(deps_count));
+    }
+    let dist_tags = serde_json::to_value(&meta.dist_tags).unwrap_or(Value::Null);
+    info.insert("distTags".to_string(), dist_tags.clone());
+    info.insert("dist-tags".to_string(), dist_tags);
+    if let Some(time) = &meta.time {
+        info.insert("time".to_string(), serde_json::to_value(time).unwrap_or(Value::Null));
+    }
+
+    Value::Object(info)
+}
+
+/// Map a metadata-fetch failure to the matching pnpm error. A `404`
+/// becomes [`ViewError::Fetch404`] (pnpm's `ERR_PNPM_FETCH_404`); every
+/// other failure is surfaced verbatim.
+fn map_fetch_error(
+    error: pacquet_resolving_npm_resolver::FetchMetadataError,
+    registry: &str,
+    pkg_name: &str,
+) -> miette::Report {
+    use pacquet_resolving_npm_resolver::FetchMetadataError;
+    if let FetchMetadataError::Network { error: ref source, .. } = error
+        && source.status() == Some(reqwest::StatusCode::NOT_FOUND)
+    {
+        return ViewError::Fetch404 {
+            url: pacquet_network::redact_url_credentials(&format!("{registry}{pkg_name}")),
+        }
+        .into();
+    }
+    miette::Report::new(error)
+}
+
+/// Render the selected `fields` of `info`. A single field unwraps to its
+/// value (raw for `--json`, plain for text); multiple fields render as a
+/// `{field: value}` object (`--json`) or `field = value` lines.
+fn render_fields(info: &Value, fields: &[String], json: bool) -> String {
+    let selected: Vec<(&String, Option<Value>)> =
+        fields.iter().map(|field| (field, get_nested_property(info, field))).collect();
+
+    if json {
+        if let [(_, value)] = selected.as_slice() {
+            return value.as_ref().map(to_pretty).unwrap_or_default();
+        }
+        let map: Map<String, Value> = selected
+            .iter()
+            .filter_map(|(field, value)| value.clone().map(|value| ((*field).clone(), value)))
+            .collect();
+        return to_pretty(&Value::Object(map));
+    }
+
+    if let [(_, value)] = selected.as_slice() {
+        return format_field_value(value.as_ref());
+    }
+
+    selected
+        .iter()
+        .map(|(field, value)| match value {
+            Some(value @ (Value::Object(_) | Value::Array(_))) => {
+                format!("{field} = {}", serde_json::to_string(value).unwrap_or_default())
+            }
+            Some(Value::String(string)) => format!("{field} = '{string}'"),
+            other => format!("{field} = {}", format_field_value(other.as_ref())),
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Walk a dotted `path` (e.g. `dist.shasum`) through `info`, returning a
+/// clone of the value or `None` when any segment is missing or not an
+/// object.
+fn get_nested_property(info: &Value, path: &str) -> Option<Value> {
+    let mut current = info;
+    for part in path.split('.') {
+        current = current.as_object()?.get(part)?;
+    }
+    Some(current.clone())
+}
+
+/// Stringify a single field value for text output: `null`/absent is empty,
+/// objects and arrays are pretty JSON, strings pass through, and scalars use
+/// their plain form.
+fn format_field_value(value: Option<&Value>) -> String {
+    match value {
+        None | Some(Value::Null) => String::new(),
+        Some(value @ (Value::Object(_) | Value::Array(_))) => to_pretty(value),
+        Some(Value::String(string)) => string.clone(),
+        Some(other) => other.to_string(),
+    }
+}
+
+/// Render the human-readable summary block: a `name@version | license |
+/// deps | versions` header followed by description, homepage, deprecation,
+/// keywords, bin, dist, dependencies, maintainers, dist-tags, and the
+/// published-by line.
+fn render_summary(info: &Value) -> String {
+    let mut header: Vec<String> = Vec::new();
+    if let (Some(name), Some(version)) = (str_field(info, "name"), str_field(info, "version")) {
+        header.push(cyan(&format!("{name}@{version}")));
+    }
+    if let Some(license) = str_field(info, "license") {
+        header.push(green(license));
+    }
+    match info.get("depsCount").and_then(Value::as_u64) {
+        Some(count) => header.push(format!("deps: {}", cyan(&count.to_string()))),
+        None => header.push("deps: none".to_string()),
+    }
+    if let Some(count) = info.get("versionsCount").and_then(Value::as_u64) {
+        header.push(format!("versions: {}", cyan(&count.to_string())));
+    }
+
+    let mut lines: Vec<String> = vec![header.join(" | ")];
+
+    if let Some(description) = str_field(info, "description") {
+        lines.push(description.to_string());
+    }
+    if let Some(homepage) = str_field(info, "homepage") {
+        lines.push(underline_blue(homepage));
+    }
+    if let Some(deprecated) = str_field(info, "deprecated") {
+        lines.push(String::new());
+        lines.push(format!("{} - {deprecated}", red("DEPRECATED!")));
+    }
+
+    if let Some(keywords) = array_field(info, "keywords") {
+        let joined = keywords.iter().filter_map(Value::as_str).collect::<Vec<_>>().join(", ");
+        lines.push(String::new());
+        lines.push(format!("keywords: {}", cyan(&joined)));
+    }
+
+    lines.extend(bin_summary(info));
+
+    if let Some(dist) = info.get("dist").and_then(Value::as_object) {
+        lines.push(String::new());
+        lines.push(bold("dist"));
+        if let Some(tarball) = obj_str(dist, "tarball") {
+            lines.push(format!(".tarball: {}", underline_blue(tarball)));
+        }
+        if let Some(shasum) = obj_str(dist, "shasum") {
+            lines.push(format!(".shasum: {}", green(shasum)));
+        }
+        if let Some(integrity) = obj_str(dist, "integrity") {
+            lines.push(format!(".integrity: {}", green(integrity)));
+        }
+        if let Some(unpacked_size) = dist.get("unpackedSize").and_then(Value::as_u64) {
+            lines.push(format!(".unpackedSize: {}", blue(&format_bytes(unpacked_size))));
+        }
+    }
+
+    if let Some(dependencies) = info.get("dependencies").and_then(Value::as_object)
+        && !dependencies.is_empty()
+    {
+        lines.push(String::new());
+        lines.push("dependencies:".to_string());
+        let entries: Vec<String> = dependencies
+            .iter()
+            .map(|(name, version)| {
+                format!("{}: {}", blue(name), version.as_str().unwrap_or_default())
+            })
+            .collect();
+        lines.push(entries.join(", "));
+    }
+
+    if let Some(maintainers) = array_field(info, "maintainers") {
+        lines.push(String::new());
+        lines.push("maintainers:".to_string());
+        for maintainer in maintainers {
+            lines.push(format!("- {}", format_person(maintainer)));
+        }
+    }
+
+    if let Some(dist_tags) = info.get("distTags").and_then(Value::as_object)
+        && !dist_tags.is_empty()
+    {
+        lines.push(String::new());
+        lines.push(bold("dist-tags:"));
+        for (tag, version) in dist_tags {
+            lines.push(format!("{}: {}", blue(tag), version.as_str().unwrap_or_default()));
+        }
+    }
+
+    if let Some(published) = published_info(info) {
+        lines.push(String::new());
+        lines.push(published);
+    }
+
+    lines.join("\n")
+}
+
+/// Render the `bin:` summary line(s). A string `bin` derives its single
+/// command from the (scope-stripped) package name; an object `bin` lists
+/// its keys.
+fn bin_summary(info: &Value) -> Vec<String> {
+    let bins: Vec<String> = match info.get("bin") {
+        Some(Value::String(bin)) if !bin.is_empty() => match str_field(info, "name") {
+            Some(name) if name.starts_with('@') => {
+                vec![name.split_once('/').map_or(name, |(_, rest)| rest).to_string()]
+            }
+            Some(name) => vec![name.to_string()],
+            None => Vec::new(),
+        },
+        Some(Value::Object(bin)) => bin.keys().cloned().collect(),
+        _ => Vec::new(),
+    };
+    if bins.is_empty() {
+        return Vec::new();
+    }
+    vec![String::new(), format!("bin: {}", cyan(&bins.join(", ")))]
+}
+
+/// Build the `published <time> ago[ by <publisher>]` line. Needs the picked
+/// version's publish timestamp; an unparsable timestamp yields no line, and
+/// a future one degrades to "just now".
+fn published_info(info: &Value) -> Option<String> {
+    let version = str_field(info, "version")?;
+    let published_time = info.get("time")?.as_object()?.get(version)?.as_str()?;
+    let date = parse_date(published_time)?;
+    let time_ago = format_time_ago(date).unwrap_or_else(|| "just now".to_string());
+    Some(match publisher(info) {
+        Some(publisher) => format!("published {} by {publisher}", cyan(&time_ago)),
+        None => format!("published {}", cyan(&time_ago)),
+    })
+}
+
+/// Resolve the publisher shown in the published-by line, preferring
+/// `_npmUser`, then the first maintainer (with `et al.` when there are
+/// more), then the author.
+fn publisher(info: &Value) -> Option<String> {
+    if let Some(npm_user) = info.get("_npmUser").and_then(Value::as_object)
+        && obj_str(npm_user, "name").is_some()
+    {
+        return Some(format_person(&Value::Object(npm_user.clone())));
+    }
+    if let Some(maintainers) = array_field(info, "maintainers") {
+        let formatted = format_person(&maintainers[0]);
+        return Some(if maintainers.len() == 1 {
+            formatted
+        } else {
+            format!("{formatted} et al.")
+        });
+    }
+    str_field(info, "author").map(ToString::to_string)
+}
+
+/// Format a `{ name, email }` person object as `name <email>` (blue name,
+/// dimmed email), or just the name when no email is present.
+fn format_person(person: &Value) -> String {
+    let name = person.get("name").and_then(Value::as_str).unwrap_or("");
+    match person.get("email").and_then(Value::as_str).filter(|email| !email.is_empty()) {
+        Some(email) => format!("{} <{}>", blue(name), dim(email)),
+        None => blue(name),
+    }
+}
+
+/// Format a byte count with a 1000-based unit and at most two decimals.
+fn format_bytes(bytes: u64) -> String {
+    if bytes == 0 {
+        return "0 B".to_string();
+    }
+    const SIZES: [&str; 6] = ["B", "kB", "MB", "GB", "TB", "PB"];
+    let bytes = bytes as f64;
+    let index = bytes.log(1000_f64).floor() as usize;
+    let index = index.min(SIZES.len() - 1);
+    let value = (bytes / 1000_f64.powi(index as i32) * 100.0).round() / 100.0;
+    format!("{value} {}", SIZES[index])
+}
+
+/// The age of `date` relative to `now`, bucketed into a coarse "N unit(s)
+/// ago" label. `None` for a future date (clock skew). Split from
+/// [`format_time_ago`] so the `now` reference is injectable in tests.
+fn format_time_ago_since(date: DateTime<Utc>, now: DateTime<Utc>) -> Option<String> {
+    let diff_ms = now.signed_duration_since(date).num_milliseconds();
+    if diff_ms < 0 {
+        return None;
+    }
+    let diff_sec = diff_ms / 1000;
+    let diff_min = diff_sec / 60;
+    let diff_hour = diff_min / 60;
+    let diff_day = diff_hour / 24;
+    let diff_month = diff_day / 30;
+    let diff_year = diff_day / 365;
+    let unit = |count: i64, singular: &str| {
+        format!("{count} {singular}{} ago", if count == 1 { "" } else { "s" })
+    };
+    Some(if diff_year > 0 {
+        unit(diff_year, "year")
+    } else if diff_month > 0 {
+        unit(diff_month, "month")
+    } else if diff_day > 0 {
+        unit(diff_day, "day")
+    } else if diff_hour > 0 {
+        unit(diff_hour, "hour")
+    } else if diff_min > 0 {
+        unit(diff_min, "minute")
+    } else {
+        "a few seconds ago".to_string()
+    })
+}
+
+fn format_time_ago(date: DateTime<Utc>) -> Option<String> {
+    format_time_ago_since(date, Utc::now())
+}
+
+fn parse_date(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value).ok().map(|date| date.with_timezone(&Utc))
+}
+
+fn to_pretty(value: &Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_default()
+}
+
+/// A field's string value, treating an empty string as absent.
+fn str_field<'a>(info: &'a Value, key: &str) -> Option<&'a str> {
+    info.get(key).and_then(Value::as_str).filter(|value| !value.is_empty())
+}
+
+fn obj_str<'a>(map: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
+    map.get(key).and_then(Value::as_str).filter(|value| !value.is_empty())
+}
+
+/// A field's array value, treating an empty array as absent.
+fn array_field<'a>(info: &'a Value, key: &str) -> Option<&'a Vec<Value>> {
+    info.get(key).and_then(Value::as_array).filter(|array| !array.is_empty())
+}
+
+fn cyan(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, OwoColorize::cyan).to_string()
+}
+
+fn green(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, OwoColorize::green).to_string()
+}
+
+fn blue(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, OwoColorize::blue).to_string()
+}
+
+fn red(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, OwoColorize::red).to_string()
+}
+
+fn bold(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, OwoColorize::bold).to_string()
+}
+
+fn dim(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, OwoColorize::dimmed).to_string()
+}
+
+fn underline_blue(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |text| text.style(Style::new().blue().underline()))
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/view/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/view/tests.rs
@@ -67,8 +67,8 @@ fn format_time_ago_buckets_by_largest_unit() {
 
 #[test]
 fn parse_date_accepts_iso_timestamps_only() {
-    assert!(parse_date("2024-01-01T00:00:00.000Z").is_some());
-    assert!(parse_date("not-a-date").is_none());
+    assert!(parse_date("2024-01-01T00:00:00.000Z").is_some(), "an ISO timestamp should parse");
+    assert!(parse_date("not-a-date").is_none(), "a non-timestamp should not parse");
 }
 
 /// A rich info object that exercises every optional summary section.

--- a/pnpm/crates/cli/src/cli_args/view/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/view/tests.rs
@@ -2,7 +2,8 @@ use chrono::{DateTime, Utc};
 use serde_json::{Value, json};
 
 use super::{
-    format_bytes, format_field_value, format_time_ago_since, get_nested_property, parse_date,
+    bin_summary, format_bytes, format_field_value, format_person, format_time_ago_since,
+    get_nested_property, parse_date, published_info, publisher, render_fields, render_summary,
 };
 
 fn utc(rfc3339: &str) -> DateTime<Utc> {
@@ -68,4 +69,161 @@ fn format_time_ago_buckets_by_largest_unit() {
 fn parse_date_accepts_iso_timestamps_only() {
     assert!(parse_date("2024-01-01T00:00:00.000Z").is_some());
     assert!(parse_date("not-a-date").is_none());
+}
+
+/// A rich info object that exercises every optional summary section.
+fn rich_info() -> Value {
+    json!({
+        "name": "is-negative",
+        "version": "1.0.0",
+        "license": "MIT",
+        "description": "Check if a number is negative",
+        "homepage": "https://npmjs.example/is-negative",
+        "deprecated": "use something else",
+        "keywords": ["negative", "number"],
+        "bin": { "is-negative": "cli.js" },
+        "dist": {
+            "tarball": "https://npmjs.example/is-negative.tgz",
+            "shasum": "1d06e1c0",
+            "integrity": "sha512-abc",
+            "unpackedSize": 1234
+        },
+        "dependencies": { "left-pad": "^1.0.0" },
+        "maintainers": [{ "name": "alice", "email": "alice@example.com" }, { "name": "bob" }],
+        "depsCount": 1,
+        "versionsCount": 3,
+        "distTags": { "latest": "1.0.0" },
+        "time": { "1.0.0": "2015-01-01T00:00:00.000Z" }
+    })
+}
+
+#[test]
+fn render_summary_includes_every_section() {
+    let out = render_summary(&rich_info());
+    for needle in [
+        "is-negative@1.0.0",
+        "deps: ",
+        "versions: ",
+        "Check if a number is negative",
+        "is-negative", // homepage host / keyword
+        "DEPRECATED! - use something else",
+        "keywords:",
+        "bin:",
+        ".tarball:",
+        ".shasum:",
+        ".integrity:",
+        ".unpackedSize:",
+        "dependencies:",
+        "maintainers:",
+        "dist-tags:",
+        "latest:",
+        "published ",
+    ] {
+        assert!(out.contains(needle), "summary missing {needle:?}:\n{out}");
+    }
+}
+
+#[test]
+fn render_summary_minimal_shows_deps_none() {
+    let out = render_summary(&json!({ "name": "x", "version": "1.0.0" }));
+    assert!(out.contains("x@1.0.0"), "{out}");
+    assert!(out.contains("deps: none"), "{out}");
+}
+
+#[test]
+fn bin_summary_covers_string_object_and_absent() {
+    // A string `bin` on an unscoped package derives the package name.
+    let unscoped = bin_summary(&json!({ "name": "hello-bin", "bin": "cli.js" }));
+    assert_eq!(unscoped.len(), 2);
+    assert!(unscoped[0].is_empty(), "the bin section opens with a blank line: {unscoped:?}");
+    assert!(unscoped[1].contains("hello-bin"), "{:?}", unscoped[1]);
+    // A string `bin` on a scoped package strips the scope.
+    let scoped = bin_summary(&json!({ "name": "@scope/hello-bin", "bin": "cli.js" }));
+    assert!(scoped[1].contains("hello-bin") && !scoped[1].contains("@scope"), "{:?}", scoped[1]);
+    // An object `bin` lists its keys.
+    let object = bin_summary(&json!({ "name": "x", "bin": { "one": "a.js" } }));
+    assert!(object[1].contains("one"), "{:?}", object[1]);
+    // No / empty bin renders nothing.
+    assert!(bin_summary(&json!({ "name": "x" })).is_empty(), "a missing bin renders nothing");
+    assert!(
+        bin_summary(&json!({ "name": "x", "bin": "" })).is_empty(),
+        "an empty bin renders nothing",
+    );
+}
+
+#[test]
+fn render_fields_multi_text_formats_by_type() {
+    let info = json!({ "name": "x", "dist": { "a": 1 } });
+    let selected = ["name".to_string(), "dist".to_string()];
+    let out = render_fields(&info, &selected, false);
+    assert!(out.contains("name = 'x'"), "{out}");
+    assert!(out.contains(r#"dist = {"a":1}"#), "{out}"); // objects render as compact JSON
+    // An absent field renders as `field = ` with an empty value.
+    let with_absent = ["missing".to_string(), "name".to_string()];
+    let out2 = render_fields(&info, &with_absent, false);
+    assert!(out2.lines().any(|line| line == "missing = "), "{out2}");
+}
+
+#[test]
+fn publisher_prefers_npm_user_then_maintainers_then_author() {
+    // `_npmUser` wins, with and without an email.
+    let with_email =
+        publisher(&json!({ "_npmUser": { "name": "alice", "email": "a@b.c" } })).unwrap();
+    assert!(with_email.contains("alice"), "{with_email}");
+    let no_email = publisher(&json!({ "_npmUser": { "name": "bob" } })).unwrap();
+    assert!(no_email.contains("bob"), "{no_email}");
+    // Then the first maintainer, with `et al.` when there is more than one.
+    let many = publisher(&json!({ "maintainers": [{ "name": "a" }, { "name": "b" }] })).unwrap();
+    assert!(many.contains("et al."), "{many}");
+    let single = publisher(&json!({ "maintainers": [{ "name": "solo" }] })).unwrap();
+    assert!(single.contains("solo") && !single.contains("et al."), "{single}");
+    // Then the author (returned verbatim, not colorized).
+    assert_eq!(publisher(&json!({ "author": "Jane Doe" })), Some("Jane Doe".to_string()));
+    // Nothing to attribute.
+    assert_eq!(publisher(&json!({})), None);
+}
+
+#[test]
+fn published_info_covers_publisher_absence_and_bad_time() {
+    let with_publisher = json!({
+        "version": "1.0.0",
+        "time": { "1.0.0": "2015-01-01T00:00:00.000Z" },
+        "maintainers": [{ "name": "alice" }],
+    });
+    let line = published_info(&with_publisher).expect("a published line");
+    assert!(
+        line.contains("published ") && line.contains(" ago") && line.contains("alice"),
+        "{line}",
+    );
+
+    let no_publisher =
+        json!({ "version": "1.0.0", "time": { "1.0.0": "2015-01-01T00:00:00.000Z" } });
+    let line = published_info(&no_publisher).expect("a published line");
+    assert!(
+        line.contains("published ") && line.contains(" ago") && !line.contains(" by "),
+        "{line}",
+    );
+
+    // A future timestamp degrades to "just now".
+    let future = json!({ "version": "1.0.0", "time": { "1.0.0": "2999-01-01T00:00:00.000Z" } });
+    let line = published_info(&future).unwrap();
+    assert!(line.contains("just now"), "{line}");
+
+    // Missing version, missing time, and an unparsable timestamp all yield no line.
+    assert_eq!(published_info(&json!({ "version": "1.0.0" })), None);
+    assert_eq!(published_info(&json!({ "time": {} })), None);
+    assert_eq!(published_info(&json!({ "version": "1.0.0", "time": { "1.0.0": "nope" } })), None);
+}
+
+#[test]
+fn format_person_renders_name_and_optional_email() {
+    let with_email = format_person(&json!({ "name": "alice", "email": "alice@example.com" }));
+    assert!(
+        with_email.contains("alice") && with_email.contains("alice@example.com"),
+        "{with_email}",
+    );
+    assert!(with_email.contains('<') && with_email.contains('>'), "{with_email}");
+
+    let without_email = format_person(&json!({ "name": "bob" }));
+    assert!(without_email.contains("bob") && !without_email.contains('<'), "{without_email}");
 }

--- a/pnpm/crates/cli/src/cli_args/view/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/view/tests.rs
@@ -1,0 +1,71 @@
+use chrono::{DateTime, Utc};
+use serde_json::{Value, json};
+
+use super::{
+    format_bytes, format_field_value, format_time_ago_since, get_nested_property, parse_date,
+};
+
+fn utc(rfc3339: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(rfc3339).expect("valid timestamp").with_timezone(&Utc)
+}
+
+#[test]
+fn format_bytes_uses_decimal_units() {
+    assert_eq!(format_bytes(0), "0 B");
+    assert_eq!(format_bytes(500), "500 B");
+    assert_eq!(format_bytes(1_500), "1.5 kB");
+    assert_eq!(format_bytes(1_000_000), "1 MB");
+    assert_eq!(format_bytes(1_250_000), "1.25 MB");
+}
+
+#[test]
+fn get_nested_property_walks_dotted_paths() {
+    let info = json!({ "name": "foo", "dist": { "shasum": "abc" } });
+    assert_eq!(get_nested_property(&info, "name"), Some(json!("foo")));
+    assert_eq!(get_nested_property(&info, "dist.shasum"), Some(json!("abc")));
+    assert_eq!(get_nested_property(&info, "dist.missing"), None);
+    assert_eq!(get_nested_property(&info, "name.shasum"), None);
+}
+
+#[test]
+fn format_field_value_matches_pnpm_rules() {
+    assert_eq!(format_field_value(None), "");
+    assert_eq!(format_field_value(Some(&Value::Null)), "");
+    assert_eq!(format_field_value(Some(&json!("hello"))), "hello");
+    assert_eq!(format_field_value(Some(&json!(42))), "42");
+    assert_eq!(format_field_value(Some(&json!(true))), "true");
+    assert_eq!(format_field_value(Some(&json!({ "a": 1 }))), "{\n  \"a\": 1\n}");
+}
+
+#[test]
+fn format_time_ago_rejects_future_dates() {
+    let now = utc("2024-01-01T00:00:00Z");
+    let future = utc("2024-01-02T00:00:00Z");
+    assert_eq!(format_time_ago_since(future, now), None);
+}
+
+#[test]
+fn format_time_ago_buckets_by_largest_unit() {
+    let now = utc("2024-06-15T12:00:00Z");
+    let cases = [
+        ("2024-06-15T11:59:58Z", "a few seconds ago"),
+        ("2024-06-15T11:59:00Z", "1 minute ago"),
+        ("2024-06-15T11:00:00Z", "1 hour ago"),
+        ("2024-06-15T09:00:00Z", "3 hours ago"),
+        ("2024-06-14T12:00:00Z", "1 day ago"),
+        ("2024-06-10T12:00:00Z", "5 days ago"),
+        ("2024-05-01T12:00:00Z", "1 month ago"),
+        ("2023-06-15T12:00:00Z", "1 year ago"),
+        ("2021-06-15T12:00:00Z", "3 years ago"),
+    ];
+    for (published, expected) in cases {
+        let ago = format_time_ago_since(utc(published), now);
+        assert_eq!(ago.as_deref(), Some(expected), "for {published}");
+    }
+}
+
+#[test]
+fn parse_date_accepts_iso_timestamps_only() {
+    assert!(parse_date("2024-01-01T00:00:00.000Z").is_some());
+    assert!(parse_date("not-a-date").is_none());
+}

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -20,6 +20,20 @@ use std::{ffi::OsString, future::Future, path::Path};
 pub fn main() -> miette::Result<()> {
     enable_tracing_by_env();
     set_panic_hook();
+    // The synchronous startup in `run_cli` — building the negation-augmented
+    // clap command (a recursive walk over every subcommand), relocating
+    // flags, and parsing argv — has a deep enough call chain to overflow
+    // Windows' 1 MiB default main-thread stack (Linux/macOS default to
+    // 8 MiB). `block_on_runtime` already moves the command body onto a
+    // roomy thread; run the parsing startup that precedes it on one too so
+    // the whole path has uniform headroom.
+    run_on_big_stack(run_cli)
+}
+
+/// Build the CLI, parse argv, take any early-return fast path, then execute
+/// the command. Split out of [`main`] so the whole path runs on a
+/// [`MAIN_STACK_SIZE`] thread; see the call site.
+fn run_cli() -> miette::Result<()> {
     // Extract pnpm's `--config.<key>=<value>` tokens before clap sees
     // argv. Clap can't parse a dotted-key flag whose right-hand name is
     // arbitrary, so a `--config.registry=...` from pnpm's forwarded flags
@@ -103,6 +117,26 @@ pub fn main() -> miette::Result<()> {
 /// the 8 MiB Linux/macOS default so the deep install call chain has the
 /// same room on every platform, including Windows (1 MiB default).
 const MAIN_STACK_SIZE: usize = 32 * 1024 * 1024;
+
+/// Run a synchronous closure on a fresh [`MAIN_STACK_SIZE`] thread and
+/// return its result, re-raising any panic on the caller. Gives the CLI
+/// startup the same stack headroom [`block_on_runtime`] gives the command,
+/// without a tokio runtime (so it can wrap code that later builds one).
+fn run_on_big_stack<Work, Output>(work: Work) -> Output
+where
+    Work: FnOnce() -> Output + Send,
+    Output: Send,
+{
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .name("pacquet-startup".to_string())
+            .stack_size(MAIN_STACK_SIZE)
+            .spawn_scoped(scope, work)
+            .expect("spawn the pacquet startup thread")
+            .join()
+            .unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+    })
+}
 
 fn block_on_runtime<Work, Output>(thread_name: &str, work: Work) -> Output
 where

--- a/pnpm/crates/cli/tests/view.rs
+++ b/pnpm/crates/cli/tests/view.rs
@@ -1,0 +1,747 @@
+//! `pacquet view` (aliases `info`, `show`, `v`) prints package metadata
+//! from the registry: a formatted summary, a JSON dump (`--json`), or
+//! selected fields.
+//!
+//! Covered here: command structure, the missing-name / non-registry /
+//! not-found / no-matching-version errors, field selection (single, nested,
+//! multiple, JSON), the summary sections (header, bin, dist, dist-tags, deps
+//! count, deprecation, published-by), and the nearest-manifest fallback when
+//! the package name is omitted.
+//!
+//! The registry is a `mockito` server the spawned `pacquet` connects to over
+//! loopback, so each test serves a crafted packument and asserts on the exact
+//! rendered output. An empty `--npmrc-auth-file` replaces the developer's real
+//! `~/.npmrc` so a token or `registry=` already on the machine can't influence
+//! the test. Output is captured through a pipe, so `supports-color` is off and
+//! the assertions match plain (un-colored) text — the CLI omits styling when
+//! stdout is not a TTY.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+/// An empty user-level `.npmrc`, returned for `--npmrc-auth-file`, so the
+/// developer's real `~/.npmrc` cannot leak a registry or token into the test.
+fn empty_auth_file(root: &Path) -> PathBuf {
+    let auth_file = root.join("auth-npmrc");
+    fs::write(&auth_file, "").expect("write empty auth .npmrc");
+    auth_file
+}
+
+/// Point the workspace's project `.npmrc` at `registry`.
+fn write_registry_npmrc(workspace: &Path, registry: &str) {
+    fs::write(workspace.join(".npmrc"), format!("registry={registry}\n"))
+        .expect("write project .npmrc");
+}
+
+fn run_view(workspace: &Path, auth_file: &Path, args: &[&str]) -> std::process::Output {
+    pacquet_at(workspace)
+        .with_arg("--npmrc-auth-file")
+        .with_arg(auth_file)
+        .with_arg("view")
+        .with_args(args.iter().copied())
+        .output()
+        .expect("spawn pacquet view")
+}
+
+fn stdout_of(output: &std::process::Output) -> String {
+    assert!(
+        output.status.success(),
+        "view must succeed (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// A full-metadata packument for `is-negative` with two live versions, a
+/// licence, description, maintainer, dist block, and per-version publish
+/// times — enough to exercise every summary section.
+fn is_negative_body() -> String {
+    serde_json::json!({
+        "name": "is-negative",
+        "dist-tags": { "latest": "2.1.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "is-negative",
+                "version": "1.0.0",
+                "license": "MIT",
+                "description": "Check if a number is negative",
+                "homepage": "https://github.com/kevva/is-negative#readme",
+                "maintainers": [{ "name": "kevva", "email": "kevva@example.com" }],
+                "dist": {
+                    "shasum": "1d06e1c0aa697471e487f3f32c39ba8a6b485e1e",
+                    "tarball": "https://registry.npmjs.org/is-negative/-/is-negative-1.0.0.tgz",
+                    "integrity": "sha512-1negative1.0.0integrityplaceholdervaluexxxxxxxxxxxxxxxxxx==",
+                    "unpackedSize": 1234
+                }
+            },
+            "2.1.0": {
+                "name": "is-negative",
+                "version": "2.1.0",
+                "license": "MIT",
+                "description": "Check if a number is negative",
+                "maintainers": [{ "name": "kevva", "email": "kevva@example.com" }],
+                "dist": {
+                    "shasum": "2c3a6e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e",
+                    "tarball": "https://registry.npmjs.org/is-negative/-/is-negative-2.1.0.tgz"
+                }
+            }
+        },
+        "time": {
+            "1.0.0": "2015-01-01T00:00:00.000Z",
+            "2.1.0": "2016-01-01T00:00:00.000Z"
+        }
+    })
+    .to_string()
+}
+
+/// Serve `body` at `GET /<path>` and return the mock so the test can keep the
+/// server alive for the duration of the request.
+fn serve(server: &mut mockito::Server, path: &str, body: &str) -> mockito::Mock {
+    server.mock("GET", path).with_status(200).with_body(body).expect_at_least(1).create()
+}
+
+#[test]
+fn aliases_are_recognised() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    for alias in ["view", "info", "show", "v"] {
+        let output = pacquet_at(&workspace)
+            .with_args([alias, "--help"])
+            .output()
+            .unwrap_or_else(|err| panic!("run pacquet {alias} --help: {err}"));
+        assert!(output.status.success(), "{alias} --help should succeed");
+    }
+    drop(root);
+}
+
+#[test]
+fn fails_without_package_name_or_manifest() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &[]);
+
+    assert!(!output.status.success(), "view without a package name must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_MISSING_PACKAGE_NAME"),
+        "stderr must name the missing-package-name diagnostic; got:\n{stderr}",
+    );
+    drop(root);
+}
+
+#[test]
+fn rejects_non_registry_spec() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["github:user/repo"]);
+
+    assert!(!output.status.success(), "a non-registry spec must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_INVALID_PACKAGE_NAME"),
+        "stderr must name the invalid-package-name diagnostic; got:\n{stderr}",
+    );
+    drop(root);
+}
+
+#[test]
+fn prints_summary_for_a_package() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative"]);
+
+    mock.assert();
+    let stdout = stdout_of(&output);
+    assert!(stdout.contains("is-negative"), "summary must mention the package: {stdout:?}");
+    drop((root, server));
+}
+
+#[test]
+fn package_not_found_is_fetch_404() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = server.mock("GET", "/not-a-real-package").with_status(404).create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["not-a-real-package"]);
+
+    mock.assert();
+    assert!(!output.status.success(), "a 404 must fail the command");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_FETCH_404"),
+        "stderr must name the fetch-404 diagnostic; got:\n{stderr}",
+    );
+    drop((root, server));
+}
+
+#[test]
+fn no_matching_version_errors() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@99999.0.0"]);
+
+    mock.assert();
+    assert!(!output.status.success(), "an unsatisfiable version must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_PACKAGE_NOT_FOUND"),
+        "stderr must name the package-not-found diagnostic; got:\n{stderr}",
+    );
+    drop((root, server));
+}
+
+#[test]
+fn json_output_parses_and_carries_name() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative", "--json"]);
+
+    mock.assert();
+    let parsed: Value = serde_json::from_str(&stdout_of(&output)).expect("output is valid JSON");
+    assert_eq!(parsed["name"], "is-negative");
+    drop((root, server));
+}
+
+#[test]
+fn single_field_prints_plain_value() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative", "name"]);
+
+    mock.assert();
+    assert_eq!(stdout_of(&output).trim(), "is-negative");
+    drop((root, server));
+}
+
+#[test]
+fn specific_version_field() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@1.0.0", "version"]);
+
+    mock.assert();
+    assert_eq!(stdout_of(&output).trim(), "1.0.0");
+    drop((root, server));
+}
+
+#[test]
+fn multiple_fields_quote_strings() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@1.0.0", "name", "version"]);
+
+    mock.assert();
+    let stdout = stdout_of(&output);
+    assert!(stdout.contains("name = 'is-negative'"), "quoted name expected: {stdout:?}");
+    assert!(stdout.contains("version = '1.0.0'"), "quoted version expected: {stdout:?}");
+    drop((root, server));
+}
+
+#[test]
+fn version_range_resolves_to_matching_version() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@^1.0.0", "version"]);
+
+    mock.assert();
+    assert_eq!(stdout_of(&output).trim(), "1.0.0");
+    drop((root, server));
+}
+
+#[test]
+fn dist_tag_resolves() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@latest", "version"]);
+
+    mock.assert();
+    assert_eq!(stdout_of(&output).trim(), "2.1.0");
+    drop((root, server));
+}
+
+#[test]
+fn nested_field_selection() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@1.0.0", "dist.shasum"]);
+
+    mock.assert();
+    assert_eq!(stdout_of(&output).trim(), "1d06e1c0aa697471e487f3f32c39ba8a6b485e1e");
+    drop((root, server));
+}
+
+#[test]
+fn field_selection_with_json() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output =
+        run_view(&workspace, &auth_file, &["is-negative@1.0.0", "name", "version", "--json"]);
+
+    mock.assert();
+    let parsed: Value = serde_json::from_str(&stdout_of(&output)).expect("valid JSON");
+    assert_eq!(parsed["name"], "is-negative");
+    assert_eq!(parsed["version"], "1.0.0");
+    drop((root, server));
+}
+
+#[test]
+fn single_field_json_unwraps_value() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@1.0.0", "name", "--json"]);
+
+    mock.assert();
+    let parsed: Value = serde_json::from_str(&stdout_of(&output)).expect("valid JSON");
+    assert_eq!(parsed, Value::String("is-negative".to_string()));
+    drop((root, server));
+}
+
+#[test]
+fn object_field_renders_as_json() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@1.0.0", "dist"]);
+
+    mock.assert();
+    let parsed: Value = serde_json::from_str(&stdout_of(&output)).expect("dist renders as JSON");
+    assert!(parsed["tarball"].is_string(), "dist.tarball present: {parsed:?}");
+    assert!(parsed["shasum"].is_string(), "dist.shasum present: {parsed:?}");
+    drop((root, server));
+}
+
+#[test]
+fn versions_field_returns_array() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative", "versions"]);
+
+    mock.assert();
+    let parsed: Value =
+        serde_json::from_str(&stdout_of(&output)).expect("versions is a JSON array");
+    let versions = parsed.as_array().expect("array");
+    assert!(versions.contains(&Value::String("1.0.0".to_string())), "{versions:?}");
+    drop((root, server));
+}
+
+#[test]
+fn dist_tags_field_returns_mapping() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative", "dist-tags", "--json"]);
+
+    mock.assert();
+    let parsed: Value = serde_json::from_str(&stdout_of(&output)).expect("valid JSON");
+    assert_eq!(parsed["latest"], "2.1.0");
+    drop((root, server));
+}
+
+#[test]
+fn time_field_returns_publish_timestamps() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative", "time", "--json"]);
+
+    mock.assert();
+    let parsed: Value = serde_json::from_str(&stdout_of(&output)).expect("valid JSON");
+    assert!(parsed["1.0.0"].is_string(), "per-version time present: {parsed:?}");
+    drop((root, server));
+}
+
+#[test]
+fn summary_header_dist_and_published_sections() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative@1.0.0"]);
+
+    mock.assert();
+    let stdout = stdout_of(&output);
+    let first_line = stdout.lines().next().unwrap_or_default();
+    assert!(first_line.contains("is-negative@1.0.0"), "header: {first_line:?}");
+    assert!(first_line.contains("deps: none"), "no-deps package: {first_line:?}");
+    assert!(stdout.contains(".tarball:"), "dist tarball: {stdout:?}");
+    assert!(stdout.contains(".shasum:"), "dist shasum: {stdout:?}");
+    assert!(stdout.contains("published "), "published line: {stdout:?}");
+    assert!(stdout.contains(" ago by "), "published-by line: {stdout:?}");
+    drop((root, server));
+}
+
+#[test]
+fn summary_dist_tags_section() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative"]);
+
+    mock.assert();
+    let stdout = stdout_of(&output);
+    assert!(stdout.contains("dist-tags:"), "dist-tags section: {stdout:?}");
+    assert!(stdout.contains("latest:"), "latest tag: {stdout:?}");
+    drop((root, server));
+}
+
+#[test]
+fn summary_shows_deps_count_and_deprecation() {
+    let body = serde_json::json!({
+        "name": "demo-pkg",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "demo-pkg",
+                "version": "1.0.0",
+                "deprecated": "use something else",
+                "dependencies": { "left-pad": "^1.0.0" },
+                "dist": { "tarball": "https://example.com/demo-pkg-1.0.0.tgz" }
+            }
+        }
+    })
+    .to_string();
+
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/demo-pkg", &body);
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["demo-pkg@1.0.0"]);
+
+    mock.assert();
+    let stdout = stdout_of(&output);
+    let first_line = stdout.lines().next().unwrap_or_default();
+    assert!(first_line.contains("deps: "), "deps count: {first_line:?}");
+    assert!(!first_line.contains("deps: none"), "should not be none: {first_line:?}");
+    assert!(stdout.contains("DEPRECATED! - use something else"), "deprecation: {stdout:?}");
+    drop((root, server));
+}
+
+#[test]
+fn summary_bin_from_object_and_string() {
+    let object_bin = serde_json::json!({
+        "name": "demo-bin",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "demo-bin",
+                "version": "1.0.0",
+                "bin": { "touch-file-one-bin": "index.js" },
+                "dist": { "tarball": "https://example.com/demo-bin-1.0.0.tgz" }
+            }
+        }
+    })
+    .to_string();
+    let string_bin = serde_json::json!({
+        "name": "@demo/scoped-bin",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "@demo/scoped-bin",
+                "version": "1.0.0",
+                "bin": "index.js",
+                "dist": { "tarball": "https://example.com/scoped-bin-1.0.0.tgz" }
+            }
+        }
+    })
+    .to_string();
+
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let object_mock = serve(&mut server, "/demo-bin", &object_bin);
+    let string_mock = serve(&mut server, "/@demo%2Fscoped-bin", &string_bin);
+    let auth_file = empty_auth_file(root.path());
+
+    let object_output = run_view(&workspace, &auth_file, &["demo-bin@1.0.0"]);
+    object_mock.assert();
+    assert!(
+        stdout_of(&object_output).contains("bin: touch-file-one-bin"),
+        "object bin lists its key",
+    );
+
+    let string_output = run_view(&workspace, &auth_file, &["@demo/scoped-bin"]);
+    string_mock.assert();
+    assert!(
+        stdout_of(&string_output).contains("bin: scoped-bin"),
+        "string bin derives the scope-stripped name",
+    );
+    drop((root, server));
+}
+
+#[test]
+fn scoped_package_lookup() {
+    let body = serde_json::json!({
+        "name": "@demo/pkg",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "@demo/pkg",
+                "version": "1.0.0",
+                "dist": { "tarball": "https://example.com/pkg-1.0.0.tgz" }
+            }
+        }
+    })
+    .to_string();
+
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/@demo%2Fpkg", &body);
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["@demo/pkg@1.0.0", "name"]);
+
+    mock.assert();
+    assert_eq!(stdout_of(&output).trim(), "@demo/pkg");
+    drop((root, server));
+}
+
+#[test]
+fn uses_manifest_name_when_package_omitted() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    fs::write(workspace.join("package.json"), r#"{"name":"is-negative"}"#)
+        .expect("write package.json");
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &[]);
+
+    mock.assert();
+    assert!(stdout_of(&output).contains("is-negative"), "summary derived from manifest name");
+    drop((root, server));
+}
+
+#[test]
+fn searches_upward_for_manifest() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    fs::write(workspace.join("package.json"), r#"{"name":"is-negative"}"#)
+        .expect("write package.json");
+    let nested = workspace.join("a").join("b");
+    fs::create_dir_all(&nested).expect("create nested dir");
+    write_registry_npmrc(&nested, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&nested, &auth_file, &[]);
+
+    mock.assert();
+    assert!(stdout_of(&output).contains("is-negative"), "manifest found by upward search");
+    drop((root, server));
+}
+
+#[test]
+fn manifest_without_name_is_invalid_package_json() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{"version":"1.0.0"}"#)
+        .expect("write package.json");
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &[]);
+
+    assert!(!output.status.success(), "a manifest with no name must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_INVALID_PACKAGE_JSON"),
+        "stderr must name the invalid-package-json diagnostic; got:\n{stderr}",
+    );
+    drop(root);
+}
+
+#[test]
+fn non_object_manifest_is_invalid_package_json() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "null").expect("write package.json");
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &[]);
+
+    assert!(!output.status.success(), "a non-object manifest must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_INVALID_PACKAGE_JSON"),
+        "stderr must name the invalid-package-json diagnostic; got:\n{stderr}",
+    );
+    drop(root);
+}
+
+#[test]
+fn versions_field_with_json_returns_array() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative", "versions", "--json"]);
+
+    mock.assert();
+    let parsed: Value =
+        serde_json::from_str(&stdout_of(&output)).expect("versions is a JSON array");
+    let versions = parsed.as_array().expect("array");
+    assert!(versions.contains(&Value::String("1.0.0".to_string())), "{versions:?}");
+    drop((root, server));
+}
+
+#[test]
+fn resolves_manifest_from_dir_flag_when_cwd_differs() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    fs::write(workspace.join("package.json"), r#"{"name":"is-negative"}"#)
+        .expect("write package.json");
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    // Run from the parent dir but point `-C` at the workspace: the nearest
+    // manifest is resolved from `--dir`, not the process cwd.
+    let output = pacquet_at(root.path())
+        .with_arg("-C")
+        .with_arg(&workspace)
+        .with_arg("--npmrc-auth-file")
+        .with_arg(&auth_file)
+        .with_arg("view")
+        .output()
+        .expect("spawn pacquet view");
+
+    mock.assert();
+    assert!(stdout_of(&output).contains("is-negative"), "manifest resolved from --dir");
+    drop((root, server));
+}
+
+#[test]
+fn derives_name_when_engines_pnpm_incompatible() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    fs::write(
+        workspace.join("package.json"),
+        r#"{"name":"is-negative","engines":{"pnpm":"999.0.0"}}"#,
+    )
+    .expect("write package.json");
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &[]);
+
+    mock.assert();
+    assert!(
+        stdout_of(&output).contains("is-negative"),
+        "view reads the manifest name without enforcing engines.pnpm",
+    );
+    drop((root, server));
+}
+
+#[test]
+#[ignore = "pacquet's project-manifest reader (pnpm_workspace::try_read_project_manifest) \
+            reads package.json only; package.yaml / package.json5 are not supported yet"]
+fn uses_package_yaml_name_when_package_omitted() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    fs::write(workspace.join("package.yaml"), "name: is-negative\n").expect("write package.yaml");
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &[]);
+
+    mock.assert();
+    assert!(stdout_of(&output).contains("is-negative"), "summary derived from package.yaml name");
+    drop((root, server));
+}
+
+#[test]
+fn absent_field_produces_no_output() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["is-negative", "no-such-field"]);
+
+    mock.assert();
+    // An absent field renders as an empty string, so nothing is printed.
+    assert_eq!(stdout_of(&output), "");
+    drop((root, server));
+}

--- a/pnpm/crates/cli/tests/view.rs
+++ b/pnpm/crates/cli/tests/view.rs
@@ -745,3 +745,32 @@ fn absent_field_produces_no_output() {
     assert_eq!(stdout_of(&output), "");
     drop((root, server));
 }
+
+#[test]
+fn object_author_collapses_to_its_name() {
+    let body = serde_json::json!({
+        "name": "authored",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "authored",
+                "version": "1.0.0",
+                "author": { "name": "Jane Doe", "email": "jane@example.com" },
+                "dist": { "tarball": "https://example.com/authored-1.0.0.tgz" }
+            }
+        }
+    })
+    .to_string();
+
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
+    let mock = serve(&mut server, "/authored", &body);
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(&workspace, &auth_file, &["authored@1.0.0", "author"]);
+
+    mock.assert();
+    assert_eq!(stdout_of(&output).trim(), "Jane Doe");
+    drop((root, server));
+}


### PR DESCRIPTION
Port the `view` command (aliases `info`, `show`, `v`) to pacquet: fetch a package's registry metadata and render a formatted summary, a JSON dump (`--json`), or selected dotted fields. When the package name is omitted, the nearest project manifest's name is used, searching upward from `--dir`.

Reuses the existing metadata-fetch stack (full-metadata fetch, `pick_package_from_meta` version selection, registry/auth resolution) and assembles the info object from the picked version's raw JSON fragment so registry key order is preserved in `--json` output. Error codes match pnpm: ERR_PNPM_MISSING_PACKAGE_NAME, ERR_PNPM_INVALID_PACKAGE_NAME, ERR_PNPM_INVALID_PACKAGE_JSON, ERR_PNPM_PACKAGE_NOT_FOUND, ERR_PNPM_FETCH_404.

The TypeScript pnpm CLI already ships `view`, so this only adds the pacquet side; no TypeScript change is needed. Covers the `view` item under the Stage 3 command surface in pnpm/pnpm#11633.

Tests: unit tests for the pure helpers (byte/time/field formatting) plus an integration suite that drives the built binary against a mockito registry, covering the upstream view scenarios. `package.yaml` name resolution is left as an ignored test — pacquet's project-manifest reader is package.json only today.

<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Implements the `pnpm view` command (aliases `info`, `show`, `v`) in the pacquet
Rust CLI. `pacquet view [<pkg>[@<spec>]] [field...]` fetches a package's registry
metadata and prints either a formatted summary, a JSON dump (`--json`), or
selected dotted fields (e.g. `dist.shasum`). When the package name is omitted,
the nearest project manifest's `name` is used, searching upward from `--dir`.

The TypeScript pnpm CLI already ships `view`, so this PR only adds the pacquet
side — no TypeScript change is required. It covers the `view` item in the Stage 3
command surface of the Rust roadmap (Related to pnpm/pnpm#11633).

Behavior parity:

- Version selection via `pick_package_from_meta` (exact / range / dist-tag).
- The info object is assembled from the picked version's raw JSON fragment, so
  registry key order is preserved in `--json` output.
- Error codes match pnpm: `ERR_PNPM_MISSING_PACKAGE_NAME`,
  `ERR_PNPM_INVALID_PACKAGE_NAME`, `ERR_PNPM_INVALID_PACKAGE_JSON`,
  `ERR_PNPM_PACKAGE_NOT_FOUND`, `ERR_PNPM_FETCH_404`.
- Colors follow the existing `if_supports_color` convention (styling off when
  stdout is not a TTY).

Known limitation: `package.yaml` / `package.json5` name resolution isn't
supported — pacquet's project-manifest reader is `package.json`-only today. The
corresponding upstream test is ported as an `#[ignore]`d test documenting the
gap.

## Squash Commit Body

```text
Port the `view` command (aliases `info`, `show`, `v`) to pacquet: fetch a
package's registry metadata and render a formatted summary, a JSON dump
(`--json`), or selected dotted fields. When the package name is omitted, the
nearest project manifest's name is used, searching upward from `--dir`.

Reuses the existing metadata-fetch stack (full-metadata fetch,
`pick_package_from_meta` version selection, registry/auth resolution) and
assembles the info object from the picked version's raw JSON fragment so
registry key order is preserved in `--json` output. Error codes match pnpm:
ERR_PNPM_MISSING_PACKAGE_NAME, ERR_PNPM_INVALID_PACKAGE_NAME,
ERR_PNPM_INVALID_PACKAGE_JSON, ERR_PNPM_PACKAGE_NOT_FOUND, ERR_PNPM_FETCH_404.

The TypeScript pnpm CLI already ships `view`, so this only adds the pacquet
side; no TypeScript change is needed. Covers the `view` item under the Stage 3
command surface in pnpm/pnpm#11633.

Tests: unit tests for the pure helpers (byte/time/field formatting) plus an
integration suite that drives the built binary against a mockito registry,
covering the upstream view scenarios. `package.yaml` name resolution is left
as an ignored test — pacquet's project-manifest reader is package.json only
today.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. — The
  TypeScript CLI already ships `view`; this PR adds the pacquet side to reach
  parity.
- [x] Added or updated tests. — Unit tests for the pure helpers plus an
  integration suite (mockito registry) covering the upstream `view.ts`
  scenarios.
- [x] Updated the documentation if needed. — No documentation change needed.

<!-- Changeset item removed: it applies to published TypeScript packages only;
this is a Rust-only change. -->

---
Made with the help of Claude Code (claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787176228&installation_model_id=426870&pr_number=13181&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13181&signature=d3687ba5e08ddc8e0c53aed02f686aaf5e125f9bd7f7ca273d1ce0ae494e1a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `pacquet view` command (aliases `info`, `show`, `v`) to display registry package info with version resolution (exact, semver ranges, dist-tags).
  * Can infer the package name from the nearest `package.json` (supports `-C/--dir`).
  * Supports human-readable output or `--json` with dotted-path field selection; absent fields output nothing.
* **Bug Fixes**
  * Improved CLI startup reliability by performing argument parsing on a larger stack across platforms.
* **Tests**
  * Added unit and integration coverage for formatting helpers, dotted-path selection, `--json` shapes, and registry/error/version-resolution scenarios (including 404).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->