### PR TITLE
fix(pkg): allow hyphens in property path identifiers

### DIFF
--- a/.changeset/hyphen-property-path-identifiers.md
+++ b/.changeset/hyphen-property-path-identifiers.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/object.property-path": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Allow hyphens in property path identifiers so `pnpm pkg get/set` accepts package names like `dependencies.some-package-name` (GH-13163).

--- a/.changeset/hyphen-property-path.md
+++ b/.changeset/hyphen-property-path.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/object.property-path": minor
+---
+
+Allow hyphens in property path identifiers so keys like `dependencies.some-package-name` parse correctly.

--- a/pnpm/crates/config/src/property_path.rs
+++ b/pnpm/crates/config/src/property_path.rs
@@ -115,7 +115,7 @@ fn parse_identifier(source: &str) -> Option<(Token, &str)> {
     }
     let mut end = first.len_utf8();
     for (i, c) in chars {
-        // `\w` in JS = [A-Za-z0-9_]; also allow '-' for package-like keys (#13163).
+        // `\w` in JS = [A-Za-z0-9_]; also allow '-' for package-like keys (GH-13163).
         if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
             end = i + c.len_utf8();
         } else {

--- a/pnpm/crates/config/src/property_path.rs
+++ b/pnpm/crates/config/src/property_path.rs
@@ -115,8 +115,8 @@ fn parse_identifier(source: &str) -> Option<(Token, &str)> {
     }
     let mut end = first.len_utf8();
     for (i, c) in chars {
-        // `\w` in JS = [A-Za-z0-9_]
-        if c.is_ascii_alphanumeric() || c == '_' {
+        // `\w` in JS = [A-Za-z0-9_]; also allow '-' for package-like keys (#13163).
+        if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
             end = i + c.len_utf8();
         } else {
             break;

--- a/pnpm/crates/config/src/property_path/tests.rs
+++ b/pnpm/crates/config/src/property_path/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    get_object_value_by_property_path, parse_property_path, ParsePropertyPathError, Segment,
+    ParsePropertyPathError, Segment, get_object_value_by_property_path, parse_property_path,
 };
 use serde_json::json;
 

--- a/pnpm/crates/config/src/property_path/tests.rs
+++ b/pnpm/crates/config/src/property_path/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    ParsePropertyPathError, Segment, get_object_value_by_property_path, parse_property_path,
+    get_object_value_by_property_path, parse_property_path, ParsePropertyPathError, Segment,
 };
 use serde_json::json;
 
@@ -41,20 +41,14 @@ fn parses_scoped_package_keys() {
 
 #[test]
 fn parses_hyphenated_package_keys() {
-    // npm pkg get/set style paths with hyphenated dependency names (#13163)
+    // npm pkg get/set style paths with hyphenated dependency names (GH-13163)
     assert_eq!(
-        keys("dependencies.replicad-evaluator"),
-        vec![
-            Segment::Key("dependencies".into()),
-            Segment::Key("replicad-evaluator".into()),
-        ],
+        keys("dependencies.some-package-name"),
+        vec![Segment::Key("dependencies".into()), Segment::Key("some-package-name".into()),],
     );
     assert_eq!(
         keys("devDependencies.some-package-name"),
-        vec![
-            Segment::Key("devDependencies".into()),
-            Segment::Key("some-package-name".into()),
-        ],
+        vec![Segment::Key("devDependencies".into()), Segment::Key("some-package-name".into()),],
     );
 }
 

--- a/pnpm/crates/config/src/property_path/tests.rs
+++ b/pnpm/crates/config/src/property_path/tests.rs
@@ -40,6 +40,25 @@ fn parses_scoped_package_keys() {
 }
 
 #[test]
+fn parses_hyphenated_package_keys() {
+    // npm pkg get/set style paths with hyphenated dependency names (#13163)
+    assert_eq!(
+        keys("dependencies.replicad-evaluator"),
+        vec![
+            Segment::Key("dependencies".into()),
+            Segment::Key("replicad-evaluator".into()),
+        ],
+    );
+    assert_eq!(
+        keys("devDependencies.some-package-name"),
+        vec![
+            Segment::Key("devDependencies".into()),
+            Segment::Key("some-package-name".into()),
+        ],
+    );
+}
+
+#[test]
 fn parse_errors() {
     assert_eq!(
         parse_property_path("foo..bar"),

--- a/pnpm11/object/property-path/src/token/Identifier.ts
+++ b/pnpm11/object/property-path/src/token/Identifier.ts
@@ -15,7 +15,7 @@ export const parseIdentifier: Tokenize<Identifier> = source => {
   source = source.slice(1)
   while (source !== '') {
     const char = source[0]
-    // Allow hyphens so keys like dependencies.replicad-evaluator parse (#13163).
+    // Allow hyphens so keys like dependencies.some-package-name parse (GH-13163).
     if (!/[\w-]/.test(char)) break
     source = source.slice(1)
     content += char

--- a/pnpm11/object/property-path/src/token/Identifier.ts
+++ b/pnpm11/object/property-path/src/token/Identifier.ts
@@ -15,7 +15,8 @@ export const parseIdentifier: Tokenize<Identifier> = source => {
   source = source.slice(1)
   while (source !== '') {
     const char = source[0]
-    if (!/\w/.test(char)) break
+    // Allow hyphens so keys like dependencies.replicad-evaluator parse (#13163).
+    if (!/[\w-]/.test(char)) break
     source = source.slice(1)
     content += char
   }

--- a/pnpm11/object/property-path/test/parse.test.ts
+++ b/pnpm11/object/property-path/test/parse.test.ts
@@ -27,6 +27,9 @@ test('valid property path', () => {
   expect(Array.from(parsePropertyPath('.a.b.c.d'))).toStrictEqual(['a', 'b', 'c', 'd'])
   expect(Array.from(parsePropertyPath('a .b .c .d'))).toStrictEqual(['a', 'b', 'c', 'd'])
   expect(Array.from(parsePropertyPath('.a .b .c .d'))).toStrictEqual(['a', 'b', 'c', 'd'])
+  // package names with hyphens (npm pkg get/set compatible) (#13163)
+  expect(Array.from(parsePropertyPath('dependencies.replicad-evaluator'))).toStrictEqual(['dependencies', 'replicad-evaluator'])
+  expect(Array.from(parsePropertyPath('devDependencies.some-package-name'))).toStrictEqual(['devDependencies', 'some-package-name'])
 })
 
 test('invalid property path', () => {

--- a/pnpm11/object/property-path/test/parse.test.ts
+++ b/pnpm11/object/property-path/test/parse.test.ts
@@ -27,8 +27,8 @@ test('valid property path', () => {
   expect(Array.from(parsePropertyPath('.a.b.c.d'))).toStrictEqual(['a', 'b', 'c', 'd'])
   expect(Array.from(parsePropertyPath('a .b .c .d'))).toStrictEqual(['a', 'b', 'c', 'd'])
   expect(Array.from(parsePropertyPath('.a .b .c .d'))).toStrictEqual(['a', 'b', 'c', 'd'])
-  // package names with hyphens (npm pkg get/set compatible) (#13163)
-  expect(Array.from(parsePropertyPath('dependencies.replicad-evaluator'))).toStrictEqual(['dependencies', 'replicad-evaluator'])
+  // package names with hyphens (npm pkg get/set compatible) (GH-13163)
+  expect(Array.from(parsePropertyPath('dependencies.some-package-name'))).toStrictEqual(['dependencies', 'some-package-name'])
   expect(Array.from(parsePropertyPath('devDependencies.some-package-name'))).toStrictEqual(['devDependencies', 'some-package-name'])
 })
 

--- a/pnpm11/object/property-path/test/token/Identifier.test.ts
+++ b/pnpm11/object/property-path/test/token/Identifier.test.ts
@@ -75,8 +75,12 @@ test('identifier and tail', () => {
   } as Identifier, '.def'])
   expect(parseIdentifier('helloWorld123-456')).toStrictEqual([{
     type: 'identifier',
-    content: 'helloWorld123',
-  } as Identifier, '-456'])
+    content: 'helloWorld123-456',
+  } as Identifier, ''])
+  expect(parseIdentifier('some-package-name.more')).toStrictEqual([{
+    type: 'identifier',
+    content: 'some-package-name',
+  } as Identifier, '.more'])
   expect(parseIdentifier('HelloWorld123 456')).toStrictEqual([{
     type: 'identifier',
     content: 'HelloWorld123',


### PR DESCRIPTION
## Description

`pnpm pkg get/set` rejected property paths with hyphens in identifiers:

```sh
pnpm pkg get dependencies.replicad-evaluator
# ERR_PNPM_UNEXPECTED_TOKEN_IN_PROPERTY_PATH Unexpected token "-"
```

npm accepts these paths. Both parsers treated identifiers as `\w` only.

## Fix

- **TypeScript** (`pnpm11/object/property-path`): continue identifiers with `[\w-]`
- **Rust** (`pacquet-config` property_path): continue identifiers with alphanumeric/`_`/`-`

## Tests

```text
cargo test --manifest-path pnpm/crates/config/Cargo.toml parses_hyphenated
# ok
```

Added TS cases for `dependencies.replicad-evaluator` and `devDependencies.some-package-name`.

## Linked Issue

Closes #13163

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787210996&installation_model_id=426870&pr_number=13188&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13188&signature=5cba6af3852e1bb85e6ca7185145ce5d4a9ae32ec80acd4a4dbe71c90604cd7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Property paths now accept hyphens in unquoted identifiers, so npm-style keys like `dependencies.some-package-name` and `devDependencies.some-package-name` parse correctly (including `pnpm pkg get/set`).
* **Tests**
  * Expanded unit and Jest coverage to verify hyphenated segments remain intact and tokenization/identifier parsing matches expected behavior.
* **Release Notes**
  * Added Changeset entries for the affected packages to reflect the identifier parsing update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->