### PR TITLE
fix(projects-graph): resolve workspace deps declared with a relative path

### DIFF
--- a/.changeset/workspace-relative-path-deps-resolved.md
+++ b/.changeset/workspace-relative-path-deps-resolved.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/workspace.projects-graph": patch
+"pnpm": patch
+---
+
+Workspace dependencies declared with a relative path (e.g. `"foo": "workspace:../foo"`) are no longer silently dropped from the workspace projects graph, so `--filter` selection and the topological order of recursive commands take them into account.

--- a/pnpm11/workspace/projects-graph/src/index.ts
+++ b/pnpm11/workspace/projects-graph/src/index.ts
@@ -49,18 +49,23 @@ export function createProjectsGraph<Pkg extends BaseProject> (projects: Pkg[], o
         try {
           if (isWorkspaceSpec) {
             const npmSpec = workspacePrefToNpm(rawSpec)
-            let parsed: ReturnType<typeof parseBareSpecifier> = null
-            try {
-              parsed = parseBareSpecifier(npmSpec, depName, 'latest', '')
-            } catch {
-              // Not a valid bare specifier (e.g. workspace:../relative/path).
-            }
-            if (parsed) {
-              rawSpec = parsed.fetchSpec
-              depName = parsed.name
-            } else {
-              // Fall back to resolving it as a directory dependency below.
+            if (isRelativePathSpec(npmSpec)) {
+              // workspace:../foo / workspace:./foo aren't bare specifiers;
+              // resolve them as directory dependencies below.
               rawSpec = npmSpec
+            } else {
+              let parsed: ReturnType<typeof parseBareSpecifier> = null
+              try {
+                parsed = parseBareSpecifier(npmSpec, depName, 'latest', '')
+              } catch {
+                // Defensive backstop for other malformed specs.
+              }
+              if (parsed) {
+                rawSpec = parsed.fetchSpec
+                depName = parsed.name
+              } else {
+                rawSpec = npmSpec
+              }
             }
           }
           spec = npa.resolve(depName, rawSpec, project.rootDir)
@@ -117,6 +122,10 @@ export function createProjectsGraph<Pkg extends BaseProject> (projects: Pkg[], o
       })
       .filter(Boolean)
   }
+}
+
+function isRelativePathSpec (spec: string): boolean {
+  return spec === '.' || spec === '..' || spec.startsWith('./') || spec.startsWith('../')
 }
 
 function createProjectMap (projects: BaseProject[]): Record<ProjectRootDir, BaseProject> {

--- a/pnpm11/workspace/projects-graph/src/index.ts
+++ b/pnpm11/workspace/projects-graph/src/index.ts
@@ -48,9 +48,20 @@ export function createProjectsGraph<Pkg extends BaseProject> (projects: Pkg[], o
         const isWorkspaceSpec = rawSpec.startsWith('workspace:')
         try {
           if (isWorkspaceSpec) {
-            const { fetchSpec, name } = parseBareSpecifier(workspacePrefToNpm(rawSpec), depName, 'latest', '')!
-            rawSpec = fetchSpec
-            depName = name
+            const npmSpec = workspacePrefToNpm(rawSpec)
+            let parsed: ReturnType<typeof parseBareSpecifier> = null
+            try {
+              parsed = parseBareSpecifier(npmSpec, depName, 'latest', '')
+            } catch {
+              // Not a valid bare specifier (e.g. workspace:../relative/path).
+            }
+            if (parsed) {
+              rawSpec = parsed.fetchSpec
+              depName = parsed.name
+            } else {
+              // Fall back to resolving it as a directory dependency below.
+              rawSpec = npmSpec
+            }
           }
           spec = npa.resolve(depName, rawSpec, project.rootDir)
         } catch {

--- a/pnpm11/workspace/projects-graph/test/index.ts
+++ b/pnpm11/workspace/projects-graph/test/index.ts
@@ -319,6 +319,32 @@ test('create package graph for local directory dependencies using the workspace 
   })
 })
 
+test('create package graph for local directory dependencies using the workspace protocol with a ./ prefix', () => {
+  const NESTED_FOO_PATH = pathResolve('/zkochan/src/bar/nested-foo')
+  const result = createProjectsGraph([
+    {
+      rootDir: BAR1_PATH,
+      manifest: {
+        name: 'bar',
+        version: '1.0.0',
+
+        dependencies: {
+          foo: 'workspace:./nested-foo',
+        },
+      },
+    },
+    {
+      rootDir: NESTED_FOO_PATH,
+      manifest: {
+        name: 'foo',
+        version: '1.0.0',
+      },
+    },
+  ])
+  expect(result.unmatched).toStrictEqual([])
+  expect(result.graph[BAR1_PATH].dependencies).toStrictEqual([NESTED_FOO_PATH])
+})
+
 test('create package graph ignoring the workspace protocol', () => {
   const result = createProjectsGraph([
     {

--- a/pnpm11/workspace/projects-graph/test/index.ts
+++ b/pnpm11/workspace/projects-graph/test/index.ts
@@ -269,6 +269,56 @@ test('create package graph for local directory dependencies', () => {
   })
 })
 
+test('create package graph for local directory dependencies using the workspace protocol', () => {
+  const result = createProjectsGraph([
+    {
+      rootDir: BAR1_PATH,
+      manifest: {
+        name: 'bar',
+        version: '1.0.0',
+
+        dependencies: {
+          foo: 'workspace:../foo',
+        },
+      },
+    },
+    {
+      rootDir: FOO1_PATH,
+      manifest: {
+        name: 'foo',
+        version: '1.0.0',
+      },
+    },
+  ])
+  expect(result.unmatched).toStrictEqual([])
+  expect(result.graph).toStrictEqual({
+    [BAR1_PATH]: {
+      dependencies: [FOO1_PATH],
+      package: {
+        rootDir: BAR1_PATH,
+        manifest: {
+          name: 'bar',
+          version: '1.0.0',
+
+          dependencies: {
+            foo: 'workspace:../foo',
+          },
+        },
+      },
+    },
+    [FOO1_PATH]: {
+      dependencies: [],
+      package: {
+        rootDir: FOO1_PATH,
+        manifest: {
+          name: 'foo',
+          version: '1.0.0',
+        },
+      },
+    },
+  })
+})
+
 test('create package graph ignoring the workspace protocol', () => {
   const result = createProjectsGraph([
     {


### PR DESCRIPTION
### What

A workspace dependency declared with a relative path, e.g.

```json
{ "dependencies": { "foo": "workspace:../foo" } }
```

is silently dropped from the project dependency graph.

### Why

In `projects-graph`, a `workspace:` spec is passed through `workspacePrefToNpm`, which for `workspace:../foo` returns the bare string `../foo` (the spec parser treats a `.`-leading value as a version, not an alias). That string is then handed to `parseBareSpecifier(spec, name, 'latest', '')`. Because the registry argument is an empty string, `bareSpecifier.startsWith(registry)` is always true, so it is routed to `parseNpmTarballUrl('../foo')`, which calls `new URL('../foo')` and throws `Invalid URL`.

The surrounding `try { ... } catch { return '' }` swallows the throw, and the trailing `.filter(Boolean)` then removes the empty result, so the edge disappears with no error or warning. This affects `--filter` selection and the topological order of recursive installs.

### Fix

When the workspace spec cannot be parsed as a bare specifier, fall back to resolving the un-prefixed value as a directory dependency through the existing `npa.resolve(depName, rawSpec, project.rootDir)` path already used for plain relative-path dependencies. The Rust engine's `workspace-projects-graph` crate already classifies a path-like workspace version as a directory before attempting bare-specifier parsing, so this brings the TypeScript engine in line with that behaviour rather than introducing new behaviour.

### Tests

Added a regression test in `projects-graph` modelled on the existing local-directory-dependency test, using `foo: 'workspace:../foo'`, asserting the edge is present in the resulting graph. With the fix reverted the new test fails (edge missing / `dependencies: []`); with the fix it passes, and all pre-existing tests continue to pass (10/10).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787214929&installation_model_id=426870&pr_number=13189&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13189&signature=92a1d3b92bbc1c4f9309e022b2f71b92ba88f6e7b92bb2c8abcbc1dc689c08ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when interpreting `workspace:`-prefixed dependency specs, including relative forms like `workspace:./...` and `workspace:../...`.
  * Prevents incorrect parsing assumptions and ensures local directory-style workspace dependencies resolve without producing unmatched entries.

* **Tests**
  * Added Jest coverage to confirm `workspace:../foo` and `workspace:./nested-foo` map to the correct workspace package nodes and produce no unmatched dependencies.
  * Verifies the original `workspace:` spec is preserved in manifest expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->