### PR TITLE
chore(rust/dylint): enable `perfectionist::unpinned_repo_ref`

### DIFF
--- a/dylint.toml
+++ b/dylint.toml
@@ -76,18 +76,9 @@ include_plain_comments = true
 reference_scope = "own_module"
 min_words = 2
 
-# Only comments carry upstream-source citations. The forge URLs that appear
-# in string literals are runtime data, not citations: the `pnpm repo` /
-# `pnpm list` output URLs asserted in `cli_args/repo/tests.rs` and
-# `cli/tests/list.rs` are branch-shaped by design (that is the behaviour
-# under test), so pinning them would be wrong. Scan comments only.
-#
-# `allow_version_patterns` accepts citations to permanent release tags
-# (`npm/hosted-git-info@v4.1.0`, `puleos/object-hash@v3.0.0`): a published
-# package's release tag is effectively immutable and the version number is
-# the meaningful reference — it ties the citation to the exact release
-# pnpm mirrors — so a SHA would obscure more than it pins. Branch refs are
-# still rejected and must be SHA-pinned.
+# Scan comments only: forge URLs in string literals are test data, not
+# citations. `allow_version_patterns` accepts version-shaped release-tag
+# citations without requiring a SHA.
 ["perfectionist::unpinned_repo_ref"]
 scan_string_literals = false
 allow_version_patterns = true

--- a/dylint.toml
+++ b/dylint.toml
@@ -44,7 +44,6 @@ ignore = [
 enable = ["unordered_derives"]
 disable = [
     "needless_borrowed_parameters",
-    "unpinned_repo_ref",
 ]
 
 # Code spans read fine in `--help` and stay useful as `cargo doc` docs, so
@@ -76,6 +75,22 @@ include_plain_comments = true
 ["perfectionist::bare_identifier_reference"]
 reference_scope = "own_module"
 min_words = 2
+
+# Only comments carry upstream-source citations. The forge URLs that appear
+# in string literals are runtime data, not citations: the `pnpm repo` /
+# `pnpm list` output URLs asserted in `cli_args/repo/tests.rs` and
+# `cli/tests/list.rs` are branch-shaped by design (that is the behaviour
+# under test), so pinning them would be wrong. Scan comments only.
+#
+# `allow_version_patterns` accepts citations to permanent release tags
+# (`npm/hosted-git-info@v4.1.0`, `puleos/object-hash@v3.0.0`): a published
+# package's release tag is effectively immutable and the version number is
+# the meaningful reference — it ties the citation to the exact release
+# pnpm mirrors — so a SHA would obscure more than it pins. Branch refs are
+# still rejected and must be SHA-pinned.
+["perfectionist::unpinned_repo_ref"]
+scan_string_literals = false
+allow_version_patterns = true
 
 ["perfectionist::unordered_derives"]
 style = "prefix_then_alphabetical"

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -1,7 +1,7 @@
 //! `pacquet sbom` — generate a Software Bill of Materials.
 //!
-//! Ports pnpm's
-//! [`sbom` command](https://github.com/pnpm/pnpm/blob/2b4952e804/pnpm11/deps/compliance/commands/src/sbom/sbom.ts).
+//! Ports pnpm's `sbom` command
+//! (`pnpm11/deps/compliance/commands/src/sbom/sbom.ts`).
 
 use crate::{State, cli_args::recursive::RecursiveSharedLockfileUnsupported};
 use clap::Args;

--- a/pnpm/crates/config/src/store_path.rs
+++ b/pnpm/crates/config/src/store_path.rs
@@ -171,7 +171,7 @@ pub(crate) fn host_can_link_between_dirs(from_dir: &Path, to_dir: &Path) -> bool
 }
 
 /// Generate a unique temp-path inside `folder`. Mirrors
-/// [`pathTemp`](https://github.com/zkochan/packages/blob/main/path-temp/index.js):
+/// [`pathTemp`](https://github.com/zkochan/packages/blob/e65701a6ae/path-temp/index.js):
 /// `<folder>/_tmp_<pid>_<random>`. Collisions across racing pacquet
 /// processes are avoided by encoding both the pid and a nanosecond
 /// reading, which is sufficient because each callsite uses the path

--- a/pnpm/crates/fs/src/is_subdir.rs
+++ b/pnpm/crates/fs/src/is_subdir.rs
@@ -4,7 +4,7 @@ use crate::lexical_normalize;
 
 /// Whether `child` lexically resolves to a path under `parent`.
 ///
-/// Mirrors npm's [`is-subdir`](https://github.com/zkochan/packages/blob/main/is-subdir/index.js),
+/// Mirrors npm's [`is-subdir`](https://github.com/zkochan/packages/blob/e65701a6ae/is-subdir/index.js),
 /// used to guard against linking dependencies outside the workspace
 /// root. Filesystem-free: both paths are lexically normalised
 /// (`.` / `..` collapsed) before the prefix check, so callers can

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -321,7 +321,7 @@ fn remove_occupant(path: &Path) -> io::Result<()> {
 
 /// `fs::rename` that overwrites the destination when it exists.
 /// Follows the
-/// [`rename-overwrite`](https://github.com/zkochan/packages/tree/main/rename-overwrite)
+/// [`rename-overwrite`](https://github.com/zkochan/packages/tree/e65701a6ae/rename-overwrite)
 /// package's approach: if the rename fails because the destination
 /// is occupied (`AlreadyExists` for files, `DirectoryNotEmpty` for
 /// dirs, `PermissionDenied` on Windows when something holds a handle

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2760,8 +2760,8 @@ fn modules_consistent_with(
 /// ones ([`crate::prune_direct_deps_excluded_by_groups`]), not by
 /// deleting the directory. pnpm never purges the root project's
 /// `node_modules` for an included mismatch — its `validateModules` only
-/// does so for non-root importers
-/// ([`lockfileDir !== rootDir`](https://github.com/pnpm/pnpm/blob/a456dc78fb/installing/deps-installer/src/install/validateModules.ts#L105))
+/// does so for non-root importers (the `lockfileDir !== rootDir` check
+/// in `pnpm11/installing/deps-installer/src/install/validateModules.ts`)
 /// — so purging here would destroy the user's own non-pnpm entries (a
 /// vendored directory, stray files) on a routine flag change. The
 /// up-to-date fast path still compares `included` via

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -407,7 +407,7 @@ fn create_with_unwritable_parent_path_errors() {
 
 /// Re-applying a Modify patch over a file that already contains the
 /// post-patch content must succeed (no-op), the same
-/// [retry-with-reverse-in-dry-run](https://github.com/ds300/patch-package/blob/master/src/applyPatches.ts)
+/// [retry-with-reverse-in-dry-run](https://github.com/ds300/patch-package/blob/be4dfd77d9/src/applyPatches.ts)
 /// idempotency `patch-package` provides. Triggers in practice when two
 /// snapshots of the same
 /// patched package share a hardlinked store file: the first apply

--- a/pnpm/crates/reporter/src/lib.rs
+++ b/pnpm/crates/reporter/src/lib.rs
@@ -817,11 +817,9 @@ pub struct ExecutionTimeLog {
     pub ended_at: u128,
 }
 
-/// `pnpm:deprecation` payload. Field names match pnpm's
-/// [`DeprecationMessage`] wire shape so `@pnpm/cli.default-reporter`
-/// dispatches on them unchanged.
-///
-/// [`DeprecationMessage`]: https://github.com/pnpm/pnpm/blob/main/core/core-loggers/src/deprecationLogger.ts
+/// `pnpm:deprecation` payload. Field names match the `DeprecationMessage`
+/// wire shape in `pnpm11/core/core-loggers/src/deprecationLogger.ts` so
+/// `@pnpm/cli.default-reporter` dispatches on them unchanged.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeprecationLog {

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata.rs
@@ -37,7 +37,7 @@ pub(crate) const ACCEPT_ABBREVIATED_DOC: &str =
 /// spec-compliant registry echoes this in the response `Content-Type` when it
 /// honors the abbreviated `Accept` header. Its absence signals that the
 /// registry ignored the header and served the full document instead.
-/// <https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md>
+/// <https://github.com/npm/registry/blob/ae49abf1ba/docs/responses/package-metadata.md>
 const ABBREVIATED_META_CONTENT_TYPE: &str = "application/vnd.npm.install-v1+json";
 
 /// Whether the response `Content-Type` declares the abbreviated packument

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -457,7 +457,7 @@ const TIME_PRECISION_HORIZON_DAYS: i64 = 7;
 
 /// Per-version fields preserved in the abbreviated form — a subset of
 /// the npm spec's abbreviated version object
-/// (<https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-object>).
+/// (<https://github.com/npm/registry/blob/ae49abf1ba/docs/responses/package-metadata.md#abbreviated-version-object>).
 /// Fields neither the pnpm nor the pacquet resolver reads are dropped
 /// to shrink the document: `funding`, `acceptDependencies`,
 /// `_hasShrinkwrap`, and `devDependencies` (a dependency's dev


### PR DESCRIPTION
## Summary

The `perfectionist::unpinned_repo_ref` dylint rule flags repository URLs in comments whose ref is a mutable branch or tag rather than a commit SHA. It had been disabled in `dylint.toml` while its citations were pinned. This PR re-enables the rule and brings the tree into conformance.

In `dylint.toml` the rule is removed from the `disable` list and configured with two options. `scan_string_literals = false`, because the forge URLs that appear in string literals are runtime data rather than citations: the `pnpm repo` / `pnpm list` output URLs asserted in the command-output tests are branch-shaped by design — that is the behaviour under test — so pinning them would be wrong. `allow_version_patterns = true`, so citations to permanent release tags stay expressed by their meaningful version number instead of an opaque SHA; a published package's release tag is effectively immutable and the version is what ties the citation to the exact release pnpm mirrors. Branch refs remain rejected and must be SHA-pinned.

The branch-ref citations are SHA-pinned to their current branch HEADs: `zkochan/packages@main → e65701a6ae` (is-subdir, path-temp, rename-overwrite), `npm/registry → ae49abf1ba` (package-metadata.md), and `ds300/patch-package@master → be4dfd77d9` (applyPatches.ts).

The three `pnpm/pnpm` self-citations are replaced with in-repo `pnpm11/` path references. Now that pacquet lives inside `pnpm/pnpm`, a link to `pnpm/pnpm` source is no longer an upstream citation, so those doc comments (in `reporter`, `package-manager`, and the `sbom` command) point at the vendored `pnpm11/` sources directly. The dead citations named in the issue (`whitecolor/is-subdir`, `pnpm/util.lex-comparator`, `pnpm/pnpm@deps`) were already gone from the tree, which had moved from perfectionist rc.21 to rc.22 since the issue was filed.

Verified locally rather than on CI: `cargo dylint --all -- --all-targets --workspace` reports no `unpinned_repo_ref` findings, and `cargo doc` (with `RUSTDOCFLAGS=-D warnings`), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `typos` all pass.

Resolves https://github.com/pnpm/pnpm/issues/12717.

## Squash Commit Body

```text
The perfectionist::unpinned_repo_ref rule flags repository URLs in
comments whose ref is a mutable branch or tag instead of a commit SHA.
It was disabled while its citations were pinned; this re-enables it and
brings the tree into conformance.

dylint.toml:
- Remove unpinned_repo_ref from the disable list.
- scan_string_literals = false: forge URLs in string literals are test
  data (branch-shaped repository URLs asserted in command-output tests),
  not citations.
- allow_version_patterns = true: accept version-shaped release-tag
  citations (hosted-git-info, object-hash) without requiring a SHA.

SHA-pin the branch-ref citations to their current branch HEADs:
- zkochan/packages main -> e65701a6ae (is-subdir, path-temp,
  rename-overwrite)
- npm/registry -> ae49abf1ba (package-metadata.md)
- ds300/patch-package master -> be4dfd77d9 (applyPatches.ts)

Replace the pnpm/pnpm self-citations with in-repo pnpm11/ path
references: now that pacquet lives inside pnpm/pnpm, a link to pnpm/pnpm
source is no longer an upstream citation.

Resolves pnpm/pnpm#12717.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. — Not applicable: a Rust-only dylint-config and doc-comment change with no user-visible behavior, so there is no TypeScript counterpart to mirror.
- [x] Added a changeset if this PR changes any published package. — Not applicable: doc-comment citations and lint configuration do not change any published package's behavior.
- [x] Added or updated tests. — Not applicable: no logic changed; the only test-file edit is a doc comment. The `cargo dylint` pass over `--all-targets` is the check that the citations conform.
- [x] Updated the documentation if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation and external references to use stable, commit-specific source links.
  * Clarified descriptions for SBOM functionality, dependency metadata handling, patch behavior, and deprecation logging.
  * Refined lint configuration guidance for repository references and version patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->