### PR TITLE
fix(pacquet): create the global bin dir and accept the silent shorthands

### DIFF
--- a/.changeset/setup-action-cli-parity.md
+++ b/.changeset/setup-action-cli-parity.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Global commands (`pnpm add -g`, `pnpm runtime set -g`, ...) now create a missing global bin directory instead of failing with `ERR_PNPM_PNPM_DIR_NOT_WRITABLE`, and the universal `--silent` / `-s` shorthands for `--reporter=silent` (e.g. `pnpm store path --silent`) are supported again.

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -88,7 +88,7 @@ mod dispatch_query;
 mod dispatch_script;
 mod package_manager;
 mod pipelines;
-mod reporter;
+pub(crate) mod reporter;
 pub(crate) mod switch_cli_version;
 mod verify_deps;
 

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -142,7 +142,17 @@ pub struct CliArgs {
     pub recursive: bool,
 
     /// Reporter output format.
-    #[clap(long, value_enum, default_value_t = ReporterType::Default, global = true)]
+    // Self-override so a repeated `--reporter` takes the last occurrence,
+    // like nopt does — `--silent` expands to `--reporter=silent` (see
+    // `crate::shorthands`), so `--silent --reporter=ndjson` must not be a
+    // duplicate-argument error.
+    #[clap(
+        long,
+        value_enum,
+        default_value_t = ReporterType::Default,
+        global = true,
+        overrides_with = "reporter"
+    )]
     pub reporter: ReporterType,
 
     /// Select which workspace projects to run on. Repeat to add more.

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -73,8 +73,14 @@ fn global_dirs(config: &Config) -> Result<(PathBuf, PathBuf), GlobalError> {
 }
 
 /// Validate the global bin dir is on `PATH` and writable, required for
-/// mutating commands.
+/// mutating commands. Mirrors pnpm's config reader: the directory is
+/// created first, so a fresh `PNPM_HOME` whose `bin` is already on `PATH`
+/// but not yet on disk works on the first global command.
 fn check_bin_dir(global_bin_dir: &Path) -> miette::Result<()> {
+    fs::create_dir_all(global_bin_dir).map_err(|error| {
+        let bin_dir = global_bin_dir.display();
+        miette::miette!("failed to create the global bin directory {bin_dir}: {error}")
+    })?;
     check_global_bin_dir(global_bin_dir, std::env::var("PATH").ok().as_deref(), true)
         .map_err(miette::Report::new)
 }

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -29,13 +29,10 @@ use std::{
     ffi::OsString,
 };
 
-/// Move pre-subcommand option tokens that belong to a subcommand's
-/// grammar to directly after the subcommand token. See the module docs.
-///
-/// `cmd` must be the same [`Command`] the returned argv is parsed with
-/// (including the [`crate::boolean_negations`] augmentation), so the
-/// hidden `--no-<flag>` negations relocate like their positive forms.
-fn find_positional(
+/// The index of the next positional token at or after `index`, stepping
+/// over option tokens (and the values they consume, per the arity tables).
+/// `None` when argv ends or a `--` terminator is reached first.
+pub(crate) fn find_positional(
     argv: &[OsString],
     mut index: usize,
     top_level: &ArgTable,
@@ -160,14 +157,14 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
 
 /// The number of argv tokens an option occupies: itself, plus its value
 /// when the value is a separate token rather than `--flag=value` inline.
-fn token_width(consumes_value: bool, has_inline_value: bool) -> usize {
+pub(crate) fn token_width(consumes_value: bool, has_inline_value: bool) -> usize {
     if consumes_value && !has_inline_value { 2 } else { 1 }
 }
 
 /// Option-name lookup table: long / short spelling → whether the option
 /// consumes the next argv token as its value.
 #[derive(Debug, Default)]
-struct ArgTable {
+pub(crate) struct ArgTable {
     longs: HashMap<String, bool>,
     shorts: HashMap<char, bool>,
 }
@@ -177,7 +174,7 @@ impl ArgTable {
     /// subcommand, which therefore stays in place. Clap only adds the
     /// automatic `--help` / `-h` at build time, so they are seeded
     /// manually.
-    fn top_level(cmd: &Command) -> Self {
+    pub(crate) fn top_level(cmd: &Command) -> Self {
         let mut table = Self::default();
         table.longs.insert("help".to_string(), false);
         table.shorts.insert('h', false);
@@ -187,7 +184,7 @@ impl ArgTable {
 
     /// The union of every subcommand's args, used only to decide how
     /// many tokens a to-be-moved option occupies.
-    fn subcommand_union(cmd: &Command) -> Self {
+    pub(crate) fn subcommand_union(cmd: &Command) -> Self {
         let mut table = Self::default();
         table.absorb(cmd.get_subcommands().flat_map(Command::get_arguments));
         table
@@ -209,11 +206,11 @@ impl ArgTable {
         }
     }
 
-    fn long_consumes_value(&self, name: &str) -> Option<bool> {
+    pub(crate) fn long_consumes_value(&self, name: &str) -> Option<bool> {
         self.longs.get(name).copied()
     }
 
-    fn short_consumes_value(&self, short: char) -> Option<bool> {
+    pub(crate) fn short_consumes_value(&self, short: char) -> Option<bool> {
         self.shorts.get(&short).copied()
     }
 }

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -4,6 +4,7 @@ mod config_deps;
 mod config_overrides;
 mod flag_relocation;
 mod job_control;
+mod shorthands;
 mod state;
 mod with_current;
 
@@ -40,6 +41,10 @@ pub fn main() -> miette::Result<()> {
     // every boolean flag, so pnpm's forwarded negations (`--no-frozen-lockfile`,
     // etc.) parse the same way nopt accepts them upstream. See `boolean_negations`.
     let command = with_boolean_negations(CliArgs::command());
+    // pnpm expands universal shorthands (`--silent` / `-s` →
+    // `--reporter=silent`) over argv before parsing; mirror that so they
+    // work with every command. See `shorthands`.
+    let argv = shorthands::expand_universal_shorthands(&command, argv);
     // pnpm's option parser is position-independent; move subcommand
     // options written before the subcommand to after it so clap agrees.
     // See `flag_relocation`.

--- a/pnpm/crates/cli/src/shorthands.rs
+++ b/pnpm/crates/cli/src/shorthands.rs
@@ -1,0 +1,103 @@
+//! Universal CLI shorthands.
+//!
+//! pnpm expands a table of universal shorthands over argv before parsing
+//! (`pnpm11/pnpm/src/shorthands.ts`): `--silent` and `-s` both mean
+//! `--reporter=silent` for every command. A command's own shorthand table
+//! overrides the universal one — `run` redefines `s` as `--sequential` —
+//! so `-s` is left untouched when the effective command is `run`,
+//! including the `pnpm <script>` fallback, which resolves to `run` and
+//! therefore inherits its shorthands. The long `--silent` form has no
+//! per-command override anywhere, so it always expands.
+//!
+//! Only the universal shorthands whose expansion targets exist in pacquet
+//! are handled here. The loglevel family (`-d`, `-q`, `--quiet`,
+//! `--verbose`, ...) expands to `--loglevel=<level>`, which pacquet has
+//! not grown yet.
+
+use crate::flag_relocation::{ArgTable, find_positional, token_width};
+use clap::Command;
+use std::ffi::OsString;
+
+/// Expand the universal shorthands in `argv`. Runs before
+/// [`crate::flag_relocation::relocate_pre_subcommand_flags`], so tokens
+/// may still appear ahead of the subcommand; option values are stepped
+/// over with the same arity tables the relocation pass uses, so a value
+/// that happens to spell `-s` (e.g. a `--filter` pattern) is never
+/// rewritten. Everything after a `--` terminator is left untouched.
+///
+/// `cmd` must be the same [`Command`] the returned argv is parsed with.
+pub fn expand_universal_shorthands(cmd: &Command, mut argv: Vec<OsString>) -> Vec<OsString> {
+    let top_level = ArgTable::top_level(cmd);
+    let subcommand_union = ArgTable::subcommand_union(cmd);
+    let run_owns_short_s = effective_command_is_run(cmd, &argv, &top_level, &subcommand_union);
+
+    let mut index = 1;
+    while index < argv.len() {
+        let Some(token) = argv[index].to_str() else {
+            index += 1;
+            continue;
+        };
+        if token == "--" {
+            break;
+        }
+        if token == "--silent" || (token == "-s" && !run_owns_short_s) {
+            argv[index] = OsString::from("--reporter=silent");
+            index += 1;
+            continue;
+        }
+        if let Some(rest) = token.strip_prefix("--") {
+            let (name, has_inline_value) =
+                rest.split_once('=').map_or((rest, false), |(name, _)| (name, true));
+            let consumes_value = top_level
+                .long_consumes_value(name)
+                .or_else(|| subcommand_union.long_consumes_value(name))
+                .unwrap_or(false);
+            index += token_width(consumes_value, has_inline_value);
+        } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
+            let short = rest.chars().next().expect("checked non-empty");
+            let is_bare_short = rest.chars().count() == 1;
+            let consumes_value = top_level
+                .short_consumes_value(short)
+                .or_else(|| subcommand_union.short_consumes_value(short))
+                .unwrap_or(false);
+            index += token_width(consumes_value && is_bare_short, false);
+        } else {
+            index += 1;
+        }
+    }
+    argv
+}
+
+/// Whether argv invokes `run` — directly, through an alias, through
+/// `recursive run`, or through the `pnpm <script>` fallback (a positional
+/// that names no known subcommand dispatches to `run`). Only `run` gives
+/// `-s` a different meaning, so this is what gates the `-s` expansion.
+fn effective_command_is_run(
+    cmd: &Command,
+    argv: &[OsString],
+    top_level: &ArgTable,
+    subcommand_union: &ArgTable,
+) -> bool {
+    let Some(mut index) = find_positional(argv, 1, top_level, subcommand_union) else {
+        // No subcommand at all: nothing owns `-s`, the universal table wins.
+        return false;
+    };
+    loop {
+        let Some(subcommand) = cmd.find_subcommand(&argv[index]) else {
+            // `pnpm <script>` fallback: dispatches to `run`.
+            return true;
+        };
+        if subcommand.get_name() == "recursive" {
+            // `pnpm recursive run ...`: the nested token names the command.
+            match find_positional(argv, index + 1, top_level, subcommand_union) {
+                Some(next) => index = next,
+                None => return false,
+            }
+            continue;
+        }
+        return subcommand.get_name() == "run";
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/shorthands/tests.rs
+++ b/pnpm/crates/cli/src/shorthands/tests.rs
@@ -1,0 +1,104 @@
+use super::expand_universal_shorthands;
+use crate::{
+    boolean_negations::with_boolean_negations,
+    cli_args::{CliArgs, reporter::ReporterType},
+    flag_relocation::relocate_pre_subcommand_flags,
+};
+use clap::{CommandFactory, FromArgMatches};
+use pretty_assertions::assert_eq;
+use std::ffi::OsString;
+
+fn expand(tokens: &[&str]) -> Vec<String> {
+    let cmd = with_boolean_negations(CliArgs::command());
+    expand_universal_shorthands(&cmd, tokens.iter().map(OsString::from).collect())
+        .into_iter()
+        .map(|token| token.into_string().expect("test tokens are UTF-8"))
+        .collect()
+}
+
+/// Run the full pre-parse pipeline (shorthands, then relocation) and parse.
+fn parse(tokens: &[&str]) -> CliArgs {
+    let cmd = with_boolean_negations(CliArgs::command());
+    let argv = expand_universal_shorthands(&cmd, tokens.iter().map(OsString::from).collect());
+    let argv = relocate_pre_subcommand_flags(&cmd, argv);
+    cmd.try_get_matches_from(argv)
+        .and_then(|matches| CliArgs::from_arg_matches(&matches))
+        .expect("parses after shorthand expansion")
+}
+
+#[test]
+fn silent_long_form_expands_for_any_command() {
+    assert_eq!(
+        expand(&["pnpm", "store", "path", "--silent"]),
+        ["pnpm", "store", "path", "--reporter=silent"],
+    );
+    assert_eq!(expand(&["pnpm", "install", "--silent"]), ["pnpm", "install", "--reporter=silent"]);
+    // `run` overrides only the short `s`; the long `--silent` stays universal.
+    assert_eq!(
+        expand(&["pnpm", "run", "build", "--silent"]),
+        ["pnpm", "run", "build", "--reporter=silent"],
+    );
+}
+
+#[test]
+fn short_s_expands_for_commands_that_do_not_own_it() {
+    assert_eq!(expand(&["pnpm", "install", "-s"]), ["pnpm", "install", "--reporter=silent"]);
+    // Pre-subcommand placement expands too — nopt is position-independent.
+    assert_eq!(expand(&["pnpm", "-s", "install"]), ["pnpm", "--reporter=silent", "install"]);
+    assert_eq!(expand(&["pnpm", "test", "-s"]), ["pnpm", "test", "--reporter=silent"]);
+}
+
+#[test]
+fn short_s_is_left_for_run_which_defines_sequential() {
+    assert_eq!(expand(&["pnpm", "run", "-s", "build"]), ["pnpm", "run", "-s", "build"]);
+    assert_eq!(expand(&["pnpm", "-s", "run", "build"]), ["pnpm", "-s", "run", "build"]);
+    // `recursive run` resolves to `run` as well.
+    assert_eq!(
+        expand(&["pnpm", "recursive", "run", "build", "-s"]),
+        ["pnpm", "recursive", "run", "build", "-s"],
+    );
+}
+
+#[test]
+fn short_s_is_left_for_the_script_fallback() {
+    // `pnpm <script>` dispatches through `run`, which inherits its
+    // shorthand table in pnpm.
+    assert_eq!(expand(&["pnpm", "my-script", "-s"]), ["pnpm", "my-script", "-s"]);
+}
+
+#[test]
+fn tokens_after_the_terminator_are_untouched() {
+    assert_eq!(
+        expand(&["pnpm", "exec", "--", "-s", "--silent"]),
+        ["pnpm", "exec", "--", "-s", "--silent"],
+    );
+}
+
+#[test]
+fn option_values_are_not_rewritten() {
+    // `--filter` consumes the next token; a value spelling `-s` stays a value.
+    assert_eq!(
+        expand(&["pnpm", "--filter", "-s", "install"]),
+        ["pnpm", "--filter", "-s", "install"],
+    );
+}
+
+#[test]
+fn expanded_silent_parses_to_the_silent_reporter() {
+    let args = parse(&["pnpm", "store", "path", "--silent"]);
+    assert!(matches!(args.reporter, ReporterType::Silent));
+
+    let args = parse(&["pnpm", "install", "-s"]);
+    assert!(matches!(args.reporter, ReporterType::Silent));
+}
+
+#[test]
+fn later_reporter_overrides_the_silent_shorthand() {
+    // nopt takes the last occurrence of a repeated option; `--silent` is
+    // sugar for `--reporter=silent`, so an explicit later `--reporter` wins.
+    let args = parse(&["pnpm", "install", "--silent", "--reporter=ndjson"]);
+    assert!(matches!(args.reporter, ReporterType::Ndjson));
+
+    let args = parse(&["pnpm", "install", "--reporter=ndjson", "--silent"]);
+    assert!(matches!(args.reporter, ReporterType::Silent));
+}

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -125,6 +125,53 @@ fn global_add_list_remove_round_trip() {
     drop(root);
 }
 
+/// A mutating global command must create a missing global bin directory
+/// instead of failing `ERR_PNPM_PNPM_DIR_NOT_WRITABLE` — pnpm's config
+/// reader runs `mkdir -p` on the bin dir for every `--global` command. A
+/// fresh `PNPM_HOME` whose `bin` is on `PATH` but not yet on disk (e.g.
+/// provisioned by a CI setup action) must work on the first `add -g` /
+/// `runtime set -g`.
+#[cfg(unix)]
+#[test]
+fn global_add_creates_a_missing_global_bin_dir() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let pnpm_home = root.path().join("pnpm-home");
+    let global_bin = pnpm_home.join("bin");
+    // Seed the pnpm home like `prepare_global_home`, but leave `bin`
+    // uncreated: `global_command` still puts the (absent) dir on PATH.
+    fs::create_dir_all(&pnpm_home).expect("create the pnpm home");
+    fs::write(pnpm_home.join(".npmrc"), format!("registry={}\n", npmrc_info.mock_instance.url()))
+        .expect("seed the pnpm-home npmrc");
+    fs::write(
+        pnpm_home.join("pnpm-workspace.yaml"),
+        format!(
+            "storeDir: {}\ncacheDir: {}\nenableGlobalVirtualStore: false\n",
+            npmrc_info.store_dir.display(),
+            npmrc_info.cache_dir.display(),
+        ),
+    )
+    .expect("seed the pnpm-home workspace yaml");
+
+    global_command(&workspace, &pnpm_home)
+        .with_arg("add")
+        .with_arg("-g")
+        .with_arg("@foo/touch-file-one-bin")
+        .assert()
+        .success();
+
+    assert!(
+        global_bin.join("touch-file-one-bin").exists(),
+        "the global bin dir should have been created and the bin linked into it",
+    );
+
+    drop(npmrc_info);
+    drop(root);
+}
+
 /// A global add must materialize the added package's transitive
 /// `optionalDependencies` in the group's virtual store: a missing slot
 /// dangles the alias symlink, and the globally installed bin then fails at

--- a/pnpm/crates/cli/tests/store.rs
+++ b/pnpm/crates/cli/tests/store.rs
@@ -22,6 +22,37 @@ fn canonicalize(path: &Path) -> PathBuf {
 }
 
 #[test]
+fn store_path_accepts_the_silent_shorthand() {
+    // `--silent` / `-s` are universal shorthands for `--reporter=silent`
+    // (pnpm expands them over argv before parsing); `pnpm store path
+    // --silent` is how pnpm/setup queried the store dir historically, so
+    // both spellings must keep working.
+    for silent_arg in ["--silent", "-s"] {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+        fs::write(workspace.join("pnpm-workspace.yaml"), "storeDir: foo/bar\n")
+            .expect("write to pnpm-workspace.yaml");
+
+        let output = pacquet
+            .with_args(["store", "path", silent_arg])
+            .output()
+            .expect("run pacquet store path with the silent shorthand");
+        assert!(output.status.success(), "store path {silent_arg} must succeed: {output:?}");
+
+        let normalize = |path: &str| path.replace('\\', "/");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim_end().pipe(normalize),
+            canonicalize(&workspace)
+                .join("foo/bar")
+                .join(STORE_VERSION)
+                .to_string_lossy()
+                .pipe_as_ref(normalize),
+        );
+
+        drop(root);
+    }
+}
+
+#[test]
 fn store_path_should_return_store_dir_from_pnpm_workspace_yaml() {
     // `storeDir` is a project-structural setting — in pnpm 11 (and now
     // pacquet) it's only honoured from `pnpm-workspace.yaml`, not `.npmrc`.


### PR DESCRIPTION
## Summary

Two parity gaps between pacquet and the TypeScript CLI, both hit by the [pnpm/setup](https://github.com/pnpm/setup) GitHub Action while provisioning a fresh `PNPM_HOME` (see pnpm/setup#11):

1. **Mutating global commands failed on a missing global bin dir.** `pnpm runtime set node 24 -g` (and `add`/`update`/`remove -g`) aborted with `ERR_PNPM_PNPM_DIR_NOT_WRITABLE` when the global bin directory was on `PATH` but not yet on disk. The TypeScript config reader runs `mkdirSync(bin, { recursive: true })` before validating the dir for every `--global` command (`pnpm11/config/reader/src/index.ts`), and `pnpm bin -g` on the pacquet side already mirrored that — but the shared `check_bin_dir` used by the mutating global commands did not. It now creates the directory first.

2. **The universal `--silent` / `-s` shorthands were not ported.** `pnpm store path --silent` aborted with `unexpected argument '--silent'`. In the TypeScript CLI these are universal shorthands expanded over argv before parsing (`pnpm11/pnpm/src/shorthands.ts`): both mean `--reporter=silent` for every command, except that `run` redefines `s` as `--sequential` (and the `pnpm <script>` fallback dispatches through `run`, inheriting its table). A new `shorthands` module does the same argv-level expansion ahead of clap, reusing `flag_relocation`'s arity tables so option values that happen to spell `-s` (e.g. a `--filter` pattern) are never rewritten, and leaving everything after a `--` terminator untouched. `--reporter` is now self-overriding (`overrides_with`), so the expanded token composes with an explicit `--reporter` under nopt's last-one-wins rule.

## Parity notes

- Both changes are Rust-only: the TypeScript CLI already behaves this way, verified against pnpm 11.13 (`runtime set -g` creates the missing bin dir; `--silent`/`-s` expand via the universal shorthand table).
- The loglevel shorthand family (`-d`, `-q`, `--quiet`, `--verbose`, ...) is deliberately **not** included: it expands to `--loglevel=<level>`, which pacquet hasn't grown yet. Noted in the module docs.
- Changeset targets `pacquet` only (patch), per the Rust-only changeset rule.

## Tests

- 8 unit tests for the shorthand expansion: long/short forms, pre-subcommand placement, `run` / `recursive run` / script-fallback exclusion for `-s`, `--` terminator, value-position tokens, and last-one-wins against an explicit `--reporter`.
- Integration: `store_path_accepts_the_silent_shorthand` (both spellings) and `global_add_creates_a_missing_global_bin_dir`.
- Regression sweep: pacquet-cli unit tests plus the run / exec / runtime / global / store / bin suites — 945/945 pass; `cargo fmt`, `clippy --all-targets`, `cargo doc` clean (pre-push gate).
- Manually verified with the built binary: `store path --silent` prints the path, and `runtime set node 24 -g` against a completely absent `PNPM_HOME` creates `bin/` and installs the runtime.

---

Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787227533&installation_model_id=426870&pr_number=13194&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13194&signature=493154dae5a44f3d94783bd4339078fbda0a9e146179fec4a59a1e6927c83729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Global commands now create a missing global bin directory automatically.
  * Added support for the universal `--silent` and `-s` options, including commands such as `store path`.
  * Repeated reporter options now use the last specified value.

* **Bug Fixes**
  * Prevented errors when global commands are run before the global bin directory exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->