### PR TITLE
fix(deps-resolver): stop partial installs from rewriting unrelated lockfile entries

### DIFF
--- a/.changeset/no-unrelated-lockfile-churn.md
+++ b/.changeset/no-unrelated-lockfile-churn.md
@@ -1,0 +1,9 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm install` rewriting unrelated `pnpm-lock.yaml` entries after a small manifest change — for example, removing one dev dependency could bump other packages' open-range dependencies (such as jest's `@types/node: '*'`) to their newest versions [pnpm/pnpm#13193](https://github.com/pnpm/pnpm/pull/13193). Three resolution-reuse gaps caused still-satisfied lockfile entries to be re-resolved from the registry:
+
+- Direct dependencies using the `catalog:` protocol were compared against the lockfile in their resolved-range form, so every catalog-managed dependency looked changed on every install, and any package depending on one was re-resolved.
+- Auto-installed (hoisted) peer dependencies were also treated as changed direct dependencies on every install.
+- When a package had to resolve freshly but landed on the version the lockfile already recorded, its dependency subtree was still re-resolved instead of being reused, drifting open ranges pinned by the lockfile.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -79,15 +79,11 @@ enum ReuseSource {
     /// snapshot already pins. `Some` reuses that key directly (no semver
     /// check — the parent version pins it); `None` means an updated
     /// ancestor discarded its child-refs, forcing this subtree to
-    /// re-resolve.
+    /// re-resolve. The parent may itself be reused (snapshot walk) or
+    /// freshly resolved onto its previously recorded version — both
+    /// keep the prior child refs alive, mirroring pnpm's
+    /// `parentPkg.updated ? undefined : resolvedDependencies`.
     Transitive { key: Option<PkgNameVerPeer> },
-    /// A child of a freshly-resolved parent: subtree reuse stays
-    /// disabled, but when the parent re-resolved to its previously
-    /// recorded version the child's prior snapshot ref is still
-    /// meaningful — it feeds the `currentPkg` payload of the child's
-    /// own re-resolution. This is the non-`updated`-parent case, where
-    /// the prior `resolvedDependencies` references stay alive.
-    PriorOnly { key: Option<PkgNameVerPeer> },
     /// Reuse disabled for this node (no prior lockfile).
     Off,
 }
@@ -107,13 +103,12 @@ impl ReuseSource {
                 wanted.alias.as_deref()?,
                 wanted.bare_specifier.as_deref()?,
             ),
-            ReuseSource::Transitive { key } | ReuseSource::PriorOnly { key } => key.clone(),
+            ReuseSource::Transitive { key } => key.clone(),
             ReuseSource::Off => None,
         }
     }
 
     /// Whether this edge may reuse the prior lockfile's subtree.
-    /// `PriorOnly` keeps the key for `currentPkg` but never reuses.
     fn allows_reuse(&self) -> bool {
         matches!(self, ReuseSource::Importer { .. } | ReuseSource::Transitive { .. })
     }
@@ -361,6 +356,7 @@ where
         let injected = injected_names.contains(name);
         wanted.push((name.to_string(), range.to_string(), optional, injected));
     }
+    record_changed_direct_deps(&ctx, pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY, &wanted);
     let direct =
         extend_tree(&ctx, resolver, wanted, pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY).await?;
     Ok(ctx.into_resolved_tree(direct))
@@ -1262,7 +1258,6 @@ where
     } else {
         ReuseSource::Off
     };
-    record_changed_direct_deps(ctx, importer_id, &wanted);
     // Phase 1: resolve every direct dep before any subtree walk, so
     // the level's resolved versions seed the children's
     // preferred-versions overlay (a per-level fold; the direct deps
@@ -1393,8 +1388,8 @@ struct PendingNode {
     depth: i32,
     current_is_optional: bool,
     /// The edge's recorded snapshot key in the prior lockfile, if
-    /// any — threads each child's `currentPkg` through the walk
-    /// phase via `ReuseSource::PriorOnly`.
+    /// any — threads each child's prior ref through the walk phase
+    /// via `ReuseSource::Transitive`.
     prior_key: Option<PkgNameVerPeer>,
 }
 
@@ -1769,13 +1764,16 @@ where
             } else {
                 Cow::Borrowed(child_specs.as_slice())
             };
-        // A freshly-resolved node forces its whole subtree to
-        // re-resolve: an updated parent discards its `resolvedDependencies`
-        // child refs. But when the parent landed back on its previously
-        // recorded version, the prior child refs are kept (the
-        // non-`updated` arm), so each child's re-resolution still
-        // receives its `currentPkg`. `PriorOnly` is that arm: the key
-        // rides along for `currentPkg` while reuse stays disabled.
+        // An *updated* parent (one that landed on a different version
+        // than the lockfile recorded, or a new dep) discards its
+        // `resolvedDependencies` child refs, forcing its subtree to
+        // re-resolve. A parent that freshly resolved but landed back on
+        // its previously recorded version keeps the prior child refs
+        // alive (pnpm's non-`parentPkg.updated` arm), and each child
+        // edge re-enters the reuse gate with its recorded key — so a
+        // still-satisfied subtree is reused rather than re-resolved.
+        // Re-resolving those children would re-pick open ranges (`*`)
+        // at their newest versions and churn the lockfile.
         let prior_children_snapshot = prior_key
             .as_ref()
             .filter(|key| landed_on_prior_entry(key, &id))
@@ -1829,7 +1827,7 @@ where
                         &next_ancestors,
                         depth + 1,
                         current_is_optional,
-                        ReuseSource::PriorOnly { key: child_prior },
+                        ReuseSource::Transitive { key: child_prior },
                         pick_overlay,
                     )
                     .await?;
@@ -2163,22 +2161,55 @@ fn level_versions(ctx: &TreeCtx, seeds: &[NodeSeed]) -> BTreeMap<String, Vec<Str
 /// Record the importer direct deps whose manifest specifier differs from
 /// the prior lockfile's recorded specifier (a new dep counts as changed).
 /// See [`WorkspaceTreeCtx::changed_direct_deps`].
-fn record_changed_direct_deps(ctx: &TreeCtx, importer_id: &str, wanted: &[WantedSpec]) {
-    let prior = ctx
-        .workspace
-        .wanted_lockfile
-        .as_ref()
-        .and_then(|lockfile| lockfile.importers.get(importer_id));
+///
+/// Called for the importer's *manifest* wave only, never for
+/// auto-installed peers: hoisted peers have no importer-snapshot entry
+/// to compare against, so recording them would mark them "changed" on
+/// every install and permanently decline subtree reuse for anything
+/// depending on them.
+pub(crate) fn record_changed_direct_deps(ctx: &TreeCtx, importer_id: &str, wanted: &[WantedSpec]) {
+    let lockfile = ctx.workspace.wanted_lockfile.as_deref();
+    let prior = lockfile.and_then(|lockfile| lockfile.importers.get(importer_id));
     let mut changed = lock_recoverable(&ctx.workspace.changed_direct_deps);
     let bucket = changed.entry(importer_id.to_string()).or_default();
     for (alias, spec, _optional, _injected) in wanted {
         let unchanged = prior
             .and_then(|importer| importer_dep_specifier(importer, alias))
-            .is_some_and(|recorded| recorded == spec);
+            .is_some_and(|recorded| {
+                recorded == spec || catalog_specifier_unchanged(lockfile, recorded, alias, spec)
+            });
         if !unchanged && let Ok(name) = alias.parse::<PkgName>() {
             bucket.insert(name);
         }
     }
+}
+
+/// Whether a `catalog:`-recorded direct dep still resolves to the same
+/// underlying range. The wanted specs reaching
+/// [`fn@record_changed_direct_deps`] have their `catalog:` protocol
+/// already replaced by the catalog's range
+/// ([`fn@resolve_catalog_specifiers`]), while the importer snapshot
+/// records the literal `catalog:` / `catalog:<name>` form — comparing
+/// those directly would mark every catalog-managed dep as changed on
+/// every install, and the changed-direct-dep reuse gate would then
+/// re-resolve (and drift) every subtree depending on one. The edge is
+/// unchanged when the lockfile's `catalogs:` snapshot recorded the same
+/// range for this alias.
+fn catalog_specifier_unchanged(
+    lockfile: Option<&pacquet_lockfile::Lockfile>,
+    recorded: &str,
+    alias: &str,
+    resolved_spec: &str,
+) -> bool {
+    let Some(catalog_name) = recorded.strip_prefix("catalog:") else {
+        return false;
+    };
+    let catalog_name = if catalog_name.is_empty() { "default" } else { catalog_name };
+    lockfile
+        .and_then(|lockfile| lockfile.catalogs.as_ref())
+        .and_then(|catalogs| catalogs.get(catalog_name))
+        .and_then(|catalog| catalog.get(alias))
+        .is_some_and(|entry| entry.specifier == resolved_spec)
 }
 
 /// The recorded specifier for direct-dep `alias` across the importer's

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     resolve_dependency_tree::{
         ResolveDependencyTreeError, TreeCtx, WantedSpec, WorkspaceTreeCtx, extend_tree,
-        importer_direct_wanted_specs,
+        importer_direct_wanted_specs, record_changed_direct_deps,
     },
     resolve_peers::{ResolvePeersOptions, ResolvePeersResult, resolve_peers},
     resolved_tree::ResolvedTree,
@@ -359,6 +359,7 @@ impl ImporterHoistState {
             .with_patched_dependencies(patched_dependencies)
             .with_resolution_mode(pick_lowest_direct, subdep_published_by)
             .with_catalogs(catalogs);
+        record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
         let direct = extend_tree(&ctx, resolver, initial_wanted, importer_id).await?;
         let parent_pkg_aliases: HashSet<String> =
             direct.iter().map(|dep| dep.alias.clone()).collect();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1322,3 +1322,367 @@ async fn reused_lockfile_entries_still_notify_the_deprecation_sink() {
     assert_eq!(deprecation.deprecated, "use new instead");
     assert_eq!(deprecation.depth, 0);
 }
+
+/// Build a reuse-seeding lockfile from a flat description:
+/// one importer with `direct` deps `(alias, specifier, version)`, a
+/// package/snapshot graph of `(key, [(child_alias, child_version)])`
+/// entries, and an optional `catalogs:` snapshot of
+/// `(catalog, alias, specifier, version)` rows.
+fn reuse_graph_lockfile(
+    importer_id: &str,
+    direct: &[(&str, &str, &str)],
+    graph: &[(&str, &[(&str, &str)])],
+    catalogs: &[(&str, &str, &str, &str)],
+) -> pacquet_lockfile::Lockfile {
+    use pacquet_lockfile::{
+        ComVer, ImporterDepVersion, Lockfile, LockfileVersion, PackageMetadata, PkgName,
+        PkgNameVerPeer, PkgVerPeer, ProjectSnapshot, RegistryResolution, ResolvedCatalogEntry,
+        ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry,
+    };
+
+    let dependencies = direct
+        .iter()
+        .map(|(alias, specifier, version)| {
+            (
+                PkgName::parse(*alias).expect("parse direct alias"),
+                ResolvedDependencySpec {
+                    specifier: (*specifier).to_string(),
+                    version: ImporterDepVersion::Regular(
+                        version.parse::<PkgVerPeer>().expect("parse direct version"),
+                    ),
+                },
+            )
+        })
+        .collect();
+    let importers = HashMap::from([(
+        importer_id.to_string(),
+        ProjectSnapshot { dependencies: Some(dependencies), ..ProjectSnapshot::default() },
+    )]);
+    let metadata = || {
+        PackageMetadata {
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
+                .parse()
+                .expect("parse integrity"),
+        }),
+        version: None,
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+    };
+    let mut packages = HashMap::new();
+    let mut snapshots = HashMap::new();
+    for (key, children) in graph {
+        let key = key.parse::<PkgNameVerPeer>().expect("parse graph key");
+        packages.insert(key.clone(), metadata());
+        let dependencies = (!children.is_empty()).then(|| {
+            children
+                .iter()
+                .map(|(alias, version)| {
+                    (
+                        PkgName::parse(*alias).expect("parse child alias"),
+                        SnapshotDepRef::Plain(
+                            version.parse::<PkgVerPeer>().expect("parse child version"),
+                        ),
+                    )
+                })
+                .collect()
+        });
+        snapshots.insert(key, SnapshotEntry { dependencies, ..SnapshotEntry::default() });
+    }
+    let catalog_snapshots = (!catalogs.is_empty()).then(|| {
+        let mut snapshot: pacquet_lockfile::CatalogSnapshots = BTreeMap::new();
+        for (catalog, alias, specifier, version) in catalogs {
+            snapshot.entry((*catalog).to_string()).or_default().insert(
+                (*alias).to_string(),
+                ResolvedCatalogEntry {
+                    specifier: (*specifier).to_string(),
+                    version: (*version).to_string(),
+                },
+            );
+        }
+        snapshot
+    });
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).expect("lockfile v9"),
+        settings: None,
+        catalogs: catalog_snapshots,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers,
+        packages: Some(packages),
+        snapshots: Some(snapshots),
+    }
+}
+
+fn graph_versions_of(result: &super::ResolveWorkspaceResult, name: &str) -> Vec<String> {
+    let prefix = format!("{name}@");
+    let mut versions: Vec<String> = result
+        .peers
+        .graph
+        .keys()
+        .filter_map(|dep_path| dep_path.as_str().strip_prefix(&prefix))
+        .map(str::to_string)
+        .collect();
+    versions.sort();
+    versions
+}
+
+/// A `catalog:` direct dep whose catalog entry is unchanged must not be
+/// treated as a changed direct dep: the wanted spec reaches the walker
+/// with the protocol already resolved to the catalog's range, and
+/// comparing that against the recorded `catalog:` specifier would
+/// decline subtree reuse for every dependent — `parent` would
+/// re-resolve to the registry's newer 1.1.0 (and re-pick its open
+/// `tool: *` edge at 2.0.0) with no manifest change, churning the
+/// lockfile.
+#[tokio::test]
+async fn unchanged_catalog_dep_keeps_dependent_subtree_pins() {
+    let (_tmp, manifest) =
+        fake_manifest(serde_json::json!({ "tool": "catalog:", "parent": "^1.0.0" }));
+    let importers = [WorkspaceImporter { id: "proj".to_string(), manifest: &manifest }];
+    let resolver = RecordingResolver {
+        table: HashMap::from([
+            (
+                ("tool".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "tool",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({ "name": "tool", "version": "1.0.0" }),
+                ),
+            ),
+            (
+                ("tool".to_string(), "*".to_string()),
+                fake_result(
+                    "tool",
+                    "2.0.0",
+                    None,
+                    serde_json::json!({ "name": "tool", "version": "2.0.0" }),
+                ),
+            ),
+            (
+                ("parent".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "parent",
+                    "1.1.0",
+                    None,
+                    serde_json::json!({
+                        "name": "parent",
+                        "version": "1.1.0",
+                        "dependencies": { "tool": "*" },
+                    }),
+                ),
+            ),
+        ]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let mut opts = workspace_opts(false, false);
+    opts.wanted_lockfile = Some(std::sync::Arc::new(reuse_graph_lockfile(
+        "proj",
+        &[("tool", "catalog:", "1.0.0"), ("parent", "^1.0.0", "1.0.0")],
+        &[("tool@1.0.0", &[]), ("parent@1.0.0", &[("tool", "1.0.0")])],
+        &[("default", "tool", "^1.0.0", "1.0.0")],
+    )));
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            let mut opts =
+                importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None);
+            opts.catalogs = BTreeMap::from([(
+                "default".to_string(),
+                BTreeMap::from([("tool".to_string(), "^1.0.0".to_string())]),
+            )]);
+            opts
+        })
+        .await
+        .expect("resolve workspace with an unchanged catalog dep");
+
+    assert_eq!(graph_versions_of(&result, "parent"), ["1.0.0"]);
+    assert_eq!(graph_versions_of(&result, "tool"), ["1.0.0"]);
+}
+
+/// A catalog range bump is a real direct-dep change: dependents that
+/// pin the old version must re-resolve so their pins land on the new
+/// catalog pick.
+#[tokio::test]
+async fn catalog_range_bump_refreshes_dependent_pins() {
+    let (_tmp, manifest) =
+        fake_manifest(serde_json::json!({ "tool": "catalog:", "parent": "^1.0.0" }));
+    let importers = [WorkspaceImporter { id: "proj".to_string(), manifest: &manifest }];
+    let resolver = RecordingResolver {
+        table: HashMap::from([
+            (
+                ("tool".to_string(), "^2.0.0".to_string()),
+                fake_result(
+                    "tool",
+                    "2.0.0",
+                    None,
+                    serde_json::json!({ "name": "tool", "version": "2.0.0" }),
+                ),
+            ),
+            (
+                ("tool".to_string(), "*".to_string()),
+                fake_result(
+                    "tool",
+                    "2.0.0",
+                    None,
+                    serde_json::json!({ "name": "tool", "version": "2.0.0" }),
+                ),
+            ),
+            (
+                ("tool".to_string(), "2.0.0".to_string()),
+                fake_result(
+                    "tool",
+                    "2.0.0",
+                    None,
+                    serde_json::json!({ "name": "tool", "version": "2.0.0" }),
+                ),
+            ),
+            (
+                ("parent".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "parent",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "parent",
+                        "version": "1.0.0",
+                        "dependencies": { "tool": "*" },
+                    }),
+                ),
+            ),
+        ]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let mut opts = workspace_opts(false, false);
+    opts.wanted_lockfile = Some(std::sync::Arc::new(reuse_graph_lockfile(
+        "proj",
+        &[("tool", "catalog:", "1.0.0"), ("parent", "^1.0.0", "1.0.0")],
+        &[("tool@1.0.0", &[]), ("parent@1.0.0", &[("tool", "1.0.0")])],
+        &[("default", "tool", "^1.0.0", "1.0.0")],
+    )));
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            let mut opts =
+                importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None);
+            opts.catalogs = BTreeMap::from([(
+                "default".to_string(),
+                BTreeMap::from([("tool".to_string(), "^2.0.0".to_string())]),
+            )]);
+            opts
+        })
+        .await
+        .expect("resolve workspace with a bumped catalog range");
+
+    assert_eq!(graph_versions_of(&result, "tool"), ["2.0.0"]);
+}
+
+/// A parent whose subtree contains a dependency cycle re-resolves
+/// fresh (the conservative cycle guard), but when it lands back on its
+/// recorded version its child edges keep their prior refs and re-enter
+/// the reuse gate — so `stable`'s cycle-free subtree is reused and its
+/// open `open: *` edge keeps the recorded 1.0.0 pin instead of
+/// re-picking the registry's newest 2.0.0.
+#[tokio::test]
+async fn fresh_resolved_parent_on_recorded_version_reuses_child_subtrees() {
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({ "app": "^1.0.0" }));
+    let importers = [WorkspaceImporter { id: "proj".to_string(), manifest: &manifest }];
+    let resolver = RecordingResolver {
+        table: HashMap::from([
+            (
+                ("app".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "app",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "app",
+                        "version": "1.0.0",
+                        "dependencies": { "cyclic": "^1.0.0", "stable": "^1.0.0" },
+                    }),
+                ),
+            ),
+            (
+                ("cyclic".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "cyclic",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "cyclic",
+                        "version": "1.0.0",
+                        "dependencies": { "loop": "^1.0.0" },
+                    }),
+                ),
+            ),
+            (
+                ("loop".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "loop",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "loop",
+                        "version": "1.0.0",
+                        "dependencies": { "cyclic": "^1.0.0" },
+                    }),
+                ),
+            ),
+            (
+                ("stable".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "stable",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "stable",
+                        "version": "1.0.0",
+                        "dependencies": { "open": "*" },
+                    }),
+                ),
+            ),
+            (
+                ("open".to_string(), "*".to_string()),
+                fake_result(
+                    "open",
+                    "2.0.0",
+                    None,
+                    serde_json::json!({ "name": "open", "version": "2.0.0" }),
+                ),
+            ),
+        ]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let mut opts = workspace_opts(false, false);
+    opts.wanted_lockfile = Some(std::sync::Arc::new(reuse_graph_lockfile(
+        "proj",
+        &[("app", "^1.0.0", "1.0.0")],
+        &[
+            ("app@1.0.0", &[("cyclic", "1.0.0"), ("stable", "1.0.0")]),
+            ("cyclic@1.0.0", &[("loop", "1.0.0")]),
+            ("loop@1.0.0", &[("cyclic", "1.0.0")]),
+            ("stable@1.0.0", &[("open", "1.0.0")]),
+            ("open@1.0.0", &[]),
+        ],
+        &[],
+    )));
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+        })
+        .await
+        .expect("resolve workspace with a cycle next to a reusable subtree");
+
+    assert_eq!(graph_versions_of(&result, "open"), ["1.0.0"]);
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1684,5 +1684,7 @@ async fn fresh_resolved_parent_on_recorded_version_reuses_child_subtrees() {
         .await
         .expect("resolve workspace with a cycle next to a reusable subtree");
 
-    assert_eq!(graph_versions_of(&result, "open"), ["1.0.0"]);
+    for name in ["app", "cyclic", "loop", "stable", "open"] {
+        assert_eq!(graph_versions_of(&result, name), ["1.0.0"], "{name} must keep 1.0.0");
+    }
 }

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -88,6 +88,55 @@ test('installing with "catalog:" should work', async () => {
   })
 })
 
+// Mirrors the pacquet regression where `catalog:` deps were treated as changed
+// direct deps on every install, re-resolving their dependents'
+// still-satisfied subdeps (https://github.com/pnpm/pnpm/pull/13193).
+test('removing an unrelated dependency does not re-resolve a catalog dependency or its subdeps', async () => {
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.0.0', distTag: 'latest' }),
+  ])
+  const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
+    {
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/pkg-with-1-dep': 'catalog:',
+        'is-positive': '1.0.0',
+      },
+    },
+  ])
+
+  const catalogs = {
+    default: { '@pnpm.e2e/pkg-with-1-dep': '^100.0.0' },
+  }
+  await mutateModules(installProjects(projects), {
+    ...options,
+    lockfileOnly: true,
+    catalogs,
+  })
+
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/pkg-with-1-dep', version: '100.1.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' }),
+  ])
+  delete projects['project1' as ProjectId].dependencies!['is-positive']
+
+  await mutateModules(installProjects(projects), {
+    ...options,
+    lockfileOnly: true,
+    catalogs,
+  })
+
+  const lockfile = readLockfile()
+  expect(lockfile.importers['project1' as ProjectId].dependencies?.['@pnpm.e2e/pkg-with-1-dep']).toEqual({
+    specifier: 'catalog:',
+    version: '100.0.0',
+  })
+  expect(lockfile.snapshots['@pnpm.e2e/pkg-with-1-dep@100.0.0'].dependencies).toStrictEqual({
+    '@pnpm.e2e/dep-of-pkg-with-1-dep': '100.0.0',
+  })
+})
+
 test('importer to importer dependency with "catalog:" should work', async () => {
   const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
     {

--- a/pnpm11/installing/deps-installer/test/install/update.ts
+++ b/pnpm11/installing/deps-installer/test/install/update.ts
@@ -172,6 +172,36 @@ test('preserve subdeps when installing on a package that has one dependency spec
   })
 })
 
+// Covers the lockfile churn seen in https://github.com/pnpm/pnpm/pull/13193
+test('removing an unrelated dependency does not re-resolve still-satisfied subdeps', async () => {
+  const project = prepareEmpty()
+
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/bar', version: '100.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/foo', version: '100.0.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/foobarqar', version: '1.0.1', distTag: 'latest' }),
+  ])
+
+  const { updatedManifest: manifest } = await addDependenciesToPackage({}, ['@pnpm.e2e/foobarqar', 'is-positive@1.0.0'], testDefaults())
+
+  await Promise.all([
+    addDistTag({ package: '@pnpm.e2e/bar', version: '100.1.0', distTag: 'latest' }),
+    addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' }),
+  ])
+
+  delete manifest.dependencies!['is-positive']
+
+  await install(manifest, testDefaults())
+
+  const lockfile = project.readLockfile()
+
+  expect(lockfile.snapshots['@pnpm.e2e/foobarqar@1.0.1'].dependencies).toStrictEqual({
+    '@pnpm.e2e/bar': '100.0.0',
+    '@pnpm.e2e/foo': '100.0.0',
+    '@pnpm.e2e/qar': '100.0.0',
+  })
+})
+
 // Covers https://github.com/pnpm/pnpm/issues/2226
 test('update only the packages that were requested to be updated when hoisting is on', async () => {
   const project = prepareEmpty()


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes the unrelated lockfile churn seen in pnpm/pnpm#13193: removing one dev dependency (`concurrently`) rewrote the whole jest cluster's `@types/node: '*'` deps from 22.20.1 to 26.1.1 and minted a new `jest-config` peer-suffix snapshot. Any partial install could drift open-range deps of unrelated, still-satisfied lockfile entries to their newest registry versions.

The churn is produced by pacquet (this repo's installs run the pinned `pnpm@12` Rust CLI). Three gaps in pacquet's lockfile-resolution reuse compounded:

1. **`catalog:` deps always counted as changed.** `record_changed_direct_deps` compared the catalog-*resolved* manifest range (`^22.19.19`) against the importer snapshot's literal `catalog:` specifier, so every catalog-managed dep of every importer was marked as a changed direct dep on every install, and the changed-direct-dep gate declined subtree reuse for every package depending on one. The comparison now consults the lockfile's `catalogs:` snapshot; a real catalog range bump still counts as changed (covered by a test).
2. **Auto-hoisted peers always counted as changed.** Hoisted peers have no importer-snapshot entry to compare against, so they were recorded as "new" changed deps on every install. Recording now runs only for the importer's manifest wave.
3. **One fresh resolve cascaded to the whole subtree.** `ReuseSource::PriorOnly` disabled reuse for every descendant of a freshly-resolved parent. Peer back-edge cycles (`browserslist ↔ update-browserslist-db`, `eslint ↔ eslint-utils`, `jest-resolve ↔ jest-pnp-resolver`) legitimately force fresh resolves via the conservative cycle guard, so `*`-ranged deps beneath them re-picked latest on every partial install. Children of a parent that landed back on its recorded version now re-enter the reuse gate with their prior refs — faithful to the TypeScript CLI's `parentPkg.updated ? undefined : resolvedDependencies` arm — and `PriorOnly` is removed.

With the fix, re-running the PR-13193 manifest change produces exactly the intended 29-line removal — zero unrelated lines (previously 51 insertions / 48 deletions of churn).

**TypeScript CLI status:** not affected, verified empirically with both the published 11.15.1 and a bundle built from this repo's `pnpm11/` main — neither produces any drift on the same repro. TS avoids all three gaps by construction: catalogs resolve inside the resolver chain (specifiers compare raw-to-raw), auto-installed peers don't feed a changed-set, and its reuse predicate already keeps child refs alive under a non-updated parent. This PR ports that behavior to pacquet, so there is no TS-side code change — but since TS had no standalone regression test for "an unrelated removal leaves still-satisfied open-range entries untouched" (and none for the `catalog:` variant), the second commit adds mirroring tests to `installing/deps-installer/test/install/update.ts` and `test/catalogs.ts` so both stacks carry matching coverage.

Known follow-ups (out of scope): the repo's `pnpm-lock.yaml` on `main` still carries the historical drift (~64 `@types/node@26.1.1` refs) — it only converges via a deliberate full re-resolution; hoisted-peer subtrees still fresh-resolve every install (perf, not correctness); and TS omits `(typanion@3.14.0)` from `@pnpm/worker`-consumer peer suffixes where pacquet keeps it — a separate parity gap.

## Squash Commit Body

```text
Removing one dev dependency could flip other packages' open-range deps
(e.g. jest's `@types/node: '*'`) to their newest versions, as seen in
pnpm/pnpm#13193. Three lockfile-resolution-reuse gaps caused
still-satisfied lockfile entries to be re-resolved from the registry:

1. Direct deps using the `catalog:` protocol reach
   record_changed_direct_deps with the protocol already resolved to the
   catalog's range, while the importer snapshot records the literal
   `catalog:` form. Every catalog-managed dep therefore looked changed
   on every install, and the changed-direct-dep gate declined subtree
   reuse for every package depending on one. The comparison now
   consults the lockfile's `catalogs:` snapshot, so only a real catalog
   range change counts as a change.

2. Auto-installed (hoisted) peers were recorded as changed direct deps
   on every install: they have no importer-snapshot entry to compare
   against, so they always counted as "new". Recording now runs only
   for the importer's manifest wave, never for hoist-round installs.

3. A node that resolved freshly but landed on its previously recorded
   version still disabled reuse for its entire subtree
   (ReuseSource::PriorOnly). Peer back-edge cycles
   (browserslist <-> update-browserslist-db, eslint <-> eslint-utils,
   jest-resolve <-> jest-pnp-resolver) force such fresh resolves on
   every install, so open-ranged deps below them re-picked the
   registry's newest version on every partial install. Children of a
   parent that landed on its prior version now re-enter the reuse gate
   with their recorded refs, faithful to pnpm's
   `parentPkg.updated ? undefined : resolvedDependencies` arm, and the
   PriorOnly variant is removed.

The TypeScript CLI is unaffected: catalogs resolve inside its resolver
chain so specifiers compare raw-to-raw, and its reuse predicate already
keeps child refs alive under a non-updated parent. This change ports
that behavior to pacquet.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(The bug is
  pacquet-only; the fix ports the TypeScript CLI's existing behavior, so there
  is no TS code change. Matching regression tests are added on both sides.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787229694&installation_model_id=426870&pr_number=13196&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13196&signature=ce01094f9283885567bdea098aebbb52ce608c12dbc44a30f726ef8dd9106b11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented `pnpm install`/updates from rewriting unrelated `pnpm-lock.yaml` entries after small manifest changes.
  - Improved dependency reuse so satisfied subtrees stay pinned, including catalog-managed direct dependencies.
  - Reduced unnecessary re-resolution churn, including scenarios with hoisted peer dependencies and conservative handling around dependency cycles.

- **Tests**
  - Added regression coverage for unchanged vs bumped `catalog:` dependencies and for removing unrelated workspace dependencies without triggering re-resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->