### PR TITLE
feat(config): add update and audit settings sections superseding updateConfig, auditConfig, and auditLevel

### DIFF
--- a/.changeset/update-settings-section.md
+++ b/.changeset/update-settings-section.md
@@ -9,7 +9,7 @@ Added `update` and `audit` settings sections to `pnpm-workspace.yaml`, supersedi
 
 ```yaml
 update:
-  ignore: # was updateConfig.ignoreDependencies
+  ignoreDeps: # was updateConfig.ignoreDependencies
     - webpack
     - "@babel/*"
 
@@ -19,6 +19,6 @@ audit:
     - GHSA-xxxx-yyyy-zzzz
 ```
 
-`update.ignore` lists package name patterns that `pnpm update` and `pnpm outdated` should skip. `audit.level` and `audit.ignore` tune `pnpm audit`.
+`update.ignoreDeps` lists dependency name patterns that `pnpm update` and `pnpm outdated` should skip. `audit.level` and `audit.ignore` tune `pnpm audit`.
 
 The deprecated `updateConfig`, `auditConfig`, and `auditLevel` settings keep working until the next major version. When both a new section value and its deprecated counterpart are set, the new section takes precedence and a warning is printed. Both the TypeScript CLI and the Rust config surface (pacquet) recognize the new sections.

--- a/.changeset/update-settings-section.md
+++ b/.changeset/update-settings-section.md
@@ -1,0 +1,16 @@
+---
+"@pnpm/config.reader": minor
+"@pnpm/types": minor
+"pnpm": minor
+---
+
+Added an `update` settings section to `pnpm-workspace.yaml`, superseding `updateConfig`. Its `ignore` field lists package name patterns that `pnpm update` and `pnpm outdated` should skip:
+
+```yaml
+update:
+  ignore:
+    - webpack
+    - "@babel/*"
+```
+
+The old `updateConfig.ignoreDependencies` setting keeps working and will be supported until the next major version. If both `update` and `updateConfig` are set, `update` takes precedence and a warning is printed.

--- a/.changeset/update-settings-section.md
+++ b/.changeset/update-settings-section.md
@@ -2,6 +2,7 @@
 "@pnpm/config.reader": minor
 "@pnpm/types": minor
 "pnpm": minor
+"pacquet": patch
 ---
 
 Added an `update` settings section to `pnpm-workspace.yaml`, superseding `updateConfig`. Its `ignore` field lists package name patterns that `pnpm update` and `pnpm outdated` should skip:
@@ -13,4 +14,4 @@ update:
     - "@babel/*"
 ```
 
-The old `updateConfig.ignoreDependencies` setting keeps working and will be supported until the next major version. If both `update` and `updateConfig` are set, `update` takes precedence and a warning is printed.
+The old `updateConfig.ignoreDependencies` setting keeps working and will be supported until the next major version. If both `update` and `updateConfig` are set, `update` takes precedence and a warning is printed. Both the TypeScript CLI and the Rust config surface (pacquet) recognize the new section.

--- a/.changeset/update-settings-section.md
+++ b/.changeset/update-settings-section.md
@@ -5,13 +5,20 @@
 "pacquet": patch
 ---
 
-Added an `update` settings section to `pnpm-workspace.yaml`, superseding `updateConfig`. Its `ignore` field lists package name patterns that `pnpm update` and `pnpm outdated` should skip:
+Added `update` and `audit` settings sections to `pnpm-workspace.yaml`, superseding the awkwardly named `updateConfig`, `auditConfig`, and top-level `auditLevel` settings:
 
 ```yaml
 update:
-  ignore:
+  ignore: # was updateConfig.ignoreDependencies
     - webpack
     - "@babel/*"
+
+audit:
+  level: high # was auditLevel
+  ignore: # was auditConfig.ignoreGhsas
+    - GHSA-xxxx-yyyy-zzzz
 ```
 
-The old `updateConfig.ignoreDependencies` setting keeps working and will be supported until the next major version. If both `update` and `updateConfig` are set, `update` takes precedence and a warning is printed. Both the TypeScript CLI and the Rust config surface (pacquet) recognize the new section.
+`update.ignore` lists package name patterns that `pnpm update` and `pnpm outdated` should skip. `audit.level` and `audit.ignore` tune `pnpm audit`.
+
+The deprecated `updateConfig`, `auditConfig`, and `auditLevel` settings keep working until the next major version. When both a new section value and its deprecated counterpart are set, the new section takes precedence and a warning is printed. Both the TypeScript CLI and the Rust config surface (pacquet) recognize the new sections.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -48,9 +48,9 @@ use crate::defaults::{
     default_registry, default_store_dir, default_user_agent, default_virtual_store_dir,
 };
 pub use workspace_yaml::{
-    GLOBAL_CONFIG_YAML_FILENAME, LoadWorkspaceYamlError, PackageExtension, PeerDependencyMeta,
-    PeerDependencyRules, UpdateConfig, WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings,
-    workspace_root_or,
+    AuditSettings, GLOBAL_CONFIG_YAML_FILENAME, LoadWorkspaceYamlError, PackageExtension,
+    PeerDependencyMeta, PeerDependencyRules, UpdateConfig, UpdateSettings,
+    WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings, workspace_root_or,
 };
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -422,10 +422,23 @@ pub struct WorkspaceSettings {
     /// `~/.config/pnpm/config.yaml`. See [`VerifyDepsBeforeRun`].
     pub verify_deps_before_run: Option<VerifyDepsBeforeRun>,
 
+    /// `audit` from `pnpm-workspace.yaml`. Supersedes `auditLevel` and
+    /// `auditConfig`; see [`AuditSettings`]. When both a value and its
+    /// deprecated counterpart are set, `audit` wins (with a warning) —
+    /// the mapping onto [`Config::audit_level`] / [`Config::audit_config`]
+    /// happens in [`Self::apply_to`].
+    pub audit: Option<AuditSettings>,
+
     /// `auditLevel` from `pnpm-workspace.yaml`.
+    ///
+    /// Deprecated in favor of [`AuditSettings::level`], kept for backward
+    /// compatibility until the next major version.
     pub audit_level: Option<AuditLevel>,
 
     /// `auditConfig` from `pnpm-workspace.yaml`.
+    ///
+    /// Deprecated in favor of [`AuditSettings::ignore`], kept for backward
+    /// compatibility until the next major version.
     pub audit_config: Option<AuditConfig>,
 
     /// `versioning` from `pnpm-workspace.yaml`: native workspace release
@@ -488,6 +501,22 @@ pub struct WorkspaceSettings {
     /// `peerDependencyRules` from `pnpm-workspace.yaml`. See
     /// [`PeerDependencyRules`].
     pub peer_dependency_rules: Option<PeerDependencyRules>,
+}
+
+/// `audit` entry: settings that tune `pnpm audit`. Supersedes the
+/// deprecated top-level `auditLevel` and the `auditConfig` entry.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AuditSettings {
+    /// Minimum vulnerability severity `pnpm audit` reports on.
+    /// Supersedes the deprecated top-level `auditLevel`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<AuditLevel>,
+
+    /// GHSA IDs `pnpm audit` ignores. Supersedes the deprecated
+    /// [`AuditConfig::ignore_ghsas`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore: Option<Vec<String>>,
 }
 
 /// `update` entry: settings that tune `pnpm update` (and `pnpm
@@ -818,9 +847,12 @@ impl WorkspaceSettings {
         let http_proxy_is_explicit = config.http_proxy_is_explicit;
         self.apply_proxy_to(&mut config.proxy, http_proxy_is_explicit);
 
-        // Captured before the `apply!` macro below moves `update_config`
-        // out of `self`; consumed after it to warn on the redundant combo.
+        // Captured before the `apply!` macro and audit if-lets below move
+        // these out of `self`; consumed after, to warn on the redundant
+        // combination of a new section key and its deprecated counterpart.
         let update_config_in_yaml = self.update_config.is_some();
+        let audit_level_in_yaml = self.audit_level.is_some();
+        let audit_config_in_yaml = self.audit_config.is_some();
 
         macro_rules! apply {
             ($($field:ident),* $(,)?) => {$(
@@ -1035,6 +1067,30 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.audit_config {
             config.audit_config = v;
+        }
+
+        // The `audit` section supersedes the deprecated `auditLevel` and
+        // `auditConfig`. Applied after them so it overrides values set in the
+        // same file; each redundant pairing is warned about.
+        if let Some(audit) = self.audit {
+            if let Some(level) = audit.level {
+                if audit_level_in_yaml {
+                    tracing::warn!(
+                        target: "pacquet::config",
+                        "Both the \"audit\" and \"auditLevel\" settings are set. The deprecated \"auditLevel\" setting is ignored in favor of \"audit\"."
+                    );
+                }
+                config.audit_level = Some(level);
+            }
+            if let Some(ignore) = audit.ignore {
+                if audit_config_in_yaml {
+                    tracing::warn!(
+                        target: "pacquet::config",
+                        "Both the \"audit\" and \"auditConfig\" settings are set. The deprecated \"auditConfig\" setting is ignored in favor of \"audit\"."
+                    );
+                }
+                config.audit_config.ignore_ghsas = ignore;
+            }
         }
         if let Some(v) = self.versioning {
             config.versioning = v;

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -473,7 +473,16 @@ pub struct WorkspaceSettings {
     /// [`Config::allowed_deprecated_versions`]: crate::Config::allowed_deprecated_versions
     pub allowed_deprecated_versions: Option<BTreeMap<String, String>>,
 
+    /// `update` from `pnpm-workspace.yaml`. Supersedes `updateConfig`;
+    /// see [`UpdateSettings`]. When both are set, `update` wins (with a
+    /// warning) — the mapping onto [`Config::update_config`] happens in
+    /// [`Self::apply_to`].
+    pub update: Option<UpdateSettings>,
+
     /// `updateConfig` from `pnpm-workspace.yaml`. See [`UpdateConfig`].
+    ///
+    /// Deprecated in favor of [`Self::update`], kept for backward
+    /// compatibility until the next major version.
     pub update_config: Option<UpdateConfig>,
 
     /// `peerDependencyRules` from `pnpm-workspace.yaml`. See
@@ -481,8 +490,24 @@ pub struct WorkspaceSettings {
     pub peer_dependency_rules: Option<PeerDependencyRules>,
 }
 
+/// `update` entry: settings that tune `pnpm update` (and `pnpm
+/// outdated`, which previews it). Supersedes the deprecated
+/// `updateConfig`. Today only `ignore` is modeled.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct UpdateSettings {
+    /// Dependency-name patterns `pnpm update` and `pnpm outdated`
+    /// skip. Glob/negation patterns. Equivalent to the deprecated
+    /// [`UpdateConfig::ignore_dependencies`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ignore: Option<Vec<String>>,
+}
+
 /// `updateConfig` entry: settings that tune `pnpm update`. Today only
 /// `ignoreDependencies` is modeled.
+///
+/// Deprecated in favor of [`UpdateSettings`], kept for backward
+/// compatibility until the next major version.
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct UpdateConfig {
@@ -793,6 +818,10 @@ impl WorkspaceSettings {
         let http_proxy_is_explicit = config.http_proxy_is_explicit;
         self.apply_proxy_to(&mut config.proxy, http_proxy_is_explicit);
 
+        // Captured before the `apply!` macro below moves `update_config`
+        // out of `self`; consumed after it to warn on the redundant combo.
+        let update_config_in_yaml = self.update_config.is_some();
+
         macro_rules! apply {
             ($($field:ident),* $(,)?) => {$(
                 if let Some(v) = self.$field {
@@ -838,6 +867,19 @@ impl WorkspaceSettings {
             allowed_deprecated_versions, update_config, peer_dependency_rules,
             enable_pre_post_scripts, dlx_cache_max_age,
             allow_unused_patches,
+        }
+
+        // The `update` section supersedes the deprecated `updateConfig`.
+        // Applied after the macro so it overrides an `updateConfig` set in
+        // the same file; both together is redundant and warned about.
+        if let Some(update) = self.update {
+            if update_config_in_yaml {
+                tracing::warn!(
+                    target: "pacquet::config",
+                    "Both the \"update\" and \"updateConfig\" settings are set. The deprecated \"updateConfig\" setting is ignored in favor of \"update\"."
+                );
+            }
+            config.update_config = UpdateConfig { ignore_dependencies: update.ignore };
         }
 
         if let Some(inner) = self.hoist_pattern {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -908,7 +908,7 @@ impl WorkspaceSettings {
             if update_config_in_yaml {
                 tracing::warn!(
                     target: "pacquet::config",
-                    "Both the \"update\" and \"updateConfig\" settings are set. The deprecated \"updateConfig\" setting is ignored in favor of \"update\"."
+                    r#"Both the "update" and "updateConfig" settings are set. The deprecated "updateConfig" setting is ignored in favor of "update"."#,
                 );
             }
             config.update_config = UpdateConfig { ignore_dependencies: update.ignore_deps };
@@ -1077,7 +1077,7 @@ impl WorkspaceSettings {
                 if audit_level_in_yaml {
                     tracing::warn!(
                         target: "pacquet::config",
-                        "Both the \"audit\" and \"auditLevel\" settings are set. The deprecated \"auditLevel\" setting is ignored in favor of \"audit\"."
+                        r#"Both the "audit" and "auditLevel" settings are set. The deprecated "auditLevel" setting is ignored in favor of "audit"."#,
                     );
                 }
                 config.audit_level = Some(level);
@@ -1086,7 +1086,7 @@ impl WorkspaceSettings {
                 if audit_config_in_yaml {
                     tracing::warn!(
                         target: "pacquet::config",
-                        "Both the \"audit\" and \"auditConfig\" settings are set. The deprecated \"auditConfig\" setting is ignored in favor of \"audit\"."
+                        r#"Both the "audit" and "auditConfig" settings are set. The deprecated "auditConfig" setting is ignored in favor of "audit"."#,
                     );
                 }
                 config.audit_config.ignore_ghsas = ignore;

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -525,11 +525,11 @@ pub struct AuditSettings {
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct UpdateSettings {
-    /// Dependency-name patterns `pnpm update` and `pnpm outdated`
-    /// skip. Glob/negation patterns. Equivalent to the deprecated
-    /// [`UpdateConfig::ignore_dependencies`].
+    /// `ignoreDeps`: dependency-name patterns `pnpm update` and `pnpm
+    /// outdated` skip. Glob/negation patterns. Equivalent to the
+    /// deprecated [`UpdateConfig::ignore_dependencies`].
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ignore: Option<Vec<String>>,
+    pub ignore_deps: Option<Vec<String>>,
 }
 
 /// `updateConfig` entry: settings that tune `pnpm update`. Today only
@@ -911,7 +911,7 @@ impl WorkspaceSettings {
                     "Both the \"update\" and \"updateConfig\" settings are set. The deprecated \"updateConfig\" setting is ignored in favor of \"update\"."
                 );
             }
-            config.update_config = UpdateConfig { ignore_dependencies: update.ignore };
+            config.update_config = UpdateConfig { ignore_dependencies: update.ignore_deps };
         }
 
         if let Some(inner) = self.hoist_pattern {

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1,7 +1,7 @@
 use super::{LoadWorkspaceYamlError, WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings};
 use crate::{
-    CatalogMode, Config, HoistingLimits, LinkWorkspacePackages, NodeLinker, NodePackageMapType,
-    ResolutionMode, ScriptsPrependNodePath, TrustPolicy, api::EnvVar,
+    AuditLevel, CatalogMode, Config, HoistingLimits, LinkWorkspacePackages, NodeLinker,
+    NodePackageMapType, ResolutionMode, ScriptsPrependNodePath, TrustPolicy, api::EnvVar,
 };
 use pacquet_store_dir::StoreDir;
 use pacquet_workspace_state::{ConfigDependency, ConfigDependencyDetail};
@@ -1556,6 +1556,48 @@ updateConfig:
         Some(&["@pnpm.e2e/foo".to_string()][..]),
         "the update section should override updateConfig",
     );
+}
+
+/// The `audit` section supersedes `auditLevel` / `auditConfig`: its
+/// `level` and `ignore` land on `Config.audit_level` and
+/// `Config.audit_config.ignore_ghsas`.
+#[test]
+fn parses_audit_section_from_yaml_and_applies() {
+    let yaml = r#"
+audit:
+  level: high
+  ignore:
+    - GHSA-1
+    - GHSA-2
+"#;
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(config.audit_level, Some(AuditLevel::High));
+    assert_eq!(config.audit_config.ignore_ghsas, vec!["GHSA-1".to_string(), "GHSA-2".to_string()],);
+}
+
+/// When both `audit` and the deprecated `auditLevel` / `auditConfig` are
+/// set, `audit` wins.
+#[test]
+fn audit_section_takes_precedence_over_audit_level_and_config() {
+    let yaml = r#"
+audit:
+  level: critical
+  ignore:
+    - GHSA-new
+auditLevel: low
+auditConfig:
+  ignoreGhsas:
+    - GHSA-old
+"#;
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(config.audit_level, Some(AuditLevel::Critical));
+    assert_eq!(config.audit_config.ignore_ghsas, vec!["GHSA-new".to_string()]);
 }
 
 /// `peerDependencyRules` parses its three sub-fields from camelCase

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1514,6 +1514,50 @@ updateConfig:
     );
 }
 
+/// The `update` section supersedes `updateConfig`: its `ignore` list
+/// lands on `Config.update_config.ignore_dependencies`.
+#[test]
+fn parses_update_ignore_from_yaml_and_applies() {
+    let yaml = r#"
+update:
+  ignore:
+    - "@pnpm.e2e/foo"
+    - "@pnpm.e2e/bar"
+"#;
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+
+    let mut config = Config::new();
+    assert!(config.update_config.ignore_dependencies.is_none(), "default is unset");
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(
+        config.update_config.ignore_dependencies.as_deref(),
+        Some(&["@pnpm.e2e/foo".to_string(), "@pnpm.e2e/bar".to_string()][..]),
+    );
+}
+
+/// When both `update` and the deprecated `updateConfig` are set,
+/// `update` wins.
+#[test]
+fn update_section_takes_precedence_over_update_config() {
+    let yaml = r#"
+update:
+  ignore:
+    - "@pnpm.e2e/foo"
+updateConfig:
+  ignoreDependencies:
+    - "@pnpm.e2e/bar"
+"#;
+    let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new("/irrelevant"));
+    assert_eq!(
+        config.update_config.ignore_dependencies.as_deref(),
+        Some(&["@pnpm.e2e/foo".to_string()][..]),
+        "the update section should override updateConfig",
+    );
+}
+
 /// `peerDependencyRules` parses its three sub-fields from camelCase
 /// yaml and lands on `Config.peer_dependency_rules`.
 #[test]

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1514,8 +1514,6 @@ updateConfig:
     );
 }
 
-/// The `update` section supersedes `updateConfig`: its `ignore` list
-/// lands on `Config.update_config.ignore_dependencies`.
 #[test]
 fn parses_update_ignore_from_yaml_and_applies() {
     let yaml = r#"
@@ -1535,8 +1533,6 @@ update:
     );
 }
 
-/// When both `update` and the deprecated `updateConfig` are set,
-/// `update` wins.
 #[test]
 fn update_section_takes_precedence_over_update_config() {
     let yaml = r#"
@@ -1558,9 +1554,6 @@ updateConfig:
     );
 }
 
-/// The `audit` section supersedes `auditLevel` / `auditConfig`: its
-/// `level` and `ignore` land on `Config.audit_level` and
-/// `Config.audit_config.ignore_ghsas`.
 #[test]
 fn parses_audit_section_from_yaml_and_applies() {
     let yaml = r#"
@@ -1578,8 +1571,6 @@ audit:
     assert_eq!(config.audit_config.ignore_ghsas, vec!["GHSA-1".to_string(), "GHSA-2".to_string()],);
 }
 
-/// When both `audit` and the deprecated `auditLevel` / `auditConfig` are
-/// set, `audit` wins.
 #[test]
 fn audit_section_takes_precedence_over_audit_level_and_config() {
     let yaml = r#"

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1515,10 +1515,10 @@ updateConfig:
 }
 
 #[test]
-fn parses_update_ignore_from_yaml_and_applies() {
+fn parses_update_ignore_deps_from_yaml_and_applies() {
     let yaml = r#"
 update:
-  ignore:
+  ignoreDeps:
     - "@pnpm.e2e/foo"
     - "@pnpm.e2e/bar"
 "#;
@@ -1537,7 +1537,7 @@ update:
 fn update_section_takes_precedence_over_update_config() {
     let yaml = r#"
 update:
-  ignore:
+  ignoreDeps:
     - "@pnpm.e2e/foo"
 updateConfig:
   ignoreDependencies:

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1556,24 +1556,24 @@ updateConfig:
 
 #[test]
 fn parses_audit_section_from_yaml_and_applies() {
-    let yaml = r#"
+    let yaml = r"
 audit:
   level: high
   ignore:
     - GHSA-1
     - GHSA-2
-"#;
+";
     let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
 
     let mut config = Config::new();
     settings.apply_to(&mut config, Path::new("/irrelevant"));
     assert_eq!(config.audit_level, Some(AuditLevel::High));
-    assert_eq!(config.audit_config.ignore_ghsas, vec!["GHSA-1".to_string(), "GHSA-2".to_string()],);
+    assert_eq!(config.audit_config.ignore_ghsas, vec!["GHSA-1".to_string(), "GHSA-2".to_string()]);
 }
 
 #[test]
 fn audit_section_takes_precedence_over_audit_level_and_config() {
-    let yaml = r#"
+    let yaml = r"
 audit:
   level: critical
   ignore:
@@ -1582,7 +1582,7 @@ auditLevel: low
 auditConfig:
   ignoreGhsas:
     - GHSA-old
-"#;
+";
     let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
 
     let mut config = Config::new();

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -88,6 +88,7 @@ export function getOptionsFromPnpmSettings (
 function translateUpdateSettings (pnpmSettings: PnpmSettings, settings: OptionsFromRootManifest): void {
   delete (settings as { update?: unknown }).update
   if (pnpmSettings.update == null) return
+  assertObjectSetting(pnpmSettings.update, 'update')
   if (pnpmSettings.updateConfig != null) {
     globalWarn('Both the "update" and "updateConfig" settings are set. The deprecated "updateConfig" setting is ignored in favor of "update".')
   }
@@ -111,6 +112,7 @@ function translateAuditSettings (pnpmSettings: PnpmSettings, settings: OptionsFr
   delete (settings as { audit?: unknown }).audit
   const audit = pnpmSettings.audit
   if (audit == null) return
+  assertObjectSetting(audit, 'audit')
   if (audit.ignore != null) {
     assertStringArray(audit.ignore, 'audit.ignore')
     if (pnpmSettings.auditConfig != null) {
@@ -163,6 +165,14 @@ const AUDIT_LEVELS = new Set(['info', 'low', 'moderate', 'high', 'critical'])
 function assertStringArray (value: unknown, settingName: string): asserts value is string[] {
   if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
     throw new PnpmError('INVALID_SETTING', `The "${settingName}" setting should be an array of strings, but got ${renderReceivedType(value)}`)
+  }
+}
+
+// Not an `asserts` guard on purpose: it only rejects malformed shapes at
+// runtime, without narrowing away the section's declared type at the call site.
+function assertObjectSetting (value: unknown, settingName: string): void {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new PnpmError('INVALID_SETTING', `The "${settingName}" setting should be an object, but got ${renderReceivedType(value)}`)
   }
 }
 

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -91,9 +91,12 @@ function translateUpdateSettings (pnpmSettings: PnpmSettings, settings: OptionsF
   if (pnpmSettings.updateConfig != null) {
     globalWarn('Both the "update" and "updateConfig" settings are set. The deprecated "updateConfig" setting is ignored in favor of "update".')
   }
-  settings.updateConfig = pnpmSettings.update.ignoreDeps != null
-    ? { ignoreDependencies: pnpmSettings.update.ignoreDeps }
-    : {}
+  if (pnpmSettings.update.ignoreDeps == null) {
+    settings.updateConfig = {}
+    return
+  }
+  assertStringArray(pnpmSettings.update.ignoreDeps, 'update.ignoreDeps')
+  settings.updateConfig = { ignoreDependencies: pnpmSettings.update.ignoreDeps }
 }
 
 /**
@@ -109,12 +112,16 @@ function translateAuditSettings (pnpmSettings: PnpmSettings, settings: OptionsFr
   const audit = pnpmSettings.audit
   if (audit == null) return
   if (audit.ignore != null) {
+    assertStringArray(audit.ignore, 'audit.ignore')
     if (pnpmSettings.auditConfig != null) {
       globalWarn('Both the "audit" and "auditConfig" settings are set. The deprecated "auditConfig" setting is ignored in favor of "audit".')
     }
     settings.auditConfig = { ...settings.auditConfig, ignoreGhsas: audit.ignore }
   }
   if (audit.level != null) {
+    if (!AUDIT_LEVELS.has(audit.level)) {
+      throw new PnpmError('INVALID_SETTING', `The "audit.level" setting should be one of ${Array.from(AUDIT_LEVELS).join(', ')}, but got ${JSON.stringify(audit.level)}`)
+    }
     if ((pnpmSettings as { auditLevel?: unknown }).auditLevel != null) {
       globalWarn('Both the "audit" and "auditLevel" settings are set. The deprecated "auditLevel" setting is ignored in favor of "audit".')
     }
@@ -143,6 +150,20 @@ function renderReceivedType (value: unknown): string {
   if (value === null) return 'null'
   if (Array.isArray(value)) return 'array'
   return typeof value
+}
+
+const AUDIT_LEVELS = new Set(['info', 'low', 'moderate', 'high', 'critical'])
+
+// The `update` and `audit` sections come from repo-controlled
+// pnpm-workspace.yaml, which is parsed untyped — so their fields are validated
+// here (the Rust config reader rejects the same malformed shapes at parse
+// time). An invalid `audit.level` is especially worth catching: it would leave
+// `pnpm audit` comparing severities against `undefined`, silently reporting no
+// advisories.
+function assertStringArray (value: unknown, settingName: string): asserts value is string[] {
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new PnpmError('INVALID_SETTING', `The "${settingName}" setting should be an array of strings, but got ${renderReceivedType(value)}`)
+  }
 }
 
 function replaceEnvInSettings (

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -66,8 +66,33 @@ export function getOptionsFromPnpmSettings (
       settings.patchedDependencies[dep] = path.join(manifestDir, patchFile)
     }
   }
+  translateUpdateSettings(pnpmSettings, settings)
 
   return settings
+}
+
+/**
+ * Translates the user-facing `update` settings section into the internal
+ * `updateConfig` shape that the rest of pnpm reads, and removes the raw
+ * `update` key from the returned options.
+ *
+ * The removal is load-bearing: these options are merged into the global config,
+ * where `update` is the boolean flag that turns an install into an update. A
+ * leaked `update` object would be truthy and make a plain `pnpm install` behave
+ * like `pnpm update`.
+ *
+ * `updateConfig` is the deprecated spelling, kept working until the next major.
+ * When both are set, `update` wins.
+ */
+function translateUpdateSettings (pnpmSettings: PnpmSettings, settings: OptionsFromRootManifest): void {
+  delete (settings as { update?: unknown }).update
+  if (pnpmSettings.update == null) return
+  if (pnpmSettings.updateConfig != null) {
+    globalWarn('Both the "update" and "updateConfig" settings are set. The deprecated "updateConfig" setting is ignored in favor of "update".')
+  }
+  settings.updateConfig = pnpmSettings.update.ignore != null
+    ? { ignoreDependencies: pnpmSettings.update.ignore }
+    : {}
 }
 
 function isGetOptionsFromPnpmSettingsOptions (

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -91,8 +91,8 @@ function translateUpdateSettings (pnpmSettings: PnpmSettings, settings: OptionsF
   if (pnpmSettings.updateConfig != null) {
     globalWarn('Both the "update" and "updateConfig" settings are set. The deprecated "updateConfig" setting is ignored in favor of "update".')
   }
-  settings.updateConfig = pnpmSettings.update.ignore != null
-    ? { ignoreDependencies: pnpmSettings.update.ignore }
+  settings.updateConfig = pnpmSettings.update.ignoreDeps != null
+    ? { ignoreDependencies: pnpmSettings.update.ignoreDeps }
     : {}
 }
 

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -67,6 +67,7 @@ export function getOptionsFromPnpmSettings (
     }
   }
   translateUpdateSettings(pnpmSettings, settings)
+  translateAuditSettings(pnpmSettings, settings)
 
   return settings
 }
@@ -93,6 +94,32 @@ function translateUpdateSettings (pnpmSettings: PnpmSettings, settings: OptionsF
   settings.updateConfig = pnpmSettings.update.ignore != null
     ? { ignoreDependencies: pnpmSettings.update.ignore }
     : {}
+}
+
+/**
+ * Translates the user-facing `audit` settings section into the internal
+ * `auditConfig` / `auditLevel` settings, and removes the raw `audit` key.
+ *
+ * `auditConfig` and `auditLevel` are the deprecated spellings, kept working
+ * until the next major. When the `audit` section provides a value, it wins
+ * over its deprecated counterpart (with a warning).
+ */
+function translateAuditSettings (pnpmSettings: PnpmSettings, settings: OptionsFromRootManifest): void {
+  delete (settings as { audit?: unknown }).audit
+  const audit = pnpmSettings.audit
+  if (audit == null) return
+  if (audit.ignore != null) {
+    if (pnpmSettings.auditConfig != null) {
+      globalWarn('Both the "audit" and "auditConfig" settings are set. The deprecated "auditConfig" setting is ignored in favor of "audit".')
+    }
+    settings.auditConfig = { ...settings.auditConfig, ignoreGhsas: audit.ignore }
+  }
+  if (audit.level != null) {
+    if ((pnpmSettings as { auditLevel?: unknown }).auditLevel != null) {
+      globalWarn('Both the "audit" and "auditLevel" settings are set. The deprecated "auditLevel" setting is ignored in favor of "audit".')
+    }
+    ;(settings as { auditLevel?: string }).auditLevel = audit.level
+  }
 }
 
 function isGetOptionsFromPnpmSettingsOptions (

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -875,6 +875,7 @@ const MIGRATED_PNPM_FIELD_KEYS = new Set<string>([
   'allowBuilds',
   'allowedDeprecatedVersions',
   'allowUnusedPatches',
+  'audit',
   'auditConfig',
   'configDependencies',
   'executionEnv',

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -865,10 +865,12 @@ function getWantedPackageManager (manifest: ProjectManifest): { pm?: WantedPacka
   return { warnings }
 }
 
-// Settings that used to be read from the `pnpm` field of `package.json` in v10
-// but moved to `pnpm-workspace.yaml` in v11. Keys not in this set (e.g. `app`,
-// or anything set by third-party tooling that piggybacks on the `pnpm` namespace)
-// are left alone to avoid false-positive warnings.
+// Settings that pnpm reads from `pnpm-workspace.yaml` and never from the `pnpm`
+// field of `package.json` — either because they moved there in v11, or because
+// (like `update`) they were introduced later and only ever lived there. When one
+// of these appears in the `pnpm` field, pnpm warns that it is ignored. Keys not
+// in this set (e.g. `app`, or anything set by third-party tooling that piggybacks
+// on the `pnpm` namespace) are left alone to avoid false-positive warnings.
 const MIGRATED_PNPM_FIELD_KEYS = new Set<string>([
   'allowBuilds',
   'allowedDeprecatedVersions',
@@ -886,6 +888,7 @@ const MIGRATED_PNPM_FIELD_KEYS = new Set<string>([
   'peerDependencyRules',
   'requiredScripts',
   'supportedArchitectures',
+  'update',
   'updateConfig',
 ])
 

--- a/pnpm11/config/reader/test/updateSettings.test.ts
+++ b/pnpm11/config/reader/test/updateSettings.test.ts
@@ -71,3 +71,50 @@ test('getOptionsFromPnpmSettings() still honors the deprecated "updateConfig" se
   })
   expect(globalWarn).not.toHaveBeenCalled()
 })
+
+test('getOptionsFromPnpmSettings() maps the "audit" settings section to auditConfig and auditLevel', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    audit: {
+      level: 'high',
+      ignore: ['GHSA-1', 'GHSA-2'],
+    },
+  }) as any // eslint-disable-line
+  expect(options.auditConfig).toStrictEqual({ ignoreGhsas: ['GHSA-1', 'GHSA-2'] })
+  expect(options.auditLevel).toBe('high')
+  expect(globalWarn).not.toHaveBeenCalled()
+})
+
+test('getOptionsFromPnpmSettings() never leaks the raw "audit" key into the options', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    audit: {
+      ignore: ['GHSA-1'],
+    },
+  })
+  expect('audit' in options).toBe(false)
+})
+
+test('getOptionsFromPnpmSettings() lets "audit" win over "auditConfig" and "auditLevel" and warns', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    audit: {
+      level: 'critical',
+      ignore: ['GHSA-new'],
+    },
+    auditConfig: {
+      ignoreGhsas: ['GHSA-old'],
+    },
+    auditLevel: 'low',
+  } as any) as any // eslint-disable-line
+  expect(options.auditConfig).toStrictEqual({ ignoreGhsas: ['GHSA-new'] })
+  expect(options.auditLevel).toBe('critical')
+  expect(globalWarn).toHaveBeenCalledTimes(2)
+})
+
+test('getOptionsFromPnpmSettings() still honors the deprecated "auditConfig" setting without warning', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    auditConfig: {
+      ignoreGhsas: ['GHSA-old'],
+    },
+  })
+  expect(options.auditConfig).toStrictEqual({ ignoreGhsas: ['GHSA-old'] })
+  expect(globalWarn).not.toHaveBeenCalled()
+})

--- a/pnpm11/config/reader/test/updateSettings.test.ts
+++ b/pnpm11/config/reader/test/updateSettings.test.ts
@@ -118,3 +118,21 @@ test('getOptionsFromPnpmSettings() still honors the deprecated "auditConfig" set
   expect(options.auditConfig).toStrictEqual({ ignoreGhsas: ['GHSA-old'] })
   expect(globalWarn).not.toHaveBeenCalled()
 })
+
+test('getOptionsFromPnpmSettings() throws when "update.ignoreDeps" is not a string array', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    update: { ignoreDeps: 'webpack' },
+  } as any)).toThrow(/update\.ignoreDeps/) // eslint-disable-line
+})
+
+test('getOptionsFromPnpmSettings() throws when "audit.ignore" is not a string array', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    audit: { ignore: 'GHSA-1' },
+  } as any)).toThrow(/audit\.ignore/) // eslint-disable-line
+})
+
+test('getOptionsFromPnpmSettings() throws on an invalid "audit.level"', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    audit: { level: 'hgih' },
+  } as any)).toThrow(/audit\.level/) // eslint-disable-line
+})

--- a/pnpm11/config/reader/test/updateSettings.test.ts
+++ b/pnpm11/config/reader/test/updateSettings.test.ts
@@ -136,3 +136,15 @@ test('getOptionsFromPnpmSettings() throws on an invalid "audit.level"', () => {
     audit: { level: 'severe' },
   } as any)).toThrow(/audit\.level/) // eslint-disable-line
 })
+
+test('getOptionsFromPnpmSettings() throws when the "update" section is not an object', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    update: 'webpack',
+  } as any)).toThrow(/"update" setting should be an object/) // eslint-disable-line
+})
+
+test('getOptionsFromPnpmSettings() throws when the "audit" section is not an object', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    audit: true,
+  } as any)).toThrow(/"audit" setting should be an object/) // eslint-disable-line
+})

--- a/pnpm11/config/reader/test/updateSettings.test.ts
+++ b/pnpm11/config/reader/test/updateSettings.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('@pnpm/logger', () => ({
+  globalWarn: jest.fn(),
+}))
+
+const { globalWarn } = await import('@pnpm/logger')
+const { getOptionsFromPnpmSettings } = await import('../lib/getOptionsFromRootManifest.js')
+
+beforeEach(() => {
+  jest.mocked(globalWarn).mockClear()
+})
+
+test('getOptionsFromPnpmSettings() maps the "update" settings section to updateConfig', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    update: {
+      ignore: ['webpack', '@babel/*'],
+    },
+  })
+  expect(options.updateConfig).toStrictEqual({
+    ignoreDependencies: ['webpack', '@babel/*'],
+  })
+  expect(globalWarn).not.toHaveBeenCalled()
+})
+
+test('getOptionsFromPnpmSettings() never leaks the raw "update" key into the options', () => {
+  // The merged config uses `update` as the boolean that turns an install into
+  // an update, so the settings object must not reach it under that key.
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    update: {
+      ignore: ['webpack'],
+    },
+  })
+  expect('update' in options).toBe(false)
+})
+
+test('getOptionsFromPnpmSettings() accepts an empty "update" section', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    update: {},
+  })
+  expect(options.updateConfig).toStrictEqual({})
+  expect('update' in options).toBe(false)
+})
+
+test('getOptionsFromPnpmSettings() lets "update" win over "updateConfig" and warns', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    update: {
+      ignore: ['webpack'],
+    },
+    updateConfig: {
+      ignoreDependencies: ['react'],
+    },
+  })
+  expect(options.updateConfig).toStrictEqual({
+    ignoreDependencies: ['webpack'],
+  })
+  expect(globalWarn).toHaveBeenCalledTimes(1)
+  const warning = jest.mocked(globalWarn).mock.calls[0][0]
+  expect(warning).toContain('update')
+  expect(warning).toContain('updateConfig')
+})
+
+test('getOptionsFromPnpmSettings() still honors the deprecated "updateConfig" setting without warning', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    updateConfig: {
+      ignoreDependencies: ['react'],
+    },
+  })
+  expect(options.updateConfig).toStrictEqual({
+    ignoreDependencies: ['react'],
+  })
+  expect(globalWarn).not.toHaveBeenCalled()
+})

--- a/pnpm11/config/reader/test/updateSettings.test.ts
+++ b/pnpm11/config/reader/test/updateSettings.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 test('getOptionsFromPnpmSettings() maps the "update" settings section to updateConfig', () => {
   const options = getOptionsFromPnpmSettings(process.cwd(), {
     update: {
-      ignore: ['webpack', '@babel/*'],
+      ignoreDeps: ['webpack', '@babel/*'],
     },
   })
   expect(options.updateConfig).toStrictEqual({
@@ -28,7 +28,7 @@ test('getOptionsFromPnpmSettings() never leaks the raw "update" key into the opt
   // an update, so the settings object must not reach it under that key.
   const options = getOptionsFromPnpmSettings(process.cwd(), {
     update: {
-      ignore: ['webpack'],
+      ignoreDeps: ['webpack'],
     },
   })
   expect('update' in options).toBe(false)
@@ -45,7 +45,7 @@ test('getOptionsFromPnpmSettings() accepts an empty "update" section', () => {
 test('getOptionsFromPnpmSettings() lets "update" win over "updateConfig" and warns', () => {
   const options = getOptionsFromPnpmSettings(process.cwd(), {
     update: {
-      ignore: ['webpack'],
+      ignoreDeps: ['webpack'],
     },
     updateConfig: {
       ignoreDependencies: ['react'],

--- a/pnpm11/config/reader/test/updateSettings.test.ts
+++ b/pnpm11/config/reader/test/updateSettings.test.ts
@@ -133,6 +133,6 @@ test('getOptionsFromPnpmSettings() throws when "audit.ignore" is not a string ar
 
 test('getOptionsFromPnpmSettings() throws on an invalid "audit.level"', () => {
   expect(() => getOptionsFromPnpmSettings(process.cwd(), {
-    audit: { level: 'hgih' },
+    audit: { level: 'severe' },
   } as any)).toThrow(/audit\.level/) // eslint-disable-line
 })

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -178,6 +178,13 @@ export interface AuditConfig {
   ignoreGhsas?: string[]
 }
 
+export interface UpdateSettings {
+  /**
+   * Package name patterns that `pnpm update` and `pnpm outdated` should skip.
+   */
+  ignore?: string[]
+}
+
 export interface PnpmSettings {
   npmrcAuthFile?: string
   registries?: Registries
@@ -191,6 +198,11 @@ export interface PnpmSettings {
   allowedDeprecatedVersions?: AllowedDeprecatedVersions
   allowUnusedPatches?: boolean
   patchedDependencies?: Record<string, string>
+  update?: UpdateSettings
+  /**
+   * @deprecated Use {@link PnpmSettings.update} instead. Kept for backward
+   * compatibility until the next major version.
+   */
   updateConfig?: {
     ignoreDependencies?: string[]
   }

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -199,9 +199,9 @@ export interface AuditSettings {
 
 export interface UpdateSettings {
   /**
-   * Package name patterns that `pnpm update` and `pnpm outdated` should skip.
+   * Dependency name patterns that `pnpm update` and `pnpm outdated` should skip.
    */
-  ignore?: string[]
+  ignoreDeps?: string[]
 }
 
 export interface PnpmSettings {

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -174,8 +174,27 @@ export type ConfigDependencies = Record<string, VersionWithIntegrity | {
  */
 export type ConfigDependencySpecifiers = Record<string, string>
 
+export type AuditLevel = 'info' | 'low' | 'moderate' | 'high' | 'critical'
+
+/**
+ * @deprecated Use {@link AuditSettings} instead. Kept for backward
+ * compatibility until the next major version.
+ */
 export interface AuditConfig {
   ignoreGhsas?: string[]
+}
+
+export interface AuditSettings {
+  /**
+   * The minimum vulnerability severity `pnpm audit` reports on. Supersedes the
+   * top-level `auditLevel` setting.
+   */
+  level?: AuditLevel
+  /**
+   * GHSA IDs that `pnpm audit` should ignore. Supersedes
+   * `auditConfig.ignoreGhsas`.
+   */
+  ignore?: string[]
 }
 
 export interface UpdateSettings {
@@ -206,6 +225,11 @@ export interface PnpmSettings {
   updateConfig?: {
     ignoreDependencies?: string[]
   }
+  audit?: AuditSettings
+  /**
+   * @deprecated Use {@link PnpmSettings.audit} instead. Kept for backward
+   * compatibility until the next major version.
+   */
   auditConfig?: AuditConfig
   requiredScripts?: string[]
   supportedArchitectures?: SupportedArchitectures


### PR DESCRIPTION
Introduces two user-facing settings sections in `pnpm-workspace.yaml`, replacing awkwardly named settings:

```yaml
update:
  ignoreDeps: # was updateConfig.ignoreDependencies
    - webpack
    - "@babel/*"

audit:
  level: high # was auditLevel
  ignore: # was auditConfig.ignoreGhsas
    - GHSA-xxxx-yyyy-zzzz
```

- `update.ignoreDeps` — dependency name patterns that `pnpm update` and `pnpm outdated` skip. Equivalent to `updateConfig.ignoreDependencies`.
- `audit.level` / `audit.ignore` — tune `pnpm audit`. Equivalent to the top-level `auditLevel` and `auditConfig.ignoreGhsas`.

The update key is `ignoreDeps` rather than a bare `ignore` deliberately: it names an axis (ignore *by dependency name*), leaving room for a future `update.ignorePaths` / `ignorePackages` (ignore *by workspace package location*) to sit beside it unambiguously — the same split Renovate makes with `ignoreDeps` / `ignorePaths`. `audit.ignore` stays bare because its values are GHSA IDs and there is no competing axis.

## Why

The `Config` suffix on `updateConfig` only exists because the natural name `update` was taken: `opts.update` is the internal boolean that turns an install into an update, threaded through the install machinery right next to `opts.updateConfig`. Users shouldn't pay for that internal collision. `auditConfig` has no such collision — it was named that way purely by symmetry — but it carries the same awkwardness, and its settings were split across a top-level `auditLevel` and a nested `auditConfig`. Grouping them under `audit` is cleaner. And as pnpm grows into a replacement for Renovate/Dependabot, update/audit policy will keep gaining settings, so both deserve clean namespaces to grow into.

## Behavior

- The new sections are honored wherever the old settings are read (`pnpm-workspace.yaml`).
- **Backward compatible**: `updateConfig`, `auditConfig`, and `auditLevel` keep working silently and stay supported until the next major.
- **Precedence**: when both a new section value and its deprecated counterpart are set, the new section wins and a warning is printed (per pairing — e.g. `audit.level` vs `auditLevel` warns independently of `audit.ignore` vs `auditConfig`).
- Putting any of these in the legacy `pnpm` field of `package.json` produces the existing "no longer read, move to pnpm-workspace.yaml" warning.

## Implementation

The translation happens at a single boundary — `getOptionsFromPnpmSettings` in `@pnpm/config.reader` — where the new sections are mapped onto the existing internal `updateConfig` / `auditConfig` / `auditLevel` shapes, so nothing downstream changes.

**Critical correctness property (update only)**: the raw `update` settings object must never reach merged command options, because `opts.update` there is the boolean that would turn a plain `pnpm install` into an update run. The mapping deletes the `update` key from the returned options, guarded by a dedicated regression test (`never leaks the raw "update" key into the options`). `audit` has no equivalent boolean, but its raw key is deleted the same way for cleanliness (also test-guarded).

## Tests

New unit tests in `@pnpm/config.reader` for both sections: the section → internal mapping, empty sections, new-wins-over-deprecated with warnings, the deprecated settings still working without warnings, and the no-leak regression guards. Full `@pnpm/config.reader` suite passes (305 tests), downstream `tsgo --build` is clean, meta-lint passes.

## pacquet (Rust) parity

The Rust config surface already modeled `updateConfig`, `auditConfig`, and `auditLevel` (parsed and stored for parity ahead of consumers). This PR adds the matching `update` and `audit` sections there too — new `UpdateSettings` / `AuditSettings` structs, the new-wins precedence with `tracing::warn!`, and the mapping onto `Config` in `apply_to`. Note the collision that motivates the `update` rename is TypeScript-only: Rust config is strongly-typed named fields, so there is no `opts.update` boolean for a settings object to leak into. New tests in `pacquet-config`; full crate suite (396 tests), clippy, and rustfmt are clean.

## Out of scope / follow-ups

- The `update` section will later gain more settings (e.g. a default for the `pnpm update --changeset` flag from #13195); only `ignore` ships here to avoid conflicting with that unmerged PR.
- The env-var overlay still uses the deprecated spellings on both engines; the new names are wired for `pnpm-workspace.yaml` only, symmetrically.
- pnpm.io docs update for the new settings (separate repo).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `update` workspace settings (`ignoreDeps`) for `pnpm update` and `pnpm outdated`.
  * Added new `audit` workspace settings (`level`, `ignore`) for `pnpm audit`.
* **Bug Fixes**
  * When both new and legacy settings are provided, the new `update`/`audit` sections take precedence and warnings are emitted.
* **Documentation**
  * Updated Changeset documentation to reflect the new settings and the legacy-to-new migration behavior.
* **Tests**
  * Expanded coverage for correct translation/deserialization, precedence, and warning behavior for `update` and `audit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->