### PR TITLE
feat(update): update GitHub Actions dependencies

### DIFF
--- a/.changeset/update-github-actions.md
+++ b/.changeset/update-github-actions.md
@@ -1,0 +1,10 @@
+---
+"@pnpm/deps.github-actions": minor
+"@pnpm/deps.inspection.commands": minor
+"@pnpm/installing.commands": minor
+"@pnpm/resolving.git-resolver": patch
+"pnpm": minor
+"pacquet": minor
+---
+
+Added GitHub Actions dependencies to `pnpm outdated` and `pnpm update`. Updated actions are pinned to exact commit hashes with their release tags preserved in comments.

--- a/.changeset/update-github-actions.md
+++ b/.changeset/update-github-actions.md
@@ -2,9 +2,11 @@
 "@pnpm/deps.github-actions": minor
 "@pnpm/deps.inspection.commands": minor
 "@pnpm/installing.commands": minor
+"@pnpm/config.reader": minor
 "@pnpm/resolving.git-resolver": patch
+"@pnpm/types": minor
 "pnpm": minor
 "pacquet": minor
 ---
 
-Added GitHub Actions dependencies to `pnpm outdated` and `pnpm update`. Updated actions are pinned to exact commit hashes with their release tags preserved in comments.
+Added GitHub Actions dependencies to `pnpm outdated` and interactive `pnpm update`. Non-interactive updates can include them with `--include-github-actions` or by setting `update.githubActions` to `true` in `pnpm-workspace.yaml`. Updated actions are pinned to exact commit hashes with their release tags preserved in comments.

--- a/.changeset/update-github-actions.md
+++ b/.changeset/update-github-actions.md
@@ -1,5 +1,4 @@
 ---
-"@pnpm/deps.github-actions": minor
 "@pnpm/deps.inspection.commands": minor
 "@pnpm/installing.commands": minor
 "@pnpm/config.reader": minor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3992,6 +3992,8 @@ dependencies = [
  "wax",
  "which 8.0.4",
  "windows-sys 0.61.2",
+ "yaml_serde",
+ "yamlpath",
  "zip",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
  "pacquet-publish",
  "pacquet-registry",
  "pacquet-reporter",
+ "pacquet-resolving-git-resolver",
  "pacquet-resolving-npm-resolver",
  "pacquet-resolving-parse-wanted-dependency",
  "pacquet-resolving-resolver-base",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3127,6 +3127,9 @@ importers:
       '@pnpm/resolving.git-resolver':
         specifier: workspace:*
         version: link:../../resolving/git-resolver
+      is-subdir:
+        specifier: 'catalog:'
+        version: 2.0.0
       p-limit:
         specifier: 'catalog:'
         version: 7.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3119,6 +3119,28 @@ importers:
         specifier: 'catalog:'
         version: 7.1.5
 
+  pnpm11/deps/github-actions:
+    dependencies:
+      '@pnpm/resolving.git-resolver':
+        specifier: workspace:*
+        version: link:../../resolving/git-resolver
+      semver:
+        specifier: 'catalog:'
+        version: 7.8.5
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
+    devDependencies:
+      '@jest/globals':
+        specifier: 'catalog:'
+        version: 30.4.1(supports-color@10.2.2)
+      '@pnpm/deps.github-actions':
+        specifier: workspace:*
+        version: 'link:'
+      '@types/semver':
+        specifier: 'catalog:'
+        version: 7.7.1
+
   pnpm11/deps/graph-builder:
     dependencies:
       '@pnpm/config.package-is-installable':
@@ -3249,6 +3271,9 @@ importers:
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../../../config/reader
+      '@pnpm/deps.github-actions':
+        specifier: workspace:*
+        version: link:../../github-actions
       '@pnpm/deps.inspection.list':
         specifier: workspace:*
         version: link:../list
@@ -5172,6 +5197,9 @@ importers:
       '@pnpm/core-loggers':
         specifier: workspace:*
         version: link:../../core/core-loggers
+      '@pnpm/deps.github-actions':
+        specifier: workspace:*
+        version: link:../../deps/github-actions
       '@pnpm/deps.inspection.outdated':
         specifier: workspace:*
         version: link:../../deps/inspection/outdated

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3121,9 +3121,15 @@ importers:
 
   pnpm11/deps/github-actions:
     dependencies:
+      '@pnpm/error':
+        specifier: workspace:*
+        version: link:../../core/error
       '@pnpm/resolving.git-resolver':
         specifier: workspace:*
         version: link:../../resolving/git-resolver
+      p-limit:
+        specifier: 'catalog:'
+        version: 7.3.0
       semver:
         specifier: 'catalog:'
         version: 7.8.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3133,6 +3133,9 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.8.5
+      write-file-atomic:
+        specifier: 'catalog:'
+        version: 7.0.1
       yaml:
         specifier: 'catalog:'
         version: 2.9.0
@@ -3146,6 +3149,9 @@ importers:
       '@types/semver':
         specifier: 'catalog:'
         version: 7.7.1
+      '@types/write-file-atomic':
+        specifier: 'catalog:'
+        version: 4.0.3
 
   pnpm11/deps/graph-builder:
     dependencies:

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -46,6 +46,7 @@ pacquet-patching                          = { workspace = true }
 pacquet-package-is-installable            = { workspace = true }
 pacquet-registry                          = { workspace = true }
 pacquet-reporter                          = { workspace = true }
+pacquet-resolving-git-resolver            = { workspace = true }
 pacquet-resolving-npm-resolver            = { workspace = true }
 pacquet-resolving-parse-wanted-dependency = { workspace = true }
 pacquet-resolving-resolver-base           = { workspace = true }

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -90,6 +90,8 @@ tokio                = { workspace = true }
 tracing              = { workspace = true }
 url                  = { workspace = true }
 which                = { workspace = true }
+yaml_serde           = { workspace = true }
+yamlpath             = { workspace = true }
 base64               = { workspace = true }
 wax                  = { workspace = true }
 

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -315,7 +315,7 @@ pub enum CliCommand {
     /// Update packages to their newest version based on the specified range
     #[clap(visible_aliases = ["up", "upgrade"])]
     Update(UpdateArgs),
-    /// Check for outdated packages
+    /// Check for outdated package and GitHub Actions dependencies
     Outdated(OutdatedArgs),
     /// Checks for known security issues with the installed packages.
     Audit(AuditArgs),

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -85,6 +85,22 @@ pub struct OutdatedPackage {
     pub homepage: Option<String>,
 }
 
+impl From<github_actions::OutdatedGitHubAction> for OutdatedPackage {
+    fn from(action: github_actions::OutdatedGitHubAction) -> Self {
+        Self {
+            alias: action.name.clone(),
+            package_name: action.name,
+            belongs_to: DependencyGroup::Dev,
+            current: action.current,
+            target: action.latest,
+            wanted: action.wanted,
+            github_action: true,
+            deprecated: None,
+            homepage: Some(action.homepage),
+        }
+    }
+}
+
 /// What counts as outdated for a [`collect_outdated`] run.
 pub struct OutdatedQuery<'a> {
     /// The registry version each dependency is compared against.
@@ -468,17 +484,7 @@ impl OutdatedArgs {
             let actions =
                 github_actions::find_outdated(root, self.compatible, action_matcher.as_ref())
                     .await?;
-            outdated.extend(actions.into_iter().map(|action| OutdatedPackage {
-                alias: action.name.clone(),
-                package_name: action.name,
-                belongs_to: DependencyGroup::Dev,
-                current: action.current,
-                target: action.latest,
-                wanted: action.wanted,
-                github_action: true,
-                deprecated: None,
-                homepage: Some(action.homepage),
-            }));
+            outdated.extend(actions.into_iter().map(OutdatedPackage::from));
         }
 
         sort_outdated(&mut outdated, self.sort_by);

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -21,6 +21,7 @@ use crate::{
         recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
         sanitize::sanitize_inline,
     },
+    github_actions,
 };
 use clap::{Args, ValueEnum};
 use miette::IntoDiagnostic;
@@ -74,6 +75,8 @@ pub struct OutdatedPackage {
     pub belongs_to: DependencyGroup,
     pub current: Version,
     pub target: Version,
+    pub wanted: Version,
+    pub github_action: bool,
     /// Deprecation reason of the `target` version, when the registry
     /// marked it deprecated.
     pub deprecated: Option<String>,
@@ -206,8 +209,10 @@ async fn collect_outdated_for_importer_with_cache(
                 alias: alias.to_string(),
                 package_name: package_name.to_string(),
                 belongs_to: group,
+                wanted: current.clone(),
                 current,
                 target: target.version.clone(),
+                github_action: false,
                 deprecated,
                 homepage: package.homepage.clone(),
             }))
@@ -404,25 +409,31 @@ impl OutdatedArgs {
 
         let config = state.config;
         let manifest = &state.manifest;
+        let root = config
+            .workspace_dir
+            .as_deref()
+            .unwrap_or_else(|| manifest.path().parent().unwrap_or_else(|| manifest.path()));
         let importer_id = state.active_importer_id();
         let lockfile = state
             .lockfile
             .get()
             .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
         let http_client = &state.http_client;
-
-        // A manifest with no dependencies at all is reported as up to date
-        // (empty, exit 0) *before* the no-lockfile check, so an empty
-        // project doesn't error just because it was never installed.
+        let package_patterns = self
+            .packages
+            .iter()
+            .filter(|selector| !github_actions::is_selector(selector))
+            .cloned()
+            .collect::<Vec<_>>();
+        // An empty package manifest does not require a lockfile, but workflow
+        // actions still need to be inspected.
         let has_any_dependency = manifest
             .dependencies([DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional])
             .next()
             .is_some();
-        if !has_any_dependency {
-            return Ok(OutdatedOutcome::UpToDate);
-        }
-
-        if lockfile.is_none() {
+        let check_packages =
+            has_any_dependency && (self.packages.is_empty() || !package_patterns.is_empty());
+        if check_packages && lockfile.is_none() {
             let dir = manifest.path().parent().unwrap_or_else(|| manifest.path());
             return Err(no_lockfile_error(dir));
         }
@@ -430,23 +441,45 @@ impl OutdatedArgs {
         let include = self.dependency_options.include();
         let target_version =
             if self.compatible { TargetVersion::WithinRange } else { TargetVersion::Latest };
-        let matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
+        let package_matcher =
+            (!package_patterns.is_empty()).then(|| create_matcher(&package_patterns));
+        let action_matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
 
         let query = OutdatedQuery {
             target_version,
             include_direct: &include,
-            match_names: matcher.as_ref(),
+            match_names: package_matcher.as_ref(),
             include_deprecated: true,
         };
-        let mut outdated = collect_outdated_for_importer(
-            manifest,
-            lockfile,
-            &importer_id,
-            config,
-            http_client,
-            &query,
-        )
-        .await?;
+        let mut outdated = if check_packages {
+            collect_outdated_for_importer(
+                manifest,
+                lockfile,
+                &importer_id,
+                config,
+                http_client,
+                &query,
+            )
+            .await?
+        } else {
+            Vec::new()
+        };
+        if include.contains(&DependencyGroup::Dev) {
+            let actions =
+                github_actions::find_outdated(root, self.compatible, action_matcher.as_ref())
+                    .await?;
+            outdated.extend(actions.into_iter().map(|action| OutdatedPackage {
+                alias: action.name.clone(),
+                package_name: action.name,
+                belongs_to: DependencyGroup::Dev,
+                current: action.current,
+                target: action.latest,
+                wanted: action.wanted,
+                github_action: true,
+                deprecated: None,
+                homepage: Some(action.homepage),
+            }));
+        }
 
         sort_outdated(&mut outdated, self.sort_by);
 
@@ -800,11 +833,12 @@ fn render_list(outdated: &[OutdatedPackage], long: bool) -> String {
 fn render_json(outdated: &[OutdatedPackage], long: bool) -> String {
     let mut map = serde_json::Map::new();
     for pkg in outdated {
-        let dependency_type: &'static str = pkg.belongs_to.into();
+        let dependency_type: &'static str =
+            if pkg.github_action { "githubAction" } else { pkg.belongs_to.into() };
         let mut entry = serde_json::json!({
             "current": pkg.current.to_string(),
             "latest": pkg.target.to_string(),
-            "wanted": pkg.current.to_string(),
+            "wanted": pkg.wanted.to_string(),
             "isDeprecated": pkg.deprecated.is_some(),
             "dependencyType": dependency_type,
         });
@@ -924,6 +958,9 @@ fn render_dependents(entry: &OutdatedInWorkspace) -> String {
 }
 
 fn render_package_name(pkg: &OutdatedPackage) -> String {
+    if pkg.github_action {
+        return format!("{} {}", pkg.package_name, dimmed("(github action)"));
+    }
     match pkg.belongs_to {
         DependencyGroup::Dev => format!("{} {}", pkg.package_name, dimmed("(dev)")),
         DependencyGroup::Optional => format!("{} {}", pkg.package_name, dimmed("(optional)")),

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -459,7 +459,7 @@ impl OutdatedArgs {
             if self.compatible { TargetVersion::WithinRange } else { TargetVersion::Latest };
         let package_matcher =
             (!package_patterns.is_empty()).then(|| create_matcher(&package_patterns));
-        let action_matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
+        let action_matcher = github_actions::selector_matcher(&self.packages);
 
         let query = OutdatedQuery {
             target_version,

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -25,6 +25,8 @@ fn pkg(name: &str, current: &str, target: &str, group: DependencyGroup) -> Outda
         belongs_to: group,
         current: v(current),
         target: v(target),
+        wanted: v(current),
+        github_action: false,
         deprecated: None,
         homepage: None,
     }

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -59,7 +59,7 @@ impl UpdateDependencyOptions {
 #[derive(Debug, Args)]
 pub struct UpdateArgs {
     /// Dependencies to update. Package names (`foo`, `@scope/bar`), GitHub
-    /// Actions (`actions/checkout`), glob
+    /// Actions (`actions/checkout`, with `--include-github-actions`), glob
     /// patterns (`@scope/bar-*`), and versioned selectors (`foo@2`) are
     /// accepted. With no arguments, every direct dependency in the
     /// included groups is updated.
@@ -101,6 +101,10 @@ pub struct UpdateArgs {
     /// Show outdated dependencies and select which ones to update.
     #[clap(short = 'i', long)]
     pub interactive: bool,
+
+    /// Also update GitHub Actions dependencies in workflow and action files.
+    #[clap(long = "include-github-actions")]
+    pub include_github_actions: bool,
 
     /// Update globally installed packages.
     #[clap(short = 'g', long)]
@@ -144,15 +148,10 @@ impl UpdateArgs {
         let actions_root =
             state.config.workspace_dir.clone().unwrap_or_else(|| manifest_root(&state.manifest));
         let include_direct = self.dependency_options.include_direct();
-        let update_actions =
-            include_direct.contains(&DependencyGroup::Dev) && !self.no_save && !self.lockfile_only;
-        let action_matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
-        let package_selectors = self
-            .packages
-            .iter()
-            .filter(|selector| !github_actions::is_selector(selector))
-            .cloned()
-            .collect::<Vec<_>>();
+        let update_actions = self.should_update_github_actions(state.config, &include_direct);
+        let action_matcher =
+            (update_actions && !self.packages.is_empty()).then(|| create_matcher(&self.packages));
+        let package_selectors = filter_package_selectors(&self.packages, update_actions);
         if !self.interactive && !self.packages.is_empty() && package_selectors.is_empty() {
             if update_actions {
                 github_actions::update(&actions_root, self.latest, action_matcher.as_ref()).await?;
@@ -198,11 +197,7 @@ impl UpdateArgs {
 
         let selected_action_matcher =
             if self.interactive { Some(create_matcher(&packages)) } else { action_matcher };
-        let package_selectors = packages
-            .iter()
-            .filter(|selector| !github_actions::is_selector(selector))
-            .cloned()
-            .collect::<Vec<_>>();
+        let package_selectors = filter_package_selectors(&packages, update_actions);
         let run_package_update = !self.interactive || !package_selectors.is_empty();
 
         if run_package_update {
@@ -247,15 +242,10 @@ impl UpdateArgs {
 
         let actions_root = selection.workspace_root.clone();
         let include_direct = self.dependency_options.include_direct();
-        let update_actions =
-            include_direct.contains(&DependencyGroup::Dev) && !self.no_save && !self.lockfile_only;
-        let action_matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
-        let package_selectors = self
-            .packages
-            .iter()
-            .filter(|selector| !github_actions::is_selector(selector))
-            .cloned()
-            .collect::<Vec<_>>();
+        let update_actions = self.should_update_github_actions(state.config, &include_direct);
+        let action_matcher =
+            (update_actions && !self.packages.is_empty()).then(|| create_matcher(&self.packages));
+        let package_selectors = filter_package_selectors(&self.packages, update_actions);
         if !self.interactive && !self.packages.is_empty() && package_selectors.is_empty() {
             if update_actions {
                 github_actions::update(&actions_root, self.latest, action_matcher.as_ref()).await?;
@@ -293,11 +283,7 @@ impl UpdateArgs {
         };
         let selected_action_matcher =
             if self.interactive { Some(create_matcher(&packages)) } else { action_matcher };
-        let package_selectors = packages
-            .iter()
-            .filter(|selector| !github_actions::is_selector(selector))
-            .cloned()
-            .collect::<Vec<_>>();
+        let package_selectors = filter_package_selectors(&packages, update_actions);
         let run_package_update = !self.interactive || !package_selectors.is_empty();
         let InstallFamilySelection {
             workspace_root: _,
@@ -372,10 +358,31 @@ impl UpdateArgs {
         ))
         .await
     }
+
+    fn should_update_github_actions(
+        &self,
+        config: &Config,
+        include_direct: &[DependencyGroup],
+    ) -> bool {
+        include_direct.contains(&DependencyGroup::Dev)
+            && !self.no_save
+            && !self.lockfile_only
+            && (self.interactive
+                || self.include_github_actions
+                || config.update_config.github_actions == Some(true))
+    }
 }
 
 fn manifest_root(manifest: &pacquet_package_manifest::PackageManifest) -> std::path::PathBuf {
     manifest.path().parent().expect("manifest path always has a parent directory").to_path_buf()
+}
+
+fn filter_package_selectors(packages: &[String], include_github_actions: bool) -> Vec<String> {
+    packages
+        .iter()
+        .filter(|selector| !include_github_actions || !github_actions::is_selector(selector))
+        .cloned()
+        .collect()
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -2,11 +2,13 @@ use crate::{
     State,
     cli_args::{
         pipelines::InstallFamilySelection, supported_architectures::SupportedArchitecturesArgs,
+        update_interactive::InteractiveUpdateOptions,
     },
+    github_actions,
 };
 use clap::Args;
 use miette::Context;
-use pacquet_config::Config;
+use pacquet_config::{Config, matcher::create_matcher};
 use pacquet_package_manager::Update;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
@@ -53,10 +55,11 @@ impl UpdateDependencyOptions {
     }
 }
 
-/// Update packages to their latest version based on the specified range.
+/// Update package and GitHub Actions dependencies to newer compatible versions.
 #[derive(Debug, Args)]
 pub struct UpdateArgs {
-    /// Packages to update. Bare names (`foo`, `@scope/bar`), glob
+    /// Dependencies to update. Package names (`foo`, `@scope/bar`), GitHub
+    /// Actions (`actions/checkout`), glob
     /// patterns (`@scope/bar-*`), and versioned selectors (`foo@2`) are
     /// accepted. With no arguments, every direct dependency in the
     /// included groups is updated.
@@ -138,6 +141,33 @@ impl UpdateArgs {
             return Err(miette::miette!("{WORKSPACE_UPDATE_UNSUPPORTED}"));
         }
 
+        let actions_root =
+            state.config.workspace_dir.clone().unwrap_or_else(|| manifest_root(&state.manifest));
+        let include_direct = self.dependency_options.include_direct();
+        let update_actions =
+            include_direct.contains(&DependencyGroup::Dev) && !self.no_save && !self.lockfile_only;
+        let action_matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
+        let package_selectors = self
+            .packages
+            .iter()
+            .filter(|selector| !github_actions::is_selector(selector))
+            .cloned()
+            .collect::<Vec<_>>();
+        let has_package_dependencies = state
+            .manifest
+            .dependencies([DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional])
+            .next()
+            .is_some();
+        if !self.interactive
+            && ((!self.packages.is_empty() && package_selectors.is_empty())
+                || (self.packages.is_empty() && !has_package_dependencies))
+        {
+            if update_actions {
+                github_actions::update(&actions_root, self.latest, action_matcher.as_ref()).await?;
+            }
+            return Ok(());
+        }
+
         let lockfile_path = state.lockfile_path();
         let active_importer_id = state.active_importer_id();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
@@ -150,13 +180,17 @@ impl UpdateArgs {
 
         let packages = if self.interactive {
             match crate::cli_args::update_interactive::select_packages(
+                &actions_root,
                 manifest,
                 lockfile,
                 &active_importer_id,
                 config,
                 http_client,
-                self.latest,
-                &self.dependency_options.include_direct(),
+                InteractiveUpdateOptions {
+                    latest: self.latest,
+                    include_direct: &include_direct,
+                    include_github_actions: update_actions,
+                },
             )
             .await?
             {
@@ -167,31 +201,47 @@ impl UpdateArgs {
                 None => return Ok(()),
             }
         } else {
-            self.packages.clone()
+            package_selectors
         };
 
-        Update {
-            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
-            resolved_packages,
-            http_client,
-            http_client_arc: std::sync::Arc::clone(http_client),
-            config,
-            manifest,
-            lockfile,
-            lockfile_path: Some(&lockfile_path),
-            packages: &packages,
-            latest: self.latest,
-            save_exact: self.save_exact,
-            save: !self.no_save,
-            include_direct: self.dependency_options.include_direct(),
-            depth: self.depth.unwrap_or(usize::MAX),
-            supported_architectures,
-            lockfile_only: self.lockfile_only,
-            resolution_observer: None,
+        let selected_action_matcher =
+            if self.interactive { Some(create_matcher(&packages)) } else { action_matcher };
+        let package_selectors = packages
+            .iter()
+            .filter(|selector| !github_actions::is_selector(selector))
+            .cloned()
+            .collect::<Vec<_>>();
+        let run_package_update = !self.interactive || !package_selectors.is_empty();
+
+        if run_package_update {
+            Update {
+                tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+                resolved_packages,
+                http_client,
+                http_client_arc: std::sync::Arc::clone(http_client),
+                config,
+                manifest,
+                lockfile,
+                lockfile_path: Some(&lockfile_path),
+                packages: &package_selectors,
+                latest: self.latest,
+                save_exact: self.save_exact,
+                save: !self.no_save,
+                include_direct,
+                depth: self.depth.unwrap_or(usize::MAX),
+                supported_architectures,
+                lockfile_only: self.lockfile_only,
+                resolution_observer: None,
+            }
+            .run::<Reporter>()
+            .await
+            .wrap_err("updating dependencies")?;
         }
-        .run::<Reporter>()
-        .await
-        .wrap_err("updating dependencies")
+        if update_actions {
+            github_actions::update(&actions_root, self.latest, selected_action_matcher.as_ref())
+                .await?;
+        }
+        Ok(())
     }
 
     pub(crate) async fn run_selected<Reporter: self::Reporter + 'static>(
@@ -203,6 +253,24 @@ impl UpdateArgs {
             return Err(miette::miette!("{WORKSPACE_UPDATE_UNSUPPORTED}"));
         }
 
+        let actions_root = selection.workspace_root.clone();
+        let include_direct = self.dependency_options.include_direct();
+        let update_actions =
+            include_direct.contains(&DependencyGroup::Dev) && !self.no_save && !self.lockfile_only;
+        let action_matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
+        let package_selectors = self
+            .packages
+            .iter()
+            .filter(|selector| !github_actions::is_selector(selector))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !self.interactive && !self.packages.is_empty() && package_selectors.is_empty() {
+            if update_actions {
+                github_actions::update(&actions_root, self.latest, action_matcher.as_ref()).await?;
+            }
+            return Ok(());
+        }
+
         let lockfile_path = state.lockfile_path();
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &mut state;
@@ -212,12 +280,16 @@ impl UpdateArgs {
             self.supported_architectures.apply_to(config.supported_architectures.clone());
         let packages = if self.interactive {
             match crate::cli_args::update_interactive::select_packages_for_projects(
+                &actions_root,
                 &selection,
                 lockfile,
                 config,
                 http_client,
-                self.latest,
-                &self.dependency_options.include_direct(),
+                InteractiveUpdateOptions {
+                    latest: self.latest,
+                    include_direct: &include_direct,
+                    include_github_actions: update_actions,
+                },
             )
             .await?
             {
@@ -225,8 +297,16 @@ impl UpdateArgs {
                 None => return Ok(()),
             }
         } else {
-            self.packages.clone()
+            package_selectors
         };
+        let selected_action_matcher =
+            if self.interactive { Some(create_matcher(&packages)) } else { action_matcher };
+        let package_selectors = packages
+            .iter()
+            .filter(|selector| !github_actions::is_selector(selector))
+            .cloned()
+            .collect::<Vec<_>>();
+        let run_package_update = !self.interactive || !package_selectors.is_empty();
         let InstallFamilySelection {
             workspace_root: _,
             mut projects,
@@ -236,34 +316,41 @@ impl UpdateArgs {
             active_manifest_is_standin,
         } = selection;
 
-        Update {
-            tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
-            resolved_packages,
-            http_client,
-            http_client_arc: std::sync::Arc::clone(http_client),
-            config,
-            manifest,
-            lockfile,
-            lockfile_path: Some(&lockfile_path),
-            packages: &packages,
-            latest: self.latest,
-            save_exact: self.save_exact,
-            save: !self.no_save,
-            include_direct: self.dependency_options.include_direct(),
-            depth: self.depth.unwrap_or(usize::MAX),
-            supported_architectures,
-            lockfile_only: self.lockfile_only,
-            resolution_observer: None,
+        if run_package_update {
+            Update {
+                tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
+                resolved_packages,
+                http_client,
+                http_client_arc: std::sync::Arc::clone(http_client),
+                config,
+                manifest,
+                lockfile,
+                lockfile_path: Some(&lockfile_path),
+                packages: &package_selectors,
+                latest: self.latest,
+                save_exact: self.save_exact,
+                save: !self.no_save,
+                include_direct,
+                depth: self.depth.unwrap_or(usize::MAX),
+                supported_architectures,
+                lockfile_only: self.lockfile_only,
+                resolution_observer: None,
+            }
+            .run_selected::<Reporter>(
+                &mut projects,
+                &ordered_groups,
+                &ordered_dirs,
+                selected_dirs.as_ref(),
+                active_manifest_is_standin,
+            )
+            .await
+            .wrap_err("updating dependencies")?;
         }
-        .run_selected::<Reporter>(
-            &mut projects,
-            &ordered_groups,
-            &ordered_dirs,
-            selected_dirs.as_ref(),
-            active_manifest_is_standin,
-        )
-        .await
-        .wrap_err("updating dependencies")
+        if update_actions {
+            github_actions::update(&actions_root, self.latest, selected_action_matcher.as_ref())
+                .await?;
+        }
+        Ok(())
     }
 
     /// `pnpm update -g`: reinstall each matching global package group,
@@ -293,6 +380,10 @@ impl UpdateArgs {
         ))
         .await
     }
+}
+
+fn manifest_root(manifest: &pacquet_package_manifest::PackageManifest) -> std::path::PathBuf {
+    manifest.path().parent().unwrap_or_else(|| manifest.path()).to_path_buf()
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -153,15 +153,7 @@ impl UpdateArgs {
             .filter(|selector| !github_actions::is_selector(selector))
             .cloned()
             .collect::<Vec<_>>();
-        let has_package_dependencies = state
-            .manifest
-            .dependencies([DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional])
-            .next()
-            .is_some();
-        if !self.interactive
-            && ((!self.packages.is_empty() && package_selectors.is_empty())
-                || (self.packages.is_empty() && !has_package_dependencies))
-        {
+        if !self.interactive && !self.packages.is_empty() && package_selectors.is_empty() {
             if update_actions {
                 github_actions::update(&actions_root, self.latest, action_matcher.as_ref()).await?;
             }
@@ -383,7 +375,7 @@ impl UpdateArgs {
 }
 
 fn manifest_root(manifest: &pacquet_package_manifest::PackageManifest) -> std::path::PathBuf {
-    manifest.path().parent().unwrap_or_else(|| manifest.path()).to_path_buf()
+    manifest.path().parent().expect("manifest path always has a parent directory").to_path_buf()
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use clap::Args;
 use miette::Context;
-use pacquet_config::{Config, matcher::create_matcher};
+use pacquet_config::Config;
 use pacquet_package_manager::Update;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
@@ -150,7 +150,7 @@ impl UpdateArgs {
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
         let action_matcher =
-            (update_actions && !self.packages.is_empty()).then(|| create_matcher(&self.packages));
+            if update_actions { github_actions::selector_matcher(&self.packages) } else { None };
         let package_selectors = filter_package_selectors(&self.packages, update_actions);
         if !self.interactive && !self.packages.is_empty() && package_selectors.is_empty() {
             if update_actions {
@@ -195,8 +195,11 @@ impl UpdateArgs {
             package_selectors
         };
 
-        let selected_action_matcher =
-            if self.interactive { Some(create_matcher(&packages)) } else { action_matcher };
+        let selected_action_matcher = if self.interactive {
+            github_actions::selector_matcher(&packages)
+        } else {
+            action_matcher
+        };
         let package_selectors = filter_package_selectors(&packages, update_actions);
         let run_package_update = !self.interactive || !package_selectors.is_empty();
 
@@ -244,7 +247,7 @@ impl UpdateArgs {
         let include_direct = self.dependency_options.include_direct();
         let update_actions = self.should_update_github_actions(state.config, &include_direct);
         let action_matcher =
-            (update_actions && !self.packages.is_empty()).then(|| create_matcher(&self.packages));
+            if update_actions { github_actions::selector_matcher(&self.packages) } else { None };
         let package_selectors = filter_package_selectors(&self.packages, update_actions);
         if !self.interactive && !self.packages.is_empty() && package_selectors.is_empty() {
             if update_actions {
@@ -281,8 +284,11 @@ impl UpdateArgs {
         } else {
             package_selectors
         };
-        let selected_action_matcher =
-            if self.interactive { Some(create_matcher(&packages)) } else { action_matcher };
+        let selected_action_matcher = if self.interactive {
+            github_actions::selector_matcher(&packages)
+        } else {
+            action_matcher
+        };
         let package_selectors = filter_package_selectors(&packages, update_actions);
         let run_package_update = !self.interactive || !package_selectors.is_empty();
         let InstallFamilySelection {

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -1,5 +1,19 @@
-use super::UpdateDependencyOptions;
+use super::{UpdateArgs, UpdateDependencyOptions};
+use clap::Parser;
+use pacquet_config::Config;
 use pacquet_package_manifest::DependencyGroup;
+
+#[derive(Debug, Parser)]
+struct UpdateArgsHarness {
+    #[clap(flatten)]
+    args: UpdateArgs,
+}
+
+fn update_args(args: &[&str]) -> UpdateArgs {
+    UpdateArgsHarness::try_parse_from(std::iter::once("pacquet-test").chain(args.iter().copied()))
+        .expect("parse update arguments")
+        .args
+}
 
 fn options(prod: bool, dev: bool, no_optional: bool) -> UpdateDependencyOptions {
     UpdateDependencyOptions { prod, dev, no_optional }
@@ -39,4 +53,23 @@ fn no_optional_alone_does_not_drop_optional() {
 fn prod_with_no_optional_drops_optional() {
     let groups = options(true, false, true).include_direct();
     assert_eq!(groups, vec![DependencyGroup::Prod]);
+}
+
+#[test]
+fn github_actions_are_opt_in_except_for_interactive_updates() {
+    let include_direct = vec![DependencyGroup::Prod, DependencyGroup::Dev];
+    let mut config = Config::new();
+
+    assert!(!update_args(&[]).should_update_github_actions(&config, &include_direct));
+    assert!(
+        update_args(&["--include-github-actions"])
+            .should_update_github_actions(&config, &include_direct),
+    );
+    assert!(update_args(&["--interactive"]).should_update_github_actions(&config, &include_direct));
+
+    config.update_config.github_actions = Some(true);
+    assert!(update_args(&[]).should_update_github_actions(&config, &include_direct));
+    assert!(
+        !update_args(&["--prod"]).should_update_github_actions(&config, &[DependencyGroup::Prod],),
+    );
 }

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -14,9 +14,12 @@
 //! otherwise the highest in-range version). The choice list is
 //! intentionally flat; the prompt is a `dialoguer` multi-select.
 
-use crate::cli_args::{
-    outdated::{OutdatedPackage, OutdatedQuery, TargetVersion, collect_outdated_for_importer},
-    pipelines::InstallFamilySelection,
+use crate::{
+    cli_args::{
+        outdated::{OutdatedPackage, OutdatedQuery, TargetVersion, collect_outdated_for_importer},
+        pipelines::InstallFamilySelection,
+    },
+    github_actions,
 };
 use dialoguer::MultiSelect;
 use miette::{IntoDiagnostic, miette};
@@ -24,39 +27,55 @@ use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use std::collections::HashSet;
+use std::{collections::HashSet, path::Path};
 
 struct InteractiveUpdateProject<'a> {
     manifest: &'a PackageManifest,
     importer_id: String,
 }
 
+pub(crate) struct InteractiveUpdateOptions<'a> {
+    pub latest: bool,
+    pub include_direct: &'a [DependencyGroup],
+    pub include_github_actions: bool,
+}
+
 /// Gather outdated direct dependencies, prompt the user, and return the
 /// selected package names. `Ok(None)` means "nothing to do" — either no
 /// dependency has an update available or the prompt was answered with an
 /// empty selection — and the caller should not run an update.
-pub async fn select_packages(
+pub(crate) async fn select_packages(
+    root: &Path,
     manifest: &PackageManifest,
     lockfile: Option<&Lockfile>,
     importer_id: &str,
     config: &Config,
     http_client: &ThrottledClient,
-    latest: bool,
-    include_direct: &[DependencyGroup],
+    options: InteractiveUpdateOptions<'_>,
 ) -> miette::Result<Option<Vec<String>>> {
     let projects = [InteractiveUpdateProject { manifest, importer_id: importer_id.to_string() }];
-    let choices =
-        collect_choices(&projects, lockfile, config, http_client, latest, include_direct).await?;
-    prompt_for_packages(&choices, latest)
+    let mut choices = collect_choices(
+        &projects,
+        lockfile,
+        config,
+        http_client,
+        options.latest,
+        options.include_direct,
+    )
+    .await?;
+    if options.include_github_actions {
+        append_github_actions(&mut choices, root, options.latest).await?;
+    }
+    prompt_for_packages(&choices, options.latest)
 }
 
 pub(crate) async fn select_packages_for_projects(
+    root: &Path,
     selection: &InstallFamilySelection,
     lockfile: Option<&Lockfile>,
     config: &Config,
     http_client: &ThrottledClient,
-    latest: bool,
-    include_direct: &[DependencyGroup],
+    options: InteractiveUpdateOptions<'_>,
 ) -> miette::Result<Option<Vec<String>>> {
     let projects = selection
         .projects
@@ -70,9 +89,40 @@ pub(crate) async fn select_packages_for_projects(
             ),
         })
         .collect::<Vec<_>>();
-    let choices =
-        collect_choices(&projects, lockfile, config, http_client, latest, include_direct).await?;
-    prompt_for_packages(&choices, latest)
+    let mut choices = collect_choices(
+        &projects,
+        lockfile,
+        config,
+        http_client,
+        options.latest,
+        options.include_direct,
+    )
+    .await?;
+    if options.include_github_actions {
+        append_github_actions(&mut choices, root, options.latest).await?;
+    }
+    prompt_for_packages(&choices, options.latest)
+}
+
+async fn append_github_actions(
+    choices: &mut Vec<OutdatedPackage>,
+    root: &Path,
+    latest: bool,
+) -> miette::Result<()> {
+    choices.extend(github_actions::find_outdated(root, !latest, None).await?.into_iter().map(
+        |action| OutdatedPackage {
+            alias: action.name.clone(),
+            package_name: action.name,
+            belongs_to: DependencyGroup::Dev,
+            current: action.current,
+            target: action.latest,
+            wanted: action.wanted,
+            github_action: true,
+            deprecated: None,
+            homepage: Some(action.homepage),
+        },
+    ));
+    Ok(())
 }
 
 async fn collect_choices(
@@ -135,11 +185,18 @@ fn prompt_for_packages(
 
     let labels: Vec<String> = choices
         .iter()
-        .map(|choice| format!("{} {} ❯ {}", choice.alias, choice.current, choice.target))
+        .map(|choice| {
+            let name = if choice.github_action {
+                format!("{} (github action)", choice.alias)
+            } else {
+                choice.alias.clone()
+            };
+            format!("{name} {} ❯ {}", choice.current, choice.target)
+        })
         .collect();
 
     let selected_indices = MultiSelect::new()
-        .with_prompt("Choose which packages to update (space to select, enter to confirm)")
+        .with_prompt("Choose which dependencies to update (space to select, enter to confirm)")
         .items(&labels)
         .interact()
         .into_diagnostic()

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -109,19 +109,12 @@ async fn append_github_actions(
     root: &Path,
     latest: bool,
 ) -> miette::Result<()> {
-    choices.extend(github_actions::find_outdated(root, !latest, None).await?.into_iter().map(
-        |action| OutdatedPackage {
-            alias: action.name.clone(),
-            package_name: action.name,
-            belongs_to: DependencyGroup::Dev,
-            current: action.current,
-            target: action.latest,
-            wanted: action.wanted,
-            github_action: true,
-            deprecated: None,
-            homepage: Some(action.homepage),
-        },
-    ));
+    choices.extend(
+        github_actions::find_outdated(root, !latest, None)
+            .await?
+            .into_iter()
+            .map(OutdatedPackage::from),
+    );
     Ok(())
 }
 

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -176,7 +176,10 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
 }
 
 async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
-    let canonical_root = fs::canonicalize(root).await.unwrap_or_else(|_| root.to_path_buf());
+    let root_display = root.display();
+    let canonical_root = fs::canonicalize(root)
+        .await
+        .map_err(|error| miette::miette!("Failed to read {root_display}: {error}"))?;
     let workflows = root.join(".github/workflows");
     let workflows_display = workflows.display();
     let mut entries = match fs::read_dir(&workflows).await {
@@ -200,15 +203,25 @@ async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
     let mut visited = HashSet::new();
     let mut actions = Vec::new();
     while let Some(file) = queue.pop_front() {
-        if !visited.insert(file.clone()) {
-            continue;
-        }
         let file_display = file.display();
-        let text = fs::read_to_string(&file)
+        let real_file = fs::canonicalize(&file)
             .await
             .map_err(|error| miette::miette!("Failed to read {file_display}: {error}"))?;
+        if !real_file.starts_with(&canonical_root) {
+            return Err(miette::miette!(
+                code = "ERR_PNPM_GITHUB_ACTIONS_WORKFLOW_OUTSIDE_ROOT",
+                "GitHub Actions workflow is outside the project root: {file_display}"
+            ));
+        }
+        if !visited.insert(real_file.clone()) {
+            continue;
+        }
+        let real_file_display = real_file.display();
+        let text = fs::read_to_string(&real_file)
+            .await
+            .map_err(|error| miette::miette!("Failed to read {real_file_display}: {error}"))?;
         for uses_value in uses_values(&text)
-            .map_err(|error| miette::miette!("Failed to parse {file_display}: {error}"))?
+            .map_err(|error| miette::miette!("Failed to parse {real_file_display}: {error}"))?
         {
             let original_value = uses_value.value;
             let (value, comment) = split_uses_value(original_value);
@@ -249,7 +262,7 @@ async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
                 .map(str::to_string);
             actions.push(ActionReference {
                 comment_version,
-                file: file.clone(),
+                file: real_file.clone(),
                 flow_style: uses_value.flow_style,
                 indentation: uses_value.indentation,
                 name: name.to_string(),
@@ -404,9 +417,7 @@ fn find_current(action: &ActionReference, versions: &[RepoVersion]) -> Option<Re
     {
         return Some(current.clone());
     }
-    if let Some(version) = parse_version(&action.ref_)
-        && action.ref_.trim_start_matches('v').split('.').count() == 3
-    {
+    if let Some(version) = parse_version(&action.ref_) {
         return versions.iter().find(|candidate| candidate.version == version).cloned();
     }
     if let Ok(major) = action.ref_.trim_start_matches('v').parse::<u64>() {

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -1,0 +1,399 @@
+use node_semver::Version;
+use pacquet_config::matcher::Matcher;
+use pacquet_resolving_git_resolver::{GitCommandRunner, RealGitRunner};
+use std::{
+    cmp::Reverse,
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
+    fs,
+    ops::Range,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone)]
+pub struct OutdatedGitHubAction {
+    pub current: Version,
+    pub homepage: String,
+    pub latest: Version,
+    pub name: String,
+    pub wanted: Version,
+}
+
+pub fn is_selector(selector: &str) -> bool {
+    let pattern = selector.strip_prefix('!').unwrap_or(selector);
+    !pattern.starts_with('@') && pattern.contains('/')
+}
+
+#[derive(Clone)]
+struct ActionReference {
+    comment_version: Option<String>,
+    file: PathBuf,
+    name: String,
+    original_value: String,
+    range: Range<usize>,
+    ref_: String,
+    repo: String,
+}
+
+#[derive(Clone)]
+struct RepoVersion {
+    commit: String,
+    tag: String,
+    version: Version,
+}
+
+struct PlannedUpdate {
+    action: ActionReference,
+    current: RepoVersion,
+    latest: RepoVersion,
+    wanted: RepoVersion,
+}
+
+pub async fn find_outdated(
+    root: &Path,
+    compatible: bool,
+    matcher: Option<&Matcher>,
+) -> miette::Result<Vec<OutdatedGitHubAction>> {
+    let plans = create_plan(root, matcher, &RealGitRunner::new()).await?;
+    Ok(to_outdated(plans, compatible))
+}
+
+pub async fn update(
+    root: &Path,
+    latest: bool,
+    matcher: Option<&Matcher>,
+) -> miette::Result<Vec<OutdatedGitHubAction>> {
+    update_with_runner(root, latest, matcher, &RealGitRunner::new()).await
+}
+
+async fn update_with_runner<Runner: GitCommandRunner + Sync>(
+    root: &Path,
+    latest: bool,
+    matcher: Option<&Matcher>,
+    runner: &Runner,
+) -> miette::Result<Vec<OutdatedGitHubAction>> {
+    let plans = create_plan(root, matcher, runner).await?;
+    let updates = plans
+        .into_iter()
+        .filter(|plan| {
+            let target = if latest { &plan.latest } else { &plan.wanted };
+            plan.current.version <= target.version
+                && (plan.action.ref_ != target.commit
+                    || plan.action.comment_version.as_deref() != Some(&target.tag))
+        })
+        .collect::<Vec<_>>();
+    let mut edits: BTreeMap<PathBuf, Vec<(Range<usize>, String)>> = BTreeMap::new();
+    for plan in &updates {
+        let target = if latest { &plan.latest } else { &plan.wanted };
+        edits
+            .entry(plan.action.file.clone())
+            .or_default()
+            .push((plan.action.range.clone(), render_target_value(&plan.action, target)));
+    }
+    for (file, mut replacements) in edits {
+        let file_display = file.display();
+        let mut text = fs::read_to_string(&file)
+            .map_err(|error| miette::miette!("Failed to read {file_display}: {error}"))?;
+        replacements.sort_by_key(|(range, _)| Reverse(range.start));
+        for (range, new) in replacements {
+            text.replace_range(range, &new);
+        }
+        fs::write(&file, text)
+            .map_err(|error| miette::miette!("Failed to write {file_display}: {error}"))?;
+    }
+    Ok(to_outdated(updates, latest))
+}
+
+async fn create_plan<Runner: GitCommandRunner + Sync>(
+    root: &Path,
+    matcher: Option<&Matcher>,
+    runner: &Runner,
+) -> miette::Result<Vec<PlannedUpdate>> {
+    let actions = discover(root)?
+        .into_iter()
+        .filter(|action| {
+            matcher.is_none_or(|matcher| {
+                matcher.matches(&action.name) || matcher.matches(&action.repo)
+            })
+        })
+        .collect::<Vec<_>>();
+    let repos = actions.iter().map(|action| action.repo.clone()).collect::<BTreeSet<_>>();
+    let refs_by_repo =
+        futures_util::future::try_join_all(repos.into_iter().map(|repo| async move {
+            let url = format!("https://github.com/{repo}.git");
+            let stdout = runner.ls_remote(&url, None).await.map_err(|error| {
+                miette::miette!("Failed to read GitHub Action refs for {repo}: {error}")
+            })?;
+            Ok::<_, miette::Report>((repo, parse_repo_versions(&stdout)))
+        }))
+        .await?
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+    let mut plans = Vec::new();
+    for action in actions {
+        let versions = &refs_by_repo[&action.repo];
+        let Some(current) = find_current(&action, versions) else { continue };
+        let candidates = versions
+            .iter()
+            .filter(|candidate| {
+                !current.version.pre_release.is_empty() || candidate.version.pre_release.is_empty()
+            })
+            .collect::<Vec<_>>();
+        let Some(latest) = candidates.last() else { continue };
+        let Some(wanted) = candidates
+            .iter()
+            .rev()
+            .find(|candidate| candidate.version.major == current.version.major)
+        else {
+            continue;
+        };
+        plans.push(PlannedUpdate {
+            action,
+            current,
+            latest: (*latest).clone(),
+            wanted: (*wanted).clone(),
+        });
+    }
+    Ok(plans)
+}
+
+fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
+    let canonical_root = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let workflows = root.join(".github/workflows");
+    let workflows_display = workflows.display();
+    let entries = match fs::read_dir(&workflows) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(miette::miette!("Failed to read {workflows_display}: {error}"));
+        }
+    };
+    let mut queue = entries
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            matches!(path.extension().and_then(|ext| ext.to_str()), Some("yml" | "yaml"))
+        })
+        .collect::<VecDeque<_>>();
+    let mut visited = HashSet::new();
+    let mut actions = Vec::new();
+    while let Some(file) = queue.pop_front() {
+        if !visited.insert(file.clone()) {
+            continue;
+        }
+        let file_display = file.display();
+        let text = fs::read_to_string(&file)
+            .map_err(|error| miette::miette!("Failed to read {file_display}: {error}"))?;
+        for uses_value in uses_values(&text) {
+            let original_value = uses_value.value;
+            let (value, comment) = split_uses_value(original_value);
+            if let Some(local) = value.strip_prefix("./") {
+                let target = root.join(local);
+                let candidate = if matches!(
+                    target.extension().and_then(|ext| ext.to_str()),
+                    Some("yml" | "yaml"),
+                ) && target.is_file()
+                {
+                    Some(target)
+                } else if target.join("action.yml").is_file() {
+                    Some(target.join("action.yml"))
+                } else if target.join("action.yaml").is_file() {
+                    Some(target.join("action.yaml"))
+                } else {
+                    None
+                };
+                if let Some(candidate) = candidate
+                    && let Ok(candidate) = fs::canonicalize(candidate)
+                    && candidate.starts_with(&canonical_root)
+                {
+                    queue.push_back(candidate);
+                }
+                continue;
+            }
+            let Some((name, ref_and_comment)) = value.rsplit_once('@') else { continue };
+            if name.starts_with("docker://") {
+                continue;
+            }
+            let mut parts = name.split('/');
+            let (Some(owner), Some(repository)) = (parts.next(), parts.next()) else { continue };
+            let comment_version = comment
+                .and_then(|comment| comment.split_whitespace().next())
+                .filter(|candidate| parse_version(candidate).is_some())
+                .map(str::to_string);
+            actions.push(ActionReference {
+                comment_version,
+                file: file.clone(),
+                name: name.to_string(),
+                original_value: original_value.to_string(),
+                range: uses_value.range,
+                ref_: ref_and_comment.to_string(),
+                repo: format!("{owner}/{repository}"),
+            });
+        }
+    }
+    Ok(actions)
+}
+
+fn split_uses_value(value: &str) -> (&str, Option<&str>) {
+    let value = value.trim();
+    if let Some(quote) = value.chars().next().filter(|quote| matches!(quote, '\'' | '"'))
+        && let Some(end) = value[1..].find(quote)
+    {
+        let end = end + 1;
+        let comment = value[end + quote.len_utf8()..].trim().strip_prefix('#').map(str::trim);
+        return (&value[1..end], comment);
+    }
+    value.split_once(" #").map_or((value, None), |(value, comment)| (value, Some(comment.trim())))
+}
+
+struct UsesValue<'a> {
+    range: Range<usize>,
+    value: &'a str,
+}
+
+fn uses_values(text: &str) -> Vec<UsesValue<'_>> {
+    let mut values = Vec::new();
+    let mut offset = 0;
+    let mut block_scalar_indent = None;
+    for segment in text.split_inclusive('\n') {
+        let line = segment.trim_end_matches(['\r', '\n']);
+        let indentation = line.len() - line.trim_start_matches(' ').len();
+        let trimmed = line.trim_start();
+        if let Some(block_indent) = block_scalar_indent {
+            if trimmed.is_empty() || indentation > block_indent {
+                offset += segment.len();
+                continue;
+            }
+            block_scalar_indent = None;
+        }
+
+        let (entry, entry_offset) =
+            trimmed.strip_prefix("- ").map_or((trimmed, line.len() - trimmed.len()), |entry| {
+                (entry, line.len() - trimmed.len() + 2)
+            });
+        let Some(separator) = entry.find(':') else {
+            offset += segment.len();
+            continue;
+        };
+        let key = &entry[..separator];
+        let untrimmed_value = &entry[separator + 1..];
+        let leading_whitespace = untrimmed_value.len() - untrimmed_value.trim_start().len();
+        let raw_value = untrimmed_value.trim_start();
+        if raw_value.starts_with(['|', '>']) {
+            block_scalar_indent = Some(indentation);
+        }
+        if !matches!(key.trim(), "uses" | "'uses'" | r#""uses""#) || raw_value.is_empty() {
+            offset += segment.len();
+            continue;
+        }
+        let value = raw_value.trim_end();
+        let start = offset + entry_offset + separator + 1 + leading_whitespace;
+        values.push(UsesValue { range: start..start + value.len(), value });
+        offset += segment.len();
+    }
+    values
+}
+
+fn parse_repo_versions(stdout: &str) -> Vec<RepoVersion> {
+    let refs = stdout
+        .lines()
+        .filter_map(|line| line.split_once('\t'))
+        .map(|(commit, ref_)| (ref_.to_string(), commit.to_string()))
+        .collect::<HashMap<_, _>>();
+    let mut versions = refs
+        .iter()
+        .filter_map(|(ref_, commit)| {
+            let tag = ref_.strip_prefix("refs/tags/")?;
+            if tag.ends_with("^{}") {
+                return None;
+            }
+            let version = parse_version(tag)?;
+            Some(RepoVersion {
+                commit: refs.get(&format!("{ref_}^{{}}")).unwrap_or(commit).clone(),
+                tag: tag.to_string(),
+                version,
+            })
+        })
+        .collect::<Vec<_>>();
+    versions.sort_by(|left, right| left.version.cmp(&right.version));
+    versions
+}
+
+fn find_current(action: &ActionReference, versions: &[RepoVersion]) -> Option<RepoVersion> {
+    if is_sha(&action.ref_)
+        && let Some(comment) = &action.comment_version
+        && let Some(version) = parse_version(comment)
+        && let Some(current) = versions
+            .iter()
+            .find(|candidate| candidate.commit == action.ref_ && candidate.version == version)
+    {
+        return Some(current.clone());
+    }
+    if let Some(version) = parse_version(&action.ref_)
+        && action.ref_.trim_start_matches('v').split('.').count() == 3
+    {
+        return versions.iter().find(|candidate| candidate.version == version).cloned();
+    }
+    if let Ok(major) = action.ref_.trim_start_matches('v').parse::<u64>() {
+        return versions
+            .iter()
+            .rfind(|candidate| {
+                candidate.version.major == major && candidate.version.pre_release.is_empty()
+            })
+            .cloned();
+    }
+    if is_sha(&action.ref_) {
+        return versions.iter().rfind(|candidate| candidate.commit == action.ref_).cloned();
+    }
+    None
+}
+
+fn render_target_ref(target: &RepoVersion) -> String {
+    target.commit.clone()
+}
+
+fn is_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn render_target_value(action: &ActionReference, target: &RepoVersion) -> String {
+    let old_reference = format!("{}@{}", action.name, action.ref_);
+    let new_reference = format!("{}@{}", action.name, render_target_ref(target));
+    let mut value = action.original_value.replacen(&old_reference, &new_reference, 1);
+    if let Some(comment_version) = &action.comment_version {
+        value = value.replacen(comment_version, &target.tag, 1);
+    } else if let Some(comment) = value.find(" #") {
+        value.insert_str(comment + 2, &format!("{} ", target.tag));
+    } else {
+        value.push_str(" # ");
+        value.push_str(&target.tag);
+    }
+    value
+}
+
+fn parse_version(input: &str) -> Option<Version> {
+    Version::parse(input).or_else(|_| Version::parse(input.trim_start_matches('v'))).ok()
+}
+
+fn to_outdated(plans: Vec<PlannedUpdate>, latest: bool) -> Vec<OutdatedGitHubAction> {
+    let mut actions = BTreeMap::new();
+    for plan in plans {
+        let target = if latest { plan.latest } else { plan.wanted.clone() };
+        if plan.current.version >= target.version {
+            continue;
+        }
+        actions.insert(
+            plan.action.name.clone(),
+            OutdatedGitHubAction {
+                current: plan.current.version,
+                homepage: format!("https://github.com/{}", plan.action.repo),
+                latest: target.version,
+                name: plan.action.name,
+                wanted: plan.wanted.version,
+            },
+        );
+    }
+    actions.into_values().collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -53,8 +53,17 @@ pub async fn find_outdated(
     compatible: bool,
     matcher: Option<&Matcher>,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    let plans = create_plan(root, matcher, &RealGitRunner::new()).await?;
-    Ok(to_outdated(plans, compatible))
+    find_outdated_with_runner(root, compatible, matcher, &RealGitRunner::new()).await
+}
+
+async fn find_outdated_with_runner<Runner: GitCommandRunner + Sync>(
+    root: &Path,
+    compatible: bool,
+    matcher: Option<&Matcher>,
+    runner: &Runner,
+) -> miette::Result<Vec<OutdatedGitHubAction>> {
+    let plans = create_plan(root, matcher, runner).await?;
+    Ok(to_outdated(plans, !compatible))
 }
 
 pub async fn update(

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -254,6 +254,7 @@ fn uses_values(text: &str) -> Vec<UsesValue<'_>> {
     let mut values = Vec::new();
     let mut offset = 0;
     let mut block_scalar_indent = None;
+    let mut path = Vec::new();
     for segment in text.split_inclusive('\n') {
         let line = segment.trim_end_matches(['\r', '\n']);
         let indentation = line.len() - line.trim_start_matches(' ').len();
@@ -265,6 +266,13 @@ fn uses_values(text: &str) -> Vec<UsesValue<'_>> {
             }
             block_scalar_indent = None;
         }
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            offset += segment.len();
+            continue;
+        }
+        while path.last().is_some_and(|(parent_indent, _)| indentation <= *parent_indent) {
+            path.pop();
+        }
 
         let (entry, entry_offset) =
             trimmed.strip_prefix("- ").map_or((trimmed, line.len() - trimmed.len()), |entry| {
@@ -274,14 +282,18 @@ fn uses_values(text: &str) -> Vec<UsesValue<'_>> {
             offset += segment.len();
             continue;
         };
-        let key = &entry[..separator];
+        let key = normalize_yaml_key(&entry[..separator]);
         let untrimmed_value = &entry[separator + 1..];
         let leading_whitespace = untrimmed_value.len() - untrimmed_value.trim_start().len();
         let raw_value = untrimmed_value.trim_start();
         if raw_value.starts_with(['|', '>']) {
             block_scalar_indent = Some(indentation);
         }
-        if !matches!(key.trim(), "uses" | "'uses'" | r#""uses""#) || raw_value.is_empty() {
+        let is_action_uses = key == "uses" && is_action_uses_path(&path);
+        if key != "uses" && (raw_value.is_empty() || raw_value.starts_with('#')) {
+            path.push((indentation, key));
+        }
+        if !is_action_uses || raw_value.is_empty() {
             offset += segment.len();
             continue;
         }
@@ -291,6 +303,20 @@ fn uses_values(text: &str) -> Vec<UsesValue<'_>> {
         offset += segment.len();
     }
     values
+}
+
+fn normalize_yaml_key(key: &str) -> &str {
+    let key = key.trim();
+    key.strip_prefix('\'')
+        .and_then(|key| key.strip_suffix('\''))
+        .or_else(|| key.strip_prefix('"').and_then(|key| key.strip_suffix('"')))
+        .unwrap_or(key)
+}
+
+fn is_action_uses_path(path: &[(usize, &str)]) -> bool {
+    (path.len() == 2 && path[0].1 == "jobs")
+        || (path.len() == 3 && path[0].1 == "jobs" && path[2].1 == "steps")
+        || (path.len() == 2 && path[0].1 == "runs" && path[1].1 == "steps")
 }
 
 fn parse_repo_versions(stdout: &str) -> Vec<RepoVersion> {

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -9,6 +9,8 @@ use std::{
     path::{Path, PathBuf},
 };
 use tokio::fs;
+use yaml_serde::Value;
+use yamlpath::{Component, Document, QueryError, Route};
 
 #[derive(Clone)]
 pub struct OutdatedGitHubAction {
@@ -28,6 +30,8 @@ pub fn is_selector(selector: &str) -> bool {
 struct ActionReference {
     comment_version: Option<String>,
     file: PathBuf,
+    flow_style: bool,
+    indentation: String,
     name: String,
     original_value: String,
     range: Range<usize>,
@@ -203,7 +207,9 @@ async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
         let text = fs::read_to_string(&file)
             .await
             .map_err(|error| miette::miette!("Failed to read {file_display}: {error}"))?;
-        for uses_value in uses_values(&text) {
+        for uses_value in uses_values(&text)
+            .map_err(|error| miette::miette!("Failed to parse {file_display}: {error}"))?
+        {
             let original_value = uses_value.value;
             let (value, comment) = split_uses_value(original_value);
             if let Some(local) = value.strip_prefix("./") {
@@ -244,6 +250,8 @@ async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
             actions.push(ActionReference {
                 comment_version,
                 file: file.clone(),
+                flow_style: uses_value.flow_style,
+                indentation: uses_value.indentation,
                 name: name.to_string(),
                 original_value: original_value.to_string(),
                 range: uses_value.range,
@@ -272,77 +280,93 @@ fn split_uses_value(value: &str) -> (&str, Option<&str>) {
 }
 
 struct UsesValue<'a> {
+    flow_style: bool,
+    indentation: String,
     range: Range<usize>,
     value: &'a str,
 }
 
-fn uses_values(text: &str) -> Vec<UsesValue<'_>> {
+fn uses_values(text: &str) -> Result<Vec<UsesValue<'_>>, QueryError> {
+    let value = yaml_serde::from_str::<Value>(text).map_err(|_| QueryError::InvalidInput)?;
+    let document = Document::new(text)?;
     let mut values = Vec::new();
-    let mut offset = 0;
-    let mut block_scalar_indent = None;
-    let mut path = Vec::new();
-    for segment in text.split_inclusive('\n') {
-        let line = segment.trim_end_matches(['\r', '\n']);
-        let indentation = line.len() - line.trim_start_matches(' ').len();
-        let trimmed = line.trim_start();
-        if let Some(block_indent) = block_scalar_indent {
-            if trimmed.is_empty() || indentation > block_indent {
-                offset += segment.len();
-                continue;
-            }
-            block_scalar_indent = None;
-        }
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            offset += segment.len();
-            continue;
-        }
-        while path.last().is_some_and(|(parent_indent, _)| indentation <= *parent_indent) {
-            path.pop();
-        }
-
-        let (entry, entry_offset) =
-            trimmed.strip_prefix("- ").map_or((trimmed, line.len() - trimmed.len()), |entry| {
-                (entry, line.len() - trimmed.len() + 2)
-            });
-        let Some(separator) = entry.find(':') else {
-            offset += segment.len();
+    for route in uses_routes(&value) {
+        let Some(feature) = document.query_exact(&route)? else {
             continue;
         };
-        let key = normalize_yaml_key(&entry[..separator]);
-        let untrimmed_value = &entry[separator + 1..];
-        let leading_whitespace = untrimmed_value.len() - untrimmed_value.trim_start().len();
-        let raw_value = untrimmed_value.trim_start();
-        if raw_value.starts_with(['|', '>']) {
-            block_scalar_indent = Some(indentation);
-        }
-        let is_action_uses = key == "uses" && is_action_uses_path(&path);
-        if key != "uses" && (raw_value.is_empty() || raw_value.starts_with('#')) {
-            path.push((indentation, key));
-        }
-        if !is_action_uses || raw_value.is_empty() {
-            offset += segment.len();
+        let key = document.query_key_only(&route)?;
+        let (start, scalar_end) = feature.location.byte_span;
+        let separator = start
+            .checked_sub(key.location.byte_span.1)
+            .map(|_| &text[key.location.byte_span.1..start]);
+        if separator.is_none_or(|separator| {
+            !separator.starts_with(':') || !separator[1..].chars().all(char::is_whitespace)
+        }) {
             continue;
         }
-        let value = raw_value.trim_end();
-        let start = offset + entry_offset + separator + 1 + leading_whitespace;
-        values.push(UsesValue { range: start..start + value.len(), value });
-        offset += segment.len();
+        let line_end = text[scalar_end..].find('\n').map_or(text.len(), |end| scalar_end + end);
+        let trailing = &text[scalar_end..line_end];
+        let following = trailing.trim_start();
+        let flow_style = matches!(following.chars().next(), Some('}' | ']' | ','));
+        let end = if following.starts_with('#') {
+            scalar_end + trailing.trim_end().len()
+        } else if flow_style {
+            scalar_end + trailing.len() - following.len()
+        } else {
+            scalar_end
+        };
+        let line_start = text[..start].rfind('\n').map_or(0, |line_break| line_break + 1);
+        values.push(UsesValue {
+            flow_style,
+            indentation: " ".repeat(start - line_start),
+            range: start..end,
+            value: &text[start..end],
+        });
     }
-    values
+    Ok(values)
 }
 
-fn normalize_yaml_key(key: &str) -> &str {
-    let key = key.trim();
-    key.strip_prefix('\'')
-        .and_then(|key| key.strip_suffix('\''))
-        .or_else(|| key.strip_prefix('"').and_then(|key| key.strip_suffix('"')))
-        .unwrap_or(key)
+fn uses_routes(value: &Value) -> Vec<Route<'static>> {
+    let mut routes = Vec::new();
+    if let Some(jobs) = value.get("jobs").and_then(Value::as_mapping) {
+        for (name, job) in jobs {
+            let Some(name) = name.as_str() else { continue };
+            if job.get("uses").and_then(Value::as_str).is_some() {
+                routes.push(Route::from(vec![
+                    "jobs".into(),
+                    name.to_string().into(),
+                    "uses".into(),
+                ]));
+            }
+            add_step_routes(
+                &mut routes,
+                job.get("steps"),
+                &["jobs".into(), name.to_string().into(), "steps".into()],
+            );
+        }
+    }
+    add_step_routes(
+        &mut routes,
+        value.get("runs").and_then(|runs| runs.get("steps")),
+        &["runs".into(), "steps".into()],
+    );
+    routes
 }
 
-fn is_action_uses_path(path: &[(usize, &str)]) -> bool {
-    (path.len() == 2 && path[0].1 == "jobs")
-        || (path.len() == 3 && path[0].1 == "jobs" && path[2].1 == "steps")
-        || (path.len() == 2 && path[0].1 == "runs" && path[1].1 == "steps")
+fn add_step_routes(
+    routes: &mut Vec<Route<'static>>,
+    steps: Option<&Value>,
+    prefix: &[Component<'static>],
+) {
+    let Some(steps) = steps.and_then(Value::as_sequence) else { return };
+    for (index, step) in steps.iter().enumerate() {
+        if step.get("uses").and_then(Value::as_str).is_none() {
+            continue;
+        }
+        let mut route = prefix.to_owned();
+        route.extend([index.into(), "uses".into()]);
+        routes.push(Route::from(route));
+    }
 }
 
 fn parse_repo_versions(stdout: &str) -> Vec<RepoVersion> {
@@ -415,6 +439,12 @@ fn render_target_value(action: &ActionReference, target: &RepoVersion) -> String
         value = value.replacen(comment_version, &target.tag, 1);
     } else if let Some(comment) = value.find(" #") {
         value.insert_str(comment + 2, &format!("{} ", target.tag));
+    } else if action.flow_style {
+        value.truncate(value.trim_end().len());
+        value.push_str(" # ");
+        value.push_str(&target.tag);
+        value.push('\n');
+        value.push_str(&action.indentation);
     } else {
         value.push_str(" # ");
         value.push_str(&target.tag);

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -106,7 +106,7 @@ async fn update_with_runner<Runner: GitCommandRunner + Sync>(
             .push((plan.action.range.clone(), render_target_value(&plan.action, target)));
     }
     for (file, mut replacements) in edits {
-        let file_display = file.display();
+        let file_display = file.display().to_string();
         let mut text = fs::read_to_string(&file)
             .await
             .map_err(|error| miette::miette!("Failed to read {file_display}: {error}"))?;
@@ -114,8 +114,9 @@ async fn update_with_runner<Runner: GitCommandRunner + Sync>(
         for (range, new) in replacements {
             text.replace_range(range, &new);
         }
-        fs::write(&file, text)
+        tokio::task::spawn_blocking(move || pacquet_fs::write_atomic(&file, text.as_bytes()))
             .await
+            .map_err(|error| miette::miette!("Failed to write {file_display}: {error}"))?
             .map_err(|error| miette::miette!("Failed to write {file_display}: {error}"))?;
     }
     Ok(to_outdated(updates, latest))

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -1,5 +1,5 @@
 use futures_util::{StreamExt, TryStreamExt, stream};
-use node_semver::Version;
+use node_semver::{Range as SemverRange, Version};
 use pacquet_config::matcher::Matcher;
 use pacquet_resolving_git_resolver::{GitCommandRunner, RealGitRunner, get_repo_refs};
 use std::{
@@ -152,6 +152,8 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
     for action in actions {
         let versions = &refs_by_repo[&action.repo];
         let Some(current) = find_current(&action, versions) else { continue };
+        let wanted_range = SemverRange::parse(format!("^{}", current.version))
+            .expect("a parsed version produces a valid caret range");
         let candidates = versions
             .iter()
             .filter(|candidate| {
@@ -159,10 +161,8 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
             })
             .collect::<Vec<_>>();
         let Some(latest) = candidates.last() else { continue };
-        let Some(wanted) = candidates
-            .iter()
-            .rev()
-            .find(|candidate| candidate.version.major == current.version.major)
+        let Some(wanted) =
+            candidates.iter().rev().find(|candidate| wanted_range.satisfies(&candidate.version))
         else {
             continue;
         };

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -1,7 +1,7 @@
 use futures_util::{StreamExt, TryStreamExt, stream};
 use node_semver::Version;
 use pacquet_config::matcher::Matcher;
-use pacquet_resolving_git_resolver::{GitCommandRunner, RealGitRunner};
+use pacquet_resolving_git_resolver::{GitCommandRunner, RealGitRunner, get_repo_refs};
 use std::{
     cmp::Reverse,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
@@ -140,10 +140,10 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
     let refs_by_repo = stream::iter(repos)
         .map(|repo| async move {
             let url = format!("https://github.com/{repo}.git");
-            let stdout = runner.ls_remote(&url, None).await.map_err(|error| {
+            let refs = get_repo_refs(runner, &url, None).await.map_err(|error| {
                 miette::miette!("Failed to read GitHub Action refs for {repo}: {error}")
             })?;
-            Ok::<_, miette::Report>((repo, parse_repo_versions(&stdout)))
+            Ok::<_, miette::Report>((repo, repo_versions(&refs)))
         })
         .buffer_unordered(GIT_CONCURRENCY)
         .try_collect::<HashMap<_, _>>()
@@ -227,25 +227,8 @@ async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
             let original_value = uses_value.value;
             let (value, comment) = split_uses_value(original_value);
             if let Some(local) = value.strip_prefix("./") {
-                let target = root.join(local);
-                let candidate = if matches!(
-                    target.extension().and_then(|ext| ext.to_str()),
-                    Some("yml" | "yaml"),
-                ) && is_file(&target).await
-                {
-                    Some(target)
-                } else {
-                    let action_yml = target.join("action.yml");
-                    if is_file(&action_yml).await {
-                        Some(action_yml)
-                    } else {
-                        let action_yaml = target.join("action.yaml");
-                        is_file(&action_yaml).await.then_some(action_yaml)
-                    }
-                };
-                if let Some(candidate) = candidate
-                    && let Ok(candidate) = fs::canonicalize(candidate).await
-                    && candidate.starts_with(&canonical_root)
+                if let Some(candidate) =
+                    resolve_local_reference(root, &canonical_root, local).await?
                 {
                     queue.push_back(candidate);
                 }
@@ -277,8 +260,43 @@ async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
     Ok(actions)
 }
 
-async fn is_file(path: &Path) -> bool {
-    fs::metadata(path).await.is_ok_and(|metadata| metadata.is_file())
+async fn resolve_local_reference(
+    root: &Path,
+    canonical_root: &Path,
+    reference: &str,
+) -> miette::Result<Option<PathBuf>> {
+    let target = root.join(reference);
+    let candidate = if matches!(
+        target.extension().and_then(|extension| extension.to_str()),
+        Some("yml" | "yaml"),
+    ) {
+        existing_file(&target).await?.then_some(target)
+    } else {
+        let action_yml = target.join("action.yml");
+        if existing_file(&action_yml).await? {
+            Some(action_yml)
+        } else {
+            let action_yaml = target.join("action.yaml");
+            existing_file(&action_yaml).await?.then_some(action_yaml)
+        }
+    };
+    let Some(candidate) = candidate else { return Ok(None) };
+    let candidate_display = candidate.display();
+    let candidate = fs::canonicalize(&candidate)
+        .await
+        .map_err(|error| miette::miette!("Failed to read {candidate_display}: {error}"))?;
+    Ok(candidate.starts_with(canonical_root).then_some(candidate))
+}
+
+async fn existing_file(path: &Path) -> miette::Result<bool> {
+    match fs::metadata(path).await {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => {
+            let path_display = path.display();
+            Err(miette::miette!("Failed to read {path_display}: {error}"))
+        }
+    }
 }
 
 fn split_uses_value(value: &str) -> (&str, Option<&str>) {
@@ -383,12 +401,7 @@ fn add_step_routes(
     }
 }
 
-fn parse_repo_versions(stdout: &str) -> Vec<RepoVersion> {
-    let refs = stdout
-        .lines()
-        .filter_map(|line| line.split_once('\t'))
-        .map(|(commit, ref_)| (ref_.to_string(), commit.to_string()))
-        .collect::<HashMap<_, _>>();
+fn repo_versions(refs: &HashMap<String, String>) -> Vec<RepoVersion> {
     let mut versions = refs
         .iter()
         .filter_map(|(ref_, commit)| {

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -1,13 +1,14 @@
+use futures_util::{StreamExt, TryStreamExt, stream};
 use node_semver::Version;
 use pacquet_config::matcher::Matcher;
 use pacquet_resolving_git_resolver::{GitCommandRunner, RealGitRunner};
 use std::{
     cmp::Reverse,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
-    fs,
     ops::Range,
     path::{Path, PathBuf},
 };
+use tokio::fs;
 
 #[derive(Clone)]
 pub struct OutdatedGitHubAction {
@@ -47,6 +48,8 @@ struct PlannedUpdate {
     latest: RepoVersion,
     wanted: RepoVersion,
 }
+
+const GIT_CONCURRENCY: usize = 8;
 
 pub async fn find_outdated(
     root: &Path,
@@ -101,12 +104,14 @@ async fn update_with_runner<Runner: GitCommandRunner + Sync>(
     for (file, mut replacements) in edits {
         let file_display = file.display();
         let mut text = fs::read_to_string(&file)
+            .await
             .map_err(|error| miette::miette!("Failed to read {file_display}: {error}"))?;
         replacements.sort_by_key(|(range, _)| Reverse(range.start));
         for (range, new) in replacements {
             text.replace_range(range, &new);
         }
         fs::write(&file, text)
+            .await
             .map_err(|error| miette::miette!("Failed to write {file_display}: {error}"))?;
     }
     Ok(to_outdated(updates, latest))
@@ -117,7 +122,8 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
     matcher: Option<&Matcher>,
     runner: &Runner,
 ) -> miette::Result<Vec<PlannedUpdate>> {
-    let actions = discover(root)?
+    let actions = discover(root)
+        .await?
         .into_iter()
         .filter(|action| {
             matcher.is_none_or(|matcher| {
@@ -126,17 +132,17 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
         })
         .collect::<Vec<_>>();
     let repos = actions.iter().map(|action| action.repo.clone()).collect::<BTreeSet<_>>();
-    let refs_by_repo =
-        futures_util::future::try_join_all(repos.into_iter().map(|repo| async move {
+    let refs_by_repo = stream::iter(repos)
+        .map(|repo| async move {
             let url = format!("https://github.com/{repo}.git");
             let stdout = runner.ls_remote(&url, None).await.map_err(|error| {
                 miette::miette!("Failed to read GitHub Action refs for {repo}: {error}")
             })?;
             Ok::<_, miette::Report>((repo, parse_repo_versions(&stdout)))
-        }))
-        .await?
-        .into_iter()
-        .collect::<HashMap<_, _>>();
+        })
+        .buffer_unordered(GIT_CONCURRENCY)
+        .try_collect::<HashMap<_, _>>()
+        .await?;
     let mut plans = Vec::new();
     for action in actions {
         let versions = &refs_by_repo[&action.repo];
@@ -165,24 +171,28 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
     Ok(plans)
 }
 
-fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
-    let canonical_root = fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+async fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
+    let canonical_root = fs::canonicalize(root).await.unwrap_or_else(|_| root.to_path_buf());
     let workflows = root.join(".github/workflows");
     let workflows_display = workflows.display();
-    let entries = match fs::read_dir(&workflows) {
+    let mut entries = match fs::read_dir(&workflows).await {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(error) => {
             return Err(miette::miette!("Failed to read {workflows_display}: {error}"));
         }
     };
-    let mut queue = entries
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| {
-            matches!(path.extension().and_then(|ext| ext.to_str()), Some("yml" | "yaml"))
-        })
-        .collect::<VecDeque<_>>();
+    let mut queue = VecDeque::new();
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .map_err(|error| miette::miette!("Failed to read {workflows_display}: {error}"))?
+    {
+        let path = entry.path();
+        if matches!(path.extension().and_then(|ext| ext.to_str()), Some("yml" | "yaml")) {
+            queue.push_back(path);
+        }
+    }
     let mut visited = HashSet::new();
     let mut actions = Vec::new();
     while let Some(file) = queue.pop_front() {
@@ -191,6 +201,7 @@ fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
         }
         let file_display = file.display();
         let text = fs::read_to_string(&file)
+            .await
             .map_err(|error| miette::miette!("Failed to read {file_display}: {error}"))?;
         for uses_value in uses_values(&text) {
             let original_value = uses_value.value;
@@ -200,18 +211,20 @@ fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
                 let candidate = if matches!(
                     target.extension().and_then(|ext| ext.to_str()),
                     Some("yml" | "yaml"),
-                ) && target.is_file()
+                ) && is_file(&target).await
                 {
                     Some(target)
-                } else if target.join("action.yml").is_file() {
-                    Some(target.join("action.yml"))
-                } else if target.join("action.yaml").is_file() {
-                    Some(target.join("action.yaml"))
                 } else {
-                    None
+                    let action_yml = target.join("action.yml");
+                    if is_file(&action_yml).await {
+                        Some(action_yml)
+                    } else {
+                        let action_yaml = target.join("action.yaml");
+                        is_file(&action_yaml).await.then_some(action_yaml)
+                    }
                 };
                 if let Some(candidate) = candidate
-                    && let Ok(candidate) = fs::canonicalize(candidate)
+                    && let Ok(candidate) = fs::canonicalize(candidate).await
                     && candidate.starts_with(&canonical_root)
                 {
                     queue.push_back(candidate);
@@ -240,6 +253,10 @@ fn discover(root: &Path) -> miette::Result<Vec<ActionReference>> {
         }
     }
     Ok(actions)
+}
+
+async fn is_file(path: &Path) -> bool {
+    fs::metadata(path).await.is_ok_and(|metadata| metadata.is_file())
 }
 
 fn split_uses_value(value: &str) -> (&str, Option<&str>) {

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -1,6 +1,6 @@
 use futures_util::{StreamExt, TryStreamExt, stream};
 use node_semver::{Range as SemverRange, Version};
-use pacquet_config::matcher::Matcher;
+use pacquet_config::matcher::{Matcher, create_matcher};
 use pacquet_resolving_git_resolver::{GitCommandRunner, RealGitRunner, get_repo_refs};
 use std::{
     cmp::Reverse,
@@ -24,6 +24,22 @@ pub struct OutdatedGitHubAction {
 pub fn is_selector(selector: &str) -> bool {
     let pattern = selector.strip_prefix('!').unwrap_or(selector);
     !pattern.starts_with('@') && pattern.contains('/')
+}
+
+pub fn normalize_selector(selector: &str) -> String {
+    if !is_selector(selector) {
+        return selector.to_string();
+    }
+    selector.rsplit_once('@').map_or(selector, |(name, _)| name).to_string()
+}
+
+pub fn selector_matcher(selectors: &[String]) -> Option<Matcher> {
+    if selectors.is_empty() {
+        return None;
+    }
+    Some(create_matcher(
+        &selectors.iter().map(|selector| normalize_selector(selector)).collect::<Vec<_>>(),
+    ))
 }
 
 #[derive(Clone)]
@@ -152,8 +168,13 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
     for action in actions {
         let versions = &refs_by_repo[&action.repo];
         let Some(current) = find_current(&action, versions) else { continue };
-        let wanted_range = SemverRange::parse(format!("^{}", current.version))
-            .expect("a parsed version produces a valid caret range");
+        let wanted_range =
+            SemverRange::parse(format!("^{}", current.version)).map_err(|error| {
+                miette::miette!(
+                    "Failed to create a compatible GitHub Action range for {}: {error}",
+                    current.version,
+                )
+            })?;
         let candidates = versions
             .iter()
             .filter(|candidate| {

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -1,20 +1,26 @@
 use super::{
     ActionReference, RepoVersion, find_current, find_outdated_with_runner, is_selector,
-    parse_repo_versions, render_target_ref, render_target_value, split_uses_value,
+    render_target_ref, render_target_value, repo_versions as versions_from_refs, split_uses_value,
     update_with_runner,
 };
 use node_semver::Version;
 use pacquet_resolving_git_resolver::{GitCommandRunner, GitRunError};
-use std::{fs, future::Future, path::PathBuf, pin::Pin};
+use std::{collections::HashMap, fs, future::Future, path::PathBuf, pin::Pin};
 
 const SHA_V4_1_0: &str = "1111111111111111111111111111111111111111";
 const SHA_V4_2_0: &str = "2222222222222222222222222222222222222222";
 const SHA_V5_0_0: &str = "3333333333333333333333333333333333333333";
 
 fn repo_versions() -> Vec<RepoVersion> {
-    parse_repo_versions(&format!(
-        "{SHA_V4_1_0}\trefs/tags/v4.1.0\n{SHA_V4_2_0}\trefs/tags/v4.2.0\n{SHA_V5_0_0}\trefs/tags/v5.0.0\n",
-    ))
+    versions_from_refs(&refs(&[
+        ("refs/tags/v4.1.0", SHA_V4_1_0),
+        ("refs/tags/v4.2.0", SHA_V4_2_0),
+        ("refs/tags/v5.0.0", SHA_V5_0_0),
+    ]))
+}
+
+fn refs(entries: &[(&str, &str)]) -> HashMap<String, String> {
+    entries.iter().map(|(ref_, commit)| ((*ref_).to_string(), (*commit).to_string())).collect()
 }
 
 fn action(original_value: &str) -> ActionReference {
@@ -66,9 +72,11 @@ fn distinguishes_action_selectors_from_package_selectors() {
 
 #[test]
 fn parses_annotated_semver_tags() {
-    let versions = parse_repo_versions(&format!(
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v4.2.0\n{SHA_V4_2_0}\trefs/tags/v4.2.0^{{}}\nnot-a-version\trefs/tags/latest\n",
-    ));
+    let versions = versions_from_refs(&refs(&[
+        ("refs/tags/v4.2.0", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        ("refs/tags/v4.2.0^{}", SHA_V4_2_0),
+        ("refs/tags/latest", "not-a-version"),
+    ]));
     assert_eq!(versions.len(), 1);
     assert_eq!(versions[0].commit, SHA_V4_2_0);
     assert_eq!(versions[0].tag, "v4.2.0");
@@ -96,9 +104,10 @@ fn floating_major_resolves_to_an_exact_commit() {
 
 #[test]
 fn resolves_prerelease_tags_containing_dots() {
-    let versions = parse_repo_versions(
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v5.0.0-alpha.1\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/v5.0.0-alpha.2\n",
-    );
+    let versions = versions_from_refs(&refs(&[
+        ("refs/tags/v5.0.0-alpha.1", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        ("refs/tags/v5.0.0-alpha.2", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+    ]));
     let current = find_current(&action("actions/checkout@v5.0.0-alpha.1"), &versions)
         .expect("prerelease version");
 
@@ -168,6 +177,29 @@ async fn rejects_workflow_symlinks_outside_the_project() {
 
     assert!(error.to_string().contains("outside the project root"));
     assert_eq!(fs::read_to_string(outside.path().join("ci.yml")).unwrap(), original);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn reports_local_action_lookup_errors() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("project directory");
+    let workflow = root.path().join(".github/workflows/ci.yml");
+    let action_dir = root.path().join(".github/actions/setup");
+    fs::create_dir_all(workflow.parent().unwrap()).expect("workflow directory");
+    fs::create_dir_all(&action_dir).expect("action directory");
+    fs::write(&workflow, "jobs:\n  test:\n    steps:\n      - uses: ./.github/actions/setup\n")
+        .expect("workflow");
+    symlink("action.yml", action_dir.join("action.yml")).expect("symlink loop");
+
+    let Err(error) = find_outdated_with_runner(root.path(), false, None, &FakeGitRunner).await
+    else {
+        panic!("local action lookup must fail");
+    };
+
+    assert!(error.to_string().contains("Failed to read"));
+    assert!(error.to_string().contains("action.yml"));
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -57,6 +57,25 @@ impl GitCommandRunner for FakeGitRunner {
     }
 }
 
+struct PreOneGitRunner;
+
+impl GitCommandRunner for PreOneGitRunner {
+    fn ls_remote<'a>(
+        &'a self,
+        _repo: &'a str,
+        _ref_: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<String, GitRunError>> + Send + 'a>> {
+        Box::pin(async {
+            Ok(concat!(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v0.5.7\n",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/v0.5.9\n",
+                "cccccccccccccccccccccccccccccccccccccccc\trefs/tags/v0.6.0\n",
+            )
+            .to_string())
+        })
+    }
+}
+
 #[test]
 fn distinguishes_action_selectors_from_package_selectors() {
     assert_eq!(
@@ -136,7 +155,7 @@ async fn updates_workflow_files_without_reformatting_them() {
 }
 
 #[tokio::test]
-async fn compatible_outdated_uses_the_current_major() {
+async fn compatible_outdated_stays_on_the_current_compatibility_line() {
     let root = tempfile::tempdir().expect("temp directory");
     let workflows = root.path().join(".github/workflows");
     fs::create_dir_all(&workflows).expect("workflow directory");
@@ -157,6 +176,37 @@ async fn compatible_outdated_uses_the_current_major() {
 
     assert_eq!(default[0].latest, Version::parse("5.0.0").unwrap());
     assert_eq!(compatible[0].latest, Version::parse("4.2.0").unwrap());
+}
+
+#[tokio::test]
+async fn keeps_pre_one_updates_caret_compatible_unless_latest_is_requested() {
+    let root = tempfile::tempdir().expect("temp directory");
+    let workflows = root.path().join(".github/workflows");
+    fs::create_dir_all(&workflows).expect("workflow directory");
+    let workflow = workflows.join("ci.yml");
+    fs::write(&workflow, "jobs:\n  test:\n    steps:\n      - uses: owner/tool@v0.5.7\n")
+        .expect("workflow");
+
+    let compatible = find_outdated_with_runner(root.path(), true, None, &PreOneGitRunner)
+        .await
+        .expect("compatible outdated");
+    assert_eq!(compatible[0].latest, Version::parse("0.5.9").unwrap());
+
+    update_with_runner(root.path(), false, None, &PreOneGitRunner)
+        .await
+        .expect("compatible update");
+    assert!(
+        fs::read_to_string(&workflow)
+            .expect("updated workflow")
+            .contains("uses: owner/tool@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # v0.5.9"),
+    );
+
+    update_with_runner(root.path(), true, None, &PreOneGitRunner).await.expect("latest update");
+    assert!(
+        fs::read_to_string(&workflow)
+            .expect("updated workflow")
+            .contains("uses: owner/tool@cccccccccccccccccccccccccccccccccccccccc # v0.6.0"),
+    );
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -1,0 +1,113 @@
+use super::{
+    ActionReference, RepoVersion, find_current, is_selector, parse_repo_versions,
+    render_target_ref, render_target_value, split_uses_value, update_with_runner,
+};
+use node_semver::Version;
+use pacquet_resolving_git_resolver::{GitCommandRunner, GitRunError};
+use std::{fs, future::Future, path::PathBuf, pin::Pin};
+
+const SHA_V4_1_0: &str = "1111111111111111111111111111111111111111";
+const SHA_V4_2_0: &str = "2222222222222222222222222222222222222222";
+const SHA_V5_0_0: &str = "3333333333333333333333333333333333333333";
+
+fn repo_versions() -> Vec<RepoVersion> {
+    parse_repo_versions(&format!(
+        "{SHA_V4_1_0}\trefs/tags/v4.1.0\n{SHA_V4_2_0}\trefs/tags/v4.2.0\n{SHA_V5_0_0}\trefs/tags/v5.0.0\n",
+    ))
+}
+
+fn action(original_value: &str) -> ActionReference {
+    let (value, comment) = split_uses_value(original_value);
+    let (name, ref_) = value.rsplit_once('@').expect("action reference");
+    ActionReference {
+        comment_version: comment
+            .and_then(|comment| comment.split_whitespace().next())
+            .map(str::to_string),
+        file: PathBuf::from("workflow.yml"),
+        name: name.to_string(),
+        original_value: original_value.to_string(),
+        range: 0..original_value.len(),
+        ref_: ref_.to_string(),
+        repo: "actions/checkout".to_string(),
+    }
+}
+
+struct FakeGitRunner;
+
+impl GitCommandRunner for FakeGitRunner {
+    fn ls_remote<'a>(
+        &'a self,
+        _repo: &'a str,
+        _ref_: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<String, GitRunError>> + Send + 'a>> {
+        Box::pin(async {
+            Ok(format!(
+                "{SHA_V4_1_0}\trefs/tags/v4.1.0\n{SHA_V4_2_0}\trefs/tags/v4.2.0\n{SHA_V5_0_0}\trefs/tags/v5.0.0\n",
+            ))
+        })
+    }
+}
+
+#[test]
+fn distinguishes_action_selectors_from_package_selectors() {
+    assert_eq!(
+        [
+            is_selector("actions/checkout"),
+            is_selector("@scope/package"),
+            is_selector("!@scope/package"),
+            is_selector("typescript"),
+        ],
+        [true, false, false, false],
+    );
+}
+
+#[test]
+fn parses_annotated_semver_tags() {
+    let versions = parse_repo_versions(&format!(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v4.2.0\n{SHA_V4_2_0}\trefs/tags/v4.2.0^{{}}\nnot-a-version\trefs/tags/latest\n",
+    ));
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].commit, SHA_V4_2_0);
+    assert_eq!(versions[0].tag, "v4.2.0");
+}
+
+#[test]
+fn preserves_quoting_and_updates_sha_comment() {
+    let action = action(&format!("'actions/checkout@{SHA_V4_1_0}' # v4.1.0 keep pinned"));
+    let target = &repo_versions()[1];
+    assert_eq!(
+        render_target_value(&action, target),
+        format!("'actions/checkout@{SHA_V4_2_0}' # v4.2.0 keep pinned"),
+    );
+}
+
+#[test]
+fn floating_major_resolves_to_an_exact_commit() {
+    let action = action("actions/checkout@v4");
+    let versions = repo_versions();
+    let current = find_current(&action, &versions).expect("current version");
+    assert_eq!(current.version, Version::parse("4.2.0").unwrap());
+    assert_eq!(render_target_ref(&versions[1]), SHA_V4_2_0);
+    assert_eq!(render_target_ref(&versions[2]), SHA_V5_0_0);
+}
+
+#[tokio::test]
+async fn updates_workflow_files_without_reformatting_them() {
+    let root = tempfile::tempdir().expect("temp directory");
+    let workflows = root.path().join(".github/workflows");
+    fs::create_dir_all(&workflows).expect("workflow directory");
+    let workflow = workflows.join("ci.yml");
+    let source = format!(
+        "name: CI\njobs:\n  test:\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - uses: 'actions/checkout@{SHA_V4_1_0}' # v4.1.0 keep pinned\n      - uses: actions/checkout@v4\n",
+    );
+    fs::write(&workflow, &source).expect("workflow");
+
+    update_with_runner(root.path(), false, None, &FakeGitRunner).await.expect("update actions");
+
+    assert_eq!(
+        fs::read_to_string(workflow).expect("updated workflow"),
+        format!(
+            "name: CI\njobs:\n  test:\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - uses: 'actions/checkout@{SHA_V4_2_0}' # v4.2.0 keep pinned\n      - uses: actions/checkout@{SHA_V4_2_0} # v4.2.0\n",
+        ),
+    );
+}

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     ActionReference, RepoVersion, find_current, find_outdated_with_runner, is_selector,
-    render_target_ref, render_target_value, repo_versions as versions_from_refs, split_uses_value,
-    update_with_runner,
+    normalize_selector, render_target_ref, render_target_value,
+    repo_versions as versions_from_refs, selector_matcher, split_uses_value, update_with_runner,
 };
 use node_semver::Version;
 use pacquet_resolving_git_resolver::{GitCommandRunner, GitRunError};
@@ -86,6 +86,18 @@ fn distinguishes_action_selectors_from_package_selectors() {
             is_selector("typescript"),
         ],
         [true, false, false, false],
+    );
+}
+
+#[test]
+fn normalizes_ref_qualified_action_selectors() {
+    assert_eq!(normalize_selector("actions/checkout@v4"), "actions/checkout");
+    assert_eq!(normalize_selector("!actions/checkout@v4"), "!actions/checkout");
+    assert_eq!(normalize_selector("@scope/package"), "@scope/package");
+    assert!(
+        selector_matcher(&["actions/checkout@v4".to_string()])
+            .expect("selector matcher")
+            .matches("actions/checkout"),
     );
 }
 

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -25,6 +25,8 @@ fn action(original_value: &str) -> ActionReference {
             .and_then(|comment| comment.split_whitespace().next())
             .map(str::to_string),
         file: PathBuf::from("workflow.yml"),
+        flow_style: false,
+        indentation: String::new(),
         name: name.to_string(),
         original_value: original_value.to_string(),
         range: 0..original_value.len(),
@@ -99,7 +101,7 @@ async fn updates_workflow_files_without_reformatting_them() {
     fs::create_dir_all(&workflows).expect("workflow directory");
     let workflow = workflows.join("ci.yml");
     let source = format!(
-        "name: CI\n\njobs:\n  test:\n    strategy: {{ matrix: {{ node: [22, 24] }} }}\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - name: nested input\n        with:\n          uses: actions/checkout@v4\n      - uses: 'actions/checkout@{SHA_V4_1_0}' # v4.1.0 keep pinned\n      - uses: actions/checkout@v4\n",
+        "name: CI\n\njobs:\n  test:\n    strategy: {{ matrix: {{ node: [22, 24] }} }}\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - name: nested input\n        with:\n          uses: actions/checkout@v4\n      - uses: 'actions/checkout@{SHA_V4_1_0}' # v4.1.0 keep pinned\n      - uses: actions/checkout@v4\n  flow:\n    steps: [{{ uses: actions/checkout@v4 }}]\n",
     );
     fs::write(&workflow, &source).expect("workflow");
 
@@ -108,7 +110,7 @@ async fn updates_workflow_files_without_reformatting_them() {
     assert_eq!(
         fs::read_to_string(workflow).expect("updated workflow"),
         format!(
-            "name: CI\n\njobs:\n  test:\n    strategy: {{ matrix: {{ node: [22, 24] }} }}\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - name: nested input\n        with:\n          uses: actions/checkout@v4\n      - uses: 'actions/checkout@{SHA_V4_2_0}' # v4.2.0 keep pinned\n      - uses: actions/checkout@{SHA_V4_2_0} # v4.2.0\n",
+            "name: CI\n\njobs:\n  test:\n    strategy: {{ matrix: {{ node: [22, 24] }} }}\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - name: nested input\n        with:\n          uses: actions/checkout@v4\n      - uses: 'actions/checkout@{SHA_V4_2_0}' # v4.2.0 keep pinned\n      - uses: actions/checkout@{SHA_V4_2_0} # v4.2.0\n  flow:\n    steps: [{{ uses: actions/checkout@{SHA_V4_2_0} # v4.2.0\n                    }}]\n",
         ),
     );
 }

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -169,3 +169,24 @@ async fn rejects_workflow_symlinks_outside_the_project() {
     assert!(error.to_string().contains("outside the project root"));
     assert_eq!(fs::read_to_string(outside.path().join("ci.yml")).unwrap(), original);
 }
+
+#[tokio::test]
+async fn does_not_mutate_an_external_hardlink_target() {
+    let root = tempfile::tempdir().expect("project directory");
+    let outside = tempfile::tempdir().expect("outside directory");
+    let original = "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v4\n";
+    let outside_workflow = outside.path().join("ci.yml");
+    let workflow = root.path().join(".github/workflows/ci.yml");
+    fs::write(&outside_workflow, original).expect("outside workflow");
+    fs::create_dir_all(workflow.parent().unwrap()).expect("workflow directory");
+    fs::hard_link(&outside_workflow, &workflow).expect("workflow hardlink");
+
+    update_with_runner(root.path(), false, None, &FakeGitRunner).await.expect("update actions");
+
+    assert!(
+        fs::read_to_string(&workflow)
+            .expect("updated workflow")
+            .contains(&format!("uses: actions/checkout@{SHA_V4_2_0} # v4.2.0")),
+    );
+    assert_eq!(fs::read_to_string(outside_workflow).unwrap(), original);
+}

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -94,6 +94,17 @@ fn floating_major_resolves_to_an_exact_commit() {
     assert_eq!(render_target_ref(&versions[2]), SHA_V5_0_0);
 }
 
+#[test]
+fn resolves_prerelease_tags_containing_dots() {
+    let versions = parse_repo_versions(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\trefs/tags/v5.0.0-alpha.1\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\trefs/tags/v5.0.0-alpha.2\n",
+    );
+    let current = find_current(&action("actions/checkout@v5.0.0-alpha.1"), &versions)
+        .expect("prerelease version");
+
+    assert_eq!(current.version, Version::parse("5.0.0-alpha.1").unwrap());
+}
+
 #[tokio::test]
 async fn updates_workflow_files_without_reformatting_them() {
     let root = tempfile::tempdir().expect("temp directory");
@@ -137,4 +148,24 @@ async fn compatible_outdated_uses_the_current_major() {
 
     assert_eq!(default[0].latest, Version::parse("5.0.0").unwrap());
     assert_eq!(compatible[0].latest, Version::parse("4.2.0").unwrap());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn rejects_workflow_symlinks_outside_the_project() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().expect("project directory");
+    let outside = tempfile::tempdir().expect("outside directory");
+    let original = "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v4\n";
+    fs::write(outside.path().join("ci.yml"), original).expect("outside workflow");
+    fs::create_dir_all(root.path().join(".github")).expect("GitHub directory");
+    symlink(outside.path(), root.path().join(".github/workflows")).expect("workflow symlink");
+
+    let Err(error) = update_with_runner(root.path(), false, None, &FakeGitRunner).await else {
+        panic!("outside workflow must be rejected");
+    };
+
+    assert!(error.to_string().contains("outside the project root"));
+    assert_eq!(fs::read_to_string(outside.path().join("ci.yml")).unwrap(), original);
 }

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    ActionReference, RepoVersion, find_current, is_selector, parse_repo_versions,
-    render_target_ref, render_target_value, split_uses_value, update_with_runner,
+    ActionReference, RepoVersion, find_current, find_outdated_with_runner, is_selector,
+    parse_repo_versions, render_target_ref, render_target_value, split_uses_value,
+    update_with_runner,
 };
 use node_semver::Version;
 use pacquet_resolving_git_resolver::{GitCommandRunner, GitRunError};
@@ -110,4 +111,28 @@ async fn updates_workflow_files_without_reformatting_them() {
             "name: CI\n\njobs:\n  test:\n    strategy: {{ matrix: {{ node: [22, 24] }} }}\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - name: nested input\n        with:\n          uses: actions/checkout@v4\n      - uses: 'actions/checkout@{SHA_V4_2_0}' # v4.2.0 keep pinned\n      - uses: actions/checkout@{SHA_V4_2_0} # v4.2.0\n",
         ),
     );
+}
+
+#[tokio::test]
+async fn compatible_outdated_uses_the_current_major() {
+    let root = tempfile::tempdir().expect("temp directory");
+    let workflows = root.path().join(".github/workflows");
+    fs::create_dir_all(&workflows).expect("workflow directory");
+    fs::write(
+        workflows.join("ci.yml"),
+        format!(
+            "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@{SHA_V4_1_0} # v4.1.0\n",
+        ),
+    )
+    .expect("workflow");
+
+    let default = find_outdated_with_runner(root.path(), false, None, &FakeGitRunner)
+        .await
+        .expect("default outdated");
+    let compatible = find_outdated_with_runner(root.path(), true, None, &FakeGitRunner)
+        .await
+        .expect("compatible outdated");
+
+    assert_eq!(default[0].latest, Version::parse("5.0.0").unwrap());
+    assert_eq!(compatible[0].latest, Version::parse("4.2.0").unwrap());
 }

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -98,7 +98,7 @@ async fn updates_workflow_files_without_reformatting_them() {
     fs::create_dir_all(&workflows).expect("workflow directory");
     let workflow = workflows.join("ci.yml");
     let source = format!(
-        "name: CI\njobs:\n  test:\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - uses: 'actions/checkout@{SHA_V4_1_0}' # v4.1.0 keep pinned\n      - uses: actions/checkout@v4\n",
+        "name: CI\n\njobs:\n  test:\n    strategy: {{ matrix: {{ node: [22, 24] }} }}\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - name: nested input\n        with:\n          uses: actions/checkout@v4\n      - uses: 'actions/checkout@{SHA_V4_1_0}' # v4.1.0 keep pinned\n      - uses: actions/checkout@v4\n",
     );
     fs::write(&workflow, &source).expect("workflow");
 
@@ -107,7 +107,7 @@ async fn updates_workflow_files_without_reformatting_them() {
     assert_eq!(
         fs::read_to_string(workflow).expect("updated workflow"),
         format!(
-            "name: CI\njobs:\n  test:\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - uses: 'actions/checkout@{SHA_V4_2_0}' # v4.2.0 keep pinned\n      - uses: actions/checkout@{SHA_V4_2_0} # v4.2.0\n",
+            "name: CI\n\njobs:\n  test:\n    strategy: {{ matrix: {{ node: [22, 24] }} }}\n    steps:\n      - run: |\n          uses: actions/checkout@{SHA_V4_1_0} # not a dependency\n      - name: nested input\n        with:\n          uses: actions/checkout@v4\n      - uses: 'actions/checkout@{SHA_V4_2_0}' # v4.2.0 keep pinned\n      - uses: actions/checkout@{SHA_V4_2_0} # v4.2.0\n",
         ),
     );
 }

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -3,6 +3,7 @@ mod cli_args;
 mod config_deps;
 mod config_overrides;
 mod flag_relocation;
+mod github_actions;
 mod job_control;
 mod shorthands;
 mod state;

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1657,8 +1657,9 @@ pub struct Config {
     pub allowed_deprecated_versions: BTreeMap<String, String>,
 
     /// `updateConfig` from `pnpm-workspace.yaml`: defaults specific to
-    /// `pnpm update`, including changeset generation and dependency-name
-    /// patterns the command skips.
+    /// `pnpm update`, including changeset generation, dependency-name
+    /// patterns the command skips, and whether GitHub Actions should be
+    /// updated.
     pub update_config: workspace_yaml::UpdateConfig,
 
     /// `peerDependencyRules` from `pnpm-workspace.yaml`: customizations

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -521,7 +521,7 @@ pub struct AuditSettings {
 
 /// `update` entry: settings that tune `pnpm update` (and `pnpm
 /// outdated`, which previews it). Supersedes the deprecated
-/// `updateConfig`. Today only `ignore` is modeled.
+/// `updateConfig`.
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct UpdateSettings {
@@ -536,6 +536,11 @@ pub struct UpdateSettings {
     /// `--changeset`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub changeset: Option<bool>,
+
+    /// Whether `pnpm update` should also update GitHub Actions
+    /// dependencies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub github_actions: Option<bool>,
 }
 
 /// `updateConfig` entry: settings that tune `pnpm update`.
@@ -553,6 +558,11 @@ pub struct UpdateConfig {
     /// patterns.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ignore_dependencies: Option<Vec<String>>,
+
+    /// Whether `pnpm update` should also update GitHub Actions
+    /// dependencies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub github_actions: Option<bool>,
 }
 
 /// `peerDependencyRules` entry: customizations applied when reporting
@@ -925,6 +935,7 @@ impl WorkspaceSettings {
             config.update_config = UpdateConfig {
                 ignore_dependencies: update.ignore_deps,
                 changeset: update.changeset,
+                github_actions: update.github_actions,
             };
         }
 

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1519,6 +1519,7 @@ fn parses_update_section_from_yaml_and_applies() {
     let yaml = r#"
 update:
   changeset: true
+  githubActions: true
   ignoreDeps:
     - "@pnpm.e2e/foo"
     - "@pnpm.e2e/bar"
@@ -1534,6 +1535,7 @@ update:
         config.update_config.ignore_dependencies.as_deref(),
         Some(&["@pnpm.e2e/foo".to_string(), "@pnpm.e2e/bar".to_string()][..]),
     );
+    assert_eq!(config.update_config.github_actions, Some(true));
 }
 
 #[test]

--- a/pnpm/crates/resolving-git-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-git-resolver/src/lib.rs
@@ -43,5 +43,7 @@ pub use hosted_git::{HostedGit, HostedGitType, HostedOpts};
 pub use parse_bare_specifier::{
     GitProbe, HostedPackageSpec, PartialSpec, ProbeFuture, parse_bare_specifier,
 };
-pub use resolve_ref::{GitCommandRunner, GitResolveRefError, GitRunError, resolve_ref};
+pub use resolve_ref::{
+    GitCommandRunner, GitResolveRefError, GitRunError, get_repo_refs, resolve_ref,
+};
 pub use runners::{RealGitProbe, RealGitRunner};

--- a/pnpm/crates/resolving-git-resolver/src/resolve_ref.rs
+++ b/pnpm/crates/resolving-git-resolver/src/resolve_ref.rs
@@ -98,13 +98,22 @@ pub async fn resolve_ref<Runner: GitCommandRunner + ?Sized>(
     // ref looks like a committish: there is no single canonical ref
     // name to filter on in those cases.
     let filter = if range.is_some() || committish { None } else { Some(ref_) };
-    let stdout = runner.ls_remote(repo, filter).await.map_err(GitResolveRefError::Runner)?;
-    let refs = parse_ls_remote(&stdout);
+    let refs = get_repo_refs(runner, repo, filter).await.map_err(GitResolveRefError::Runner)?;
     let commit = resolve_ref_from_refs(&refs, repo, ref_, committish, range)?;
     if committish && !commit.starts_with(ref_) {
         return Err(GitResolveRefError::AmbiguousRef { ref_: ref_.to_string(), commit });
     }
     Ok(commit)
+}
+
+/// Read all matching refs from a git repository.
+pub async fn get_repo_refs<Runner: GitCommandRunner + ?Sized>(
+    runner: &Runner,
+    repo: &str,
+    ref_: Option<&str>,
+) -> Result<HashMap<String, String>, GitRunError> {
+    let stdout = runner.ls_remote(repo, ref_).await?;
+    Ok(parse_ls_remote(&stdout))
 }
 
 /// `true` when `ref` is a 7-40-character lowercase hex string.

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -104,6 +104,10 @@ function translateUpdateSettings (pnpmSettings: PnpmSettings, settings: OptionsF
     assertBoolean(update.changeset, 'update.changeset')
     updateConfig.changeset = update.changeset
   }
+  if (update.githubActions != null) {
+    assertBoolean(update.githubActions, 'update.githubActions')
+    updateConfig.githubActions = update.githubActions
+  }
   settings.updateConfig = updateConfig
 }
 

--- a/pnpm11/config/reader/test/updateSettings.test.ts
+++ b/pnpm11/config/reader/test/updateSettings.test.ts
@@ -14,10 +14,12 @@ beforeEach(() => {
 test('getOptionsFromPnpmSettings() maps the "update" settings section to updateConfig', () => {
   const options = getOptionsFromPnpmSettings(process.cwd(), {
     update: {
+      githubActions: true,
       ignoreDeps: ['webpack', '@babel/*'],
     },
   })
   expect(options.updateConfig).toStrictEqual({
+    githubActions: true,
     ignoreDependencies: ['webpack', '@babel/*'],
   })
   expect(globalWarn).not.toHaveBeenCalled()
@@ -59,6 +61,14 @@ test('getOptionsFromPnpmSettings() accepts an empty "update" section', () => {
   })
   expect(options.updateConfig).toStrictEqual({})
   expect('update' in options).toBe(false)
+})
+
+test('getOptionsFromPnpmSettings() validates update.githubActions', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    update: {
+      githubActions: 'yes',
+    },
+  } as any)).toThrow('The "update.githubActions" setting should be a boolean, but got string') // eslint-disable-line
 })
 
 test('getOptionsFromPnpmSettings() lets "update" win over "updateConfig" and warns', () => {

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -207,6 +207,10 @@ export interface UpdateSettings {
    * as if `pnpm update` were run with `--changeset`.
    */
   changeset?: boolean
+  /**
+   * Whether `pnpm update` should also update GitHub Actions dependencies.
+   */
+  githubActions?: boolean
 }
 
 export interface PnpmSettings {
@@ -230,6 +234,7 @@ export interface PnpmSettings {
   updateConfig?: {
     changeset?: boolean
     ignoreDependencies?: string[]
+    githubActions?: boolean
   }
   audit?: AuditSettings
   /**

--- a/pnpm11/deps/github-actions/README.md
+++ b/pnpm11/deps/github-actions/README.md
@@ -1,0 +1,42 @@
+# @pnpm/deps.github-actions
+
+> Discover and update GitHub Actions dependencies
+
+[![npm version](https://img.shields.io/npm/v/@pnpm/deps.github-actions.svg)](https://npmx.dev/package/@pnpm/deps.github-actions)
+
+## Installation
+
+```sh
+pnpm add @pnpm/deps.github-actions
+```
+
+## Usage
+
+```ts
+import {
+  findOutdatedGitHubActions,
+  updateGitHubActions,
+} from '@pnpm/deps.github-actions'
+
+const outdated = await findOutdatedGitHubActions({
+  dir: process.cwd(),
+})
+
+await updateGitHubActions({
+  dir: process.cwd(),
+})
+```
+
+The package scans workflow files in `.github/workflows` and follows referenced local reusable workflows and composite actions. Only `uses` fields in jobs and steps are treated as dependencies.
+
+Updates are always pinned to an exact commit SHA. The corresponding semantic version tag is written in a comment:
+
+```yaml
+- uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+```
+
+By default, `updateGitHubActions` selects the newest release in the current major version. Set `latest: true` to allow major-version updates. `findOutdatedGitHubActions` reports the newest release by default; set `compatible: true` to report only updates in the current major version.
+
+## License
+
+MIT

--- a/pnpm11/deps/github-actions/README.md
+++ b/pnpm11/deps/github-actions/README.md
@@ -35,7 +35,7 @@ Updates are always pinned to an exact commit SHA. The corresponding semantic ver
 - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 ```
 
-By default, `updateGitHubActions` selects the newest release in the current major version. Set `latest: true` to allow major-version updates. `findOutdatedGitHubActions` reports the newest release by default; set `compatible: true` to report only updates in the current major version.
+By default, `updateGitHubActions` selects the newest caret-compatible release. This keeps `0.5.x` releases below `0.6.0`, since pre-1.0 minor releases may contain breaking changes. Set `latest: true` to allow incompatible updates. `findOutdatedGitHubActions` reports the newest release by default; set `compatible: true` to report only caret-compatible updates.
 
 ## License
 

--- a/pnpm11/deps/github-actions/package.json
+++ b/pnpm11/deps/github-actions/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@pnpm/error": "workspace:*",
     "@pnpm/resolving.git-resolver": "workspace:*",
+    "is-subdir": "catalog:",
     "p-limit": "catalog:",
     "semver": "catalog:",
     "write-file-atomic": "catalog:",

--- a/pnpm11/deps/github-actions/package.json
+++ b/pnpm11/deps/github-actions/package.json
@@ -36,12 +36,14 @@
     "@pnpm/resolving.git-resolver": "workspace:*",
     "p-limit": "catalog:",
     "semver": "catalog:",
+    "write-file-atomic": "catalog:",
     "yaml": "catalog:"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
     "@pnpm/deps.github-actions": "workspace:*",
-    "@types/semver": "catalog:"
+    "@types/semver": "catalog:",
+    "@types/write-file-atomic": "catalog:"
   },
   "engines": {
     "node": ">=22.13"

--- a/pnpm11/deps/github-actions/package.json
+++ b/pnpm11/deps/github-actions/package.json
@@ -32,7 +32,9 @@
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
+    "@pnpm/error": "workspace:*",
     "@pnpm/resolving.git-resolver": "workspace:*",
+    "p-limit": "catalog:",
     "semver": "catalog:",
     "yaml": "catalog:"
   },

--- a/pnpm11/deps/github-actions/package.json
+++ b/pnpm11/deps/github-actions/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@pnpm/deps.github-actions",
+  "version": "1100.0.0",
+  "description": "Discover and update GitHub Actions dependencies",
+  "keywords": [
+    "pnpm",
+    "pnpm11",
+    "github-actions"
+  ],
+  "license": "MIT",
+  "funding": "https://opencollective.com/pnpm",
+  "repository": "https://github.com/pnpm/pnpm/tree/main/pnpm11/deps/github-actions",
+  "homepage": "https://github.com/pnpm/pnpm/tree/main/pnpm11/deps/github-actions#readme",
+  "bugs": {
+    "url": "https://github.com/pnpm/pnpm/issues"
+  },
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "exports": {
+    ".": "./lib/index.js"
+  },
+  "files": [
+    "lib",
+    "!*.map"
+  ],
+  "scripts": {
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "test": "pn compile && pn .test",
+    "prepublishOnly": "tsgo --build",
+    "compile": "tsgo --build && pn lint --fix",
+    ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
+  },
+  "dependencies": {
+    "@pnpm/resolving.git-resolver": "workspace:*",
+    "semver": "catalog:",
+    "yaml": "catalog:"
+  },
+  "devDependencies": {
+    "@jest/globals": "catalog:",
+    "@pnpm/deps.github-actions": "workspace:*",
+    "@types/semver": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.13"
+  },
+  "jest": {
+    "preset": "@pnpm/jest-config"
+  }
+}

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -6,6 +6,7 @@ import { PnpmError } from '@pnpm/error'
 import { getRepoRefs } from '@pnpm/resolving.git-resolver'
 import pLimit from 'p-limit'
 import semver from 'semver'
+import writeFileAtomic from 'write-file-atomic'
 import YAML, { isMap, isNode, isScalar, isSeq, type Node, type Scalar } from 'yaml'
 
 export interface OutdatedGitHubAction {
@@ -110,7 +111,7 @@ export async function updateGitHubActions (
       source = source.slice(0, replacement.range[0]) + replacement.value + source.slice(replacement.range[1])
     }
     try {
-      await fs.writeFile(file.path, source)
+      await writeFileAtomic(file.path, source)
     } catch (err: unknown) {
       throw workflowError('WRITE', file.path, err)
     }

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -2,7 +2,9 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import util from 'node:util'
 
+import { PnpmError } from '@pnpm/error'
 import { getRepoRefs } from '@pnpm/resolving.git-resolver'
+import pLimit from 'p-limit'
 import semver from 'semver'
 import YAML, { isMap, isNode, isScalar, isSeq, type Node, type Scalar } from 'yaml'
 
@@ -57,6 +59,7 @@ interface PlannedUpdate {
 }
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/
+const limitRepoReads = pLimit(8)
 
 export function isGitHubActionSelector (selector: string): boolean {
   const pattern = selector.startsWith('!') ? selector.slice(1) : selector
@@ -104,7 +107,11 @@ export async function updateGitHubActions (
     for (const replacement of replacements) {
       source = source.slice(0, replacement.range[0]) + replacement.value + source.slice(replacement.range[1])
     }
-    await fs.writeFile(file.path, source)
+    try {
+      await fs.writeFile(file.path, source)
+    } catch (err: unknown) {
+      throw workflowError('WRITE', file.path, err)
+    }
   }))
   return dedupeOutdated(updates.map((plan) => {
     const target = opts.latest ? plan.latest : plan.wanted
@@ -126,7 +133,7 @@ async function createUpdatePlan (opts: GitHubActionsOptions): Promise<PlannedUpd
   return (await Promise.all(selected.map(async (action): Promise<PlannedUpdate | null> => {
     let versionsPromise = refsByRepo.get(action.repo)
     if (versionsPromise == null) {
-      versionsPromise = readRepoRefs(action.repo).then(parseRepoVersions)
+      versionsPromise = limitRepoReads(() => readRepoRefs(action.repo).then(parseRepoVersions))
       refsByRepo.set(action.repo, versionsPromise)
     }
     const versions = await versionsPromise
@@ -148,7 +155,7 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
     entries = await fs.readdir(workflowDir)
   } catch (err: unknown) {
     if (isErrorCode(err, 'ENOENT')) return []
-    throw err
+    throw workflowError('READ', workflowDir, err)
   }
   const workflowFiles = entries
     .filter((entry) => entry.endsWith('.yml') || entry.endsWith('.yaml'))
@@ -161,9 +168,14 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
   async function scanFile (filePath: string): Promise<void> {
     if (visited.has(filePath)) return
     visited.add(filePath)
-    const source = await fs.readFile(filePath, 'utf8')
+    let source: string
+    try {
+      source = await fs.readFile(filePath, 'utf8')
+    } catch (err: unknown) {
+      throw workflowError('READ', filePath, err)
+    }
     const document = YAML.parseDocument(source)
-    if (document.errors.length > 0) throw document.errors[0]
+    if (document.errors.length > 0) throw workflowError('PARSE', filePath, document.errors[0])
     const file = { path: filePath, source }
     const localReferences: string[] = []
     for (const node of findUsesScalars(document.contents)) {
@@ -235,7 +247,13 @@ async function resolveLocalReference (rootDir: string, reference: string): Promi
     : (await Promise.all(['action.yml', 'action.yaml'].map(async (filename) => existingPath(path.join(target, filename)))))
       .find((candidate): candidate is string => candidate != null) ?? null
   if (candidate == null) return null
-  const [realRoot, realCandidate] = await Promise.all([fs.realpath(rootDir), fs.realpath(candidate)])
+  let realRoot: string
+  let realCandidate: string
+  try {
+    [realRoot, realCandidate] = await Promise.all([fs.realpath(rootDir), fs.realpath(candidate)])
+  } catch (err: unknown) {
+    throw workflowError('READ', candidate, err)
+  }
   const relative = path.relative(realRoot, realCandidate)
   return relative === '' || (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
     ? realCandidate
@@ -247,7 +265,7 @@ async function existingPath (candidate: string): Promise<string | null> {
     await fs.access(candidate)
     return candidate
   } catch (err: unknown) {
-    if (!isErrorCode(err, 'ENOENT')) throw err
+    if (!isErrorCode(err, 'ENOENT')) throw workflowError('READ', candidate, err)
     return null
   }
 }
@@ -327,6 +345,11 @@ function dedupeOutdated (actions: OutdatedGitHubAction[]): OutdatedGitHubAction[
 
 async function readRefsWithGit (repo: string): Promise<Record<string, string>> {
   return getRepoRefs(`https://github.com/${repo}.git`, null)
+}
+
+function workflowError (operation: 'PARSE' | 'READ' | 'WRITE', filePath: string, cause: unknown): PnpmError {
+  const detail = util.types.isNativeError(cause) ? cause.message : String(cause)
+  return new PnpmError(`GITHUB_ACTIONS_WORKFLOW_${operation}`, `Failed to ${operation.toLowerCase()} GitHub Actions workflow ${filePath}: ${detail}`, { cause })
 }
 
 function isErrorCode (err: unknown, code: string): err is NodeJS.ErrnoException {

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -33,6 +33,8 @@ export interface UpdateGitHubActionsOptions extends GitHubActionsOptions {
 interface ActionReference {
   commentVersion?: string
   file: ActionFile
+  flowStyle: boolean
+  indentation: string
   name: string
   originalValue: string
   range: readonly [number, number]
@@ -192,6 +194,8 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
         ...parsed,
         commentVersion: getCommentVersion(node),
         file,
+        flowStyle: isFlowStyle(source, node.range[1]),
+        indentation: getIndentation(source, node.range[0]),
         originalValue: source.slice(node.range[0], end),
         range: [node.range[0], end],
       })
@@ -329,8 +333,23 @@ function renderTargetValue (action: ActionReference, target: RepoVersion): strin
   let value = action.originalValue.replace(oldReference, newReference)
   if (action.commentVersion != null) return value.replace(action.commentVersion, target.tag)
   const comment = value.indexOf(' #')
-  if (comment === -1) return `${value} # ${target.tag}`
+  if (comment === -1) {
+    return action.flowStyle
+      ? `${value.trimEnd()} # ${target.tag}\n${action.indentation}`
+      : `${value} # ${target.tag}`
+  }
   return `${value.slice(0, comment + 2)}${target.tag} ${value.slice(comment + 2).trimStart()}`
+}
+
+function isFlowStyle (source: string, end: number): boolean {
+  const lineEnd = source.indexOf('\n', end)
+  const following = source.slice(end, lineEnd === -1 ? source.length : lineEnd).trimStart()
+  return following.startsWith('}') || following.startsWith(']') || following.startsWith(',')
+}
+
+function getIndentation (source: string, start: number): string {
+  const lineStart = source.lastIndexOf('\n', start - 1) + 1
+  return ' '.repeat(start - lineStart)
 }
 
 function trimLineBreak (source: string, end: number): number {

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -4,7 +4,7 @@ import util from 'node:util'
 
 import { getRepoRefs } from '@pnpm/resolving.git-resolver'
 import semver from 'semver'
-import YAML, { type Document, isMap, isNode, isScalar, isSeq, type Node, type Scalar } from 'yaml'
+import YAML, { isMap, isNode, isScalar, isSeq, type Node, type Scalar } from 'yaml'
 
 export interface OutdatedGitHubAction {
   current: string
@@ -32,14 +32,15 @@ interface ActionReference {
   commentVersion?: string
   file: ActionFile
   name: string
-  node: Scalar<string>
+  originalValue: string
+  range: readonly [number, number]
   ref: string
   repo: string
 }
 
 interface ActionFile {
-  document: Document
   path: string
+  source: string
 }
 
 interface RepoVersion {
@@ -87,14 +88,24 @@ export async function updateGitHubActions (
     return semver.lte(plan.current.version, target.version) &&
       (plan.action.ref !== target.commit || plan.action.commentVersion !== target.tag)
   })
-  const changedFiles = new Set<ActionFile>()
+  const edits = new Map<ActionFile, Array<{ range: readonly [number, number], value: string }>>()
   for (const plan of updates) {
     const target = opts.latest ? plan.latest : plan.wanted
-    plan.action.node.value = `${plan.action.name}@${renderTargetRef(target)}`
-    updateVersionComment(plan.action.node, plan.action.commentVersion, target)
-    changedFiles.add(plan.action.file)
+    const replacements = edits.get(plan.action.file) ?? []
+    replacements.push({
+      range: plan.action.range,
+      value: renderTargetValue(plan.action, target),
+    })
+    edits.set(plan.action.file, replacements)
   }
-  await Promise.all([...changedFiles].map(async (file) => fs.writeFile(file.path, file.document.toString())))
+  await Promise.all([...edits].map(async ([file, replacements]) => {
+    let source = file.source
+    replacements.sort((left, right) => right.range[0] - left.range[0])
+    for (const replacement of replacements) {
+      source = source.slice(0, replacement.range[0]) + replacement.value + source.slice(replacement.range[1])
+    }
+    await fs.writeFile(file.path, source)
+  }))
   return dedupeOutdated(updates.map((plan) => {
     const target = opts.latest ? plan.latest : plan.wanted
     return {
@@ -151,10 +162,11 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
     if (visited.has(filePath)) return
     visited.add(filePath)
     const source = await fs.readFile(filePath, 'utf8')
-    const file = { document: YAML.parseDocument(source), path: filePath }
-    if (file.document.errors.length > 0) throw file.document.errors[0]
+    const document = YAML.parseDocument(source)
+    if (document.errors.length > 0) throw document.errors[0]
+    const file = { path: filePath, source }
     const localReferences: string[] = []
-    for (const node of findUsesScalars(file.document.contents)) {
+    for (const node of findUsesScalars(document.contents)) {
       const value = node.value
       if (value.startsWith('./')) {
         localReferences.push(value)
@@ -162,11 +174,14 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
       }
       const parsed = parseActionReference(value)
       if (parsed == null) continue
+      if (node.range == null) throw new Error(`Missing source range for GitHub Action in ${filePath}`)
+      const end = trimLineBreak(source, node.range[2] ?? node.range[1])
       actions.push({
         ...parsed,
         commentVersion: getCommentVersion(node),
         file,
-        node,
+        originalValue: source.slice(node.range[0], end),
+        range: [node.range[0], end],
       })
     }
     const localFiles = await Promise.all(localReferences.map(async (reference) => resolveLocalReference(dir, reference)))
@@ -175,22 +190,42 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
 }
 
 function findUsesScalars (node: Node | null | undefined): Array<Scalar<string>> {
-  if (node == null) return []
-  if (isMap(node)) {
-    const found: Array<Scalar<string>> = []
-    for (const pair of node.items) {
-      if (isScalar(pair.key) && pair.key.value === 'uses' && isScalar(pair.value) && typeof pair.value.value === 'string') {
-        found.push(pair.value as Scalar<string>)
-      } else if (isNode(pair.value)) {
-        found.push(...findUsesScalars(pair.value))
-      }
+  if (!isMap(node)) return []
+  const found: Array<Scalar<string>> = []
+  const jobs = findMapValue(node, 'jobs')
+  if (isMap(jobs)) {
+    for (const job of jobs.items) {
+      if (!isMap(job.value)) continue
+      const jobUses = findStringScalar(job.value, 'uses')
+      if (jobUses != null) found.push(jobUses)
+      found.push(...findStepUses(findMapValue(job.value, 'steps')))
     }
-    return found
   }
-  if (isSeq(node)) {
-    return node.items.flatMap((item) => isNode(item) ? findUsesScalars(item) : [])
+  const runs = findMapValue(node, 'runs')
+  if (isMap(runs)) {
+    found.push(...findStepUses(findMapValue(runs, 'steps')))
   }
-  return []
+  return found
+}
+
+function findStepUses (node: Node | null): Array<Scalar<string>> {
+  if (!isSeq(node)) return []
+  return node.items.flatMap((item) => {
+    if (!isMap(item)) return []
+    const uses = findStringScalar(item, 'uses')
+    return uses == null ? [] : [uses]
+  })
+}
+
+function findMapValue (node: Node, key: string): Node | null {
+  if (!isMap(node)) return null
+  const value = node.items.find((pair) => isScalar(pair.key) && pair.key.value === key)?.value
+  return isNode(value) ? value : null
+}
+
+function findStringScalar (node: Node, key: string): Scalar<string> | null {
+  const value = findMapValue(node, key)
+  return isScalar(value) && typeof value.value === 'string' ? value as Scalar<string> : null
 }
 
 async function resolveLocalReference (rootDir: string, reference: string): Promise<string | null> {
@@ -265,21 +300,24 @@ function findCurrentVersion (action: ActionReference, versions: RepoVersion[]): 
   return null
 }
 
-function renderTargetRef (target: RepoVersion): string {
-  return target.commit
-}
-
 function getCommentVersion (node: Scalar<string>): string | undefined {
   const candidate = node.comment?.trimStart().split(/\s/, 1)[0]
   return candidate != null && semver.valid(candidate, { loose: true }) != null ? candidate : undefined
 }
 
-function updateVersionComment (node: Scalar<string>, previousVersion: string | undefined, target: RepoVersion): void {
-  if (previousVersion != null && node.comment != null) {
-    node.comment = node.comment.replace(previousVersion, target.tag)
-  } else {
-    node.comment = ` ${target.tag}${node.comment == null ? '' : ` ${node.comment.trimStart()}`}`
-  }
+function renderTargetValue (action: ActionReference, target: RepoVersion): string {
+  const oldReference = `${action.name}@${action.ref}`
+  const newReference = `${action.name}@${target.commit}`
+  let value = action.originalValue.replace(oldReference, newReference)
+  if (action.commentVersion != null) return value.replace(action.commentVersion, target.tag)
+  const comment = value.indexOf(' #')
+  if (comment === -1) return `${value} # ${target.tag}`
+  return `${value.slice(0, comment + 2)}${target.tag} ${value.slice(comment + 2).trimStart()}`
+}
+
+function trimLineBreak (source: string, end: number): number {
+  while (end > 0 && (source[end - 1] === '\n' || source[end - 1] === '\r')) end--
+  return end
 }
 
 function dedupeOutdated (actions: OutdatedGitHubAction[]): OutdatedGitHubAction[] {

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -4,6 +4,7 @@ import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
 import { getRepoRefs } from '@pnpm/resolving.git-resolver'
+import { isSubdir } from 'is-subdir'
 import pLimit from 'p-limit'
 import semver from 'semver'
 import writeFileAtomic from 'write-file-atomic'
@@ -181,7 +182,7 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
     } catch (err: unknown) {
       throw workflowError('READ', filePath, err)
     }
-    if (!isPathInside(realRoot, realFilePath)) {
+    if (!isSubdir(realRoot, realFilePath)) {
       throw new PnpmError('GITHUB_ACTIONS_WORKFLOW_OUTSIDE_ROOT', `GitHub Actions workflow is outside the project root: ${filePath}`)
     }
     if (visited.has(realFilePath)) return
@@ -274,7 +275,7 @@ async function resolveLocalReference (rootDir: string, reference: string): Promi
   } catch (err: unknown) {
     throw workflowError('READ', candidate, err)
   }
-  return isPathInside(realRoot, realCandidate) ? realCandidate : null
+  return isSubdir(realRoot, realCandidate) ? realCandidate : null
 }
 
 async function existingPath (candidate: string): Promise<string | null> {
@@ -382,11 +383,6 @@ async function readRefsWithGit (repo: string): Promise<Record<string, string>> {
 function workflowError (operation: 'PARSE' | 'READ' | 'WRITE', filePath: string, cause: unknown): PnpmError {
   const detail = util.types.isNativeError(cause) ? cause.message : String(cause)
   return new PnpmError(`GITHUB_ACTIONS_WORKFLOW_${operation}`, `Failed to ${operation.toLowerCase()} GitHub Actions workflow ${filePath}: ${detail}`, { cause })
-}
-
-function isPathInside (root: string, candidate: string): boolean {
-  const relative = path.relative(root, candidate)
-  return relative === '' || (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
 }
 
 function isErrorCode (err: unknown, code: string): err is NodeJS.ErrnoException {

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -151,6 +151,12 @@ async function createUpdatePlan (opts: GitHubActionsOptions): Promise<PlannedUpd
 }
 
 async function discoverActions (dir: string): Promise<ActionReference[]> {
+  let realRoot: string
+  try {
+    realRoot = await fs.realpath(dir)
+  } catch (err: unknown) {
+    throw workflowError('READ', dir, err)
+  }
   const workflowDir = path.join(dir, '.github', 'workflows')
   let entries: string[]
   try {
@@ -168,17 +174,26 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
   return actions
 
   async function scanFile (filePath: string): Promise<void> {
-    if (visited.has(filePath)) return
-    visited.add(filePath)
-    let source: string
+    let realFilePath: string
     try {
-      source = await fs.readFile(filePath, 'utf8')
+      realFilePath = await fs.realpath(filePath)
     } catch (err: unknown) {
       throw workflowError('READ', filePath, err)
     }
+    if (!isPathInside(realRoot, realFilePath)) {
+      throw new PnpmError('GITHUB_ACTIONS_WORKFLOW_OUTSIDE_ROOT', `GitHub Actions workflow is outside the project root: ${filePath}`)
+    }
+    if (visited.has(realFilePath)) return
+    visited.add(realFilePath)
+    let source: string
+    try {
+      source = await fs.readFile(realFilePath, 'utf8')
+    } catch (err: unknown) {
+      throw workflowError('READ', realFilePath, err)
+    }
     const document = YAML.parseDocument(source)
-    if (document.errors.length > 0) throw workflowError('PARSE', filePath, document.errors[0])
-    const file = { path: filePath, source }
+    if (document.errors.length > 0) throw workflowError('PARSE', realFilePath, document.errors[0])
+    const file = { path: realFilePath, source }
     const localReferences: string[] = []
     for (const node of findUsesScalars(document.contents)) {
       const value = node.value
@@ -188,7 +203,7 @@ async function discoverActions (dir: string): Promise<ActionReference[]> {
       }
       const parsed = parseActionReference(value)
       if (parsed == null) continue
-      if (node.range == null) throw new Error(`Missing source range for GitHub Action in ${filePath}`)
+      if (node.range == null) throw new Error(`Missing source range for GitHub Action in ${realFilePath}`)
       const end = trimLineBreak(source, node.range[2] ?? node.range[1])
       actions.push({
         ...parsed,
@@ -258,10 +273,7 @@ async function resolveLocalReference (rootDir: string, reference: string): Promi
   } catch (err: unknown) {
     throw workflowError('READ', candidate, err)
   }
-  const relative = path.relative(realRoot, realCandidate)
-  return relative === '' || (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
-    ? realCandidate
-    : null
+  return isPathInside(realRoot, realCandidate) ? realCandidate : null
 }
 
 async function existingPath (candidate: string): Promise<string | null> {
@@ -309,7 +321,7 @@ function findCurrentVersion (action: ActionReference, versions: RepoVersion[]): 
     }
   }
   const parsed = semver.parse(action.ref, { loose: true })
-  if (parsed != null && parsed.raw.replace(/^v/, '').split('.').length === 3) {
+  if (parsed != null) {
     return versions.find(({ version }) => semver.eq(version, parsed)) ?? null
   }
   if (/^v?\d+$/.test(action.ref)) {
@@ -369,6 +381,11 @@ async function readRefsWithGit (repo: string): Promise<Record<string, string>> {
 function workflowError (operation: 'PARSE' | 'READ' | 'WRITE', filePath: string, cause: unknown): PnpmError {
   const detail = util.types.isNativeError(cause) ? cause.message : String(cause)
   return new PnpmError(`GITHUB_ACTIONS_WORKFLOW_${operation}`, `Failed to ${operation.toLowerCase()} GitHub Actions workflow ${filePath}: ${detail}`, { cause })
+}
+
+function isPathInside (root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate)
+  return relative === '' || (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
 }
 
 function isErrorCode (err: unknown, code: string): err is NodeJS.ErrnoException {

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -70,6 +70,12 @@ export function isGitHubActionSelector (selector: string): boolean {
   return !pattern.startsWith('@') && pattern.includes('/')
 }
 
+export function normalizeGitHubActionSelector (selector: string): string {
+  if (!isGitHubActionSelector(selector)) return selector
+  const refSeparator = selector.lastIndexOf('@')
+  return refSeparator === -1 ? selector : selector.slice(0, refSeparator)
+}
+
 export async function findOutdatedGitHubActions (
   opts: FindOutdatedGitHubActionsOptions
 ): Promise<OutdatedGitHubAction[]> {

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -1,0 +1,296 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import util from 'node:util'
+
+import { getRepoRefs } from '@pnpm/resolving.git-resolver'
+import semver from 'semver'
+import YAML, { type Document, isMap, isNode, isScalar, isSeq, type Node, type Scalar } from 'yaml'
+
+export interface OutdatedGitHubAction {
+  current: string
+  latest: string
+  name: string
+  wanted: string
+  homepage: string
+}
+
+export interface GitHubActionsOptions {
+  dir: string
+  match?: (name: string) => boolean
+  readRepoRefs?: (repo: string) => Promise<Record<string, string>>
+}
+
+export interface FindOutdatedGitHubActionsOptions extends GitHubActionsOptions {
+  compatible?: boolean
+}
+
+export interface UpdateGitHubActionsOptions extends GitHubActionsOptions {
+  latest?: boolean
+}
+
+interface ActionReference {
+  commentVersion?: string
+  file: ActionFile
+  name: string
+  node: Scalar<string>
+  ref: string
+  repo: string
+}
+
+interface ActionFile {
+  document: Document
+  path: string
+}
+
+interface RepoVersion {
+  commit: string
+  tag: string
+  version: semver.SemVer
+}
+
+interface PlannedUpdate {
+  action: ActionReference
+  current: RepoVersion
+  latest: RepoVersion
+  wanted: RepoVersion
+}
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/
+
+export function isGitHubActionSelector (selector: string): boolean {
+  const pattern = selector.startsWith('!') ? selector.slice(1) : selector
+  return !pattern.startsWith('@') && pattern.includes('/')
+}
+
+export async function findOutdatedGitHubActions (
+  opts: FindOutdatedGitHubActionsOptions
+): Promise<OutdatedGitHubAction[]> {
+  const plans = await createUpdatePlan(opts)
+  const target = (plan: PlannedUpdate) => opts.compatible ? plan.wanted : plan.latest
+  return dedupeOutdated(plans
+    .filter((plan) => semver.lt(plan.current.version, target(plan).version))
+    .map((plan) => ({
+      current: plan.current.version.version,
+      latest: target(plan).version.version,
+      name: plan.action.name,
+      wanted: plan.wanted.version.version,
+      homepage: `https://github.com/${plan.action.repo}`,
+    })))
+}
+
+export async function updateGitHubActions (
+  opts: UpdateGitHubActionsOptions
+): Promise<OutdatedGitHubAction[]> {
+  const plans = await createUpdatePlan(opts)
+  const updates = plans.filter((plan) => {
+    const target = opts.latest ? plan.latest : plan.wanted
+    return semver.lte(plan.current.version, target.version) &&
+      (plan.action.ref !== target.commit || plan.action.commentVersion !== target.tag)
+  })
+  const changedFiles = new Set<ActionFile>()
+  for (const plan of updates) {
+    const target = opts.latest ? plan.latest : plan.wanted
+    plan.action.node.value = `${plan.action.name}@${renderTargetRef(target)}`
+    updateVersionComment(plan.action.node, plan.action.commentVersion, target)
+    changedFiles.add(plan.action.file)
+  }
+  await Promise.all([...changedFiles].map(async (file) => fs.writeFile(file.path, file.document.toString())))
+  return dedupeOutdated(updates.map((plan) => {
+    const target = opts.latest ? plan.latest : plan.wanted
+    return {
+      current: plan.current.version.version,
+      latest: target.version.version,
+      name: plan.action.name,
+      wanted: plan.wanted.version.version,
+      homepage: `https://github.com/${plan.action.repo}`,
+    }
+  }))
+}
+
+async function createUpdatePlan (opts: GitHubActionsOptions): Promise<PlannedUpdate[]> {
+  const actions = await discoverActions(opts.dir)
+  const selected = opts.match == null ? actions : actions.filter((action) => opts.match!(action.name) || opts.match!(action.repo))
+  const readRepoRefs = opts.readRepoRefs ?? readRefsWithGit
+  const refsByRepo = new Map<string, Promise<RepoVersion[]>>()
+  return (await Promise.all(selected.map(async (action): Promise<PlannedUpdate | null> => {
+    let versionsPromise = refsByRepo.get(action.repo)
+    if (versionsPromise == null) {
+      versionsPromise = readRepoRefs(action.repo).then(parseRepoVersions)
+      refsByRepo.set(action.repo, versionsPromise)
+    }
+    const versions = await versionsPromise
+    const current = findCurrentVersion(action, versions)
+    if (current == null) return null
+    const stable = versions.filter(({ version }) => version.prerelease.length === 0)
+    const candidates = current.version.prerelease.length === 0 ? stable : versions
+    const latest = candidates.at(-1)
+    const wanted = candidates.filter(({ version }) => version.major === current.version.major).at(-1)
+    if (latest == null || wanted == null) return null
+    return { action, current, latest, wanted }
+  }))).filter((plan): plan is PlannedUpdate => plan != null)
+}
+
+async function discoverActions (dir: string): Promise<ActionReference[]> {
+  const workflowDir = path.join(dir, '.github', 'workflows')
+  let entries: string[]
+  try {
+    entries = await fs.readdir(workflowDir)
+  } catch (err: unknown) {
+    if (isErrorCode(err, 'ENOENT')) return []
+    throw err
+  }
+  const workflowFiles = entries
+    .filter((entry) => entry.endsWith('.yml') || entry.endsWith('.yaml'))
+    .map((entry) => path.join(workflowDir, entry))
+  const visited = new Set<string>()
+  const actions: ActionReference[] = []
+  await Promise.all(workflowFiles.map(scanFile))
+  return actions
+
+  async function scanFile (filePath: string): Promise<void> {
+    if (visited.has(filePath)) return
+    visited.add(filePath)
+    const source = await fs.readFile(filePath, 'utf8')
+    const file = { document: YAML.parseDocument(source), path: filePath }
+    if (file.document.errors.length > 0) throw file.document.errors[0]
+    const localReferences: string[] = []
+    for (const node of findUsesScalars(file.document.contents)) {
+      const value = node.value
+      if (value.startsWith('./')) {
+        localReferences.push(value)
+        continue
+      }
+      const parsed = parseActionReference(value)
+      if (parsed == null) continue
+      actions.push({
+        ...parsed,
+        commentVersion: getCommentVersion(node),
+        file,
+        node,
+      })
+    }
+    const localFiles = await Promise.all(localReferences.map(async (reference) => resolveLocalReference(dir, reference)))
+    await Promise.all(localFiles.filter((local): local is string => local != null).map(scanFile))
+  }
+}
+
+function findUsesScalars (node: Node | null | undefined): Array<Scalar<string>> {
+  if (node == null) return []
+  if (isMap(node)) {
+    const found: Array<Scalar<string>> = []
+    for (const pair of node.items) {
+      if (isScalar(pair.key) && pair.key.value === 'uses' && isScalar(pair.value) && typeof pair.value.value === 'string') {
+        found.push(pair.value as Scalar<string>)
+      } else if (isNode(pair.value)) {
+        found.push(...findUsesScalars(pair.value))
+      }
+    }
+    return found
+  }
+  if (isSeq(node)) {
+    return node.items.flatMap((item) => isNode(item) ? findUsesScalars(item) : [])
+  }
+  return []
+}
+
+async function resolveLocalReference (rootDir: string, reference: string): Promise<string | null> {
+  const target = path.resolve(rootDir, reference)
+  const candidate = target.endsWith('.yml') || target.endsWith('.yaml')
+    ? await existingPath(target)
+    : (await Promise.all(['action.yml', 'action.yaml'].map(async (filename) => existingPath(path.join(target, filename)))))
+      .find((candidate): candidate is string => candidate != null) ?? null
+  if (candidate == null) return null
+  const [realRoot, realCandidate] = await Promise.all([fs.realpath(rootDir), fs.realpath(candidate)])
+  const relative = path.relative(realRoot, realCandidate)
+  return relative === '' || (!path.isAbsolute(relative) && relative !== '..' && !relative.startsWith(`..${path.sep}`))
+    ? realCandidate
+    : null
+}
+
+async function existingPath (candidate: string): Promise<string | null> {
+  try {
+    await fs.access(candidate)
+    return candidate
+  } catch (err: unknown) {
+    if (!isErrorCode(err, 'ENOENT')) throw err
+    return null
+  }
+}
+
+function parseActionReference (value: string): Pick<ActionReference, 'name' | 'ref' | 'repo'> | null {
+  if (value.startsWith('docker://')) return null
+  const at = value.lastIndexOf('@')
+  if (at <= 0 || at === value.length - 1) return null
+  const name = value.slice(0, at)
+  const parts = name.split('/')
+  if (parts.length < 2 || parts[0] === '' || parts[1] === '') return null
+  return { name, ref: value.slice(at + 1), repo: `${parts[0]}/${parts[1]}` }
+}
+
+function parseRepoVersions (refs: Record<string, string>): RepoVersion[] {
+  const versions: RepoVersion[] = []
+  for (const [ref, commit] of Object.entries(refs)) {
+    const match = /^refs\/tags\/(v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/.exec(ref)
+    if (match == null) continue
+    const version = semver.parse(match[1], { loose: true })
+    if (version == null) continue
+    versions.push({
+      commit: refs[`${ref}^{}`] ?? commit,
+      tag: match[1],
+      version,
+    })
+  }
+  return versions.sort((left, right) => semver.compare(left.version, right.version))
+}
+
+function findCurrentVersion (action: ActionReference, versions: RepoVersion[]): RepoVersion | null {
+  if (SHA_PATTERN.test(action.ref) && action.commentVersion != null) {
+    const parsed = semver.parse(action.commentVersion, { loose: true })
+    if (parsed != null) {
+      const annotated = versions.find(({ commit, version }) => commit === action.ref && semver.eq(version, parsed))
+      if (annotated != null) return annotated
+    }
+  }
+  const parsed = semver.parse(action.ref, { loose: true })
+  if (parsed != null && parsed.raw.replace(/^v/, '').split('.').length === 3) {
+    return versions.find(({ version }) => semver.eq(version, parsed)) ?? null
+  }
+  if (/^v?\d+$/.test(action.ref)) {
+    const major = Number(action.ref.replace(/^v/, ''))
+    return versions.filter(({ version }) => version.major === major && version.prerelease.length === 0).at(-1) ?? null
+  }
+  if (SHA_PATTERN.test(action.ref)) {
+    return versions.filter(({ commit }) => commit === action.ref).at(-1) ?? null
+  }
+  return null
+}
+
+function renderTargetRef (target: RepoVersion): string {
+  return target.commit
+}
+
+function getCommentVersion (node: Scalar<string>): string | undefined {
+  const candidate = node.comment?.trimStart().split(/\s/, 1)[0]
+  return candidate != null && semver.valid(candidate, { loose: true }) != null ? candidate : undefined
+}
+
+function updateVersionComment (node: Scalar<string>, previousVersion: string | undefined, target: RepoVersion): void {
+  if (previousVersion != null && node.comment != null) {
+    node.comment = node.comment.replace(previousVersion, target.tag)
+  } else {
+    node.comment = ` ${target.tag}${node.comment == null ? '' : ` ${node.comment.trimStart()}`}`
+  }
+}
+
+function dedupeOutdated (actions: OutdatedGitHubAction[]): OutdatedGitHubAction[] {
+  return [...new Map(actions.map((action) => [action.name, action])).values()]
+    .sort((left, right) => left.name.localeCompare(right.name))
+}
+
+async function readRefsWithGit (repo: string): Promise<Record<string, string>> {
+  return getRepoRefs(`https://github.com/${repo}.git`, null)
+}
+
+function isErrorCode (err: unknown, code: string): err is NodeJS.ErrnoException {
+  return util.types.isNativeError(err) && 'code' in err && err.code === code
+}

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -146,7 +146,9 @@ async function createUpdatePlan (opts: GitHubActionsOptions): Promise<PlannedUpd
     const stable = versions.filter(({ version }) => version.prerelease.length === 0)
     const candidates = current.version.prerelease.length === 0 ? stable : versions
     const latest = candidates.at(-1)
-    const wanted = candidates.filter(({ version }) => version.major === current.version.major).at(-1)
+    const wanted = candidates
+      .filter(({ version }) => semver.satisfies(version, `^${current.version.version}`))
+      .at(-1)
     if (latest == null || wanted == null) return null
     return { action, current, latest, wanted }
   }))).filter((plan): plan is PlannedUpdate => plan != null)

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -151,6 +151,26 @@ jobs:
     await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: actions/checkout@${'a'.repeat(40)} # v4.2.0`)
   })
 
+  test('updates prerelease tags containing dots', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v5.0.0-alpha.1
+`,
+    })
+
+    await updateGitHubActions({
+      dir,
+      readRepoRefs: async () => repoRefs([
+        ['v5.0.0-alpha.1', 'a'.repeat(40)],
+        ['v5.0.0-alpha.2', 'b'.repeat(40)],
+      ]),
+    })
+
+    await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: actions/checkout@${'b'.repeat(40)} # v5.0.0-alpha.2`)
+  })
+
   test('updates flow-style steps without commenting out their delimiters', async () => {
     const dir = await fixture({
       '.github/workflows/ci.yml': `jobs:
@@ -212,6 +232,26 @@ ${Array.from({ length: actionCount }, (_, index) => `      - uses: owner/action-
       code: 'ERR_PNPM_GITHUB_ACTIONS_WORKFLOW_PARSE',
       message: expect.stringContaining(path.join(dir, '.github/workflows/ci.yml')),
     })
+  })
+
+  test('rejects workflow directory symlinks outside the project', async () => {
+    const dir = await fixture({})
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-actions-outside-'))
+    dirs.push(outsideDir)
+    const outsideWorkflow = path.join(outsideDir, 'ci.yml')
+    const original = `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+`
+    await fs.writeFile(outsideWorkflow, original)
+    await fs.mkdir(path.join(dir, '.github'), { recursive: true })
+    await fs.symlink(outsideDir, path.join(dir, '.github/workflows'), 'junction')
+
+    await expect(updateGitHubActions({ dir })).rejects.toMatchObject({
+      code: 'ERR_PNPM_GITHUB_ACTIONS_WORKFLOW_OUTSIDE_ROOT',
+    })
+    await expect(fs.readFile(outsideWorkflow, 'utf8')).resolves.toBe(original)
   })
 })
 

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, test } from '@jest/globals'
+import { findOutdatedGitHubActions, isGitHubActionSelector, updateGitHubActions } from '@pnpm/deps.github-actions'
+
+const dirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map(async (dir) => fs.rm(dir, { force: true, recursive: true })))
+})
+
+describe('GitHub Actions dependencies', () => {
+  test('distinguishes action selectors from npm package selectors', () => {
+    expect(isGitHubActionSelector('actions/checkout')).toBe(true)
+    expect(isGitHubActionSelector('@scope/package')).toBe(false)
+    expect(isGitHubActionSelector('!@scope/package')).toBe(false)
+    expect(isGitHubActionSelector('typescript')).toBe(false)
+  })
+
+  test('finds actions in workflows and referenced local composite actions', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - uses: ./.github/actions/setup
+      - uses: docker://alpine:3.20
+`,
+      '.github/actions/setup/action.yml': `runs:
+  using: composite
+  steps:
+    - uses: owner/tool/subpath@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v2.0.0
+`,
+    })
+
+    const refs = new Map([
+      ['actions/checkout', repoRefs([
+        ['v4.1.0', 'a'.repeat(40)],
+        ['v4.2.0', 'b'.repeat(40)],
+        ['v5.0.0', 'c'.repeat(40)],
+      ])],
+      ['owner/tool', repoRefs([
+        ['v2.0.0', 'a'.repeat(40)],
+        ['v2.1.0', 'b'.repeat(40)],
+      ])],
+    ])
+
+    await expect(findOutdatedGitHubActions({
+      dir,
+      readRepoRefs: async (repo) => refs.get(repo)!,
+    })).resolves.toEqual([
+      {
+        current: '4.1.0',
+        homepage: 'https://github.com/actions/checkout',
+        latest: '5.0.0',
+        name: 'actions/checkout',
+        wanted: '4.2.0',
+      },
+      {
+        current: '2.0.0',
+        homepage: 'https://github.com/owner/tool',
+        latest: '2.1.0',
+        name: 'owner/tool/subpath',
+        wanted: '2.1.0',
+      },
+    ])
+  })
+
+  test('updates within the current major and preserves SHA comments and unrelated formatting', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `name: CI
+jobs:
+  test:
+    steps:
+      - uses: 'actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' # v4.1.0 # keep
+      - uses: owner/floating@v2
+`,
+    })
+    const refs = new Map([
+      ['actions/checkout', repoRefs([
+        ['v4.1.0', 'a'.repeat(40)],
+        ['v4.2.0', 'b'.repeat(40)],
+        ['v5.0.0', 'c'.repeat(40)],
+      ])],
+      ['owner/floating', repoRefs([
+        ['v2.1.0', 'd'.repeat(40)],
+        ['v3.0.0', 'e'.repeat(40)],
+      ])],
+    ])
+
+    await updateGitHubActions({
+      dir,
+      readRepoRefs: async (repo) => refs.get(repo)!,
+    })
+
+    await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toBe(`name: CI
+jobs:
+  test:
+    steps:
+      - uses: 'actions/checkout@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' # v4.2.0 # keep
+      - uses: owner/floating@dddddddddddddddddddddddddddddddddddddddd # v2.1.0
+`)
+  })
+
+  test('--latest pins a floating major tag to the newest release commit', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+`,
+    })
+    await updateGitHubActions({
+      dir,
+      latest: true,
+      readRepoRefs: async () => repoRefs([
+        ['v4.2.0', 'a'.repeat(40)],
+        ['v5.0.0', 'b'.repeat(40)],
+      ]),
+    })
+    await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: actions/checkout@${'b'.repeat(40)} # v5.0.0`)
+  })
+
+  test('pins an already-current floating major tag', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+`,
+    })
+    await updateGitHubActions({
+      dir,
+      readRepoRefs: async () => repoRefs([
+        ['v4.2.0', 'a'.repeat(40)],
+        ['v5.0.0', 'b'.repeat(40)],
+      ]),
+    })
+    await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: actions/checkout@${'a'.repeat(40)} # v4.2.0`)
+  })
+})
+
+async function fixture (files: Record<string, string>): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-actions-'))
+  dirs.push(dir)
+  await Promise.all(Object.entries(files).map(async ([relativePath, content]) => {
+    const filePath = path.join(dir, relativePath)
+    await fs.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.writeFile(filePath, content)
+  }))
+  return dir
+}
+
+function repoRefs (versions: Array<[string, string]>): Record<string, string> {
+  return Object.fromEntries(versions.map(([tag, commit]) => [`refs/tags/${tag}`, commit]))
+}

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -253,6 +253,33 @@ ${Array.from({ length: actionCount }, (_, index) => `      - uses: owner/action-
     })
     await expect(fs.readFile(outsideWorkflow, 'utf8')).resolves.toBe(original)
   })
+
+  test('does not mutate an external hardlink target', async () => {
+    const dir = await fixture({})
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-actions-outside-'))
+    dirs.push(outsideDir)
+    const outsideWorkflow = path.join(outsideDir, 'ci.yml')
+    const workflow = path.join(dir, '.github/workflows/ci.yml')
+    const original = `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+`
+    await fs.writeFile(outsideWorkflow, original)
+    await fs.mkdir(path.dirname(workflow), { recursive: true })
+    await fs.link(outsideWorkflow, workflow)
+
+    await updateGitHubActions({
+      dir,
+      readRepoRefs: async () => repoRefs([
+        ['v4.2.0', 'a'.repeat(40)],
+        ['v5.0.0', 'b'.repeat(40)],
+      ]),
+    })
+
+    await expect(fs.readFile(workflow, 'utf8')).resolves.toContain(`uses: actions/checkout@${'a'.repeat(40)} # v4.2.0`)
+    await expect(fs.readFile(outsideWorkflow, 'utf8')).resolves.toBe(original)
+  })
 })
 
 async function fixture (files: Record<string, string>): Promise<string> {

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -151,6 +151,28 @@ jobs:
     await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: actions/checkout@${'a'.repeat(40)} # v4.2.0`)
   })
 
+  test('updates flow-style steps without commenting out their delimiters', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps: [{ uses: actions/checkout@v4 }]
+`,
+    })
+    const refs = repoRefs([
+      ['v4.2.0', 'a'.repeat(40)],
+      ['v5.0.0', 'b'.repeat(40)],
+    ])
+
+    await updateGitHubActions({ dir, readRepoRefs: async () => refs })
+
+    await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toBe(`jobs:
+  test:
+    steps: [{ uses: actions/checkout@${'a'.repeat(40)} # v4.2.0
+                    }]
+`)
+    await expect(findOutdatedGitHubActions({ compatible: true, dir, readRepoRefs: async () => refs })).resolves.toEqual([])
+  })
+
   test('limits concurrent repository lookups', async () => {
     const actionCount = 12
     const dir = await fixture({

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -227,10 +227,11 @@ ${Array.from({ length: actionCount }, (_, index) => `      - uses: owner/action-
     const dir = await fixture({
       '.github/workflows/ci.yml': 'jobs: [\n',
     })
+    const workflow = await fs.realpath(path.join(dir, '.github/workflows/ci.yml'))
 
     await expect(findOutdatedGitHubActions({ dir })).rejects.toMatchObject({
       code: 'ERR_PNPM_GITHUB_ACTIONS_WORKFLOW_PARSE',
-      message: expect.stringContaining(path.join(dir, '.github/workflows/ci.yml')),
+      message: expect.stringContaining(workflow),
     })
   })
 

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -151,6 +151,37 @@ jobs:
     await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: actions/checkout@${'a'.repeat(40)} # v4.2.0`)
   })
 
+  test('keeps pre-1.0 updates within the caret-compatible range unless latest is requested', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: owner/tool@v0.5.7
+`,
+    })
+    const refs = repoRefs([
+      ['v0.5.7', 'a'.repeat(40)],
+      ['v0.5.9', 'b'.repeat(40)],
+      ['v0.6.0', 'c'.repeat(40)],
+    ])
+
+    await expect(findOutdatedGitHubActions({ compatible: true, dir, readRepoRefs: async () => refs })).resolves.toEqual([
+      {
+        current: '0.5.7',
+        homepage: 'https://github.com/owner/tool',
+        latest: '0.5.9',
+        name: 'owner/tool',
+        wanted: '0.5.9',
+      },
+    ])
+
+    await updateGitHubActions({ dir, readRepoRefs: async () => refs })
+    await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: owner/tool@${'b'.repeat(40)} # v0.5.9`)
+
+    await updateGitHubActions({ dir, latest: true, readRepoRefs: async () => refs })
+    await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: owner/tool@${'c'.repeat(40)} # v0.6.0`)
+  })
+
   test('updates prerelease tags containing dots', async () => {
     const dir = await fixture({
       '.github/workflows/ci.yml': `jobs:

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { afterEach, describe, expect, test } from '@jest/globals'
-import { findOutdatedGitHubActions, isGitHubActionSelector, updateGitHubActions } from '@pnpm/deps.github-actions'
+import { findOutdatedGitHubActions, isGitHubActionSelector, normalizeGitHubActionSelector, updateGitHubActions } from '@pnpm/deps.github-actions'
 
 const dirs: string[] = []
 
@@ -17,6 +17,13 @@ describe('GitHub Actions dependencies', () => {
     expect(isGitHubActionSelector('@scope/package')).toBe(false)
     expect(isGitHubActionSelector('!@scope/package')).toBe(false)
     expect(isGitHubActionSelector('typescript')).toBe(false)
+  })
+
+  test('normalizes action selectors without changing package selectors', () => {
+    expect(normalizeGitHubActionSelector('actions/checkout@v4')).toBe('actions/checkout')
+    expect(normalizeGitHubActionSelector('!actions/checkout@v4')).toBe('!actions/checkout')
+    expect(normalizeGitHubActionSelector('actions/checkout')).toBe('actions/checkout')
+    expect(normalizeGitHubActionSelector('@scope/package')).toBe('@scope/package')
   })
 
   test('finds actions in workflows and referenced local composite actions', async () => {

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -71,10 +71,15 @@ describe('GitHub Actions dependencies', () => {
   test('updates within the current major and preserves SHA comments and unrelated formatting', async () => {
     const dir = await fixture({
       '.github/workflows/ci.yml': `name: CI
+
 jobs:
   test:
+    strategy: { matrix: { node: [22, 24] } }
     steps:
       - uses: 'actions/checkout@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' # v4.1.0 # keep
+      - name: nested input
+        with:
+          uses: actions/checkout@v4
       - uses: owner/floating@v2
 `,
     })
@@ -96,10 +101,15 @@ jobs:
     })
 
     await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toBe(`name: CI
+
 jobs:
   test:
+    strategy: { matrix: { node: [22, 24] } }
     steps:
       - uses: 'actions/checkout@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' # v4.2.0 # keep
+      - name: nested input
+        with:
+          uses: actions/checkout@v4
       - uses: owner/floating@dddddddddddddddddddddddddddddddddddddddd # v2.1.0
 `)
   })

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -150,6 +150,47 @@ jobs:
     })
     await expect(fs.readFile(path.join(dir, '.github/workflows/ci.yml'), 'utf8')).resolves.toContain(`uses: actions/checkout@${'a'.repeat(40)} # v4.2.0`)
   })
+
+  test('limits concurrent repository lookups', async () => {
+    const actionCount = 12
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+${Array.from({ length: actionCount }, (_, index) => `      - uses: owner/action-${index}@v1`).join('\n')}
+`,
+    })
+    let active = 0
+    let maxActive = 0
+
+    const outdated = await findOutdatedGitHubActions({
+      dir,
+      readRepoRefs: async () => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        active--
+        return repoRefs([
+          ['v1.0.0', 'a'.repeat(40)],
+          ['v2.0.0', 'b'.repeat(40)],
+        ])
+      },
+    })
+
+    expect(outdated).toHaveLength(actionCount)
+    expect(maxActive).toBeLessThanOrEqual(8)
+  })
+
+  test('reports invalid workflow YAML with a stable contextual error', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': 'jobs: [\n',
+    })
+
+    await expect(findOutdatedGitHubActions({ dir })).rejects.toMatchObject({
+      code: 'ERR_PNPM_GITHUB_ACTIONS_WORKFLOW_PARSE',
+      message: expect.stringContaining(path.join(dir, '.github/workflows/ci.yml')),
+    })
+  })
 })
 
 async function fixture (files: Record<string, string>): Promise<string> {

--- a/pnpm11/deps/github-actions/test/tsconfig.json
+++ b/pnpm11/deps/github-actions/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "../node_modules/.test.lib",
+    "rootDir": "..",
+    "isolatedModules": true
+  },
+  "include": [
+    "**/*.ts",
+    "../../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": ".."
+    }
+  ]
+}

--- a/pnpm11/deps/github-actions/tsconfig.json
+++ b/pnpm11/deps/github-actions/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../core/error"
+    },
+    {
       "path": "../../resolving/git-resolver"
     }
   ]

--- a/pnpm11/deps/github-actions/tsconfig.json
+++ b/pnpm11/deps/github-actions/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@pnpm/tsconfig",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "../../resolving/git-resolver"
+    }
+  ]
+}

--- a/pnpm11/deps/github-actions/tsconfig.lint.json
+++ b/pnpm11/deps/github-actions/tsconfig.lint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "../../__typings__/**/*.d.ts"
+  ]
+}

--- a/pnpm11/deps/inspection/commands/package.json
+++ b/pnpm11/deps/inspection/commands/package.json
@@ -38,6 +38,7 @@
     "@pnpm/config.matcher": "workspace:*",
     "@pnpm/config.pick-registry-for-package": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
+    "@pnpm/deps.github-actions": "workspace:*",
     "@pnpm/deps.inspection.list": "workspace:*",
     "@pnpm/deps.inspection.outdated": "workspace:*",
     "@pnpm/deps.inspection.peers-checker": "workspace:*",

--- a/pnpm11/deps/inspection/commands/src/outdated/outdated.ts
+++ b/pnpm11/deps/inspection/commands/src/outdated/outdated.ts
@@ -11,7 +11,7 @@ import {
 import { colorizeSemverDiff } from '@pnpm/colorize-semver-diff'
 import { createMatcher } from '@pnpm/config.matcher'
 import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config.reader'
-import { findOutdatedGitHubActions, isGitHubActionSelector } from '@pnpm/deps.github-actions'
+import { findOutdatedGitHubActions, isGitHubActionSelector, normalizeGitHubActionSelector } from '@pnpm/deps.github-actions'
 import {
   outdatedDepsOfProjects,
   type OutdatedPackage,
@@ -233,7 +233,7 @@ export async function handler (
       : findOutdatedGitHubActions({
         compatible: opts.compatible,
         dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
-        match: params.length > 0 ? createMatcher(params) : undefined,
+        match: params.length > 0 ? createMatcher(params.map(normalizeGitHubActionSelector)) : undefined,
       }),
   ])
   const outdatedPackages: OutdatedItem[] = [

--- a/pnpm11/deps/inspection/commands/src/outdated/outdated.ts
+++ b/pnpm11/deps/inspection/commands/src/outdated/outdated.ts
@@ -9,7 +9,9 @@ import {
   TABLE_OPTIONS,
 } from '@pnpm/cli.utils'
 import { colorizeSemverDiff } from '@pnpm/colorize-semver-diff'
+import { createMatcher } from '@pnpm/config.matcher'
 import { type Config, type ConfigContext, types as allTypes } from '@pnpm/config.reader'
+import { findOutdatedGitHubActions, isGitHubActionSelector } from '@pnpm/deps.github-actions'
 import {
   outdatedDepsOfProjects,
   type OutdatedPackage,
@@ -64,7 +66,7 @@ export const commandNames = ['outdated']
 
 export function help (): string {
   return renderHelp({
-    description: `Check for outdated packages. The check can be limited to a subset of the installed packages by providing arguments (patterns are supported).
+    description: `Check for outdated package and GitHub Actions dependencies. The check can be limited to a subset of dependencies by providing arguments (patterns are supported).
 
 Examples:
 pnpm outdated
@@ -170,6 +172,7 @@ export type OutdatedCommandOptions = {
 | 'tag'
 | 'userAgent'
 | 'updateConfig'
+| 'workspaceDir'
 > & Pick<ConfigContext,
 | 'allProjects'
 | 'selectedProjectsGraph'
@@ -206,22 +209,37 @@ export async function handler (
       },
     ]
   }
-  const outdatedPerProject = await outdatedDepsOfProjects(packages, params, {
-    ...opts,
-    fullMetadata: opts.long,
-    ignoreDependencies: opts.updateConfig?.ignoreDependencies,
-    include,
-    minimumReleaseAge: opts.minimumReleaseAge,
-    minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
-    retry: {
-      factor: opts.fetchRetryFactor,
-      maxTimeout: opts.fetchRetryMaxtimeout,
-      minTimeout: opts.fetchRetryMintimeout,
-      retries: opts.fetchRetries,
-    },
-    timeout: opts.fetchTimeout,
-  })
-  const outdatedPackages = outdatedPerProject.flat()
+  const packageParams = params.filter((param) => !isGitHubActionSelector(param))
+  const [outdatedPerProject, outdatedActions] = await Promise.all([
+    params.length === 0 || packageParams.length > 0
+      ? outdatedDepsOfProjects(packages, packageParams, {
+        ...opts,
+        fullMetadata: opts.long,
+        ignoreDependencies: opts.updateConfig?.ignoreDependencies,
+        include,
+        minimumReleaseAge: opts.minimumReleaseAge,
+        minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
+        retry: {
+          factor: opts.fetchRetryFactor,
+          maxTimeout: opts.fetchRetryMaxtimeout,
+          minTimeout: opts.fetchRetryMintimeout,
+          retries: opts.fetchRetries,
+        },
+        timeout: opts.fetchTimeout,
+      })
+      : [],
+    opts.global || !include.devDependencies
+      ? []
+      : findOutdatedGitHubActions({
+        compatible: opts.compatible,
+        dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
+        match: params.length > 0 ? createMatcher(params) : undefined,
+      }),
+  ])
+  const outdatedPackages: OutdatedItem[] = [
+    ...outdatedPerProject.flat(),
+    ...outdatedActions.map(toOutdatedAction),
+  ]
 
   let output!: string
   switch (opts.format ?? 'table') {
@@ -247,7 +265,9 @@ export async function handler (
   }
 }
 
-function renderOutdatedTable (outdatedPackages: readonly OutdatedPackage[], opts: { long?: boolean, sortBy?: 'name' }): string {
+export type OutdatedItem = OutdatedPackage & { dependencyType?: 'githubAction' }
+
+function renderOutdatedTable (outdatedPackages: readonly OutdatedItem[], opts: { long?: boolean, sortBy?: 'name' }): string {
   if (outdatedPackages.length === 0) return ''
   const columnNames = [
     'Package',
@@ -295,7 +315,7 @@ function renderOutdatedTable (outdatedPackages: readonly OutdatedPackage[], opts
   return table(data, tableOptions)
 }
 
-function renderOutdatedList (outdatedPackages: readonly OutdatedPackage[], opts: { long?: boolean, sortBy?: 'name' }): string {
+function renderOutdatedList (outdatedPackages: readonly OutdatedItem[], opts: { long?: boolean, sortBy?: 'name' }): string {
   if (outdatedPackages.length === 0) return ''
   return sortOutdatedPackages(outdatedPackages, { sortBy: opts.sortBy })
     .map((outdatedPkg) => {
@@ -320,11 +340,11 @@ export interface OutdatedPackageJSONOutput {
   latest?: string
   wanted: string
   isDeprecated: boolean
-  dependencyType: DependenciesField
+  dependencyType: DependenciesField | 'githubAction'
   latestManifest?: PackageManifest
 }
 
-function renderOutdatedJSON (outdatedPackages: readonly OutdatedPackage[], opts: { long?: boolean, sortBy?: 'name' }): string {
+function renderOutdatedJSON (outdatedPackages: readonly OutdatedItem[], opts: { long?: boolean, sortBy?: 'name' }): string {
   const outdatedPackagesJSON: Record<string, OutdatedPackageJSONOutput> = sortOutdatedPackages(outdatedPackages, { sortBy: opts.sortBy })
     .reduce((acc, outdatedPkg) => {
       acc[outdatedPkg.packageName] = {
@@ -332,7 +352,7 @@ function renderOutdatedJSON (outdatedPackages: readonly OutdatedPackage[], opts:
         latest: outdatedPkg.latestManifest?.version,
         wanted: outdatedPkg.wanted,
         isDeprecated: Boolean(outdatedPkg.latestManifest?.deprecated),
-        dependencyType: outdatedPkg.belongsTo,
+        dependencyType: outdatedPkg.dependencyType ?? outdatedPkg.belongsTo,
       }
       if (opts.long) {
         acc[outdatedPkg.packageName].latestManifest = outdatedPkg.latestManifest
@@ -342,7 +362,7 @@ function renderOutdatedJSON (outdatedPackages: readonly OutdatedPackage[], opts:
   return JSON.stringify(outdatedPackagesJSON, null, 2)
 }
 
-function sortOutdatedPackages (outdatedPackages: readonly OutdatedPackage[], opts?: { sortBy?: 'name' }) {
+function sortOutdatedPackages (outdatedPackages: readonly OutdatedItem[], opts?: { sortBy?: 'name' }) {
   const sortBy = opts?.sortBy
   const comparators = (sortBy === 'name') ? [NAME_COMPARATOR] : DEFAULT_COMPARATORS
   return sortWith(
@@ -375,7 +395,8 @@ export function toOutdatedWithVersionDiff<Pkg extends OutdatedPackage> (outdated
   }
 }
 
-export function renderPackageName ({ belongsTo, packageName }: OutdatedPackage): string {
+export function renderPackageName ({ belongsTo, dependencyType, packageName }: OutdatedItem): string {
+  if (dependencyType === 'githubAction') return `${packageName} ${chalk.dim('(github action)')}`
   switch (belongsTo) {
     case 'devDependencies': return `${packageName} ${chalk.dim('(dev)')}`
     case 'optionalDependencies': return `${packageName} ${chalk.dim('(optional)')}`
@@ -416,4 +437,20 @@ export function renderDetails ({ latestManifest }: OutdatedPackage): string {
     outputs.push(chalk.underline(latestManifest.homepage))
   }
   return outputs.join('\n')
+}
+
+export function toOutdatedAction (action: Awaited<ReturnType<typeof findOutdatedGitHubActions>>[number]): OutdatedItem {
+  return {
+    alias: action.name,
+    belongsTo: 'devDependencies',
+    current: action.current,
+    dependencyType: 'githubAction',
+    latestManifest: {
+      name: action.name,
+      version: action.latest,
+      homepage: action.homepage,
+    },
+    packageName: action.name,
+    wanted: action.wanted,
+  }
 }

--- a/pnpm11/deps/inspection/commands/src/outdated/recursive.ts
+++ b/pnpm11/deps/inspection/commands/src/outdated/recursive.ts
@@ -1,6 +1,6 @@
 import { TABLE_OPTIONS } from '@pnpm/cli.utils'
 import { createMatcher } from '@pnpm/config.matcher'
-import { findOutdatedGitHubActions, isGitHubActionSelector } from '@pnpm/deps.github-actions'
+import { findOutdatedGitHubActions, isGitHubActionSelector, normalizeGitHubActionSelector } from '@pnpm/deps.github-actions'
 import {
   outdatedDepsOfProjects,
 } from '@pnpm/deps.inspection.outdated'
@@ -87,7 +87,7 @@ export async function outdatedRecursive (
     const outdatedActions = await findOutdatedGitHubActions({
       compatible: opts.compatible,
       dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
-      match: params.length > 0 ? createMatcher(params) : undefined,
+      match: params.length > 0 ? createMatcher(params.map(normalizeGitHubActionSelector)) : undefined,
     })
     for (const action of outdatedActions) {
       const outdatedAction = toOutdatedAction(action)

--- a/pnpm11/deps/inspection/commands/src/outdated/recursive.ts
+++ b/pnpm11/deps/inspection/commands/src/outdated/recursive.ts
@@ -1,7 +1,8 @@
 import { TABLE_OPTIONS } from '@pnpm/cli.utils'
+import { createMatcher } from '@pnpm/config.matcher'
+import { findOutdatedGitHubActions, isGitHubActionSelector } from '@pnpm/deps.github-actions'
 import {
   outdatedDepsOfProjects,
-  type OutdatedPackage,
 } from '@pnpm/deps.inspection.outdated'
 import { PnpmError } from '@pnpm/error'
 import type {
@@ -17,11 +18,13 @@ import { isEmpty, sortWith } from 'ramda'
 import {
   getCellWidth,
   type OutdatedCommandOptions,
+  type OutdatedItem,
   type OutdatedPackageJSONOutput,
   renderCurrent,
   renderDetails,
   renderLatest,
   renderPackageName,
+  toOutdatedAction,
   toOutdatedWithVersionDiff,
 } from './outdated.js'
 import { DEFAULT_COMPARATORS, type OutdatedWithVersionDiff } from './utils.js'
@@ -38,7 +41,7 @@ const COMPARATORS = [
     DEP_PRIORITY[o1.belongsTo] - DEP_PRIORITY[o2.belongsTo],
 ]
 
-interface OutdatedInWorkspace extends OutdatedPackage {
+interface OutdatedInWorkspace extends OutdatedItem {
   belongsTo: DependenciesField
   current?: string
   dependentPkgs: Array<{ location: string, manifest: ProjectManifest }>
@@ -53,20 +56,23 @@ export async function outdatedRecursive (
   opts: OutdatedCommandOptions & { include: IncludedDependencies }
 ): Promise<{ output: string, exitCode: number }> {
   const outdatedMap = {} as Record<string, OutdatedInWorkspace>
-  const outdatedPackagesByProject = await outdatedDepsOfProjects(pkgs, params, {
-    ...opts,
-    fullMetadata: opts.long,
-    ignoreDependencies: opts.updateConfig?.ignoreDependencies,
-    minimumReleaseAge: opts.minimumReleaseAge,
-    minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
-    retry: {
-      factor: opts.fetchRetryFactor,
-      maxTimeout: opts.fetchRetryMaxtimeout,
-      minTimeout: opts.fetchRetryMintimeout,
-      retries: opts.fetchRetries,
-    },
-    timeout: opts.fetchTimeout,
-  })
+  const packageParams = params.filter((param) => !isGitHubActionSelector(param))
+  const outdatedPackagesByProject = params.length === 0 || packageParams.length > 0
+    ? await outdatedDepsOfProjects(pkgs, packageParams, {
+      ...opts,
+      fullMetadata: opts.long,
+      ignoreDependencies: opts.updateConfig?.ignoreDependencies,
+      minimumReleaseAge: opts.minimumReleaseAge,
+      minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
+      retry: {
+        factor: opts.fetchRetryFactor,
+        maxTimeout: opts.fetchRetryMaxtimeout,
+        minTimeout: opts.fetchRetryMintimeout,
+        retries: opts.fetchRetries,
+      },
+      timeout: opts.fetchTimeout,
+    })
+    : pkgs.map(() => [])
   for (let i = 0; i < outdatedPackagesByProject.length; i++) {
     const { rootDir, manifest } = pkgs[i]
     for (const outdatedPkg of outdatedPackagesByProject[i]) {
@@ -75,6 +81,21 @@ export async function outdatedRecursive (
         outdatedMap[key] = { ...outdatedPkg, dependentPkgs: [] }
       }
       outdatedMap[key].dependentPkgs.push({ location: rootDir, manifest })
+    }
+  }
+  if (opts.include.devDependencies) {
+    const outdatedActions = await findOutdatedGitHubActions({
+      compatible: opts.compatible,
+      dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
+      match: params.length > 0 ? createMatcher(params) : undefined,
+    })
+    for (const action of outdatedActions) {
+      const outdatedAction = toOutdatedAction(action)
+      const key = JSON.stringify([outdatedAction.packageName, outdatedAction.current, outdatedAction.dependencyType])
+      outdatedMap[key] = {
+        ...outdatedAction,
+        dependentPkgs: [{ location: opts.workspaceDir ?? opts.dir, manifest: { name: '.github' } }],
+      }
     }
   }
 
@@ -190,7 +211,7 @@ function renderOutdatedJSON (
         latest: outdatedPkg.latestManifest?.version,
         wanted: outdatedPkg.wanted,
         isDeprecated: Boolean(outdatedPkg.latestManifest?.deprecated),
-        dependencyType: outdatedPkg.belongsTo,
+        dependencyType: outdatedPkg.dependencyType ?? outdatedPkg.belongsTo,
         dependentPackages: outdatedPkg.dependentPkgs.map(({ manifest, location }) => ({ name: manifest.name!, location })),
       }
       if (opts.long) {

--- a/pnpm11/deps/inspection/commands/src/outdated/recursive.ts
+++ b/pnpm11/deps/inspection/commands/src/outdated/recursive.ts
@@ -94,7 +94,7 @@ export async function outdatedRecursive (
       const key = JSON.stringify([outdatedAction.packageName, outdatedAction.current, outdatedAction.dependencyType])
       outdatedMap[key] = {
         ...outdatedAction,
-        dependentPkgs: [{ location: opts.workspaceDir ?? opts.dir, manifest: { name: '.github' } }],
+        dependentPkgs: [{ location: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir, manifest: { name: '.github' } }],
       }
     }
   }

--- a/pnpm11/deps/inspection/commands/test/outdated/index.ts
+++ b/pnpm11/deps/inspection/commands/test/outdated/index.ts
@@ -378,9 +378,15 @@ test('pnpm outdated: print only compatible versions', async () => {
 })
 
 test('ignore packages in package.json > pnpm.updateConfig.ignoreDependencies in outdated command', async () => {
+  tempDir()
+  fs.copyFileSync(path.join(withPnpmUpdateIgnore, 'package.json'), path.resolve('package.json'))
+  fs.copyFileSync(path.join(withPnpmUpdateIgnore, WANTED_LOCKFILE), path.resolve(WANTED_LOCKFILE))
+  fs.mkdirSync(path.resolve('node_modules/.pnpm'), { recursive: true })
+  fs.copyFileSync(path.join(withPnpmUpdateIgnore, WANTED_LOCKFILE), path.resolve('node_modules/.pnpm/lock.yaml'))
+
   const { output, exitCode } = await outdated.handler({
     ...OUTDATED_OPTIONS,
-    dir: withPnpmUpdateIgnore,
+    dir: process.cwd(),
     updateConfig: {
       ignoreDependencies: [
         'is-positive',

--- a/pnpm11/deps/inspection/commands/tsconfig.json
+++ b/pnpm11/deps/inspection/commands/tsconfig.json
@@ -88,6 +88,9 @@
       "path": "../../../workspace/projects-filter"
     },
     {
+      "path": "../../github-actions"
+    },
+    {
       "path": "../list"
     },
     {

--- a/pnpm11/installing/commands/package.json
+++ b/pnpm11/installing/commands/package.json
@@ -49,6 +49,7 @@
     "@pnpm/config.writer": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
+    "@pnpm/deps.github-actions": "workspace:*",
     "@pnpm/deps.inspection.outdated": "workspace:*",
     "@pnpm/deps.path": "workspace:*",
     "@pnpm/deps.security.signatures": "workspace:*",

--- a/pnpm11/installing/commands/src/update/getUpdateChoices.ts
+++ b/pnpm11/installing/commands/src/update/getUpdateChoices.ts
@@ -20,18 +20,20 @@ type ChoiceGroup = Array<{
   disabled?: boolean
 }>
 
-export function getUpdateChoices (outdatedPkgsOfProjects: OutdatedPackage[], workspacesEnabled: boolean): ChoiceGroup {
+type UpdateChoiceDependency = OutdatedPackage & { dependencyType?: 'githubAction' }
+
+export function getUpdateChoices (outdatedPkgsOfProjects: UpdateChoiceDependency[], workspacesEnabled: boolean): ChoiceGroup {
   if (isEmpty(outdatedPkgsOfProjects)) {
     return []
   }
 
-  const pkgUniqueKey = (outdatedPkg: OutdatedPackage) => {
-    return JSON.stringify([outdatedPkg.packageName, outdatedPkg.latestManifest?.version, outdatedPkg.current])
+  const pkgUniqueKey = (outdatedPkg: UpdateChoiceDependency) => {
+    return JSON.stringify([outdatedPkg.packageName, outdatedPkg.latestManifest?.version, outdatedPkg.current, outdatedPkg.dependencyType])
   }
 
   const dedupeAndGroupPkgs = pipe(
-    uniqBy((outdatedPkg: OutdatedPackage) => pkgUniqueKey(outdatedPkg)),
-    groupBy((outdatedPkg: OutdatedPackage) => outdatedPkg.belongsTo)
+    uniqBy((outdatedPkg: UpdateChoiceDependency) => pkgUniqueKey(outdatedPkg)),
+    groupBy((outdatedPkg: UpdateChoiceDependency) => outdatedPkg.dependencyType ?? outdatedPkg.belongsTo)
   )
 
   const groupPkgsByType = dedupeAndGroupPkgs(outdatedPkgsOfProjects)
@@ -85,10 +87,12 @@ export function getUpdateChoices (outdatedPkgsOfProjects: OutdatedPackage[], wor
       }
     })
 
-    // To filter out selected "dependencies" or "devDependencies" in the final output,
-    // we rename it here to "[dependencies]" or "[devDependencies]",
-    // which will be filtered out in the format function of the prompt.
-    finalChoices.push({ name: `[${depGroup}]`, choices, message: depGroup })
+    // The prompt renderer treats bracketed names as group labels rather than selectable values.
+    finalChoices.push({
+      name: `[${depGroup}]`,
+      choices,
+      message: depGroup === 'githubAction' ? 'GitHub Actions' : depGroup,
+    })
   }
   return finalChoices
 }
@@ -99,7 +103,7 @@ interface RawChoice {
   disabled?: boolean
 }
 
-function buildPkgChoice (outdatedPkg: OutdatedPackage, workspacesEnabled: boolean): RawChoice {
+function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled: boolean): RawChoice {
   const sdiff = semverDiff(outdatedPkg.wanted, outdatedPkg.latestManifest!.version)
   const nextVersion = sdiff.change === null
     ? outdatedPkg.latestManifest!.version

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -82,6 +82,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
   return {
     ...rcOptionsTypes(),
     changeset: Boolean,
+    'include-github-actions': Boolean,
     interactive: Boolean,
     latest: Boolean,
     recursive: Boolean,
@@ -103,7 +104,7 @@ export const completion: CompletionFunc = async (cliOpts) => {
 export function help (): string {
   return renderHelp({
     aliases: ['up', 'upgrade'],
-    description: 'Updates package and GitHub Actions dependencies to their latest version based on the specified range. You can use "*" in a dependency name to update all dependencies with the same pattern.',
+    description: 'Updates package dependencies to their latest version based on the specified range. GitHub Actions dependencies can be included with --include-github-actions. You can use "*" in a dependency name to update all dependencies with the same pattern.',
     descriptionLists: [
       {
         title: 'Options',
@@ -161,6 +162,10 @@ dependencies is not found inside the workspace',
             name: '--changeset',
           },
           {
+            description: 'Also update GitHub Actions dependencies in workflow and action files',
+            name: '--include-github-actions',
+          },
+          {
             description: 'Don\'t update the ranges in package.json.',
             name: '--no-save',
           },
@@ -178,6 +183,7 @@ dependencies is not found inside the workspace',
 export type UpdateCommandOptions = InstallCommandOptions & {
   changeset?: boolean
   include?: IncludedDependencies
+  includeGithubActions?: boolean
   interactive?: boolean
   latest?: boolean
   packageVulnerabilityAudit?: PackageVulnerabilityAudit
@@ -318,7 +324,7 @@ async function interactiveUpdate (
     throw err
   }
 
-  return update(updatePkgNames, opts, rebuildHandler) as Promise<undefined>
+  return update(updatePkgNames, { ...opts, includeGithubActions: true }, rebuildHandler) as Promise<undefined>
 }
 
 async function update (
@@ -333,7 +339,13 @@ async function update (
     }
   }
   const includeDirect = makeIncludeDependenciesFromCLI(opts.cliOptions)
-  const packageDependencies = dependencies.filter((dependency) => !isGitHubActionSelector(dependency))
+  const updateActions = includeDirect.devDependencies &&
+    opts.save !== false &&
+    !opts.lockfileOnly &&
+    (opts.includeGithubActions === true || opts.updateConfig?.githubActions === true)
+  const packageDependencies = updateActions
+    ? dependencies.filter((dependency) => !isGitHubActionSelector(dependency))
+    : dependencies
   // include is always all-true for updates: updates should not change which
   // dep types the modules directory supports. The filtering of which deps to
   // actually resolve/update is handled by includeDirect (from CLI flags).
@@ -374,7 +386,7 @@ async function update (
       dryRun: false,
     }, packageDependencies)
   }
-  if (includeDirect.devDependencies && opts.save !== false && !opts.lockfileOnly) {
+  if (updateActions) {
     await updateGitHubActions({
       dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
       latest: opts.latest,

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -9,7 +9,7 @@ import {
 } from '@pnpm/cli.utils'
 import { createMatcher } from '@pnpm/config.matcher'
 import { types as allTypes } from '@pnpm/config.reader'
-import { findOutdatedGitHubActions, isGitHubActionSelector, updateGitHubActions } from '@pnpm/deps.github-actions'
+import { findOutdatedGitHubActions, isGitHubActionSelector, normalizeGitHubActionSelector, updateGitHubActions } from '@pnpm/deps.github-actions'
 import { outdatedDepsOfProjects } from '@pnpm/deps.inspection.outdated'
 import { PnpmError } from '@pnpm/error'
 import { handleGlobalUpdate } from '@pnpm/global.commands'
@@ -247,7 +247,7 @@ async function interactiveUpdate (
       ? findOutdatedGitHubActions({
         compatible: opts.latest !== true,
         dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
-        match: input.length > 0 ? createMatcher(input) : undefined,
+        match: input.length > 0 ? createMatcher(input.map(normalizeGitHubActionSelector)) : undefined,
       })
       : [],
   ])
@@ -332,17 +332,18 @@ async function update (
   opts: UpdateCommandOptions,
   rebuildHandler?: CommandHandler
 ): Promise<void> {
-  if (opts.latest) {
-    const dependenciesWithTags = dependencies.filter((name) => parseUpdateParam(name).versionSpec != null)
-    if (dependenciesWithTags.length) {
-      throw new PnpmError('LATEST_WITH_SPEC', `Specs are not allowed to be used with --latest (${dependenciesWithTags.join(', ')})`)
-    }
-  }
   const includeDirect = makeIncludeDependenciesFromCLI(opts.cliOptions)
   const updateActions = includeDirect.devDependencies &&
     opts.save !== false &&
     !opts.lockfileOnly &&
     (opts.includeGithubActions === true || opts.updateConfig?.githubActions === true)
+  if (opts.latest) {
+    const dependenciesWithTags = dependencies.filter((name) =>
+      (!updateActions || !isGitHubActionSelector(name)) && parseUpdateParam(name).versionSpec != null)
+    if (dependenciesWithTags.length) {
+      throw new PnpmError('LATEST_WITH_SPEC', `Specs are not allowed to be used with --latest (${dependenciesWithTags.join(', ')})`)
+    }
+  }
   const packageDependencies = updateActions
     ? dependencies.filter((dependency) => !isGitHubActionSelector(dependency))
     : dependencies
@@ -390,7 +391,7 @@ async function update (
     await updateGitHubActions({
       dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
       latest: opts.latest,
-      match: dependencies.length > 0 ? createMatcher(dependencies) : undefined,
+      match: dependencies.length > 0 ? createMatcher(dependencies.map(normalizeGitHubActionSelector)) : undefined,
     })
   }
   if (changesetContext != null) {

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -9,6 +9,7 @@ import {
 } from '@pnpm/cli.utils'
 import { createMatcher } from '@pnpm/config.matcher'
 import { types as allTypes } from '@pnpm/config.reader'
+import { findOutdatedGitHubActions, isGitHubActionSelector, updateGitHubActions } from '@pnpm/deps.github-actions'
 import { outdatedDepsOfProjects } from '@pnpm/deps.inspection.outdated'
 import { PnpmError } from '@pnpm/error'
 import { handleGlobalUpdate } from '@pnpm/global.commands'
@@ -102,7 +103,7 @@ export const completion: CompletionFunc = async (cliOpts) => {
 export function help (): string {
   return renderHelp({
     aliases: ['up', 'upgrade'],
-    description: 'Updates packages to their latest version based on the specified range. You can use "*" in package name to update all packages with the same pattern.',
+    description: 'Updates package and GitHub Actions dependencies to their latest version based on the specified range. You can use "*" in a dependency name to update all dependencies with the same pattern.',
     descriptionLists: [
       {
         title: 'Options',
@@ -219,21 +220,44 @@ async function interactiveUpdate (
         manifest: await readProjectManifestOnly(opts.dir, opts),
       },
     ]
-  const outdatedPkgsOfProjects = await outdatedDepsOfProjects(projects, input, {
-    ...opts,
-    compatible: opts.latest !== true,
-    ignoreDependencies: opts.updateConfig?.ignoreDependencies,
-    include,
-    retry: {
-      factor: opts.fetchRetryFactor,
-      maxTimeout: opts.fetchRetryMaxtimeout,
-      minTimeout: opts.fetchRetryMintimeout,
-      retries: opts.fetchRetries,
-    },
-    timeout: opts.fetchTimeout,
-  })
+  const packageInput = input.filter((selector) => !isGitHubActionSelector(selector))
+  const [outdatedPkgsOfProjects, outdatedActions] = await Promise.all([
+    input.length === 0 || packageInput.length > 0
+      ? outdatedDepsOfProjects(projects, packageInput, {
+        ...opts,
+        compatible: opts.latest !== true,
+        ignoreDependencies: opts.updateConfig?.ignoreDependencies,
+        include,
+        retry: {
+          factor: opts.fetchRetryFactor,
+          maxTimeout: opts.fetchRetryMaxtimeout,
+          minTimeout: opts.fetchRetryMintimeout,
+          retries: opts.fetchRetries,
+        },
+        timeout: opts.fetchTimeout,
+      })
+      : projects.map(() => []),
+    include.devDependencies && opts.save !== false && !opts.lockfileOnly
+      ? findOutdatedGitHubActions({
+        compatible: opts.latest !== true,
+        dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
+        match: input.length > 0 ? createMatcher(input) : undefined,
+      })
+      : [],
+  ])
   const workspacesEnabled = !!opts.workspaceDir
-  const choiceGroups = getUpdateChoices(unnest(outdatedPkgsOfProjects), workspacesEnabled)
+  const choiceGroups = getUpdateChoices([
+    ...unnest(outdatedPkgsOfProjects),
+    ...outdatedActions.map((action) => ({
+      alias: action.name,
+      belongsTo: 'devDependencies' as const,
+      current: action.current,
+      dependencyType: 'githubAction' as const,
+      latestManifest: { name: action.name, version: action.latest, homepage: action.homepage },
+      packageName: action.name,
+      wanted: action.wanted,
+    })),
+  ], workspacesEnabled)
   if (choiceGroups.length === 0) {
     if (opts.latest) {
       return 'All of your dependencies are already up to date'
@@ -261,7 +285,7 @@ async function interactiveUpdate (
     }
   }
 
-  const message = 'Choose which packages to update ' +
+  const message = 'Choose which dependencies to update ' +
     `(Press ${chalk.cyan('<space>')} to select, ` +
     `${chalk.cyan('<a>')} to toggle all, ` +
     `${chalk.cyan('<i>')} to invert selection)\n\nEnter to start updating. Ctrl-c to cancel.`
@@ -274,7 +298,7 @@ async function interactiveUpdate (
       required: true,
       validate: (values) => {
         if (values.length === 0) {
-          return 'You must choose at least one package.'
+          return 'You must choose at least one dependency.'
         }
         return true
       },
@@ -309,6 +333,7 @@ async function update (
     }
   }
   const includeDirect = makeIncludeDependenciesFromCLI(opts.cliOptions)
+  const packageDependencies = dependencies.filter((dependency) => !isGitHubActionSelector(dependency))
   // include is always all-true for updates: updates should not change which
   // dep types the modules directory supports. The filtering of which deps to
   // actually resolve/update is handled by includeDirect (from CLI flags).
@@ -324,29 +349,38 @@ async function update (
   if (opts.packageVulnerabilityAudit != null) {
     updateMatching = createVulnerabilityUpdateMatching(opts.packageVulnerabilityAudit)
   } else if (
-    (dependencies.length > 0) && dependencies.every(dep => !dep.substring(1).includes('@')) && depth > 0 && !opts.latest
+    (packageDependencies.length > 0) && packageDependencies.every(dep => !dep.substring(1).includes('@')) && depth > 0 && !opts.latest
   ) {
-    updateMatching = createMatcher(dependencies)
+    updateMatching = createMatcher(packageDependencies)
   }
   const generateChangeset = opts.changeset ?? opts.updateConfig?.changeset ?? false
   const changesetContext = generateChangeset ? await captureUpdateChangesetContext(opts) : undefined
-  await installDeps({
-    ...opts,
-    rebuildHandler,
-    allowNew: false,
-    depth,
-    ignoreCurrentSpecifiers: false,
-    include,
-    includeDirect,
-    update: true,
-    updateToLatest: opts.latest,
-    updateMatching,
-    updatePackageManifest: opts.save !== false,
-    resolutionMode: opts.save === false ? 'highest' : opts.resolutionMode,
-    // `--dry-run` is an `install`-only preview; never let a config-level
-    // `dry-run` turn `update` into a no-op check.
-    dryRun: false,
-  }, dependencies)
+  if (dependencies.length === 0 || packageDependencies.length > 0) {
+    await installDeps({
+      ...opts,
+      rebuildHandler,
+      allowNew: false,
+      depth,
+      ignoreCurrentSpecifiers: false,
+      include,
+      includeDirect,
+      update: true,
+      updateToLatest: opts.latest,
+      updateMatching,
+      updatePackageManifest: opts.save !== false,
+      resolutionMode: opts.save === false ? 'highest' : opts.resolutionMode,
+      // `--dry-run` is an `install`-only preview; never let a config-level
+      // `dry-run` turn `update` into a no-op check.
+      dryRun: false,
+    }, packageDependencies)
+  }
+  if (includeDirect.devDependencies && opts.save !== false && !opts.lockfileOnly) {
+    await updateGitHubActions({
+      dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
+      latest: opts.latest,
+      match: dependencies.length > 0 ? createMatcher(dependencies) : undefined,
+    })
+  }
   if (changesetContext != null) {
     await generateUpdateChangeset(changesetContext)
   }

--- a/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
+++ b/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
@@ -177,3 +177,23 @@ test('getUpdateChoices() handles long version strings without wrapping', () => {
   // when chalk has colors enabled.
   expect(stripVTControlCharacters(dataRow.message)).toContain('7.0.0-dev.20251214.1')
 })
+
+test('getUpdateChoices() groups GitHub Actions separately', () => {
+  const choices = getUpdateChoices([{
+    alias: 'actions/checkout',
+    belongsTo: 'devDependencies',
+    current: '4.1.0',
+    dependencyType: 'githubAction',
+    latestManifest: {
+      name: 'actions/checkout',
+      version: '4.2.2',
+      homepage: 'https://github.com/actions/checkout',
+    },
+    packageName: 'actions/checkout',
+    wanted: '4.2.2',
+  }], false)
+
+  expect(choices).toHaveLength(1)
+  expect(choices[0].message).toBe('GitHub Actions')
+  expect(choices[0].choices[1]).toMatchObject({ name: 'actions/checkout', value: 'actions/checkout' })
+})

--- a/pnpm11/installing/commands/test/update/interactive.ts
+++ b/pnpm11/installing/commands/test/update/interactive.ts
@@ -127,7 +127,7 @@ test('interactively update', async () => {
   expect(mockCheckbox).toHaveBeenCalledWith(
     expect.objectContaining({
       message:
-        'Choose which packages to update ' +
+        'Choose which dependencies to update ' +
         `(Press ${chalk.cyan('<space>')} to select, ` +
         `${chalk.cyan('<a>')} to toggle all, ` +
         `${chalk.cyan('<i>')} to invert selection)\n\nEnter to start updating. Ctrl-c to cancel.`,
@@ -183,7 +183,7 @@ test('interactively update', async () => {
   expect(mockCheckbox).toHaveBeenCalledWith(
     expect.objectContaining({
       message:
-        'Choose which packages to update ' +
+        'Choose which dependencies to update ' +
         `(Press ${chalk.cyan('<space>')} to select, ` +
         `${chalk.cyan('<a>')} to toggle all, ` +
         `${chalk.cyan('<i>')} to invert selection)\n\nEnter to start updating. Ctrl-c to cancel.`,
@@ -324,7 +324,7 @@ test('interactively update should ignore dependencies from the ignoreDependencie
   expect(mockCheckbox).toHaveBeenCalledWith(
     expect.objectContaining({
       message:
-        'Choose which packages to update ' +
+        'Choose which dependencies to update ' +
         `(Press ${chalk.cyan('<space>')} to select, ` +
         `${chalk.cyan('<a>')} to toggle all, ` +
         `${chalk.cyan('<i>')} to invert selection)\n\nEnter to start updating. Ctrl-c to cancel.`,

--- a/pnpm11/installing/commands/tsconfig.json
+++ b/pnpm11/installing/commands/tsconfig.json
@@ -76,6 +76,9 @@
       "path": "../../core/types"
     },
     {
+      "path": "../../deps/github-actions"
+    },
+    {
       "path": "../../deps/inspection/outdated"
     },
     {

--- a/pnpm11/resolving/git-resolver/src/index.ts
+++ b/pnpm11/resolving/git-resolver/src/index.ts
@@ -117,7 +117,7 @@ function resolveVTags (vTags: string[], range: string): string | null {
   return semver.maxSatisfying(vTags, range, true)
 }
 
-async function getRepoRefs (repo: string, ref: string | null): Promise<Record<string, string>> {
+export async function getRepoRefs (repo: string, ref: string | null): Promise<Record<string, string>> {
   const gitArgs = [repo]
   if (ref) {
     gitArgs.push(ref)
@@ -130,7 +130,7 @@ async function getRepoRefs (repo: string, ref: string | null): Promise<Record<st
   const refs: Record<string, string> = {}
   for (const line of result.stdout.split('\n')) {
     const [commit, refName] = line.split('\t')
-    refs[refName] = commit
+    if (commit && refName) refs[refName] = commit
   }
   return refs
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Treat semantic-versioned GitHub Actions references as development dependencies in `pnpm outdated` and interactive `pnpm update`, including compatible/latest selection and dependency selectors.
- Keep non-interactive `pnpm update` package-only by default; GitHub Actions can be enabled per invocation with `--include-github-actions` or per workspace with `update.githubActions: true`.
- Discover actions in workflow files and referenced local reusable workflows or composite actions while conservatively ignoring Docker and non-semver references.
- Always write updated actions as exact 40-character commit hashes and retain the resolved release tag in an adjacent comment, for example `actions/checkout@<sha> # v4.4.0`.
- Implement matching behavior in the TypeScript CLI and pacquet, with focused tests and a release changeset for both products.

Validation included the full pacquet workspace test suite, workspace clippy with warnings denied, the `perfectionist` dylint suite, the pnpm bundled CLI build, focused outdated/update tests, live update checks against GitHub refs, and the complete pre-push hook.

The command documentation is maintained outside this repository; the included changeset provides the in-repository user-facing release note.

## Squash Commit Body

```text
Teach `outdated`, interactive `update`, and opt-in non-interactive updates to discover GitHub Actions dependencies in workflow files and referenced local action definitions.

Model actions as development dependencies so the existing production/development filters, compatible/latest behavior, explicit selectors, interactive selection, recursive workspace handling, and no-save/lockfile-only semantics remain consistent with package and runtime updates. Keep non-interactive updates package-only unless `--include-github-actions` is passed or `update.githubActions` is enabled in `pnpm-workspace.yaml`.

Resolve semantic release tags through Git refs, but never persist a tag as the executable reference. Every changed action is pinned to the resolved commit SHA, with the semantic tag retained in an adjacent comment for readability and future version comparison. Non-semver and Docker references are left untouched.

Implement the behavior in both the TypeScript CLI and pacquet and cover discovery, version selection, exact-SHA pinning, comment preservation, selector handling, and formatting preservation.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787248618&installation_model_id=426870&pr_number=13198&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13198&signature=21b34a31e9e727cd48658535212502a931e179eac5948b37510c1060f56e654e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm outdated` now reports GitHub Actions–backed dependencies alongside registry packages, with clearer labeling and richer JSON output (`dependencyType: "githubAction"` and `wanted`).
  * `pnpm update` can update GitHub Actions in both interactive and non-interactive modes, rewriting `uses:` entries to newer commit-pinned refs while preserving existing inline tag comments/formatting.
* **Bug Fixes**
  * Improved safety when rewriting workflow files (including hardlink cases), avoiding unintended mutations.
* **Tests**
  * Expanded GitHub Actions detection, version/compatibility resolution, rendering/grouping, and workflow rewriting coverage.
* **Chores**
  * Updated GitHub Actions tooling/package version bumps used by CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->