### PR TITLE
feat(pacquet): support recursive outdated queries

### DIFF
--- a/.changeset/recursive-outdated-queries.md
+++ b/.changeset/recursive-outdated-queries.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added recursive workspace support to `pnpm outdated`. `pnpm list` and `pnpm ll` now inspect all workspace projects by default, matching the TypeScript CLI.

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -241,6 +241,17 @@ impl CliArgs {
         }
     }
 
+    /// Promote commands marked recursive-by-default by pnpm when they run
+    /// inside a workspace.
+    pub fn promote_recursive_by_default(&mut self) {
+        if !self.recursive
+            && self.command.recursive_by_default()
+            && pacquet_workspace::find_workspace_dir(&self.dir).is_ok_and(|dir| dir.is_some())
+        {
+            self.recursive = true;
+        }
+    }
+
     /// `restart` also runs scripts and accepts its own `--if-present`,
     /// so the top-level spelling is valid for it too — unlike the
     /// recursive-only flags, which `restart` rejects. `exec` is the
@@ -489,6 +500,10 @@ pub enum CliCommand {
 }
 
 impl CliCommand {
+    fn recursive_by_default(&self) -> bool {
+        matches!(self, CliCommand::List(_) | CliCommand::Ll(_))
+    }
+
     pub(crate) fn default_reporter_summary_scope(&self) -> SummaryScope {
         match self {
             CliCommand::Access(_) => SummaryScope::CurrentPrefix,

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -896,7 +896,7 @@ fn render_recursive_json(outdated: &[OutdatedInWorkspace], long: bool) -> String
             "dependencyType": dependency_type,
             "dependentPackages": entry.dependents.iter().map(|dependent| serde_json::json!({
                 "name": dependent.name,
-                "location": dependent.location,
+                "location": dependent.location.to_string_lossy(),
             })).collect::<Vec<_>>(),
         });
         if long {

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -229,7 +229,7 @@ async fn fetch_package_cached(
 ) -> Result<Arc<Package>, RegistryError> {
     let key = (registry.to_string(), package_name.to_string());
     let entry = {
-        let mut cache = cache.lock().expect("packument cache mutex poisoned");
+        let mut cache = cache.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         Arc::clone(cache.entry(key).or_default())
     };
     let package = entry

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -9,15 +9,20 @@
 //! in-range version under `--compatible`), while `update` compares against
 //! the version a bump would move to.
 //!
-//! Scope vs. pnpm: pacquet loads a single lockfile (the *wanted*
-//! lockfile), so there is no separate *current* lockfile to diff against —
-//! a dependency's `current` and `wanted` versions are always equal, and
-//! the "missing (wanted X)" state pnpm shows for a resolved-but-not-
-//! installed dependency does not arise. Recursive (`-r`) and global
-//! (`-g`) runs are rejected, matching `pacquet update`.
+//! Scope vs. pnpm: pacquet loads the *wanted* lockfile, so there is no
+//! separate *current* lockfile to diff against — a dependency's `current`
+//! and `wanted` versions are always equal, and the "missing (wanted X)"
+//! state pnpm shows for a resolved-but-not-installed dependency does not
+//! arise.
 
-use crate::State;
+use crate::{
+    State,
+    cli_args::recursive::{
+        AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+    },
+};
 use clap::{Args, ValueEnum};
+use miette::IntoDiagnostic;
 use node_semver::Version;
 use owo_colors::{OwoColorize, Stream};
 use pacquet_config::{
@@ -29,7 +34,7 @@ use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_npm_resolver::pick_registry_for_package;
-use std::{collections::HashMap, io::Write};
+use std::{collections::HashMap, io::Write, path::PathBuf};
 
 /// Which registry version a dependency is compared against to decide
 /// whether it is outdated.
@@ -314,12 +319,23 @@ pub enum OutdatedOutcome {
     Outdated,
 }
 
+struct OutdatedInWorkspace {
+    package: OutdatedPackage,
+    dependents: Vec<DependentProject>,
+}
+
+#[derive(Clone)]
+struct DependentProject {
+    name: String,
+    location: PathBuf,
+}
+
 impl OutdatedArgs {
     /// Run the check and print the report to stdout. Returns whether any
     /// dependency was outdated; the caller decides the process exit code.
     pub async fn run(self, state: State) -> miette::Result<OutdatedOutcome> {
         if state.config.recursive {
-            return Err(miette::miette!("`pnpm outdated --recursive` is not supported yet."));
+            return self.run_recursive(state).await;
         }
 
         let config = state.config;
@@ -343,11 +359,8 @@ impl OutdatedArgs {
         }
 
         if lockfile.is_none() {
-            let dir = manifest.path().parent().unwrap_or_else(|| manifest.path()).display();
-            return Err(miette::miette!(
-                code = "ERR_PNPM_OUTDATED_NO_LOCKFILE",
-                r#"No lockfile in directory "{dir}". Run `pnpm install` to generate one."#
-            ));
+            let dir = manifest.path().parent().unwrap_or_else(|| manifest.path());
+            return Err(no_lockfile_error(dir));
         }
 
         let include = self.dependency_options.include();
@@ -379,6 +392,108 @@ impl OutdatedArgs {
             OutdatedFormat::Json => render_json(&outdated, self.long),
         };
 
+        let mut stdout = std::io::stdout();
+        let _ = writeln!(stdout, "{output}");
+        let _ = stdout.flush();
+
+        Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
+    }
+
+    async fn run_recursive(self, state: State) -> miette::Result<OutdatedOutcome> {
+        let config = state.config;
+        let workspace_root =
+            config.workspace_dir.clone().unwrap_or_else(|| state.lockfile_dir().to_path_buf());
+        let (projects, _) = discover_workspace_projects(&workspace_root)?;
+        let prefix = state.manifest.path().parent().unwrap_or_else(|| state.manifest.path());
+        let selection =
+            select_recursive_projects(&projects, config, prefix, AutoExcludeRoot::Disabled)?;
+        let include = self.dependency_options.include();
+        let target_version =
+            if self.compatible { TargetVersion::WithinRange } else { TargetVersion::Latest };
+        let matcher = (!self.packages.is_empty()).then(|| create_matcher(&self.packages));
+        let query = OutdatedQuery {
+            target_version,
+            include_direct: &include,
+            match_names: matcher.as_ref(),
+            include_deprecated: true,
+        };
+
+        let shared_lockfile = if config.shared_workspace_lockfile {
+            state
+                .lockfile
+                .get()
+                .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?
+        } else {
+            None
+        };
+        let mut outdated: Vec<OutdatedInWorkspace> = Vec::new();
+        let mut outdated_indexes: HashMap<String, usize> = HashMap::new();
+        for (project_dir, node) in &selection.selected {
+            let project = node.package.project;
+            let has_any_dependency = project
+                .manifest
+                .dependencies([
+                    DependencyGroup::Prod,
+                    DependencyGroup::Dev,
+                    DependencyGroup::Optional,
+                ])
+                .next()
+                .is_some();
+            if !has_any_dependency {
+                continue;
+            }
+
+            let project_lockfile;
+            let (lockfile, importer_id) = if config.shared_workspace_lockfile {
+                (
+                    shared_lockfile,
+                    pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
+                )
+            } else {
+                project_lockfile = Lockfile::load_wanted_from_dir(project_dir).into_diagnostic()?;
+                (project_lockfile.as_ref(), Lockfile::ROOT_IMPORTER_KEY.to_string())
+            };
+            let Some(lockfile) = lockfile else {
+                return Err(no_lockfile_error(project_dir));
+            };
+            let project_outdated = collect_outdated_for_importer(
+                &project.manifest,
+                Some(lockfile),
+                &importer_id,
+                config,
+                &state.http_client,
+                &query,
+            )
+            .await?;
+            let dependent = DependentProject {
+                name: project
+                    .manifest
+                    .value()
+                    .get("name")
+                    .and_then(|name| name.as_str())
+                    .map_or_else(|| project_dir.to_string_lossy().into_owned(), str::to_owned),
+                location: project_dir.clone(),
+            };
+            for package in project_outdated {
+                let dependency_type: &'static str = package.belongs_to.into();
+                let key =
+                    format!("{}\0{}\0{}", package.package_name, package.current, dependency_type);
+                if let Some(&index) = outdated_indexes.get(&key) {
+                    outdated[index].dependents.push(dependent.clone());
+                } else {
+                    outdated_indexes.insert(key, outdated.len());
+                    outdated
+                        .push(OutdatedInWorkspace { package, dependents: vec![dependent.clone()] });
+                }
+            }
+        }
+
+        sort_workspace_outdated(&mut outdated);
+        let output = match self.resolve_format() {
+            OutdatedFormat::Table => render_recursive_table(&outdated, self.long),
+            OutdatedFormat::List => render_recursive_list(&outdated, self.long),
+            OutdatedFormat::Json => render_recursive_json(&outdated, self.long),
+        };
         let mut stdout = std::io::stdout();
         let _ = writeln!(stdout, "{output}");
         let _ = stdout.flush();
@@ -466,6 +581,14 @@ impl OutdatedArgs {
     }
 }
 
+fn no_lockfile_error(dir: &std::path::Path) -> miette::Report {
+    let dir = dir.display();
+    miette::miette!(
+        code = "ERR_PNPM_OUTDATED_NO_LOCKFILE",
+        r#"No lockfile in directory "{dir}". Run `pnpm install` to generate one."#,
+    )
+}
+
 /// The kind of semver bump from `current` to `target`. Drives the default
 /// sort order and the colorized highlight in the `Latest` column.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -504,18 +627,40 @@ fn change_priority(change: Change) -> u8 {
 }
 
 fn sort_outdated(outdated: &mut [OutdatedPackage], sort_by: Option<SortBy>) {
-    match sort_by {
-        Some(SortBy::Name) => {
-            outdated.sort_by(|left, right| left.package_name.cmp(&right.package_name));
-        }
-        None => outdated.sort_by(|left, right| {
-            let by_change = change_priority(classify(&left.current, &left.target))
-                .cmp(&change_priority(classify(&right.current, &right.target)));
-            by_change
-                .then_with(|| left.package_name.cmp(&right.package_name))
-                .then_with(|| left.current.to_string().cmp(&right.current.to_string()))
-        }),
+    outdated.sort_by(|left, right| compare_outdated(left, right, sort_by));
+}
+
+fn sort_workspace_outdated(outdated: &mut [OutdatedInWorkspace]) {
+    outdated.sort_by(|left, right| {
+        compare_outdated(&left.package, &right.package, None).then_with(|| {
+            dependency_group_priority(left.package.belongs_to)
+                .cmp(&dependency_group_priority(right.package.belongs_to))
+        })
+    });
+}
+
+fn dependency_group_priority(group: DependencyGroup) -> u8 {
+    match group {
+        DependencyGroup::Optional => 0,
+        DependencyGroup::Prod => 1,
+        DependencyGroup::Dev => 2,
+        DependencyGroup::Peer => 3,
     }
+}
+
+fn compare_outdated(
+    left: &OutdatedPackage,
+    right: &OutdatedPackage,
+    sort_by: Option<SortBy>,
+) -> std::cmp::Ordering {
+    if sort_by == Some(SortBy::Name) {
+        return left.package_name.cmp(&right.package_name);
+    }
+    let by_change = change_priority(classify(&left.current, &left.target))
+        .cmp(&change_priority(classify(&right.current, &right.target)));
+    by_change
+        .then_with(|| left.package_name.cmp(&right.package_name))
+        .then_with(|| left.current.to_string().cmp(&right.current.to_string()))
 }
 
 fn render_table(outdated: &[OutdatedPackage], long: bool) -> String {
@@ -592,6 +737,104 @@ fn render_json(outdated: &[OutdatedPackage], long: bool) -> String {
     }
     serde_json::to_string_pretty(&serde_json::Value::Object(map))
         .expect("serialize outdated report to JSON")
+}
+
+fn render_recursive_table(outdated: &[OutdatedInWorkspace], long: bool) -> String {
+    if outdated.is_empty() {
+        return String::new();
+    }
+    use tabled::builder::Builder;
+    use tabled::settings::Style;
+
+    let mut header: Vec<String> = ["Package", "Current", "Latest", "Dependents"]
+        .iter()
+        .map(|heading| bright_blue(heading))
+        .collect();
+    if long {
+        header.push(bright_blue("Details"));
+    }
+    let mut builder = Builder::default();
+    builder.push_record(header);
+    for entry in outdated {
+        let mut row = vec![
+            render_package_name(&entry.package),
+            entry.package.current.to_string(),
+            render_latest(&entry.package),
+            render_dependents(entry),
+        ];
+        if long {
+            row.push(render_details(&entry.package));
+        }
+        builder.push_record(row);
+    }
+    let mut table = builder.build();
+    table.with(Style::modern());
+    table.to_string()
+}
+
+fn render_recursive_list(outdated: &[OutdatedInWorkspace], long: bool) -> String {
+    outdated
+        .iter()
+        .map(|entry| {
+            let package = &entry.package;
+            let label = if entry.dependents.len() == 1 { "Dependent:" } else { "Dependents:" };
+            let mut info = format!(
+                "{}\n{} {} {}\n{} {}",
+                bold(&render_package_name(package)),
+                package.current,
+                grey("=>"),
+                render_latest(package),
+                bold(label),
+                render_dependents(entry),
+            );
+            if long {
+                let details = render_details(package);
+                if !details.is_empty() {
+                    info.push('\n');
+                    info.push_str(&details);
+                }
+            }
+            info
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn render_recursive_json(outdated: &[OutdatedInWorkspace], long: bool) -> String {
+    let mut map = serde_json::Map::new();
+    for entry in outdated {
+        let package = &entry.package;
+        let dependency_type: &'static str = package.belongs_to.into();
+        let mut value = serde_json::json!({
+            "current": package.current.to_string(),
+            "latest": package.target.to_string(),
+            "wanted": package.current.to_string(),
+            "isDeprecated": package.deprecated.is_some(),
+            "dependencyType": dependency_type,
+            "dependentPackages": entry.dependents.iter().map(|dependent| serde_json::json!({
+                "name": dependent.name,
+                "location": dependent.location,
+            })).collect::<Vec<_>>(),
+        });
+        if long {
+            value["latestManifest"] = serde_json::json!({
+                "name": package.package_name,
+                "version": package.target.to_string(),
+                "deprecated": package.deprecated,
+                "homepage": package.homepage,
+            });
+        }
+        map.insert(package.package_name.clone(), value);
+    }
+    serde_json::to_string_pretty(&serde_json::Value::Object(map))
+        .expect("serialize recursive outdated report to JSON")
+}
+
+fn render_dependents(entry: &OutdatedInWorkspace) -> String {
+    let mut names: Vec<&str> =
+        entry.dependents.iter().map(|dependent| dependent.name.as_str()).collect();
+    names.sort_unstable();
+    names.join(", ")
 }
 
 fn render_package_name(pkg: &OutdatedPackage) -> String {

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -17,8 +17,9 @@
 
 use crate::{
     State,
-    cli_args::recursive::{
-        AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+    cli_args::{
+        recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
+        sanitize::sanitize_inline,
     },
 };
 use clap::{Args, ValueEnum};
@@ -34,7 +35,15 @@ use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::{Package, PackageVersion};
 use pacquet_resolving_npm_resolver::pick_registry_for_package;
-use std::{collections::HashMap, io::Write, path::PathBuf};
+use std::{
+    collections::HashMap,
+    io::Write,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+use tokio::sync::OnceCell;
+
+type PackumentCache = Mutex<HashMap<(String, String), Arc<OnceCell<Option<Arc<Package>>>>>>;
 
 /// Which registry version a dependency is compared against to decide
 /// whether it is outdated.
@@ -121,6 +130,27 @@ pub(crate) async fn collect_outdated_for_importer(
     http_client: &ThrottledClient,
     query: &OutdatedQuery<'_>,
 ) -> miette::Result<Vec<OutdatedPackage>> {
+    collect_outdated_for_importer_with_cache(
+        manifest,
+        lockfile,
+        importer_id,
+        config,
+        http_client,
+        query,
+        &PackumentCache::default(),
+    )
+    .await
+}
+
+async fn collect_outdated_for_importer_with_cache(
+    manifest: &PackageManifest,
+    lockfile: Option<&Lockfile>,
+    importer_id: &str,
+    config: &Config,
+    http_client: &ThrottledClient,
+    query: &OutdatedQuery<'_>,
+    packument_cache: &PackumentCache,
+) -> miette::Result<Vec<OutdatedPackage>> {
     let current_versions =
         current_versions_from_importer(lockfile, importer_id, query.include_direct);
     let current_versions = &current_versions;
@@ -150,14 +180,14 @@ pub(crate) async fn collect_outdated_for_importer(
                 config.resolved_registries().into_iter().collect();
             let registry =
                 pick_registry_for_package(&registries, package_name, Some(bare_specifier));
-            let package = Package::fetch_from_registry(
+            let package = fetch_package_cached(
+                packument_cache,
                 package_name,
                 http_client,
                 &registry,
                 &config.auth_headers,
             )
-            .await
-            .ok()?;
+            .await?;
             let target = resolve_target(&package, range, query.target_version)?;
             let deprecated = target.deprecated.clone();
             let is_newer = target.version > current;
@@ -171,11 +201,34 @@ pub(crate) async fn collect_outdated_for_importer(
                 current,
                 target: target.version.clone(),
                 deprecated,
-                homepage: package.homepage,
+                homepage: package.homepage.clone(),
             })
         });
 
     Ok(futures_util::future::join_all(fetches).await.into_iter().flatten().collect())
+}
+
+async fn fetch_package_cached(
+    cache: &PackumentCache,
+    package_name: &str,
+    http_client: &ThrottledClient,
+    registry: &str,
+    auth_headers: &pacquet_network::AuthHeaders,
+) -> Option<Arc<Package>> {
+    let key = (registry.to_string(), package_name.to_string());
+    let entry = {
+        let mut cache = cache.lock().expect("packument cache mutex poisoned");
+        Arc::clone(cache.entry(key).or_default())
+    };
+    entry
+        .get_or_init(|| async {
+            Package::fetch_from_registry(package_name, http_client, registry, auth_headers)
+                .await
+                .ok()
+                .map(Arc::new)
+        })
+        .await
+        .clone()
 }
 
 /// Resolve the [`TargetVersion`] to a concrete published version, or
@@ -426,9 +479,8 @@ impl OutdatedArgs {
         } else {
             None
         };
-        let mut outdated: Vec<OutdatedInWorkspace> = Vec::new();
-        let mut outdated_indexes: HashMap<String, usize> = HashMap::new();
-        for (project_dir, node) in &selection.selected {
+        let packument_cache = PackumentCache::default();
+        let project_queries = selection.selected.iter().filter_map(|(project_dir, node)| {
             let project = node.package.project;
             let has_any_dependency = project
                 .manifest
@@ -440,40 +492,55 @@ impl OutdatedArgs {
                 .next()
                 .is_some();
             if !has_any_dependency {
-                continue;
+                return None;
             }
-
-            let project_lockfile;
-            let (lockfile, importer_id) = if config.shared_workspace_lockfile {
-                (
-                    shared_lockfile,
-                    pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
+            Some(async {
+                let project_lockfile;
+                let (lockfile, importer_id) = if config.shared_workspace_lockfile {
+                    (
+                        shared_lockfile,
+                        pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
+                    )
+                } else {
+                    project_lockfile =
+                        Lockfile::load_wanted_from_dir(project_dir).into_diagnostic()?;
+                    (project_lockfile.as_ref(), Lockfile::ROOT_IMPORTER_KEY.to_string())
+                };
+                let Some(lockfile) = lockfile else {
+                    let lockfile_dir = if config.shared_workspace_lockfile {
+                        workspace_root.as_path()
+                    } else {
+                        project_dir.as_path()
+                    };
+                    return Err(no_lockfile_error(lockfile_dir));
+                };
+                let project_outdated = collect_outdated_for_importer_with_cache(
+                    &project.manifest,
+                    Some(lockfile),
+                    &importer_id,
+                    config,
+                    &state.http_client,
+                    &query,
+                    &packument_cache,
                 )
-            } else {
-                project_lockfile = Lockfile::load_wanted_from_dir(project_dir).into_diagnostic()?;
-                (project_lockfile.as_ref(), Lockfile::ROOT_IMPORTER_KEY.to_string())
-            };
-            let Some(lockfile) = lockfile else {
-                return Err(no_lockfile_error(project_dir));
-            };
-            let project_outdated = collect_outdated_for_importer(
-                &project.manifest,
-                Some(lockfile),
-                &importer_id,
-                config,
-                &state.http_client,
-                &query,
-            )
-            .await?;
-            let dependent = DependentProject {
-                name: project
-                    .manifest
-                    .value()
-                    .get("name")
-                    .and_then(|name| name.as_str())
-                    .map_or_else(|| project_dir.to_string_lossy().into_owned(), str::to_owned),
-                location: project_dir.clone(),
-            };
+                .await?;
+                let dependent = DependentProject {
+                    name: project
+                        .manifest
+                        .value()
+                        .get("name")
+                        .and_then(|name| name.as_str())
+                        .map_or_else(|| project_dir.to_string_lossy().into_owned(), str::to_owned),
+                    location: project_dir.clone(),
+                };
+                Ok::<_, miette::Report>((project_outdated, dependent))
+            })
+        });
+        let project_results = futures_util::future::join_all(project_queries).await;
+        let mut outdated: Vec<OutdatedInWorkspace> = Vec::new();
+        let mut outdated_indexes: HashMap<String, usize> = HashMap::new();
+        for result in project_results {
+            let (project_outdated, dependent) = result?;
             for package in project_outdated {
                 let dependency_type: &'static str = package.belongs_to.into();
                 let key =
@@ -831,8 +898,11 @@ fn render_recursive_json(outdated: &[OutdatedInWorkspace], long: bool) -> String
 }
 
 fn render_dependents(entry: &OutdatedInWorkspace) -> String {
-    let mut names: Vec<&str> =
-        entry.dependents.iter().map(|dependent| dependent.name.as_str()).collect();
+    let mut names: Vec<String> = entry
+        .dependents
+        .iter()
+        .map(|dependent| sanitize_inline(&dependent.name).into_owned())
+        .collect();
     names.sort_unstable();
     names.join(", ")
 }

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -33,7 +33,7 @@ use pacquet_config::{
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
-use pacquet_registry::{Package, PackageVersion};
+use pacquet_registry::{Package, PackageVersion, RegistryError};
 use pacquet_resolving_npm_resolver::pick_registry_for_package;
 use std::{
     collections::HashMap,
@@ -43,7 +43,7 @@ use std::{
 };
 use tokio::sync::OnceCell;
 
-type PackumentCache = Mutex<HashMap<(String, String), Arc<OnceCell<Option<Arc<Package>>>>>>;
+type PackumentCache = Mutex<HashMap<(String, String), Arc<OnceCell<Arc<Package>>>>>;
 
 /// Which registry version a dependency is compared against to decide
 /// whether it is outdated.
@@ -102,8 +102,8 @@ pub struct OutdatedQuery<'a> {
 /// the lockfile-pinned `current` version (or, per
 /// [`OutdatedQuery::include_deprecated`], whose `target` is deprecated).
 ///
-/// A dependency the registry cannot serve (private, renamed, offline) is
-/// skipped rather than failing the whole run.
+/// Registry failures abort the query with package context; dependencies whose
+/// metadata has no compatible target are omitted from the result.
 pub async fn collect_outdated(
     manifest: &PackageManifest,
     lockfile: Option<&Lockfile>,
@@ -159,8 +159,7 @@ async fn collect_outdated_for_importer_with_cache(
     // fetch their packuments concurrently — mirroring pnpm's
     // `Promise.all` fan-out. Concurrency is bounded by the HTTP client's
     // per-registry limit (`network_concurrency`), so this does not flood
-    // the registry. Dependencies without a lockfile pin are dropped here;
-    // those the registry cannot serve are dropped after the fetch.
+    // the registry. Dependencies without a lockfile pin are dropped here.
     let fetches = query
         .include_direct
         .iter()
@@ -187,14 +186,23 @@ async fn collect_outdated_for_importer_with_cache(
                 &registry,
                 &config.auth_headers,
             )
-            .await?;
-            let target = resolve_target(&package, range, query.target_version)?;
+            .await
+            .map_err(|error| {
+                let reason = pacquet_network::redact_url_credentials(&error.to_string());
+                miette::miette!(
+                    code = "ERR_PNPM_OUTDATED_REGISTRY_ERROR",
+                    r#"Failed to fetch metadata for "{package_name}": {reason}"#,
+                )
+            })?;
+            let Some(target) = resolve_target(&package, range, query.target_version) else {
+                return Ok(None);
+            };
             let deprecated = target.deprecated.clone();
             let is_newer = target.version > current;
             if !(is_newer || (query.include_deprecated && deprecated.is_some())) {
-                return None;
+                return Ok(None);
             }
-            Some(OutdatedPackage {
+            Ok(Some(OutdatedPackage {
                 alias: alias.to_string(),
                 package_name: package_name.to_string(),
                 belongs_to: group,
@@ -202,10 +210,14 @@ async fn collect_outdated_for_importer_with_cache(
                 target: target.version.clone(),
                 deprecated,
                 homepage: package.homepage.clone(),
-            })
+            }))
         });
 
-    Ok(futures_util::future::join_all(fetches).await.into_iter().flatten().collect())
+    let fetched = futures_util::future::join_all(fetches)
+        .await
+        .into_iter()
+        .collect::<miette::Result<Vec<_>>>()?;
+    Ok(fetched.into_iter().flatten().collect())
 }
 
 async fn fetch_package_cached(
@@ -214,21 +226,20 @@ async fn fetch_package_cached(
     http_client: &ThrottledClient,
     registry: &str,
     auth_headers: &pacquet_network::AuthHeaders,
-) -> Option<Arc<Package>> {
+) -> Result<Arc<Package>, RegistryError> {
     let key = (registry.to_string(), package_name.to_string());
     let entry = {
         let mut cache = cache.lock().expect("packument cache mutex poisoned");
         Arc::clone(cache.entry(key).or_default())
     };
-    entry
-        .get_or_init(|| async {
+    let package = entry
+        .get_or_try_init(|| async {
             Package::fetch_from_registry(package_name, http_client, registry, auth_headers)
                 .await
-                .ok()
                 .map(Arc::new)
         })
-        .await
-        .clone()
+        .await?;
+    Ok(Arc::clone(package))
 }
 
 /// Resolve the [`TargetVersion`] to a concrete published version, or
@@ -445,9 +456,7 @@ impl OutdatedArgs {
             OutdatedFormat::Json => render_json(&outdated, self.long),
         };
 
-        let mut stdout = std::io::stdout();
-        let _ = writeln!(stdout, "{output}");
-        let _ = stdout.flush();
+        write_output(&output)?;
 
         Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
     }
@@ -479,8 +488,8 @@ impl OutdatedArgs {
         } else {
             None
         };
-        let packument_cache = PackumentCache::default();
-        let project_queries = selection.selected.iter().filter_map(|(project_dir, node)| {
+        let mut project_inputs = Vec::new();
+        for (project_dir, node) in &selection.selected {
             let project = node.package.project;
             let has_any_dependency = project
                 .manifest
@@ -492,18 +501,24 @@ impl OutdatedArgs {
                 .next()
                 .is_some();
             if !has_any_dependency {
-                return None;
+                continue;
             }
-            Some(async {
-                let project_lockfile;
+            let project_lockfile = if config.shared_workspace_lockfile {
+                None
+            } else {
+                Lockfile::load_wanted_from_dir(project_dir).into_diagnostic()?
+            };
+            project_inputs.push((project_dir, project, project_lockfile));
+        }
+        let packument_cache = PackumentCache::default();
+        let project_queries =
+            project_inputs.iter().map(|(project_dir, project, project_lockfile)| async {
                 let (lockfile, importer_id) = if config.shared_workspace_lockfile {
                     (
                         shared_lockfile,
                         pacquet_workspace::importer_id_from_root_dir(&workspace_root, project_dir),
                     )
                 } else {
-                    project_lockfile =
-                        Lockfile::load_wanted_from_dir(project_dir).into_diagnostic()?;
                     (project_lockfile.as_ref(), Lockfile::ROOT_IMPORTER_KEY.to_string())
                 };
                 let Some(lockfile) = lockfile else {
@@ -531,11 +546,10 @@ impl OutdatedArgs {
                         .get("name")
                         .and_then(|name| name.as_str())
                         .map_or_else(|| project_dir.to_string_lossy().into_owned(), str::to_owned),
-                    location: project_dir.clone(),
+                    location: (*project_dir).clone(),
                 };
                 Ok::<_, miette::Report>((project_outdated, dependent))
-            })
-        });
+            });
         let project_results = futures_util::future::join_all(project_queries).await;
         let mut outdated: Vec<OutdatedInWorkspace> = Vec::new();
         let mut outdated_indexes: HashMap<String, usize> = HashMap::new();
@@ -561,9 +575,7 @@ impl OutdatedArgs {
             OutdatedFormat::List => render_recursive_list(&outdated, self.long),
             OutdatedFormat::Json => render_recursive_json(&outdated, self.long),
         };
-        let mut stdout = std::io::stdout();
-        let _ = writeln!(stdout, "{output}");
-        let _ = stdout.flush();
+        write_output(&output)?;
 
         Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
     }
@@ -626,9 +638,7 @@ impl OutdatedArgs {
             OutdatedFormat::Json => render_json(&outdated, self.long),
         };
 
-        let mut stdout = std::io::stdout();
-        let _ = writeln!(stdout, "{output}");
-        let _ = stdout.flush();
+        write_output(&output)?;
 
         Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
     }
@@ -654,6 +664,12 @@ fn no_lockfile_error(dir: &std::path::Path) -> miette::Report {
         code = "ERR_PNPM_OUTDATED_NO_LOCKFILE",
         r#"No lockfile in directory "{dir}". Run `pnpm install` to generate one."#,
     )
+}
+
+fn write_output(output: &str) -> miette::Result<()> {
+    let mut stdout = std::io::stdout();
+    writeln!(stdout, "{output}").into_diagnostic()?;
+    stdout.flush().into_diagnostic()
 }
 
 /// The kind of semver bump from `current` to `target`. Drives the default

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -236,3 +236,38 @@ async fn packument_cache_does_not_memoize_failures() {
     assert_eq!(package.name, "foo");
     successful_request.assert_async().await;
 }
+
+#[tokio::test]
+async fn packument_cache_recovers_from_poisoning() {
+    let mut server = mockito::Server::new_async().await;
+    let package = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{ "name": "foo", "dist-tags": {}, "versions": {} }"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let config = Config::new();
+    let client = ThrottledClient::default();
+    let cache = PackumentCache::default();
+
+    std::thread::scope(|scope| {
+        assert!(
+            scope
+                .spawn(|| {
+                    let _guard = cache.lock().expect("lock packument cache");
+                    panic!("poison packument cache");
+                })
+                .join()
+                .is_err(),
+        );
+    });
+
+    let fetched = fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers)
+        .await
+        .expect("fetch package after cache poisoning");
+    assert_eq!(fetched.name, "foo");
+    package.assert_async().await;
+}

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,11 +1,14 @@
 use super::{
-    Change, OutdatedDependencyOptions, OutdatedPackage, classify, current_versions_from_importer,
-    render_json, render_latest, sort_outdated,
+    Change, DependentProject, OutdatedDependencyOptions, OutdatedInWorkspace, OutdatedPackage,
+    PackumentCache, classify, current_versions_from_importer, fetch_package_cached,
+    render_dependents, render_json, render_latest, sort_outdated,
 };
 use node_semver::Version;
+use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
+use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 use text_block_macros::text_block;
 
 fn v(text: &str) -> Version {
@@ -154,4 +157,43 @@ fn json_report_long_includes_latest_manifest() {
     assert_eq!(manifest["deprecated"], "do not use");
     assert_eq!(manifest["homepage"], "https://example.com");
     assert_eq!(value["foo"]["isDeprecated"], true);
+}
+
+#[test]
+fn dependent_names_are_sanitized_for_terminal_output() {
+    let entry = OutdatedInWorkspace {
+        package: pkg("foo", "1.0.0", "2.0.0", DependencyGroup::Prod),
+        dependents: vec![DependentProject {
+            name: "app\n\t\u{1b}[2J".to_string(),
+            location: PathBuf::from("packages/app"),
+        }],
+    };
+
+    assert_eq!(render_dependents(&entry), "app[2J");
+}
+
+#[tokio::test]
+async fn packument_cache_deduplicates_concurrent_fetches() {
+    let mut server = mockito::Server::new_async().await;
+    let package = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{ "name": "foo", "dist-tags": {}, "versions": {} }"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let config = Config::new();
+    let client = ThrottledClient::default();
+    let cache = PackumentCache::default();
+    let first_fetch = fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers);
+    let second_fetch =
+        fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers);
+
+    let (first, second) = tokio::join!(first_fetch, second_fetch);
+
+    assert_eq!(first.expect("first fetch").name, "foo");
+    assert_eq!(second.expect("second fetch").name, "foo");
+    package.assert_async().await;
 }

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -197,3 +197,42 @@ async fn packument_cache_deduplicates_concurrent_fetches() {
     assert_eq!(second.expect("second fetch").name, "foo");
     package.assert_async().await;
 }
+
+#[tokio::test]
+async fn packument_cache_does_not_memoize_failures() {
+    let mut server = mockito::Server::new_async().await;
+    let failed_request = server
+        .mock("GET", "/foo")
+        .with_status(500)
+        .with_body("not package metadata")
+        .expect(1)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let config = Config::new();
+    let client = ThrottledClient::default();
+    let cache = PackumentCache::default();
+
+    assert!(
+        fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers)
+            .await
+            .is_err(),
+    );
+    failed_request.assert_async().await;
+    failed_request.remove_async().await;
+
+    let successful_request = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{ "name": "foo", "dist-tags": {}, "versions": {} }"#)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let package = fetch_package_cached(&cache, "foo", &client, &registry, &config.auth_headers)
+        .await
+        .expect("retry package fetch");
+    assert_eq!(package.name, "foo");
+    successful_request.assert_async().await;
+}

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     Change, DependentProject, OutdatedDependencyOptions, OutdatedInWorkspace, OutdatedPackage,
     PackumentCache, classify, current_versions_from_importer, fetch_package_cached,
-    render_dependents, render_json, render_latest, sort_outdated,
+    render_dependents, render_json, render_latest, render_recursive_json, sort_outdated,
 };
 use node_semver::Version;
 use pacquet_config::Config;
@@ -10,6 +10,9 @@ use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
 use std::{collections::HashMap, path::PathBuf};
 use text_block_macros::text_block;
+
+#[cfg(unix)]
+use std::{ffi::OsString, os::unix::ffi::OsStringExt};
 
 fn v(text: &str) -> Version {
     text.parse().expect("parse semver")
@@ -170,6 +173,22 @@ fn dependent_names_are_sanitized_for_terminal_output() {
     };
 
     assert_eq!(render_dependents(&entry), "app[2J");
+}
+
+#[cfg(unix)]
+#[test]
+fn recursive_json_replaces_invalid_utf8_in_locations() {
+    let entry = OutdatedInWorkspace {
+        package: pkg("foo", "1.0.0", "2.0.0", DependencyGroup::Prod),
+        dependents: vec![DependentProject {
+            name: "app".to_string(),
+            location: PathBuf::from(OsString::from_vec(b"packages/\xff-app".to_vec())),
+        }],
+    };
+
+    let value: serde_json::Value =
+        serde_json::from_str(&render_recursive_json(&[entry], false)).expect("valid JSON");
+    assert_eq!(value["foo"]["dependentPackages"][0]["location"], "packages/�-app");
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/src/cli_args/sanitize.rs
+++ b/pnpm/crates/cli/src/cli_args/sanitize.rs
@@ -14,6 +14,15 @@ pub fn sanitize(text: &str) -> Cow<'_, str> {
     }
 }
 
+/// Strip every control character from text embedded in a single-line field.
+pub fn sanitize_inline(text: &str) -> Cow<'_, str> {
+    if text.chars().any(char::is_control) {
+        Cow::Owned(text.chars().filter(|ch| !ch.is_control()).collect())
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
 /// Render a capped response body for an error message: lossy UTF-8,
 /// sanitized, with a truncation note when the cap was hit.
 pub fn body_display_string(body: &LimitedBody) -> String {

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -293,6 +293,58 @@ fn no_filter_leaves_recursive_untouched() {
 }
 
 #[test]
+fn recursive_by_default_command_is_promoted_inside_workspace() {
+    let workspace = tempfile::tempdir().expect("creates workspace");
+    std::fs::write(workspace.path().join("pnpm-workspace.yaml"), "packages: []\n")
+        .expect("writes workspace manifest");
+    let mut parsed = CliArgs::try_parse_from([
+        "pacquet",
+        "--dir",
+        workspace.path().to_str().expect("UTF-8 path"),
+        "list",
+    ])
+    .expect("parses");
+
+    parsed.promote_recursive_by_default();
+
+    assert!(parsed.recursive);
+}
+
+#[test]
+fn recursive_by_default_command_stays_non_recursive_outside_workspace() {
+    let project = tempfile::tempdir().expect("creates project");
+    let mut parsed = CliArgs::try_parse_from([
+        "pacquet",
+        "--dir",
+        project.path().to_str().expect("UTF-8 path"),
+        "list",
+    ])
+    .expect("parses");
+
+    parsed.promote_recursive_by_default();
+
+    assert!(!parsed.recursive);
+}
+
+#[test]
+fn commands_without_recursive_by_default_stay_non_recursive_in_workspace() {
+    let workspace = tempfile::tempdir().expect("creates workspace");
+    std::fs::write(workspace.path().join("pnpm-workspace.yaml"), "packages: []\n")
+        .expect("writes workspace manifest");
+    let mut parsed = CliArgs::try_parse_from([
+        "pacquet",
+        "--dir",
+        workspace.path().to_str().expect("UTF-8 path"),
+        "outdated",
+    ])
+    .expect("parses");
+
+    parsed.promote_recursive_by_default();
+
+    assert!(!parsed.recursive);
+}
+
+#[test]
 fn runtime_alias_and_flags_parse() {
     let parsed = CliArgs::try_parse_from(["pacquet", "rt", "set", "node", "22", "-P"])
         .expect("parses runtime alias");

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -74,6 +74,7 @@ pub fn main() -> miette::Result<()> {
         err.exit();
     }
     args.promote_recursive_for_filter();
+    args.promote_recursive_by_default();
     if let Some(plan) = cli_args::switch_cli_version::switch_plan(&args, &config_overrides)?
         && block_on_runtime(
             "pacquet-switch",

--- a/pnpm/crates/cli/tests/list.rs
+++ b/pnpm/crates/cli/tests/list.rs
@@ -79,6 +79,43 @@ fn recursive_list_depth_minus_one_json_lists_workspace_projects() {
 }
 
 #[test]
+fn list_is_recursive_by_default_inside_workspace() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", json!({ "name": "project-1", "version": "1.0.0" })),
+            ("project-2", json!({ "name": "project-2", "version": "1.0.0" })),
+        ],
+    );
+
+    let output = pacquet
+        .with_arg("list")
+        .with_arg("--depth")
+        .with_arg("-1")
+        .with_arg("--json")
+        .output()
+        .expect("spawn pacquet list");
+
+    assert!(
+        output.status.success(),
+        "list should succeed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let packages: Vec<Value> = serde_json::from_slice(&output.stdout).expect("parse list JSON");
+    let names: BTreeSet<String> = packages
+        .iter()
+        .map(|pkg| pkg["name"].as_str().expect("package name").to_string())
+        .collect();
+    assert_eq!(
+        names,
+        BTreeSet::from(["project-1".to_string(), "project-2".to_string(), "root".to_string()]),
+    );
+
+    drop(root);
+}
+
+#[test]
 fn recursive_list_depth_minus_one_json_keeps_project_only_output_with_package_params() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_workspace(
@@ -810,7 +847,8 @@ fn list_only_projects_shows_only_projects() {
     }
     run_ok(&workspace, &["install"]);
 
-    let output = run_ok(&workspace, &["list", "--depth", "999", "--only-projects"]);
+    let output =
+        run_ok(&workspace, &["--filter", ".", "list", "--depth", "999", "--only-projects"]);
     let dir = canonical(&workspace);
     assert_eq!(
         output,

--- a/pnpm/crates/cli/tests/outdated.rs
+++ b/pnpm/crates/cli/tests/outdated.rs
@@ -199,6 +199,40 @@ fn outdated_without_lockfile_errors() {
 }
 
 #[test]
+fn recursive_outdated_reports_the_shared_lockfile_directory() {
+    let (root, workspace, anchor) = setup();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    write_manifest(&workspace, "{}");
+    let project = workspace.join("packages/app");
+    fs::create_dir_all(&project).expect("create workspace project");
+    fs::write(
+        project.join("package.json"),
+        format!(
+            r#"{{ "name": "app", "version": "1.0.0", "dependencies": {{ "{DEP}": "^100.0.0" }} }}"#,
+        ),
+    )
+    .expect("write project manifest");
+
+    let output = pacquet(&workspace, ["outdated", "--recursive"])
+        .output()
+        .expect("run recursive outdated without a shared lockfile");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(r#"workspace""#),
+        "error should point to the shared lockfile directory: {stderr}",
+    );
+    assert!(
+        !stderr.contains(r#"app""#),
+        "error should not point to a project-specific lockfile: {stderr}",
+    );
+
+    drop((root, anchor));
+}
+
+#[test]
 fn outdated_recursive_aggregates_workspace_dependents() {
     let (root, workspace, anchor) = setup();
     fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")

--- a/pnpm/crates/cli/tests/outdated.rs
+++ b/pnpm/crates/cli/tests/outdated.rs
@@ -263,10 +263,18 @@ fn outdated_recursive_aggregates_workspace_dependents() {
     assert_eq!(dependents[0]["name"], "app-a");
     assert_eq!(dependents[1]["name"], "app-b");
     assert!(
-        dependents[0]["location"].as_str().is_some_and(|path| path.ends_with("packages/app-a")),
+        dependents[0]["location"]
+            .as_str()
+            .is_some_and(|path| Path::new(path).ends_with(Path::new("packages").join("app-a"))),
+        "unexpected app-a location: {}",
+        dependents[0]["location"],
     );
     assert!(
-        dependents[1]["location"].as_str().is_some_and(|path| path.ends_with("packages/app-b")),
+        dependents[1]["location"]
+            .as_str()
+            .is_some_and(|path| Path::new(path).ends_with(Path::new("packages").join("app-b"))),
+        "unexpected app-b location: {}",
+        dependents[1]["location"],
     );
 
     let filtered =

--- a/pnpm/crates/cli/tests/outdated.rs
+++ b/pnpm/crates/cli/tests/outdated.rs
@@ -198,19 +198,84 @@ fn outdated_without_lockfile_errors() {
     drop((root, anchor));
 }
 
-/// `--recursive` is rejected until workspace-wide inspection is ported.
 #[test]
-fn outdated_recursive_is_rejected() {
+fn outdated_recursive_aggregates_workspace_dependents() {
     let (root, workspace, anchor) = setup();
-
-    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    write_manifest(&workspace, "{}");
+    for name in ["app-a", "app-b"] {
+        let project = workspace.join("packages").join(name);
+        fs::create_dir_all(&project).expect("create workspace project");
+        fs::write(
+            project.join("package.json"),
+            format!(
+                r#"{{ "name": "{name}", "version": "1.0.0", "dependencies": {{ "{DEP}": "^100.0.0" }} }}"#,
+            ),
+        )
+        .expect("write project manifest");
+    }
     pacquet(&workspace, ["install"]).assert().success();
 
-    let output =
-        pacquet(&workspace, ["outdated", "--recursive"]).output().expect("run pacquet outdated");
-    assert!(!output.status.success(), "recursive outdated should be rejected");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("not supported yet"), "stderr should say it is unsupported: {stderr}");
+    let output = pacquet(&workspace, ["outdated", "--recursive", "--format", "json"])
+        .output()
+        .expect("run recursive outdated");
+
+    assert_eq!(output.status.code(), Some(1));
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("recursive outdated should emit valid JSON");
+    let dependents = value[DEP]["dependentPackages"].as_array().expect("dependent package list");
+    assert_eq!(dependents.len(), 2);
+    assert_eq!(dependents[0]["name"], "app-a");
+    assert_eq!(dependents[1]["name"], "app-b");
+    assert!(
+        dependents[0]["location"].as_str().is_some_and(|path| path.ends_with("packages/app-a")),
+    );
+    assert!(
+        dependents[1]["location"].as_str().is_some_and(|path| path.ends_with("packages/app-b")),
+    );
+
+    let filtered =
+        pacquet(&workspace, ["--filter", "app-a", "outdated", "--recursive", "--format", "json"])
+            .output()
+            .expect("run filtered recursive outdated");
+    assert_eq!(filtered.status.code(), Some(1));
+    let value: serde_json::Value = serde_json::from_slice(&filtered.stdout)
+        .expect("filtered recursive outdated should emit valid JSON");
+    assert_eq!(value[DEP]["dependentPackages"].as_array().map(Vec::len), Some(1));
+    assert_eq!(value[DEP]["dependentPackages"][0]["name"], "app-a");
+
+    drop((root, anchor));
+}
+
+#[test]
+fn outdated_recursive_reads_dedicated_project_lockfiles() {
+    let (root, workspace, anchor) = setup();
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
+    write_manifest(&workspace, "{}");
+    let project = workspace.join("packages/app");
+    fs::create_dir_all(&project).expect("create workspace project");
+    fs::write(
+        project.join("package.json"),
+        format!(
+            r#"{{ "name": "app", "version": "1.0.0", "dependencies": {{ "{DEP}": "^100.0.0" }} }}"#,
+        ),
+    )
+    .expect("write project manifest");
+    pacquet(&workspace, ["install"]).assert().success();
+
+    let output = pacquet(&workspace, ["outdated", "--recursive"])
+        .output()
+        .expect("run recursive outdated with dedicated lockfiles");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains(DEP), "report should mention the package: {stdout}");
+    assert!(stdout.contains("app"), "report should name the dependent: {stdout}");
 
     drop((root, anchor));
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Add recursive workspace support to pacquet's `pnpm outdated`, including filters and both shared and dedicated lockfiles.
- Aggregate matching outdated dependencies across projects and report their dependents in table, list, and JSON output, matching the TypeScript CLI.
- Make pacquet's `pnpm list`/`ls` and `pnpm ll`/`la` recursive by default inside workspaces, as they are in the TypeScript CLI.

The TypeScript CLI already supports these behaviors, so this PR only changes the Rust implementation. This is a partial fix for the recursive-command parity audit; the remaining commands stay tracked in pnpm/pnpm#13201.

Related to pnpm/pnpm#13201.

## Squash Commit Body

```text
Pacquet rejected recursive outdated queries and kept list/ll scoped to the active project even though the TypeScript CLI traverses selected workspace projects.

Reuse the existing workspace discovery and filtering path to select projects for outdated. Load a shared lockfile once or each selected project's dedicated lockfile as appropriate, preserve importer identity, and group equivalent findings across projects so every output format can expose the affected dependents. Keep the existing nonzero exit status when outdated dependencies are found.

Promote list and ll to recursive mode by default when invoked inside a workspace. Limit the shared promotion mechanism to commands whose recursive paths already support both lockfile layouts; the other audited commands remain tracked separately.

Related to pnpm/pnpm#13201.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787259246&installation_model_id=426870&pr_number=13202&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13202&signature=53054776605d586675ccb77901faa2a3d7b3e367e0ffa3385f6e93f0162e92c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm list` and `pnpm ll` now run recursively by default within workspaces (standalone projects remain non-recursive).
  * `pnpm outdated --recursive` is now supported, aggregating workspace results and reporting dependents in table/list/JSON.
* **Bug Fixes**
  * Improved recursive `outdated` behavior and output ordering.
  * Enhanced dependents rendering to sanitize terminal output; centralized and clarified shared lockfile error handling.
  * Reduced repeated registry lookups via cache-aware fetching.
* **Tests**
  * Added/updated coverage for recursive-by-default promotion, recursive `outdated` dependents/filtering, and cache deduplication/retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->