### PR TITLE
fix(version): support from-git

### DIFF
--- a/.changeset/support-version-from-git.md
+++ b/.changeset/support-version-from-git.md
@@ -1,0 +1,6 @@
+﻿---
+"@pnpm/releasing.commands": patch
+"pnpm": patch
+---
+
+Support the `from-git` argument in the `pnpm version` command.

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -93,7 +93,7 @@ enum VersionError {
     InvalidBump { raw: String },
 
     #[display(
-        "Could not determine a valid version from Git in {dir} using tag prefix {tag_version_prefix}: {reason}"
+        "Could not determine a valid version from Git in {dir:?} using tag prefix {tag_version_prefix:?}: {reason}"
     )]
     #[diagnostic(code(ERR_PNPM_INVALID_VERSION_FROM_GIT))]
     InvalidVersionFromGit { dir: String, tag_version_prefix: String, reason: String },
@@ -645,45 +645,58 @@ fn identifier_text(identifier: &Identifier) -> String {
     }
 }
 
+/// Build the canonical cross-stack error for an invalid version from Git.
+fn invalid_version_from_git(
+    cwd: &Path,
+    tag_version_prefix: &str,
+    reason: impl Into<String>,
+) -> VersionError {
+    VersionError::InvalidVersionFromGit {
+        dir: cwd.display().to_string(),
+        tag_version_prefix: tag_version_prefix.to_string(),
+        reason: reason.into(),
+    }
+}
+
 /// Read the nearest matching Git tag and parse the part after the configured
 /// tag prefix as an exact semantic version.
 fn version_from_git(cwd: &Path, tag_version_prefix: &str) -> Result<Version, VersionError> {
     let pattern = format!("{tag_version_prefix}*.*.*");
     let args = ["describe", "--tags", "--abbrev=0", "--match", pattern.as_str()];
     let output = <Host as RunCommand>::run("git", &args, Some(cwd)).map_err(|err| {
-        VersionError::InvalidVersionFromGit {
-            dir: cwd.display().to_string(),
-            tag_version_prefix: tag_version_prefix.to_string(),
-            reason: err.to_string(),
-        }
+        VersionError::GitCommandFailed { args: args.join(" "), stderr: err.to_string() }
     })?;
 
     if !output.success {
         let stderr = output.stderr.trim();
-        return Err(VersionError::InvalidVersionFromGit {
-            dir: cwd.display().to_string(),
-            tag_version_prefix: tag_version_prefix.to_string(),
-            reason: if stderr.is_empty() {
-                "git describe failed".to_string()
-            } else {
-                stderr.to_string()
-            },
+        if stderr.contains("No names found") || stderr.contains("No tags can describe") {
+            return Err(invalid_version_from_git(
+                cwd,
+                tag_version_prefix,
+                "no matching Git tag found",
+            ));
+        }
+        return Err(VersionError::GitCommandFailed {
+            args: args.join(" "),
+            stderr: stderr.to_string(),
         });
     }
 
     let tag = output.stdout.trim();
     let Some(raw_version) = tag.strip_prefix(tag_version_prefix) else {
-        return Err(VersionError::InvalidVersionFromGit {
-            dir: cwd.display().to_string(),
-            tag_version_prefix: tag_version_prefix.to_string(),
-            reason: format!("tag is not a valid version: {tag:?}"),
-        });
+        return Err(invalid_version_from_git(
+            cwd,
+            tag_version_prefix,
+            format!("tag is not a valid version: {tag:?}"),
+        ));
     };
 
-    Version::parse(raw_version).map_err(|_| VersionError::InvalidVersionFromGit {
-        dir: cwd.display().to_string(),
-        tag_version_prefix: tag_version_prefix.to_string(),
-        reason: format!("tag is not a valid version: {tag:?}"),
+    Version::parse(raw_version).map_err(|_| {
+        invalid_version_from_git(
+            cwd,
+            tag_version_prefix,
+            format!("tag is not a valid version: {tag:?}"),
+        )
     })
 }
 

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -662,27 +662,35 @@ fn invalid_version_from_git(
 /// tag prefix as an exact semantic version.
 fn version_from_git(cwd: &Path, tag_version_prefix: &str) -> Result<Version, VersionError> {
     let pattern = format!("{tag_version_prefix}*.*.*");
-    let args = ["describe", "--tags", "--abbrev=0", "--match", pattern.as_str()];
+    let args = ["describe", "--tags", "--abbrev=0", "--always", "--match", pattern.as_str()];
     let output = <Host as RunCommand>::run("git", &args, Some(cwd)).map_err(|err| {
         VersionError::GitCommandFailed { args: args.join(" "), stderr: err.to_string() }
     })?;
 
     if !output.success {
-        let stderr = output.stderr.trim();
-        if stderr.contains("No names found") || stderr.contains("No tags can describe") {
-            return Err(invalid_version_from_git(
-                cwd,
-                tag_version_prefix,
-                "no matching Git tag found",
-            ));
-        }
         return Err(VersionError::GitCommandFailed {
             args: args.join(" "),
-            stderr: stderr.to_string(),
+            stderr: output.stderr.trim().to_string(),
         });
     }
 
     let tag = output.stdout.trim();
+    let tag_args = ["tag", "--list", tag];
+    let matching_tag = <Host as RunCommand>::run("git", &tag_args, Some(cwd)).map_err(|err| {
+        VersionError::GitCommandFailed { args: tag_args.join(" "), stderr: err.to_string() }
+    })?;
+
+    if !matching_tag.success {
+        return Err(VersionError::GitCommandFailed {
+            args: tag_args.join(" "),
+            stderr: matching_tag.stderr.trim().to_string(),
+        });
+    }
+
+    if matching_tag.stdout.trim() != tag {
+        return Err(invalid_version_from_git(cwd, tag_version_prefix, "no matching Git tag found"));
+    }
+
     let Some(raw_version) = tag.strip_prefix(tag_version_prefix) else {
         return Err(invalid_version_from_git(
             cwd,

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -29,7 +29,7 @@ use crate::cli_args::{
 #[derive(Debug, Args)]
 pub struct VersionArgs {
     /// A valid semver version (e.g. 1.2.3) or one of: major, minor, patch,
-    /// premajor, preminor, prepatch, prerelease. Omit it and pass `-r` to
+    /// premajor, preminor, prepatch, prerelease, from-git. Omit it and pass `-r` to
     /// apply the pending change intents instead.
     pub params: Vec<String>,
 
@@ -81,16 +81,22 @@ pub struct VersionArgs {
 #[derive(Debug, Display, Error, Diagnostic)]
 enum VersionError {
     #[display(
-        "A version argument is required. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease"
+        "A version argument is required. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease, from-git"
     )]
     #[diagnostic(code(ERR_PNPM_INVALID_VERSION_BUMP))]
     MissingBump,
 
     #[display(
-        "Invalid version argument: {raw}. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease"
+        "Invalid version argument: {raw}. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease, from-git"
     )]
     #[diagnostic(code(ERR_PNPM_INVALID_VERSION_BUMP))]
     InvalidBump { raw: String },
+
+    #[display(
+        "Could not determine a valid version from Git in {dir} using tag prefix {tag_version_prefix}: {reason}"
+    )]
+    #[diagnostic(code(ERR_PNPM_INVALID_VERSION_FROM_GIT))]
+    InvalidVersionFromGit { dir: String, tag_version_prefix: String, reason: String },
 
     #[display("Invalid version in {dir}: {version}")]
     #[diagnostic(code(ERR_PNPM_INVALID_VERSION))]
@@ -149,9 +155,12 @@ impl VersionArgs {
         recursive: bool,
     ) -> miette::Result<()> {
         let raw = self.params[0].as_str();
-        let bump = parse_bump(raw)?;
-
         let git_cwd = config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+        let bump = if raw == "from-git" {
+            Bump::Explicit(version_from_git(&git_cwd, &self.tag_version_prefix)?)
+        } else {
+            parse_bump(raw)?
+        };
         if config.git_checks
             && !self.no_git_checks
             && is_git_repo::<Host>(&git_cwd)
@@ -634,6 +643,48 @@ fn identifier_text(identifier: &Identifier) -> String {
         Identifier::Numeric(number) => number.to_string(),
         Identifier::AlphaNumeric(text) => text.clone(),
     }
+}
+
+/// Read the nearest matching Git tag and parse the part after the configured
+/// tag prefix as an exact semantic version.
+fn version_from_git(cwd: &Path, tag_version_prefix: &str) -> Result<Version, VersionError> {
+    let pattern = format!("{tag_version_prefix}*.*.*");
+    let args = ["describe", "--tags", "--abbrev=0", "--match", pattern.as_str()];
+    let output = <Host as RunCommand>::run("git", &args, Some(cwd)).map_err(|err| {
+        VersionError::InvalidVersionFromGit {
+            dir: cwd.display().to_string(),
+            tag_version_prefix: tag_version_prefix.to_string(),
+            reason: err.to_string(),
+        }
+    })?;
+
+    if !output.success {
+        let stderr = output.stderr.trim();
+        return Err(VersionError::InvalidVersionFromGit {
+            dir: cwd.display().to_string(),
+            tag_version_prefix: tag_version_prefix.to_string(),
+            reason: if stderr.is_empty() {
+                "git describe failed".to_string()
+            } else {
+                stderr.to_string()
+            },
+        });
+    }
+
+    let tag = output.stdout.trim();
+    let Some(raw_version) = tag.strip_prefix(tag_version_prefix) else {
+        return Err(VersionError::InvalidVersionFromGit {
+            dir: cwd.display().to_string(),
+            tag_version_prefix: tag_version_prefix.to_string(),
+            reason: format!("tag is not a valid version: {tag:?}"),
+        });
+    };
+
+    Version::parse(raw_version).map_err(|_| VersionError::InvalidVersionFromGit {
+        dir: cwd.display().to_string(),
+        tag_version_prefix: tag_version_prefix.to_string(),
+        reason: format!("tag is not a valid version: {tag:?}"),
+    })
 }
 
 /// Run a git command in `cwd`, failing with the command line and git's stderr

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -658,8 +658,6 @@ fn invalid_version_from_git(
     }
 }
 
-/// Read the nearest matching Git tag and parse the part after the configured
-/// tag prefix as an exact semantic version.
 fn version_from_git(cwd: &Path, tag_version_prefix: &str) -> Result<Version, VersionError> {
     let pattern = format!("{tag_version_prefix}*.*.*");
     let args = ["describe", "--tags", "--abbrev=0", "--always", "--match", pattern.as_str()];
@@ -675,7 +673,7 @@ fn version_from_git(cwd: &Path, tag_version_prefix: &str) -> Result<Version, Ver
     }
 
     let tag = output.stdout.trim();
-    let tag_args = ["tag", "--list", tag];
+    let tag_args = ["tag", "--list", "--", tag];
     let matching_tag = <Host as RunCommand>::run("git", &tag_args, Some(cwd)).map_err(|err| {
         VersionError::GitCommandFailed { args: tag_args.join(" "), stderr: err.to_string() }
     })?;

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -371,7 +371,7 @@ fn from_git_fails_when_no_matching_tag_exists() {
         .chars()
         .filter(|character| !character.is_whitespace() && *character != '│')
         .collect();
-    assert!(compact_stderr.contains("usingtagprefix\"v\":nomatchingGittagfound"), "{stderr}");
+    assert!(compact_stderr.contains(r#"usingtagprefix"v":nomatchingGittagfound"#), "{stderr}");
     drop(root);
 }
 
@@ -398,8 +398,8 @@ fn from_git_rejects_a_malformed_version_tag() {
         .filter(|character| !character.is_whitespace() && *character != '│')
         .collect();
     assert!(
-        compact_stderr.contains("usingtagprefix\"v\":tagisnotavalidversion:\"v-release-2.3.4\""),
-        "{stderr}"
+        compact_stderr.contains(r#"usingtagprefix"v":tagisnotavalidversion:"v-release-2.3.4""#),
+        "{stderr}",
     );
     drop(root);
 }
@@ -424,6 +424,29 @@ fn from_git_respects_tag_version_prefix() {
 
     assert!(output.status.success(), "{}", stderr_of(&output));
     assert_eq!(manifest_version(&workspace), "4.5.6");
+    drop(root);
+}
+
+#[test]
+fn from_git_handles_tag_starting_with_dash() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    init_git(&workspace);
+    write_manifest(&workspace, r#"{"name":"test-pkg","version":"1.0.0"}"#);
+    git_commit_all(&workspace, "init");
+    let status = Command::new("git")
+        .args(["update-ref", "refs/tags/-1.2.3", "HEAD"])
+        .current_dir(&workspace)
+        .status()
+        .expect("create tag starting with dash");
+    assert!(status.success());
+
+    let output = pacquet_version(
+        &workspace,
+        &["from-git", "--tag-version-prefix", "-", "--no-git-tag-version"],
+    );
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert_eq!(manifest_version(&workspace), "1.2.3");
     drop(root);
 }
 

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -365,8 +365,9 @@ fn from_git_fails_when_no_matching_tag_exists() {
     let output = pacquet_version(&workspace, &["from-git", "--no-git-tag-version"]);
 
     assert!(!output.status.success(), "from-git without a matching tag must fail");
-    let stderr = stderr_of(&output);
+    let stderr = stderr_of(&output).replace("\n  │ ", " ");
     assert!(stderr.contains("ERR_PNPM_INVALID_VERSION_FROM_GIT"), "{stderr}");
+    assert!(stderr.contains("using tag prefix \"v\": no matching Git tag found"), "{stderr}");
     drop(root);
 }
 
@@ -386,8 +387,12 @@ fn from_git_rejects_a_malformed_version_tag() {
     let output = pacquet_version(&workspace, &["from-git", "--no-git-tag-version"]);
 
     assert!(!output.status.success(), "a malformed version tag must fail");
-    let stderr = stderr_of(&output);
+    let stderr = stderr_of(&output).replace("\n  │ ", " ");
     assert!(stderr.contains("ERR_PNPM_INVALID_VERSION_FROM_GIT"), "{stderr}");
+    assert!(
+        stderr.contains("using tag prefix \"v\": tag is not a valid version: \"v-release-2.3.4\""),
+        "{stderr}"
+    );
     drop(root);
 }
 

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -365,9 +365,13 @@ fn from_git_fails_when_no_matching_tag_exists() {
     let output = pacquet_version(&workspace, &["from-git", "--no-git-tag-version"]);
 
     assert!(!output.status.success(), "from-git without a matching tag must fail");
-    let stderr = stderr_of(&output).replace("\n  │ ", " ");
+    let stderr = stderr_of(&output);
     assert!(stderr.contains("ERR_PNPM_INVALID_VERSION_FROM_GIT"), "{stderr}");
-    assert!(stderr.contains("using tag prefix \"v\": no matching Git tag found"), "{stderr}");
+    let compact_stderr: String = stderr
+        .chars()
+        .filter(|character| !character.is_whitespace() && *character != '│')
+        .collect();
+    assert!(compact_stderr.contains("usingtagprefix\"v\":nomatchingGittagfound"), "{stderr}");
     drop(root);
 }
 
@@ -387,10 +391,14 @@ fn from_git_rejects_a_malformed_version_tag() {
     let output = pacquet_version(&workspace, &["from-git", "--no-git-tag-version"]);
 
     assert!(!output.status.success(), "a malformed version tag must fail");
-    let stderr = stderr_of(&output).replace("\n  │ ", " ");
+    let stderr = stderr_of(&output);
     assert!(stderr.contains("ERR_PNPM_INVALID_VERSION_FROM_GIT"), "{stderr}");
+    let compact_stderr: String = stderr
+        .chars()
+        .filter(|character| !character.is_whitespace() && *character != '│')
+        .collect();
     assert!(
-        stderr.contains("using tag prefix \"v\": tag is not a valid version: \"v-release-2.3.4\""),
+        compact_stderr.contains("usingtagprefix\"v\":tagisnotavalidversion:\"v-release-2.3.4\""),
         "{stderr}"
     );
     drop(root);

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -326,6 +326,95 @@ fn tag_version_prefix_replaces_the_default_v() {
 }
 
 #[test]
+fn from_git_sets_the_version_from_the_latest_matching_tag() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    init_git(&workspace);
+    write_manifest(&workspace, r#"{"name":"test-pkg","version":"1.0.0"}"#);
+    git_commit_all(&workspace, "init");
+
+    let status = Command::new("git")
+        .args(["tag", "v1.5.0"])
+        .current_dir(&workspace)
+        .status()
+        .expect("tag first version");
+    assert!(status.success());
+
+    fs::write(workspace.join("new-file.txt"), "new commit").expect("write new file");
+    git_commit_all(&workspace, "new commit");
+    let status = Command::new("git")
+        .args(["tag", "v2.3.4"])
+        .current_dir(&workspace)
+        .status()
+        .expect("tag latest version");
+    assert!(status.success());
+
+    let output = pacquet_version(&workspace, &["from-git", "--no-git-tag-version"]);
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert_eq!(manifest_version(&workspace), "2.3.4");
+    drop(root);
+}
+
+#[test]
+fn from_git_fails_when_no_matching_tag_exists() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    init_git(&workspace);
+    write_manifest(&workspace, r#"{"name":"test-pkg","version":"1.0.0"}"#);
+    git_commit_all(&workspace, "init");
+
+    let output = pacquet_version(&workspace, &["from-git", "--no-git-tag-version"]);
+
+    assert!(!output.status.success(), "from-git without a matching tag must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_INVALID_VERSION_FROM_GIT"), "{stderr}");
+    drop(root);
+}
+
+#[test]
+fn from_git_rejects_a_malformed_version_tag() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    init_git(&workspace);
+    write_manifest(&workspace, r#"{"name":"test-pkg","version":"1.0.0"}"#);
+    git_commit_all(&workspace, "init");
+    let status = Command::new("git")
+        .args(["tag", "v-release-2.3.4"])
+        .current_dir(&workspace)
+        .status()
+        .expect("tag malformed version");
+    assert!(status.success());
+
+    let output = pacquet_version(&workspace, &["from-git", "--no-git-tag-version"]);
+
+    assert!(!output.status.success(), "a malformed version tag must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_INVALID_VERSION_FROM_GIT"), "{stderr}");
+    drop(root);
+}
+
+#[test]
+fn from_git_respects_tag_version_prefix() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    init_git(&workspace);
+    write_manifest(&workspace, r#"{"name":"test-pkg","version":"1.0.0"}"#);
+    git_commit_all(&workspace, "init");
+    let status = Command::new("git")
+        .args(["tag", "release-4.5.6"])
+        .current_dir(&workspace)
+        .status()
+        .expect("tag custom prefix version");
+    assert!(status.success());
+
+    let output = pacquet_version(
+        &workspace,
+        &["from-git", "--tag-version-prefix", "release-", "--no-git-tag-version"],
+    );
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    assert_eq!(manifest_version(&workspace), "4.5.6");
+    drop(root);
+}
+
+#[test]
 fn message_substitutes_the_new_version() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     init_git(&workspace);
@@ -521,6 +610,7 @@ fn help_describes_the_bump_forms_and_flags() {
         "minor",
         "patch",
         "prerelease",
+        "from-git",
         "--preid",
         "--allow-same-version",
         "--message",

--- a/pnpm11/pnpm/test/version.ts
+++ b/pnpm11/pnpm/test/version.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@jest/globals'
-import { preparePackages } from '@pnpm/prepare'
+import { prepare, preparePackages } from '@pnpm/prepare'
+import { safeExeca as execa } from 'execa'
 import { loadJsonFileSync } from 'load-json-file'
 import { writeYamlFileSync } from 'write-yaml-file'
 
@@ -29,4 +30,20 @@ test('version --recursive --filter bumps only the selected package', async () =>
 
   expect(loadJsonFileSync<{ version: string }>('project-1/package.json').version).toBe('1.0.0')
   expect(loadJsonFileSync<{ version: string }>('project-2/package.json').version).toBe('2.3.1')
+})
+
+test('version from-git is wired through the compiled CLI', async () => {
+  prepare({ name: 'test-pkg', version: '1.0.0' })
+
+  await execa('git', ['init', '--initial-branch=main'])
+  await execa('git', ['config', 'user.email', 'x@y.z'])
+  await execa('git', ['config', 'user.name', 'xyz'])
+  await execa('git', ['config', 'tag.gpgSign', 'false'])
+  await execa('git', ['add', 'package.json'])
+  await execa('git', ['commit', '-m', 'init', '--no-gpg-sign'])
+  await execa('git', ['tag', 'v2.3.4'])
+
+  await execPnpm(['version', 'from-git', '--no-git-checks', '--no-git-tag-version'])
+
+  expect(loadJsonFileSync<{ version: string }>('package.json').version).toBe('2.3.4')
 })

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -307,7 +307,7 @@ function invalidVersionFromGitError (cwd: string, tagVersionPrefix: string, reas
 async function versionFromGit (cwd: string, tagVersionPrefix = 'v'): Promise<string> {
   const { stdout } = await execa('git', ['describe', '--tags', '--abbrev=0', '--always', '--match=' + tagVersionPrefix + '*.*.*'], { cwd })
   const tag = typeof stdout === 'string' ? stdout.trim() : ''
-  const { stdout: matchingTag } = await execa('git', ['tag', '--list', tag], { cwd })
+  const { stdout: matchingTag } = await execa('git', ['tag', '--list', '--', tag], { cwd })
 
   if (typeof matchingTag !== 'string' || matchingTag.trim() !== tag) {
     throw invalidVersionFromGitError(cwd, tagVersionPrefix, 'no matching Git tag found')

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -305,8 +305,19 @@ async function versionFromGit (cwd: string, tagVersionPrefix = 'v'): Promise<str
   try {
     const { stdout } = await execa('git', ['describe', '--tags', '--abbrev=0', '--match=' + tagVersionPrefix + '*.*.*'], { cwd })
     tag = typeof stdout === 'string' ? stdout.trim() : ''
-  } catch {
-    throw new PnpmError('INVALID_VERSION_FROM_GIT', 'No matching Git tag found in ' + JSON.stringify(cwd) + ' for prefix: ' + JSON.stringify(tagVersionPrefix))
+  } catch (err: unknown) {
+    if (
+      err !== null &&
+      typeof err === 'object' &&
+      'exitCode' in err &&
+      err.exitCode === 128 &&
+      'stderr' in err &&
+      typeof err.stderr === 'string' &&
+      /No names found|No tags can describe/.test(err.stderr)
+    ) {
+      throw new PnpmError('INVALID_VERSION_FROM_GIT', 'No matching Git tag found in ' + JSON.stringify(cwd) + ' for prefix: ' + JSON.stringify(tagVersionPrefix))
+    }
+    throw err
   }
   const version = tag.startsWith(tagVersionPrefix)
     ? valid(tag.slice(tagVersionPrefix.length))

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -305,24 +305,14 @@ function invalidVersionFromGitError (cwd: string, tagVersionPrefix: string, reas
 }
 
 async function versionFromGit (cwd: string, tagVersionPrefix = 'v'): Promise<string> {
-  let tag: string
-  try {
-    const { stdout } = await execa('git', ['describe', '--tags', '--abbrev=0', '--match=' + tagVersionPrefix + '*.*.*'], { cwd })
-    tag = typeof stdout === 'string' ? stdout.trim() : ''
-  } catch (err: unknown) {
-    if (
-      err !== null &&
-      typeof err === 'object' &&
-      'exitCode' in err &&
-      err.exitCode === 128 &&
-      'stderr' in err &&
-      typeof err.stderr === 'string' &&
-      /No names found|No tags can describe/.test(err.stderr)
-    ) {
-      throw invalidVersionFromGitError(cwd, tagVersionPrefix, 'no matching Git tag found')
-    }
-    throw err
+  const { stdout } = await execa('git', ['describe', '--tags', '--abbrev=0', '--always', '--match=' + tagVersionPrefix + '*.*.*'], { cwd })
+  const tag = typeof stdout === 'string' ? stdout.trim() : ''
+  const { stdout: matchingTag } = await execa('git', ['tag', '--list', tag], { cwd })
+
+  if (typeof matchingTag !== 'string' || matchingTag.trim() !== tag) {
+    throw invalidVersionFromGitError(cwd, tagVersionPrefix, 'no matching Git tag found')
   }
+
   const version = tag.startsWith(tagVersionPrefix)
     ? valid(tag.slice(tagVersionPrefix.length))
     : null

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -300,6 +300,10 @@ function buildVerifyPublished (opts: VersionHandlerOptions): ApplyReleasePlanOpt
   }
 }
 
+function invalidVersionFromGitError (cwd: string, tagVersionPrefix: string, reason: string): PnpmError {
+  return new PnpmError('INVALID_VERSION_FROM_GIT', `Could not determine a valid version from Git in ${JSON.stringify(cwd)} using tag prefix ${JSON.stringify(tagVersionPrefix)}: ${reason}`)
+}
+
 async function versionFromGit (cwd: string, tagVersionPrefix = 'v'): Promise<string> {
   let tag: string
   try {
@@ -315,7 +319,7 @@ async function versionFromGit (cwd: string, tagVersionPrefix = 'v'): Promise<str
       typeof err.stderr === 'string' &&
       /No names found|No tags can describe/.test(err.stderr)
     ) {
-      throw new PnpmError('INVALID_VERSION_FROM_GIT', 'No matching Git tag found in ' + JSON.stringify(cwd) + ' for prefix: ' + JSON.stringify(tagVersionPrefix))
+      throw invalidVersionFromGitError(cwd, tagVersionPrefix, 'no matching Git tag found')
     }
     throw err
   }
@@ -323,7 +327,7 @@ async function versionFromGit (cwd: string, tagVersionPrefix = 'v'): Promise<str
     ? valid(tag.slice(tagVersionPrefix.length))
     : null
   if (!version) {
-    throw new PnpmError('INVALID_VERSION_FROM_GIT', 'Tag is not a valid version: ' + JSON.stringify(tag))
+    throw invalidVersionFromGitError(cwd, tagVersionPrefix, 'tag is not a valid version: ' + JSON.stringify(tag))
   }
   return version
 }

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -18,7 +18,7 @@ import type { Project, ProjectsGraph } from '@pnpm/types'
 import { safeExeca as execa } from 'execa'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
-import { coerce, inc, valid } from 'semver'
+import { inc, valid } from 'semver'
 
 import { renderReleasePlan, toWorkspaceProjects } from '../change/index.js'
 import { changelogHasSection, fetchPublishedChangelog } from '../publish/previousChangelog.js'
@@ -301,9 +301,16 @@ function buildVerifyPublished (opts: VersionHandlerOptions): ApplyReleasePlanOpt
 }
 
 async function versionFromGit (cwd: string, tagVersionPrefix = 'v'): Promise<string> {
-  const { stdout } = await execa('git', ['describe', '--tags', '--abbrev=0', '--match=' + tagVersionPrefix + '*.*.*'], { cwd })
-  const tag = typeof stdout === 'string' ? stdout.trim() : ''
-  const version = coerce(tag, { loose: true, includePrerelease: true })?.version
+  let tag: string
+  try {
+    const { stdout } = await execa('git', ['describe', '--tags', '--abbrev=0', '--match=' + tagVersionPrefix + '*.*.*'], { cwd })
+    tag = typeof stdout === 'string' ? stdout.trim() : ''
+  } catch {
+    throw new PnpmError('INVALID_VERSION_FROM_GIT', 'No matching Git tag found in ' + JSON.stringify(cwd) + ' for prefix: ' + JSON.stringify(tagVersionPrefix))
+  }
+  const version = tag.startsWith(tagVersionPrefix)
+    ? valid(tag.slice(tagVersionPrefix.length))
+    : null
   if (!version) {
     throw new PnpmError('INVALID_VERSION_FROM_GIT', 'Tag is not a valid version: ' + JSON.stringify(tag))
   }

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -18,7 +18,7 @@ import type { Project, ProjectsGraph } from '@pnpm/types'
 import { safeExeca as execa } from 'execa'
 import { pick } from 'ramda'
 import { renderHelp } from 'render-help'
-import { inc, valid } from 'semver'
+import { coerce, inc, valid } from 'semver'
 
 import { renderReleasePlan, toWorkspaceProjects } from '../change/index.js'
 import { changelogHasSection, fetchPublishedChangelog } from '../publish/previousChangelog.js'
@@ -59,7 +59,7 @@ export function help (): string {
     description: 'Bumps the version of a package.',
     usages: [
       'pnpm version <newversion>',
-      'pnpm version <major|minor|patch|premajor|preminor|prepatch|prerelease>',
+      'pnpm version <major|minor|patch|premajor|preminor|prepatch|prerelease|from-git>',
       'pnpm version -r [--dry-run]',
     ],
     descriptionLists: [
@@ -154,15 +154,16 @@ export async function handler (
     if (opts.recursive) {
       return releaseFromIntents(opts)
     }
-    throw new PnpmError('INVALID_VERSION_BUMP', 'A version argument is required. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease')
-  }
-
-  const explicitVersion = valid(rawBump)
-  if (!explicitVersion && !isBumpType(rawBump)) {
-    throw new PnpmError('INVALID_VERSION_BUMP', `Invalid version argument: ${rawBump}. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease`)
+    throw new PnpmError('INVALID_VERSION_BUMP', 'A version argument is required. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease, from-git')
   }
 
   const gitCwd = opts.workspaceDir ?? opts.dir
+  const explicitVersion = rawBump === 'from-git'
+    ? await versionFromGit(gitCwd, opts.tagVersionPrefix)
+    : valid(rawBump)
+  if (!explicitVersion && !isBumpType(rawBump)) {
+    throw new PnpmError('INVALID_VERSION_BUMP', `Invalid version argument: ${rawBump}. Must be a valid semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, preminor, prepatch, prerelease, from-git`)
+  }
 
   if (opts.gitChecks !== false && await isGitRepo({ cwd: gitCwd })) {
     if (!await isWorkingTreeClean({ cwd: gitCwd })) {
@@ -297,6 +298,16 @@ function buildVerifyPublished (opts: VersionHandlerOptions): ApplyReleasePlanOpt
       return false
     }
   }
+}
+
+async function versionFromGit (cwd: string, tagVersionPrefix = 'v'): Promise<string> {
+  const { stdout } = await execa('git', ['describe', '--tags', '--abbrev=0', '--match=' + tagVersionPrefix + '*.*.*'], { cwd })
+  const tag = typeof stdout === 'string' ? stdout.trim() : ''
+  const version = coerce(tag, { loose: true, includePrerelease: true })?.version
+  if (!version) {
+    throw new PnpmError('INVALID_VERSION_FROM_GIT', 'Tag is not a valid version: ' + JSON.stringify(tag))
+  }
+  return version
 }
 
 async function bumpPackageVersion (

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -327,6 +327,30 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
       expect(updated.version).toBe('2.3.4')
     })
 
+    it('should throw a pnpm error when no matching git tag exists', async () => {
+      await expect(
+        handler({
+          dir: tempDir,
+          workspaceDir: tempDir,
+          gitChecks: false,
+          gitTagVersion: false,
+        } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
+      ).rejects.toMatchObject({ code: 'ERR_PNPM_INVALID_VERSION_FROM_GIT' })
+    })
+
+    it('should reject a malformed version tag', async () => {
+      await execa('git', ['tag', 'v-release-2.3.4'], { cwd: tempDir })
+
+      await expect(
+        handler({
+          dir: tempDir,
+          workspaceDir: tempDir,
+          gitChecks: false,
+          gitTagVersion: false,
+        } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
+      ).rejects.toMatchObject({ code: 'ERR_PNPM_INVALID_VERSION_FROM_GIT' })
+    })
+
     it('should use tagVersionPrefix with from-git', async () => {
       await execa('git', ['tag', 'release-4.5.6'], { cwd: tempDir })
       fs.writeFileSync(path.join(tempDir, 'new-file.txt'), 'new commit')

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -338,6 +338,19 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
       ).rejects.toMatchObject({ code: 'ERR_PNPM_INVALID_VERSION_FROM_GIT' })
     })
 
+    it('should rethrow unexpected git describe errors', async () => {
+      fs.rmSync(path.join(tempDir, '.git'), { recursive: true, force: true })
+
+      await expect(
+        handler({
+          dir: tempDir,
+          workspaceDir: tempDir,
+          gitChecks: false,
+          gitTagVersion: false,
+        } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
+      ).rejects.toMatchObject({ exitCode: 128 })
+    })
+
     it('should reject a malformed version tag', async () => {
       await execa('git', ['tag', 'v-release-2.3.4'], { cwd: tempDir })
 

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -335,7 +335,10 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
           gitChecks: false,
           gitTagVersion: false,
         } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
-      ).rejects.toMatchObject({ code: 'ERR_PNPM_INVALID_VERSION_FROM_GIT' })
+      ).rejects.toMatchObject({
+        code: 'ERR_PNPM_INVALID_VERSION_FROM_GIT',
+        message: `Could not determine a valid version from Git in ${JSON.stringify(tempDir)} using tag prefix "v": no matching Git tag found`,
+      })
     })
 
     it('should rethrow unexpected git describe errors', async () => {
@@ -361,7 +364,10 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
           gitChecks: false,
           gitTagVersion: false,
         } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
-      ).rejects.toMatchObject({ code: 'ERR_PNPM_INVALID_VERSION_FROM_GIT' })
+      ).rejects.toMatchObject({
+        code: 'ERR_PNPM_INVALID_VERSION_FROM_GIT',
+        message: `Could not determine a valid version from Git in ${JSON.stringify(tempDir)} using tag prefix "v": tag is not a valid version: "v-release-2.3.4"`,
+      })
     })
 
     it('should use tagVersionPrefix with from-git', async () => {

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -310,7 +310,7 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
 
     it('should set the version from the latest git tag', async () => {
       await execa('git', ['tag', 'v1.5.0'], { cwd: tempDir })
-      fs.writeFileSync(path.join(tempDir, 'new-file.txt'), 'new commit')
+      await fs.promises.writeFile(path.join(tempDir, 'new-file.txt'), 'new commit')
       await execa('git', ['add', 'new-file.txt'], { cwd: tempDir })
       await execa('git', ['commit', '-m', 'new commit'], { cwd: tempDir })
       await execa('git', ['tag', 'v2.3.4'], { cwd: tempDir })
@@ -323,7 +323,7 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
       } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
 
       expect(result).toContain('1.0.0 → 2.3.4')
-      const updated = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8'))
+      const updated = JSON.parse(await fs.promises.readFile(path.join(tempDir, 'package.json'), 'utf-8'))
       expect(updated.version).toBe('2.3.4')
     })
 
@@ -372,7 +372,7 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
 
     it('should use tagVersionPrefix with from-git', async () => {
       await execa('git', ['tag', 'release-4.5.6'], { cwd: tempDir })
-      fs.writeFileSync(path.join(tempDir, 'new-file.txt'), 'new commit')
+      await fs.promises.writeFile(path.join(tempDir, 'new-file.txt'), 'new commit')
       await execa('git', ['add', 'new-file.txt'], { cwd: tempDir })
       await execa('git', ['commit', '-m', 'new commit'], { cwd: tempDir })
       await execa('git', ['tag', 'v9.9.9'], { cwd: tempDir })
@@ -385,8 +385,23 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
         tagVersionPrefix: 'release-',
       } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
 
-      const updated = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8'))
+      const updated = JSON.parse(await fs.promises.readFile(path.join(tempDir, 'package.json'), 'utf-8'))
       expect(updated.version).toBe('4.5.6')
+    })
+
+    it('should handle a git tag starting with a dash', async () => {
+      await execa('git', ['update-ref', 'refs/tags/-1.2.3', 'HEAD'], { cwd: tempDir })
+
+      await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        gitChecks: false,
+        gitTagVersion: false,
+        tagVersionPrefix: '-',
+      } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const updated = JSON.parse(await fs.promises.readFile(path.join(tempDir, 'package.json'), 'utf-8'))
+      expect(updated.version).toBe('1.2.3')
     })
 
     it('should substitute %s in the commit message', async () => {

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -30,6 +30,7 @@ describe('version command', () => {
     expect(helpText).toContain('Bumps the version')
     expect(helpText).toContain('major')
     expect(helpText).toContain('minor')
+    expect(helpText).toContain('from-git')
   })
 
   it('should have correct cli option types', () => {
@@ -305,6 +306,44 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
 
       const { stdout: tags } = await execa('git', ['tag', '--list'], { cwd: tempDir })
       expect(tags).toBe('release-1.0.1')
+    })
+
+    it('should set the version from the latest git tag', async () => {
+      await execa('git', ['tag', 'v1.5.0'], { cwd: tempDir })
+      fs.writeFileSync(path.join(tempDir, 'new-file.txt'), 'new commit')
+      await execa('git', ['add', 'new-file.txt'], { cwd: tempDir })
+      await execa('git', ['commit', '-m', 'new commit'], { cwd: tempDir })
+      await execa('git', ['tag', 'v2.3.4'], { cwd: tempDir })
+
+      const result = await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        gitChecks: false,
+        gitTagVersion: false,
+      } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      expect(result).toContain('1.0.0 → 2.3.4')
+      const updated = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8'))
+      expect(updated.version).toBe('2.3.4')
+    })
+
+    it('should use tagVersionPrefix with from-git', async () => {
+      await execa('git', ['tag', 'release-4.5.6'], { cwd: tempDir })
+      fs.writeFileSync(path.join(tempDir, 'new-file.txt'), 'new commit')
+      await execa('git', ['add', 'new-file.txt'], { cwd: tempDir })
+      await execa('git', ['commit', '-m', 'new commit'], { cwd: tempDir })
+      await execa('git', ['tag', 'v9.9.9'], { cwd: tempDir })
+
+      await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        gitChecks: false,
+        gitTagVersion: false,
+        tagVersionPrefix: 'release-',
+      } as any, ['from-git']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const updated = JSON.parse(fs.readFileSync(path.join(tempDir, 'package.json'), 'utf-8'))
+      expect(updated.version).toBe('4.5.6')
     })
 
     it('should substitute %s in the commit message', async () => {


### PR DESCRIPTION
## Summary
- support the `from-git` argument in `pnpm version`
- resolve the version from the latest matching Git tag
- respect `tag-version-prefix`
- document the argument in command help

## Tests
- `pnpm --filter @pnpm/releasing.commands run test -- version/index.test.ts`
- 29 tests passed

Fixes #13118

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787261096&installation_model_id=426870&pr_number=13203&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13203&signature=281d751a4a281d8b22c280a4b193223493b7bbee01649c1b2788e55b530eeb89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `from-git` support to `pnpm version` to set the manifest version from the latest matching Git tag.
  - Ensures `--tag-version-prefix` is honored when selecting and interpreting tags.
- **Documentation**
  - Updated `pnpm version` help text and related diagnostics to mention `from-git`.
- **Bug Fixes**
  - Improved validation and error handling for `from-git`, including clearer `INVALID_VERSION_FROM_GIT` reasons.
- **Tests**
  - Added coverage for successful version resolution, missing/malformed tags, prefix handling, and unexpected Git failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->