### PR TITLE
feat(pacquet): align recursive why and peers

### DIFF
--- a/.changeset/recursive-why-peers.md
+++ b/.changeset/recursive-why-peers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Made `pnpm why` and `pnpm peers` recursive by default in workspaces. Recursive peer checks now honor workspace filters, and recursive `why` can inspect the active project when a workspace uses dedicated lockfiles.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13711,8 +13711,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -20182,7 +20182,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -21492,7 +21492,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -505,7 +505,10 @@ pub enum CliCommand {
 
 impl CliCommand {
     fn recursive_by_default(&self) -> bool {
-        matches!(self, CliCommand::List(_) | CliCommand::Ll(_))
+        matches!(
+            self,
+            CliCommand::List(_) | CliCommand::Ll(_) | CliCommand::Why(_) | CliCommand::Peers(_),
+        )
     }
 
     pub(crate) fn default_reporter_summary_scope(&self) -> SummaryScope {

--- a/pnpm/crates/cli/src/cli_args/peers.rs
+++ b/pnpm/crates/cli/src/cli_args/peers.rs
@@ -15,7 +15,10 @@ use pacquet_package_manifest::PackageManifest;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use pacquet_resolving_resolver_base::get_peer_version_range;
 
-use crate::cli_args::sanitize::sanitize;
+use crate::cli_args::{
+    recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
+    sanitize::sanitize,
+};
 
 #[derive(Debug, Default, Clone, Serialize)]
 struct ParentPkg {
@@ -79,7 +82,22 @@ impl PeersArgs {
         dir: &std::path::Path,
         recursive: bool,
     ) -> miette::Result<PeersOutcome> {
-        let lockfile_dir = config.workspace_dir.as_deref().unwrap_or(dir);
+        let lockfile_dir = if config.shared_workspace_lockfile {
+            config.workspace_dir.as_deref().unwrap_or(dir)
+        } else {
+            dir
+        };
+        let project_dirs = if recursive {
+            let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
+            let (projects, _) = discover_workspace_projects(workspace_root)?;
+            select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?
+                .selected
+                .keys()
+                .cloned()
+                .collect()
+        } else {
+            vec![dir.to_path_buf()]
+        };
 
         let lockfile = if self.lockfile_only {
             Lockfile::load_wanted_from_dir(lockfile_dir)
@@ -98,7 +116,7 @@ impl PeersArgs {
         // path (`{}` for `--json`, "No peer dependency issues found" otherwise).
         let issues = match &lockfile {
             Some(lockfile) => {
-                check_peer_dependencies_from_lockfile(lockfile, lockfile_dir, dir, recursive)
+                check_peer_dependencies_from_lockfile(lockfile, lockfile_dir, &project_dirs)
             }
             None => IssuesByProjects::new(),
         };
@@ -125,20 +143,20 @@ impl PeersArgs {
 fn check_peer_dependencies_from_lockfile(
     lockfile: &Lockfile,
     lockfile_dir: &std::path::Path,
-    dir: &std::path::Path,
-    recursive: bool,
+    project_dirs: &[std::path::PathBuf],
 ) -> IssuesByProjects {
     let empty_packages = HashMap::new();
     let empty_snapshots = HashMap::new();
     let packages = lockfile.packages.as_ref().unwrap_or(&empty_packages);
     let snapshots = lockfile.snapshots.as_ref().unwrap_or(&empty_snapshots);
 
-    let mut importer_ids: Vec<String> = if recursive {
-        lockfile.importers.keys().cloned().collect()
-    } else {
-        vec![resolve_importer_id(lockfile_dir, dir)]
-    };
+    let mut importer_ids: Vec<String> = project_dirs
+        .iter()
+        .map(|project_dir| pacquet_workspace::importer_id_from_root_dir(lockfile_dir, project_dir))
+        .filter(|importer_id| lockfile.importers.contains_key(importer_id))
+        .collect();
     importer_ids.sort();
+    importer_ids.dedup();
 
     let mut result: IssuesByProjects = BTreeMap::new();
     // Shared across importers so each package is evaluated once, matching
@@ -183,18 +201,6 @@ fn check_peer_dependencies_from_lockfile(
     }
 
     result
-}
-
-fn resolve_importer_id(lockfile_dir: &std::path::Path, dir: &std::path::Path) -> String {
-    if dir == lockfile_dir {
-        Lockfile::ROOT_IMPORTER_KEY.to_string()
-    } else {
-        dir.strip_prefix(lockfile_dir)
-            .ok()
-            .map(|rel| rel.to_string_lossy().replace('\\', "/"))
-            .filter(|id| !id.is_empty())
-            .unwrap_or_else(|| Lockfile::ROOT_IMPORTER_KEY.to_string())
-    }
 }
 
 fn path_is_within(path: &std::path::Path, base: &std::path::Path) -> bool {
@@ -361,7 +367,10 @@ fn collect_initial_keys(
                 if !path_is_within(&linked_importer_path, lockfile_dir) {
                     continue;
                 }
-                let linked_importer_id = resolve_importer_id(lockfile_dir, &linked_importer_path);
+                let linked_importer_id = pacquet_workspace::importer_id_from_root_dir(
+                    lockfile_dir,
+                    &linked_importer_path,
+                );
                 collect_initial_keys(
                     &linked_importer_id,
                     lockfile,

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -297,33 +297,37 @@ fn recursive_by_default_command_is_promoted_inside_workspace() {
     let workspace = tempfile::tempdir().expect("creates workspace");
     std::fs::write(workspace.path().join("pnpm-workspace.yaml"), "packages: []\n")
         .expect("writes workspace manifest");
-    let mut parsed = CliArgs::try_parse_from([
-        "pacquet",
-        "--dir",
-        workspace.path().to_str().expect("UTF-8 path"),
-        "list",
-    ])
-    .expect("parses");
+    for command in ["list", "why", "peers"] {
+        let mut parsed = CliArgs::try_parse_from([
+            "pacquet",
+            "--dir",
+            workspace.path().to_str().expect("UTF-8 path"),
+            command,
+        ])
+        .expect("parses");
 
-    parsed.promote_recursive_by_default();
+        parsed.promote_recursive_by_default();
 
-    assert!(parsed.recursive);
+        assert!(parsed.recursive, "{command} should be recursive inside a workspace");
+    }
 }
 
 #[test]
 fn recursive_by_default_command_stays_non_recursive_outside_workspace() {
     let project = tempfile::tempdir().expect("creates project");
-    let mut parsed = CliArgs::try_parse_from([
-        "pacquet",
-        "--dir",
-        project.path().to_str().expect("UTF-8 path"),
-        "list",
-    ])
-    .expect("parses");
+    for command in ["list", "why", "peers"] {
+        let mut parsed = CliArgs::try_parse_from([
+            "pacquet",
+            "--dir",
+            project.path().to_str().expect("UTF-8 path"),
+            command,
+        ])
+        .expect("parses");
 
-    parsed.promote_recursive_by_default();
+        parsed.promote_recursive_by_default();
 
-    assert!(!parsed.recursive);
+        assert!(!parsed.recursive, "{command} should stay non-recursive outside a workspace");
+    }
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/why.rs
+++ b/pnpm/crates/cli/src/cli_args/why.rs
@@ -16,10 +16,7 @@ use crate::{
             search::Searcher,
         },
         list::print_output,
-        recursive::{
-            AutoExcludeRoot, RecursiveSharedLockfileUnsupported, discover_workspace_projects,
-            select_recursive_projects,
-        },
+        recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
     },
 };
 
@@ -84,13 +81,6 @@ impl WhyArgs {
                 "`pnpm why` requires the package name or --find-by=<finder-name>"
             ));
         }
-        if state.config.recursive && !state.config.shared_workspace_lockfile {
-            return Err(RecursiveSharedLockfileUnsupported::new(
-                "Recursive and filtered `pnpm why`",
-            )
-            .into());
-        }
-
         let lockfile_dir = state.lockfile_dir().to_path_buf();
         let project_dir = state
             .manifest
@@ -100,7 +90,8 @@ impl WhyArgs {
             .to_path_buf();
 
         let project_dirs: Vec<PathBuf> = if state.config.recursive {
-            let (projects, _) = discover_workspace_projects(&lockfile_dir)?;
+            let workspace_root = state.config.workspace_dir.as_deref().unwrap_or(&lockfile_dir);
+            let (projects, _) = discover_workspace_projects(workspace_root)?;
             select_recursive_projects(
                 &projects,
                 state.config,

--- a/pnpm/crates/cli/tests/peers.rs
+++ b/pnpm/crates/cli/tests/peers.rs
@@ -1,0 +1,76 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use serde_json::Value;
+use std::{fs, process::Command};
+
+fn write_project(workspace: &std::path::Path, relative_dir: &str, name: &str) {
+    let project_dir = workspace.join(relative_dir);
+    fs::create_dir_all(&project_dir).expect("create project directory");
+    fs::write(
+        project_dir.join("package.json"),
+        serde_json::json!({ "name": name, "version": "1.0.0" }).to_string(),
+    )
+    .expect("write project manifest");
+}
+
+fn run_peers(workspace: &std::path::Path, args: &[&str]) -> Value {
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(workspace)
+        .with_args(args)
+        .output()
+        .expect("run pnpm peers");
+    assert!(output.status.success(), "peers should succeed: {output:?}");
+    serde_json::from_slice(&output.stdout).expect("parse peers JSON")
+}
+
+#[test]
+fn peers_is_recursive_by_default_and_honors_filters() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write root manifest");
+    write_project(&workspace, "packages/app-a", "app-a");
+    write_project(&workspace, "packages/app-b", "app-b");
+    fs::write(
+        workspace.join("pnpm-lock.yaml"),
+        "lockfileVersion: '9.0'\nimporters:\n  .: {}\n  packages/app-a: {}\n  packages/app-b: {}\n",
+    )
+    .expect("write lockfile");
+
+    let all = run_peers(&workspace, &["peers", "--lockfile-only", "--json"]);
+    assert_eq!(all.as_object().map(serde_json::Map::len), Some(3));
+
+    let filtered =
+        run_peers(&workspace, &["--filter", "app-a", "peers", "--lockfile-only", "--json"]);
+    let filtered = filtered.as_object().expect("filtered peer issues object");
+    assert_eq!(filtered.len(), 1);
+    assert!(filtered.contains_key("packages/app-a"));
+
+    drop(root);
+}
+
+#[test]
+fn recursive_peers_uses_the_active_dedicated_lockfile() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write root manifest");
+    write_project(&workspace, "packages/app", "app");
+    let app = workspace.join("packages/app");
+    fs::write(app.join("pnpm-lock.yaml"), "lockfileVersion: '9.0'\nimporters:\n  .: {}\n")
+        .expect("write dedicated lockfile");
+
+    let issues = run_peers(&app, &["peers", "--lockfile-only", "--json"]);
+    let issues = issues.as_object().expect("peer issues object");
+    assert_eq!(issues.len(), 1);
+    assert!(issues.contains_key("."));
+
+    drop(root);
+}

--- a/pnpm/crates/cli/tests/why.rs
+++ b/pnpm/crates/cli/tests/why.rs
@@ -45,7 +45,7 @@ fn why_fails_without_package_name() {
 }
 
 #[test]
-fn filtered_why_rejects_per_project_workspace_lockfiles() {
+fn recursive_why_uses_the_active_dedicated_lockfile() {
     let (_root, workspace, _anchor) = setup();
     fs::write(
         workspace.join("pnpm-workspace.yaml"),
@@ -53,17 +53,24 @@ fn filtered_why_rejects_per_project_workspace_lockfiles() {
     )
     .expect("write workspace manifest");
     write_manifest(&workspace, "{}");
+    let app = workspace.join("packages/app");
+    fs::create_dir_all(&app).expect("create app project");
+    fs::write(
+        app.join("package.json"),
+        format!(
+            r#"{{ "name": "app", "version": "1.0.0", "dependencies": {{ "{PKG}": "100.0.0" }} }}"#,
+        ),
+    )
+    .expect("write app manifest");
+    pacquet(&app, ["install"]).assert().success();
 
-    let output = pacquet(&workspace, ["--filter", ".", "why", PKG])
-        .output()
-        .expect("run filtered pacquet why");
+    let output = pacquet(&app, ["-r", "why", PKG]).output().expect("run recursive pacquet why");
 
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "recursive why should succeed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED")
-            && stderr.contains("sharedWorkspaceLockfile=false"),
-        "stderr: {stderr}",
+        stdout.contains(PKG) && stdout.contains("app@1.0.0"),
+        "recursive why should query the active project lockfile: {stdout}",
     );
 }
 
@@ -244,7 +251,7 @@ fn filtered_why_excludes_unselected_workspace_siblings() {
 }
 
 #[test]
-fn recursive_why_includes_all_workspace_projects() {
+fn why_is_recursive_by_default_inside_a_workspace() {
     let (_root, workspace, _anchor) = setup();
     fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
         .expect("write workspace manifest");
@@ -260,9 +267,9 @@ fn recursive_why_includes_all_workspace_projects() {
     .expect("write sibling package.json");
     pacquet(&workspace, ["install"]).assert().success();
 
-    let output = pacquet(&workspace, ["-r", "why", HELLO])
+    let output = pacquet(&workspace, ["why", HELLO])
         .output()
-        .expect("query recursive workspace dependency");
+        .expect("query default-recursive workspace dependency");
 
     assert!(output.status.success(), "recursive why should succeed: {output:?}");
     let stdout = String::from_utf8_lossy(&output.stdout);


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13201.

Aligns Rust pnpm's `why` and `peers` recursive behavior with the TypeScript CLI:

- marks both commands recursive by default inside workspaces;
- applies recursive project selection and filters to `peers` instead of checking every lockfile importer;
- uses the active project lockfile for `why` and `peers` in workspaces configured with dedicated lockfiles;
- adds focused tests for workspace defaults, filters, and dedicated-lockfile behavior;
- updates the transitive `fast-uri` resolution to 3.1.4 after the PR audit detected GHSA-v2hh-gcrm-f6hx.

TypeScript already has these command semantics, so no TypeScript implementation change is needed.

## Squash Commit Body

```text
Make Rust pnpm promote why and peers to recursive mode when they run inside a workspace. Route peer checks through the selected-project set so filters exclude unselected importers.

For workspaces with dedicated lockfiles, inspect the active project's lockfile while discovering selection candidates from the workspace root. This matches the TypeScript commands' active-lockfile behavior rather than aggregating every project lockfile.

Related to pnpm/pnpm#13201.

Refresh the transitive fast-uri lockfile resolution to 3.1.4 after the dependency audit began rejecting 3.1.3 for GHSA-v2hh-gcrm-f6hx.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).
