### PR TITLE
feat(pacquet): add recursive rebuild selection

### DIFF
--- a/.changeset/recursive-rebuild.md
+++ b/.changeset/recursive-rebuild.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Made recursive `pnpm rebuild` honor workspace filters with shared and dedicated lockfiles.

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -220,7 +220,7 @@ impl CliArgs {
             self.validate_report_summary_global_option()?;
         }
         if self.no_bail {
-            self.validate_run_scoped_global_option("--no-bail")?;
+            self.validate_no_bail_global_option()?;
         }
         if self.if_present {
             self.validate_if_present_top_level_option()?;
@@ -292,6 +292,13 @@ impl CliArgs {
             return Ok(());
         }
         self.validate_run_scoped_global_option("--report-summary")
+    }
+
+    fn validate_no_bail_global_option(&self) -> Result<(), clap::Error> {
+        if matches!(self.command, CliCommand::Rebuild(_)) {
+            return Ok(());
+        }
+        self.validate_run_scoped_global_option("--no-bail")
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -411,13 +411,47 @@ pub(super) fn rebuild<'a>(
     ctx: &RunCtx<'a>,
     args: RebuildArgs,
 ) -> miette::Result<CommandFuture<'a>> {
-    Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>((ctx.state)(true)?))
+    let dir = ctx.dir;
+    let manifest_path = ctx.manifest_path;
+    let reporter = ctx.reporter;
+    let recursive_sort = ctx.recursive_sort;
+    let recursive_no_bail = ctx.recursive_no_bail;
+    let config = ctx.config;
+    Ok(Box::pin(async move {
+        match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                Box::pin(args.run_from_cli::<DefaultReporter>(
+                    config()?,
+                    dir.to_path_buf(),
+                    manifest_path.to_path_buf(),
+                    recursive_sort,
+                    recursive_no_bail,
+                ))
+                .await?;
+            }
+            ReporterType::Ndjson => {
+                Box::pin(args.run_from_cli::<NdjsonReporter>(
+                    config()?,
+                    dir.to_path_buf(),
+                    manifest_path.to_path_buf(),
+                    recursive_sort,
+                    recursive_no_bail,
+                ))
+                .await?;
+            }
+            ReporterType::Silent => {
+                Box::pin(args.run_from_cli::<SilentReporter>(
+                    config()?,
+                    dir.to_path_buf(),
+                    manifest_path.to_path_buf(),
+                    recursive_sort,
+                    recursive_no_bail,
+                ))
+                .await?;
+            }
         }
-        ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>((ctx.state)(true)?)),
-        ReporterType::Silent => Box::pin(args.run::<SilentReporter>((ctx.state)(true)?)),
-    })
+        Ok(())
+    }))
 }
 
 pub(super) fn runtime<'a>(
@@ -568,13 +602,13 @@ pub(super) fn approve_builds<'a>(
         super::rebuild::RebuildSelection { names: Some(build_packages), projects: Vec::new() };
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => Box::pin(async move {
-            super::rebuild::run_rebuild::<DefaultReporter>(&rebuild_state, selected).await
+            super::rebuild::run_rebuild::<DefaultReporter>(&rebuild_state, selected, None).await
         }),
         ReporterType::Ndjson => Box::pin(async move {
-            super::rebuild::run_rebuild::<NdjsonReporter>(&rebuild_state, selected).await
+            super::rebuild::run_rebuild::<NdjsonReporter>(&rebuild_state, selected, None).await
         }),
         ReporterType::Silent => Box::pin(async move {
-            super::rebuild::run_rebuild::<SilentReporter>(&rebuild_state, selected).await
+            super::rebuild::run_rebuild::<SilentReporter>(&rebuild_state, selected, None).await
         }),
     })
 }

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -435,7 +435,7 @@ async fn prompt_approve_global_builds<Reporter: self::Reporter + 'static>(
             names: Some(build_packages),
             projects: Vec::new(),
         };
-        run_rebuild::<Reporter>(&rebuild_state, selection).await?;
+        run_rebuild::<Reporter>(&rebuild_state, selection, None).await?;
     }
     Ok(())
 }

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -60,8 +60,28 @@ fn select_install_family_plan(
     recursive_sort: bool,
     auto_exclude_root: bool,
 ) -> miette::Result<InstallFamilyPlan> {
-    if !cfg.recursive {
+    let Some(selection) =
+        select_workspace_projects(cfg, prefix, manifest_path, recursive_sort, auto_exclude_root)?
+    else {
         return Ok(InstallFamilyPlan::Single);
+    };
+    if !cfg.shared_workspace_lockfile {
+        let mut project_dirs: Vec<PathBuf> = selection.selected_dirs.iter().cloned().collect();
+        project_dirs.sort();
+        return Ok(InstallFamilyPlan::PerProject(project_dirs));
+    }
+    Ok(InstallFamilyPlan::Shared(Box::new(selection)))
+}
+
+pub(crate) fn select_workspace_projects(
+    cfg: &Config,
+    prefix: &Path,
+    manifest_path: &Path,
+    recursive_sort: bool,
+    auto_exclude_root: bool,
+) -> miette::Result<Option<InstallFamilySelection>> {
+    if !cfg.recursive {
+        return Ok(None);
     }
 
     let workspace_root = cfg.workspace_dir.as_deref().unwrap_or(prefix).to_path_buf();
@@ -85,11 +105,6 @@ fn select_install_family_plan(
                 AutoExcludeRoot::Disabled
             },
         )?;
-        if !cfg.shared_workspace_lockfile {
-            let mut project_dirs: Vec<PathBuf> = selection.selected.keys().cloned().collect();
-            project_dirs.sort();
-            return Ok(InstallFamilyPlan::PerProject(project_dirs));
-        }
         let ordered_groups = if recursive_sort {
             sort_filtered_projects(
                 &selection.selected,
@@ -115,14 +130,14 @@ fn select_install_family_plan(
             pacquet_fs::lexical_normalize(&project.root_dir) == normalized_active_dir
         });
 
-    Ok(InstallFamilyPlan::Shared(Box::new(InstallFamilySelection {
+    Ok(Some(InstallFamilySelection {
         workspace_root,
         projects,
         ordered_groups,
         ordered_dirs,
         selected_dirs,
         active_manifest_is_standin,
-    })))
+    }))
 }
 
 /// Build the project-anchored `State` for one project of a

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -8,13 +8,21 @@ use pacquet_package_manager::{
 };
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::Reporter;
-use std::{collections::HashSet, path::Path};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
-use crate::State;
+use crate::{
+    State,
+    cli_args::pipelines::{
+        InstallFamilySelection, anchor_dedicated_project_config, select_workspace_projects,
+    },
+};
 
 /// `pacquet rebuild` — re-run the lifecycle scripts of installed
 /// dependencies.
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct RebuildArgs {
     /// Rebuild only the named packages. With no names, every dependency
     /// that requires a build is rebuilt.
@@ -27,9 +35,74 @@ pub struct RebuildArgs {
 }
 
 impl RebuildArgs {
-    pub async fn run<Reporter: self::Reporter + 'static>(self, state: State) -> miette::Result<()> {
+    pub async fn run<Reporter: self::Reporter + 'static>(
+        self,
+        state: State,
+        workspace_selection: Option<InstallFamilySelection>,
+    ) -> miette::Result<()> {
         let selection = resolve_selection(&self.packages, self.pending, state.config)?;
-        run_rebuild::<Reporter>(&state, selection).await
+        run_rebuild::<Reporter>(&state, selection, workspace_selection).await
+    }
+
+    pub async fn run_from_cli<Reporter: self::Reporter + 'static>(
+        self,
+        cfg: &'static Config,
+        prefix: PathBuf,
+        manifest_path: PathBuf,
+        recursive_sort: bool,
+        no_bail: bool,
+    ) -> miette::Result<()> {
+        let workspace_selection =
+            select_workspace_projects(cfg, &prefix, &manifest_path, recursive_sort, false)?;
+        if workspace_selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty())
+        {
+            return Ok(());
+        }
+        if !cfg.shared_workspace_lockfile
+            && let Some(workspace_selection) = workspace_selection
+        {
+            let base_config = cfg.clone();
+            let concurrency =
+                usize::try_from(cfg.workspace_concurrency).unwrap_or(usize::MAX).max(1);
+            let mut first_error = None;
+            for group in workspace_selection.ordered_groups {
+                for batch in group.chunks(concurrency) {
+                    let rebuilds = batch.iter().cloned().map(|project_dir| {
+                        let args = self.clone();
+                        let mut project_config = base_config.clone();
+                        anchor_dedicated_project_config(&mut project_config, &project_dir);
+                        async move {
+                            let project_config = Config::leak(project_config);
+                            let state =
+                                State::init(project_dir.join("package.json"), project_config, true)
+                                    .wrap_err_with(|| {
+                                        format!(
+                                            "initialize the rebuild state for {}",
+                                            project_dir.display(),
+                                        )
+                                    })?;
+                            Box::pin(args.run::<Reporter>(state, None)).await
+                        }
+                    });
+                    for result in futures_util::future::join_all(rebuilds).await {
+                        if let Err(error) = result {
+                            if !no_bail {
+                                return Err(error);
+                            }
+                            first_error.get_or_insert(error);
+                        }
+                    }
+                }
+            }
+            if let Some(error) = first_error {
+                return Err(error);
+            }
+            return Ok(());
+        }
+
+        let state =
+            State::init(manifest_path, cfg, true).wrap_err("initialize the rebuild state")?;
+        Box::pin(self.run::<Reporter>(state, workspace_selection)).await
     }
 }
 
@@ -99,6 +172,7 @@ fn resolve_selection(
 pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
     state: &State,
     selection: RebuildSelection,
+    workspace_selection: Option<InstallFamilySelection>,
 ) -> miette::Result<()> {
     let lockfile_path = state.lockfile_path();
     let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
@@ -111,7 +185,7 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
 
     let dependency_groups = rebuild_dependency_groups(config)?;
 
-    Install {
+    let install = Install {
         tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
         http_client,
         http_client_arc: std::sync::Arc::clone(http_client),
@@ -148,9 +222,24 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
         disable_optimistic_repeat_install: false,
         pnpmfile_hook_override: None,
         workspace_projects_override: None,
+    };
+    match workspace_selection.as_ref() {
+        Some(selection) => {
+            install
+                .run_selected_rebuild::<Reporter>(
+                    pacquet_package_manager::WorkspaceInstallSelection {
+                        all_projects: &selection.projects,
+                        ordered_groups: &selection.ordered_groups,
+                        ordered_dirs: &selection.ordered_dirs,
+                        selected_dirs: selection.selected_dirs.as_ref(),
+                        active_manifest_is_standin: selection.active_manifest_is_standin,
+                    },
+                    rebuild,
+                )
+                .await
+        }
+        None => install.run_rebuild::<Reporter>(rebuild).await,
     }
-    .run_rebuild::<Reporter>(rebuild)
-    .await
     .wrap_err("rebuilding dependencies")?;
 
     Ok(())

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -140,6 +140,7 @@ fn script_scoped_global_flags_parse_before_script_commands() {
         ["pacquet", "--report-summary", "test"].as_slice(),
         ["pacquet", "--resume-from", "pkg", "start"].as_slice(),
         ["pacquet", "--no-bail", "stop"].as_slice(),
+        ["pacquet", "-r", "--no-bail", "rebuild"].as_slice(),
         ["pacquet", "-r", "--report-summary", ".test"].as_slice(),
     ] {
         let parsed = CliArgs::try_parse_from(argv).expect("parses script-scoped global flag");
@@ -221,6 +222,7 @@ fn script_scoped_global_flags_reject_unrelated_commands() {
         ["pacquet", "install", "--no-bail"].as_slice(),
         ["pacquet", "restart", "--report-summary"].as_slice(),
         ["pacquet", "restart", "--no-bail"].as_slice(),
+        ["pacquet", "rebuild", "--resume-from", "pkg"].as_slice(),
         ["pacquet", "publish", "--resume-from", "pkg"].as_slice(),
         ["pacquet", "publish", "--no-bail"].as_slice(),
     ] {

--- a/pnpm/crates/cli/tests/rebuild_recursive.rs
+++ b/pnpm/crates/cli/tests/rebuild_recursive.rs
@@ -1,0 +1,119 @@
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{fs, path::Path, process::Command};
+
+fn write_project(workspace: &Path, relative_dir: &str, name: &str) {
+    let project_dir = workspace.join(relative_dir);
+    fs::create_dir_all(&project_dir).expect("create project directory");
+    fs::write(
+        project_dir.join("package.json"),
+        serde_json::json!({
+            "name": name,
+            "version": "1.0.0",
+            "scripts": {
+                "install": r#"node -e "require('fs').writeFileSync('rebuilt.txt','ran')""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write project manifest");
+}
+
+fn filtered_rebuild_only_runs_selected_project(shared_workspace_lockfile: bool) {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let dedicated_setting =
+        if shared_workspace_lockfile { "" } else { "sharedWorkspaceLockfile: false\n" };
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!("packages:\n  - packages/*\n{dedicated_setting}"),
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write root manifest");
+    write_project(&workspace, "packages/app-a", "app-a");
+    write_project(&workspace, "packages/app-b", "app-b");
+
+    pacquet.with_args(["install", "--ignore-scripts", "--reporter=silent"]).assert().success();
+    let selected_marker = workspace.join("packages/app-a/rebuilt.txt");
+    let unselected_marker = workspace.join("packages/app-b/rebuilt.txt");
+    assert!(!selected_marker.exists());
+    assert!(!unselected_marker.exists());
+
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["--filter", "app-a", "rebuild", "--pending", "--reporter=silent"])
+        .assert()
+        .success();
+
+    assert!(selected_marker.exists(), "selected project install script should run");
+    assert!(!unselected_marker.exists(), "unselected project install script should not run");
+
+    drop(root);
+}
+
+#[test]
+fn filtered_rebuild_selects_projects_with_a_shared_lockfile() {
+    filtered_rebuild_only_runs_selected_project(true);
+}
+
+#[test]
+fn filtered_rebuild_selects_projects_with_dedicated_lockfiles() {
+    filtered_rebuild_only_runs_selected_project(false);
+}
+
+#[test]
+fn dedicated_recursive_rebuild_no_bail_continues_topological_chunks() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write root manifest");
+    let app_a = workspace.join("packages/app-a");
+    let app_b = workspace.join("packages/app-b");
+    fs::create_dir_all(&app_a).expect("create app-a");
+    fs::create_dir_all(&app_b).expect("create app-b");
+    fs::write(
+        app_a.join("package.json"),
+        serde_json::json!({
+            "name": "app-a",
+            "version": "1.0.0",
+            "scripts": { "install": r#"node -e "process.exit(1)""# },
+        })
+        .to_string(),
+    )
+    .expect("write app-a manifest");
+    fs::write(
+        app_b.join("package.json"),
+        serde_json::json!({
+            "name": "app-b",
+            "version": "1.0.0",
+            "dependencies": { "app-a": "workspace:*" },
+            "scripts": {
+                "install": r#"node -e "require('fs').writeFileSync('rebuilt.txt','ran')""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write app-b manifest");
+
+    pacquet.with_args(["install", "--ignore-scripts", "--reporter=silent"]).assert().success();
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["-r", "--no-bail", "rebuild", "--pending", "--reporter=silent"])
+        .output()
+        .expect("run recursive rebuild");
+
+    assert!(!output.status.success(), "the failed project should fail the command");
+    assert!(
+        app_b.join("rebuilt.txt").exists(),
+        "--no-bail should continue to the dependent project's topological chunk: {output:?}",
+    );
+
+    drop(root);
+}

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -696,6 +696,21 @@ where
         .await
     }
 
+    /// Execute a forced rebuild limited to the selected workspace importers.
+    pub async fn run_selected_rebuild<Reporter: self::Reporter + 'static>(
+        self,
+        selection: WorkspaceInstallSelection<'_>,
+        rebuild: RebuildOptions,
+    ) -> Result<(), InstallError> {
+        assert!(self.frozen_lockfile, "run_selected_rebuild requires frozen_lockfile = true");
+        Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
+            rebuild: Some(rebuild),
+            selection: Some(selection),
+            ..Default::default()
+        }))
+        .await
+    }
+
     async fn run_inner<Reporter: self::Reporter + 'static>(
         self,
         options: InstallRunOptions<'a, '_>,


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#13201.

Adds recursive project selection to pacquet's `rebuild` command so `pnpm -r rebuild` and filter-promoted rebuilds match the existing TypeScript implementation.

- Rebuilds only selected importers when the workspace uses a shared lockfile.
- Rebuilds dedicated-lockfile projects in topological chunks while honoring workspace concurrency and `--no-bail`.
- Adds focused coverage for shared lockfiles, dedicated lockfiles, filtering, and continued execution after a project failure.

The TypeScript CLI already has this behavior, so no TypeScript change is needed.

## Squash Commit Body

```text
Route recursive rebuilds through workspace project selection instead of rebuilding an unselected state. Shared-lockfile workspaces rebuild the selected importers together, while dedicated-lockfile workspaces rebuild each selected project in topological chunks with workspace concurrency and bail behavior preserved.

Related to pnpm/pnpm#13201.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787268060&installation_model_id=426870&pr_number=13206&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13206&signature=c2504bd6428c75586e2d840a985f6aad1a1a8da5fca059d20ab117dcfb950759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recursive `rebuild` now honors workspace filters and rebuild scope, targeting only the selected workspace projects.
  * Recursive rebuild behavior now works consistently with both shared and dedicated lockfile setups.

* **Bug Fixes**
  * Script execution during `rebuild --recursive` is correctly limited to the selected projects.
  * `--no-bail` handling is improved for recursive rebuilds, including continuation after upstream failures.

* **Tests**
  * Added integration coverage for recursive rebuild filtering and failure/continuation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->