### PR TITLE
feat(releasing): publish a new package's first release at its manifest version

### DIFF
--- a/.changeset/first-release-verbatim.md
+++ b/.changeset/first-release-verbatim.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/releasing.versioning": minor
+"@pnpm/releasing.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+The first release of a package now publishes the version written in its manifest verbatim, instead of bumping off it. `pnpm version -r` and `pnpm change status` check the registry for each release's current version; when that version is not yet published, the package debuts at it and its pending changesets apply only from the next release. A newly added package seeded at `1100.0.0` with a `minor` changeset is therefore published as `1100.0.0` rather than skipping straight to `1100.1.0`.

--- a/pnpm/crates/cli/src/cli_args/change.rs
+++ b/pnpm/crates/cli/src/cli_args/change.rs
@@ -19,7 +19,9 @@ use std::{
     process::Command,
 };
 
-use crate::cli_args::recursive::discover_workspace_projects;
+use crate::cli_args::{
+    changelog::unpublished_release_dirs, recursive::discover_workspace_projects,
+};
 
 /// `pnpm change` — record a change intent: which packages a change affects,
 /// the bump type for each, and a summary that becomes the changelog entry.
@@ -69,7 +71,7 @@ enum ChangeError {
 }
 
 impl ChangeArgs {
-    pub fn run(self, config: &Config) -> miette::Result<()> {
+    pub async fn run(self, config: &Config) -> miette::Result<()> {
         let Some(workspace_dir) = config.workspace_dir.clone() else {
             return Err(ChangeError::WorkspaceOnly.into());
         };
@@ -83,7 +85,7 @@ impl ChangeArgs {
             && self.bump.is_none()
             && self.summary.is_none()
         {
-            let output = render_status(&workspace_dir, &engine_projects, config)?;
+            let output = render_status(&workspace_dir, &engine_projects, config).await?;
             println!("{output}");
             return Ok(());
         }
@@ -285,21 +287,28 @@ fn prompt_bump_types(pkg_refs: &[String]) -> miette::Result<IndexMap<String, Int
     Ok(pkg_refs.iter().map(|reference| (reference.clone(), bump_by_ref[reference])).collect())
 }
 
-fn render_status(
+async fn render_status(
     workspace_dir: &Path,
     projects: &[WorkspaceProject],
     config: &Config,
 ) -> miette::Result<String> {
     let intents = read_change_intents(workspace_dir)?;
     let ledger = read_ledger(workspace_dir)?;
-    let plan = assemble_release_plan(
-        projects,
-        workspace_dir,
-        &intents,
-        &ledger,
-        Some(&config.versioning),
-        &AssembleReleasePlanOptions::default(),
-    )?;
+    let assemble = |unpublished_dirs: HashSet<String>| {
+        assemble_release_plan(
+            projects,
+            workspace_dir,
+            &intents,
+            &ledger,
+            Some(&config.versioning),
+            &AssembleReleasePlanOptions { unpublished_dirs, ..Default::default() },
+        )
+    };
+    // First release of a never-published package publishes its manifest version
+    // verbatim, so the preview matches the release: probe the first pass's
+    // releases and re-assemble with those held at their current version.
+    let unpublished_dirs = unpublished_release_dirs(config, &assemble(HashSet::new())?).await?;
+    let plan = assemble(unpublished_dirs)?;
     if plan.releases.is_empty() {
         return Ok("No pending changes.".to_string());
     }

--- a/pnpm/crates/cli/src/cli_args/change.rs
+++ b/pnpm/crates/cli/src/cli_args/change.rs
@@ -304,8 +304,7 @@ async fn render_status(
             &AssembleReleasePlanOptions { unpublished_dirs, ..Default::default() },
         )
     };
-    // Probe as the release does, so the preview matches it: assemble, probe the
-    // plan's releases for `unpublished_dirs`, then re-assemble with it.
+    // Probe as the release does, so the preview matches it.
     let unpublished_dirs = unpublished_release_dirs(config, &assemble(HashSet::new())?).await?;
     let plan = assemble(unpublished_dirs)?;
     if plan.releases.is_empty() {

--- a/pnpm/crates/cli/src/cli_args/change.rs
+++ b/pnpm/crates/cli/src/cli_args/change.rs
@@ -304,9 +304,8 @@ async fn render_status(
             &AssembleReleasePlanOptions { unpublished_dirs, ..Default::default() },
         )
     };
-    // First release of a never-published package publishes its manifest version
-    // verbatim, so the preview matches the release: probe the first pass's
-    // releases and re-assemble with those held at their current version.
+    // Probe as the release does, so the preview matches it: assemble, probe the
+    // plan's releases for `unpublished_dirs`, then re-assemble with it.
     let unpublished_dirs = unpublished_release_dirs(config, &assemble(HashSet::new())?).await?;
     let plan = assemble(unpublished_dirs)?;
     if plan.releases.is_empty() {

--- a/pnpm/crates/cli/src/cli_args/changelog.rs
+++ b/pnpm/crates/cli/src/cli_args/changelog.rs
@@ -8,11 +8,13 @@ use std::{collections::HashSet, io::Read, path::Path};
 
 use flate2::read::GzDecoder;
 use futures_util::StreamExt;
+use miette::IntoDiagnostic;
 use pacquet_config::Config;
+use pacquet_network::encode_package_name;
 use pacquet_registry::Package;
 use pacquet_versioning::{
-    ChangelogStorage, changelog_storage, list_pending_changelogs, read_pending_changelog,
-    render_changelog,
+    ChangelogStorage, ReleasePlan, changelog_storage, list_pending_changelogs,
+    read_pending_changelog, render_changelog,
 };
 use tar::Archive;
 
@@ -74,6 +76,65 @@ pub async fn confirmed_published_versions(
             changelog.contains(section.trim()).then(|| format!("{name}@{version}"))
         });
     Ok(futures_util::future::join_all(checks).await.into_iter().flatten().collect())
+}
+
+/// The directories in `plan` whose current manifest version is not yet
+/// published to its registry — the packages whose first release must publish
+/// that version verbatim instead of bumping off it. Probes every release
+/// concurrently; any probe failure propagates so the command fails rather than
+/// release a wrong version. Feeds `AssembleReleasePlanOptions::unpublished_dirs`.
+/// Mirrors the TypeScript `resolveUnpublishedDirs`.
+pub async fn unpublished_release_dirs(
+    config: &Config,
+    plan: &ReleasePlan,
+) -> miette::Result<HashSet<String>> {
+    // Debug-only test seam: the engine's integration tests advance manifests
+    // without a real publish cycle (a lane prerelease is written but never
+    // published, for instance), so they set this to make every release bump as
+    // if already published. Compiled out of release builds, so a production
+    // `pnpm` always probes.
+    #[cfg(debug_assertions)]
+    if std::env::var_os("PACQUET_ASSUME_VERSIONS_PUBLISHED").is_some() {
+        return Ok(HashSet::new());
+    }
+    let checks = plan.releases.iter().map(|release| async move {
+        is_version_published(config, &release.name, &release.current_version)
+            .await
+            .map(|published| (release.dir.clone(), published))
+    });
+    let probed = futures_util::future::try_join_all(checks).await?;
+    Ok(probed.into_iter().filter_map(|(dir, published)| (!published).then_some(dir)).collect())
+}
+
+/// Whether `name@version` is already published to its registry. A registry 404
+/// (no such package) and a package published but missing this exact version
+/// both read as `false` — a never-published version, i.e. a first release. Any
+/// other outcome (offline, 5xx, malformed body) errors, so the caller fails
+/// rather than guess a version's fate.
+async fn is_version_published(config: &Config, name: &str, version: &str) -> miette::Result<bool> {
+    let client = build_registry_client(config)?;
+    let registry = registry_for(config, name);
+    let url = format!("{registry}{}", encode_package_name(name));
+    let guard = client.acquire_for_url(&url).await;
+    let mut request = guard.get(&url).header(
+        "accept",
+        "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+    );
+    if let Some(value) = config.auth_headers.for_url_with_package(&url, Some(name)) {
+        request = request.header("authorization", value);
+    }
+    let response = request.send().await.into_diagnostic()?;
+    if response.status().as_u16() == 404 {
+        return Ok(false);
+    }
+    if !response.status().is_success() {
+        return Err(miette::miette!(
+            "registry returned status {} for {url} while checking whether {name}@{version} is published",
+            response.status(),
+        ));
+    }
+    let package: Package = response.json().await.into_diagnostic()?;
+    Ok(package.versions.contains_key(version))
 }
 
 enum VersionPick<'a> {

--- a/pnpm/crates/cli/src/cli_args/changelog.rs
+++ b/pnpm/crates/cli/src/cli_args/changelog.rs
@@ -84,6 +84,12 @@ pub async fn confirmed_published_versions(
 /// concurrently; any probe failure propagates so the command fails rather than
 /// release a wrong version. Feeds `AssembleReleasePlanOptions::unpublished_dirs`.
 /// Mirrors the TypeScript `resolveUnpublishedDirs`.
+///
+/// A first assembly pass (without `unpublished_dirs`) supplies `plan`. Holding
+/// a package at its current version can only remove dependent propagation,
+/// never add it (the materialized range already admits the unchanged version),
+/// so the re-assembled plan is a subset of `plan` — every dir it can hold was
+/// probed here.
 pub async fn unpublished_release_dirs(
     config: &Config,
     plan: &ReleasePlan,

--- a/pnpm/crates/cli/src/cli_args/changelog.rs
+++ b/pnpm/crates/cli/src/cli_args/changelog.rs
@@ -78,36 +78,20 @@ pub async fn confirmed_published_versions(
     Ok(futures_util::future::join_all(checks).await.into_iter().flatten().collect())
 }
 
-/// The directories in `plan` whose current manifest version is not yet
-/// published to its registry — the packages whose first release must publish
-/// that version verbatim instead of bumping off it. Probes every release
-/// concurrently; any probe failure propagates so the command fails rather than
-/// release a wrong version. Feeds `AssembleReleasePlanOptions::unpublished_dirs`.
+/// The releases in `plan` whose current version the registry does not have —
+/// `AssembleReleasePlanOptions::unpublished_dirs`. Probe failures propagate.
 /// Mirrors the TypeScript `resolveUnpublishedDirs`.
-///
-/// A first assembly pass (without `unpublished_dirs`) supplies `plan`. Holding
-/// a package at its current version can only remove dependent propagation,
-/// never add it (the materialized range already admits the unchanged version),
-/// so the re-assembled plan is a subset of `plan` — every dir it can hold was
-/// probed here.
 pub async fn unpublished_release_dirs(
     config: &Config,
     plan: &ReleasePlan,
 ) -> miette::Result<HashSet<String>> {
-    // Debug-only test seam: the engine's integration tests advance manifests
-    // without a real publish cycle (a lane prerelease is written but never
-    // published, for instance), so they set this to make every release bump as
-    // if already published. Compiled out of release builds, so a production
-    // `pnpm` always probes.
+    // Debug-only test seam, compiled out of release builds: the engine tests
+    // advance manifests without publishing, so they force "all published".
     #[cfg(debug_assertions)]
     if std::env::var_os("PACQUET_ASSUME_VERSIONS_PUBLISHED").is_some() {
         return Ok(HashSet::new());
     }
-    // One client, shared across the concurrent probes, so the global
-    // network-concurrency bound and connection pool are respected rather than
-    // reconstructed per release: `is_version_published` awaits the client's
-    // per-origin semaphore (`acquire_for_url`), which caps how many probes hit
-    // the registry at once even though every future is spawned up front.
+    // One client for the batch; its per-origin semaphore bounds the fan-out.
     let client = build_registry_client(config)?;
     let checks = plan.releases.iter().map(|release| {
         let client = &client;
@@ -122,11 +106,8 @@ pub async fn unpublished_release_dirs(
     Ok(probed.into_iter().filter_map(|(dir, published)| (!published).then_some(dir)).collect())
 }
 
-/// Whether `name@version` is already published to its registry. A registry 404
-/// (no such package) and a package published but missing this exact version
-/// both read as `false` — a never-published version, i.e. a first release. Any
-/// other outcome (offline, 5xx, malformed body) errors, so the caller fails
-/// rather than guess a version's fate.
+/// Whether `name@version` is published. A 404 reads as unpublished; any other
+/// failure errors.
 async fn is_version_published(
     client: &ThrottledClient,
     config: &Config,

--- a/pnpm/crates/cli/src/cli_args/changelog.rs
+++ b/pnpm/crates/cli/src/cli_args/changelog.rs
@@ -124,13 +124,13 @@ async fn is_version_published(config: &Config, name: &str, version: &str) -> mie
         request = request.header("authorization", value);
     }
     let response = request.send().await.into_diagnostic()?;
-    if response.status().as_u16() == 404 {
+    let status = response.status();
+    if status.as_u16() == 404 {
         return Ok(false);
     }
-    if !response.status().is_success() {
+    if !status.is_success() {
         return Err(miette::miette!(
-            "registry returned status {} for {url} while checking whether {name}@{version} is published",
-            response.status(),
+            "registry returned status {status} for {url} while checking whether {name}@{version} is published",
         ));
     }
     let package: Package = response.json().await.into_diagnostic()?;

--- a/pnpm/crates/cli/src/cli_args/changelog.rs
+++ b/pnpm/crates/cli/src/cli_args/changelog.rs
@@ -99,7 +99,9 @@ pub async fn unpublished_release_dirs(
     }
     // One client, shared across the concurrent probes, so the global
     // network-concurrency bound and connection pool are respected rather than
-    // reconstructed per release.
+    // reconstructed per release: `is_version_published` awaits the client's
+    // per-origin semaphore (`acquire_for_url`), which caps how many probes hit
+    // the registry at once even though every future is spawned up front.
     let client = build_registry_client(config)?;
     let checks = plan.releases.iter().map(|release| {
         let client = &client;

--- a/pnpm/crates/cli/src/cli_args/changelog.rs
+++ b/pnpm/crates/cli/src/cli_args/changelog.rs
@@ -10,7 +10,7 @@ use flate2::read::GzDecoder;
 use futures_util::StreamExt;
 use miette::IntoDiagnostic;
 use pacquet_config::Config;
-use pacquet_network::encode_package_name;
+use pacquet_network::{ThrottledClient, encode_package_name, redact_url_credentials};
 use pacquet_registry::Package;
 use pacquet_versioning::{
     ChangelogStorage, ReleasePlan, changelog_storage, list_pending_changelogs,
@@ -97,10 +97,18 @@ pub async fn unpublished_release_dirs(
     if std::env::var_os("PACQUET_ASSUME_VERSIONS_PUBLISHED").is_some() {
         return Ok(HashSet::new());
     }
-    let checks = plan.releases.iter().map(|release| async move {
-        is_version_published(config, &release.name, &release.current_version)
-            .await
-            .map(|published| (release.dir.clone(), published))
+    // One client, shared across the concurrent probes, so the global
+    // network-concurrency bound and connection pool are respected rather than
+    // reconstructed per release.
+    let client = build_registry_client(config)?;
+    let checks = plan.releases.iter().map(|release| {
+        let client = &client;
+        async move {
+            let published =
+                is_version_published(client, config, &release.name, &release.current_version)
+                    .await?;
+            Ok::<_, miette::Report>((release.dir.clone(), published))
+        }
     });
     let probed = futures_util::future::try_join_all(checks).await?;
     Ok(probed.into_iter().filter_map(|(dir, published)| (!published).then_some(dir)).collect())
@@ -111,8 +119,12 @@ pub async fn unpublished_release_dirs(
 /// both read as `false` — a never-published version, i.e. a first release. Any
 /// other outcome (offline, 5xx, malformed body) errors, so the caller fails
 /// rather than guess a version's fate.
-async fn is_version_published(config: &Config, name: &str, version: &str) -> miette::Result<bool> {
-    let client = build_registry_client(config)?;
+async fn is_version_published(
+    client: &ThrottledClient,
+    config: &Config,
+    name: &str,
+    version: &str,
+) -> miette::Result<bool> {
     let registry = registry_for(config, name);
     let url = format!("{registry}{}", encode_package_name(name));
     let guard = client.acquire_for_url(&url).await;
@@ -129,8 +141,9 @@ async fn is_version_published(config: &Config, name: &str, version: &str) -> mie
         return Ok(false);
     }
     if !status.is_success() {
+        let display_url = redact_url_credentials(&url);
         return Err(miette::miette!(
-            "registry returned status {status} for {url} while checking whether {name}@{version} is published",
+            "registry returned status {status} for {display_url} while checking whether {name}@{version} is published",
         ));
     }
     let package: Package = response.json().await.into_diagnostic()?;

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -234,12 +234,9 @@ pub(super) fn dist_tag<'a>(
     }))
 }
 
-/// `change` and `version` are synchronous file-and-prompt commands; the
-/// returned future only carries their already-computed result.
 pub(super) fn change<'a>(ctx: &RunCtx<'a>, args: ChangeArgs) -> miette::Result<CommandFuture<'a>> {
     let cfg: &Config = (ctx.config)()?;
-    let result = args.run(cfg);
-    Ok(Box::pin(std::future::ready(result)))
+    Ok(Box::pin(async move { args.run(cfg).await }))
 }
 
 pub(super) fn lane<'a>(ctx: &RunCtx<'a>, args: LaneArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -378,9 +378,8 @@ impl VersionArgs {
                 },
             )
         };
-        // First release of a never-published package publishes its manifest
-        // version verbatim, so probe the registry for the first pass's releases
-        // and re-assemble with those held at their current version.
+        // Two-pass: probe the first plan's releases for `unpublished_dirs`, then
+        // re-assemble with it.
         let unpublished_dirs = unpublished_release_dirs(config, &assemble(HashSet::new())?).await?;
         let plan = assemble(unpublished_dirs)?;
 

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -18,7 +18,7 @@ use std::{
 
 use crate::cli_args::{
     change::{render_release_plan, to_engine_projects},
-    changelog::confirmed_published_versions,
+    changelog::{confirmed_published_versions, unpublished_release_dirs},
     recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
 };
 
@@ -363,18 +363,26 @@ impl VersionArgs {
             )
         };
         let is_filtered = filter.is_some();
-        let plan = assemble_release_plan(
-            &engine_projects,
-            &workspace_dir,
-            &intents,
-            &ledger,
-            Some(&config.versioning),
-            &AssembleReleasePlanOptions {
-                filter,
-                snapshot_suffix: None,
-                enforce_workspace_protocol: true,
-            },
-        )?;
+        let assemble = |unpublished_dirs: HashSet<String>| {
+            assemble_release_plan(
+                &engine_projects,
+                &workspace_dir,
+                &intents,
+                &ledger,
+                Some(&config.versioning),
+                &AssembleReleasePlanOptions {
+                    filter: filter.clone(),
+                    snapshot_suffix: None,
+                    enforce_workspace_protocol: true,
+                    unpublished_dirs,
+                },
+            )
+        };
+        // First release of a never-published package publishes its manifest
+        // version verbatim, so probe the registry for the first pass's releases
+        // and re-assemble with those held at their current version.
+        let unpublished_dirs = unpublished_release_dirs(config, &assemble(HashSet::new())?).await?;
+        let plan = assemble(unpublished_dirs)?;
 
         if plan.releases.is_empty() {
             // A full (unfiltered) run garbage-collects the intent files an

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -378,8 +378,6 @@ impl VersionArgs {
                 },
             )
         };
-        // Two-pass: probe the first plan's releases for `unpublished_dirs`, then
-        // re-assemble with it.
         let unpublished_dirs = unpublished_release_dirs(config, &assemble(HashSet::new())?).await?;
         let plan = assemble(unpublished_dirs)?;
 

--- a/pnpm/crates/cli/tests/change.rs
+++ b/pnpm/crates/cli/tests/change.rs
@@ -85,6 +85,43 @@ fn first_release_probe_debuts_an_unpublished_version_verbatim() {
     drop(root);
 }
 
+/// A registry that cannot answer the probe (here an unroutable port, so the
+/// check fails with a connection error rather than a 404) must fail
+/// `pnpm change status` and `pnpm version -r` rather than guess a version.
+/// Mirrors the TypeScript `a registry probe failure fails the command` test.
+#[test]
+fn first_release_probe_failure_fails_the_command() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write yaml");
+    fs::write(workspace.join(".npmrc"), "registry=http://127.0.0.1:1/\n").expect("write npmrc");
+    fs::write(workspace.join("package.json"), "{\"name\": \"e2e-root\", \"private\": true}\n")
+        .expect("write root package.json");
+    add_scoped_pkg(&workspace, "foo", "@pnpm.e2e/foo", "1.2.0");
+
+    // Recording an intent does not probe, so it succeeds despite the dead registry.
+    stdout_of(pnpm_probing(&workspace).with_args([
+        "change",
+        "--bump",
+        "minor",
+        "--summary",
+        "A feature.",
+        "@pnpm.e2e/foo",
+    ]));
+
+    let status =
+        pnpm_probing(&workspace).with_args(["change", "status"]).output().expect("run pnpm");
+    assert!(!status.status.success(), "change status must fail when the probe errors");
+
+    let release = pnpm_probing(&workspace).with_args(["version", "-r"]).output().expect("run pnpm");
+    assert!(!release.status.success(), "version -r must fail when the probe errors");
+
+    // No version was guessed: the manifest is untouched.
+    assert_eq!(manifest_version(&workspace, "foo"), "1.2.0");
+
+    drop(root);
+}
+
 fn write_workspace(workspace: &Path) {
     // These tests assert committed CHANGELOG.md files, which predate the
     // `registry`-storage default (where a release's section is parked under
@@ -116,7 +153,7 @@ fn pnpm(workspace: &Path) -> Command {
     // release's current version against the registry; assume every version is
     // already published so the engine bumps normally without a network round
     // trip. The probe's own behavior is covered against the mock registry by
-    // `first_release_of_an_unpublished_version_is_published_verbatim`.
+    // the `first_release_probe_*` tests below.
     Command::cargo_bin("pnpm")
         .expect("find the pnpm binary")
         .with_current_dir(workspace)

--- a/pnpm/crates/cli/tests/change.rs
+++ b/pnpm/crates/cli/tests/change.rs
@@ -10,6 +10,81 @@ use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;
 use std::{fs, path::Path, process::Command};
 
+/// A `pnpm` command that actually probes the registry (no assume-published
+/// seam), for the first-release tests that run against the mock registry.
+fn pnpm_probing(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+/// Point a mocked-registry workspace at `packages/*` and give it a private
+/// root; `add_mocked_registry` writes store/cache config but no package globs.
+fn setup_mock_workspace(workspace: &Path) {
+    let mut yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read yaml");
+    yaml.push_str("packages:\n  - packages/*\n");
+    fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write yaml");
+    fs::write(workspace.join("package.json"), "{\"name\": \"e2e-root\", \"private\": true}\n")
+        .expect("write root package.json");
+}
+
+fn add_scoped_pkg(workspace: &Path, dir: &str, name: &str, version: &str) {
+    let pkg_dir = workspace.join("packages").join(dir);
+    fs::create_dir_all(&pkg_dir).expect("create package dir");
+    fs::write(
+        pkg_dir.join("package.json"),
+        format!("{{\"name\": \"{name}\", \"version\": \"{version}\"}}\n"),
+    )
+    .expect("write package.json");
+}
+
+/// The first-release probe against a real (mock) registry: `@pnpm.e2e/foo@1.2.0`
+/// is a published version among the fixture's packument, so a `minor` intent
+/// bumps it normally. Runs without the assume-published seam, exercising the
+/// actual registry round trip that decides first-vs-follow-up.
+#[test]
+fn first_release_probe_bumps_a_version_the_registry_reports_published() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init().add_mocked_registry();
+    setup_mock_workspace(&workspace);
+    add_scoped_pkg(&workspace, "foo", "@pnpm.e2e/foo", "1.2.0");
+
+    stdout_of(pnpm_probing(&workspace).with_args([
+        "change",
+        "--bump",
+        "minor",
+        "--summary",
+        "A feature.",
+        "@pnpm.e2e/foo",
+    ]));
+    let applied = stdout_of(pnpm_probing(&workspace).with_args(["version", "-r"]));
+    assert!(applied.contains("@pnpm.e2e/foo: 1.2.0 → 1.3.0"), "unexpected: {applied}");
+    assert_eq!(manifest_version(&workspace, "foo"), "1.3.0");
+
+    drop(root);
+}
+
+/// The mirror: `@pnpm.e2e/foo@999.0.0` is not among the fixture's published
+/// versions, so the registry probe reports it unpublished and its first release
+/// publishes `999.0.0` verbatim rather than bumping to `999.1.0`.
+#[test]
+fn first_release_probe_debuts_an_unpublished_version_verbatim() {
+    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init().add_mocked_registry();
+    setup_mock_workspace(&workspace);
+    add_scoped_pkg(&workspace, "foo", "@pnpm.e2e/foo", "999.0.0");
+
+    stdout_of(pnpm_probing(&workspace).with_args([
+        "change",
+        "--bump",
+        "minor",
+        "--summary",
+        "Initial release.",
+        "@pnpm.e2e/foo",
+    ]));
+    let applied = stdout_of(pnpm_probing(&workspace).with_args(["version", "-r"]));
+    assert!(applied.contains("@pnpm.e2e/foo: 999.0.0 → 999.0.0"), "unexpected: {applied}");
+    assert_eq!(manifest_version(&workspace, "foo"), "999.0.0");
+
+    drop(root);
+}
+
 fn write_workspace(workspace: &Path) {
     // These tests assert committed CHANGELOG.md files, which predate the
     // `registry`-storage default (where a release's section is parked under
@@ -36,7 +111,16 @@ fn add_pkg(workspace: &Path, name: &str, version: &str, deps: &str) {
 }
 
 fn pnpm(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+    // These tests exercise the change/version/lane engine, advancing manifests
+    // without a real publish cycle. The first-release probe compares each
+    // release's current version against the registry; assume every version is
+    // already published so the engine bumps normally without a network round
+    // trip. The probe's own behavior is covered against the mock registry by
+    // `first_release_of_an_unpublished_version_is_published_verbatim`.
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(workspace)
+        .with_env("PACQUET_ASSUME_VERSIONS_PUBLISHED", "1")
 }
 
 fn stdout_of(mut command: Command) -> String {

--- a/pnpm/crates/cli/tests/change.rs
+++ b/pnpm/crates/cli/tests/change.rs
@@ -36,10 +36,8 @@ fn add_scoped_pkg(workspace: &Path, dir: &str, name: &str, version: &str) {
     .expect("write package.json");
 }
 
-/// The first-release probe against a real (mock) registry: `@pnpm.e2e/foo@1.2.0`
-/// is a published version among the fixture's packument, so a `minor` intent
-/// bumps it normally. Runs without the assume-published seam, exercising the
-/// actual registry round trip that decides first-vs-follow-up.
+/// The real registry probe (no seam): `@pnpm.e2e/foo@1.2.0` is in the fixture
+/// packument, so it bumps as a follow-up release.
 #[test]
 fn first_release_probe_bumps_a_version_the_registry_reports_published() {
     let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init().add_mocked_registry();
@@ -61,9 +59,8 @@ fn first_release_probe_bumps_a_version_the_registry_reports_published() {
     drop(root);
 }
 
-/// The mirror: `@pnpm.e2e/foo@999.0.0` is not among the fixture's published
-/// versions, so the registry probe reports it unpublished and its first release
-/// publishes `999.0.0` verbatim rather than bumping to `999.1.0`.
+/// The mirror: `@pnpm.e2e/foo@999.0.0` is not in the fixture, so the probe
+/// reports it unpublished and it debuts verbatim.
 #[test]
 fn first_release_probe_debuts_an_unpublished_version_verbatim() {
     let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/versioning/src/plan.rs
+++ b/pnpm/crates/versioning/src/plan.rs
@@ -102,22 +102,12 @@ pub struct AssembleReleasePlanOptions {
     /// (`pnpm change status`) leave it off so a diagnostic never fails on an
     /// unmigrated dependency.
     pub enforce_workspace_protocol: bool,
-    /// Directories whose current manifest version is not yet published to the
-    /// registry. Such a package's first release publishes that version
-    /// verbatim; its pending change intents (which still compose the changelog
-    /// and are ledgered) bump it only from the second release onward. Without
-    /// this the engine would `inc` off the seeded version and skip it — a new
-    /// package seeded at the epic band floor `1100.0.0` with a `minor` intent
-    /// would debut at `1100.1.0`, never publishing `1100.0.0`. Resolved by the
-    /// CLI (a registry probe); the pure assembler just consumes the set.
-    ///
-    /// Fixed-group sharing and epic band re-basing still apply on top of the
-    /// verbatim debut, because they are workspace-wide version-assignment
-    /// invariants a single package cannot opt out of: a fixed-group member
-    /// takes the group's shared version (its peers move in lockstep), and an
-    /// epic member re-bases to the new band floor when its lead crosses a major
-    /// — debuting verbatim there would break lockstep or land the member out of
-    /// its band (which `enforce_epic_bands` rejects).
+    /// Directories whose current manifest version the registry does not have.
+    /// Their first release publishes that version verbatim, so the pending
+    /// change intents bump it only from the next release. Resolved by the CLI's
+    /// registry probe. Fixed-group sharing and epic band re-basing still
+    /// override it, since a package cannot opt out of those workspace-wide
+    /// version rules.
     pub unpublished_dirs: HashSet<String>,
 }
 

--- a/pnpm/crates/versioning/src/plan.rs
+++ b/pnpm/crates/versioning/src/plan.rs
@@ -102,6 +102,15 @@ pub struct AssembleReleasePlanOptions {
     /// (`pnpm change status`) leave it off so a diagnostic never fails on an
     /// unmigrated dependency.
     pub enforce_workspace_protocol: bool,
+    /// Directories whose current manifest version is not yet published to the
+    /// registry. Such a package's first release publishes that version
+    /// verbatim; its pending change intents (which still compose the changelog
+    /// and are ledgered) bump it only from the second release onward. Without
+    /// this the engine would `inc` off the seeded version and skip it — a new
+    /// package seeded at the epic band floor `1100.0.0` with a `minor` intent
+    /// would debut at `1100.1.0`, never publishing `1100.0.0`. Resolved by the
+    /// CLI (a registry probe); the pure assembler just consumes the set.
+    pub unpublished_dirs: HashSet<String>,
 }
 
 /// Whether a package reference is a workspace-relative directory path rather
@@ -319,6 +328,7 @@ fn assemble(
                         pkg_state.bump_type,
                         ctx.lanes_by_dir.get(dir).map(String::as_str),
                         cumulative_bump(dir, pkg_state.bump_type),
+                        ctx.opts.unpublished_dirs.contains(dir),
                     ),
                 );
             }
@@ -978,9 +988,16 @@ fn compute_new_version(
     bump_type: ReleaseBumpType,
     lane_tag: Option<&str>,
     cumulative_bump: ReleaseBumpType,
+    first_release: bool,
 ) -> String {
     let current_version = Version::parse(current).expect("participants have valid versions");
     let Some(lane_tag) = lane_tag else {
+        if first_release {
+            // First release: the manifest version is the deliberate debut
+            // version and is published verbatim; the bump applies only from the
+            // next release.
+            return current.to_string();
+        }
         if current_version.pre_release.is_empty() {
             return inc_stable(&current_version, bump_type);
         }
@@ -988,7 +1005,9 @@ fn compute_new_version(
         // toward.
         return escalate_stable_target(&stable_part(&current_version), cumulative_bump);
     };
-    let target = if current_version.pre_release.is_empty() {
+    let target = if first_release {
+        stable_part(&current_version)
+    } else if current_version.pre_release.is_empty() {
         inc_stable(&current_version, cumulative_bump)
     } else {
         escalate_stable_target(&stable_part(&current_version), cumulative_bump)

--- a/pnpm/crates/versioning/src/plan.rs
+++ b/pnpm/crates/versioning/src/plan.rs
@@ -1000,15 +1000,32 @@ fn compute_new_version(
         // toward.
         return escalate_stable_target(&stable_part(&current_version), cumulative_bump);
     };
-    let target = if first_release {
-        stable_part(&current_version)
-    } else if current_version.pre_release.is_empty() {
+    if first_release {
+        // A manifest prerelease already on this lane is published verbatim; a
+        // stable (or off-lane) seed debuts at the lane's first prerelease.
+        return if is_prerelease_on_lane(&current_version, lane_tag) {
+            current.to_string()
+        } else {
+            format!("{}-{lane_tag}.0", stable_part(&current_version))
+        };
+    }
+    let target = if current_version.pre_release.is_empty() {
         inc_stable(&current_version, cumulative_bump)
     } else {
         escalate_stable_target(&stable_part(&current_version), cumulative_bump)
     };
     let next_n = next_prerelease_number(&current_version, &target, lane_tag);
     format!("{target}-{lane_tag}.{next_n}")
+}
+
+fn is_prerelease_on_lane(version: &Version, lane_tag: &str) -> bool {
+    // semver parses an all-digit prerelease identifier as a number, so match the
+    // tag comparison in `next_prerelease_number`.
+    match version.pre_release.first() {
+        Some(Identifier::AlphaNumeric(tag)) => tag == lane_tag,
+        Some(Identifier::Numeric(tag)) => tag.to_string() == lane_tag,
+        None => false,
+    }
 }
 
 fn inc_stable(version: &Version, bump_type: ReleaseBumpType) -> String {

--- a/pnpm/crates/versioning/src/plan.rs
+++ b/pnpm/crates/versioning/src/plan.rs
@@ -110,6 +110,14 @@ pub struct AssembleReleasePlanOptions {
     /// package seeded at the epic band floor `1100.0.0` with a `minor` intent
     /// would debut at `1100.1.0`, never publishing `1100.0.0`. Resolved by the
     /// CLI (a registry probe); the pure assembler just consumes the set.
+    ///
+    /// Fixed-group sharing and epic band re-basing still apply on top of the
+    /// verbatim debut, because they are workspace-wide version-assignment
+    /// invariants a single package cannot opt out of: a fixed-group member
+    /// takes the group's shared version (its peers move in lockstep), and an
+    /// epic member re-bases to the new band floor when its lead crosses a major
+    /// — debuting verbatim there would break lockstep or land the member out of
+    /// its band (which `enforce_epic_bands` rejects).
     pub unpublished_dirs: HashSet<String>,
 }
 

--- a/pnpm/crates/versioning/src/plan.rs
+++ b/pnpm/crates/versioning/src/plan.rs
@@ -1001,9 +1001,6 @@ fn compute_new_version(
     let current_version = Version::parse(current).expect("participants have valid versions");
     let Some(lane_tag) = lane_tag else {
         if first_release {
-            // First release: the manifest version is the deliberate debut
-            // version and is published verbatim; the bump applies only from the
-            // next release.
             return current.to_string();
         }
         if current_version.pre_release.is_empty() {

--- a/pnpm/crates/versioning/src/plan/tests.rs
+++ b/pnpm/crates/versioning/src/plan/tests.rs
@@ -879,3 +879,16 @@ fn a_first_release_on_a_lane_debuts_at_a_prerelease_of_the_current_version() {
     let plan = assemble_with_unpublished(&projects, &intents, Some(&versioning), &["cli"]);
     assert_eq!(release(&plan, "cli").new_version, "12.0.0-alpha.0");
 }
+
+#[test]
+fn an_unpublished_epic_member_re_bases_to_the_new_band_floor_when_the_lead_crosses_a_major() {
+    let projects = [make_project("pnpm", "11.0.0", &[]), make_project("lib", "1100.0.0", &[])];
+    let intents = [make_intent("one", &[("pnpm", "major"), ("lib", "minor")])];
+    let versioning =
+        VersioningSettings { epics: vec![epic("pnpm", &["lib"])], ..VersioningSettings::default() };
+    let plan = assemble_with_unpublished(&projects, &intents, Some(&versioning), &["lib"]);
+    // Debuting verbatim at 1100.0.0 would land the member outside the new
+    // 1200-1299 band, so the epic re-base to the floor supersedes it.
+    assert_eq!(release(&plan, "pnpm").new_version, "12.0.0");
+    assert_eq!(release(&plan, "lib").new_version, "1200.0.0");
+}

--- a/pnpm/crates/versioning/src/plan/tests.rs
+++ b/pnpm/crates/versioning/src/plan/tests.rs
@@ -818,3 +818,64 @@ fn an_epic_whose_lead_is_not_a_releasable_project_fails_the_plan() {
         "unexpected error: {err}",
     );
 }
+
+fn assemble_with_unpublished(
+    projects: &[WorkspaceProject],
+    intents: &[ChangeIntent],
+    versioning: Option<&VersioningSettings>,
+    unpublished: &[&str],
+) -> ReleasePlan {
+    assemble_release_plan(
+        projects,
+        std::path::Path::new("/ws"),
+        intents,
+        &Ledger::new(),
+        versioning,
+        &AssembleReleasePlanOptions {
+            unpublished_dirs: unpublished.iter().map(|dir| (*dir).to_string()).collect(),
+            ..AssembleReleasePlanOptions::default()
+        },
+    )
+    .expect("plan assembles")
+}
+
+#[test]
+fn a_first_release_publishes_the_current_version_verbatim_ignoring_the_intent_bump() {
+    let projects = [make_project("newpkg", "1100.0.0", &[])];
+    let intents = [make_intent("one", &[("newpkg", "minor")])];
+    let plan = assemble_with_unpublished(&projects, &intents, None, &["newpkg"]);
+    let release = release(&plan, "newpkg");
+    assert_eq!(release.new_version, "1100.0.0");
+    // The intent is still consumed for the changelog and the ledger.
+    let intent_ids: Vec<&str> = release.intents.iter().map(|intent| intent.id.as_str()).collect();
+    assert_eq!(intent_ids, ["one"]);
+}
+
+#[test]
+fn a_published_current_version_bumps_normally_on_the_second_release() {
+    let projects = [make_project("newpkg", "1100.0.0", &[])];
+    let intents = [make_intent("one", &[("newpkg", "minor")])];
+    let plan = assemble_with_unpublished(&projects, &intents, None, &[]);
+    assert_eq!(release(&plan, "newpkg").new_version, "1100.1.0");
+}
+
+#[test]
+fn a_first_release_does_not_propagate_to_dependents_since_its_version_does_not_move() {
+    let projects = [
+        make_project("lib", "1100.0.0", &[]),
+        make_project("cli", "3.0.0", &[("lib", "workspace:^")]),
+    ];
+    let intents = [make_intent("one", &[("lib", "minor")])];
+    let plan = assemble_with_unpublished(&projects, &intents, None, &["lib"]);
+    assert_eq!(release(&plan, "lib").new_version, "1100.0.0");
+    assert_eq!(release_names(&plan), ["lib"]);
+}
+
+#[test]
+fn a_first_release_on_a_lane_debuts_at_a_prerelease_of_the_current_version() {
+    let projects = [make_project("cli", "12.0.0", &[])];
+    let intents = [make_intent("one", &[("cli", "minor")])];
+    let versioning = on_lane("cli", "alpha");
+    let plan = assemble_with_unpublished(&projects, &intents, Some(&versioning), &["cli"]);
+    assert_eq!(release(&plan, "cli").new_version, "12.0.0-alpha.0");
+}

--- a/pnpm/crates/versioning/src/plan/tests.rs
+++ b/pnpm/crates/versioning/src/plan/tests.rs
@@ -881,6 +881,15 @@ fn a_first_release_on_a_lane_debuts_at_a_prerelease_of_the_current_version() {
 }
 
 #[test]
+fn a_first_release_on_a_lane_whose_manifest_is_already_an_unpublished_prerelease_is_verbatim() {
+    let projects = [make_project("cli", "2.0.0-alpha.3", &[])];
+    let intents = [make_intent("one", &[("cli", "minor")])];
+    let versioning = on_lane("cli", "alpha");
+    let plan = assemble_with_unpublished(&projects, &intents, Some(&versioning), &["cli"]);
+    assert_eq!(release(&plan, "cli").new_version, "2.0.0-alpha.3");
+}
+
+#[test]
 fn an_unpublished_epic_member_re_bases_to_the_new_band_floor_when_the_lead_crosses_a_major() {
     let projects = [make_project("pnpm", "11.0.0", &[]), make_project("lib", "1100.0.0", &[])];
     let intents = [make_intent("one", &[("pnpm", "major"), ("lib", "minor")])];

--- a/pnpm11/releasing/commands/src/change/index.ts
+++ b/pnpm11/releasing/commands/src/change/index.ts
@@ -20,6 +20,8 @@ import { safeExeca as execa } from 'execa'
 import { renderHelp } from 'render-help'
 import { valid } from 'semver'
 
+import { resolveUnpublishedDirs, type UnpublishedProbeOptions } from '../resolveUnpublishedDirs.js'
+
 export function rcOptionsTypes (): Record<string, unknown> {
   return {}
 }
@@ -65,7 +67,7 @@ export type ChangeCommandOptions = Pick<Config,
 | 'testPattern'
 | 'versioning'
 | 'workspaceDir'
-> & {
+> & UnpublishedProbeOptions & {
   allProjects?: Project[]
   bump?: string
   summary?: string
@@ -235,13 +237,15 @@ async function promptBumpTypes (pkgRefs: string[]): Promise<Record<string, Inten
 async function renderStatus (workspaceDir: string, opts: ChangeCommandOptions): Promise<string> {
   const intents = await readChangeIntents(workspaceDir)
   const ledger = await readLedger(workspaceDir)
-  const plan = assembleReleasePlan({
+  const baseArgs = {
     workspaceDir,
     projects: toWorkspaceProjects(opts.allProjects ?? []),
     intents,
     ledger,
     versioning: opts.versioning,
-  })
+  }
+  const unpublishedDirs = await resolveUnpublishedDirs(assembleReleasePlan(baseArgs), opts)
+  const plan = assembleReleasePlan({ ...baseArgs, unpublishedDirs })
   if (plan.releases.length === 0) {
     return 'No pending changes.'
   }

--- a/pnpm11/releasing/commands/src/publish/previousChangelog.ts
+++ b/pnpm11/releasing/commands/src/publish/previousChangelog.ts
@@ -81,6 +81,18 @@ export function changelogHasSection (changelog: string, section: string): boolea
   return changelog.includes(section.trim())
 }
 
+/**
+ * Whether `pkgName@version` is already published to its registry. A package
+ * with no published metadata (registry 404) and a package published but
+ * missing this exact version both read as `false` — the first release of a
+ * never-published version. Any other failure (offline, 5xx, auth) propagates,
+ * so the caller fails the command rather than guess a version's fate.
+ */
+export async function isVersionPublished (opts: PreviousChangelogOptions, pkgName: string, version: string): Promise<boolean> {
+  const meta = await fetchPackument(createRegistryClient(opts), opts, pkgName)
+  return meta?.versions[version] != null
+}
+
 async function fetchPackument (client: RegistryClient, opts: PreviousChangelogOptions, pkgName: string): Promise<PackageMeta | undefined> {
   const registry = pickRegistryForPackage(opts.registries, pkgName)
   let fetchResult

--- a/pnpm11/releasing/commands/src/publish/previousChangelog.ts
+++ b/pnpm11/releasing/commands/src/publish/previousChangelog.ts
@@ -82,15 +82,23 @@ export function changelogHasSection (changelog: string, section: string): boolea
 }
 
 /**
- * Whether `pkgName@version` is already published to its registry. A package
- * with no published metadata (registry 404) and a package published but
+ * A checker for whether `pkgName@version` is published to its registry,
+ * holding one registry client for the batch so a fan-out of probes reuses the
+ * dispatcher/TLS setup and connection pool instead of rebuilding them per
+ * call. A package with no published metadata (registry 404) and a package
  * missing this exact version both read as `false` — the first release of a
  * never-published version. Any other failure (offline, 5xx, auth) propagates,
- * so the caller fails the command rather than guess a version's fate.
+ * so the caller fails the command rather than guess a version's fate. The
+ * probe passes no cache validator (`etag`/`modified`), so `fetchPackument`
+ * resolves the packument or throws — never a 304 not-modified — and `undefined`
+ * always means the 404 caught below, i.e. unpublished.
  */
-export async function isVersionPublished (opts: PreviousChangelogOptions, pkgName: string, version: string): Promise<boolean> {
-  const meta = await fetchPackument(createRegistryClient(opts), opts, pkgName)
-  return meta?.versions[version] != null
+export function createVersionPublishedChecker (opts: PreviousChangelogOptions): (pkgName: string, version: string) => Promise<boolean> {
+  const client = createRegistryClient(opts)
+  return async (pkgName, version) => {
+    const meta = await fetchPackument(client, opts, pkgName)
+    return meta?.versions[version] != null
+  }
 }
 
 async function fetchPackument (client: RegistryClient, opts: PreviousChangelogOptions, pkgName: string): Promise<PackageMeta | undefined> {

--- a/pnpm11/releasing/commands/src/publish/previousChangelog.ts
+++ b/pnpm11/releasing/commands/src/publish/previousChangelog.ts
@@ -82,16 +82,9 @@ export function changelogHasSection (changelog: string, section: string): boolea
 }
 
 /**
- * A checker for whether `pkgName@version` is published to its registry,
- * holding one registry client for the batch so a fan-out of probes reuses the
- * dispatcher/TLS setup and connection pool instead of rebuilding them per
- * call. A package with no published metadata (registry 404) and a package
- * missing this exact version both read as `false` — the first release of a
- * never-published version. Any other failure (offline, 5xx, auth) propagates,
- * so the caller fails the command rather than guess a version's fate. The
- * probe passes no cache validator (`etag`/`modified`), so `fetchPackument`
- * resolves the packument or throws — never a 304 not-modified — and `undefined`
- * always means the 404 caught below, i.e. unpublished.
+ * Whether `pkgName@version` is published, reusing one client across the batch.
+ * `fetchPackument` returning `undefined` always means the 404 (unpublished): the
+ * probe sends no cache validator, so it never yields a 304 not-modified.
  */
 export function createVersionPublishedChecker (opts: PreviousChangelogOptions): (pkgName: string, version: string) => Promise<boolean> {
   const client = createRegistryClient(opts)

--- a/pnpm11/releasing/commands/src/resolveUnpublishedDirs.ts
+++ b/pnpm11/releasing/commands/src/resolveUnpublishedDirs.ts
@@ -1,0 +1,41 @@
+import type { ReleasePlan } from '@pnpm/releasing.versioning'
+
+import { isVersionPublished, type PreviousChangelogOptions } from './publish/previousChangelog.js'
+
+/**
+ * Resolves whether `pkgName@version` is already published — the seam that
+ * decides whether a release is a package's first (publish the version
+ * verbatim) or a follow-up (bump). Production leaves it unset and the registry
+ * is probed; tests override it to steer the outcome without a network round
+ * trip, matching the injected `verifyPublished` gate the apply path uses.
+ */
+export type CheckVersionPublished = (pkgName: string, version: string) => Promise<boolean>
+
+export type UnpublishedProbeOptions = PreviousChangelogOptions & {
+  checkVersionPublished?: CheckVersionPublished
+}
+
+/**
+ * The directories in `plan` whose current manifest version is not yet on the
+ * registry — the packages whose first release must publish that version
+ * verbatim instead of bumping off it. Probes every release concurrently; a
+ * probe failure rejects, so the surrounding command fails rather than release
+ * a wrong version. Feeds {@link assembleReleasePlan}'s `unpublishedDirs`.
+ *
+ * A first assembly pass (without `unpublishedDirs`) supplies `plan`. Holding a
+ * package at its current version can only remove dependent propagation, never
+ * add it (the materialized range already admits the unchanged version), so the
+ * re-assembled plan is a subset of `plan` — every dir it can hold was probed
+ * here.
+ */
+export async function resolveUnpublishedDirs (plan: ReleasePlan, opts: UnpublishedProbeOptions): Promise<Set<string>> {
+  const checkVersionPublished = opts.checkVersionPublished ??
+    ((pkgName, version) => isVersionPublished(opts, pkgName, version))
+  const probed = await Promise.all(
+    plan.releases.map(async (release) => ({
+      dir: release.dir,
+      published: await checkVersionPublished(release.name, release.currentVersion),
+    }))
+  )
+  return new Set(probed.filter(({ published }) => !published).map(({ dir }) => dir))
+}

--- a/pnpm11/releasing/commands/src/resolveUnpublishedDirs.ts
+++ b/pnpm11/releasing/commands/src/resolveUnpublishedDirs.ts
@@ -1,6 +1,6 @@
 import type { ReleasePlan } from '@pnpm/releasing.versioning'
 
-import { isVersionPublished, type PreviousChangelogOptions } from './publish/previousChangelog.js'
+import { createVersionPublishedChecker, type PreviousChangelogOptions } from './publish/previousChangelog.js'
 
 /**
  * Resolves whether `pkgName@version` is already published — the seam that
@@ -29,8 +29,7 @@ export type UnpublishedProbeOptions = PreviousChangelogOptions & {
  * here.
  */
 export async function resolveUnpublishedDirs (plan: ReleasePlan, opts: UnpublishedProbeOptions): Promise<Set<string>> {
-  const checkVersionPublished = opts.checkVersionPublished ??
-    ((pkgName, version) => isVersionPublished(opts, pkgName, version))
+  const checkVersionPublished = opts.checkVersionPublished ?? createVersionPublishedChecker(opts)
   const probed = await Promise.all(
     plan.releases.map(async (release) => ({
       dir: release.dir,

--- a/pnpm11/releasing/commands/src/resolveUnpublishedDirs.ts
+++ b/pnpm11/releasing/commands/src/resolveUnpublishedDirs.ts
@@ -3,38 +3,17 @@ import pLimit from 'p-limit'
 
 import { createVersionPublishedChecker, type PreviousChangelogOptions } from './publish/previousChangelog.js'
 
-/** pnpm's default `network-concurrency`, the cap for the probe fan-out. */
 const DEFAULT_NETWORK_CONCURRENCY = 16
 
-/**
- * Resolves whether `pkgName@version` is already published — the seam that
- * decides whether a release is a package's first (publish the version
- * verbatim) or a follow-up (bump). Production leaves it unset and the registry
- * is probed; tests override it to steer the outcome without a network round
- * trip, matching the injected `verifyPublished` gate the apply path uses.
- */
 export type CheckVersionPublished = (pkgName: string, version: string) => Promise<boolean>
 
 export type UnpublishedProbeOptions = PreviousChangelogOptions & {
+  /** Overridable for tests; production probes the registry. */
   checkVersionPublished?: CheckVersionPublished
   networkConcurrency?: number
 }
 
-/**
- * The directories in `plan` whose current manifest version is not yet on the
- * registry — the packages whose first release must publish that version
- * verbatim instead of bumping off it. Probes the releases concurrently, bounded
- * by `networkConcurrency`, so a large recursive release does not burst
- * unbounded registry connections; a probe failure rejects, so the surrounding
- * command fails rather than release a wrong version. Feeds
- * {@link assembleReleasePlan}'s `unpublishedDirs`.
- *
- * A first assembly pass (without `unpublishedDirs`) supplies `plan`. Holding a
- * package at its current version can only remove dependent propagation, never
- * add it (the materialized range already admits the unchanged version), so the
- * re-assembled plan is a subset of `plan` — every dir it can hold was probed
- * here.
- */
+/** The releases in `plan` whose current version the registry does not have — {@link assembleReleasePlan}'s `unpublishedDirs`. */
 export async function resolveUnpublishedDirs (plan: ReleasePlan, opts: UnpublishedProbeOptions): Promise<Set<string>> {
   const checkVersionPublished = opts.checkVersionPublished ?? createVersionPublishedChecker(opts)
   const limit = pLimit(opts.networkConcurrency ?? DEFAULT_NETWORK_CONCURRENCY)

--- a/pnpm11/releasing/commands/src/resolveUnpublishedDirs.ts
+++ b/pnpm11/releasing/commands/src/resolveUnpublishedDirs.ts
@@ -1,6 +1,10 @@
 import type { ReleasePlan } from '@pnpm/releasing.versioning'
+import pLimit from 'p-limit'
 
 import { createVersionPublishedChecker, type PreviousChangelogOptions } from './publish/previousChangelog.js'
+
+/** pnpm's default `network-concurrency`, the cap for the probe fan-out. */
+const DEFAULT_NETWORK_CONCURRENCY = 16
 
 /**
  * Resolves whether `pkgName@version` is already published — the seam that
@@ -13,14 +17,17 @@ export type CheckVersionPublished = (pkgName: string, version: string) => Promis
 
 export type UnpublishedProbeOptions = PreviousChangelogOptions & {
   checkVersionPublished?: CheckVersionPublished
+  networkConcurrency?: number
 }
 
 /**
  * The directories in `plan` whose current manifest version is not yet on the
  * registry — the packages whose first release must publish that version
- * verbatim instead of bumping off it. Probes every release concurrently; a
- * probe failure rejects, so the surrounding command fails rather than release
- * a wrong version. Feeds {@link assembleReleasePlan}'s `unpublishedDirs`.
+ * verbatim instead of bumping off it. Probes the releases concurrently, bounded
+ * by `networkConcurrency`, so a large recursive release does not burst
+ * unbounded registry connections; a probe failure rejects, so the surrounding
+ * command fails rather than release a wrong version. Feeds
+ * {@link assembleReleasePlan}'s `unpublishedDirs`.
  *
  * A first assembly pass (without `unpublishedDirs`) supplies `plan`. Holding a
  * package at its current version can only remove dependent propagation, never
@@ -30,11 +37,12 @@ export type UnpublishedProbeOptions = PreviousChangelogOptions & {
  */
 export async function resolveUnpublishedDirs (plan: ReleasePlan, opts: UnpublishedProbeOptions): Promise<Set<string>> {
   const checkVersionPublished = opts.checkVersionPublished ?? createVersionPublishedChecker(opts)
+  const limit = pLimit(opts.networkConcurrency ?? DEFAULT_NETWORK_CONCURRENCY)
   const probed = await Promise.all(
-    plan.releases.map(async (release) => ({
+    plan.releases.map((release) => limit(async () => ({
       dir: release.dir,
       published: await checkVersionPublished(release.name, release.currentVersion),
-    }))
+    })))
   )
   return new Set(probed.filter(({ published }) => !published).map(({ dir }) => dir))
 }

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -22,6 +22,7 @@ import { inc, valid } from 'semver'
 
 import { renderReleasePlan, toWorkspaceProjects } from '../change/index.js'
 import { changelogHasSection, fetchPublishedChangelog } from '../publish/previousChangelog.js'
+import { type CheckVersionPublished, resolveUnpublishedDirs } from '../resolveUnpublishedDirs.js'
 
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([
@@ -131,6 +132,7 @@ interface VersionChange {
 interface VersionHandlerOptions extends Config {
   allProjects?: Project[]
   allowSameVersion?: boolean
+  checkVersionPublished?: CheckVersionPublished
   commitHooks?: boolean
   dryRun?: boolean
   gitChecks?: boolean
@@ -233,7 +235,7 @@ async function releaseFromIntents (opts: VersionHandlerOptions): Promise<string>
     ? new Set(Object.keys(opts.selectedProjectsGraph ?? {}).map((rootDir) => toProjectDir(workspaceDir, rootDir)))
     : undefined
 
-  const plan = assembleReleasePlan({
+  const baseArgs = {
     workspaceDir,
     projects,
     intents,
@@ -241,7 +243,9 @@ async function releaseFromIntents (opts: VersionHandlerOptions): Promise<string>
     versioning: opts.versioning,
     filter,
     enforceWorkspaceProtocol: true,
-  })
+  }
+  const unpublishedDirs = await resolveUnpublishedDirs(assembleReleasePlan(baseArgs), opts)
+  const plan = assembleReleasePlan({ ...baseArgs, unpublishedDirs })
 
   const applyOpts: ApplyReleasePlanOptions = {
     workspaceDir,

--- a/pnpm11/releasing/commands/test/change/index.test.ts
+++ b/pnpm11/releasing/commands/test/change/index.test.ts
@@ -38,6 +38,9 @@ describe('change command and intent-consuming version -r', () => {
       allProjects: projects,
       gitChecks: false,
       recursive: true,
+      // The fixture packages stand in for already-published ones, so their
+      // releases bump normally. Overridden per test for the first-release path.
+      checkVersionPublished: async () => true,
     }
   }
 
@@ -207,5 +210,37 @@ describe('change command and intent-consuming version -r', () => {
     const cli = addPkg({ name: 'cli', version: '2.0.0' })
     const output = await lane.handler(baseOpts([cli]) as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
     expect(output).toBe('All packages are on the main lane.')
+  })
+
+  it('a package not yet on the registry debuts at its manifest version, not a bump above it', async () => {
+    const lib = addPkg({ name: 'lib', version: '1100.0.0' })
+    // The new package is unpublished; every other release is already published.
+    const opts = { ...baseOpts([lib]), checkVersionPublished: async (name: string) => name !== 'lib' }
+
+    await change.handler({ ...opts, bump: 'minor', summary: 'Initial release.' } as any, ['lib']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const status = await change.handler(opts as any, ['status']) // eslint-disable-line @typescript-eslint/no-explicit-any
+    expect(status).toContain('lib: 1100.0.0 → 1100.0.0')
+
+    const applied = await version.handler(opts as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
+    expect(applied).toContain('lib: 1100.0.0 → 1100.0.0')
+    expect(JSON.parse(fs.readFileSync(path.join(lib.rootDir, 'package.json'), 'utf8')).version).toBe('1100.0.0')
+    // The intent is still consumed and ledgered against the debut version.
+    expect(fs.readFileSync(path.join(tempDir, '.changeset', 'ledger.yaml'), 'utf8')).toContain('lib@1100.0.0:')
+  })
+
+  it('a registry probe failure fails the command rather than guessing the version', async () => {
+    const lib = addPkg({ name: 'lib', version: '1.0.0' })
+    const opts = {
+      ...baseOpts([lib]),
+      checkVersionPublished: async () => {
+        throw new Error('registry unreachable')
+      },
+    }
+
+    await change.handler({ ...baseOpts([lib]), bump: 'patch', summary: 'A fix.' } as any, ['lib']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    await expect(change.handler(opts as any, ['status'])).rejects.toThrow('registry unreachable') // eslint-disable-line @typescript-eslint/no-explicit-any
+    await expect(version.handler(opts as any, [])).rejects.toThrow('registry unreachable') // eslint-disable-line @typescript-eslint/no-explicit-any
   })
 })

--- a/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
@@ -67,6 +67,17 @@ export interface AssembleReleasePlanOptions {
    * leave it off so a diagnostic never fails on an unmigrated dependency.
    */
   enforceWorkspaceProtocol?: boolean
+  /**
+   * Directories whose current manifest version is not yet published to the
+   * registry. Such a package's first release publishes that version verbatim;
+   * its pending change intents (which still compose the changelog and are
+   * ledgered) bump it only from the second release onward. Without this the
+   * engine would `inc` off the seeded version and skip it — e.g. a new package
+   * seeded at the epic band floor `1100.0.0` with a `minor` intent would debut
+   * at `1100.1.0`, never publishing `1100.0.0`. Resolved by the command layer
+   * (a registry probe); the pure assembler just consumes the set.
+   */
+  unpublishedDirs?: Set<string>
 }
 
 const BUMP_ORDER: Record<ReleaseBumpType, number> = { patch: 1, minor: 2, major: 3 }
@@ -257,6 +268,7 @@ function assemble (ctx: AssembleContext, selection: Set<string> | undefined): Re
       newVersions.set(dir, computeNewVersion(participant, pkgState.bumpType, {
         laneTag: lanesByDir.get(dir),
         cumulativeBump: cumulativeBump(dir, pkgState.bumpType),
+        firstRelease: opts.unpublishedDirs?.has(dir) ?? false,
       }))
     }
     applyFixedGroupVersions({ participants, state, newVersions, cumulativeBump, fixedGroups, lanesByDir })
@@ -725,11 +737,20 @@ interface NewVersionOptions {
    * prereleases — which keeps the stable target stable across `-tag.N` runs.
    */
   cumulativeBump: ReleaseBumpType
+  /**
+   * The package has never been published at its current version — its first
+   * release. The manifest version is the deliberate debut version and is
+   * published verbatim, so the bump is not applied; it takes effect only from
+   * the next release. On a lane, the first prerelease targets the current
+   * stable version without incrementing it.
+   */
+  firstRelease: boolean
 }
 
 function computeNewVersion (participant: Participant, bumpType: ReleaseBumpType, opts: NewVersionOptions): string {
   const current = participant.currentVersion
   if (opts.laneTag == null) {
+    if (opts.firstRelease) return current
     if (parsePrerelease(current) == null) {
       return inc(current, bumpType)!
     }
@@ -737,9 +758,11 @@ function computeNewVersion (participant: Participant, bumpType: ReleaseBumpType,
     // building toward.
     return escalateStableTarget(stablePart(current), opts.cumulativeBump)
   }
-  const target = parsePrerelease(current) == null
-    ? inc(current, opts.cumulativeBump)!
-    : escalateStableTarget(stablePart(current), opts.cumulativeBump)
+  const target = opts.firstRelease
+    ? stablePart(current)
+    : parsePrerelease(current) == null
+      ? inc(current, opts.cumulativeBump)!
+      : escalateStableTarget(stablePart(current), opts.cumulativeBump)
   return `${target}-${opts.laneTag}.${nextPrereleaseNumber(current, target, opts.laneTag)}`
 }
 

--- a/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
@@ -734,7 +734,7 @@ interface NewVersionOptions {
    * prereleases — which keeps the stable target stable across `-tag.N` runs.
    */
   cumulativeBump: ReleaseBumpType
-  /** First release: publish `current` verbatim (on a lane, its first prerelease). See `unpublishedDirs`. */
+  /** First release: publish `current` verbatim — a stable seed on a lane debuts at its first prerelease. See `unpublishedDirs`. */
   firstRelease: boolean
 }
 
@@ -749,12 +749,23 @@ function computeNewVersion (participant: Participant, bumpType: ReleaseBumpType,
     // building toward.
     return escalateStableTarget(stablePart(current), opts.cumulativeBump)
   }
-  const target = opts.firstRelease
-    ? stablePart(current)
-    : parsePrerelease(current) == null
-      ? inc(current, opts.cumulativeBump)!
-      : escalateStableTarget(stablePart(current), opts.cumulativeBump)
+  if (opts.firstRelease) {
+    // A manifest prerelease already on this lane is published verbatim; a
+    // stable (or off-lane) seed debuts at the lane's first prerelease.
+    return isPrereleaseOnLane(current, opts.laneTag)
+      ? current
+      : `${stablePart(current)}-${opts.laneTag}.0`
+  }
+  const target = parsePrerelease(current) == null
+    ? inc(current, opts.cumulativeBump)!
+    : escalateStableTarget(stablePart(current), opts.cumulativeBump)
   return `${target}-${opts.laneTag}.${nextPrereleaseNumber(current, target, opts.laneTag)}`
+}
+
+function isPrereleaseOnLane (version: string, laneTag: string): boolean {
+  const prerelease = parsePrerelease(version)
+  // semver parses an all-digit identifier as a number, so compare stringified.
+  return prerelease != null && String(prerelease[0]) === laneTag
 }
 
 /**

--- a/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
@@ -746,11 +746,9 @@ interface NewVersionOptions {
    */
   cumulativeBump: ReleaseBumpType
   /**
-   * The package has never been published at its current version — its first
-   * release. The manifest version is the deliberate debut version and is
-   * published verbatim, so the bump is not applied; it takes effect only from
-   * the next release. On a lane, the first prerelease targets the current
-   * stable version without incrementing it.
+   * Whether this is the package's first release (see `unpublishedDirs`): the
+   * manifest version is published verbatim rather than bumped. On a lane, the
+   * first prerelease targets the current stable version without incrementing it.
    */
   firstRelease: boolean
 }

--- a/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
@@ -68,22 +68,11 @@ export interface AssembleReleasePlanOptions {
    */
   enforceWorkspaceProtocol?: boolean
   /**
-   * Directories whose current manifest version is not yet published to the
-   * registry. Such a package's first release publishes that version verbatim;
-   * its pending change intents (which still compose the changelog and are
-   * ledgered) bump it only from the second release onward. Without this the
-   * engine would `inc` off the seeded version and skip it — e.g. a new package
-   * seeded at the epic band floor `1100.0.0` with a `minor` intent would debut
-   * at `1100.1.0`, never publishing `1100.0.0`. Resolved by the command layer
-   * (a registry probe); the pure assembler just consumes the set.
-   *
-   * Fixed-group sharing and epic band re-basing still apply on top of the
-   * verbatim debut, because they are workspace-wide version-assignment
-   * invariants a single package cannot opt out of: a fixed-group member takes
-   * the group's shared version (its peers move in lockstep), and an epic member
-   * re-bases to the new band floor when its lead crosses a major — debuting
-   * verbatim there would break lockstep or land the member out of its band
-   * (which {@link enforceEpicBands} rejects).
+   * Directories whose current manifest version the registry does not have.
+   * Their first release publishes that version verbatim, so the pending change
+   * intents bump it only from the next release. Resolved by the command layer's
+   * registry probe. Fixed-group sharing and epic band re-basing still override
+   * it, since a package cannot opt out of those workspace-wide version rules.
    */
   unpublishedDirs?: Set<string>
 }
@@ -745,11 +734,7 @@ interface NewVersionOptions {
    * prereleases — which keeps the stable target stable across `-tag.N` runs.
    */
   cumulativeBump: ReleaseBumpType
-  /**
-   * Whether this is the package's first release (see `unpublishedDirs`): the
-   * manifest version is published verbatim rather than bumped. On a lane, the
-   * first prerelease targets the current stable version without incrementing it.
-   */
+  /** First release: publish `current` verbatim (on a lane, its first prerelease). See `unpublishedDirs`. */
   firstRelease: boolean
 }
 

--- a/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/src/assembleReleasePlan.ts
@@ -76,6 +76,14 @@ export interface AssembleReleasePlanOptions {
    * seeded at the epic band floor `1100.0.0` with a `minor` intent would debut
    * at `1100.1.0`, never publishing `1100.0.0`. Resolved by the command layer
    * (a registry probe); the pure assembler just consumes the set.
+   *
+   * Fixed-group sharing and epic band re-basing still apply on top of the
+   * verbatim debut, because they are workspace-wide version-assignment
+   * invariants a single package cannot opt out of: a fixed-group member takes
+   * the group's shared version (its peers move in lockstep), and an epic member
+   * re-bases to the new band floor when its lead crosses a major — debuting
+   * verbatim there would break lockstep or land the member out of its band
+   * (which {@link enforceEpicBands} rejects).
    */
   unpublishedDirs?: Set<string>
 }

--- a/pnpm11/releasing/versioning/test/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/test/assembleReleasePlan.ts
@@ -638,3 +638,18 @@ test('a first release on a lane debuts at a prerelease of the current version', 
   })
   expect(plan.releases.find((release) => release.name === 'cli')!.newVersion).toBe('12.0.0-alpha.0')
 })
+
+test('an unpublished epic member re-bases to the new band floor, not its manifest version, when the lead crosses a major', () => {
+  const plan = assembleReleasePlan({
+    workspaceDir: '/ws',
+    projects: [makeProject('pnpm', '11.0.0'), makeProject('lib', '1100.0.0')],
+    intents: [makeIntent('one', { pnpm: 'major', lib: 'minor' })],
+    ledger: NO_LEDGER,
+    versioning: { epics: [{ lead: 'pnpm', packages: ['lib'] }] },
+    unpublishedDirs: new Set(['lib']),
+  })
+  // Debuting verbatim at 1100.0.0 would land the member outside the new
+  // 1200-1299 band, so the epic re-base to the floor supersedes it.
+  expect(plan.releases.find((release) => release.name === 'pnpm')!.newVersion).toBe('12.0.0')
+  expect(plan.releases.find((release) => release.name === 'lib')!.newVersion).toBe('1200.0.0')
+})

--- a/pnpm11/releasing/versioning/test/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/test/assembleReleasePlan.ts
@@ -639,6 +639,18 @@ test('a first release on a lane debuts at a prerelease of the current version', 
   expect(plan.releases.find((release) => release.name === 'cli')!.newVersion).toBe('12.0.0-alpha.0')
 })
 
+test('a first release on a lane whose manifest is already an unpublished prerelease publishes it verbatim', () => {
+  const plan = assembleReleasePlan({
+    workspaceDir: '/ws',
+    projects: [makeProject('cli', '2.0.0-alpha.3')],
+    intents: [makeIntent('one', { cli: 'minor' })],
+    ledger: NO_LEDGER,
+    versioning: { lanes: { cli: 'alpha' } },
+    unpublishedDirs: new Set(['cli']),
+  })
+  expect(plan.releases.find((release) => release.name === 'cli')!.newVersion).toBe('2.0.0-alpha.3')
+})
+
 test('an unpublished epic member re-bases to the new band floor, not its manifest version, when the lead crosses a major', () => {
   const plan = assembleReleasePlan({
     workspaceDir: '/ws',

--- a/pnpm11/releasing/versioning/test/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/test/assembleReleasePlan.ts
@@ -586,3 +586,55 @@ test('an epic whose lead is not a releasable project fails the plan', () => {
     versioning: { epics: [{ lead: 'ghost', packages: ['lib'] }] },
   })).toThrow(/is not a releasable workspace project/)
 })
+
+test('a first release publishes the current version verbatim, ignoring the intent bump', () => {
+  const plan = assembleReleasePlan({
+    workspaceDir: '/ws',
+    projects: [makeProject('newpkg', '1100.0.0')],
+    intents: [makeIntent('one', { newpkg: 'minor' })],
+    ledger: NO_LEDGER,
+    unpublishedDirs: new Set(['newpkg']),
+  })
+  const release = plan.releases.find((release) => release.name === 'newpkg')!
+  expect(release.newVersion).toBe('1100.0.0')
+  // The intent is still consumed for the changelog and the ledger.
+  expect(release.intents.map((intent) => intent.id)).toStrictEqual(['one'])
+})
+
+test('a package whose current version is published bumps normally (second release)', () => {
+  const plan = assembleReleasePlan({
+    workspaceDir: '/ws',
+    projects: [makeProject('newpkg', '1100.0.0')],
+    intents: [makeIntent('one', { newpkg: 'minor' })],
+    ledger: NO_LEDGER,
+    unpublishedDirs: new Set(),
+  })
+  expect(plan.releases.find((release) => release.name === 'newpkg')!.newVersion).toBe('1100.1.0')
+})
+
+test('a first release does not propagate to dependents, since its version does not move', () => {
+  const plan = assembleReleasePlan({
+    workspaceDir: '/ws',
+    projects: [
+      makeProject('lib', '1100.0.0'),
+      makeProject('cli', '3.0.0', { lib: 'workspace:^' }),
+    ],
+    intents: [makeIntent('one', { lib: 'minor' })],
+    ledger: NO_LEDGER,
+    unpublishedDirs: new Set(['lib']),
+  })
+  expect(plan.releases.find((release) => release.name === 'lib')!.newVersion).toBe('1100.0.0')
+  expect(plan.releases.find((release) => release.name === 'cli')).toBeUndefined()
+})
+
+test('a first release on a lane debuts at a prerelease of the current version', () => {
+  const plan = assembleReleasePlan({
+    workspaceDir: '/ws',
+    projects: [makeProject('cli', '12.0.0')],
+    intents: [makeIntent('one', { cli: 'minor' })],
+    ledger: NO_LEDGER,
+    versioning: { lanes: { cli: 'alpha' } },
+    unpublishedDirs: new Set(['cli']),
+  })
+  expect(plan.releases.find((release) => release.name === 'cli')!.newVersion).toBe('12.0.0-alpha.0')
+})

--- a/pnpm11/releasing/versioning/test/assembleReleasePlan.ts
+++ b/pnpm11/releasing/versioning/test/assembleReleasePlan.ts
@@ -590,12 +590,12 @@ test('an epic whose lead is not a releasable project fails the plan', () => {
 test('a first release publishes the current version verbatim, ignoring the intent bump', () => {
   const plan = assembleReleasePlan({
     workspaceDir: '/ws',
-    projects: [makeProject('newpkg', '1100.0.0')],
-    intents: [makeIntent('one', { newpkg: 'minor' })],
+    projects: [makeProject('lib', '1100.0.0')],
+    intents: [makeIntent('one', { lib: 'minor' })],
     ledger: NO_LEDGER,
-    unpublishedDirs: new Set(['newpkg']),
+    unpublishedDirs: new Set(['lib']),
   })
-  const release = plan.releases.find((release) => release.name === 'newpkg')!
+  const release = plan.releases.find((release) => release.name === 'lib')!
   expect(release.newVersion).toBe('1100.0.0')
   // The intent is still consumed for the changelog and the ledger.
   expect(release.intents.map((intent) => intent.id)).toStrictEqual(['one'])
@@ -604,12 +604,12 @@ test('a first release publishes the current version verbatim, ignoring the inten
 test('a package whose current version is published bumps normally (second release)', () => {
   const plan = assembleReleasePlan({
     workspaceDir: '/ws',
-    projects: [makeProject('newpkg', '1100.0.0')],
-    intents: [makeIntent('one', { newpkg: 'minor' })],
+    projects: [makeProject('lib', '1100.0.0')],
+    intents: [makeIntent('one', { lib: 'minor' })],
     ledger: NO_LEDGER,
     unpublishedDirs: new Set(),
   })
-  expect(plan.releases.find((release) => release.name === 'newpkg')!.newVersion).toBe('1100.1.0')
+  expect(plan.releases.find((release) => release.name === 'lib')!.newVersion).toBe('1100.1.0')
 })
 
 test('a first release does not propagate to dependents, since its version does not move', () => {


### PR DESCRIPTION
## Summary

The release engine computed every new version as `inc(currentVersion, bump)`, with no notion of whether `currentVersion` was ever published. A brand-new package seeded at the epic band floor (e.g. `1100.0.0`) with a `minor` changeset therefore debuted at `1100.1.0`, silently skipping `1100.0.0` — even though epic re-base already publishes members *at* the `x00.0.0` floor, so a new package should debut there too. This surfaced in pnpm/pnpm#13198, which adds `@pnpm/deps.github-actions` at `1100.0.0` with a `minor` changeset; that package would have first published as `1100.1.0`.

This teaches the engine that **a package's first release publishes the version in its manifest verbatim.** `pnpm version -r` and `pnpm change status` now probe the registry for each release's current version and hold the never-published ones at that version: the first release publishes it as-is, and the pending changesets — still composed into the changelog and recorded in the ledger — apply only from the *next* release.

Per the discussion that motivated this approach:

- **Always probe, uniformly.** The probe runs the same way in `pnpm version -r`, `pnpm change status`, and `--dry-run` — no offline special case.
- **Fail on error.** Only a definitive 404 means "not published"; any other registry/network failure fails the command rather than guessing a version's fate.

How it's wired (both stacks, in lockstep):

- `@pnpm/releasing.versioning` / `pacquet-versioning`: `assembleReleasePlan` gains an `unpublishedDirs` input; `computeNewVersion` returns the current version verbatim for those dirs (and, on a lane, a prerelease of the current version without incrementing).
- `@pnpm/releasing.commands` / the pacquet CLI: a registry probe (`isVersionPublished` / `unpublished_release_dirs`, reusing the existing packument-fetch plumbing) resolves that set, threaded through a two-pass assembly (assemble → probe the plan's releases → re-assemble). Holding a package at its current version can only *remove* dependent propagation, never add it, so the second pass is a subset of the first — every dir it can hold was probed.

### Notes for review

- **TS test seam.** The command handlers accept an injectable `checkVersionPublished` (mirroring the existing injected `verifyPublished` gate) so the command tests steer first-vs-follow-up without a network round trip. Production leaves it unset and probes.
- **Rust test seam.** The engine's Rust integration tests advance manifests without a real publish cycle (a lane prerelease is written but never published), so they set a **`debug_assertions`-gated** `PACQUET_ASSUME_VERSIONS_PUBLISHED` env var that makes every release bump as if published. It is **compiled out of release builds**, so a production `pnpm` always probes — worst-case misuse in a debug build only reverts to the pre-PR bump-always behavior, never an incorrect publish. Two new integration tests exercise the *real* probe against the mock registry (`@pnpm.e2e/foo@1.2.0` → bumps; `@pnpm.e2e/foo@999.0.0` → verbatim).
- The `pacquet` `change` command became `async` to run the probe (its dispatch now awaits it).

Validation: `@pnpm/releasing.versioning` (63) and `@pnpm/releasing.commands` change-suite (15) Jest tests, `pacquet-versioning` (66) and `pacquet-cli::change` (9) tests, plus workspace `cargo fmt` / `taplo` / `clippy -D warnings`.

## Squash Commit Body

```text
The release engine computed every new version as inc(currentVersion, bump),
with no notion of whether currentVersion was ever published. A brand-new
package seeded at the epic band floor (e.g. 1100.0.0) with a minor changeset
therefore debuted at 1100.1.0, silently skipping 1100.0.0 — the deliberate
band-floor debut that epic re-base already publishes members at. Surfaced by
pnpm/pnpm#13198, which adds `@pnpm/deps.github-actions` at 1100.0.0.

pnpm version -r and pnpm change status now probe the registry for each
release's current version and hold the never-published ones at their manifest
version: the first release publishes it verbatim, and the pending changesets
(still composed into the changelog and recorded in the ledger) apply only from
the next release. The probe always runs (version, change status, dry-run alike)
and a probe failure fails the command rather than guessing.

Mirrored in both stacks: `@pnpm/releasing.versioning` gains an unpublishedDirs
input to assembleReleasePlan, resolved by `@pnpm/releasing.commands` via a
registry probe threaded through a two-pass assembly; pacquet mirrors it in
pacquet-versioning's plan and the CLI's change/version commands. Command tests
inject the probe (TS) or a debug-only PACQUET_ASSUME_VERSIONS_PUBLISHED seam
that is compiled out of release builds (Rust); two Rust tests exercise the real
probe against the mock registry.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787268820&installation_model_id=426870&pr_number=13207&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13207&signature=1d1b1bcdd198d8bd231cae730dc3145ce395fcb69f0525c2f42878f49daf53f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added registry probing to detect whether package versions are already published during `change` and recursive `version -r`.
  * Updated `change status` previews to reflect the effective published/unpublished state used for planning.
* **Bug Fixes**
  * First releases of packages that are not yet published now debut verbatim at the manifest version, including correct lane/prerelease behavior.
  * Registry probe failures now fail the commands instead of falling back to guessed versions.
  * Prevents incorrect dependent version propagation when the first release does not advance the package version.
* **Tests**
  * Added end-to-end and unit coverage for published vs unpublished first-release behavior and probe failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->