### PR TITLE
feat(cli): support recursive install family with dedicated lockfiles

### DIFF
--- a/.changeset/recursive-install-family-dedicated-lockfiles.md
+++ b/.changeset/recursive-install-family-dedicated-lockfiles.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install`, `pnpm add`, `pnpm update`, and `pnpm remove` now support recursive (`-r`) and filtered (`--filter`) execution in workspaces configured with one lockfile per project (`sharedWorkspaceLockfile: false`), instead of failing with `ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED`. Each selected project is installed independently against its own `pnpm-lock.yaml`, `node_modules`, and virtual store, matching pnpm.

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -19,7 +19,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct AddDependencyOptions {
     /// Install the specified packages as regular dependencies.
     #[clap(short = 'P', long)]
@@ -79,7 +79,7 @@ impl AddDependencyOptions {
     }
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct AddArgs {
     /// Names of the packages to add.
     #[clap(required = true)]

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -6,8 +6,8 @@ use super::{
     package_manager::{PackageManagerToSync, package_manager_to_sync},
     prune::PruneArgs,
     recursive::{
-        AutoExcludeRoot, RecursiveSharedLockfileUnsupported, discover_workspace_projects,
-        select_recursive_projects, sort_filtered_projects,
+        AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+        sort_filtered_projects,
     },
     remove::RemoveArgs,
     update::UpdateArgs,
@@ -32,21 +32,36 @@ pub(crate) struct InstallFamilySelection {
     pub(crate) active_manifest_is_standin: bool,
 }
 
-fn select_install_family_projects(
+/// How a recursive / filtered install-family command should be dispatched,
+/// resolved from the config and the workspace selection.
+pub(crate) enum InstallFamilyPlan {
+    /// Not recursive (`!cfg.recursive`): run against the active project only.
+    /// The pipelines keep their own non-recursive handling (the dedicated
+    /// per-project anchor for `add` / `update` / `remove`, and the
+    /// dedicated-lockfile workspace install for `install`).
+    Single,
+    /// Recursive / filtered over a shared workspace lockfile: one mutation
+    /// pass writes every selected importer into the shared `pnpm-lock.yaml`.
+    Shared(Box<InstallFamilySelection>),
+    /// Recursive / filtered with one lockfile per project
+    /// (`sharedWorkspaceLockfile: false`): the selected project directories,
+    /// each installed independently against its own `pnpm-lock.yaml`,
+    /// `node_modules`, and virtual store. Mirrors pnpm's per-project loop in
+    /// its recursive dispatch. The order is not topological — each project
+    /// resolves in isolation — so the dirs are sorted for a deterministic run
+    /// order, matching pnpm's alphabetical `Object.keys(...).sort()`.
+    PerProject(Vec<PathBuf>),
+}
+
+fn select_install_family_plan(
     cfg: &Config,
     prefix: &Path,
     manifest_path: &Path,
     recursive_sort: bool,
     auto_exclude_root: bool,
-) -> miette::Result<Option<InstallFamilySelection>> {
+) -> miette::Result<InstallFamilyPlan> {
     if !cfg.recursive {
-        return Ok(None);
-    }
-    if !cfg.shared_workspace_lockfile {
-        return Err(RecursiveSharedLockfileUnsupported::new(
-            "Recursive and filtered install-family commands",
-        )
-        .into());
+        return Ok(InstallFamilyPlan::Single);
     }
 
     let workspace_root = cfg.workspace_dir.as_deref().unwrap_or(prefix).to_path_buf();
@@ -70,6 +85,11 @@ fn select_install_family_projects(
                 AutoExcludeRoot::Disabled
             },
         )?;
+        if !cfg.shared_workspace_lockfile {
+            let mut project_dirs: Vec<PathBuf> = selection.selected.keys().cloned().collect();
+            project_dirs.sort();
+            return Ok(InstallFamilyPlan::PerProject(project_dirs));
+        }
         let ordered_groups = if recursive_sort {
             sort_filtered_projects(
                 &selection.selected,
@@ -95,14 +115,32 @@ fn select_install_family_projects(
             pacquet_fs::lexical_normalize(&project.root_dir) == normalized_active_dir
         });
 
-    Ok(Some(InstallFamilySelection {
+    Ok(InstallFamilyPlan::Shared(Box::new(InstallFamilySelection {
         workspace_root,
         projects,
         ordered_groups,
         ordered_dirs,
         selected_dirs,
         active_manifest_is_standin,
-    }))
+    })))
+}
+
+/// Build the project-anchored `State` for one project of a
+/// `sharedWorkspaceLockfile: false` workspace: clone `cfg`, re-anchor its
+/// output paths under `project_dir` via [`anchor_dedicated_project_config`],
+/// and initialize the state. The clone is leaked because [`State::init`] needs
+/// a `&'static Config`; see [`run_dedicated_lockfile_workspace_install`] for
+/// why the bounded leak is acceptable.
+fn init_dedicated_project_state(
+    cfg: &Config,
+    project_dir: &Path,
+    require_lockfile: bool,
+) -> miette::Result<State> {
+    let mut project_config = cfg.clone();
+    anchor_dedicated_project_config(&mut project_config, project_dir);
+    let project_config = Config::leak(project_config);
+    State::init(project_dir.join("package.json"), project_config, require_lockfile)
+        .wrap_err_with(|| format!("initialize the state for {}", project_dir.display()))
 }
 
 /// The reporter-generic body of `pacquet install`: it threads one `Reporter`
@@ -146,30 +184,43 @@ impl InstallPipeline {
         }
         config_deps::install_config_deps::<Reporter>(cfg, &config_root, frozen_lockfile).await?;
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
-        let selection =
-            select_install_family_projects(cfg, &prefix, &manifest_path, recursive_sort, false)?;
-        if selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty()) {
-            return Ok(());
-        }
-        if selection.is_none()
-            && !cfg.shared_workspace_lockfile
-            && let Some(workspace_dir) = cfg.workspace_dir.clone()
-        {
-            let cfg: &'static Config = cfg;
-            return run_dedicated_lockfile_workspace_install::<Reporter>(
-                &args,
-                cfg,
-                &workspace_dir,
-                require_lockfile,
-            )
-            .await;
-        }
-        let cfg: &'static Config = cfg;
-        let state =
-            State::init(manifest_path, cfg, require_lockfile).wrap_err("initialize the state")?;
-        match selection {
-            Some(selection) => Box::pin(args.run_selected::<Reporter>(state, selection)).await,
-            None => Box::pin(args.run::<Reporter>(state)).await,
+        let plan = select_install_family_plan(cfg, &prefix, &manifest_path, recursive_sort, false)?;
+        match plan {
+            InstallFamilyPlan::PerProject(project_dirs) => {
+                let cfg: &Config = cfg;
+                for project_dir in project_dirs {
+                    let state = init_dedicated_project_state(cfg, &project_dir, require_lockfile)?;
+                    Box::pin(args.clone().run::<Reporter>(state)).await?;
+                }
+                Ok(())
+            }
+            InstallFamilyPlan::Shared(selection) => {
+                if selection.selected_dirs.is_empty() {
+                    return Ok(());
+                }
+                let cfg: &'static Config = cfg;
+                let state = State::init(manifest_path, cfg, require_lockfile)
+                    .wrap_err("initialize the state")?;
+                Box::pin(args.run_selected::<Reporter>(state, *selection)).await
+            }
+            InstallFamilyPlan::Single => {
+                if !cfg.shared_workspace_lockfile
+                    && let Some(workspace_dir) = cfg.workspace_dir.clone()
+                {
+                    let cfg: &'static Config = cfg;
+                    return run_dedicated_lockfile_workspace_install::<Reporter>(
+                        &args,
+                        cfg,
+                        &workspace_dir,
+                        require_lockfile,
+                    )
+                    .await;
+                }
+                let cfg: &'static Config = cfg;
+                let state = State::init(manifest_path, cfg, require_lockfile)
+                    .wrap_err("initialize the state")?;
+                Box::pin(args.run::<Reporter>(state)).await
+            }
         }
     }
 }
@@ -214,34 +265,51 @@ impl AddPipeline {
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
         // `--config` targets the workspace's configuration dependencies, not
         // any project's manifest, so it bypasses project selection entirely.
-        let selection = if config_dependencies.is_some() {
-            None
+        let plan = if config_dependencies.is_some() {
+            InstallFamilyPlan::Single
         } else {
-            select_install_family_projects(cfg, &prefix, &manifest_path, recursive_sort, true)?
+            select_install_family_plan(cfg, &prefix, &manifest_path, recursive_sort, true)?
         };
-        if selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty()) {
-            return Ok(());
-        }
-        // Dedicated per-project lockfiles: `add` mutates only the
-        // active project, whose outputs anchor at the project dir.
-        // `--config` targets the workspace's configuration
-        // dependencies, which stay workspace-anchored.
-        if selection.is_none()
-            && config_dependencies.is_none()
-            && !cfg.shared_workspace_lockfile
-            && cfg.workspace_dir.is_some()
-        {
-            let manifest_dir = manifest_path
-                .parent()
-                .expect("manifest path always has a parent dir")
-                .to_path_buf();
-            anchor_dedicated_project_config(cfg, &manifest_dir);
-        }
-        let cfg: &'static Config = cfg;
-        let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-        match selection {
-            Some(selection) => Box::pin(args.run_selected::<Reporter>(state, selection)).await,
-            None => Box::pin(args.run::<Reporter>(state, config_dependencies)).await,
+        match plan {
+            InstallFamilyPlan::PerProject(project_dirs) => {
+                // Dedicated per-project lockfiles: add the packages to each
+                // selected project independently.
+                let cfg: &Config = cfg;
+                for project_dir in project_dirs {
+                    let state = init_dedicated_project_state(cfg, &project_dir, false)?;
+                    Box::pin(args.clone().run::<Reporter>(state, None)).await?;
+                }
+                Ok(())
+            }
+            InstallFamilyPlan::Shared(selection) => {
+                if selection.selected_dirs.is_empty() {
+                    return Ok(());
+                }
+                let cfg: &'static Config = cfg;
+                let state =
+                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(args.run_selected::<Reporter>(state, *selection)).await
+            }
+            InstallFamilyPlan::Single => {
+                // Dedicated per-project lockfiles: `add` mutates only the
+                // active project, whose outputs anchor at the project dir.
+                // `--config` targets the workspace's configuration
+                // dependencies, which stay workspace-anchored.
+                if config_dependencies.is_none()
+                    && !cfg.shared_workspace_lockfile
+                    && cfg.workspace_dir.is_some()
+                {
+                    let manifest_dir = manifest_path
+                        .parent()
+                        .expect("manifest path always has a parent dir")
+                        .to_path_buf();
+                    anchor_dedicated_project_config(cfg, &manifest_dir);
+                }
+                let cfg: &'static Config = cfg;
+                let state =
+                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(args.run::<Reporter>(state, config_dependencies)).await
+            }
         }
     }
 }
@@ -279,15 +347,25 @@ impl UpdatePipeline {
         }
         config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
-        let selection =
-            select_install_family_projects(cfg, &prefix, &manifest_path, recursive_sort, false)?;
-        if selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty()) {
-            return Ok(());
+        let plan = select_install_family_plan(cfg, &prefix, &manifest_path, recursive_sort, false)?;
+        // An empty selection has nothing to update, and — like the shared
+        // path — must not generate a changeset.
+        match &plan {
+            InstallFamilyPlan::PerProject(project_dirs) if project_dirs.is_empty() => {
+                return Ok(());
+            }
+            InstallFamilyPlan::Shared(selection) if selection.selected_dirs.is_empty() => {
+                return Ok(());
+            }
+            _ => {}
         }
         // Dedicated per-project lockfiles: the non-recursive command
         // mutates only the active project, whose outputs anchor at the
         // project dir.
-        if selection.is_none() && !cfg.shared_workspace_lockfile && cfg.workspace_dir.is_some() {
+        if matches!(plan, InstallFamilyPlan::Single)
+            && !cfg.shared_workspace_lockfile
+            && cfg.workspace_dir.is_some()
+        {
             let manifest_dir = manifest_path
                 .parent()
                 .expect("manifest path always has a parent dir")
@@ -304,12 +382,27 @@ impl UpdatePipeline {
         let changeset_context = generate_changeset
             .then(|| UpdateChangesetContext::capture(cfg, &manifest_path))
             .transpose()?;
-        let cfg: &'static Config = cfg;
-        let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-        match selection {
-            Some(selection) => Box::pin(args.run_selected::<Reporter>(state, selection)).await,
-            None => Box::pin(args.run::<Reporter>(state)).await,
-        }?;
+        match plan {
+            InstallFamilyPlan::PerProject(project_dirs) => {
+                let cfg: &Config = cfg;
+                for project_dir in project_dirs {
+                    let state = init_dedicated_project_state(cfg, &project_dir, false)?;
+                    Box::pin(args.clone().run::<Reporter>(state)).await?;
+                }
+            }
+            InstallFamilyPlan::Shared(selection) => {
+                let cfg: &'static Config = cfg;
+                let state =
+                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(args.run_selected::<Reporter>(state, *selection)).await?;
+            }
+            InstallFamilyPlan::Single => {
+                let cfg: &'static Config = cfg;
+                let state =
+                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(args.run::<Reporter>(state)).await?;
+            }
+        }
         if let Some(changeset_context) = changeset_context {
             changeset_context.generate::<Reporter>()?;
         }
@@ -350,26 +443,43 @@ impl RemovePipeline {
         }
         config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
-        let selection =
-            select_install_family_projects(cfg, &prefix, &manifest_path, recursive_sort, false)?;
-        if selection.as_ref().is_some_and(|selection| selection.selected_dirs.is_empty()) {
-            return Ok(());
-        }
-        // Dedicated per-project lockfiles: the non-recursive command
-        // mutates only the active project, whose outputs anchor at the
-        // project dir.
-        if selection.is_none() && !cfg.shared_workspace_lockfile && cfg.workspace_dir.is_some() {
-            let manifest_dir = manifest_path
-                .parent()
-                .expect("manifest path always has a parent dir")
-                .to_path_buf();
-            anchor_dedicated_project_config(cfg, &manifest_dir);
-        }
-        let cfg: &'static Config = cfg;
-        let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-        match selection {
-            Some(selection) => Box::pin(args.run_selected::<Reporter>(state, selection)).await,
-            None => Box::pin(args.run::<Reporter>(state)).await,
+        let plan = select_install_family_plan(cfg, &prefix, &manifest_path, recursive_sort, false)?;
+        match plan {
+            InstallFamilyPlan::PerProject(project_dirs) => {
+                // Dedicated per-project lockfiles: remove the packages from
+                // each selected project independently.
+                let cfg: &Config = cfg;
+                for project_dir in project_dirs {
+                    let state = init_dedicated_project_state(cfg, &project_dir, false)?;
+                    Box::pin(args.clone().run::<Reporter>(state)).await?;
+                }
+                Ok(())
+            }
+            InstallFamilyPlan::Shared(selection) => {
+                if selection.selected_dirs.is_empty() {
+                    return Ok(());
+                }
+                let cfg: &'static Config = cfg;
+                let state =
+                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(args.run_selected::<Reporter>(state, *selection)).await
+            }
+            InstallFamilyPlan::Single => {
+                // Dedicated per-project lockfiles: the non-recursive command
+                // mutates only the active project, whose outputs anchor at the
+                // project dir.
+                if !cfg.shared_workspace_lockfile && cfg.workspace_dir.is_some() {
+                    let manifest_dir = manifest_path
+                        .parent()
+                        .expect("manifest path always has a parent dir")
+                        .to_path_buf();
+                    anchor_dedicated_project_config(cfg, &manifest_dir);
+                }
+                let cfg: &'static Config = cfg;
+                let state =
+                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(args.run::<Reporter>(state)).await
+            }
         }
     }
 }
@@ -464,11 +574,7 @@ async fn run_dedicated_lockfile_workspace_install<Reporter: self::Reporter + 'st
     // reclaimed at process exit — the same lifetime deploy's derived
     // install config has.
     for project_dir in project_dirs {
-        let mut project_config = cfg.clone();
-        anchor_dedicated_project_config(&mut project_config, &project_dir);
-        let project_config = Config::leak(project_config);
-        let state = State::init(project_dir.join("package.json"), project_config, require_lockfile)
-            .wrap_err_with(|| format!("initialize the state for {}", project_dir.display()))?;
+        let state = init_dedicated_project_state(cfg, &project_dir, require_lockfile)?;
         Box::pin(args.clone().run::<Reporter>(state)).await?;
     }
     Ok(())

--- a/pnpm/crates/cli/src/cli_args/remove.rs
+++ b/pnpm/crates/cli/src/cli_args/remove.rs
@@ -5,7 +5,7 @@ use pacquet_package_manager::Remove;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::Reporter;
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct RemoveDependencyOptions {
     /// Remove the dependency only from "dependencies".
     #[clap(short = 'P', long)]
@@ -35,7 +35,7 @@ impl RemoveDependencyOptions {
     }
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct RemoveArgs {
     /// Names of the packages to remove.
     pub package_names: Vec<String>,

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -16,7 +16,7 @@ use pacquet_reporter::Reporter;
 
 /// The `--prod`, `--dev`, and `--no-optional` flags that select which
 /// dependency groups to update.
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct UpdateDependencyOptions {
     /// Update packages only in "dependencies" and "optionalDependencies".
     #[clap(short = 'P', long)]
@@ -56,7 +56,7 @@ impl UpdateDependencyOptions {
 }
 
 /// Update package and GitHub Actions dependencies to newer compatible versions.
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct UpdateArgs {
     /// Dependencies to update. Package names (`foo`, `@scope/bar`), GitHub
     /// Actions (`actions/checkout`, with `--include-github-actions`), glob

--- a/pnpm/crates/cli/tests/install_filters.rs
+++ b/pnpm/crates/cli/tests/install_filters.rs
@@ -941,20 +941,172 @@ fn workspace_non_project_subdirectory_does_not_create_active_importer() {
 }
 
 #[test]
-fn filtered_install_rejects_per_project_workspace_lockfiles() {
+fn filtered_install_with_dedicated_lockfiles_installs_only_selected_project() {
     let fixture = WorkspaceFixture::new();
     fixture.append_workspace_yaml("sharedWorkspaceLockfile: false\n");
-    fixture.project("app", "app", ManifestDeps::default());
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
 
-    let output =
-        fixture.command_at(&fixture.workspace, ["--filter", "app", "install", "--lockfile-only"]);
+    fixture.run(["--filter", "selected", "install"]);
 
-    assert!(!output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let selected_lockfile = read_lockfile(&selected.join("pnpm-lock.yaml"));
+    assert_full_wanted(&selected_lockfile, &["."]);
+    assert!(has_snapshot(&selected_lockfile, HELLO, "1.0.0"));
+    assert!(has_link(&selected, HELLO));
+    assert!(!unselected.join("pnpm-lock.yaml").exists(), "unselected must not be installed");
+    assert!(!unselected.join("node_modules").exists(), "unselected node_modules must be absent");
     assert!(
-        stderr.contains("ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED")
-            && stderr.contains("sharedWorkspaceLockfile=false"),
-        "stderr: {stderr}",
+        !fixture.workspace.join("pnpm-lock.yaml").exists(),
+        "dedicated lockfiles must not write a shared workspace lockfile",
+    );
+}
+
+#[test]
+fn recursive_install_with_dedicated_lockfiles_installs_every_project() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("sharedWorkspaceLockfile: false\n");
+    let first = fixture.project(
+        "first",
+        "first",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let second = fixture.project(
+        "second",
+        "second",
+        ManifestDeps { prod: &[(PARENT, "100.0.0")], ..Default::default() },
+    );
+
+    fixture.run(["--recursive", "install"]);
+
+    for (project, dependency) in [(&first, HELLO), (&second, PARENT)] {
+        let lockfile = read_lockfile(&project.join("pnpm-lock.yaml"));
+        assert_full_wanted(&lockfile, &["."]);
+        assert!(has_link(project, dependency));
+    }
+    assert!(!fixture.workspace.join("pnpm-lock.yaml").exists());
+}
+
+#[test]
+fn filtered_add_with_dedicated_lockfiles_mutates_only_selected_project() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("sharedWorkspaceLockfile: false\n");
+    let selected = fixture.project("selected", "selected", ManifestDeps::default());
+    let unselected = fixture.project("unselected", "unselected", ManifestDeps::default());
+
+    fixture.run(["--filter", "selected", "add", HELLO, "--lockfile-only"]);
+
+    assert_eq!(dependency_spec(&selected, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    assert_eq!(dependency_spec(&unselected, "dependencies", HELLO), None);
+    let selected_lockfile = read_lockfile(&selected.join("pnpm-lock.yaml"));
+    assert_eq!(importer_version(&selected_lockfile, ".", HELLO), "1.0.0");
+    assert!(!unselected.join("pnpm-lock.yaml").exists(), "unselected must not be mutated");
+    assert!(!fixture.workspace.join("pnpm-lock.yaml").exists());
+}
+
+#[test]
+fn recursive_add_with_dedicated_lockfiles_excludes_workspace_root() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("sharedWorkspaceLockfile: false\n");
+    fixture.write_root_manifest("workspace-root", ManifestDeps::default());
+    let member_a = fixture.project("member-a", "member-a", ManifestDeps::default());
+    let member_b = fixture.project("member-b", "member-b", ManifestDeps::default());
+
+    fixture.run(["-r", "add", HELLO, "--lockfile-only"]);
+
+    assert_eq!(dependency_spec(&fixture.workspace, "dependencies", HELLO), None);
+    assert_eq!(dependency_spec(&member_a, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    assert_eq!(dependency_spec(&member_b, "dependencies", HELLO).as_deref(), Some("^1.0.0"));
+    for member in [&member_a, &member_b] {
+        assert_eq!(
+            importer_version(&read_lockfile(&member.join("pnpm-lock.yaml")), ".", HELLO),
+            "1.0.0",
+        );
+    }
+    assert!(
+        !fixture.workspace.join("pnpm-lock.yaml").exists(),
+        "the auto-excluded root must not get its own lockfile",
+    );
+}
+
+#[test]
+fn filtered_update_with_dedicated_lockfiles_mutates_only_selected_project() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("sharedWorkspaceLockfile: false\n");
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(DEP, "100.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    for project in [&selected, &unselected] {
+        set_dependency(project, "dependencies", DEP, "^100.0.0");
+    }
+    let unselected_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    let unselected_lockfile_before =
+        fs::read(unselected.join("pnpm-lock.yaml")).expect("read lockfile");
+
+    fixture.run(["--filter", "selected", "update", DEP, "--latest", "--lockfile-only"]);
+
+    assert_eq!(dependency_spec(&selected, "dependencies", DEP).as_deref(), Some("^101.0.0"));
+    assert_eq!(
+        importer_version(&read_lockfile(&selected.join("pnpm-lock.yaml")), ".", DEP),
+        "101.0.0",
+    );
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+    assert_eq!(
+        fs::read(unselected.join("pnpm-lock.yaml")).expect("read lockfile"),
+        unselected_lockfile_before,
+    );
+    assert!(!fixture.workspace.join("pnpm-lock.yaml").exists());
+}
+
+#[test]
+fn filtered_remove_with_dedicated_lockfiles_mutates_only_selected_project() {
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml("sharedWorkspaceLockfile: false\n");
+    let selected = fixture.project(
+        "selected",
+        "selected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    let unselected = fixture.project(
+        "unselected",
+        "unselected",
+        ManifestDeps { prod: &[(HELLO, "1.0.0")], ..Default::default() },
+    );
+    fixture.run(["install", "--lockfile-only"]);
+    let unselected_manifest = fs::read(unselected.join("package.json")).expect("read manifest");
+    let unselected_lockfile_before =
+        fs::read(unselected.join("pnpm-lock.yaml")).expect("read lockfile");
+
+    fixture.run(["--filter", "selected", "remove", HELLO, "--lockfile-only"]);
+
+    assert_eq!(dependency_spec(&selected, "dependencies", HELLO), None);
+    let selected_lockfile = read_lockfile(&selected.join("pnpm-lock.yaml"));
+    assert!(!has_snapshot(&selected_lockfile, HELLO, "1.0.0"));
+    assert_eq!(
+        fs::read(unselected.join("package.json")).expect("read manifest"),
+        unselected_manifest,
+    );
+    assert_eq!(
+        fs::read(unselected.join("pnpm-lock.yaml")).expect("read lockfile"),
+        unselected_lockfile_before,
     );
     assert!(!fixture.workspace.join("pnpm-lock.yaml").exists());
 }


### PR DESCRIPTION
## Summary

Finishes the `install` / `add` / `update` / `remove` row of the recursive-command-parity tracker (Related to pnpm/pnpm#13201).

These commands already accepted the global `-r` / `--filter` flags in a workspace, but pacquet's common install-family selector rejected **every** recursive or filtered invocation when `sharedWorkspaceLockfile: false`, failing with `ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED`. The TypeScript CLI already supports both shared and per-project lockfiles here, so this brings pacquet up to that behavior.

The selection now resolves into a three-way `InstallFamilyPlan`:

- **`Single`** — not recursive: the existing active-project path (and the existing dedicated-lockfile whole-workspace `install` loop).
- **`Shared`** — recursive/filtered over one shared `pnpm-lock.yaml` (unchanged).
- **`PerProject`** — recursive/filtered with `sharedWorkspaceLockfile: false`: run one independent single-project install/add/update/remove for each selected project against its own `pnpm-lock.yaml`, `node_modules`, and virtual store, mirroring pnpm's per-project loop in its recursive dispatch (`installing/commands/src/recursive.ts`).

The per-project loop reuses the same config re-anchoring (`anchor_dedicated_project_config`) that the non-recursive dedicated-lockfile install already uses, factored into a shared `init_dedicated_project_state` helper.

Notes for reviewers:

- **This is a pacquet-only change** — it makes pacquet match behavior the TypeScript CLI already has, so no TypeScript-side commit is needed.
- Per-project installs run **sequentially** (pnpm uses a `pLimit(workspaceConcurrency)`); each dedicated lockfile is independent, so the final state is identical and this matches pacquet's existing non-recursive dedicated-lockfile install. The dirs are sorted, matching pnpm's `Object.keys(selectedProjectsGraph).sort()`.
- `update`'s changeset generation stays a pipeline-level concern (captured before, generated after the loop), unchanged for the per-project case.

## Squash Commit Body

```text
`pnpm install`, `pnpm add`, `pnpm update`, and `pnpm remove` accepted the
global `-r` / `--filter` flags in a workspace, but the shared install-family
selector rejected every recursive or filtered invocation when
`sharedWorkspaceLockfile: false` with
`ERR_PNPM_RECURSIVE_SHARED_LOCKFILE_UNSUPPORTED`.

Resolve the selection into a three-way `InstallFamilyPlan` (single, shared,
per-project). For the per-project (dedicated-lockfile) case, run one
independent single-project install/add/update/remove for each selected
project against its own `pnpm-lock.yaml`, `node_modules`, and virtual store,
mirroring pnpm's per-project loop in its recursive dispatch. Both stacks now
match for `sharedWorkspaceLockfile=true` and `false`.

Related to pnpm/pnpm#13201.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. — pacquet-only;
  matches existing TypeScript CLI behavior (noted above).
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package.
- [x] Added or updated tests. — `install`/`add`/`update`/`remove` dedicated-lockfile
  cases in `crates/cli/tests/install_filters.rs`; replaced the test that asserted
  the old rejection.
- [ ] Updated the documentation if needed. — no doc change; matches documented pnpm behavior.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787268931&installation_model_id=426870&pr_number=13208&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13208&signature=eab20901fc0c9487d5dc1ed3ad5386bbaeb0bcc85aa1245b0c5849c4b8a56f15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recursive (`-r`) and filtered (`--filter`) support for install, add, update, and remove commands in workspaces using dedicated lockfiles.
  * Selected projects are processed independently with their own lockfiles and installation state.
  * Recursive operations now create and update per-project lockfiles without generating a shared workspace lockfile.

* **Bug Fixes**
  * Removed failures when running supported recursive or filtered commands with dedicated workspace lockfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->