### PR TITLE
feat(cli): route unlink through the recursive install pipeline

### DIFF
--- a/.changeset/unlink-recursive-install-family.md
+++ b/.changeset/unlink-recursive-install-family.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm unlink` now reinstalls through the selection-aware install pipeline, matching pnpm: it honors `-r` / `--filter`, installs recursively by default inside a workspace, and supports both a shared workspace lockfile and one lockfile per project (`sharedWorkspaceLockfile: false`). Previously it always reinstalled only the active project.

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -393,18 +393,46 @@ pub(super) fn link<'a>(ctx: &RunCtx<'a>, args: LinkArgs) -> miette::Result<Comma
 }
 
 pub(super) fn unlink<'a>(ctx: &RunCtx<'a>, args: UnlinkArgs) -> miette::Result<CommandFuture<'a>> {
-    let manifest_path = ctx.manifest_path.to_path_buf();
-    Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>((ctx.config)()?, manifest_path))
+    let dir = ctx.dir;
+    let manifest_path = ctx.manifest_path;
+    let reporter = ctx.reporter;
+    let recursive_sort = ctx.recursive_sort;
+    let config = ctx.config;
+    Ok(Box::pin(async move {
+        let cfg = config()?;
+        // Strip the matching `link:` overrides; stop early when there is
+        // nothing to unlink.
+        if !args.strip_link_overrides(cfg, manifest_path)? {
+            return Ok(());
         }
-        ReporterType::Ndjson => {
-            Box::pin(args.run::<NdjsonReporter>((ctx.config)()?, manifest_path))
+        // Reinstall through the install-family pipeline, exactly as pnpm's
+        // `unlink` delegates to its install handler, so `-r` / `--filter`
+        // selection and per-project lockfiles apply. The reinstall forces a
+        // fresh resolution so the removed `link:` overrides re-resolve from
+        // the registry.
+        let (config_root, package_manager_to_sync) =
+            derive_config_root_and_package_manager_to_sync(cfg, dir)
+                .wrap_err("derive workspace root and package manager policy")?;
+        let pipeline = InstallPipeline {
+            args: InstallArgs::for_reresolving_install(),
+            cfg,
+            config_root,
+            package_manager_to_sync,
+            prefix: dir.to_path_buf(),
+            manifest_path: manifest_path.to_path_buf(),
+            recursive_sort,
+            require_lockfile: false,
+            frozen_lockfile: false,
+        };
+        match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                Box::pin(pipeline.run::<DefaultReporter>()).await?;
+            }
+            ReporterType::Ndjson => Box::pin(pipeline.run::<NdjsonReporter>()).await?,
+            ReporterType::Silent => Box::pin(pipeline.run::<SilentReporter>()).await?,
         }
-        ReporterType::Silent => {
-            Box::pin(args.run::<SilentReporter>((ctx.config)()?, manifest_path))
-        }
-    })
+        Ok(())
+    }))
 }
 
 pub(super) fn rebuild<'a>(
@@ -474,7 +502,7 @@ pub(super) fn patch_commit<'a>(
         ReporterType::Default | ReporterType::AppendOnly => Box::pin(async move {
             if Box::pin(args.run::<DefaultReporter>(dir, state(false)?)).await? {
                 Box::pin(
-                    InstallArgs::for_patch_manifest_change().run::<DefaultReporter>(state(false)?),
+                    InstallArgs::for_reresolving_install().run::<DefaultReporter>(state(false)?),
                 )
                 .await?;
             }
@@ -483,7 +511,7 @@ pub(super) fn patch_commit<'a>(
         ReporterType::Ndjson => Box::pin(async move {
             if Box::pin(args.run::<NdjsonReporter>(dir, state(false)?)).await? {
                 Box::pin(
-                    InstallArgs::for_patch_manifest_change().run::<NdjsonReporter>(state(false)?),
+                    InstallArgs::for_reresolving_install().run::<NdjsonReporter>(state(false)?),
                 )
                 .await?;
             }
@@ -492,7 +520,7 @@ pub(super) fn patch_commit<'a>(
         ReporterType::Silent => Box::pin(async move {
             if Box::pin(args.run::<SilentReporter>(dir, state(false)?)).await? {
                 Box::pin(
-                    InstallArgs::for_patch_manifest_change().run::<SilentReporter>(state(false)?),
+                    InstallArgs::for_reresolving_install().run::<SilentReporter>(state(false)?),
                 )
                 .await?;
             }
@@ -510,21 +538,19 @@ pub(super) fn patch_remove<'a>(
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => Box::pin(async move {
             Box::pin(args.run(dir, state(false)?)).await?;
-            Box::pin(
-                InstallArgs::for_patch_manifest_change().run::<DefaultReporter>(state(false)?),
-            )
-            .await?;
+            Box::pin(InstallArgs::for_reresolving_install().run::<DefaultReporter>(state(false)?))
+                .await?;
             Ok(())
         }),
         ReporterType::Ndjson => Box::pin(async move {
             Box::pin(args.run(dir, state(false)?)).await?;
-            Box::pin(InstallArgs::for_patch_manifest_change().run::<NdjsonReporter>(state(false)?))
+            Box::pin(InstallArgs::for_reresolving_install().run::<NdjsonReporter>(state(false)?))
                 .await?;
             Ok(())
         }),
         ReporterType::Silent => Box::pin(async move {
             Box::pin(args.run(dir, state(false)?)).await?;
-            Box::pin(InstallArgs::for_patch_manifest_change().run::<SilentReporter>(state(false)?))
+            Box::pin(InstallArgs::for_reresolving_install().run::<SilentReporter>(state(false)?))
                 .await?;
             Ok(())
         }),

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -224,7 +224,13 @@ pub(crate) fn resolve_bool_override(force_on: bool, force_off: bool, config: boo
 }
 
 impl InstallArgs {
-    pub(crate) fn for_patch_manifest_change() -> Self {
+    /// The install args for a reinstall triggered by an out-of-band change to
+    /// the install inputs: `patch-commit` / `patch-remove` (which rewrite the
+    /// manifest's `patchedDependencies`) and `unlink` (which removes `link:`
+    /// overrides from `pnpm-workspace.yaml`). Forces a fresh resolution
+    /// (`preferFrozenLockfile: false`, via `no_prefer_frozen_lockfile`) so the
+    /// changed inputs re-resolve rather than reusing the stale lockfile.
+    pub(crate) fn for_reresolving_install() -> Self {
         Self {
             dependency_options: InstallDependencyOptions {
                 prod: false,

--- a/pnpm/crates/cli/src/cli_args/unlink.rs
+++ b/pnpm/crates/cli/src/cli_args/unlink.rs
@@ -1,15 +1,8 @@
-use crate::State;
 use clap::Args;
 use miette::Context;
 use pacquet_config::Config;
-use pacquet_package_manager::{Install, UpdateSeedPolicy};
-use pacquet_package_manifest::DependencyGroup;
-use pacquet_reporter::Reporter;
 use pacquet_workspace_manifest_writer::remove_overrides;
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::path::Path;
 
 /// Remove the link created by `pnpm link` and reinstall the package as
 /// declared in `package.json`.
@@ -22,17 +15,22 @@ pub struct UnlinkArgs {
 }
 
 impl UnlinkArgs {
-    pub async fn run<Reporter: self::Reporter + 'static>(
-        self,
-        config: &'static mut Config,
-        manifest_path: PathBuf,
-    ) -> miette::Result<()> {
-        // pnpm prints "Nothing to unlink" and stops when no overrides are
-        // configured; otherwise it strips the matching link: overrides and
-        // reinstalls — running the install even when nothing matched.
+    /// Strip the matching `link:` overrides from `config` (in memory) and
+    /// from `pnpm-workspace.yaml`, returning whether the caller should
+    /// reinstall.
+    ///
+    /// Mirrors pnpm: when no overrides are configured it prints "Nothing to
+    /// unlink" and returns `false` so the caller stops; otherwise it removes
+    /// the `link:` overrides — the ones named, or all of them — and returns
+    /// `true` so the caller reinstalls, even when nothing matched.
+    pub(crate) fn strip_link_overrides(
+        &self,
+        config: &mut Config,
+        manifest_path: &Path,
+    ) -> miette::Result<bool> {
         let Some(overrides) = config.overrides.as_mut() else {
             println!("Nothing to unlink");
-            return Ok(());
+            return Ok(false);
         };
 
         let removed: Vec<String> = overrides
@@ -60,50 +58,6 @@ impl UnlinkArgs {
                 .wrap_err("removing link: overrides from pnpm-workspace.yaml")?;
         }
 
-        let state = State::init(manifest_path, config, false).wrap_err("initialize the state")?;
-        let lockfile_path = state.lockfile_path();
-        let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
-            &state;
-
-        Install {
-            tarball_mem_cache: Arc::clone(tarball_mem_cache),
-            http_client,
-            http_client_arc: Arc::clone(http_client),
-            config,
-            manifest,
-            emit_initial_manifest: true,
-            lockfile: pacquet_lockfile::MaybeLazyLockfile::Lazy(lockfile),
-            lockfile_path: Some(&lockfile_path),
-            dependency_groups: [
-                DependencyGroup::Prod,
-                DependencyGroup::Dev,
-                DependencyGroup::Optional,
-            ]
-            .into_iter(),
-            frozen_lockfile: false,
-            prefer_frozen_lockfile: Some(false),
-            ignore_manifest_check: false,
-            skip_runtimes: config.skip_runtimes,
-            trust_lockfile: config.trust_lockfile,
-            update_checksums: false,
-            is_full_install: false,
-            installs_only: false,
-            resolved_packages,
-            supported_architectures: config.supported_architectures.clone(),
-            node_linker: config.node_linker,
-            lockfile_only: false,
-            dry_run: false,
-            disable_optimistic_repeat_install: false,
-            pnpmfile_hook_override: None,
-            workspace_projects_override: None,
-            update_seed_policy: UpdateSeedPolicy::KeepAll,
-            auth_override: None,
-            resolution_observer: None,
-            peer_issues_sink: None,
-            catalogs_override: None,
-        }
-        .run::<Reporter>()
-        .await
-        .wrap_err("unlinking dependencies")
+        Ok(true)
     }
 }

--- a/pnpm/crates/cli/tests/unlink.rs
+++ b/pnpm/crates/cli/tests/unlink.rs
@@ -1,10 +1,55 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 fn write_manifest(workspace: &Path, manifest: &serde_json::Value) {
     fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+}
+
+/// Scaffold a `sharedWorkspaceLockfile: false` workspace with two projects
+/// (`packages/first`, `packages/second`) that both depend on `pkg`, plus a
+/// `link:` override redirecting `pkg` to a local directory. Returns the two
+/// project dirs. Callers run `unlink` *before* any install, so the link is
+/// stripped and never materialized — the reinstall re-resolves `pkg` from the
+/// registry.
+fn scaffold_dedicated_link_workspace(workspace: &Path, pkg: &str) -> (PathBuf, PathBuf) {
+    let local_target = workspace.join("local-dep");
+    fs::create_dir_all(&local_target).expect("create local target dir");
+    fs::write(
+        local_target.join("package.json"),
+        serde_json::json!({ "name": pkg, "version": "1.0.0" }).to_string(),
+    )
+    .expect("write local target package.json");
+
+    let mut project_dirs = Vec::new();
+    for name in ["first", "second"] {
+        let dir = workspace.join("packages").join(name);
+        fs::create_dir_all(&dir).expect("create project dir");
+        fs::write(
+            dir.join("package.json"),
+            serde_json::json!({
+                "name": name,
+                "version": "1.0.0",
+                "dependencies": { pkg: "100.0.0" },
+            })
+            .to_string(),
+        )
+        .expect("write project manifest");
+        project_dirs.push(dir);
+    }
+    add_overrides(
+        workspace,
+        &format!(
+            "packages:\n  - 'packages/*'\nsharedWorkspaceLockfile: false\noverrides:\n  '{pkg}': link:./local-dep\n",
+        ),
+    );
+    let second = project_dirs.pop().expect("second project dir");
+    let first = project_dirs.pop().expect("first project dir");
+    (first, second)
 }
 
 /// Append an `overrides` block to the `pnpm-workspace.yaml` the mocked
@@ -225,6 +270,84 @@ fn unlink_restores_registry_package_in_lockfile() {
     assert!(
         !lockfile.contains("link:"),
         "lockfile must not keep the link: resolution after unlink: {lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// `pnpm -r unlink` strips the workspace `link:` override once and reinstalls
+/// every selected project, so in a `sharedWorkspaceLockfile: false` workspace
+/// each project gets its own lockfile that re-resolves the dependency from the
+/// registry.
+#[test]
+fn recursive_unlink_with_dedicated_lockfiles_reinstalls_each_project() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    const PKG: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+    let (first, second) = scaffold_dedicated_link_workspace(&workspace, PKG);
+
+    let mut unlink = std::process::Command::cargo_bin("pnpm").expect("locate pacquet binary");
+    unlink.current_dir(&workspace);
+    unlink.with_args(["-r", "unlink", PKG]).assert().success();
+
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(
+        !workspace_yaml.contains("link:"),
+        "the link override must be removed once: {workspace_yaml}",
+    );
+    for project in [&first, &second] {
+        let lockfile = fs::read_to_string(project.join("pnpm-lock.yaml")).unwrap_or_else(|error| {
+            panic!("each selected project must get its own lockfile ({error}): {project:?}")
+        });
+        assert!(
+            lockfile.contains("dep-of-pkg-with-1-dep@100.0.0"),
+            "{project:?} must re-resolve the dependency from the registry: {lockfile}",
+        );
+        assert!(
+            !lockfile.contains("link:"),
+            "{project:?} must not keep a link: resolution: {lockfile}",
+        );
+    }
+    assert!(
+        !workspace.join("pnpm-lock.yaml").exists(),
+        "dedicated lockfiles must not write a shared workspace lockfile",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// `pnpm --filter <project> unlink` strips the override and reinstalls only the
+/// selected project — the unselected project's dedicated lockfile is never
+/// created.
+#[test]
+fn filtered_unlink_with_dedicated_lockfiles_reinstalls_only_selected_project() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    const PKG: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+    let (first, second) = scaffold_dedicated_link_workspace(&workspace, PKG);
+
+    let mut unlink = std::process::Command::cargo_bin("pnpm").expect("locate pacquet binary");
+    unlink.current_dir(&workspace);
+    unlink.with_args(["--filter", "first", "unlink", PKG]).assert().success();
+
+    let workspace_yaml = read_workspace_yaml(&workspace);
+    assert!(
+        !workspace_yaml.contains("link:"),
+        "the link override must be removed: {workspace_yaml}",
+    );
+    let first_lockfile =
+        fs::read_to_string(first.join("pnpm-lock.yaml")).expect("selected project lockfile");
+    assert!(
+        first_lockfile.contains("dep-of-pkg-with-1-dep@100.0.0"),
+        "the selected project must re-resolve from the registry: {first_lockfile}",
+    );
+    assert!(
+        !second.join("pnpm-lock.yaml").exists(),
+        "the unselected project must not be installed",
     );
 
     drop((root, mock_instance));


### PR DESCRIPTION
## Summary

Finishes the `unlink` row of the recursive-command-parity tracker (Related to pnpm/pnpm#13201).

pnpm's `unlink` handler strips the matching `link:` overrides from `pnpm-workspace.yaml` and then delegates to the **install handler** (`installing/commands/src/unlink.ts` → `install.handler`), which is recursive-by-default and supports shared and per-project lockfiles. pacquet's `unlink` instead reinstalled only the active project through a bespoke single-project `Install`, so `-r` / `--filter` selection, recursive-by-default-in-a-workspace, and per-project-lockfile recursion (`sharedWorkspaceLockfile: false`) were all ignored.

Now `unlink`:

1. Strips the matching `link:` overrides (unchanged behavior — extracted into `UnlinkArgs::strip_link_overrides`).
2. Reinstalls through the same `InstallPipeline` that `install` uses, so it goes through the three-way `InstallFamilyPlan` (single / shared / per-project) added in #13208.

The reinstall uses a re-resolving full install (`preferFrozenLockfile: false`) so the removed `link:` overrides re-resolve from the registry. The shared install-args constructor `for_patch_manifest_change` is renamed to `for_reresolving_install`, since `patch-commit` / `patch-remove` (manifest `patchedDependencies` changed) and `unlink` (overrides changed) all want the same re-resolving full reinstall.

Notes for reviewers:

- **This is a pacquet-only change** — it makes pacquet match behavior the TypeScript CLI already has (`unlink` → `install.handler`), so no TypeScript-side commit is needed.
- Previously `unlink` set `is_full_install: false` / `installs_only: false`; routing through the install pipeline makes both `true`, matching pnpm's `install.handler` (`mutation: 'install'`) — the project's own lifecycle scripts now run on the reinstall, as pnpm does.

## Squash Commit Body

```text
`pnpm unlink` reinstalled only the active project through a bespoke
single-project `Install`, so `-r` / `--filter` selection and per-project
lockfiles (`sharedWorkspaceLockfile: false`) were ignored — unlike pnpm,
whose `unlink` handler delegates to the install handler.

Strip the matching `link:` overrides (unchanged), then reinstall through
the same `InstallPipeline` that `install` uses (the three-way
`InstallFamilyPlan`: single / shared / per-project), forcing a fresh
resolution so the removed links re-resolve from the registry. Rename the
shared install-args constructor `for_patch_manifest_change` to
`for_reresolving_install`, since both patch and unlink want a re-resolving
full reinstall.

Related to pnpm/pnpm#13201.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. — pacquet-only;
  matches existing TypeScript CLI behavior (noted above).
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package.
- [x] Added or updated tests. — recursive and filtered dedicated-lockfile `unlink`
  cases in `crates/cli/tests/unlink.rs`.
- [ ] Updated the documentation if needed. — no doc change; matches documented pnpm behavior.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787291706&installation_model_id=426870&pr_number=13212&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13212&signature=4aeea26aed03f6f7a52bc904c099fac93c7e24e2cf8ba61697252a238c89e58b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `pnpm unlink` now reinstalls dependencies across a workspace by default.
  * Supports recursive (`-r`) and filtered (`--filter`) unlink operations.
  * Correctly handles workspaces using shared or project-specific lockfiles.
  * Removed links are re-resolved from the registry during reinstalls.
* **Bug Fixes**
  * Fixed unlink operations to update all applicable projects instead of only the active project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->