### PR TITLE
feat(cli): implement native ci/clean-install command in Rust

### DIFF
--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -9,6 +9,7 @@ pub mod cat_file;
 pub mod cat_index;
 pub mod change;
 pub mod changelog;
+pub mod ci;
 pub mod clean;
 pub mod completion;
 pub mod config;

--- a/pnpm/crates/cli/src/cli_args/ci.rs
+++ b/pnpm/crates/cli/src/cli_args/ci.rs
@@ -1,0 +1,11 @@
+use super::{clean::CleanArgs, install::InstallArgs};
+use clap::Args;
+
+#[derive(Debug, Args)]
+pub struct CiArgs {
+    #[clap(flatten)]
+    pub install_args: InstallArgs,
+
+    #[clap(flatten)]
+    pub clean_args: CleanArgs,
+}

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -9,6 +9,7 @@ use super::{
     cat_file::CatFileArgs,
     cat_index::CatIndexArgs,
     change::ChangeArgs,
+    ci::CiArgs,
     clean::CleanArgs,
     completion::{CompletionArgs, CompletionServerArgs},
     config::ConfigArgs,
@@ -441,6 +442,10 @@ pub enum CliCommand {
     /// (not a `clean` script) overrides it when present.
     #[clap(name = "purge")]
     Purge(CleanArgs),
+    /// Runs `pnpm clean` followed by `pnpm install --frozen-lockfile`.
+    /// Designed for CI/CD environments.
+    #[clap(visible_aliases = ["clean-install", "ic", "install-clean"])]
+    Ci(CiArgs),
     /// Print the effective `node_modules` directory.
     Root(RootArgs),
     /// Print the current package prefix.
@@ -514,7 +519,11 @@ impl CliCommand {
     fn recursive_by_default(&self) -> bool {
         matches!(
             self,
-            CliCommand::List(_) | CliCommand::Ll(_) | CliCommand::Why(_) | CliCommand::Peers(_),
+            CliCommand::List(_)
+                | CliCommand::Ll(_)
+                | CliCommand::Why(_)
+                | CliCommand::Peers(_)
+                | CliCommand::Ci(_),
         )
     }
 

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -442,8 +442,7 @@ pub enum CliCommand {
     /// (not a `clean` script) overrides it when present.
     #[clap(name = "purge")]
     Purge(CleanArgs),
-    /// Runs `pnpm clean` followed by `pnpm install --frozen-lockfile`.
-    /// Designed for CI/CD environments.
+    /// Runs clean then install with a frozen lockfile.
     #[clap(visible_aliases = ["clean-install", "ic", "install-clean"])]
     Ci(CiArgs),
     /// Print the effective `node_modules` directory.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -177,6 +177,7 @@ impl CliArgs {
                 | CliCommand::Remove(_)
                 | CliCommand::Install(_)
                 | CliCommand::InstallTest(_)
+                | CliCommand::Ci(_)
                 | CliCommand::Dlx(_)
                 | CliCommand::Link(_)
                 | CliCommand::Import(_)
@@ -333,6 +334,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Add(args) => dispatch_install::add(ctx, args),
         CliCommand::Install(args) => dispatch_install::install(ctx, args),
         CliCommand::InstallTest(args) => dispatch_install::install_test(ctx, args),
+        CliCommand::Ci(args) => dispatch_install::ci(ctx, args),
         CliCommand::Update(args) => dispatch_install::update(ctx, args),
         CliCommand::Outdated(args) => dispatch_query::outdated(ctx, args),
         CliCommand::Audit(args) => dispatch_query::audit(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -1,6 +1,7 @@
 use super::{
     add::AddArgs,
     approve_builds::ApproveBuildsArgs,
+    ci::CiArgs,
     create::CreateArgs,
     dedupe::DedupeArgs,
     deploy::DeployArgs,
@@ -263,6 +264,22 @@ pub(super) fn install_test<'a>(
 
         Ok(())
     }))
+}
+
+pub(super) fn ci<'a>(ctx: &RunCtx<'a>, args: CiArgs) -> miette::Result<CommandFuture<'a>> {
+    let clean_args = args.clean_args;
+    let mut install_args = args.install_args;
+    install_args.frozen_lockfile = true;
+
+    // `clean` is synchronous — run it eagerly before constructing the
+    // async future so errors surface immediately.  Pass "clean" as the
+    // command name so a `clean` script in package.json overrides the
+    // built-in, matching TypeScript's `clean.handler(opts)` call path.
+    clean_args.run(ctx, "clean")?;
+
+    let install_future = install(ctx, install_args)?;
+
+    Ok(Box::pin(async move { install_future.await }))
 }
 
 pub(super) fn deploy<'a>(ctx: &RunCtx<'a>, args: DeployArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -271,10 +271,7 @@ pub(super) fn ci<'a>(ctx: &RunCtx<'a>, args: CiArgs) -> miette::Result<CommandFu
     let mut install_args = args.install_args;
     install_args.frozen_lockfile = true;
 
-    // `clean` is synchronous — run it eagerly before constructing the
-    // async future so errors surface immediately.  Pass "clean" as the
-    // command name so a `clean` script in package.json overrides the
-    // built-in, matching TypeScript's `clean.handler(opts)` call path.
+    // Run clean eagerly before the async future so errors surface immediately. Pass the command name so a package.json script can override the built-in.
     clean_args.run(ctx, "clean")?;
 
     install(ctx, install_args)

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -277,9 +277,7 @@ pub(super) fn ci<'a>(ctx: &RunCtx<'a>, args: CiArgs) -> miette::Result<CommandFu
     // built-in, matching TypeScript's `clean.handler(opts)` call path.
     clean_args.run(ctx, "clean")?;
 
-    let install_future = install(ctx, install_args)?;
-
-    Ok(Box::pin(async move { install_future.await }))
+    install(ctx, install_args)
 }
 
 pub(super) fn deploy<'a>(ctx: &RunCtx<'a>, args: DeployArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -508,6 +508,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Bin(_) => "bin",
         CliCommand::Clean(_) => "clean",
         CliCommand::Purge(_) => "purge",
+        CliCommand::Ci(_) => "ci",
         CliCommand::Root(_) => "root",
         CliCommand::Prefix(_) => "prefix",
         CliCommand::Config(_) => "config",

--- a/pnpm/crates/cli/tests/completion.rs
+++ b/pnpm/crates/cli/tests/completion.rs
@@ -158,7 +158,7 @@ fn completion_server_lists_nested_subcommands() {
 #[test]
 fn completion_server_lists_ci_command() {
     let output = pacquet()
-        .args(["completion-server", "--", "pnpm", "ci", ""])
+        .args(["completion-server", "--", "pnpm", "ci", "--"])
         .output()
         .expect("run pnpm completion-server");
     let reply = stdout(output);
@@ -209,10 +209,7 @@ fn completion_server_filters_command_prefixes() {
         .expect("run pnpm completion-server");
     let reply = stdout(output);
 
-    assert_eq!(
-        reply.lines().collect::<Vec<_>>(),
-        ["install", "install-clean", "install-test"]
-    );
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install", "install-test"]);
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/completion.rs
+++ b/pnpm/crates/cli/tests/completion.rs
@@ -209,7 +209,7 @@ fn completion_server_filters_command_prefixes() {
         .expect("run pnpm completion-server");
     let reply = stdout(output);
 
-    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install", "install-test"]);
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install", "install-clean", "install-test"]);
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/completion.rs
+++ b/pnpm/crates/cli/tests/completion.rs
@@ -209,7 +209,7 @@ fn completion_server_filters_command_prefixes() {
         .expect("run pnpm completion-server");
     let reply = stdout(output);
 
-    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install", "install-clean", "install-test"]);
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install", "install-test", "install-clean"]);
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/completion.rs
+++ b/pnpm/crates/cli/tests/completion.rs
@@ -202,6 +202,17 @@ fn completion_server_completes_ic_alias() {
 }
 
 #[test]
+fn completion_server_completes_install_clean_alias() {
+    let output = pacquet()
+        .args(["completion-server", "--", "pnpm", "install-clean"])
+        .output()
+        .expect("run pnpm completion-server");
+    let reply = stdout(output);
+
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install-clean"]);
+}
+
+#[test]
 fn completion_server_filters_command_prefixes() {
     let output = pacquet()
         .args(["completion-server", "--", "pnpm", "inst"])

--- a/pnpm/crates/cli/tests/completion.rs
+++ b/pnpm/crates/cli/tests/completion.rs
@@ -156,6 +156,52 @@ fn completion_server_lists_nested_subcommands() {
 }
 
 #[test]
+fn completion_server_lists_ci_command() {
+    let output = pacquet()
+        .args(["completion-server", "--", "pnpm", "ci", ""])
+        .output()
+        .expect("run pnpm completion-server");
+    let reply = stdout(output);
+
+    assert!(reply.lines().any(|line| line == "--frozen-lockfile"), "{reply}");
+    assert!(reply.lines().any(|line| line == "--dry-run"), "{reply}");
+    assert!(reply.lines().any(|line| line == "--lockfile"), "{reply}");
+}
+
+#[test]
+fn completion_server_completes_ci_aliases() {
+    let output = pacquet()
+        .args(["completion-server", "--", "pnpm", "ci"])
+        .output()
+        .expect("run pnpm completion-server");
+    let reply = stdout(output);
+
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["ci"]);
+}
+
+#[test]
+fn completion_server_completes_clean_install_alias() {
+    let output = pacquet()
+        .args(["completion-server", "--", "pnpm", "clean-install"])
+        .output()
+        .expect("run pnpm completion-server");
+    let reply = stdout(output);
+
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["clean-install"]);
+}
+
+#[test]
+fn completion_server_completes_ic_alias() {
+    let output = pacquet()
+        .args(["completion-server", "--", "pnpm", "ic"])
+        .output()
+        .expect("run pnpm completion-server");
+    let reply = stdout(output);
+
+    assert_eq!(reply.lines().collect::<Vec<_>>(), ["ic"]);
+}
+
+#[test]
 fn completion_server_filters_command_prefixes() {
     let output = pacquet()
         .args(["completion-server", "--", "pnpm", "inst"])
@@ -163,7 +209,10 @@ fn completion_server_filters_command_prefixes() {
         .expect("run pnpm completion-server");
     let reply = stdout(output);
 
-    assert_eq!(reply.lines().collect::<Vec<_>>(), ["install", "install-test"]);
+    assert_eq!(
+        reply.lines().collect::<Vec<_>>(),
+        ["install", "install-clean", "install-test"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Related to #11633. Implements the `ci` command (and its aliases `clean-install`, `ic`, `install-clean`) natively in Rust, matching the TypeScript behavior: runs `pnpm clean` followed by `pnpm install --frozen-lockfile`. Also fixes a missing match arm in the `command_name` exhaustive match in `switch_cli_version.rs` that caused compilation failure across all Rust CI jobs.

## Squash Commit Body

```text
Implement the `ci` (clean-install) command in Rust, matching the TypeScript
behavior from pnpm11/pnpm/src/cmd/cleanInstall.ts. The command runs a
synchronous `pnpm clean` step first, then delegates to the frozen-lockfile
install path.

The implementation adds a `CiArgs` struct that wraps existing `InstallArgs`
and `CleanArgs`, a `Ci` variant in `CliCommand` with visible aliases
matching TypeScript (`clean-install`, `ic`, `install-clean`), and dispatches
to a `ci()` function that runs clean eagerly before constructing the async
install future. The command is recursive by default in workspaces, forced
into the install-family for the "Done in ..." footer timing, and forces
`--frozen-lockfile` to `true` regardless of user flags.

All install flags are available (`--prod`, `--dev`, `--no-optional`, etc.).
A `clean` script in `package.json` overrides the built-in clean step, and
workspace root `clean` script override detection from subdirectories is
preserved, matching TypeScript's `clean.handler(opts)` call path.

A compilation fix is included: the `command_name()` function in
`switch_cli_version.rs` had an exhaustive match on `CliCommand` that was
missing the new `Ci` variant, causing `error[E0004]: non-exhaustive
patterns` which cascaded into all 9 failing Rust CI jobs (Clippy, Doc,
Dylint, Test on all platforms, Code Coverage, Integrated Benchmark, and
the Success gate).

The redundant `Box::pin(async move { install_future.await })` wrapper in
the ci dispatch is also removed, since `install()` already returns a
`CommandFuture`.

Behavioral parity with TypeScript:
- `pnpm clean` script in `package.json` overrides the built-in clean step
- Workspace root `clean` script override detection from subdirectories
- All install flags available (`--prod`, `--dev`, `--no-optional`, etc.)
- `--frozen-lockfile` forced to `true` regardless of user flags
- Recursive by default in workspaces
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `pnpm ci` command to perform a clean, reproducible install using a frozen lockfile.
  - Included `ci` alongside other “recursive-by-default” commands and enabled CI-related command aliases.

- **Bug Fixes**
  - Improved `completion-server` behavior and completion output for `pnpm ci`, adding CI-specific flags (including `--frozen-lockfile`, `--dry-run`, and `--lockfile`) and resolving CI/related aliases to canonical command names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->