### PR TITLE
fix(install-summary): suppress '(X is available)' when latest is held back by minimumReleaseAge

### DIFF
--- a/.changeset/policy-aware-install-summary-latest.md
+++ b/.changeset/policy-aware-install-summary-latest.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+The install summary no longer prints `(X is available)` when the registry's `dist-tags.latest` is still held back by the active `minimumReleaseAge` policy. The hint only ever names the actual latest tag, so an immature latest suppresses the hint instead of advertising the version pnpm just refused to install [#11698](https://github.com/pnpm/pnpm/issues/11698).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4180,6 +4180,7 @@ dependencies = [
  "chrono",
  "insta",
  "libc",
+ "node-semver",
  "owo-colors",
  "pacquet-reporter",
  "pretty_assertions",

--- a/pnpm/crates/default-reporter/Cargo.toml
+++ b/pnpm/crates/default-reporter/Cargo.toml
@@ -13,10 +13,11 @@ repository.workspace  = true
 [dependencies]
 pacquet-reporter = { workspace = true }
 
-chrono     = { workspace = true }
-libc       = { workspace = true }
-owo-colors = { workspace = true }
-serde_json = { workspace = true }
+chrono      = { workspace = true }
+libc        = { workspace = true }
+node-semver = { workspace = true }
+owo-colors  = { workspace = true }
+serde_json  = { workspace = true }
 
 [dev-dependencies]
 insta             = { workspace = true }

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -855,8 +855,13 @@ impl ReporterState {
         if let Some(version) = &pkg.version {
             result.push(' ');
             result.push_str(&self.colors.grey(version));
+            // Only advertise an upgrade when latest is strictly newer than
+            // the installed version. A bare `!=` would also fire when the
+            // user has pinned a newer version than the registry's latest
+            // tag (e.g. a beta), wrongly suggesting a downgrade.
             if let Some(latest) = &pkg.latest
                 && latest != version
+                && is_strictly_newer(latest, version)
             {
                 result.push(' ');
                 result.push_str(&self.colors.grey(&format!("({latest} is available)")));
@@ -1386,6 +1391,13 @@ fn cached_verdict(verified_at: Option<&str>, now: DateTime<Utc>) -> String {
             format!("verified {} ago", pretty_ms_compact(elapsed_ms.unsigned_abs().into()))
         }
         None => "previously verified".to_string(),
+    }
+}
+
+fn is_strictly_newer(latest: &str, version: &str) -> bool {
+    match (node_semver::Version::parse(latest), node_semver::Version::parse(version)) {
+        (Ok(l), Ok(v)) => l > v,
+        _ => false,
     }
 }
 

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -115,6 +115,16 @@ fn added_root(name: &str, version: &str, dt: DependencyType) -> LogEvent {
 }
 
 fn added_root_at(prefix: &str, name: &str, version: &str, dt: DependencyType) -> LogEvent {
+    added_root_with_latest_at(prefix, name, version, None, dt)
+}
+
+fn added_root_with_latest_at(
+    prefix: &str,
+    name: &str,
+    version: &str,
+    latest: Option<&str>,
+    dt: DependencyType,
+) -> LogEvent {
     LogEvent::Root(RootLog {
         level: LogLevel::Debug,
         message: RootMessage::Added {
@@ -125,7 +135,7 @@ fn added_root_at(prefix: &str, name: &str, version: &str, dt: DependencyType) ->
                 version: Some(version.to_string()),
                 dependency_type: Some(dt),
                 id: None,
-                latest: None,
+                latest: latest.map(str::to_string),
                 linked_from: None,
             },
         },
@@ -463,6 +473,64 @@ fn summary_groups_by_dependency_type_in_order() {
         ],
     );
     assert_eq!(frame, "\ndependencies:\n+ foo 1.0.0\n\ndevDependencies:\n+ bar 2.0.0\n");
+}
+
+#[test]
+fn summary_prints_is_available_when_latest_is_newer_than_version() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            added_root_with_latest_at(CWD, "foo", "1.0.0", Some("2.0.0"), DependencyType::Prod),
+            summary(),
+        ],
+    );
+    assert_eq!(frame, "\ndependencies:\n+ foo 1.0.0 (2.0.0 is available)\n");
+}
+
+#[test]
+fn summary_omits_is_available_when_latest_equals_version() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            added_root_with_latest_at(CWD, "foo", "3.9.5", Some("3.9.5"), DependencyType::Prod),
+            summary(),
+        ],
+    );
+    assert_eq!(frame, "\ndependencies:\n+ foo 3.9.5\n");
+}
+
+#[test]
+fn summary_omits_is_available_when_latest_is_older_than_version() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            added_root_with_latest_at(CWD, "foo", "2.0.0", Some("1.0.0"), DependencyType::Prod),
+            summary(),
+        ],
+    );
+    assert_eq!(frame, "\ndependencies:\n+ foo 2.0.0\n");
+}
+
+#[test]
+fn summary_omits_is_available_when_latest_is_not_semver() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            added_root_with_latest_at(
+                CWD,
+                "foo",
+                "1.0.0",
+                Some("not-a-version"),
+                DependencyType::Prod,
+            ),
+            summary(),
+        ],
+    );
+    assert_eq!(frame, "\ndependencies:\n+ foo 1.0.0\n");
 }
 
 #[test]

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver/tests.rs
@@ -3,6 +3,7 @@ use std::{
     sync::Arc,
 };
 
+use chrono::TimeZone;
 use pacquet_lockfile::LockfileResolution;
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
@@ -442,4 +443,36 @@ async fn calculates_prefixed_specifier_for_aliased_named_registry() {
 
     let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
     assert_eq!(result.normalized_bare_specifier.as_deref(), Some("gh:@acme/private@^1.0.0"));
+}
+
+#[tokio::test]
+async fn latest_is_suppressed_when_published_by_holds_back_raw_latest() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/@acme%2Fprivate")
+        .with_status(200)
+        .with_body(ACME_PRIVATE_BODY)
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+
+    let mut user = HashMap::new();
+    user.insert("gh".to_string(), registry);
+    let (resolver, _tempdir) = build_resolver(user);
+
+    // ACME_PRIVATE_BODY has 1.0.0 (2024-01-10), 2.0.0 (2024-06-01), 2.1.0
+    // (2024-12-10); dist-tags.latest = 2.1.0. Cutoff 2024-07-01 leaves 2.1.0
+    // immature, so the named-registry path must suppress the hint.
+    let wanted = WantedDependency {
+        alias: Some("@acme/private".to_string()),
+        bare_specifier: Some("gh:^2.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let opts = ResolveOptions {
+        published_by: Some(chrono::Utc.with_ymd_and_hms(2024, 7, 1, 0, 0, 0).unwrap()),
+        ..ResolveOptions::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.id.as_str(), "@acme/private@2.0.0");
+    assert!(result.latest.is_none(), "immature dist-tags.latest suppresses the hint");
 }

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -901,9 +901,6 @@ fn fail_if_trust_downgraded_for_pick(
         .map_err(|err| Box::new(err) as ResolveError)
 }
 
-/// Resolver-time `minimumReleaseAge` check. Returns a violation entry
-/// when the picked version's publish timestamp falls past the policy
-/// cutoff and isn't excluded by name/version.
 /// The raw `dist-tags.latest` when the active `minimumReleaseAge`
 /// policy would allow installing it, `None` otherwise. The install
 /// summary's `(X is available)` hint must only ever name the actual
@@ -938,6 +935,9 @@ fn latest_allowed_by_policy<'a>(
     }
 }
 
+/// Resolver-time `minimumReleaseAge` check. Returns a violation entry
+/// when the picked version's publish timestamp falls past the policy
+/// cutoff and isn't excluded by name/version.
 fn detect_min_release_age_violation(
     name: &PkgName,
     version: &str,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -266,7 +266,12 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
                 opts,
             )
         {
-            result.latest = picked.meta.dist_tag("latest").map(str::to_string);
+            result.latest = latest_allowed_by_policy(
+                &picked.meta,
+                opts.published_by,
+                opts.published_by_exclude.as_ref(),
+            )
+            .map(str::to_string);
             return Ok(Some(result));
         }
 
@@ -844,7 +849,8 @@ pub(crate) fn build_resolve_result(
     Ok(ResolveResult {
         id,
         name_ver: Some(name_ver),
-        latest: meta.dist_tag("latest").map(str::to_string),
+        latest: latest_allowed_by_policy(meta, published_by, published_by_exclude)
+            .map(str::to_string),
         published_at,
         manifest,
         resolution,
@@ -898,6 +904,40 @@ fn fail_if_trust_downgraded_for_pick(
 /// Resolver-time `minimumReleaseAge` check. Returns a violation entry
 /// when the picked version's publish timestamp falls past the policy
 /// cutoff and isn't excluded by name/version.
+/// The raw `dist-tags.latest` when the active `minimumReleaseAge`
+/// policy would allow installing it, `None` otherwise. The install
+/// summary's `(X is available)` hint must only ever name the actual
+/// latest tag, so an immature latest suppresses the hint instead of
+/// being rewritten to an older mature version. Suppression requires
+/// positive evidence of immaturity: a missing or unparsable
+/// timestamp keeps the raw tag, matching
+/// [`detect_min_release_age_violation`], which likewise only flags a
+/// version it can date.
+fn latest_allowed_by_policy<'a>(
+    meta: &'a Package,
+    published_by: Option<DateTime<Utc>>,
+    published_by_exclude: Option<&PackageVersionPolicy>,
+) -> Option<&'a str> {
+    let latest = meta.dist_tag("latest")?;
+    let Some(cutoff) = published_by else { return Some(latest) };
+    if let Some(policy) = published_by_exclude {
+        use pacquet_config::version_policy::PolicyMatch;
+        match policy.matches(&meta.name) {
+            PolicyMatch::AnyVersion => return Some(latest),
+            PolicyMatch::ExactVersions(versions)
+                if versions.iter().any(|exact| exact == latest) =>
+            {
+                return Some(latest);
+            }
+            _ => {}
+        }
+    }
+    match meta.published_at(latest).and_then(parse_packument_timestamp) {
+        Some(published_at) if published_at > cutoff => None,
+        _ => Some(latest),
+    }
+}
+
 fn detect_min_release_age_violation(
     name: &PkgName,
     version: &str,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use chrono::TimeZone;
-use pacquet_config::TrustPolicy;
+use pacquet_config::{TrustPolicy, version_policy::create_package_version_policy};
 use pacquet_lockfile::LockfileResolution;
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pacquet_resolving_resolver_base::{
@@ -1370,4 +1370,172 @@ async fn non_404_registry_error_not_masked_by_workspace_version_mismatch() {
         !err_msg.contains("inside the workspace"),
         "workspace mismatch must not mask a non-404 registry error, got: {err_msg}",
     );
+}
+
+#[tokio::test]
+async fn latest_is_suppressed_when_published_by_holds_back_raw_latest() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // PACKAGE_BODY has 1.0.0 (2024-01-10) and 1.1.0 (2024-12-10),
+    // dist-tags.latest = 1.1.0. Cutoff 2024-06-01 leaves 1.1.0 immature:
+    // the hint must not fire rather than name a non-latest version.
+    let published_by = Some(chrono::Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap());
+    let opts = ResolveOptions { published_by, ..ResolveOptions::default() };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.0.0");
+    assert!(result.latest.is_none(), "immature dist-tags.latest suppresses the hint");
+    assert!(result.policy_violation.is_none(), "1.0.0 is mature, no violation");
+}
+
+#[tokio::test]
+async fn latest_is_raw_registry_tag_when_it_satisfies_published_by() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // Cutoff 2025-01-01 is after both versions, so the pinned 1.0.0 install
+    // still advertises the mature 1.1.0.
+    let published_by = Some(chrono::Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap());
+    let opts = ResolveOptions { published_by, ..ResolveOptions::default() };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.0.0");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+}
+
+#[tokio::test]
+async fn latest_is_raw_registry_tag_when_published_by_is_none() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.1.0");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+}
+
+#[tokio::test]
+async fn latest_is_raw_registry_tag_when_published_by_exclude_matches_package() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // The exclude policy disables the maturity policy for `acme` entirely, so
+    // neither the pick nor the latest hint may be affected by the cutoff.
+    let published_by = Some(chrono::Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap());
+    let exclude = create_package_version_policy(["acme"]).expect("policy");
+    let opts = ResolveOptions {
+        published_by,
+        published_by_exclude: Some(exclude),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.1.0");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+    assert!(result.policy_violation.is_none(), "excluded package has no violation");
+}
+
+#[tokio::test]
+async fn latest_is_raw_registry_tag_when_published_by_exclude_trusts_that_version() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let published_by = Some(chrono::Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap());
+    let exclude = create_package_version_policy(["acme@1.1.0"]).expect("policy");
+    let opts = ResolveOptions {
+        published_by,
+        published_by_exclude: Some(exclude),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.1.0");
+    assert_eq!(result.latest.as_deref(), Some("1.1.0"));
+}
+
+#[tokio::test]
+async fn latest_is_suppressed_when_all_versions_are_immature_fallback_case() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    // Cutoff 2023-12-01 is before both versions → the pick falls back to the
+    // lowest version; latest stays suppressed because the raw tag is immature.
+    let published_by = Some(chrono::Utc.with_ymd_and_hms(2023, 12, 1, 0, 0, 0).unwrap());
+    let opts = ResolveOptions { published_by, ..ResolveOptions::default() };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.0.0");
+    assert!(result.latest.is_none(), "immature dist-tags.latest suppresses the hint");
+}
+
+#[tokio::test]
+async fn jsr_specifier_suppresses_latest_when_published_by_holds_back_raw_latest() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/@jsr%2Ffoo__bar")
+        .with_status(200)
+        .with_body(JSR_PACKAGE_BODY)
+        .create_async()
+        .await;
+    let jsr_registry = format!("{}/", server.url());
+    let mut registries = HashMap::new();
+    registries.insert("default".to_string(), "https://registry.npmjs.org/".to_string());
+    registries.insert("@jsr".to_string(), jsr_registry);
+    let (resolver, _tempdir) = build_resolver_with_registries(registries);
+
+    let wanted = WantedDependency {
+        alias: Some("@foo/bar".to_string()),
+        bare_specifier: Some("jsr:@foo/bar@^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let opts = ResolveOptions {
+        published_by: Some(chrono::Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap()),
+        ..ResolveOptions::default()
+    };
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.0.0");
+    assert!(result.latest.is_none(), "immature dist-tags.latest suppresses the hint");
 }

--- a/pnpm11/cli/default-reporter/test/index.ts
+++ b/pnpm11/cli/default-reporter/test/index.ts
@@ -300,6 +300,49 @@ ${ADD} qar ${versionColor('2.0.0')}
 `)
 })
 
+test('does not print "(X is available)" when latest equals the installed version (policy-aware latest)', async () => {
+  // When minimumReleaseAge holds back the registry's raw latest, the resolver
+  // returns the policy-aware latest as `latest`. If that equals the picked
+  // version, the install summary must not advertise an upgrade.
+  const prefix = '/home/jane/project'
+  const output$ = toOutput$({
+    context: {
+      argv: ['install'],
+      config: { dir: prefix } as Config & ConfigContext,
+    },
+    streamParser: createStreamParser(),
+  })
+
+  rootLogger.debug({
+    added: {
+      dependencyType: 'prod',
+      id: 'registry.npmjs.org/foo/3.9.5',
+      latest: '3.9.5',
+      name: 'foo',
+      realName: 'foo',
+      version: '3.9.5',
+    },
+    prefix,
+  })
+  packageManifestLogger.debug({
+    prefix,
+    updated: {
+      dependencies: {
+        foo: '^3.0.0',
+      },
+    },
+  })
+  summaryLogger.debug({ prefix })
+
+  expect.assertions(1)
+
+  const output = await firstValueFrom(output$.pipe(take(1), map(normalizeNewline)))
+  expect(output).toBe(EOL + `\
+${h1('dependencies:')}
+${ADD} foo ${versionColor('3.9.5')}
+`)
+})
+
 test('does not print deprecation message when log level is set to error', async () => {
   const prefix = '/home/jane/project'
   const output$ = toOutput$({

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -680,7 +680,7 @@ async function resolveNpm (
           calcSpecifier: opts.calcSpecifier,
           rangeSpecStyle: opts.rangeSpecStyle,
         }),
-        latest: meta['dist-tags'].latest,
+        latest: latestAllowedByPolicy(meta, opts),
       }
     }
     const localVersion = pickMatchingLocalVersionOrNull(workspacePkgsMatchingName, spec)
@@ -695,7 +695,7 @@ async function resolveNpm (
           calcSpecifier: opts.calcSpecifier,
           rangeSpecStyle: opts.rangeSpecStyle,
         }),
-        latest: meta['dist-tags'].latest,
+        latest: latestAllowedByPolicy(meta, opts),
       }
     }
   }
@@ -718,7 +718,7 @@ async function resolveNpm (
   const publishedAt = meta.time?.[pickedPackage.version]
   return {
     id,
-    latest: meta['dist-tags'].latest,
+    latest: latestAllowedByPolicy(meta, opts),
     manifest: pickedPackage,
     resolution,
     resolvedVia: 'npm-registry',
@@ -870,7 +870,7 @@ async function pickFromSimpleRegistry (
   const publishedAt = meta.time?.[pickedPackage.version]
   return {
     id: `${pickedPackage.name}@${pickedPackage.version}` as PkgResolutionId,
-    latest: meta['dist-tags'].latest,
+    latest: latestAllowedByPolicy(meta, opts),
     manifest: pickedPackage,
     resolution,
     publishedAt,
@@ -1147,6 +1147,34 @@ function defaultTagForAlias (alias: string, defaultTag: string): RegistryPackage
  * full-name exclusions (`pkg`) are both honored so an entry already on
  * the user's exclude list isn't re-announced every install.
  */
+/**
+ * The raw `dist-tags.latest` when the active `minimumReleaseAge` policy would
+ * allow installing it, `undefined` otherwise. The install summary's
+ * "(X is available)" hint must only ever name the actual latest tag, so an
+ * immature latest suppresses the hint instead of being rewritten to an older
+ * mature version. Suppression requires positive evidence of immaturity: a
+ * missing or unparsable timestamp keeps the raw tag, matching
+ * `detectMinReleaseAgeViolation`, which likewise only flags a version it can
+ * date.
+ */
+function latestAllowedByPolicy (
+  meta: PackageMeta,
+  opts: {
+    publishedBy?: Date
+    publishedByExclude?: PackageVersionPolicy
+  }
+): string | undefined {
+  const latest = meta['dist-tags'].latest
+  if (!latest || !opts.publishedBy) return latest
+  const excludeResult = opts.publishedByExclude?.(meta.name)
+  if (excludeResult === true) return latest
+  if (Array.isArray(excludeResult) && excludeResult.includes(latest)) return latest
+  const publishedAt = meta.time?.[latest]
+  if (publishedAt == null) return latest
+  const ts = new Date(publishedAt).getTime()
+  return (Number.isNaN(ts) || ts <= opts.publishedBy.getTime()) ? latest : undefined
+}
+
 function detectMinReleaseAgeViolation (args: {
   name: string
   version: string

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -666,6 +666,7 @@ async function resolveNpm (
     failIfTrustDowngraded(meta, pickedPackage.version, opts)
   }
 
+  const latest = latestAllowedByPolicy(meta, opts)
   const workspacePkgsMatchingName = workspacePackages?.get(pickedPackage.name)
   if (workspacePkgsMatchingName && opts.projectDir) {
     const matchedPkg = workspacePkgsMatchingName.get(pickedPackage.version)
@@ -680,7 +681,7 @@ async function resolveNpm (
           calcSpecifier: opts.calcSpecifier,
           rangeSpecStyle: opts.rangeSpecStyle,
         }),
-        latest: latestAllowedByPolicy(meta, opts),
+        latest,
       }
     }
     const localVersion = pickMatchingLocalVersionOrNull(workspacePkgsMatchingName, spec)
@@ -695,7 +696,7 @@ async function resolveNpm (
           calcSpecifier: opts.calcSpecifier,
           rangeSpecStyle: opts.rangeSpecStyle,
         }),
-        latest: latestAllowedByPolicy(meta, opts),
+        latest,
       }
     }
   }
@@ -718,7 +719,7 @@ async function resolveNpm (
   const publishedAt = meta.time?.[pickedPackage.version]
   return {
     id,
-    latest: latestAllowedByPolicy(meta, opts),
+    latest,
     manifest: pickedPackage,
     resolution,
     resolvedVia: 'npm-registry',

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -1133,21 +1133,6 @@ function defaultTagForAlias (alias: string, defaultTag: string): RegistryPackage
 }
 
 /**
- * Inline minimumReleaseAge detection: returns a violation entry when the
- * picked version's publish timestamp is past the policy cutoff (and
- * isn't covered by `publishedByExclude`). The resolver already has the
- * timestamp in hand, so reporting inline saves the install layer from
- * re-walking the resolved tree and re-fetching the same metadata. The
- * deps-resolver aggregates the per-resolve `policyViolation` fields into
- * a single set the install command reacts to.
- *
- * Returns `undefined` for resolutions outside the policy — no policy
- * active, version excluded by pattern, timestamp missing or malformed,
- * or version mature. Specific-version exclusions (`pkg@1.0.0`) and
- * full-name exclusions (`pkg`) are both honored so an entry already on
- * the user's exclude list isn't re-announced every install.
- */
-/**
  * The raw `dist-tags.latest` when the active `minimumReleaseAge` policy would
  * allow installing it, `undefined` otherwise. The install summary's
  * "(X is available)" hint must only ever name the actual latest tag, so an
@@ -1175,6 +1160,21 @@ function latestAllowedByPolicy (
   return (Number.isNaN(ts) || ts <= opts.publishedBy.getTime()) ? latest : undefined
 }
 
+/**
+ * Inline minimumReleaseAge detection: returns a violation entry when the
+ * picked version's publish timestamp is past the policy cutoff (and
+ * isn't covered by `publishedByExclude`). The resolver already has the
+ * timestamp in hand, so reporting inline saves the install layer from
+ * re-walking the resolved tree and re-fetching the same metadata. The
+ * deps-resolver aggregates the per-resolve `policyViolation` fields into
+ * a single set the install command reacts to.
+ *
+ * Returns `undefined` for resolutions outside the policy — no policy
+ * active, version excluded by pattern, timestamp missing or malformed,
+ * or version mature. Specific-version exclusions (`pkg@1.0.0`) and
+ * full-name exclusions (`pkg`) are both honored so an entry already on
+ * the user's exclude list isn't re-announced every install.
+ */
 function detectMinReleaseAgeViolation (args: {
   name: string
   version: string

--- a/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/publishedBy.test.ts
@@ -270,6 +270,9 @@ test('ignoreMissingTimeField=true skips maturity check when full metadata has no
 
   expect(resolveResult!.resolvedVia).toBe('npm-registry')
   expect(resolveResult!.id).toBe('is-positive@3.1.0')
+  // No `time` field means no positive evidence latest is immature, so the raw
+  // tag survives — matching the pick, which skipped the maturity check too.
+  expect(resolveResult!.latest).toBe('3.1.0')
 })
 
 test('ignoreMissingTimeField=true still upgrades abbreviated→full when time is missing', async () => {
@@ -584,4 +587,141 @@ test('excluded packages bypass the mtime cache shortcut and refresh stale metada
 
   expect(resolveResult!.resolvedVia).toBe('npm-registry')
   expect(resolveResult!.id).toBe('is-positive@3.1.0')
+})
+
+test('latest is suppressed when publishedBy holds back the registry latest', async () => {
+  // is-positive-full has 1.0.0 (2015-06-02), 2.0.0 (2015-06-17), 3.0.0
+  // (2015-07-10), 3.1.0 (2016-01-11); dist-tags.latest = 3.1.0. publishedBy
+  // 2015-10-01 leaves 3.1.0 immature, so the '(X is available)' hint must not
+  // fire: latest only ever names the actual latest tag, and here the policy
+  // itself would refuse to install it.
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^3.0.0' }, {
+    publishedBy: new Date('2015-10-01T00:00:00.000Z'),
+  })
+
+  expect(resolveResult!.id).toBe('is-positive@3.0.0')
+  expect(resolveResult!.latest).toBeUndefined()
+})
+
+test('latest is the raw registry tag when it satisfies publishedBy', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '3.0.0' }, {
+    publishedBy: new Date('2016-02-01T00:00:00.000Z'),
+  })
+
+  expect(resolveResult!.id).toBe('is-positive@3.0.0')
+  expect(resolveResult!.latest).toBe('3.1.0')
+})
+
+test('latest is the raw registry tag when publishedBy is not set', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^3.0.0' }, {})
+
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
+  expect(resolveResult!.latest).toBe('3.1.0')
+})
+
+test('latest is the raw registry tag when publishedByExclude fully excludes the package', async () => {
+  // The exclude policy returns true for is-positive, so the maturity policy
+  // does not apply to it at all: neither the pick nor the latest hint may be
+  // affected by the cutoff.
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^3.0.0' }, {
+    publishedBy: new Date('2015-10-01T00:00:00.000Z'),
+    publishedByExclude: (pkgName) => pkgName === 'is-positive',
+  })
+
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
+  expect(resolveResult!.latest).toBe('3.1.0')
+})
+
+test('latest is the raw registry tag when publishedByExclude trusts that exact version', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^3.0.0' }, {
+    publishedBy: new Date('2015-10-01T00:00:00.000Z'),
+    publishedByExclude: (pkgName) => pkgName === 'is-positive' ? ['3.1.0'] : false,
+  })
+
+  expect(resolveResult!.id).toBe('is-positive@3.1.0')
+  expect(resolveResult!.latest).toBe('3.1.0')
+})
+
+test('latest is suppressed when all versions are immature (fallback case)', async () => {
+  // publishedBy 2015-06-01 is before every is-positive version → the pick
+  // falls back to the lowest version; latest stays undefined because the raw
+  // tag (3.1.0) is immature too.
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, isPositiveMeta)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+  })
+  const resolveResult = await resolveFromNpm({ alias: 'is-positive', bareSpecifier: '^1.0.0' }, {
+    publishedBy: new Date('2015-06-01T00:00:00.000Z'),
+  })
+
+  expect(resolveResult!.id).toBe('is-positive@1.0.0')
+  expect(resolveResult!.latest).toBeUndefined()
 })

--- a/pnpm11/resolving/npm-resolver/test/resolveJsr.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/resolveJsr.test.ts
@@ -164,3 +164,34 @@ test('resolveFromJsr() returns the immature pick with policyViolation when publi
     },
   })
 })
+
+test('resolveFromJsr() suppresses latest when publishedBy holds back the raw tag', async () => {
+  // jsr-rus-greet has 0.0.1 (16:08), 0.0.2 (16:13), 0.0.3 (16:31); dist-tags.latest = 0.0.3.
+  // publishedBy between 0.0.2 and 0.0.3 leaves 0.0.3 immature, so the JSR path
+  // (pickFromSimpleRegistry) must suppress latest rather than surface a tag the
+  // policy would refuse to install.
+  const slash = '%2F'
+  const defaultPool = getMockAgent().get(registries.default.replace(/\/$/, ''))
+  defaultPool.intercept({ path: `/@jsr${slash}rus__greet`, method: 'GET' }).reply(404, {})
+  const jsrPool = getMockAgent().get(registries['@jsr'].replace(/\/$/, ''))
+  jsrPool.intercept({ path: `/@jsr${slash}rus__greet`, method: 'GET' }).reply(200, jsrRusGreetMeta)
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromJsr } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+  })
+  const result = await resolveFromJsr(
+    { alias: '@rus/greet', bareSpecifier: 'jsr:0.0.2' },
+    { publishedBy: new Date('2024-11-16T16:20:00.000Z') }
+  )
+
+  expect(result).toMatchObject({
+    resolvedVia: 'jsr-registry',
+    id: '@jsr/rus__greet@0.0.2',
+  })
+  expect(result!.latest).toBeUndefined()
+})

--- a/pnpm11/resolving/npm-resolver/test/resolveNamedRegistry.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/resolveNamedRegistry.test.ts
@@ -348,3 +348,31 @@ test('resolveFromNamedRegistry() preserves vulnerability-avoidance range selecto
 
   expect(resolveResult).toMatchObject({ id: '@acme/private@2.0.0' })
 })
+
+test('resolveFromNamedRegistry() suppresses latest when publishedBy holds back the raw tag', async () => {
+  // gh-acme-private has 1.0.0 (2024-01-15), 2.0.0 (2024-06-01), 2.1.0 (2024-08-01);
+  // dist-tags.latest = 2.1.0. publishedBy 2024-07-01 leaves 2.1.0 immature, so the
+  // named-registry path (which shares pickFromSimpleRegistry with JSR) must
+  // suppress latest rather than surface a tag the policy would refuse to install.
+  interceptGhAcmePrivate()
+
+  const cacheDir = temporaryDirectory()
+  const { resolveFromNamedRegistry } = createNpmResolver(fetch, () => undefined, {
+    storeDir: temporaryDirectory(),
+    cacheDir,
+    filterMetadata: true,
+    fullMetadata: true,
+    registries,
+  })
+
+  const resolveResult = await resolveFromNamedRegistry(
+    { alias: '@acme/private', bareSpecifier: 'gh:^2.0.0' },
+    { publishedBy: new Date('2024-07-01T00:00:00.000Z') }
+  )
+
+  expect(resolveResult).toMatchObject({
+    resolvedVia: 'named-registry',
+    id: '@acme/private@2.0.0',
+  })
+  expect(resolveResult!.latest).toBeUndefined()
+})


### PR DESCRIPTION
## Summary

When `minimumReleaseAge` (default: 24h) left the registry's `dist-tags.latest` immature, the install summary still printed `(X is available)` for it — advertising the exact version pnpm had just refused to install ([pnpm/pnpm#11698](https://github.com/pnpm/pnpm/issues/11698)).

**Approach.** The hint only ever names the actual latest tag. The resolvers now surface `dist-tags.latest` on the resolve result only when the active policy would allow installing it; an immature latest **suppresses** the hint instead of being rewritten to an older mature version, so the hint never presents a non-latest version as latest. (An earlier revision of this PR threaded a rewritten "policy-aware latest" — the highest mature version — through the whole picker chain; that both mislabeled a non-latest version as latest and required invasive plumbing through the picker return types in both stacks. The current approach replaces it.)

The check is O(1) at the resolve-result construction sites: look up the tag, look up its publish timestamp, compare against the cutoff — no re-run of the version filter. `publishedByExclude` full-name and exact-version (trusted) entries keep the raw tag. Suppression requires positive evidence of immaturity: a missing or unparsable timestamp keeps the raw tag, matching the pick itself, which only enforces the policy when the packument's `time` map is usable.

### TypeScript CLI

- `latestAllowedByPolicy(meta, opts)` in `@pnpm/resolving.npm-resolver`, used at all four `latest:` return sites (`resolveNpm` main + two workspace-shadow paths, and `pickFromSimpleRegistry` shared by JSR / named registries). Mirrors `detectMinReleaseAgeViolation`'s exclusion and timestamp semantics.

### pacquet (Rust)

- `latest_allowed_by_policy` in the npm resolver, used by `build_resolve_result` (npm + JSR + named-registry paths) and the workspace-shadow path.
- Also fixes a pre-existing divergence in the Rust reporter: it gated `(X is available)` on `latest != version` rather than `latest > version`, so it would suggest downgrading to an older latest tag. Now uses `node-semver` comparison, matching the TS `semver.lt` check.

### Test coverage (both stacks)

- Immature latest → hint suppressed (main npm path, JSR, named registry)
- Mature latest with an older pinned install → raw tag shown
- No `publishedBy` → raw tag shown
- `publishedByExclude` full-name and trusted-exact-version entries → raw tag shown
- All versions immature (lowest-version fallback install) → suppressed
- Missing `time` field (warn-and-skip path) → raw tag shown
- Reporter: newer latest prints, equal/older/malformed latest suppresses (the older-than case caught the reporter bug)

### Out of scope (noted for follow-up)

pacquet's `outdated` command does not yet implement `minimumReleaseAge` support at all (pre-existing gap, separate work). Only the install-summary side of pnpm/pnpm#11698 is fixed on both stacks.

## Squash Commit Body

```text
fix(install-summary): suppress '(X is available)' when latest is held back by minimumReleaseAge

When minimumReleaseAge (default: 24h) left the registry's
dist-tags.latest immature, the install summary still printed
'(X is available)' for it — advertising the exact version the policy
had just refused to install.

The hint only ever names the actual latest tag: the resolvers now
surface dist-tags.latest on the resolve result only when the active
policy would allow installing it (latest_allowed_by_policy /
latestAllowedByPolicy — an O(1) check of the tag's publish timestamp
against the cutoff, honoring publishedByExclude full-name and exact-
version entries). An immature latest suppresses the hint instead of
being rewritten to an older mature version, so the hint never names a
non-latest version as latest. Suppression requires positive evidence
of immaturity: a missing or unparsable timestamp keeps the raw tag,
matching the pick itself, which only enforces the policy when the
packument's time map is usable.

Also fixes a pre-existing divergence in the pacquet reporter: it gated
the hint on 'latest != version' rather than 'latest > version', so it
would suggest downgrading when the installed version was newer than
the latest tag. Now uses node-semver comparison, matching the
TypeScript reporter's semver.lt check.

Closes pnpm/pnpm#11698.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm change`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!--
No user-visible CLI surface change (flags, defaults, help text) — only
install-summary output behavior, covered by the changeset's release note.
-->

---
Written by an agent (opencode, glm-5.2); rewritten by an agent (Claude Code, claude-fable-5).
