### PR TITLE
fix(audit): respect saveExact and savePrefix in audit --fix=override

### DIFF
--- a/.changeset/audit-fix-override-respects-save-exact.md
+++ b/.changeset/audit-fix-override-respects-save-exact.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+---
+
+`pnpm audit --fix=override` now respects `saveExact` and `savePrefix` config. Previously, override versions always used a caret prefix (`^`) regardless of these settings, while `--fix=update` correctly inherited them through the normal install pipeline. See pnpm/pnpm#13209.

--- a/.changeset/audit-fix-override-respects-save-exact.md
+++ b/.changeset/audit-fix-override-respects-save-exact.md
@@ -1,6 +1,7 @@
 ---
 "@pnpm/deps.compliance.commands": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 `pnpm audit --fix=override` now respects `saveExact` and `savePrefix` config. Previously, override versions always used a caret prefix (`^`) regardless of these settings, while `--fix=update` correctly inherited them through the normal install pipeline. See pnpm/pnpm#13209.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2905,6 +2905,9 @@ importers:
       '@pnpm/object.key-sorting':
         specifier: workspace:*
         version: link:../../../object/key-sorting
+      '@pnpm/pkg-manifest.utils':
+        specifier: workspace:*
+        version: link:../../../pkg-manifest/utils
       '@pnpm/store.path':
         specifier: workspace:*
         version: link:../../../store/path

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -13,6 +13,7 @@ use pacquet_lockfile::{
 use pacquet_network::{RetryOpts, send_with_retry};
 use pacquet_package_manager::{ResolutionObserver, ResolvedPackageHint, Update};
 use pacquet_package_manifest::DependencyGroup;
+use pacquet_registry::RangeSpecStyle;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_resolver_base::{
     PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
@@ -219,7 +220,7 @@ impl AuditArgs {
             // override path's fixable filter would.
             let filtered = filter_advisories_for_fix(&report, audit_level, state.config);
             let filtered = if self.interactive {
-                match interactive_select(filtered)? {
+                match interactive_select(filtered, range_spec_style_from_config(state.config))? {
                     Some(selected) => selected,
                     // Cancelled or nothing selected — nothing to fix.
                     None => return Ok(AuditOutcome::Clean),
@@ -1566,27 +1567,41 @@ fn filter_advisories_for_fix(
         .collect()
 }
 
-/// The minimum patched version with a caret, mirroring pnpm's
-/// `caretRangeForPatched`: `^X.Y.Z` keeps the resolver within the same major
-/// the user pinned to, where a bare `>=X.Y.Z` could silently promote a dep to
-/// a later breaking major. `patched` is always pacquet's inferred `>=V` form,
-/// so its minimum is the version after `>=`.
-fn caret_range_for_patched(patched: &str) -> String {
+/// The range spec style for written overrides, from the `saveExact` /
+/// `savePrefix` settings. `audit` has no `--save-exact` / `--save-prefix`
+/// flags (matching pnpm), so only the config values apply.
+fn range_spec_style_from_config(config: &Config) -> RangeSpecStyle {
+    RangeSpecStyle::from_save_options(config.save_exact, config.save_prefix.as_deref())
+}
+
+/// The minimum patched version written with the user's range spec style,
+/// mirroring pnpm's `versionRangeForPatched`: the default `^X.Y.Z` keeps the
+/// resolver within the same major the user pinned to, where a bare `>=X.Y.Z`
+/// could silently promote a dep to a later breaking major. `patched` is
+/// always pacquet's inferred `>=V` form, so its minimum is the version after
+/// `>=`.
+fn version_range_for_patched(patched: &str, range_spec_style: RangeSpecStyle) -> String {
     patched
         .strip_prefix(">=")
         .and_then(|version| version.trim().parse::<Version>().ok())
-        .map_or_else(|| patched.to_string(), |version| format!("^{version}"))
+        .map_or_else(
+            || patched.to_string(),
+            |version| format!("{}{version}", range_spec_style.range_prefix()),
+        )
 }
 
-/// Build the `name@vulnerable_versions → ^patched` override map from the
+/// Build the `name@vulnerable_versions → patched range` override map from the
 /// fixable advisories (those with an inferred patched range). Keyed by a
 /// `BTreeMap` so the output is sorted, mirroring pnpm's `sortDirectKeys`.
-fn create_overrides(advisories: &BTreeMap<String, AuditAdvisory>) -> BTreeMap<String, String> {
+fn create_overrides(
+    advisories: &BTreeMap<String, AuditAdvisory>,
+    range_spec_style: RangeSpecStyle,
+) -> BTreeMap<String, String> {
     let mut overrides = BTreeMap::new();
     for advisory in advisories.values() {
         let Some(patched) = advisory.patched_versions.as_deref() else { continue };
         let key = format!("{}@{}", advisory.module_name, advisory.vulnerable_versions);
-        overrides.insert(key, caret_range_for_patched(patched));
+        overrides.insert(key, version_range_for_patched(patched, range_spec_style));
     }
     overrides
 }
@@ -1598,7 +1613,7 @@ fn fix_override(
     settings_dir: &std::path::Path,
     config: &Config,
 ) -> miette::Result<String> {
-    let overrides = create_overrides(advisories);
+    let overrides = create_overrides(advisories, range_spec_style_from_config(config));
     if overrides.is_empty() {
         return Ok("No fixes were made".to_string());
     }
@@ -1740,6 +1755,7 @@ fn ignore_vulnerabilities(
 /// severity-grouped table.
 fn interactive_select(
     advisories: BTreeMap<String, AuditAdvisory>,
+    range_spec_style: RangeSpecStyle,
 ) -> miette::Result<Option<BTreeMap<String, AuditAdvisory>>> {
     let mut fixable: Vec<&AuditAdvisory> =
         advisories.values().filter(|advisory| advisory.patched_versions.is_some()).collect();
@@ -1753,8 +1769,11 @@ fn interactive_select(
         if !seen.insert(key.clone()) {
             continue;
         }
-        let patched =
-            advisory.patched_versions.as_deref().map(caret_range_for_patched).unwrap_or_default();
+        let patched = advisory
+            .patched_versions
+            .as_deref()
+            .map(|versions| version_range_for_patched(versions, range_spec_style))
+            .unwrap_or_default();
         labels.push(format!(
             "[{}] {} {} ❯ {} {}",
             severity_name(advisory.severity),

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -2,12 +2,12 @@ use super::{
     AuditAdvisory, AuditFinding, AuditMetadata, AuditPathIndex, AuditReport,
     AuditVulnerabilityCounts, BTreeMap, Config, ConfigAuditLevel, Cwe, HashMap, Include,
     InstalledPackages, MAX_PATHS_PER_FINDING, PackageVersionGuard, PackageVersionGuardDecision,
-    PathInfo, Range, RawBulkAdvisory, SnapshotDepRef, VulnerabilityGuard, build_audit_path_index,
-    bulk_response_to_audit_report, caret_range_for_patched, classify_for_update, create_overrides,
+    PathInfo, Range, RangeSpecStyle, RawBulkAdvisory, SnapshotDepRef, VulnerabilityGuard,
+    build_audit_path_index, bulk_response_to_audit_report, classify_for_update, create_overrides,
     filter_advisories_for_fix, filter_ignored_advisories, format_fix_with_update_output,
     lockfile_to_audit_request, minimum_release_age_excludes, normalize_ghsa_id,
     redact_url_userinfo, render_json_report, render_text_report, report_fixed_remaining,
-    sanitize_control_chars, satisfies_safe,
+    sanitize_control_chars, satisfies_safe, version_range_for_patched,
 };
 use pacquet_lockfile::{EnvLockfile, Lockfile, SnapshotEntry, SpecifierAndResolution};
 use std::{collections::HashSet, fmt::Write as _};
@@ -1017,11 +1017,14 @@ fn advisory(id: u64, title: &str, severity: ConfigAuditLevel, ghsa: &str) -> Aud
 }
 
 #[test]
-fn caret_range_for_patched_uses_minimum_with_caret() {
-    assert_eq!(caret_range_for_patched(">=2.0.0"), "^2.0.0");
-    assert_eq!(caret_range_for_patched(">=1.2.3"), "^1.2.3");
+fn version_range_for_patched_uses_minimum_with_range_spec_style() {
+    assert_eq!(version_range_for_patched(">=2.0.0", RangeSpecStyle::Major), "^2.0.0");
+    assert_eq!(version_range_for_patched(">=1.2.3", RangeSpecStyle::Major), "^1.2.3");
+    assert_eq!(version_range_for_patched(">=1.2.3", RangeSpecStyle::Minor), "~1.2.3");
+    assert_eq!(version_range_for_patched(">=1.2.3", RangeSpecStyle::Patch), "1.2.3");
+    assert_eq!(version_range_for_patched(">=1.2.3", RangeSpecStyle::Exact), "=1.2.3");
     // A non-inferred range is passed through unchanged.
-    assert_eq!(caret_range_for_patched("not-a-range"), "not-a-range");
+    assert_eq!(version_range_for_patched("not-a-range", RangeSpecStyle::Major), "not-a-range");
 }
 
 fn fix_advisory(
@@ -1073,7 +1076,7 @@ fn create_overrides_sorts_and_skips_unfixable() {
         ),
     ]);
 
-    let overrides = create_overrides(&advisories);
+    let overrides = create_overrides(&advisories, RangeSpecStyle::Major);
 
     assert_eq!(
         overrides.into_iter().collect::<Vec<_>>(),

--- a/pnpm/crates/cli/tests/audit.rs
+++ b/pnpm/crates/cli/tests/audit.rs
@@ -691,6 +691,52 @@ fn audit_fix_override_writes_overrides_to_workspace_manifest() {
 }
 
 #[test]
+fn audit_fix_override_respects_save_exact() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("vulnerable", 123, "high", "<2.0.0", "test", "GHSA-test-1111-2222"),
+    )
+    .create();
+    write_audit_workspace(&workspace, &registry.url(), "saveExact: true\n");
+
+    let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
+
+    assert_success(&output);
+    let manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    assert!(
+        manifest.contains("vulnerable@<2.0.0: 2.0.0"),
+        "manifest should hold the exact-version override:\n{manifest}",
+    );
+    mock.assert();
+}
+
+#[test]
+fn audit_fix_override_respects_save_prefix() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("vulnerable", 123, "high", "<2.0.0", "test", "GHSA-test-1111-2222"),
+    )
+    .create();
+    write_audit_workspace(&workspace, &registry.url(), "savePrefix: '~'\n");
+
+    let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
+
+    assert_success(&output);
+    let manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    assert!(
+        manifest.contains("vulnerable@<2.0.0: ~2.0.0"),
+        "manifest should hold the tilde-range override:\n{manifest}",
+    );
+    mock.assert();
+}
+
+#[test]
 fn audit_fix_override_writes_minimum_release_age_excludes_when_configured() {
     let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
     let mut registry = mockito::Server::new();

--- a/pnpm/crates/cli/tests/audit.rs
+++ b/pnpm/crates/cli/tests/audit.rs
@@ -737,6 +737,29 @@ fn audit_fix_override_respects_save_prefix() {
 }
 
 #[test]
+fn audit_fix_override_respects_save_prefix_equals() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &advisory_response("vulnerable", 123, "high", "<2.0.0", "test", "GHSA-test-1111-2222"),
+    )
+    .create();
+    write_audit_workspace(&workspace, &registry.url(), "savePrefix: '='\n");
+
+    let output = pacquet.arg("audit").arg("--fix").output().expect("run pacquet audit --fix");
+
+    assert_success(&output);
+    let manifest =
+        fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read workspace manifest");
+    assert!(
+        manifest.contains("vulnerable@<2.0.0: =2.0.0"),
+        "manifest should hold the =-pinned override:\n{manifest}",
+    );
+    mock.assert();
+}
+
+#[test]
 fn audit_fix_override_writes_minimum_release_age_excludes_when_configured() {
     let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
     let mut registry = mockito::Server::new();

--- a/pnpm11/deps/compliance/commands/package.json
+++ b/pnpm11/deps/compliance/commands/package.json
@@ -58,6 +58,7 @@
     "@pnpm/lockfile.walker": "workspace:*",
     "@pnpm/network.auth-header": "workspace:*",
     "@pnpm/object.key-sorting": "workspace:*",
+    "@pnpm/pkg-manifest.utils": "workspace:*",
     "@pnpm/store.path": "workspace:*",
     "@pnpm/types": "workspace:*",
     "@pnpm/workspace.project-manifest-reader": "workspace:*",

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -6,6 +6,7 @@ import { PnpmError } from '@pnpm/error'
 import { type InstallCommandOptions, update } from '@pnpm/installing.commands'
 import { globalInfo } from '@pnpm/logger'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
+import { getRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
 import type { Registries } from '@pnpm/types'
 import { table } from '@zkochan/table'
 import chalk, { type ChalkInstance } from 'chalk'
@@ -263,7 +264,7 @@ export async function handler (opts: AuditOptions, params: string[] = []): Promi
       advisories: filterAdvisoriesForFix(auditReport.advisories, opts),
     }
     if (opts.interactive) {
-      filteredAuditReport = await interactiveAuditFix(filteredAuditReport)
+      filteredAuditReport = await interactiveAuditFix(filteredAuditReport, opts)
     }
     if (fixMethod === 'update') {
       const result = await fixWithUpdate(filteredAuditReport, { ...opts, include })
@@ -462,8 +463,8 @@ function filterAdvisoriesForFix (
   )
 }
 
-async function interactiveAuditFix (auditReport: AuditReport): Promise<AuditReport> {
-  const choiceGroups = getAuditFixChoices(Object.values(auditReport.advisories))
+async function interactiveAuditFix (auditReport: AuditReport, opts: Pick<AuditOptions, 'saveExact' | 'savePrefix'>): Promise<AuditReport> {
+  const choiceGroups = getAuditFixChoices(Object.values(auditReport.advisories), getRangeSpecStyle(opts))
   if (choiceGroups.length === 0) {
     return auditReport
   }

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -13,7 +13,7 @@ export interface FixResult {
 
 export async function fix (auditReport: AuditReport, opts: AuditOptions): Promise<FixResult> {
   const fixableAdvisories = getFixableAdvisories(Object.values(auditReport.advisories), opts.auditConfig?.ignoreGhsas)
-  const vulnOverrides = createOverrides(fixableAdvisories)
+  const vulnOverrides = createOverrides(fixableAdvisories, opts.saveExact, opts.savePrefix)
   if (Object.values(vulnOverrides).length === 0) return { vulnOverrides, addedAgeExcludes: [] }
   const addedAgeExcludes = opts.minimumReleaseAge ? createMinimumReleaseAgeExcludes(fixableAdvisories) : []
   await writeSettings({
@@ -38,11 +38,11 @@ function getFixableAdvisories (advisories: AuditAdvisory[], ignoreGhsas?: string
   return advisories.filter(({ patched_versions: patchedVersions }) => patchedVersions != null)
 }
 
-function createOverrides (advisories: AuditAdvisory[]): Record<string, string> {
+function createOverrides (advisories: AuditAdvisory[], saveExact?: boolean, savePrefix?: string): Record<string, string> {
   const entries: Array<[string, string]> = []
   for (const advisory of advisories) {
     if (!advisory.patched_versions) continue
-    entries.push([`${advisory.module_name}@${advisory.vulnerable_versions}`, caretRangeForPatched(advisory.patched_versions)])
+    entries.push([`${advisory.module_name}@${advisory.vulnerable_versions}`, caretRangeForPatched(advisory.patched_versions, saveExact, savePrefix)])
   }
   return sortDirectKeys(Object.fromEntries(entries))
 }
@@ -51,9 +51,14 @@ function createOverrides (advisories: AuditAdvisory[]): Record<string, string> {
 // same major as the fix. `>=X.Y.Z` alone can silently promote a dep to a
 // later breaking major; `^X.Y.Z` still satisfies the patch while
 // preserving the major the user originally pinned to.
-export function caretRangeForPatched (patchedRange: string): string {
+// Respects saveExact / savePrefix so --fix=override matches the behavior of
+// --fix=update (which inherits these from the normal install pipeline).
+export function caretRangeForPatched (patchedRange: string, saveExact?: boolean, savePrefix?: string): string {
   const min = semver.minVersion(patchedRange)
-  return min ? `^${min.version}` : patchedRange
+  if (!min) return patchedRange
+  if (saveExact === true || savePrefix === '') return min.version
+  if (savePrefix === '~') return `~${min.version}`
+  return `^${min.version}`
 }
 
 export function createMinimumReleaseAgeExcludes (advisories: AuditAdvisory[]): string[] {

--- a/pnpm11/deps/compliance/commands/src/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/fix.ts
@@ -2,6 +2,8 @@ import { mergePackageVersionSpecs } from '@pnpm/config.version-policy'
 import { writeSettings } from '@pnpm/config.writer'
 import { type AuditAdvisory, type AuditReport, normalizeGhsaId } from '@pnpm/deps.compliance.audit'
 import { sortDirectKeys } from '@pnpm/object.key-sorting'
+import { getRangeSpecStyle, versionWithRangeSpecStyle } from '@pnpm/pkg-manifest.utils'
+import type { RangeSpecStyle } from '@pnpm/types'
 import semver from 'semver'
 
 import type { AuditOptions } from './audit.js'
@@ -13,7 +15,7 @@ export interface FixResult {
 
 export async function fix (auditReport: AuditReport, opts: AuditOptions): Promise<FixResult> {
   const fixableAdvisories = getFixableAdvisories(Object.values(auditReport.advisories), opts.auditConfig?.ignoreGhsas)
-  const vulnOverrides = createOverrides(fixableAdvisories, opts.saveExact, opts.savePrefix)
+  const vulnOverrides = createOverrides(fixableAdvisories, getRangeSpecStyle(opts))
   if (Object.values(vulnOverrides).length === 0) return { vulnOverrides, addedAgeExcludes: [] }
   const addedAgeExcludes = opts.minimumReleaseAge ? createMinimumReleaseAgeExcludes(fixableAdvisories) : []
   await writeSettings({
@@ -38,27 +40,22 @@ function getFixableAdvisories (advisories: AuditAdvisory[], ignoreGhsas?: string
   return advisories.filter(({ patched_versions: patchedVersions }) => patchedVersions != null)
 }
 
-function createOverrides (advisories: AuditAdvisory[], saveExact?: boolean, savePrefix?: string): Record<string, string> {
+function createOverrides (advisories: AuditAdvisory[], rangeSpecStyle: RangeSpecStyle): Record<string, string> {
   const entries: Array<[string, string]> = []
   for (const advisory of advisories) {
     if (!advisory.patched_versions) continue
-    entries.push([`${advisory.module_name}@${advisory.vulnerable_versions}`, caretRangeForPatched(advisory.patched_versions, saveExact, savePrefix)])
+    entries.push([`${advisory.module_name}@${advisory.vulnerable_versions}`, versionRangeForPatched(advisory.patched_versions, rangeSpecStyle)])
   }
   return sortDirectKeys(Object.fromEntries(entries))
 }
 
-// Use the minimum patched version with a caret so pnpm stays within the
-// same major as the fix. `>=X.Y.Z` alone can silently promote a dep to a
-// later breaking major; `^X.Y.Z` still satisfies the patch while
-// preserving the major the user originally pinned to.
-// Respects saveExact / savePrefix so --fix=override matches the behavior of
-// --fix=update (which inherits these from the normal install pipeline).
-export function caretRangeForPatched (patchedRange: string, saveExact?: boolean, savePrefix?: string): string {
+// Save the minimum patched version with the user's range spec style rather
+// than the advisory's own range: `>=X.Y.Z` alone can silently promote a dep
+// to a later breaking major, while `^X.Y.Z` (the default style) still
+// satisfies the patch and preserves the major the user originally pinned to.
+export function versionRangeForPatched (patchedRange: string, rangeSpecStyle: RangeSpecStyle): string {
   const min = semver.minVersion(patchedRange)
-  if (!min) return patchedRange
-  if (saveExact === true || savePrefix === '') return min.version
-  if (savePrefix === '~') return `~${min.version}`
-  return `^${min.version}`
+  return min ? versionWithRangeSpecStyle(min.version, rangeSpecStyle) : patchedRange
 }
 
 export function createMinimumReleaseAgeExcludes (advisories: AuditAdvisory[]): string[] {

--- a/pnpm11/deps/compliance/commands/src/audit/getAuditFixChoices.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/getAuditFixChoices.ts
@@ -1,9 +1,10 @@
 import type { AuditAdvisory, AuditLevelString } from '@pnpm/deps.compliance.audit'
+import type { RangeSpecStyle } from '@pnpm/types'
 import { getBorderCharacters, table } from '@zkochan/table'
 import chalk from 'chalk'
 import { groupBy } from 'ramda'
 
-import { caretRangeForPatched } from './fix.js'
+import { versionRangeForPatched } from './fix.js'
 
 const AUDIT_COLOR: Record<AuditLevelString, (s: string) => string> = {
   info: chalk.dim,
@@ -39,7 +40,7 @@ type AuditChoiceGroup = Array<{
   disabled?: boolean
 }>
 
-export function getAuditFixChoices (advisories: AuditAdvisory[]): AuditChoiceGroup {
+export function getAuditFixChoices (advisories: AuditAdvisory[], rangeSpecStyle: RangeSpecStyle): AuditChoiceGroup {
   if (advisories.length === 0) {
     return []
   }
@@ -77,7 +78,7 @@ export function getAuditFixChoices (advisories: AuditAdvisory[]): AuditChoiceGro
         raw: [
           advisory.module_name,
           advisory.vulnerable_versions,
-          advisory.patched_versions ? caretRangeForPatched(advisory.patched_versions) : '',
+          advisory.patched_versions ? versionRangeForPatched(advisory.patched_versions, rangeSpecStyle) : '',
           advisory.github_advisory_id ?? '',
         ],
         key,

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -130,6 +130,52 @@ test('audit --fix respects auditLevel and only fixes matching severities', async
   expect(manifest.overrides?.['url-parse@<1.5.6']).toBeFalsy()
 })
 
+test('audit --fix uses exact version when saveExact is true', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+    saveExact: true,
+  })
+
+  expect(exitCode).toBe(0)
+  expect(output).toMatch(/Run "pnpm install"/)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('0.18.1')
+})
+
+test('audit --fix uses tilde prefix when savePrefix is ~', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+    savePrefix: '~',
+  })
+
+  expect(exitCode).toBe(0)
+  expect(output).toMatch(/Run "pnpm install"/)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('~0.18.1')
+})
+
 function advisory (moduleName: string, vulnerableVersions: string, patchedVersions?: string): AuditAdvisory {
   return {
     findings: [],
@@ -202,5 +248,21 @@ describe('caretRangeForPatched', () => {
 
   test('picks the minimum version from a complex range', () => {
     expect(caretRangeForPatched('>=1.0.0 <2.0.0')).toBe('^1.0.0')
+  })
+
+  test('returns exact version when saveExact is true', () => {
+    expect(caretRangeForPatched('>=0.18.1', true)).toBe('0.18.1')
+  })
+
+  test('returns exact version when savePrefix is empty string', () => {
+    expect(caretRangeForPatched('>=0.18.1', undefined, '')).toBe('0.18.1')
+  })
+
+  test('returns tilde-prefixed version when savePrefix is ~', () => {
+    expect(caretRangeForPatched('>=0.18.1', undefined, '~')).toBe('~0.18.1')
+  })
+
+  test('returns caret-prefixed version when saveExact is false and savePrefix is undefined', () => {
+    expect(caretRangeForPatched('>=0.18.1', false)).toBe('^0.18.1')
   })
 })

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -7,7 +7,7 @@ import { fixtures } from '@pnpm/test-fixtures'
 import { getMockAgent, setupMockAgent, teardownMockAgent } from '@pnpm/testing.mock-agent'
 import { readYamlFileSync } from 'read-yaml-file'
 
-import { caretRangeForPatched, createMinimumReleaseAgeExcludes } from '../../src/audit/fix.js'
+import { createMinimumReleaseAgeExcludes, versionRangeForPatched } from '../../src/audit/fix.js'
 import { AUDIT_REGISTRY, AUDIT_REGISTRY_OPTS } from './utils/options.js'
 import * as responses from './utils/responses/index.js'
 
@@ -176,6 +176,29 @@ test('audit --fix uses tilde prefix when savePrefix is ~', async () => {
   expect(manifest.overrides?.['axios@<=0.18.0']).toBe('~0.18.1')
 })
 
+test('audit --fix uses an explicit = operator when savePrefix is =', async () => {
+  const tmp = f.prepare('has-vulnerabilities')
+
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
+
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: true,
+    savePrefix: '=',
+  })
+
+  expect(exitCode).toBe(0)
+  expect(output).toMatch(/Run "pnpm install"/)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('=0.18.1')
+})
+
 function advisory (moduleName: string, vulnerableVersions: string, patchedVersions?: string): AuditAdvisory {
   return {
     findings: [],
@@ -241,28 +264,24 @@ describe('createMinimumReleaseAgeExcludes', () => {
   })
 })
 
-describe('caretRangeForPatched', () => {
+describe('versionRangeForPatched', () => {
   test('converts a >= range to a caret range', () => {
-    expect(caretRangeForPatched('>=0.18.1')).toBe('^0.18.1')
+    expect(versionRangeForPatched('>=0.18.1', 'major')).toBe('^0.18.1')
   })
 
   test('picks the minimum version from a complex range', () => {
-    expect(caretRangeForPatched('>=1.0.0 <2.0.0')).toBe('^1.0.0')
+    expect(versionRangeForPatched('>=1.0.0 <2.0.0', 'major')).toBe('^1.0.0')
   })
 
-  test('returns exact version when saveExact is true', () => {
-    expect(caretRangeForPatched('>=0.18.1', true)).toBe('0.18.1')
+  test('returns the bare version for the patch style', () => {
+    expect(versionRangeForPatched('>=0.18.1', 'patch')).toBe('0.18.1')
   })
 
-  test('returns exact version when savePrefix is empty string', () => {
-    expect(caretRangeForPatched('>=0.18.1', undefined, '')).toBe('0.18.1')
+  test('returns a tilde-prefixed version for the minor style', () => {
+    expect(versionRangeForPatched('>=0.18.1', 'minor')).toBe('~0.18.1')
   })
 
-  test('returns tilde-prefixed version when savePrefix is ~', () => {
-    expect(caretRangeForPatched('>=0.18.1', undefined, '~')).toBe('~0.18.1')
-  })
-
-  test('returns caret-prefixed version when saveExact is false and savePrefix is undefined', () => {
-    expect(caretRangeForPatched('>=0.18.1', false)).toBe('^0.18.1')
+  test('returns an =-prefixed version for the exact style', () => {
+    expect(versionRangeForPatched('>=0.18.1', 'exact')).toBe('=0.18.1')
   })
 })

--- a/pnpm11/deps/compliance/commands/tsconfig.json
+++ b/pnpm11/deps/compliance/commands/tsconfig.json
@@ -77,6 +77,9 @@
       "path": "../../../pkg-manifest/reader"
     },
     {
+      "path": "../../../pkg-manifest/utils"
+    },
+    {
       "path": "../../../store/path"
     },
     {


### PR DESCRIPTION
## Summary

`pnpm audit --fix=override` unconditionally wrote caret-prefixed override versions (`^X.Y.Z`), ignoring the user's `saveExact` and `savePrefix` configuration. By contrast, `--fix=update` correctly inherited these settings through the normal install pipeline.

The fix derives the range spec style from `saveExact` / `savePrefix` with the existing `getRangeSpecStyle()` / `versionWithRangeSpecStyle()` helpers from `@pnpm/pkg-manifest.utils` (so a `savePrefix` of `=` is honored too) and applies it in `versionRangeForPatched()` (renamed from `caretRangeForPatched()`), both when writing the overrides and in the interactive fix picker's "Patched" column:

- `saveExact: true` or `savePrefix: ''` → exact version (`X.Y.Z`)
- `savePrefix: '~'` → tilde-prefixed (`~X.Y.Z`)
- `savePrefix: '='` → `=`-prefixed (`=X.Y.Z`)
- Otherwise → caret-prefixed (`^X.Y.Z`, existing default)

The same fix is applied to the pacquet implementation of `audit --fix=override` (`version_range_for_patched` in `pnpm/crates/cli/src/cli_args/audit.rs`, using `RangeSpecStyle::from_save_options`), with matching unit and e2e tests.

Closes pnpm/pnpm#13209

## Squash Commit Body

```text
pnpm audit --fix=override unconditionally returned caret-prefixed
versions (^X.Y.Z) regardless of saveExact or savePrefix configuration.
By contrast, --fix=update inherited these settings through the normal
install pipeline and produced the correct prefix.

The root cause was in caretRangeForPatched() which hard-coded the caret
prefix. The fix interprets saveExact / savePrefix with the existing
getRangeSpecStyle() / versionWithRangeSpecStyle() helpers and applies
the resulting style in versionRangeForPatched() (renamed from
caretRangeForPatched()) — exact when saveExact is true or savePrefix is
empty, tilde for '~', '=' for '=', caret otherwise — both when writing
the overrides and in the interactive fix picker.

The same bug existed in the pacquet port's audit --fix=override; it is
fixed there the same way via RangeSpecStyle::from_save_options.

Closes pnpm/pnpm#13209
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(Implemented in both stacks.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. *(No docs update needed — this is a bug fix restoring expected behavior.)*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787312637&installation_model_id=426870&pr_number=13215&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13215&signature=5be320865e802732c614bf9f14ae49d5d49633f3d83059cc8917e2eeb0e99d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm audit --fix=override` now respects `saveExact` and `savePrefix` when generating override version specifiers, including pinned (`savePrefix: '='`) behavior.
  * Override version formatting during interactive “fix” selection now consistently follows the configured range-spec style (exact, `~`, or `^`) instead of a hardcoded caret.
* **Tests**
  * Expanded unit and integration coverage for `saveExact` and `savePrefix` (including `=`).
* **Documentation**
  * Updated the patch release metadata to reflect the corrected override formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
