### PR TITLE
fix(pacquet-cli): accept --registry in pnpm view; make recursive-publish probe hermetic

### DIFF
--- a/.changeset/view-registry-flag.md
+++ b/.changeset/view-registry-flag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm view` now accepts the `--registry` option, matching the TypeScript CLI. Previously the flag was rejected as an unknown argument.

--- a/pnpm/crates/cli/src/cli_args/view.rs
+++ b/pnpm/crates/cli/src/cli_args/view.rs
@@ -24,6 +24,8 @@ use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use pacquet_workspace::try_read_project_manifest;
 use serde_json::{Map, Value};
 
+use super::deprecate::normalize_registry_url;
+
 /// Errors from `pacquet view`. The codes are the `ERR_PNPM_*` codes pnpm
 /// defines for these failures.
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -70,6 +72,10 @@ pub struct ViewArgs {
     /// omitted, the nearest project manifest's name is used.
     pub params: Vec<String>,
 
+    /// The base URL of the npm registry.
+    #[clap(long)]
+    pub registry: Option<String>,
+
     /// Show information in JSON format.
     #[clap(long)]
     pub json: bool,
@@ -87,7 +93,7 @@ impl ViewArgs {
         };
         let fields = self.params.get(1..).unwrap_or(&[]);
 
-        let info = fetch_package_info(config, &package_spec).await?;
+        let info = fetch_package_info(config, self.registry.as_deref(), &package_spec).await?;
 
         if !fields.is_empty() {
             return Ok(render_fields(&info, fields, self.json));
@@ -147,14 +153,21 @@ fn invalid_manifest(dir: &Path) -> ViewError {
 /// version satisfying the spec, then extend that version's manifest with the
 /// packument-level `versions`, `dist-tags`, and `time` fields the renderers
 /// read.
-async fn fetch_package_info(config: &Config, package_spec: &str) -> miette::Result<Value> {
+async fn fetch_package_info(
+    config: &Config,
+    registry_override: Option<&str>,
+    package_spec: &str,
+) -> miette::Result<Value> {
     let parsed = parse_wanted_dependency(package_spec);
     let alias = parsed.alias.as_deref();
     let bare = parsed.bare_specifier.as_deref().unwrap_or("latest");
     let name_hint = alias.unwrap_or(package_spec);
 
-    let registries: std::collections::HashMap<String, String> =
+    let mut registries: std::collections::HashMap<String, String> =
         config.resolved_registries().into_iter().collect();
+    if let Some(registry) = registry_override {
+        registries.insert("default".to_string(), normalize_registry_url(registry));
+    }
     let registry = pick_registry_for_package(&registries, name_hint, Some(bare));
 
     let spec = parse_bare_specifier(bare, alias, "latest", &registry)

--- a/pnpm/crates/cli/tests/view.rs
+++ b/pnpm/crates/cli/tests/view.rs
@@ -193,6 +193,52 @@ fn package_not_found_is_fetch_404() {
 }
 
 #[test]
+fn registry_flag_overrides_configured_registry() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut configured = mockito::Server::new();
+    let configured_mock = configured.mock("GET", "/is-negative").expect(0).create();
+    write_registry_npmrc(&workspace, &format!("{}/", configured.url()));
+    let mut overriding = mockito::Server::new();
+    let mock = serve(&mut overriding, "/is-negative", &is_negative_body());
+    let auth_file = empty_auth_file(root.path());
+
+    let output =
+        run_view(&workspace, &auth_file, &["is-negative", "--registry", &overriding.url()]);
+
+    mock.assert();
+    configured_mock.assert();
+    let stdout = stdout_of(&output);
+    assert!(stdout.contains("is-negative"), "summary must mention the package: {stdout:?}");
+    drop((root, configured, overriding));
+}
+
+/// `pnpm view <unpublished> versions --registry <url> --json` must exit with
+/// code 1 (not clap's usage-error 2): the TypeScript stack's recursive-publish
+/// test drives this exact invocation to probe for an unpublished package.
+#[test]
+fn registry_flag_404_exits_with_code_1() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let mock = server.mock("GET", "/not-a-real-package").with_status(404).create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_view(
+        &workspace,
+        &auth_file,
+        &["not-a-real-package", "versions", "--registry", &server.url(), "--json"],
+    );
+
+    mock.assert();
+    assert_eq!(output.status.code(), Some(1), "a 404 must exit with code 1");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_FETCH_404"),
+        "stderr must name the fetch-404 diagnostic; got:\n{stderr}",
+    );
+    drop((root, server));
+}
+
+#[test]
 fn no_matching_version_errors() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     let mut server = mockito::Server::new();

--- a/pnpm11/releasing/commands/test/publish/recursivePublish.ts
+++ b/pnpm11/releasing/commands/test/publish/recursivePublish.ts
@@ -8,7 +8,6 @@ import { publish } from '@pnpm/releasing.commands'
 import { getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import type { ProjectManifest } from '@pnpm/types'
 import { filterProjectsBySelectorObjectsFromDir } from '@pnpm/workspace.projects-filter'
-import crossSpawn from 'cross-spawn'
 import { safeExeca as execa } from 'execa'
 import { loadJsonFileSync } from 'load-json-file'
 
@@ -83,12 +82,12 @@ test('recursive publish', async () => {
   }, [])
 
   {
-    const { status } = crossSpawn.sync('pnpm', ['view', pkg1.name, 'versions', '--registry', `http://localhost:${REGISTRY_MOCK_PORT}`, '--json'])
-    expect(status).toBe(1)
+    const { exitCode } = await execa('pnpm', ['view', pkg1.name, 'versions', '--registry', `http://localhost:${REGISTRY_MOCK_PORT}`, '--json'], { reject: false })
+    expect(exitCode).toBe(1)
   }
   {
-    const { status } = crossSpawn.sync('pnpm', ['view', pkg2.name, 'versions', '--registry', `http://localhost:${REGISTRY_MOCK_PORT}`, '--json'])
-    expect(status).toBe(1)
+    const { exitCode } = await execa('pnpm', ['view', pkg2.name, 'versions', '--registry', `http://localhost:${REGISTRY_MOCK_PORT}`, '--json'], { reject: false })
+    expect(exitCode).toBe(1)
   }
 
   await publish.handler({


### PR DESCRIPTION
## Summary

Fixes the `test/publish/recursivePublish.ts` failure that has been breaking CI on `main` since the pnpm pin was bumped to `12.0.0-alpha.18` (run 29958537865). Two changes, one per root cause:

- **pacquet:** `pnpm view` (added to pacquet in pnpm/pnpm#13181, first shipped in `12.0.0-alpha.18`) did not accept `--registry`, so `pnpm view <pkg> --registry <url>` died with a clap usage error (exit code 2) instead of consulting the given registry. The flag is now accepted and overrides the default registry, the same way `dist-tag`, `deprecate`, and their siblings handle it.
- **TypeScript test:** the recursive-publish test probed for unpublished packages by spawning `pnpm` through `cross-spawn`, which resolves the binary from the child's PATH. Inside jest, the workspace-shim PATH prepend only exists on the sandbox's copy of `process.env`, so the probe actually executed the *release-pinned pacquet* from the runner's PATH — coupling the test to whatever the pinned release ships. On alpha.16 the probe passed by accident (`view` didn't exist, so the unknown command fell through to "missing script", exit 1 — the same code a 404 produces). On alpha.18, `view` exists but rejected `--registry`, exit 2. The probes now go through `safe-execa`, which resolves the absolute binary path from the calling process's PATH — the way `checkPkgExists` in the same suite already does — so they deterministically exercise the workspace TypeScript CLI.

The other failures in that run (`runtimeOnFail.ts`, `nodeRuntime.ts` on Windows) are runtime-download timeouts against real network endpoints (`The operation was aborted due to timeout` after the 60 s fetch timeout); the previous run timed out the same way on a different platform/test (`denoRuntime.ts` on ubuntu) while earlier same-day runs passed, so those are transient network slowness, not code regressions.

## Squash Commit Body

```text
CI on main broke when the pnpm pin moved to pacquet 12.0.0-alpha.18: the
recursive-publish test expects `pnpm view <unpublished> --registry <mock>`
to exit 1 (fetch 404), but got clap's usage-error exit 2.

Two root causes, fixed together:

pacquet's view command (new in alpha.18) did not accept --registry.
Accept the flag and let it override the default registry, mirroring
dist-tag and the other registry-facing commands; covered by integration
tests including the exact exit-code-1 contract the TS suite drives.

The TS test spawned `pnpm` via cross-spawn, which resolves the binary
from the child's PATH; jest's workspace-shim PATH prepend only lands on
the sandbox copy of process.env, so the probe silently ran the
release-pinned pacquet from the runner's PATH instead of the workspace
CLI (passing on alpha.16 only because the then-unknown `view` command
fell through to "missing script", which also exits 1). Resolve through
safe-execa like checkPkgExists already does, so the probe
deterministically runs the workspace TypeScript CLI.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(The
  TypeScript CLI already accepts `--registry` for `view`; this ports that to
  pacquet. The test change is TS-only infrastructure.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787352034&installation_model_id=426870&pr_number=13218&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13218&signature=85dea5916ca20770036a9873821cb6fca541e009c7cc22e25bd9c133cd335b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `--registry <url>` option in `pnpm view`, allowing package information to be retrieved from a specified registry.

- **Bug Fixes**
  - Corrected `pnpm view` behavior when a registry returns a 404, ensuring the command exits with status 1 and reports the appropriate diagnostic.

- **Tests**
  - Added coverage for registry overrides and 404 responses.
  - Improved recursive publish failure checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->