### PR TITLE
feat(pacquet): implement the pnpm unpublish command

### DIFF
--- a/.changeset/pacquet-unpublish.md
+++ b/.changeset/pacquet-unpublish.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added the `pnpm unpublish` command: remove a package from the registry entirely (requires `--force`), or remove the versions matching `<package>@<range>`, re-pointing `dist-tags` that referenced them and deleting the orphaned tarballs. Supports `--registry` and `--otp`.

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -74,6 +74,7 @@ pub mod supported_architectures;
 pub mod team;
 pub mod undeprecate;
 pub mod unlink;
+pub mod unpublish;
 pub mod unstar;
 pub mod update;
 mod update_changeset;

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -67,6 +67,7 @@ use super::{
     team::TeamArgs,
     undeprecate::UndeprecateArgs,
     unlink::UnlinkArgs,
+    unpublish::UnpublishArgs,
     unstar::UnstarArgs,
     update::UpdateArgs,
     version::VersionArgs,
@@ -358,6 +359,8 @@ pub enum CliCommand {
     Deprecate(DeprecateArgs),
     /// Removes deprecation from a version of a package in the registry. Only works on already deprecated versions.
     Undeprecate(UndeprecateArgs),
+    /// Removes a package from the registry.
+    Unpublish(UnpublishArgs),
     /// Marks a package as a favorite.
     Star(StarArgs),
     /// Unmarks a package as a favorite.

--- a/pnpm/crates/cli/src/cli_args/deprecate.rs
+++ b/pnpm/crates/cli/src/cli_args/deprecate.rs
@@ -216,7 +216,7 @@ pub(crate) async fn update_deprecation(
 
     let package_url = package_url(package_name, &registry_url)?;
 
-    let mut package_meta =
+    let mut package_meta: PackageMeta =
         fetch_package_meta(context, &package_url, auth_header.as_deref(), package_name).await?;
 
     if package_meta.versions.is_empty() {
@@ -304,12 +304,12 @@ struct VersionInfo {
     other: serde_json::Value,
 }
 
-async fn fetch_package_meta(
+pub(crate) async fn fetch_package_meta<Meta: serde::de::DeserializeOwned>(
     context: &DeprecateContext<'_>,
     url: &str,
     auth_header: Option<&str>,
     package_name: &str,
-) -> miette::Result<PackageMeta> {
+) -> miette::Result<Meta> {
     retry_async(url, context.retry_opts, FetchError::is_retryable, || async {
         fetch_package_meta_once(context, url, auth_header).await
     })
@@ -333,11 +333,11 @@ impl FetchError {
     }
 }
 
-async fn fetch_package_meta_once(
+async fn fetch_package_meta_once<Meta: serde::de::DeserializeOwned>(
     context: &DeprecateContext<'_>,
     url: &str,
     auth_header: Option<&str>,
-) -> Result<PackageMeta, FetchError> {
+) -> Result<Meta, FetchError> {
     let (_guard, response) =
         send_with_retry(&context.http_client, url, context.retry_opts, |client| {
             let mut builder = client.get(url);
@@ -423,7 +423,10 @@ async fn put_package_meta(
     write_error_from_response(response, action).await
 }
 
-async fn write_error_from_response(response: Response, action: String) -> miette::Result<()> {
+pub(crate) async fn write_error_from_response(
+    response: Response,
+    action: String,
+) -> miette::Result<()> {
     let status = response.status();
     let status_text = status.canonical_reason().unwrap_or_default().to_string();
     let body =
@@ -441,7 +444,10 @@ async fn write_error_from_response(response: Response, action: String) -> miette
         .into())
 }
 
-fn registry_operation_error<ErrorType>(operation: &'static str, error: ErrorType) -> miette::Report
+pub(crate) fn registry_operation_error<ErrorType>(
+    operation: &'static str,
+    error: ErrorType,
+) -> miette::Report
 where
     ErrorType: std::fmt::Display,
 {

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -355,6 +355,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Owner(args) => dispatch_query::owner(ctx, args),
         CliCommand::Deprecate(args) => dispatch_query::deprecate(ctx, args),
         CliCommand::Undeprecate(args) => dispatch_query::undeprecate(ctx, args),
+        CliCommand::Unpublish(args) => dispatch_query::unpublish(ctx, args),
         CliCommand::Ping(args) => dispatch_query::ping(ctx, args),
         CliCommand::Doctor(args) => dispatch_query::doctor(ctx, args),
         CliCommand::Search(args) => dispatch_query::search(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -42,6 +42,7 @@ use super::{
     store::StoreCommand,
     team::TeamArgs,
     undeprecate::UndeprecateArgs,
+    unpublish::UnpublishArgs,
     unstar::UnstarArgs,
     version::VersionArgs,
     view::ViewArgs,
@@ -284,6 +285,23 @@ pub(super) fn deprecate<'a>(
 pub(super) fn undeprecate<'a>(
     ctx: &RunCtx<'a>,
     args: UndeprecateArgs,
+) -> miette::Result<CommandFuture<'a>> {
+    let cfg: &Config = (ctx.config)()?;
+    Ok(Box::pin(async move {
+        if let Some(output) = args.run(cfg).await? {
+            let output = super::sanitize::sanitize(&output);
+            if output.is_empty() {
+                return Ok(());
+            }
+            println!("{output}");
+        }
+        Ok(())
+    }))
+}
+
+pub(super) fn unpublish<'a>(
+    ctx: &RunCtx<'a>,
+    args: UnpublishArgs,
 ) -> miette::Result<CommandFuture<'a>> {
     let cfg: &Config = (ctx.config)()?;
     Ok(Box::pin(async move {

--- a/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
+++ b/pnpm/crates/cli/src/cli_args/switch_cli_version.rs
@@ -477,6 +477,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Whoami => "whoami",
         CliCommand::Deprecate(_) => "deprecate",
         CliCommand::Undeprecate(_) => "undeprecate",
+        CliCommand::Unpublish(_) => "unpublish",
         CliCommand::Star(_) => "star",
         CliCommand::Unstar(_) => "unstar",
         CliCommand::Stars(_) => "stars",

--- a/pnpm/crates/cli/src/cli_args/unpublish.rs
+++ b/pnpm/crates/cli/src/cli_args/unpublish.rs
@@ -12,7 +12,7 @@ use pacquet_network::send_with_retry;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 /// Remove a package, or a range of its versions, from the registry.
 ///
@@ -76,10 +76,13 @@ struct Packument {
     name: String,
     #[serde(rename = "_rev", default, skip_serializing_if = "Option::is_none")]
     rev: Option<String>,
+    // `serde_json::Map` preserves the registry's key order (the workspace
+    // enables `preserve_order`), so the confirm-message version list and the
+    // `PUT` body keep the packument's own ordering like the TypeScript CLI.
     #[serde(rename = "dist-tags", default)]
-    dist_tags: BTreeMap<String, String>,
+    dist_tags: Map<String, Value>,
     #[serde(default)]
-    versions: BTreeMap<String, Value>,
+    versions: Map<String, Value>,
     #[serde(flatten)]
     other: Map<String, Value>,
 }
@@ -196,11 +199,15 @@ async fn unpublish_versions(
     }
 
     let removed: HashSet<&str> = versions.iter().map(String::as_str).collect();
-    let latest_was_removed =
-        pkg.dist_tags.get("latest").is_some_and(|latest| removed.contains(latest.as_str()));
-    pkg.dist_tags.retain(|_, target| !removed.contains(target.as_str()));
+    let latest_was_removed = pkg
+        .dist_tags
+        .get("latest")
+        .and_then(Value::as_str)
+        .is_some_and(|latest| removed.contains(latest));
+    pkg.dist_tags
+        .retain(|_, target| !target.as_str().is_some_and(|target| removed.contains(target)));
     if latest_was_removed && let Some(highest) = highest_version(&pkg.versions) {
-        pkg.dist_tags.insert("latest".to_string(), highest);
+        pkg.dist_tags.insert("latest".to_string(), Value::String(highest));
     }
 
     // Internal CouchDB metadata must not round-trip into the PUT.
@@ -287,7 +294,7 @@ fn rev_str(rev: Option<&str>) -> &str {
 
 /// The version keys `range` matches. An unparsable range matches nothing,
 /// mirroring `semver.satisfies`.
-fn versions_matching_range(versions: &BTreeMap<String, Value>, range: &str) -> Vec<String> {
+fn versions_matching_range(versions: &Map<String, Value>, range: &str) -> Vec<String> {
     match Range::parse(range) {
         Ok(range) => versions
             .keys()
@@ -300,7 +307,7 @@ fn versions_matching_range(versions: &BTreeMap<String, Value>, range: &str) -> V
 
 /// The highest remaining semver version — the new `latest` after the old
 /// one is unpublished.
-fn highest_version(versions: &BTreeMap<String, Value>) -> Option<String> {
+fn highest_version(versions: &Map<String, Value>) -> Option<String> {
     versions
         .keys()
         .filter_map(|ver_str| Version::parse(ver_str).ok().map(|ver| (ver, ver_str)))

--- a/pnpm/crates/cli/src/cli_args/unpublish.rs
+++ b/pnpm/crates/cli/src/cli_args/unpublish.rs
@@ -1,0 +1,339 @@
+use super::deprecate::{
+    DeprecateContext, DeprecateError, PackageSpec, auth_header_for_registry, fetch_package_meta,
+    package_url, parse_package_spec, registry_for_package, registry_operation_error,
+    write_error_from_response,
+};
+use clap::Args;
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use node_semver::{Range, Version};
+use pacquet_config::Config;
+use pacquet_network::send_with_retry;
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, HashSet};
+
+/// Remove a package, or a range of its versions, from the registry.
+///
+/// A bare package name removes every published version and requires
+/// --force; a pkg@range spec removes only the matching versions,
+/// re-pointing dist-tags that referenced them.
+#[derive(Debug, Args)]
+pub struct UnpublishArgs {
+    /// The base URL of the npm registry.
+    #[clap(long)]
+    pub registry: Option<String>,
+
+    /// One-time password for registries that require two-factor
+    /// authentication.
+    #[clap(long)]
+    pub otp: Option<String>,
+
+    /// Removes the package from the registry regardless of what version is
+    /// currently published. Without this flag, pnpm refuses to unpublish an
+    /// entire package.
+    #[clap(long)]
+    pub force: bool,
+
+    /// The package to remove, optionally with a version range (pkg@1.x).
+    pub params: Vec<String>,
+}
+
+/// Errors specific to `pnpm unpublish`. Codes and messages match the
+/// TypeScript CLI; the registry-communication errors are shared with
+/// [`DeprecateError`].
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum UnpublishError {
+    #[display("Package name is required")]
+    #[diagnostic(code(ERR_PNPM_UNPUBLISH_REQUIRED))]
+    PackageRequired,
+
+    #[display(
+        "Run pnpm unpublish --force to remove all published versions of {package_name} ({versions_list}) from the registry.\nThis is a protection mechanism to prevent accidental unpublish of packages with many versions.\nIf you want to unpublish a specific version, run pnpm unpublish {package_name}@<version>"
+    )]
+    #[diagnostic(code(ERR_PNPM_UNPUBLISH_CONFIRM))]
+    ConfirmRequired {
+        #[error(not(source))]
+        package_name: String,
+        #[error(not(source))]
+        versions_list: String,
+    },
+
+    #[display(
+        "This package cannot be completely unpublished. Deprecate it instead or contact npm support."
+    )]
+    #[diagnostic(code(ERR_PNPM_UNPUBLISH_FORBIDDEN))]
+    CompletelyForbidden,
+}
+
+/// The full packument as the registry returns it: the fields unpublish
+/// mutates are typed, everything else round-trips through `other` so the
+/// `PUT` sends the document back unchanged.
+#[derive(Debug, Serialize, Deserialize)]
+struct Packument {
+    name: String,
+    #[serde(rename = "_rev", default, skip_serializing_if = "Option::is_none")]
+    rev: Option<String>,
+    #[serde(rename = "dist-tags", default)]
+    dist_tags: BTreeMap<String, String>,
+    #[serde(default)]
+    versions: BTreeMap<String, Value>,
+    #[serde(flatten)]
+    other: Map<String, Value>,
+}
+
+impl UnpublishArgs {
+    pub async fn run(self, config: &Config) -> miette::Result<Option<String>> {
+        let context = DeprecateContext::new(config, self.registry.as_ref(), self.otp.clone())?;
+
+        let spec = self.params.first().ok_or(UnpublishError::PackageRequired)?;
+        let PackageSpec { name: package_name, version: version_range } = parse_package_spec(spec)?;
+
+        let registry_url = registry_for_package(&context, &package_name);
+        let auth_header = auth_header_for_registry(&context, &registry_url, &package_name);
+        let package_url = package_url(&package_name, &registry_url)?;
+
+        let pkg: Packument =
+            fetch_package_meta(&context, &package_url, auth_header.as_deref(), &package_name)
+                .await?;
+        if pkg.versions.is_empty() {
+            return Err(DeprecateError::NoVersions { package_name }.into());
+        }
+
+        let Some(range) = version_range else {
+            return self
+                .unpublish_all(&context, &package_url, &pkg, auth_header.as_deref())
+                .await
+                .map(Some);
+        };
+
+        let versions_to_unpublish = versions_matching_range(&pkg.versions, &range);
+        if versions_to_unpublish.is_empty() {
+            return Err(DeprecateError::NoMatchingVersions { version_range: range }.into());
+        }
+
+        // Removing every version is a full unpublish, protections included.
+        if versions_to_unpublish.len() == pkg.versions.len() {
+            return self
+                .unpublish_all(&context, &package_url, &pkg, auth_header.as_deref())
+                .await
+                .map(Some);
+        }
+
+        unpublish_versions(
+            &context,
+            &package_url,
+            &registry_url,
+            pkg,
+            &versions_to_unpublish,
+            auth_header.as_deref(),
+        )
+        .await
+        .map(Some)
+    }
+
+    /// Delete the whole packument (`DELETE <package>/-rev/<rev>`). Refused
+    /// without `--force`; a 405 from the registry means the package may only
+    /// be deprecated, not removed.
+    async fn unpublish_all(
+        &self,
+        context: &DeprecateContext<'_>,
+        package_url: &str,
+        pkg: &Packument,
+        auth_header: Option<&str>,
+    ) -> miette::Result<String> {
+        if !self.force {
+            return Err(UnpublishError::ConfirmRequired {
+                package_name: pkg.name.clone(),
+                versions_list: pkg.versions.keys().cloned().collect::<Vec<_>>().join(", "),
+            }
+            .into());
+        }
+
+        let url = format!("{package_url}/-rev/{}", rev_str(pkg.rev.as_deref()));
+        let response = send_delete(context, &url, auth_header).await?;
+        if !response.status().is_success() {
+            if response.status() == StatusCode::METHOD_NOT_ALLOWED {
+                return Err(UnpublishError::CompletelyForbidden.into());
+            }
+            write_error_from_response(response, "unpublish".to_string()).await?;
+        }
+
+        Ok(format!(
+            "Successfully unpublished all {} version(s) of {}",
+            pkg.versions.len(),
+            pkg.name,
+        ))
+    }
+}
+
+/// Remove `versions` from the packument, re-point the dist-tags that
+/// referenced them, `PUT` the updated document back, then delete the
+/// orphaned tarballs (a 404 there is fine — some registries clean tarballs
+/// up on the packument update themselves).
+async fn unpublish_versions(
+    context: &DeprecateContext<'_>,
+    package_url: &str,
+    registry_url: &str,
+    mut pkg: Packument,
+    versions: &[String],
+    auth_header: Option<&str>,
+) -> miette::Result<String> {
+    let mut tarballs: Vec<String> = Vec::new();
+    for version in versions {
+        let tarball = pkg
+            .versions
+            .get(version)
+            .and_then(|data| data.get("dist"))
+            .and_then(|dist| dist.get("tarball"))
+            .and_then(Value::as_str);
+        if let Some(tarball) = tarball {
+            tarballs.push(tarball.to_string());
+        }
+        pkg.versions.remove(version);
+    }
+
+    let removed: HashSet<&str> = versions.iter().map(String::as_str).collect();
+    let latest_was_removed =
+        pkg.dist_tags.get("latest").is_some_and(|latest| removed.contains(latest.as_str()));
+    pkg.dist_tags.retain(|_, target| !removed.contains(target.as_str()));
+    if latest_was_removed && let Some(highest) = highest_version(&pkg.versions) {
+        pkg.dist_tags.insert("latest".to_string(), highest);
+    }
+
+    // Internal CouchDB metadata must not round-trip into the PUT.
+    pkg.other.remove("_revisions");
+    pkg.other.remove("_attachments");
+
+    let put_url = format!("{package_url}/-rev/{}", rev_str(pkg.rev.as_deref()));
+    put_packument(context, &put_url, &pkg, auth_header).await?;
+
+    let registry_origin = registry_origin(registry_url)?;
+    for tarball in &tarballs {
+        // Every delete bumps the packument revision; refetch for the current
+        // one like the TypeScript CLI does.
+        let updated: Packument =
+            fetch_package_meta(context, package_url, auth_header, &pkg.name).await?;
+        let pathname = tarball_pathname(tarball, registry_url)?;
+        let url = format!("{registry_origin}/{pathname}/-rev/{}", rev_str(updated.rev.as_deref()));
+        let response = send_delete(context, &url, auth_header).await?;
+        if !response.status().is_success() && response.status() != StatusCode::NOT_FOUND {
+            write_error_from_response(response, "unpublish".to_string()).await?;
+        }
+    }
+
+    Ok(format!("Successfully unpublished {} version(s) of {}", versions.len(), pkg.name))
+}
+
+async fn put_packument(
+    context: &DeprecateContext<'_>,
+    url: &str,
+    pkg: &Packument,
+    auth_header: Option<&str>,
+) -> miette::Result<()> {
+    let body = serde_json::to_string(pkg).expect("a struct serializes");
+    let (_guard, response) =
+        send_with_retry(&context.http_client, url, context.retry_opts, |client| {
+            let mut builder =
+                client.put(url).header("content-type", "application/json").body(body.clone());
+            if let Some(auth_header) = auth_header {
+                builder = builder.header("authorization", auth_header);
+            }
+            if let Some(otp) = context.otp.as_deref() {
+                builder = builder.header("npm-otp", otp);
+            }
+            builder
+        })
+        .await
+        .map_err(|source| {
+            registry_operation_error("requesting the registry put endpoint", source)
+        })?;
+    if response.status().is_success() {
+        return Ok(());
+    }
+    write_error_from_response(response, "unpublish".to_string()).await
+}
+
+async fn send_delete(
+    context: &DeprecateContext<'_>,
+    url: &str,
+    auth_header: Option<&str>,
+) -> miette::Result<reqwest::Response> {
+    let (_guard, response) =
+        send_with_retry(&context.http_client, url, context.retry_opts, |client| {
+            let mut builder = client.delete(url);
+            if let Some(auth_header) = auth_header {
+                builder = builder.header("authorization", auth_header);
+            }
+            if let Some(otp) = context.otp.as_deref() {
+                builder = builder.header("npm-otp", otp);
+            }
+            builder
+        })
+        .await
+        .map_err(|source| {
+            registry_operation_error("requesting the registry delete endpoint", source)
+        })?;
+    Ok(response)
+}
+
+/// The `-rev` path segment. A packument without `_rev` renders as the
+/// literal `undefined`, exactly like the TypeScript template string does.
+fn rev_str(rev: Option<&str>) -> &str {
+    rev.unwrap_or("undefined")
+}
+
+/// The version keys `range` matches. An unparsable range matches nothing,
+/// mirroring `semver.satisfies`.
+fn versions_matching_range(versions: &BTreeMap<String, Value>, range: &str) -> Vec<String> {
+    match Range::parse(range) {
+        Ok(range) => versions
+            .keys()
+            .filter(|ver_str| Version::parse(ver_str).is_ok_and(|ver| range.satisfies(&ver)))
+            .cloned()
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// The highest remaining semver version — the new `latest` after the old
+/// one is unpublished.
+fn highest_version(versions: &BTreeMap<String, Value>) -> Option<String> {
+    versions
+        .keys()
+        .filter_map(|ver_str| Version::parse(ver_str).ok().map(|ver| (ver, ver_str)))
+        .max_by(|(left, _), (right, _)| left.cmp(right))
+        .map(|(_, ver_str)| ver_str.clone())
+}
+
+/// The `scheme://host[:port]` origin of the registry, which tarball URLs
+/// are deleted relative to.
+fn registry_origin(registry_url: &str) -> miette::Result<String> {
+    reqwest::Url::parse(registry_url)
+        .map(|url| url.origin().ascii_serialization())
+        .map_err(|source| registry_operation_error("build registry URL", source))
+}
+
+/// The tarball's pathname with the registry's own path prefix stripped, so
+/// registries mounted under a path delete the right resource.
+fn tarball_pathname(tarball_url: &str, registry_url: &str) -> miette::Result<String> {
+    let registry_path = reqwest::Url::parse(registry_url)
+        .map_err(|source| registry_operation_error("build registry URL", source))?
+        .path()
+        .trim_start_matches('/')
+        .to_string();
+    let tarball_path = reqwest::Url::parse(tarball_url)
+        .map_err(|source| registry_operation_error("build tarball URL", source))?
+        .path()
+        .trim_start_matches('/')
+        .to_string();
+    Ok(match tarball_path.strip_prefix(&registry_path) {
+        Some(stripped) if !registry_path.is_empty() => stripped.to_string(),
+        _ => tarball_path,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/unpublish/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/unpublish/tests.rs
@@ -1,11 +1,10 @@
-use serde_json::{Value, json};
-use std::collections::BTreeMap;
+use serde_json::{Map, Value, json};
 
 use super::{
     Packument, highest_version, registry_origin, rev_str, tarball_pathname, versions_matching_range,
 };
 
-fn versions(keys: &[&str]) -> BTreeMap<String, Value> {
+fn versions(keys: &[&str]) -> Map<String, Value> {
     keys.iter().map(|key| ((*key).to_string(), json!({}))).collect()
 }
 
@@ -86,4 +85,18 @@ fn packument_round_trips_unknown_fields() {
     assert_eq!(serialized.get("readme"), Some(&json!("hello")), "unknown fields survive");
     assert!(serialized.get("_revisions").is_none(), "couchdb metadata is dropped");
     assert!(serialized.get("_attachments").is_none(), "couchdb metadata is dropped");
+}
+
+/// The version keys keep the packument's own order — `1.10.0` after `1.9.0`
+/// when the registry sent them that way — like the TypeScript CLI's
+/// `Object.keys`, not lexicographic or semver order.
+#[test]
+fn version_keys_keep_the_packument_order() {
+    let packument: Packument = serde_json::from_value(json!({
+        "name": "pkg",
+        "versions": { "1.9.0": {}, "1.10.0": {}, "1.2.0": {} },
+    }))
+    .expect("a packument deserializes");
+    let keys: Vec<&String> = packument.versions.keys().collect();
+    assert_eq!(keys, ["1.9.0", "1.10.0", "1.2.0"], "insertion order survives");
 }

--- a/pnpm/crates/cli/src/cli_args/unpublish/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/unpublish/tests.rs
@@ -1,0 +1,89 @@
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+
+use super::{
+    Packument, highest_version, registry_origin, rev_str, tarball_pathname, versions_matching_range,
+};
+
+fn versions(keys: &[&str]) -> BTreeMap<String, Value> {
+    keys.iter().map(|key| ((*key).to_string(), json!({}))).collect()
+}
+
+#[test]
+fn rev_str_falls_back_to_the_undefined_literal() {
+    assert_eq!(rev_str(Some("3-abc")), "3-abc");
+    // A packument without _rev renders like the TypeScript template string.
+    assert_eq!(rev_str(None), "undefined");
+}
+
+#[test]
+fn versions_matching_range_mirrors_semver_satisfies() {
+    let versions = versions(&["1.0.0", "1.5.0", "2.0.0"]);
+    assert_eq!(versions_matching_range(&versions, "1.0.0"), ["1.0.0"]);
+    assert_eq!(versions_matching_range(&versions, "^1.0.0"), ["1.0.0", "1.5.0"]);
+    assert_eq!(versions_matching_range(&versions, ">=1.0.0"), ["1.0.0", "1.5.0", "2.0.0"]);
+    assert!(versions_matching_range(&versions, "9.9.9").is_empty(), "no match yields empty");
+    assert!(versions_matching_range(&versions, "not a range").is_empty(), "junk matches nothing");
+}
+
+#[test]
+fn highest_version_picks_the_new_latest() {
+    assert_eq!(
+        highest_version(&versions(&["1.0.0", "10.0.0", "9.0.0"])).as_deref(),
+        Some("10.0.0"),
+    );
+    assert_eq!(
+        highest_version(&versions(&["1.0.0", "1.0.1-beta.1"])).as_deref(),
+        Some("1.0.1-beta.1"),
+    );
+    assert_eq!(highest_version(&versions(&[])), None);
+}
+
+#[test]
+fn registry_origin_drops_the_registry_path() {
+    let origin = registry_origin("https://registry.example.com:8443/npm/").expect("an origin");
+    assert_eq!(origin, "https://registry.example.com:8443");
+}
+
+#[test]
+fn tarball_pathname_strips_the_registry_path_prefix() {
+    // A registry at the host root keeps the tarball path as is.
+    let pathname = tarball_pathname(
+        "https://registry.example.com/pkg/-/pkg-1.0.0.tgz",
+        "https://registry.example.com/",
+    )
+    .expect("a pathname");
+    assert_eq!(pathname, "pkg/-/pkg-1.0.0.tgz");
+
+    // A registry mounted under a path is stripped from the tarball path.
+    let pathname = tarball_pathname(
+        "https://registry.example.com/npm/pkg/-/pkg-1.0.0.tgz",
+        "https://registry.example.com/npm/",
+    )
+    .expect("a pathname");
+    assert_eq!(pathname, "pkg/-/pkg-1.0.0.tgz");
+}
+
+/// The packument round-trips unknown fields and drops the `CouchDB` metadata
+/// keys the way the PUT body requires.
+#[test]
+fn packument_round_trips_unknown_fields() {
+    let raw = json!({
+        "name": "pkg",
+        "_rev": "3-abc",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": { "1.0.0": { "dist": { "tarball": "https://x/pkg-1.0.0.tgz" } } },
+        "readme": "hello",
+        "_revisions": { "start": 3 },
+        "_attachments": {},
+    });
+    let mut packument: Packument = serde_json::from_value(raw).expect("a packument deserializes");
+    assert_eq!(packument.rev.as_deref(), Some("3-abc"));
+
+    packument.other.remove("_revisions");
+    packument.other.remove("_attachments");
+    let serialized = serde_json::to_value(&packument).expect("a packument serializes");
+    assert_eq!(serialized.get("readme"), Some(&json!("hello")), "unknown fields survive");
+    assert!(serialized.get("_revisions").is_none(), "couchdb metadata is dropped");
+    assert!(serialized.get("_attachments").is_none(), "couchdb metadata is dropped");
+}

--- a/pnpm/crates/cli/tests/unpublish.rs
+++ b/pnpm/crates/cli/tests/unpublish.rs
@@ -350,3 +350,28 @@ fn an_unauthorized_delete_reports_unauthorized() {
     assert!(stderr.contains("You must be logged in to unpublish packages"), "{stderr}");
     drop((root, server));
 }
+
+#[test]
+fn the_force_hint_lists_versions_in_packument_order() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    // 1.10.0 after 1.9.0 in the packument; lexicographic order would flip
+    // them, the TypeScript CLI's Object.keys does not.
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(
+            r#"{"name":"test-pkg","_rev":"3-abc","versions":{"1.9.0":{},"1.10.0":{},"1.2.0":{}}}"#,
+        )
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg"]);
+
+    get_mock.assert();
+    assert!(!output.status.success(), "a full unpublish without --force must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("1.9.0, 1.10.0, 1.2.0"), "packument order survives: {stderr}");
+    drop((root, server));
+}

--- a/pnpm/crates/cli/tests/unpublish.rs
+++ b/pnpm/crates/cli/tests/unpublish.rs
@@ -1,0 +1,352 @@
+//! `pacquet unpublish` removes a package, or a range of its versions, from
+//! the registry.
+//!
+//! Ported from the upstream suite `registry-access/commands/test/unpublish.ts`
+//! plus the error paths its handler defines: the missing-name / not-found /
+//! no-versions / no-matching-versions errors, the `--force` protection for a
+//! full unpublish (also when a range matches every version), the partial
+//! unpublish `PUT` (versions removed, dist-tags re-pointed, `latest`
+//! reassigned), tolerated tarball-delete 404s, and the 405/401 registry
+//! answers.
+//!
+//! The registry is a `mockito` server; an empty `--npmrc-auth-file` keeps the
+//! developer's real `~/.npmrc` from influencing the test.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use mockito::Matcher;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use serde_json::json;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+fn empty_auth_file(root: &Path) -> PathBuf {
+    let auth_file = root.join("auth-npmrc");
+    fs::write(&auth_file, "").expect("write empty auth .npmrc");
+    auth_file
+}
+
+fn run_unpublish(
+    workspace: &Path,
+    auth_file: &Path,
+    registry: Option<&str>,
+    params: &[&str],
+) -> std::process::Output {
+    let mut command = pacquet_at(workspace)
+        .with_arg("--npmrc-auth-file")
+        .with_arg(auth_file)
+        .with_arg("unpublish");
+    if let Some(registry) = registry {
+        command = command.with_arg("--registry").with_arg(registry);
+    }
+    for param in params {
+        command = command.with_arg(param);
+    }
+    command.output().expect("spawn pacquet unpublish")
+}
+
+fn stderr_of(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// A two-version packument whose tarballs live on `server_url`, with `latest`
+/// and a `beta` tag both pointing at 0.0.1.
+fn two_version_packument(server_url: &str) -> String {
+    json!({
+        "name": "test-pkg",
+        "_rev": "3-abc",
+        "dist-tags": { "latest": "0.0.1", "beta": "0.0.1" },
+        "versions": {
+            "0.0.1": { "dist": { "tarball": format!("{server_url}/test-pkg/-/test-pkg-0.0.1.tgz") } },
+            "0.0.2": { "dist": { "tarball": format!("{server_url}/test-pkg/-/test-pkg-0.0.2.tgz") } },
+        },
+        "readme": "hello",
+    })
+    .to_string()
+}
+
+#[test]
+fn fails_when_package_is_not_provided() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, None, &[]);
+
+    assert!(!output.status.success(), "a bare unpublish must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_UNPUBLISH_REQUIRED"), "{stderr}");
+    assert!(stderr.contains("Package name is required"), "{stderr}");
+    drop(root);
+}
+
+#[test]
+fn fails_when_package_is_not_found() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server.mock("GET", "/nonexistent-package-99999").with_status(404).create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output =
+        run_unpublish(&workspace, &auth_file, Some(&registry), &["nonexistent-package-99999"]);
+
+    get_mock.assert();
+    assert!(!output.status.success(), "a 404 must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_PACKAGE_NOT_FOUND"), "{stderr}");
+    assert!(
+        stderr.contains(r#"Package "nonexistent-package-99999" not found in registry"#),
+        "{stderr}",
+    );
+    drop((root, server));
+}
+
+#[test]
+fn fails_when_the_package_has_no_versions() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(r#"{"name":"test-pkg","versions":{}}"#)
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg"]);
+
+    get_mock.assert();
+    assert!(!output.status.success(), "an empty packument must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_NO_VERSIONS"), "{stderr}");
+    drop((root, server));
+}
+
+#[test]
+fn fails_when_no_versions_match_the_range() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg@9.9.9"]);
+
+    get_mock.assert();
+    assert!(!output.status.success(), "a non-matching range must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_NO_MATCHING_VERSIONS"), "{stderr}");
+    assert!(stderr.contains(r#"No versions match "9.9.9""#), "{stderr}");
+    drop((root, server));
+}
+
+#[test]
+fn refuses_a_full_unpublish_without_force() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let delete_mock = server.mock("DELETE", "/test-pkg/-rev/3-abc").expect(0).create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg"]);
+
+    get_mock.assert();
+    delete_mock.assert();
+    assert!(!output.status.success(), "a full unpublish without --force must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_UNPUBLISH_CONFIRM"), "{stderr}");
+    assert!(stderr.contains("pnpm unpublish --force"), "{stderr}");
+    assert!(stderr.contains("0.0.1, 0.0.2"), "the versions are listed: {stderr}");
+    drop((root, server));
+}
+
+#[test]
+fn a_range_matching_every_version_is_a_full_unpublish() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg@>=0.0.1"]);
+
+    get_mock.assert();
+    assert!(!output.status.success(), "removing every version needs --force too");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_UNPUBLISH_CONFIRM"), "{stderr}");
+    drop((root, server));
+}
+
+#[test]
+fn force_unpublishes_the_entire_package() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let delete_mock =
+        server.mock("DELETE", "/test-pkg/-rev/3-abc").with_status(200).with_body("{}").create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg", "--force"]);
+
+    get_mock.assert();
+    delete_mock.assert();
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Successfully unpublished all 2 version(s) of test-pkg"), "{stdout}");
+    drop((root, server));
+}
+
+#[test]
+fn unpublishes_a_specific_version_and_repoints_dist_tags() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let server_url = server.url();
+
+    // The refetch before each tarball delete hits GET again.
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server_url))
+        .expect_at_least(2)
+        .create();
+    // 0.0.1 disappears; the `beta` tag pointing at it is dropped and `latest`
+    // is re-pointed at the highest remaining version.
+    let put_mock = server
+        .mock("PUT", "/test-pkg/-rev/3-abc")
+        .match_header("content-type", "application/json")
+        .match_body(Matcher::Json(json!({
+            "name": "test-pkg",
+            "_rev": "3-abc",
+            "dist-tags": { "latest": "0.0.2" },
+            "versions": {
+                "0.0.2": { "dist": { "tarball": format!("{server_url}/test-pkg/-/test-pkg-0.0.2.tgz") } },
+            },
+            "readme": "hello",
+        })))
+        .with_status(200)
+        .with_body("{}")
+        .create();
+    let tarball_delete_mock = server
+        .mock("DELETE", "/test-pkg/-/test-pkg-0.0.1.tgz/-rev/3-abc")
+        .with_status(200)
+        .with_body("{}")
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg@0.0.1"]);
+
+    get_mock.assert();
+    put_mock.assert();
+    tarball_delete_mock.assert();
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Successfully unpublished 1 version(s) of test-pkg"), "{stdout}");
+    drop((root, server));
+}
+
+#[test]
+fn a_tarball_delete_404_is_tolerated() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .expect_at_least(2)
+        .create();
+    let put_mock =
+        server.mock("PUT", "/test-pkg/-rev/3-abc").with_status(200).with_body("{}").create();
+    // Some registries clean tarballs up on the packument update themselves.
+    let tarball_delete_mock = server
+        .mock("DELETE", "/test-pkg/-/test-pkg-0.0.1.tgz/-rev/3-abc")
+        .with_status(404)
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg@0.0.1"]);
+
+    get_mock.assert();
+    put_mock.assert();
+    tarball_delete_mock.assert();
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    drop((root, server));
+}
+
+#[test]
+fn a_405_on_a_full_unpublish_reports_unpublish_forbidden() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let delete_mock = server.mock("DELETE", "/test-pkg/-rev/3-abc").with_status(405).create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg", "--force"]);
+
+    get_mock.assert();
+    delete_mock.assert();
+    assert!(!output.status.success(), "a 405 must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_UNPUBLISH_FORBIDDEN"), "{stderr}");
+    assert!(stderr.contains("cannot be completely unpublished"), "{stderr}");
+    drop((root, server));
+}
+
+#[test]
+fn an_unauthorized_delete_reports_unauthorized() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let delete_mock = server
+        .mock("DELETE", "/test-pkg/-rev/3-abc")
+        .with_status(401)
+        .with_body(r#"{"error":"unauthorized"}"#)
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg", "--force"]);
+
+    get_mock.assert();
+    delete_mock.assert();
+    assert!(!output.status.success(), "a 401 must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_UNAUTHORIZED"), "{stderr}");
+    assert!(stderr.contains("You must be logged in to unpublish packages"), "{stderr}");
+    drop((root, server));
+}


### PR DESCRIPTION
Port the `unpublish` command to pacquet: remove a package from the registry entirely, or remove the versions matching `<package>@<range>`. A full unpublish (bare name, or a range matching every version) is refused without `--force` and issues `DELETE <package>/-rev/<rev>`, mapping a 405 to ERR_PNPM_UNPUBLISH_FORBIDDEN. A partial unpublish removes the versions from the packument, drops dist-tags pointing at them, re-points `latest` at the highest remaining version, PUTs the updated document back, and deletes the orphaned tarballs, tolerating a 404 from registries that clean tarballs up themselves. `--registry` and `--otp` are supported.

Reuses the deprecate command's registry plumbing (context, auth and registry resolution, packument fetch with retries and body limits, and the shared 401/403/error mapping); the packument fetch is generalized over the deserialized type so both commands share it. Error codes match the TypeScript CLI: ERR_PNPM_UNPUBLISH_REQUIRED,
ERR_PNPM_UNPUBLISH_CONFIRM, ERR_PNPM_UNPUBLISH_FORBIDDEN, plus the shared ERR_PNPM_PACKAGE_NOT_FOUND, ERR_PNPM_NO_VERSIONS, ERR_PNPM_NO_MATCHING_VERSIONS, ERR_PNPM_UNAUTHORIZED and ERR_PNPM_FORBIDDEN.

The TypeScript CLI already ships `unpublish`
(registry-access/commands/src/unpublish.ts), so only the pacquet side changes; no TypeScript change is needed.

Tests: unit tests for the pure helpers (range matching, latest reselection, tarball-path stripping, packument round-tripping) plus a mockito integration suite porting the upstream scenarios and the handler's error paths — the --force protections, the partial-unpublish PUT with re-pointed dist-tags, tolerated tarball-delete 404s, and the 405/401 registry answers.

<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Implements the `pnpm unpublish` command in pacquet. The TypeScript CLI already ships it (`pnpm11/registry-access/commands/src/unpublish.ts`), so only the pacquet side changes. Covers the `unpublish` item of the command surface in the Rust Roadmap, pnpm/pnpm#11633.

Behavior, mirroring the TypeScript handler:

- **Full unpublish** (a bare package name, or a range matching every published version) is refused without `--force` with the exact upstream protection message (`ERR_PNPM_UNPUBLISH_CONFIRM`), and issues `DELETE <package>/-rev/<rev>`; a 405 maps to `ERR_PNPM_UNPUBLISH_FORBIDDEN` ("deprecate it instead").
- **Partial unpublish** (`<package>@<range>`) removes the matching versions from the packument, drops the dist-tags pointing at them, re-points `latest` at the highest remaining version, `PUT`s the updated document back, then deletes the orphaned tarballs — tolerating a 404 from registries that clean tarballs up on the packument update themselves.
- `--registry` and `--otp` are supported; error codes match the TypeScript CLI (`ERR_PNPM_UNPUBLISH_REQUIRED`, `ERR_PNPM_PACKAGE_NOT_FOUND`, `ERR_PNPM_NO_VERSIONS`, `ERR_PNPM_NO_MATCHING_VERSIONS`, `ERR_PNPM_UNAUTHORIZED`, `ERR_PNPM_FORBIDDEN`).

Implementation-wise the command reuses the deprecate command's registry plumbing (context, auth/registry resolution, retried packument fetch with body limits, and the shared 401/403/error mapping); the packument fetch was generalized over the deserialized type so both commands share one code path. The packument round-trips unknown fields through a flattened map, so the `PUT` sends the registry's own document back minus the removed versions and the internal `_revisions`/`_attachments` keys.

Tests: unit tests for the pure helpers (range matching, `latest` reselection, tarball-path stripping for path-mounted registries, packument round-tripping) plus a mockito integration suite porting the upstream scenarios from `registry-access/commands/test/unpublish.ts` and the handler's error paths — the `--force` protections, the partial-unpublish `PUT` with re-pointed dist-tags asserted on the request body, tolerated tarball-delete 404s, and the 405/401 registry answers.

## Squash Commit Body

```text
Port the `unpublish` command to pacquet: remove a package from the
registry entirely, or remove the versions matching `<package>@<range>`.
A full unpublish (bare name, or a range matching every version) is
refused without `--force` and issues `DELETE <package>/-rev/<rev>`,
mapping a 405 to ERR_PNPM_UNPUBLISH_FORBIDDEN. A partial unpublish
removes the versions from the packument, drops dist-tags pointing at
them, re-points `latest` at the highest remaining version, PUTs the
updated document back, and deletes the orphaned tarballs, tolerating a
404 from registries that clean tarballs up themselves. `--registry` and
`--otp` are supported.

Reuses the deprecate command's registry plumbing (context, auth and
registry resolution, packument fetch with retries and body limits, and
the shared 401/403/error mapping); the packument fetch is generalized
over the deserialized type so both commands share it. Error codes match
the TypeScript CLI: ERR_PNPM_UNPUBLISH_REQUIRED,
ERR_PNPM_UNPUBLISH_CONFIRM, ERR_PNPM_UNPUBLISH_FORBIDDEN, plus the
shared ERR_PNPM_PACKAGE_NOT_FOUND, ERR_PNPM_NO_VERSIONS,
ERR_PNPM_NO_MATCHING_VERSIONS, ERR_PNPM_UNAUTHORIZED and
ERR_PNPM_FORBIDDEN.

The TypeScript CLI already ships `unpublish`
(registry-access/commands/src/unpublish.ts), so only the pacquet side
changes; no TypeScript change is needed. Covers the `unpublish` item of
the command surface in the Rust Roadmap, pnpm/pnpm#11633.

Tests: unit tests for the pure helpers (range matching, latest
reselection, tarball-path stripping, packument round-tripping) plus a
mockito integration suite porting the upstream scenarios and the
handler's error paths — the --force protections, the partial-unpublish
PUT with re-pointed dist-tags, tolerated tarball-delete 404s, and the
405/401 registry answers.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(The TypeScript CLI already ships `unpublish`; this PR adds the pacquet side.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] ~Updated the documentation if needed.~ *(No docs change: the command is
  already documented for the TypeScript CLI.)*

---
Made with the help of Claude Code (claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `pnpm unpublish` command.
  - Remove an entire package with `--force`, or unpublish versions matching a package range.
  - Automatically update dist-tags and remove associated package tarballs.
  - Added support for custom registries and one-time passwords.

- **Bug Fixes**
  - Provides clear confirmation prompts and error messages for unsupported or unauthorized unpublishing operations.
  - Handles already-missing tarballs without failing the operation.

- **Tests**
  - Added comprehensive coverage for full and partial unpublishing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->