### PR TITLE
fix: make `pnpm version -r --json` emit JSON when there are no pending changes

### DIFF
--- a/.changeset/version-json-empty-output.md
+++ b/.changeset/version-json-empty-output.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/releasing.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm version -r --json` now outputs `[]` instead of human-readable text when no pending changes exist [`pnpm/pnpm#13217`](https://github.com/pnpm/pnpm/issues/13217).

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use derive_more::{Display, Error};
-use miette::{Context, Diagnostic, IntoDiagnostic};
+use miette::{Context, Diagnostic};
 use node_semver::{Identifier, Version};
 use pacquet_config::Config;
 use pacquet_executor::{RunPostinstallHooks, run_lifecycle_hook};
@@ -72,8 +72,8 @@ pub struct VersionArgs {
     #[clap(long = "tag-version-prefix", default_value = "v")]
     pub tag_version_prefix: String,
 
-    /// Output release details in JSON format.
-    #[clap(long = "json")]
+    /// Show information in JSON format.
+    #[clap(long)]
     pub json: bool,
 }
 
@@ -435,7 +435,7 @@ impl VersionArgs {
         )?;
 
         if self.json {
-            println!("{}", serde_json::to_string_pretty(&applied).into_diagnostic()?);
+            println!("{}", serde_json::to_string_pretty(&applied).expect("serialize applied releases"));
             return Ok(());
         }
 

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use derive_more::{Display, Error};
-use miette::{Context, Diagnostic};
+use miette::{Context, Diagnostic, IntoDiagnostic};
 use node_semver::{Identifier, Version};
 use pacquet_config::Config;
 use pacquet_executor::{RunPostinstallHooks, run_lifecycle_hook};
@@ -72,8 +72,8 @@ pub struct VersionArgs {
     #[clap(long = "tag-version-prefix", default_value = "v")]
     pub tag_version_prefix: String,
 
-    /// Show information in JSON format.
-    #[clap(long)]
+    /// Output release details in JSON format.
+    #[clap(long = "json")]
     pub json: bool,
 }
 
@@ -411,7 +411,11 @@ impl VersionArgs {
                     &confirmed,
                 )?;
             }
-            println!(r#"No pending changes. Record one with "pnpm change"."#);
+            if self.json {
+                println!("[]");
+            } else {
+                println!(r#"No pending changes. Record one with "pnpm change"."#);
+            }
             return Ok(());
         }
         if self.dry_run {
@@ -429,6 +433,11 @@ impl VersionArgs {
             Some(&config.versioning),
             &confirmed,
         )?;
+
+        if self.json {
+            println!("{}", serde_json::to_string_pretty(&applied).into_diagnostic()?);
+            return Ok(());
+        }
 
         use std::fmt::Write as _;
         let mut output = String::from("Versions applied:\n");

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -435,7 +435,10 @@ impl VersionArgs {
         )?;
 
         if self.json {
-            println!("{}", serde_json::to_string_pretty(&applied).expect("serialize applied releases"));
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&applied).expect("serialize applied releases")
+            );
             return Ok(());
         }
 

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -437,7 +437,7 @@ impl VersionArgs {
         if self.json {
             println!(
                 "{}",
-                serde_json::to_string_pretty(&applied).expect("serialize applied releases")
+                serde_json::to_string_pretty(&applied).expect("serialize applied releases"),
             );
             return Ok(());
         }

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -775,3 +775,50 @@ fn an_empty_tag_version_prefix_removes_the_v() {
     assert_eq!(git_stdout(&workspace, &["tag", "--list"]), "1.0.1");
     drop(root);
 }
+
+#[test]
+fn version_recursive_json_prints_empty_array_when_no_pending_changes() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{"name":"root","version":"1.0.0"}"#)
+        .expect("write package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - '.'\n")
+        .expect("write pnpm-workspace.yaml");
+
+    let output = test_command(pacquet, root.path())
+        .current_dir(&workspace)
+        .args(["version", "-r", "--json"])
+        .output()
+        .expect("run pacquet version -r --json");
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "[]");
+
+    drop(root);
+}
+
+#[test]
+fn version_recursive_json_prints_applied_releases_when_pending_changes() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let (_pkg_a, _pkg_b) = write_two_package_workspace(&workspace);
+    fs::create_dir_all(workspace.join(".changeset")).expect("create .changeset");
+    let intent = workspace.join(".changeset").join("calm-cats-smile.md");
+    fs::write(&intent, "---\n\"pkg-a\": minor\n---\n\nA pending change intent.\n")
+        .expect("write change intent");
+
+    let output = test_command(pacquet, root.path())
+        .env("PACQUET_ASSUME_VERSIONS_PUBLISHED", "1")
+        .current_dir(&workspace)
+        .args(["version", "-r", "--json", "--no-git-checks"])
+        .output()
+        .expect("run pacquet version -r --json");
+    assert!(output.status.success(), "{}", stderr_of(&output));
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+            .expect("stdout must be JSON");
+    let entry = &parsed.as_array().expect("a JSON array")[0];
+    assert_eq!(entry.get("name").and_then(serde_json::Value::as_str), Some("pkg-a"));
+    assert_eq!(entry.get("currentVersion").and_then(serde_json::Value::as_str), Some("1.0.0"));
+    assert_eq!(entry.get("newVersion").and_then(serde_json::Value::as_str), Some("1.1.0"));
+
+    drop(root);
+}

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -793,7 +793,7 @@ fn version_json_outputs_release_details_in_json() {
     assert_eq!(arr.len(), 1, "expected exactly one release entry");
     let entry = &arr[0];
     assert_eq!(entry.get("name").and_then(serde_json::Value::as_str), Some("test-pkg"));
-    assert_eq!(entry.get("currentVersion").and_then(serde_json::Value::as_str), Some("1.0.0"),);
+    assert_eq!(entry.get("currentVersion").and_then(serde_json::Value::as_str), Some("1.0.0"));
     assert_eq!(entry.get("newVersion").and_then(serde_json::Value::as_str), Some("1.0.1"));
     drop(root);
 }

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -777,6 +777,28 @@ fn an_empty_tag_version_prefix_removes_the_v() {
 }
 
 #[test]
+fn version_json_outputs_release_details_in_json() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    init_git(&workspace);
+    write_manifest(&workspace, r#"{"name":"test-pkg","version":"1.0.0"}"#);
+    git_commit_all(&workspace, "init");
+
+    let output = pacquet_version(&workspace, &["patch", "--json", "--no-git-tag-version"]);
+
+    assert!(output.status.success(), "{}", stderr_of(&output));
+    let parsed: serde_json::Value =
+        serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
+            .expect("stdout must be JSON");
+    let arr = parsed.as_array().expect("a JSON array");
+    assert_eq!(arr.len(), 1, "expected exactly one release entry");
+    let entry = &arr[0];
+    assert_eq!(entry.get("name").and_then(serde_json::Value::as_str), Some("test-pkg"));
+    assert_eq!(entry.get("currentVersion").and_then(serde_json::Value::as_str), Some("1.0.0"),);
+    assert_eq!(entry.get("newVersion").and_then(serde_json::Value::as_str), Some("1.0.1"));
+    drop(root);
+}
+
+#[test]
 fn version_recursive_json_prints_empty_array_when_no_pending_changes() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     fs::write(workspace.join("package.json"), r#"{"name":"root","version":"1.0.0"}"#)
@@ -815,7 +837,9 @@ fn version_recursive_json_prints_applied_releases_when_pending_changes() {
     let parsed: serde_json::Value =
         serde_json::from_str(String::from_utf8_lossy(&output.stdout).trim())
             .expect("stdout must be JSON");
-    let entry = &parsed.as_array().expect("a JSON array")[0];
+    let arr = parsed.as_array().expect("a JSON array");
+    assert_eq!(arr.len(), 1, "expected exactly one release entry");
+    let entry = &arr[0];
     assert_eq!(entry.get("name").and_then(serde_json::Value::as_str), Some("pkg-a"));
     assert_eq!(entry.get("currentVersion").and_then(serde_json::Value::as_str), Some("1.0.0"));
     assert_eq!(entry.get("newVersion").and_then(serde_json::Value::as_str), Some("1.1.0"));

--- a/pnpm/crates/versioning/src/apply.rs
+++ b/pnpm/crates/versioning/src/apply.rs
@@ -13,8 +13,10 @@ use crate::{
     plan::{ReleasePlan, WorkspaceProject, index_project_refs},
     settings::{ChangelogStorage, VersioningSettings, changelog_storage},
 };
+use serde::Serialize;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppliedRelease {
     pub name: String,
     pub current_version: String,

--- a/pnpm/crates/versioning/src/apply.rs
+++ b/pnpm/crates/versioning/src/apply.rs
@@ -4,6 +4,8 @@ use std::{
     path::Path,
 };
 
+use serde::Serialize;
+
 use crate::{
     changelog::{compose_changelog_section, prepend_changelog_section},
     error::VersioningError,
@@ -13,7 +15,6 @@ use crate::{
     plan::{ReleasePlan, WorkspaceProject, index_project_refs},
     settings::{ChangelogStorage, VersioningSettings, changelog_storage},
 };
-use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/pnpm11/pnpm/test/version.ts
+++ b/pnpm11/pnpm/test/version.ts
@@ -4,7 +4,7 @@ import { safeExeca as execa } from 'execa'
 import { loadJsonFileSync } from 'load-json-file'
 import { writeYamlFileSync } from 'write-yaml-file'
 
-import { execPnpm } from './utils/index.js'
+import { execPnpm, execPnpmSync } from './utils/index.js'
 
 test('version --recursive bumps every workspace package', async () => {
   preparePackages([
@@ -30,6 +30,18 @@ test('version --recursive --filter bumps only the selected package', async () =>
 
   expect(loadJsonFileSync<{ version: string }>('project-1/package.json').version).toBe('1.0.0')
   expect(loadJsonFileSync<{ version: string }>('project-2/package.json').version).toBe('2.3.1')
+})
+
+test('version --recursive --json prints an empty JSON array when there are no pending changes', async () => {
+  preparePackages([
+    { name: 'project-1', version: '1.0.0' },
+  ])
+  writeYamlFileSync('pnpm-workspace.yaml', { packages: ['project-*'] })
+
+  const result = execPnpmSync(['version', '--recursive', '--json', '--no-git-checks'])
+
+  expect(result.status).toBe(0)
+  expect(result.stdout.toString().trim()).toBe('[]')
 })
 
 test('version from-git is wired through the compiled CLI', async () => {

--- a/pnpm11/releasing/commands/src/version/index.ts
+++ b/pnpm11/releasing/commands/src/version/index.ts
@@ -267,7 +267,7 @@ async function releaseFromIntents (opts: VersionHandlerOptions): Promise<string>
     if (!opts.dryRun && filter == null) {
       await applyReleasePlan(plan, applyOpts)
     }
-    return 'No pending changes. Record one with "pnpm change".'
+    return opts.json ? '[]' : 'No pending changes. Record one with "pnpm change".'
   }
 
   if (opts.dryRun) {

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -599,5 +599,45 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
 
       expect(result).toBe('[]')
     })
+
+    it('should return JSON array with release details when json mode and pending changes exist', async () => {
+      const pkgADir = path.join(tempDir, 'packages', 'pkg-a')
+      fs.mkdirSync(pkgADir, { recursive: true })
+
+      const rootManifest = { name: 'my-workspace', version: '1.0.0' }
+      const pkgAManifest = { name: 'pkg-a', version: '1.0.0' }
+      fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify(rootManifest))
+      fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n')
+      fs.writeFileSync(path.join(pkgADir, 'package.json'), JSON.stringify(pkgAManifest))
+
+      const changesetDir = path.join(tempDir, '.changeset')
+      fs.mkdirSync(changesetDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(changesetDir, 'test-change.md'),
+        '---\n"pkg-a": minor\n---\n\nA pending change.\n'
+      )
+
+      const result = await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        gitChecks: false,
+        gitTagVersion: false,
+        recursive: true,
+        json: true,
+        allProjects: [
+          { rootDir: pkgADir, manifest: { name: 'pkg-a', version: '1.0.0' } },
+        ],
+        // Stub out the registry probe to avoid network calls in tests.
+        checkVersionPublished: async () => true,
+      } as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const parsed = JSON.parse(result as string)
+      expect(Array.isArray(parsed)).toBe(true)
+      expect(parsed.length).toBeGreaterThan(0)
+      const entry = parsed[0]
+      expect(entry.name).toBe('pkg-a')
+      expect(entry.currentVersion).toBe('1.0.0')
+      expect(entry.newVersion).toBe('1.1.0')
+    })
   })
 })

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -633,7 +633,7 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
 
       const parsed = JSON.parse(result as string)
       expect(Array.isArray(parsed)).toBe(true)
-      expect(parsed.length).toBeGreaterThan(0)
+      expect(parsed).toHaveLength(1)
       const entry = parsed[0]
       expect(entry.name).toBe('pkg-a')
       expect(entry.currentVersion).toBe('1.0.0')

--- a/pnpm11/releasing/commands/test/version/index.test.ts
+++ b/pnpm11/releasing/commands/test/version/index.test.ts
@@ -576,5 +576,28 @@ fs.appendFileSync(process.argv[2], process.argv[3] + ':' + manifest.version + '\
       const pkgManifest = JSON.parse(fs.readFileSync(path.join(pkgDir, 'package.json'), 'utf-8'))
       expect(pkgManifest.version).toBe('1.0.0')
     })
+
+    it('should return [] in json mode when no pending changes exist', async () => {
+      const pkgADir = path.join(tempDir, 'packages', 'pkg-a')
+      fs.mkdirSync(pkgADir, { recursive: true })
+
+      fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'my-workspace', version: '1.0.0' }))
+      fs.writeFileSync(path.join(tempDir, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n')
+      fs.writeFileSync(path.join(pkgADir, 'package.json'), JSON.stringify({ name: 'pkg-a', version: '1.0.0' }))
+
+      const result = await handler({
+        dir: tempDir,
+        workspaceDir: tempDir,
+        gitChecks: false,
+        gitTagVersion: false,
+        recursive: true,
+        json: true,
+        selectedProjectsGraph: {
+          [pkgADir]: { dependencies: [], package: {} },
+        },
+      } as any, []) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      expect(result).toBe('[]')
+    })
   })
 })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#13217.

`pnpm version -r --json` printed the human-readable `No pending changes. Record one with "pnpm change".` text to stdout, breaking consumers that parse the output as JSON. It now prints `[]` when there are no pending changes. When there are pending releases, both stacks emit the applied releases as a pretty-printed JSON array of `{name, currentVersion, newVersion}` objects — the pacquet side gains a camelCase `Serialize` derive on `AppliedRelease` to match the TypeScript CLI's existing shape.

Covered by tests at every level: unit tests on the TypeScript handler, an e2e test through the bundled TypeScript CLI, and pacquet integration tests through the real binary.

## Squash Commit Body

```text
With --json, "pnpm version -r" must emit machine-readable output in every
case. The no-pending-changes branch printed a human-readable sentence to
stdout; it now prints an empty JSON array. The applied-releases branch in
pacquet now serializes the AppliedRelease list as camelCase JSON, matching
the TypeScript CLI's output shape exactly.

Fixes pnpm/pnpm#13217.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (Not needed — no new flags or settings.)

---
Written by an agent (Claude Code, claude-fable-5).
