### PR TITLE
test(pacquet/network-web-auth-testing): panic on any log event in `UnexpectedReporter`

### DIFF
--- a/pnpm/crates/network-web-auth-testing/src/lib.rs
+++ b/pnpm/crates/network-web-auth-testing/src/lib.rs
@@ -227,20 +227,14 @@ macro_rules! web_auth_fake {
             }
         }
 
-        /// Panics on any global message — the strict reporter for a test that
-        /// expects no warning.
+        /// Panics on any log event — the strict reporter for a test that
+        /// expects no emission at all.
         #[allow(dead_code)]
         struct UnexpectedReporter;
 
         impl ::pacquet_reporter::Reporter for UnexpectedReporter {
             fn emit(event: &::pacquet_reporter::LogEvent) {
-                if let ::pacquet_reporter::LogEvent::Global(::pacquet_reporter::GlobalLog {
-                    message,
-                    ..
-                }) = event
-                {
-                    panic!("unexpected global message: {message}");
-                }
+                panic!("unexpected log: {event:?}");
             }
         }
 


### PR DESCRIPTION
## Summary

The `UnexpectedReporter` dependency-injection fake in `pacquet-network-web-auth-testing` is documented as the strict reporter for a test that expects no emission at all, yet its `panic!` was guarded by `if let LogEvent::Global(..)`, so every non-`Global` `LogEvent` variant fell through silently — an unexpected non-`Global` emission from the code under test would have passed the assertion unnoticed, a false negative that defeats the fake's purpose.

`UnexpectedReporter::emit` now panics unconditionally on any event, and the doc comment says so. `LogEvent` derives `Debug`, so the panic message uses `{event:?}`, which is also more informative than a single field. Because the fake is emitted by the `web_auth_fake!` macro, this strengthens every dependency-injection test that turbofishes `UnexpectedReporter` — the `with_otp_handling`, `login`, and `SyntheticOtpError::from_unknown_body` tests.

Resolves <https://github.com/pnpm/pnpm/issues/13221>.

## Squash Commit Body

```text
The UnexpectedReporter dependency-injection fake is documented as the strict
reporter for a test that expects no emission at all, but its panic was guarded
by `if let LogEvent::Global(..)`, so every non-Global LogEvent variant fell
through silently. An unexpected non-Global emission would have passed the
assertion unnoticed -- a false negative that defeats the fake's purpose.

Panic unconditionally on any event and correct the doc comment. LogEvent
derives Debug, so `{event:?}` yields a more useful failure message than a single
field. The fake is emitted by the web_auth_fake! macro, so this also strengthens
every DI test that turbofishes UnexpectedReporter (the with_otp_handling, login,
and SyntheticOtpError::from_unknown_body tests).

Resolves https://github.com/pnpm/pnpm/issues/13221
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. — Rust-only test-utility change; the TypeScript stack has its own separate reporter fakes and no user-visible behavior changes, so there is nothing to port.
- [x] Added a changeset if this PR changes any published package. — Not applicable: `pacquet-network-web-auth-testing` is `publish = false` and the change is test-only, so no published package is affected.
- [x] Added or updated tests. — This hardens a test-only fake; the existing `with_otp_handling` suite already instantiates `UnexpectedReporter` and continues to pass (63 tests).
- [x] Updated the documentation if needed. — Not needed; no user-facing behavior changed.