### PR TITLE
fix: keep the worker pool reference after finishWorkers()

### DIFF
--- a/.changeset/keep-worker-pool-for-stragglers.md
+++ b/.changeset/keep-worker-pool-for-stragglers.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/worker": patch
+"pnpm": patch
+---
+
+Fixed `pnpm install` sometimes never exiting after printing `Done in Xs` [#12297](https://github.com/pnpm/pnpm/issues/12297). A worker call arriving after the CLI's final `finishWorkers()` — typically a tarball fetch for a package that is never linked (e.g. a foreign-architecture optional dependency), delayed past install completion by a network retry — lazily re-created the worker pool, and nothing ever finished the new pool, so its idle worker thread kept the process alive until an external timeout killed it. `finishWorkers()` now keeps the finished pool's reference: straggler tasks are still serviced, and their workers are torn down again at check-in.

--- a/.changeset/keep-worker-pool-for-stragglers.md
+++ b/.changeset/keep-worker-pool-for-stragglers.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Fixed `pnpm install` sometimes never exiting after printing `Done in Xs` [#12297](https://github.com/pnpm/pnpm/issues/12297). A worker call arriving after the CLI's final `finishWorkers()` — typically a tarball fetch for a package that is never linked (e.g. a foreign-architecture optional dependency), delayed past install completion by a network retry — lazily re-created the worker pool, and nothing ever finished the new pool, so its idle worker thread kept the process alive until an external timeout killed it. `finishWorkers()` now keeps the finished pool's reference: straggler tasks are still serviced, and their workers are torn down again at check-in.
+Fixed `pnpm install` sometimes not exiting after printing `Done in Xs` [#12297](https://github.com/pnpm/pnpm/issues/12297).

--- a/pnpm11/worker/src/index.ts
+++ b/pnpm11/worker/src/index.ts
@@ -33,7 +33,13 @@ export async function finishWorkers (): Promise<void> {
   // @ts-expect-error
   global.finishWorkers = undefined
   await finish?.()
-  workerPool = undefined
+  // Deliberately keep the `workerPool` reference. The finished pool still
+  // services straggler tasks (e.g. a tarball fetch delayed by a network retry
+  // that completes after the CLI's final drain): each such task spawns a
+  // worker that is torn down again at check-in because the pool is finishing.
+  // Clearing the reference would make stragglers lazily create a fresh pool
+  // that nothing ever finishes, leaving an idle worker thread that keeps the
+  // process alive forever (#12297).
 }
 
 function createTarballWorkerPool (): WorkerPool {

--- a/pnpm11/worker/src/index.ts
+++ b/pnpm11/worker/src/index.ts
@@ -33,13 +33,6 @@ export async function finishWorkers (): Promise<void> {
   // @ts-expect-error
   global.finishWorkers = undefined
   await finish?.()
-  // Deliberately keep the `workerPool` reference. The finished pool still
-  // services straggler tasks (e.g. a tarball fetch delayed by a network retry
-  // that completes after the CLI's final drain): each such task spawns a
-  // worker that is torn down again at check-in because the pool is finishing.
-  // Clearing the reference would make stragglers lazily create a fresh pool
-  // that nothing ever finishes, leaving an idle worker thread that keeps the
-  // process alive forever (#12297).
 }
 
 function createTarballWorkerPool (): WorkerPool {

--- a/pnpm11/worker/test/finishWorkers.test.ts
+++ b/pnpm11/worker/test/finishWorkers.test.ts
@@ -1,0 +1,39 @@
+import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+
+const libIndex = new URL('../lib/index.js', import.meta.url).href
+
+// Regression test for https://github.com/pnpm/pnpm/issues/12297: a worker
+// call that arrives after finishWorkers() (e.g. a tarball fetch delayed by a
+// network retry, finishing after the CLI's final drain) must not leave a
+// worker thread alive — a leaked idle worker keeps the process from exiting.
+test('process exits after a worker call that arrives after finishWorkers()', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-worker-straggler-'))
+  const storeDir = path.join(tmp, 'store')
+  fs.mkdirSync(storeDir)
+  const scenario = path.join(tmp, 'scenario.mjs')
+  fs.writeFileSync(scenario, `
+const { finishWorkers, readPkgFromCafs } = await import(${JSON.stringify(libIndex)})
+const ctx = { storeDir: ${JSON.stringify(storeDir)}, verifyStoreIntegrity: false }
+await readPkgFromCafs(ctx, ${JSON.stringify(path.join(storeDir, 'idx-1'))}) // normal install work
+await finishWorkers() // the CLI's final drain
+await readPkgFromCafs(ctx, ${JSON.stringify(path.join(storeDir, 'idx-2'))}) // late straggler task
+`)
+  const exitCode = await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scenario], { stdio: 'ignore' })
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      resolve('leaked worker kept the process alive')
+    }, 8000)
+    child.on('error', reject)
+    child.on('exit', (code) => {
+      clearTimeout(timer)
+      resolve(code)
+    })
+  })
+  expect(exitCode).toBe(0)
+}, 15000)


### PR DESCRIPTION
## Summary

Fixes #12297 — `pnpm install` sometimes never exits after printing `Done in Xs` (CI, Linux/macOS, all of 11.x, ~5% of runs with downloads in our CI).

## Root cause

`finishWorkers()` clears the `workerPool` reference, but every worker API lazily re-creates the pool:

1. pnpm fetches lockfile packages that never get linked (e.g. foreign-architecture optional dependencies). The install does not wait for those fetches.
2. `Done in Xs` prints; the CLI's `finally { await finishWorkers() }` drains the pool and sets `workerPool = undefined`.
3. A straggler fetch — classically one delayed exactly 10s by an `ECONNRESET`/`UND_ERR_SOCKET` retry — completes and calls `addFilesFromTarball` → `if (!workerPool) workerPool = createTarballWorkerPool()` builds a fresh pool.
4. Nothing ever finishes that pool: its idle worker thread and MessagePort keep the event loop alive until an external timeout kills the process.

Node diagnostic reports (`--report-on-signal`) from 25+ hung CI runs all show the same signature: one leftover worker thread plus one referenced `async` handle, no sockets, no timers.

The regression came in with #10827 (`1941ce75`, first shipped in v11.0.0-alpha.13), which added `workerPool = undefined` to fix a fetch-test timeout during development. The companion Jest-hang fix from that PR — clearing `global.finishWorkers` to stop chain accumulation across test files (`349019bb`) — is **kept**; only the pool-reference clear is reverted.

## Why keeping the reference is safe

A finished pool still services stragglers: `checkoutWorkerAsync` spawns a fresh worker, and `checkinWorker` tears it down again because `_finishing === true`. Verified:

- New regression test (`worker/test/finishWorkers.test.ts`): a child process doing *worker call → finishWorkers() → worker call* must exit on its own. Fails on `main` (killed at the 8s timeout by the leaked worker), passes with this change.
- `installing/commands` suite — includes the exact install → `finishWorkers()` → `fetch` scenario that `1941ce75` was protecting: 31/31 suites, 169 passed.
- `installing/package-requester` 27/27, `store/index`, `store/cafs` 34/34, `worker` 3/3.
- Stress shape: 5× (work → finishWorkers) lifecycle rounds plus 50 concurrent post-drain calls in one process — everything resolves and the process exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GUwtbafvtMPoNSDEZvNk3M

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787389333&installation_model_id=426870&pr_number=13226&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13226&signature=1f65edb3f14e3e47e2cf83afb16a0b741df0abd428f31eb2f2e367cf15b63d61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm install` processes occasionally hanging after completion.
  - Ensured late-running tasks finish cleanly without leaving idle worker threads behind.
  - Improved worker shutdown handling so processes exit reliably after all work is complete.
  - Reduced the risk of commands remaining active after installation has finished.

- **Tests**
  - Added regression coverage for late worker activity, cleanup, and successful process exit after installation completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->