### PR TITLE
fix(pacquet-cli): align outdated table borders when output is colorized

### DIFF
--- a/.changeset/outdated-table-ansi-alignment.md
+++ b/.changeset/outdated-table-ansi-alignment.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm outdated` now aligns its table borders when the output is colorized. The color escape codes in the `Package` and `Latest` cells were being counted as visible characters, so the columns and box-drawing borders drifted out of alignment on a terminal.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
+dependencies = [
+ "nom 7.1.3",
+ "vte",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +232,12 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert-json-diff"
@@ -5211,6 +5236,8 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
+ "ansi-str",
+ "ansitok",
  "bytecount",
  "fnv",
  "unicode-width 0.2.2",
@@ -7352,6 +7379,8 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
+ "ansi-str",
+ "ansitok",
  "papergrid",
  "tabled_derive",
  "testing_table",
@@ -7428,6 +7457,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
+ "ansitok",
  "unicode-width 0.2.2",
 ]
 
@@ -8070,6 +8100,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "arrayvec",
+ "memchr",
+]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,25 +140,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi-str"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060de1453b69f46304b28274f382132f4e72c55637cf362920926a70d090890d"
-dependencies = [
- "ansitok",
-]
-
-[[package]]
-name = "ansitok"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
-dependencies = [
- "nom 7.1.3",
- "vte",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,12 +213,6 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert-json-diff"
@@ -5236,8 +5211,6 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
- "ansi-str",
- "ansitok",
  "bytecount",
  "fnv",
  "unicode-width 0.2.2",
@@ -7379,8 +7352,6 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
- "ansi-str",
- "ansitok",
  "papergrid",
  "tabled_derive",
  "testing_table",
@@ -7457,7 +7428,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
- "ansitok",
  "unicode-width 0.2.2",
 ]
 
@@ -8100,16 +8070,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "vte"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
-dependencies = [
- "arrayvec",
- "memchr",
-]
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ split-first-char   = { version = "2.0.1" }
 ssri               = { version = "9.2.0" }
 strum              = { version = "0.28.0", features = ["derive"] }
 sysinfo            = { version = "0.39.2" }
-tabled             = { version = "0.21" }
+tabled             = { version = "0.21", features = ["ansi"] }
 tar                = { version = "0.4.46" }
 text-block-macros  = { version = "0.2.0" }
 tower              = { version = "0.5.3" }

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -173,7 +173,7 @@ fn assert_borders_aligned(table: &str) {
     let widths: Vec<usize> = table.lines().map(visible_width).collect();
     assert!(
         widths.windows(2).all(|pair| pair[0] == pair[1]),
-        "every row must have the same display width so the borders line up, got {widths:?} for:\n{table}"
+        "every row must have the same display width so the borders line up, got {widths:?} for:\n{table}",
     );
 }
 

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -6,10 +6,15 @@ use super::{
 };
 use node_semver::Version;
 use pacquet_config::Config;
+use pacquet_default_reporter::format::visible_width;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Mutex, PoisonError},
+};
 use text_block_macros::text_block;
 
 #[cfg(unix)]
@@ -151,24 +156,6 @@ fn render_latest_outdated_and_not_deprecated() {
     assert!(!output.contains("(deprecated)"), "no deprecation marker: {output}");
 }
 
-/// Display width of `line`, ignoring ANSI SGR escape sequences.
-fn visible_width(line: &str) -> usize {
-    let mut chars = line.chars();
-    let mut width = 0;
-    while let Some(ch) = chars.next() {
-        if ch == '\u{1b}' {
-            for escape_ch in chars.by_ref() {
-                if escape_ch == 'm' {
-                    break;
-                }
-            }
-        } else {
-            width += 1;
-        }
-    }
-    width
-}
-
 fn assert_borders_aligned(table: &str) {
     let widths: Vec<usize> = table.lines().map(visible_width).collect();
     assert!(
@@ -177,13 +164,33 @@ fn assert_borders_aligned(table: &str) {
     );
 }
 
+/// Forces `owo_colors` global color on for the scope of a test and clears it
+/// on drop, so the process-global override can't leak into other tests even
+/// if an assertion panics. Paired with [`COLOR_OVERRIDE_LOCK`] to serialize
+/// the tests that toggle it.
+struct ForcedColor;
+
+impl Drop for ForcedColor {
+    fn drop(&mut self) {
+        owo_colors::unset_override();
+    }
+}
+
+fn force_color() -> ForcedColor {
+    owo_colors::set_override(true);
+    ForcedColor
+}
+
+static COLOR_OVERRIDE_LOCK: Mutex<()> = Mutex::new(());
+
 // A colored cell carries ANSI escape sequences whose bytes must not count
 // toward the column width, or the borders drift out of alignment. Force
 // color on and check that the box-drawing borders stay vertically aligned
 // across rows whose cells differ in how many escapes they hold.
 #[test]
 fn colored_table_borders_stay_aligned() {
-    owo_colors::set_override(true);
+    let _lock = COLOR_OVERRIDE_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+    let _color = force_color();
 
     let packages = [
         pkg("actions/checkout", "7.0.0", "7.0.1", DependencyGroup::Dev),
@@ -200,8 +207,6 @@ fn colored_table_borders_stay_aligned() {
         }],
     }];
     assert_borders_aligned(&render_recursive_table(&workspace, false));
-
-    owo_colors::unset_override();
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,19 +1,14 @@
 use super::{
     Change, DependentProject, OutdatedDependencyOptions, OutdatedInWorkspace, OutdatedPackage,
     PackumentCache, classify, current_versions_from_importer, fetch_package_cached,
-    render_dependents, render_json, render_latest, render_recursive_json, render_recursive_table,
-    render_table, sort_outdated,
+    render_dependents, render_json, render_latest, render_recursive_json, sort_outdated,
 };
 use node_semver::Version;
 use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::{Mutex, PoisonError},
-};
+use std::{collections::HashMap, path::PathBuf};
 use text_block_macros::text_block;
 
 #[cfg(unix)]
@@ -194,49 +189,44 @@ fn assert_borders_aligned(table: &str) {
     }
 }
 
-/// Forces `owo_colors` global color on for the scope of a test and clears it
-/// on drop, so the process-global override can't leak into other tests even
-/// if an assertion panics. Paired with [`COLOR_OVERRIDE_LOCK`] to serialize
-/// the tests that toggle it.
-struct ForcedColor;
-
-impl Drop for ForcedColor {
-    fn drop(&mut self) {
-        owo_colors::unset_override();
-    }
-}
-
-fn force_color() -> ForcedColor {
-    owo_colors::set_override(true);
-    ForcedColor
-}
-
-static COLOR_OVERRIDE_LOCK: Mutex<()> = Mutex::new(());
-
-// A colored cell carries ANSI escape sequences whose bytes must not count
-// toward the column width, or the borders drift out of alignment. Force
-// color on and check that the box-drawing borders stay vertically aligned
-// across rows whose cells differ in how many escapes they hold.
+// Enabling `tabled`'s `ansi` feature makes it size a colored cell by its
+// visible glyphs, not its escape bytes; without it the columns and borders
+// drift apart. Feed a modern-style table the kind of ANSI-colored cells the
+// `outdated` renderers emit — a highlighted version segment, a dim group
+// label, bright-blue headers — and confirm every vertical border lands on the
+// same column. Coloring the cells directly (`owo_colors` unconditional
+// styling) rather than forcing the global color override keeps the test free
+// of process-global state, so it can't leak into or be perturbed by other
+// tests running in the same binary.
 #[test]
 fn colored_table_borders_stay_aligned() {
-    let _lock = COLOR_OVERRIDE_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
-    let _color = force_color();
+    use owo_colors::OwoColorize;
+    use tabled::builder::Builder;
+    use tabled::settings::Style;
 
-    let packages = [
-        pkg("actions/checkout", "7.0.0", "7.0.1", DependencyGroup::Dev),
-        pkg("typescript", "6.0.3", "7.0.2", DependencyGroup::Dev),
-        pkg("@typescript/native-preview", "1.0.0", "26.1.1", DependencyGroup::Dev),
+    let header = ["Package", "Current", "Latest"].map(|name| name.bright_blue().to_string());
+    let rows = [
+        [
+            format!("actions/checkout {}", "(github action)".dimmed()),
+            "7.0.0".to_owned(),
+            format!("7.0.{}", "1".green()),
+        ],
+        [
+            format!("@typescript/native-preview {}", "(dev)".dimmed()),
+            "1.0.0".to_owned(),
+            "26.1.1".red().to_string(),
+        ],
     ];
-    assert_borders_aligned(&render_table(&packages, false));
 
-    let workspace = [OutdatedInWorkspace {
-        package: pkg("typescript", "6.0.3", "7.0.2", DependencyGroup::Dev),
-        dependents: vec![DependentProject {
-            name: "app".to_string(),
-            location: PathBuf::from("packages/app"),
-        }],
-    }];
-    assert_borders_aligned(&render_recursive_table(&workspace, false));
+    let mut builder = Builder::default();
+    builder.push_record(header);
+    for row in rows {
+        builder.push_record(row);
+    }
+    let mut table = builder.build();
+    table.with(Style::modern());
+
+    assert_borders_aligned(&table.to_string());
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -6,7 +6,6 @@ use super::{
 };
 use node_semver::Version;
 use pacquet_config::Config;
-use pacquet_default_reporter::format::visible_width;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::DependencyGroup;
@@ -156,12 +155,43 @@ fn render_latest_outdated_and_not_deprecated() {
     assert!(!output.contains("(deprecated)"), "no deprecation marker: {output}");
 }
 
+/// Visible column indices of the box-drawing characters that carry a
+/// vertical stroke, ignoring ANSI SGR escapes so a colored cell only counts
+/// its glyphs. These are the column boundaries a well-aligned table keeps
+/// identical on every row.
+fn border_columns(line: &str) -> Vec<usize> {
+    const VERTICAL_BORDERS: &[char] = &['│', '┌', '┐', '├', '┤', '┼', '└', '┘', '┬', '┴'];
+    let mut columns = Vec::new();
+    let mut chars = line.chars();
+    let mut column = 0;
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            for esc in chars.by_ref() {
+                if esc.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            if VERTICAL_BORDERS.contains(&ch) {
+                columns.push(column);
+            }
+            column += 1;
+        }
+    }
+    columns
+}
+
 fn assert_borders_aligned(table: &str) {
-    let widths: Vec<usize> = table.lines().map(visible_width).collect();
-    assert!(
-        widths.windows(2).all(|pair| pair[0] == pair[1]),
-        "every row must have the same display width so the borders line up, got {widths:?} for:\n{table}",
-    );
+    let mut rows = table.lines();
+    let expected = rows.next().map(border_columns).unwrap_or_default();
+    assert!(!expected.is_empty(), "expected box-drawing borders in:\n{table}");
+    for row in table.lines() {
+        assert_eq!(
+            border_columns(row),
+            expected,
+            "every row must place its vertical borders at the same columns:\n{table}",
+        );
+    }
 }
 
 /// Forces `owo_colors` global color on for the scope of a test and clears it

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     Change, DependentProject, OutdatedDependencyOptions, OutdatedInWorkspace, OutdatedPackage,
     PackumentCache, classify, current_versions_from_importer, fetch_package_cached,
-    render_dependents, render_json, render_latest, render_recursive_json, sort_outdated,
+    render_dependents, render_json, render_latest, render_recursive_json, render_recursive_table,
+    render_table, sort_outdated,
 };
 use node_semver::Version;
 use pacquet_config::Config;
@@ -148,6 +149,59 @@ fn render_latest_outdated_and_not_deprecated() {
     let output = render_latest(&item);
     assert!(output.contains("1.0.0"), "shows the latest version: {output}");
     assert!(!output.contains("(deprecated)"), "no deprecation marker: {output}");
+}
+
+/// Display width of `line`, ignoring ANSI SGR escape sequences.
+fn visible_width(line: &str) -> usize {
+    let mut chars = line.chars();
+    let mut width = 0;
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            for escape_ch in chars.by_ref() {
+                if escape_ch == 'm' {
+                    break;
+                }
+            }
+        } else {
+            width += 1;
+        }
+    }
+    width
+}
+
+fn assert_borders_aligned(table: &str) {
+    let widths: Vec<usize> = table.lines().map(visible_width).collect();
+    assert!(
+        widths.windows(2).all(|pair| pair[0] == pair[1]),
+        "every row must have the same display width so the borders line up, got {widths:?} for:\n{table}"
+    );
+}
+
+// A colored cell carries ANSI escape sequences whose bytes must not count
+// toward the column width, or the borders drift out of alignment. Force
+// color on and check that the box-drawing borders stay vertically aligned
+// across rows whose cells differ in how many escapes they hold.
+#[test]
+fn colored_table_borders_stay_aligned() {
+    owo_colors::set_override(true);
+
+    let packages = [
+        pkg("actions/checkout", "7.0.0", "7.0.1", DependencyGroup::Dev),
+        pkg("typescript", "6.0.3", "7.0.2", DependencyGroup::Dev),
+        pkg("@typescript/native-preview", "1.0.0", "26.1.1", DependencyGroup::Dev),
+    ];
+    assert_borders_aligned(&render_table(&packages, false));
+
+    let workspace = [OutdatedInWorkspace {
+        package: pkg("typescript", "6.0.3", "7.0.2", DependencyGroup::Dev),
+        dependents: vec![DependentProject {
+            name: "app".to_string(),
+            location: PathBuf::from("packages/app"),
+        }],
+    }];
+    assert_borders_aligned(&render_recursive_table(&workspace, false));
+
+    owo_colors::unset_override();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`pnpm outdated` renders a misaligned table on a terminal: the columns and box-drawing borders drift out of alignment, producing what looks like a spurious empty column.

The report is rendered (in the Rust `pnpm/` port) with the `tabled` crate, whose ANSI-handling (`ansi`) feature is **not** enabled by default. When the output goes to a TTY the cells are colorized — the blue headers, the green/yellow/red highlighted segment of the `Latest` version, and the dim `(dev)` / `(github action)` labels — and without the feature `tabled` counts the invisible color-escape bytes toward each cell's width. Because different cells carry different amounts of escape codes, columns get padded inconsistently and the borders no longer line up.

Enabling `tabled`'s `ansi` feature makes it measure width by display columns, ignoring SGR escapes. This also corrects the `outdated --long`, recursive, `licenses`, and `audit` tables, which share the crate.

The TypeScript CLI is **not** affected: it renders with `@zkochan/table`, which is already ANSI-width-aware (verified directly — colored cells still produce equal-width, aligned rows). So this is a Rust-only fix; there is no counterpart change to make on the TS side.

## Squash Commit Body

```text
pacquet renders the `pnpm outdated` report with the `tabled` crate, whose
ANSI-handling (`ansi`) feature is not enabled by default. On a terminal the
cells are colorized (blue headers, green/yellow/red `Latest` version segments,
dim `(dev)`/`(github action)` labels), and without the feature `tabled` counts
the invisible color-escape bytes toward each cell's width. Cells carry
different amounts of escape codes, so columns were padded inconsistently and
the box-drawing borders drifted out of alignment.

Enable the `tabled` `ansi` feature so widths are measured by display columns,
ignoring SGR escapes. This also corrects the `outdated --long`, recursive,
`licenses`, and `audit` tables, which share the crate.

The TypeScript CLI is unaffected: it renders with `@zkochan/table`, which is
already ANSI-width-aware, so this is a Rust-only fix.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. _(Rust-only bug; the TS CLI is already correct — see Summary.)_
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787390439&installation_model_id=426870&pr_number=13227&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13227&signature=3f55ee08ffea8679e12e253f3ccc489cf3410c70c1ed02f4ea294fe721d2e692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table border misalignment and drifting column widths in `pnpm outdated` when ANSI-colored output is enabled.
  * Ensured borders remain correctly aligned in both the standard and recursive table displays under colored output.

* **Tests**
  * Added ANSI-aware assertions to confirm vertical border columns stay consistent across rows with styled/colored table cells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->