### PR TITLE
feat: configurable GitHub server for GitHub Actions dependencies

### DIFF
--- a/.changeset/github-actions-server-setting.md
+++ b/.changeset/github-actions-server-setting.md
@@ -4,6 +4,7 @@
 "@pnpm/deps.github-actions": minor
 "@pnpm/deps.inspection.commands": minor
 "@pnpm/installing.commands": minor
+"@pnpm/resolving.git-resolver": patch
 "pnpm": minor
 "pacquet": minor
 ---

--- a/.changeset/github-actions-server-setting.md
+++ b/.changeset/github-actions-server-setting.md
@@ -1,0 +1,15 @@
+---
+"@pnpm/types": minor
+"@pnpm/config.reader": minor
+"@pnpm/deps.github-actions": minor
+"@pnpm/deps.inspection.commands": minor
+"@pnpm/installing.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Added a new setting, `update.githubActionsServer`, for specifying the base URL of the GitHub server that hosts the repositories of the GitHub Actions referenced by the workflow files (for example, a GitHub Enterprise Server). When the setting is not defined, the URL is read from the `GITHUB_SERVER_URL` environment variable, falling back to `https://github.com` [#13220](https://github.com/pnpm/pnpm/issues/13220).
+
+`pnpm outdated` and `pnpm update` no longer fail when the refs of a GitHub Action's repository cannot be read (for example, when the action's repository is private or hosted on a different GitHub server). Such actions are now skipped with a warning.
+
+Setting `update.githubActions` to `false` now makes `pnpm outdated` and the interactive `pnpm update` skip GitHub Actions dependencies.

--- a/.changeset/github-actions-server-setting.md
+++ b/.changeset/github-actions-server-setting.md
@@ -3,13 +3,14 @@
 "@pnpm/config.reader": minor
 "@pnpm/deps.github-actions": minor
 "@pnpm/deps.inspection.commands": minor
+"@pnpm/error": minor
 "@pnpm/installing.commands": minor
 "@pnpm/resolving.git-resolver": patch
 "pnpm": minor
 "pacquet": minor
 ---
 
-Added a new setting, `update.githubActionsServer`, for specifying the base URL of the GitHub server that hosts the repositories of the GitHub Actions referenced by the workflow files (for example, a GitHub Enterprise Server). When the setting is not defined, the URL is read from the `GITHUB_SERVER_URL` environment variable, falling back to `https://github.com` [#13220](https://github.com/pnpm/pnpm/issues/13220).
+Added a new setting, `update.githubActionsServer`, for specifying the base URL of the GitHub server that hosts the repositories of the GitHub Actions referenced by the workflow files (for example, a GitHub Enterprise Server). When the setting is not defined, the URL is read from the `GITHUB_SERVER_URL` environment variable, falling back to `https://github.com`. The URL must use the `https://` or `http://` protocol [#13220](https://github.com/pnpm/pnpm/issues/13220).
 
 `pnpm outdated` and `pnpm update` no longer fail when the refs of a GitHub Action's repository cannot be read (for example, when the action's repository is private or hosted on a different GitHub server). Such actions are now skipped with a warning.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3124,6 +3124,9 @@ importers:
       '@pnpm/error':
         specifier: workspace:*
         version: link:../../core/error
+      '@pnpm/logger':
+        specifier: 'catalog:'
+        version: 1100.0.0
       '@pnpm/resolving.git-resolver':
         specifier: workspace:*
         version: link:../../resolving/git-resolver

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -63,9 +63,10 @@ pub(super) fn recursive<'a>(_ctx: &RunCtx<'a>) -> miette::Result<CommandFuture<'
 }
 
 // `outdated` is a read-only query: it prints a report to stdout and never
-// installs, so it has no reporter-typed install pipeline to dispatch on. It
-// reports back whether any dependency was outdated; process termination stays
-// here, at the top-level harness, rather than inside the command.
+// installs. The reporter type only routes the `globalWarn` channel (skipped
+// GitHub Actions repositories). It reports back whether any dependency was
+// outdated; process termination stays here, at the top-level harness, rather
+// than inside the command.
 pub(super) fn outdated<'a>(
     ctx: &RunCtx<'a>,
     args: OutdatedArgs,
@@ -84,16 +85,25 @@ pub(super) fn outdated<'a>(
         }));
     }
     let command_state = (ctx.state)(false)?;
-    Ok(Box::pin(async move {
-        if args.run(command_state).await? == OutdatedOutcome::Outdated {
-            #[expect(
-                clippy::exit,
-                reason = "`outdated` exits non-zero when a dependency is outdated, mirroring pnpm"
-            )]
-            std::process::exit(1);
-        }
-        Ok(())
-    }))
+    macro_rules! run_outdated {
+        ($reporter:ty) => {
+            Box::pin(async move {
+                if args.run::<$reporter>(command_state).await? == OutdatedOutcome::Outdated {
+                    #[expect(
+                        clippy::exit,
+                        reason = "`outdated` exits non-zero when a dependency is outdated, mirroring pnpm"
+                    )]
+                    std::process::exit(1);
+                }
+                Ok(())
+            })
+        };
+    }
+    Ok(match ctx.reporter {
+        ReporterType::Default | ReporterType::AppendOnly => run_outdated!(DefaultReporter),
+        ReporterType::Ndjson => run_outdated!(NdjsonReporter),
+        ReporterType::Silent => run_outdated!(SilentReporter),
+    })
 }
 
 pub(super) fn audit<'a>(ctx: &RunCtx<'a>, args: AuditArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -419,7 +419,10 @@ struct DependentProject {
 impl OutdatedArgs {
     /// Run the check and print the report to stdout. Returns whether any
     /// dependency was outdated; the caller decides the process exit code.
-    pub async fn run<R: Reporter>(self, state: State) -> miette::Result<OutdatedOutcome> {
+    pub async fn run<Reporter: self::Reporter>(
+        self,
+        state: State,
+    ) -> miette::Result<OutdatedOutcome> {
         if state.config.recursive {
             return self.run_recursive(state).await;
         }
@@ -484,7 +487,7 @@ impl OutdatedArgs {
         if include.contains(&DependencyGroup::Dev)
             && config.update_config.github_actions != Some(false)
         {
-            let actions = github_actions::find_outdated::<R>(
+            let actions = github_actions::find_outdated::<Reporter>(
                 root,
                 self.compatible,
                 action_matcher.as_ref(),

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -35,6 +35,7 @@ use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::{Package, PackageVersion, RegistryError};
+use pacquet_reporter::Reporter;
 use pacquet_resolving_npm_resolver::pick_registry_for_package;
 use std::{
     collections::HashMap,
@@ -418,7 +419,7 @@ struct DependentProject {
 impl OutdatedArgs {
     /// Run the check and print the report to stdout. Returns whether any
     /// dependency was outdated; the caller decides the process exit code.
-    pub async fn run(self, state: State) -> miette::Result<OutdatedOutcome> {
+    pub async fn run<R: Reporter>(self, state: State) -> miette::Result<OutdatedOutcome> {
         if state.config.recursive {
             return self.run_recursive(state).await;
         }
@@ -480,10 +481,16 @@ impl OutdatedArgs {
         } else {
             Vec::new()
         };
-        if include.contains(&DependencyGroup::Dev) {
-            let actions =
-                github_actions::find_outdated(root, self.compatible, action_matcher.as_ref())
-                    .await?;
+        if include.contains(&DependencyGroup::Dev)
+            && config.update_config.github_actions != Some(false)
+        {
+            let actions = github_actions::find_outdated::<R>(
+                root,
+                self.compatible,
+                action_matcher.as_ref(),
+                config.update_config.github_actions_server.as_deref(),
+            )
+            .await?;
             outdated.extend(actions.into_iter().map(OutdatedPackage::from));
         }
 

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -424,7 +424,7 @@ impl OutdatedArgs {
         state: State,
     ) -> miette::Result<OutdatedOutcome> {
         if state.config.recursive {
-            return self.run_recursive(state).await;
+            return self.run_recursive::<Reporter>(state).await;
         }
 
         let config = state.config;
@@ -510,7 +510,10 @@ impl OutdatedArgs {
         Ok(if outdated.is_empty() { OutdatedOutcome::UpToDate } else { OutdatedOutcome::Outdated })
     }
 
-    async fn run_recursive(self, state: State) -> miette::Result<OutdatedOutcome> {
+    async fn run_recursive<Reporter: self::Reporter>(
+        self,
+        state: State,
+    ) -> miette::Result<OutdatedOutcome> {
         let config = state.config;
         let workspace_root =
             config.workspace_dir.clone().unwrap_or_else(|| state.lockfile_dir().to_path_buf());
@@ -616,6 +619,26 @@ impl OutdatedArgs {
                         .push(OutdatedInWorkspace { package, dependents: vec![dependent.clone()] });
                 }
             }
+        }
+
+        if include.contains(&DependencyGroup::Dev)
+            && config.update_config.github_actions != Some(false)
+        {
+            let action_matcher = github_actions::selector_matcher(&self.packages);
+            let actions = github_actions::find_outdated::<Reporter>(
+                &workspace_root,
+                self.compatible,
+                action_matcher.as_ref(),
+                config.update_config.github_actions_server.as_deref(),
+            )
+            .await?;
+            outdated.extend(actions.into_iter().map(|action| OutdatedInWorkspace {
+                package: OutdatedPackage::from(action),
+                dependents: vec![DependentProject {
+                    name: ".github".to_string(),
+                    location: workspace_root.clone(),
+                }],
+            }));
         }
 
         sort_workspace_outdated(&mut outdated);
@@ -937,7 +960,8 @@ fn render_recursive_json(outdated: &[OutdatedInWorkspace], long: bool) -> String
     let mut map = serde_json::Map::new();
     for entry in outdated {
         let package = &entry.package;
-        let dependency_type: &'static str = package.belongs_to.into();
+        let dependency_type: &'static str =
+            if package.github_action { "githubAction" } else { package.belongs_to.into() };
         let mut value = serde_json::json!({
             "current": package.current.to_string(),
             "latest": package.target.to_string(),

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -154,7 +154,13 @@ impl UpdateArgs {
         let package_selectors = filter_package_selectors(&self.packages, update_actions);
         if !self.interactive && !self.packages.is_empty() && package_selectors.is_empty() {
             if update_actions {
-                github_actions::update(&actions_root, self.latest, action_matcher.as_ref()).await?;
+                github_actions::update::<Reporter>(
+                    &actions_root,
+                    self.latest,
+                    action_matcher.as_ref(),
+                    state.config.update_config.github_actions_server.as_deref(),
+                )
+                .await?;
             }
             return Ok(());
         }
@@ -170,7 +176,7 @@ impl UpdateArgs {
             self.supported_architectures.apply_to(config.supported_architectures.clone());
 
         let packages = if self.interactive {
-            match crate::cli_args::update_interactive::select_packages(
+            match crate::cli_args::update_interactive::select_packages::<Reporter>(
                 &actions_root,
                 manifest,
                 lockfile,
@@ -228,8 +234,13 @@ impl UpdateArgs {
             .wrap_err("updating dependencies")?;
         }
         if update_actions {
-            github_actions::update(&actions_root, self.latest, selected_action_matcher.as_ref())
-                .await?;
+            github_actions::update::<Reporter>(
+                &actions_root,
+                self.latest,
+                selected_action_matcher.as_ref(),
+                config.update_config.github_actions_server.as_deref(),
+            )
+            .await?;
         }
         Ok(())
     }
@@ -251,7 +262,13 @@ impl UpdateArgs {
         let package_selectors = filter_package_selectors(&self.packages, update_actions);
         if !self.interactive && !self.packages.is_empty() && package_selectors.is_empty() {
             if update_actions {
-                github_actions::update(&actions_root, self.latest, action_matcher.as_ref()).await?;
+                github_actions::update::<Reporter>(
+                    &actions_root,
+                    self.latest,
+                    action_matcher.as_ref(),
+                    state.config.update_config.github_actions_server.as_deref(),
+                )
+                .await?;
             }
             return Ok(());
         }
@@ -264,7 +281,7 @@ impl UpdateArgs {
         let supported_architectures =
             self.supported_architectures.apply_to(config.supported_architectures.clone());
         let packages = if self.interactive {
-            match crate::cli_args::update_interactive::select_packages_for_projects(
+            match crate::cli_args::update_interactive::select_packages_for_projects::<Reporter>(
                 &actions_root,
                 &selection,
                 lockfile,
@@ -331,8 +348,13 @@ impl UpdateArgs {
             .wrap_err("updating dependencies")?;
         }
         if update_actions {
-            github_actions::update(&actions_root, self.latest, selected_action_matcher.as_ref())
-                .await?;
+            github_actions::update::<Reporter>(
+                &actions_root,
+                self.latest,
+                selected_action_matcher.as_ref(),
+                config.update_config.github_actions_server.as_deref(),
+            )
+            .await?;
         }
         Ok(())
     }
@@ -373,7 +395,7 @@ impl UpdateArgs {
         include_direct.contains(&DependencyGroup::Dev)
             && !self.no_save
             && !self.lockfile_only
-            && (self.interactive
+            && ((self.interactive && config.update_config.github_actions != Some(false))
                 || self.include_github_actions
                 || config.update_config.github_actions == Some(true))
     }

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -72,4 +72,15 @@ fn github_actions_are_opt_in_except_for_interactive_updates() {
     assert!(
         !update_args(&["--prod"]).should_update_github_actions(&config, &[DependencyGroup::Prod],),
     );
+
+    // An explicit `false` opts interactive updates out of GitHub Actions,
+    // but never overrides the explicit `--include-github-actions` flag.
+    config.update_config.github_actions = Some(false);
+    assert!(
+        !update_args(&["--interactive"]).should_update_github_actions(&config, &include_direct),
+    );
+    assert!(
+        update_args(&["--include-github-actions"])
+            .should_update_github_actions(&config, &include_direct),
+    );
 }

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -45,7 +45,7 @@ pub(crate) struct InteractiveUpdateOptions<'a> {
 /// selected package names. `Ok(None)` means "nothing to do" — either no
 /// dependency has an update available or the prompt was answered with an
 /// empty selection — and the caller should not run an update.
-pub(crate) async fn select_packages<R: Reporter>(
+pub(crate) async fn select_packages<Reporter: self::Reporter>(
     root: &Path,
     manifest: &PackageManifest,
     lockfile: Option<&Lockfile>,
@@ -65,7 +65,7 @@ pub(crate) async fn select_packages<R: Reporter>(
     )
     .await?;
     if options.include_github_actions {
-        append_github_actions::<R>(
+        append_github_actions::<Reporter>(
             &mut choices,
             root,
             options.latest,
@@ -76,7 +76,7 @@ pub(crate) async fn select_packages<R: Reporter>(
     prompt_for_packages(&choices, options.latest)
 }
 
-pub(crate) async fn select_packages_for_projects<R: Reporter>(
+pub(crate) async fn select_packages_for_projects<Reporter: self::Reporter>(
     root: &Path,
     selection: &InstallFamilySelection,
     lockfile: Option<&Lockfile>,
@@ -106,7 +106,7 @@ pub(crate) async fn select_packages_for_projects<R: Reporter>(
     )
     .await?;
     if options.include_github_actions {
-        append_github_actions::<R>(
+        append_github_actions::<Reporter>(
             &mut choices,
             root,
             options.latest,
@@ -117,14 +117,14 @@ pub(crate) async fn select_packages_for_projects<R: Reporter>(
     prompt_for_packages(&choices, options.latest)
 }
 
-async fn append_github_actions<R: Reporter>(
+async fn append_github_actions<Reporter: self::Reporter>(
     choices: &mut Vec<OutdatedPackage>,
     root: &Path,
     latest: bool,
     server_url: Option<&str>,
 ) -> miette::Result<()> {
     choices.extend(
-        github_actions::find_outdated::<R>(root, !latest, None, server_url)
+        github_actions::find_outdated::<Reporter>(root, !latest, None, server_url)
             .await?
             .into_iter()
             .map(OutdatedPackage::from),

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -27,6 +27,7 @@ use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_reporter::Reporter;
 use std::{collections::HashSet, path::Path};
 
 struct InteractiveUpdateProject<'a> {
@@ -44,7 +45,7 @@ pub(crate) struct InteractiveUpdateOptions<'a> {
 /// selected package names. `Ok(None)` means "nothing to do" — either no
 /// dependency has an update available or the prompt was answered with an
 /// empty selection — and the caller should not run an update.
-pub(crate) async fn select_packages(
+pub(crate) async fn select_packages<R: Reporter>(
     root: &Path,
     manifest: &PackageManifest,
     lockfile: Option<&Lockfile>,
@@ -64,12 +65,18 @@ pub(crate) async fn select_packages(
     )
     .await?;
     if options.include_github_actions {
-        append_github_actions(&mut choices, root, options.latest).await?;
+        append_github_actions::<R>(
+            &mut choices,
+            root,
+            options.latest,
+            config.update_config.github_actions_server.as_deref(),
+        )
+        .await?;
     }
     prompt_for_packages(&choices, options.latest)
 }
 
-pub(crate) async fn select_packages_for_projects(
+pub(crate) async fn select_packages_for_projects<R: Reporter>(
     root: &Path,
     selection: &InstallFamilySelection,
     lockfile: Option<&Lockfile>,
@@ -99,18 +106,25 @@ pub(crate) async fn select_packages_for_projects(
     )
     .await?;
     if options.include_github_actions {
-        append_github_actions(&mut choices, root, options.latest).await?;
+        append_github_actions::<R>(
+            &mut choices,
+            root,
+            options.latest,
+            config.update_config.github_actions_server.as_deref(),
+        )
+        .await?;
     }
     prompt_for_packages(&choices, options.latest)
 }
 
-async fn append_github_actions(
+async fn append_github_actions<R: Reporter>(
     choices: &mut Vec<OutdatedPackage>,
     root: &Path,
     latest: bool,
+    server_url: Option<&str>,
 ) -> miette::Result<()> {
     choices.extend(
-        github_actions::find_outdated(root, !latest, None)
+        github_actions::find_outdated::<R>(root, !latest, None, server_url)
             .await?
             .into_iter()
             .map(OutdatedPackage::from),

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -1,6 +1,7 @@
-use futures_util::{StreamExt, TryStreamExt, stream};
+use futures_util::{StreamExt, stream};
 use node_semver::{Range as SemverRange, Version};
 use pacquet_config::matcher::{Matcher, create_matcher};
+use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
 use pacquet_resolving_git_resolver::{GitCommandRunner, RealGitRunner, get_repo_refs};
 use std::{
     cmp::Reverse,
@@ -71,39 +72,57 @@ struct PlannedUpdate {
 
 const GIT_CONCURRENCY: usize = 8;
 
-pub async fn find_outdated(
+pub async fn find_outdated<R: Reporter>(
     root: &Path,
     compatible: bool,
     matcher: Option<&Matcher>,
+    server_url: Option<&str>,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    find_outdated_with_runner(root, compatible, matcher, &RealGitRunner::new()).await
+    find_outdated_with_runner::<R, _>(
+        root,
+        compatible,
+        matcher,
+        &resolve_server_url(server_url),
+        &RealGitRunner::new(),
+    )
+    .await
 }
 
-async fn find_outdated_with_runner<Runner: GitCommandRunner + Sync>(
+async fn find_outdated_with_runner<R: Reporter, Runner: GitCommandRunner + Sync>(
     root: &Path,
     compatible: bool,
     matcher: Option<&Matcher>,
+    server_url: &str,
     runner: &Runner,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    let plans = create_plan(root, matcher, runner).await?;
-    Ok(to_outdated(plans, !compatible))
+    let plans = create_plan::<R, _>(root, matcher, server_url, runner).await?;
+    Ok(to_outdated(plans, !compatible, server_url))
 }
 
-pub async fn update(
+pub async fn update<R: Reporter>(
     root: &Path,
     latest: bool,
     matcher: Option<&Matcher>,
+    server_url: Option<&str>,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    update_with_runner(root, latest, matcher, &RealGitRunner::new()).await
+    update_with_runner::<R, _>(
+        root,
+        latest,
+        matcher,
+        &resolve_server_url(server_url),
+        &RealGitRunner::new(),
+    )
+    .await
 }
 
-async fn update_with_runner<Runner: GitCommandRunner + Sync>(
+async fn update_with_runner<R: Reporter, Runner: GitCommandRunner + Sync>(
     root: &Path,
     latest: bool,
     matcher: Option<&Matcher>,
+    server_url: &str,
     runner: &Runner,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    let plans = create_plan(root, matcher, runner).await?;
+    let plans = create_plan::<R, _>(root, matcher, server_url, runner).await?;
     let updates = plans
         .into_iter()
         .filter(|plan| {
@@ -135,12 +154,13 @@ async fn update_with_runner<Runner: GitCommandRunner + Sync>(
             .map_err(|error| miette::miette!("Failed to write {file_display}: {error}"))?
             .map_err(|error| miette::miette!("Failed to write {file_display}: {error}"))?;
     }
-    Ok(to_outdated(updates, latest))
+    Ok(to_outdated(updates, latest, server_url))
 }
 
-async fn create_plan<Runner: GitCommandRunner + Sync>(
+async fn create_plan<R: Reporter, Runner: GitCommandRunner + Sync>(
     root: &Path,
     matcher: Option<&Matcher>,
+    server_url: &str,
     runner: &Runner,
 ) -> miette::Result<Vec<PlannedUpdate>> {
     let actions = discover(root)
@@ -155,18 +175,27 @@ async fn create_plan<Runner: GitCommandRunner + Sync>(
     let repos = actions.iter().map(|action| action.repo.clone()).collect::<BTreeSet<_>>();
     let refs_by_repo = stream::iter(repos)
         .map(|repo| async move {
-            let url = format!("https://github.com/{repo}.git");
-            let refs = get_repo_refs(runner, &url, None).await.map_err(|error| {
-                miette::miette!("Failed to read GitHub Action refs for {repo}: {error}")
-            })?;
-            Ok::<_, miette::Report>((repo, repo_versions(&refs)))
+            let url = format!("{server_url}/{repo}.git");
+            match get_repo_refs(runner, &url, None).await {
+                Ok(refs) => {
+                    let versions = repo_versions(&refs);
+                    Some((repo, versions))
+                }
+                Err(error) => {
+                    global_warn::<R>(format!(
+                        r#"Skipping the GitHub Actions from "{repo}": {error}"#
+                    ));
+                    None
+                }
+            }
         })
         .buffer_unordered(GIT_CONCURRENCY)
-        .try_collect::<HashMap<_, _>>()
-        .await?;
+        .filter_map(|entry| async move { entry })
+        .collect::<HashMap<_, _>>()
+        .await;
     let mut plans = Vec::new();
     for action in actions {
-        let versions = &refs_by_repo[&action.repo];
+        let Some(versions) = refs_by_repo.get(&action.repo) else { continue };
         let Some(current) = find_current(&action, versions) else { continue };
         let wanted_range =
             SemverRange::parse(format!("^{}", current.version)).map_err(|error| {
@@ -502,7 +531,11 @@ fn parse_version(input: &str) -> Option<Version> {
     Version::parse(input).or_else(|_| Version::parse(input.trim_start_matches('v'))).ok()
 }
 
-fn to_outdated(plans: Vec<PlannedUpdate>, latest: bool) -> Vec<OutdatedGitHubAction> {
+fn to_outdated(
+    plans: Vec<PlannedUpdate>,
+    latest: bool,
+    server_url: &str,
+) -> Vec<OutdatedGitHubAction> {
     let mut actions = BTreeMap::new();
     for plan in plans {
         let target = if latest { plan.latest } else { plan.wanted.clone() };
@@ -513,7 +546,7 @@ fn to_outdated(plans: Vec<PlannedUpdate>, latest: bool) -> Vec<OutdatedGitHubAct
             plan.action.name.clone(),
             OutdatedGitHubAction {
                 current: plan.current.version,
-                homepage: format!("https://github.com/{}", plan.action.repo),
+                homepage: format!("{server_url}/{}", plan.action.repo),
                 latest: target.version,
                 name: plan.action.name,
                 wanted: plan.wanted.version,
@@ -521,6 +554,23 @@ fn to_outdated(plans: Vec<PlannedUpdate>, latest: bool) -> Vec<OutdatedGitHubAct
         );
     }
     actions.into_values().collect()
+}
+
+/// Resolves the effective GitHub server base URL: the
+/// `update.githubActionsServer` setting, the `GITHUB_SERVER_URL`
+/// environment variable, or <https://github.com> — first non-empty wins.
+fn resolve_server_url(server_url: Option<&str>) -> String {
+    server_url
+        .filter(|url| !url.is_empty())
+        .map(str::to_string)
+        .or_else(|| std::env::var("GITHUB_SERVER_URL").ok().filter(|url| !url.is_empty()))
+        .unwrap_or_else(|| "https://github.com".to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn global_warn<R: Reporter>(message: String) {
+    R::emit(&LogEvent::Global(GlobalLog { level: LogLevel::Warn, message }));
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -1,6 +1,7 @@
 use futures_util::{StreamExt, stream};
 use node_semver::{Range as SemverRange, Version};
 use pacquet_config::matcher::{Matcher, create_matcher};
+use pacquet_network::redact_and_sanitize;
 use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
 use pacquet_resolving_git_resolver::{GitCommandRunner, RealGitRunner, get_repo_refs};
 use std::{
@@ -82,7 +83,7 @@ pub async fn find_outdated<Reporter: self::Reporter>(
         root,
         compatible,
         matcher,
-        &resolve_server_url(server_url),
+        &resolve_server_url(server_url)?,
         &RealGitRunner::new(),
     )
     .await
@@ -109,7 +110,7 @@ pub async fn update<Reporter: self::Reporter>(
         root,
         latest,
         matcher,
-        &resolve_server_url(server_url),
+        &resolve_server_url(server_url)?,
         &RealGitRunner::new(),
     )
     .await
@@ -182,9 +183,12 @@ async fn create_plan<Reporter: self::Reporter, Runner: GitCommandRunner + Sync>(
                     Some((repo, versions))
                 }
                 Err(error) => {
-                    global_warn::<Reporter>(format!(
+                    // The git error may echo a credentialed URL or raw stderr
+                    // back, so it is redacted and stripped of control
+                    // characters before logging.
+                    global_warn::<Reporter>(redact_and_sanitize(&format!(
                         r#"Skipping the GitHub Actions from "{repo}": {error}"#,
-                    ));
+                    )));
                     None
                 }
             }
@@ -559,14 +563,21 @@ fn to_outdated(
 /// Resolves the effective GitHub server base URL: the
 /// `update.githubActionsServer` setting, the `GITHUB_SERVER_URL`
 /// environment variable, or <https://github.com> — first non-empty wins.
-fn resolve_server_url(server_url: Option<&str>) -> String {
-    server_url
+fn resolve_server_url(server_url: Option<&str>) -> miette::Result<String> {
+    let url = server_url
         .filter(|url| !url.is_empty())
         .map(str::to_string)
         .or_else(|| std::env::var("GITHUB_SERVER_URL").ok().filter(|url| !url.is_empty()))
-        .unwrap_or_else(|| "https://github.com".to_string())
-        .trim_end_matches('/')
-        .to_string()
+        .unwrap_or_else(|| "https://github.com".to_string());
+    // Only allow http(s) so the value cannot select another git transport
+    // (e.g. `ext::`, which executes an arbitrary command).
+    if !url.starts_with("https://") && !url.starts_with("http://") {
+        return Err(miette::miette!(
+            code = "ERR_PNPM_GITHUB_ACTIONS_SERVER_PROTOCOL",
+            r#"The GitHub Actions server URL must use the "https://" or "http://" protocol, but got {url:?}"#,
+        ));
+    }
+    Ok(url.trim_end_matches('/').to_string())
 }
 
 fn global_warn<Reporter: self::Reporter>(message: String) {

--- a/pnpm/crates/cli/src/github_actions.rs
+++ b/pnpm/crates/cli/src/github_actions.rs
@@ -72,13 +72,13 @@ struct PlannedUpdate {
 
 const GIT_CONCURRENCY: usize = 8;
 
-pub async fn find_outdated<R: Reporter>(
+pub async fn find_outdated<Reporter: self::Reporter>(
     root: &Path,
     compatible: bool,
     matcher: Option<&Matcher>,
     server_url: Option<&str>,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    find_outdated_with_runner::<R, _>(
+    find_outdated_with_runner::<Reporter, _>(
         root,
         compatible,
         matcher,
@@ -88,24 +88,24 @@ pub async fn find_outdated<R: Reporter>(
     .await
 }
 
-async fn find_outdated_with_runner<R: Reporter, Runner: GitCommandRunner + Sync>(
+async fn find_outdated_with_runner<Reporter: self::Reporter, Runner: GitCommandRunner + Sync>(
     root: &Path,
     compatible: bool,
     matcher: Option<&Matcher>,
     server_url: &str,
     runner: &Runner,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    let plans = create_plan::<R, _>(root, matcher, server_url, runner).await?;
+    let plans = create_plan::<Reporter, _>(root, matcher, server_url, runner).await?;
     Ok(to_outdated(plans, !compatible, server_url))
 }
 
-pub async fn update<R: Reporter>(
+pub async fn update<Reporter: self::Reporter>(
     root: &Path,
     latest: bool,
     matcher: Option<&Matcher>,
     server_url: Option<&str>,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    update_with_runner::<R, _>(
+    update_with_runner::<Reporter, _>(
         root,
         latest,
         matcher,
@@ -115,14 +115,14 @@ pub async fn update<R: Reporter>(
     .await
 }
 
-async fn update_with_runner<R: Reporter, Runner: GitCommandRunner + Sync>(
+async fn update_with_runner<Reporter: self::Reporter, Runner: GitCommandRunner + Sync>(
     root: &Path,
     latest: bool,
     matcher: Option<&Matcher>,
     server_url: &str,
     runner: &Runner,
 ) -> miette::Result<Vec<OutdatedGitHubAction>> {
-    let plans = create_plan::<R, _>(root, matcher, server_url, runner).await?;
+    let plans = create_plan::<Reporter, _>(root, matcher, server_url, runner).await?;
     let updates = plans
         .into_iter()
         .filter(|plan| {
@@ -157,7 +157,7 @@ async fn update_with_runner<R: Reporter, Runner: GitCommandRunner + Sync>(
     Ok(to_outdated(updates, latest, server_url))
 }
 
-async fn create_plan<R: Reporter, Runner: GitCommandRunner + Sync>(
+async fn create_plan<Reporter: self::Reporter, Runner: GitCommandRunner + Sync>(
     root: &Path,
     matcher: Option<&Matcher>,
     server_url: &str,
@@ -182,8 +182,8 @@ async fn create_plan<R: Reporter, Runner: GitCommandRunner + Sync>(
                     Some((repo, versions))
                 }
                 Err(error) => {
-                    global_warn::<R>(format!(
-                        r#"Skipping the GitHub Actions from "{repo}": {error}"#
+                    global_warn::<Reporter>(format!(
+                        r#"Skipping the GitHub Actions from "{repo}": {error}"#,
                     ));
                     None
                 }
@@ -569,8 +569,8 @@ fn resolve_server_url(server_url: Option<&str>) -> String {
         .to_string()
 }
 
-fn global_warn<R: Reporter>(message: String) {
-    R::emit(&LogEvent::Global(GlobalLog { level: LogLevel::Warn, message }));
+fn global_warn<Reporter: self::Reporter>(message: String) {
+    Reporter::emit(&LogEvent::Global(GlobalLog { level: LogLevel::Warn, message }));
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -419,7 +419,12 @@ async fn skips_repositories_whose_refs_cannot_be_read_and_warns() {
         ) -> Pin<Box<dyn Future<Output = Result<String, GitRunError>> + Send + 'a>> {
             Box::pin(async move {
                 if repo.contains("private-action") {
-                    return Err(GitRunError { message: "Repository not found.".to_string() });
+                    // A credentialed URL and control characters, which the
+                    // warning must redact and strip.
+                    return Err(GitRunError {
+                        message: "\u{1b}[31mhttps://user:token@ghes.example.com/x.git\u{1b}[0m\nnot found"
+                            .to_string(),
+                    });
                 }
                 Ok(format!("{SHA_V4_1_0}\trefs/tags/v4.1.0\n{SHA_V4_2_0}\trefs/tags/v4.2.0\n"))
             })
@@ -459,6 +464,20 @@ async fn skips_repositories_whose_refs_cannot_be_read_and_warns() {
     assert_eq!(warnings.len(), 1);
     assert_eq!(
         warnings[0].message,
-        r#"Skipping the GitHub Actions from "owner/private-action": git ls-remote failed: Repository not found."#,
+        r#"Skipping the GitHub Actions from "owner/private-action": git ls-remote failed: [31mhttps://ghes.example.com/x.git[0mnot found"#,
     );
+}
+
+#[tokio::test]
+async fn rejects_a_server_url_that_is_not_http() {
+    let root = tempfile::tempdir().expect("temp directory");
+
+    let Err(error) =
+        super::find_outdated::<SilentReporter>(root.path(), false, None, Some("ext::sh -c date"))
+            .await
+    else {
+        panic!("non-http server URL must be rejected");
+    };
+
+    assert!(error.to_string().contains(r#"must use the "https://" or "http://" protocol"#));
 }

--- a/pnpm/crates/cli/src/github_actions/tests.rs
+++ b/pnpm/crates/cli/src/github_actions/tests.rs
@@ -4,8 +4,9 @@ use super::{
     repo_versions as versions_from_refs, selector_matcher, split_uses_value, update_with_runner,
 };
 use node_semver::Version;
+use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter, SilentReporter};
 use pacquet_resolving_git_resolver::{GitCommandRunner, GitRunError};
-use std::{collections::HashMap, fs, future::Future, path::PathBuf, pin::Pin};
+use std::{collections::HashMap, fs, future::Future, path::PathBuf, pin::Pin, sync::Mutex};
 
 const SHA_V4_1_0: &str = "1111111111111111111111111111111111111111";
 const SHA_V4_2_0: &str = "2222222222222222222222222222222222222222";
@@ -156,7 +157,15 @@ async fn updates_workflow_files_without_reformatting_them() {
     );
     fs::write(&workflow, &source).expect("workflow");
 
-    update_with_runner(root.path(), false, None, &FakeGitRunner).await.expect("update actions");
+    update_with_runner::<SilentReporter, _>(
+        root.path(),
+        false,
+        None,
+        "https://github.com",
+        &FakeGitRunner,
+    )
+    .await
+    .expect("update actions");
 
     assert_eq!(
         fs::read_to_string(workflow).expect("updated workflow"),
@@ -179,12 +188,24 @@ async fn compatible_outdated_stays_on_the_current_compatibility_line() {
     )
     .expect("workflow");
 
-    let default = find_outdated_with_runner(root.path(), false, None, &FakeGitRunner)
-        .await
-        .expect("default outdated");
-    let compatible = find_outdated_with_runner(root.path(), true, None, &FakeGitRunner)
-        .await
-        .expect("compatible outdated");
+    let default = find_outdated_with_runner::<SilentReporter, _>(
+        root.path(),
+        false,
+        None,
+        "https://github.com",
+        &FakeGitRunner,
+    )
+    .await
+    .expect("default outdated");
+    let compatible = find_outdated_with_runner::<SilentReporter, _>(
+        root.path(),
+        true,
+        None,
+        "https://github.com",
+        &FakeGitRunner,
+    )
+    .await
+    .expect("compatible outdated");
 
     assert_eq!(default[0].latest, Version::parse("5.0.0").unwrap());
     assert_eq!(compatible[0].latest, Version::parse("4.2.0").unwrap());
@@ -199,21 +220,41 @@ async fn keeps_pre_one_updates_caret_compatible_unless_latest_is_requested() {
     fs::write(&workflow, "jobs:\n  test:\n    steps:\n      - uses: owner/tool@v0.5.7\n")
         .expect("workflow");
 
-    let compatible = find_outdated_with_runner(root.path(), true, None, &PreOneGitRunner)
-        .await
-        .expect("compatible outdated");
+    let compatible = find_outdated_with_runner::<SilentReporter, _>(
+        root.path(),
+        true,
+        None,
+        "https://github.com",
+        &PreOneGitRunner,
+    )
+    .await
+    .expect("compatible outdated");
     assert_eq!(compatible[0].latest, Version::parse("0.5.9").unwrap());
 
-    update_with_runner(root.path(), false, None, &PreOneGitRunner)
-        .await
-        .expect("compatible update");
+    update_with_runner::<SilentReporter, _>(
+        root.path(),
+        false,
+        None,
+        "https://github.com",
+        &PreOneGitRunner,
+    )
+    .await
+    .expect("compatible update");
     assert!(
         fs::read_to_string(&workflow)
             .expect("updated workflow")
             .contains("uses: owner/tool@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb # v0.5.9"),
     );
 
-    update_with_runner(root.path(), true, None, &PreOneGitRunner).await.expect("latest update");
+    update_with_runner::<SilentReporter, _>(
+        root.path(),
+        true,
+        None,
+        "https://github.com",
+        &PreOneGitRunner,
+    )
+    .await
+    .expect("latest update");
     assert!(
         fs::read_to_string(&workflow)
             .expect("updated workflow")
@@ -233,7 +274,15 @@ async fn rejects_workflow_symlinks_outside_the_project() {
     fs::create_dir_all(root.path().join(".github")).expect("GitHub directory");
     symlink(outside.path(), root.path().join(".github/workflows")).expect("workflow symlink");
 
-    let Err(error) = update_with_runner(root.path(), false, None, &FakeGitRunner).await else {
+    let Err(error) = update_with_runner::<SilentReporter, _>(
+        root.path(),
+        false,
+        None,
+        "https://github.com",
+        &FakeGitRunner,
+    )
+    .await
+    else {
         panic!("outside workflow must be rejected");
     };
 
@@ -255,7 +304,14 @@ async fn reports_local_action_lookup_errors() {
         .expect("workflow");
     symlink("action.yml", action_dir.join("action.yml")).expect("symlink loop");
 
-    let Err(error) = find_outdated_with_runner(root.path(), false, None, &FakeGitRunner).await
+    let Err(error) = find_outdated_with_runner::<SilentReporter, _>(
+        root.path(),
+        false,
+        None,
+        "https://github.com",
+        &FakeGitRunner,
+    )
+    .await
     else {
         panic!("local action lookup must fail");
     };
@@ -275,7 +331,15 @@ async fn does_not_mutate_an_external_hardlink_target() {
     fs::create_dir_all(workflow.parent().unwrap()).expect("workflow directory");
     fs::hard_link(&outside_workflow, &workflow).expect("workflow hardlink");
 
-    update_with_runner(root.path(), false, None, &FakeGitRunner).await.expect("update actions");
+    update_with_runner::<SilentReporter, _>(
+        root.path(),
+        false,
+        None,
+        "https://github.com",
+        &FakeGitRunner,
+    )
+    .await
+    .expect("update actions");
 
     assert!(
         fs::read_to_string(&workflow)
@@ -283,4 +347,118 @@ async fn does_not_mutate_an_external_hardlink_target() {
             .contains(&format!("uses: actions/checkout@{SHA_V4_2_0} # v4.2.0")),
     );
     assert_eq!(fs::read_to_string(outside_workflow).unwrap(), original);
+}
+
+/// Serves refs only for URLs on the given server base, so a test fails
+/// (via the skip-with-warning path) when the wrong server is queried.
+struct ServerBoundGitRunner {
+    server_url: &'static str,
+}
+
+impl GitCommandRunner for ServerBoundGitRunner {
+    fn ls_remote<'a>(
+        &'a self,
+        repo: &'a str,
+        _ref_: Option<&'a str>,
+    ) -> Pin<Box<dyn Future<Output = Result<String, GitRunError>> + Send + 'a>> {
+        Box::pin(async move {
+            if !repo.starts_with(self.server_url) {
+                return Err(GitRunError { message: format!("unexpected repository URL {repo}") });
+            }
+            Ok(format!(
+                "{SHA_V4_1_0}\trefs/tags/v4.1.0\n{SHA_V4_2_0}\trefs/tags/v4.2.0\n{SHA_V5_0_0}\trefs/tags/v5.0.0\n",
+            ))
+        })
+    }
+}
+
+#[tokio::test]
+async fn reads_refs_from_the_configured_server_and_uses_it_in_homepages() {
+    let root = tempfile::tempdir().expect("temp directory");
+    let workflows = root.path().join(".github/workflows");
+    fs::create_dir_all(&workflows).expect("workflow directory");
+    fs::write(
+        workflows.join("ci.yml"),
+        "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v4.1.0\n",
+    )
+    .expect("workflow");
+    let runner = ServerBoundGitRunner { server_url: "https://github.example.com/" };
+
+    let outdated = find_outdated_with_runner::<SilentReporter, _>(
+        root.path(),
+        false,
+        None,
+        "https://github.example.com",
+        &runner,
+    )
+    .await
+    .expect("outdated actions");
+
+    assert_eq!(outdated.len(), 1);
+    assert_eq!(outdated[0].homepage, "https://github.example.com/actions/checkout");
+}
+
+#[tokio::test]
+async fn skips_repositories_whose_refs_cannot_be_read_and_warns() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().expect("lock").clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().expect("lock").push(event.clone());
+        }
+    }
+
+    struct PartiallyBrokenGitRunner;
+    impl GitCommandRunner for PartiallyBrokenGitRunner {
+        fn ls_remote<'a>(
+            &'a self,
+            repo: &'a str,
+            _ref_: Option<&'a str>,
+        ) -> Pin<Box<dyn Future<Output = Result<String, GitRunError>> + Send + 'a>> {
+            Box::pin(async move {
+                if repo.contains("private-action") {
+                    return Err(GitRunError { message: "Repository not found.".to_string() });
+                }
+                Ok(format!("{SHA_V4_1_0}\trefs/tags/v4.1.0\n{SHA_V4_2_0}\trefs/tags/v4.2.0\n"))
+            })
+        }
+    }
+
+    let root = tempfile::tempdir().expect("temp directory");
+    let workflows = root.path().join(".github/workflows");
+    fs::create_dir_all(&workflows).expect("workflow directory");
+    fs::write(
+        workflows.join("ci.yml"),
+        "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v4.1.0\n      - uses: owner/private-action@v1.0.0\n",
+    )
+    .expect("workflow");
+
+    let outdated = find_outdated_with_runner::<RecordingReporter, _>(
+        root.path(),
+        false,
+        None,
+        "https://github.com",
+        &PartiallyBrokenGitRunner,
+    )
+    .await
+    .expect("outdated actions");
+
+    assert_eq!(outdated.len(), 1);
+    assert_eq!(outdated[0].name, "actions/checkout");
+    let events = EVENTS.lock().expect("lock");
+    let warnings: Vec<&GlobalLog> = events
+        .iter()
+        .filter_map(|event| match event {
+            LogEvent::Global(log) if log.level == LogLevel::Warn => Some(log),
+            _ => None,
+        })
+        .collect();
+    dbg!(&warnings);
+    assert_eq!(warnings.len(), 1);
+    assert_eq!(
+        warnings[0].message,
+        r#"Skipping the GitHub Actions from "owner/private-action": git ls-remote failed: Repository not found."#,
+    );
 }

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -538,9 +538,19 @@ pub struct UpdateSettings {
     pub changeset: Option<bool>,
 
     /// Whether `pnpm update` should also update GitHub Actions
-    /// dependencies.
+    /// dependencies. When explicitly set to `false`, `pnpm outdated`
+    /// and the interactive `pnpm update` skip GitHub Actions
+    /// dependencies as well.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_actions: Option<bool>,
+
+    /// `githubActionsServer`: the base URL of the GitHub server that
+    /// hosts the repositories of the GitHub Actions referenced by the
+    /// workflow files (for example, a GitHub Enterprise Server). When
+    /// not set, the `GITHUB_SERVER_URL` environment variable is used,
+    /// falling back to <https://github.com>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub github_actions_server: Option<String>,
 }
 
 /// `updateConfig` entry: settings that tune `pnpm update`.
@@ -560,9 +570,19 @@ pub struct UpdateConfig {
     pub ignore_dependencies: Option<Vec<String>>,
 
     /// Whether `pnpm update` should also update GitHub Actions
-    /// dependencies.
+    /// dependencies. When explicitly set to `false`, `pnpm outdated`
+    /// and the interactive `pnpm update` skip GitHub Actions
+    /// dependencies as well.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub github_actions: Option<bool>,
+
+    /// The base URL of the GitHub server that hosts the repositories of
+    /// the GitHub Actions referenced by the workflow files (for example,
+    /// a GitHub Enterprise Server). When not set, the
+    /// `GITHUB_SERVER_URL` environment variable is used, falling back to
+    /// <https://github.com>.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub github_actions_server: Option<String>,
 }
 
 /// `peerDependencyRules` entry: customizations applied when reporting
@@ -936,6 +956,7 @@ impl WorkspaceSettings {
                 ignore_dependencies: update.ignore_deps,
                 changeset: update.changeset,
                 github_actions: update.github_actions,
+                github_actions_server: update.github_actions_server,
             };
         }
 

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1520,6 +1520,7 @@ fn parses_update_section_from_yaml_and_applies() {
 update:
   changeset: true
   githubActions: true
+  githubActionsServer: https://github.example.com
   ignoreDeps:
     - "@pnpm.e2e/foo"
     - "@pnpm.e2e/bar"
@@ -1536,6 +1537,10 @@ update:
         Some(&["@pnpm.e2e/foo".to_string(), "@pnpm.e2e/bar".to_string()][..]),
     );
     assert_eq!(config.update_config.github_actions, Some(true));
+    assert_eq!(
+        config.update_config.github_actions_server.as_deref(),
+        Some("https://github.example.com"),
+    );
 }
 
 #[test]

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -764,16 +764,22 @@ pub fn redact_url_credentials(text: &str) -> String {
     out
 }
 
-/// Make untrusted, URL-bearing text safe to print or log: redact inline
-/// `user:pass@` credentials ([`redact_url_credentials`]) and strip every
-/// control character. Used for registry URLs and network-error messages
-/// alike — both can carry basic-auth or escape sequences from an untrusted
-/// `.npmrc` / `--registry` (or a `reqwest` error that echoes the request URL
-/// back), which must not leak credentials or inject terminal output via raw
-/// escapes / `\r` / `\n`.
+/// Make untrusted, URL-bearing text safe to print or log: strip every
+/// control character, then redact inline `user:pass@` credentials
+/// ([`redact_url_credentials`]). Used for registry URLs and network-error
+/// messages alike — both can carry basic-auth or escape sequences from an
+/// untrusted `.npmrc` / `--registry` (or a `reqwest` error that echoes the
+/// request URL back), which must not leak credentials or inject terminal
+/// output via raw escapes / `\r` / `\n`.
+///
+/// The order is load-bearing: a control character inside the userinfo
+/// (`user:pass\r@host`) would split the authority across the redaction
+/// scan, and removing it afterwards would rejoin the credentials into the
+/// output.
 #[must_use]
 pub fn redact_and_sanitize(text: &str) -> String {
-    redact_url_credentials(text).chars().filter(|character| !character.is_control()).collect()
+    let sanitized: String = text.chars().filter(|character| !character.is_control()).collect();
+    redact_url_credentials(&sanitized)
 }
 
 /// If the authority leading `text` contains `userinfo@`, return the slice after

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -228,6 +228,9 @@ fn redact_and_sanitize_strips_credentials_and_control_chars() {
     assert_eq!(redact_and_sanitize("https://user:pass@host/pkg\u{7}\r\n"), "https://host/pkg");
     // A clean URL is returned unchanged.
     assert_eq!(redact_and_sanitize("https://host/pkg"), "https://host/pkg");
+    // A control character inside the userinfo must not break the redaction:
+    // controls are stripped first, then credentials are redacted.
+    assert_eq!(redact_and_sanitize("https://user:pass\r@host/x"), "https://host/x");
 }
 
 fn build(entries: &[(&str, &str)]) -> AuthHeaders {

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -108,6 +108,10 @@ function translateUpdateSettings (pnpmSettings: PnpmSettings, settings: OptionsF
     assertBoolean(update.githubActions, 'update.githubActions')
     updateConfig.githubActions = update.githubActions
   }
+  if (update.githubActionsServer != null) {
+    assertString(update.githubActionsServer, 'update.githubActionsServer')
+    updateConfig.githubActionsServer = update.githubActionsServer
+  }
   settings.updateConfig = updateConfig
 }
 
@@ -182,6 +186,12 @@ function assertStringArray (value: unknown, settingName: string): asserts value 
 function assertBoolean (value: unknown, settingName: string): asserts value is boolean {
   if (typeof value !== 'boolean') {
     throw new PnpmError('INVALID_SETTING', `The "${settingName}" setting should be a boolean, but got ${renderReceivedType(value)}`)
+  }
+}
+
+function assertString (value: unknown, settingName: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new PnpmError('INVALID_SETTING', `The "${settingName}" setting should be a string, but got ${renderReceivedType(value)}`)
   }
 }
 

--- a/pnpm11/config/reader/test/updateSettings.test.ts
+++ b/pnpm11/config/reader/test/updateSettings.test.ts
@@ -71,6 +71,25 @@ test('getOptionsFromPnpmSettings() validates update.githubActions', () => {
   } as any)).toThrow('The "update.githubActions" setting should be a boolean, but got string') // eslint-disable-line
 })
 
+test('getOptionsFromPnpmSettings() maps "update.githubActionsServer" to updateConfig.githubActionsServer', () => {
+  const options = getOptionsFromPnpmSettings(process.cwd(), {
+    update: {
+      githubActionsServer: 'https://github.example.com',
+    },
+  })
+  expect(options.updateConfig).toStrictEqual({
+    githubActionsServer: 'https://github.example.com',
+  })
+})
+
+test('getOptionsFromPnpmSettings() validates update.githubActionsServer', () => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    update: {
+      githubActionsServer: true,
+    },
+  } as any)).toThrow('The "update.githubActionsServer" setting should be a string, but got boolean') // eslint-disable-line
+})
+
 test('getOptionsFromPnpmSettings() lets "update" win over "updateConfig" and warns', () => {
   const options = getOptionsFromPnpmSettings(process.cwd(), {
     update: {

--- a/pnpm11/core/error/src/index.ts
+++ b/pnpm11/core/error/src/index.ts
@@ -109,13 +109,17 @@ export function redactUrlCredentials (text: string): string {
  * or inject terminal output via raw escapes / `\r` / `\n`.
  */
 export function redactAndSanitize (text: string): string {
-  let result = ''
-  for (const char of redactUrlCredentials(text)) {
+  // Controls are stripped BEFORE redacting: a control character inside the
+  // userinfo (`user:pass\r@host`) would otherwise split the authority across
+  // the redaction scan, and removing it afterwards would rejoin the
+  // credentials into the output.
+  let sanitized = ''
+  for (const char of text) {
     const code = char.codePointAt(0)!
     if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) continue
-    result += char
+    sanitized += char
   }
-  return result
+  return redactUrlCredentials(sanitized)
 }
 
 function isSchemeTailChar (code: number): boolean {

--- a/pnpm11/core/error/src/index.ts
+++ b/pnpm11/core/error/src/index.ts
@@ -101,6 +101,23 @@ export function redactUrlCredentials (text: string): string {
   return result
 }
 
+/**
+ * Make untrusted, URL-bearing text safe to print or log: redact inline
+ * `user:pass@` credentials ({@link redactUrlCredentials}) and strip every
+ * control character. Both can appear in error messages that echo an
+ * untrusted URL or subprocess stderr back, which must not leak credentials
+ * or inject terminal output via raw escapes / `\r` / `\n`.
+ */
+export function redactAndSanitize (text: string): string {
+  let result = ''
+  for (const char of redactUrlCredentials(text)) {
+    const code = char.codePointAt(0)!
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) continue
+    result += char
+  }
+  return result
+}
+
 function isSchemeTailChar (code: number): boolean {
   return (code >= 0x30 && code <= 0x39) || (code >= 0x41 && code <= 0x5a) || (code >= 0x61 && code <= 0x7a)
 }

--- a/pnpm11/core/error/test/index.ts
+++ b/pnpm11/core/error/test/index.ts
@@ -87,4 +87,7 @@ test('redactAndSanitize', () => {
   expect(redactAndSanitize('fatal: \u001b[31mhttps://user:pass@host/repo.git\u001b[0m\r\nnot found\u0000'))
     .toBe('fatal: [31mhttps://host/repo.git[0mnot found')
   expect(redactAndSanitize('plain text')).toBe('plain text')
+  // A control character inside the userinfo must not break the redaction:
+  // controls are stripped first, then credentials are redacted.
+  expect(redactAndSanitize('https://user:pass\r@host/x')).toBe('https://host/x')
 })

--- a/pnpm11/core/error/test/index.ts
+++ b/pnpm11/core/error/test/index.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { FetchError, PnpmError, redactUrlCredentials } from '@pnpm/error'
+import { FetchError, PnpmError, redactAndSanitize, redactUrlCredentials } from '@pnpm/error'
 
 test('PnpmError exposes cause when provided', () => {
   const cause = new Error('original failure')
@@ -79,4 +79,12 @@ test('redactUrlCredentials', () => {
   // Multiple credentialed URLs in one message are all redacted.
   expect(redactUrlCredentials('a https://u:p@h1/x and b https://t@h2/y'))
     .toBe('a https://h1/x and b https://h2/y')
+})
+
+test('redactAndSanitize', () => {
+  // Credentials are redacted and every control character (C0, DEL, C1) is
+  // stripped, so raw stderr can't leak secrets or inject terminal escapes.
+  expect(redactAndSanitize('fatal: \u001b[31mhttps://user:pass@host/repo.git\u001b[0m\r\nnot found\u0000'))
+    .toBe('fatal: [31mhttps://host/repo.git[0mnot found')
+  expect(redactAndSanitize('plain text')).toBe('plain text')
 })

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -209,8 +209,17 @@ export interface UpdateSettings {
   changeset?: boolean
   /**
    * Whether `pnpm update` should also update GitHub Actions dependencies.
+   * When explicitly set to `false`, `pnpm outdated` and the interactive
+   * `pnpm update` skip GitHub Actions dependencies as well.
    */
   githubActions?: boolean
+  /**
+   * The base URL of the GitHub server that hosts the repositories of the
+   * GitHub Actions referenced by the workflow files (for example, a GitHub
+   * Enterprise Server). When not set, the `GITHUB_SERVER_URL` environment
+   * variable is used, falling back to https://github.com.
+   */
+  githubActionsServer?: string
 }
 
 export interface PnpmSettings {
@@ -235,6 +244,7 @@ export interface PnpmSettings {
     changeset?: boolean
     ignoreDependencies?: string[]
     githubActions?: boolean
+    githubActionsServer?: string
   }
   audit?: AuditSettings
   /**

--- a/pnpm11/deps/github-actions/package.json
+++ b/pnpm11/deps/github-actions/package.json
@@ -40,6 +40,9 @@
     "write-file-atomic": "catalog:",
     "yaml": "catalog:"
   },
+  "peerDependencies": {
+    "@pnpm/logger": "catalog:"
+  },
   "devDependencies": {
     "@jest/globals": "catalog:",
     "@pnpm/deps.github-actions": "workspace:*",

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
+import { globalWarn } from '@pnpm/logger'
 import { getRepoRefs } from '@pnpm/resolving.git-resolver'
 import { isSubdir } from 'is-subdir'
 import pLimit from 'p-limit'
@@ -22,6 +23,12 @@ export interface GitHubActionsOptions {
   dir: string
   match?: (name: string) => boolean
   readRepoRefs?: (repo: string) => Promise<Record<string, string>>
+  /**
+   * The base URL of the GitHub server hosting the action repositories.
+   * Defaults to the `GITHUB_SERVER_URL` environment variable, or
+   * https://github.com.
+   */
+  serverUrl?: string
 }
 
 export interface FindOutdatedGitHubActionsOptions extends GitHubActionsOptions {
@@ -80,6 +87,7 @@ export async function findOutdatedGitHubActions (
   opts: FindOutdatedGitHubActionsOptions
 ): Promise<OutdatedGitHubAction[]> {
   const plans = await createUpdatePlan(opts)
+  const serverUrl = resolveServerUrl(opts.serverUrl)
   const target = (plan: PlannedUpdate) => opts.compatible ? plan.wanted : plan.latest
   return dedupeOutdated(plans
     .filter((plan) => semver.lt(plan.current.version, target(plan).version))
@@ -88,7 +96,7 @@ export async function findOutdatedGitHubActions (
       latest: target(plan).version.version,
       name: plan.action.name,
       wanted: plan.wanted.version.version,
-      homepage: `https://github.com/${plan.action.repo}`,
+      homepage: `${serverUrl}/${plan.action.repo}`,
     })))
 }
 
@@ -123,6 +131,7 @@ export async function updateGitHubActions (
       throw workflowError('WRITE', file.path, err)
     }
   }))
+  const serverUrl = resolveServerUrl(opts.serverUrl)
   return dedupeOutdated(updates.map((plan) => {
     const target = opts.latest ? plan.latest : plan.wanted
     return {
@@ -130,7 +139,7 @@ export async function updateGitHubActions (
       latest: target.version.version,
       name: plan.action.name,
       wanted: plan.wanted.version.version,
-      homepage: `https://github.com/${plan.action.repo}`,
+      homepage: `${serverUrl}/${plan.action.repo}`,
     }
   }))
 }
@@ -138,12 +147,20 @@ export async function updateGitHubActions (
 async function createUpdatePlan (opts: GitHubActionsOptions): Promise<PlannedUpdate[]> {
   const actions = await discoverActions(opts.dir)
   const selected = opts.match == null ? actions : actions.filter((action) => opts.match!(action.name) || opts.match!(action.repo))
-  const readRepoRefs = opts.readRepoRefs ?? readRefsWithGit
+  const serverUrl = resolveServerUrl(opts.serverUrl)
+  const readRepoRefs = opts.readRepoRefs ?? (async (repo: string) => getRepoRefs(`${serverUrl}/${repo}.git`, null))
   const refsByRepo = new Map<string, Promise<RepoVersion[]>>()
   return (await Promise.all(selected.map(async (action): Promise<PlannedUpdate | null> => {
     let versionsPromise = refsByRepo.get(action.repo)
     if (versionsPromise == null) {
-      versionsPromise = limitRepoReads(() => readRepoRefs(action.repo).then(parseRepoVersions))
+      versionsPromise = limitRepoReads(async () => {
+        try {
+          return parseRepoVersions(await readRepoRefs(action.repo))
+        } catch (err: unknown) {
+          globalWarn(`Skipping the GitHub Actions from "${action.repo}": ${util.types.isNativeError(err) ? err.message : String(err)}`)
+          return []
+        }
+      })
       refsByRepo.set(action.repo, versionsPromise)
     }
     const versions = await versionsPromise
@@ -384,8 +401,10 @@ function dedupeOutdated (actions: OutdatedGitHubAction[]): OutdatedGitHubAction[
     .sort((left, right) => left.name.localeCompare(right.name))
 }
 
-async function readRefsWithGit (repo: string): Promise<Record<string, string>> {
-  return getRepoRefs(`https://github.com/${repo}.git`, null)
+function resolveServerUrl (serverUrl: string | undefined): string {
+  let url = serverUrl || process.env.GITHUB_SERVER_URL || 'https://github.com'
+  while (url.endsWith('/')) url = url.slice(0, -1)
+  return url
 }
 
 function workflowError (operation: 'PARSE' | 'READ' | 'WRITE', filePath: string, cause: unknown): PnpmError {

--- a/pnpm11/deps/github-actions/src/index.ts
+++ b/pnpm11/deps/github-actions/src/index.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import util from 'node:util'
 
-import { PnpmError } from '@pnpm/error'
+import { PnpmError, redactAndSanitize } from '@pnpm/error'
 import { globalWarn } from '@pnpm/logger'
 import { getRepoRefs } from '@pnpm/resolving.git-resolver'
 import { isSubdir } from 'is-subdir'
@@ -157,7 +157,9 @@ async function createUpdatePlan (opts: GitHubActionsOptions): Promise<PlannedUpd
         try {
           return parseRepoVersions(await readRepoRefs(action.repo))
         } catch (err: unknown) {
-          globalWarn(`Skipping the GitHub Actions from "${action.repo}": ${util.types.isNativeError(err) ? err.message : String(err)}`)
+          // The git error may echo a credentialed URL or raw stderr back, so
+          // it is redacted and stripped of control characters before logging.
+          globalWarn(redactAndSanitize(`Skipping the GitHub Actions from "${action.repo}": ${util.types.isNativeError(err) ? err.message : String(err)}`))
           return []
         }
       })
@@ -403,6 +405,11 @@ function dedupeOutdated (actions: OutdatedGitHubAction[]): OutdatedGitHubAction[
 
 function resolveServerUrl (serverUrl: string | undefined): string {
   let url = serverUrl || process.env.GITHUB_SERVER_URL || 'https://github.com'
+  // Only allow http(s) so the value cannot select another git transport
+  // (e.g. `ext::`, which executes an arbitrary command).
+  if (!url.startsWith('https://') && !url.startsWith('http://')) {
+    throw new PnpmError('GITHUB_ACTIONS_SERVER_PROTOCOL', `The GitHub Actions server URL must use the "https://" or "http://" protocol, but got ${JSON.stringify(url)}`)
+  }
   while (url.endsWith('/')) url = url.slice(0, -1)
   return url
 }

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -2,12 +2,29 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { afterEach, describe, expect, test } from '@jest/globals'
-import { findOutdatedGitHubActions, isGitHubActionSelector, normalizeGitHubActionSelector, updateGitHubActions } from '@pnpm/deps.github-actions'
+import { afterEach, describe, expect, jest, test } from '@jest/globals'
+
+jest.unstable_mockModule('@pnpm/logger', () => ({
+  globalWarn: jest.fn(),
+}))
+
+const { globalWarn } = await import('@pnpm/logger')
+const {
+  findOutdatedGitHubActions,
+  isGitHubActionSelector,
+  normalizeGitHubActionSelector,
+  updateGitHubActions,
+} = await import('@pnpm/deps.github-actions')
 
 const dirs: string[] = []
 
+// The homepage and git URL fall back to GITHUB_SERVER_URL, which is set on
+// GitHub Actions runners — the tests assume the https://github.com default.
+delete process.env.GITHUB_SERVER_URL
+
 afterEach(async () => {
+  delete process.env.GITHUB_SERVER_URL
+  jest.mocked(globalWarn).mockClear()
   await Promise.all(dirs.splice(0).map(async (dir) => fs.rm(dir, { force: true, recursive: true })))
 })
 
@@ -73,6 +90,85 @@ describe('GitHub Actions dependencies', () => {
         wanted: '2.1.0',
       },
     ])
+  })
+
+  test('builds homepages from the configured server URL', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4.1.0
+`,
+    })
+
+    await expect(findOutdatedGitHubActions({
+      dir,
+      readRepoRefs: async () => repoRefs([
+        ['v4.1.0', 'a'.repeat(40)],
+        ['v4.2.0', 'b'.repeat(40)],
+      ]),
+      serverUrl: 'https://github.example.com/',
+    })).resolves.toEqual([
+      {
+        current: '4.1.0',
+        homepage: 'https://github.example.com/actions/checkout',
+        latest: '4.2.0',
+        name: 'actions/checkout',
+        wanted: '4.2.0',
+      },
+    ])
+  })
+
+  test('falls back to the GITHUB_SERVER_URL environment variable for the server URL', async () => {
+    process.env.GITHUB_SERVER_URL = 'https://ghes.example.com'
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4.1.0
+`,
+    })
+
+    const outdated = await findOutdatedGitHubActions({
+      dir,
+      readRepoRefs: async () => repoRefs([
+        ['v4.1.0', 'a'.repeat(40)],
+        ['v4.2.0', 'b'.repeat(40)],
+      ]),
+    })
+    expect(outdated[0].homepage).toBe('https://ghes.example.com/actions/checkout')
+  })
+
+  test('skips actions whose repository refs cannot be read and warns', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - uses: owner/private-action@v1.0.0
+`,
+    })
+
+    await expect(findOutdatedGitHubActions({
+      dir,
+      readRepoRefs: async (repo) => {
+        if (repo === 'owner/private-action') throw new Error('Repository not found.')
+        return repoRefs([
+          ['v4.1.0', 'a'.repeat(40)],
+          ['v4.2.0', 'b'.repeat(40)],
+        ])
+      },
+    })).resolves.toEqual([
+      {
+        current: '4.1.0',
+        homepage: 'https://github.com/actions/checkout',
+        latest: '4.2.0',
+        name: 'actions/checkout',
+        wanted: '4.2.0',
+      },
+    ])
+    expect(globalWarn).toHaveBeenCalledTimes(1)
+    expect(globalWarn).toHaveBeenCalledWith('Skipping the GitHub Actions from "owner/private-action": Repository not found.')
   })
 
   test('updates within the current major and preserves SHA comments and unrelated formatting', async () => {

--- a/pnpm11/deps/github-actions/test/index.test.ts
+++ b/pnpm11/deps/github-actions/test/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { afterEach, describe, expect, jest, test } from '@jest/globals'
+import { afterAll, afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals'
 
 jest.unstable_mockModule('@pnpm/logger', () => ({
   globalWarn: jest.fn(),
@@ -20,10 +20,21 @@ const dirs: string[] = []
 
 // The homepage and git URL fall back to GITHUB_SERVER_URL, which is set on
 // GitHub Actions runners — the tests assume the https://github.com default.
-delete process.env.GITHUB_SERVER_URL
+const originalGithubServerUrl = process.env.GITHUB_SERVER_URL
+
+beforeEach(() => {
+  delete process.env.GITHUB_SERVER_URL
+})
+
+afterAll(() => {
+  if (originalGithubServerUrl == null) {
+    delete process.env.GITHUB_SERVER_URL
+  } else {
+    process.env.GITHUB_SERVER_URL = originalGithubServerUrl
+  }
+})
 
 afterEach(async () => {
-  delete process.env.GITHUB_SERVER_URL
   jest.mocked(globalWarn).mockClear()
   await Promise.all(dirs.splice(0).map(async (dir) => fs.rm(dir, { force: true, recursive: true })))
 })
@@ -169,6 +180,39 @@ describe('GitHub Actions dependencies', () => {
     ])
     expect(globalWarn).toHaveBeenCalledTimes(1)
     expect(globalWarn).toHaveBeenCalledWith('Skipping the GitHub Actions from "owner/private-action": Repository not found.')
+  })
+
+  test('redacts credentials and control characters from the skip warning', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: owner/private-action@v1.0.0
+`,
+    })
+
+    await findOutdatedGitHubActions({
+      dir,
+      readRepoRefs: async () => {
+        throw new Error('fatal: unable to access \u001b[31mhttps://user:token@ghes.example.com/owner/private-action.git\u001b[0m\nnot found')
+      },
+    })
+    expect(globalWarn).toHaveBeenCalledWith('Skipping the GitHub Actions from "owner/private-action": fatal: unable to access [31mhttps://ghes.example.com/owner/private-action.git[0mnot found')
+  })
+
+  test('rejects a server URL that is not http(s)', async () => {
+    const dir = await fixture({
+      '.github/workflows/ci.yml': `jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4.1.0
+`,
+    })
+
+    await expect(findOutdatedGitHubActions({
+      dir,
+      serverUrl: 'ext::sh -c date',
+    })).rejects.toMatchObject({ code: 'ERR_PNPM_GITHUB_ACTIONS_SERVER_PROTOCOL' })
   })
 
   test('updates within the current major and preserves SHA comments and unrelated formatting', async () => {

--- a/pnpm11/deps/inspection/commands/src/outdated/outdated.ts
+++ b/pnpm11/deps/inspection/commands/src/outdated/outdated.ts
@@ -228,12 +228,13 @@ export async function handler (
         timeout: opts.fetchTimeout,
       })
       : [],
-    opts.global || !include.devDependencies
+    opts.global || !include.devDependencies || opts.updateConfig?.githubActions === false
       ? []
       : findOutdatedGitHubActions({
         compatible: opts.compatible,
         dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
         match: params.length > 0 ? createMatcher(params.map(normalizeGitHubActionSelector)) : undefined,
+        serverUrl: opts.updateConfig?.githubActionsServer,
       }),
   ])
   const outdatedPackages: OutdatedItem[] = [

--- a/pnpm11/deps/inspection/commands/src/outdated/recursive.ts
+++ b/pnpm11/deps/inspection/commands/src/outdated/recursive.ts
@@ -83,11 +83,12 @@ export async function outdatedRecursive (
       outdatedMap[key].dependentPkgs.push({ location: rootDir, manifest })
     }
   }
-  if (opts.include.devDependencies) {
+  if (opts.include.devDependencies && opts.updateConfig?.githubActions !== false) {
     const outdatedActions = await findOutdatedGitHubActions({
       compatible: opts.compatible,
       dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
       match: params.length > 0 ? createMatcher(params.map(normalizeGitHubActionSelector)) : undefined,
+      serverUrl: opts.updateConfig?.githubActionsServer,
     })
     for (const action of outdatedActions) {
       const outdatedAction = toOutdatedAction(action)

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -243,11 +243,12 @@ async function interactiveUpdate (
         timeout: opts.fetchTimeout,
       })
       : projects.map(() => []),
-    include.devDependencies && opts.save !== false && !opts.lockfileOnly
+    include.devDependencies && opts.save !== false && !opts.lockfileOnly && opts.updateConfig?.githubActions !== false
       ? findOutdatedGitHubActions({
         compatible: opts.latest !== true,
         dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
         match: input.length > 0 ? createMatcher(input.map(normalizeGitHubActionSelector)) : undefined,
+        serverUrl: opts.updateConfig?.githubActionsServer,
       })
       : [],
   ])
@@ -392,6 +393,7 @@ async function update (
       dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
       latest: opts.latest,
       match: dependencies.length > 0 ? createMatcher(dependencies.map(normalizeGitHubActionSelector)) : undefined,
+      serverUrl: opts.updateConfig?.githubActionsServer,
     })
   }
   if (changesetContext != null) {

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -243,7 +243,8 @@ async function interactiveUpdate (
         timeout: opts.fetchTimeout,
       })
       : projects.map(() => []),
-    include.devDependencies && opts.save !== false && !opts.lockfileOnly && opts.updateConfig?.githubActions !== false
+    include.devDependencies && opts.save !== false && !opts.lockfileOnly &&
+    (opts.updateConfig?.githubActions !== false || opts.includeGithubActions === true)
       ? findOutdatedGitHubActions({
         compatible: opts.latest !== true,
         dir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
@@ -325,7 +326,12 @@ async function interactiveUpdate (
     throw err
   }
 
-  return update(updatePkgNames, { ...opts, includeGithubActions: true }, rebuildHandler) as Promise<undefined>
+  // An explicit `update.githubActions: false` must survive into the update
+  // phase — only the `--include-github-actions` flag may override it.
+  return update(updatePkgNames, {
+    ...opts,
+    includeGithubActions: opts.includeGithubActions === true || opts.updateConfig?.githubActions !== false,
+  }, rebuildHandler) as Promise<undefined>
 }
 
 async function update (

--- a/pnpm11/resolving/git-resolver/src/index.ts
+++ b/pnpm11/resolving/git-resolver/src/index.ts
@@ -118,7 +118,9 @@ function resolveVTags (vTags: string[], range: string): string | null {
 }
 
 export async function getRepoRefs (repo: string, ref: string | null): Promise<Record<string, string>> {
-  const gitArgs = [repo]
+  // `--` keeps a repo URL that starts with a dash (e.g. from a malicious
+  // config value) from being parsed as a git flag, matching the Rust runner.
+  const gitArgs = ['--', repo]
   if (ref) {
     gitArgs.push(ref)
     // Also request the peeled ref for annotated tags (e.g., refs/tags/v1.0.0^{})


### PR DESCRIPTION
## Summary

`pnpm outdated` (and the GitHub Actions handling in `pnpm update`) hardcoded `https://github.com` as the host of every `uses:` repository, so on GitHub Enterprise Server instances — where `actions/*` resolves against the GHES host — `git ls-remote` failed with "Repository not found" and aborted the whole command. Closes pnpm/pnpm#13220.

Three changes, landed in both the TypeScript CLI and the Rust port:

1. **Unreadable action repositories no longer abort the command.** A failed `git ls-remote` for one repository (private repo, deleted repo, GHES-hosted action) now emits a warning — `Skipping the GitHub Actions from "<owner>/<repo>": <cause>` — and skips that repository's actions instead of failing `pnpm outdated`/`pnpm update` outright. This alone un-breaks the reporter's scenario even with no configuration.
2. **New `update.githubActionsServer` setting** (`pnpm-workspace.yaml`): the base URL of the GitHub server hosting the referenced action repositories. Used for both the `git ls-remote` remote and the `homepage` links in the outdated report. When unset, it falls back to the `GITHUB_SERVER_URL` environment variable (set on all GitHub runners, so GHES CI works with zero configuration; on github.com runners it is `https://github.com`, so nothing changes there) and then to `https://github.com`.
3. **Opt-out:** explicitly setting `update.githubActions: false` now makes `pnpm outdated` and the interactive `pnpm update` skip GitHub Actions dependencies entirely. Unset keeps today's behavior, and the explicit `--include-github-actions` flag still wins over the config.

The warning goes through the reporter's `globalWarn` channel in both stacks (the pacquet `outdated` command dispatch now threads the reporter type for this).

**Hardening and follow-ups from review:**

- The skip warning is passed through credential redaction and control-character stripping in both stacks (new `redactAndSanitize` export in `@pnpm/error`, mirroring the existing `pacquet_network::redact_and_sanitize`), since git errors can echo a credentialed URL or raw stderr back.
- The resolved server URL must use `http(s)://` (`ERR_PNPM_GITHUB_ACTIONS_SERVER_PROTOCOL`), so a repo-controlled value cannot select another git transport such as `ext::` (which executes a command). The TypeScript `getRepoRefs` also now passes `--` before the repository URL, matching the Rust runner, so a dash-prefixed value cannot be parsed as a git flag.
- pacquet `pnpm outdated -r` now includes GitHub Actions dependencies, closing a pre-existing parity gap with the TypeScript recursive outdated (same gate, server URL, skip warnings, `.github` dependent entry, and `dependencyType: "githubAction"` in JSON output).
- The TypeScript interactive update no longer re-enables GitHub Actions in its update phase after an explicit `update.githubActions: false`; only `--include-github-actions` overrides the opt-out, matching pacquet.

## Squash Commit Body

```text
The GitHub Actions dependency checking in `outdated` and `update`
hardcoded https://github.com as the git host of every `uses:`
repository. On GitHub Enterprise Server, actions resolve against the
GHES instance instead, so `git ls-remote` failed with "Repository not
found" and the error aborted the entire command (the same failure
mode existed for private or deleted action repositories on
github.com).

- Read refs failures per repository are now non-fatal: the repository
  is skipped with a `globalWarn` ("Skipping the GitHub Actions from
  ...") instead of failing the command. One warning per repository.
- New `update.githubActionsServer` setting: the base URL of the
  GitHub server hosting the action repositories, used for both the
  git remote and the homepage links. Defaults to the
  GITHUB_SERVER_URL environment variable (set by GitHub runners,
  including GHES) and then https://github.com. Trailing slashes are
  stripped; the empty string counts as unset.
- `update.githubActions: false` (explicit) now opts `pnpm outdated`
  and the interactive `pnpm update` out of GitHub Actions checking.
  Unset preserves the previous behavior, and the explicit
  `--include-github-actions` flag still overrides the config.

Both stacks change together. On the pacquet side, the `outdated`
command dispatch now threads the reporter type so the skip warnings
reach the `globalWarn` channel, matching the TypeScript CLI's log
emissions, and the recursive outdated now includes GitHub Actions,
closing a pre-existing parity gap.

Hardening: the skip warning is credential-redacted and stripped of
control characters in both stacks (new redactAndSanitize export in
the error package); the resolved server URL is restricted to http(s)
(ERR_PNPM_GITHUB_ACTIONS_SERVER_PROTOCOL) so a repo-controlled value
cannot select another git transport such as ext::; and the
TypeScript getRepoRefs passes "--" before the repository URL like
the Rust runner already did. The interactive update no longer
re-enables actions after an explicit opt-out; only the
--include-github-actions flag overrides it.

Closes pnpm/pnpm#13220.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed — `update.githubActionsServer` and the
  `update.githubActions: false` opt-out need documenting on pnpm.io (docs repo).

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom GitHub Actions server URL (`githubActionsServer` / `update.githubActionsServer`, defaulting to `GITHUB_SERVER_URL` or `https://github.com`).
  * GitHub Actions action metadata now reflects the configured server when generating homepages.

* **Bug Fixes**
  * `pnpm outdated` and update flows no longer fail when GitHub Actions repo refs can’t be read; those actions are skipped with a warning.
  * When GitHub Actions are disabled, outdated detection and interactive updates correctly honor the setting (including explicit disable).
  * Safer Git ref resolution (prevents malformed URLs being treated as git flags) and warning output is sanitized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->