### PR TITLE
fix: resolve catalog references when installing via a pnpr server

### DIFF
--- a/.changeset/pnpr-catalog-overrides.md
+++ b/.changeset/pnpr-catalog-overrides.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/pnpr.client": patch
+"pnpm": patch
+"@pnpm/pnpr": patch
+---
+
+Fixed `catalog:` references in dependencies and overrides failing to resolve when installing through a pnpr server, which errored with "No catalog entry '<name>' was found for catalog 'default'." even though the catalog entry existed [#13232](https://github.com/pnpm/pnpm/issues/13232).

--- a/.changeset/pnpr-catalog-overrides.md
+++ b/.changeset/pnpr-catalog-overrides.md
@@ -5,4 +5,4 @@
 "@pnpm/pnpr": patch
 ---
 
-Fixed `catalog:` references in dependencies and overrides failing to resolve when installing through a pnpr server, which errored with "No catalog entry '<name>' was found for catalog 'default'." even though the catalog entry existed [#13232](https://github.com/pnpm/pnpm/issues/13232).
+Fixed `catalog:` references in dependencies and overrides failing to resolve when installing through a pnpr server, which errored with "No catalog entry '<name>' was found for catalog 'default'." even though the catalog entry existed. Also fixed a crash on Windows when installing a nested workspace member (e.g. `packages/foo`) through a pnpr server [#13232](https://github.com/pnpm/pnpm/issues/13232).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5544,6 +5544,7 @@ dependencies = [
  "mockito",
  "node-semver",
  "object_store",
+ "pacquet-catalogs-types",
  "pacquet-config",
  "pacquet-config-dir",
  "pacquet-env-replace",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10127,6 +10127,9 @@ importers:
 
   pnpr/client:
     dependencies:
+      '@pnpm/catalogs.types':
+        specifier: workspace:*
+        version: link:../../pnpm11/catalogs/types
       '@pnpm/lockfile.fs':
         specifier: workspace:*
         version: link:../../pnpm11/lockfile/fs

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -45,6 +45,7 @@ import { readModulesManifest, type StrictModules, writeModulesManifest } from '@
 import {
   type CatalogSnapshots,
   cleanGitBranchLockfiles,
+  getLockfileImporterId,
   getWantedLockfileName,
   isEmptyLockfile,
   type LockfileObject,
@@ -2757,7 +2758,10 @@ async function installViaPnprServer (
           {
             binsDir: path.join(p.rootDir, 'node_modules', '.bin'),
             buildIndex: i,
-            id: (path.relative(lockfileDir, p.rootDir) || '.') as ProjectId,
+            // POSIX-normalize so the importer id matches the lockfile keys the
+            // pnpr server emits — on Windows a nested member's `path.relative`
+            // would otherwise be `packages\foo`, missing `packages/foo`.
+            id: getLockfileImporterId(lockfileDir, p.rootDir),
             manifest: p.manifest,
             modulesDir: path.join(p.rootDir, 'node_modules'),
             rootDir: p.rootDir,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2695,6 +2695,10 @@ async function installViaPnprServer (
       namedRegistries: opts.namedRegistries,
       authorization: pnprAuthorization,
       overrides: opts.overrides,
+      // The reconstructed workspace the server builds from this request has no
+      // catalog sections, so forward the catalogs for the server to resolve
+      // `catalog:` specifiers in both dependencies and overrides.
+      catalogs: opts.catalogs,
       minimumReleaseAge: opts.minimumReleaseAge,
       lockfile: existingLockfile ?? undefined,
     })

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -57,6 +57,24 @@ test("pnpr forwards a single project's name and version", async () => {
   }))
 })
 
+test('pnpr forwards catalogs and overrides so the server can resolve catalog references', async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir, {
+    catalogs: { default: { '@tanstack/store': '0.11.0' } },
+    overrides: { '@tanstack/store': 'catalog:', foo: '1.0.0' },
+  })
+
+  await install(manifest, options)
+
+  expect(resolveViaPnprServer).toHaveBeenCalledTimes(1)
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    catalogs: { default: { '@tanstack/store': '0.11.0' } },
+    overrides: { '@tanstack/store': 'catalog:', foo: '1.0.0' },
+  }))
+})
+
 test("pnpr forwards every workspace project's name and version", async () => {
   const workspaceRoot = prepareEmpty().dir()
   const appManifest: ProjectManifest = {

--- a/pnpm11/pnpm/test/install/pnpmRegistry.ts
+++ b/pnpm11/pnpm/test/install/pnpmRegistry.ts
@@ -318,6 +318,49 @@ test('pnpm add inside a workspace project uses pnpr server', async () => {
   expect(projectBManifest.dependencies?.['is-negative']).toBe('1.0.0')
 })
 
+test('pnpm install with pnpr server resolves catalog references in dependencies and overrides', async () => {
+  prepareWorkspace([
+    {
+      location: '.',
+      package: {
+        name: 'root',
+        version: '0.0.0',
+        private: true,
+      },
+    },
+    {
+      location: 'packages/a',
+      package: {
+        name: 'a',
+        version: '1.0.0',
+        dependencies: {
+          'is-positive': 'catalog:',
+        },
+      },
+    },
+  ])
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    packages: ['packages/*'],
+    catalog: {
+      'is-positive': '1.0.0',
+    },
+    overrides: {
+      'is-positive': 'catalog:',
+    },
+  })
+
+  requestCount = 0
+
+  await execPnpm(
+    ['install', `--config.pnprServer=http://localhost:${serverPort}`]
+  )
+
+  expect(requestCount).toBeGreaterThanOrEqual(1)
+  expect(fs.existsSync(WANTED_LOCKFILE)).toBe(true)
+  expect(fs.existsSync('packages/a/node_modules/is-positive')).toBe(true)
+})
+
 test('pnpm install with pnpr server works in a workspace with multiple projects', async () => {
   prepareWorkspace([
     {

--- a/pnpr/client/package.json
+++ b/pnpr/client/package.json
@@ -32,6 +32,7 @@
     "compile": "tsgo --build && pn lint --fix"
   },
   "dependencies": {
+    "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/lockfile.fs": "workspace:*",
     "@pnpm/lockfile.types": "workspace:*"
   },

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -3,6 +3,7 @@ import https from 'node:https'
 import { URL } from 'node:url'
 import { gunzip } from 'node:zlib'
 
+import type { Catalogs } from '@pnpm/catalogs.types'
 import { convertToLockfileObject } from '@pnpm/lockfile.fs'
 import type { LockfileFile, LockfileObject } from '@pnpm/lockfile.types'
 
@@ -49,6 +50,13 @@ export interface ResolveViaPnprServerOptions {
   authorization?: string
   /** Overrides */
   overrides?: Record<string, string>
+  /**
+   * Workspace catalogs (`catalog:` / `catalogs:` from `pnpm-workspace.yaml`),
+   * keyed by catalog name with the default catalog under `default`. The
+   * server resolves `catalog:` specifiers in dependencies and overrides
+   * against these — it never reads the workspace manifest itself.
+   */
+  catalogs?: Catalogs
   /** Node.js version for resolution */
   nodeVersion?: string
   /** Minimum release age in minutes */
@@ -107,6 +115,7 @@ export async function resolveViaPnprServer (
     registry: opts.registry,
     namedRegistries: opts.namedRegistries,
     overrides: opts.overrides,
+    catalogs: opts.catalogs,
     nodeVersion: opts.nodeVersion ?? process.version.slice(1),
     os: process.platform,
     arch: process.arch,

--- a/pnpr/client/tsconfig.json
+++ b/pnpr/client/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../pnpm11/catalogs/types"
+    },
+    {
       "path": "../../pnpm11/core/types"
     },
     {

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -25,6 +25,7 @@ backend-mysql    = ["dep:sqlx", "sqlx/mysql"]
 backend-postgres = ["dep:sqlx", "sqlx/postgres"]
 
 [dependencies]
+pacquet-catalogs-types          = { workspace = true }
 pacquet-config                  = { workspace = true }
 pacquet-config-dir              = { workspace = true }
 pacquet-env-replace             = { workspace = true }

--- a/pnpr/crates/pnpr/src/resolver/protocol.rs
+++ b/pnpr/crates/pnpr/src/resolver/protocol.rs
@@ -3,6 +3,7 @@
 
 use std::collections::BTreeMap;
 
+use pacquet_catalogs_types::Catalogs;
 use pacquet_network::AuthHeadersByScope;
 use serde::Deserialize;
 
@@ -68,6 +69,14 @@ pub struct ResolveRequest {
     /// server-side.
     #[serde(default)]
     pub overrides: Option<serde_json::Value>,
+    /// The client's workspace catalogs (`catalog:` / `catalogs:` from
+    /// `pnpm-workspace.yaml`), keyed by catalog name with the default
+    /// catalog at `"default"`. The reconstructed workspace has no catalog
+    /// sections, so these are forwarded and used as the resolution's
+    /// catalog set to resolve `catalog:` specifiers in both dependencies
+    /// and overrides.
+    #[serde(default)]
+    pub catalogs: Option<Catalogs>,
     /// The client's existing on-disk lockfile, when present. Sent both
     /// as the verification target (the server verifies it under the
     /// client's policy before resolving) and as the resolution-reuse

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -223,7 +223,10 @@ pub async fn resolve(
         // single terminal `done` frame carrying the whole lockfile.
         resolution_observer: observer,
         peer_issues_sink: None,
-        catalogs_override: None,
+        // The reconstructed workspace carries no catalog sections, so the
+        // client's catalogs are forwarded here and used to resolve
+        // `catalog:` specifiers in dependencies and overrides.
+        catalogs_override: request.catalogs.clone(),
         disable_optimistic_repeat_install: false,
         pnpmfile_hook_override: None,
         workspace_projects_override: None,

--- a/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve/tests.rs
@@ -1,6 +1,6 @@
 use super::{importer_manifest_name, sanitized_importer_dir};
 use crate::resolver::protocol::ResolveRequest;
-use pacquet_config::Config;
+use pacquet_config::{Config, LinkWorkspacePackages};
 use pacquet_lockfile::{ImporterDepVersion, Lockfile, PkgName};
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_store_dir::StoreDir;
@@ -81,6 +81,39 @@ async fn workspace_star_uses_forwarded_project_name() {
             }
         ]
     })))
+    .await;
+
+    assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
+}
+
+#[tokio::test]
+async fn forwarded_catalogs_resolve_catalog_specifiers() {
+    // The reconstructed workspace carries no catalog sections, so a
+    // `catalog:` specifier resolves only because the request's `catalogs`
+    // are forwarded into the install as the catalog set. The catalog entry
+    // is a plain version that matches a workspace sibling, so
+    // `link-workspace-packages` links it and the assertion stays offline.
+    let lockfile = Box::pin(resolve_json_with(
+        serde_json::json!({
+            "projects": [
+                {
+                    "dir": "packages/app",
+                    "name": "app",
+                    "version": "1.0.0",
+                    "dependencies": { "lib": "catalog:" }
+                },
+                {
+                    "dir": "packages/lib",
+                    "name": "lib",
+                    "version": "1.2.3"
+                }
+            ],
+            "catalogs": {
+                "default": { "lib": "^1.0.0" }
+            }
+        }),
+        |config| config.link_workspace_packages = LinkWorkspacePackages::Deep,
+    ))
     .await;
 
     assert_workspace_link(&lockfile, "packages/app", "lib", "../lib");
@@ -242,7 +275,21 @@ async fn resolve_json(request: serde_json::Value) -> Lockfile {
     try_resolve_json(request).await.expect("offline workspace resolution succeeds")
 }
 
+async fn resolve_json_with(
+    request: serde_json::Value,
+    configure: impl FnOnce(&mut Config),
+) -> Lockfile {
+    try_resolve_json_with(request, configure).await.expect("offline workspace resolution succeeds")
+}
+
 async fn try_resolve_json(request: serde_json::Value) -> Result<Lockfile, super::ResolveError> {
+    try_resolve_json_with(request, |_| {}).await
+}
+
+async fn try_resolve_json_with(
+    request: serde_json::Value,
+    configure: impl FnOnce(&mut Config),
+) -> Result<Lockfile, super::ResolveError> {
     let temp = tempfile::tempdir().expect("create resolver test directory");
     let mut config = Config::new();
     config.offline = true;
@@ -251,6 +298,7 @@ async fn try_resolve_json(request: serde_json::Value) -> Result<Lockfile, super:
     config.cache_dir = temp.path().join("cache");
     config.modules_dir = temp.path().join("node_modules");
     config.virtual_store_dir = temp.path().join("node_modules/.pnpm");
+    configure(&mut config);
     let config = Box::leak(Box::new(config));
     let request: ResolveRequest = serde_json::from_value(request).expect("resolve request parses");
 


### PR DESCRIPTION
## Summary

Fixes a regression where a `catalog:` specifier fails to resolve when the install is routed through a **pnpr server**, erroring with:

```text
resolution failed: ... No catalog entry '@tanstack/store' was found for catalog 'default'.
```

even though the catalog entry exists in `pnpm-workspace.yaml`.

### Root cause

The pnpr server reconstructs the requested workspace in a temp dir from the resolve request (`pnpr/crates/pnpr/src/resolver/resolve.rs`). That reconstruction wrote a `pnpm-workspace.yaml` with only a `packages:` section — **no catalog definitions** — and passed `catalogs_override: None` into the install. So the server had no catalogs and could not resolve *any* `catalog:` specifier.

This affected **both**:
- `catalog:` in **overrides** (the error in the issue, which fires first), and
- `catalog:` in **regular dependencies** (verified separately — it fails the same way once the overrides error is out of the way).

### Fix

Forward the client's workspace catalogs in the resolve request and use them as the install's `catalogs_override`, which feeds both dependency and override catalog resolution in one place. The client now sends its raw overrides (the server resolves their `catalog:` references) rather than pre-resolving them locally.

This mirrors the approach suggested in review — resolving `catalog:` server-side rather than patching each reference on the client — and keeps dependency and override catalog handling consistent.

### Scope (parity change — TypeScript + Rust pnpr server)

- **TS client** (`@pnpm/pnpr.client`): new `catalogs` field on the resolve request, added to the wire body.
- **TS installer** (`@pnpm/installing.deps-installer`): forward `opts.catalogs`; send raw overrides.
- **Rust pnpr server** (`@pnpm/pnpr`): new `catalogs` field on `ResolveRequest`; passed as `catalogs_override`.

No `pnpm-workspace.yaml` reconstruction change is needed — `catalogs_override` bypasses the manifest read.

### Tests

- **Rust** (`resolve/tests.rs`): `forwarded_catalogs_resolve_catalog_specifiers` — an offline resolve where a `catalog:` dependency resolves only because the catalogs are forwarded. Verified it fails with the exact issue error (`No catalog entry 'lib' ...`) when the fix is reverted.
- **TS e2e** (`pnpmRegistry.ts`): faithful reproduction of the issue (root + `packages/a`, `catalog:` dependency + `catalog:` override) against a real pnpr server.
- **TS unit** (`pnprWorkspaceMetadata.ts`): asserts catalogs and raw overrides are forwarded.

### Follow-up noted (not fixed here)

While reproducing, I found a **separate, pre-existing** bug: a workspace with exactly **one non-root importer** (e.g. only `packages/a` with no root project) fails the pnpr path with `Cannot read properties of undefined (reading 'dependencies')`, because `installViaPnprServer` only builds the `projects` list when `allInstallProjects.length > 1`, so a single member is sent as a root (`.`) importer and the headless install then can't find its importer id. It reproduces without catalogs and is orthogonal to this fix. The issue's real-world repro has a root importer too (root + member = 2 importers), so it is unaffected. Happy to file/fix separately.

Closes pnpm/pnpm#13232

## Squash Commit Body

```text
A `catalog:` specifier in a workspace's dependencies or overrides failed to
resolve when the install was routed through a pnpr server, erroring with
"No catalog entry '<name>' was found for catalog 'default'." even though the
catalog entry existed.

The pnpr server reconstructs the requested workspace in a temp dir from the
resolve request. That reconstruction wrote a pnpm-workspace.yaml with only a
packages: section and no catalog definitions, and passed catalogs_override:
None to the install — so the server had no catalogs and could not resolve any
catalog: specifier, in dependencies or overrides.

Forward the client's workspace catalogs in the resolve request and use them as
the install's catalogs_override, which feeds both dependency and override
catalog resolution. The client now sends its raw overrides (the server resolves
their catalog: references) instead of pre-resolving them locally.

Closes pnpm/pnpm#13232
```

## Checklist

- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- Both stacks touched: the TypeScript client/installer and the Rust pnpr
server. The Rust pacquet CLI port does not use the pnpr-client path, so no
pacquet-side change is required. No documentation change is needed. -->

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pnpr-server installs failing to resolve `catalog:` references inside `overrides` (including cases where the catalog entry exists).
  * Improved pnpr-server installs by forwarding workspace catalog data and overrides through resolution so `catalog:` specifiers resolve consistently in dependency and override handling.
  * Fixed a Windows crash when installing a nested workspace member via a pnpr server.

* **Tests**
  * Added Jest and Tokio coverage to verify `catalogs`/`overrides` are sent to the pnpr resolver and that installs resolve `catalog:` references in both `dependencies` and `overrides`.

* **Chores**
  * Patch version bump for related pnpr/pnpm packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->