### PR TITLE
ci: post to Discord when an issue is labeled regression

### DIFF
--- a/.github/ISSUE_TEMPLATE/regression-report.yaml
+++ b/.github/ISSUE_TEMPLATE/regression-report.yaml
@@ -1,6 +1,6 @@
 name: Regression Report 🚫
 description: Report a regression in pnpm
-labels: ['type: regression']
+labels: ['regression']
 body:
   - type: input
     id: last-working-version

--- a/.github/workflows/notify-regression.yml
+++ b/.github/workflows/notify-regression.yml
@@ -1,0 +1,57 @@
+name: Notify Discord on Regression
+
+# Posts a message to Discord whenever an issue is labeled `regression` (applied
+# by the Oz triage agent or a maintainer). The `labeled` event fires each time
+# the label is added, so the job only runs for that specific label.
+#
+# Setup:
+#   - The DISCORD_WEBHOOK_REGRESSION repository secret must hold the target
+#     channel webhook. When it is unset, the job is skipped (no failure).
+
+on:
+  issues:
+    types: [labeled]
+
+# Coalesce duplicate fires for the same issue+label.
+concurrency:
+  group: notify-regression-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    name: Announce regression on Discord
+    if: github.event.label.name == 'regression'
+    runs-on: ubuntu-latest
+    # No repo contents or issue writes are needed; the event payload carries the
+    # issue data and the only outbound call is the Discord webhook.
+    permissions: {}
+    steps:
+      - name: Announce on Discord
+        # The webhook is optional; skip the step when it is unset. HAS_WEBHOOK is
+        # resolved at job level because step-level env is not visible to `if`.
+        if: env.HAS_WEBHOOK == 'true'
+        env:
+          HAS_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_REGRESSION != '' }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_REGRESSION }}
+          # Issue fields are passed as env, never inlined into the script, so a
+          # title like "$(rm -rf)" cannot be interpreted as shell code.
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          # Fields are read as data via jq --arg. allowed_mentions parse:[] stops
+          # a title like "@everyone" from pinging the Discord server.
+          payload="$(jq -n \
+            --arg n "$ISSUE_NUMBER" \
+            --arg t "$ISSUE_TITLE" \
+            --arg u "$ISSUE_URL" \
+            '{content: ("🚫 New regression reported in pnpm — issue #" + $n + ": " + $t + "\n" + $u), allowed_mentions: {parse: []}}')"
+          curl -fsS \
+            --connect-timeout 5 \
+            --max-time 20 \
+            --retry 3 \
+            --retry-all-errors \
+            --retry-delay 2 \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK"

--- a/.github/workflows/notify-regression.yml
+++ b/.github/workflows/notify-regression.yml
@@ -12,9 +12,12 @@ on:
   issues:
     types: [labeled]
 
-# Coalesce duplicate fires for the same issue+label.
+# Coalesce genuine duplicate fires for the same issue+label. The label must be
+# part of the key: this workflow triggers on every `labeled` event, so keying on
+# the issue number alone would let a newer non-regression label event on the same
+# issue evict a still-pending regression run and drop its notification.
 concurrency:
-  group: notify-regression-${{ github.event.issue.number }}
+  group: notify-regression-${{ github.event.issue.number }}-${{ github.event.label.name }}
   cancel-in-progress: false
 
 jobs:
@@ -48,11 +51,14 @@ jobs:
             --arg t "$ISSUE_TITLE" \
             --arg u "$ISSUE_URL" \
             '{content: ("🚫 New regression reported in pnpm — issue #" + $n + ": " + $t + "\n" + $u), allowed_mentions: {parse: []}}')"
+          # --retry (without --retry-all-errors) recovers from transient
+          # failures (connection errors, timeouts, 429/5xx) only. Retrying on
+          # *every* error risks re-POSTing after Discord already accepted the
+          # message, which would duplicate the notification.
           curl -fsS \
             --connect-timeout 5 \
             --max-time 20 \
             --retry 3 \
-            --retry-all-errors \
             --retry-delay 2 \
             -H "Content-Type: application/json" \
             -d "$payload" \

--- a/.github/workflows/notify-regression.yml
+++ b/.github/workflows/notify-regression.yml
@@ -25,13 +25,15 @@ jobs:
     # No repo contents or issue writes are needed; the event payload carries the
     # issue data and the only outbound call is the Discord webhook.
     permissions: {}
+    # Defined at job level, not step level: a step's own `if` is evaluated before
+    # its step-level env exists, so the gate must live here to be visible to `if`.
+    env:
+      HAS_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_REGRESSION != '' }}
     steps:
       - name: Announce on Discord
-        # The webhook is optional; skip the step when it is unset. HAS_WEBHOOK is
-        # resolved at job level because step-level env is not visible to `if`.
+        # The webhook is optional; skip the step when it is unset.
         if: env.HAS_WEBHOOK == 'true'
         env:
-          HAS_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_REGRESSION != '' }}
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_REGRESSION }}
           # Issue fields are passed as env, never inlined into the script, so a
           # title like "$(rm -rf)" cannot be interpreted as shell code.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that posts to Discord the moment an issue is labeled `regression`, giving the team a real-time heads-up whenever the Oz triage agent (or a maintainer) tags a regression report.

- **`.github/workflows/notify-regression.yml`** — triggers on `issues: labeled`, filtered to the `regression` label, and posts `🚫 New regression reported in pnpm — issue #N: <title>` + the issue URL to a dedicated channel via the new `DISCORD_WEBHOOK_REGRESSION` secret. Skips silently if the secret is unset.
- **`.github/ISSUE_TEMPLATE/regression-report.yaml`** — fixes a pre-existing label mismatch: the template declared `type: regression`, which is not a real repository label. The actual label is `regression`, so template-filed reports were never auto-labeled (and thus wouldn't be announced). Aligning it makes template reports auto-labeled → auto-announced.

Security notes: issue fields are passed via env vars and read with `jq --arg` (never inlined into the shell), `allowed_mentions: {parse: []}` prevents mention-injection from a crafted title, and the job runs with `permissions: {}` since the only outbound call is the webhook.

## Squash Commit Body

```text
Add a workflow that fires on the `issues: labeled` event and, when the added
label is `regression`, posts an alert to a dedicated Discord channel via the
DISCORD_WEBHOOK_REGRESSION secret. This gives the team a real-time ping
whenever the Oz triage agent or a maintainer tags a regression.

Issue fields are passed through env vars and read with `jq --arg` rather than
inlined into the shell, so a crafted issue title cannot inject shell code.
`allowed_mentions: {parse: []}` prevents a title like `@everyone` from pinging
the server, and the job runs with empty permissions since the only outbound
call is the webhook. The step is skipped when the secret is unset.

Also fix the regression report issue template, which declared the nonexistent
`type: regression` label; the real repository label is `regression`. Aligning
the template means template-filed reports are auto-labeled and therefore
auto-announced.
```

## Checklist

- [x] The change is CI/tooling only (no CLI behavior), so no Rust `pnpm/` port is needed.
- [x] No published package changes, so no changeset is required.
- [ ] Added or updated tests. — n/a (GitHub Actions workflow)
- [x] Updated the documentation if needed. — n/a

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787410681&installation_model_id=426870&pr_number=13235&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13235&signature=bfa7bb583fe165c5191cd0e201a63e98b1033efe6da2a592ec43594a3fa32c54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Discord notifications when an issue is labeled as a regression.
  * Notifications include the issue number, title, and link, and avoid mention pings.
* **Bug Fixes**
  * Updated the regression issue template to apply the correct default `regression` label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->