### PR TITLE
fix(release): repair payload verification and Rust draft-release failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,28 +398,37 @@ jobs:
         # steps below will use and reports every tarball's file list, so a
         # packing regression fails here, before the first immutable npm
         # publish. `pnpm pack` does not run `prepublishOnly`, so the
-        # compiled payloads are built first with the same script CI uses
-        # (mostly warm after the build-artifacts step above). The
+        # publishable projects' src tsconfigs are built first — only those:
+        # the typecheck-everything graph also drags in test tsconfigs,
+        # whose devDependencies this runner's install does not provide
+        # (mostly warm after the build-artifacts step above anyway). The
         # publishable projects are selected by explicit name filters:
         # unlike recursive publish, recursive pack does not skip private
         # packages, and packing the private workspace root would walk the
         # whole repository.
         run: |
           set -euo pipefail
-          pn compile-only
           verify_dir=$(mktemp -d)
           pn list --filter=!pnpm --filter=!@pnpm/exe --depth=-1 --json > "$verify_dir/projects.json"
           filters=()
-          while IFS= read -r filter; do
-            filters+=("$filter")
+          tsconfig_dirs=()
+          while IFS=$'\t' read -r name dir; do
+            filters+=("--filter=$name")
+            if [ -n "$dir" ]; then
+              tsconfig_dirs+=("$dir")
+            fi
           done < <(node -e '
+            const { existsSync } = require("node:fs")
+            const { join } = require("node:path")
             const projects = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))
             for (const project of projects) {
               if (!project.private && project.name && project.version && project.path) {
-                console.log(`--filter=${project.name}`)
+                const dir = existsSync(join(project.path, "tsconfig.json")) ? project.path : ""
+                console.log(`${project.name}\t${dir}`)
               }
             }
           ' "$verify_dir/projects.json")
+          pn exec tsgo --build "${tsconfig_dirs[@]}"
           # Recursive pack runs one project at a time, so pack in four
           # concurrent chunks; dry-run packing only reads the tree.
           chunk_size=$(( (${#filters[@]} + 3) / 4 ))


### PR DESCRIPTION
## Summary

Fixes the three failures uncovered by the v11.17.0 / v12.0.0-alpha.19 release runs. All of them failed closed — the only thing published so far is `@pnpm/exe@11.17.0` (and the complete, verified pacquet 12.0.0-alpha.19 npm release).

1. **Payload verify compiled too much** ([first v11.17.0 run](https://github.com/pnpm/pnpm/actions/runs/30019060378/job/89247945631)): `pn compile-only` typechecks test tsconfigs, whose devDependencies the release runner's install does not provide. The step now builds only the publishable projects' own tsconfigs (skipping the plain-JS and artifact packages), derived from the same `pn list` output that drives the pack filters.
2. **Filtered pnpm commands pruned `node_modules` mid-job** ([second v11.17.0 run](https://github.com/pnpm/pnpm/actions/runs/30020979197)): the verify step's `--filter=!pnpm --filter=!@pnpm/exe` selections made pnpm's implicit up-to-date check remove the excluded projects' modules (`Packages: +1568 -34`), so the pnpm package's `symlink-dir` was gone when the artifact packages' `prepublishOnly` (`verify-binary.mjs`) ran during publish. A new step reinstalls the full workspace (`pn install --frozen-lockfile`) after verification. (This pruning behavior is arguably a pacquet bug worth its own issue.)
3. **Rust draft-release 403** ([v12.0.0-alpha.19 run](https://github.com/pnpm/pnpm/actions/runs/30019061960/job/89253367537), reproduced on rerun): with immutable releases enabled, passing `target_commitish` to release creation makes GitHub reject the workflow token with 403 "Resource not accessible by integration" (see [cli/cli#9514](https://github.com/cli/cli/issues/9514)). The input never did anything — GitHub ignores it when the tag exists, and the job's assert step already pins the commit — so it is dropped. The pnpr job never passed it, which is why its draft succeeded the same day. The alpha.19 draft release has been created and populated manually from the run's artifacts in the meantime.

After merging: re-point `v11.17.0` at the merge commit (committed version is still 11.17.0, `@pnpm/exe@11.17.0` republish is skipped by the resume logic) and the release rerun completes the interrupted publish.

## Squash Commit Body

```text
Three release-workflow fixes from the v11.17.0 / v12.0.0-alpha.19 runs:

Compile only the publishable projects own tsconfigs before payload
verification. pn compile-only also typechecks test tsconfigs, whose
devDependencies the release runner install does not provide.

Reinstall the full workspace after payload verification. The verify
step's filter selections exclude pnpm and @pnpm/exe, and pnpm's
implicit up-to-date check prunes the excluded projects modules, which
broke the artifact packages prepublishOnly during publish.

Drop target_commitish from the Rust draft-release step. With immutable
releases enabled it makes release creation fail with 403 for the
workflow token, GitHub ignores it when the tag exists anyway, and the
assert step already pins the commit.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Release-workflow-only change.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. *(No published package is changed.)*

---
Written by an agent (Claude Code, claude-fable-5).