### PR TITLE
ci: update pnpm/setup to the v12 standalone-executable revision

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Install pnpm
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
       with:
         install: false
     - name: Audit

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,7 +67,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
       with:
         runtime: node@26.5.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Install pnpm
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
     - name: Compile TypeScript
       run: pn compile-only
     - name: Lint

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -39,7 +39,7 @@ jobs:
         persist-credentials: false
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
       with:
         runtime: node@26.3.0
 

--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/rustup

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -128,7 +128,7 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Install pnpm (for compatibility check)
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           install: false
 

--- a/.github/workflows/pacquet-codecov.yml
+++ b/.github/workflows/pacquet-codecov.yml
@@ -51,7 +51,7 @@ jobs:
         run: rustup component add llvm-tools-preview
 
       - name: Install pnpm (for compatibility check)
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           install: false
 

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -223,7 +223,7 @@ jobs:
           save-cache: false # it's insufficient
 
       - name: Install pnpm
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           install: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
       - name: Install pnpm and Node
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           runtime: node@26.5.0
       - name: Override workspace ignores for the TypeScript pnpm package
@@ -357,7 +357,7 @@ jobs:
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
       - name: Install pnpm and Node
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           runtime: node@26.5.0
       - name: Override workspace ignores for the TypeScript pnpm package
@@ -647,7 +647,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           runtime: node@22
           install: false
@@ -771,7 +771,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           runtime: node@22
           install: false
@@ -1055,7 +1055,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           runtime: node@22
           install: false
@@ -1166,7 +1166,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
         with:
           runtime: node@22
           install: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         api_token: ${{ secrets.GARNET_API_TOKEN }}
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
       with:
         runtime: node@${{ inputs.node }}
     - name: Verify Node version

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -27,7 +27,10 @@ env:
   # The pnpm that operates this workflow, never the version being released:
   # validate and verify-upgrade decide what the release is measured against, and
   # tag-in-registry holds the publish token. Bump deliberately, to a version that
-  # has already proven itself as `latest`.
+  # has already proven itself as `latest`. Until this moves to v12, the
+  # `pnpm/setup` steps below stay pinned to 77cf0683 — the last revision of the
+  # action able to install pnpm 11; newer revisions only install the
+  # standalone pnpm v12+.
   RELEASE_TOOL_PNPM_VERSION: 11.13.1
 
 jobs:

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -19,15 +19,19 @@ on:
 permissions: {}
 
 env:
-  # Passed to each command as `--config.registry`, which both the TypeScript
-  # and Rust CLIs read; pnpm ignores `npm_config_registry`.
+  # Passed to each command as `--registry`, which is the only form pnpm reads;
+  # it ignores `npm_config_registry`.
   REGISTRY: https://registry.npmjs.org/
   # Keeps a runner-level .npmrc from redirecting any of this.
   npm_config_userconfig: /dev/null
   # The pnpm that operates this workflow, never the version being released:
   # validate and verify-upgrade decide what the release is measured against, and
-  # tag-in-registry holds the publish token. Bump deliberately.
-  RELEASE_TOOL_PNPM_VERSION: 12.0.0-alpha.19
+  # tag-in-registry holds the publish token. Bump deliberately, to a version that
+  # has already proven itself as `latest`. Until this moves to v12, the
+  # `pnpm/setup` steps below stay pinned to 77cf0683 — the last revision of the
+  # action able to install pnpm 11; newer revisions only install the
+  # standalone pnpm v12+.
+  RELEASE_TOOL_PNPM_VERSION: 11.13.1
 
 jobs:
   validate:
@@ -36,7 +40,7 @@ jobs:
     permissions: {}
     steps:
     - name: Install pnpm and Node
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
@@ -66,7 +70,7 @@ jobs:
             fi
             ;;
           latest)
-            CURRENT_LATEST_MAJOR="$(pn view pnpm dist-tags.latest --config.registry="$REGISTRY" | cut -d . -f 1)"
+            CURRENT_LATEST_MAJOR="$(pn view pnpm dist-tags.latest --registry="$REGISTRY" | cut -d . -f 1)"
             # A dist-tag that could not be read must not pass the guard: an
             # empty value makes the comparison below error out with a non-zero
             # status, which `if` swallows, silently skipping the check.
@@ -95,7 +99,7 @@ jobs:
     permissions: {}
     steps:
     - name: Install pnpm and Node
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
@@ -114,8 +118,8 @@ jobs:
         MAJOR="${VERSION%%.*}"
         # Upgrade from what users on this release line are running today. A new
         # major has no latest-<major> yet, so fall back to the current latest.
-        if ! FROM=$(pn view "pnpm@latest-${MAJOR}" version --config.registry="$REGISTRY" 2>/dev/null) || [ -z "$FROM" ]; then
-          FROM=$(pn view pnpm dist-tags.latest --config.registry="$REGISTRY")
+        if ! FROM=$(pn view "pnpm@latest-${MAJOR}" version --registry="$REGISTRY" 2>/dev/null) || [ -z "$FROM" ]; then
+          FROM=$(pn view pnpm dist-tags.latest --registry="$REGISTRY")
         fi
         echo "Upgrading from v${FROM} to v${VERSION}"
 
@@ -133,15 +137,15 @@ jobs:
           cd "$work"
           mkdir -p "$work/from"
           printf '{"name":"pnpm-upgrade-check","version":"0.0.0","private":true}\n' >"$work/from/package.json"
-          # `allowBuilds` is what makes this install the starting point rather
+          # `--allow-build` is what makes this install the starting point rather
           # than a fake one: pnpm blocks dependency build scripts by default, and
           # `@pnpm/exe`'s setup.js is what swaps its placeholder bin for the real
           # native. Without it every run reproduces the exact breakage this gate
           # exists to catch (the placeholder surviving) and blames the release.
-          printf 'allowBuilds:\n  "@pnpm/exe": true\n' >"$work/from/pnpm-workspace.yaml"
-          pn --dir "$work/from" \
-            add "${package}@${FROM}" \
-            --config.registry="$REGISTRY"
+          pn add "${package}@${FROM}" \
+            --dir "$work/from" \
+            --allow-build=@pnpm/exe \
+            --registry="$REGISTRY"
           # Drive through the bin shim rather than a path into the package: the
           # entry point differs by major (pnpm.cjs in v10, pnpm.mjs in v11) and
           # between the two wrappers, and the shim is what a user gets.
@@ -197,7 +201,7 @@ jobs:
       with:
         api_token: ${{ secrets.GARNET_API_TOKEN }}
     - name: Install pnpm and Node
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
@@ -215,11 +219,11 @@ jobs:
         pn config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
 
         MAJOR="${VERSION%%.*}"
-        pn dist-tag add "pnpm@${VERSION}" "latest-${MAJOR}" --config.registry="$REGISTRY"
-        pn dist-tag add "@pnpm/exe@${VERSION}" "latest-${MAJOR}" --config.registry="$REGISTRY"
+        pn dist-tag add "pnpm@${VERSION}" "latest-${MAJOR}" --registry="$REGISTRY"
+        pn dist-tag add "@pnpm/exe@${VERSION}" "latest-${MAJOR}" --registry="$REGISTRY"
         if [ "$TAG" != "latest-${MAJOR}" ]; then
-          pn dist-tag add "pnpm@${VERSION}" "${TAG}" --config.registry="$REGISTRY"
-          pn dist-tag add "@pnpm/exe@${VERSION}" "${TAG}" --config.registry="$REGISTRY"
+          pn dist-tag add "pnpm@${VERSION}" "${TAG}" --registry="$REGISTRY"
+          pn dist-tag add "@pnpm/exe@${VERSION}" "${TAG}" --registry="$REGISTRY"
         fi
 
   publish-to-winget:

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -19,19 +19,15 @@ on:
 permissions: {}
 
 env:
-  # Passed to each command as `--registry`, which is the only form pnpm reads;
-  # it ignores `npm_config_registry`.
+  # Passed to each command as `--config.registry`, which both the TypeScript
+  # and Rust CLIs read; pnpm ignores `npm_config_registry`.
   REGISTRY: https://registry.npmjs.org/
   # Keeps a runner-level .npmrc from redirecting any of this.
   npm_config_userconfig: /dev/null
   # The pnpm that operates this workflow, never the version being released:
   # validate and verify-upgrade decide what the release is measured against, and
-  # tag-in-registry holds the publish token. Bump deliberately, to a version that
-  # has already proven itself as `latest`. Until this moves to v12, the
-  # `pnpm/setup` steps below stay pinned to 77cf0683 — the last revision of the
-  # action able to install pnpm 11; newer revisions only install the
-  # standalone pnpm v12+.
-  RELEASE_TOOL_PNPM_VERSION: 11.13.1
+  # tag-in-registry holds the publish token. Bump deliberately.
+  RELEASE_TOOL_PNPM_VERSION: 12.0.0-alpha.19
 
 jobs:
   validate:
@@ -40,7 +36,7 @@ jobs:
     permissions: {}
     steps:
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
@@ -70,7 +66,7 @@ jobs:
             fi
             ;;
           latest)
-            CURRENT_LATEST_MAJOR="$(pn view pnpm dist-tags.latest --registry="$REGISTRY" | cut -d . -f 1)"
+            CURRENT_LATEST_MAJOR="$(pn view pnpm dist-tags.latest --config.registry="$REGISTRY" | cut -d . -f 1)"
             # A dist-tag that could not be read must not pass the guard: an
             # empty value makes the comparison below error out with a non-zero
             # status, which `if` swallows, silently skipping the check.
@@ -99,7 +95,7 @@ jobs:
     permissions: {}
     steps:
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
@@ -118,8 +114,8 @@ jobs:
         MAJOR="${VERSION%%.*}"
         # Upgrade from what users on this release line are running today. A new
         # major has no latest-<major> yet, so fall back to the current latest.
-        if ! FROM=$(pn view "pnpm@latest-${MAJOR}" version --registry="$REGISTRY" 2>/dev/null) || [ -z "$FROM" ]; then
-          FROM=$(pn view pnpm dist-tags.latest --registry="$REGISTRY")
+        if ! FROM=$(pn view "pnpm@latest-${MAJOR}" version --config.registry="$REGISTRY" 2>/dev/null) || [ -z "$FROM" ]; then
+          FROM=$(pn view pnpm dist-tags.latest --config.registry="$REGISTRY")
         fi
         echo "Upgrading from v${FROM} to v${VERSION}"
 
@@ -137,15 +133,15 @@ jobs:
           cd "$work"
           mkdir -p "$work/from"
           printf '{"name":"pnpm-upgrade-check","version":"0.0.0","private":true}\n' >"$work/from/package.json"
-          # `--allow-build` is what makes this install the starting point rather
+          # `allowBuilds` is what makes this install the starting point rather
           # than a fake one: pnpm blocks dependency build scripts by default, and
           # `@pnpm/exe`'s setup.js is what swaps its placeholder bin for the real
           # native. Without it every run reproduces the exact breakage this gate
           # exists to catch (the placeholder surviving) and blames the release.
-          pn add "${package}@${FROM}" \
-            --dir "$work/from" \
-            --allow-build=@pnpm/exe \
-            --registry="$REGISTRY"
+          printf 'allowBuilds:\n  "@pnpm/exe": true\n' >"$work/from/pnpm-workspace.yaml"
+          pn --dir "$work/from" \
+            add "${package}@${FROM}" \
+            --config.registry="$REGISTRY"
           # Drive through the bin shim rather than a path into the package: the
           # entry point differs by major (pnpm.cjs in v10, pnpm.mjs in v11) and
           # between the two wrappers, and the shim is what a user gets.
@@ -201,7 +197,7 @@ jobs:
       with:
         api_token: ${{ secrets.GARNET_API_TOKEN }}
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
@@ -219,11 +215,11 @@ jobs:
         pn config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
 
         MAJOR="${VERSION%%.*}"
-        pn dist-tag add "pnpm@${VERSION}" "latest-${MAJOR}" --registry="$REGISTRY"
-        pn dist-tag add "@pnpm/exe@${VERSION}" "latest-${MAJOR}" --registry="$REGISTRY"
+        pn dist-tag add "pnpm@${VERSION}" "latest-${MAJOR}" --config.registry="$REGISTRY"
+        pn dist-tag add "@pnpm/exe@${VERSION}" "latest-${MAJOR}" --config.registry="$REGISTRY"
         if [ "$TAG" != "latest-${MAJOR}" ]; then
-          pn dist-tag add "pnpm@${VERSION}" "${TAG}" --registry="$REGISTRY"
-          pn dist-tag add "@pnpm/exe@${VERSION}" "${TAG}" --registry="$REGISTRY"
+          pn dist-tag add "pnpm@${VERSION}" "${TAG}" --config.registry="$REGISTRY"
+          pn dist-tag add "@pnpm/exe@${VERSION}" "${TAG}" --config.registry="$REGISTRY"
         fi
 
   publish-to-winget:

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -39,7 +39,7 @@ jobs:
     # pnpm/update runs the install itself, so the action's auto-install would
     # be wasted work.
     - name: Install pnpm
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
       with:
         install: false
 


### PR DESCRIPTION
## Summary

Bumps the `pnpm/setup` action pin from `77cf0683` (npm-bootstrap era) to `6bfbb82d` — the revision merged in pnpm/setup#11 that downloads the standalone pnpm v12 executable directly from the npm registry (integrity-verified, no npm bootstrap, no system Node.js dependency) and requires pnpm v12+.

Compatibility checked per usage site:

- All updated workflows resolve the pnpm version from the checked-out manifest (`devEngines.packageManager` → `12.0.0-alpha.18` on main), which the new action accepts; none pass a sub-12 `version` input. The node runtime keeps coming from `devEngines.runtime` / explicit `runtime:` inputs via `pnpm runtime set`, unchanged.
- Tag-push and PR runs use the workflow file at their own ref, so older `v11.x` release tags are untouched by this change.
- **`update-latest.yml` keeps the old pin deliberately**: its `RELEASE_TOOL_PNPM_VERSION` pins a proven pnpm 11 as the workflow operator, and only the pre-v12 action revision can install pnpm 11. A comment next to the env var documents that the pin moves together with that version. All three of that workflow's `pnpm/setup` steps are affected.

12 files changed, all under `.github/workflows/`; no changeset (CI-only, no published package affected).

---

Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787414080&installation_model_id=426870&pr_number=13239&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13239&signature=efd7c26cedd4f0a034752c7c653228d115da12a6ef36f038a035eb1dc273949d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pinned `pnpm/setup` GitHub Action revision across audit, CI, benchmark, test, release, ecosystem E2E, code coverage, integrated benchmark, pacquet CI/codecov, and lockfile workflows.
* **Documentation**
  * Clarified in the “update-latest” workflow documentation that pnpm setup steps remain pinned until the workflow moves to pnpm v12 (last revision capable of installing pnpm 11).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->