### PR TITLE
fix(release): drop target_commitish and the on-disk pnpm manifest strip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -829,9 +829,12 @@ jobs:
 
       - name: Assert the version tag points at this commit
         # Same tag↔commit invariant as the TypeScript release job's guard: the
-        # binaries below were built from this run's commit, and `target_commitish`
-        # cannot pin the release to it — GitHub ignores it whenever the tag
-        # already exists.
+        # binaries below were built from this run's commit, and this assert is
+        # the only thing pinning the release to it. A `target_commitish` input
+        # cannot: GitHub ignores it whenever the tag already exists, and with
+        # immutable releases enabled its mere presence makes release creation
+        # fail with 403 "Resource not accessible by integration" for the
+        # workflow token (the v12.0.0-alpha.19 draft-release failure).
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.plan.outputs.rust_version }}
@@ -879,7 +882,6 @@ jobs:
           prerelease: ${{ contains(needs.plan.outputs.rust_version, '-') }}
           make_latest: false
           tag_name: v${{ needs.plan.outputs.rust_version }}
-          target_commitish: ${{ github.sha }}
           name: pnpm ${{ needs.plan.outputs.rust_version }}
           body_path: RELEASE.md
           files: |

--- a/pnpm11/pnpm/bundle-deps.ts
+++ b/pnpm11/pnpm/bundle-deps.ts
@@ -55,7 +55,6 @@ import { execSync } from 'node:child_process'
 
 const WORKSPACE_DIR = path.join(import.meta.dirname, '..', '..')
 const DEPLOY_DIR = path.join(import.meta.dirname, 'temp-deploy')
-const MANIFEST_PATH = path.join(import.meta.dirname, 'package.json')
 
 const NODE_MODULES_TEMP_DIR = path.join(DEPLOY_DIR, 'node_modules')
 const NODE_MODULES_DEST_DIR = path.join(import.meta.dirname, 'dist/node_modules')
@@ -116,14 +115,10 @@ createDistNodeModules()
 // dependency, so the published manifest must not declare dependencies or
 // devDependencies — otherwise pnpm would install them a second time (and the
 // internal-only devDependencies, e.g. @pnpm/test-ipc-server, aren't even
-// published, so the install would fail).
-//
-// The workspace .pnpmfile.cjs beforePacking hook already drops these fields when
-// packing. This on-disk strip is a temporary workaround for pnpm/pnpm#12955: the
-// pnpm v12 alpha that currently runs the release does not yet honor beforePacking,
-// so it published 11.12.0 with the fields intact. Remove this once the release
-// runs a pnpm that applies the hook.
-const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'))
-delete manifest.dependencies
-delete manifest.devDependencies
-fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, undefined, 2)}\n`)
+// published, so the install would fail). The workspace .pnpmfile.cjs
+// beforePacking hook drops these fields when packing (the release-pinned
+// pnpm honors it since pnpm/pnpm#12955 was fixed, and the release workflow
+// asserts the packed manifest carries no dependency fields before the first
+// publish). The manifest on disk must stay untouched: stripping it here made
+// every later `pnpm install` — including the verifyDepsBeforeRun gate's
+// spawned one — remove the pnpm package's own node_modules mid-release.


### PR DESCRIPTION
## Summary

Rebased over [pnpm/pnpm#13241](https://github.com/pnpm/pnpm/pull/13241), which removed the payload-verification step entirely — the modules-restore step this PR originally carried is obsolete with it and has been dropped. Two fixes remain, both still live on main:

- **Drop `target_commitish` from the Rust draft-release step.** With immutable releases enabled, passing it makes release creation fail with 403 "Resource not accessible by integration" for the workflow token ([the v12.0.0-alpha.19 draft failure](https://github.com/pnpm/pnpm/actions/runs/30019061960/job/89253367537), byte-identical on rerun; see [cli/cli#9514](https://github.com/cli/cli/issues/9514)). The input never did anything — GitHub ignores it when the tag exists, and the job's assert step already pins the commit. The pnpr draft job never passed it, which is why its release succeeded the same day. (The alpha.19 draft release itself was reconstructed manually from the run's artifacts and is ready to publish.)
- **Stop stripping the manifest on disk in `bundle-deps.ts`.** It deleted `dependencies`/`devDependencies` from `pnpm11/pnpm/package.json` on disk — a workaround from before the release-pinned pnpm honored `beforePacking` ([pnpm/pnpm#12955](https://github.com/pnpm/pnpm/issues/12955)). This was the root cause of the v11.17.0 publish failure: after build-artifacts stripped the manifest, the first `pn run`/`pn exec` tripped the `verifyDepsBeforeRun: install` gate, whose spawned install synced `node_modules` to the stripped manifest and removed the pnpm package's deps — including the `symlink-dir` that the artifact packages' `prepublishOnly` (`verify-binary.mjs`) needs during publish. The packed manifest stays dependency-free via the `.pnpmfile.cjs` hook, which the now-pinned pacquet honors and the release workflow asserts before the first publish.

## Squash Commit Body

```text
Two release fixes from the v11.17.0 / v12.0.0-alpha.19 failures:

Drop target_commitish from the Rust draft-release step. With immutable
releases enabled it makes release creation fail with 403 for the
workflow token, GitHub ignores it when the tag exists anyway, and the
assert step already pins the commit.

Stop stripping dependencies/devDependencies from the pnpm manifest on
disk in bundle-deps.ts, a workaround kept from before the
release-pinned pnpm honored beforePacking (pnpm/pnpm#12955). The
on-disk strip made any post-build-artifacts verifyDepsBeforeRun
auto-install sync node_modules to the stripped manifest and remove the
pnpm package deps that the artifact packages prepublishOnly needs
during publish. The packed manifest stays dependency-free via the
.pnpmfile.cjs beforePacking hook, asserted by the release workflow
before the first publish.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Release-workflow and build-tooling change only.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. *(No published output changes: the packed pnpm manifest is identical, produced by the hook instead of the on-disk strip.)*

---
Written by an agent (Claude Code, claude-fable-5).