### PR TITLE
fix(package-manager): unbreak the update-lockfile job's update --latest

### DIFF
--- a/.changeset/update-latest-npm-alias-target.md
+++ b/.changeset/update-latest-npm-alias-target.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm update --latest` now resolves a dependency declared through an `npm:` alias — directly in `package.json` or in the catalog entry a `catalog:` reference points to — to the latest version of the aliased package, keeping the `npm:<name>@` prefix in the rewritten specifier. Previously the alias name itself was looked up on the registry, failing the update with a 404 when no package of that name exists.

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -767,8 +767,7 @@ fn update_latest_no_save_catalog_bumps_lockfile_only() {
     drop((root, anchor));
 }
 
-/// `update --latest` must resolve the *aliased* package: the alias name
-/// itself does not exist on the registry, so resolving it would 404.
+/// The alias name does not exist in the mock registry.
 #[test]
 fn update_latest_npm_alias_resolves_aliased_package() {
     let (root, workspace, anchor) = setup();
@@ -787,8 +786,7 @@ fn update_latest_npm_alias_resolves_aliased_package() {
     drop((root, anchor));
 }
 
-/// The same alias unwrapping applies to the `npm:` alias stored in the
-/// catalog entry a `catalog:` reference points to.
+/// The alias name does not exist in the mock registry.
 #[test]
 fn update_latest_catalog_npm_alias_resolves_aliased_package() {
     let (root, workspace, anchor) = setup();

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -767,6 +767,53 @@ fn update_latest_no_save_catalog_bumps_lockfile_only() {
     drop((root, anchor));
 }
 
+/// `pacquet update --latest` on an `npm:` alias resolves the latest version
+/// of the *aliased* package — the alias name itself does not exist on the
+/// registry — and rewrites the manifest keeping the `npm:<real name>@`
+/// prefix and the entry's own range operator.
+#[test]
+fn update_latest_npm_alias_resolves_aliased_package() {
+    let (root, workspace, anchor) = setup();
+
+    write_manifest(&workspace, &format!(r#"{{ "dep-alias": "npm:{DEP}@~100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.0.0"));
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, "dep-alias").as_deref(), Some(&*format!("npm:{DEP}@~101.0.0")));
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@101.0.0"));
+
+    drop((root, anchor));
+}
+
+/// The same alias unwrapping applies when the `npm:` alias lives in the
+/// catalog entry a `catalog:` reference points to: the manifest keeps the
+/// `catalog:` reference and the bumped catalog entry keeps the alias prefix.
+#[test]
+fn update_latest_catalog_npm_alias_resolves_aliased_package() {
+    let (root, workspace, anchor) = setup();
+
+    set_named_catalog(&workspace, "grp1", &[("dep-alias", &format!("npm:{DEP}@~100.0.0"))]);
+    write_manifest(&workspace, r#"{ "dep-alias": "catalog:grp1" }"#);
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, "dep-alias").as_deref(), Some("catalog:grp1"));
+
+    let yaml = read_workspace_yaml(&workspace);
+    assert!(
+        yaml.contains(&format!("npm:{DEP}@~101.0.0")),
+        "catalog entry should be bumped to npm:{DEP}@~101.0.0: {yaml}",
+    );
+    assert!(!yaml.contains("100.0.0"), "stale catalog entry should be gone: {yaml}");
+
+    drop((root, anchor));
+}
+
 /// The same preservation applies to the default catalog (`catalog:`).
 #[test]
 fn update_latest_default_catalog_preserves_reference() {

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -767,10 +767,8 @@ fn update_latest_no_save_catalog_bumps_lockfile_only() {
     drop((root, anchor));
 }
 
-/// `pacquet update --latest` on an `npm:` alias resolves the latest version
-/// of the *aliased* package — the alias name itself does not exist on the
-/// registry — and rewrites the manifest keeping the `npm:<real name>@`
-/// prefix and the entry's own range operator.
+/// `update --latest` must resolve the *aliased* package: the alias name
+/// itself does not exist on the registry, so resolving it would 404.
 #[test]
 fn update_latest_npm_alias_resolves_aliased_package() {
     let (root, workspace, anchor) = setup();
@@ -789,9 +787,8 @@ fn update_latest_npm_alias_resolves_aliased_package() {
     drop((root, anchor));
 }
 
-/// The same alias unwrapping applies when the `npm:` alias lives in the
-/// catalog entry a `catalog:` reference points to: the manifest keeps the
-/// `catalog:` reference and the bumped catalog entry keeps the alias prefix.
+/// The same alias unwrapping applies to the `npm:` alias stored in the
+/// catalog entry a `catalog:` reference points to.
 #[test]
 fn update_latest_catalog_npm_alias_resolves_aliased_package() {
     let (root, workspace, anchor) = setup();

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -521,10 +521,17 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
             if latest && !is_local_specifier(previous) {
                 let picker =
                     ensure_latest_picker(latest_picker, config, http_client, resolution_observer)?;
-                let version = resolve_latest_version(picker, name, lockfile_only).await?;
-                let pin =
-                    latest_pin(&mut catalog_ctx, manifest, config, previous, name, pinned_version)?;
-                rewrites.push((name.clone(), *group, version.serialize(pin)));
+                let effective =
+                    effective_specifier(&mut catalog_ctx, manifest, config, previous, name)?;
+                let specifier = resolve_latest_specifier(
+                    picker,
+                    &effective,
+                    name,
+                    pinned_version,
+                    lockfile_only,
+                )
+                .await?;
+                rewrites.push((name.clone(), *group, specifier));
             }
             drop_names.insert(name.clone());
         }
@@ -610,16 +617,17 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
                         http_client,
                         resolution_observer,
                     )?;
-                    let version = resolve_latest_version(picker, name, lockfile_only).await?;
-                    let pin = latest_pin(
-                        &mut catalog_ctx,
-                        manifest,
-                        config,
-                        previous,
+                    let effective =
+                        effective_specifier(&mut catalog_ctx, manifest, config, previous, name)?;
+                    let specifier = resolve_latest_specifier(
+                        picker,
+                        &effective,
                         name,
                         pinned_version,
-                    )?;
-                    rewrites.push((name.clone(), *group, version.serialize(pin)));
+                        lockfile_only,
+                    )
+                    .await?;
+                    rewrites.push((name.clone(), *group, specifier));
                 } else if let Some(specifier) = selectors
                     .iter()
                     .find(|selector| matcher_one(&selector.pattern).matches(name))
@@ -869,29 +877,74 @@ fn ensure_catalog_ctx<'slot>(
     Ok(slot.as_ref().expect("just populated"))
 }
 
-/// The range operator to write a `--latest` bump with: the operator the
-/// dependency already pinned wins over the
-/// configured default. For a `catalog:` reference the pin comes from the
-/// catalog entry it points to (the reference carries none of its own), which
-/// is the only case that needs to consult the catalogs.
-fn latest_pin(
+/// The specifier a `--latest` bump derives its rewrite from: the catalog
+/// entry for a `catalog:` reference (the reference itself carries neither an
+/// alias target nor a range operator), the dependency's own specifier
+/// otherwise. Reading the catalogs is deferred to here so an update that
+/// rewrites nothing never parses them.
+fn effective_specifier(
     catalog_ctx: &mut Option<CatalogCtx>,
     manifest: &PackageManifest,
     config: &Config,
     prev: &str,
     name: &str,
-    default: PinnedVersion,
-) -> Result<PinnedVersion, UpdateError> {
+) -> Result<String, UpdateError> {
     if let Some(catalog_name) = parse_catalog_protocol(prev) {
         let ctx = ensure_catalog_ctx(catalog_ctx, manifest, config)?;
-        return Ok(ctx
-            .catalogs
-            .get(catalog_name)
-            .and_then(|catalog| catalog.get(name))
-            .and_then(|spec| which_version_is_pinned(spec))
-            .unwrap_or(default));
+        if let Some(spec) = ctx.catalogs.get(catalog_name).and_then(|catalog| catalog.get(name)) {
+            return Ok(spec.clone());
+        }
     }
-    Ok(which_version_is_pinned(prev).unwrap_or(default))
+    Ok(prev.to_string())
+}
+
+/// Compute the rewritten specifier for one direct dependency under
+/// `--latest`. The `effective` specifier decides both halves of the rewrite:
+///
+/// * **Which package "latest" means.** An `npm:` alias (written directly or
+///   stored in the catalog entry a `catalog:` reference points to) resolves
+///   the *aliased* package — the alias name itself may not exist on the
+///   registry — and keeps the `npm:<real name>@` prefix in the written
+///   specifier. Mirrors the TypeScript resolver's
+///   `unwrapPackageName`/`calcSpecifier` pair.
+/// * **The range operator to write.** The operator the dependency already
+///   pinned wins over the configured default.
+async fn resolve_latest_specifier(
+    picker: &LatestPicker<'_>,
+    effective: &str,
+    name: &str,
+    default_pin: PinnedVersion,
+    lockfile_only: bool,
+) -> Result<String, UpdateError> {
+    let target = npm_alias_target(effective, name);
+    let version = resolve_latest_version(picker, target.unwrap_or(name), lockfile_only).await?;
+    let range = version.serialize(which_version_is_pinned(effective).unwrap_or(default_pin));
+    Ok(match target {
+        Some(real_name) => format!("npm:{real_name}@{range}"),
+        None => range,
+    })
+}
+
+/// The real registry package an `npm:` alias specifier installs under a
+/// different name (`bar` for `foo@npm:bar@^4`), or `None` when the rewrite
+/// needs no `npm:` prefix: a non-`npm:` specifier, the `npm:<range>`
+/// shorthand (the body is a version range, so the alias is the real package
+/// name), or an alias of the package's own name — the TypeScript resolver's
+/// `calcSpecifier` writes a plain range for those. A sibling of the
+/// deps-resolver's `real_package_name_of`, which answers the same question
+/// for update-target matching.
+fn npm_alias_target<'a>(bare_specifier: &'a str, alias: &str) -> Option<&'a str> {
+    let rest = bare_specifier.strip_prefix("npm:")?;
+    if rest.parse::<node_semver::Range>().is_ok() {
+        return None;
+    }
+    // The last `@` separates the real name from the version range; without
+    // one the whole body is the name (default-tag form `npm:bar`).
+    let name = match rest.rfind('@') {
+        Some(idx) if idx >= 1 => &rest[..idx],
+        _ => rest,
+    };
+    (!name.is_empty() && name != alias).then_some(name)
 }
 
 /// Read the effective catalogs and the directories around them.

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -877,11 +877,6 @@ fn ensure_catalog_ctx<'slot>(
     Ok(slot.as_ref().expect("just populated"))
 }
 
-/// The specifier a `--latest` bump derives its rewrite from: the catalog
-/// entry for a `catalog:` reference (the reference itself carries neither an
-/// alias target nor a range operator), the dependency's own specifier
-/// otherwise. Reading the catalogs is deferred to here so an update that
-/// rewrites nothing never parses them.
 fn effective_specifier(
     catalog_ctx: &mut Option<CatalogCtx>,
     manifest: &PackageManifest,
@@ -898,17 +893,6 @@ fn effective_specifier(
     Ok(prev.to_string())
 }
 
-/// Compute the rewritten specifier for one direct dependency under
-/// `--latest`. The `effective` specifier decides both halves of the rewrite:
-///
-/// * **Which package "latest" means.** An `npm:` alias (written directly or
-///   stored in the catalog entry a `catalog:` reference points to) resolves
-///   the *aliased* package — the alias name itself may not exist on the
-///   registry — and keeps the `npm:<real name>@` prefix in the written
-///   specifier. Mirrors the TypeScript resolver's
-///   `unwrapPackageName`/`calcSpecifier` pair.
-/// * **The range operator to write.** The operator the dependency already
-///   pinned wins over the configured default.
 async fn resolve_latest_specifier(
     picker: &LatestPicker<'_>,
     effective: &str,
@@ -925,21 +909,13 @@ async fn resolve_latest_specifier(
     })
 }
 
-/// The real registry package an `npm:` alias specifier installs under a
-/// different name (`bar` for `foo@npm:bar@^4`), or `None` when the rewrite
-/// needs no `npm:` prefix: a non-`npm:` specifier, the `npm:<range>`
-/// shorthand (the body is a version range, so the alias is the real package
-/// name), or an alias of the package's own name — the TypeScript resolver's
-/// `calcSpecifier` writes a plain range for those. A sibling of the
-/// deps-resolver's `real_package_name_of`, which answers the same question
-/// for update-target matching.
+/// Mirrors the TypeScript resolver's `unwrapPackageName`/`calcSpecifier`
+/// pair.
 fn npm_alias_target<'a>(bare_specifier: &'a str, alias: &str) -> Option<&'a str> {
     let rest = bare_specifier.strip_prefix("npm:")?;
     if rest.parse::<node_semver::Range>().is_ok() {
         return None;
     }
-    // The last `@` separates the real name from the version range; without
-    // one the whole body is the name (default-tag form `npm:bar`).
     let name = match rest.rfind('@') {
         Some(idx) if idx >= 1 => &rest[..idx],
         _ => rest,

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -75,13 +75,10 @@ fn npm_alias_specifiers_yield_their_real_package_name() {
 #[test]
 fn non_alias_specifiers_have_no_npm_alias_target() {
     for (spec, alias) in [
-        // Plain and protocol specifiers are no aliases at all.
         ("^1.0.0", "foo"),
         ("catalog:", "foo"),
         ("workspace:*", "foo"),
-        // The `npm:<range>` shorthand: the alias is the real package name.
         ("npm:^1.0.0", "foo"),
-        // An alias of the package's own name is written as a plain range.
         ("npm:foo@^1.0.0", "foo"),
     ] {
         assert_eq!(npm_alias_target(spec, alias), None, "target of {alias}@{spec}");

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    is_workspace_local_path_specifier, parse_update_param, persist_selected_manifests,
-    prepare_selected_manifests, selected_project_indices,
+    is_workspace_local_path_specifier, npm_alias_target, parse_update_param,
+    persist_selected_manifests, prepare_selected_manifests, selected_project_indices,
 };
 use pacquet_config::{CatalogMode, Config};
 use pacquet_network::ThrottledClient;
@@ -58,6 +58,34 @@ fn negated_unscoped_pattern_without_version() {
     let parsed = parse_update_param("!foo");
     assert_eq!(parsed.pattern, "!foo");
     assert_eq!(parsed.version, None);
+}
+
+#[test]
+fn npm_alias_specifiers_yield_their_real_package_name() {
+    for (spec, alias, target) in [
+        ("npm:bar@^4.0.0", "foo", Some("bar")),
+        ("npm:bar", "foo", Some("bar")),
+        ("npm:@types/table@6.3.2", "@types/zkochan__table", Some("@types/table")),
+        ("npm:@types/table", "@types/zkochan__table", Some("@types/table")),
+    ] {
+        assert_eq!(npm_alias_target(spec, alias), target, "target of {alias}@{spec}");
+    }
+}
+
+#[test]
+fn non_alias_specifiers_have_no_npm_alias_target() {
+    for (spec, alias) in [
+        // Plain and protocol specifiers are no aliases at all.
+        ("^1.0.0", "foo"),
+        ("catalog:", "foo"),
+        ("workspace:*", "foo"),
+        // The `npm:<range>` shorthand: the alias is the real package name.
+        ("npm:^1.0.0", "foo"),
+        // An alias of the package's own name is written as a plain range.
+        ("npm:foo@^1.0.0", "foo"),
+    ] {
+        assert_eq!(npm_alias_target(spec, alias), None, "target of {alias}@{spec}");
+    }
 }
 
 #[test]

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -503,3 +503,34 @@ test('should not update tag version when --latest not set', async () => {
   expect(manifest.dependencies?.['@pnpm.e2e/peer-c']).toBe('canary')
   expect(manifest.dependencies?.['@pnpm.e2e/foo']).toBe('1.0.0')
 })
+
+test('update --latest resolves an npm: alias to the latest version of the aliased package', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+  // The alias name does not exist on the registry, so resolving it instead of
+  // the aliased package would fail.
+  const project = prepare({
+    dependencies: {
+      'foo-alias': 'npm:@pnpm.e2e/foo@~1.0.0',
+    },
+  })
+
+  await install.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+  })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    latest: true,
+  })
+
+  const manifest = loadJsonFileSync<ProjectManifest>('package.json')
+  expect(manifest.dependencies).toStrictEqual({
+    'foo-alias': 'npm:@pnpm.e2e/foo@~100.1.0',
+  })
+
+  const lockfile = project.readLockfile()
+  expect(lockfile.packages['@pnpm.e2e/foo@100.1.0']).toBeTruthy()
+})

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -507,8 +507,7 @@ test('should not update tag version when --latest not set', async () => {
 test('update --latest resolves an npm: alias to the latest version of the aliased package', async () => {
   await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
 
-  // The alias name does not exist on the registry, so resolving it instead of
-  // the aliased package would fail.
+  // The alias name does not exist on the registry.
   const project = prepare({
     dependencies: {
       'foo-alias': 'npm:@pnpm.e2e/foo@~1.0.0',

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1967,7 +1967,7 @@ describe('update', () => {
     }])
 
     const catalogs = {
-      default: { 'foo-alias': 'npm:@pnpm.e2e/foo@1.0.0' },
+      default: { 'foo-alias': 'npm:@pnpm.e2e/foo@~1.0.0' },
     }
 
     const mutateOpts = {
@@ -1979,7 +1979,7 @@ describe('update', () => {
     await mutateModules(installProjects(projects), mutateOpts)
 
     expect(readLockfile().catalogs.default).toEqual({
-      'foo-alias': { specifier: 'npm:@pnpm.e2e/foo@1.0.0', version: '1.0.0' },
+      'foo-alias': { specifier: 'npm:@pnpm.e2e/foo@~1.0.0', version: '1.0.0' },
     })
 
     const { updatedCatalogs, updatedManifest } = await addDependenciesToPackage(
@@ -1994,7 +1994,7 @@ describe('update', () => {
       })
 
     // The manifest keeps the catalog reference; the bumped catalog entry
-    // keeps the npm: alias prefix.
+    // keeps the npm: alias prefix and the entry's own range operator.
     expect(updatedManifest).toEqual({
       name: 'project1',
       dependencies: {
@@ -2003,7 +2003,7 @@ describe('update', () => {
     })
     expect(updatedCatalogs).toEqual({
       default: {
-        'foo-alias': 'npm:@pnpm.e2e/foo@100.1.0',
+        'foo-alias': 'npm:@pnpm.e2e/foo@~100.1.0',
       },
     })
 

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1957,8 +1957,7 @@ describe('update', () => {
   test('update --latest resolves an npm: alias catalog entry to the aliased package', async () => {
     await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
 
-    // The alias name does not exist on the registry, so resolving it instead
-    // of the aliased package would fail.
+    // The alias name does not exist on the registry.
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
       name: 'project1',
       dependencies: {
@@ -1993,8 +1992,6 @@ describe('update', () => {
         updateToLatest: true,
       })
 
-    // The manifest keeps the catalog reference; the bumped catalog entry
-    // keeps the npm: alias prefix and the entry's own range operator.
     expect(updatedManifest).toEqual({
       name: 'project1',
       dependencies: {

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1954,6 +1954,62 @@ describe('update', () => {
     expect(Object.keys(lockfile.snapshots)).toEqual(['@pnpm.e2e/foo@100.1.0'])
   })
 
+  test('update --latest resolves an npm: alias catalog entry to the aliased package', async () => {
+    await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+    // The alias name does not exist on the registry, so resolving it instead
+    // of the aliased package would fail.
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        'foo-alias': 'catalog:',
+      },
+    }])
+
+    const catalogs = {
+      default: { 'foo-alias': 'npm:@pnpm.e2e/foo@1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    expect(readLockfile().catalogs.default).toEqual({
+      'foo-alias': { specifier: 'npm:@pnpm.e2e/foo@1.0.0', version: '1.0.0' },
+    })
+
+    const { updatedCatalogs, updatedManifest } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['foo-alias'],
+      {
+        ...mutateOpts,
+        dir: path.join(process.cwd(), 'project1'),
+        allowNew: false,
+        update: true,
+        updateToLatest: true,
+      })
+
+    // The manifest keeps the catalog reference; the bumped catalog entry
+    // keeps the npm: alias prefix.
+    expect(updatedManifest).toEqual({
+      name: 'project1',
+      dependencies: {
+        'foo-alias': 'catalog:',
+      },
+    })
+    expect(updatedCatalogs).toEqual({
+      default: {
+        'foo-alias': 'npm:@pnpm.e2e/foo@100.1.0',
+      },
+    })
+
+    expect(Object.keys(readLockfile().snapshots)).toEqual(['@pnpm.e2e/foo@100.1.0'])
+  })
+
   test('update --latest works on named catalog dependency with catalogMode=prefer', async () => {
     await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
 


### PR DESCRIPTION
## Summary

The daily [Update Lockfile job failed](https://github.com/pnpm/pnpm/actions/runs/30024708601/job/89266092015) on its first run after [pnpm/pnpm#13229](https://github.com/pnpm/pnpm/pull/13229) switched the workflow to the `pnpm/update` action with `update-deps: latest`. Replaying the job's `pnpm update --recursive --latest` locally with a patched pacquet uncovered **three independent blockers**; this PR fixes all of them, and the full job command now completes cleanly in a local replay.

**1. `npm:` aliases resolved by their alias name (the failure in the run above).** `@types/zkochan__table` is declared as `catalog:`, and its catalog entry is the alias `npm:@types/table@6.3.2`. Pacquet's `update --latest` resolved the `latest` tag by the dependency's *alias* name — which 404s on the registry — instead of the aliased package. It now resolves the *aliased* package (directly in `package.json` or through the catalog entry a `catalog:` reference points to) and writes the bump back with the `npm:<real name>@` prefix and the entry's own range operator preserved, matching the TypeScript resolver's `unwrapPackageName`/`calcSpecifier` pair. The `npm:<range>` shorthand and a self-named alias are written as a plain range, also matching TS.

**2. `runtime:` dependencies rewritten into npm registry packages.** `update --latest` treated `node: runtime:26.5.0` as a registry dependency: it fetched the latest dist-tag of the unrelated npm package `node` and rewrote the specifier to a plain version — whose install script then failed the strict ignored-builds check. The TypeScript CLI leaves `runtime:` deps to the runtime resolvers, which re-resolve within the manifest spec; pacquet's `--latest` rewrite now skips them the same way.

**3. `update --latest` bumps the deps deliberately held below their latest majors.** The catalog documents (with comments) entries kept back because their newer majors require Node.js above pnpm's supported floor (>=22.13), which `engineStrict` enforces against `nodeVersion` — but nothing told `pnpm update` to skip them, so the job bumped them and correctly failed on `ERR_PNPM_UNSUPPORTED_ENGINE` (the TypeScript CLI fails identically here; this is by design). A scan of every catalog entry's latest `engines.node` found the 8 already-commented hold-backs plus five new ones (`@babel/core`, `@babel/plugin-transform-explicit-resource-management`, `bin-links`, `libnpmpublish`, `npm-registry-fetch`) and the directly-declared `node-gyp`. They are now listed in `updateConfig.ignoreDependencies`, with catalog comments added for the new ones following the existing convention.

The TypeScript stack behaves correctly on (1) and (2) but had no tests pinning either scenario — the coverage gap that let both regressions ship in pacquet — so the pacquet e2e tests are mirrored as TypeScript tests (`installing/commands` for the direct alias, `installing/deps-installer` for the catalog alias entry and the runtime dep).

**Verification.** `pnpm update --recursive --latest --changeset` (the job's exact command after `refresh-lockfile` deletes `pnpm-lock.yaml`), run with a locally built pacquet from this branch on node 26.5.0, completes with exit 0: catalog and lockfile updated, alias entries bumped with prefixes preserved, held-back entries untouched, `node-gyp` and the virtual `node` runtime dep left alone. Note: pacquet warns `No changeset was generated because .changeset/config.json does not exist` — this repo uses the native changeset flow without that file, so the update PRs will carry no auto-generated changeset (same as before this PR).

## Squash Commit Body

```text
The update-lockfile workflow's new update --latest flow (pnpm/pnpm#13229)
never succeeded; a local replay of its exact command with a patched pacquet
surfaced three independent blockers, all fixed here.

(1) prepare_manifest's --latest branches resolved `latest` by the manifest
key (the install alias) and only consulted the catalogs to recover the range
operator, so an npm: alias — like the catalog entry npm:@types/table@6.3.2
behind @types/zkochan__table — 404'd on the alias name. Both branches now
compute the effective specifier (the catalog entry for a catalog: reference,
the dependency's own specifier otherwise), unwrap an npm: alias to the real
package name for the dist-tag lookup, and serialize the rewrite with the
npm:<real name>@ prefix preserved. The npm:<range> shorthand and a
self-named alias are written as a plain range, matching the TypeScript
resolver's unwrapPackageName/calcSpecifier pair. latest_pin is folded into
the new effective_specifier + resolve_latest_specifier helpers; the
pin-recovery behavior is unchanged.

(2) The same branches treated runtime: specifiers as registry deps,
resolving the unrelated npm package `node` and rewriting the manifest to a
plain version whose install script then failed the strict ignored-builds
check. The --latest rewrite now skips runtime: specifiers; the runtime
resolvers re-resolve them within the manifest spec, as in the TypeScript
CLI.

(3) pnpm-workspace.yaml gains updateConfig.ignoreDependencies for the deps
held below majors that require Node.js above pnpm's supported floor
(>=22.13), which engineStrict correctly fails against nodeVersion — the 8
already-commented catalog hold-backs plus @babel/core,
@babel/plugin-transform-explicit-resource-management, bin-links,
libnpmpublish, npm-registry-fetch (newly floor-blocked, now commented at
their catalog entries too) and the directly-declared node-gyp.

The TypeScript implementation needs no code change for (1) and (2); it gains
tests pinning both scenarios, which were uncovered.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).
