### PR TITLE
fix(publish): retry the sigstore signing exchange and cap it with fetch-timeout

### DIFF
--- a/.changeset/retry-provenance-signing.md
+++ b/.changeset/retry-provenance-signing.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm publish --provenance` now retries the sigstore signing exchange (Fulcio, timestamp authority, Rekor) up to two more times with exponential backoff when it fails, instead of aborting the publish on the first transient network error.

--- a/.changeset/retry-provenance-signing.md
+++ b/.changeset/retry-provenance-signing.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm publish --provenance` now retries the sigstore signing exchange (Fulcio, timestamp authority, Rekor) up to two more times with exponential backoff when it fails, instead of aborting the publish on the first transient network error.
+`pnpm publish --provenance` now retries the sigstore signing exchange up to two more times with exponential backoff when a request to the sigstore infrastructure fails, instead of aborting the publish on the first transient network error.

--- a/.changeset/retry-provenance-signing.md
+++ b/.changeset/retry-provenance-signing.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm publish --provenance` now retries the sigstore signing exchange up to two more times with exponential backoff when a request to the sigstore infrastructure fails, instead of aborting the publish on the first transient network error.
+`pnpm publish --provenance` now applies the `fetch-timeout` setting to the sigstore signing exchange and retries it up to two more times with exponential backoff when it fails or times out, instead of aborting the publish on the first transient network error or hanging on a stalled connection.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,6 +4807,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tracing",
  "url",
 ]
 

--- a/pnpm/crates/publish/Cargo.toml
+++ b/pnpm/crates/publish/Cargo.toml
@@ -34,6 +34,8 @@ sha2          = { workspace = true }
 sigstore-sign = { workspace = true }
 ssri          = { workspace = true }
 tar           = { workspace = true }
+tokio         = { workspace = true, features = ["time"] }
+tracing       = { workspace = true }
 url           = { workspace = true }
 
 [dev-dependencies]

--- a/pnpm/crates/publish/src/provenance_gen.rs
+++ b/pnpm/crates/publish/src/provenance_gen.rs
@@ -12,7 +12,10 @@
 //! recorded in the Rekor transparency log), so the modern bundle is sufficient
 //! and no legacy-compatibility path is needed.
 
+use std::time::Duration;
+
 use pacquet_diagnostics::miette::{self, Diagnostic};
+use pacquet_network::RetryOpts;
 use pacquet_reporter::Reporter;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha512};
@@ -97,6 +100,7 @@ pub trait SignProvenance {
 
 /// A signed sigstore bundle: its media type and the serialized bundle JSON
 /// (stored verbatim in the publish document, not base64-encoded).
+#[derive(Debug)]
 pub struct SignedProvenance {
     pub media_type: String,
     pub data: String,
@@ -109,13 +113,64 @@ impl SignProvenance for Host {
     ) -> Result<SignedProvenance, ProvenanceGenError> {
         let token = IdentityToken::from_jwt(jwt)
             .map_err(|source| ProvenanceGenError::IdentityToken { source: source.to_string() })?;
-        let bundle = SigningContext::production()
-            .signer(token)
-            .sign_raw_statement(statement)
-            .await
-            .map_err(|source| ProvenanceGenError::Sign { source: source.to_string() })?;
-        let data = serde_json::to_string(&bundle).expect("serialize sigstore bundle");
-        Ok(SignedProvenance { media_type: bundle.media_type, data })
+        let context = SigningContext::production();
+        sign_with_retry(SIGN_RETRY_OPTS, || async {
+            let bundle = context
+                .signer(token.clone())
+                .sign_raw_statement(statement)
+                .await
+                .map_err(|source| ProvenanceGenError::Sign { source: source.to_string() })?;
+            let data = serde_json::to_string(&bundle).expect("serialize sigstore bundle");
+            Ok(SignedProvenance { media_type: bundle.media_type, data })
+        })
+        .await
+    }
+}
+
+/// The TypeScript CLI signs through sigstore-js, which wraps every Fulcio /
+/// TSA / Rekor request in `make-fetch-happen` with its default retry policy
+/// (2 retries, factor 2, 1 s floor), so a transient sigstore outage does not
+/// abort the publish. The `sigstore_sign` crate issues each request exactly
+/// once, so pacquet retries at the boundary it owns instead: the whole
+/// signing exchange. Every step is idempotent (a fresh ephemeral key,
+/// certificate, timestamp, and transparency-log entry per attempt), so
+/// re-running it is safe.
+const SIGN_RETRY_OPTS: RetryOpts = RetryOpts {
+    retries: 2,
+    factor: 2,
+    min_timeout: Duration::from_secs(1),
+    max_timeout: Duration::from_mins(1),
+};
+
+/// Run `attempt_fn` — one full signing exchange — retrying under
+/// `retry_opts`'s exponential backoff until it succeeds or the retries are
+/// exhausted.
+async fn sign_with_retry<Fut>(
+    retry_opts: RetryOpts,
+    mut attempt_fn: impl FnMut() -> Fut,
+) -> Result<SignedProvenance, ProvenanceGenError>
+where
+    Fut: Future<Output = Result<SignedProvenance, ProvenanceGenError>>,
+{
+    let mut attempt = 0;
+    loop {
+        match attempt_fn().await {
+            Ok(signed) => return Ok(signed),
+            Err(error) if attempt < retry_opts.retries => {
+                let delay = retry_opts.delay_for(attempt);
+                tracing::warn!(
+                    target: "pacquet_publish::provenance",
+                    %error,
+                    attempt = attempt + 1,
+                    max_attempts = retry_opts.retries + 1,
+                    ?delay,
+                    "Signing the provenance statement failed; retrying after backoff",
+                );
+                tokio::time::sleep(delay).await;
+                attempt += 1;
+            }
+            Err(error) => return Err(error),
+        }
     }
 }
 

--- a/pnpm/crates/publish/src/provenance_gen.rs
+++ b/pnpm/crates/publish/src/provenance_gen.rs
@@ -74,7 +74,8 @@ where
     let statement_bytes = serde_json::to_vec(&statement).expect("serialize provenance statement");
 
     let jwt = fetch_sigstore_token::<Sys, Reporter>(options).await?;
-    let signed = Sys::sign_statement(&jwt, &statement_bytes).await?;
+    let timeout = options.fetch_timeout.map(Duration::from_millis);
+    let signed = Sys::sign_statement(&jwt, &statement_bytes, timeout).await?;
 
     global_info::<Reporter>("Signed provenance statement with source and build information");
 
@@ -91,10 +92,13 @@ where
 /// so [`generate_provenance`] runs offline and deterministically.
 pub trait SignProvenance {
     /// Sign `statement` (the serialized in-toto statement) using `jwt`, the
-    /// OIDC token minted for the `sigstore` audience.
+    /// OIDC token minted for the `sigstore` audience. `timeout` caps each
+    /// signing attempt (`fetch-timeout`); `None` falls back to the
+    /// implementation's default, mirroring sigstore-js's `options.timeout`.
     fn sign_statement(
         jwt: &str,
         statement: &[u8],
+        timeout: Option<Duration>,
     ) -> impl Future<Output = Result<SignedProvenance, ProvenanceGenError>>;
 }
 
@@ -110,18 +114,21 @@ impl SignProvenance for Host {
     async fn sign_statement(
         jwt: &str,
         statement: &[u8],
+        timeout: Option<Duration>,
     ) -> Result<SignedProvenance, ProvenanceGenError> {
         let token = IdentityToken::from_jwt(jwt)
             .map_err(|source| ProvenanceGenError::IdentityToken { source: source.to_string() })?;
         let context = SigningContext::production();
-        sign_with_retry(SIGN_RETRY_OPTS, || async {
-            let bundle = context
-                .signer(token.clone())
-                .sign_raw_statement(statement)
-                .await
-                .map_err(|source| ProvenanceGenError::Sign { source: source.to_string() })?;
-            let data = serde_json::to_string(&bundle).expect("serialize sigstore bundle");
-            Ok(SignedProvenance { media_type: bundle.media_type, data })
+        let deadline = timeout.unwrap_or(DEFAULT_SIGN_TIMEOUT);
+        sign_with_retry(SIGN_RETRY_OPTS, || {
+            with_sign_deadline(deadline, async {
+                let bundle =
+                    context.signer(token.clone()).sign_raw_statement(statement).await.map_err(
+                        |source| ProvenanceGenError::Sign { source: source.to_string() },
+                    )?;
+                let data = serde_json::to_string(&bundle).expect("serialize sigstore bundle");
+                Ok(SignedProvenance { media_type: bundle.media_type, data })
+            })
         })
         .await
     }
@@ -141,6 +148,32 @@ const SIGN_RETRY_OPTS: RetryOpts = RetryOpts {
     min_timeout: Duration::from_secs(1),
     max_timeout: Duration::from_mins(1),
 };
+
+/// sigstore-js's `DEFAULT_TIMEOUT`, used only when the caller supplies no
+/// `fetch-timeout` — the sigstore-rust clients set no request timeout of
+/// their own, so without a deadline a hung connection stalls the publish
+/// until the OS gives up on the socket.
+const DEFAULT_SIGN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Cap one signing attempt at `deadline`, converting an elapsed timer into a
+/// retryable [`ProvenanceGenError::Sign`].
+async fn with_sign_deadline<Fut>(
+    deadline: Duration,
+    attempt: Fut,
+) -> Result<SignedProvenance, ProvenanceGenError>
+where
+    Fut: Future<Output = Result<SignedProvenance, ProvenanceGenError>>,
+{
+    match tokio::time::timeout(deadline, attempt).await {
+        Ok(result) => result,
+        Err(_) => Err(ProvenanceGenError::Sign {
+            source: format!(
+                "no response from the sigstore signing exchange within {} ms",
+                deadline.as_millis(),
+            ),
+        }),
+    }
+}
 
 /// Run `attempt_fn` — one full signing exchange — retrying under
 /// `retry_opts`'s exponential backoff until it succeeds or the retries are

--- a/pnpm/crates/publish/src/provenance_gen.rs
+++ b/pnpm/crates/publish/src/provenance_gen.rs
@@ -15,7 +15,7 @@
 use std::time::Duration;
 
 use pacquet_diagnostics::miette::{self, Diagnostic};
-use pacquet_network::RetryOpts;
+use pacquet_network::{RetryOpts, redact_url_credentials};
 use pacquet_reporter::Reporter;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha512};
@@ -160,7 +160,7 @@ where
                 let delay = retry_opts.delay_for(attempt);
                 tracing::warn!(
                     target: "pacquet_publish::provenance",
-                    %error,
+                    error = %redact_url_credentials(&error.to_string()),
                     attempt = attempt + 1,
                     max_attempts = retry_opts.retries + 1,
                     ?delay,

--- a/pnpm/crates/publish/src/provenance_gen.rs
+++ b/pnpm/crates/publish/src/provenance_gen.rs
@@ -93,8 +93,7 @@ where
 pub trait SignProvenance {
     /// Sign `statement` (the serialized in-toto statement) using `jwt`, the
     /// OIDC token minted for the `sigstore` audience. `timeout` caps each
-    /// signing attempt (`fetch-timeout`); `None` falls back to the
-    /// implementation's default, mirroring sigstore-js's `options.timeout`.
+    /// signing attempt; `None` falls back to the implementation's default.
     fn sign_statement(
         jwt: &str,
         statement: &[u8],
@@ -155,8 +154,6 @@ const SIGN_RETRY_OPTS: RetryOpts = RetryOpts {
 /// until the OS gives up on the socket.
 const DEFAULT_SIGN_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Cap one signing attempt at `deadline`, converting an elapsed timer into a
-/// retryable [`ProvenanceGenError::Sign`].
 async fn with_sign_deadline<Fut>(
     deadline: Duration,
     attempt: Fut,
@@ -175,9 +172,6 @@ where
     }
 }
 
-/// Run `attempt_fn` — one full signing exchange — retrying under
-/// `retry_opts`'s exponential backoff until it succeeds or the retries are
-/// exhausted.
 async fn sign_with_retry<Fut>(
     retry_opts: RetryOpts,
     mut attempt_fn: impl FnMut() -> Fut,

--- a/pnpm/crates/publish/src/provenance_gen/tests.rs
+++ b/pnpm/crates/publish/src/provenance_gen/tests.rs
@@ -3,6 +3,7 @@ use std::{cell::Cell, time::Duration};
 use super::{
     ProvenanceGenError, SignProvenance, SignedProvenance, build_statement, fetch_sigstore_token,
     generate_provenance, github_statement, gitlab_statement, npm_purl, sign_with_retry,
+    with_sign_deadline,
 };
 use crate::{
     capabilities::{Clock, EnvVar, OidcFetch, OidcFetchError, OidcRequest, OidcResponse},
@@ -292,9 +293,11 @@ impl SignProvenance for GhSignSys {
     async fn sign_statement(
         jwt: &str,
         statement: &[u8],
+        timeout: Option<Duration>,
     ) -> Result<SignedProvenance, ProvenanceGenError> {
         assert_eq!(jwt, "sigstore-token", "the sigstore-audience token is passed to the signer");
         assert!(!statement.is_empty(), "a serialized statement is signed");
+        assert_eq!(timeout, None, "no fetch-timeout was configured");
         Ok(SignedProvenance {
             media_type: "application/vnd.dev.sigstore.bundle.v0.3+json".to_owned(),
             data: r#"{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}"#.to_owned(),
@@ -320,6 +323,43 @@ async fn generate_provenance_builds_the_signed_attachment() {
     assert_eq!(attachment.data, r#"{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}"#);
 }
 
+/// The configured `fetch-timeout` (milliseconds) reaches the signer as its
+/// per-attempt deadline.
+#[tokio::test]
+async fn generate_provenance_forwards_fetch_timeout_to_the_signer() {
+    struct TimeoutSys;
+    impl Clock for TimeoutSys {
+        fn now_ms() -> u64 {
+            0
+        }
+    }
+    impl EnvVar for TimeoutSys {
+        fn var(name: &str) -> Option<String> {
+            GhSignSys::var(name)
+        }
+    }
+    impl OidcFetch for TimeoutSys {
+        async fn fetch(request: OidcRequest<'_>) -> Result<OidcResponse, OidcFetchError> {
+            GhSignSys::fetch(request).await
+        }
+    }
+    impl SignProvenance for TimeoutSys {
+        async fn sign_statement(
+            _: &str,
+            _: &[u8],
+            timeout: Option<Duration>,
+        ) -> Result<SignedProvenance, ProvenanceGenError> {
+            assert_eq!(timeout, Some(Duration::from_millis(1234)));
+            Ok(SignedProvenance { media_type: "bundle".to_owned(), data: "{}".to_owned() })
+        }
+    }
+
+    let options = OidcHttpOptions { fetch_timeout: Some(1234), ..OidcHttpOptions::default() };
+    generate_provenance::<TimeoutSys, SilentReporter>("pkg", "1.0.0", b"tarball", &options)
+        .await
+        .expect("provenance generation succeeds");
+}
+
 /// A signer failure propagates as the publish-facing provenance error.
 #[tokio::test]
 async fn generate_provenance_surfaces_a_signer_failure() {
@@ -340,7 +380,11 @@ async fn generate_provenance_surfaces_a_signer_failure() {
         }
     }
     impl SignProvenance for FailingSigner {
-        async fn sign_statement(_: &str, _: &[u8]) -> Result<SignedProvenance, ProvenanceGenError> {
+        async fn sign_statement(
+            _: &str,
+            _: &[u8],
+            _: Option<Duration>,
+        ) -> Result<SignedProvenance, ProvenanceGenError> {
             Err(ProvenanceGenError::Sign { source: "fulcio rejected the request".to_owned() })
         }
     }
@@ -363,6 +407,24 @@ const INSTANT_RETRIES: pacquet_network::RetryOpts = pacquet_network::RetryOpts {
     min_timeout: Duration::ZERO,
     max_timeout: Duration::ZERO,
 };
+
+#[tokio::test]
+async fn with_sign_deadline_times_out_a_hung_attempt() {
+    let err = with_sign_deadline(Duration::ZERO, std::future::pending())
+        .await
+        .expect_err("a hung exchange hits the deadline");
+    assert!(matches!(err, ProvenanceGenError::Sign { .. }), "got {err:?}");
+}
+
+#[tokio::test]
+async fn with_sign_deadline_passes_a_completed_attempt_through() {
+    let signed = with_sign_deadline(Duration::from_secs(5), async {
+        Ok(SignedProvenance { media_type: "bundle".to_owned(), data: "{}".to_owned() })
+    })
+    .await
+    .expect("a completed attempt is returned unchanged");
+    assert_eq!(signed.data, "{}");
+}
 
 #[tokio::test]
 async fn sign_with_retry_recovers_from_transient_failures() {

--- a/pnpm/crates/publish/src/provenance_gen/tests.rs
+++ b/pnpm/crates/publish/src/provenance_gen/tests.rs
@@ -1,6 +1,8 @@
+use std::{cell::Cell, time::Duration};
+
 use super::{
     ProvenanceGenError, SignProvenance, SignedProvenance, build_statement, fetch_sigstore_token,
-    generate_provenance, github_statement, gitlab_statement, npm_purl,
+    generate_provenance, github_statement, gitlab_statement, npm_purl, sign_with_retry,
 };
 use crate::{
     capabilities::{Clock, EnvVar, OidcFetch, OidcFetchError, OidcRequest, OidcResponse},
@@ -352,6 +354,48 @@ async fn generate_provenance_surfaces_a_signer_failure() {
     .await
     .expect_err("a signer failure aborts provenance generation");
     assert!(matches!(err, ProvenanceGenError::Sign { .. }), "got {err:?}");
+}
+
+/// A zero-delay policy so the retry tests don't sleep.
+const INSTANT_RETRIES: pacquet_network::RetryOpts = pacquet_network::RetryOpts {
+    retries: 2,
+    factor: 2,
+    min_timeout: Duration::ZERO,
+    max_timeout: Duration::ZERO,
+};
+
+#[tokio::test]
+async fn sign_with_retry_recovers_from_transient_failures() {
+    let attempts = Cell::new(0u32);
+    let signed = sign_with_retry(INSTANT_RETRIES, || {
+        let attempt = attempts.get();
+        attempts.set(attempt + 1);
+        async move {
+            if attempt < 2 {
+                return Err(ProvenanceGenError::Sign {
+                    source: "Failed to get timestamp".to_owned(),
+                });
+            }
+            Ok(SignedProvenance { media_type: "bundle".to_owned(), data: "{}".to_owned() })
+        }
+    })
+    .await
+    .expect("the third attempt succeeds");
+    assert_eq!(signed.data, "{}");
+    assert_eq!(attempts.get(), 3);
+}
+
+#[tokio::test]
+async fn sign_with_retry_surfaces_the_final_failure_once_retries_are_exhausted() {
+    let attempts = Cell::new(0u32);
+    let err = sign_with_retry(INSTANT_RETRIES, || {
+        attempts.set(attempts.get() + 1);
+        async { Err(ProvenanceGenError::Sign { source: "Failed to get timestamp".to_owned() }) }
+    })
+    .await
+    .expect_err("every attempt fails");
+    assert!(matches!(err, ProvenanceGenError::Sign { .. }), "got {err:?}");
+    assert_eq!(attempts.get(), INSTANT_RETRIES.retries + 1);
 }
 
 #[tokio::test]

--- a/pnpm/crates/publish/src/publish_packed_pkg/tests.rs
+++ b/pnpm/crates/publish/src/publish_packed_pkg/tests.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use super::{
     DistHashes, PackedPkg, PublishHttpError, PublishNetwork, PublishPackedPkgError,
     PublishPackedPkgOptions, build_publish_document, clean_version, is_otp_challenge,
@@ -648,7 +650,11 @@ impl OidcFetch for OfflineSys {
     }
 }
 impl SignProvenance for OfflineSys {
-    async fn sign_statement(_: &str, _: &[u8]) -> Result<SignedProvenance, ProvenanceGenError> {
+    async fn sign_statement(
+        _: &str,
+        _: &[u8],
+        _: Option<Duration>,
+    ) -> Result<SignedProvenance, ProvenanceGenError> {
         unreachable!("a dry run never signs provenance")
     }
 }
@@ -737,7 +743,11 @@ impl OidcFetch for ProvenanceSys {
     }
 }
 impl SignProvenance for ProvenanceSys {
-    async fn sign_statement(_: &str, _: &[u8]) -> Result<SignedProvenance, ProvenanceGenError> {
+    async fn sign_statement(
+        _: &str,
+        _: &[u8],
+        _: Option<Duration>,
+    ) -> Result<SignedProvenance, ProvenanceGenError> {
         Ok(SignedProvenance {
             media_type: "application/vnd.dev.sigstore.bundle.v0.3+json".to_owned(),
             data: "signed-bundle-json".to_owned(),


### PR DESCRIPTION
## Summary

The v11.17.0 release run ([job 89266951584](https://github.com/pnpm/pnpm/actions/runs/30024580049/job/89266951584)) failed with `ERR_PNPM_PROVENANCE_SIGN` while publishing `@pnpm/resolving.parse-wanted-dependency`: a single request to the sigstore timestamp authority (`https://timestamp.sigstore.dev/api/v1/timestamp`) errored, and the whole publish aborted — after eight packages had already signed and published fine.

The TypeScript CLI is not affected because it signs through sigstore-js, which runs every Fulcio / TSA / Rekor request under `make-fetch-happen` with its default retry policy (2 retries, factor 2, 1 s floor) and under the caller's `timeout` option — which pnpm wires to `fetch-timeout` (default 60 s), with sigstore-js's own 5 s default as the fallback. pacquet called `sigstore_sign`'s `sign_raw_statement` exactly once, with no retry and no request timeout (the sigstore-rust clients build bare `reqwest::Client`s), so any transient sigstore network error killed the release, and a stalled connection hung until the OS dropped the socket (~78 s in the failed run).

This PR closes both gaps:

- **Retry**: the production `SignProvenance` impl retries the signing exchange with sigstore-js's policy. The `sigstore_sign` crate issues each HTTP request once and exposes no per-request retry hook, so the retry wraps the boundary pacquet owns: the whole signing exchange. Every step of that exchange is idempotent (a fresh ephemeral key, certificate, timestamp, and transparency-log entry per attempt), so re-running it is safe.
- **Timeout**: `generate_provenance` forwards `fetch-timeout` to the signer, and each signing attempt runs under that deadline (5 s fallback when unset, matching sigstore-js's `DEFAULT_TIMEOUT`). An elapsed deadline becomes a retryable signing error, so the retry loop picks it up instead of the publish hanging.

Placing both below the DI seam mirrors where sigstore-js keeps them on the TypeScript side and leaves the `generate_provenance` contract and its test fakes unchanged (the fakes only gained the pass-through `timeout` parameter).

The retry loop reuses `pacquet_network::RetryOpts` for the backoff math (the retry module's docs already bless purpose-specific loops that reuse `RetryOpts`, e.g. the tarball fetcher); `retry_async` itself was not reused because its warn log line is specific to body-read failures and would mislead someone debugging a release. Retry warnings go through `tracing` only, not the `RequestRetry` reporter event, because the TypeScript CLI's sigstore retries are likewise invisible in the reporter stream — emitting the event here would diverge the two stacks' output.

## Squash Commit Body

```text
The v11.17.0 release run aborted with ERR_PNPM_PROVENANCE_SIGN after a
single dropped request to the sigstore timestamp authority, even though
the eight packages published before it signed fine.

The TypeScript CLI signs through sigstore-js, which runs every Fulcio /
TSA / Rekor request under make-fetch-happen with its default retry
policy (2 retries, factor 2, 1 s floor) and under the caller's timeout
option, which pnpm wires to fetch-timeout (default 60 s, sigstore-js
falls back to 5 s when unset). pacquet called sign_raw_statement exactly
once with no retry and no request timeout (the sigstore-rust clients
build bare reqwest clients), turning any single network flake into a
failed release and letting a stalled connection hang until the OS
dropped the socket.

Retry the whole signing exchange in the Host SignProvenance impl with
the same policy, and cap each attempt with fetch-timeout (5 s fallback),
converting an elapsed deadline into a retryable signing error. The
exchange is idempotent (fresh ephemeral key, certificate, timestamp,
and transparency-log entry per attempt), so re-running it is safe. Both
sit below the DI seam, matching where sigstore-js keeps them on the
TypeScript side, so the generate_provenance contract is unchanged apart
from the pass-through timeout parameter.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only:
  the TypeScript CLI already retries and applies `fetch-timeout` via
  sigstore-js; this brings pacquet to parity.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provenance signing now honors the configured fetch timeout.
  * Transient signing failures are automatically retried up to two additional times with exponential backoff.
  * Stalled signing requests now time out instead of hanging indefinitely.

* **Documentation**
  * Updated patch release notes to document the improved provenance-signing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->