### PR TITLE
fix(cli): close three CLI parity gaps found moving the Tag workflow to v12

### DIFF
--- a/.changeset/pacquet-registry-allow-build-dir-parity.md
+++ b/.changeset/pacquet-registry-allow-build-dir-parity.md
@@ -1,0 +1,9 @@
+---
+"pacquet": patch
+---
+
+Close three CLI parity gaps with the TypeScript pnpm CLI:
+
+- `--registry <url>` is now accepted on every command as a universal rc-option, not only through `--config.registry=<url>` (`pnpm view pnpm dist-tags.latest --registry=https://registry.npmjs.org/`).
+- `pnpm add` (and `pnpm add -g`) now accept `--allow-build=<pkg>`, appending the named packages to `allowBuilds` so they can run their lifecycle scripts during the install (`pnpm add @pnpm/exe@11.16.0 --allow-build=@pnpm/exe`).
+- `--dir` / `-C` is now position-independent: it is accepted anywhere on the command line, before or after the subcommand (`pnpm add foo --dir /tmp/proj`).

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -7,13 +7,15 @@ use crate::{
     config_deps,
 };
 use clap::Args;
-use miette::Context;
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_package_manager::Add;
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
+use pacquet_workspace_manifest_writer::set_allow_builds;
 use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
@@ -106,6 +108,10 @@ pub struct AddArgs {
     /// Add the package as a configuration dependency.
     #[clap(long = "config")]
     pub config: bool,
+    /// Package names allowed to run lifecycle (build) scripts during this
+    /// install, appended to `allowBuilds`. May be repeated.
+    #[clap(long = "allow-build")]
+    pub allow_build: Vec<String>,
     /// Dependencies are not downloaded. Only `pnpm-lock.yaml` is updated.
     #[clap(long = "lockfile-only")]
     pub lockfile_only: bool,
@@ -315,10 +321,59 @@ impl AddArgs {
             &self.package_names,
             pinned_version,
             supported_architectures,
+            &self.allow_build,
             dir,
         ))
         .await
     }
+}
+
+/// Honor `--allow-build`: reject any package the root project explicitly
+/// disallows (`allowBuilds: false`), persist the allowed names to
+/// `settings_dir`'s `pnpm-workspace.yaml`, and enable them for this
+/// install. `settings_dir` is the workspace root, or the project
+/// directory outside a workspace. Mirrors pnpm's `add` handler; shared by
+/// the workspace and `--global` add paths.
+pub(crate) fn apply_allow_build(
+    config: &mut Config,
+    allow_build: &[String],
+    settings_dir: &Path,
+) -> miette::Result<()> {
+    if allow_build.is_empty() {
+        return Ok(());
+    }
+    let overlap: Vec<&str> = allow_build
+        .iter()
+        .filter(|pkg| config.allow_builds.get(pkg.as_str()) == Some(&false))
+        .map(String::as_str)
+        .collect();
+    if !overlap.is_empty() {
+        return Err(AllowBuildError::OverridingIgnoredBuiltDependencies {
+            dependencies: overlap.join(", "),
+        }
+        .into());
+    }
+    set_allow_builds(settings_dir, allow_build.iter().map(|pkg| (pkg.as_str(), true)))
+        .into_diagnostic()?;
+    for pkg in allow_build {
+        config.allow_builds.insert(pkg.clone(), true);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum AllowBuildError {
+    #[display(
+        "The following dependencies are ignored by the root project, but are allowed to be built by the current command: {dependencies}"
+    )]
+    #[diagnostic(
+        code(ERR_PNPM_OVERRIDING_IGNORED_BUILT_DEPENDENCIES),
+        help(
+            "If you are sure you want to allow those dependencies to run installation scripts, remove them from the allowBuilds list (or change their value to true)."
+        )
+    )]
+    OverridingIgnoredBuiltDependencies { dependencies: String },
 }
 
 /// Add a single package to `state`'s manifest and install it.

--- a/pnpm/crates/cli/src/cli_args/add/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/add/tests.rs
@@ -10,13 +10,11 @@ fn allow_build_merges_into_config_and_persists_to_workspace_yaml() {
     apply_allow_build(&mut config, &["esbuild".to_string()], dir.path())
         .expect("allow-build applies");
 
-    // Enabled for the current install.
-    assert_eq!(config.allow_builds.get("esbuild"), Some(&true));
+    assert_eq!(config.allow_builds.get("esbuild"), Some(&true), "enabled for this install");
 
-    // Persisted to the settings dir's pnpm-workspace.yaml.
     let yaml = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml"))
         .expect("pnpm-workspace.yaml written");
-    assert!(yaml.contains("esbuild"), "allowBuilds entry written, got:\n{yaml}");
+    assert!(yaml.contains("esbuild"), "allowBuilds entry persisted, got:\n{yaml}");
 }
 
 #[test]
@@ -31,8 +29,7 @@ fn allow_build_rejects_a_package_the_root_disallows() {
         err.code().map(|code| code.to_string()).as_deref(),
         Some("ERR_PNPM_OVERRIDING_IGNORED_BUILT_DEPENDENCIES"),
     );
-    // Nothing was persisted for a rejected apply.
-    assert!(!dir.path().join("pnpm-workspace.yaml").exists());
+    assert!(!dir.path().join("pnpm-workspace.yaml").exists(), "a rejected apply persists nothing");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/add/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/add/tests.rs
@@ -1,6 +1,48 @@
-use super::AddDependencyOptions;
+use super::{AddDependencyOptions, apply_allow_build};
+use pacquet_config::Config;
 use pacquet_package_manifest::DependencyGroup;
 use pretty_assertions::assert_eq;
+
+#[test]
+fn allow_build_merges_into_config_and_persists_to_workspace_yaml() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let mut config = Config::default();
+    apply_allow_build(&mut config, &["esbuild".to_string()], dir.path())
+        .expect("allow-build applies");
+
+    // Enabled for the current install.
+    assert_eq!(config.allow_builds.get("esbuild"), Some(&true));
+
+    // Persisted to the settings dir's pnpm-workspace.yaml.
+    let yaml = std::fs::read_to_string(dir.path().join("pnpm-workspace.yaml"))
+        .expect("pnpm-workspace.yaml written");
+    assert!(yaml.contains("esbuild"), "allowBuilds entry written, got:\n{yaml}");
+}
+
+#[test]
+fn allow_build_rejects_a_package_the_root_disallows() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let mut config = Config::default();
+    config.allow_builds.insert("esbuild".to_string(), false);
+
+    let err = apply_allow_build(&mut config, &["esbuild".to_string()], dir.path())
+        .expect_err("disallowed package is rejected");
+    assert_eq!(
+        err.code().map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_OVERRIDING_IGNORED_BUILT_DEPENDENCIES"),
+    );
+    // Nothing was persisted for a rejected apply.
+    assert!(!dir.path().join("pnpm-workspace.yaml").exists());
+}
+
+#[test]
+fn allow_build_is_a_noop_when_empty() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let mut config = Config::default();
+    apply_allow_build(&mut config, &[], dir.path()).expect("empty allow-build is a no-op");
+    assert!(config.allow_builds.is_empty());
+    assert!(!dir.path().join("pnpm-workspace.yaml").exists());
+}
 
 #[test]
 fn dependency_options_to_dependency_groups() {

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -105,8 +105,9 @@ pub struct CliArgs {
     #[clap(short = 'y', long, global = true)]
     pub yes: bool,
 
-    /// Set working directory.
-    #[clap(short = 'C', long, default_value = ".")]
+    /// Set working directory. Accepted anywhere on the command line,
+    /// before or after the subcommand, like every other rc-option.
+    #[clap(short = 'C', long, default_value = ".", global = true)]
     pub dir: PathBuf,
 
     /// Directory in which the package store is created. Relative paths
@@ -125,6 +126,13 @@ pub struct CliArgs {
     /// default `~/.npmrc`.
     #[clap(long = "npmrc-auth-file", visible_alias = "userconfig", global = true)]
     pub npmrc_auth_file: Option<PathBuf>,
+
+    /// Base URL of the npm registry to resolve and fetch packages from.
+    /// Universal rc-option: accepted on every command and layered onto
+    /// the config like `--config.registry=<url>`. Commands that expose
+    /// their own `--registry` still read the same value.
+    #[clap(long, global = true)]
+    pub registry: Option<String>,
 
     /// Proxy for HTTPS registry and tarball requests.
     #[clap(long = "https-proxy", global = true)]

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     State,
-    config_overrides::{ConfigOverrides, apply_store_dir_override},
+    config_overrides::{ConfigOverrides, apply_registry_override, apply_store_dir_override},
 };
 use miette::{Context, IntoDiagnostic};
 use pacquet_config::{Config, Host, default_pnpm_home_dir};
@@ -96,6 +96,9 @@ impl CliArgs {
             self.http_proxy.as_deref(),
             self.no_proxy.as_deref(),
         );
+        if let Some(registry) = self.registry.as_deref() {
+            apply_registry_override(&mut config, registry);
+        }
         if let Some(store_dir) = self.store_dir.as_deref()
             && apply_store_dir_override::<Host>(&mut config, store_dir, &dir).is_err()
         {
@@ -133,6 +136,7 @@ impl CliArgs {
             dir,
             store_dir,
             npmrc_auth_file,
+            registry,
             https_proxy,
             http_proxy,
             no_proxy,
@@ -217,6 +221,9 @@ impl CliArgs {
                         http_proxy.as_deref(),
                         no_proxy.as_deref(),
                     );
+                    if let Some(registry) = registry.as_deref() {
+                        apply_registry_override(&mut cfg, registry);
+                    }
                     if let Some(store_dir) = store_dir.as_deref() {
                         apply_store_dir_override::<Host>(&mut cfg, store_dir, anchor)?;
                     }

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -1,5 +1,5 @@
 use super::{
-    add::AddArgs,
+    add::{AddArgs, apply_allow_build},
     approve_builds::ApproveBuildsArgs,
     create::CreateArgs,
     dedupe::DedupeArgs,
@@ -59,6 +59,7 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
         let (config_root, package_manager_to_sync) =
             derive_config_root_and_package_manager_to_sync(cfg, dir)
                 .wrap_err("derive workspace root and package manager policy")?;
+        apply_allow_build(cfg, &args.allow_build, &config_root)?;
         let pipeline = AddPipeline {
             args,
             cfg,

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -9,8 +9,10 @@
 use crate::{
     State,
     cli_args::{
-        add::add_packages, approve_builds::ApproveBuildsArgs,
-        ignored_builds::get_automatically_ignored_builds, rebuild::run_rebuild,
+        add::{add_packages, apply_allow_build},
+        approve_builds::ApproveBuildsArgs,
+        ignored_builds::get_automatically_ignored_builds,
+        rebuild::run_rebuild,
     },
 };
 use derive_more::{Display, Error};
@@ -92,6 +94,7 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
     params: &[String],
     pinned_version: PinnedVersion,
     supported_architectures: Option<SupportedArchitectures>,
+    allow_build: &[String],
     cwd: &Path,
 ) -> miette::Result<()> {
     // Normalize each selector to its package name first, so versioned forms
@@ -115,6 +118,7 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
             &group,
             pinned_version,
             supported_architectures.clone(),
+            allow_build,
         ))
         .await?;
 
@@ -207,6 +211,9 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
             &selectors,
             pinned_version,
             supported_architectures.clone(),
+            // `update -g` takes no `--allow-build`; the build policy comes
+            // from the global `allowBuilds` loaded in `run_group_install`.
+            &[],
         ))
         .await?;
         let _ = config;
@@ -301,6 +308,7 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
     selectors: &[String],
     pinned_version: PinnedVersion,
     supported_architectures: Option<SupportedArchitectures>,
+    allow_build: &[String],
 ) -> miette::Result<(PathBuf, &'static Config)> {
     let install_dir = create_install_dir(global_pkg_dir)
         .into_diagnostic()
@@ -361,6 +369,10 @@ async fn run_group_install<Reporter: self::Reporter + 'static>(
             cfg.dangerously_allow_all_builds = allow_all;
         }
     }
+    // `pnpm add -g --allow-build=<pkg>` opts the named packages into their
+    // build scripts for this global install and persists them to the
+    // global `allowBuilds`, on top of the settings just loaded.
+    apply_allow_build(&mut cfg, allow_build, global_pkg_dir)?;
     // Don't fail the install when a dependency's build is ignored; the
     // global approval prompt (run after the install) records the ignored
     // builds and prompts rather than erroring under `strictDepBuilds`.

--- a/pnpm/crates/cli/src/cli_args/runtime.rs
+++ b/pnpm/crates/cli/src/cli_args/runtime.rs
@@ -107,6 +107,9 @@ impl RuntimeArgs {
             std::slice::from_ref(&request.package_name),
             PinnedVersion::Major,
             config.supported_architectures.clone(),
+            // `pnpm runtime` installs a runtime, not user packages; it has
+            // no `--allow-build`.
+            &[],
             dir,
         ))
         .await

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -1,5 +1,6 @@
 use super::{
     CliArgs,
+    add::AddArgs,
     cli_command::CliCommand,
     install::{InstallArgs, resolve_bool_override},
     list::RecursionLimit,
@@ -21,6 +22,47 @@ fn install_args(argv: &[&str]) -> InstallArgs {
 
 fn default_reporter_summary_scope(argv: &[&str]) -> SummaryScope {
     CliArgs::try_parse_from(argv).expect("parses").command.default_reporter_summary_scope()
+}
+
+fn add_args(argv: &[&str]) -> AddArgs {
+    match CliArgs::try_parse_from(argv).expect("parses").command {
+        CliCommand::Add(add) => add,
+        other => panic!("expected add, got {other:?}"),
+    }
+}
+
+#[test]
+fn dir_is_global_and_parses_on_either_side_of_the_subcommand() {
+    for argv in [
+        ["pacquet", "--dir", "project", "add", "foo"].as_slice(),
+        ["pacquet", "add", "foo", "--dir", "project"].as_slice(),
+        ["pacquet", "add", "foo", "-C", "project"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses global --dir");
+        assert_eq!(parsed.dir, std::path::PathBuf::from("project"));
+        assert!(matches!(parsed.command, CliCommand::Add(_)));
+    }
+}
+
+#[test]
+fn registry_is_a_universal_global_option() {
+    // Accepted on a command that has no command-local `--registry`
+    // (`add`, `view`), before or after the subcommand.
+    for argv in [
+        ["pacquet", "--registry=https://r.test/", "add", "foo"].as_slice(),
+        ["pacquet", "add", "foo", "--registry=https://r.test/"].as_slice(),
+        ["pacquet", "view", "foo", "--registry=https://r.test/"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses universal --registry");
+        assert_eq!(parsed.registry.as_deref(), Some("https://r.test/"));
+    }
+}
+
+#[test]
+fn add_allow_build_collects_repeated_values() {
+    let args =
+        add_args(&["pacquet", "add", "foo", "--allow-build=esbuild", "--allow-build", "sharp"]);
+    assert_eq!(args.allow_build, ["esbuild", "sharp"]);
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -46,8 +46,6 @@ fn dir_is_global_and_parses_on_either_side_of_the_subcommand() {
 
 #[test]
 fn registry_is_a_universal_global_option() {
-    // Accepted on a command that has no command-local `--registry`
-    // (`add`, `view`), before or after the subcommand.
     for argv in [
         ["pacquet", "--registry=https://r.test/", "add", "foo"].as_slice(),
         ["pacquet", "add", "foo", "--registry=https://r.test/"].as_slice(),

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -178,13 +178,7 @@ impl ConfigOverrides {
             self.no_proxy.as_deref(),
         );
         if let Some(registry) = &self.registry {
-            config.registry.clone_from(registry);
-            config.registries.insert("default".to_string(), registry.clone());
-            config.package_manager_bootstrap.registry.clone_from(registry);
-            config
-                .package_manager_bootstrap
-                .registries
-                .insert("default".to_string(), registry.clone());
+            apply_registry_override(config, registry);
         }
         for (scope, registry) in &self.registries {
             config.registries.insert(scope.clone(), registry.clone());
@@ -275,6 +269,7 @@ fn global_option_width(arg: &str) -> Option<usize> {
             | "https-proxy"
             | "no-proxy"
             | "npmrc-auth-file"
+            | "registry"
             | "reporter"
             | "store-dir"
             | "userconfig",
@@ -314,6 +309,20 @@ fn classify(arg: &OsStr) -> ConfigToken<'_> {
 fn scoped_registry_key(key: &str) -> Option<&str> {
     key.strip_suffix(":registry")
         .filter(|scope| scope.starts_with('@') && scope.len() > 1 && !scope.contains('/'))
+}
+
+/// Layer a registry URL (the universal `--registry` flag or a
+/// `--config.registry=<url>` override) onto `config`, setting the default
+/// registry everywhere it is read: the resolved registry, the `default`
+/// entry of the named-registry map, and the package-manager bootstrap
+/// copies of both. The URL is normalized to a trailing slash first, so an
+/// already-normalized override applies idempotently.
+pub(crate) fn apply_registry_override(config: &mut Config, registry: &str) {
+    let registry = normalize_registry_url(registry);
+    config.registry.clone_from(&registry);
+    config.registries.insert("default".to_string(), registry.clone());
+    config.package_manager_bootstrap.registry.clone_from(&registry);
+    config.package_manager_bootstrap.registries.insert("default".to_string(), registry);
 }
 
 fn normalize_registry_url(registry: &str) -> String {

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -1,4 +1,4 @@
-use super::{ConfigOverrides, apply_store_dir_override};
+use super::{ConfigOverrides, apply_registry_override, apply_store_dir_override};
 use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker};
 use pacquet_store_dir::STORE_VERSION;
 use pretty_assertions::assert_eq;
@@ -25,6 +25,20 @@ fn extract_separates_config_tokens_from_argv() {
     assert_eq!(
         config.package_manager_bootstrap.registries.get("default").map(String::as_str),
         Some("https://example.test/"),
+    );
+}
+
+#[test]
+fn registry_cli_override_normalizes_and_sets_every_registry_slot() {
+    let mut config = Config::default();
+    // No trailing slash on the input; it is normalized on the way in.
+    apply_registry_override(&mut config, "https://cli.example");
+    assert_eq!(config.registry, "https://cli.example/");
+    assert_eq!(config.registries.get("default").map(String::as_str), Some("https://cli.example/"));
+    assert_eq!(config.package_manager_bootstrap.registry, "https://cli.example/");
+    assert_eq!(
+        config.package_manager_bootstrap.registries.get("default").map(String::as_str),
+        Some("https://cli.example/"),
     );
 }
 

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -30,10 +30,7 @@ where
     (root, workspace, npmrc_info)
 }
 
-/// `add` accepts the three universal options together, in the exact flag
-/// shape the Tag release operator uses (pnpm/pnpm#13242): `pnpm add <pkg>
-/// --dir <d> --allow-build=<pkg> --registry=<url>`, with every option
-/// written after the subcommand and its positional.
+/// Regression test for the Tag release operator's invocation (pnpm/pnpm#13242).
 #[test]
 fn add_accepts_dir_allow_build_and_registry_after_the_subcommand() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -53,8 +50,6 @@ fn add_accepts_dir_allow_build_and_registry_after_the_subcommand() {
         .assert()
         .success();
 
-    // `--allow-build` alone, with no pre-existing `allowBuilds`, is enough
-    // to opt the package into its lifecycle scripts.
     let pkg_dir = workspace.join(
         "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
          /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -30,6 +30,52 @@ where
     (root, workspace, npmrc_info)
 }
 
+/// The three CLI parity gaps from pnpm/pnpm#13242, reproduced together in
+/// the exact flag shape the Tag release operator uses: `pnpm add <pkg>
+/// --dir <d> --allow-build=<pkg> --registry=<url>`, with every option
+/// written *after* the subcommand and its positional. Before the fix each
+/// option aborted the parse with "unexpected argument".
+#[test]
+fn add_accepts_dir_allow_build_and_registry_after_the_subcommand() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let registry = mock_instance.url();
+
+    pacquet
+        .with_args([
+            "add",
+            "@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0",
+            "--dir",
+            ".",
+            "--allow-build=@pnpm.e2e/pre-and-postinstall-scripts-example",
+        ])
+        .with_arg(format!("--registry={registry}"))
+        .assert()
+        .success();
+
+    // `--allow-build` alone (no pre-existing `allowBuilds`) opted the
+    // package into its lifecycle scripts, so the postinstall ran.
+    let pkg_dir = workspace.join(
+        "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
+         /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
+    );
+    assert!(
+        pkg_dir.join("generated-by-postinstall.js").exists(),
+        "the --allow-build package should have run its postinstall",
+    );
+
+    // The allowed package was persisted to the project's workspace settings.
+    let yaml = std::fs::read_to_string(workspace.join("pnpm-workspace.yaml"))
+        .expect("pnpm-workspace.yaml present");
+    assert!(
+        yaml.contains("@pnpm.e2e/pre-and-postinstall-scripts-example"),
+        "allowBuilds entry should be persisted, got:\n{yaml}",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn should_install_all_dependencies() {
     let (root, workspace, anchor) =

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -30,11 +30,10 @@ where
     (root, workspace, npmrc_info)
 }
 
-/// The three CLI parity gaps from pnpm/pnpm#13242, reproduced together in
-/// the exact flag shape the Tag release operator uses: `pnpm add <pkg>
+/// `add` accepts the three universal options together, in the exact flag
+/// shape the Tag release operator uses (pnpm/pnpm#13242): `pnpm add <pkg>
 /// --dir <d> --allow-build=<pkg> --registry=<url>`, with every option
-/// written *after* the subcommand and its positional. Before the fix each
-/// option aborted the parse with "unexpected argument".
+/// written after the subcommand and its positional.
 #[test]
 fn add_accepts_dir_allow_build_and_registry_after_the_subcommand() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -54,8 +53,8 @@ fn add_accepts_dir_allow_build_and_registry_after_the_subcommand() {
         .assert()
         .success();
 
-    // `--allow-build` alone (no pre-existing `allowBuilds`) opted the
-    // package into its lifecycle scripts, so the postinstall ran.
+    // `--allow-build` alone, with no pre-existing `allowBuilds`, is enough
+    // to opt the package into its lifecycle scripts.
     let pkg_dir = workspace.join(
         "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
          /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",
@@ -65,7 +64,6 @@ fn add_accepts_dir_allow_build_and_registry_after_the_subcommand() {
         "the --allow-build package should have run its postinstall",
     );
 
-    // The allowed package was persisted to the project's workspace settings.
     let yaml = std::fs::read_to_string(workspace.join("pnpm-workspace.yaml"))
         .expect("pnpm-workspace.yaml present");
     assert!(

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -252,6 +252,15 @@ where
 
     let mut changed = false;
     for (name, value) in entries {
+        // The block-style splice writes `- name: true` on one line, so a
+        // control character in `name` (e.g. a newline from a crafted
+        // `--allow-build`) would corrupt the document — refuse instead.
+        if has_control_char(name) {
+            return Err(UpdateWorkspaceManifestError::InvalidControlCharacter {
+                path,
+                value: name.to_string(),
+            });
+        }
         changed |= edit::add_allow_build(&mut manifest, name, value);
     }
     if !changed {

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -900,6 +900,20 @@ fn set_overrides_refuses_inline_flow_block() {
 }
 
 #[test]
+fn set_allow_builds_rejects_control_characters() {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);
+
+    // A newline in a package name (e.g. a crafted `--allow-build`) would
+    // splice into a multi-line scalar and corrupt the block.
+    let err = crate::set_allow_builds(dir.path(), [("esbuild\ninjected: true", true)])
+        .expect_err("must reject a control character");
+
+    assert!(matches!(err, crate::UpdateWorkspaceManifestError::InvalidControlCharacter { .. }));
+    assert!(!path.exists(), "nothing should be written");
+}
+
+#[test]
 fn ignore_ghsas_rejects_control_characters() {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13242.

Moving the Tag workflow's operator pnpm to `12.0.0-alpha.19` surfaced three CLI surfaces the TypeScript CLI has that pacquet did not. The operator runs a single command:

```
pnpm add "<pkg>" --dir "<d>" --allow-build=@pnpm/exe --registry="<url>"
```

and against pacquet each option aborted the parse with `error: unexpected argument '...' found`. This brings pacquet's surface in line with the TypeScript CLI:

1. **`--registry <url>` is now universal.** It is a global clap arg accepted on every command, layered onto the config exactly like `--config.registry=<url>` (default registry + `default` named-registry + the package-manager bootstrap copies). The registry-scoped commands that already spelled `--registry` out locally keep working — clap lets the global and the command-local arg coexist and both receive the value.
2. **`pnpm add` / `pnpm add -g` accept `--allow-build=<pkg>`.** The named packages are appended to `allowBuilds`: any the root project explicitly disallows (`allowBuilds: false`) are rejected with `ERR_PNPM_OVERRIDING_IGNORED_BUILT_DEPENDENCIES`, the rest are persisted to `pnpm-workspace.yaml` and enabled for the install. This mirrors the TS `add` handler.
3. **`--dir` / `-C` is now `global = true`,** so it parses on either side of the subcommand instead of only before it.

### Notes / decisions

- **`install` deliberately does *not* accept `--allow-build`.** The issue text says "install / add", but the TS `install` command does not register `allow-build` in its option types, so `pnpm install --allow-build=foo` errors there with `Unknown option: 'allow-build'` (exit 1). pacquet's `install` already rejects the unknown flag the same way, so honoring it would be a divergence. Only `add` (and the pre-existing `dlx` / `create`) accept it. The concrete operator command is `add`, so this covers the reported use case.
- **Audit of the other non-global top-level args** (issue asked for this): `--if-present` stays non-global — the script subcommands (`run`, `stop`, `restart`, …) declare their own `--if-present`, and a global would collide; the existing tests document that `install --if-present` fails at parse time by design. `--version` stays a top-level-only `Version` action. Only `--dir` was wrongly position-bound.

## Squash Commit Body

```text
The Tag release operator runs `pnpm add <pkg> --dir <d>
--allow-build=<pkg> --registry=<url>`; against pacquet each option
aborted the parse with "unexpected argument". Bring pacquet's surface
in line with the TypeScript CLI:

- `--registry <url>` is now a universal rc-option accepted on every
  command (a global clap arg layered onto the config the same way
  `--config.registry=<url>` is), not only the registry-scoped commands
  that spelled it out locally.
- `pnpm add` / `pnpm add -g` accept `--allow-build=<pkg>`, appending the
  named packages to `allowBuilds` — rejecting any the root explicitly
  disallows, persisting the rest to `pnpm-workspace.yaml`, and enabling
  them for the install. `pnpm install` still rejects it, matching the TS
  CLI (which errors on the unknown option there).
- `--dir` / `-C` is now `global = true`, so it parses on either side of
  the subcommand instead of only before it.

Refs pnpm/pnpm#13242.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. — pacquet-only: these are gaps *in* pacquet; the TypeScript CLI already has all three surfaces.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. — `pacquet` patch.
- [x] Added or updated tests. — parse-level unit tests, `apply_allow_build` / `apply_registry_override` unit tests, and an end-to-end `add` test in the operator's exact flag shape.
- [ ] Updated the documentation if needed. — n/a (parity with existing documented flags).

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787417408&installation_model_id=426870&pr_number=13246&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13246&signature=a7c03458d7b63f2703bda013756ed1c7314d6003946722ba978b73c7b0ff6561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added universal `--registry <url>` support across commands.
  * `--dir` / `-C` is now position-independent and can appear anywhere on the command line.
  * Added `--allow-build=<package>` to `add` and `add -g`, enabling selected build scripts during installation and persisting the setting for future installs.

* **Bug Fixes**
  * Prevented `--allow-build` from overriding explicitly disabled build dependencies, returning a clear error instead.
  * Workspace manifest updates now reject invalid control characters in persisted `allowBuilds` entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->