### PR TITLE
ci(triage): time out hung Oz triage runs instead of waiting 6h

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -40,10 +40,6 @@ jobs:
       - name: Triage with Oz agent
         uses: warpdotdev/oz-agent-action@fcbed2c2043c310881424f41757da05d5c9d4047 # v1.0.24
         id: triage
-        # Every hang observed so far wedges inside this step before the agent
-        # takes its first turn, producing no output and no issue comment. A
-        # step-level timeout surfaces that as a red run within minutes and
-        # still lets post-job cleanup reap the orphaned `oz` process.
         timeout-minutes: 20
         env:
           # Authenticates the `gh` CLI the agent uses to read/label/comment.

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -27,9 +27,6 @@ jobs:
     # Skip automated issues (Renovate, Dependabot, bots) — they are not user
     # reports and each triage run consumes Warp credits.
     if: github.event.issue.user.type != 'Bot'
-    # Backstop so a wedged run cannot occupy a runner until GitHub's 6h job
-    # ceiling. Successful triage runs finish in ~3 min (13 min worst case so
-    # far), so this only ever fires on a hang.
     timeout-minutes: 30
     permissions:
       contents: read   # let the agent inspect the checked-out codebase

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -27,6 +27,10 @@ jobs:
     # Skip automated issues (Renovate, Dependabot, bots) — they are not user
     # reports and each triage run consumes Warp credits.
     if: github.event.issue.user.type != 'Bot'
+    # Backstop so a wedged run cannot occupy a runner until GitHub's 6h job
+    # ceiling. Successful triage runs finish in ~3 min (13 min worst case so
+    # far), so this only ever fires on a hang.
+    timeout-minutes: 30
     permissions:
       contents: read   # let the agent inspect the checked-out codebase
       issues: write     # let the agent apply labels and comment
@@ -39,6 +43,11 @@ jobs:
       - name: Triage with Oz agent
         uses: warpdotdev/oz-agent-action@fcbed2c2043c310881424f41757da05d5c9d4047 # v1.0.24
         id: triage
+        # Every hang observed so far wedges inside this step before the agent
+        # takes its first turn, producing no output and no issue comment. A
+        # step-level timeout surfaces that as a red run within minutes and
+        # still lets post-job cleanup reap the orphaned `oz` process.
+        timeout-minutes: 20
         env:
           # Authenticates the `gh` CLI the agent uses to read/label/comment.
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What

Adds a 20 minute `timeout-minutes` to the `Triage with Oz agent` step, plus a 30 minute job-level backstop.

## Why

Eight triage runs have hung at the Oz step until GitHub's 6 hour job ceiling cancelled them:

runs [105](https://github.com/pnpm/pnpm/actions/runs/29465550870), [114](https://github.com/pnpm/pnpm/actions/runs/29567161849), [115](https://github.com/pnpm/pnpm/actions/runs/29568577458), [116](https://github.com/pnpm/pnpm/actions/runs/29582113731), [118](https://github.com/pnpm/pnpm/actions/runs/29582153100), [131](https://github.com/pnpm/pnpm/actions/runs/29760735313), [133](https://github.com/pnpm/pnpm/actions/runs/29863554101), [139](https://github.com/pnpm/pnpm/actions/runs/29998693103).

Each one hangs *before* the agent takes its first turn, so nothing is written to the issue. In run 131 the last output is the run ID at `16:42:49Z`, then six hours of silence, then cleanup reaping an orphaned `oz` process. These issues did not get a `state:` label as a result: #13067, #13095, #13104, #13106, #13179, #13201, #13228, #13236.

Successful triage runs finish in a median of ~3 minutes, with 13 minutes the slowest observed, so a 20 minute step timeout has enough headroom.

I'll see if we can investigate on Warp's end. One interesting note: these hangs occurred Blacksmith runner `blacksmith-4vcpu-ubuntu-2404`, not on GitHub runners using `ubuntu-latest`. It's a small sample though; 8/39 hangs on Blacksmith and 0/15 on GHA.

## Test plan

Config-only change to an `issues: opened` triggered workflow, so it cannot be exercised from a PR. Verified the YAML parses and that both `timeout-minutes` keys sit at valid positions (job level under `jobs.triage`, step level under the `Triage with Oz agent` step).

---

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787420678&installation_model_id=426870&pr_number=13249&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13249&signature=431794ad2fe3139106ff514560121f089c4833c7a4c84684e31b3dbdc4f94e34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added time limits to issue triage automation to prevent jobs from running indefinitely.
  * Set a 30-minute limit for the triage job and a 20-minute limit for the automated triage step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->