### PR TITLE
fix(package-manager): let the resolvers decide what update --latest writes

### DIFF
--- a/.changeset/update-latest-non-registry-specs.md
+++ b/.changeset/update-latest-non-registry-specs.md
@@ -2,6 +2,6 @@
 "pacquet": patch
 ---
 
-`pnpm update --latest` no longer corrupts dependencies the npm registry does not serve. A `runtime:` dependency (such as `"node": "runtime:26.5.0"`), a `git`/`github:` URL, or a remote tarball URL had the dependency's *name* looked up on the npm registry and its specifier overwritten with that unrelated package's version. Each dependency's own resolver now decides what its specifier should become, so these keep the form they were declared in.
+`pnpm update --latest` now keeps dependencies that the npm registry does not serve in the form they were declared. A `runtime:` dependency (such as `"node": "runtime:26.5.0"`), a `git`/`github:` URL, or a remote tarball URL previously had its *name* looked up on the npm registry and its specifier overwritten with that unrelated package's version.
 
 `pnpm update --latest` also no longer rewrites `package.json` when a dependency is already at its latest version.

--- a/.changeset/update-latest-non-registry-specs.md
+++ b/.changeset/update-latest-non-registry-specs.md
@@ -1,0 +1,7 @@
+---
+"pacquet": patch
+---
+
+`pnpm update --latest` no longer corrupts dependencies the npm registry does not serve. A `runtime:` dependency (such as `"node": "runtime:26.5.0"`), a `git`/`github:` URL, or a remote tarball URL had the dependency's *name* looked up on the npm registry and its specifier overwritten with that unrelated package's version. Each dependency's own resolver now decides what its specifier should become, so these keep the form they were declared in.
+
+`pnpm update --latest` also no longer rewrites `package.json` when a dependency is already at its latest version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,6 +5014,7 @@ dependencies = [
  "node-semver",
  "pacquet-config",
  "pacquet-lockfile",
+ "pacquet-registry",
  "serde",
  "serde_json",
  "ssri",

--- a/pnpm/crates/cli/tests/install_runtimes.rs
+++ b/pnpm/crates/cli/tests/install_runtimes.rs
@@ -132,6 +132,36 @@ fn installs_node_runtime_from_the_rc_channel() {
     assert!(fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap().contains(version));
 }
 
+/// The registry mock knows no package named "node", so resolving the alias
+/// name there instead of leaving the dependency to the runtime resolver
+/// fails the update.
+#[test]
+fn update_latest_keeps_runtime_dependency_on_the_runtime_resolver() {
+    let root = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new();
+    let version = "24.0.0-rc.4";
+    let _mocks = mock_node_release(&mut server, version);
+    let workspace = prepare_workspace(
+        &root,
+        format!("nodeDownloadMirrors:\n  rc: '{}/'\n", server.url()).as_str(),
+    );
+    fs::write(workspace.join(".npmrc"), format!("registry={}/npm/\n", server.url())).unwrap();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "dependencies": { "node": format!("runtime:{version}") } }).to_string(),
+    )
+    .unwrap();
+    command(&workspace).with_arg("install").assert().success();
+
+    command(&workspace).with_args(["update", "--latest"]).assert().success();
+
+    let manifest = fs::read_to_string(workspace.join("package.json")).unwrap();
+    assert!(
+        manifest.contains(&format!("runtime:{version}")),
+        "the manifest keeps the runtime spec: {manifest}",
+    );
+}
+
 #[test]
 fn fresh_install_with_no_runtime_resolves_but_does_not_fetch_the_runtime() {
     let root = tempfile::tempdir().unwrap();

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -7,9 +7,9 @@ use crate::{
     },
     decide_catalog, emit_initial_package_manifest, package_manifest_prefix,
     resolution_policy::PickPolicy,
-    resolve_latest::LatestPicker,
     selected_project_indices,
 };
+use chrono::{DateTime, Utc};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_catalogs_config::{
@@ -17,13 +17,23 @@ use pacquet_catalogs_config::{
 };
 use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_types::Catalogs;
-use pacquet_config::{CatalogMode, Config, matcher::create_matcher};
+use pacquet_config::{
+    CatalogMode, Config, matcher::create_matcher, version_policy::PackageVersionPolicy,
+};
+use pacquet_engine_runtime_bun_resolver::BunResolver;
+use pacquet_engine_runtime_deno_resolver::DenoResolver;
+use pacquet_engine_runtime_node_resolver::NodeResolver;
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
-use pacquet_registry::{PackageVersion, PinnedVersion};
+use pacquet_registry::PinnedVersion;
 use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
-use pacquet_resolving_npm_resolver::{shared_packument_fetch_locker, which_version_is_pinned};
+use pacquet_resolving_default_resolver::DefaultResolver;
+use pacquet_resolving_npm_resolver::{
+    InMemoryPackageMetaCache, NpmResolver, merge_named_registries, shared_packument_fetch_locker,
+    shared_picked_manifest_cache,
+};
+use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, UpdateBehavior, WantedDependency};
 use pacquet_tarball::MemCache;
 use std::{
     collections::{BTreeMap, HashSet},
@@ -122,15 +132,21 @@ pub enum UpdateError {
     #[diagnostic(code(ERR_PNPM_NO_PACKAGE_IN_DEPENDENCIES))]
     NoPackageInDependencies,
 
-    /// Resolving a package's `latest` tag against the registry failed while
-    /// computing the new manifest range for `--latest`.
+    /// A resolver failed while computing the specifier `--latest` should
+    /// write for a direct dependency.
     #[display("Failed to resolve the latest version of {name}: {error}")]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_UPDATE_RESOLVE_LATEST))]
     ResolveLatest {
         name: String,
         #[error(source)]
-        error: crate::resolve_latest::ResolveLatestError,
+        error: pacquet_resolving_resolver_base::ResolveError,
     },
+
+    /// A `named-registries` alias is misconfigured.
+    #[diagnostic(transparent)]
+    InvalidNamedRegistry(
+        #[error(source)] pacquet_resolving_npm_resolver::MergeNamedRegistriesError,
+    ),
 
     /// `minimumReleaseAgeExclude` contained an invalid rule.
     #[display("Invalid value in minimumReleaseAgeExclude: {_0}")]
@@ -219,10 +235,10 @@ impl Update<'_> {
         crate::minimum_release_age::ensure_strict_minimum_release_age_can_save(config, save)
             .map_err(UpdateError::MinimumReleaseAge)?;
 
-        let mut latest_picker = None;
+        let mut latest_chain = None;
         let Some(prepared) = prepare_manifest::<Reporter>(
             manifest,
-            http_client,
+            &http_client_arc,
             config,
             lockfile,
             packages,
@@ -232,7 +248,7 @@ impl Update<'_> {
             &include_direct,
             depth,
             None,
-            &mut latest_picker,
+            &mut latest_chain,
             lockfile_only,
             resolution_observer.as_ref(),
         )
@@ -352,7 +368,7 @@ impl Update<'_> {
             projects,
             &selected_indices,
             workspace_root,
-            http_client,
+            &http_client_arc,
             config,
             lockfile,
             packages,
@@ -448,10 +464,10 @@ struct SelectedUpdatePreparation {
     clippy::too_many_arguments,
     reason = "manifest preparation consumes the update command's matching inputs"
 )]
-async fn prepare_manifest<'a, Reporter: self::Reporter>(
+async fn prepare_manifest<Reporter: self::Reporter>(
     manifest: &mut PackageManifest,
-    http_client: &'a ThrottledClient,
-    config: &'a Config,
+    http_client_arc: &Arc<ThrottledClient>,
+    config: &Config,
     lockfile: Option<&Lockfile>,
     packages: &[String],
     latest: bool,
@@ -460,7 +476,7 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
     include_direct: &[DependencyGroup],
     depth: usize,
     catalogs_seed: Option<&Catalogs>,
-    latest_picker: &mut Option<LatestPicker<'a>>,
+    latest_chain: &mut Option<LatestResolverChain>,
     lockfile_only: bool,
     resolution_observer: Option<&Arc<dyn crate::ResolutionObserver>>,
 ) -> Result<Option<UpdatePreparation>, UpdateError> {
@@ -506,6 +522,15 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
         && depth > 0
         && !latest;
 
+    let rewrite_ctx = LatestRewriteCtx {
+        manifest,
+        config,
+        http_client_arc,
+        resolution_observer,
+        pinned_version,
+        lockfile_only,
+    };
+
     let seed_policy = if selectors.is_empty() {
         // `updateConfig.ignoreDependencies` applies only when no selector was
         // supplied and remains scoped by the included direct groups.
@@ -518,19 +543,11 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
             if is_ignored(name) {
                 continue;
             }
-            if latest && !is_local_specifier(previous) {
-                let picker =
-                    ensure_latest_picker(latest_picker, config, http_client, resolution_observer)?;
-                let effective =
-                    effective_specifier(&mut catalog_ctx, manifest, config, previous, name)?;
-                let specifier = resolve_latest_specifier(
-                    picker,
-                    &effective,
-                    name,
-                    pinned_version,
-                    lockfile_only,
-                )
-                .await?;
+            if latest
+                && let Some(specifier) =
+                    latest_specifier(&rewrite_ctx, latest_chain, &mut catalog_ctx, name, previous)
+                        .await?
+            {
                 rewrites.push((name.clone(), *group, specifier));
             }
             drop_names.insert(name.clone());
@@ -610,29 +627,18 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
         } else {
             for (name, group, previous) in &matched_direct {
                 drop_names.insert(name.clone());
-                if latest && !is_local_specifier(previous) {
-                    let picker = ensure_latest_picker(
-                        latest_picker,
-                        config,
-                        http_client,
-                        resolution_observer,
-                    )?;
-                    let effective =
-                        effective_specifier(&mut catalog_ctx, manifest, config, previous, name)?;
-                    let specifier = resolve_latest_specifier(
-                        picker,
-                        &effective,
-                        name,
-                        pinned_version,
-                        lockfile_only,
-                    )
-                    .await?;
-                    rewrites.push((name.clone(), *group, specifier));
-                } else if let Some(specifier) = selectors
-                    .iter()
-                    .find(|selector| matcher_one(&selector.pattern).matches(name))
-                    .and_then(|selector| selector.version.clone())
-                {
+                // The two sources are exclusive: `--latest` rejects versioned
+                // selectors above, so under it no selector carries a version.
+                let rewrite = if latest {
+                    latest_specifier(&rewrite_ctx, latest_chain, &mut catalog_ctx, name, previous)
+                        .await?
+                } else {
+                    selectors
+                        .iter()
+                        .find(|selector| matcher_one(&selector.pattern).matches(name))
+                        .and_then(|selector| selector.version.clone())
+                };
+                if let Some(specifier) = rewrite {
                     rewrites.push((name.clone(), *group, specifier));
                 }
             }
@@ -726,12 +732,12 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
     clippy::too_many_arguments,
     reason = "selected update preparation reuses the command's matching inputs"
 )]
-async fn prepare_selected_manifests<'a, Reporter: self::Reporter>(
+async fn prepare_selected_manifests<Reporter: self::Reporter>(
     projects: &mut [pacquet_workspace::Project],
     selected_indices: &[usize],
     workspace_root: &Path,
-    http_client: &'a ThrottledClient,
-    config: &'a Config,
+    http_client_arc: &Arc<ThrottledClient>,
+    config: &Config,
     lockfile: Option<&Lockfile>,
     packages: &[String],
     latest: bool,
@@ -744,7 +750,7 @@ async fn prepare_selected_manifests<'a, Reporter: self::Reporter>(
 ) -> Result<SelectedUpdatePreparation, UpdateError> {
     // One picker across every selected project: it is created on first
     // use, so a selection that resolves no `latest` tag never builds one.
-    let mut latest_picker = None;
+    let mut latest_chain = None;
     let mut seed_policies = BTreeMap::new();
     let mut persist_indices = Vec::new();
     let mut updated_catalogs = Catalogs::new();
@@ -755,7 +761,7 @@ async fn prepare_selected_manifests<'a, Reporter: self::Reporter>(
     for &index in selected_indices {
         let Some(prepared) = prepare_manifest::<Reporter>(
             &mut projects[index].manifest,
-            http_client,
+            http_client_arc,
             config,
             lockfile,
             packages,
@@ -765,7 +771,7 @@ async fn prepare_selected_manifests<'a, Reporter: self::Reporter>(
             include_direct,
             depth,
             catalogs_override.as_ref(),
-            &mut latest_picker,
+            &mut latest_chain,
             lockfile_only,
             resolution_observer,
         )
@@ -893,36 +899,6 @@ fn effective_specifier(
     Ok(prev.to_string())
 }
 
-async fn resolve_latest_specifier(
-    picker: &LatestPicker<'_>,
-    effective: &str,
-    name: &str,
-    default_pin: PinnedVersion,
-    lockfile_only: bool,
-) -> Result<String, UpdateError> {
-    let target = npm_alias_target(effective, name);
-    let version = resolve_latest_version(picker, target.unwrap_or(name), lockfile_only).await?;
-    let range = version.serialize(which_version_is_pinned(effective).unwrap_or(default_pin));
-    Ok(match target {
-        Some(real_name) => format!("npm:{real_name}@{range}"),
-        None => range,
-    })
-}
-
-/// Mirrors the TypeScript resolver's `unwrapPackageName`/`calcSpecifier`
-/// pair.
-fn npm_alias_target<'a>(bare_specifier: &'a str, alias: &str) -> Option<&'a str> {
-    let rest = bare_specifier.strip_prefix("npm:")?;
-    if rest.parse::<node_semver::Range>().is_ok() {
-        return None;
-    }
-    let name = match rest.rfind('@') {
-        Some(idx) if idx >= 1 => &rest[..idx],
-        _ => rest,
-    };
-    (!name.is_empty() && name != alias).then_some(name)
-}
-
 /// Read the effective catalogs and the directories around them.
 ///
 /// The catalogs prefer a post-`updateConfig` pnpmfile hook's output
@@ -968,44 +944,133 @@ fn read_catalog_ctx_with_catalogs(
     Ok(CatalogCtx { catalogs, workspace_dir_opt, manifest_dir, prefix })
 }
 
-/// The run's [`LatestPicker`], created on first use so that command
-/// validation and no-op updates never parse `minimumReleaseAgeExclude`,
-/// matching the TypeScript CLI, which parses the excludes only once
-/// resolution starts. The resolution observer can widen the excludes,
-/// matching the follow-up install's own resolution.
-fn ensure_latest_picker<'p, 'a>(
-    picker: &'p mut Option<LatestPicker<'a>>,
+/// The `--latest` inputs that are the same for every direct dependency of a
+/// project, gathered so [`latest_specifier`] takes them as one argument.
+struct LatestRewriteCtx<'a, 'borrow> {
+    manifest: &'borrow PackageManifest,
     config: &'a Config,
-    http_client: &'a ThrottledClient,
-    resolution_observer: Option<&Arc<dyn crate::ResolutionObserver>>,
-) -> Result<&'p LatestPicker<'a>, UpdateError> {
-    if picker.is_none() {
-        let extra_excludes = resolution_observer
-            .and_then(|observer| observer.minimum_release_age_exclude_override());
-        let policy = PickPolicy::from_config_with_extra_excludes(config, extra_excludes.as_deref())
-            .map_err(UpdateError::MinimumReleaseAgeExclude)?;
-        *picker = Some(LatestPicker::new(
-            config,
-            http_client,
-            policy,
-            Arc::default(),
-            shared_packument_fetch_locker(),
-        ));
-    }
-    Ok(picker.as_ref().expect("picker initialized above"))
+    http_client_arc: &'borrow Arc<ThrottledClient>,
+    resolution_observer: Option<&'borrow Arc<dyn crate::ResolutionObserver>>,
+    pinned_version: PinnedVersion,
+    lockfile_only: bool,
 }
 
-/// [`LatestPicker::resolve`] with the failure tagged with `name` as an
-/// [`UpdateError`].
-async fn resolve_latest_version(
-    picker: &LatestPicker<'_>,
+/// The specifier `--latest` should write for `name`, or `None` when no
+/// resolver claims the dependency and its manifest entry therefore stands.
+///
+/// The answer is the resolvers': the chain is asked to resolve the
+/// dependency with [`UpdateBehavior::Latest`], and whichever resolver
+/// claims it reports back the specifier its own protocol round-trips to —
+/// the npm picker takes the higher of the declared range and the `latest`
+/// tag, the `runtime:` resolvers re-resolve within the spec the manifest
+/// already declares, and the local resolvers echo their spec unchanged.
+/// Nothing here needs to know which protocols those are.
+async fn latest_specifier(
+    ctx: &LatestRewriteCtx<'_, '_>,
+    chain: &mut Option<LatestResolverChain>,
+    catalog_ctx: &mut Option<CatalogCtx>,
     name: &str,
-    lockfile_only: bool,
-) -> Result<Arc<PackageVersion>, UpdateError> {
-    picker
-        .resolve(name, lockfile_only)
+    previous: &str,
+) -> Result<Option<String>, UpdateError> {
+    let effective = effective_specifier(catalog_ctx, ctx.manifest, ctx.config, previous, name)?;
+    // `preserveWorkspaceProtocol` is always on under `update --latest`, so a
+    // `workspace:` entry keeps its text whatever version the workspace
+    // package is at. Asking the chain would also hand the npm resolver a
+    // spec it answers only against the install's workspace-package map,
+    // which manifest preparation has not built.
+    if effective.starts_with("workspace:") {
+        return Ok(None);
+    }
+    let chain = ensure_latest_resolver_chain(chain, ctx)?;
+    let wanted = WantedDependency {
+        alias: Some(name.to_string()),
+        bare_specifier: Some(effective.clone()),
+        ..WantedDependency::default()
+    };
+    let manifest_dir =
+        ctx.manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf();
+    let opts = ResolveOptions {
+        project_dir: manifest_dir.clone(),
+        lockfile_dir: manifest_dir,
+        default_tag: Some("latest".to_string()),
+        update: UpdateBehavior::Latest,
+        calc_specifier: true,
+        pinned_version: Some(ctx.pinned_version),
+        published_by: chain.published_by,
+        published_by_exclude: chain.published_by_exclude.clone(),
+        dry_run: ctx.lockfile_only,
+        ..ResolveOptions::default()
+    };
+    let resolved = Resolver::resolve(&chain.resolver, &wanted, &opts)
         .await
-        .map_err(|error| UpdateError::ResolveLatest { name: name.to_string(), error })
+        .map_err(|error| UpdateError::ResolveLatest { name: name.to_string(), error })?;
+    // A resolver that reports back what the manifest already says has
+    // nothing to rewrite. Recording it anyway would mark the manifest dirty
+    // and persist it, which for a `runtime:` dependency means rewriting the
+    // entry into `devEngines.runtime` — a change the user never asked for.
+    Ok(resolved
+        .and_then(|result| result.normalized_bare_specifier)
+        .filter(|specifier| *specifier != effective))
+}
+
+/// The resolvers that can answer "what is the latest for this dependency",
+/// built on first use so an update whose deps are all local opens no
+/// client. Deliberately excludes the git, tarball and local-path
+/// resolvers: they have no notion of a `latest`, and asking them would
+/// clone or download during manifest preparation only to be told the
+/// specifier stands.
+struct LatestResolverChain {
+    resolver: DefaultResolver,
+    published_by: Option<DateTime<Utc>>,
+    published_by_exclude: Option<PackageVersionPolicy>,
+}
+
+fn ensure_latest_resolver_chain<'chain>(
+    chain: &'chain mut Option<LatestResolverChain>,
+    ctx: &LatestRewriteCtx<'_, '_>,
+) -> Result<&'chain LatestResolverChain, UpdateError> {
+    if chain.is_none() {
+        let extra_excludes = ctx
+            .resolution_observer
+            .and_then(|observer| observer.minimum_release_age_exclude_override());
+        let policy =
+            PickPolicy::from_config_with_extra_excludes(ctx.config, extra_excludes.as_deref())
+                .map_err(UpdateError::MinimumReleaseAgeExclude)?;
+        let named_registries =
+            merge_named_registries(&ctx.config.named_registries.clone().into_iter().collect())
+                .map_err(UpdateError::InvalidNamedRegistry)?;
+        let npm_resolver: Arc<dyn Resolver> = Arc::new(NpmResolver {
+            registries: ctx.config.resolved_registries().into_iter().collect(),
+            named_registries,
+            http_client: Arc::clone(ctx.http_client_arc),
+            auth_headers: Arc::clone(&ctx.config.auth_headers),
+            meta_cache: Arc::<InMemoryPackageMetaCache>::default(),
+            fetch_locker: shared_packument_fetch_locker(),
+            picked_manifest_cache: shared_picked_manifest_cache(),
+            cache_dir: Some(ctx.config.cache_dir.clone()),
+            offline: ctx.config.offline,
+            prefer_offline: ctx.config.prefer_offline,
+            ignore_missing_time_field: ctx.config.minimum_release_age_ignore_missing_time,
+            full_metadata: policy.full_metadata,
+            filter_metadata: policy.full_metadata,
+            retry_opts: crate::retry_config::retry_opts_from_config(ctx.config),
+        });
+        let mut node_resolver = NodeResolver::new(Arc::clone(ctx.http_client_arc));
+        node_resolver.node_download_mirrors.clone_from(&ctx.config.node_download_mirrors);
+        node_resolver.offline = ctx.config.offline;
+        let resolver = DefaultResolver::new(vec![
+            Box::new(Arc::clone(&npm_resolver)) as Box<dyn Resolver>,
+            Box::new(node_resolver),
+            Box::new(DenoResolver::new(Arc::clone(ctx.http_client_arc), Arc::clone(&npm_resolver))),
+            Box::new(BunResolver::new(Arc::clone(ctx.http_client_arc), Arc::clone(&npm_resolver))),
+        ]);
+        *chain = Some(LatestResolverChain {
+            resolver,
+            published_by: policy.published_by,
+            published_by_exclude: policy.published_by_exclude,
+        });
+    }
+    Ok(chain.as_ref().expect("chain initialized above"))
 }
 
 /// Whether `bare_specifier` is a `workspace:` spec that points at a local
@@ -1027,17 +1092,6 @@ pub(crate) fn is_workspace_local_path_specifier(bare_specifier: &str) -> bool {
         chars.next().is_some_and(|first| first.is_ascii_alphabetic()) && chars.next() == Some(':')
     };
     pref.starts_with('.') || pref.starts_with('/') || pref.starts_with("~/") || is_windows_drive
-}
-
-/// Whether `bare_specifier` resolves to a local package — `workspace:`, `link:`,
-/// or `file:` — rather than a registry one. Such a package resolves to a
-/// directory on disk and may not be published at all, so there is no registry
-/// "latest" to resolve under `--latest`; it is skipped and preserved verbatim.
-/// Mirrors the TS `isLocalRef` in `@pnpm/outdated`.
-fn is_local_specifier(bare_specifier: &str) -> bool {
-    bare_specifier.starts_with("workspace:")
-        || bare_specifier.starts_with("link:")
-        || bare_specifier.starts_with("file:")
 }
 
 #[cfg(test)]

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -246,14 +246,13 @@ async fn selected_update_latest_depth_zero_is_noop_when_no_project_matches() {
     assert!(prepared.persist_indices.is_empty());
 }
 
-/// `--latest` rewrites a dependency only if a resolver claims it and
-/// reports a specifier back. No resolver in the latest-capable chain
-/// claims any of these, so each manifest entry survives verbatim — and
-/// none of them costs a network round trip during manifest preparation.
-/// The sibling test below is the positive control, proving the skip is a
-/// decision rather than an inert harness.
+// No resolver in the latest-capable chain claims any of these, so none of
+// them may cost a network round trip during manifest preparation — which is
+// what the closed-port registry enforces. `runtime:` is covered end to end
+// by the `update_latest_keeps_runtime_dependency_on_the_runtime_resolver`
+// CLI test instead: its resolver does claim it, against a mocked mirror.
 #[tokio::test]
-async fn latest_leaves_specifiers_the_npm_resolver_does_not_claim() {
+async fn latest_leaves_specifiers_no_resolver_claims() {
     for specifier in [
         "workspace:*",
         "workspace:^1.0.0",
@@ -269,7 +268,7 @@ async fn latest_leaves_specifiers_the_npm_resolver_does_not_claim() {
         let config = unroutable_registry_config();
         let http_client = std::sync::Arc::new(ThrottledClient::default());
 
-        prepare_selected_manifests::<SilentReporter>(
+        let prepared = prepare_selected_manifests::<SilentReporter>(
             &mut projects,
             &[0],
             dir.path(),
@@ -291,7 +290,10 @@ async fn latest_leaves_specifiers_the_npm_resolver_does_not_claim() {
         });
 
         assert_eq!(dependency_specifier(&projects[0].manifest), specifier);
-        assert_eq!(saved_dependency_specifier(&projects[0].manifest), specifier);
+        assert!(
+            prepared.persist_indices.is_empty(),
+            "{specifier} was queued for a manifest rewrite",
+        );
     }
 }
 
@@ -342,9 +344,9 @@ fn project_with_foo_specifier(root: &std::path::Path, name: &str, specifier: &st
     }
 }
 
-/// A config whose registry is a closed port, so any dependency that reaches
-/// registry resolution fails loudly instead of hitting the network. Retries
-/// are off so that failure is immediate rather than a minute of backoff.
+// A closed port, so any dependency that reaches registry resolution fails
+// loudly instead of hitting the network. Retries are off so that failure is
+// immediate rather than a minute of backoff.
 fn unroutable_registry_config() -> Config {
     Config { registry: "http://127.0.0.1:1/".to_string(), fetch_retries: 0, ..Config::new() }
 }

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    is_workspace_local_path_specifier, npm_alias_target, parse_update_param,
-    persist_selected_manifests, prepare_selected_manifests, selected_project_indices,
+    is_workspace_local_path_specifier, parse_update_param, persist_selected_manifests,
+    prepare_selected_manifests, selected_project_indices,
 };
 use pacquet_config::{CatalogMode, Config};
 use pacquet_network::ThrottledClient;
@@ -61,31 +61,6 @@ fn negated_unscoped_pattern_without_version() {
 }
 
 #[test]
-fn npm_alias_specifiers_yield_their_real_package_name() {
-    for (spec, alias, target) in [
-        ("npm:bar@^4.0.0", "foo", Some("bar")),
-        ("npm:bar", "foo", Some("bar")),
-        ("npm:@types/table@6.3.2", "@types/zkochan__table", Some("@types/table")),
-        ("npm:@types/table", "@types/zkochan__table", Some("@types/table")),
-    ] {
-        assert_eq!(npm_alias_target(spec, alias), target, "target of {alias}@{spec}");
-    }
-}
-
-#[test]
-fn non_alias_specifiers_have_no_npm_alias_target() {
-    for (spec, alias) in [
-        ("^1.0.0", "foo"),
-        ("catalog:", "foo"),
-        ("workspace:*", "foo"),
-        ("npm:^1.0.0", "foo"),
-        ("npm:foo@^1.0.0", "foo"),
-    ] {
-        assert_eq!(npm_alias_target(spec, alias), None, "target of {alias}@{spec}");
-    }
-}
-
-#[test]
 fn workspace_local_path_specifiers_are_detected() {
     for spec in [
         "workspace:.",
@@ -129,7 +104,7 @@ async fn selected_update_prepares_and_persists_only_selected_projects() {
     let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
     let config = Config::new();
-    let http_client = ThrottledClient::default();
+    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
@@ -173,7 +148,7 @@ async fn selected_update_no_save_mutates_in_memory_without_persisting() {
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
     let mut config = Config::new();
     config.catalog_mode = CatalogMode::Prefer;
-    let http_client = ThrottledClient::default();
+    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
@@ -215,7 +190,7 @@ async fn selected_update_depth_zero_skips_projects_without_a_matching_dependency
     let mut projects = [project_without_foo(dir.path(), "a"), project_with_foo(dir.path(), "b")];
     let selected_indices = [0, 1];
     let config = Config::new();
-    let http_client = ThrottledClient::default();
+    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
@@ -246,7 +221,7 @@ async fn selected_update_latest_depth_zero_is_noop_when_no_project_matches() {
     let mut projects = [project_without_foo(dir.path(), "a"), project_without_foo(dir.path(), "b")];
     let selected_indices = [0, 1];
     let config = Config::new();
-    let http_client = ThrottledClient::default();
+    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
@@ -271,19 +246,107 @@ async fn selected_update_latest_depth_zero_is_noop_when_no_project_matches() {
     assert!(prepared.persist_indices.is_empty());
 }
 
+/// `--latest` rewrites a dependency only if a resolver claims it and
+/// reports a specifier back. No resolver in the latest-capable chain
+/// claims any of these, so each manifest entry survives verbatim — and
+/// none of them costs a network round trip during manifest preparation.
+/// The sibling test below is the positive control, proving the skip is a
+/// decision rather than an inert harness.
+#[tokio::test]
+async fn latest_leaves_specifiers_the_npm_resolver_does_not_claim() {
+    for specifier in [
+        "workspace:*",
+        "workspace:^1.0.0",
+        "workspace:../packages/foo",
+        "link:../foo",
+        "file:../foo.tgz",
+        "github:user/repo",
+        "git+ssh://git@github.com/user/repo.git#v1.0.0",
+        "https://example.com/foo.tgz",
+    ] {
+        let dir = tempdir().expect("create tempdir");
+        let mut projects = [project_with_foo_specifier(dir.path(), "a", specifier)];
+        let config = unroutable_registry_config();
+        let http_client = std::sync::Arc::new(ThrottledClient::default());
+
+        prepare_selected_manifests::<SilentReporter>(
+            &mut projects,
+            &[0],
+            dir.path(),
+            &http_client,
+            &config,
+            None,
+            &[],
+            true,
+            false,
+            true,
+            &[DependencyGroup::Prod],
+            0,
+            false,
+            None,
+        )
+        .await
+        .unwrap_or_else(|error| {
+            panic!("update --latest reached the registry for {specifier}: {error}")
+        });
+
+        assert_eq!(dependency_specifier(&projects[0].manifest), specifier);
+        assert_eq!(saved_dependency_specifier(&projects[0].manifest), specifier);
+    }
+}
+
+#[tokio::test]
+async fn latest_rewrites_a_specifier_the_npm_resolver_claims() {
+    let dir = tempdir().expect("create tempdir");
+    let mut projects = [project_with_foo(dir.path(), "a")];
+    let config = unroutable_registry_config();
+    let http_client = std::sync::Arc::new(ThrottledClient::default());
+
+    let result = prepare_selected_manifests::<SilentReporter>(
+        &mut projects,
+        &[0],
+        dir.path(),
+        &http_client,
+        &config,
+        None,
+        &[],
+        true,
+        false,
+        true,
+        &[DependencyGroup::Prod],
+        0,
+        false,
+        None,
+    )
+    .await;
+
+    assert!(result.is_err(), "a range specifier is the registry's to bump, so it must be fetched");
+}
+
 fn project_with_foo(root: &std::path::Path, name: &str) -> Project {
+    project_with_foo_specifier(root, name, "^1.0.0")
+}
+
+fn project_with_foo_specifier(root: &std::path::Path, name: &str, specifier: &str) -> Project {
     let root_dir = root.join(name);
     std::fs::create_dir_all(&root_dir).expect("create project directory");
     let package_json = root_dir.join("package.json");
     std::fs::write(
         &package_json,
-        json!({ "name": name, "dependencies": { "foo": "^1.0.0" } }).to_string(),
+        json!({ "name": name, "dependencies": { "foo": specifier } }).to_string(),
     )
     .expect("write package.json");
     Project {
         root_dir,
         manifest: PackageManifest::from_path(package_json).expect("read package.json"),
     }
+}
+
+/// A config whose registry is a closed port, so any dependency that reaches
+/// registry resolution fails loudly instead of hitting the network. Retries
+/// are off so that failure is immediate rather than a minute of backoff.
+fn unroutable_registry_config() -> Config {
+    Config { registry: "http://127.0.0.1:1/".to_string(), fetch_retries: 0, ..Config::new() }
 }
 
 fn project_without_foo(root: &std::path::Path, name: &str) -> Project {

--- a/pnpm/crates/resolving-npm-resolver/src/calc_specifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/calc_specifier.rs
@@ -1,0 +1,55 @@
+//! Manifest-ready specifiers for freshly picked registry versions.
+//!
+//! `add` and `update` rewrite `package.json` from what the resolver
+//! picked. What that text should look like is the resolver's business,
+//! not the command's: only the npm resolver knows that an npm alias
+//! round-trips as `npm:<real name>@<range>`, or that a prerelease pick
+//! is written without a range operator.
+
+use node_semver::Range;
+use pacquet_registry::{PackageVersion, PinnedVersion};
+
+use crate::which_version_is_pinned::which_version_is_pinned;
+
+/// The specifier to write for `picked` when the dependency currently
+/// declares `bare_specifier` under the install name `alias`.
+///
+/// Keeps the range operator the dependency already declared — `^` stays
+/// `^`, `~` stays `~`, an exact pin stays exact — and falls back to
+/// `default_pin` when it declares none. An npm alias is re-wrapped so the
+/// entry keeps pointing at the same real package.
+///
+/// Mirrors the TypeScript resolver's `unwrapPackageName` / `calcSpecifier`
+/// pair.
+#[must_use]
+pub fn calc_specifier(
+    bare_specifier: &str,
+    alias: Option<&str>,
+    picked: &PackageVersion,
+    default_pin: PinnedVersion,
+) -> String {
+    let range = picked.serialize(which_version_is_pinned(bare_specifier).unwrap_or(default_pin));
+    match npm_alias_target(bare_specifier, alias) {
+        Some(real_name) => format!("npm:{real_name}@{range}"),
+        None => range,
+    }
+}
+
+/// The real package name behind an `npm:` alias, or `None` when the
+/// specifier is not an alias — a plain `npm:<range>`, or an
+/// `npm:<name>@<range>` whose name is the install name anyway, both
+/// round-trip as a bare range.
+fn npm_alias_target<'a>(bare_specifier: &'a str, alias: Option<&str>) -> Option<&'a str> {
+    let rest = bare_specifier.strip_prefix("npm:")?;
+    if rest.parse::<Range>().is_ok() {
+        return None;
+    }
+    let name = match rest.rfind('@') {
+        Some(idx) if idx >= 1 => &rest[..idx],
+        _ => rest,
+    };
+    (!name.is_empty() && Some(name) != alias).then_some(name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-npm-resolver/src/calc_specifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/calc_specifier/tests.rs
@@ -1,0 +1,78 @@
+use pacquet_registry::{PackageVersion, PinnedVersion};
+
+use super::calc_specifier;
+
+fn picked(version: &str) -> PackageVersion {
+    serde_json::from_value(serde_json::json!({
+        "name": "foo",
+        "version": version,
+        "dist": { "tarball": "https://registry.npmjs.org/foo/-/foo.tgz" },
+    }))
+    .expect("build a package version")
+}
+
+#[test]
+fn keeps_the_range_operator_the_dependency_already_declared() {
+    for (bare_specifier, expected) in
+        [("^1.0.0", "^4.2.0"), ("~1.0.0", "~4.2.0"), ("1.0.0", "4.2.0"), ("*", "^4.2.0")]
+    {
+        assert_eq!(
+            calc_specifier(bare_specifier, Some("foo"), &picked("4.2.0"), PinnedVersion::Major),
+            expected,
+            "specifier for {bare_specifier}",
+        );
+    }
+}
+
+#[test]
+fn falls_back_to_the_default_pin_when_none_is_declared() {
+    for (default_pin, expected) in [
+        (PinnedVersion::Major, "^4.2.0"),
+        (PinnedVersion::Minor, "~4.2.0"),
+        (PinnedVersion::Patch, "4.2.0"),
+    ] {
+        assert_eq!(
+            calc_specifier("latest", Some("foo"), &picked("4.2.0"), default_pin),
+            expected,
+            "specifier for default pin {default_pin:?}",
+        );
+    }
+}
+
+#[test]
+fn rewraps_an_npm_alias_around_the_new_range() {
+    assert_eq!(
+        calc_specifier("npm:bar@^1.0.0", Some("foo"), &picked("4.2.0"), PinnedVersion::Major),
+        "npm:bar@^4.2.0",
+    );
+    assert_eq!(
+        calc_specifier(
+            "npm:@types/table@6.0.0",
+            Some("@types/zkochan__table"),
+            &picked("7.0.0"),
+            PinnedVersion::Major,
+        ),
+        "npm:@types/table@7.0.0",
+    );
+}
+
+#[test]
+fn an_alias_that_names_the_install_name_round_trips_as_a_bare_range() {
+    for bare_specifier in ["npm:^1.0.0", "npm:foo@^1.0.0"] {
+        assert_eq!(
+            calc_specifier(bare_specifier, Some("foo"), &picked("4.2.0"), PinnedVersion::Major),
+            "^4.2.0",
+            "specifier for {bare_specifier}",
+        );
+    }
+}
+
+/// A prerelease has no meaningful range operator, so it is pinned exactly
+/// whatever the declared specifier or the default asks for.
+#[test]
+fn a_prerelease_pick_is_written_exactly() {
+    assert_eq!(
+        calc_specifier("^1.0.0", Some("foo"), &picked("5.0.0-rc.1"), PinnedVersion::Major),
+        "5.0.0-rc.1",
+    );
+}

--- a/pnpm/crates/resolving-npm-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/lib.rs
@@ -15,6 +15,7 @@
 //!   `minimumReleaseAge` and `trustPolicy='no-downgrade'` to every
 //!   npm-resolved lockfile entry the install loads.
 
+mod calc_specifier;
 mod create_npm_resolution_verifier;
 mod errors;
 mod fetch_attestation_published_at;
@@ -36,6 +37,7 @@ mod violation_codes;
 mod which_version_is_pinned;
 mod workspace_pref_to_npm;
 
+pub use calc_specifier::calc_specifier;
 pub use create_npm_resolution_verifier::{
     CreateNpmResolutionVerifierOptions, DistStats, NpmResolutionVerifier, ObservedDistStats,
     create_npm_resolution_verifier, observed_dist_stats_sink,

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -153,6 +153,12 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             published_by: opts.published_by,
             published_by_exclude: opts.published_by_exclude.as_ref(),
             picked_manifest_cache: &self.picked_manifest_cache,
+            // A named-registry entry round-trips as
+            // `<alias>:<name>@<range>`, a shape `calc_specifier` does not
+            // build. Reporting an npm-shaped range here would drop the
+            // alias and repoint the dependency at the default registry,
+            // so the entry is left as declared.
+            calc_specifier_from: None,
         })?;
 
         Ok(Some(result))

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -30,7 +30,7 @@ use node_semver::Version;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
-use pacquet_registry::{Package, PackageVersion};
+use pacquet_registry::{Package, PackageVersion, PinnedVersion};
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, PackageVersionGuardDecision, ResolutionPolicyViolation, ResolveError,
     ResolveFuture, ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior,
@@ -275,6 +275,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             published_by: opts.published_by,
             published_by_exclude: opts.published_by_exclude.as_ref(),
             picked_manifest_cache: &self.picked_manifest_cache,
+            calc_specifier_from: calc_specifier_from(wanted_dependency, opts),
         })?;
 
         Ok(Some(result))
@@ -321,6 +322,11 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             published_by: opts.published_by,
             published_by_exclude: opts.published_by_exclude.as_ref(),
             picked_manifest_cache: &self.picked_manifest_cache,
+            // A `jsr:` entry round-trips as `jsr:@scope/name@<range>`, a
+            // shape `calc_specifier` does not build. Reporting an
+            // npm-shaped range here would rewrite the manifest into a
+            // registry dependency, so the entry is left as declared.
+            calc_specifier_from: None,
         })?;
 
         Ok(Some(result))
@@ -654,6 +660,10 @@ pub(crate) struct BuildResolveResult<'a> {
     pub published_by: Option<DateTime<Utc>>,
     pub published_by_exclude: Option<&'a PackageVersionPolicy>,
     pub picked_manifest_cache: &'a crate::PickedManifestCache,
+    /// The dependency's current specifier, when the caller asked for a
+    /// manifest-ready one back (`ResolveOptions::calc_specifier`), paired
+    /// with the pin to apply if it declares no range operator.
+    pub calc_specifier_from: Option<(&'a str, PinnedVersion)>,
 }
 
 #[expect(
@@ -673,6 +683,7 @@ pub(crate) fn build_resolve_result(
         published_by,
         published_by_exclude,
         picked_manifest_cache,
+        calc_specifier_from,
     } = args;
     let pkg_name =
         PkgName::parse(picked.name.as_str()).map_err(|err| Box::new(err) as ResolveError)?;
@@ -729,10 +740,28 @@ pub(crate) fn build_resolve_result(
         manifest,
         resolution,
         resolved_via: resolved_via.to_string(),
-        normalized_bare_specifier: spec.normalized_bare_specifier.clone(),
+        normalized_bare_specifier: spec.normalized_bare_specifier.clone().or_else(|| {
+            calc_specifier_from.map(|(bare_specifier, default_pin)| {
+                crate::calc_specifier(bare_specifier, alias, picked, default_pin)
+            })
+        }),
         alias: alias.map(str::to_string),
         policy_violation,
     })
+}
+
+/// The `(specifier, pin)` pair [`build_resolve_result`] needs to compute a
+/// manifest-ready specifier, or `None` when the caller did not ask for one.
+/// Caret is the fallback pin, matching pnpm's default save prefix.
+fn calc_specifier_from<'a>(
+    wanted_dependency: &'a WantedDependency,
+    opts: &ResolveOptions,
+) -> Option<(&'a str, PinnedVersion)> {
+    if !opts.calc_specifier {
+        return None;
+    }
+    let bare_specifier = wanted_dependency.bare_specifier.as_deref()?;
+    Some((bare_specifier, opts.pinned_version.unwrap_or(PinnedVersion::Major)))
 }
 
 /// Resolver-time `trustPolicy='no-downgrade'` check on a fresh pick.

--- a/pnpm/crates/resolving-resolver-base/Cargo.toml
+++ b/pnpm/crates/resolving-resolver-base/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace  = true
 [dependencies]
 pacquet-config   = { workspace = true }
 pacquet-lockfile = { workspace = true }
+pacquet-registry = { workspace = true }
 
 chrono      = { workspace = true }
 derive_more = { workspace = true }

--- a/pnpm/crates/resolving-resolver-base/src/resolve.rs
+++ b/pnpm/crates/resolving-resolver-base/src/resolve.rs
@@ -12,6 +12,7 @@ use chrono::{DateTime, Utc};
 use derive_more::{Display, From};
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgNameVer};
+use pacquet_registry::PinnedVersion;
 use serde::{Deserialize, Serialize};
 
 use crate::verifier::ResolutionPolicyViolation;
@@ -317,7 +318,19 @@ pub struct ResolveOptions {
     /// flag.
     pub update_checksums: bool,
     pub inject_workspace_packages: bool,
+    /// Ask the resolver to report a manifest-ready
+    /// [`normalized_bare_specifier`](ResolveResult::normalized_bare_specifier)
+    /// for the version it picked, so `add` / `update` can write it back
+    /// without re-deriving what the specifier for this protocol should
+    /// look like. Set for importer-level deps only — nothing below the
+    /// top level is written to a manifest.
     pub calc_specifier: bool,
+    /// The range operator to apply when [`Self::calc_specifier`] computes
+    /// a specifier for a dependency whose current one declares none.
+    /// A specifier that already carries an operator keeps it (`^` stays
+    /// `^`, `~` stays `~`, an exact pin stays exact). `None` leaves the
+    /// choice to the resolver's own default.
+    pub pinned_version: Option<PinnedVersion>,
     /// `minimumReleaseAge` cutoff. Versions published after this point
     /// are filtered out by the npm picker (or reported inline via
     /// [`ResolveResult::policy_violation`] when no mature pick exists).

--- a/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
+++ b/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
@@ -431,3 +431,22 @@ test('installing Node.js runtime, when it is set via the engines field of a depe
   )
   expect(fs.readFileSync('node_modules/@pnpm.e2e/cli-with-node-engine/node-version', 'utf8')).toBe('v22.19.0')
 })
+
+test('update --latest keeps a Node.js runtime dependency on the runtime resolver', async () => {
+  prepareEmpty()
+  const manifest = {
+    dependencies: {
+      node: 'runtime:22.0.0',
+    },
+  }
+  await install(manifest, testDefaults({ fastUnpack: false }))
+
+  const { updatedManifest } = await install(manifest, testDefaults({
+    update: true,
+    updateToLatest: true,
+    updatePackageManifest: true,
+    fastUnpack: false,
+  }))
+
+  expect(updatedManifest.dependencies).toStrictEqual({ node: 'runtime:22.0.0' })
+})


### PR DESCRIPTION
## Summary

Follow-up to [pnpm/pnpm#13244](https://github.com/pnpm/pnpm/pull/13244): replaying the update-lockfile job's full `pnpm update --recursive --latest` locally showed the alias fix alone is not enough. `update --latest` treated the virtual `node: runtime:26.5.0` dependency (from `devEngines.runtime`) as a registry dep — it fetched the latest dist-tag of the unrelated npm package `node` and rewrote the specifier to a plain version, whose install script then failed the strict ignored-builds check with `ERR_PNPM_IGNORED_BUILDS`.

The narrow fix would have been another prefix to skip. The cause is one level down: `prepare_manifest` asked *"what is the latest version of this name"* outside the resolver chain, guarded by a hand-maintained list of protocols the registry does not own (`workspace:`, `link:`, `file:`). Every protocol the chain grows has to be repeated there — and the ones never added were silently mis-resolved. `github:owner/repo`, `git+ssh://…` and remote tarball URLs were all looked up under their alias name on the npm registry and rewritten to a plain version.

**The resolvers now decide.** `prepare_manifest` resolves each direct dependency through a `DefaultResolver` chain with `UpdateBehavior::Latest` and takes the `normalized_bare_specifier` the claiming resolver reports back:

| specifier | before | after |
|---|---|---|
| `^1.0.0`, `latest`, `npm:bar@^1` | bumped to latest | unchanged — the npm picker keeps the higher of the range pick and the `latest` tag |
| `runtime:26.5.0` | **resolved the npm package `node`** | the runtime resolver re-resolves within the manifest spec, as in the TypeScript CLI |
| `github:…`, `git+ssh://…`, remote tarballs | **resolved under the alias name** | no resolver in the chain claims them, so the entry stands |
| `workspace:`, `link:`, `file:` | skipped by the prefix list | unchanged |

The chain deliberately omits the git, tarball and local-path resolvers: they have no notion of a `latest`, and asking them would clone or download during manifest preparation only to be told the specifier stands.

This required implementing `ResolveOptions::calc_specifier`, which pacquet declared but never read — so `normalized_bare_specifier` was only ever populated for tarball URLs on the npm side, while the runtime, git and local resolvers already filled it. `npm_alias_target` moves out of the update command into the new `pacquet-resolving-npm-resolver::calc_specifier` alongside it, since the npm-alias round-trip (`npm:<real name>@<range>`) is the npm resolver's business, not the update command's. `is_local_specifier`, `is_runtime_specifier`, `resolve_latest_specifier` and `resolve_latest_version` are gone.

Two behaviors worth calling out:

- **An unchanged specifier is no longer a rewrite.** Recording one marked the manifest dirty and persisted it, which for a `runtime:` dependency rewrote the entry into `devEngines.runtime` — a change the user never asked for.
- **`workspace:` keeps an explicit skip.** `preserveWorkspaceProtocol` is always on under `--latest`, and the npm resolver answers those only against the install's workspace-package map, which manifest preparation has not built.

`jsr:` and named-registry entries are claimed and resolved but report no specifier yet, so they keep their declared form. Bumping them needs their own specifier shapes (`jsr:@scope/name@<range>`, `<alias>:<name>@<range>`) — a follow-up.

The ordering is unchanged: the pre-resolve still runs before the install, so catalog reconciliation, `catalogs_override`, the `UpdateSeedPolicy` seed, `--no-save` and `--lockfile-only` all behave exactly as before. `minimumReleaseAge` / `minimumReleaseAgeExclude` now reach the resolvers through `ResolveOptions` from the same `PickPolicy` the picker used.

Note: the job runs the *pinned* pacquet, so it only benefits once an alpha carrying pnpm/pnpm#13244 and this PR is published and the `packageManager`/`devEngines` pin on main is bumped to it.

## Squash Commit Body

```text
Replaying the update-lockfile job's update --recursive --latest showed
prepare_manifest treating the virtual `node: runtime:26.5.0` dependency as
a registry dep: it resolved the unrelated npm package `node` and rewrote
the manifest to a plain version whose install script then failed the
strict ignored-builds check.

The cause was that prepare_manifest asked "what is the latest version of
this name" outside the resolver chain, against a hand-maintained list of
protocols the registry does not own (workspace:, link:, file:). Every
protocol the chain grew had to be repeated there, and the ones never added
were silently mis-resolved: git/github: URLs and remote tarballs were all
looked up under their alias name on the npm registry and rewritten to a
plain version.

Ask the resolvers instead. prepare_manifest now resolves each direct
dependency through a DefaultResolver chain with UpdateBehavior::Latest and
takes the normalized_bare_specifier the claiming resolver reports, so each
protocol's own resolver decides what its manifest entry becomes: the npm
picker takes the higher of the declared range and the `latest` tag, the
runtime resolvers re-resolve within the spec the manifest already declares
(as in the TypeScript CLI, which needs no code change and gains a test
pinning the scenario, as does pacquet), and a dependency no resolver in the
chain claims keeps its entry. The chain deliberately omits the git, tarball
and local-path resolvers: they have no notion of a latest, and asking them
would clone or download during manifest preparation only to be told the
specifier stands.

That required implementing ResolveOptions::calc_specifier, which pacquet
declared but never read, so the npm resolver reports a manifest-ready
specifier for the version it picked. `npm_alias_target` moves out of the
update command into the new pacquet-resolving-npm-resolver::calc_specifier
alongside it, since the npm-alias round-trip is the npm resolver's business.
jsr: and named-registry entries are claimed and resolved but report no
specifier yet, so they keep their declared form.

A resolver that reports back what the manifest already says no longer
counts as a rewrite. Recording it marked the manifest dirty and persisted
it, which for a `runtime:` dependency rewrote the entry into
devEngines.runtime — a change the user never asked for.

`workspace:` keeps an explicit skip: preserveWorkspaceProtocol is always on
under --latest, and the npm resolver answers those only against the
install's workspace-package map, which manifest preparation has not built.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-4-8[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `update --latest` incorrectly rewriting non-registry dependency specifications, including runtime, Git, GitHub, and remote archive references.
  * Preserved runtime dependency declarations during updates and installs.
  * Prevented `package.json` changes when dependencies are already at their latest versions.
  * Preserved npm alias formats and appropriate version range operators when updating dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->