### PR TITLE
chore: hold back deps whose latest drops the supported Node.js floor

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -102,6 +102,8 @@ auditConfig:
     - GHSA-h67p-54hq-rp68
 
 catalog:
+  # @babel/core 8.x (and its plugins) require Node.js ^22.18.0 || >=24.11.0,
+  # above pnpm's supported floor of Node.js >=22.13.
   '@babel/core': ^7.29.7
   '@babel/plugin-transform-explicit-resource-management': ^7.29.7
   '@commitlint/cli': ^21.0.2
@@ -187,6 +189,8 @@ catalog:
   ansi-diff: ^1.2.0
   archy: ^1.0.0
   better-path-resolve: 2.0.0
+  # bin-links 7.x requires Node.js ^22.22.2 || ^24.15.0 || >=26.0.0, above pnpm's
+  # supported floor of Node.js >=22.13.
   bin-links: ^6.0.2
   # bole 6 is ESM-only. Under Jest, the workspace logger's ESM bole and the
   # published @pnpm/logger's CJS bole 5 land in different realms, so the
@@ -258,6 +262,8 @@ catalog:
   json5: ^2.2.3
   keyv: 5.6.0
   lcov-result-merger: ^6.0.0
+  # libnpmpublish 12.x requires Node.js ^22.22.2 || ^24.15.0 || >=26.0.0, above
+  # pnpm's supported floor of Node.js >=22.13.
   libnpmpublish: ^11.2.0
   load-json-file: ^7.0.1
   lodash.kebabcase: ^4.1.1
@@ -279,6 +285,8 @@ catalog:
   # npm-packlist 11.x requires Node.js ^22.22.2 || ^24.15.0 || >=26.0.0, above
   # pnpm's supported floor of Node.js >=22.13.
   npm-packlist: 10.0.4
+  # npm-registry-fetch 20.x requires Node.js ^22.22.2 || ^24.15.0 || >=26.0.0,
+  # above pnpm's supported floor of Node.js >=22.13.
   npm-registry-fetch: ^19.0.0
   object-hash: 3.0.0
   open: ^11.0.0
@@ -540,5 +548,25 @@ trustPolicyExclude:
   - undici-types@6.21.0
 
 trustPolicyIgnoreAfter: 10080 # 1 week
+
+# Packages whose newer versions require a Node.js version above pnpm's supported
+# floor (>=22.13). `pnpm update --latest` (run by the update-lockfile workflow)
+# would otherwise bump them past the versions pinned in the catalog above, where
+# each entry's comment records the exact Node.js requirement that holds it back.
+update:
+  ignoreDeps:
+    - '@babel/core'
+    - '@babel/plugin-transform-explicit-resource-management'
+    - bin-links
+    - cspell
+    - ini
+    - libnpmpublish
+    - normalize-package-data
+    - npm-packlist
+    - npm-registry-fetch
+    - ssri
+    - undici
+    - validate-npm-package-name
+    - write-file-atomic
 
 verifyDepsBeforeRun: install


### PR DESCRIPTION
## Summary

The `update-lockfile` workflow runs `pnpm update --latest`, which bumps dependencies across majors regardless of the caret pins in the catalog. Several dependencies have a `latest` whose newest major raises its `engines.node` above pnpm's supported floor (`>=22.13`), so adopting them would break users on Node 22.13.

This adds an `update.ignoreDeps` section to `pnpm-workspace.yaml` listing every such dependency, so `--latest` leaves them alone.

The catalog already pinned eight of these (`cspell`, `ini`, `normalize-package-data`, `npm-packlist`, `ssri`, `undici`, `validate-npm-package-name`, `write-file-atomic`) with explanatory comments, but nothing stopped `--latest` from overriding the pins. Auditing the `latest` `engines.node` of all 243 catalog entries against `22.13.0` surfaced five more in the same situation:

| Package | latest | latest requires |
|---|---|---|
| `@babel/core` | 8.0.1 | `^22.18.0 \|\| >=24.11.0` |
| `@babel/plugin-transform-explicit-resource-management` | 8.0.1 | `^22.18.0 \|\| >=24.11.0` |
| `bin-links` | 7.0.0 | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |
| `libnpmpublish` | 12.0.0 | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |
| `npm-registry-fetch` | 20.0.1 | `^22.22.2 \|\| ^24.15.0 \|\| >=26.0.0` |

All thirteen are now listed in `update.ignoreDeps`, and the five newly-found catalog entries get the same held-back-because-of-Node comment the others already carry.

## Squash Commit Body

```text
Add an `update.ignoreDeps` section to pnpm-workspace.yaml so the
update-lockfile workflow's `pnpm update --latest` stops bumping
dependencies whose newest major requires a Node.js version above pnpm's
supported floor (>=22.13).

The catalog already pinned eight such packages with explanatory comments,
but nothing prevented `--latest` from overriding those pins. Auditing the
`latest` engines.node of every catalog entry against 22.13.0 surfaced five
more: @babel/core (and its explicit-resource-management plugin), bin-links,
libnpmpublish, and npm-registry-fetch. List all thirteen in
update.ignoreDeps and give the five newly-found catalog entries the same
held-back-because-of-Node comment the others carry.
```

## Checklist

- [x] This is a workspace-config-only change (dev dependency management for the TypeScript monorepo); nothing to port to the Rust `pnpm/` port.
- [x] No changeset: this changes no published package, only the repo's own dependency-update config.
- [x] No tests: configuration-only change.
- [x] No documentation change needed.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787425174&installation_model_id=426870&pr_number=13253&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13253&signature=745c79f7b4c5fdb7008a7210ba3a6329d67503ee216036eb21c21541ee57091d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documented minimum Node.js requirements for selected package versions.
  * Prevented automatic latest-version updates from upgrading pinned packages beyond supported compatibility limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->