### PR TITLE
chore: hold back node-gyp and the commented catalog pins from update --latest

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -549,22 +549,29 @@ trustPolicyExclude:
 
 trustPolicyIgnoreAfter: 10080 # 1 week
 
-# Packages whose newer versions require a Node.js version above pnpm's supported
-# floor (>=22.13). `pnpm update --latest` (run by the update-lockfile workflow)
-# would otherwise bump them past the versions pinned in the catalog above, where
-# each entry's comment records the exact Node.js requirement that holds it back.
+# Dependencies deliberately held back, which `pnpm update --latest` (run by the
+# update-lockfile workflow) would otherwise bump. Most of them are packages
+# whose newer versions require a Node.js version above pnpm's supported floor
+# (>=22.13); the comment at each catalog entry above records the reason. node-gyp
+# is not in the catalog: it is declared directly in pnpm11/pnpm/package.json, and
+# node-gyp 13 (with its nopt 10 and which 7 dependencies) requires Node.js
+# ^22.22.2 || ^24.15.0 || >=26.0.0.
 update:
   ignoreDeps:
     - '@babel/core'
     - '@babel/plugin-transform-explicit-resource-management'
+    - '@types/node'
     - bin-links
+    - bole
     - cspell
     - ini
     - libnpmpublish
+    - node-gyp
     - normalize-package-data
     - npm-packlist
     - npm-registry-fetch
     - ssri
+    - tempy
     - undici
     - validate-npm-package-name
     - write-file-atomic


### PR DESCRIPTION
## Summary

The daily update-lockfile job fails with `ERR_PNPM_UNSUPPORTED_ENGINE` on `which@7.0.0` ([run 30036170950](https://github.com/pnpm/pnpm/actions/runs/30036170950/job/89304586982)). The culprit is `node-gyp`: it is declared directly in `pnpm11/pnpm/package.json`, so the catalog-oriented sweep in pnpm/pnpm#13253 missed it. `pnpm update --latest` bumps it 12.4.0 → 13.0.1, and node-gyp 13 — together with its `nopt` 10 and `which` 7 dependencies — requires Node.js `^22.22.2 || ^24.15.0 || >=26.0.0`, which `engineStrict` correctly rejects against `nodeVersion: 22.13.0`.

Overrides would not help here: the bump is of a direct dependency, and pinning `which` back would still leave node-gyp 13 and nopt 10 failing the same check (the local replay hits `nopt@10.0.1` next).

Verified by replaying the job locally (lockfile deleted, `pnpm update --recursive --latest`, as `refresh-lockfile: true` does). With `node-gyp` held back, resolution completes with **no engine errors** and node-gyp stays at 12.4.0 — it was the last floor-blocked dependency for today's registry state. The replay then stops at the next, separate blocker: `ERR_PNPM_IGNORED_BUILDS` for `node@26.5.0`, the `runtime:` specifier bug fixed by pnpm/pnpm#13250. **This PR therefore does not make the job green on its own** — that also needs pnpm/pnpm#13250 to land, ship in an alpha, and have the pin on main bumped to it.

The same replay showed three catalog entries being bumped past pins their own comments say must hold, because only the engine-related ones were listed:

- `@types/node` — kept on 22.x to match the supported Node.js floor (replay bumped it to ^26.1.1).
- `bole` — kept on 5.x so the published `@pnpm/logger`'s CJS bole shares the `globalThis.$$bole` output registry under Jest (replay bumped it to ^6.0.6).
- `tempy` — kept at 3.0.0, since later versions deadlock the bundled binary at startup (replay bumped it to 3.2.0).

They are added to the list too, so the pins are enforced rather than only documented.

Note: pnpm/pnpm#13250 carries an overlapping list under the older `updateConfig.ignoreDependencies` key; whichever lands second will need to reconcile with the `update.ignoreDeps` block on main.

## Squash Commit Body

```text
The daily update-lockfile job fails with ERR_PNPM_UNSUPPORTED_ENGINE on
which@7.0.0. The source is node-gyp, declared directly in
pnpm11/pnpm/package.json and therefore missed by the catalog-oriented sweep
in pnpm/pnpm#13253: `pnpm update --latest` bumps it 12.4.0 -> 13.0.1, and
node-gyp 13 -- along with its nopt 10 and which 7 dependencies -- requires
Node.js ^22.22.2 || ^24.15.0 || >=26.0.0, which engineStrict correctly
rejects against nodeVersion 22.13.0.

Replaying the job locally (lockfile deleted, `pnpm update --recursive
--latest`) confirms node-gyp was the last floor-blocked dependency: with it
held back, resolution completes with no engine errors and node-gyp stays at
12.4.0. The replay stops at the next, separate blocker instead --
ERR_PNPM_IGNORED_BUILDS for node@26.5.0, the runtime: specifier fix in
pnpm/pnpm#13250.

The same replay also showed three catalog entries being bumped past pins
their comments say must hold: `@types/node` (22.x, matching the supported
Node.js floor), bole (5.x, so the published `@pnpm/logger`'s CJS bole shares
the output registry under Jest) and tempy (3.0.0, whose later versions
deadlock the bundled binary at startup). Only the engine-related pins were
enforced, so those three are added to the list as well.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Repository configuration only — no code in either stack.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. (No published package changes.)

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787434481&installation_model_id=426870&pr_number=13257&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13257&signature=db52528eaf00c670268021c34deaf1141f964c9978a7d5ec300f850c03d881e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to preserve compatibility with required Node.js versions.
  * Prevented selected development dependencies from being automatically upgraded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->