### PR TITLE
feat(pack): report the published manifest in `pack --json`

### DIFF
--- a/.changeset/pack-json-published-manifest.md
+++ b/.changeset/pack-json-published-manifest.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/releasing.commands": minor
+"pacquet": minor
+"pnpm": minor
+---
+
+`pnpm pack --json` now also prints the manifest that goes into the tarball, so `pnpm pack --dry-run --json` previews the published `package.json` — with `publishConfig` overrides applied, `workspace:`/`catalog:`/`jsr:` specifiers replaced, and the publish lifecycle scripts and the `pnpm` field stripped — without writing a tarball.
+
+`pnpm pack` accepts `--ignore-scripts` now, which skips the `prepack`, `prepare`, and `postpack` scripts. Combined with `--dry-run --json`, it prints the manifest without building the package.

--- a/.changeset/pack-json-published-manifest.md
+++ b/.changeset/pack-json-published-manifest.md
@@ -4,6 +4,6 @@
 "pnpm": minor
 ---
 
-`pnpm pack --json` now also prints the manifest that goes into the tarball, so `pnpm pack --dry-run --json` previews the published `package.json` — with `publishConfig` overrides applied, `workspace:`/`catalog:`/`jsr:` specifiers replaced, and the publish lifecycle scripts and the `pnpm` field stripped — without writing a tarball.
+`pnpm pack --json` now also prints the manifest that goes into the tarball, so `pnpm pack --dry-run --json` previews the published `package.json` — with `publishConfig` overrides applied, `workspace:`/`catalog:`/`jsr:` specifiers replaced, the `pnpm` field dropped, and the publish lifecycle scripts stripped unless `--skip-manifest-obfuscation` keeps them — without writing a tarball.
 
 `pnpm pack` accepts `--ignore-scripts` now, which skips the `prepack`, `prepare`, and `postpack` scripts. Combined with `--dry-run --json`, it prints the manifest without building the package.

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -10,9 +10,12 @@
 //! `embedReadme` / `extraEnv` config keys are not surfaced by `Config`
 //! yet, so they take their `false` / empty defaults.
 
-use crate::cli_args::install::resolve_bool_override;
-use crate::cli_args::recursive::{
-    AutoExcludeRoot, discover_workspace_projects, select_recursive_projects, sort_filtered_projects,
+use crate::cli_args::{
+    install::resolve_bool_override,
+    recursive::{
+        AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+        sort_filtered_projects,
+    },
 };
 use clap::Args;
 use miette::{Context, IntoDiagnostic};

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -10,6 +10,7 @@
 //! `embedReadme` / `extraEnv` config keys are not surfaced by `Config`
 //! yet, so they take their `false` / empty defaults.
 
+use crate::cli_args::install::resolve_bool_override;
 use crate::cli_args::recursive::{
     AutoExcludeRoot, discover_workspace_projects, select_recursive_projects, sort_filtered_projects,
 };
@@ -66,6 +67,16 @@ pub struct PackArgs {
     /// working directory.
     #[clap(long = "pack-destination")]
     pub pack_destination: Option<String>,
+
+    /// Don't run the `prepack`, `prepare` and `postpack` lifecycle
+    /// scripts. Combined with `--dry-run --json`, this prints the manifest
+    /// that would be published without building the package.
+    #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
+    pub ignore_scripts: bool,
+
+    /// Force-enable lifecycle scripts for this invocation.
+    #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
+    pub no_ignore_scripts: bool,
 
     /// Print the packed tarball and its contents in JSON.
     #[clap(long)]
@@ -235,7 +246,11 @@ impl PackArgs {
         PackOptions {
             dir,
             catalogs,
-            ignore_scripts: config.ignore_scripts,
+            ignore_scripts: resolve_bool_override(
+                self.ignore_scripts,
+                self.no_ignore_scripts,
+                config.ignore_scripts,
+            ),
             unsafe_perm: config.unsafe_perm,
             embed_readme: false,
             pack_gzip_level: self.pack_gzip_level,

--- a/pnpm/crates/cli/tests/pack.rs
+++ b/pnpm/crates/cli/tests/pack.rs
@@ -221,7 +221,7 @@ fn ignore_scripts_skips_the_pack_lifecycle_scripts() {
         json!({
             "name": "pkg",
             "version": "1.0.0",
-            "scripts": { "prepack": "node -e \"require('fs').writeFileSync('prepack-ran', '')\"" },
+            "scripts": { "prepack": r#"node -e "require('fs').writeFileSync('prepack-ran', '')""# },
         })
         .to_string(),
     )

--- a/pnpm/crates/cli/tests/pack.rs
+++ b/pnpm/crates/cli/tests/pack.rs
@@ -170,8 +170,9 @@ fn recursive_pack_applies_before_packing_hook_to_every_project() {
     drop(root);
 }
 
-/// `--dry-run --json` reports the manifest that would be packed, with the
-/// publish-time transformations applied and no tarball written.
+/// The reported manifest is the tarball's, not the registry metadata: the
+/// two differ by the readme, which `with_registry_readme` adds to the
+/// published manifest whatever `embed_readme` says.
 #[test]
 fn dry_run_json_reports_the_publish_transformed_manifest() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -188,6 +189,7 @@ fn dry_run_json_reports_the_publish_transformed_manifest() {
         .to_string(),
     )
     .expect("write package.json");
+    fs::write(workspace.join("README.md"), "# pkg").expect("write README.md");
 
     let output = pacquet
         .with_arg("pack")
@@ -206,13 +208,17 @@ fn dry_run_json_reports_the_publish_transformed_manifest() {
     assert!(manifest.get("publishConfig").is_none(), "publishConfig must be stripped");
     assert_eq!(manifest["scripts"], json!({ "build": "exit 0" }));
     assert!(manifest.get("pnpm").is_none(), "the pnpm field must be stripped");
+    assert!(
+        manifest.get("readme").is_none(),
+        "the readme is registry metadata, not part of the packed manifest",
+    );
     assert!(!workspace.join("pkg-1.0.0.tgz").exists(), "--dry-run must not write a tarball");
 
     drop(root);
 }
 
-/// `--ignore-scripts` skips the pack lifecycle scripts, so the manifest
-/// can be inspected without building the package.
+/// Skipping the scripts is what makes `--dry-run --json` usable as a
+/// side-effect-free query for the manifest.
 #[test]
 fn ignore_scripts_skips_the_pack_lifecycle_scripts() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/pack.rs
+++ b/pnpm/crates/cli/tests/pack.rs
@@ -170,6 +170,70 @@ fn recursive_pack_applies_before_packing_hook_to_every_project() {
     drop(root);
 }
 
+/// `--dry-run --json` reports the manifest that would be packed, with the
+/// publish-time transformations applied and no tarball written.
+#[test]
+fn dry_run_json_reports_the_publish_transformed_manifest() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "main": "./src/index.ts",
+            "publishConfig": { "main": "./dist/index.js" },
+            "scripts": { "build": "exit 0", "prepublishOnly": "exit 0" },
+            "pnpm": { "overrides": { "is-positive": "1.0.0" } },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet
+        .with_arg("pack")
+        .with_arg("--dry-run")
+        .with_arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let result: serde_json::Value =
+        serde_json::from_slice(&output).expect("parse pack --json output");
+    let manifest = &result["manifest"];
+
+    assert_eq!(manifest["main"], json!("./dist/index.js"), "publishConfig must be applied");
+    assert!(manifest.get("publishConfig").is_none(), "publishConfig must be stripped");
+    assert_eq!(manifest["scripts"], json!({ "build": "exit 0" }));
+    assert!(manifest.get("pnpm").is_none(), "the pnpm field must be stripped");
+    assert!(!workspace.join("pkg-1.0.0.tgz").exists(), "--dry-run must not write a tarball");
+
+    drop(root);
+}
+
+/// `--ignore-scripts` skips the pack lifecycle scripts, so the manifest
+/// can be inspected without building the package.
+#[test]
+fn ignore_scripts_skips_the_pack_lifecycle_scripts() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "scripts": { "prepack": "node -e \"require('fs').writeFileSync('prepack-ran', '')\"" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("pack").with_arg("--dry-run").with_arg("--ignore-scripts").assert().success();
+
+    assert!(!workspace.join("prepack-ran").exists(), "prepack must not run");
+
+    drop(root);
+}
+
 /// Extract `package/package.json` from a packed tarball.
 fn read_manifest_from_tarball(tarball: &Path) -> serde_json::Value {
     use std::io::Read as _;

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -115,8 +115,8 @@ pub struct PackOptions {
 /// Result of packing one project.
 #[derive(Debug)]
 pub struct PackResult {
-    /// The manifest sent to the registry as package metadata. See
-    /// [`with_registry_readme`].
+    /// The manifest sent to the registry as package metadata. It always
+    /// carries the readme, whatever `embed_readme` says.
     pub published_manifest: Value,
     /// The `package.json` written into the tarball.
     pub packed_manifest: Value,

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -115,8 +115,11 @@ pub struct PackOptions {
 /// Result of packing one project.
 #[derive(Debug)]
 pub struct PackResult {
-    /// The manifest packed inside the tarball.
+    /// The manifest sent to the registry as package metadata. See
+    /// [`with_registry_readme`].
     pub published_manifest: Value,
+    /// The `package.json` written into the tarball.
+    pub packed_manifest: Value,
     /// Sorted, de-duplicated list of the tarball's contents (paths
     /// relative to the package root, `package.json` for the manifest).
     pub contents: Vec<String>,
@@ -134,6 +137,7 @@ pub struct PackResultJson {
     pub version: String,
     pub filename: String,
     pub files: Vec<PackFile>,
+    pub manifest: Value,
 }
 
 /// One entry of [`PackResultJson::files`].
@@ -375,8 +379,14 @@ where
 
     let tarball_path = packed_tarball_path(&opts.dir, &dir, &dest_dir, &tarball_name);
 
-    let published_manifest = with_registry_readme(publish_manifest, &dir)?;
-    Ok(PackResult { published_manifest, contents, tarball_path, unpacked_size })
+    let published_manifest = with_registry_readme(publish_manifest.clone(), &dir)?;
+    Ok(PackResult {
+        published_manifest,
+        packed_manifest: publish_manifest,
+        contents,
+        tarball_path,
+        unpacked_size,
+    })
 }
 
 /// The readme is always reported as part of the published manifest, matching the npm CLI, so a
@@ -443,12 +453,13 @@ fn before_packing_logger<Reporter: self::Reporter>(pnpmfile: &Path, prefix: &str
 /// Project a [`PackResult`] into its JSON shape.
 #[must_use]
 pub fn to_pack_result_json(result: &PackResult) -> PackResultJson {
-    let manifest = &result.published_manifest;
+    let manifest = &result.packed_manifest;
     PackResultJson {
         name: manifest.get("name").and_then(Value::as_str).unwrap_or_default().to_string(),
         version: manifest.get("version").and_then(Value::as_str).unwrap_or_default().to_string(),
         filename: result.tarball_path.clone(),
         files: result.contents.iter().map(|path| PackFile { path: path.clone() }).collect(),
+        manifest: manifest.clone(),
     }
 }
 

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -532,8 +532,10 @@ fn tarball_write_failure_surfaces_as_write_error() {
 
 #[test]
 fn format_pack_output_json_single_vs_multiple() {
+    // The two manifests differ by the readme, the way `with_registry_readme`
+    // leaves them, so serializing the registry one would be visible here.
     let result = PackResult {
-        published_manifest: json!({ "name": "foo", "version": "1.0.0" }),
+        published_manifest: json!({ "name": "foo", "version": "1.0.0", "readme": "# foo" }),
         packed_manifest: json!({ "name": "foo", "version": "1.0.0" }),
         contents: vec!["package.json".to_string()],
         tarball_path: "foo-1.0.0.tgz".to_string(),
@@ -544,7 +546,7 @@ fn format_pack_output_json_single_vs_multiple() {
     assert_eq!(parsed["name"], json!("foo"));
     assert_eq!(parsed["filename"], json!("foo-1.0.0.tgz"));
     assert_eq!(parsed["files"], json!([{ "path": "package.json" }]));
-    assert_eq!(parsed["manifest"], json!({ "name": "foo", "version": "1.0.0" }));
+    assert_eq!(parsed["manifest"], result.packed_manifest);
 
     let two = vec![to_pack_result_json(&result), to_pack_result_json(&result)];
     let json_multi = format_pack_output(&two, true, false);

--- a/pnpm/crates/pack/src/tests.rs
+++ b/pnpm/crates/pack/src/tests.rs
@@ -534,6 +534,7 @@ fn tarball_write_failure_surfaces_as_write_error() {
 fn format_pack_output_json_single_vs_multiple() {
     let result = PackResult {
         published_manifest: json!({ "name": "foo", "version": "1.0.0" }),
+        packed_manifest: json!({ "name": "foo", "version": "1.0.0" }),
         contents: vec!["package.json".to_string()],
         tarball_path: "foo-1.0.0.tgz".to_string(),
         unpacked_size: 42,
@@ -543,6 +544,7 @@ fn format_pack_output_json_single_vs_multiple() {
     assert_eq!(parsed["name"], json!("foo"));
     assert_eq!(parsed["filename"], json!("foo-1.0.0.tgz"));
     assert_eq!(parsed["files"], json!([{ "path": "package.json" }]));
+    assert_eq!(parsed["manifest"], json!({ "name": "foo", "version": "1.0.0" }));
 
     let two = vec![to_pack_result_json(&result), to_pack_result_json(&result)];
     let json_multi = format_pack_output(&two, true, false);
@@ -568,6 +570,7 @@ fn text_output_strips_control_characters_from_paths() {
     // verbatim, or it could spoof/obscure the printed output.
     let result = PackResult {
         published_manifest: json!({ "name": "foo", "version": "1.0.0" }),
+        packed_manifest: json!({ "name": "foo", "version": "1.0.0" }),
         contents: vec!["evil\u{1b}[2K.js".to_string(), "package.json".into()],
         tarball_path: "foo-1.0.0.tgz".to_string(),
         unpacked_size: 0,
@@ -581,6 +584,7 @@ fn text_output_strips_control_characters_from_paths() {
 fn format_pack_output_text_block() {
     let result = PackResult {
         published_manifest: json!({ "name": "foo", "version": "1.0.0" }),
+        packed_manifest: json!({ "name": "foo", "version": "1.0.0" }),
         contents: vec!["index.js".to_string(), "package.json".into()],
         tarball_path: "foo-1.0.0.tgz".to_string(),
         unpacked_size: 0,

--- a/pnpm11/releasing/commands/src/publish/pack.ts
+++ b/pnpm11/releasing/commands/src/publish/pack.ts
@@ -45,6 +45,7 @@ export function cliOptionsTypes (): Record<string, unknown> {
     recursive: Boolean,
     ...pick([
       'dry-run',
+      'ignore-scripts',
       'pack-destination',
       'pack-gzip-level',
       'json',
@@ -74,7 +75,11 @@ export function help (): string {
             name: '--pack-destination <dir>',
           },
           {
-            description: 'Prints the packed tarball and contents in the json format.',
+            description: 'Does not run the `prepack`, `prepare` and `postpack` lifecycle scripts. Combined with `--dry-run --json`, this prints the manifest that would be published without building the package.',
+            name: '--ignore-scripts',
+          },
+          {
+            description: 'Prints the packed tarball, its contents and the manifest that goes into it in the json format.',
             name: '--json',
           },
           {
@@ -155,6 +160,7 @@ export interface PackResultJson {
   version: string
   filename: string
   files: Array<{ path: string }>
+  manifest: ExportedManifest
 }
 
 export async function handler (opts: PackOptions): Promise<string> {
@@ -376,6 +382,7 @@ export async function api (opts: PackOptions): Promise<PackResult> {
   }
   return {
     publishedManifest: await withRegistryReadme(publishManifest, dir),
+    packedManifest: publishManifest,
     contents: packedContents,
     tarballPath: packedTarballPath,
     unpackedSize,
@@ -397,7 +404,10 @@ async function withRegistryReadme (manifest: ExportedManifest, projectDir: strin
 }
 
 export interface PackResult {
+  /** The manifest sent to the registry as package metadata. See {@link withRegistryReadme}. */
   publishedManifest: ExportedManifest
+  /** The `package.json` written into the tarball. */
+  packedManifest: ExportedManifest
   contents: string[]
   tarballPath: string
   /** Total uncompressed size of all files in the tarball, in bytes. */
@@ -506,11 +516,12 @@ async function createPublishManifest (opts: {
 }
 
 function toPackResultJson (packResult: PackResult): PackResultJson {
-  const { publishedManifest, contents, tarballPath } = packResult
+  const { packedManifest, contents, tarballPath } = packResult
   return {
-    name: publishedManifest.name as string,
-    version: publishedManifest.version as string,
+    name: packedManifest.name as string,
+    version: packedManifest.version as string,
     filename: tarballPath,
     files: contents.map((file) => ({ path: file })),
+    manifest: packedManifest,
   }
 }

--- a/pnpm11/releasing/commands/test/publish/FailedToPublishError.test.ts
+++ b/pnpm11/releasing/commands/test/publish/FailedToPublishError.test.ts
@@ -9,6 +9,10 @@ const pack = (): PackResult => ({
     name: 'example-pack',
     version: '0.1.2',
   },
+  packedManifest: {
+    name: 'example-pack',
+    version: '0.1.2',
+  },
   tarballPath: 'example-pack.tgz',
   unpackedSize: 0,
 })

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -952,7 +952,7 @@ test('pack: json output contains the publish-transformed manifest', async () => 
         'is-positive': '1.0.0',
       },
     },
-  })
+  } as Parameters<typeof prepare>[0] & { pnpm?: Record<string, unknown> })
 
   const output = await pack.handler({
     ...DEFAULT_OPTS,

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -953,6 +953,7 @@ test('pack: json output contains the publish-transformed manifest', async () => 
       },
     },
   } as Parameters<typeof prepare>[0] & { pnpm?: Record<string, unknown> })
+  fs.writeFileSync('README.md', '# test-published-manifest', 'utf8')
 
   const output = await pack.handler({
     ...DEFAULT_OPTS,
@@ -969,6 +970,9 @@ test('pack: json output contains the publish-transformed manifest', async () => 
   expect(manifest.publishConfig).toBeUndefined()
   expect(manifest.scripts).toStrictEqual({ build: 'exit 0' })
   expect(manifest.pnpm).toBeUndefined()
+  // The readme is registry metadata that `withRegistryReadme` adds to the
+  // published manifest regardless of `embedReadme`; the packed one omits it.
+  expect(manifest.readme).toBeUndefined()
   expect(fs.existsSync('test-published-manifest-0.0.0.tgz')).toBeFalsy()
 })
 

--- a/pnpm11/releasing/commands/test/publish/pack.ts
+++ b/pnpm11/releasing/commands/test/publish/pack.ts
@@ -928,7 +928,71 @@ test('pack: display in json format', async () => {
         path: 'src/index.ts',
       },
     ],
+    manifest: {
+      name: 'test-publish-package.json',
+      version: '0.0.0',
+    },
   }, null, 2))
+})
+
+test('pack: json output contains the publish-transformed manifest', async () => {
+  prepare({
+    name: 'test-published-manifest',
+    version: '0.0.0',
+    main: './src/index.ts',
+    publishConfig: {
+      main: './dist/index.js',
+    },
+    scripts: {
+      build: 'exit 0',
+      prepublishOnly: 'exit 0',
+    },
+    pnpm: {
+      overrides: {
+        'is-positive': '1.0.0',
+      },
+    },
+  })
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    dryRun: true,
+    json: true,
+  })
+
+  const { manifest }: PackResultJson = JSON.parse(output)
+
+  expect(manifest.main).toBe('./dist/index.js')
+  expect(manifest.publishConfig).toBeUndefined()
+  expect(manifest.scripts).toStrictEqual({ build: 'exit 0' })
+  expect(manifest.pnpm).toBeUndefined()
+  expect(fs.existsSync('test-published-manifest-0.0.0.tgz')).toBeFalsy()
+})
+
+test('pack: --ignore-scripts does not run the lifecycle scripts', async () => {
+  prepare({
+    name: 'test-pack-ignore-scripts',
+    version: '0.0.0',
+    scripts: {
+      prepack: 'node -e "require(\'fs\').writeFileSync(\'prepack-ran\', \'\')"',
+    },
+  })
+
+  const output = await pack.handler({
+    ...DEFAULT_OPTS,
+    argv: { original: [] },
+    dir: process.cwd(),
+    extraBinPaths: [],
+    dryRun: true,
+    ignoreScripts: true,
+    json: true,
+  })
+
+  expect(fs.existsSync('prepack-ran')).toBeFalsy()
+  expect((JSON.parse(output) as PackResultJson).manifest.name).toBe('test-pack-ignore-scripts')
 })
 
 test('pack: recursive pack and display in json format', async () => {
@@ -1010,6 +1074,7 @@ test('pack: recursive pack and display in json format', async () => {
     expect(pkg).toHaveProperty('version')
     expect(pkg).toHaveProperty('filename')
     expect(pkg).toHaveProperty('files')
+    expect(pkg.manifest.name).toBe(pkg.name)
     expect(Array.isArray(pkg.files)).toBeTruthy()
     for (const file of pkg.files) {
       expect(file).toHaveProperty('path')


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Makes `pnpm pack --dry-run --json` answer "what will my published `package.json` look like?".

`pack` already builds the publish-transformed manifest and hands it to the tarball; `toPackResultJson` was throwing it away and keeping only `name` and `version`. This reports it as a `manifest` field instead, so the preview is the very thing that gets packed — no parallel transform pipeline that can drift.

`pack` also accepts `--ignore-scripts` now. `ignoreScripts` was already a `PackOptions` field fed from the config, but had no CLI flag, so the only way to inspect a manifest without running `prepack` / `prepare` was to set the config key. With the flag, `pnpm pack --dry-run --json --ignore-scripts` is a side-effect-free query; without it, the reported manifest reflects whatever `prepack` generated, matching a real publish.

```console
$ pnpm pack --dry-run --json --ignore-scripts
{
  "name": "smoke-pkg",
  "version": "1.2.3",
  "filename": "smoke-pkg-1.2.3.tgz",
  "files": [ { "path": "package.json" } ],
  "manifest": {
    "name": "smoke-pkg",
    "version": "1.2.3",
    "main": "./dist/index.js",
    "scripts": { "build": "exit 0" }
  }
}
```

Supersedes pnpm/pnpm#12707, which added a `pnpm pkg get-published` subcommand for the same goal. That approach reimplemented the transform pipeline and its own `publishConfig.directory` handling, which diverged from `pack` in two ways a preview cannot afford: it rejected directories outside the project that `pack` accepts, and it skipped `prepack`, so a project that generates its dist manifest there would be shown stale data. Both divergences disappear when the preview is the pack itself.

Note on the manifest reported: `PackResult` now carries the packed manifest next to the published one. The two differ by the readme — the published manifest always carries it as registry metadata, while the tarball's `package.json` only gets it under `embedReadme`. The JSON reports the tarball's, since that is the manifest consumers resolve against.

## Squash Commit Body

```text
`pack --json` already had the publish-transformed manifest in hand and
dropped everything but `name` and `version` on the way out. Report it as a
`manifest` field so `pnpm pack --dry-run --json` answers "what will my
published package.json look like?" without a second code path that could
drift from what actually gets packed.

`PackResult` now carries the packed manifest next to the published one.
The two differ by the readme: the published manifest always carries it as
registry metadata, while the tarball's `package.json` only gets it under
`embedReadme`. The JSON reports the tarball's, since that is the manifest
consumers resolve against.

Also accept `--ignore-scripts` on `pack`. It was already a `PackOptions`
field fed from the config, but had no CLI flag, so the only way to inspect
a manifest without running `prepack` / `prepare` was to set the config key.
With the flag, `pnpm pack --dry-run --json --ignore-scripts` is a
side-effect-free query; without it, the reported manifest reflects whatever
`prepack` generated, matching a real publish.

Supersedes pnpm/pnpm#12707, which added a `pnpm pkg get-published`
subcommand for the same goal. That approach reimplemented the transform
pipeline and its `publishConfig.directory` handling, which diverged from
`pack` in two ways a preview cannot afford — it rejected directories
outside the project that `pack` accepts, and it skipped `prepack`, so a
project generating its dist manifest there would be shown stale data.

Both stacks change together; the JSON output is byte-identical between them.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed — the `pnpm pack` page lives in
  `pnpm/pnpm.io` and needs a follow-up for the new `manifest` field and the
  `--ignore-scripts` flag.

---
Written by an agent (Claude Code, claude-opus-4-8).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787439225&installation_model_id=426870&pr_number=13260&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13260&signature=ff08b687f5f585835c6b6a12bb41f8ad924c00d3e03be711a44cde68453ded2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm pack --json` now includes the manifest from the generated tarball.
  * Use `--dry-run --json` to preview the final manifest without creating a tarball.
  * Added `--ignore-scripts` and `--no-ignore-scripts` to control pack lifecycle script execution.

* **Bug Fixes**
  * Pack JSON output now reflects publish-time manifest transformations consistently (including removed publishing metadata and rewritten fields).
  * Dry-run packing with scripts disabled no longer runs pack lifecycle scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->