### PR TITLE
fix(audit): accept string "true" for --fix option to prevent ERR_PNPM…

### DIFF
--- a/.changeset/fix-audit-bare-fix-option.md
+++ b/.changeset/fix-audit-bare-fix-option.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fix `pnpm audit --fix` (without value) throwing `ERR_PNPM_INVALID_FIX_OPTION` in pnpm v11.

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -247,7 +247,7 @@ export async function handler (opts: AuditOptions, params: string[] = []): Promi
   let fixMethod: 'update' | 'override' | undefined
   if (opts.fix === 'update' || opts.fix === 'override') {
     fixMethod = opts.fix
-  } else if (opts.fix === true || (opts.interactive && !opts.fix)) {
+  } else if (opts.fix === true || opts.fix === 'true' || (opts.interactive && !opts.fix)) {
     fixMethod = DEFAULT_FIX_METHOD
   } else if (!opts.fix) {
     fixMethod = undefined

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -158,7 +158,7 @@ export function help (): string {
 }
 
 export type AuditOptions = Pick<UniversalOptions, 'dir'> & {
-  fix?: boolean | 'override' | 'update'
+  fix?: boolean | 'override' | 'update' | 'true'
   ignoreRegistryErrors?: boolean
   interactive?: boolean
   json?: boolean

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -54,27 +54,27 @@ test('overrides are added for vulnerable dependencies', async () => {
 })
 
 test('audit --fix without value (string "true") works like boolean true', async () => {
-    const tmp = f.prepare('has-vulnerabilities')
+  const tmp = f.prepare('has-vulnerabilities')
 
-    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
-      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
-      .reply(200, responses.ALL_VULN_RESP)
+  getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+    .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+    .reply(200, responses.ALL_VULN_RESP)
 
-    const { exitCode, output } = await audit.handler({
-      ...AUDIT_REGISTRY_OPTS,
-      auditLevel: 'moderate',
-      minimumReleaseAge: 1440,
-      dir: tmp,
-      rootProjectManifestDir: tmp,
-      fix: 'true' as unknown as true, // Simulate the CLI parsing bug where --fix without value gets string "true"
-    })
-
-    expect(exitCode).toBe(0)
-    expect(output).toMatch(/Run "pnpm install"/)
-
-    const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
-    expect(manifest.overrides?.['axios@<=0.18.0']).toBe('^0.18.1')
+  const { exitCode, output } = await audit.handler({
+    ...AUDIT_REGISTRY_OPTS,
+    auditLevel: 'moderate',
+    minimumReleaseAge: 1440,
+    dir: tmp,
+    rootProjectManifestDir: tmp,
+    fix: 'true',
   })
+
+  expect(exitCode).toBe(0)
+  expect(output).toMatch(/Run "pnpm install"/)
+
+  const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+  expect(manifest.overrides?.['axios@<=0.18.0']).toBe('^0.18.1')
+})
 
   test('no overrides are added if no vulnerabilities are found', async () => {
   const tmp = f.prepare('fixture')

--- a/pnpm11/deps/compliance/commands/test/audit/fix.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/fix.ts
@@ -53,7 +53,30 @@ test('overrides are added for vulnerable dependencies', async () => {
   expect(axiosExclude).toContain('0.21.2')
 })
 
-test('no overrides are added if no vulnerabilities are found', async () => {
+test('audit --fix without value (string "true") works like boolean true', async () => {
+    const tmp = f.prepare('has-vulnerabilities')
+
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+      .reply(200, responses.ALL_VULN_RESP)
+
+    const { exitCode, output } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      auditLevel: 'moderate',
+      minimumReleaseAge: 1440,
+      dir: tmp,
+      rootProjectManifestDir: tmp,
+      fix: 'true' as unknown as true, // Simulate the CLI parsing bug where --fix without value gets string "true"
+    })
+
+    expect(exitCode).toBe(0)
+    expect(output).toMatch(/Run "pnpm install"/)
+
+    const manifest = readYamlFileSync<{ overrides?: Record<string, string> }>(path.join(tmp, 'pnpm-workspace.yaml'))
+    expect(manifest.overrides?.['axios@<=0.18.0']).toBe('^0.18.1')
+  })
+
+  test('no overrides are added if no vulnerabilities are found', async () => {
   const tmp = f.prepare('fixture')
 
   getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))


### PR DESCRIPTION
…_INVALID_FIX_OPTION

When pnpm audit --fix is called without a value, the option parser can convert the bare --fix boolean to the string "true" instead of boolean true. The handler only matched boolean true, so it fell through to the error branch and threw ERR_PNPM_INVALID_FIX_OPTION.

Match both boolean true and string "true" in the guard so bare --fix works as expected, defaulting to the "override" fix method.

Fixes #13261

<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Explain what changed and why. Reference issues here too (Closes pnpm/pnpm#123).
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787475855&installation_model_id=426870&pr_number=13262&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13262&signature=ee61925d031c8f6d5c2f2029cb132fbf4b9da033cdbbe7f44967c58c08647e99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm audit --fix` behavior when the `--fix` value is provided as the string `"true"`, matching the existing boolean `true` behavior.
  * Ensures the vulnerability remediation flow completes successfully and the expected workspace override entries are produced.
* **Tests**
  * Added coverage to confirm `"true"` is handled the same as `true` during audit fixes.
* **Documentation**
  * Added a changeset note for this patch-level fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->