### PR TITLE
ci(release): choose which products to release per run

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -7,6 +7,24 @@ on:
         description: Branch to release (the PR base; e.g. main or release/11.1).
         default: main
         required: true
+      # Each product is a separate checkbox, so a release can cover any
+      # combination. Only the checked products' pending changesets are consumed;
+      # the rest stay in the ledger for a later release. This lets a rapid v12
+      # (Rust) cadence release without dragging the TypeScript CLI (v11) along —
+      # and with it the near-daily "Update available!" notification. Leaving all
+      # three checked reproduces the historical "release everything pending" run.
+      pnpm11:
+        description: Release pnpm v11 (the TypeScript CLI) and the rest of the default lane.
+        type: boolean
+        default: true
+      pnpm:
+        description: Release pnpm (the Rust CLI, v12 alpha prerelease) and its @pnpm/napi addon.
+        type: boolean
+        default: true
+      pnpr:
+        description: Release pnpr (the registry server).
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -62,7 +80,12 @@ jobs:
     # keys, so a stale set could break verification after a key rotation. Any
     # drift is committed below along with the version bumps, so the new trust
     # roots are reviewed as part of the release PR diff.
+    # The embedded trust roots ship in the TypeScript CLI (v11) release, so they
+    # are only refreshed when pnpm11 is one of the products being released. A run
+    # that releases only the Rust products leaves v11 alone; any key drift is
+    # picked up by the next release that includes pnpm11.
     - name: Update embedded npm signing keys
+      if: github.event.inputs.pnpm11 == 'true'
       run: node pnpm11/deps/security/signatures/scripts/update-npm-signing-keys.mjs --update
 
     # Refresh the embedded Node.js release keys (used to verify the signature of
@@ -70,6 +93,7 @@ jobs:
     # nodejs/release-keys list, so a new release signer cannot break Node.js
     # runtime verification. Reviewed in the release PR diff like the npm keys.
     - name: Update embedded Node.js release keys
+      if: github.event.inputs.pnpm11 == 'true'
       run: node pnpm11/crypto/shasums-file/scripts/update-node-release-keys.mjs --update
 
     # A refreshed trust root must show up in the changelogs, so synthesize a
@@ -78,6 +102,7 @@ jobs:
     # on the PR, so a trust-root change cannot hide in a large version-bump diff.
     - name: Add changesets for refreshed keys
       id: keys
+      if: github.event.inputs.pnpm11 == 'true'
       run: |
         drifted=""
         if ! git diff --quiet -- pnpm11/deps/security/signatures/src/npmSigningKeys.ts; then
@@ -105,10 +130,24 @@ jobs:
         echo "drifted=$drifted" >> "$GITHUB_OUTPUT"
 
     # Consumes the pending changesets: bumps versions, writes changelogs, updates
-    # the ledger, and syncs manifests. A no-op (no pending changesets) leaves the
-    # tree clean and the steps below skip.
+    # the ledger, and syncs manifests. Only the checked products' intents are
+    # consumed; the rest stay in the ledger for a later release. A no-op (nothing
+    # pending in scope) leaves the tree clean and the steps below skip.
     - name: Bump versions
-      run: pnpm bump
+      env:
+        RELEASE_PNPM11: ${{ github.event.inputs.pnpm11 }}
+        RELEASE_PNPM: ${{ github.event.inputs.pnpm }}
+        RELEASE_PNPR: ${{ github.event.inputs.pnpr }}
+      run: |
+        args=()
+        [ "$RELEASE_PNPM11" = "true" ] && args+=(--release pnpm11)
+        [ "$RELEASE_PNPM" = "true" ] && args+=(--release pnpm)
+        [ "$RELEASE_PNPR" = "true" ] && args+=(--release pnpr)
+        if [ ${#args[@]} -eq 0 ]; then
+          echo "Select at least one product to release." >&2
+          exit 1
+        fi
+        pnpm run bump -- "${args[@]}"
 
     - name: Check for changes
       id: changes

--- a/pnpm11/__utils__/scripts/src/bump.ts
+++ b/pnpm11/__utils__/scripts/src/bump.ts
@@ -11,20 +11,84 @@
 // meta-updater then copies those versions into the Rust sources that embed
 // them (see the Rust-source handlers in `.meta-updater/src/index.ts`);
 // `meta-updater --test` in pre-push and CI enforces the same sync.
+//
+// `--release <product>` (repeatable) restricts the run to a subset of the three
+// releasable products, so a frequent v12 (Rust) release no longer has to drag
+// the TypeScript CLI (v11) along. With no `--release` flag every pending intent
+// is consumed, so a bare `pnpm bump` still cuts a full release.
 
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import url from 'node:url'
+
+// The workspace package selectors for each alpha-lane product, keyed by the
+// product's release token. These mirror `versioning.lanes` in
+// pnpm-workspace.yaml. The `pnpm` product is the Rust CLI (published to npm as
+// `pnpm`, named `pacquet` in-repo, carrying its versioning.fixed `@pnpm/napi`
+// sibling). The `pnpm11` product — the TypeScript CLI and the rest of the
+// default lane — has no single positive selector, so it is expressed as the
+// complement of the alpha products (see releaseFilterArgs).
+const ALPHA_PRODUCT_PACKAGES = {
+  pnpm: ['pacquet', '@pnpm/napi'],
+  pnpr: ['@pnpm/pnpr'],
+} as const
+
+type AlphaProduct = keyof typeof ALPHA_PRODUCT_PACKAGES
+type Product = 'pnpm11' | AlphaProduct
+
+const PRODUCTS: readonly Product[] = ['pnpm11', 'pnpm', 'pnpr']
 
 // The module-level consts are still in their temporal dead zone while this
 // file's statements run, so the actual `main()` call sits at the bottom.
 function main (): void {
   const repoRoot = findRepoRoot(import.meta.dirname)
+  const filterArgs = releaseFilterArgs(parseSelectedProducts(process.argv.slice(2)))
   // The release PR branch is dirty here (refreshed trust roots, synthesized
-  // changesets), so skip the clean-tree check.
-  execSync('pnpm version -r --no-git-checks', { cwd: repoRoot, stdio: 'inherit' })
-  execSync('pnpm update-manifests', { cwd: repoRoot, stdio: 'inherit' })
+  // changesets), so skip the clean-tree check. Pass the arguments as an argv
+  // array (no shell) so a filter value is never interpreted by a shell.
+  execFileSync('pnpm', ['version', '-r', '--no-git-checks', ...filterArgs], { cwd: repoRoot, stdio: 'inherit' })
+  execFileSync('pnpm', ['update-manifests'], { cwd: repoRoot, stdio: 'inherit' })
+}
+
+export function parseSelectedProducts (argv: readonly string[]): Set<Product> {
+  const selected = new Set<Product>()
+  for (let i = 0; i < argv.length; i++) {
+    // Fail closed: an unrecognized token (e.g. a `--releases` typo) must not be
+    // silently skipped, which would leave the selection empty and release
+    // every product. Only "--release <product>" is accepted; no args at all
+    // still means a full release (see releaseFilterArgs).
+    if (argv[i] !== '--release') {
+      throw new Error(`Unexpected bump argument: ${String(argv[i])}. Only "--release <product>" is supported.`)
+    }
+    const product = argv[++i]
+    if (product === undefined || !(PRODUCTS as readonly string[]).includes(product)) {
+      throw new Error(`Unknown --release product: ${String(product)}. Expected one of ${PRODUCTS.join(', ')}.`)
+    }
+    selected.add(product as Product)
+  }
+  return selected
+}
+
+// Turns the selected products into `--filter` arguments for `pnpm version -r`.
+// An empty selection releases everything (no filter). When `pnpm11` is selected
+// the run starts from the whole workspace and excludes only the alpha products
+// left unselected (an exclude-only filter selects "every project minus these"),
+// so selecting all three yields no filter — a full release. When `pnpm11` is not
+// selected only the chosen alpha products' packages are included.
+export function releaseFilterArgs (selected: ReadonlySet<Product>): string[] {
+  if (selected.size === 0) return []
+  const alphaProducts = Object.keys(ALPHA_PRODUCT_PACKAGES) as AlphaProduct[]
+  if (selected.has('pnpm11')) {
+    return alphaProducts
+      .filter((product) => !selected.has(product))
+      .flatMap((product) => ALPHA_PRODUCT_PACKAGES[product])
+      .map((pkg) => `--filter=!${pkg}`)
+  }
+  return alphaProducts
+    .filter((product) => selected.has(product))
+    .flatMap((product) => ALPHA_PRODUCT_PACKAGES[product])
+    .map((pkg) => `--filter=${pkg}`)
 }
 
 export function findRepoRoot (startDir: string): string {

--- a/pnpm11/__utils__/scripts/test/bump.ts
+++ b/pnpm11/__utils__/scripts/test/bump.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
 
-import { findRepoRoot } from '../src/bump.js'
+import { findRepoRoot, parseSelectedProducts, releaseFilterArgs } from '../src/bump.js'
 
 describe('findRepoRoot', () => {
   let dir: string
@@ -22,5 +22,50 @@ describe('findRepoRoot', () => {
 
   test('throws when no .changeset directory exists above', () => {
     expect(() => findRepoRoot(dir)).toThrow(/No \.changeset directory/)
+  })
+})
+
+describe('parseSelectedProducts', () => {
+  test('collects the products named by --release', () => {
+    expect(parseSelectedProducts(['--release', 'pnpm11', '--release', 'pnpr']))
+      .toEqual(new Set(['pnpm11', 'pnpr']))
+  })
+
+  test('is empty when no argument is passed (a bare `pnpm bump` releases everything)', () => {
+    expect(parseSelectedProducts([])).toEqual(new Set())
+  })
+
+  test('throws on an unknown product', () => {
+    expect(() => parseSelectedProducts(['--release', 'bogus'])).toThrow(/Unknown --release product/)
+  })
+
+  test('fails closed on a misspelled flag instead of releasing everything', () => {
+    expect(() => parseSelectedProducts(['--releases', 'pnpr'])).toThrow(/Unexpected bump argument/)
+  })
+})
+
+describe('releaseFilterArgs', () => {
+  test('releases everything (no filter) when nothing is selected', () => {
+    expect(releaseFilterArgs(new Set())).toEqual([])
+  })
+
+  test('releases everything (no filter) when all three products are selected', () => {
+    expect(releaseFilterArgs(new Set(['pnpm11', 'pnpm', 'pnpr']))).toEqual([])
+  })
+
+  test('excludes the unselected alpha products when pnpm11 is selected', () => {
+    expect(releaseFilterArgs(new Set(['pnpm11'])))
+      .toEqual(['--filter=!pacquet', '--filter=!@pnpm/napi', '--filter=!@pnpm/pnpr'])
+    expect(releaseFilterArgs(new Set(['pnpm11', 'pnpr'])))
+      .toEqual(['--filter=!pacquet', '--filter=!@pnpm/napi'])
+  })
+
+  test('includes only the selected alpha products when pnpm11 is not selected', () => {
+    expect(releaseFilterArgs(new Set(['pnpm'])))
+      .toEqual(['--filter=pacquet', '--filter=@pnpm/napi'])
+    expect(releaseFilterArgs(new Set(['pnpm', 'pnpr'])))
+      .toEqual(['--filter=pacquet', '--filter=@pnpm/napi', '--filter=@pnpm/pnpr'])
+    expect(releaseFilterArgs(new Set(['pnpr'])))
+      .toEqual(['--filter=@pnpm/pnpr'])
   })
 })


### PR DESCRIPTION
## Summary

The "Update available!" notification pops up almost every day (pnpm/pnpm#13264). The root cause is the release process: the pnpm v11 (TypeScript CLI) and v12 (Rust) releases are entangled. `pnpm bump` ran `pnpm version -r` unfiltered, consuming the entire `.changeset` ledger in one pass, so cutting a frequent v12 alpha prerelease also released v11 every time — and each v11 release triggers the update notification.

This PR lets a release cover **any combination** of the three products. `create-release-pr.yml` gains three checkboxes:

- **pnpm11** — the TypeScript CLI (v11) and the rest of the default lane.
- **pnpm** — the Rust CLI (v12 alpha prerelease) and its `@pnpm/napi` addon.
- **pnpr** — the registry server.

Only the checked products' pending changesets are consumed; the rest stay in the ledger for a later release. So you can dispatch a v12-alpha release with only **pnpm** checked and v11 never moves — no v11 release, no notification churn — while update notifications stay fully intact for real v11 releases. Leaving all three checked reproduces today's "release everything pending" run.

### How it works

`bump.ts` translates the selected products into `pnpm version -r --filter` arguments:

- **pnpm11** has no single positive selector (it's the whole default lane), so it's expressed as the *complement* of the unselected alpha products — an exclude-only filter (`--filter=!pacquet …`), which `pnpm version -r` resolves as "every project minus these" (`filter.rs:118`). Selecting all three yields no filter — a full release.
- **pnpm** / **pnpr** map to positive `--filter` selectors for their workspace packages (`pnpm` → `pacquet` + `@pnpm/napi`; the Rust CLI is named `pacquet` in-repo).

The embedded trust-root refresh steps run only when **pnpm11** is selected, since those keys ship in the TypeScript CLI. The version command is built as an argv array (`execFileSync`, no shell). The product→package mapping lives in `bump.ts` (dependency-light — the release workflow doesn't build packages) and is unit-tested.

Related to pnpm/pnpm#13264.

## Squash Commit Body

```text
The pnpm v11 (TypeScript CLI) and v12 (Rust) release processes were entangled:
`pnpm bump` ran `pnpm version -r` unfiltered, consuming the whole changeset
ledger, so every frequent v12 alpha release also released v11 — and each v11
release triggered the "Update available!" notification (pnpm/pnpm#13264).

Give create-release-pr.yml three checkboxes — pnpm11 (the TypeScript CLI), pnpm
(the Rust CLI, v12 alpha), and pnpr — in any combination. bump.ts translates the
selected products into `pnpm version -r --filter` arguments, consuming only
their intents and leaving the rest in the ledger. The default lane (pnpm11) is
expressed as the complement of the unselected alpha products (an exclude-only
filter selects every project minus those); selecting all three yields no filter,
a full release. Trust-root refresh steps run only when pnpm11 is selected, since
those keys ship in the TypeScript CLI. The version command is built as an argv
array (execFileSync, no shell).

Related to pnpm/pnpm#13264.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Release-tooling only. It builds on `pnpm version -r --filter`, which the
  Rust engine already implements; no product behavior changes in either stack. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. <!-- Not needed: only the private `@pnpm/scripts` script and a
  GitHub Actions workflow change; no published package is affected. -->
- [x] Added or updated tests. <!-- Unit tests for the product→filter mapping in
  bump.ts (test/bump.ts). -->
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-4-8).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release initiation now offers three boolean product selections (pnpm11, pnpm, pnpr), defaulting to enabled.
* **Improvements**
  * Version bumping now targets only the selected products using generated include/exclude package filters.
  * Refreshed npm signing keys and refreshed-key changesets run only when pnpm11 is selected, and the release process stops if no products are selected.
* **Tests**
  * Added Jest coverage for parsing selected products from CLI flags and for the resulting filter arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->