### PR TITLE
fix: forward resolutionPolicyViolations from the pnpr install path

### DIFF
--- a/.changeset/pnpr-install-policy-violations.md
+++ b/.changeset/pnpr-install-policy-violations.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Workspace installs through a pnpr server no longer crash with `Cannot read properties of undefined (reading 'filter')` after linking, when `minimumReleaseAge` is active [#13275](https://github.com/pnpm/pnpm/issues/13275).

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2609,7 +2609,8 @@ async function mutateModulesViaPnpr (
     updatedProjects,
     stats: result.stats,
     ignoredBuilds: result.ignoredBuilds,
-  } as MutateModulesResult
+    resolutionPolicyViolations: result.resolutionPolicyViolations,
+  }
 }
 
 /**

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -127,6 +127,19 @@ test("pnpr forwards every workspace project's name and version", async () => {
   }
 })
 
+test('pnpr returns the resolution policy violations the install command reacts to', async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir, {
+    allProjects: [{ buildIndex: 0, manifest, rootDir }],
+  })
+
+  const result = await mutateModules([{ mutation: 'install', rootDir }], options)
+
+  expect(result.resolutionPolicyViolations).toStrictEqual([])
+})
+
 function createOptions (
   workspaceRoot: string,
   rootDir: ProjectRootDir,


### PR DESCRIPTION
## Summary

Installs going through a pnpr server crashed after linking with
`Cannot read properties of undefined (reading 'filter')` whenever a resolution
policy handler was active — which, since `minimumReleaseAge` defaults to
`24 * 60`, is the normal case.

`installViaPnprServer` already returns `resolutionPolicyViolations: []` (the
pnpr server enforces `minimumReleaseAge` itself and `trustPolicy` is refused
up front), but `mutateModulesViaPnpr` built its own result object and dropped
the field. It got away with it because the object literal ended in an
`as MutateModulesResult` cast, which papers over missing required properties.
The install command then called `policyHandlers.pickManifestUpdates(undefined)`
→ `filterImmatureViolations(undefined)` → crash, after packages were linked
and lifecycle scripts had run.

The fix forwards the field and drops the cast, so any future missing property
is a compile error instead of a runtime crash. Hardening
`filterImmatureViolations` against `undefined` was considered and skipped: its
parameter is non-optional, so the type hole was the actual defect.

Closes pnpm/pnpm#13275

## Squash Commit Body

```text
mutateModulesViaPnpr built its result with an `as MutateModulesResult` cast,
which silently allowed the required resolutionPolicyViolations field to be
missing. With the default minimumReleaseAge active, the install command's
policy handler then ran `undefined.filter(...)` and crashed after packages
were already linked.

Forward the field from installViaPnprServer (which already returns an empty
list — the pnpr server enforces minimumReleaseAge server-side) and remove the
cast so the type checker catches a dropped field next time.

Closes pnpm/pnpm#13275
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- TypeScript-only defect: pacquet's `install_via_pnpr` returns
  `miette::Result<()>` and has no optional violations slot to drop, so there is
  nothing to mirror. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787520713&installation_model_id=426870&pr_number=13278&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13278&signature=5de0b082157965d416f3c5ca979071d88c2c7b1e0a7427e48902d49c85cc8e7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace installs routed through a pnpr server that could crash when `minimumReleaseAge` was enabled.
  * Resolution-policy violations are now correctly included in installation results.
* **Tests**
  * Added coverage verifying successful installs return an empty resolution-policy violation list.
* **Documentation**
  * Added a Changeset documenting the patch fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->