### PR TITLE
fix(pnpr): send the full request both clients owe the server (policy, catalogs, resolution mode)

### DIFF
--- a/.changeset/pacquet-pnpr-catalogs.md
+++ b/.changeset/pacquet-pnpr-catalogs.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `catalog:` references failing to resolve when installing through a pnpr server, which errored with "No catalog entry '<name>' was found for catalog 'default'." even though the catalog entry existed. The workspace the server reconstructs from the request has no catalog sections, so the client now sends its catalogs along with the request [#13232](https://github.com/pnpm/pnpm/issues/13232).

--- a/.changeset/pnpr-forward-verification-policy.md
+++ b/.changeset/pnpr-forward-verification-policy.md
@@ -7,3 +7,5 @@
 Installs through a pnpr server now send the whole verification policy to the server, not just `minimumReleaseAge`. Previously `minimumReleaseAgeExclude`, `minimumReleaseAgeIgnoreMissingTime`, `trustPolicy`, `trustPolicyExclude`, `trustPolicyIgnoreAfter`, and `trustLockfile` were dropped from the request, so the server enforced a stricter policy than configured — packages listed in `minimumReleaseAgeExclude` were still held back, and a lockfile containing them could be rejected outright.
 
 `trustPolicy: no-downgrade` no longer fails with `TRUST_POLICY_INCOMPATIBLE_WITH_PNPR` when a pnpr server is configured; the server enforces the policy for both reused and freshly-resolved entries.
+
+`--frozen-lockfile` and `--no-prefer-frozen-lockfile` are now honored on the pnpr path. Previously the server always reused and updated the lockfile, so a frozen install could resolve and rewrite the lockfile it was supposed to leave untouched. Since `frozenLockfile` defaults to `true` on CI, a CI install through a pnpr server now fails on an out-of-date lockfile instead of silently updating it.

--- a/.changeset/pnpr-forward-verification-policy.md
+++ b/.changeset/pnpr-forward-verification-policy.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/pnpr.client": patch
+"pnpm": patch
+---
+
+Installs through a pnpr server now send the whole verification policy to the server, not just `minimumReleaseAge`. Previously `minimumReleaseAgeExclude`, `minimumReleaseAgeIgnoreMissingTime`, `trustPolicy`, `trustPolicyExclude`, `trustPolicyIgnoreAfter`, and `trustLockfile` were dropped from the request, so the server enforced a stricter policy than configured — packages listed in `minimumReleaseAgeExclude` were still held back, and a lockfile containing them could be rejected outright.
+
+`trustPolicy: no-downgrade` no longer fails with `TRUST_POLICY_INCOMPATIBLE_WITH_PNPR` when a pnpr server is configured; the server enforces the policy for both reused and freshly-resolved entries.

--- a/.changeset/pnpr-forward-verification-policy.md
+++ b/.changeset/pnpr-forward-verification-policy.md
@@ -4,8 +4,8 @@
 "pnpm": patch
 ---
 
-Installs through a pnpr server now send the whole verification policy to the server, not just `minimumReleaseAge`. Previously `minimumReleaseAgeExclude`, `minimumReleaseAgeIgnoreMissingTime`, `trustPolicy`, `trustPolicyExclude`, `trustPolicyIgnoreAfter`, and `trustLockfile` were dropped from the request, so the server enforced a stricter policy than configured — packages listed in `minimumReleaseAgeExclude` were still held back, and a lockfile containing them could be rejected outright.
+Installs through a pnpr server now apply the project's whole verification policy. `minimumReleaseAgeExclude`, `minimumReleaseAgeIgnoreMissingTime`, `trustPolicy`, `trustPolicyExclude`, `trustPolicyIgnoreAfter`, and `trustLockfile` were ignored, so excluded packages were still held back and a lockfile containing them could be rejected.
 
-`trustPolicy: no-downgrade` no longer fails with `TRUST_POLICY_INCOMPATIBLE_WITH_PNPR` when a pnpr server is configured; the server enforces the policy for both reused and freshly-resolved entries.
+`trustPolicy: no-downgrade` no longer fails with `TRUST_POLICY_INCOMPATIBLE_WITH_PNPR` when a pnpr server is configured.
 
-`--frozen-lockfile` and `--no-prefer-frozen-lockfile` are now honored on the pnpr path. Previously the server always reused and updated the lockfile, so a frozen install could resolve and rewrite the lockfile it was supposed to leave untouched. Since `frozenLockfile` defaults to `true` on CI, a CI install through a pnpr server now fails on an out-of-date lockfile instead of silently updating it.
+`--frozen-lockfile` and `--no-prefer-frozen-lockfile` are now honored on the pnpr path, instead of resolving and rewriting the lockfile anyway. Since `frozenLockfile` defaults to `true` on CI, a CI install through a pnpr server now fails on an out-of-date lockfile rather than updating it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4817,6 +4817,7 @@ dependencies = [
  "derive_more",
  "futures-util",
  "mockito",
+ "pacquet-catalogs-types",
  "pacquet-config",
  "pacquet-lockfile",
  "pacquet-lockfile-verification",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10136,6 +10136,9 @@ importers:
       '@pnpm/lockfile.types':
         specifier: workspace:*
         version: link:../../pnpm11/lockfile/types
+      '@pnpm/types':
+        specifier: workspace:*
+        version: link:../../pnpm11/core/types
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -10143,9 +10146,6 @@ importers:
       '@pnpm/pnpr.client':
         specifier: workspace:*
         version: 'link:'
-      '@pnpm/types':
-        specifier: workspace:*
-        version: link:../../pnpm11/core/types
 
   pnpr/npm/pnpr: {}
 

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -7,7 +7,9 @@ use crate::{
 };
 use clap::{Args, ValueEnum};
 use derive_more::{Display, Error};
-use miette::{Context, Diagnostic};
+use miette::{Context, Diagnostic, IntoDiagnostic};
+use pacquet_catalogs_config::get_catalogs_from_workspace_manifest;
+use pacquet_catalogs_types::Catalogs;
 use pacquet_config::NodeLinker;
 use pacquet_lockfile::{Lockfile, LockfileResolution, MaybeLazyLockfile};
 use pacquet_modules_yaml::IncludedDependencies;
@@ -739,6 +741,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         // route policy, so they stay out of the request body.
         authorization: state.config.auth_headers.for_url(pnpr_server),
         overrides,
+        catalogs: pnpr_catalogs(state)?,
         lockfile: previous_wanted.clone(),
         frozen_lockfile: link.frozen_lockfile,
         prefer_frozen_lockfile: Some(link.prefer_frozen_lockfile),
@@ -1049,6 +1052,26 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     }
 
     Ok(())
+}
+
+/// The catalogs the pnpr server resolves `catalog:` specifiers against,
+/// picked the same way [`pacquet_package_manager::Install`] picks them:
+/// an `updateConfig` pnpmfile hook's complete set when it produced one,
+/// otherwise the raw workspace-manifest read. `None` when the workspace
+/// defines none, which keeps the field off the request entirely.
+fn pnpr_catalogs(state: &State) -> miette::Result<Option<Catalogs>> {
+    if let Some(catalogs) = state.config.catalogs.clone() {
+        return Ok(Some(catalogs));
+    }
+    let workspace_root = state.config.workspace_dir.as_deref().unwrap_or_else(|| {
+        state.manifest.path().parent().expect("manifest path always has a parent dir")
+    });
+    let workspace_manifest =
+        pacquet_workspace::read_workspace_manifest(workspace_root).into_diagnostic()?;
+    let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+        .into_diagnostic()
+        .wrap_err("reading catalogs to forward to the pnpr server")?;
+    Ok((!catalogs.is_empty()).then_some(catalogs))
 }
 
 fn resolve_projects_for_pnpr(

--- a/pnpm/crates/cli/tests/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/pnpr_install.rs
@@ -17,6 +17,7 @@ use pacquet_testing_utils::{
 };
 use pnpr::TokenBackend;
 use std::{
+    fmt::Write as _,
     fs,
     net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
     path::Path,
@@ -384,6 +385,37 @@ fn assert_standard_workspace_pnpr_from(project: Option<&str>) {
     );
     assert!(workspace_has_link(&workspace, "app", WORKSPACE_HELLO));
     assert!(workspace_has_link(&workspace, "lib", WORKSPACE_PARENT));
+
+    drop((root, mock_instance));
+}
+
+/// The workspace the server reconstructs from a resolve request has no
+/// catalog sections of its own, so an unsent catalog leaves every
+/// `catalog:` specifier unresolvable
+/// ([pnpm/pnpm#13232](https://github.com/pnpm/pnpm/issues/13232)).
+#[test]
+fn workspace_install_via_pnpr_resolves_catalog_references() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+    configure_workspace(&workspace);
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&path).expect("read pnpm-workspace.yaml");
+    writeln!(yaml, "catalog:\n  '{WORKSPACE_HELLO}': 1.0.0").expect("append the catalog");
+    fs::write(&path, yaml).expect("write pnpm-workspace.yaml");
+    write_workspace_project(&workspace, "app", "app", (WORKSPACE_HELLO, "catalog:"));
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["install", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+
+    let wanted = read_workspace_lockfile(&workspace);
+    assert_eq!(workspace_importer_version(&wanted, "packages/app", WORKSPACE_HELLO), "1.0.0");
+    assert!(workspace_has_link(&workspace, "app", WORKSPACE_HELLO));
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/pnpr-client/Cargo.toml
+++ b/pnpm/crates/pnpr-client/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+pacquet-catalogs-types        = { workspace = true }
 pacquet-config                = { workspace = true }
 pacquet-lockfile              = { workspace = true }
 pacquet-lockfile-verification = { workspace = true }

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -21,6 +21,7 @@ use std::collections::{BTreeMap, HashSet};
 
 use derive_more::{Display, Error, From};
 use futures_util::StreamExt as _;
+use pacquet_catalogs_types::Catalogs;
 use pacquet_config::TrustPolicy;
 use pacquet_lockfile::Lockfile;
 use pacquet_lockfile_verification::{RenderedViolation, VerifyError};
@@ -54,8 +55,15 @@ pub struct ResolveOptions {
     /// its route policy, so none are placed in the request body.
     pub authorization: Option<String>,
     /// The client's `overrides` (selector -> spec) as raw JSON, applied
-    /// at resolve time server-side.
+    /// at resolve time server-side. Sent unresolved: `catalog:` references
+    /// in them are resolved server-side against [`Self::catalogs`].
     pub overrides: Option<serde_json::Value>,
+    /// The client's workspace catalogs (`catalog:` / `catalogs:` from
+    /// `pnpm-workspace.yaml`). The workspace the server reconstructs from
+    /// this request carries no catalog sections, so without these it
+    /// cannot resolve a `catalog:` specifier in either dependencies or
+    /// overrides ([pnpm/pnpm#13232](https://github.com/pnpm/pnpm/issues/13232)).
+    pub catalogs: Option<Catalogs>,
     /// The client's existing on-disk lockfile, when present. Sent both
     /// as the verification target and the resolution-reuse seed.
     pub lockfile: Option<Lockfile>,
@@ -105,6 +113,7 @@ pub struct ResolveProjectsOptions {
     pub named_registries: DepMap,
     pub authorization: Option<String>,
     pub overrides: Option<serde_json::Value>,
+    pub catalogs: Option<Catalogs>,
     pub lockfile: Option<Lockfile>,
     pub frozen_lockfile: bool,
     pub prefer_frozen_lockfile: Option<bool>,
@@ -133,6 +142,7 @@ impl From<ResolveOptions> for ResolveProjectsOptions {
             named_registries: opts.named_registries,
             authorization: opts.authorization,
             overrides: opts.overrides,
+            catalogs: opts.catalogs,
             lockfile: opts.lockfile,
             frozen_lockfile: opts.frozen_lockfile,
             prefer_frozen_lockfile: opts.prefer_frozen_lockfile,
@@ -427,6 +437,7 @@ impl PnprClient {
             "registry": opts.registry,
             "namedRegistries": opts.named_registries,
             "overrides": opts.overrides,
+            "catalogs": opts.catalogs,
             "lockfile": opts.lockfile,
             "frozenLockfile": opts.frozen_lockfile,
             "preferFrozenLockfile": opts.prefer_frozen_lockfile,

--- a/pnpm/crates/pnpr-client/src/tests.rs
+++ b/pnpm/crates/pnpr-client/src/tests.rs
@@ -1,4 +1,76 @@
-use super::{Frame, PnprClientError, VerifyError, build_verify_error, parse_frame};
+use std::collections::BTreeMap;
+
+use pacquet_config::TrustPolicy;
+use serde_json::json;
+
+use super::{
+    Frame, PnprClient, PnprClientError, ResolveProject, ResolveProjectsOptions, VerifyError,
+    build_verify_error, parse_frame,
+};
+
+/// The request body is the whole contract with the server: a field the
+/// client omits is not defaulted server-side but cleared, so the server
+/// resolves under a policy the user never configured and cannot see
+/// `catalog:` definitions at all. Assert on what actually goes over the
+/// wire rather than on the options struct.
+#[tokio::test]
+async fn the_resolve_request_carries_the_catalogs_and_the_whole_policy() {
+    let mut server = mockito::Server::new_async().await;
+    let resolve_mock = server
+        .mock("POST", "/-/pnpr/v0/resolve")
+        .match_body(mockito::Matcher::PartialJson(json!({
+            "catalogs": { "default": { "acme": "^1.0.0" } },
+            "minimumReleaseAge": 1440,
+            "minimumReleaseAgeExclude": ["@acme/*"],
+            "minimumReleaseAgeIgnoreMissingTime": false,
+            "trustPolicy": "no-downgrade",
+            "trustPolicyExclude": ["legacy-pkg"],
+            "trustPolicyIgnoreAfter": 43200,
+            "trustLockfile": true,
+        })))
+        .with_body("{\"type\":\"done\",\"lockfile\":{\"lockfileVersion\":\"9.0\"}}\n")
+        .create_async()
+        .await;
+
+    let _outcome = PnprClient::new(server.url())
+        .resolve_projects(resolve_projects_options())
+        .await
+        .expect("the resolve succeeds");
+
+    resolve_mock.assert_async().await;
+}
+
+fn resolve_projects_options() -> ResolveProjectsOptions {
+    ResolveProjectsOptions {
+        projects: vec![ResolveProject {
+            dir: ".".to_string(),
+            name: Some("app".to_string()),
+            version: Some("1.0.0".to_string()),
+            dependencies: BTreeMap::from([("acme".to_string(), "catalog:".to_string())]),
+            dev_dependencies: BTreeMap::new(),
+            optional_dependencies: BTreeMap::new(),
+        }],
+        registry: "https://registry.test/".to_string(),
+        named_registries: BTreeMap::new(),
+        authorization: None,
+        overrides: None,
+        catalogs: Some(BTreeMap::from([(
+            "default".to_string(),
+            BTreeMap::from([("acme".to_string(), "^1.0.0".to_string())]),
+        )])),
+        lockfile: None,
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        trust_lockfile: true,
+        minimum_release_age: Some(1440),
+        minimum_release_age_exclude: Some(vec!["@acme/*".to_string()]),
+        minimum_release_age_ignore_missing_time: false,
+        trust_policy: TrustPolicy::NoDowngrade,
+        trust_policy_exclude: Some(vec!["legacy-pkg".to_string()]),
+        trust_policy_ignore_after: Some(43200),
+    }
+}
 
 #[test]
 fn a_violations_frame_rebuilds_a_verify_error() {

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -209,6 +209,7 @@ fn options(
         named_registries: BTreeMap::new(),
         authorization: Some(authorization.to_string()),
         overrides: None,
+        catalogs: None,
         lockfile: None,
         frozen_lockfile: false,
         prefer_frozen_lockfile: None,

--- a/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
+++ b/pnpm11/installing/deps-installer/src/install/extendInstallOptions.ts
@@ -186,6 +186,7 @@ export interface StrictInstallOptions {
   ci?: boolean
   minimumReleaseAge?: number
   minimumReleaseAgeExclude?: string[]
+  minimumReleaseAgeIgnoreMissingTime?: boolean
   /**
    * Resolver-agnostic post-tree gate, invoked between
    * `resolveDependencyTree` and `resolvePeers` inside

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2789,11 +2789,10 @@ async function installViaPnprServer (
       // `pnpm:stats` log events.
       stats: stats ?? { added: 0, removed: 0, linkedToRoot: 0 },
       lockfile,
-      // Server-side resolution (pnpr server) enforces `minimumReleaseAge`
-      // itself — the pnpr server picks only mature versions and the lockfile
-      // can't contain immature entries to auto-collect. `trustPolicy` is
-      // guarded above (we refuse to enter this path when it's set), so
-      // there's nothing for the install command to react to here.
+      // The pnpr server enforces the whole verification policy itself and
+      // reports any violation as a terminal `violations` frame, which the
+      // client turns into a thrown error — so a resolve that got this far
+      // produced a policy-clean lockfile with nothing left to react to.
       resolutionPolicyViolations: [],
     }
   } finally {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2696,6 +2696,11 @@ async function installViaPnprServer (
       trustPolicyExclude: opts.trustPolicyExclude,
       trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
       trustLockfile: opts.trustLockfile,
+      // Resolution mode. Without these the server always reuse-and-updates,
+      // so `--frozen-lockfile` would silently resolve and rewrite the very
+      // lockfile it promises to leave alone.
+      frozenLockfile: opts.frozenLockfile === true || (opts.frozenLockfileIfExists === true && existingLockfile != null),
+      preferFrozenLockfile: opts.preferFrozenLockfile,
       lockfile: existingLockfile ?? undefined,
     })
 

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2637,18 +2637,6 @@ async function installViaPnprServer (
       { hint: 'Disable the pnpr server (unset `--pnpr-server` / `pnprServer` in pnpm-workspace.yaml) so the install reads from the existing store, or unset `frozenStore` to allow store writes.' }
     )
   }
-  // The pnpr server path skips client-side resolution, so resolver-side policies
-  // can't be enforced locally. `minimumReleaseAge` is forwarded to the
-  // pnpr server and enforced server-side. `trustPolicy` has no server-side
-  // counterpart yet, so refuse to run under it instead of silently
-  // letting through a lockfile the local verifier would reject.
-  if (opts.trustPolicy === 'no-downgrade') {
-    throw new PnpmError(
-      'TRUST_POLICY_INCOMPATIBLE_WITH_PNPR',
-      'The pnpr server does not yet enforce `trustPolicy: no-downgrade`, so running an install through it under this policy would produce a lockfile that the local verifier rejects.',
-      { hint: 'Unset `trustPolicy` for this install, or disable the pnpr server (unset `--pnpr-server` / `pnprServer` in pnpm-workspace.yaml) so resolution runs locally and the trust check applies.' }
-    )
-  }
   const { resolveViaPnprServer } = await import('@pnpm/pnpr.client')
   const { createGetAuthHeaderByURI } = await import('@pnpm/network.auth-header')
 
@@ -2702,6 +2690,12 @@ async function installViaPnprServer (
       // `catalog:` specifiers in both dependencies and overrides.
       catalogs: opts.catalogs,
       minimumReleaseAge: opts.minimumReleaseAge,
+      minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
+      minimumReleaseAgeIgnoreMissingTime: opts.minimumReleaseAgeIgnoreMissingTime,
+      trustPolicy: opts.trustPolicy,
+      trustPolicyExclude: opts.trustPolicyExclude,
+      trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
+      trustLockfile: opts.trustLockfile,
       lockfile: existingLockfile ?? undefined,
     })
 

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -140,6 +140,44 @@ test('pnpr returns the resolution policy violations the install command reacts t
   expect(result.resolutionPolicyViolations).toStrictEqual([])
 })
 
+test("pnpr forwards the client's whole verification policy, not just the age cutoff", async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir, {
+    minimumReleaseAge: 1440,
+    minimumReleaseAgeExclude: ['@acme/*'],
+    minimumReleaseAgeIgnoreMissingTime: false,
+    trustPolicy: 'no-downgrade',
+    trustPolicyExclude: ['legacy-pkg'],
+    trustPolicyIgnoreAfter: 43200,
+    trustLockfile: true,
+  })
+
+  await install(manifest, options)
+
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    minimumReleaseAge: 1440,
+    minimumReleaseAgeExclude: ['@acme/*'],
+    minimumReleaseAgeIgnoreMissingTime: false,
+    trustPolicy: 'no-downgrade',
+    trustPolicyExclude: ['legacy-pkg'],
+    trustPolicyIgnoreAfter: 43200,
+    trustLockfile: true,
+  }))
+})
+
+test('pnpr runs under trustPolicy instead of refusing the install', async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir, { trustPolicy: 'no-downgrade' })
+
+  await expect(install(manifest, options)).resolves.toBeDefined()
+
+  expect(resolveViaPnprServer).toHaveBeenCalledTimes(1)
+})
+
 function createOptions (
   workspaceRoot: string,
   rootDir: ProjectRootDir,

--- a/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
+++ b/pnpm11/installing/deps-installer/test/install/pnprWorkspaceMetadata.ts
@@ -167,6 +167,23 @@ test("pnpr forwards the client's whole verification policy, not just the age cut
   }))
 })
 
+test('pnpr forwards the resolution mode so --frozen-lockfile is not silently ignored', async () => {
+  const workspaceRoot = prepareEmpty().dir()
+  const rootDir = workspaceRoot as ProjectRootDir
+  const manifest: ProjectManifest = { name: 'app', version: '1.2.3' }
+  const options = createOptions(workspaceRoot, rootDir, {
+    frozenLockfile: true,
+    preferFrozenLockfile: false,
+  })
+
+  await install(manifest, options)
+
+  expect(resolveViaPnprServer).toHaveBeenCalledWith(expect.objectContaining({
+    frozenLockfile: true,
+    preferFrozenLockfile: false,
+  }))
+})
+
 test('pnpr runs under trustPolicy instead of refusing the install', async () => {
   const workspaceRoot = prepareEmpty().dir()
   const rootDir = workspaceRoot as ProjectRootDir

--- a/pnpr/client/package.json
+++ b/pnpr/client/package.json
@@ -34,12 +34,12 @@
   "dependencies": {
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/lockfile.fs": "workspace:*",
-    "@pnpm/lockfile.types": "workspace:*"
+    "@pnpm/lockfile.types": "workspace:*",
+    "@pnpm/types": "workspace:*"
   },
   "devDependencies": {
     "@jest/globals": "catalog:",
-    "@pnpm/pnpr.client": "workspace:*",
-    "@pnpm/types": "workspace:*"
+    "@pnpm/pnpr.client": "workspace:*"
   },
   "engines": {
     "node": ">=22.13"

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -83,6 +83,13 @@ export interface ResolveViaPnprServerOptions {
    */
   trustLockfile?: boolean
   /**
+   * Resolution behavior — whether the server uses the lockfile as-is or
+   * reuses its pins and resolves what changed. Distinct from the policy
+   * fields above: neither affects whether the input lockfile is verified.
+   */
+  frozenLockfile?: boolean
+  preferFrozenLockfile?: boolean
+  /**
    * Existing lockfile for incremental resolution, in the on-disk format
    * the wire protocol carries. The caller reads it with
    * `readWantedLockfileFile` so no in-memory→on-disk round-trip is needed.
@@ -147,6 +154,8 @@ export async function resolveViaPnprServer (
     trustPolicyExclude: opts.trustPolicyExclude,
     trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
     trustLockfile: opts.trustLockfile,
+    frozenLockfile: opts.frozenLockfile,
+    preferFrozenLockfile: opts.preferFrozenLockfile,
     // Sent as-is: `opts.lockfile` is already the on-disk format the wire
     // protocol carries (split `packages`/`snapshots`, `{ specifier, version }`
     // importer deps).

--- a/pnpr/client/src/resolveViaPnprServer.ts
+++ b/pnpr/client/src/resolveViaPnprServer.ts
@@ -6,6 +6,7 @@ import { gunzip } from 'node:zlib'
 import type { Catalogs } from '@pnpm/catalogs.types'
 import { convertToLockfileObject } from '@pnpm/lockfile.fs'
 import type { LockfileFile, LockfileObject } from '@pnpm/lockfile.types'
+import type { TrustPolicy } from '@pnpm/types'
 
 import type { ResponseMetadata } from './protocol.js'
 
@@ -59,8 +60,28 @@ export interface ResolveViaPnprServerOptions {
   catalogs?: Catalogs
   /** Node.js version for resolution */
   nodeVersion?: string
-  /** Minimum release age in minutes */
+  /**
+   * The client's verification policy. The server is the only place these
+   * run on the pnpr path — the client skips its own
+   * `verifyLockfileResolutions` whenever a pnpr server is configured — so
+   * every field has to travel with the request. Anything omitted is not
+   * merely defaulted server-side: the server clears the field from its
+   * config, which enforces a *stricter* policy than the user configured
+   * (an omitted `minimumReleaseAgeExclude` re-applies the age gate to
+   * packages the user opted out of).
+   */
   minimumReleaseAge?: number
+  minimumReleaseAgeExclude?: string[]
+  minimumReleaseAgeIgnoreMissingTime?: boolean
+  trustPolicy?: TrustPolicy
+  trustPolicyExclude?: string[]
+  trustPolicyIgnoreAfter?: number
+  /**
+   * The client's `trustLockfile` opt-out. When true the server skips the
+   * input-lockfile verification gate but still reuses the lockfile for
+   * resolution.
+   */
+  trustLockfile?: boolean
   /**
    * Existing lockfile for incremental resolution, in the on-disk format
    * the wire protocol carries. The caller reads it with
@@ -120,6 +141,12 @@ export async function resolveViaPnprServer (
     os: process.platform,
     arch: process.arch,
     minimumReleaseAge: opts.minimumReleaseAge,
+    minimumReleaseAgeExclude: opts.minimumReleaseAgeExclude,
+    minimumReleaseAgeIgnoreMissingTime: opts.minimumReleaseAgeIgnoreMissingTime,
+    trustPolicy: opts.trustPolicy,
+    trustPolicyExclude: opts.trustPolicyExclude,
+    trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
+    trustLockfile: opts.trustLockfile,
     // Sent as-is: `opts.lockfile` is already the on-disk format the wire
     // protocol carries (split `packages`/`snapshots`, `{ specifier, version }`
     // importer deps).


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13278. pnpr's design is that resolution *and* policy checks
run server-side — neither client runs its own `verifyLockfileResolutions` when a
pnpr server is configured. That only works if the server receives what the user
actually configured, and both clients were leaving fields out.

The omissions are not benign. `resolver.rs` assigns each field from the request
unconditionally (`config.minimum_release_age_exclude.clone_from(&request.minimum_release_age_exclude)`),
so a field the client omits is **cleared**, not defaulted — the server then
resolves under inputs the user never chose.

### 1. TypeScript client sent only `minimumReleaseAge` of the verification policy

Now forwards `minimumReleaseAgeExclude`, `minimumReleaseAgeIgnoreMissingTime`,
`trustPolicy`, `trustPolicyExclude`, `trustPolicyIgnoreAfter`, `trustLockfile`.
Previously the server enforced a *stricter* policy than configured: packages in
`minimumReleaseAgeExclude` were held back anyway, and the input-lockfile verifier
could reject a committed lockfile whose entries the user had explicitly excluded.
pacquet already sent all of these, so this is TS catching up.

This also drops the `TRUST_POLICY_INCOMPATIBLE_WITH_PNPR` guard. Its premise —
"the pnpr server does not yet enforce `trustPolicy`" — is stale: the guard landed
2026-06-03 and the server gained enforcement three days later in pnpm/pnpm#12232,
wiring `trust_policy*` into the config behind both the input-lockfile verifier and
the resolver's pick-time gate. Nothing referenced the error code and no test
covered it. With the policy forwarded, an install under `trustPolicy: no-downgrade`
produces a lockfile the local verifier accepts — which is what the guard existed to
protect, and what pacquet already does.

### 2. pacquet never sent `catalogs`

pnpm/pnpm#13233 fixed `catalog:` resolution through pnpr for the TypeScript client
and the server; its changeset names no Rust package, and the Rust client was left
behind. A pacquet user with catalogs and a pnpr server still hit
`No catalog entry '<name>' was found for catalog 'default'.` — reproduced by the new
end-to-end test before the fix.

Worth flagging for review: the obvious fix (forward `state.config.catalogs`) is
**wrong on its own**. That field is `None` unless an `updateConfig` pnpmfile hook
produced catalogs; otherwise the install reads them from the workspace manifest.
The client now picks them the same way `Install` does — hook set first, else the
manifest read. The unit test passes either way; only the end-to-end test catches it.

### 3. TypeScript client never sent the resolution mode

`frozenLockfile` and `preferFrozenLockfile` now travel with the request. Without
them the server always reuse-and-updates, so `--frozen-lockfile` through pnpr
silently resolved and rewrote the lockfile it promises to leave alone.

**Behavior change worth a careful look:** `frozenLockfile` defaults to `true` on CI,
so a CI install through a pnpr server now *fails* on an out-of-date lockfile instead
of quietly updating it. That is the point of the fix, but it will surface in existing
setups. One rough edge: the failure arrives as the server's error text rather than
pnpm's `ERR_PNPM_OUTDATED_LOCKFILE`. Loud-and-differently-worded beats silent, but
say the word and I'll map it.

`ignoreManifestCheck` is deliberately not forwarded from the TypeScript side — it has
no counterpart in the TypeScript CLI's config.

## Testing

Tests assert what actually goes over the wire, since a silently missing field is the
failure mode:

- `pnprWorkspaceMetadata.ts` — three new cases (full policy forwarded, `trustPolicy`
  proceeds instead of throwing, resolution mode forwarded). Each fails against the
  pre-change build.
- `pacquet-pnpr-client` — a mockito body matcher over catalogs + the whole policy set.
  Verified it fails when the field is removed.
- `pnpr_install.rs` — an end-to-end catalog install against a real in-process pnpr.
- Full `pnpm11/pnpm/test/install/pnpmRegistry.ts` (12 e2e tests) green, plus
  `cargo nextest` for both Rust crates, clippy `--deny warnings`, and `cargo fmt`.

## Squash Commit Body

```text
pnpr resolves and enforces policy server-side, and neither client runs its own
verifyLockfileResolutions when a pnpr server is configured. The server assigns
each field from the request unconditionally, so a field a client omits is cleared
rather than defaulted, and the server resolves under inputs the user never chose.

The TypeScript client sent only minimumReleaseAge of the verification policy, so
minimumReleaseAgeExclude entries stopped applying and the input-lockfile verifier
could reject a lockfile whose entries the user had explicitly excluded. It also
never sent the resolution mode, so --frozen-lockfile silently resolved and rewrote
the lockfile it promises to leave alone.

pacquet never sent catalogs, so every catalog: specifier failed to resolve — the
bug #13233 fixed for the TypeScript client and the server, leaving the Rust client
behind.

Drop the TRUST_POLICY_INCOMPATIBLE_WITH_PNPR guard, written before the server
gained trust-policy enforcement and refusing an install pacquet runs happily.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Each gap is fixed in the stack that had it: policy + resolution mode in
  TypeScript (pacquet already sent both), catalogs in pacquet (TypeScript already
  sent them). -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PNPR-based installs now send the full verification policy (including trust and minimum release age controls) and honor frozen-lockfile settings.
  * PNPR-based resolution now forwards workspace `catalog:` mappings to resolve catalog protocol references correctly.
* **Bug Fixes**
  * Fixed `trustPolicy: no-downgrade` failing when using a pnpr server.
* **Tests**
  * Added/updated coverage for verification-policy forwarding, lockfile flag behavior, and `catalog:` resolution via pnpr-server.
* **Chores**
  * Updated pnpr client dependency placement to ensure required types are available at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->