### PR TITLE
feat(cli): support the --workspace-root (-w) flag

### DIFF
--- a/.changeset/pacquet-workspace-root-flag.md
+++ b/.changeset/pacquet-workspace-root-flag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Added the `--workspace-root` (`-w`) flag, which runs the command on the root workspace project. `pnpm add -D typescript prettier -w` from a workspace subdirectory now saves to the root `package.json` instead of failing with "unexpected argument '-w' found" [#13031](https://github.com/pnpm/pnpm/issues/13031). Combined with `--recursive`, the flag narrows the run to the root project alone. `-w` may not be used together with `--global`, and may only be used inside a workspace.

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -259,25 +259,14 @@ impl CliArgs {
     }
 
     /// Apply `--workspace-root` / `-w`: point `--dir` at the workspace
-    /// root so the command runs on the root project.
+    /// root so the command runs on the root project. Call after
+    /// [`Self::promote_recursive_for_filter`] and before anything reads
+    /// `--dir`, matching where pnpm's CLI parser applies it.
     ///
-    /// Call after [`Self::promote_recursive_for_filter`] and before
-    /// anything reads `--dir`, matching where pnpm's CLI parser applies
-    /// it.
-    ///
-    /// `--dir` is resolved to its real path before the upward walk for the
-    /// workspace manifest, mirroring the `fs.realpath.native` that pnpm's
-    /// `findWorkspaceDir` applies for this flag's sake: a case-insensitive
-    /// filesystem otherwise finds the root under one spelling and the
-    /// member projects under another.
-    ///
-    /// Resolution failure falls back to `--dir` made absolute rather than
-    /// erroring, also matching pnpm — the walk is lexical from there, so a
-    /// `--dir` that does not exist yet still redirects to the workspace
-    /// root above it. Absolutizing is itself fallible (it reads the process
-    /// cwd), and a last fallback keeps `--dir` verbatim; that leaves the
-    /// walk relative, but a process whose cwd cannot be read has no
-    /// workspace to find either way.
+    /// The `--dir` resolution mirrors pnpm's `findWorkspaceDir`: real path
+    /// first, because a case-insensitive filesystem otherwise finds the
+    /// root under one spelling and the members under another; then a
+    /// lexical fallback, so an unresolvable `--dir` is not fatal.
     pub fn apply_workspace_root(&mut self) -> Result<(), WorkspaceRootError> {
         if !self.workspace_root {
             return Ok(());
@@ -584,9 +573,8 @@ pub enum CliCommand {
 }
 
 impl CliCommand {
-    /// Whether `--global` / `-g` was passed. pnpm parses `--global` as one
-    /// CLI-wide option; pacquet declares it per subcommand, so this
-    /// reassembles that CLI-wide view across every subcommand declaring it.
+    /// Whether `--global` was passed. pnpm parses it as one CLI-wide
+    /// option; pacquet declares it per subcommand.
     fn is_global(&self) -> bool {
         match self {
             CliCommand::Add(args) => args.global,

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -80,7 +80,7 @@ use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_default_reporter::SummaryScope;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Experimental package manager for node.js written in rust.
 #[derive(Debug, Parser)]
@@ -263,13 +263,16 @@ impl CliArgs {
     ///
     /// Call after [`Self::promote_recursive_for_filter`] and before
     /// anything reads `--dir`, matching where pnpm's CLI parser applies
-    /// it. `--dir` is canonicalized first so the upward walk for the
-    /// workspace manifest starts from a real absolute path — the whole
-    /// point of the flag is to be run from a subdirectory, which a
-    /// relative `--dir` has no ancestors to walk up from. A `--dir` that
-    /// cannot be canonicalized is reported as such rather than as a
-    /// missing workspace, so `-w` does not change which error an
-    /// unusable `--dir` produces.
+    /// it.
+    ///
+    /// `--dir` is resolved to its real path before the upward walk for the
+    /// workspace manifest, mirroring the `fs.realpath.native` that pnpm's
+    /// `findWorkspaceDir` applies for this flag's sake: a case-insensitive
+    /// filesystem otherwise finds the root under one spelling and the
+    /// member projects under another. Resolution failure falls back to
+    /// `--dir` made absolute rather than erroring, also matching pnpm — the
+    /// walk is lexical from there, so a `--dir` that does not exist yet
+    /// still redirects to the workspace root above it.
     pub fn apply_workspace_root(&mut self) -> Result<(), WorkspaceRootError> {
         if !self.workspace_root {
             return Ok(());
@@ -277,9 +280,7 @@ impl CliArgs {
         if self.command.is_global() {
             return Err(WorkspaceRootError::GlobalConflict);
         }
-        let dir = dunce::canonicalize(&self.dir).map_err(|source| {
-            WorkspaceRootError::CanonicalizeDir { path: self.dir.clone(), source }
-        })?;
+        let dir = dunce::canonicalize(&self.dir).unwrap_or_else(|_| absolute_dir(&self.dir));
         let workspace_dir = pacquet_workspace::find_workspace_dir(&dir)
             .map_err(WorkspaceRootError::FindWorkspaceDir)?
             .ok_or(WorkspaceRootError::NotInWorkspace)?;
@@ -347,6 +348,17 @@ impl CliArgs {
     }
 }
 
+/// `path` resolved against the process cwd, without requiring it to exist.
+/// The workspace-manifest walk climbs `Path::ancestors`, which a bare
+/// relative path runs out of at `""` — the resulting empty workspace dir
+/// would then fail to canonicalize downstream.
+fn absolute_dir(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
+}
+
 /// Error type of [`CliArgs::apply_workspace_root`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum WorkspaceRootError {
@@ -357,14 +369,6 @@ pub enum WorkspaceRootError {
     #[display("--workspace-root may only be used inside a workspace")]
     #[diagnostic(code(ERR_PNPM_NOT_IN_WORKSPACE))]
     NotInWorkspace,
-
-    #[display("canonicalizing the `--dir` argument: {}: {source}", path.display())]
-    #[diagnostic(code(ERR_PNPM_CANONICALIZE_DIR))]
-    CanonicalizeDir {
-        path: PathBuf,
-        #[error(source)]
-        source: std::io::Error,
-    },
 
     #[diagnostic(transparent)]
     FindWorkspaceDir(#[error(source)] pacquet_workspace::FindWorkspaceDirError),

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -80,7 +80,7 @@ use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_default_reporter::SummaryScope;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Experimental package manager for node.js written in rust.
 #[derive(Debug, Parser)]
@@ -269,10 +269,15 @@ impl CliArgs {
     /// workspace manifest, mirroring the `fs.realpath.native` that pnpm's
     /// `findWorkspaceDir` applies for this flag's sake: a case-insensitive
     /// filesystem otherwise finds the root under one spelling and the
-    /// member projects under another. Resolution failure falls back to
-    /// `--dir` made absolute rather than erroring, also matching pnpm — the
-    /// walk is lexical from there, so a `--dir` that does not exist yet
-    /// still redirects to the workspace root above it.
+    /// member projects under another.
+    ///
+    /// Resolution failure falls back to `--dir` made absolute rather than
+    /// erroring, also matching pnpm — the walk is lexical from there, so a
+    /// `--dir` that does not exist yet still redirects to the workspace
+    /// root above it. Absolutizing is itself fallible (it reads the process
+    /// cwd), and a last fallback keeps `--dir` verbatim; that leaves the
+    /// walk relative, but a process whose cwd cannot be read has no
+    /// workspace to find either way.
     pub fn apply_workspace_root(&mut self) -> Result<(), WorkspaceRootError> {
         if !self.workspace_root {
             return Ok(());
@@ -280,7 +285,9 @@ impl CliArgs {
         if self.command.is_global() {
             return Err(WorkspaceRootError::GlobalConflict);
         }
-        let dir = dunce::canonicalize(&self.dir).unwrap_or_else(|_| absolute_dir(&self.dir));
+        let dir = dunce::canonicalize(&self.dir)
+            .or_else(|_| std::path::absolute(&self.dir))
+            .unwrap_or_else(|_| self.dir.clone());
         let workspace_dir = pacquet_workspace::find_workspace_dir(&dir)
             .map_err(WorkspaceRootError::FindWorkspaceDir)?
             .ok_or(WorkspaceRootError::NotInWorkspace)?;
@@ -346,17 +353,6 @@ impl CliArgs {
         }
         self.validate_run_scoped_global_option("--no-bail")
     }
-}
-
-/// `path` resolved against the process cwd, without requiring it to exist.
-/// The workspace-manifest walk climbs `Path::ancestors`, which a bare
-/// relative path runs out of at `""` — the resulting empty workspace dir
-/// would then fail to canonicalize downstream.
-fn absolute_dir(path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        return path.to_path_buf();
-    }
-    std::env::current_dir().map_or_else(|_| path.to_path_buf(), |cwd| cwd.join(path))
 }
 
 /// Error type of [`CliArgs::apply_workspace_root`].

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -77,6 +77,8 @@ use super::{
     with::WithArgs,
 };
 use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
 use pacquet_default_reporter::SummaryScope;
 use std::path::PathBuf;
 
@@ -178,6 +180,10 @@ pub struct CliArgs {
     #[clap(long = "filter-prod", global = true)]
     pub filter_prod: Vec<String>,
 
+    /// Run the command on the root workspace project.
+    #[clap(short = 'w', long = "workspace-root", global = true)]
+    pub workspace_root: bool,
+
     /// Glob patterns naming test files, used by the `[since]` `--filter`
     /// selector to decide which changes count.
     #[clap(long = "test-pattern", global = true)]
@@ -252,6 +258,30 @@ impl CliArgs {
         }
     }
 
+    /// Apply `--workspace-root` / `-w`: point `--dir` at the workspace
+    /// root so the command runs on the root project.
+    ///
+    /// Call after [`Self::promote_recursive_for_filter`] and before
+    /// anything reads `--dir`, matching where pnpm's CLI parser applies
+    /// it. `--dir` is canonicalized first so the upward walk for the
+    /// workspace manifest starts from a real absolute path — the whole
+    /// point of the flag is to be run from a subdirectory, which a
+    /// relative `--dir` has no ancestors to walk up from.
+    pub fn apply_workspace_root(&mut self) -> Result<(), WorkspaceRootError> {
+        if !self.workspace_root {
+            return Ok(());
+        }
+        if self.command.is_global() {
+            return Err(WorkspaceRootError::GlobalConflict);
+        }
+        let dir = dunce::canonicalize(&self.dir).unwrap_or_else(|_| self.dir.clone());
+        let workspace_dir = pacquet_workspace::find_workspace_dir(&dir)
+            .map_err(WorkspaceRootError::FindWorkspaceDir)?
+            .ok_or(WorkspaceRootError::NotInWorkspace)?;
+        self.dir = workspace_dir;
+        Ok(())
+    }
+
     /// Promote commands marked recursive-by-default by pnpm when they run
     /// inside a workspace.
     pub fn promote_recursive_by_default(&mut self) {
@@ -310,6 +340,21 @@ impl CliArgs {
         }
         self.validate_run_scoped_global_option("--no-bail")
     }
+}
+
+/// Error type of [`CliArgs::apply_workspace_root`].
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum WorkspaceRootError {
+    #[display("--workspace-root may not be used with --global")]
+    #[diagnostic(code(ERR_PNPM_OPTIONS_CONFLICT))]
+    GlobalConflict,
+
+    #[display("--workspace-root may only be used inside a workspace")]
+    #[diagnostic(code(ERR_PNPM_NOT_IN_WORKSPACE))]
+    NotInWorkspace,
+
+    #[diagnostic(transparent)]
+    FindWorkspaceDir(#[error(source)] pacquet_workspace::FindWorkspaceDirError),
 }
 
 #[derive(Debug, Subcommand)]
@@ -526,6 +571,26 @@ pub enum CliCommand {
 }
 
 impl CliCommand {
+    /// Whether `--global` / `-g` was passed. pnpm parses `--global` as one
+    /// CLI-wide option; pacquet declares it per subcommand, so this
+    /// reassembles that CLI-wide view across every subcommand declaring it.
+    fn is_global(&self) -> bool {
+        match self {
+            CliCommand::Add(args) => args.global,
+            CliCommand::ApproveBuilds(args) => args.global,
+            CliCommand::Bin(args) => args.global,
+            CliCommand::Config(args) => args.is_global(),
+            CliCommand::List(args) | CliCommand::Ll(args) => args.global,
+            CliCommand::Outdated(args) => args.global,
+            CliCommand::Prefix(args) => args.global,
+            CliCommand::Remove(args) => args.global,
+            CliCommand::Root(args) => args.global,
+            CliCommand::Runtime(args) => args.global,
+            CliCommand::Update(args) => args.global,
+            _ => false,
+        }
+    }
+
     fn recursive_by_default(&self) -> bool {
         matches!(
             self,

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -266,7 +266,10 @@ impl CliArgs {
     /// it. `--dir` is canonicalized first so the upward walk for the
     /// workspace manifest starts from a real absolute path — the whole
     /// point of the flag is to be run from a subdirectory, which a
-    /// relative `--dir` has no ancestors to walk up from.
+    /// relative `--dir` has no ancestors to walk up from. A `--dir` that
+    /// cannot be canonicalized is reported as such rather than as a
+    /// missing workspace, so `-w` does not change which error an
+    /// unusable `--dir` produces.
     pub fn apply_workspace_root(&mut self) -> Result<(), WorkspaceRootError> {
         if !self.workspace_root {
             return Ok(());
@@ -274,7 +277,9 @@ impl CliArgs {
         if self.command.is_global() {
             return Err(WorkspaceRootError::GlobalConflict);
         }
-        let dir = dunce::canonicalize(&self.dir).unwrap_or_else(|_| self.dir.clone());
+        let dir = dunce::canonicalize(&self.dir).map_err(|source| {
+            WorkspaceRootError::CanonicalizeDir { path: self.dir.clone(), source }
+        })?;
         let workspace_dir = pacquet_workspace::find_workspace_dir(&dir)
             .map_err(WorkspaceRootError::FindWorkspaceDir)?
             .ok_or(WorkspaceRootError::NotInWorkspace)?;
@@ -352,6 +357,14 @@ pub enum WorkspaceRootError {
     #[display("--workspace-root may only be used inside a workspace")]
     #[diagnostic(code(ERR_PNPM_NOT_IN_WORKSPACE))]
     NotInWorkspace,
+
+    #[display("canonicalizing the `--dir` argument: {}: {source}", path.display())]
+    #[diagnostic(code(ERR_PNPM_CANONICALIZE_DIR))]
+    CanonicalizeDir {
+        path: PathBuf,
+        #[error(source)]
+        source: std::io::Error,
+    },
 
     #[diagnostic(transparent)]
     FindWorkspaceDir(#[error(source)] pacquet_workspace::FindWorkspaceDirError),

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -34,6 +34,19 @@ pub struct ConfigArgs {
     pub command: ConfigSubcommand,
 }
 
+impl ConfigArgs {
+    /// Whether `--global` / `-g` was passed, ignoring the default
+    /// [`resolve_global`] applies when no location flag is given.
+    pub(super) fn is_global(&self) -> bool {
+        match &self.command {
+            ConfigSubcommand::Set(args) => args.flags.global,
+            ConfigSubcommand::Get(args) => args.flags.global,
+            ConfigSubcommand::Delete(args) => args.flags.global,
+            ConfigSubcommand::List(args) => args.flags.global,
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum ConfigSubcommand {
     /// Set the config key to the value provided.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -149,6 +149,7 @@ impl CliArgs {
             reporter,
             filter,
             filter_prod,
+            workspace_root,
             test_pattern,
             changed_files_ignore_pattern,
             version: _,
@@ -232,13 +233,15 @@ impl CliArgs {
                 if let Some(store_dir) = store_dir.as_deref() {
                     apply_store_dir_override::<Host>(&mut cfg, store_dir, anchor)?;
                 }
-                // `--recursive` / `--filter` / `--filter-prod` are
-                // CLI-only upstream (not `.npmrc` / yaml keys), so the
-                // global flags are threaded in here. Mirrors pnpm's
-                // `Config.recursive` / `.filter` / `.filterProd`.
+                // `--recursive` / `--filter` / `--filter-prod` /
+                // `--workspace-root` are CLI-only upstream (not `.npmrc` /
+                // yaml keys), so the global flags are threaded in here.
+                // Mirrors pnpm's `Config.recursive` / `.filter` /
+                // `.filterProd` / `.workspaceRoot`.
                 cfg.recursive = recursive;
                 cfg.filter.clone_from(&filter);
                 cfg.filter_prod.clone_from(&filter_prod);
+                cfg.workspace_root = workspace_root;
                 // Unlike the CLI-only selectors above, these two are
                 // genuine config keys — the flag overrides yaml / env
                 // only when actually given.

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -298,10 +298,7 @@ pub fn select_recursive_projects<'a>(
     };
     let all = build_graph(projects, graph_options);
 
-    // The main-dispatch `{<workspace-root>}` selector: an inclusion under
-    // `--workspace-root`, otherwise the `run` / `exec` exclusion that drops
-    // the workspace root from an unfiltered or all-exclusion selection. It
-    // routes into the selection pass whose `follow_prod_deps_only` matches: the
+    // Routes into the selection pass whose `follow_prod_deps_only` matches: the
     // prod pass when a `--filter-prod` selector is present, otherwise the
     // regular pass.
     let root_selector = auto_exclude_root.root_selector(config, prefix);
@@ -442,9 +439,6 @@ fn filter_against<Pkg: BaseProject>(
 /// For `run` / `exec` (and `add` / `test`) a `!{<workspace-root>}`
 /// selector is appended so a recursive `run` / `exec` skips the root
 /// project unless it is explicitly included.
-///
-/// `--workspace-root` replaces that exclusion with an inclusion for every
-/// variant, whichever command is running.
 #[derive(Clone, Copy)]
 pub enum AutoExcludeRoot<'a> {
     /// `run` / `exec` (also `add` / `test`): exclude the root when no
@@ -463,10 +457,9 @@ impl AutoExcludeRoot<'_> {
     /// the pass whose `follow_prod_deps_only` matches (the prod pass when
     /// a `--filter-prod` selector is present, else the regular pass).
     fn root_selector(&self, config: &Config, prefix: &Path) -> Option<String> {
-        // `--workspace-root` adds the root project to the selection for
-        // every recursive command: unlike the exclusion below, it is not
-        // gated on the command being `run` / `exec` / `add` / `test`, and
-        // it augments rather than overrides the `--filter` selectors.
+        // pnpm pushes this inclusion onto the `--filter` list rather than
+        // replacing it, and for every recursive command — so unlike the
+        // exclusion below it is ungated, and it is additive.
         if config.workspace_root {
             return Some(format!("{{{}}}", relative_workspace_dir(config, prefix)));
         }

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -298,14 +298,15 @@ pub fn select_recursive_projects<'a>(
     };
     let all = build_graph(projects, graph_options);
 
-    // The main-dispatch `!{<workspace-root>}` selector for `run` / `exec` drops
+    // The main-dispatch `{<workspace-root>}` selector: an inclusion under
+    // `--workspace-root`, otherwise the `run` / `exec` exclusion that drops
     // the workspace root from an unfiltered or all-exclusion selection. It
     // routes into the selection pass whose `follow_prod_deps_only` matches: the
     // prod pass when a `--filter-prod` selector is present, otherwise the
     // regular pass.
-    let root_exclusion = auto_exclude_root.root_exclusion(config, prefix);
+    let root_selector = auto_exclude_root.root_selector(config, prefix);
 
-    if config.filter.is_empty() && config.filter_prod.is_empty() && root_exclusion.is_none() {
+    if config.filter.is_empty() && config.filter_prod.is_empty() && root_selector.is_none() {
         return Ok(RecursiveSelection {
             selected: all,
             all: None,
@@ -346,7 +347,7 @@ pub fn select_recursive_projects<'a>(
     let regular_selected = filter_against(
         &all,
         &config.filter,
-        root_exclusion.as_deref().filter(|_| !root_in_prod),
+        root_selector.as_deref().filter(|_| !root_in_prod),
         false,
         prefix,
         &walk_opts,
@@ -355,7 +356,7 @@ pub fn select_recursive_projects<'a>(
         Some(prod_all) => filter_against(
             prod_all,
             &config.filter_prod,
-            root_exclusion.as_deref().filter(|_| root_in_prod),
+            root_selector.as_deref().filter(|_| root_in_prod),
             true,
             prefix,
             &walk_opts,
@@ -405,24 +406,24 @@ fn build_graph(
 
 /// Apply one group of selectors (regular or `--filter-prod`) against the
 /// already-built `graph` and return the selected project directories, in
-/// selection order. `root_exclusion` is the optional
-/// `!{<workspace-root>}` selector appended to this pass. A pass with no
-/// `filters` and no `root_exclusion` selects nothing.
+/// selection order. `root_selector` is the optional
+/// `{<workspace-root>}` selector appended to this pass. A pass with no
+/// `filters` and no `root_selector` selects nothing.
 fn filter_against<Pkg: BaseProject>(
     graph: &ProjectGraph<Pkg>,
     filters: &[String],
-    root_exclusion: Option<&str>,
+    root_selector: Option<&str>,
     follow_prod_deps_only: bool,
     prefix: &Path,
     walk_opts: &FilterWorkspaceProjectsOptions,
 ) -> miette::Result<Vec<PathBuf>> {
-    if filters.is_empty() && root_exclusion.is_none() {
+    if filters.is_empty() && root_selector.is_none() {
         return Ok(Vec::new());
     }
     let selectors: Vec<ProjectSelector> = filters
         .iter()
         .map(String::as_str)
-        .chain(root_exclusion)
+        .chain(root_selector)
         .map(|filter| {
             let mut selector = parse_project_selector(filter, prefix);
             selector.follow_prod_deps_only = follow_prod_deps_only;
@@ -441,6 +442,9 @@ fn filter_against<Pkg: BaseProject>(
 /// For `run` / `exec` (and `add` / `test`) a `!{<workspace-root>}`
 /// selector is appended so a recursive `run` / `exec` skips the root
 /// project unless it is explicitly included.
+///
+/// `--workspace-root` takes precedence over every variant: it pins the
+/// selection to the root project itself, whichever command is running.
 #[derive(Clone, Copy)]
 pub enum AutoExcludeRoot<'a> {
     /// `run` / `exec` (also `add` / `test`): exclude the root when no
@@ -453,19 +457,23 @@ pub enum AutoExcludeRoot<'a> {
 }
 
 impl AutoExcludeRoot<'_> {
-    /// The `!{<workspace-root>}` selector to append to the `--filter` /
-    /// `--filter-prod` selection, or `None` when the augmentation does not
-    /// apply. [`select_recursive_projects`] routes it into the pass whose
-    /// `follow_prod_deps_only` matches (the prod pass when a `--filter-prod`
-    /// selector is present, else the regular pass).
-    fn root_exclusion(&self, config: &Config, prefix: &Path) -> Option<String> {
+    /// The extra `{<workspace-root>}` selector to append to the
+    /// `--filter` / `--filter-prod` selection, or `None` when no
+    /// augmentation applies. [`select_recursive_projects`] routes it into
+    /// the pass whose `follow_prod_deps_only` matches (the prod pass when
+    /// a `--filter-prod` selector is present, else the regular pass).
+    fn root_selector(&self, config: &Config, prefix: &Path) -> Option<String> {
+        // `--workspace-root` pins the run to the root project, for every
+        // recursive command — unlike the exclusion below, it is not gated
+        // on the command being `run` / `exec` / `add` / `test`.
+        if config.workspace_root {
+            return Some(format!("{{{}}}", relative_workspace_dir(config, prefix)));
+        }
         let AutoExcludeRoot::Enabled { workspace_patterns } = self else {
             return None;
         };
         // pnpm additionally suppresses the exclusion under
-        // `--include-workspace-root` and, for `--workspace-root`, pushes
-        // an inclusion `{<root>}` filter instead. pacquet surfaces
-        // neither flag yet, so only this exclusion arm applies.
+        // `--include-workspace-root`, which pacquet does not surface yet.
         // An inclusion selector already pins the selected set, so the
         // root is kept only if it matches one.
         if config
@@ -483,13 +491,18 @@ impl AutoExcludeRoot<'_> {
         if is_root_only_patterns(patterns) {
             return None;
         }
-        let workspace_root = config.workspace_dir.as_deref().unwrap_or(prefix);
-        let relative = pathdiff::diff_paths(workspace_root, prefix)
-            .map(|path| path.to_string_lossy().into_owned())
-            .filter(|path| !path.is_empty())
-            .unwrap_or_else(|| ".".to_string());
-        Some(format!("!{{{relative}}}"))
+        Some(format!("!{{{}}}", relative_workspace_dir(config, prefix)))
     }
+}
+
+/// The workspace root as a path selectors can resolve against `prefix`,
+/// which is where a `{<dir>}` selector is anchored.
+fn relative_workspace_dir(config: &Config, prefix: &Path) -> String {
+    let workspace_root = config.workspace_dir.as_deref().unwrap_or(prefix);
+    pathdiff::diff_paths(workspace_root, prefix)
+        .map(|path| path.to_string_lossy().into_owned())
+        .filter(|path| !path.is_empty())
+        .unwrap_or_else(|| ".".to_string())
 }
 
 /// Whether the workspace enumerates the root project only.

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -443,8 +443,8 @@ fn filter_against<Pkg: BaseProject>(
 /// selector is appended so a recursive `run` / `exec` skips the root
 /// project unless it is explicitly included.
 ///
-/// `--workspace-root` takes precedence over every variant: it pins the
-/// selection to the root project itself, whichever command is running.
+/// `--workspace-root` replaces that exclusion with an inclusion for every
+/// variant, whichever command is running.
 #[derive(Clone, Copy)]
 pub enum AutoExcludeRoot<'a> {
     /// `run` / `exec` (also `add` / `test`): exclude the root when no
@@ -463,9 +463,10 @@ impl AutoExcludeRoot<'_> {
     /// the pass whose `follow_prod_deps_only` matches (the prod pass when
     /// a `--filter-prod` selector is present, else the regular pass).
     fn root_selector(&self, config: &Config, prefix: &Path) -> Option<String> {
-        // `--workspace-root` pins the run to the root project, for every
-        // recursive command — unlike the exclusion below, it is not gated
-        // on the command being `run` / `exec` / `add` / `test`.
+        // `--workspace-root` adds the root project to the selection for
+        // every recursive command: unlike the exclusion below, it is not
+        // gated on the command being `run` / `exec` / `add` / `test`, and
+        // it augments rather than overrides the `--filter` selectors.
         if config.workspace_root {
             return Some(format!("{{{}}}", relative_workspace_dir(config, prefix)));
         }

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     CliArgs,
     add::AddArgs,
-    cli_command::CliCommand,
+    cli_command::{CliCommand, WorkspaceRootError},
     install::{InstallArgs, resolve_bool_override},
     list::RecursionLimit,
     package_manager::{
@@ -584,6 +584,97 @@ fn trust_lockfile_pair_resolves_last_one_wins() {
     assert!(last_off.no_trust_lockfile && !last_off.trust_lockfile, "--no wins when last");
     let last_on = install_args(&["pacquet", "install", "--no-trust-lockfile", "--trust-lockfile"]);
     assert!(last_on.trust_lockfile && !last_on.no_trust_lockfile, "--trust wins when last");
+}
+
+/// A workspace root holding a `pnpm-workspace.yaml` plus a `packages/a`
+/// project, returned with its canonicalized path so a `--dir` redirect
+/// compares equal on platforms whose temp dir is a symlink.
+fn workspace_fixture() -> (TempDir, std::path::PathBuf) {
+    let root = TempDir::new().expect("tmp dir");
+    std::fs::write(root.path().join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    std::fs::create_dir_all(root.path().join("packages/a")).expect("create project dir");
+    let canonical = dunce::canonicalize(root.path()).expect("canonicalize root");
+    (root, canonical)
+}
+
+#[test]
+fn workspace_root_is_global_and_parses_on_either_side_of_the_subcommand() {
+    for argv in [
+        ["pacquet", "--workspace-root", "add", "foo"].as_slice(),
+        ["pacquet", "add", "foo", "--workspace-root"].as_slice(),
+        ["pacquet", "-w", "add", "foo"].as_slice(),
+        ["pacquet", "add", "foo", "-w"].as_slice(),
+    ] {
+        let parsed = CliArgs::try_parse_from(argv).expect("parses global --workspace-root");
+        assert!(parsed.workspace_root, "{argv:?}");
+        assert!(matches!(parsed.command, CliCommand::Add(_)));
+    }
+}
+
+#[test]
+fn workspace_root_points_dir_at_the_workspace_root() {
+    let (root, canonical) = workspace_fixture();
+    let subdir = root.path().join("packages/a");
+
+    let mut args =
+        CliArgs::try_parse_from(["pacquet", "add", "foo", "-w", "-C", &subdir.to_string_lossy()])
+            .expect("parses");
+    args.apply_workspace_root().expect("redirects to the workspace root");
+
+    assert_eq!(args.dir, canonical);
+}
+
+#[test]
+fn workspace_root_leaves_dir_alone_when_not_requested() {
+    let (root, _canonical) = workspace_fixture();
+    let subdir = root.path().join("packages/a");
+
+    let mut args =
+        CliArgs::try_parse_from(["pacquet", "add", "foo", "-C", &subdir.to_string_lossy()])
+            .expect("parses");
+    args.apply_workspace_root().expect("no-op without --workspace-root");
+
+    assert_eq!(args.dir, subdir);
+}
+
+#[test]
+fn workspace_root_conflicts_with_global() {
+    let (root, _canonical) = workspace_fixture();
+
+    let mut args = CliArgs::try_parse_from([
+        "pacquet",
+        "add",
+        "foo",
+        "-w",
+        "-g",
+        "-C",
+        &root.path().to_string_lossy(),
+    ])
+    .expect("parses");
+    let error = args.apply_workspace_root().expect_err("--global conflicts");
+
+    dbg!(&error);
+    assert!(matches!(error, WorkspaceRootError::GlobalConflict));
+}
+
+#[test]
+fn workspace_root_requires_a_workspace() {
+    let outside = TempDir::new().expect("tmp dir");
+
+    let mut args = CliArgs::try_parse_from([
+        "pacquet",
+        "add",
+        "foo",
+        "-w",
+        "-C",
+        &outside.path().to_string_lossy(),
+    ])
+    .expect("parses");
+    let error = args.apply_workspace_root().expect_err("no workspace to redirect to");
+
+    dbg!(&error);
+    assert!(matches!(error, WorkspaceRootError::NotInWorkspace));
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -586,9 +586,8 @@ fn trust_lockfile_pair_resolves_last_one_wins() {
     assert!(last_on.trust_lockfile && !last_on.no_trust_lockfile, "--trust wins when last");
 }
 
-/// A workspace root holding a `pnpm-workspace.yaml` plus a `packages/a`
-/// project, returned with its canonicalized path so a `--dir` redirect
-/// compares equal on platforms whose temp dir is a symlink.
+/// Returns the canonicalized root too: a temp dir is a symlink on some
+/// platforms, so a `--dir` redirect would not compare equal otherwise.
 fn workspace_fixture() -> (TempDir, std::path::PathBuf) {
     let root = TempDir::new().expect("tmp dir");
     std::fs::write(root.path().join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
@@ -638,24 +637,62 @@ fn workspace_root_leaves_dir_alone_when_not_requested() {
     assert_eq!(args.dir, subdir);
 }
 
+/// Every subcommand declaring `--global`. A new one added without wiring
+/// it into [`CliCommand::is_global`] slips past the conflict check.
+const GLOBAL_SUBCOMMAND_ARGV: [&[&str]; 12] = [
+    &["add", "foo"],
+    &["approve-builds"],
+    &["bin"],
+    &["config", "get", "store-dir"],
+    &["list"],
+    &["ll"],
+    &["outdated"],
+    &["prefix"],
+    &["remove", "foo"],
+    &["root"],
+    &["runtime", "use", "node@20"],
+    &["update"],
+];
+
 #[test]
-fn workspace_root_conflicts_with_global() {
+fn workspace_root_conflicts_with_global_for_every_subcommand() {
     let (root, _canonical) = workspace_fixture();
 
-    let mut args = CliArgs::try_parse_from([
-        "pacquet",
-        "add",
-        "foo",
-        "-w",
-        "-g",
-        "-C",
-        &root.path().to_string_lossy(),
-    ])
-    .expect("parses");
-    let error = args.apply_workspace_root().expect_err("--global conflicts");
+    for subcommand in GLOBAL_SUBCOMMAND_ARGV {
+        let argv = std::iter::once("pacquet")
+            .chain(subcommand.iter().copied())
+            // The long form throughout: `approve-builds` declares
+            // `--global` without a `-g` short.
+            .chain(["-w", "--global", "-C"])
+            .chain([root.path().to_str().expect("utf-8 tmp dir")]);
+        let mut args = CliArgs::try_parse_from(argv).unwrap_or_else(|error| {
+            panic!("{subcommand:?} should parse with -w --global: {error}");
+        });
+        let error = args
+            .apply_workspace_root()
+            .expect_err(&format!("{subcommand:?} must reject -w with --global"));
 
-    dbg!(&error);
-    assert!(matches!(error, WorkspaceRootError::GlobalConflict));
+        dbg!(subcommand, &error);
+        assert!(matches!(error, WorkspaceRootError::GlobalConflict), "{subcommand:?}");
+    }
+}
+
+#[test]
+fn workspace_root_is_allowed_for_subcommands_without_global() {
+    let (root, canonical) = workspace_fixture();
+
+    for subcommand in [["install"].as_slice(), ["run", "build"].as_slice(), ["pack"].as_slice()] {
+        let argv = std::iter::once("pacquet")
+            .chain(subcommand.iter().copied())
+            .chain(["-w", "-C"])
+            .chain([root.path().to_str().expect("utf-8 tmp dir")]);
+        let mut args = CliArgs::try_parse_from(argv).expect("parses");
+        args.apply_workspace_root().unwrap_or_else(|error| {
+            panic!("{subcommand:?} should accept -w: {error}");
+        });
+
+        assert_eq!(args.dir, canonical, "{subcommand:?}");
+    }
 }
 
 #[test]
@@ -677,11 +714,8 @@ fn workspace_root_requires_a_workspace() {
     assert!(matches!(error, WorkspaceRootError::NotInWorkspace));
 }
 
-/// A `--dir` that does not exist still redirects to the workspace root
-/// above it: pnpm's `findWorkspaceDir` falls back to the given path when
-/// `fs.realpath` fails and walks it lexically, so `pnpm --dir
-/// packages/does-not-exist add <pkg> -w` adds to the root manifest instead
-/// of failing. Erroring here would diverge from that.
+/// pnpm's `findWorkspaceDir` falls back to a lexical walk when
+/// `fs.realpath` fails, so erroring here would diverge.
 #[test]
 fn workspace_root_tolerates_a_dir_that_does_not_exist() {
     let (root, canonical) = workspace_fixture();

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -677,6 +677,23 @@ fn workspace_root_requires_a_workspace() {
     assert!(matches!(error, WorkspaceRootError::NotInWorkspace));
 }
 
+/// An unusable `--dir` is reported as such, not as a missing workspace:
+/// `-w` must not change which error a bad `--dir` produces, and the
+/// walk it drives would otherwise silently start from an unresolved path.
+#[test]
+fn workspace_root_reports_an_uncanonicalizable_dir() {
+    let (root, _canonical) = workspace_fixture();
+    let missing = root.path().join("packages/does-not-exist");
+
+    let mut args =
+        CliArgs::try_parse_from(["pacquet", "add", "foo", "-w", "-C", &missing.to_string_lossy()])
+            .expect("parses");
+    let error = args.apply_workspace_root().expect_err("--dir cannot be canonicalized");
+
+    dbg!(&error);
+    assert!(matches!(error, WorkspaceRootError::CanonicalizeDir { .. }));
+}
+
 #[test]
 fn config_merged_boolean_negations_parse() {
     // Each config-OR-merged boolean now exposes an explicit `--no-` inverse

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -677,21 +677,23 @@ fn workspace_root_requires_a_workspace() {
     assert!(matches!(error, WorkspaceRootError::NotInWorkspace));
 }
 
-/// An unusable `--dir` is reported as such, not as a missing workspace:
-/// `-w` must not change which error a bad `--dir` produces, and the
-/// walk it drives would otherwise silently start from an unresolved path.
+/// A `--dir` that does not exist still redirects to the workspace root
+/// above it: pnpm's `findWorkspaceDir` falls back to the given path when
+/// `fs.realpath` fails and walks it lexically, so `pnpm --dir
+/// packages/does-not-exist add <pkg> -w` adds to the root manifest instead
+/// of failing. Erroring here would diverge from that.
 #[test]
-fn workspace_root_reports_an_uncanonicalizable_dir() {
-    let (root, _canonical) = workspace_fixture();
-    let missing = root.path().join("packages/does-not-exist");
+fn workspace_root_tolerates_a_dir_that_does_not_exist() {
+    let (root, canonical) = workspace_fixture();
+    let missing = canonical.join("packages/does-not-exist");
 
     let mut args =
         CliArgs::try_parse_from(["pacquet", "add", "foo", "-w", "-C", &missing.to_string_lossy()])
             .expect("parses");
-    let error = args.apply_workspace_root().expect_err("--dir cannot be canonicalized");
+    args.apply_workspace_root().expect("redirects to the workspace root anyway");
 
-    dbg!(&error);
-    assert!(matches!(error, WorkspaceRootError::CanonicalizeDir { .. }));
+    assert_eq!(args.dir, canonical);
+    drop(root); // cleanup
 }
 
 #[test]

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -89,6 +89,7 @@ fn run_cli() -> miette::Result<()> {
         err.exit();
     }
     args.promote_recursive_for_filter();
+    args.apply_workspace_root()?;
     args.promote_recursive_by_default();
     if let Some(plan) = cli_args::switch_cli_version::switch_plan(&args, &config_overrides)?
         && block_on_runtime(

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -236,11 +236,8 @@ fn write_workspace_with_local_fixtures(workspace: &Path) -> PathBuf {
     member_dir
 }
 
-/// A `--dir` that does not exist still redirects to the workspace root
-/// above it, matching pnpm: its `findWorkspaceDir` falls back to the given
-/// path when `fs.realpath` fails, then walks it for the manifest. Covered
-/// end to end because a relative `--dir` resolves against the process cwd,
-/// which a unit test must not mutate.
+/// End to end rather than a unit test: a relative `--dir` resolves
+/// against the process cwd, which a unit test must not mutate.
 #[test]
 fn add_workspace_root_tolerates_a_dir_that_does_not_exist() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -283,9 +280,8 @@ fn add_workspace_root_saves_to_the_root_manifest_from_a_subdir() {
             "packages/a",
             "add",
             "-D",
-            // Relative to the workspace root: `--workspace-root` moves the
-            // add to the root manifest, and a `file:` spec resolves from
-            // the manifest that records it.
+            // Relative to the root: a `file:` spec resolves from the
+            // manifest that records it, which `-w` makes the root's.
             "local-a@file:./fixtures/local-a",
             "local-b@file:./fixtures/local-b",
             "-w",

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -16,7 +16,11 @@ use pipe_trait::Pipe;
 use pretty_assertions::assert_eq;
 #[cfg(unix)]
 use std::fs;
-use std::{ffi::OsStr, path::PathBuf, process::Command};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::Command,
+};
 use tempfile::TempDir;
 
 fn exec_pacquet_in_temp_cwd<Args>(args: Args) -> (TempDir, PathBuf, AddMockedRegistry)
@@ -200,12 +204,11 @@ fn add_accepts_multiple_local_package_selectors() {
     drop(root); // cleanup
 }
 
-/// `pnpm add -D <pkg> <pkg> -w` run from a workspace subdirectory
-/// (pnpm/pnpm#13031).
-#[test]
-fn add_workspace_root_saves_to_the_root_manifest_from_a_subdir() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-
+/// Declare `packages/*` as workspace packages with a single `packages/a`
+/// member, and write `local-a` / `local-b` under `fixtures/`, so a `-w` add
+/// can use `file:` specs that resolve from the root manifest instead of
+/// reaching the registry. Returns the member's directory.
+fn write_workspace_with_local_fixtures(workspace: &Path) -> PathBuf {
     let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
     let mut workspace_yaml = std::fs::read_to_string(&workspace_yaml_path).unwrap_or_default();
     if !workspace_yaml.is_empty() && !workspace_yaml.ends_with('\n') {
@@ -214,9 +217,8 @@ fn add_workspace_root_saves_to_the_root_manifest_from_a_subdir() {
     workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
     std::fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
 
-    let fixtures_dir = workspace.join("fixtures");
     for package_name in ["local-a", "local-b"] {
-        let package_dir = fixtures_dir.join(package_name);
+        let package_dir = workspace.join("fixtures").join(package_name);
         std::fs::create_dir_all(&package_dir).expect("create local package directory");
         std::fs::write(
             package_dir.join("package.json"),
@@ -232,6 +234,49 @@ fn add_workspace_root_saves_to_the_root_manifest_from_a_subdir() {
         serde_json::json!({ "name": "a", "version": "1.0.0" }).to_string(),
     )
     .expect("write packages/a/package.json");
+    member_dir
+}
+
+/// A `--dir` that does not exist still redirects to the workspace root
+/// above it, matching pnpm: its `findWorkspaceDir` falls back to the given
+/// path when `fs.realpath` fails, then walks it for the manifest. Covered
+/// end to end because a relative `--dir` resolves against the process cwd,
+/// which a unit test must not mutate.
+#[test]
+fn add_workspace_root_tolerates_a_dir_that_does_not_exist() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_with_local_fixtures(&workspace);
+
+    pacquet
+        .with_args([
+            "--dir",
+            "packages/does-not-exist",
+            "add",
+            "-D",
+            "local-a@file:./fixtures/local-a",
+            "-w",
+        ])
+        .assert()
+        .success();
+
+    let root_manifest = workspace
+        .join("package.json")
+        .pipe(PackageManifest::from_path)
+        .expect("read root manifest");
+    assert!(
+        root_manifest.dependencies([DependencyGroup::Dev]).any(|(key, _)| key == "local-a"),
+        "a nonexistent --dir must still redirect the add to the root manifest",
+    );
+
+    drop(root); // cleanup
+}
+
+/// `pnpm add -D <pkg> <pkg> -w` run from a workspace subdirectory
+/// (pnpm/pnpm#13031).
+#[test]
+fn add_workspace_root_saves_to_the_root_manifest_from_a_subdir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let member_dir = write_workspace_with_local_fixtures(&workspace);
 
     pacquet
         .with_args([

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -204,10 +204,9 @@ fn add_accepts_multiple_local_package_selectors() {
     drop(root); // cleanup
 }
 
-/// Declare `packages/*` as workspace packages with a single `packages/a`
-/// member, and write `local-a` / `local-b` under `fixtures/`, so a `-w` add
-/// can use `file:` specs that resolve from the root manifest instead of
-/// reaching the registry. Returns the member's directory.
+/// A one-member workspace whose `fixtures/` packages let a `-w` add use
+/// `file:` specs instead of reaching the registry. Returns the member's
+/// directory.
 fn write_workspace_with_local_fixtures(workspace: &Path) -> PathBuf {
     let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
     let mut workspace_yaml = std::fs::read_to_string(&workspace_yaml_path).unwrap_or_default();

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -200,6 +200,86 @@ fn add_accepts_multiple_local_package_selectors() {
     drop(root); // cleanup
 }
 
+/// `pnpm add -D <pkg> <pkg> -w` run from a workspace subdirectory
+/// (pnpm/pnpm#13031).
+#[test]
+fn add_workspace_root_saves_to_the_root_manifest_from_a_subdir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml = std::fs::read_to_string(&workspace_yaml_path).unwrap_or_default();
+    if !workspace_yaml.is_empty() && !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    std::fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    let fixtures_dir = workspace.join("fixtures");
+    for package_name in ["local-a", "local-b"] {
+        let package_dir = fixtures_dir.join(package_name);
+        std::fs::create_dir_all(&package_dir).expect("create local package directory");
+        std::fs::write(
+            package_dir.join("package.json"),
+            serde_json::json!({ "name": package_name, "version": "1.0.0" }).to_string(),
+        )
+        .expect("write local package manifest");
+    }
+
+    let member_dir = workspace.join("packages/a");
+    std::fs::create_dir_all(&member_dir).expect("mkdir packages/a");
+    std::fs::write(
+        member_dir.join("package.json"),
+        serde_json::json!({ "name": "a", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write packages/a/package.json");
+
+    pacquet
+        .with_args([
+            "--dir",
+            "packages/a",
+            "add",
+            "-D",
+            // Relative to the workspace root: `--workspace-root` moves the
+            // add to the root manifest, and a `file:` spec resolves from
+            // the manifest that records it.
+            "local-a@file:./fixtures/local-a",
+            "local-b@file:./fixtures/local-b",
+            "-w",
+        ])
+        .assert()
+        .success();
+
+    let root_manifest = workspace
+        .join("package.json")
+        .pipe(PackageManifest::from_path)
+        .expect("read root manifest");
+    for package_name in ["local-a", "local-b"] {
+        assert!(
+            root_manifest.dependencies([DependencyGroup::Dev]).any(|(key, _)| key == package_name),
+            "--workspace-root must save {package_name} to the root manifest",
+        );
+    }
+
+    let member_manifest = member_dir
+        .join("package.json")
+        .pipe(PackageManifest::from_path)
+        .expect("read packages/a manifest");
+    assert_eq!(
+        member_manifest
+            .dependencies([
+                DependencyGroup::Prod,
+                DependencyGroup::Dev,
+                DependencyGroup::Optional,
+                DependencyGroup::Peer,
+            ])
+            .count(),
+        0,
+        "--workspace-root must leave the `--dir` project's manifest untouched",
+    );
+
+    drop(root); // cleanup
+}
+
 #[test]
 fn add_runs_with_ndjson_and_silent_reporters() {
     for reporter in ["--reporter=ndjson", "--reporter=silent"] {

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -321,9 +321,6 @@ fn recursive_run_settings_only_workspace_enumerates_root_only() {
     drop(root);
 }
 
-/// An unfiltered `pacquet -r -w run <script>` narrows the recursive run to
-/// the root project — the inverse of the `!{<workspace-root>}`
-/// auto-exclusion an unfiltered recursive `run` otherwise applies.
 #[test]
 fn recursive_run_workspace_root_selects_only_the_root_project() {
     for start_dir in WORKSPACE_ROOT_START_DIRS {
@@ -335,12 +332,7 @@ fn recursive_run_workspace_root_selects_only_the_root_project() {
     }
 }
 
-/// `--workspace-root` *adds* the root project to a `--filter` selection
-/// rather than replacing it, so `-r -w --filter <name>` runs both. pnpm
-/// pushes the `{<workspace-root>}` selector onto the `--filter` /
-/// `--filter-prod` list, and `pnpm -r -w --filter project-1 run build`
-/// accordingly reports `Scope: 2 of 3 workspace projects`. Narrowing to
-/// the root alone here would diverge from it.
+/// pnpm reports `Scope: 2 of 3 workspace projects` for this command.
 #[test]
 fn recursive_run_workspace_root_adds_the_root_to_a_filter_selection() {
     for start_dir in WORKSPACE_ROOT_START_DIRS {
@@ -352,18 +344,12 @@ fn recursive_run_workspace_root_adds_the_root_to_a_filter_selection() {
     }
 }
 
-/// The `--dir` values every `--workspace-root` selection case is checked
-/// from. Starting inside a member project is the scenario the flag exists
-/// for (pnpm/pnpm#13031), so each case is asserted to select the same
-/// projects from there as from the workspace root — the whole path from
-/// the `--dir` redirect through manifest discovery to the script lookup
-/// has to hold, not just the selector.
+/// Starting inside a member project is what the flag exists for
+/// (pnpm/pnpm#13031), so every case is checked from both.
 const WORKSPACE_ROOT_START_DIRS: [&str; 2] = [".", "project-1"];
 
-/// Run `-r -w [--filter <filter>] run build` from `start_dir` in a fresh
-/// workspace of a root project plus `project-1` / `project-2`, each
-/// writing a marker when its `build` runs, and return the names that ran
-/// (`"<root>"` for the root project) in workspace order.
+/// The projects whose `build` ran, in workspace order, naming the root
+/// project `"<root>"`.
 fn workspace_root_run_selection(start_dir: &str, filter: Option<&str>) -> Vec<String> {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_workspace(

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -321,6 +321,46 @@ fn recursive_run_settings_only_workspace_enumerates_root_only() {
     drop(root);
 }
 
+/// `pacquet -r -w run <script>` narrows the recursive run to the root
+/// project — the inverse of the `!{<workspace-root>}` auto-exclusion that
+/// an unfiltered recursive `run` applies.
+#[test]
+fn recursive_run_workspace_root_selects_only_the_root_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", build_writes_marker("project-2")),
+        ],
+    );
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "root",
+            "version": "1.0.0",
+            "scripts": { "build": "touch root-ran.txt" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+
+    pacquet.with_arg("-r").with_arg("-w").with_arg("run").with_arg("build").assert().success();
+
+    assert!(
+        workspace.join("root-ran.txt").exists(),
+        "--workspace-root should select the root project",
+    );
+    for name in ["project-1", "project-2"] {
+        assert!(
+            !workspace.join(name).join("ran.txt").exists(),
+            "{name} must not run under --workspace-root",
+        );
+    }
+
+    drop(root);
+}
+
 /// `pacquet -r --filter <name> run <script>` runs the script only in the
 /// `--filter`-selected project, leaving the rest untouched. Threads
 /// `config.filter` through the recursive dispatch to build the selected

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -326,39 +326,13 @@ fn recursive_run_settings_only_workspace_enumerates_root_only() {
 /// auto-exclusion an unfiltered recursive `run` otherwise applies.
 #[test]
 fn recursive_run_workspace_root_selects_only_the_root_project() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    write_workspace(
-        &workspace,
-        &[
-            ("project-1", build_writes_marker("project-1")),
-            ("project-2", build_writes_marker("project-2")),
-        ],
-    );
-    fs::write(
-        workspace.join("package.json"),
-        json!({
-            "name": "root",
-            "version": "1.0.0",
-            "scripts": { "build": "touch root-ran.txt" },
-        })
-        .to_string(),
-    )
-    .expect("write root package.json");
-
-    pacquet.with_arg("-r").with_arg("-w").with_arg("run").with_arg("build").assert().success();
-
-    assert!(
-        workspace.join("root-ran.txt").exists(),
-        "--workspace-root should select the root project",
-    );
-    for name in ["project-1", "project-2"] {
-        assert!(
-            !workspace.join(name).join("ran.txt").exists(),
-            "{name} must not run under --workspace-root",
+    for start_dir in WORKSPACE_ROOT_START_DIRS {
+        assert_eq!(
+            workspace_root_run_selection(start_dir, None),
+            ["<root>"],
+            "--dir {start_dir}: --workspace-root selects the root project alone",
         );
     }
-
-    drop(root);
 }
 
 /// `--workspace-root` *adds* the root project to a `--filter` selection
@@ -369,6 +343,28 @@ fn recursive_run_workspace_root_selects_only_the_root_project() {
 /// the root alone here would diverge from it.
 #[test]
 fn recursive_run_workspace_root_adds_the_root_to_a_filter_selection() {
+    for start_dir in WORKSPACE_ROOT_START_DIRS {
+        assert_eq!(
+            workspace_root_run_selection(start_dir, Some("project-1")),
+            ["<root>", "project-1"],
+            "--dir {start_dir}: --workspace-root keeps the --filter-selected project",
+        );
+    }
+}
+
+/// The `--dir` values every `--workspace-root` selection case is checked
+/// from. Starting inside a member project is the scenario the flag exists
+/// for (pnpm/pnpm#13031), so each case is asserted to select the same
+/// projects from there as from the workspace root — the whole path from
+/// the `--dir` redirect through manifest discovery to the script lookup
+/// has to hold, not just the selector.
+const WORKSPACE_ROOT_START_DIRS: [&str; 2] = [".", "project-1"];
+
+/// Run `-r -w [--filter <filter>] run build` from `start_dir` in a fresh
+/// workspace of a root project plus `project-1` / `project-2`, each
+/// writing a marker when its `build` runs, and return the names that ran
+/// (`"<root>"` for the root project) in workspace order.
+fn workspace_root_run_selection(start_dir: &str, filter: Option<&str>) -> Vec<String> {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_workspace(
         &workspace,
@@ -388,19 +384,21 @@ fn recursive_run_workspace_root_adds_the_root_to_a_filter_selection() {
     )
     .expect("write root package.json");
 
-    pacquet.with_args(["-r", "-w", "--filter", "project-1", "run", "build"]).assert().success();
+    let mut args = vec!["--dir", start_dir, "-r", "-w"];
+    if let Some(filter) = filter {
+        args.extend(["--filter", filter]);
+    }
+    args.extend(["run", "build"]);
+    pacquet.with_args(args).assert().success();
 
-    assert!(workspace.join("root-ran.txt").exists(), "--workspace-root selects the root project");
-    assert!(
-        workspace.join("project-1").join("ran.txt").exists(),
-        "--workspace-root must not drop the --filter-selected project",
-    );
-    assert!(
-        !workspace.join("project-2").join("ran.txt").exists(),
-        "project-2 matches neither the filter nor the root selector",
-    );
+    let ran = std::iter::once(("<root>", workspace.join("root-ran.txt")))
+        .chain(["project-1", "project-2"].map(|name| (name, workspace.join(name).join("ran.txt"))))
+        .filter(|(_, marker)| marker.exists())
+        .map(|(name, _)| name.to_string())
+        .collect();
 
-    drop(root);
+    drop(root); // cleanup
+    ran
 }
 
 /// `pacquet -r --filter <name> run <script>` runs the script only in the

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -321,9 +321,9 @@ fn recursive_run_settings_only_workspace_enumerates_root_only() {
     drop(root);
 }
 
-/// `pacquet -r -w run <script>` narrows the recursive run to the root
-/// project — the inverse of the `!{<workspace-root>}` auto-exclusion that
-/// an unfiltered recursive `run` applies.
+/// An unfiltered `pacquet -r -w run <script>` narrows the recursive run to
+/// the root project — the inverse of the `!{<workspace-root>}`
+/// auto-exclusion an unfiltered recursive `run` otherwise applies.
 #[test]
 fn recursive_run_workspace_root_selects_only_the_root_project() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -357,6 +357,48 @@ fn recursive_run_workspace_root_selects_only_the_root_project() {
             "{name} must not run under --workspace-root",
         );
     }
+
+    drop(root);
+}
+
+/// `--workspace-root` *adds* the root project to a `--filter` selection
+/// rather than replacing it, so `-r -w --filter <name>` runs both. pnpm
+/// pushes the `{<workspace-root>}` selector onto the `--filter` /
+/// `--filter-prod` list, and `pnpm -r -w --filter project-1 run build`
+/// accordingly reports `Scope: 2 of 3 workspace projects`. Narrowing to
+/// the root alone here would diverge from it.
+#[test]
+fn recursive_run_workspace_root_adds_the_root_to_a_filter_selection() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", build_writes_marker("project-2")),
+        ],
+    );
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "root",
+            "version": "1.0.0",
+            "scripts": { "build": "touch root-ran.txt" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+
+    pacquet.with_args(["-r", "-w", "--filter", "project-1", "run", "build"]).assert().success();
+
+    assert!(workspace.join("root-ran.txt").exists(), "--workspace-root selects the root project");
+    assert!(
+        workspace.join("project-1").join("ran.txt").exists(),
+        "--workspace-root must not drop the --filter-selected project",
+    );
+    assert!(
+        !workspace.join("project-2").join("ran.txt").exists(),
+        "project-2 matches neither the filter nor the root selector",
+    );
 
     drop(root);
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1401,6 +1401,13 @@ pub struct Config {
     /// dependency walk runs. A CLI-only array.
     pub filter_prod: Vec<String>,
 
+    /// `--workspace-root` / `-w`: run the command on the root workspace
+    /// project. The CLI points `--dir` at the workspace root before the
+    /// command runs; a recursive command additionally narrows its
+    /// selection to the root project alone. CLI-only, like
+    /// [`Self::filter`].
+    pub workspace_root: bool,
+
     /// `testPattern` from `pnpm-workspace.yaml` /
     /// `PNPM_CONFIG_TEST_PATTERN`, overridable by the `--test-pattern`
     /// CLI flag. Glob patterns naming test files: when a `[<since>]`

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1402,10 +1402,7 @@ pub struct Config {
     pub filter_prod: Vec<String>,
 
     /// `--workspace-root` / `-w`: run the command on the root workspace
-    /// project. The CLI points `--dir` at the workspace root before the
-    /// command runs; a recursive command additionally narrows its
-    /// selection to the root project alone. CLI-only, like
-    /// [`Self::filter`].
+    /// project. CLI-only, like [`Self::filter`].
     pub workspace_root: bool,
 
     /// `testPattern` from `pnpm-workspace.yaml` /

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -122,6 +122,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         recursive: false,
         filter: Vec::new(),
         filter_prod: Vec::new(),
+        workspace_root: false,
         test_pattern: Vec::new(),
         changed_files_ignore_pattern: Vec::new(),
         git_shallow_hosts: pacquet_config::default_git_shallow_hosts(),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

`pnpm add -D <pkg> <pkg> -w` from a workspace subdirectory failed on the Rust CLI with a raw clap error, because `-w` / `--workspace-root` was not declared at all:

```console
$ pnpm add -D oxlint@latest oxfmt@latest oxlint-tsgolint@latest -w
error: unexpected argument '-w' found
```

(The multiple-selector half of the original report was already fixed by pnpm/pnpm#12995; `-w` was the remaining gap.)

This PR adds the flag, matching what pnpm's CLI arg pass does with it:

- it points `--dir` at the workspace root, so a non-recursive command such as `add` writes to the root `package.json`;
- under `--recursive` it appends a `{<workspace-root>}` **inclusion** selector to the `--filter` / `--filter-prod` list — the inverse of the `!{<workspace-root>}` auto-exclusion an unfiltered recursive `run` / `exec` / `add` / `test` already applies. Note the selector is *appended*, not substituted, exactly as pnpm does it: an unfiltered `-r -w` runs the root alone, while `-r -w --filter project-1` runs the root **and** `project-1` (pnpm v11.17.0 reports `Scope: 2 of 3 workspace projects` for that command). Both cases have a regression test;
- `--global` and "not inside a workspace" are rejected with pnpm's `ERR_PNPM_OPTIONS_CONFLICT` / `ERR_PNPM_NOT_IN_WORKSPACE` codes and messages. A `--dir` that does not exist is *not* an error under `-w`: pnpm's `findWorkspaceDir` falls back to the given path when `fs.realpath` fails and walks it lexically, so the redirect to the workspace root still happens — verified against pnpm v11.17.0 and covered by a test.

Verified against the exact reproduction in the issue: all three packages land in the root manifest, `packages/a/package.json` is untouched, and both importers stay in the lockfile.

TypeScript CLI: no change needed — it already implements `--workspace-root` (`cli/parse-cli-args`, `pnpm/src/main.ts`). This is a pacquet-only parity gap, so the changeset targets `pacquet` alone.

Closes pnpm/pnpm#13031

## Squash Commit Body

```text
pnpm parses `--workspace-root` in its CLI arg pass: it points `--dir` at
the workspace root, and under `--recursive` it pushes a `{<root>}`
inclusion selector so the run narrows to the root project. pacquet
surfaced neither, so the `pnpm add -D <pkg> <pkg> -w` form from a
workspace subdirectory died in clap with `unexpected argument '-w'
found`.

Declare `-w` as a CLI-wide flag, apply the `--dir` redirect between the
`--filter` and recursive-by-default promotions (where pnpm applies it),
and thread it into `Config` alongside the other CLI-only selectors.
`AutoExcludeRoot::root_exclusion` becomes `root_selector`: under
`--workspace-root` it returns the `{<root>}` inclusion for every
recursive command, otherwise the existing `run` / `exec` / `add` /
`test` `!{<root>}` exclusion.

`--global` and a missing workspace are rejected with pnpm's
`ERR_PNPM_OPTIONS_CONFLICT` / `ERR_PNPM_NOT_IN_WORKSPACE` codes and
messages. `CliCommand::is_global` reassembles pnpm's CLI-wide
`--global` view from the per-subcommand flags pacquet declares.

Closes pnpm/pnpm#13031
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <sub>TypeScript CLI already had `--workspace-root`; nothing to port.</sub>
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <sub>Parsing / redirect / conflict / not-in-workspace unit tests, plus e2e tests for `add -w` from a subdir and `-r -w run`.</sub>

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `--workspace-root` (`-w`) option to run commands against the workspace root project.
  * `pnpm add -w` now correctly updates the root `package.json` when invoked from a workspace subdirectory.
  * Recursive commands (`-r`) with `-w` can select only the root project or include it alongside filtered projects.

* **Bug Fixes**
  * Improved behavior when `-w` is used with `--dir` (including nonexistent paths).
  * Added clear errors when used outside a workspace or combined with global operations (`--global`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->