### PR TITLE
test(pacquet): drop the stale engineStrict known-failure stub

### DIFF
--- a/pnpm/crates/cli/tests/optional_dependencies.rs
+++ b/pnpm/crates/cli/tests/optional_dependencies.rs
@@ -252,38 +252,6 @@ fn forced_frozen_install_materializes_incompatible_optionals() {
     drop((root, npmrc_info)); // cleanup
 }
 
-mod known_failures {
-    //! Optional-dependency cases blocked on engine behavior pacquet
-    //! hasn't built yet. Each entry stubs the not-yet-built subject
-    //! under test through [`pacquet_testing_utils::allow_known_failure`]
-    //! so the test exits early rather than masking a real bug.
-
-    use pacquet_testing_utils::{
-        allow_known_failure,
-        known_failure::{KnownFailure, KnownResult},
-    };
-
-    fn edge_aware_engine_strict() -> KnownResult<()> {
-        Err(KnownFailure::new(
-            "pacquet's `engineStrict` dispatch keys on the lockfile's \
-             snapshot-level `optional: true` flag, so an incompatible \
-             package that is only optionally *reachable* is skipped even \
-             when its inbound edge is a regular dependency. Upstream \
-             evaluates installability per edge at resolve time and fails \
-             this shape (pnpm/pnpm#13143).",
-        ))
-    }
-
-    /// TS: `fail on unsupported dependency of optional dependency`
-    /// (`optionalDependencies.ts:552`). Under `engineStrict`, an
-    /// installable optional whose *regular* dependency is incompatible
-    /// fails the install upstream.
-    #[test]
-    fn fail_on_unsupported_dependency_of_optional_dependency() {
-        allow_known_failure!(edge_aware_engine_strict());
-    }
-}
-
 /// TS: `only skip optional dependencies`
 /// (`optionalDependencies.ts:610`).
 #[test]


### PR DESCRIPTION
## Summary

Removes the `known_failures` stub for `fail_on_unsupported_dependency_of_optional_dependency` in `pnpm/crates/cli/tests/optional_dependencies.rs`.

Edge-aware `engineStrict` dispatch — the actual subject of pnpm/pnpm#13143 — already landed in pnpm/pnpm#13172 (`walk_lockfile_edges` / `LockfileEdgeReach` in `pnpm/crates/package-manager/src/installability.rs`), and the real port of the upstream test landed alongside it in pnpm/pnpm#13173. The stub for the same scenario was left behind, so `just known-failures` kept advertising the behavior as unimplemented while the real test was already green, and a future regression in the stubbed path would have been masked by a trivially-passing duplicate.

Verified before removing:

- `cargo nextest run -p pacquet-cli --test optional_dependencies` — 32/32 pass, including the real `fail_on_unsupported_dependency_of_optional_dependency` (asserts `ERR_PNPM_UNSUPPORTED_PLATFORM`) and its `do_not_fail_...` neighbour.
- `cargo nextest run -p pacquet-package-manager installability` — 36/36 pass, covering both dispatch directions directly (`engine_strict_fails_incompatible_regular_dep_of_installed_optional`, `incompatible_regular_dep_of_skipped_optional_is_skipped_not_failed`, `regular_edge_from_installed_parent_wins_over_optional_reachability`).
- `just known-failures` no longer lists the entry; the two remaining stubs are unrelated.

Closes pnpm/pnpm#13143.

## Squash Commit Body

```text
test(pacquet): drop the stale engineStrict known-failure stub

Edge-aware `engineStrict` dispatch landed in pnpm/pnpm#13172, and the real
port of the upstream `fail on unsupported dependency of optional dependency`
test landed alongside it in pnpm/pnpm#13173. The `known_failures` stub for
the same scenario was left behind, so `just known-failures` still advertised
the behavior as unimplemented while the real test was already green.

Closes pnpm/pnpm#13143.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Test-only cleanup in the Rust stack; the TypeScript CLI always had the
  correct behavior and already covers it in
  `installing/deps-installer/test/install/optionalDependencies.ts`. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <!-- Not applicable: no published package changes. The behavior changeset
  shipped with pnpm/pnpm#13172 and is already in the
  pacquet@12.0.0-alpha.17 changelog. -->
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787528807&installation_model_id=426870&pr_number=13282&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13282&signature=6740b46e58a33540881c62f9dbd4212dfb118b0b7ebbca9940f2ab090e64314c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an obsolete known-failure test for unsupported optional dependencies under strict engine settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->