### PR TITLE
feat(cli): check the pinned package manager and runtimes before a command

### DIFF
--- a/.changeset/pacquet-pre-command-checks.md
+++ b/.changeset/pacquet-pre-command-checks.md
@@ -1,0 +1,11 @@
+---
+"pacquet": patch
+---
+
+Validate the project's pinned package manager and runtimes before running a command, matching the pnpm CLI:
+
+- A `packageManager` / `devEngines.packageManager` pin that the running pnpm does not satisfy now fails with `ERR_PNPM_BAD_PM_VERSION` (or `ERR_PNPM_OTHER_PM_EXPECTED` when the project is pinned to another package manager), instead of being silently ignored. The check also runs under corepack, where pnpm cannot switch versions itself, and says so.
+- `devEngines.runtime` / `engines.runtime` entries with `onFail: "error"` or `onFail: "warn"` are validated against the Node.js, Deno, or Bun installed on the system, failing with `ERR_PNPM_BAD_RUNTIME_VERSION`.
+- `pmOnFail` and `runtimeOnFail` are honored as bypasses and can now be passed as `--pm-on-fail=<value>` / `--runtime-on-fail=<value>`, the form the error hints suggest.
+
+Global commands (`--global`) and commands that do not belong to the project (`store`, `dlx`, `self-update`, …) skip these checks, as does a project pin that only asked pnpm to switch versions when `manage-package-manager-versions` is turned off.

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -93,8 +93,8 @@ mod dispatch_query;
 mod dispatch_script;
 mod package_manager;
 mod pipelines;
+pub(crate) mod pre_command;
 pub(crate) mod reporter;
-pub(crate) mod switch_cli_version;
 mod verify_deps;
 
 pub(crate) use cli_command::CliArgs;

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -1,9 +1,20 @@
+//! pnpm's pre-command handling: before a command runs, the pinned package
+//! manager and the pinned runtimes are reconciled with what is actually
+//! running. A pnpm pin with `onFail: "download"` switches the CLI to the
+//! wanted version; every other pin is validated in place and fails or warns.
+//!
+//! Mirrors the block at the top of pnpm's `pnpm/src/main.ts`.
+
+mod system_runtime_version;
+
 use super::{
     cli_command::{CliArgs, CliCommand},
+    config::ConfigSubcommand,
     package_manager::{
         PACKAGE_MANAGER_SWITCH_ENV_VARS, WantedPackageManager, read_manifest_json,
         should_persist_package_manager_lockfile, version_satisfies, wanted_package_manager,
     },
+    reporter::reporter_emit,
     self_update::install_pnpm::{assert_release_is_installable, pnpm_package_to_install},
     with::{
         PackageManagerCheck,
@@ -12,37 +23,58 @@ use super::{
     },
 };
 use crate::{config_deps, config_overrides::ConfigOverrides};
-use miette::{Context, IntoDiagnostic};
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::{Config, Host, PNPM_VERSION, PmOnFail};
+use pacquet_default_reporter::DefaultReporter;
 use pacquet_lockfile::{EnvLockfile, LockfileResolution, PackageKey, PackageMetadata, VersionPart};
-use pacquet_reporter::SilentReporter;
+use pacquet_package_manifest::{apply_runtime_on_fail_override, is_runtime_alias};
+use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter, SilentReporter};
+use serde_json::Value;
 use std::{
     collections::HashSet,
     ffi::{OsStr, OsString},
-    fmt::Display,
     path::{Path, PathBuf},
 };
+use system_runtime_version::system_runtime_version;
 
-pub(crate) fn switch_plan(
+/// Run the pre-command checks and return the version switch they ask for,
+/// if any. The checks themselves report through `args.reporter` and fail
+/// the command by returning an error.
+pub(crate) fn pre_command_plan(
     args: &CliArgs,
     config_overrides: &ConfigOverrides,
 ) -> miette::Result<Option<SwitchPlan>> {
     if should_skip_command(&args.command) {
         return Ok(None);
     }
-    switch_plan_from_input(
-        &SwitchInput::from_cli_args(args),
+    pre_command_plan_from_input(
+        &PreCommandInput {
+            switch: SwitchInput::from_cli_args(args),
+            global: is_global(&args.command),
+            check_runtimes: true,
+            emit: reporter_emit(args.reporter),
+        },
         config_overrides,
         SwitchProcessState::current(),
     )
 }
 
-pub(crate) fn switch_plan_for_version_flag(
+/// The `pnpm --version` path, which clap answers before a command is
+/// parsed. pnpm checks the package manager there too, but skips the runtime
+/// checks — printing the version must work in a project whose runtime pin
+/// the system cannot satisfy.
+pub(crate) fn pre_command_plan_for_version_flag(
     argv: &[OsString],
     config_overrides: &ConfigOverrides,
 ) -> miette::Result<Option<SwitchPlan>> {
-    switch_plan_from_input(
-        &SwitchInput::from_version_argv(argv),
+    pre_command_plan_from_input(
+        &PreCommandInput {
+            switch: SwitchInput::from_version_argv(argv),
+            global: false,
+            check_runtimes: false,
+            emit: DefaultReporter::emit,
+        },
         config_overrides,
         SwitchProcessState::current(),
     )
@@ -93,34 +125,271 @@ pub(crate) async fn execute_switch(
     Ok(true)
 }
 
-fn switch_plan_from_input(
-    input: &SwitchInput,
+fn pre_command_plan_from_input(
+    input: &PreCommandInput,
     config_overrides: &ConfigOverrides,
     process_state: SwitchProcessState,
 ) -> miette::Result<Option<SwitchPlan>> {
-    if input.command.as_deref().is_some_and(should_skip_command_name)
-        || process_state.package_manager_switch_disabled
-        || process_state.executed_by_corepack
-    {
+    let switch = &input.switch;
+    if switch.command.as_deref().is_some_and(should_skip_command_name) {
         return Ok(None);
     }
-    let dir = dunce::canonicalize(&input.dir).into_diagnostic().wrap_err_with(|| {
-        format!("canonicalizing the `--dir` argument: {}", input.dir.display())
+    let dir = dunce::canonicalize(&switch.dir).into_diagnostic().wrap_err_with(|| {
+        format!("canonicalizing the `--dir` argument: {}", switch.dir.display())
     })?;
-    let mut config = Config { npmrc_auth_file: input.npmrc_auth_file.clone(), ..Config::default() }
-        .current::<Host>(&dir)
-        .map_err(miette::Report::new)
-        .wrap_err("load configuration")?;
+    let mut config =
+        Config { npmrc_auth_file: switch.npmrc_auth_file.clone(), ..Config::default() }
+            .current::<Host>(&dir)
+            .map_err(miette::Report::new)
+            .wrap_err("load configuration")?;
     config_overrides.apply(&mut config);
 
     let root_dir = config.workspace_dir.clone().unwrap_or_else(|| dir.clone());
-    let Some(target) = switch_target(&config, &root_dir)? else {
-        return Ok(None);
-    };
-    if version_satisfies(PNPM_VERSION, &target.spec) {
-        return Ok(None);
+    let manifest = read_manifest_json(&root_dir.join("package.json"))?;
+
+    if let Some(pm) = manifest.as_ref().and_then(wanted_package_manager) {
+        let on_fail = effective_on_fail(&config, &pm);
+        let switch_wanted = pm.name == "pnpm" && on_fail == PmOnFail::Download;
+        // Turning `manage-package-manager-versions` off is the user taking
+        // over version selection, so a pin that only asked pnpm to switch has
+        // nothing left to report. Corepack is the opposite case: it manages
+        // the version and picked the wrong one, so the mismatch is reported
+        // rather than switched.
+        let unmanaged_pin = switch_wanted && process_state.package_manager_switch_disabled;
+        if on_fail != PmOnFail::Ignore && !unmanaged_pin {
+            if switch_wanted && !process_state.executed_by_corepack {
+                if let Some(target) = switch_target(&config, &root_dir)?
+                    && !version_satisfies(PNPM_VERSION, &target.spec)
+                {
+                    return Ok(Some(SwitchPlan { config, target }));
+                }
+            } else if input.global {
+                global_warn(
+                    input.emit,
+                    "Using --global skips the package manager check for this project".to_string(),
+                );
+            } else {
+                check_package_manager(&pm, on_fail, process_state, input.emit)?;
+            }
+        }
     }
-    Ok(Some(SwitchPlan { config, target }))
+
+    if input.check_runtimes
+        && !input.global
+        && let Some(manifest) = manifest
+    {
+        check_runtimes(manifest, &config, input.emit)?;
+    }
+    Ok(None)
+}
+
+/// pnpm's `checkPackageManager`. `on_fail` is already resolved against the
+/// `pmOnFail` setting and is never [`PmOnFail::Ignore`] here.
+fn check_package_manager(
+    pm: &WantedPackageManager,
+    on_fail: PmOnFail,
+    process_state: SwitchProcessState,
+    emit: fn(&LogEvent),
+) -> miette::Result<()> {
+    // `download` reaches this function only when the switch it asks for
+    // cannot happen, which leaves the mismatch unresolved — as strict a
+    // failure as `error`.
+    let should_error = matches!(on_fail, PmOnFail::Error | PmOnFail::Download);
+    if pm.name.is_empty() {
+        return Ok(());
+    }
+    if pm.name != "pnpm" {
+        if should_error {
+            return Err(PreCommandError::OtherPmExpected { name: pm.name.clone() }.into());
+        }
+        global_warn(emit, format!("This project is configured to use {}", pm.name));
+        return Ok(());
+    }
+    let Some(wanted) = pm.version.as_deref() else {
+        return Ok(());
+    };
+    if version_satisfies(PNPM_VERSION, wanted) {
+        return Ok(());
+    }
+    let (note, hint) = if process_state.executed_by_corepack {
+        (COREPACK_NOTE, format!("{COREPACK_PM_HINT_PREFIX}\n{PM_ON_FAIL_HINT}"))
+    } else {
+        ("", PM_ON_FAIL_HINT.to_string())
+    };
+    let error = PreCommandError::BadPmVersion { wanted: wanted.to_string(), note, hint };
+    if should_error {
+        return Err(error.into());
+    }
+    global_warn(emit, error.to_string());
+    Ok(())
+}
+
+/// pnpm's `getWantedRuntimes` + `checkRuntime`: validate every runtime the
+/// root manifest pins against the runtime installed on the system.
+fn check_runtimes(mut manifest: Value, config: &Config, emit: fn(&LogEvent)) -> miette::Result<()> {
+    if let Some(runtime_on_fail) = config.runtime_on_fail {
+        apply_runtime_on_fail_override(&mut manifest, runtime_on_fail.as_str());
+    }
+    // `devEngines.runtime` wins over `engines.runtime`: the first entry seen
+    // for a runtime is the one that gets checked.
+    let mut checked = HashSet::new();
+    for engines_field in ["devEngines", "engines"] {
+        let Some(runtime_entry) =
+            manifest.get(engines_field).and_then(|engines| engines.get("runtime"))
+        else {
+            continue;
+        };
+        let runtimes: &[Value] = match runtime_entry {
+            Value::Array(runtimes) => runtimes.as_slice(),
+            runtime @ Value::Object(_) => std::slice::from_ref(runtime),
+            _ => continue,
+        };
+        for runtime in runtimes {
+            let Some(name) = runtime.get("name").and_then(Value::as_str) else {
+                continue;
+            };
+            if !is_runtime_alias(name) || !checked.insert(name.to_string()) {
+                continue;
+            }
+            check_runtime(runtime, name, emit)?;
+        }
+    }
+    Ok(())
+}
+
+fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Result<()> {
+    let on_fail = runtime.get("onFail").and_then(Value::as_str);
+    if matches!(on_fail, None | Some("ignore" | "download")) {
+        return Ok(());
+    }
+    let display_name = runtime_display_name(name);
+    let wanted_range = runtime.get("version").and_then(Value::as_str).map(str::trim);
+    let Some(wanted_range) = wanted_range.filter(|range| !range.is_empty()) else {
+        return fail_runtime_check(
+            on_fail,
+            format!(
+                "This project requires a {display_name} runtime but does not specify a version range"
+            ),
+            emit,
+        );
+    };
+    if node_semver::Range::parse(wanted_range).is_err() {
+        return fail_runtime_check(
+            on_fail,
+            format!(
+                "This project requires an invalid {display_name} version range: {wanted_range}"
+            ),
+            emit,
+        );
+    }
+    let Some(current_version) = system_runtime_version(name) else {
+        return fail_runtime_check(
+            on_fail,
+            format!(
+                "This project requires {display_name} {wanted_range}, but {display_name} was not found on the system"
+            ),
+            emit,
+        );
+    };
+    if version_satisfies(&current_version, wanted_range) {
+        return Ok(());
+    }
+    fail_runtime_check(
+        on_fail,
+        format!(
+            "This project requires {display_name} {wanted_range}. Your current {display_name} is v{current_version}"
+        ),
+        emit,
+    )
+}
+
+/// Every `onFail` other than `error` — including a value pnpm does not
+/// define — degrades to a warning.
+fn fail_runtime_check(
+    on_fail: Option<&str>,
+    message: String,
+    emit: fn(&LogEvent),
+) -> miette::Result<()> {
+    if on_fail == Some("error") {
+        return Err(PreCommandError::BadRuntimeVersion { message }.into());
+    }
+    global_warn(emit, message);
+    Ok(())
+}
+
+fn runtime_display_name(runtime: &str) -> &'static str {
+    match runtime {
+        "deno" => "Deno",
+        "bun" => "Bun",
+        _ => "Node.js",
+    }
+}
+
+fn global_warn(emit: fn(&LogEvent), message: String) {
+    emit(&LogEvent::Global(GlobalLog { level: LogLevel::Warn, message }));
+}
+
+const PM_ON_FAIL_HINT: &str = r#"If you want to bypass this version check, you can set the "pmOnFail" configuration to "warn" or "ignore" (e.g. via --pm-on-fail=ignore). If using "devEngines.packageManager", you can set its "onFail" to "warn" or "ignore""#;
+
+/// Corepack, not pnpm, picks the running version, so the mismatch survives
+/// even the `download` policy that would otherwise switch versions. Both
+/// the message and the hint have to say so, or the user is left with a
+/// download-on-mismatch contract that silently did not download.
+const COREPACK_NOTE: &str = "\nCorepack invoked pnpm with this version, and pnpm does not switch versions when running under corepack.";
+
+const COREPACK_PM_HINT_PREFIX: &str = "Align the \"packageManager\" field in package.json with \"devEngines.packageManager\", or invoke pnpm directly (without corepack) so it can switch versions automatically.";
+
+const RUNTIME_ON_FAIL_HINT: &str = r#"If you want to bypass this version check, set "runtimeOnFail" to "warn" or "ignore" (e.g. via --runtime-on-fail=ignore), or set "devEngines.runtime.onFail"/"engines.runtime.onFail" to "warn" or "ignore""#;
+
+#[derive(Debug, Display, Error, Diagnostic)]
+pub(crate) enum PreCommandError {
+    #[display("This project is configured to use {name}")]
+    #[diagnostic(code(ERR_PNPM_OTHER_PM_EXPECTED))]
+    OtherPmExpected { name: String },
+
+    #[display(
+        "This project is configured to use {wanted} of pnpm. Your current pnpm is v{PNPM_VERSION}{note}"
+    )]
+    #[diagnostic(code(ERR_PNPM_BAD_PM_VERSION), help("{hint}"))]
+    BadPmVersion { wanted: String, note: &'static str, hint: String },
+
+    #[display("{message}")]
+    #[diagnostic(code(ERR_PNPM_BAD_RUNTIME_VERSION), help("{RUNTIME_ON_FAIL_HINT}"))]
+    BadRuntimeVersion { message: String },
+}
+
+struct PreCommandInput {
+    switch: SwitchInput,
+    global: bool,
+    check_runtimes: bool,
+    emit: fn(&LogEvent),
+}
+
+/// pnpm treats `--global` as an opt-out of the project's package manager
+/// and runtime pins — a global install does not belong to the project.
+fn is_global(command: &CliCommand) -> bool {
+    match command {
+        CliCommand::Add(args) => args.global,
+        CliCommand::ApproveBuilds(args) => args.global,
+        CliCommand::Bin(args) => args.global,
+        CliCommand::Config(args) => match &args.command {
+            ConfigSubcommand::Set(args) => args.flags.global,
+            ConfigSubcommand::Get(args) => args.flags.global,
+            ConfigSubcommand::Delete(args) => args.flags.global,
+            ConfigSubcommand::List(args) => args.flags.global,
+        },
+        CliCommand::List(args) | CliCommand::Ll(args) => args.global,
+        CliCommand::Outdated(args) => args.global,
+        CliCommand::Prefix(args) => args.global,
+        CliCommand::Remove(args) => args.global,
+        CliCommand::Root(args) => args.global,
+        CliCommand::Runtime(args) => args.global,
+        CliCommand::Update(args) => args.global,
+        // `pnpm link` with no arguments links the current project into the
+        // global directory.
+        CliCommand::Link(args) => args.package_paths.is_empty(),
+        _ => false,
+    }
 }
 
 fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<SwitchTarget>> {
@@ -291,7 +560,7 @@ fn assert_integrity_only_resolution(
     }
 }
 
-fn invalid_package_manager_lockfile(dep_path: impl Display) -> miette::Report {
+fn invalid_package_manager_lockfile(dep_path: impl std::fmt::Display) -> miette::Report {
     miette::miette!(
         r#"The packageManager dependency "{}" in pnpm-lock.yaml must use a registry package path and an integrity-only resolution"#,
         dep_path,
@@ -317,12 +586,20 @@ fn on_fail_str(on_fail: PmOnFail) -> &'static str {
     }
 }
 
+/// The commands pnpm marks with `skipPackageManagerCheck`, plus `setup` —
+/// they either predate the project's pins (`setup`), inspect pnpm itself
+/// (`store`, `doctor`, …), or run something that is not the project
+/// (`dlx`).
 fn should_skip_command(command: &CliCommand) -> bool {
     matches!(
         command,
-        CliCommand::Completion(_)
+        CliCommand::CatFile(_)
+            | CliCommand::CatIndex(_)
+            | CliCommand::Completion(_)
             | CliCommand::CompletionServer(_)
+            | CliCommand::Dlx(_)
             | CliCommand::Doctor(_)
+            | CliCommand::FindHash(_)
             | CliCommand::Runtime(_)
             | CliCommand::SelfUpdate(_)
             | CliCommand::Setup(_)
@@ -334,10 +611,14 @@ fn should_skip_command(command: &CliCommand) -> bool {
 fn should_skip_command_name(command: &str) -> bool {
     matches!(
         command,
-        "completion"
+        "cat-file"
+            | "cat-index"
+            | "completion"
             | "completion-server"
+            | "dlx"
             | "doctor"
             | "env"
+            | "find-hash"
             | "runtime"
             | "rt"
             | "self-update"
@@ -378,6 +659,7 @@ struct SwitchTarget {
     source: SwitchSource,
 }
 
+#[derive(Debug)]
 pub(crate) struct SwitchPlan {
     config: Config,
     target: SwitchTarget,

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -268,7 +268,7 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
         return fail_runtime_check(
             on_fail,
             format!(
-                "This project requires a {display_name} runtime but does not specify a version range"
+                "This project requires a {display_name} runtime but does not specify a version range",
             ),
             emit,
         );
@@ -277,7 +277,7 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
         return fail_runtime_check(
             on_fail,
             format!(
-                "This project requires an invalid {display_name} version range: {wanted_range}"
+                "This project requires an invalid {display_name} version range: {wanted_range}",
             ),
             emit,
         );
@@ -286,7 +286,7 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
         return fail_runtime_check(
             on_fail,
             format!(
-                "This project requires {display_name} {wanted_range}, but {display_name} was not found on the system"
+                "This project requires {display_name} {wanted_range}, but {display_name} was not found on the system",
             ),
             emit,
         );
@@ -297,7 +297,7 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
     fail_runtime_check(
         on_fail,
         format!(
-            "This project requires {display_name} {wanted_range}. Your current {display_name} is v{current_version}"
+            "This project requires {display_name} {wanted_range}. Your current {display_name} is v{current_version}",
         ),
         emit,
     )
@@ -337,7 +337,7 @@ const PM_ON_FAIL_HINT: &str = r#"If you want to bypass this version check, you c
 /// download-on-mismatch contract that silently did not download.
 const COREPACK_NOTE: &str = "\nCorepack invoked pnpm with this version, and pnpm does not switch versions when running under corepack.";
 
-const COREPACK_PM_HINT_PREFIX: &str = "Align the \"packageManager\" field in package.json with \"devEngines.packageManager\", or invoke pnpm directly (without corepack) so it can switch versions automatically.";
+const COREPACK_PM_HINT_PREFIX: &str = r#"Align the "packageManager" field in package.json with "devEngines.packageManager", or invoke pnpm directly (without corepack) so it can switch versions automatically."#;
 
 const RUNTIME_ON_FAIL_HINT: &str = r#"If you want to bypass this version check, set "runtimeOnFail" to "warn" or "ignore" (e.g. via --runtime-on-fail=ignore), or set "devEngines.runtime.onFail"/"engines.runtime.onFail" to "warn" or "ignore""#;
 
@@ -588,7 +588,7 @@ fn on_fail_str(on_fail: PmOnFail) -> &'static str {
 
 /// The commands pnpm marks with `skipPackageManagerCheck`, plus `setup` —
 /// they either predate the project's pins (`setup`), inspect pnpm itself
-/// (`store`, `doctor`, …), or run something that is not the project
+/// (`store`, `doctor`, and so on), or run something that is not the project
 /// (`dlx`).
 fn should_skip_command(command: &CliCommand) -> bool {
     matches!(

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -15,6 +15,7 @@ use super::{
         should_persist_package_manager_lockfile, version_satisfies, wanted_package_manager,
     },
     reporter::reporter_emit,
+    sanitize::sanitize_inline,
     self_update::install_pnpm::{assert_release_is_installable, pnpm_package_to_install},
     with::{
         PackageManagerCheck,
@@ -166,7 +167,7 @@ fn pre_command_plan_from_input(
             } else if input.global {
                 global_warn(
                     input.emit,
-                    "Using --global skips the package manager check for this project".to_string(),
+                    "Using --global skips the package manager check for this project",
                 );
             } else {
                 check_package_manager(&pm, on_fail, process_state, input.emit)?;
@@ -199,10 +200,11 @@ fn check_package_manager(
         return Ok(());
     }
     if pm.name != "pnpm" {
+        let name = sanitize_inline(&pm.name).into_owned();
         if should_error {
-            return Err(PreCommandError::OtherPmExpected { name: pm.name.clone() }.into());
+            return Err(PreCommandError::OtherPmExpected { name }.into());
         }
-        global_warn(emit, format!("This project is configured to use {}", pm.name));
+        global_warn(emit, &format!("This project is configured to use {name}"));
         return Ok(());
     }
     let Some(wanted) = pm.version.as_deref() else {
@@ -216,11 +218,12 @@ fn check_package_manager(
     } else {
         ("", PM_ON_FAIL_HINT.to_string())
     };
-    let error = PreCommandError::BadPmVersion { wanted: wanted.to_string(), note, hint };
+    let error =
+        PreCommandError::BadPmVersion { wanted: sanitize_inline(wanted).into_owned(), note, hint };
     if should_error {
         return Err(error.into());
     }
-    global_warn(emit, error.to_string());
+    global_warn(emit, &error.to_string());
     Ok(())
 }
 
@@ -267,7 +270,7 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
     let Some(wanted_range) = wanted_range.filter(|range| !range.is_empty()) else {
         return fail_runtime_check(
             on_fail,
-            format!(
+            &format!(
                 "This project requires a {display_name} runtime but does not specify a version range",
             ),
             emit,
@@ -276,7 +279,7 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
     if node_semver::Range::parse(wanted_range).is_err() {
         return fail_runtime_check(
             on_fail,
-            format!(
+            &format!(
                 "This project requires an invalid {display_name} version range: {wanted_range}",
             ),
             emit,
@@ -285,7 +288,7 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
     let Some(current_version) = system_runtime_version(name) else {
         return fail_runtime_check(
             on_fail,
-            format!(
+            &format!(
                 "This project requires {display_name} {wanted_range}, but {display_name} was not found on the system",
             ),
             emit,
@@ -296,7 +299,7 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
     }
     fail_runtime_check(
         on_fail,
-        format!(
+        &format!(
             "This project requires {display_name} {wanted_range}. Your current {display_name} is v{current_version}",
         ),
         emit,
@@ -307,10 +310,11 @@ fn check_runtime(runtime: &Value, name: &str, emit: fn(&LogEvent)) -> miette::Re
 /// define — degrades to a warning.
 fn fail_runtime_check(
     on_fail: Option<&str>,
-    message: String,
+    message: &str,
     emit: fn(&LogEvent),
 ) -> miette::Result<()> {
     if on_fail == Some("error") {
+        let message = sanitize_inline(message).into_owned();
         return Err(PreCommandError::BadRuntimeVersion { message }.into());
     }
     global_warn(emit, message);
@@ -325,7 +329,11 @@ fn runtime_display_name(runtime: &str) -> &'static str {
     }
 }
 
-fn global_warn(emit: fn(&LogEvent), message: String) {
+/// Every warning here quotes the project's manifest, which is untrusted
+/// input in a repository the user has only cloned, so control characters
+/// are stripped before the message reaches the terminal.
+fn global_warn(emit: fn(&LogEvent), message: &str) {
+    let message = sanitize_inline(message).into_owned();
     emit(&LogEvent::Global(GlobalLog { level: LogLevel::Warn, message }));
 }
 

--- a/pnpm/crates/cli/src/cli_args/pre_command/system_runtime_version.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/system_runtime_version.rs
@@ -15,7 +15,12 @@ pub(crate) fn system_runtime_version(runtime: &str) -> Option<String> {
     }
 }
 
+/// Resolve `program` on `PATH` and run `<program> --version`. The lookup is
+/// explicit because a bare [`Command::new`] on Windows also searches the
+/// current directory, which would let a runtime pin in an untrusted
+/// repository run a `deno.exe` / `bun.exe` checked in beside it.
 fn run_version_command(program: &str) -> Option<String> {
+    let program = which::which(program).ok()?;
     let output = Command::new(program).arg("--version").output().ok()?;
     if !output.status.success() {
         return None;
@@ -32,24 +37,22 @@ fn parse_deno_version(stdout: &str) -> Option<String> {
             return None;
         }
         let version = rest.split_whitespace().next()?;
-        starts_with_version(version).then(|| version.to_string())
+        accept_version(version)
     })
 }
 
 /// `bun --version` prints the bare version and nothing else.
 fn parse_bun_version(stdout: &str) -> Option<String> {
-    let version = stdout.trim();
-    starts_with_version(version).then(|| version.to_string())
+    accept_version(stdout.trim())
 }
 
-/// Whether `text` starts with `<digits>.<digits>.<digit>` — the shape both
-/// upstream probes require before accepting the reported version.
-fn starts_with_version(text: &str) -> bool {
-    let mut parts = text.splitn(3, '.');
-    let is_number = |part: &str| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit());
-    parts.next().is_some_and(is_number)
-        && parts.next().is_some_and(is_number)
-        && parts.next().is_some_and(|patch| patch.starts_with(|char: char| char.is_ascii_digit()))
+/// `text` when it is a whole semver version. The probed binary is only as
+/// trustworthy as `PATH`, and its output is echoed back in the
+/// runtime-mismatch message, so anything that is not a version — including
+/// a version followed by terminal escapes — is rejected outright rather
+/// than reported as the installed version.
+fn accept_version(text: &str) -> Option<String> {
+    node_semver::Version::parse(text).ok().map(|_| text.to_string())
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/pre_command/system_runtime_version.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/system_runtime_version.rs
@@ -1,0 +1,56 @@
+//! Probe the runtimes installed on the system, mirroring
+//! `@pnpm/engine.runtime.system-version`.
+
+use std::process::Command;
+
+/// The version of `runtime` as installed on the system, without a leading
+/// `v`, or `None` when the runtime is not on `PATH` or prints something
+/// unparsable.
+pub(crate) fn system_runtime_version(runtime: &str) -> Option<String> {
+    match runtime {
+        "node" => pacquet_graph_hasher::detect_node_version(),
+        "deno" => run_version_command("deno").as_deref().and_then(parse_deno_version),
+        "bun" => run_version_command("bun").as_deref().and_then(parse_bun_version),
+        _ => None,
+    }
+}
+
+fn run_version_command(program: &str) -> Option<String> {
+    let output = Command::new(program).arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(std::str::from_utf8(&output.stdout).ok()?.to_string())
+}
+
+/// `deno --version` prints several lines, the first of them
+/// `deno <version> (release, <target>)`.
+fn parse_deno_version(stdout: &str) -> Option<String> {
+    stdout.lines().find_map(|line| {
+        let rest = line.strip_prefix("deno")?;
+        if !rest.starts_with(char::is_whitespace) {
+            return None;
+        }
+        let version = rest.split_whitespace().next()?;
+        starts_with_version(version).then(|| version.to_string())
+    })
+}
+
+/// `bun --version` prints the bare version and nothing else.
+fn parse_bun_version(stdout: &str) -> Option<String> {
+    let version = stdout.trim();
+    starts_with_version(version).then(|| version.to_string())
+}
+
+/// Whether `text` starts with `<digits>.<digits>.<digit>` — the shape both
+/// upstream probes require before accepting the reported version.
+fn starts_with_version(text: &str) -> bool {
+    let mut parts = text.splitn(3, '.');
+    let is_number = |part: &str| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit());
+    parts.next().is_some_and(is_number)
+        && parts.next().is_some_and(is_number)
+        && parts.next().is_some_and(|patch| patch.starts_with(|char: char| char.is_ascii_digit()))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/pre_command/system_runtime_version/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/system_runtime_version/tests.rs
@@ -36,6 +36,16 @@ fn bun_version_is_the_whole_trimmed_output() {
 }
 
 #[test]
+fn a_version_trailed_by_terminal_escapes_is_rejected() {
+    let deno = parse_deno_version("deno 1.40.0\u{1b}[2J (release, x86_64-unknown-linux-gnu)\n");
+    let bun = parse_bun_version("1.1.0\u{1b}[2J\n");
+
+    dbg!(&deno, &bun);
+    assert!(deno.is_none(), "unexpected Deno version");
+    assert!(bun.is_none(), "unexpected Bun version");
+}
+
+#[test]
 fn bun_version_is_none_when_the_output_is_not_a_version() {
     let outputs = ["bun 1.1.0\n", "1.1\n", ""];
 

--- a/pnpm/crates/cli/src/cli_args/pre_command/system_runtime_version/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/system_runtime_version/tests.rs
@@ -1,0 +1,47 @@
+use super::{parse_bun_version, parse_deno_version};
+
+#[test]
+fn deno_version_is_read_from_the_leading_line() {
+    let stdout =
+        "deno 1.40.0 (release, x86_64-unknown-linux-gnu)\nv8 12.1.285.6\ntypescript 5.3.3\n";
+
+    let version = parse_deno_version(stdout);
+
+    assert_eq!(version.as_deref(), Some("1.40.0"));
+}
+
+#[test]
+fn deno_prerelease_version_keeps_its_suffix() {
+    let version = parse_deno_version("deno 2.0.0-rc.1 (release, aarch64-apple-darwin)\n");
+
+    assert_eq!(version.as_deref(), Some("2.0.0-rc.1"));
+}
+
+#[test]
+fn deno_version_is_none_when_the_output_has_no_version() {
+    let outputs = ["denoland 1.40.0\n", "deno\n", "deno not-a-version\n", ""];
+
+    for output in outputs {
+        let version = parse_deno_version(output);
+        dbg!(output, &version);
+        assert!(version.is_none(), "unexpected version for {output:?}");
+    }
+}
+
+#[test]
+fn bun_version_is_the_whole_trimmed_output() {
+    let version = parse_bun_version("1.1.0\n");
+
+    assert_eq!(version.as_deref(), Some("1.1.0"));
+}
+
+#[test]
+fn bun_version_is_none_when_the_output_is_not_a_version() {
+    let outputs = ["bun 1.1.0\n", "1.1\n", ""];
+
+    for output in outputs {
+        let version = parse_bun_version(output);
+        dbg!(output, &version);
+        assert!(version.is_none(), "unexpected version for {output:?}");
+    }
+}

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -1,6 +1,10 @@
-use super::{SwitchInput, SwitchProcessState, SwitchSource, switch_plan_from_input, switch_target};
+use super::{
+    PreCommandInput, SwitchInput, SwitchProcessState, SwitchSource, pre_command_plan_from_input,
+    switch_target,
+};
 use crate::config_overrides::ConfigOverrides;
 use pacquet_config::{Config, PmOnFail};
+use pacquet_reporter::{Reporter, SilentReporter};
 use std::{
     ffi::OsString,
     fs,
@@ -72,18 +76,111 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
 }
 
 #[test]
-fn switch_plan_skips_when_executed_by_corepack() {
-    let input =
-        SwitchInput { dir: PathBuf::from("missing-project"), npmrc_auth_file: None, command: None };
+fn pre_command_plan_reports_a_pnpm_pin_corepack_prevents_switching() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(root.path(), r#"{"packageManager":"pnpm@9.3.0"}"#);
 
-    let plan = switch_plan_from_input(
-        &input,
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
         &ConfigOverrides::default(),
         SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: true },
-    )
-    .expect("switch plan");
+    );
 
-    assert!(plan.is_none(), "unexpected switch plan when executed by Corepack");
+    // Corepack owns version selection, so the mismatch is reported instead
+    // of switched.
+    let error = plan.expect_err("expected the package manager check to fail");
+    dbg!(&error);
+    assert!(
+        error.to_string().contains("This project is configured to use 9.3.0 of pnpm"),
+        "unexpected error: {error:?}",
+    );
+}
+
+#[test]
+fn pre_command_plan_accepts_a_pnpm_pin_when_version_switching_is_turned_off() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(root.path(), r#"{"packageManager":"pnpm@9.3.0"}"#);
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: true, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(plan.is_none(), "unexpected switch plan");
+}
+
+#[test]
+fn pre_command_plan_reports_a_project_pinned_to_another_package_manager() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(root.path(), r#"{"packageManager":"yarn@4.0.0"}"#);
+
+    let error = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: true, executed_by_corepack: false },
+    )
+    .expect_err("expected the package manager check to fail");
+
+    dbg!(&error);
+    assert!(
+        error.to_string().contains("This project is configured to use yarn"),
+        "unexpected error: {error:?}",
+    );
+}
+
+#[test]
+fn pre_command_plan_checks_the_runtime_pinned_by_the_root_manifest() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(
+        root.path(),
+        r#"{"devEngines":{"runtime":{"name":"node","version":"99999.0.0","onFail":"error"}}}"#,
+    );
+
+    let error = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState::current(),
+    )
+    .expect_err("expected the runtime check to fail");
+
+    dbg!(&error);
+    assert!(
+        error.to_string().contains("This project requires Node.js 99999.0.0"),
+        "unexpected error: {error:?}",
+    );
+}
+
+#[test]
+fn pre_command_plan_skips_the_runtime_check_for_global_commands() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(
+        root.path(),
+        r#"{"devEngines":{"runtime":{"name":"node","version":"99999.0.0","onFail":"error"}}}"#,
+    );
+
+    let plan = pre_command_plan_from_input(
+        &PreCommandInput { global: true, ..pre_command_input(root.path()) },
+        &ConfigOverrides::default(),
+        SwitchProcessState::current(),
+    )
+    .expect("pre-command plan");
+
+    assert!(plan.is_none(), "unexpected switch plan");
+}
+
+fn pre_command_input(dir: &Path) -> PreCommandInput {
+    PreCommandInput {
+        switch: SwitchInput {
+            dir: dir.to_path_buf(),
+            npmrc_auth_file: None,
+            command: Some("install".to_string()),
+        },
+        global: false,
+        check_runtimes: true,
+        emit: SilentReporter::emit,
+    }
 }
 
 #[test]

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -105,10 +105,14 @@ impl ConfigOverrides {
     {
         let argv = argv.into_iter().collect::<Vec<_>>();
         let external_command_index = external_command_index(&argv);
+        // Everything past `--` belongs to whatever pnpm runs, not to pnpm.
+        let separator_index = argv.iter().position(|arg| arg == "--");
         let mut overrides = Self::default();
         let mut remaining = Vec::new();
         for (index, arg) in argv.into_iter().enumerate() {
-            if external_command_index.is_some_and(|command_index| index > command_index) {
+            if external_command_index.is_some_and(|command_index| index > command_index)
+                || separator_index.is_some_and(|separator| index > separator)
+            {
                 remaining.push(arg);
                 continue;
             }

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -1,7 +1,8 @@
 use crate::cli_args::CliArgs;
 use clap::CommandFactory;
 use pacquet_config::{
-    Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker, VerifyDepsBeforeRun,
+    Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker, PmOnFail, RuntimeOnFail,
+    VerifyDepsBeforeRun,
 };
 use pacquet_fs::lexical_normalize;
 use pacquet_store_dir::StoreDir;
@@ -85,6 +86,8 @@ pub struct ConfigOverrides {
     force_legacy_deploy: Option<bool>,
     inject_workspace_packages: Option<bool>,
     node_linker: Option<NodeLinker>,
+    pm_on_fail: Option<PmOnFail>,
+    runtime_on_fail: Option<RuntimeOnFail>,
     shared_workspace_lockfile: Option<bool>,
     verify_deps_before_run: Option<VerifyDepsBeforeRun>,
     https_proxy: Option<String>,
@@ -151,8 +154,15 @@ impl ConfigOverrides {
             return;
         }
         if key == "node-linker" {
-            self.node_linker =
-                serde_json::from_value(serde_json::Value::String(value.to_string())).ok();
+            self.node_linker = parse_enum(value);
+            return;
+        }
+        if key == "pm-on-fail" {
+            self.pm_on_fail = parse_enum(value);
+            return;
+        }
+        if key == "runtime-on-fail" {
+            self.runtime_on_fail = parse_enum(value);
             return;
         }
         if key == "shared-workspace-lockfile" {
@@ -195,6 +205,12 @@ impl ConfigOverrides {
         }
         if let Some(value) = self.node_linker {
             config.node_linker = value;
+        }
+        if let Some(value) = self.pm_on_fail {
+            config.pm_on_fail = Some(value);
+        }
+        if let Some(value) = self.runtime_on_fail {
+            config.runtime_on_fail = Some(value);
         }
         if let Some(value) = self.shared_workspace_lockfile {
             config.shared_workspace_lockfile = value;
@@ -290,21 +306,36 @@ enum ConfigToken<'a> {
 }
 
 /// Decide whether an argv token belongs to the `--config.<key>=<value>`
-/// family. Everything with a `--config.` prefix is claimed, so a typo
-/// like `--config.foo` never escapes into clap's "unexpected argument"
-/// path; non-prefixed tokens are returned untouched.
+/// family or is one of the [`BARE_SETTING_FLAGS`]. Everything with a
+/// `--config.` prefix is claimed, so a typo like `--config.foo` never
+/// escapes into clap's "unexpected argument" path; every other token is
+/// returned untouched.
 fn classify(arg: &OsStr) -> ConfigToken<'_> {
-    let Some(rest) = arg.to_str().and_then(|arg| arg.strip_prefix("--config.")) else {
+    let Some(arg) = arg.to_str() else {
         return ConfigToken::NotOurs;
     };
-    let Some((key, value)) = rest.split_once('=') else {
-        return ConfigToken::Malformed;
-    };
-    if key.is_empty() {
-        return ConfigToken::Malformed;
+    if let Some(rest) = arg.strip_prefix("--config.") {
+        let Some((key, value)) = rest.split_once('=') else {
+            return ConfigToken::Malformed;
+        };
+        if key.is_empty() {
+            return ConfigToken::Malformed;
+        }
+        return ConfigToken::WellFormed { key, value };
     }
-    ConfigToken::WellFormed { key, value }
+    match arg.strip_prefix("--").and_then(|flag| flag.split_once('=')) {
+        Some((key, value)) if BARE_SETTING_FLAGS.contains(&key) => {
+            ConfigToken::WellFormed { key, value }
+        }
+        _ => ConfigToken::NotOurs,
+    }
 }
+
+/// Settings pnpm's own error hints tell the user to pass as a bare
+/// `--<setting>=<value>` flag. pnpm accepts every setting that way; pacquet
+/// only declares a clap flag for a subset, so these are recognized here to
+/// keep the hints they appear in actionable.
+const BARE_SETTING_FLAGS: [&str; 2] = ["pm-on-fail", "runtime-on-fail"];
 
 fn scoped_registry_key(key: &str) -> Option<&str> {
     key.strip_suffix(":registry")
@@ -327,6 +358,10 @@ pub(crate) fn apply_registry_override(config: &mut Config, registry: &str) {
 
 fn normalize_registry_url(registry: &str) -> String {
     if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") }
+}
+
+fn parse_enum<Value: serde::de::DeserializeOwned>(value: &str) -> Option<Value> {
+    serde_json::from_value(serde_json::Value::String(value.to_string())).ok()
 }
 
 fn parse_bool(value: &str) -> Option<bool> {

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -46,6 +46,35 @@ fn extract_accepts_the_on_fail_settings_as_bare_flags() {
 }
 
 #[test]
+fn extract_leaves_config_tokens_after_the_separator_for_the_child() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "run",
+        "build",
+        "--",
+        "--pm-on-fail=ignore",
+        "--config.registry=https://example.test/",
+    ]));
+
+    // Past `--` the tokens are the script's arguments, not pnpm's settings.
+    assert_eq!(
+        remaining,
+        argv([
+            "pacquet",
+            "run",
+            "build",
+            "--",
+            "--pm-on-fail=ignore",
+            "--config.registry=https://example.test/",
+        ]),
+    );
+    let mut config = Config::default();
+    overrides.apply(&mut config);
+    assert_eq!(config.pm_on_fail, None);
+    assert_eq!(config.registry, Config::default().registry);
+}
+
+#[test]
 fn extract_leaves_other_bare_flags_for_clap() {
     let (_, remaining) =
         ConfigOverrides::extract(argv(["pacquet", "install", "--node-linker=hoisted"]));

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -1,5 +1,7 @@
 use super::{ConfigOverrides, apply_registry_override, apply_store_dir_override};
-use pacquet_config::{Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker};
+use pacquet_config::{
+    Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker, PmOnFail, RuntimeOnFail,
+};
 use pacquet_store_dir::STORE_VERSION;
 use pretty_assertions::assert_eq;
 use std::{ffi::OsString, path::PathBuf};
@@ -26,6 +28,28 @@ fn extract_separates_config_tokens_from_argv() {
         config.package_manager_bootstrap.registries.get("default").map(String::as_str),
         Some("https://example.test/"),
     );
+}
+
+#[test]
+fn extract_accepts_the_on_fail_settings_as_bare_flags() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--pm-on-fail=ignore",
+        "--runtime-on-fail=warn",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+    let mut config = Config::default();
+    overrides.apply(&mut config);
+    assert_eq!(config.pm_on_fail, Some(PmOnFail::Ignore));
+    assert_eq!(config.runtime_on_fail, Some(RuntimeOnFail::Warn));
+}
+
+#[test]
+fn extract_leaves_other_bare_flags_for_clap() {
+    let (_, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "install", "--node-linker=hoisted"]));
+    assert_eq!(remaining, argv(["pacquet", "install", "--node-linker=hoisted"]));
 }
 
 #[test]

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -71,13 +71,13 @@ fn run_cli() -> miette::Result<()> {
         Ok(args) => args,
         // pnpm prints the bare version, not clap's "pnpm <version>" rendering.
         Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {
-            if let Some(plan) = cli_args::switch_cli_version::switch_plan_for_version_flag(
-                &argv,
-                &config_overrides,
-            )? && block_on_runtime(
-                "pacquet-switch",
-                cli_args::switch_cli_version::execute_switch(plan, &child_argv),
-            )? {
+            if let Some(plan) =
+                cli_args::pre_command::pre_command_plan_for_version_flag(&argv, &config_overrides)?
+                && block_on_runtime(
+                    "pacquet-pre-command",
+                    cli_args::pre_command::execute_switch(plan, &child_argv),
+                )?
+            {
                 return Ok(());
             }
             println!("{}", pacquet_config::PNPM_VERSION);
@@ -90,10 +90,10 @@ fn run_cli() -> miette::Result<()> {
     }
     args.promote_recursive_for_filter();
     args.promote_recursive_by_default();
-    if let Some(plan) = cli_args::switch_cli_version::switch_plan(&args, &config_overrides)?
+    if let Some(plan) = cli_args::pre_command::pre_command_plan(&args, &config_overrides)?
         && block_on_runtime(
-            "pacquet-switch",
-            cli_args::switch_cli_version::execute_switch(plan, &child_argv),
+            "pacquet-pre-command",
+            cli_args::pre_command::execute_switch(plan, &child_argv),
         )?
     {
         return Ok(());

--- a/pnpm/crates/cli/tests/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/package_manager_check.rs
@@ -539,7 +539,17 @@ fn run(command: Command, root: &Path, args: &[&str]) -> Output {
     // suppress the removal of `PNPM_CONFIG_PM_ON_FAIL`.
     let explicitly_set =
         command.get_envs().map(|(name, _)| name.to_string_lossy().into_owned()).collect::<Vec<_>>();
-    for name in ["pnpm_config_pm_on_fail", "PNPM_CONFIG_PM_ON_FAIL", "COREPACK_ROOT"] {
+    for name in [
+        "pnpm_config_pm_on_fail",
+        "PNPM_CONFIG_PM_ON_FAIL",
+        "pnpm_config_runtime_on_fail",
+        "PNPM_CONFIG_RUNTIME_ON_FAIL",
+        "npm_config_manage_package_manager_versions",
+        "NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
+        "pnpm_config_manage_package_manager_versions",
+        "PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS",
+        "COREPACK_ROOT",
+    ] {
         if !explicitly_set.iter().any(|set_name| set_name.eq_ignore_ascii_case(name)) {
             command.env_remove(name);
         }

--- a/pnpm/crates/cli/tests/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/package_manager_check.rs
@@ -1,0 +1,599 @@
+//! Ports `pnpm11/pnpm/test/packageManagerCheck.test.ts`.
+
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+#[test]
+fn install_fails_when_the_project_pins_another_package_manager() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "yarn@4.0.0" }));
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_failure(&output);
+    assert_contains(&stderr(&output), "This project is configured to use yarn");
+}
+
+#[test]
+fn pm_on_fail_warn_downgrades_the_other_package_manager_failure_to_a_warning() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "yarn@4.0.0" }));
+
+    let output = run(pacquet, root.path(), &["install", "--config.pm-on-fail=warn"]);
+
+    assert_success(&output);
+    assert_contains(&output_text(&output), "This project is configured to use yarn");
+}
+
+#[test]
+fn pm_on_fail_error_reports_a_package_manager_version_mismatch() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "pnpm@0.0.0" }));
+
+    let output = run(pacquet, root.path(), &["install", "--config.pm-on-fail=error"]);
+
+    assert_failure(&output);
+    assert_contains(
+        &stderr(&output),
+        "This project is configured to use 0.0.0 of pnpm. Your current pnpm is",
+    );
+}
+
+#[test]
+fn pm_on_fail_ignore_bypasses_the_package_manager_version_mismatch() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "pnpm@0.0.0" }));
+
+    let output = run(pacquet, root.path(), &["install", "--config.pm-on-fail=ignore"]);
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("0.0.0"), "unexpected mention of the pinned version");
+}
+
+#[test]
+fn a_package_manager_field_with_an_integrity_hash_matches_the_running_version() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let pinned = format!("pnpm@{}+sha256.123456789", pacquet_config::PNPM_VERSION);
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": pinned }));
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_success(&output);
+}
+
+#[test]
+fn a_package_manager_field_holding_a_url_is_not_checked() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "packageManager": "pnpm@https://github.com/pnpm/pnpm" }),
+    );
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_success(&output);
+}
+
+#[test]
+fn commands_that_do_not_belong_to_the_project_skip_the_check() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "yarn@3.0.0" }));
+
+    let output = run(pacquet, root.path(), &["store", "path"]);
+
+    assert_success(&output);
+}
+
+#[test]
+fn dev_engines_package_manager_with_on_fail_error_reports_a_version_mismatch() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", "0.0.1", Some("error"));
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_failure(&output);
+    assert_contains(&stderr(&output), "This project is configured to use 0.0.1 of pnpm");
+}
+
+#[test]
+fn dev_engines_package_manager_with_on_fail_warn_warns_about_a_version_mismatch() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", "0.0.1", Some("warn"));
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_success(&output);
+    assert_contains(&output_text(&output), "This project is configured to use 0.0.1 of pnpm");
+}
+
+#[test]
+fn dev_engines_package_manager_with_on_fail_ignore_is_not_checked() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", "0.0.1", Some("ignore"));
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("0.0.1"), "unexpected mention of the pinned version");
+}
+
+#[test]
+fn dev_engines_package_manager_naming_another_package_manager_fails() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "yarn", ">=4.0.0", Some("error"));
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_failure(&output);
+    assert_contains(&stderr(&output), "This project is configured to use yarn");
+}
+
+#[test]
+fn dev_engines_package_manager_array_selects_the_pnpm_entry() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "devEngines": {
+                "packageManager": [
+                    { "name": "yarn", "version": ">=4.0.0", "onFail": "ignore" },
+                    { "name": "pnpm", "version": "0.0.1", "onFail": "error" },
+                ],
+            },
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_failure(&output);
+    assert_contains(&stderr(&output), "This project is configured to use 0.0.1 of pnpm");
+}
+
+#[test]
+fn dev_engines_package_manager_array_defaults_on_fail_to_ignore_before_the_last_entry() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "devEngines": {
+                "packageManager": [
+                    { "name": "pnpm", "version": "0.0.1" },
+                    { "name": "yarn", "version": ">=4.0.0" },
+                ],
+            },
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_success(&output);
+}
+
+#[test]
+fn the_pm_on_fail_hint_can_be_followed_as_a_bare_flag() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", "0.0.1", Some("error"));
+
+    let output = run(pacquet, root.path(), &["install", "--pm-on-fail=ignore"]);
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("0.0.1"), "unexpected mention of the pinned version");
+}
+
+#[test]
+fn the_runtime_on_fail_hint_can_be_followed_as_a_bare_flag() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "node", "version": "99999.0.0", "onFail": "error",
+        }),
+    );
+
+    let output = run(
+        pacquet,
+        root.path(),
+        &[
+            "--config.verify-deps-before-run=false",
+            "--runtime-on-fail=ignore",
+            "exec",
+            "node",
+            "--version",
+        ],
+    );
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("99999.0.0"), "unexpected mention of the pinned range");
+}
+
+#[test]
+fn pm_on_fail_ignore_from_the_env_bypasses_the_check() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", "0.0.1", Some("error"));
+
+    let output =
+        run(pacquet.with_env("pnpm_config_pm_on_fail", "ignore"), root.path(), &["install"]);
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("0.0.1"), "unexpected mention of the pinned version");
+}
+
+#[test]
+fn pm_on_fail_ignore_from_the_workspace_manifest_bypasses_the_check() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", "0.0.1", Some("error"));
+    fs::write(workspace.join("pnpm-workspace.yaml"), "pmOnFail: ignore\n")
+        .expect("write pnpm-workspace.yaml");
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("0.0.1"), "unexpected mention of the pinned version");
+}
+
+#[test]
+fn the_check_still_runs_under_corepack_and_explains_why_no_switch_happened() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", "0.0.1", Some("warn"));
+
+    let output =
+        run(pacquet.with_env("COREPACK_ROOT", "/fake/corepack"), root.path(), &["install"]);
+
+    assert_success(&output);
+    let text = output_text(&output);
+    assert_contains(&text, "This project is configured to use 0.0.1 of pnpm");
+    assert_contains(&text, "Corepack invoked pnpm");
+}
+
+#[test]
+fn on_fail_download_under_corepack_fails_instead_of_switching_versions() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", "0.0.1", Some("download"));
+
+    let output =
+        run(pacquet.with_env("COREPACK_ROOT", "/fake/corepack"), root.path(), &["install"]);
+
+    assert_failure(&output);
+    let stderr = stderr(&output);
+    assert_contains(&stderr, "This project is configured to use 0.0.1 of pnpm");
+    assert_contains(&stderr, "does not switch versions when running under corepack");
+    assert_contains(&stderr, "invoke pnpm directly");
+}
+
+#[test]
+fn turning_off_version_management_accepts_a_mismatched_pnpm_pin() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "pnpm@0.0.0" }));
+
+    let output = run(
+        pacquet.with_env("PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS", "false"),
+        root.path(),
+        &["install"],
+    );
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("0.0.0"), "unexpected mention of the pinned version");
+}
+
+#[test]
+fn a_global_command_warns_instead_of_failing_the_package_manager_check() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "yarn@4.0.0" }));
+
+    let output = run(pacquet, root.path(), &["list", "--global"]);
+
+    assert_success(&output);
+    assert_contains(
+        &output_text(&output),
+        "Using --global skips the package manager check for this project",
+    );
+}
+
+#[test]
+fn dev_engines_runtime_with_on_fail_error_reports_a_node_version_mismatch() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "node", "version": "99999.0.0", "onFail": "error",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_failure(&output);
+    assert_contains(&stderr(&output), "This project requires Node.js 99999.0.0");
+}
+
+#[test]
+fn dev_engines_runtime_with_on_fail_warn_warns_about_a_node_version_mismatch() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "node", "version": "99999.0.0", "onFail": "warn",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_success(&output);
+    assert_contains(&output_text(&output), "This project requires Node.js 99999.0.0");
+}
+
+#[test]
+fn dev_engines_runtime_with_on_fail_ignore_is_not_checked() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "node", "version": "99999.0.0", "onFail": "ignore",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("99999.0.0"), "unexpected mention of the pinned range");
+}
+
+#[test]
+fn engines_runtime_is_checked_too() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "engines",
+        &serde_json::json!({
+            "name": "node", "version": "99999.0.0", "onFail": "error",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_failure(&output);
+    assert_contains(&stderr(&output), "This project requires Node.js 99999.0.0");
+}
+
+#[test]
+fn an_invalid_node_version_range_fails_with_the_runtime_on_fail_hint() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "node", "version": "invalid range", "onFail": "error",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_failure(&output);
+    let stderr = stderr(&output);
+    assert_contains(
+        &stderr,
+        "This project requires an invalid Node.js version range: invalid range",
+    );
+    assert_contains(&stderr, "--runtime-on-fail=ignore");
+}
+
+#[test]
+fn an_invalid_deno_version_range_names_deno() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "deno", "version": "invalid range", "onFail": "error",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_failure(&output);
+    assert_contains(
+        &stderr(&output),
+        "This project requires an invalid Deno version range: invalid range",
+    );
+}
+
+#[test]
+fn an_invalid_bun_version_range_names_bun() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "bun", "version": "invalid range", "onFail": "error",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_failure(&output);
+    assert_contains(
+        &stderr(&output),
+        "This project requires an invalid Bun version range: invalid range",
+    );
+}
+
+#[test]
+fn a_runtime_without_a_version_range_fails() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "node", "onFail": "error",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_failure(&output);
+    assert_contains(
+        &stderr(&output),
+        "This project requires a Node.js runtime but does not specify a version range",
+    );
+}
+
+#[test]
+fn runtime_array_entries_are_checked_beyond_the_first_one() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!([
+            { "name": "node", "version": "*", "onFail": "error" },
+            { "name": "deno", "version": "invalid range", "onFail": "error" },
+        ]),
+    );
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_failure(&output);
+    assert_contains(
+        &stderr(&output),
+        "This project requires an invalid Deno version range: invalid range",
+    );
+}
+
+#[test]
+fn runtime_on_fail_ignore_bypasses_the_manifest_on_fail() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "node", "version": "99999.0.0", "onFail": "error",
+        }),
+    );
+
+    let output = run(
+        pacquet,
+        root.path(),
+        &[
+            "--config.verify-deps-before-run=false",
+            "--config.runtime-on-fail=ignore",
+            "exec",
+            "node",
+            "--version",
+        ],
+    );
+
+    assert_success(&output);
+    assert!(!output_text(&output).contains("99999.0.0"), "unexpected mention of the pinned range");
+}
+
+#[test]
+fn a_failing_runtime_check_does_not_block_the_version_output() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_runtime(
+        &workspace,
+        "devEngines",
+        &serde_json::json!({
+            "name": "node", "version": "99999.0.0", "onFail": "error",
+        }),
+    );
+
+    let output = run(pacquet, root.path(), &["--version"]);
+
+    assert_success(&output);
+    assert_eq!(stdout(&output).trim(), pacquet_config::PNPM_VERSION);
+}
+
+/// `exec` is the cheapest command that still goes through the pre-command
+/// checks; the dependency verification it would otherwise run is unrelated.
+const EXEC_NODE_VERSION: [&str; 4] =
+    ["--config.verify-deps-before-run=false", "exec", "node", "--version"];
+
+fn run(command: Command, root: &Path, args: &[&str]) -> Output {
+    let mut command = command;
+    command.env("PNPM_HOME", root.join("pnpm-home"));
+    command.env("HOME", root);
+    command.env("XDG_CONFIG_HOME", root.join("xdg-config"));
+    for name in ["pnpm_config_pm_on_fail", "PNPM_CONFIG_PM_ON_FAIL", "COREPACK_ROOT"] {
+        if command.get_envs().all(|(set_name, _)| set_name != name) {
+            command.env_remove(name);
+        }
+    }
+    let output = command.args(args).output().expect("run pacquet");
+    dbg!(&output);
+    output
+}
+
+fn write_manifest(workspace: &Path, manifest: &serde_json::Value) {
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+}
+
+fn write_dev_engines_package_manager(
+    workspace: &Path,
+    name: &str,
+    version: &str,
+    on_fail: Option<&str>,
+) {
+    let mut package_manager = serde_json::json!({ "name": name, "version": version });
+    if let Some(on_fail) = on_fail {
+        package_manager["onFail"] = serde_json::Value::String(on_fail.to_string());
+    }
+    write_manifest(
+        workspace,
+        &serde_json::json!({ "devEngines": { "packageManager": package_manager } }),
+    );
+}
+
+fn write_runtime(workspace: &Path, engines_field: &str, runtime: &serde_json::Value) {
+    write_manifest(workspace, &serde_json::json!({ engines_field: { "runtime": runtime } }));
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command should succeed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output),
+    );
+}
+
+fn assert_failure(output: &Output) {
+    assert!(
+        !output.status.success(),
+        "command should fail\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output),
+    );
+}
+
+fn assert_contains(text: &str, expected: &str) {
+    assert!(
+        unwrap_diagnostic(text).contains(&unwrap_diagnostic(expected)),
+        "expected {expected:?} in:\n{text}"
+    );
+}
+
+/// miette hard-wraps a diagnostic to the terminal width and prefixes the
+/// continuation lines with `│`, so an expected message only matches after
+/// both sides are flattened to single-spaced text.
+fn unwrap_diagnostic(text: &str) -> String {
+    text.replace('│', " ").split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn output_text(output: &Output) -> String {
+    format!("{}{}", stdout(output), stderr(output))
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}

--- a/pnpm/crates/cli/tests/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/package_manager_check.rs
@@ -575,7 +575,7 @@ fn assert_failure(output: &Output) {
 fn assert_contains(text: &str, expected: &str) {
     assert!(
         unwrap_diagnostic(text).contains(&unwrap_diagnostic(expected)),
-        "expected {expected:?} in:\n{text}"
+        "expected {expected:?} in:\n{text}",
     );
 }
 

--- a/pnpm/crates/cli/tests/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/package_manager_check.rs
@@ -80,6 +80,19 @@ fn a_package_manager_field_holding_a_url_is_not_checked() {
 }
 
 #[test]
+fn control_characters_in_a_package_manager_name_are_stripped_from_the_output() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "packageManager": "ya\u{1b}[2Jrn@4.0.0" }));
+
+    let output = run(pacquet, root.path(), &["install"]);
+
+    assert_failure(&output);
+    let stderr = stderr(&output);
+    assert!(!stderr.contains('\u{1b}'), "escape sequence reached the terminal:\n{stderr}");
+    assert_contains(&stderr, "This project is configured to use ya[2Jrn");
+}
+
+#[test]
 fn commands_that_do_not_belong_to_the_project_skip_the_check() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_manifest(&workspace, &serde_json::json!({ "packageManager": "yarn@3.0.0" }));
@@ -520,8 +533,14 @@ fn run(command: Command, root: &Path, args: &[&str]) -> Output {
     command.env("PNPM_HOME", root.join("pnpm-home"));
     command.env("HOME", root);
     command.env("XDG_CONFIG_HOME", root.join("xdg-config"));
+    // Clear the inherited settings the checks read, without disturbing the
+    // ones a test set on purpose. Windows matches environment names
+    // case-insensitively, so an explicit `pnpm_config_pm_on_fail` must also
+    // suppress the removal of `PNPM_CONFIG_PM_ON_FAIL`.
+    let explicitly_set =
+        command.get_envs().map(|(name, _)| name.to_string_lossy().into_owned()).collect::<Vec<_>>();
     for name in ["pnpm_config_pm_on_fail", "PNPM_CONFIG_PM_ON_FAIL", "COREPACK_ROOT"] {
-        if command.get_envs().all(|(set_name, _)| set_name != name) {
+        if !explicitly_set.iter().any(|set_name| set_name.eq_ignore_ascii_case(name)) {
             command.env_remove(name);
         }
     }


### PR DESCRIPTION
## Summary

pacquet silently ignored the project's `packageManager` / `devEngines.packageManager` pin whenever it could not switch to it, and ignored `devEngines.runtime` / `engines.runtime` entirely. A project that the TypeScript pnpm CLI refuses to install (`devEngines.runtime: { name: 'node', version: '99999.0.0', onFail: 'error' }`) installed cleanly under pacquet.

This ports pnpm's pre-command block (`pnpm11/pnpm/src/main.ts`) into the pacquet module that already owned the version switch, renamed `switch_cli_version` → `pre_command` to match what it now does:

- **`checkPackageManager`** — `ERR_PNPM_BAD_PM_VERSION` / `ERR_PNPM_OTHER_PM_EXPECTED`, with the same messages and hints, including the corepack wording (corepack picks the running version, so a mismatch survives even `onFail: "download"`).
- **`getWantedRuntimes` + `checkRuntime`** — `ERR_PNPM_BAD_RUNTIME_VERSION` against the Node.js / Deno / Bun installed on the system, with `devEngines.runtime` winning over `engines.runtime` and `onFail: "download"` / `"ignore"` skipped. The system probe mirrors `@pnpm/engine.runtime.system-version` in a new `system_runtime_version` module.
- The **`--global`** opt-out, the **skipped-command** set (`store`, `dlx`, `self-update`, `doctor`, …), and the **`pnpm --version`** path, which checks the package manager but not the runtimes — printing the version has to work in a project whose runtime pin the system cannot satisfy.

Two follow-on bits the checks need to be usable:

- `pmOnFail` / `runtimeOnFail` are honored as bypasses, and `--pm-on-fail=<value>` / `--runtime-on-fail=<value>` are now accepted as bare flags. pnpm accepts every setting that way and the hints these errors print name them, so without this the error told the user to run a flag pacquet rejected.
- With `manage-package-manager-versions` turned off, a pin that only asked pnpm to *switch* is no longer reported. That opt-out is the user taking over version selection, so there is nothing left to complain about — unlike corepack, which manages the version and picked the wrong one. This keeps `PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS=false` working as the "run this local build, don't delegate" escape hatch.

### Hardening against untrusted repositories

Everything above reads the project's `package.json`, which is untrusted input in a repository the user has only cloned, so the follow-up commit closes three ways that input could reach further than intended:

- The runtime probe resolves `deno` / `bun` through `which` and spawns the resolved path, instead of letting a bare `Command::new` pick up an executable committed next to the manifest that pins the runtime (Windows searches the current directory).
- `sanitize_inline` is applied at the output boundaries — `global_warn` and every `PreCommandError` variant carrying manifest text — so a `packageManager` name cannot inject terminal escapes.
- A probe result is accepted only when the whole token parses as semver, so a hostile runtime earlier on `PATH` cannot echo escapes back through the mismatch message.

### Not included: widening `syncEnvLockfile`

The issue's third item is already implemented in pacquet: `config_deps::sync_package_manager_dependencies` writes `packageManagerDependencies` from the install-family pipelines, gated by `should_persist_package_manager_lockfile` exactly like pnpm's `shouldPersistLockfile`. The only remaining delta is *when* it runs — pnpm also syncs on non-install commands (`pnpm run`, `pnpm list`, `pnpm --version`).

I left that out deliberately: pacquet hard-fails a frozen install whose `packageManagerDependencies` are out of date (`ConfigDepError::FrozenLockfileOutdated`, a strictness pnpm does not have), so syncing unconditionally in the pre-command block would silently repair the lockfile before that check could fire. Making the two agree is its own change, with its own review. Happy to do it in this PR if you'd rather it land together.

Closes pnpm/pnpm#11947

## Squash Commit Body

```text
pacquet ignored the project's packageManager / devEngines.packageManager
pin whenever it could not switch to it, and ignored devEngines.runtime /
engines.runtime entirely, so a project the TypeScript CLI refuses to
install installed cleanly under pacquet.

Port pnpm's pre-command block into the module that already owned the
version switch, renamed switch_cli_version -> pre_command:

- checkPackageManager: ERR_PNPM_BAD_PM_VERSION / ERR_PNPM_OTHER_PM_EXPECTED
  with pnpm's messages and hints, including the corepack wording, since
  corepack picks the running version and pnpm cannot switch under it.
- getWantedRuntimes + checkRuntime: ERR_PNPM_BAD_RUNTIME_VERSION against the
  Node.js / Deno / Bun on the system, devEngines.runtime winning over
  engines.runtime. The probe mirrors `@pnpm/engine.runtime.system-version`.
- The --global opt-out, the skipped-command set, and the --version path,
  which checks the package manager but not the runtimes.

pmOnFail / runtimeOnFail are honored as bypasses and accepted as bare
--pm-on-fail= / --runtime-on-fail= flags: pnpm takes every setting that way
and the hints these errors print name them, so otherwise the error pointed
at a flag pacquet rejected.

With manage-package-manager-versions off, a pin that only asked pnpm to
switch is no longer reported. That opt-out is the user taking over version
selection; corepack is the opposite case, where the version is managed and
wrong, so it still reports.

syncEnvLockfile, the issue's third item, already runs in pacquet's install
pipelines. Widening it to every command is left out: pacquet hard-fails a
frozen install whose packageManagerDependencies are stale, and an
unconditional pre-command sync would repair the lockfile before that check
could fire.

Closes pnpm/pnpm#11947
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- The TypeScript side already shipped this in pnpm/pnpm#11822; this PR is the pacquet half. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-command validation for pinned package manager and runtime versions.
  * Reports clear errors when installed versions do not meet project requirements.
  * Supports Node.js, Deno, and Bun runtime checks.
  * Added `--pm-on-fail` and `--runtime-on-fail` options to warn, ignore, or enforce mismatches.
  * Skips validation for global and non-project commands where appropriate.
* **Bug Fixes**
  * Improved handling of Corepack, disabled version management, and package manager switching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->