### PR TITLE
feat(update): support --workspace in pacquet and honor --depth per dependency

### DIFF
--- a/.changeset/pacquet-update-workspace-and-depth.md
+++ b/.changeset/pacquet-update-workspace-and-depth.md
@@ -1,0 +1,7 @@
+---
+"pacquet": minor
+---
+
+`pnpm update --workspace` is supported: dependencies that a workspace project publishes are re-pointed at the local copies through the `workspace:` protocol. The `saveWorkspaceProtocol` setting is honored — under its `rolling` default an entry becomes `workspace:*`, `workspace:^`, or `workspace:~` (whichever matches the range it already declared), so a sibling's next release does not invalidate it. Naming a dependency that is not in the workspace fails with `ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND`, and combining the flag with `--latest` fails with `ERR_PNPM_BAD_OPTIONS`.
+
+`pnpm update --depth <number>` is now applied per dependency instead of only distinguishing `0` from higher values: a dependency deeper than the given depth keeps its locked resolution, so `pnpm update --depth 0` updates direct dependencies only.

--- a/.changeset/update-workspace-only-links-named-deps.md
+++ b/.changeset/update-workspace-only-links-named-deps.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+`pnpm update --workspace` no longer links dependencies the user never named:
+
+- Running it with `updateConfig.ignoreDependencies` configured no longer fails with `ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND` for a dependency that is only published to the registry. Such dependencies keep their specifiers, as they already did when no dependencies were ignored.
+- Passing package selectors that match no direct dependency no longer falls back to linking every workspace dependency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4761,6 +4761,7 @@ dependencies = [
  "pacquet-testing-utils",
  "pacquet-workspace",
  "pacquet-workspace-manifest-writer",
+ "pacquet-workspace-range-resolver",
  "pacquet-workspace-state",
  "pathdiff",
  "pipe-trait",

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -1903,6 +1903,7 @@ async fn fix_with_update<Reporter: self::Reporter + 'static>(
                 DependencyGroup::Optional,
             ],
             depth: usize::MAX,
+            workspace_packages: None,
             supported_architectures: config.supported_architectures.clone(),
             lockfile_only: false,
             resolution_observer: Some(observer),

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -60,7 +60,7 @@ impl DedupeArgs {
             node_linker: config.node_linker,
             lockfile_only: true,
             dry_run: false,
-            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::DropAll,
+            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::drop_all(),
             auth_override: None,
             resolution_observer: None,
             peer_issues_sink: None,

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -83,7 +83,7 @@ impl ImportArgs {
                 node_linker: config.node_linker,
                 lockfile_only: true,
                 dry_run: false,
-                update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::DropAll,
+                update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::drop_all(),
                 auth_override: None,
                 resolution_observer: None,
                 peer_issues_sink: None,

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -1,18 +1,21 @@
 use crate::{
     State,
     cli_args::{
-        pipelines::InstallFamilySelection, supported_architectures::SupportedArchitecturesArgs,
+        pipelines::InstallFamilySelection, recursive,
+        supported_architectures::SupportedArchitecturesArgs,
         update_interactive::InteractiveUpdateOptions,
     },
     github_actions,
 };
 use clap::Args;
-use miette::Context;
+use derive_more::{Display, Error};
+use miette::{Context, Diagnostic};
 use pacquet_config::Config;
-use pacquet_package_manager::Update;
+use pacquet_package_manager::{Update, build_workspace_packages_map};
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::Reporter;
+use std::path::Path;
 
 /// The `--prod`, `--dev`, and `--no-optional` flags that select which
 /// dependency groups to update.
@@ -126,24 +129,33 @@ pub struct UpdateArgs {
     pub no_changeset: bool,
 }
 
-/// The `pnpm update --workspace` rejection message. `--workspace` needs
-/// workspace-protocol version linking, which has not been ported yet, so
-/// every dispatch path — plain, selected, and global — refuses it with the
-/// same wording rather than silently doing a plain update.
-const WORKSPACE_UPDATE_UNSUPPORTED: &str = "`pnpm update --workspace` is not supported yet.";
+/// The option combinations `--workspace` rejects, checked before any
+/// resolution happens on every dispatch path — plain, selected, and
+/// global (whose global directory is never a workspace).
+#[derive(Debug, Display, Error, Diagnostic)]
+enum WorkspaceUpdateError {
+    #[display("Cannot use --latest with --workspace simultaneously")]
+    #[diagnostic(code(ERR_PNPM_BAD_OPTIONS))]
+    LatestWithWorkspace,
+
+    #[display("--workspace can only be used inside a workspace")]
+    #[diagnostic(code(ERR_PNPM_WORKSPACE_OPTION_OUTSIDE_WORKSPACE))]
+    OutsideWorkspace,
+}
 
 impl UpdateArgs {
     pub async fn run<Reporter: self::Reporter + 'static>(
         self,
         mut state: State,
     ) -> miette::Result<()> {
-        // Workspace-link updates depend on workspace-protocol version
-        // linking, which pacquet hasn't ported yet. Refuse rather than
-        // silently doing a plain update. (`--global` is routed to
-        // [`Self::run_global`] before `run` is reached.)
-        if self.workspace {
-            return Err(miette::miette!("{WORKSPACE_UPDATE_UNSUPPORTED}"));
-        }
+        let workspace_packages = self
+            .check_workspace_option(state.config.workspace_dir.as_deref())?
+            .map(|workspace_root| {
+                recursive::discover_workspace_projects(workspace_root)
+                    .map(|(projects, _)| build_workspace_packages_map(Some(&projects)))
+            })
+            .transpose()?
+            .flatten();
 
         let actions_root =
             state.config.workspace_dir.clone().unwrap_or_else(|| manifest_root(&state.manifest));
@@ -225,6 +237,7 @@ impl UpdateArgs {
                 save: !self.no_save,
                 include_direct,
                 depth: self.depth.unwrap_or(usize::MAX),
+                workspace_packages: workspace_packages.as_ref(),
                 supported_architectures,
                 lockfile_only: self.lockfile_only,
                 resolution_observer: None,
@@ -250,9 +263,9 @@ impl UpdateArgs {
         mut state: State,
         selection: InstallFamilySelection,
     ) -> miette::Result<()> {
-        if self.workspace {
-            return Err(miette::miette!("{WORKSPACE_UPDATE_UNSUPPORTED}"));
-        }
+        let workspace_packages = self
+            .check_workspace_option(state.config.workspace_dir.as_deref())?
+            .and_then(|_| build_workspace_packages_map(Some(&selection.projects)));
 
         let actions_root = selection.workspace_root.clone();
         let include_direct = self.dependency_options.include_direct();
@@ -333,6 +346,7 @@ impl UpdateArgs {
                 save: !self.no_save,
                 include_direct,
                 depth: self.depth.unwrap_or(usize::MAX),
+                workspace_packages: workspace_packages.as_ref(),
                 supported_architectures,
                 lockfile_only: self.lockfile_only,
                 resolution_observer: None,
@@ -366,9 +380,7 @@ impl UpdateArgs {
         self,
         config: &'static Config,
     ) -> miette::Result<()> {
-        if self.workspace {
-            return Err(miette::miette!("{WORKSPACE_UPDATE_UNSUPPORTED}"));
-        }
+        self.check_workspace_option(None)?;
         if self.interactive {
             return Err(miette::miette!(
                 "`pnpm update --global --interactive` is not supported yet."
@@ -385,6 +397,24 @@ impl UpdateArgs {
             supported_architectures,
         ))
         .await
+    }
+
+    /// Validate `--workspace` against the rest of the invocation,
+    /// returning the workspace root the link targets are read from.
+    /// `Ok(None)` means the flag was not passed. Every dispatch path
+    /// calls this before any resolution happens, `--global` included —
+    /// the global directory is never a workspace.
+    fn check_workspace_option<'root>(
+        &self,
+        workspace_root: Option<&'root Path>,
+    ) -> miette::Result<Option<&'root Path>> {
+        if !self.workspace {
+            return Ok(None);
+        }
+        if self.latest {
+            return Err(WorkspaceUpdateError::LatestWithWorkspace.into());
+        }
+        workspace_root.ok_or_else(|| WorkspaceUpdateError::OutsideWorkspace.into()).map(Some)
     }
 
     fn should_update_github_actions(

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -111,5 +111,5 @@ fn workspace_option_is_checked_before_anything_is_read() {
     let with_latest = update_args(&["--workspace", "--latest"])
         .check_workspace_option(Some(workspace_root))
         .expect_err("--workspace with --latest");
-    assert_eq!(with_latest.to_string(), "Cannot use --latest with --workspace simultaneously",);
+    assert_eq!(with_latest.to_string(), "Cannot use --latest with --workspace simultaneously");
 }

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -89,3 +89,27 @@ fn github_actions_are_opt_in_for_every_update() {
             .should_update_github_actions(&config, &include_direct),
     );
 }
+
+#[test]
+fn workspace_option_is_checked_before_anything_is_read() {
+    let workspace_root = std::path::Path::new("/workspace");
+
+    assert_eq!(
+        update_args(&[]).check_workspace_option(Some(workspace_root)).expect("no flag"),
+        None,
+    );
+    assert_eq!(
+        update_args(&["--workspace"]).check_workspace_option(Some(workspace_root)).expect("linked"),
+        Some(workspace_root),
+    );
+
+    let outside = update_args(&["--workspace"])
+        .check_workspace_option(None)
+        .expect_err("--workspace outside a workspace");
+    assert_eq!(outside.to_string(), "--workspace can only be used inside a workspace");
+
+    let with_latest = update_args(&["--workspace", "--latest"])
+        .check_workspace_option(Some(workspace_root))
+        .expect_err("--workspace with --latest");
+    assert_eq!(with_latest.to_string(), "Cannot use --latest with --workspace simultaneously",);
+}

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -64,6 +64,29 @@ fn set_ignore_dependencies(workspace: &Path, names: &[&str]) {
     fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
 }
 
+/// Create a sibling workspace project and register its directory in
+/// `pnpm-workspace.yaml`'s `packages` list.
+fn add_workspace_package(workspace: &Path, name: &str, version: &str) {
+    let project = workspace.join(name);
+    fs::create_dir_all(&project).expect("mkdir workspace project");
+    fs::write(
+        project.join("package.json"),
+        format!(r#"{{ "name": "{name}", "version": "{version}" }}"#),
+    )
+    .expect("write workspace project package.json");
+
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    if !yaml.contains("packages:") {
+        yaml.push_str("packages:\n");
+    }
+    writeln!(yaml, "  - '{name}'").unwrap();
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+}
+
 /// [`append_workspace_yaml_key`] for `dedupePeerDependents: false` — the
 /// setting under which pnpm/pnpm#12456 reproduces on the TypeScript stack.
 fn disable_dedupe_peer_dependents(workspace: &Path) {
@@ -359,24 +382,7 @@ fn update_latest_preserves_workspace_local_path_specifier() {
 
     // A workspace-only sibling package, not published to the mocked
     // registry, referenced by a `workspace:` local path.
-    let sibling = workspace.join("local-dep");
-    fs::create_dir_all(&sibling).expect("mkdir local-dep");
-    fs::write(sibling.join("package.json"), r#"{ "name": "local-dep", "version": "1.0.0" }"#)
-        .expect("write local-dep/package.json");
-
-    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
-    let mut yaml = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
-    // Fail loudly if the harness ever starts writing `packages:` — appending a
-    // second top-level mapping key produces invalid YAML.
-    assert!(
-        !yaml.contains("packages:"),
-        "pnpm-workspace.yaml already has a `packages:` key — update this test",
-    );
-    if !yaml.ends_with('\n') {
-        yaml.push('\n');
-    }
-    yaml.push_str("packages:\n  - 'local-dep'\n");
-    fs::write(&workspace_yaml, yaml).expect("write pnpm-workspace.yaml");
+    add_workspace_package(&workspace, "local-dep", "1.0.0");
 
     write_manifest(&workspace, r#"{ "local-dep": "workspace:./local-dep" }"#);
     pacquet(&workspace, ["install"]).assert().success();
@@ -464,6 +470,40 @@ fn update_depth_zero_unknown_package_errors() {
     assert!(
         stderr.contains("None of the specified packages were found in the dependencies"),
         "stderr did not mention NO_PACKAGE_IN_DEPENDENCIES: {stderr}",
+    );
+
+    drop((root, anchor));
+}
+
+/// `--depth 0` reaches direct dependencies only: a transitive
+/// dependency keeps its locked resolution even though the same update
+/// without the flag bumps it.
+#[test]
+fn update_depth_zero_leaves_transitive_dependencies_locked() {
+    let (root, workspace, anchor) = setup();
+
+    // Pin the transitive dep-of-pkg-with-1-dep at 100.0.0 through a
+    // direct exact entry, then drop it to a pure transitive of
+    // pkg-with-1-dep, whose ^100.0.0 range a fresh resolve answers with
+    // 100.1.0.
+    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0", "{DEP}": "100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+    write_manifest(&workspace, &format!(r#"{{ "{PARENT}": "100.0.0" }}"#));
+
+    pacquet(&workspace, ["update", "--depth", "0"]).assert().success();
+
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(
+        !virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
+        "a depth-0 update should not reach a transitive dependency",
+    );
+
+    pacquet(&workspace, ["update"]).assert().success();
+
+    eprintln!("virtual store contents: {:?}", list_virtual_store(&workspace));
+    assert!(
+        virtual_store_has(&workspace, "@pnpm.e2e+dep-of-pkg-with-1-dep@100.1.0"),
+        "the default unlimited depth should reach the transitive dependency",
     );
 
     drop((root, anchor));
@@ -642,6 +682,135 @@ fn update_latest_with_spec_is_rejected() {
     assert!(
         stderr.contains("Specs are not allowed to be used with --latest"),
         "stderr did not mention the LATEST_WITH_SPEC error: {stderr}",
+    );
+
+    drop((root, anchor));
+}
+
+/// The failing half of a `pacquet update` run: the command must exit
+/// non-zero and its stderr must mention `needle`.
+fn assert_update_fails(workspace: &Path, args: &[&str], needle: &str) {
+    let output = pacquet(workspace, args).output().expect("run pacquet update");
+    assert!(!output.status.success(), "`pacquet {}` should fail", args.join(" "));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains(needle), "stderr did not mention {needle:?}: {stderr}");
+}
+
+/// `--workspace` re-points a dependency that a workspace project
+/// publishes at the local copy. Under the default `rolling`
+/// `saveWorkspaceProtocol`, an exactly-pinned dependency becomes
+/// `workspace:*` — a specifier the sibling's next release does not
+/// invalidate.
+#[test]
+fn update_workspace_links_to_the_local_package() {
+    let (root, workspace, anchor) = setup();
+
+    add_workspace_package(&workspace, "sibling", "2.0.0");
+    write_manifest(&workspace, r#"{ "sibling": "0.0.0" }"#);
+
+    pacquet(&workspace, ["update", "--workspace"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, "sibling").as_deref(), Some("workspace:*"));
+
+    drop((root, anchor));
+}
+
+/// A caret-ranged dependency keeps its operator when it is linked.
+#[test]
+fn update_workspace_keeps_the_declared_range_operator() {
+    let (root, workspace, anchor) = setup();
+
+    add_workspace_package(&workspace, "sibling", "2.0.0");
+    write_manifest(&workspace, r#"{ "sibling": "^1.0.0" }"#);
+
+    pacquet(&workspace, ["update", "--workspace", "sibling"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, "sibling").as_deref(), Some("workspace:^"));
+
+    drop((root, anchor));
+}
+
+/// With `saveWorkspaceProtocol: false` the linked version is written out
+/// in full — the protocol itself is kept regardless, since dropping it
+/// would send the dependency back to the registry.
+#[test]
+fn update_workspace_writes_the_version_when_not_rolling() {
+    let (root, workspace, anchor) = setup();
+
+    add_workspace_package(&workspace, "sibling", "2.0.0");
+    append_workspace_yaml_key(&workspace, "saveWorkspaceProtocol", false);
+    write_manifest(&workspace, r#"{ "sibling": "0.0.0" }"#);
+
+    pacquet(&workspace, ["update", "--workspace"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, "sibling").as_deref(), Some("workspace:2.0.0"));
+
+    drop((root, anchor));
+}
+
+/// A dependency no workspace project publishes is left alone by a
+/// selector-less `--workspace`.
+#[test]
+fn update_workspace_leaves_registry_dependencies_alone() {
+    let (root, workspace, anchor) = setup();
+
+    add_workspace_package(&workspace, "sibling", "2.0.0");
+    write_manifest(&workspace, &format!(r#"{{ "sibling": "0.0.0", "{DEP}": "^100.0.0" }}"#));
+
+    pacquet(&workspace, ["update", "--workspace"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, "sibling").as_deref(), Some("workspace:*"));
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+
+    drop((root, anchor));
+}
+
+/// Naming a dependency that no workspace project publishes fails, since
+/// there is nothing to link it to.
+#[test]
+fn update_workspace_rejects_a_dependency_outside_the_workspace() {
+    let (root, workspace, anchor) = setup();
+
+    add_workspace_package(&workspace, "sibling", "2.0.0");
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+
+    assert_update_fails(&workspace, &["update", "--workspace", DEP], "not found in the workspace");
+
+    drop((root, anchor));
+}
+
+/// A `--workspace` selector that matches no direct dependency links
+/// nothing — the run falls back to an ordinary update of that selector,
+/// rather than linking every workspace dependency the user never named.
+#[test]
+fn update_workspace_with_an_unmatched_selector_links_nothing() {
+    let (root, workspace, anchor) = setup();
+
+    add_workspace_package(&workspace, "sibling", "2.0.0");
+    append_workspace_yaml_key(&workspace, "linkWorkspacePackages", true);
+    write_manifest(&workspace, r#"{ "sibling": "^2.0.0" }"#);
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--workspace", "@pnpm.e2e/not-a-dependency"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, "sibling").as_deref(), Some("^2.0.0"));
+
+    drop((root, anchor));
+}
+
+/// `--latest` rewrites ranges from the registry and `--workspace` from
+/// the workspace, so the two cannot both apply.
+#[test]
+fn update_workspace_with_latest_is_rejected() {
+    let (root, workspace, anchor) = setup();
+
+    add_workspace_package(&workspace, "sibling", "2.0.0");
+    write_manifest(&workspace, r#"{ "sibling": "0.0.0" }"#);
+
+    assert_update_fails(
+        &workspace,
+        &["update", "--workspace", "--latest"],
+        "Cannot use --latest with --workspace simultaneously",
     );
 
     drop((root, anchor));

--- a/pnpm/crates/cli/tests/update.rs
+++ b/pnpm/crates/cli/tests/update.rs
@@ -765,6 +765,37 @@ fn update_workspace_leaves_registry_dependencies_alone() {
     drop((root, anchor));
 }
 
+/// `--workspace` that links nothing is an ordinary selector-less
+/// update, so it stays a *full* install and runs the project's own
+/// lifecycle scripts. Only the dependencies it actually re-points make
+/// the run partial.
+#[test]
+fn update_workspace_that_links_nothing_still_runs_project_scripts() {
+    let (root, workspace, anchor) = setup();
+
+    // A workspace sibling exists, but nothing depends on it, so
+    // `--workspace` has no link target.
+    add_workspace_package(&workspace, "sibling", "2.0.0");
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{ "name": "test-update", "version": "1.0.0",
+                  "scripts": {{ "postinstall": "node -e \"require('fs').writeFileSync('postinstall-ran', '')\"" }},
+                  "dependencies": {{ "{DEP}": "^100.0.0" }} }}"#,
+        ),
+    )
+    .expect("write package.json");
+
+    pacquet(&workspace, ["update", "--workspace"]).assert().success();
+
+    assert!(
+        workspace.join("postinstall-ran").exists(),
+        "a --workspace update with nothing to link should run the project's own scripts",
+    );
+
+    drop((root, anchor));
+}
+
 /// Naming a dependency that no workspace project publishes fails, since
 /// there is nothing to link it to.
 #[test]

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -437,6 +437,75 @@ impl<'de> serde::Deserialize<'de> for LinkWorkspacePackages {
     }
 }
 
+/// `saveWorkspaceProtocol`. How a dependency linked to a workspace
+/// package is written back to `package.json`.
+///
+/// The setting is `saveWorkspaceProtocol: boolean | 'rolling'`. Default
+/// is [`SaveWorkspaceProtocol::Rolling`]
+/// (`'save-workspace-protocol': 'rolling'`).
+///
+/// [`SaveWorkspaceProtocol::Off`] only suppresses the `workspace:`
+/// prefix for a dependency that did not already declare one; a
+/// `workspace:` specifier always keeps its protocol, so the two
+/// non-rolling states behave alike wherever the protocol is already
+/// present.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum SaveWorkspaceProtocol {
+    /// `false`.
+    Off,
+    /// `true`. The resolved version is written under the protocol,
+    /// keeping the range operator the dependency already declared
+    /// (`workspace:^1.2.3`).
+    On,
+    /// `"rolling"`. The range operator is written without a version
+    /// (`workspace:*`, `workspace:^`, `workspace:~`), so the entry
+    /// never needs rewriting when the workspace package's version
+    /// changes.
+    #[default]
+    Rolling,
+}
+
+impl serde::Serialize for SaveWorkspaceProtocol {
+    fn serialize<Ser: serde::Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
+        match self {
+            SaveWorkspaceProtocol::Off => serializer.serialize_bool(false),
+            SaveWorkspaceProtocol::On => serializer.serialize_bool(true),
+            SaveWorkspaceProtocol::Rolling => serializer.serialize_str("rolling"),
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for SaveWorkspaceProtocol {
+    fn deserialize<De>(deserializer: De) -> Result<Self, De::Error>
+    where
+        De: serde::Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+        use std::fmt;
+
+        struct V;
+        impl Visitor<'_> for V {
+            type Value = SaveWorkspaceProtocol;
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(r#"a boolean or the string "rolling""#)
+            }
+            fn visit_bool<DeError: de::Error>(self, value: bool) -> Result<Self::Value, DeError> {
+                Ok(if value { SaveWorkspaceProtocol::On } else { SaveWorkspaceProtocol::Off })
+            }
+            fn visit_str<DeError: de::Error>(self, value: &str) -> Result<Self::Value, DeError> {
+                match value {
+                    "rolling" => Ok(SaveWorkspaceProtocol::Rolling),
+                    other => Err(DeError::invalid_value(
+                        de::Unexpected::Str(other),
+                        &r#"true, false, or "rolling""#,
+                    )),
+                }
+            }
+        }
+        deserializer.deserialize_any(V)
+    }
+}
+
 /// How the resolver picks a version for a direct dependency when more
 /// than one satisfies the wanted range.
 ///
@@ -973,6 +1042,12 @@ pub struct Config {
     /// [`LinkWorkspacePackages`] for the tri-state semantics.
     /// Default `false` (`'link-workspace-packages': false`).
     pub link_workspace_packages: LinkWorkspacePackages,
+
+    /// `saveWorkspaceProtocol`. How `pacquet update --workspace`
+    /// writes a dependency it links to a workspace package. See
+    /// [`SaveWorkspaceProtocol`].
+    /// Default `"rolling"` (`'save-workspace-protocol': 'rolling'`).
+    pub save_workspace_protocol: SaveWorkspaceProtocol,
 
     /// `injectWorkspacePackages` from `pnpm-workspace.yaml`. When
     /// `true`, workspace-package resolutions materialize as `file:`

--- a/pnpm/crates/config/src/pnpm_default_parity.rs
+++ b/pnpm/crates/config/src/pnpm_default_parity.rs
@@ -27,7 +27,7 @@
 
 use crate::{
     CatalogMode, Config, LinkWorkspacePackages, NodeLinker, NodePackageMapType, ResolutionMode,
-    ScriptsPrependNodePath, VerifyDepsBeforeRun,
+    SaveWorkspaceProtocol, ScriptsPrependNodePath, VerifyDepsBeforeRun,
 };
 use std::collections::BTreeSet;
 
@@ -82,7 +82,6 @@ const NOT_PORTED: &[&str] = &[
     "pending",
     "recursive-install",
     "reverse",
-    "save-workspace-protocol",
     "shell-emulator",
     "skip-manifest-obfuscation",
     "sort",
@@ -132,6 +131,8 @@ fn mapped_rows(cfg: &Config) -> Vec<(&'static str, Scalar)> {
         ("verify-store-integrity", Bool(cfg.verify_store_integrity)),
         // `boolean | 'deep'` upstream; the default is `false`.
         ("link-workspace-packages", link_workspace_packages_scalar(cfg.link_workspace_packages)),
+        // `boolean | 'rolling'` upstream; the default is `'rolling'`.
+        ("save-workspace-protocol", save_workspace_protocol_scalar(cfg.save_workspace_protocol)),
         // `boolean | 'install' | 'warn' | 'error' | 'prompt'` upstream;
         // the default is `'install'`.
         ("verify-deps-before-run", verify_deps_before_run_scalar(cfg.verify_deps_before_run)),
@@ -227,6 +228,14 @@ fn link_workspace_packages_scalar(value: LinkWorkspacePackages) -> Scalar {
         LinkWorkspacePackages::Off => Scalar::Bool(false),
         LinkWorkspacePackages::DirectOnly => Scalar::Bool(true),
         LinkWorkspacePackages::Deep => s("deep"),
+    }
+}
+
+fn save_workspace_protocol_scalar(value: SaveWorkspaceProtocol) -> Scalar {
+    match value {
+        SaveWorkspaceProtocol::Off => Scalar::Bool(false),
+        SaveWorkspaceProtocol::On => Scalar::Bool(true),
+        SaveWorkspaceProtocol::Rolling => s("rolling"),
     }
 }
 

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1,7 +1,7 @@
 use crate::{
     AuditConfig, AuditLevel, CatalogMode, Config, HoistingLimits, LinkWorkspacePackages,
     NodeLinker, NodePackageMapType, PackageImportMethod, PmOnFail, ResolutionMode, RuntimeOnFail,
-    ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun, api::EnvVar,
+    SaveWorkspaceProtocol, ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun, api::EnvVar,
     npmrc_auth::parse_no_proxy, resolve_child_concurrency,
 };
 use derive_more::{Display, Error};
@@ -149,6 +149,9 @@ pub struct WorkspaceSettings {
     /// `linkWorkspacePackages` from `pnpm-workspace.yaml`. Tri-state
     /// (`true | false | "deep"`) — see [`LinkWorkspacePackages`].
     pub link_workspace_packages: Option<LinkWorkspacePackages>,
+    /// `saveWorkspaceProtocol` from `pnpm-workspace.yaml`. Tri-state
+    /// (`true | false | "rolling"`) — see [`SaveWorkspaceProtocol`].
+    pub save_workspace_protocol: Option<SaveWorkspaceProtocol>,
     /// `injectWorkspacePackages` from `pnpm-workspace.yaml`. When
     /// `true`, every workspace-resolved dep is materialized as a
     /// `file:` (hard-linked copy) instead of a `link:` symlink. See
@@ -793,6 +796,7 @@ impl WorkspaceSettings {
         self.exclude_links_from_lockfile = None;
         self.hoist_workspace_packages = None;
         self.link_workspace_packages = None;
+        self.save_workspace_protocol = None;
         self.inject_workspace_packages = None;
         self.dedupe_peer_dependents = None;
         self.dedupe_peers = None;
@@ -970,6 +974,7 @@ impl WorkspaceSettings {
             verify_deps_before_run,
             block_exotic_subdeps,
             link_workspace_packages,
+            save_workspace_protocol,
             inject_workspace_packages,
             prefer_workspace_packages,
             side_effects_cache, side_effects_cache_readonly,

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -302,7 +302,7 @@ fn run_install_inner(
     // `update: true` re-resolves the whole graph to the highest in-range
     // version — pnpm's `update: true` / `depth: Infinity`. The binding takes no
     // package selectors, so an update always targets every dependency
-    // (`UpdateSeedPolicy::DropAll`); `depth` is only pnpm's direct-vs-any-depth
+    // (`UpdateSeedPolicy::drop_all()`); `depth` is only pnpm's direct-vs-any-depth
     // selector toggle, which has no effect without selectors and is accepted for
     // API compatibility only. Mirrors `pacquet_package_manager::Update`, which
     // forces `prefer_frozen_lockfile: false` and a non-frozen path so the
@@ -344,7 +344,7 @@ fn run_install_inner(
         options.prefer_frozen_lockfile
     };
     let update_seed_policy =
-        if update_requested { UpdateSeedPolicy::DropAll } else { UpdateSeedPolicy::KeepAll };
+        if update_requested { UpdateSeedPolicy::drop_all() } else { UpdateSeedPolicy::KeepAll };
     let is_full_install = matches!(mode, EngineMode::Install);
 
     let runtime =

--- a/pnpm/crates/package-manager/Cargo.toml
+++ b/pnpm/crates/package-manager/Cargo.toml
@@ -52,6 +52,7 @@ pacquet-store-dir                         = { workspace = true }
 pacquet-tarball                           = { workspace = true }
 pacquet-workspace                         = { workspace = true }
 pacquet-workspace-manifest-writer         = { workspace = true }
+pacquet-workspace-range-resolver          = { workspace = true }
 pacquet-workspace-state                   = { workspace = true }
 
 async-recursion = { workspace = true }

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -3964,7 +3964,13 @@ fn configured_or_discovered_workspace_dir(
 /// entries (`{ rootDir, manifest }`) consumed by the resolver.
 /// Projects whose manifest lacks a name are skipped. A missing or null
 /// version is indexed as `0.0.0`; malformed non-string versions are skipped.
-fn build_workspace_packages_map(
+/// Index the workspace projects by package name and version — the
+/// resolver's view of what the workspace publishes, and the link
+/// targets `pacquet update --workspace` re-points dependencies at. A
+/// project without a name publishes nothing; a missing or null version
+/// reads as `0.0.0`, matching pnpm.
+#[must_use]
+pub fn build_workspace_packages_map(
     projects: Option<&[pacquet_workspace::Project]>,
 ) -> Option<pacquet_resolving_resolver_base::WorkspacePackages> {
     let projects = projects?;

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -603,7 +603,7 @@ async fn install_with_drop_all_seed_policy_bumps_dependency_within_range() {
         lockfile_only: false,
         dry_run: false,
         resolved_packages: &Default::default(),
-        update_seed_policy: crate::UpdateSeedPolicy::DropAll,
+        update_seed_policy: crate::UpdateSeedPolicy::drop_all(),
         auth_override: None,
         resolution_observer: None,
         peer_issues_sink: None,

--- a/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry/tests.rs
@@ -76,6 +76,7 @@ fn create_config(store_dir: &Path, modules_dir: &Path, virtual_store_dir: &Path)
         hoist_workspace_packages: true,
         hoisting_limits: Default::default(),
         link_workspace_packages: Default::default(),
+        save_workspace_protocol: Default::default(),
         inject_workspace_packages: false,
         prefer_workspace_packages: false,
         external_dependencies: Default::default(),

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -30,6 +30,7 @@ use pacquet_reporter::{
 use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_deps_resolver::{
     ManifestHook, ResolveDependencyTreeError, ResolveImporterError, ResolveImporterOptions,
+    UpdateDepth,
 };
 use pacquet_resolving_git_resolver::{GitFetchContext, GitResolver, RealGitProbe, RealGitRunner};
 use pacquet_resolving_local_resolver::{
@@ -235,6 +236,11 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
 ///
 /// `KeepAll` is the install/add default (every pin seeds the table, so
 /// unrelated entries keep their resolutions on a rewrite).
+///
+/// Every withholding variant carries the update's `--depth` ceiling,
+/// which bounds how deep the re-resolution reaches: a node past it keeps
+/// its locked resolution even when its name is a target. See
+/// [`UpdateDepth`].
 #[derive(Debug, Default, Clone)]
 pub enum UpdateSeedPolicy {
     /// Seed every lockfile pin. `pacquet install` / `pacquet add`.
@@ -242,12 +248,39 @@ pub enum UpdateSeedPolicy {
     KeepAll,
     /// Withhold every lockfile pin. `pacquet update` with no package
     /// selectors — the whole graph re-resolves to highest-in-range.
-    DropAll,
+    DropAll {
+        max_depth: UpdateDepth,
+    },
     /// Withhold only the named packages' pins. `pacquet update <pattern>`
-    /// — matched names (at any depth) re-resolve while everything else
-    /// keeps its pin. Keyed by package name (scope included).
-    DropOnly(std::collections::HashSet<String>),
-    ByImporter(BTreeMap<String, ImporterUpdateSeedPolicy>),
+    /// — matched names re-resolve while everything else keeps its pin.
+    /// Keyed by package name (scope included).
+    DropOnly {
+        names: std::collections::HashSet<String>,
+        max_depth: UpdateDepth,
+    },
+    ByImporter {
+        policies: BTreeMap<String, ImporterUpdateSeedPolicy>,
+        max_depth: UpdateDepth,
+    },
+}
+
+impl UpdateSeedPolicy {
+    /// Withhold every pin at every depth — the re-resolve `pacquet
+    /// dedupe` / `pacquet import` and the napi install perform, none of
+    /// which expose a `--depth`.
+    #[must_use]
+    pub fn drop_all() -> Self {
+        UpdateSeedPolicy::DropAll { max_depth: UpdateDepth::UNLIMITED }
+    }
+
+    fn max_depth(&self) -> UpdateDepth {
+        match self {
+            UpdateSeedPolicy::KeepAll => UpdateDepth::UNLIMITED,
+            UpdateSeedPolicy::DropAll { max_depth }
+            | UpdateSeedPolicy::DropOnly { max_depth, .. }
+            | UpdateSeedPolicy::ByImporter { max_depth, .. } => *max_depth,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -266,11 +299,11 @@ fn update_reuse_scopes(
 
     match policy {
         UpdateSeedPolicy::KeepAll => (UpdateReuseScope::All, BTreeMap::new()),
-        UpdateSeedPolicy::DropAll => (UpdateReuseScope::None, BTreeMap::new()),
-        UpdateSeedPolicy::DropOnly(names) => {
+        UpdateSeedPolicy::DropAll { .. } => (UpdateReuseScope::None, BTreeMap::new()),
+        UpdateSeedPolicy::DropOnly { names, .. } => {
             (UpdateReuseScope::Except(names.clone()), BTreeMap::new())
         }
-        UpdateSeedPolicy::ByImporter(policies) => (
+        UpdateSeedPolicy::ByImporter { policies, .. } => (
             UpdateReuseScope::All,
             policies
                 .iter()
@@ -1125,19 +1158,19 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // else keeps its pin. Manifest preferences remain workspace-wide.
         let lockfile_snapshots = wanted_lockfile.and_then(|lockfile| lockfile.snapshots.as_ref());
         let all_preferred_versions = match &update_seed_policy {
-            UpdateSeedPolicy::KeepAll | UpdateSeedPolicy::ByImporter(_) => {
+            UpdateSeedPolicy::KeepAll | UpdateSeedPolicy::ByImporter { .. } => {
                 pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
                     lockfile_snapshots,
                     manifests_for_preferred.as_slice(),
                 )
             }
-            UpdateSeedPolicy::DropAll => {
+            UpdateSeedPolicy::DropAll { .. } => {
                 pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
                     None,
                     manifests_for_preferred.as_slice(),
                 )
             }
-            UpdateSeedPolicy::DropOnly(names) => {
+            UpdateSeedPolicy::DropOnly { names, .. } => {
                 let excluded_names = names
                     .iter()
                     .filter_map(|name| pacquet_lockfile::PkgName::parse(name.as_str()).ok())
@@ -1155,7 +1188,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // with a refcount bump rather than deep-cloning the map.
         let preferred_versions_seed = Arc::new(all_preferred_versions);
         let mut preferred_versions_seeds_by_importer = BTreeMap::new();
-        if let UpdateSeedPolicy::ByImporter(policies) = &update_seed_policy {
+        if let UpdateSeedPolicy::ByImporter { policies, .. } = &update_seed_policy {
             let mut drop_all_seed = None;
             let mut drop_only_seeds = HashMap::new();
             for (importer_id, policy) in policies {
@@ -1345,6 +1378,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             wanted_lockfile: lockfile_reuse_seed.cloned().map(Arc::new),
             update_reuse_scope,
             update_reuse_scopes_by_importer,
+            update_depth: update_seed_policy.max_depth(),
             auto_install_peers: config.auto_install_peers,
             registries,
             allowed_deprecated_versions: config.allowed_deprecated_versions.clone(),

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -123,10 +123,13 @@ fn importer_scoped_update_custom_refresh_widens_every_importer() {
 fn importer_scoped_update_absent_importer_keeps_all_reuse() {
     use pacquet_resolving_deps_resolver::UpdateReuseScope;
 
-    let policy = UpdateSeedPolicy::ByImporter(std::collections::BTreeMap::from([(
-        "selected".to_string(),
-        ImporterUpdateSeedPolicy::DropAll,
-    )]));
+    let policy = UpdateSeedPolicy::ByImporter {
+        policies: std::collections::BTreeMap::from([(
+            "selected".to_string(),
+            ImporterUpdateSeedPolicy::DropAll,
+        )]),
+        max_depth: pacquet_resolving_deps_resolver::UpdateDepth::UNLIMITED,
+    };
     let (default_scope, scopes) = update_reuse_scopes(&policy);
     assert_eq!(default_scope, UpdateReuseScope::All);
     assert_eq!(scopes.get("selected"), Some(&UpdateReuseScope::None));

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -298,7 +298,6 @@ impl Update<'_> {
         let UpdatePreparation {
             seed_policy,
             persist_manifest: should_persist_manifest,
-            linked_workspace_packages,
             catalogs_override,
             ..
         } = prepared;
@@ -326,9 +325,10 @@ impl Update<'_> {
             // A targeted `pacquet update <pkg>` is a partial install
             // (pnpm's `installSome`); a bare `pacquet update` is a full
             // install that runs the project's own lifecycle scripts.
-            // `--workspace` names the dependencies it re-points, so a
-            // run that linked any of them is partial too.
-            is_full_install: packages.is_empty() && !linked_workspace_packages,
+            // `--workspace` does not enter into it: pnpm picks the
+            // mutation from the selectors the user passed, so a
+            // selector-less workspace-link update stays a full install.
+            is_full_install: packages.is_empty(),
             installs_only: true,
             resolved_packages,
             supported_architectures,
@@ -443,7 +443,7 @@ impl Update<'_> {
             skip_runtimes: config.skip_runtimes,
             trust_lockfile: config.trust_lockfile,
             update_checksums: false,
-            is_full_install: packages.is_empty() && !prepared.linked_workspace_packages,
+            is_full_install: packages.is_empty(),
             installs_only: true,
             resolved_packages,
             supported_architectures,
@@ -480,11 +480,6 @@ impl Update<'_> {
 struct UpdatePreparation {
     seed_policy: UpdateSeedPolicy,
     persist_manifest: bool,
-    /// Whether `--workspace` found anything to link. `false` when the
-    /// flag was absent, and also when it was passed but matched no
-    /// linkable direct dependency — that run is an ordinary update, so
-    /// it must not be downgraded to a partial install.
-    linked_workspace_packages: bool,
     updated_catalogs: Catalogs,
     catalogs_override: Option<Catalogs>,
     workspace_dir_for_catalogs: Option<PathBuf>,
@@ -493,9 +488,6 @@ struct UpdatePreparation {
 struct SelectedUpdatePreparation {
     seed_policies: BTreeMap<String, ImporterUpdateSeedPolicy>,
     persist_indices: Vec<usize>,
-    /// Whether `--workspace` linked anything in any selected project.
-    /// See [`UpdatePreparation::linked_workspace_packages`].
-    linked_workspace_packages: bool,
     updated_catalogs: Catalogs,
     catalogs_override: Option<Catalogs>,
     workspace_dir_for_catalogs: Option<PathBuf>,
@@ -584,9 +576,8 @@ async fn prepare_manifest<Reporter: self::Reporter>(
         .transpose()?
         .unwrap_or_default();
 
-    let linked_workspace_packages = !workspace_targets.is_empty();
     let seed_policy = if let Some(workspace_packages) =
-        workspace_packages.filter(|_| linked_workspace_packages)
+        workspace_packages.filter(|_| !workspace_targets.is_empty())
     {
         for target in workspace_targets {
             let specifier = workspace_specifier(
@@ -790,7 +781,6 @@ async fn prepare_manifest<Reporter: self::Reporter>(
     Ok(Some(UpdatePreparation {
         seed_policy,
         persist_manifest,
-        linked_workspace_packages,
         updated_catalogs,
         catalogs_override,
         workspace_dir_for_catalogs,
@@ -827,7 +817,6 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     let mut catalogs_override = None;
     let mut workspace_dir_for_catalogs = None;
     let mut any_work = false;
-    let mut linked_workspace_packages = false;
 
     for &index in selected_indices {
         let Some(prepared) = prepare_manifest::<Reporter>(
@@ -866,7 +855,6 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
                 unreachable!("per-manifest preparation never produces importer policies")
             }
         }
-        linked_workspace_packages |= prepared.linked_workspace_packages;
         if prepared.persist_manifest {
             persist_indices.push(index);
         }
@@ -886,7 +874,6 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     Ok(SelectedUpdatePreparation {
         seed_policies,
         persist_indices,
-        linked_workspace_packages,
         updated_catalogs,
         catalogs_override,
         workspace_dir_for_catalogs,

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -298,6 +298,7 @@ impl Update<'_> {
         let UpdatePreparation {
             seed_policy,
             persist_manifest: should_persist_manifest,
+            linked_workspace_packages,
             catalogs_override,
             ..
         } = prepared;
@@ -325,9 +326,9 @@ impl Update<'_> {
             // A targeted `pacquet update <pkg>` is a partial install
             // (pnpm's `installSome`); a bare `pacquet update` is a full
             // install that runs the project's own lifecycle scripts.
-            // `--workspace` always names the dependencies it re-points,
-            // so it is partial too.
-            is_full_install: packages.is_empty() && workspace_packages.is_none(),
+            // `--workspace` names the dependencies it re-points, so a
+            // run that linked any of them is partial too.
+            is_full_install: packages.is_empty() && !linked_workspace_packages,
             installs_only: true,
             resolved_packages,
             supported_architectures,
@@ -442,7 +443,7 @@ impl Update<'_> {
             skip_runtimes: config.skip_runtimes,
             trust_lockfile: config.trust_lockfile,
             update_checksums: false,
-            is_full_install: packages.is_empty() && workspace_packages.is_none(),
+            is_full_install: packages.is_empty() && !prepared.linked_workspace_packages,
             installs_only: true,
             resolved_packages,
             supported_architectures,
@@ -479,6 +480,11 @@ impl Update<'_> {
 struct UpdatePreparation {
     seed_policy: UpdateSeedPolicy,
     persist_manifest: bool,
+    /// Whether `--workspace` found anything to link. `false` when the
+    /// flag was absent, and also when it was passed but matched no
+    /// linkable direct dependency — that run is an ordinary update, so
+    /// it must not be downgraded to a partial install.
+    linked_workspace_packages: bool,
     updated_catalogs: Catalogs,
     catalogs_override: Option<Catalogs>,
     workspace_dir_for_catalogs: Option<PathBuf>,
@@ -487,6 +493,9 @@ struct UpdatePreparation {
 struct SelectedUpdatePreparation {
     seed_policies: BTreeMap<String, ImporterUpdateSeedPolicy>,
     persist_indices: Vec<usize>,
+    /// Whether `--workspace` linked anything in any selected project.
+    /// See [`UpdatePreparation::linked_workspace_packages`].
+    linked_workspace_packages: bool,
     updated_catalogs: Catalogs,
     catalogs_override: Option<Catalogs>,
     workspace_dir_for_catalogs: Option<PathBuf>,
@@ -575,8 +584,9 @@ async fn prepare_manifest<Reporter: self::Reporter>(
         .transpose()?
         .unwrap_or_default();
 
+    let linked_workspace_packages = !workspace_targets.is_empty();
     let seed_policy = if let Some(workspace_packages) =
-        workspace_packages.filter(|_| !workspace_targets.is_empty())
+        workspace_packages.filter(|_| linked_workspace_packages)
     {
         for target in workspace_targets {
             let specifier = workspace_specifier(
@@ -780,6 +790,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
     Ok(Some(UpdatePreparation {
         seed_policy,
         persist_manifest,
+        linked_workspace_packages,
         updated_catalogs,
         catalogs_override,
         workspace_dir_for_catalogs,
@@ -816,6 +827,7 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     let mut catalogs_override = None;
     let mut workspace_dir_for_catalogs = None;
     let mut any_work = false;
+    let mut linked_workspace_packages = false;
 
     for &index in selected_indices {
         let Some(prepared) = prepare_manifest::<Reporter>(
@@ -854,6 +866,7 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
                 unreachable!("per-manifest preparation never produces importer policies")
             }
         }
+        linked_workspace_packages |= prepared.linked_workspace_packages;
         if prepared.persist_manifest {
             persist_indices.push(index);
         }
@@ -873,6 +886,7 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     Ok(SelectedUpdatePreparation {
         seed_policies,
         persist_indices,
+        linked_workspace_packages,
         updated_catalogs,
         catalogs_override,
         workspace_dir_for_catalogs,
@@ -960,6 +974,12 @@ fn workspace_link_targets(
 
     let patterns = selectors.iter().map(|selector| selector.pattern.clone()).collect::<Vec<_>>();
     let matcher = create_matcher(&patterns);
+    // Per-selector matchers, compiled once, map a matched dependency back
+    // to the selector that claimed it — and so to the version it asked for.
+    let claims = selectors
+        .iter()
+        .map(|selector| (matcher_one(&selector.pattern), selector.version.as_deref()))
+        .collect::<Vec<_>>();
     for (name, group, declared) in direct {
         if !matcher.matches(name.as_str()) {
             continue;
@@ -967,16 +987,16 @@ fn workspace_link_targets(
         if !workspace_packages.contains_key(name) {
             return Err(UpdateError::WorkspacePackageNotFound(name.clone()));
         }
-        let wanted = selectors
+        let wanted = claims
             .iter()
-            .find(|selector| matcher_one(&selector.pattern).matches(name))
-            .and_then(|selector| selector.version.clone())
-            .unwrap_or_else(|| "*".to_string());
+            .find(|(matcher, _)| matcher.matches(name))
+            .and_then(|(_, version)| *version)
+            .unwrap_or("*");
         targets.push(WorkspaceLinkTarget {
             name: name.clone(),
             group: *group,
             declared: declared.clone(),
-            wanted_range: wanted.strip_prefix("workspace:").unwrap_or(&wanted).to_string(),
+            wanted_range: wanted.strip_prefix("workspace:").unwrap_or(wanted).to_string(),
         });
     }
     Ok(targets)

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -18,7 +18,8 @@ use pacquet_catalogs_config::{
 use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_config::{
-    CatalogMode, Config, matcher::create_matcher, version_policy::PackageVersionPolicy,
+    CatalogMode, Config, SaveWorkspaceProtocol, matcher::create_matcher,
+    version_policy::PackageVersionPolicy,
 };
 use pacquet_engine_runtime_bun_resolver::BunResolver;
 use pacquet_engine_runtime_deno_resolver::DenoResolver;
@@ -29,12 +30,17 @@ use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifest
 use pacquet_registry::PinnedVersion;
 use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
 use pacquet_resolving_default_resolver::DefaultResolver;
+use pacquet_resolving_deps_resolver::UpdateDepth;
 use pacquet_resolving_npm_resolver::{
     InMemoryPackageMetaCache, NpmResolver, merge_named_registries, shared_packument_fetch_locker,
-    shared_picked_manifest_cache,
+    shared_picked_manifest_cache, which_version_is_pinned,
 };
-use pacquet_resolving_resolver_base::{ResolveOptions, Resolver, UpdateBehavior, WantedDependency};
+use pacquet_resolving_resolver_base::{
+    ResolveOptions, Resolver, UpdateBehavior, WantedDependency, WorkspacePackages,
+    WorkspacePackagesByVersion,
+};
 use pacquet_tarball::MemCache;
+use pacquet_workspace_range_resolver::resolve_workspace_range;
 use std::{
     collections::{BTreeMap, HashSet},
     path::{Path, PathBuf},
@@ -57,6 +63,11 @@ use std::{
 ///   the dependency already pinned (`^` stays `^`, `~` stays `~`, an exact
 ///   pin stays exact) and falling back to the configured default
 ///   otherwise. The follow-up install then resolves the new range.
+/// * **`--workspace`** ([`Update::workspace_packages`]): each matched
+///   direct dependency that a workspace project publishes is re-pointed
+///   at the local copy through the `workspace:` protocol, with
+///   `saveWorkspaceProtocol` deciding whether the linked version is
+///   written out or only its range operator.
 ///
 /// Selector handling:
 /// bare-name selectors (`foo`, `@scope/bar-*`) with `depth > 0` and no
@@ -99,10 +110,17 @@ pub struct Update<'a> {
     /// dependency set is always all three groups (the `node_modules`
     /// layout is unchanged); this only narrows the update scope.
     pub include_direct: Vec<DependencyGroup>,
-    /// `--depth`. Only its `> 0` predicate is consulted (the `depth > 0`
-    /// gate on the name matcher); `usize::MAX` stands in for the
-    /// `Infinity` default.
+    /// `--depth`: how deep into the dependency graph the update reaches.
+    /// A node below the ceiling keeps its locked resolution even when its
+    /// name is a target, so `0` updates direct dependencies only.
+    /// `usize::MAX` stands in for the `Infinity` default.
     pub depth: usize,
+    /// `--workspace`: what the workspace projects publish, as built by
+    /// [`crate::build_workspace_packages_map`]. `Some` turns the update
+    /// into a workspace-link update — the matched direct dependencies
+    /// are re-pointed at the workspace copies through the `workspace:`
+    /// protocol instead of the registry. `None` is a plain update.
+    pub workspace_packages: Option<&'a WorkspacePackages>,
     /// CLI-merged `supportedArchitectures`, forwarded to the install.
     pub supported_architectures: Option<pacquet_package_is_installable::SupportedArchitectures>,
     /// `--lockfile-only`: re-resolve and rewrite `pnpm-lock.yaml` without
@@ -131,6 +149,12 @@ pub enum UpdateError {
     #[display("None of the specified packages were found in the dependencies.")]
     #[diagnostic(code(ERR_PNPM_NO_PACKAGE_IN_DEPENDENCIES))]
     NoPackageInDependencies,
+
+    /// A `--workspace` selector named a dependency that no workspace
+    /// project publishes.
+    #[display(r#""{_0}" not found in the workspace"#)]
+    #[diagnostic(code(ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND))]
+    WorkspacePackageNotFound(#[error(not(source))] String),
 
     /// A resolver failed while computing the specifier `--latest` should
     /// write for a direct dependency.
@@ -227,6 +251,7 @@ impl Update<'_> {
             save,
             include_direct,
             depth,
+            workspace_packages,
             supported_architectures,
             lockfile_only,
             resolution_observer,
@@ -247,6 +272,7 @@ impl Update<'_> {
             save,
             &include_direct,
             depth,
+            workspace_packages,
             None,
             &mut latest_chain,
             lockfile_only,
@@ -299,7 +325,9 @@ impl Update<'_> {
             // A targeted `pacquet update <pkg>` is a partial install
             // (pnpm's `installSome`); a bare `pacquet update` is a full
             // install that runs the project's own lifecycle scripts.
-            is_full_install: packages.is_empty(),
+            // `--workspace` always names the dependencies it re-points,
+            // so it is partial too.
+            is_full_install: packages.is_empty() && workspace_packages.is_none(),
             installs_only: true,
             resolved_packages,
             supported_architectures,
@@ -349,6 +377,7 @@ impl Update<'_> {
             save,
             include_direct,
             depth,
+            workspace_packages,
             supported_architectures,
             lockfile_only,
             resolution_observer,
@@ -377,6 +406,7 @@ impl Update<'_> {
             save,
             &include_direct,
             depth,
+            workspace_packages,
             lockfile_only,
             resolution_observer.as_ref(),
         )
@@ -412,14 +442,17 @@ impl Update<'_> {
             skip_runtimes: config.skip_runtimes,
             trust_lockfile: config.trust_lockfile,
             update_checksums: false,
-            is_full_install: packages.is_empty(),
+            is_full_install: packages.is_empty() && workspace_packages.is_none(),
             installs_only: true,
             resolved_packages,
             supported_architectures,
             node_linker: config.node_linker,
             lockfile_only,
             dry_run: false,
-            update_seed_policy: UpdateSeedPolicy::ByImporter(prepared.seed_policies),
+            update_seed_policy: UpdateSeedPolicy::ByImporter {
+                policies: prepared.seed_policies,
+                max_depth: UpdateDepth::new(depth),
+            },
             auth_override: None,
             resolution_observer,
             peer_issues_sink: None,
@@ -475,6 +508,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
     save: bool,
     include_direct: &[DependencyGroup],
     depth: usize,
+    workspace_packages: Option<&WorkspacePackages>,
     catalogs_seed: Option<&Catalogs>,
     latest_chain: &mut Option<LatestResolverChain>,
     lockfile_only: bool,
@@ -516,6 +550,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
         .transpose()?;
     let mut drop_names = HashSet::new();
     let mut rewrites = Vec::new();
+    let max_depth = UpdateDepth::new(depth);
     // Bare-name selectors with depth update matching names at any depth.
     let use_name_matcher = !selectors.is_empty()
         && selectors.iter().all(|selector| selector.version.is_none())
@@ -531,7 +566,30 @@ async fn prepare_manifest<Reporter: self::Reporter>(
         lockfile_only,
     };
 
-    let seed_policy = if selectors.is_empty() {
+    // `--workspace` with nothing to link falls through to the ordinary
+    // branches below: a selector that matched no direct dependency still
+    // updates that name deeper in the graph, and an empty selector list
+    // still updates every direct dependency.
+    let workspace_targets = workspace_packages
+        .map(|packages| workspace_link_targets(&selectors, &direct, packages, config))
+        .transpose()?
+        .unwrap_or_default();
+
+    let seed_policy = if let Some(workspace_packages) =
+        workspace_packages.filter(|_| !workspace_targets.is_empty())
+    {
+        for target in workspace_targets {
+            let specifier = workspace_specifier(
+                &target,
+                &workspace_packages[&target.name],
+                config.save_workspace_protocol,
+                pinned_version,
+            );
+            drop_names.insert(target.name.clone());
+            rewrites.push((target.name, target.group, specifier));
+        }
+        UpdateSeedPolicy::DropOnly { names: drop_names, max_depth }
+    } else if selectors.is_empty() {
         // `updateConfig.ignoreDependencies` applies only when no selector was
         // supplied and remains scoped by the included direct groups.
         let ignore_patterns =
@@ -554,7 +612,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
         }
         if updates_all_groups && ignore_patterns.is_empty() {
             // A bare, ungated update re-resolves the whole graph.
-            UpdateSeedPolicy::DropAll
+            UpdateSeedPolicy::DropAll { max_depth }
         } else {
             if updates_all_groups
                 && !(latest && drop_names.is_empty())
@@ -567,7 +625,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                     }
                 }
             }
-            UpdateSeedPolicy::DropOnly(drop_names)
+            UpdateSeedPolicy::DropOnly { names: drop_names, max_depth }
         }
     } else if use_name_matcher {
         let patterns =
@@ -587,7 +645,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                 }
             }
         }
-        UpdateSeedPolicy::DropOnly(drop_names)
+        UpdateSeedPolicy::DropOnly { names: drop_names, max_depth }
     } else {
         let patterns =
             selectors.iter().map(|selector| selector.pattern.clone()).collect::<Vec<_>>();
@@ -643,7 +701,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                 }
             }
         }
-        UpdateSeedPolicy::DropOnly(drop_names)
+        UpdateSeedPolicy::DropOnly { names: drop_names, max_depth }
     };
 
     // Reconcile only manifest rewrites. Existing `catalog:` references retain
@@ -745,6 +803,7 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     save: bool,
     include_direct: &[DependencyGroup],
     depth: usize,
+    workspace_packages: Option<&WorkspacePackages>,
     lockfile_only: bool,
     resolution_observer: Option<&Arc<dyn crate::ResolutionObserver>>,
 ) -> Result<SelectedUpdatePreparation, UpdateError> {
@@ -770,6 +829,7 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
             save,
             include_direct,
             depth,
+            workspace_packages,
             catalogs_override.as_ref(),
             &mut latest_chain,
             lockfile_only,
@@ -784,13 +844,13 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
             pacquet_workspace::importer_id_from_root_dir(workspace_root, &projects[index].root_dir);
         match prepared.seed_policy {
             UpdateSeedPolicy::KeepAll => {}
-            UpdateSeedPolicy::DropAll => {
+            UpdateSeedPolicy::DropAll { .. } => {
                 seed_policies.insert(importer_id, ImporterUpdateSeedPolicy::DropAll);
             }
-            UpdateSeedPolicy::DropOnly(names) => {
+            UpdateSeedPolicy::DropOnly { names, .. } => {
                 seed_policies.insert(importer_id, ImporterUpdateSeedPolicy::DropOnly(names));
             }
-            UpdateSeedPolicy::ByImporter(_) => {
+            UpdateSeedPolicy::ByImporter { .. } => {
                 unreachable!("per-manifest preparation never produces importer policies")
             }
         }
@@ -849,6 +909,124 @@ fn persist_manifest<Reporter: self::Reporter>(
         message: PackageManifestMessage::Updated { prefix, updated },
     }));
     Ok(())
+}
+
+/// One direct dependency `--workspace` re-points at the workspace copy
+/// of the same name.
+struct WorkspaceLinkTarget {
+    name: String,
+    group: DependencyGroup,
+    /// The specifier the manifest declares today, which decides the range
+    /// operator the rewritten `workspace:` specifier keeps.
+    declared: String,
+    /// The range the selector asked for (`*` for a bare `foo`), which the
+    /// workspace version has to satisfy.
+    wanted_range: String,
+}
+
+/// The direct dependencies `--workspace` re-points, in manifest order.
+///
+/// With no selectors every direct dependency that a workspace project
+/// publishes is linked (minus `updateConfig.ignoreDependencies`); the
+/// rest keep their registry specifiers. With selectors, each *matched*
+/// direct dependency must be a workspace package — naming one that isn't
+/// is the failure the `--workspace` help text advertises.
+fn workspace_link_targets(
+    selectors: &[ParsedSelector],
+    direct: &[(String, DependencyGroup, String)],
+    workspace_packages: &WorkspacePackages,
+    config: &Config,
+) -> Result<Vec<WorkspaceLinkTarget>, UpdateError> {
+    let mut targets = Vec::new();
+    if selectors.is_empty() {
+        let ignore_patterns =
+            config.update_config.ignore_dependencies.as_deref().unwrap_or_default();
+        let ignore_matcher = (!ignore_patterns.is_empty()).then(|| create_matcher(ignore_patterns));
+        for (name, group, declared) in direct {
+            let ignored =
+                ignore_matcher.as_ref().is_some_and(|matcher| matcher.matches(name.as_str()));
+            if ignored || !workspace_packages.contains_key(name) {
+                continue;
+            }
+            targets.push(WorkspaceLinkTarget {
+                name: name.clone(),
+                group: *group,
+                declared: declared.clone(),
+                wanted_range: "*".to_string(),
+            });
+        }
+        return Ok(targets);
+    }
+
+    let patterns = selectors.iter().map(|selector| selector.pattern.clone()).collect::<Vec<_>>();
+    let matcher = create_matcher(&patterns);
+    for (name, group, declared) in direct {
+        if !matcher.matches(name.as_str()) {
+            continue;
+        }
+        if !workspace_packages.contains_key(name) {
+            return Err(UpdateError::WorkspacePackageNotFound(name.clone()));
+        }
+        let wanted = selectors
+            .iter()
+            .find(|selector| matcher_one(&selector.pattern).matches(name))
+            .and_then(|selector| selector.version.clone())
+            .unwrap_or_else(|| "*".to_string());
+        targets.push(WorkspaceLinkTarget {
+            name: name.clone(),
+            group: *group,
+            declared: declared.clone(),
+            wanted_range: wanted.strip_prefix("workspace:").unwrap_or(&wanted).to_string(),
+        });
+    }
+    Ok(targets)
+}
+
+/// The `workspace:` specifier `--workspace` writes for a linked
+/// dependency.
+///
+/// Under [`SaveWorkspaceProtocol::Rolling`] the range operator is written
+/// without a version, so the entry survives the workspace package's next
+/// release; otherwise the linked version is written under the operator
+/// the dependency already declared.
+fn workspace_specifier(
+    target: &WorkspaceLinkTarget,
+    versions: &WorkspacePackagesByVersion,
+    protocol: SaveWorkspaceProtocol,
+    default_pin: PinnedVersion,
+) -> String {
+    // Nothing satisfies the requested range: keep it, so the install
+    // reports it as `NO_MATCHING_VERSION_INSIDE_WORKSPACE` against the
+    // range the user asked for.
+    let Some(version) = pick_workspace_version(versions, &target.wanted_range) else {
+        return format!("workspace:{}", target.wanted_range);
+    };
+    if protocol == SaveWorkspaceProtocol::Rolling {
+        let operator = match target.declared.as_str() {
+            "workspace:*" | "workspace:^" | "workspace:~" => {
+                return target.declared.clone();
+            }
+            _ => match which_version_is_pinned(&target.declared) {
+                Some(PinnedVersion::Minor) => "~",
+                Some(PinnedVersion::Patch | PinnedVersion::None) => "*",
+                Some(PinnedVersion::Major) | None => "^",
+            },
+        };
+        return format!("workspace:{operator}");
+    }
+    if node_semver::Version::parse(&version).is_ok_and(|version| !version.pre_release.is_empty()) {
+        return format!("workspace:{version}");
+    }
+    let pin = which_version_is_pinned(&target.declared).unwrap_or(default_pin);
+    format!("workspace:{}{version}", pin.range_prefix())
+}
+
+/// The workspace version a `workspace:<range>` specifier would resolve
+/// to. A range that isn't semver is a dist-tag, which the workspace
+/// answers with its highest version.
+fn pick_workspace_version(versions: &WorkspacePackagesByVersion, range: &str) -> Option<String> {
+    let range = if node_semver::Range::parse(range).is_ok() { range } else { "*" };
+    resolve_workspace_range(range, &versions.keys().cloned().collect::<Vec<_>>())
 }
 
 /// Compile a single pattern into a matcher. Used to map a matched direct

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -119,6 +119,7 @@ async fn selected_update_prepares_and_persists_only_selected_projects() {
         true,
         &[DependencyGroup::Prod],
         0,
+        None,
         false,
         None,
     )
@@ -163,6 +164,7 @@ async fn selected_update_no_save_mutates_in_memory_without_persisting() {
         false,
         &[DependencyGroup::Prod],
         0,
+        None,
         false,
         None,
     )
@@ -205,6 +207,7 @@ async fn selected_update_depth_zero_skips_projects_without_a_matching_dependency
         true,
         &[DependencyGroup::Prod],
         0,
+        None,
         false,
         None,
     )
@@ -236,6 +239,7 @@ async fn selected_update_latest_depth_zero_is_noop_when_no_project_matches() {
         true,
         &[DependencyGroup::Prod],
         0,
+        None,
         false,
         None,
     )
@@ -281,6 +285,7 @@ async fn latest_leaves_specifiers_no_resolver_claims() {
             true,
             &[DependencyGroup::Prod],
             0,
+            None,
             false,
             None,
         )
@@ -317,6 +322,7 @@ async fn latest_rewrites_a_specifier_the_npm_resolver_claims() {
         true,
         &[DependencyGroup::Prod],
         0,
+        None,
         false,
         None,
     )

--- a/pnpm/crates/resolving-deps-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lib.rs
@@ -87,7 +87,7 @@ pub use pacquet_deps_path::DepPath;
 pub use resolve_dependency_tree::{
     Deprecation, DeprecationLogFn, ManifestHook, ResolveDependencyTreeError,
     ResolveDependencyTreeOptions, SkippedOptionalDependency, SkippedOptionalDependencyParent,
-    SkippedOptionalLogFn, TreeCtx, UpdateReuseScope, WorkspaceTreeCtx, extend_tree,
+    SkippedOptionalLogFn, TreeCtx, UpdateDepth, UpdateReuseScope, WorkspaceTreeCtx, extend_tree,
     resolve_dependency_tree,
 };
 pub use resolve_importer::{

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -57,9 +57,52 @@ pub enum UpdateReuseScope {
     /// Reuse nothing — the whole graph re-resolves. `pacquet update`
     /// with no selectors.
     None,
-    /// Reuse everything except the named packages (matched at any depth).
-    /// `pacquet update <pattern>`.
+    /// Reuse everything except the named packages (matched at any depth
+    /// the update reaches). `pacquet update <pattern>`.
     Except(std::collections::HashSet<String>),
+}
+
+/// How deep `pacquet update` reaches — the `--depth` ceiling. A node
+/// below it keeps its locked resolution even when its name is an update
+/// target, matching pnpm's `currentDepth <= updateDepth` gate.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct UpdateDepth(Option<i32>);
+
+impl UpdateDepth {
+    /// `--depth Infinity`, the default.
+    pub const UNLIMITED: Self = Self(None);
+
+    /// A depth no dependency graph can reach — `usize::MAX`, which the
+    /// CLI uses for the `Infinity` default, among them — is unlimited.
+    #[must_use]
+    pub fn new(depth: usize) -> Self {
+        i32::try_from(depth).map_or(Self::UNLIMITED, |depth| Self(Some(depth)))
+    }
+
+    /// Whether an update reaches a node at `depth`.
+    #[must_use]
+    fn reaches(self, depth: i32) -> bool {
+        self.0.is_none_or(|max_depth| depth <= max_depth)
+    }
+
+    /// The depth to memoise a subtree-reuse answer under. Beyond the
+    /// ceiling no node is an update target, so every deeper level shares
+    /// one answer — and an unlimited update never varies by depth at all.
+    #[must_use]
+    fn memo_bucket(self, depth: i32) -> i32 {
+        match self.0 {
+            None => 0,
+            Some(max_depth) => depth.min(max_depth.saturating_add(1)),
+        }
+    }
+}
+
+/// The `pacquet update` scope a node is judged against: which names the
+/// update targets, and how deep it reaches.
+#[derive(Debug, Clone, Copy)]
+struct UpdateScope<'a> {
+    reuse: &'a UpdateReuseScope,
+    max_depth: UpdateDepth,
 }
 
 /// How the current [`fn@resolve_node`] call may reuse the prior
@@ -526,7 +569,7 @@ type WantedKey = (
     bool,
 );
 
-type SubtreeReuseKey = (Option<String>, PkgNameVerPeer);
+type SubtreeReuseKey = (Option<String>, PkgNameVerPeer, i32);
 
 /// Whether a wanted dep's resolution is computed relative to the
 /// consuming importer's directory rather than being
@@ -623,6 +666,8 @@ pub struct WorkspaceTreeCtx {
     /// Importer overrides used by filtered workspace updates. IDs absent from
     /// this map keep the workspace default above.
     update_reuse_scopes_by_importer: BTreeMap<String, UpdateReuseScope>,
+    /// `pacquet update --depth`: how deep the suppression above reaches.
+    update_depth: UpdateDepth,
     /// Memoises [`fn@subtree_fully_reusable`] per update scope and snapshot
     /// key. Keep-all importers share one scope; update-active importers use
     /// isolated scopes so one importer's reuse answer cannot leak to another.
@@ -722,6 +767,7 @@ impl Default for WorkspaceTreeCtx {
             wanted_lockfile: None,
             update_reuse_scope: UpdateReuseScope::All,
             update_reuse_scopes_by_importer: BTreeMap::new(),
+            update_depth: UpdateDepth::UNLIMITED,
             subtree_reusable: Mutex::new(HashMap::new()),
             pnpmfile_hook: None,
             read_package_log: None,
@@ -851,6 +897,12 @@ impl WorkspaceTreeCtx {
         scopes: BTreeMap<String, UpdateReuseScope>,
     ) -> Self {
         self.update_reuse_scopes_by_importer = scopes;
+        self
+    }
+
+    #[must_use]
+    pub fn with_update_depth(mut self, update_depth: UpdateDepth) -> Self {
+        self.update_depth = update_depth;
         self
     }
 
@@ -1100,6 +1152,10 @@ impl TreeCtx {
 
     fn update_reuse_scope(&self) -> &UpdateReuseScope {
         self.workspace.update_reuse_scope_for(&self.importer_id)
+    }
+
+    fn update_scope(&self) -> UpdateScope<'_> {
+        UpdateScope { reuse: self.update_reuse_scope(), max_depth: self.workspace.update_depth }
     }
 
     fn update_cache_scope(&self) -> Option<String> {
@@ -1452,7 +1508,7 @@ where
     // would keep the pin, leaving the lockfile non-convergent).
     if reuse.allows_reuse()
         && !node_depends_on_changed_direct_dep(ctx, prior_key.as_ref())
-        && let Some(reused) = try_reuse_node(ctx, &wanted, prior_key.as_ref())
+        && let Some(reused) = try_reuse_node(ctx, &wanted, prior_key.as_ref(), depth)
     {
         return resolve_reused_node(
             ctx,
@@ -1534,7 +1590,7 @@ where
             view
         })
         .unwrap_or_default();
-    let update_target = is_update_target(ctx.update_reuse_scope(), &wanted);
+    let update_target = is_update_target(ctx.update_scope(), &wanted, depth);
     let cache_key: WantedKey = (
         wanted.alias.clone(),
         wanted.bare_specifier.clone(),
@@ -2125,7 +2181,7 @@ where
                     None,
                     Vec::new(),
                     ctx.update_cache_scope(),
-                    is_update_target(ctx.update_reuse_scope(), &wanted),
+                    is_update_target(ctx.update_scope(), &wanted, pending.depth + 1),
                 );
                 let _ = resolve_wanted_cached(ctx, resolver, &wanted, opts, None, cache_key).await;
             }
@@ -2372,23 +2428,30 @@ fn try_reuse_node(
     ctx: &TreeCtx,
     wanted: &WantedDependency,
     prior_key: Option<&PkgNameVerPeer>,
+    depth: i32,
 ) -> Option<ReusedNode> {
     let lockfile = ctx.workspace.wanted_lockfile.as_ref()?;
-    if matches!(ctx.update_reuse_scope(), UpdateReuseScope::None) {
+    let scope = ctx.update_scope();
+    if matches!(scope.reuse, UpdateReuseScope::None) && scope.max_depth.reaches(depth) {
         return None;
     }
     let alias = wanted.alias.as_deref()?;
     let key = prior_key?;
-    if !subtree_fully_reusable(ctx, lockfile, key) {
+    if !subtree_fully_reusable(ctx, lockfile, key, depth) {
         return None;
     }
     let result = synthesize_reused_result(lockfile, key, alias)?;
     Some(ReusedNode { key: key.clone(), result })
 }
 
-/// `true` when `name` is a `pacquet update` target excluded from reuse.
-fn update_excludes(scope: &UpdateReuseScope, name: &str) -> bool {
-    match scope {
+/// `true` when a node named `name` at `depth` is a `pacquet update`
+/// target, and so excluded from reuse. Past the `--depth` ceiling the
+/// update no longer reaches, so every node keeps its locked resolution.
+fn update_excludes(scope: UpdateScope<'_>, name: &str, depth: i32) -> bool {
+    if !scope.max_depth.reaches(depth) {
+        return false;
+    }
+    match scope.reuse {
         UpdateReuseScope::All => false,
         // `None` is handled earlier in `try_reuse_node`; treat it the
         // same here for completeness.
@@ -2544,15 +2607,18 @@ fn real_package_name_of(wanted: &WantedDependency) -> Option<Cow<'_, str>> {
 /// picker's held-back-update warning.
 ///
 /// Returns `false` for `All`/`None` scopes (no individually targeted
-/// packages) and for `Except` scopes where the wanted package's real
-/// name is not in the target list. Returns `true` only when the real
-/// name is in the `Except` set.
+/// packages), for a node past the `--depth` ceiling, and for `Except`
+/// scopes where the wanted package's real name is not in the target
+/// list. Returns `true` only when the real name is in the `Except` set.
 #[inline]
-fn is_update_target(scope: &UpdateReuseScope, wanted: &WantedDependency) -> bool {
-    match scope {
+fn is_update_target(scope: UpdateScope<'_>, wanted: &WantedDependency, depth: i32) -> bool {
+    if !scope.max_depth.reaches(depth) {
+        return false;
+    }
+    match scope.reuse {
         UpdateReuseScope::All | UpdateReuseScope::None => false,
         UpdateReuseScope::Except(_) => {
-            real_package_name_of(wanted).is_some_and(|n| update_excludes(scope, n.as_ref()))
+            real_package_name_of(wanted).is_some_and(|n| update_excludes(scope, n.as_ref(), depth))
         }
     }
 }
@@ -2576,8 +2642,10 @@ fn subtree_fully_reusable(
     ctx: &TreeCtx,
     lockfile: &pacquet_lockfile::Lockfile,
     key: &PkgNameVerPeer,
+    depth: i32,
 ) -> bool {
-    let memo_key = (ctx.update_cache_scope(), key.clone());
+    let scope = ctx.update_scope();
+    let memo_key = (ctx.update_cache_scope(), key.clone(), scope.max_depth.memo_bucket(depth));
     if let Some(&cached) = lock_recoverable(&ctx.workspace.subtree_reusable).get(&memo_key) {
         return cached;
     }
@@ -2587,11 +2655,11 @@ fn subtree_fully_reusable(
     lock_recoverable(&ctx.workspace.subtree_reusable).insert(memo_key.clone(), false);
     // A `pacquet update` target anywhere in the subtree forces the whole
     // subtree to re-resolve so the bump's new transitive deps are picked
-    // up — update names match at any depth.
+    // up — update names match at every depth the update reaches.
     let name = key.name.to_string();
-    let reusable = !update_excludes(ctx.update_reuse_scope(), &name)
+    let reusable = !update_excludes(scope, &name, depth)
         && synthesize_reused_result(lockfile, key, &name).is_some()
-        && subtree_children_reusable(ctx, lockfile, key);
+        && subtree_children_reusable(ctx, lockfile, key, depth);
     lock_recoverable(&ctx.workspace.subtree_reusable).insert(memo_key, reusable);
     reusable
 }
@@ -2604,6 +2672,7 @@ fn subtree_children_reusable(
     ctx: &TreeCtx,
     lockfile: &pacquet_lockfile::Lockfile,
     key: &PkgNameVerPeer,
+    depth: i32,
 ) -> bool {
     let Some(snapshot) = lockfile.snapshots.as_ref().and_then(|snaps| snaps.get(key)) else {
         // No snapshot entry → the lockfile doesn't record this node's
@@ -2621,7 +2690,7 @@ fn subtree_children_reusable(
             let Some(child_key) = dep_ref.resolve(child_name) else {
                 return false;
             };
-            if !subtree_fully_reusable(ctx, lockfile, &child_key) {
+            if !subtree_fully_reusable(ctx, lockfile, &child_key, depth + 1) {
                 return false;
             }
         }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -435,7 +435,7 @@ mod is_update_target {
 
     use pacquet_resolving_resolver_base::WantedDependency;
 
-    use super::super::{UpdateReuseScope, is_update_target};
+    use super::super::{UpdateDepth, UpdateReuseScope, UpdateScope, is_update_target};
 
     fn wanted_with(alias: Option<&str>, bare_specifier: Option<&str>) -> WantedDependency {
         WantedDependency {
@@ -449,12 +449,19 @@ mod is_update_target {
         UpdateReuseScope::Except(names.iter().map(|s| (*s).to_string()).collect::<HashSet<_>>())
     }
 
+    /// The scope of a `--depth Infinity` update — the default, under
+    /// which every node is judged by name alone.
+    fn unlimited(reuse: &UpdateReuseScope) -> UpdateScope<'_> {
+        UpdateScope { reuse, max_depth: UpdateDepth::UNLIMITED }
+    }
+
     #[test]
     fn returns_false_for_all_scope() {
         // `All` = install/add default: no package is targeted for update.
         assert!(!is_update_target(
-            &UpdateReuseScope::All,
+            unlimited(&UpdateReuseScope::All),
             &wanted_with(Some("foo"), Some("^1.0.0")),
+            0,
         ));
     }
 
@@ -462,8 +469,9 @@ mod is_update_target {
     fn returns_false_for_none_scope() {
         // `None` is the "no reuse" sentinel; same outcome as `All` here.
         assert!(!is_update_target(
-            &UpdateReuseScope::None,
+            unlimited(&UpdateReuseScope::None),
             &wanted_with(Some("foo"), Some("^1.0.0")),
+            0,
         ));
     }
 
@@ -471,13 +479,21 @@ mod is_update_target {
     fn returns_true_for_except_scope_when_targeted() {
         // `foo` is in the user's update target list → this resolution
         // carries `update_requested`.
-        assert!(is_update_target(&except(&["foo"]), &wanted_with(Some("foo"), Some("^1.0.0")),));
+        assert!(is_update_target(
+            unlimited(&except(&["foo"])),
+            &wanted_with(Some("foo"), Some("^1.0.0")),
+            0,
+        ));
     }
 
     #[test]
     fn returns_false_for_except_scope_when_not_targeted() {
         // `foo` is not in the user's update target list.
-        assert!(!is_update_target(&except(&["bar"]), &wanted_with(Some("foo"), Some("^1.0.0")),));
+        assert!(!is_update_target(
+            unlimited(&except(&["bar"])),
+            &wanted_with(Some("foo"), Some("^1.0.0")),
+            0,
+        ));
     }
 
     #[test]
@@ -485,14 +501,46 @@ mod is_update_target {
         // The user updates `bar`, but the importer installed it under
         // alias `foo` via `foo@npm:bar@^4`. The real name `bar` is in
         // the target list, so the aliased dep counts as a target.
-        assert!(is_update_target(&except(&["bar"]), &wanted_with(Some("foo"), Some("npm:bar@^4"))));
+        assert!(is_update_target(
+            unlimited(&except(&["bar"])),
+            &wanted_with(Some("foo"), Some("npm:bar@^4")),
+            0,
+        ));
     }
 
     #[test]
     fn returns_false_when_real_name_is_unrecoverable() {
         // Alias missing AND no bare_specifier pattern that yields a name.
         // Defensive: "not a targeted update" since we can't match.
-        assert!(!is_update_target(&except(&["foo"]), &wanted_with(None, None),));
+        assert!(!is_update_target(unlimited(&except(&["foo"])), &wanted_with(None, None), 0));
+    }
+
+    #[test]
+    fn depth_zero_targets_direct_dependencies_only() {
+        let reuse = except(&["foo"]);
+        let scope = UpdateScope { reuse: &reuse, max_depth: UpdateDepth::new(0) };
+        let wanted = wanted_with(Some("foo"), Some("^1.0.0"));
+
+        assert!(is_update_target(scope, &wanted, 0));
+        assert!(!is_update_target(scope, &wanted, 1));
+    }
+
+    #[test]
+    fn a_finite_depth_reaches_every_level_up_to_it() {
+        let reuse = except(&["foo"]);
+        let scope = UpdateScope { reuse: &reuse, max_depth: UpdateDepth::new(2) };
+        let wanted = wanted_with(Some("foo"), Some("^1.0.0"));
+
+        assert!(is_update_target(scope, &wanted, 2));
+        assert!(!is_update_target(scope, &wanted, 3));
+    }
+
+    #[test]
+    fn a_depth_no_graph_can_reach_is_unlimited() {
+        let reuse = except(&["foo"]);
+        let scope = UpdateScope { reuse: &reuse, max_depth: UpdateDepth::new(usize::MAX) };
+
+        assert!(is_update_target(scope, &wanted_with(Some("foo"), Some("^1.0.0")), i32::MAX));
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -17,7 +17,7 @@
 
 use crate::{
     resolve_dependency_tree::{
-        ManifestHook, UpdateReuseScope, WorkspaceTreeCtx, importer_direct_wanted_specs,
+        ManifestHook, UpdateDepth, UpdateReuseScope, WorkspaceTreeCtx, importer_direct_wanted_specs,
     },
     resolve_importer::{ImporterHoistState, ResolveImporterError, ResolveImporterOptions},
     resolve_peers::{
@@ -99,6 +99,10 @@ pub struct WorkspaceResolveOptions {
     /// Per-importer update scopes for filtered workspace updates. An importer
     /// absent from this map uses [`Self::update_reuse_scope`].
     pub update_reuse_scopes_by_importer: BTreeMap<String, UpdateReuseScope>,
+    /// `pacquet update --depth`: how deep the update reaches. Nodes
+    /// past the ceiling keep their locked resolutions even when their
+    /// name is an update target.
+    pub update_depth: UpdateDepth,
 
     /// `pnpmfileHook` applied to every resolved manifest before it
     /// enters the wanted-dep cache. Workspace-wide (one hook per
@@ -189,6 +193,7 @@ where
         wanted_lockfile,
         update_reuse_scope,
         update_reuse_scopes_by_importer,
+        update_depth,
         auto_install_peers,
         registries,
     } = opts;
@@ -198,6 +203,7 @@ where
             .with_wanted_lockfile(wanted_lockfile)
             .with_update_reuse_scope(update_reuse_scope)
             .with_update_reuse_scopes_by_importer(update_reuse_scopes_by_importer)
+            .with_update_depth(update_depth)
             .with_pnpmfile_hook(pnpmfile_hook)
             .with_read_package_log(read_package_log)
             .with_skipped_optional_log(skipped_optional_log)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -209,6 +209,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         wanted_lockfile: None,
         update_reuse_scope: crate::UpdateReuseScope::All,
         update_reuse_scopes_by_importer: BTreeMap::new(),
+        update_depth: crate::UpdateDepth::UNLIMITED,
         auto_install_peers: false,
         registries: HashMap::new(),
     }

--- a/pnpm11/installing/commands/src/installDeps.ts
+++ b/pnpm11/installing/commands/src/installDeps.ts
@@ -56,7 +56,7 @@ import {
   type UpdateDepsMatcher,
 } from './recursive.js'
 import { makeRunPacquet } from './runPacquet.js'
-import { createWorkspaceSpecs, updateToWorkspacePackagesFromManifest } from './updateWorkspaceDependencies.js'
+import { toWorkspaceSpecs } from './updateWorkspaceDependencies.js'
 import { verifyPacquetIdentity } from './verifyPacquetIdentity.js'
 
 const OVERWRITE_UPDATE_OPTIONS = {
@@ -397,16 +397,12 @@ export async function installDeps (
     params = Object.keys(filterDependenciesByType(manifest, includeDirect))
   }
   if (opts.workspace) {
-    if (!params || (params.length === 0)) {
-      // The user's own selectors matched no direct dependency, so there is
-      // nothing they asked to link; linking every workspace dependency instead
-      // would update packages that were never named.
-      if (!userNamedDeps) {
-        params = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
-      }
-    } else {
-      params = createWorkspaceSpecs(params, workspacePackages, { skipPackagesOutsideWorkspace: !userNamedDeps })
-    }
+    params = toWorkspaceSpecs(params ?? [], {
+      manifest,
+      include: includeDirect,
+      workspacePackages,
+      userNamedDeps,
+    })
   }
   if (params?.length) {
     const mutatedProject = {

--- a/pnpm11/installing/commands/src/installDeps.ts
+++ b/pnpm11/installing/commands/src/installDeps.ts
@@ -357,6 +357,10 @@ export async function installDeps (
   let updateMatch: UpdateDepsMatcher | null
   let updatePackageManifest = opts.updatePackageManifest
   let updateMatching: UpdateMatchingFunction | undefined
+  // `params` is rewritten below into the dependency names it matched, so
+  // remember whether the user named any package. `--workspace` only insists
+  // that a dependency exists in the workspace when it was asked for by name.
+  const userNamedDeps = params.length > 0
   if (opts.update) {
     if (params.length === 0) {
       const ignoreDeps = opts.updateConfig?.ignoreDependencies
@@ -394,9 +398,14 @@ export async function installDeps (
   }
   if (opts.workspace) {
     if (!params || (params.length === 0)) {
-      params = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
+      // The user's own selectors matched no direct dependency, so there is
+      // nothing they asked to link; linking every workspace dependency instead
+      // would update packages that were never named.
+      if (!userNamedDeps) {
+        params = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
+      }
     } else {
-      params = createWorkspaceSpecs(params, workspacePackages)
+      params = createWorkspaceSpecs(params, workspacePackages, { skipPackagesOutsideWorkspace: !userNamedDeps })
     }
   }
   if (params?.length) {

--- a/pnpm11/installing/commands/src/recursive.ts
+++ b/pnpm11/installing/commands/src/recursive.ts
@@ -58,7 +58,7 @@ import { getPinnedVersion } from './getPinnedVersion.js'
 import { getSaveType } from './getSaveType.js'
 import { handleIgnoredBuilds } from './handleIgnoredBuilds.js'
 import { type PolicyViolation, setupPolicyHandlers } from './policyHandlers.js'
-import { createWorkspaceSpecs, updateToWorkspacePackagesFromManifest } from './updateWorkspaceDependencies.js'
+import { toWorkspaceSpecs } from './updateWorkspaceDependencies.js'
 
 export type RecursiveOptions = CreateStoreControllerOptions & Pick<Config,
 | 'bail'
@@ -277,13 +277,12 @@ export async function recursive (
         currentInput = Object.keys(filterDependenciesByType(manifest, includeDirect))
       }
       if (opts.workspace) {
-        if (!currentInput || (currentInput.length === 0)) {
-          if (!userNamedDeps) {
-            currentInput = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
-          }
-        } else {
-          currentInput = createWorkspaceSpecs(currentInput, workspacePackages, { skipPackagesOutsideWorkspace: !userNamedDeps })
-        }
+        currentInput = toWorkspaceSpecs(currentInput, {
+          manifest,
+          include: includeDirect,
+          workspacePackages,
+          userNamedDeps,
+        })
       }
       switch (mutation) {
         case 'uninstallSome':
@@ -407,13 +406,12 @@ export async function recursive (
           currentInput = Object.keys(filterDependenciesByType(manifest, includeDirect))
         }
         if (opts.workspace) {
-          if (!currentInput || (currentInput.length === 0)) {
-            if (!userNamedDeps) {
-              currentInput = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
-            }
-          } else {
-            currentInput = createWorkspaceSpecs(currentInput, workspacePackages, { skipPackagesOutsideWorkspace: !userNamedDeps })
-          }
+          currentInput = toWorkspaceSpecs(currentInput, {
+            manifest,
+            include: includeDirect,
+            workspacePackages,
+            userNamedDeps,
+          })
         }
 
         type ActionOpts =

--- a/pnpm11/installing/commands/src/recursive.ts
+++ b/pnpm11/installing/commands/src/recursive.ts
@@ -226,6 +226,10 @@ export async function recursive (
   }
 
   let updateMatch: UpdateDepsMatcher | null
+  // `params` is rewritten per project into the dependency names it matched, so
+  // remember whether the user named any package. `--workspace` only insists
+  // that a dependency exists in the workspace when it was asked for by name.
+  const userNamedDeps = params.length > 0
   if (cmdFullName === 'update') {
     if (params.length === 0) {
       const ignoreDeps = opts.updateConfig?.ignoreDependencies
@@ -274,9 +278,11 @@ export async function recursive (
       }
       if (opts.workspace) {
         if (!currentInput || (currentInput.length === 0)) {
-          currentInput = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
+          if (!userNamedDeps) {
+            currentInput = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
+          }
         } else {
-          currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
+          currentInput = createWorkspaceSpecs(currentInput, workspacePackages, { skipPackagesOutsideWorkspace: !userNamedDeps })
         }
       }
       switch (mutation) {
@@ -402,9 +408,11 @@ export async function recursive (
         }
         if (opts.workspace) {
           if (!currentInput || (currentInput.length === 0)) {
-            currentInput = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
+            if (!userNamedDeps) {
+              currentInput = updateToWorkspacePackagesFromManifest(manifest, includeDirect, workspacePackages)
+            }
           } else {
-            currentInput = createWorkspaceSpecs(currentInput, workspacePackages)
+            currentInput = createWorkspaceSpecs(currentInput, workspacePackages, { skipPackagesOutsideWorkspace: !userNamedDeps })
           }
         }
 

--- a/pnpm11/installing/commands/src/updateWorkspaceDependencies.ts
+++ b/pnpm11/installing/commands/src/updateWorkspaceDependencies.ts
@@ -18,13 +18,36 @@ export function updateToWorkspacePackagesFromManifest (
     .map(depName => `${depName}@workspace:*`)
 }
 
-export function createWorkspaceSpecs (specs: string[], workspacePackages: WorkspacePackages): string[] {
-  return specs.map((spec) => {
+/**
+ * Rewrite dependency selectors to point at the workspace copies of the same
+ * packages.
+ *
+ * A selector naming a package the workspace doesn't have is an error, since
+ * `--workspace` was asked to link something that isn't there. Pass
+ * `skipPackagesOutsideWorkspace` when the selectors weren't named by the user
+ * (they were derived from the manifest), where a registry dependency is
+ * expected and simply keeps its specifier.
+ */
+export function createWorkspaceSpecs (
+  specs: string[],
+  workspacePackages: WorkspacePackages,
+  opts?: { skipPackagesOutsideWorkspace?: boolean }
+): string[] {
+  const workspaceSpecs: string[] = []
+  for (const spec of specs) {
     const parsed = parseWantedDependency(spec)
     if (!parsed.alias) throw new PnpmError('NO_PKG_NAME_IN_SPEC', `Cannot update/install from workspace through "${spec}"`)
-    if (!workspacePackages.has(parsed.alias)) throw new PnpmError('WORKSPACE_PACKAGE_NOT_FOUND', `"${parsed.alias}" not found in the workspace`)
-    if (!parsed.bareSpecifier) return `${parsed.alias}@workspace:*`
-    if (parsed.bareSpecifier.startsWith('workspace:')) return spec
-    return `${parsed.alias}@workspace:${parsed.bareSpecifier}`
-  })
+    if (!workspacePackages.has(parsed.alias)) {
+      if (opts?.skipPackagesOutsideWorkspace) continue
+      throw new PnpmError('WORKSPACE_PACKAGE_NOT_FOUND', `"${parsed.alias}" not found in the workspace`)
+    }
+    if (!parsed.bareSpecifier) {
+      workspaceSpecs.push(`${parsed.alias}@workspace:*`)
+    } else if (parsed.bareSpecifier.startsWith('workspace:')) {
+      workspaceSpecs.push(spec)
+    } else {
+      workspaceSpecs.push(`${parsed.alias}@workspace:${parsed.bareSpecifier}`)
+    }
+  }
+  return workspaceSpecs
 }

--- a/pnpm11/installing/commands/src/updateWorkspaceDependencies.ts
+++ b/pnpm11/installing/commands/src/updateWorkspaceDependencies.ts
@@ -19,6 +19,32 @@ export function updateToWorkspacePackagesFromManifest (
 }
 
 /**
+ * The dependency selectors a `--workspace` install resolves from the workspace
+ * instead of the registry.
+ *
+ * `selectors` are the dependency names the update already matched, which is
+ * empty both when the user named nothing and when the packages they named
+ * matched no direct dependency. `userNamedDeps` separates those: only the
+ * former expands to every workspace dependency in the manifest, and only the
+ * latter treats a dependency missing from the workspace as an error.
+ */
+export function toWorkspaceSpecs (
+  selectors: string[],
+  opts: {
+    manifest: ProjectManifest
+    include: IncludedDependencies
+    workspacePackages: WorkspacePackages
+    userNamedDeps: boolean
+  }
+): string[] {
+  if (selectors.length > 0) {
+    return createWorkspaceSpecs(selectors, opts.workspacePackages, { skipPackagesOutsideWorkspace: !opts.userNamedDeps })
+  }
+  if (opts.userNamedDeps) return []
+  return updateToWorkspacePackagesFromManifest(opts.manifest, opts.include, opts.workspacePackages)
+}
+
+/**
  * Rewrite dependency selectors to point at the workspace copies of the same
  * packages.
  *

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -225,6 +225,68 @@ test('update: fail when both "latest" and "workspace" are true', async () => {
   expect(err.message).toBe('Cannot use --latest with --workspace simultaneously')
 })
 
+test('update --workspace leaves registry dependencies alone when some dependencies are ignored', async () => {
+  preparePackages([
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      dependencies: {
+        '@pnpm.e2e/foo': '1.0.0',
+        'project-2': '0.0.0',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '2.0.0',
+    },
+  ])
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: path.resolve('project-1'),
+    saveWorkspaceProtocol: 'rolling',
+    updateConfig: { ignoreDependencies: ['@pnpm.e2e/bar'] },
+    workspace: true,
+    workspaceDir: process.cwd(),
+  })
+
+  const manifest = loadJsonFileSync<ProjectManifest>(path.resolve('project-1/package.json'))
+
+  expect(manifest.dependencies).toStrictEqual({
+    '@pnpm.e2e/foo': '1.0.0',
+    'project-2': 'workspace:*',
+  })
+})
+
+test('update --workspace links nothing when the given selectors match no direct dependency', async () => {
+  preparePackages([
+    {
+      name: 'project-1',
+      version: '1.0.0',
+      dependencies: {
+        'project-2': '^2.0.0',
+      },
+    },
+    {
+      name: 'project-2',
+      version: '2.0.0',
+    },
+  ])
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    depth: 1,
+    dir: path.resolve('project-1'),
+    lockfileDir: process.cwd(),
+    workspace: true,
+    workspaceDir: process.cwd(),
+  }, ['@pnpm.e2e/not-a-dependency'])
+
+  const manifest = loadJsonFileSync<ProjectManifest>(path.resolve('project-1/package.json'))
+
+  expect(manifest.dependencies).toStrictEqual({ 'project-2': '^2.0.0' })
+})
+
 test('update --latest forbids specs', async () => {
   prepare()
 

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -225,7 +225,7 @@ test('update: fail when both "latest" and "workspace" are true', async () => {
   expect(err.message).toBe('Cannot use --latest with --workspace simultaneously')
 })
 
-test('update --workspace leaves registry dependencies alone when some dependencies are ignored', async () => {
+test('update --workspace skips ignored dependencies and leaves registry dependencies alone', async () => {
   preparePackages([
     {
       name: 'project-1',
@@ -233,11 +233,16 @@ test('update --workspace leaves registry dependencies alone when some dependenci
       dependencies: {
         '@pnpm.e2e/foo': '1.0.0',
         'project-2': '0.0.0',
+        'project-3': '^3.0.0',
       },
     },
     {
       name: 'project-2',
       version: '2.0.0',
+    },
+    {
+      name: 'project-3',
+      version: '3.0.0',
     },
   ])
 
@@ -245,7 +250,7 @@ test('update --workspace leaves registry dependencies alone when some dependenci
     ...DEFAULT_OPTS,
     dir: path.resolve('project-1'),
     saveWorkspaceProtocol: 'rolling',
-    updateConfig: { ignoreDependencies: ['@pnpm.e2e/bar'] },
+    updateConfig: { ignoreDependencies: ['project-3'] },
     workspace: true,
     workspaceDir: process.cwd(),
   })
@@ -253,8 +258,12 @@ test('update --workspace leaves registry dependencies alone when some dependenci
   const manifest = loadJsonFileSync<ProjectManifest>(path.resolve('project-1/package.json'))
 
   expect(manifest.dependencies).toStrictEqual({
+    // Only published to the registry: nothing to link it to, and having
+    // any ignored dependency must not turn that into an error.
     '@pnpm.e2e/foo': '1.0.0',
     'project-2': 'workspace:*',
+    // A workspace package, but ignored, so it keeps its specifier.
+    'project-3': '^3.0.0',
   })
 })
 

--- a/pnpm11/installing/commands/test/updateWorkspaceDependencies.test.ts
+++ b/pnpm11/installing/commands/test/updateWorkspaceDependencies.test.ts
@@ -85,3 +85,8 @@ test('createWorkspaceSpecs', () => {
   expect(err.code).toBe('ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND')
   expect(err.message).toBe('"express" not found in the workspace')
 })
+
+test('createWorkspaceSpecs() may skip packages that are not in the workspace', () => {
+  expect(createWorkspaceSpecs(['express', 'foo'], WORKSPACE_PACKAGES, { skipPackagesOutsideWorkspace: true }))
+    .toStrictEqual(['foo@workspace:*'])
+})


### PR DESCRIPTION
## Summary

Two of the gaps tracked in pnpm/pnpm#12101 — pacquet's `pnpm update --workspace` and per-dependency `--depth` — plus the two TypeScript `--workspace` bugs that stood in the way of making the stacks agree.

**`--workspace` (pacquet).** A workspace-link update rewrites each matched direct dependency to a `workspace:` specifier before the install resolves it, so the existing `workspace:` resolver produces the link and its errors (`ERR_PNPM_NO_MATCHING_VERSION_INSIDE_WORKSPACE` and friends). Which dependencies are matched follows the TypeScript CLI: with no selectors, every direct dependency (minus `updateConfig.ignoreDependencies`) that a workspace project publishes; with selectors, the direct dependencies they match, where naming one the workspace does not publish fails with `ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND`. `--latest` and running outside a workspace are rejected up front with the same codes the TypeScript CLI uses.

The written specifier reproduces `calcSpecifierForWorkspaceDep`: under `saveWorkspaceProtocol: 'rolling'` (the default) the declared range operator is written alone (`workspace:*` / `^` / `~`), otherwise the linked version is written under that operator. `saveWorkspaceProtocol` therefore joins pacquet's config and leaves the not-ported list in `pnpm_default_parity`.

**`--depth` (pacquet).** The flag was only consulted as a `> 0` predicate gating the name matcher, so a compatible bump always behaved as `depth = Infinity`. `UpdateDepth` now travels with the seed policy into the resolver and gates reuse per node, matching pnpm's `currentDepth <= updateDepth`: a node past the ceiling keeps its locked resolution even when its name is an update target.

**`--workspace` fixes (TypeScript).** Two cases linked dependencies the user never named. Both come from `params` being rewritten into the matched dependency names before the workspace block reads it, so the block could no longer tell "the user named nothing" from "the user's selectors matched nothing":

- With `updateConfig.ignoreDependencies` set, `params` becomes the non-ignored dependency names, and `createWorkspaceSpecs` then threw `ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND` for the project's ordinary registry dependencies — so `pnpm update --workspace` could not be run at all in a workspace that ignores any dependency.
- Selectors that matched no direct dependency left `params` empty, which read as "no selectors given" and answered by linking every workspace dependency.

Both now key off whether the user named any package.

Related to pnpm/pnpm#12101 — `--global`, the recursive sibling-manifest rewrite, and full interactive parity are still open there.

## Squash Commit Body

```text
Two of the gaps tracked in pnpm/pnpm#12101.

`--workspace` (pacquet): a workspace-link update rewrites each matched direct
dependency to a `workspace:` specifier before the install resolves it, so the
existing `workspace:` resolver produces the link and its errors. Which
dependencies are matched follows the TypeScript CLI exactly: with no selectors,
every direct dependency (minus `updateConfig.ignoreDependencies`) that a
workspace project publishes; with selectors, the direct dependencies they
match, where naming one the workspace does not publish fails with
ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND. `--latest` and running outside a
workspace are rejected up front with the same codes the TypeScript CLI uses.
Selecting nothing to link is not an error: the run falls through to the
ordinary update branches.

The written specifier reproduces `calcSpecifierForWorkspaceDep`:
`saveWorkspaceProtocol: 'rolling'` (the default) writes the declared range
operator alone, so a sibling's next release does not invalidate the entry;
otherwise the linked version is written under that operator. This adds
`saveWorkspaceProtocol` to pacquet's config, which is why it leaves the
not-ported list in `pnpm_default_parity`. The workspace-packages map the
resolver already builds is reused as the source of link targets.

`--depth` (pacquet): the flag was only consulted as a `> 0` predicate gating
the name matcher, so a compatible bump always behaved as `depth = Infinity`.
`UpdateDepth` now travels with the seed policy into the resolver and gates
reuse per node, matching pnpm's `currentDepth <= updateDepth`. The
subtree-reuse memo is keyed by depth bucket, collapsed to a single bucket for
an unlimited update and to `max_depth + 1` beyond the ceiling, so the common
case costs nothing.

`--workspace` fixes (TypeScript): two cases linked dependencies the user never
named, which pacquet would otherwise have had to reproduce. Both come from
`params` being rewritten into the matched dependency names before the workspace
block reads it, so the block could not tell "the user named nothing" from "the
user's selectors matched nothing". With `updateConfig.ignoreDependencies` set,
`createWorkspaceSpecs` threw ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND for the
project's ordinary registry dependencies; those are now skipped, as they
already were when nothing was ignored. Selectors that matched no direct
dependency left `params` empty, which the workspace block answered by linking
every workspace dependency. Both now key off whether the user named any
package.

Related to pnpm/pnpm#12101.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787531241&installation_model_id=426870&pr_number=13288&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13288&signature=17c84ad842a4b652c5a02552eef0507e2013f4060ea5a8c2dc0127144fce766d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `save-workspace-protocol` (off/on/rolling) support and honored it from workspace configuration.
* **Bug Fixes**
  * Refined `pnpm update --workspace` to link only explicitly targeted workspace deps, preserve non-targeted registry specs, avoid errors when dependencies are ignored, and handle unmatched selectors without modifying `package.json`.
  * Improved validation for `--workspace` usage (including rejecting `--workspace` with `--latest`) and clearer missing-workspace errors.
  * Refined `pnpm update --depth` so depth limits apply per dependency, with correct `--depth 0` behavior.
* **Tests**
  * Expanded coverage for `--workspace` and `--depth 0`, including new negative cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->