### PR TITLE
test(pacquet): drop a leftover debug print in the engineStrict port

### DIFF
--- a/pnpm/crates/cli/tests/optional_dependencies.rs
+++ b/pnpm/crates/cli/tests/optional_dependencies.rs
@@ -903,7 +903,6 @@ fn fail_on_unsupported_dependency_of_optional_dependency() {
         .assert()
         .failure();
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
-    eprintln!("STDERR:\n{stderr}\n");
     assert!(
         stderr.contains("ERR_PNPM_UNSUPPORTED_PLATFORM"),
         "the incompatible regular dependency of an installable optional must fail the install; got:\n{stderr}",


### PR DESCRIPTION
## Summary

Rebased onto `main`. The stale `known_failures` stub this PR originally removed landed upstream in the meantime, so what remains is one line: `fail_on_unsupported_dependency_of_optional_dependency` printed the captured stderr unconditionally on its way to asserting on it, so every run of the suite emitted the install's error output as noise. The assertion already interpolates the same stderr into its failure message.

`cargo nextest run -p pacquet-cli --test optional_dependencies fail_on_unsupported` passes on the rebased base.

## Squash Commit Body

```text
`fail_on_unsupported_dependency_of_optional_dependency` printed the
captured stderr unconditionally on its way to asserting on it, so every
run of the suite emitted the install's error output as noise. The
assertion already includes the stderr in its failure message.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(Test-only cleanup in the Rust stack; no behavior change, nothing to mirror.)*
- [x] Added or updated tests. *(Removes debug output from an existing test; its assertions are unchanged.)*

*No changeset: no published behavior changes.*

---
Written by an agent (Claude Code, claude-opus-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reduced unnecessary diagnostic output during automated checks by removing extra captured `stderr` logging.
  * Continued asserting that unsupported optional dependency platform failures report the expected error.

* **Bug Fixes**
  * Strengthened verification that unsupported optional dependencies report the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->