### PR TITLE
feat(pacquet): add the -w / --workspace-root option

### DIFF
--- a/.changeset/pacquet-workspace-root-flag.md
+++ b/.changeset/pacquet-workspace-root-flag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added the `-w` / `--workspace-root` option, which runs the command on the root workspace project from any directory inside the workspace — so `pnpm add -D pkg-a pkg-b -w` from a workspace package saves the dependencies to the workspace root's `package.json` [#13031](https://github.com/pnpm/pnpm/issues/13031). Combining it with `--global` fails with `ERR_PNPM_OPTIONS_CONFLICT`, and using it outside a workspace fails with `ERR_PNPM_NOT_IN_WORKSPACE`.

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -77,6 +77,8 @@ use super::{
     with::WithArgs,
 };
 use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
 use pacquet_default_reporter::SummaryScope;
 use std::path::PathBuf;
 
@@ -151,6 +153,13 @@ pub struct CliArgs {
     /// the project in `--dir`.
     #[clap(short = 'r', long, global = true)]
     pub recursive: bool,
+
+    /// Run the command on the root workspace project, whatever directory
+    /// it is invoked from.
+    // Resolved by `CliArgs::apply_workspace_root`, which folds the flag
+    // into `dir` before dispatch.
+    #[clap(short = 'w', long = "workspace-root", global = true)]
+    pub workspace_root: bool,
 
     /// Reporter output format.
     // Self-override so a repeated `--reporter` takes the last occurrence,
@@ -250,6 +259,31 @@ impl CliArgs {
         if !self.filter.is_empty() || !self.filter_prod.is_empty() {
             self.recursive = true;
         }
+    }
+
+    /// Re-anchor `--dir` at the workspace root for `-w` /
+    /// `--workspace-root`, so the command runs on the root project from
+    /// anywhere inside the workspace.
+    ///
+    /// Rewriting `dir` is the whole implementation, matching pnpm: every
+    /// command already resolves its project from `dir`, so none of them
+    /// need to know the flag exists.
+    pub fn apply_workspace_root(&mut self) -> Result<(), WorkspaceRootError> {
+        if !self.workspace_root {
+            return Ok(());
+        }
+        if self.command.is_global() {
+            return Err(WorkspaceRootError::ConflictsWithGlobal);
+        }
+        // The upward walk needs a real path to climb: `--dir` still holds
+        // whatever was typed, and its default `.` has no parent to walk to.
+        // Dispatch canonicalizes `dir` again later, which is idempotent.
+        let from = dunce::canonicalize(&self.dir).unwrap_or_else(|_| self.dir.clone());
+        let workspace_dir = pacquet_workspace::find_workspace_dir(&from)
+            .map_err(|_| WorkspaceRootError::NotInWorkspace)?
+            .ok_or(WorkspaceRootError::NotInWorkspace)?;
+        self.dir = workspace_dir;
+        Ok(())
     }
 
     /// Promote commands marked recursive-by-default by pnpm when they run
@@ -526,6 +560,25 @@ pub enum CliCommand {
 }
 
 impl CliCommand {
+    /// Whether the command was given `-g` / `--global`. Only the commands
+    /// that expose the flag can answer yes; the rest have no global mode
+    /// to conflict with.
+    fn is_global(&self) -> bool {
+        match self {
+            CliCommand::Add(args) => args.global,
+            CliCommand::Bin(args) => args.global,
+            CliCommand::Config(args) => args.is_global(),
+            CliCommand::List(args) | CliCommand::Ll(args) => args.global,
+            CliCommand::Outdated(args) => args.global,
+            CliCommand::Prefix(args) => args.global,
+            CliCommand::Remove(args) => args.global,
+            CliCommand::Root(args) => args.global,
+            CliCommand::Runtime(args) => args.global,
+            CliCommand::Update(args) => args.global,
+            _ => false,
+        }
+    }
+
     fn recursive_by_default(&self) -> bool {
         matches!(
             self,
@@ -551,4 +604,28 @@ impl CliCommand {
             _ => SummaryScope::CurrentPrefix,
         }
     }
+}
+
+/// `-w` / `--workspace-root` could not be honored. Mirrors the two
+/// conditions pnpm rejects when resolving the flag.
+#[derive(Debug, Display, Error, Diagnostic)]
+pub enum WorkspaceRootError {
+    /// Mirrors pnpm's `ERR_PNPM_OPTIONS_CONFLICT`.
+    #[display("--workspace-root may not be used with --global")]
+    #[diagnostic(
+        code(ERR_PNPM_OPTIONS_CONFLICT),
+        help(
+            "Drop --global to act on the workspace root, or drop --workspace-root to act on the globally installed packages."
+        )
+    )]
+    ConflictsWithGlobal,
+    /// Mirrors pnpm's `ERR_PNPM_NOT_IN_WORKSPACE`.
+    #[display("--workspace-root may only be used inside a workspace")]
+    #[diagnostic(
+        code(ERR_PNPM_NOT_IN_WORKSPACE),
+        help(
+            "Run the command from a directory inside a workspace — one with a pnpm-workspace.yaml at its root."
+        )
+    )]
+    NotInWorkspace,
 }

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -34,6 +34,19 @@ pub struct ConfigArgs {
     pub command: ConfigSubcommand,
 }
 
+impl ConfigArgs {
+    /// Whether `-g` / `--global` was given. The flag lives on each
+    /// subcommand's [`ConfigFlags`] rather than on [`ConfigArgs`] itself.
+    pub(crate) fn is_global(&self) -> bool {
+        match &self.command {
+            ConfigSubcommand::Set(args) => args.flags.global,
+            ConfigSubcommand::Get(args) => args.flags.global,
+            ConfigSubcommand::Delete(args) => args.flags.global,
+            ConfigSubcommand::List(args) => args.flags.global,
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum ConfigSubcommand {
     /// Set the config key to the value provided.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -154,6 +154,9 @@ impl CliArgs {
             version: _,
             color: _,
             yes: _,
+            // Consumed before dispatch by `CliArgs::apply_workspace_root`,
+            // which folds it into `dir`.
+            workspace_root: _,
             sort: _,
             no_sort,
             workspace_concurrency,

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -88,6 +88,9 @@ fn run_cli() -> miette::Result<()> {
     if let Err(err) = args.validate_command_scoped_global_options() {
         err.exit();
     }
+    // Before the recursive promotions and the install fast path, both of
+    // which resolve the project from `--dir`.
+    args.apply_workspace_root()?;
     args.promote_recursive_for_filter();
     args.promote_recursive_by_default();
     if let Some(plan) = cli_args::switch_cli_version::switch_plan(&args, &config_overrides)?

--- a/pnpm/crates/cli/tests/optional_dependencies.rs
+++ b/pnpm/crates/cli/tests/optional_dependencies.rs
@@ -252,38 +252,6 @@ fn forced_frozen_install_materializes_incompatible_optionals() {
     drop((root, npmrc_info)); // cleanup
 }
 
-mod known_failures {
-    //! Optional-dependency cases blocked on engine behavior pacquet
-    //! hasn't built yet. Each entry stubs the not-yet-built subject
-    //! under test through [`pacquet_testing_utils::allow_known_failure`]
-    //! so the test exits early rather than masking a real bug.
-
-    use pacquet_testing_utils::{
-        allow_known_failure,
-        known_failure::{KnownFailure, KnownResult},
-    };
-
-    fn edge_aware_engine_strict() -> KnownResult<()> {
-        Err(KnownFailure::new(
-            "pacquet's `engineStrict` dispatch keys on the lockfile's \
-             snapshot-level `optional: true` flag, so an incompatible \
-             package that is only optionally *reachable* is skipped even \
-             when its inbound edge is a regular dependency. Upstream \
-             evaluates installability per edge at resolve time and fails \
-             this shape (pnpm/pnpm#13143).",
-        ))
-    }
-
-    /// TS: `fail on unsupported dependency of optional dependency`
-    /// (`optionalDependencies.ts:552`). Under `engineStrict`, an
-    /// installable optional whose *regular* dependency is incompatible
-    /// fails the install upstream.
-    #[test]
-    fn fail_on_unsupported_dependency_of_optional_dependency() {
-        allow_known_failure!(edge_aware_engine_strict());
-    }
-}
-
 /// TS: `only skip optional dependencies`
 /// (`optionalDependencies.ts:610`).
 #[test]
@@ -935,7 +903,6 @@ fn fail_on_unsupported_dependency_of_optional_dependency() {
         .assert()
         .failure();
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
-    eprintln!("STDERR:\n{stderr}\n");
     assert!(
         stderr.contains("ERR_PNPM_UNSUPPORTED_PLATFORM"),
         "the incompatible regular dependency of an installable optional must fail the install; got:\n{stderr}",

--- a/pnpm/crates/cli/tests/workspace_root.rs
+++ b/pnpm/crates/cli/tests/workspace_root.rs
@@ -1,0 +1,114 @@
+//! `-w` / `--workspace-root`: run the command on the root workspace
+//! project from anywhere inside the workspace.
+
+pub mod _utils;
+pub use _utils::*;
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::CommandTempCwd;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// A workspace whose root and one member both carry a manifest, plus the
+/// nested directory the command is invoked from.
+fn workspace_with_member(workspace: &Path) -> PathBuf {
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write the root manifest");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - 'packages/*'\n")
+        .expect("write pnpm-workspace.yaml");
+    let member = workspace.join("packages/foo");
+    fs::create_dir_all(&member).expect("create the member dir");
+    fs::write(member.join("package.json"), r#"{ "name": "foo", "version": "1.0.0" }"#)
+        .expect("write the member manifest");
+    member
+}
+
+/// The reported shape of pnpm/pnpm#13031: several packages added to the
+/// workspace root from a member directory.
+#[test]
+fn add_with_workspace_root_saves_to_the_root_manifest() {
+    let fixture = WorkspaceFixture::new();
+    fixture.write_root_manifest("root", ManifestDeps::default());
+    let member = fixture.project("foo", "foo", ManifestDeps::default());
+
+    let output =
+        fixture.command_at(&member, ["add", "-D", "is-positive@1.0.0", "is-negative@1.0.0", "-w"]);
+    assert!(output.status.success(), "add -w should succeed: {output:?}");
+
+    let root_dev = read_manifest(&fixture.workspace)["devDependencies"].clone();
+    assert_eq!(root_dev["is-positive"], "1.0.0");
+    assert_eq!(root_dev["is-negative"], "1.0.0");
+    assert!(
+        read_manifest(&member).get("devDependencies").is_none(),
+        "the member the command ran from must keep its manifest untouched",
+    );
+}
+
+/// `-w` re-anchors the command's directory, so a command that reports
+/// where it is running reports the workspace root.
+#[test]
+fn workspace_root_runs_the_command_on_the_root_project() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let member = workspace_with_member(&workspace);
+    let nested = member.join("src/utils");
+    fs::create_dir_all(&nested).expect("create the nested dir");
+
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&nested)
+        .with_args(["prefix", "-w"])
+        .output()
+        .expect("run pnpm prefix -w");
+    assert!(output.status.success(), "prefix -w should succeed: {output:?}");
+
+    let expected = dunce::canonicalize(&workspace).expect("canonicalize the workspace");
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim_end(), expected.display().to_string());
+
+    drop(root);
+}
+
+/// `--global` acts on the globally installed packages, which have no
+/// workspace root — pnpm rejects the pair rather than picking one.
+#[test]
+fn workspace_root_conflicts_with_global() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let member = workspace_with_member(&workspace);
+
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&member)
+        .with_args(["prefix", "-g", "-w"])
+        .output()
+        .expect("run pnpm prefix -g -w");
+    assert!(!output.status.success(), "-g with -w must fail: {output:?}");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_OPTIONS_CONFLICT"),
+        "stderr should carry pnpm's conflict code: {stderr}",
+    );
+
+    drop(root);
+}
+
+#[test]
+fn workspace_root_outside_a_workspace_is_an_error() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "name": "lonely", "version": "1.0.0" }"#)
+        .expect("write the manifest");
+
+    let output = pacquet.with_args(["prefix", "-w"]).output().expect("run pnpm prefix -w");
+    assert!(!output.status.success(), "-w outside a workspace must fail: {output:?}");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_NOT_IN_WORKSPACE"),
+        "stderr should carry pnpm's not-in-workspace code: {stderr}",
+    );
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

`pnpm add -D oxlint@latest oxfmt@latest oxlint-tsgolint@latest -w` (pnpm/pnpm#13031) still fails on current `main`. The multi-package half was fixed earlier; what remains is the flag:

```
$ pnpm add -D oxlint@latest oxfmt@latest -w
error: unexpected argument '-w' found
```

pacquet had no `-w` / `--workspace-root` at all. This adds it, implemented where pnpm implements it — as a universal option resolved before dispatch that rewrites `--dir` to the workspace root. Every command already resolves its project from `dir`, so no command needs to know the flag exists.

Both of pnpm's guards come along:

| case | code |
|---|---|
| `-w` with `--global` | `ERR_PNPM_OPTIONS_CONFLICT` |
| `-w` outside a workspace | `ERR_PNPM_NOT_IN_WORKSPACE` |

`--global` is per-command in pacquet rather than universal, so `CliCommand::is_global` asks the ten commands that expose it; `config` keeps its copy on each subcommand's `ConfigFlags`, hence the small accessor there.

One subtlety worth calling out for review: the upward walk runs on a **canonicalized** path. At this point `--dir` still holds whatever was typed, and its default `.` has no parent to climb — searching from it reports "not in a workspace" from every directory. Dispatch canonicalizes `dir` again later, which is idempotent.

### Verification

Behavior checked against the built TypeScript bundle rather than inferred from its source — identical in all four cases:

| invocation (from `packages/foo/src/utils`) | TypeScript CLI | pacquet |
|---|---|---|
| `pnpm prefix` | `…/wroot/packages/foo` | same |
| `pnpm prefix -w` | `…/wroot` | same |
| `pnpm prefix -g -w` | `--workspace-root may not be used with --global` | same + `ERR_PNPM_OPTIONS_CONFLICT` |
| `pnpm prefix -w` outside a workspace | `--workspace-root may only be used inside a workspace` | same + `ERR_PNPM_NOT_IN_WORKSPACE` |

Four tests in `crates/cli/tests/workspace_root.rs`, including the reported `add -D … -w` shape asserting the deps land in the root manifest and *not* in the member the command ran from. I checked the tests fail against a deliberately neutered re-anchor before committing (2 of 4 fail, the two behavioral ones).

`just ready` green (6936 tests) and `cargo dylint` clean.

Fixes pnpm/pnpm#13031.

## Squash Commit Body

```text
pnpm's `-w` runs a command on the root workspace project from anywhere
inside the workspace; pacquet had no such flag, so the reported
`pnpm add -D oxlint@latest oxfmt@latest oxlint-tsgolint@latest -w` failed
with "unexpected argument '-w' found". Multi-package `add` was fixed
earlier, leaving the flag as the remaining half of that report.

Implemented where pnpm implements it — as a universal option resolved
before dispatch, by rewriting `--dir` to the workspace root. Every command
already resolves its project from `dir`, so none of them need to know the
flag exists.

The upward walk runs on a canonicalized path: `--dir` still holds whatever
was typed at this point, and its default `.` has no parent to climb, so
searching from it would report "not in a workspace" from every directory.

Both of pnpm's guards come along: `--global` has no workspace root to act
on (`ERR_PNPM_OPTIONS_CONFLICT`), and outside a workspace there is nothing
to re-anchor to (`ERR_PNPM_NOT_IN_WORKSPACE`). `--global` is per-command in
pacquet rather than universal, so `CliCommand::is_global` asks the ten
commands that expose it; `config` keeps its copy on each subcommand's
`ConfigFlags`, hence the accessor there.

Verified against the TypeScript CLI: `prefix -w`, plain `prefix`, `-g -w`,
and `-w` outside a workspace all produce identical results in both stacks.

Fixes pnpm/pnpm#13031.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(pacquet-only catch-up: the TypeScript CLI already has `-w`.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. *(The flag documents itself in `--help`; pnpm.io already documents `-w`.)*

### Follow-up, deliberately not in this PR

pnpm also refuses a bare `pnpm add` at the workspace root when the workspace defines more than one package pattern, telling the user to pass `-w` (`ERR_PNPM_ADDING_TO_ROOT`, bypassed by `ignoreWorkspaceRootCheck`). pacquet knows the `ignore-workspace-root-check` config key but has no such guard. That is a separate behavior change — it makes a currently-working command start failing — so it belongs in its own PR rather than riding along with the flag it references.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787563132&installation_model_id=426870&pr_number=13294&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13294&signature=07a99e01aaf2a42dc0f18636ed8b7a33829ea7178a5539c932c7ca369ac241e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `-w` / `--workspace-root` to run commands against the workspace root from any workspace directory.
  * Workspace-local dependency installs can now save dependencies to the root project manifest.
* **Bug Fixes**
  * Added clear errors when combining `--workspace-root` with global mode or using it outside a workspace.
* **Documentation**
  * Documented the new workspace-root option and its expected error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->