### PR TITLE
fix(cli): reject a --workspace-root --dir that points outside the workspace

### DIFF
--- a/.changeset/workspace-root-dir-outside-workspace.md
+++ b/.changeset/workspace-root-dir-outside-workspace.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `--workspace-root` (`-w`) selecting the current workspace when `--dir` pointed at a nonexistent directory outside it (for example `pnpm --dir ../../elsewhere add -w foo`). The command now fails with `ERR_PNPM_NOT_IN_WORKSPACE`, matching pnpm. A nonexistent `--dir` inside the workspace still resolves to the workspace root as before.

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -80,6 +80,7 @@ use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_default_reporter::SummaryScope;
+use pipe_trait::Pipe;
 use std::path::PathBuf;
 
 /// Experimental package manager for node.js written in rust.
@@ -281,11 +282,10 @@ impl CliArgs {
         if self.command.is_global() {
             return Err(WorkspaceRootError::GlobalConflict);
         }
-        let dir =
-            dunce::canonicalize(&self.dir).or_else(|_| std::path::absolute(&self.dir)).map_or_else(
-                |_| pacquet_fs::lexical_normalize(&self.dir),
-                |dir| pacquet_fs::lexical_normalize(&dir),
-            );
+        let dir = dunce::canonicalize(&self.dir)
+            .or_else(|_| std::path::absolute(&self.dir))
+            .unwrap_or_else(|_| self.dir.clone())
+            .pipe_deref(pacquet_fs::lexical_normalize);
         let workspace_dir = pacquet_workspace::find_workspace_dir(&dir)
             .map_err(WorkspaceRootError::FindWorkspaceDir)?
             .ok_or(WorkspaceRootError::NotInWorkspace)?;

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -267,6 +267,13 @@ impl CliArgs {
     /// first, because a case-insensitive filesystem otherwise finds the
     /// root under one spelling and the members under another; then a
     /// lexical fallback, so an unresolvable `--dir` is not fatal.
+    ///
+    /// The fallback resolves `..` itself rather than leaving the components
+    /// in place. [`pacquet_workspace::find_workspace_dir`] walks ancestors
+    /// lexically, so a `--dir` that climbs out of the workspace and lands
+    /// on a directory that does not exist — `../../elsewhere` — would
+    /// otherwise walk right back up through its own `..` components and
+    /// select the workspace the user pointed away from.
     pub fn apply_workspace_root(&mut self) -> Result<(), WorkspaceRootError> {
         if !self.workspace_root {
             return Ok(());
@@ -274,9 +281,11 @@ impl CliArgs {
         if self.command.is_global() {
             return Err(WorkspaceRootError::GlobalConflict);
         }
-        let dir = dunce::canonicalize(&self.dir)
-            .or_else(|_| std::path::absolute(&self.dir))
-            .unwrap_or_else(|_| self.dir.clone());
+        let dir =
+            dunce::canonicalize(&self.dir).or_else(|_| std::path::absolute(&self.dir)).map_or_else(
+                |_| pacquet_fs::lexical_normalize(&self.dir),
+                |dir| pacquet_fs::lexical_normalize(&dir),
+            );
         let workspace_dir = pacquet_workspace::find_workspace_dir(&dir)
             .map_err(WorkspaceRootError::FindWorkspaceDir)?
             .ok_or(WorkspaceRootError::NotInWorkspace)?;

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -268,11 +268,8 @@ fn add_workspace_root_tolerates_a_dir_that_does_not_exist() {
     drop(root); // cleanup
 }
 
-/// A nonexistent `--dir` that climbs *out* of the workspace is a
-/// different case from one that stays inside it: the workspace the
-/// command was invoked from must not be selected after the user pointed
-/// away from it. The ancestor walk is lexical, so the `..` components
-/// have to be resolved before it runs, or it climbs back through them.
+/// The counterpart to the tolerated nonexistent `--dir` above: one that
+/// climbs *out* of the workspace must not fall back to it.
 #[test]
 fn add_workspace_root_rejects_a_dir_that_climbs_out_of_the_workspace() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -268,8 +268,7 @@ fn add_workspace_root_tolerates_a_dir_that_does_not_exist() {
     drop(root); // cleanup
 }
 
-/// The counterpart to the tolerated nonexistent `--dir` above: one that
-/// climbs *out* of the workspace must not fall back to it.
+/// The counterpart to the tolerated nonexistent `--dir` above.
 #[test]
 fn add_workspace_root_rejects_a_dir_that_climbs_out_of_the_workspace() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -268,6 +268,37 @@ fn add_workspace_root_tolerates_a_dir_that_does_not_exist() {
     drop(root); // cleanup
 }
 
+/// A nonexistent `--dir` that climbs *out* of the workspace is a
+/// different case from one that stays inside it: the workspace the
+/// command was invoked from must not be selected after the user pointed
+/// away from it. The ancestor walk is lexical, so the `..` components
+/// have to be resolved before it runs, or it climbs back through them.
+#[test]
+fn add_workspace_root_rejects_a_dir_that_climbs_out_of_the_workspace() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_with_local_fixtures(&workspace);
+
+    let output = pacquet
+        .with_args([
+            "--dir",
+            "../../outside-does-not-exist",
+            "add",
+            "-D",
+            "local-a@file:./fixtures/local-a",
+            "-w",
+        ])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_NOT_IN_WORKSPACE"),
+        "a --dir pointing outside the workspace must not fall back to it: {stderr}",
+    );
+
+    drop(root); // cleanup
+}
+
 /// `pnpm add -D <pkg> <pkg> -w` run from a workspace subdirectory
 /// (pnpm/pnpm#13031).
 #[test]


### PR DESCRIPTION
## Summary

`-w` landed in pnpm/pnpm#13281. One shape of `--dir` still disagrees with pnpm: a nonexistent directory *outside* the workspace silently selects the workspace the command was invoked from.

| `--dir` (run from `wroot/packages/child`) | pacquet before | TypeScript CLI |
|---|---|---|
| `./missing-subdir` — missing, inside the workspace | workspace root | workspace root ✅ |
| `../../../outside-missing` — missing, outside | **workspace root** | `ERR_PNPM_NOT_IN_WORKSPACE` ❌ |
| `/tmp` — exists, outside | `ERR_PNPM_NOT_IN_WORKSPACE` | same ✅ |

`apply_workspace_root` falls back to `std::path::absolute` when `--dir` cannot be canonicalized — that fallback is what keeps the first row working, and it is deliberate. But on Unix `absolute` leaves `..` components in place, and `find_workspace_dir` walks ancestors lexically, so the walk climbed back up through the very `..` components that had taken it out of the workspace:

```
/wroot/packages/child/../../../outside-missing
  → /wroot/packages/child/../../..   (no manifest)
  → /wroot/packages/child/../..      (no manifest)
  → /wroot/packages/child/..         → finds /wroot   ← the workspace the user pointed away from
```

The fix resolves `..` in the fallback with `pacquet_fs::lexical_normalize` — the repo's existing filesystem-free normalizer, already used by `is_subdir` — before the walk. All three rows now match the TypeScript CLI.

Propagating the canonicalization failure instead (the other obvious fix) would break row 1, which pnpm supports and pnpm/pnpm#13281 covers with `add_workspace_root_tolerates_a_dir_that_does_not_exist`.

### Provenance

Found by CodeRabbit reviewing pnpm/pnpm#13294 — a duplicate `-w` implementation I closed in favor of pnpm/pnpm#13281. The finding turned out to apply to the merged code, not just the duplicate, so it is worth landing on its own.

### Verification

New test `add_workspace_root_rejects_a_dir_that_climbs_out_of_the_workspace` alongside the existing `-w` tests; confirmed it fails against the pre-fix fallback before committing. `just ready` green (7005 tests), `cargo dylint` clean, and the three `--dir` shapes above re-checked against the built TypeScript bundle.

## Squash Commit Body

```text
`pnpm --dir ../../elsewhere add -w foo` from inside a workspace added to
that workspace's root instead of failing, when `../../elsewhere` did not
exist. pnpm reports ERR_PNPM_NOT_IN_WORKSPACE.

`apply_workspace_root` falls back to `std::path::absolute` when the `--dir`
cannot be canonicalized, which is what keeps a nonexistent `--dir` inside
the workspace working. On Unix that leaves `..` components in place, and
`find_workspace_dir` walks ancestors lexically — so the walk climbed back
up through the very `..` components that had taken it out of the workspace
and found the workspace it had just left.

Resolve `..` in the fallback with `pacquet_fs::lexical_normalize` (the
existing filesystem-free normalizer) before the walk. A nonexistent `--dir`
that stays inside the workspace still resolves to the root, and an existing
directory outside it still errors — both already covered by tests.

Found by CodeRabbit on pnpm/pnpm#13294, a duplicate of pnpm/pnpm#13281
closed in favor of it; the finding applies to the merged implementation.
Verified against the TypeScript CLI: all three `--dir` shapes now agree.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(pacquet-only: this aligns pacquet with the TypeScript CLI's existing behavior.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. *(No user-facing docs describe this edge case.)*

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787564500&installation_model_id=426870&pr_number=13297&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13297&signature=d02ea40029a9a911e4064522a38d3a340f8b472c1c5724fd35c776b50095ffc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `--workspace-root` now returns `ERR_PNPM_NOT_IN_WORKSPACE` when `--dir` points to a nonexistent location outside the current workspace.
  * Improved workspace detection so path traversal via `..` no longer incorrectly falls back to the workspace root.
  * Kept the existing behavior when `--dir` refers to a nonexistent path inside the workspace.
* **Tests**
  * Added an end-to-end regression test covering the outside-workspace `--dir` failure case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->