### PR TITLE
feat(update): group the interactive update list by dependency type

### DIFF
--- a/.changeset/interactive-update-groups-choices.md
+++ b/.changeset/interactive-update-groups-choices.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm update --interactive` now groups the dependencies it offers by dependency type — `dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`, and GitHub Actions each get their own heading — and lays each group out as a column-aligned table with a `Package`/`Current`/`Target`/`URL` header, instead of one flat list.

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -1012,6 +1012,17 @@ fn render_package_name(pkg: &OutdatedPackage) -> String {
     }
 }
 
+/// The `target` version with the segment that changed highlighted, and
+/// nothing else — the form the interactive update list shows, where a
+/// deprecation is not part of the row.
+pub(crate) fn colorize_target(pkg: &OutdatedPackage) -> String {
+    let change = classify(&pkg.current, &pkg.target);
+    if change == Change::None {
+        return pkg.target.to_string();
+    }
+    colorize_version(&pkg.target, change)
+}
+
 fn render_latest(pkg: &OutdatedPackage) -> String {
     let change = classify(&pkg.current, &pkg.target);
     if change == Change::None {

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -11,8 +11,9 @@
 //! callers differ only in
 //! the [`TargetVersion`] they compare against: `update` targets the
 //! version a bump would move to (the `latest` tag under `--latest`,
-//! otherwise the highest in-range version). The choice list is
-//! intentionally flat; the prompt is a `dialoguer` multi-select.
+//! otherwise the highest in-range version). [`choices::update_choices`]
+//! turns that set into the grouped, column-aligned list the prompt — a
+//! `dialoguer` multi-select — renders.
 
 use crate::{
     cli_args::{
@@ -23,6 +24,7 @@ use crate::{
 };
 use dialoguer::MultiSelect;
 use miette::{IntoDiagnostic, miette};
+use owo_colors::{OwoColorize, Stream};
 use pacquet_config::Config;
 use pacquet_lockfile::Lockfile;
 use pacquet_network::ThrottledClient;
@@ -190,17 +192,8 @@ fn prompt_for_packages(
         return Ok(None);
     }
 
-    let labels: Vec<String> = choices
-        .iter()
-        .map(|choice| {
-            let name = if choice.github_action {
-                format!("{} (github action)", choice.alias)
-            } else {
-                choice.alias.clone()
-            };
-            format!("{name} {} ❯ {}", choice.current, choice.target)
-        })
-        .collect();
+    let groups = choices::update_choices(&choices.iter().collect::<Vec<_>>());
+    let (labels, values) = flatten_groups(&groups);
 
     let selected_indices = MultiSelect::new()
         .with_prompt("Choose which dependencies to update (space to select, enter to confirm)")
@@ -209,14 +202,51 @@ fn prompt_for_packages(
         .into_diagnostic()
         .map_err(|err| miette!("interactive update selection failed: {err}"))?;
 
-    let selected: Vec<String> =
-        selected_indices.into_iter().map(|index| choices[index].alias.clone()).collect();
-
+    let selected = selected_packages(&values, &selected_indices);
     if selected.is_empty() {
         return Ok(None);
     }
     Ok(Some(selected))
 }
+
+/// Flatten the groups into the one item list `dialoguer` takes, paired
+/// with the package each item updates. A group heading and a group's
+/// header row have no package: `dialoguer` cannot mark an item
+/// unselectable the way pnpm's prompt does, so [`selected_packages`]
+/// drops them from the answer instead.
+fn flatten_groups(groups: &[choices::ChoiceGroup]) -> (Vec<String>, Vec<Option<String>>) {
+    let mut labels = Vec::new();
+    let mut values = Vec::new();
+    for group in groups {
+        labels.push(bold(&group.message));
+        values.push(None);
+        for row in &group.rows {
+            labels.push(row.label.clone());
+            values.push(row.value.clone());
+        }
+    }
+    (labels, values)
+}
+
+/// The packages behind `indices`, in the order the user checked them and
+/// without repeats — the same package can be offered by two importers.
+fn selected_packages(values: &[Option<String>], indices: &[usize]) -> Vec<String> {
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for &index in indices {
+        let Some(value) = values.get(index).and_then(Option::as_ref) else { continue };
+        if seen.insert(value.as_str()) {
+            selected.push(value.clone());
+        }
+    }
+    selected
+}
+
+fn bold(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
+}
+
+mod choices;
 
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -4,7 +4,10 @@
 //! split into one group per dependency type, and each group is rendered
 //! as a column-aligned table under a header row.
 
-use crate::cli_args::outdated::{OutdatedPackage, colorize_target};
+use crate::cli_args::{
+    outdated::{OutdatedPackage, colorize_target},
+    sanitize::sanitize_inline,
+};
 use pacquet_package_manifest::DependencyGroup;
 use std::collections::HashSet;
 
@@ -70,15 +73,19 @@ impl ChoiceGroupKind {
 /// `groupBy`.
 ///
 /// A package that is outdated in more than one dependency type appears
-/// once, under whichever type came first: the deduplication key is the
-/// package, its versions, and whether it is a GitHub Action — not the
-/// dependency type. This matches pnpm, whose `uniqBy` runs before its
-/// `groupBy` over the same key.
+/// once, under whichever type came first: the deduplication key omits
+/// the dependency type. This matches pnpm, whose `uniqBy` runs before
+/// its `groupBy` over the same key.
 pub(crate) fn update_choices(outdated: &[&OutdatedPackage]) -> Vec<ChoiceGroup> {
     let mut seen = HashSet::new();
     let mut grouped: Vec<(ChoiceGroupKind, Vec<&OutdatedPackage>)> = Vec::new();
     for package in outdated {
+        // Keyed by alias as well as package name, because the alias is
+        // what a selected row updates: two manifest entries aliasing one
+        // package (`"a": "npm:foo@1"`, `"b": "npm:foo@1"`) are separate
+        // dependencies and both have to be offered.
         let key = (
+            package.alias.as_str(),
             package.package_name.as_str(),
             package.current.to_string(),
             package.target.to_string(),
@@ -116,12 +123,16 @@ fn render_rows(packages: &[&OutdatedPackage]) -> Vec<ChoiceRow> {
 
     let mut cells = vec![header];
     for package in packages {
+        // The name and homepage are registry metadata, so they are
+        // stripped of control characters before reaching the terminal:
+        // an escape sequence would corrupt the prompt's redraw, and a
+        // newline would break the row apart.
         let row = vec![
-            package.package_name.clone(),
+            sanitize_inline(&package.package_name).into_owned(),
             package.current.to_string(),
             "❯".to_string(),
             colorize_target(package),
-            package.homepage.clone().unwrap_or_default(),
+            package.homepage.as_deref().map(sanitize_inline).unwrap_or_default().into_owned(),
         ];
         cells.push(row);
     }
@@ -181,7 +192,14 @@ fn pad_row(row: &[String], widths: &[usize]) -> String {
     line.trim_end().to_string()
 }
 
-/// The displayed width of `text`, ignoring ANSI colour escapes.
+/// The column width of `text`, skipping the SGR escapes that colour it.
+///
+/// Only the colouring this module applies through [`colorize_target`]
+/// reaches here — every other cell is stripped of control characters by
+/// [`sanitize_inline`] first — so this handles the `ESC [ … m` sequences
+/// `owo_colors` emits rather than ANSI in general. Width is counted in
+/// characters, which matches column width for the ASCII that package
+/// names and semver versions are made of.
 fn printable_width(text: &str) -> usize {
     let mut width = 0;
     let mut chars = text.chars();

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -1,0 +1,203 @@
+//! The choice list `pacquet update --interactive` presents.
+//!
+//! Mirrors pnpm's `getUpdateChoices`: the outdated set is deduplicated,
+//! split into one group per dependency type, and each group is rendered
+//! as a column-aligned table under a header row.
+
+use crate::cli_args::outdated::{OutdatedPackage, colorize_target};
+use pacquet_package_manifest::DependencyGroup;
+use std::collections::HashSet;
+
+/// One line of a [`ChoiceGroup`].
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ChoiceRow {
+    /// The rendered, column-aligned line shown in the prompt.
+    pub label: String,
+    /// The package name selecting this row updates. `None` marks the
+    /// group's header row, which carries no selection — pnpm renders it
+    /// as a disabled entry, and `dialoguer` has no such notion, so
+    /// [`super::prompt_for_packages`] drops it from the result instead.
+    pub value: Option<String>,
+}
+
+/// The outdated dependencies of one dependency type.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ChoiceGroup {
+    /// The heading shown above the group.
+    pub message: String,
+    pub rows: Vec<ChoiceRow>,
+}
+
+/// The dependency type a choice is grouped under. GitHub Actions form
+/// their own group even though they are read out of `devDependencies`.
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum ChoiceGroupKind {
+    Prod,
+    Dev,
+    Optional,
+    Peer,
+    GitHubAction,
+}
+
+impl ChoiceGroupKind {
+    fn of(package: &OutdatedPackage) -> Self {
+        if package.github_action {
+            return ChoiceGroupKind::GitHubAction;
+        }
+        match package.belongs_to {
+            DependencyGroup::Prod => ChoiceGroupKind::Prod,
+            DependencyGroup::Dev => ChoiceGroupKind::Dev,
+            DependencyGroup::Optional => ChoiceGroupKind::Optional,
+            DependencyGroup::Peer => ChoiceGroupKind::Peer,
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            ChoiceGroupKind::Prod => "dependencies",
+            ChoiceGroupKind::Dev => "devDependencies",
+            ChoiceGroupKind::Optional => "optionalDependencies",
+            ChoiceGroupKind::Peer => "peerDependencies",
+            ChoiceGroupKind::GitHubAction => "GitHub Actions",
+        }
+    }
+}
+
+/// Group `outdated` for the interactive prompt.
+///
+/// Groups appear in the order their dependency type is first seen, which
+/// is the order the outdated set was collected in, matching pnpm's
+/// `groupBy`.
+///
+/// A package that is outdated in more than one dependency type appears
+/// once, under whichever type came first: the deduplication key is the
+/// package, its versions, and whether it is a GitHub Action — not the
+/// dependency type. This matches pnpm, whose `uniqBy` runs before its
+/// `groupBy` over the same key.
+pub(crate) fn update_choices(outdated: &[&OutdatedPackage]) -> Vec<ChoiceGroup> {
+    let mut seen = HashSet::new();
+    let mut grouped: Vec<(ChoiceGroupKind, Vec<&OutdatedPackage>)> = Vec::new();
+    for package in outdated {
+        let key = (
+            package.package_name.as_str(),
+            package.current.to_string(),
+            package.target.to_string(),
+            package.github_action,
+        );
+        if !seen.insert(key) {
+            continue;
+        }
+        let kind = ChoiceGroupKind::of(package);
+        match grouped.iter_mut().find(|(group, _)| *group == kind) {
+            Some((_, packages)) => packages.push(package),
+            None => grouped.push((kind, vec![*package])),
+        }
+    }
+
+    grouped
+        .into_iter()
+        .map(|(kind, packages)| ChoiceGroup {
+            message: kind.message().to_string(),
+            rows: render_rows(&packages),
+        })
+        .collect()
+}
+
+/// The header row plus one row per package, padded so every column lines
+/// up within the group.
+fn render_rows(packages: &[&OutdatedPackage]) -> Vec<ChoiceRow> {
+    let header = vec![
+        "Package".to_string(),
+        "Current".to_string(),
+        String::new(),
+        "Target".to_string(),
+        "URL".to_string(),
+    ];
+
+    let mut cells = vec![header];
+    for package in packages {
+        let row = vec![
+            package.package_name.clone(),
+            package.current.to_string(),
+            "❯".to_string(),
+            colorize_target(package),
+            package.homepage.clone().unwrap_or_default(),
+        ];
+        cells.push(row);
+    }
+
+    let widths = column_widths(&cells);
+    let mut rows =
+        cells.into_iter().map(|row| ChoiceRow { label: pad_row(&row, &widths), value: None });
+    let header = rows.next().expect("the header row is always pushed first");
+    std::iter::once(header)
+        .chain(
+            rows.zip(packages)
+                .map(|(row, package)| ChoiceRow { value: Some(package.alias.clone()), ..row }),
+        )
+        .collect()
+}
+
+/// The width of each column, measured on the printable text so the
+/// colour escapes `colorize_target` embeds do not inflate the padding.
+fn column_widths(cells: &[Vec<String>]) -> Vec<usize> {
+    let column_count = cells.iter().map(Vec::len).max().unwrap_or_default();
+    (0..column_count)
+        .map(|column| {
+            cells
+                .iter()
+                .filter_map(|row| row.get(column))
+                .map(|cell| printable_width(cell))
+                .max()
+                .unwrap_or_default()
+        })
+        .collect()
+}
+
+/// The column holding the current version, right-aligned so the versions
+/// of a group end at the same offset, as pnpm aligns it.
+const CURRENT_COLUMN: usize = 1;
+
+fn pad_row(row: &[String], widths: &[usize]) -> String {
+    let mut line = String::new();
+    for (index, cell) in row.iter().enumerate() {
+        if index > 0 {
+            line.push(' ');
+        }
+        let padding =
+            widths.get(index).copied().unwrap_or_default().saturating_sub(printable_width(cell));
+        if index == CURRENT_COLUMN {
+            line.extend(std::iter::repeat_n(' ', padding));
+            line.push_str(cell);
+            continue;
+        }
+        line.push_str(cell);
+        // The last column is never padded, so a row with an empty URL
+        // does not end in a run of spaces.
+        if index + 1 < row.len() {
+            line.extend(std::iter::repeat_n(' ', padding));
+        }
+    }
+    line.trim_end().to_string()
+}
+
+/// The displayed width of `text`, ignoring ANSI colour escapes.
+fn printable_width(text: &str) -> usize {
+    let mut width = 0;
+    let mut chars = text.chars();
+    while let Some(character) = chars.next() {
+        if character == '\u{1b}' {
+            for escape in chars.by_ref() {
+                if escape == 'm' {
+                    break;
+                }
+            }
+            continue;
+        }
+        width += 1;
+    }
+    width
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -30,7 +30,7 @@ pub(crate) struct ChoiceGroup {
 
 /// The dependency type a choice is grouped under. GitHub Actions form
 /// their own group even though they are read out of `devDependencies`.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum ChoiceGroupKind {
     Prod,
     Dev,

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
@@ -1,0 +1,185 @@
+//! Ports `getUpdateChoices()` from
+//! `pnpm11/installing/commands/test/update/getUpdateChoices.test.ts`.
+//!
+//! The rendered padding is pacquet's own — pnpm lays its table out with
+//! `@zkochan/table` and fixed column widths — so these assert the shape
+//! the user sees: which groups appear, in what order, which packages sit
+//! in each, and that every column lines up.
+
+use super::{ChoiceGroup, printable_width, update_choices};
+use crate::cli_args::outdated::OutdatedPackage;
+use node_semver::Version;
+use pacquet_package_manifest::DependencyGroup;
+
+fn v(text: &str) -> Version {
+    text.parse().expect("parse semver")
+}
+
+fn pkg(
+    alias: &str,
+    package_name: &str,
+    current: &str,
+    target: &str,
+    group: DependencyGroup,
+) -> OutdatedPackage {
+    OutdatedPackage {
+        alias: alias.to_string(),
+        package_name: package_name.to_string(),
+        belongs_to: group,
+        current: v(current),
+        target: v(target),
+        wanted: v(current),
+        github_action: false,
+        deprecated: None,
+        homepage: None,
+    }
+}
+
+/// The package each selectable row of a group updates, in order.
+fn values(group: &ChoiceGroup) -> Vec<&str> {
+    group.rows.iter().filter_map(|row| row.value.as_deref()).collect()
+}
+
+#[test]
+fn groups_by_dependency_type_in_manifest_order() {
+    let packages = [
+        pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod),
+        pkg("qar", "qar", "1.0.0", "1.2.0", DependencyGroup::Dev),
+        pkg("zoo", "zoo", "1.1.0", "1.2.0", DependencyGroup::Dev),
+        pkg("qaz", "qaz", "1.0.1", "1.2.0", DependencyGroup::Optional),
+    ];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    let rendered: Vec<(&str, Vec<&str>)> =
+        groups.iter().map(|group| (group.message.as_str(), values(group))).collect();
+    assert_eq!(
+        rendered,
+        vec![
+            ("dependencies", vec!["foo"]),
+            ("devDependencies", vec!["qar", "zoo"]),
+            ("optionalDependencies", vec!["qaz"]),
+        ],
+    );
+}
+
+/// Every group opens with a header row that names the columns and is not
+/// selectable — pnpm renders it as a disabled entry.
+#[test]
+fn each_group_opens_with_an_unselectable_header() {
+    let packages = [pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod)];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    let header = &groups[0].rows[0];
+    assert_eq!(header.value, None);
+    for column in ["Package", "Current", "Target", "URL"] {
+        assert!(header.label.contains(column), "header is missing {column}: {}", header.label);
+    }
+}
+
+/// The same package outdated under two dependency types is offered once.
+/// pnpm deduplicates before grouping, and its key does not include the
+/// dependency type, so the first group to claim the package keeps it.
+#[test]
+fn a_package_outdated_in_two_groups_is_offered_once() {
+    let packages = [
+        pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod),
+        pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Dev),
+    ];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0].message, "dependencies");
+    assert_eq!(values(&groups[0]), vec!["foo"]);
+}
+
+/// Differing versions make two entries distinct even under one name, so
+/// both are offered.
+#[test]
+fn the_same_name_at_different_versions_is_offered_twice() {
+    let packages = [
+        pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Dev),
+        pkg("qaz", "foo", "1.0.1", "1.2.0", DependencyGroup::Dev),
+    ];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    // The row is labelled by package name but selects by alias, so the
+    // npm-aliased entry updates `qaz` rather than the name it resolves to.
+    assert_eq!(values(&groups[0]), vec!["foo", "qaz"]);
+}
+
+/// GitHub Actions are read out of `devDependencies` but form their own
+/// group, titled the way pnpm titles it.
+#[test]
+fn github_actions_form_their_own_group() {
+    let mut action =
+        pkg("actions/checkout", "actions/checkout", "4.1.0", "4.2.2", DependencyGroup::Dev);
+    action.github_action = true;
+    let packages = [pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Dev), action];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    let rendered: Vec<(&str, Vec<&str>)> =
+        groups.iter().map(|group| (group.message.as_str(), values(group))).collect();
+    assert_eq!(
+        rendered,
+        vec![("devDependencies", vec!["foo"]), ("GitHub Actions", vec!["actions/checkout"])],
+    );
+}
+
+/// A long version must not wrap the row onto a second line, and both
+/// versions stay readable — the regression pnpm's
+/// "handles long version strings without wrapping" case covers.
+#[test]
+fn a_long_version_keeps_the_row_on_one_line() {
+    let packages = [pkg(
+        "@typescript/native-preview",
+        "@typescript/native-preview",
+        "7.0.0-dev.20251209.1",
+        "7.0.0-dev.20251214.1",
+        DependencyGroup::Dev,
+    )];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    let row = &groups[0].rows[1];
+    assert_eq!(row.value.as_deref(), Some("@typescript/native-preview"));
+    assert!(!row.label.contains('\n'), "row wrapped: {}", row.label);
+    assert!(row.label.contains("7.0.0-dev.20251209.1"), "current missing: {}", row.label);
+    assert!(row.label.contains("7.0.0-dev.20251214.1"), "target missing: {}", row.label);
+}
+
+/// Columns are padded to a common width, so the `❯` of every row in a
+/// group starts at the same offset however wide the names are.
+#[test]
+fn columns_line_up_within_a_group() {
+    let packages = [
+        pkg(
+            "a-very-long-package-name",
+            "a-very-long-package-name",
+            "1.0.0",
+            "2.0.0",
+            DependencyGroup::Prod,
+        ),
+        pkg("b", "b", "1.0.0", "2.0.0", DependencyGroup::Prod),
+    ];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    let arrow_offsets: Vec<usize> = groups[0]
+        .rows
+        .iter()
+        .skip(1)
+        .map(|row| printable_width(row.label.split('❯').next().expect("row has an arrow")))
+        .collect();
+    assert_eq!(arrow_offsets[0], arrow_offsets[1]);
+}
+
+/// Nothing outdated means nothing to choose from.
+#[test]
+fn an_empty_set_produces_no_groups() {
+    assert_eq!(update_choices(&[]), Vec::new());
+}

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
@@ -183,3 +183,35 @@ fn columns_line_up_within_a_group() {
 fn an_empty_set_produces_no_groups() {
     assert_eq!(update_choices(&[]), Vec::new());
 }
+
+/// Two manifest entries aliasing the same package are separate
+/// dependencies: updating one must not silently drop the other, so both
+/// are offered even though their package name and versions match.
+#[test]
+fn two_aliases_of_one_package_are_both_offered() {
+    let packages = [
+        pkg("a", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod),
+        pkg("b", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod),
+    ];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    assert_eq!(values(&groups[0]), vec!["a", "b"]);
+}
+
+/// Registry metadata reaches the prompt as a label, so control
+/// characters are stripped: an escape sequence would corrupt the
+/// prompt's redraw and a newline would split the row in two.
+#[test]
+fn control_characters_in_registry_metadata_are_stripped() {
+    let mut package = pkg("foo", "foo\u{1b}[31m", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    package.homepage = Some("https://example.test/\u{1b}[2J\nEVIL".to_string());
+    let packages = [package];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+
+    let row = &groups[0].rows[1];
+    assert!(!row.label.contains('\u{1b}'), "escape survived: {:?}", row.label);
+    assert!(!row.label.contains('\n'), "newline survived: {:?}", row.label);
+    assert!(row.label.contains("https://example.test/"), "url lost: {:?}", row.label);
+}

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -181,3 +181,67 @@ fn package_body(name: &str, registry: &str) -> String {
     })
     .to_string()
 }
+
+mod selection {
+    use super::super::{
+        choices::{ChoiceGroup, ChoiceRow},
+        flatten_groups, selected_packages,
+    };
+
+    fn group(message: &str, rows: &[(&str, Option<&str>)]) -> ChoiceGroup {
+        ChoiceGroup {
+            message: message.to_string(),
+            rows: rows
+                .iter()
+                .map(|(label, value)| ChoiceRow {
+                    label: (*label).to_string(),
+                    value: value.map(str::to_string),
+                })
+                .collect(),
+        }
+    }
+
+    /// Checking a group heading or a column header updates nothing —
+    /// `dialoguer` lets either be checked, where pnpm's prompt disables
+    /// them outright.
+    #[test]
+    fn headings_and_headers_select_nothing() {
+        let groups =
+            [group("dependencies", &[("Package Current", None), ("foo 1 ❯ 2", Some("foo"))])];
+
+        let (labels, values) = flatten_groups(&groups);
+
+        assert_eq!(labels.len(), 3, "heading, header row, and one package");
+        // 0 is the heading, 1 the column header, 2 the package.
+        assert_eq!(selected_packages(&values, &[0, 1]), Vec::<String>::new());
+        assert_eq!(selected_packages(&values, &[2]), vec!["foo".to_string()]);
+    }
+
+    /// The same package offered by two importers is returned once, in the
+    /// order it was first checked.
+    #[test]
+    fn a_package_checked_twice_is_returned_once() {
+        let groups = [
+            group("dependencies", &[("hdr", None), ("foo", Some("foo"))]),
+            group("devDependencies", &[("hdr", None), ("bar", Some("bar")), ("foo", Some("foo"))]),
+        ];
+
+        let (_, values) = flatten_groups(&groups);
+
+        // 2 = foo (prod), 5 = bar, 6 = foo (dev).
+        assert_eq!(
+            selected_packages(&values, &[2, 5, 6]),
+            vec!["foo".to_string(), "bar".to_string()],
+        );
+    }
+
+    /// An out-of-range index cannot panic the selection.
+    #[test]
+    fn an_unknown_index_is_ignored() {
+        let groups = [group("dependencies", &[("hdr", None), ("foo", Some("foo"))])];
+
+        let (_, values) = flatten_groups(&groups);
+
+        assert_eq!(selected_packages(&values, &[99]), Vec::<String>::new());
+    }
+}


### PR DESCRIPTION
## Summary

The next piece of `pnpm update --interactive` parity from pnpm/pnpm#12101, whose description named it as *"pacquet computes 'outdated' inline … and presents a flat list. pnpm uses … `getUpdateChoices` (grouped by dependency type, workspace-aware)."*

pacquet presented one flat list labelled `<name> <current> ❯ <target>`, so a project with many outdated dependencies gave no clue which were production dependencies and which were dev, and the versions did not line up. `update_choices` now mirrors `getUpdateChoices`: the outdated set is deduplicated, split into one group per dependency type — GitHub Actions get their own, titled as upstream titles it — and each group renders as a column-aligned table under a `Package`/`Current`/`Target`/`URL` header, with the current versions right-aligned.

Before:

```
@types/node 20.1.0 ❯ 20.2.0
react 18.2.0 ❯ 19.1.0
typescript 5.4.2 ❯ 5.4.5
```

After:

```
dependencies
Package Current   Target URL
react    18.2.0 ❯ 19.1.0 https://react.dev/
devDependencies
Package     Current   Target URL
typescript    5.4.2 ❯ 5.4.5
@types/node  20.1.0 ❯ 20.2.0 https://github.com/DefinitelyTyped/DefinitelyTyped
```

Two upstream behaviors worth calling out, both pinned by tests:

- The deduplication runs **before** the grouping and its key does not include the dependency type, so a package outdated under two types is offered once, under whichever type was seen first. That is what upstream does (its `uniqBy` precedes its `groupBy` over the same key) rather than something chosen here.
- Groups appear in the order their dependency type is first seen, matching `groupBy`'s insertion order, not a fixed order.

`dialoguer` has no unselectable item the way upstream's prompt does, so the group headings and column headers are ordinary items whose rows carry no package; `selected_packages` drops them from the answer.

This is a pacquet-only change — the TypeScript CLI already groups — so there is nothing to mirror.

**Not in this PR, deliberately:**

- **The `Workspace` column.** Upstream shows it when workspaces are enabled; adding it needs the originating project threaded through the outdated collector, which is a separate mechanical change. Left for a follow-up so this stays reviewable.
- **Hiding or truncating the `URL` column.** pnpm/pnpm#12395 reports that long URLs wrap and make the v11 list a mess, and @vladshcherbin asked on pnpm/pnpm#12101 that v12 not inherit it. This PR matches upstream's columns rather than deciding that unilaterally — say the word and I will gate it behind a setting in both stacks under #12395.

## Squash Commit Body

```text
`pacquet update --interactive` presented one flat list labelled
`<name> <current> ❯ <target>`, so a project with many outdated
dependencies gave no clue which were production dependencies and which
were dev, and the versions did not line up.

`update_choices` now mirrors pnpm's `getUpdateChoices`: the outdated set
is deduplicated, split into one group per dependency type — GitHub
Actions get their own, as upstream titles them — and each group is
rendered as a column-aligned table under a `Package`/`Current`/`Target`/
`URL` header, with the current versions right-aligned.

The deduplication runs before the grouping and its key does not include
the dependency type, so a package outdated under two types is offered
once, under whichever type was seen first. That is upstream's behavior
(its `uniqBy` precedes its `groupBy` over the same key) and the ported
tests pin it. Groups appear in the order their dependency type is first
seen, matching `groupBy`'s insertion order.

`dialoguer` has no unselectable item, so the group headings and column
headers are ordinary items whose rows carry no package;
`selected_packages` drops them from the answer.

Ports `getUpdateChoices.test.ts` from
`pnpm11/installing/commands/test/update/`. The rendered padding is
pacquet's own — upstream lays its table out with `@zkochan/table` — so
the ports assert the grouping, ordering, and alignment rather than
byte-identical output.

The `Workspace` column and the `URL` column's width behavior
(pnpm/pnpm#12395) are left for follow-ups.

Related to pnpm/pnpm#12101.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787564509&installation_model_id=426870&pr_number=13298&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13298&signature=a3fde99f9be75daa3dd29d2eae3a71848e2388c4908e527f2c02907f69660cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->