### PR TITLE
feat: support the saveWorkspaceProtocol setting in the Rust engine

### DIFF
--- a/.changeset/pacquet-save-workspace-protocol.md
+++ b/.changeset/pacquet-save-workspace-protocol.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+The Rust engine now supports the `saveWorkspaceProtocol` setting, so `pnpm add <pkg>@workspace:…` writes back the same specifier pnpm does. Under the default `rolling`, a request like `workspace:^1.2.3` is saved as `workspace:^` — a range with no version in it, so bumping the workspace package never has to touch its dependents' manifests. `saveWorkspaceProtocol: true` saves the workspace package's resolved version instead (`workspace:^2.5.0`), and `false` keeps the `workspace:` form only when it was asked for explicitly. Previously the specifier was written back exactly as typed.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4762,6 +4762,7 @@ dependencies = [
  "pacquet-workspace",
  "pacquet-workspace-manifest-writer",
  "pacquet-workspace-range-resolver",
+ "pacquet-workspace-spec",
  "pacquet-workspace-state",
  "pathdiff",
  "pipe-trait",

--- a/pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs
+++ b/pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs
@@ -1,0 +1,75 @@
+//! The `pnpm` field of `package.json` is no longer read for install
+//! settings — pnpm 10 moved them all to `pnpm-workspace.yaml`. A project
+//! that still carries one of the migrated keys gets a warning naming it,
+//! so the setting isn't silently dropped.
+
+use pacquet_reporter::{GlobalLog, LogEvent, LogLevel};
+use std::path::Path;
+
+/// Keys pnpm reads from `pnpm-workspace.yaml` and never from the `pnpm`
+/// field of `package.json` — either because they moved there in v11, or
+/// because (like `update`) they were introduced later and only ever
+/// lived there. Keys outside this set (`app`, or anything third-party
+/// tooling piggybacks on the `pnpm` namespace for) are left alone so the
+/// warning can't fire on something pnpm never owned.
+const MIGRATED_PNPM_FIELD_KEYS: &[&str] = &[
+    "allowBuilds",
+    "allowedDeprecatedVersions",
+    "allowUnusedPatches",
+    "audit",
+    "auditConfig",
+    "configDependencies",
+    "executionEnv",
+    "ignoredOptionalDependencies",
+    "neverBuiltDependencies",
+    "onlyBuiltDependencies",
+    "onlyBuiltDependenciesFile",
+    "overrides",
+    "packageExtensions",
+    "patchedDependencies",
+    "peerDependencyRules",
+    "requiredScripts",
+    "supportedArchitectures",
+    "update",
+    "updateConfig",
+];
+
+/// Warn about every migrated key the root project manifest still
+/// declares under `pnpm`. An unreadable or malformed manifest is not
+/// this function's problem — the install path reports it with far more
+/// context — so it simply produces no warning.
+pub(crate) fn warn_ignored_pnpm_manifest_fields(root_dir: &Path, emit: fn(&LogEvent)) {
+    let ignored = ignored_pnpm_field_keys(root_dir);
+    if ignored.is_empty() {
+        return;
+    }
+    let keys = ignored.iter().map(|key| format!(r#""pnpm.{key}""#)).collect::<Vec<_>>().join(", ");
+    emit(&LogEvent::Global(GlobalLog {
+        level: LogLevel::Warn,
+        message: format!(
+            "The \"pnpm\" field in package.json is no longer read by pnpm. \
+             The following keys were ignored: {keys}. \
+             See https://pnpm.io/settings for the new home of each setting.",
+        ),
+    }));
+}
+
+fn ignored_pnpm_field_keys(root_dir: &Path) -> Vec<String> {
+    let Ok(bytes) = std::fs::read(root_dir.join("package.json")) else {
+        return Vec::new();
+    };
+    let Ok(manifest) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Vec::new();
+    };
+    let Some(legacy_field) = manifest.get("pnpm").and_then(serde_json::Value::as_object) else {
+        return Vec::new();
+    };
+    legacy_field
+        .keys()
+        .filter(|key| MIGRATED_PNPM_FIELD_KEYS.contains(&key.as_str()))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/legacy_pnpm_field/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/legacy_pnpm_field/tests.rs
@@ -1,0 +1,41 @@
+use super::ignored_pnpm_field_keys;
+use std::fs;
+
+fn write_manifest(dir: &std::path::Path, contents: &str) {
+    fs::write(dir.join("package.json"), contents).expect("write package.json");
+}
+
+#[test]
+fn reports_migrated_keys_in_declaration_order() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    write_manifest(
+        dir.path(),
+        r#"{"pnpm":{"onlyBuiltDependencies":["a"],"app":{},"overrides":{"x":"1"}}}"#,
+    );
+    assert_eq!(
+        ignored_pnpm_field_keys(dir.path()),
+        vec!["onlyBuiltDependencies".to_string(), "overrides".to_string()],
+    );
+}
+
+#[test]
+fn ignores_manifests_without_a_migrated_key() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    write_manifest(dir.path(), r#"{"pnpm":{"app":{}},"name":"x"}"#);
+    assert!(ignored_pnpm_field_keys(dir.path()).is_empty());
+}
+
+/// A non-object `pnpm` field belongs to some other tool; there is
+/// nothing to warn about, and a malformed or missing manifest is
+/// reported by the install path with far better context.
+#[test]
+fn tolerates_absent_malformed_and_non_object_manifests() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    assert!(ignored_pnpm_field_keys(dir.path()).is_empty(), "no manifest");
+
+    write_manifest(dir.path(), "{ not json");
+    assert!(ignored_pnpm_field_keys(dir.path()).is_empty(), "malformed manifest");
+
+    write_manifest(dir.path(), r#"{"pnpm":"11.0.0"}"#);
+    assert!(ignored_pnpm_field_keys(dir.path()).is_empty(), "non-object pnpm field");
+}

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -1127,8 +1127,9 @@ fn save_workspace_protocol_decides_the_saved_workspace_range() {
         let protocol_line = setting
             .map(|setting| format!("saveWorkspaceProtocol: {setting}\n"))
             .unwrap_or_default();
-        let yaml =
-            format!("packages:\n  - packages/*\nlinkWorkspacePackages: true\n{protocol_line}");
+        let yaml = format!(
+            "{HERMETIC_STORE_YAML}packages:\n  - packages/*\nlinkWorkspacePackages: true\n{protocol_line}",
+        );
         std::fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write workspace yaml");
         write_json(&workspace.join("package.json"), &serde_json::json!({ "name": "root" }));
         for (dir, manifest) in [
@@ -1159,6 +1160,110 @@ fn save_workspace_protocol_decides_the_saved_workspace_range() {
         drop(root);
     }
 }
+
+/// `workspace:<target>@<range>` installs `<target>` under the name the
+/// selector gave, so the saved specifier has to keep naming the target —
+/// dropping it would leave a `workspace:` entry pointing at the install
+/// name, which resolves to nothing.
+///
+/// Verified against the TypeScript CLI.
+#[test]
+fn an_aliased_workspace_add_keeps_naming_its_target() {
+    const TARGET: &str = "@pnpm.e2e/ws-target";
+    for (setting, expected) in [
+        (None, "workspace:@pnpm.e2e/ws-target@^"),
+        (Some("true"), "workspace:@pnpm.e2e/ws-target@^1.2.3"),
+    ] {
+        let (root, app_dir) =
+            workspace_with_lib(setting, &[(TARGET, "1.2.3")], "packages/app/package.json");
+        add_in(&app_dir, &format!("myalias@workspace:{TARGET}@^1.0.0"));
+
+        assert_eq!(saved_spec(&app_dir, "myalias").as_deref(), Some(expected));
+        drop(root);
+    }
+}
+
+/// The pinned form picks the workspace version by semver, not by string
+/// order: a workspace holding both `9.0.0` and `10.0.0` must pin to
+/// `10.0.0`, which sorts *before* `9.0.0` lexicographically.
+///
+/// Verified against the TypeScript CLI.
+#[test]
+fn the_pinned_form_picks_the_highest_workspace_version_by_semver() {
+    const LIB: &str = "@pnpm.e2e/ws-multi";
+    let (root, app_dir) = workspace_with_lib(
+        Some("true"),
+        &[(LIB, "9.0.0"), (LIB, "10.0.0")],
+        "packages/app/package.json",
+    );
+    add_in(&app_dir, &format!("{LIB}@workspace:*"));
+
+    assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:^10.0.0"));
+    drop(root);
+}
+
+/// Scaffold a workspace whose `packages/*` hold `libs` (one directory
+/// per entry, so the same name may appear at several versions) plus an
+/// `app` member. Returns the temp root and the app's directory.
+fn workspace_with_lib(
+    save_workspace_protocol: Option<&str>,
+    libs: &[(&str, &str)],
+    app_manifest_path: &str,
+) -> (TempDir, PathBuf) {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let protocol_line = save_workspace_protocol
+        .map(|setting| format!("saveWorkspaceProtocol: {setting}\n"))
+        .unwrap_or_default();
+    std::fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!("{HERMETIC_STORE_YAML}packages:\n  - packages/*\nlinkWorkspacePackages: true\n{protocol_line}"),
+    )
+    .expect("write workspace yaml");
+    write_json(&workspace.join("package.json"), &serde_json::json!({ "name": "root" }));
+    for (index, (name, version)) in libs.iter().enumerate() {
+        let package_dir = workspace.join("packages").join(format!("lib{index}"));
+        std::fs::create_dir_all(&package_dir).expect("create lib dir");
+        write_json(
+            &package_dir.join("package.json"),
+            &serde_json::json!({ "name": name, "version": version }),
+        );
+    }
+    let app_dir = workspace.join(app_manifest_path).parent().expect("app dir").to_path_buf();
+    std::fs::create_dir_all(&app_dir).expect("create app dir");
+    write_json(
+        &app_dir.join("package.json"),
+        &serde_json::json!({ "name": "ws-app", "version": "1.0.0" }),
+    );
+    (root, app_dir)
+}
+
+fn add_in(dir: &Path, selector: &str) {
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(dir)
+        .with_args(["add", selector, "--lockfile-only"])
+        .assert()
+        .success();
+}
+
+fn saved_spec(dir: &Path, name: &str) -> Option<String> {
+    PackageManifest::from_path(dir.join("package.json"))
+        .expect("read manifest")
+        .dependencies([DependencyGroup::Prod])
+        .find(|(dep_name, _)| *dep_name == name)
+        .map(|(_, spec)| spec.to_string())
+}
+
+/// Store and cache directories pinned inside the test's own temp root,
+/// and the global virtual store pinned off.
+///
+/// `CommandTempCwd::add_mocked_registry` writes these for tests that
+/// need a registry. The workspace-protocol tests resolve only local
+/// packages, so they skip the registry — but they still have to pin the
+/// directories, or they race every other test over the developer's real
+/// store.
+const HERMETIC_STORE_YAML: &str =
+    "storeDir: ../pacquet-store\ncacheDir: ../pacquet-cache\nenableGlobalVirtualStore: false\n";
 
 fn write_json(path: &Path, value: &serde_json::Value) {
     std::fs::write(path, value.to_string()).expect("write manifest");

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -1202,6 +1202,31 @@ fn the_pinned_form_picks_the_highest_workspace_version_by_semver() {
     drop(root);
 }
 
+/// The setting is readable from `PNPM_CONFIG_SAVE_WORKSPACE_PROTOCOL`
+/// too, not only `pnpm-workspace.yaml` — pnpm exposes every setting
+/// through its env pass.
+#[test]
+fn the_env_var_drives_the_saved_workspace_range() {
+    const LIB: &str = "@pnpm.e2e/ws-env";
+    for (value, expected) in
+        [("true", "workspace:^1.2.3"), ("rolling", "workspace:^"), ("false", "workspace:^1.2.3")]
+    {
+        let (root, app_dir) =
+            workspace_with_lib(None, &[(LIB, "1.2.3")], "packages/app/package.json");
+        Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(&app_dir)
+            .with_args(["add", &format!("{LIB}@workspace:^1.0.0"), "--lockfile-only"])
+            .env("PNPM_CONFIG_SAVE_WORKSPACE_PROTOCOL", value)
+            .assert()
+            .success();
+
+        eprintln!("PNPM_CONFIG_SAVE_WORKSPACE_PROTOCOL={value} -> {:?}", saved_spec(&app_dir, LIB));
+        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some(expected));
+        drop(root);
+    }
+}
+
 /// Scaffold a workspace whose `packages/*` hold `libs` (one directory
 /// per entry, so the same name may appear at several versions) plus an
 /// `app` member. Returns the temp root and the app's directory.

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -1095,3 +1095,71 @@ fn add_with_save_settings(args: &[&str]) -> (TempDir, PathBuf, TestRegistry) {
 
     (root, workspace, mock_instance)
 }
+
+/// `saveWorkspaceProtocol` decides what `pnpm add <pkg>@workspace:…`
+/// writes back. The rolling default drops the version so the range
+/// never has to be rewritten when the local package is bumped; `true`
+/// pins the workspace package's *actual* version (not the one the user
+/// typed); `false` still honors an explicit `workspace:` request.
+///
+/// Verified against the TypeScript CLI for every row.
+#[test]
+fn save_workspace_protocol_decides_the_saved_workspace_range() {
+    const LIB: &str = "@pnpm.e2e/ws-lib";
+    let cases = [
+        (None, "workspace:^1.2.3", "1.2.3", "workspace:^"),
+        (None, "workspace:~1.2.3", "1.2.3", "workspace:~"),
+        (None, "workspace:1.2.3", "1.2.3", "workspace:*"),
+        (None, "workspace:*", "1.2.3", "workspace:*"),
+        (Some("true"), "workspace:^1.2.3", "1.2.3", "workspace:^1.2.3"),
+        // The typed `~` loses to the default `^`: the pinned form reads
+        // its operator off the previous entry, and there is none here.
+        (Some("true"), "workspace:~1.2.3", "1.2.3", "workspace:^1.2.3"),
+        // The local version wins over the typed range.
+        (Some("true"), "workspace:^1.0.0", "2.5.0", "workspace:^2.5.0"),
+        // A range over a prerelease would not match it, so it is exact.
+        (Some("true"), "workspace:^1.0.0", "2.0.0-beta.1", "workspace:2.0.0-beta.1"),
+        (Some("false"), "workspace:^1.2.3", "1.2.3", "workspace:^1.2.3"),
+    ];
+
+    for (setting, requested, lib_version, expected) in cases {
+        let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+        let protocol_line = setting
+            .map(|setting| format!("saveWorkspaceProtocol: {setting}\n"))
+            .unwrap_or_default();
+        let yaml =
+            format!("packages:\n  - packages/*\nlinkWorkspacePackages: true\n{protocol_line}");
+        std::fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write workspace yaml");
+        write_json(&workspace.join("package.json"), &serde_json::json!({ "name": "root" }));
+        for (dir, manifest) in [
+            ("lib", serde_json::json!({ "name": LIB, "version": lib_version })),
+            ("app", serde_json::json!({ "name": "ws-app", "version": "1.0.0" })),
+        ] {
+            let package_dir = workspace.join("packages").join(dir);
+            std::fs::create_dir_all(&package_dir).expect("create package dir");
+            write_json(&package_dir.join("package.json"), &manifest);
+        }
+
+        let app_dir = workspace.join("packages/app");
+        Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(&app_dir)
+            .with_args(["add", &format!("{LIB}@{requested}"), "--lockfile-only"])
+            .assert()
+            .success();
+
+        let saved = PackageManifest::from_path(app_dir.join("package.json"))
+            .expect("read app manifest")
+            .dependencies([DependencyGroup::Prod])
+            .find(|(name, _)| *name == LIB)
+            .map(|(_, spec)| spec.to_string());
+        eprintln!("setting={setting:?} requested={requested} local={lib_version} -> {saved:?}");
+        assert_eq!(saved.as_deref(), Some(expected));
+
+        drop(root);
+    }
+}
+
+fn write_json(path: &Path, value: &serde_json::Value) {
+    std::fs::write(path, value.to_string()).expect("write manifest");
+}

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -13,8 +13,8 @@
 
 use crate::{
     AuditLevel, CatalogMode, HoistingLimits, NodeLinker, NodePackageMapType, PackageImportMethod,
-    PmOnFail, ResolutionMode, RuntimeOnFail, ScriptsPrependNodePath, TrustPolicy,
-    VerifyDepsBeforeRun, WorkspaceSettings, api::EnvVar,
+    PmOnFail, ResolutionMode, RuntimeOnFail, SaveWorkspaceProtocol, ScriptsPrependNodePath,
+    TrustPolicy, VerifyDepsBeforeRun, WorkspaceSettings, api::EnvVar,
 };
 use serde::de::DeserializeOwned;
 
@@ -256,6 +256,7 @@ impl WorkspaceSettings {
             settings.save_prefix = Some(save_prefix);
         }
         json_field!(save_peer, "SAVE_PEER");
+        enum_field!(save_workspace_protocol, "SAVE_WORKSPACE_PROTOCOL", SaveWorkspaceProtocol);
         json_field!(registry_supports_time_field, "REGISTRY_SUPPORTS_TIME_FIELD");
         json_field!(allowed_deprecated_versions, "ALLOWED_DEPRECATED_VERSIONS");
         json_field!(update_config, "UPDATE_CONFIG");

--- a/pnpm/crates/config/src/env_overlay/tests.rs
+++ b/pnpm/crates/config/src/env_overlay/tests.rs
@@ -1,5 +1,8 @@
 use super::{WorkspaceSettings, parse_json_or_string, parse_tri_array};
-use crate::{NodeLinker, NodePackageMapType, ScriptsPrependNodePath, TrustPolicy, api::EnvVar};
+use crate::{
+    NodeLinker, NodePackageMapType, SaveWorkspaceProtocol, ScriptsPrependNodePath, TrustPolicy,
+    api::EnvVar,
+};
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -42,6 +45,34 @@ fn empty_save_prefix_env_var_survives() {
     }
     let settings = WorkspaceSettings::from_pnpm_config_env::<EnvEmptySavePrefix>();
     assert_eq!(settings.save_prefix.as_deref(), Some(""));
+}
+
+/// `saveWorkspaceProtocol` is `boolean | "rolling"`, so its env var has
+/// to accept both JSON booleans and the bare identifier.
+#[test]
+fn save_workspace_protocol_env_var_accepts_all_three_shapes() {
+    for (value, expected) in [
+        ("true", SaveWorkspaceProtocol::On),
+        ("false", SaveWorkspaceProtocol::Off),
+        ("rolling", SaveWorkspaceProtocol::Rolling),
+    ] {
+        assert_eq!(parse_json_or_string::<SaveWorkspaceProtocol>(value), Some(expected));
+    }
+    assert_eq!(parse_json_or_string::<SaveWorkspaceProtocol>("nonsense"), None);
+}
+
+/// The binding is wired to the `PNPM_CONFIG_*` name pnpm uses, not just
+/// parseable in isolation.
+#[test]
+fn save_workspace_protocol_reads_from_the_environment() {
+    struct EnvPinned;
+    impl EnvVar for EnvPinned {
+        fn var(name: &str) -> Option<String> {
+            (name == "PNPM_CONFIG_SAVE_WORKSPACE_PROTOCOL").then(|| "true".to_owned())
+        }
+    }
+    let settings = WorkspaceSettings::from_pnpm_config_env::<EnvPinned>();
+    assert_eq!(settings.save_workspace_protocol, Some(SaveWorkspaceProtocol::On));
 }
 
 #[test]

--- a/pnpm/crates/package-manager/Cargo.toml
+++ b/pnpm/crates/package-manager/Cargo.toml
@@ -53,6 +53,7 @@ pacquet-tarball                           = { workspace = true }
 pacquet-workspace                         = { workspace = true }
 pacquet-workspace-manifest-writer         = { workspace = true }
 pacquet-workspace-range-resolver          = { workspace = true }
+pacquet-workspace-spec                    = { workspace = true }
 pacquet-workspace-state                   = { workspace = true }
 
 async-recursion = { workspace = true }

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -16,7 +16,7 @@ use pacquet_catalogs_config::{
     InvalidCatalogsConfigurationError, get_catalogs_from_workspace_manifest,
 };
 use pacquet_catalogs_types::Catalogs;
-use pacquet_config::Config;
+use pacquet_config::{Config, SaveWorkspaceProtocol};
 use pacquet_engine_runtime_node_resolver::{NodeResolver, NodeResolverError};
 use pacquet_lockfile::{Lockfile, MaybeLazyLockfile};
 use pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests;
@@ -29,10 +29,11 @@ use pacquet_resolving_git_resolver::{
     GitFetchContext, GitResolver, HostedGit, HostedOpts, RealGitProbe, RealGitRunner,
 };
 use pacquet_resolving_npm_resolver::{
-    InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageError, PickPackageOptions,
-    parse_bare_specifier, pick_package, pick_registry_for_package, shared_packument_fetch_locker,
-    which_version_is_pinned,
+    DeclaredSpecifiers, InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageError,
+    PickPackageOptions, calc_specifier_for_workspace_dep, parse_bare_specifier, pick_package,
+    pick_registry_for_package, shared_packument_fetch_locker, which_version_is_pinned,
 };
+use pacquet_resolving_resolver_base::WorkspacePackages;
 use pacquet_tarball::MemCache;
 use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
@@ -183,6 +184,13 @@ where
         let meta_cache = std::sync::Arc::new(InMemoryPackageMetaCache::default());
         let fetch_locker = shared_packument_fetch_locker();
         let catalog_ctx = read_catalog_ctx(manifest, config)?;
+        // The rolling default writes a range with no version in it, so
+        // the workspace only has to be enumerated for the shapes that
+        // carry the local package's actual version. Skipping the walk
+        // otherwise keeps the default `add` off the filesystem.
+        let workspace_packages = (config.save_workspace_protocol != SaveWorkspaceProtocol::Rolling)
+            .then(|| workspace_packages_for_add(config))
+            .flatten();
         let updated_catalogs = prepare_manifest::<Reporter>(
             manifest,
             http_client,
@@ -198,6 +206,7 @@ where
             &catalog_ctx.prefix,
             &meta_cache,
             &fetch_locker,
+            workspace_packages.as_ref(),
         )
         .await?;
 
@@ -420,6 +429,11 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     let latest_picker = tokio::sync::OnceCell::new();
     let meta_cache = std::sync::Arc::new(InMemoryPackageMetaCache::default());
     let fetch_locker = shared_packument_fetch_locker();
+    // Indexed once, before the loop mutates any manifest: a
+    // `workspace:` request saved into project A resolves against the
+    // versions the projects declared on entry, not against a sibling
+    // that this same command already rewrote.
+    let workspace_packages = crate::install::build_workspace_packages_map(Some(projects));
 
     for &index in selected_indices {
         let updates = prepare_manifest::<Reporter>(
@@ -437,6 +451,7 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
             &catalog_ctx.prefix,
             &meta_cache,
             &fetch_locker,
+            workspace_packages.as_ref(),
         )
         .await?;
         merge_catalogs(&mut catalogs, &updates);
@@ -488,6 +503,7 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
     prefix: &str,
     meta_cache: &std::sync::Arc<InMemoryPackageMetaCache>,
     fetch_locker: &PackumentFetchLocker,
+    workspace_packages: Option<&WorkspacePackages>,
 ) -> Result<Catalogs, AddError> {
     let resolved_dependencies = {
         let mut resolution_futures = FuturesOrdered::new();
@@ -506,6 +522,7 @@ async fn prepare_manifest<'a, Reporter: self::Reporter>(
                 prefix,
                 meta_cache,
                 fetch_locker,
+                workspace_packages,
             ));
         }
         let mut dependencies = Vec::with_capacity(package_names.len());
@@ -636,6 +653,7 @@ async fn resolve_added_dependency<'a>(
     prefix: &str,
     meta_cache: &std::sync::Arc<InMemoryPackageMetaCache>,
     fetch_locker: &PackumentFetchLocker,
+    workspace_packages: Option<&WorkspacePackages>,
 ) -> Result<ResolvedAddedDependency, AddError> {
     let parsed =
         pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency(package_selector);
@@ -685,60 +703,68 @@ async fn resolve_added_dependency<'a>(
     //   exact pin) — `pnpm add <existing>` without a
     //   version leaves the declared range untouched;
     // - a brand-new dependency fetches and pins the `latest` range.
-    let bare_specifier =
-        if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
-            let mut node_resolver = NodeResolver::new(std::sync::Arc::clone(http_client_arc));
-            node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
-            node_resolver.offline = config.offline;
-            node_resolver
-                .resolve_save_specifier(version_spec, prev_specifier.as_deref())
-                .await
-                .map_err(AddError::ResolveRuntimeSpec)?
-        } else {
-            match (explicit_spec, prev_specifier.as_deref()) {
-                (Some(spec), prev) => resolve_explicit_registry_spec(
-                    package_name,
-                    spec,
-                    prev,
-                    config,
-                    http_client,
-                    pinned_version,
-                    lockfile,
-                    manifest,
-                    meta_cache,
-                    fetch_locker,
-                )
-                .await?
-                .unwrap_or_else(|| normalized_save_specifier(spec)),
-                (None, Some(prev)) => prev.to_string(),
-                (None, None) => {
-                    let latest = latest_picker
-                        .get_or_try_init(|| {
-                            std::future::ready(
-                                PickPolicy::from_config(config)
-                                    .map(|policy| {
-                                        LatestPicker::new(
-                                            config,
-                                            http_client,
-                                            policy,
-                                            std::sync::Arc::clone(meta_cache),
-                                            std::sync::Arc::clone(fetch_locker),
-                                        )
-                                    })
-                                    .map_err(AddError::MinimumReleaseAgeExclude),
-                            )
-                        })
-                        .await?
-                        .resolve(package_name, false)
-                        .await
-                        .map_err(|error| AddError::ResolveLatest {
-                            name: package_name.to_string(),
-                            error,
-                        })?;
-                    latest.serialize(pinned_version)
-                }
+    let bare_specifier = if let Some(workspace_specifier) = workspace_save_specifier(
+        package_name,
+        explicit_spec,
+        prev_specifier.as_deref(),
+        config.save_workspace_protocol,
+        pinned_version,
+        workspace_packages,
+    ) {
+        workspace_specifier
+    } else if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
+        let mut node_resolver = NodeResolver::new(std::sync::Arc::clone(http_client_arc));
+        node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
+        node_resolver.offline = config.offline;
+        node_resolver
+            .resolve_save_specifier(version_spec, prev_specifier.as_deref())
+            .await
+            .map_err(AddError::ResolveRuntimeSpec)?
+    } else {
+        match (explicit_spec, prev_specifier.as_deref()) {
+            (Some(spec), prev) => resolve_explicit_registry_spec(
+                package_name,
+                spec,
+                prev,
+                config,
+                http_client,
+                pinned_version,
+                lockfile,
+                manifest,
+                meta_cache,
+                fetch_locker,
+            )
+            .await?
+            .unwrap_or_else(|| normalized_save_specifier(spec)),
+            (None, Some(prev)) => prev.to_string(),
+            (None, None) => {
+                let latest = latest_picker
+                    .get_or_try_init(|| {
+                        std::future::ready(
+                            PickPolicy::from_config(config)
+                                .map(|policy| {
+                                    LatestPicker::new(
+                                        config,
+                                        http_client,
+                                        policy,
+                                        std::sync::Arc::clone(meta_cache),
+                                        std::sync::Arc::clone(fetch_locker),
+                                    )
+                                })
+                                .map_err(AddError::MinimumReleaseAgeExclude),
+                        )
+                    })
+                    .await?
+                    .resolve(package_name, false)
+                    .await
+                    .map_err(|error| AddError::ResolveLatest {
+                        name: package_name.to_string(),
+                        error,
+                    })?;
+                latest.serialize(pinned_version)
             }
-        };
+        }
+    };
 
     let mut updated_catalogs = Catalogs::new();
     let dep = CatalogModeDep {
@@ -928,6 +954,65 @@ async fn resolve_explicit_registry_spec(
 fn is_registry_style_specifier(specifier: &str, package_name: &str, registry: &str) -> bool {
     parse_bare_specifier(specifier, Some(package_name), "latest", registry)
         .is_some_and(|parsed| parsed.normalized_bare_specifier.is_none())
+}
+
+/// Index the workspace projects by name and version, or `None` when
+/// there is no workspace or it cannot be enumerated.
+///
+/// A failure to walk the workspace is not this function's problem to
+/// report — the install that follows the manifest write surfaces it with
+/// far more context — so it degrades to "no workspace packages", which
+/// only costs the pinned form its version.
+fn workspace_packages_for_add(config: &Config) -> Option<WorkspacePackages> {
+    let workspace_dir = config.workspace_dir.as_ref()?;
+    let manifest = pacquet_workspace::read_workspace_manifest(workspace_dir).ok()??;
+    let projects = pacquet_workspace::find_workspace_projects(
+        workspace_dir,
+        &pacquet_workspace::FindWorkspaceProjectsOpts {
+            patterns: Some(pacquet_workspace::workspace_package_patterns(&manifest)),
+        },
+    )
+    .ok()?;
+    crate::install::build_workspace_packages_map(Some(&projects))
+}
+
+/// The `workspace:` specifier to save for `package_name`, or `None`
+/// when this add isn't a workspace dependency at all.
+///
+/// A dependency counts as one when the user asked for `workspace:`
+/// explicitly, or when the workspace index carries the name and
+/// `saveWorkspaceProtocol` is on — the latter matching pnpm, which
+/// rewrites a bare-semver request into the protocol once it resolves
+/// locally.
+///
+/// A relative `workspace:./pkg` is left alone: it names a directory, not
+/// a range, so there is no operator to roll.
+fn workspace_save_specifier(
+    package_name: &str,
+    explicit_spec: Option<&str>,
+    prev_specifier: Option<&str>,
+    save_workspace_protocol: SaveWorkspaceProtocol,
+    pinned_version: PinnedVersion,
+    workspace_packages: Option<&WorkspacePackages>,
+) -> Option<String> {
+    let asked_for_workspace = explicit_spec.is_some_and(|spec| spec.starts_with("workspace:"));
+    if explicit_spec.is_some_and(|spec| spec.starts_with("workspace:.")) {
+        return None;
+    }
+    let versions = workspace_packages.and_then(|packages| packages.get(package_name));
+    if !asked_for_workspace
+        && (versions.is_none() || save_workspace_protocol == SaveWorkspaceProtocol::Off)
+    {
+        return None;
+    }
+    Some(calc_specifier_for_workspace_dep(
+        DeclaredSpecifiers { prev: prev_specifier, bare: explicit_spec },
+        Some(package_name),
+        package_name,
+        versions.and_then(|versions| versions.keys().next_back()).map(String::as_str),
+        save_workspace_protocol,
+        pinned_version,
+    ))
 }
 
 /// Split a `pacquet add` argument into its package name and optional

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -35,6 +35,8 @@ use pacquet_resolving_npm_resolver::{
 };
 use pacquet_resolving_resolver_base::WorkspacePackages;
 use pacquet_tarball::MemCache;
+use pacquet_workspace_range_resolver::resolve_workspace_range;
+use pacquet_workspace_spec::WorkspaceSpec;
 use std::{collections::HashSet, path::PathBuf, sync::Arc};
 
 #[must_use]
@@ -977,13 +979,13 @@ fn workspace_packages_for_add(config: &Config) -> Option<WorkspacePackages> {
 }
 
 /// The `workspace:` specifier to save for `package_name`, or `None`
-/// when this add isn't a workspace dependency at all.
+/// when this add isn't a workspace dependency.
 ///
-/// A dependency counts as one when the user asked for `workspace:`
-/// explicitly, or when the workspace index carries the name and
-/// `saveWorkspaceProtocol` is on — the latter matching pnpm, which
-/// rewrites a bare-semver request into the protocol once it resolves
-/// locally.
+/// Only an explicit `workspace:` request is rewritten. pnpm also
+/// rewrites a bare-semver request once it resolves to a local package,
+/// but pacquet's resolver has no workspace fallback for that case yet
+/// (it fails against the registry first), so there is nothing here to
+/// rewrite.
 ///
 /// A relative `workspace:./pkg` is left alone: it names a directory, not
 /// a range, so there is no operator to roll.
@@ -995,21 +997,30 @@ fn workspace_save_specifier(
     pinned_version: PinnedVersion,
     workspace_packages: Option<&WorkspacePackages>,
 ) -> Option<String> {
-    let asked_for_workspace = explicit_spec.is_some_and(|spec| spec.starts_with("workspace:"));
-    if explicit_spec.is_some_and(|spec| spec.starts_with("workspace:.")) {
+    let spec = WorkspaceSpec::parse(explicit_spec?)?;
+    if spec.version.starts_with('.') {
         return None;
     }
-    let versions = workspace_packages.and_then(|packages| packages.get(package_name));
-    if !asked_for_workspace
-        && (versions.is_none() || save_workspace_protocol == SaveWorkspaceProtocol::Off)
-    {
-        return None;
-    }
+    // `workspace:<target>@<range>` installs `<target>` under the name
+    // the selector gave, so the target — not the install name — is what
+    // the workspace is searched for and what the saved specifier names.
+    let target_name = spec.alias.as_deref().unwrap_or(package_name);
+    let resolved_version =
+        workspace_packages.and_then(|packages| packages.get(target_name)).and_then(|versions| {
+            let available: Vec<String> = versions.keys().cloned().collect();
+            // The highest local version, semver-aware, so a workspace
+            // holding both `9.0.0` and `10.0.0` does not pin to the
+            // lexicographically greater `9.0.0`. Deliberately not
+            // filtered by the requested range: pnpm pins whatever the
+            // workspace holds, leaving a genuine mismatch for the
+            // install to report as `NO_MATCHING_VERSION_INSIDE_WORKSPACE`.
+            resolve_workspace_range("*", &available)
+        });
     Some(calc_specifier_for_workspace_dep(
         DeclaredSpecifiers { prev: prev_specifier, bare: explicit_spec },
         Some(package_name),
-        package_name,
-        versions.and_then(|versions| versions.keys().next_back()).map(String::as_str),
+        target_name,
+        resolved_version.as_deref(),
         save_workspace_protocol,
         pinned_version,
     ))

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -32,8 +32,8 @@ use pacquet_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMe
 use pacquet_resolving_default_resolver::DefaultResolver;
 use pacquet_resolving_deps_resolver::UpdateDepth;
 use pacquet_resolving_npm_resolver::{
-    InMemoryPackageMetaCache, NpmResolver, merge_named_registries, shared_packument_fetch_locker,
-    shared_picked_manifest_cache, which_version_is_pinned,
+    DeclaredSpecifiers, InMemoryPackageMetaCache, NpmResolver, calc_specifier_for_workspace_dep,
+    merge_named_registries, shared_packument_fetch_locker, shared_picked_manifest_cache,
 };
 use pacquet_resolving_resolver_base::{
     ResolveOptions, Resolver, UpdateBehavior, WantedDependency, WorkspacePackages,
@@ -992,10 +992,9 @@ fn workspace_link_targets(
 /// The `workspace:` specifier `--workspace` writes for a linked
 /// dependency.
 ///
-/// Under [`SaveWorkspaceProtocol::Rolling`] the range operator is written
-/// without a version, so the entry survives the workspace package's next
-/// release; otherwise the linked version is written under the operator
-/// the dependency already declared.
+/// `--workspace` is an explicit request for the protocol, so unlike
+/// `pnpm add` this never declines on [`SaveWorkspaceProtocol::Off`] —
+/// the setting only chooses the shape.
 fn workspace_specifier(
     target: &WorkspaceLinkTarget,
     versions: &WorkspacePackagesByVersion,
@@ -1008,24 +1007,14 @@ fn workspace_specifier(
     let Some(version) = pick_workspace_version(versions, &target.wanted_range) else {
         return format!("workspace:{}", target.wanted_range);
     };
-    if protocol == SaveWorkspaceProtocol::Rolling {
-        let operator = match target.declared.as_str() {
-            "workspace:*" | "workspace:^" | "workspace:~" => {
-                return target.declared.clone();
-            }
-            _ => match which_version_is_pinned(&target.declared) {
-                Some(PinnedVersion::Minor) => "~",
-                Some(PinnedVersion::Patch | PinnedVersion::None) => "*",
-                Some(PinnedVersion::Major) | None => "^",
-            },
-        };
-        return format!("workspace:{operator}");
-    }
-    if node_semver::Version::parse(&version).is_ok_and(|version| !version.pre_release.is_empty()) {
-        return format!("workspace:{version}");
-    }
-    let pin = which_version_is_pinned(&target.declared).unwrap_or(default_pin);
-    format!("workspace:{}{version}", pin.range_prefix())
+    calc_specifier_for_workspace_dep(
+        DeclaredSpecifiers { prev: Some(&target.declared), bare: None },
+        None,
+        &target.name,
+        Some(&version),
+        protocol,
+        default_pin,
+    )
 }
 
 /// The workspace version a `workspace:<range>` specifier would resolve

--- a/pnpm/crates/resolving-npm-resolver/src/calc_specifier_for_workspace_dep.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/calc_specifier_for_workspace_dep.rs
@@ -1,7 +1,7 @@
 //! Manifest-ready specifiers for dependencies that resolve to a
 //! workspace package.
 //!
-//! The registry counterpart lives in [`crate::calc_specifier`]. A
+//! The registry counterpart lives in [`crate::calc_specifier()`]. A
 //! workspace pick differs in that the text written back keeps the
 //! `workspace:` protocol, and under the default
 //! [`SaveWorkspaceProtocol::Rolling`] carries no version at all — the

--- a/pnpm/crates/resolving-npm-resolver/src/calc_specifier_for_workspace_dep.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/calc_specifier_for_workspace_dep.rs
@@ -1,0 +1,97 @@
+//! Manifest-ready specifiers for dependencies that resolve to a
+//! workspace package.
+//!
+//! The registry counterpart lives in [`crate::calc_specifier`]. A
+//! workspace pick differs in that the text written back keeps the
+//! `workspace:` protocol, and under the default
+//! [`SaveWorkspaceProtocol::Rolling`] carries no version at all — the
+//! range tracks whatever the local package's version happens to be, so
+//! bumping it never has to touch its dependents' manifests.
+//!
+//! Rendering only. *Whether* a dependency should be written under the
+//! protocol is the caller's decision: `pnpm update --workspace` asks for
+//! it outright, while `pnpm add` writes a registry range instead when
+//! `saveWorkspaceProtocol` is off and the user didn't ask for
+//! `workspace:` themselves.
+
+use pacquet_config::SaveWorkspaceProtocol;
+use pacquet_registry::PinnedVersion;
+
+use crate::which_version_is_pinned::which_version_is_pinned;
+
+/// What the dependency currently declares: the entry already in the
+/// manifest, and the specifier the user typed.
+///
+/// The two protocols consult them in different orders, so they stay
+/// separate rather than being collapsed by the caller.
+#[derive(Debug, Clone, Copy)]
+pub struct DeclaredSpecifiers<'a> {
+    pub prev: Option<&'a str>,
+    pub bare: Option<&'a str>,
+}
+
+/// The `workspace:` specifier to write for a dependency that resolves to
+/// workspace package `resolved_name` at `resolved_version`, under
+/// install name `alias`.
+///
+/// `resolved_version` may be `None` when the caller has not resolved the
+/// workspace package. Only [`SaveWorkspaceProtocol::On`] needs it — the
+/// rolling form writes a range with no version in it — so a `None` there
+/// falls back to the rolling shape rather than inventing a version.
+#[must_use]
+pub fn calc_specifier_for_workspace_dep(
+    declared: DeclaredSpecifiers<'_>,
+    alias: Option<&str>,
+    resolved_name: &str,
+    resolved_version: Option<&str>,
+    save_workspace_protocol: SaveWorkspaceProtocol,
+    default_pin: PinnedVersion,
+) -> String {
+    // An aliased dependency has to name its target inside the protocol
+    // (`workspace:<real name>@<range>`), otherwise the entry would point
+    // at whatever package shares the install name.
+    let prefix = match alias {
+        Some(alias) if alias != resolved_name => format!("workspace:{resolved_name}@"),
+        _ => "workspace:".to_string(),
+    };
+
+    let Some(resolved_version) =
+        resolved_version.filter(|_| save_workspace_protocol != SaveWorkspaceProtocol::Rolling)
+    else {
+        return rolling_specifier(&prefix, declared);
+    };
+
+    // A prerelease is written exactly: a `^`/`~` range over it would not
+    // match the prerelease it was resolved from.
+    if is_prerelease(resolved_version) {
+        return format!("{prefix}{resolved_version}");
+    }
+    let pin = declared.prev.and_then(which_version_is_pinned).unwrap_or(default_pin);
+    format!("{prefix}{}{resolved_version}", pin.range_prefix())
+}
+
+/// The version-less rolling form: `workspace:*`, `workspace:^`, or
+/// `workspace:~`, keeping whatever operator the dependency pinned to.
+fn rolling_specifier(prefix: &str, declared: DeclaredSpecifiers<'_>) -> String {
+    let Some(specifier) = declared.prev.or(declared.bare) else {
+        return format!("{prefix}^");
+    };
+    if ["*", "^", "~"].iter().any(|suffix| specifier == format!("{prefix}{suffix}")) {
+        return specifier.to_string();
+    }
+    let suffix = match which_version_is_pinned(specifier) {
+        Some(PinnedVersion::Minor) => "~",
+        Some(PinnedVersion::Patch | PinnedVersion::None) => "*",
+        // A specifier with no recoverable pin (a tag, a multi-comparator
+        // range) rolls to `^`, matching pnpm's fallback.
+        Some(PinnedVersion::Major) | None => "^",
+    };
+    format!("{prefix}{suffix}")
+}
+
+fn is_prerelease(version: &str) -> bool {
+    version.parse::<node_semver::Version>().is_ok_and(|parsed| !parsed.pre_release.is_empty())
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-npm-resolver/src/calc_specifier_for_workspace_dep/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/calc_specifier_for_workspace_dep/tests.rs
@@ -1,0 +1,180 @@
+use super::{DeclaredSpecifiers, calc_specifier_for_workspace_dep};
+use pacquet_config::SaveWorkspaceProtocol;
+use pacquet_registry::PinnedVersion;
+use pretty_assertions::assert_eq;
+
+/// `calc_specifier_for_workspace_dep` for a non-aliased dependency on
+/// `my-lib@1.2.3`, with no previous lockfile entry.
+fn fresh(bare: &str, protocol: SaveWorkspaceProtocol) -> String {
+    calc_specifier_for_workspace_dep(
+        DeclaredSpecifiers { prev: None, bare: Some(bare) },
+        Some("my-lib"),
+        "my-lib",
+        Some("1.2.3"),
+        protocol,
+        PinnedVersion::Major,
+    )
+}
+
+#[test]
+fn rolling_collapses_a_pinned_range_to_the_bare_operator() {
+    use SaveWorkspaceProtocol::Rolling;
+    assert_eq!(fresh("workspace:^1.2.3", Rolling), "workspace:^");
+    assert_eq!(fresh("workspace:~1.2.3", Rolling), "workspace:~");
+    assert_eq!(fresh("workspace:1.2.3", Rolling), "workspace:*");
+}
+
+/// An already-rolling specifier is returned untouched rather than
+/// re-derived, so `workspace:*` never silently becomes `workspace:^`.
+#[test]
+fn rolling_preserves_an_operator_only_specifier() {
+    use SaveWorkspaceProtocol::Rolling;
+    for specifier in ["workspace:*", "workspace:^", "workspace:~"] {
+        assert_eq!(fresh(specifier, Rolling), specifier);
+    }
+}
+
+/// A bare-semver request (no `workspace:` prefix) still rolls, because
+/// the dependency did resolve to a workspace package.
+#[test]
+fn rolling_applies_to_a_bare_semver_request() {
+    use SaveWorkspaceProtocol::Rolling;
+    assert_eq!(fresh("^1.0.0", Rolling), "workspace:^");
+    assert_eq!(fresh("~1.0.0", Rolling), "workspace:~");
+    assert_eq!(fresh("1.0.0", Rolling), "workspace:*");
+}
+
+/// A tag or an unrecoverable range has no operator to carry over, so it
+/// falls back to `^`.
+#[test]
+fn rolling_falls_back_to_caret() {
+    use SaveWorkspaceProtocol::Rolling;
+    assert_eq!(fresh("latest", Rolling), "workspace:^");
+    assert_eq!(
+        calc_specifier_for_workspace_dep(
+            DeclaredSpecifiers { prev: None, bare: None },
+            Some("my-lib"),
+            "my-lib",
+            Some("1.2.3"),
+            Rolling,
+            PinnedVersion::Major,
+        ),
+        "workspace:^",
+    );
+}
+
+/// The previous manifest entry wins over what the user typed, so
+/// re-running `add` on a dependency already saved as `workspace:~`
+/// keeps the tilde.
+#[test]
+fn rolling_prefers_the_previous_specifier() {
+    assert_eq!(
+        calc_specifier_for_workspace_dep(
+            DeclaredSpecifiers { prev: Some("workspace:~"), bare: Some("^1.0.0") },
+            Some("my-lib"),
+            "my-lib",
+            Some("1.2.3"),
+            SaveWorkspaceProtocol::Rolling,
+            PinnedVersion::Major,
+        ),
+        "workspace:~",
+    );
+}
+
+#[test]
+fn pinned_writes_the_resolved_version_with_the_default_operator() {
+    use SaveWorkspaceProtocol::On;
+    assert_eq!(fresh("^1.0.0", On), "workspace:^1.2.3");
+    assert_eq!(
+        calc_specifier_for_workspace_dep(
+            DeclaredSpecifiers { prev: None, bare: Some("^1.0.0") },
+            Some("my-lib"),
+            "my-lib",
+            Some("1.2.3"),
+            On,
+            PinnedVersion::Patch,
+        ),
+        "workspace:1.2.3",
+    );
+}
+
+/// Unlike the rolling form, the pinned form reads the operator off the
+/// *previous* specifier only — matching pnpm, which does not consult
+/// the freshly typed one here.
+#[test]
+fn pinned_takes_its_operator_from_the_previous_specifier() {
+    assert_eq!(
+        calc_specifier_for_workspace_dep(
+            DeclaredSpecifiers { prev: Some("workspace:~1.0.0"), bare: Some("^1.0.0") },
+            Some("my-lib"),
+            "my-lib",
+            Some("1.2.3"),
+            SaveWorkspaceProtocol::On,
+            PinnedVersion::Major,
+        ),
+        "workspace:~1.2.3",
+    );
+}
+
+/// A `^`/`~` range over a prerelease would not match the prerelease it
+/// was resolved from, so it is written exactly.
+#[test]
+fn pinned_writes_a_prerelease_exactly() {
+    assert_eq!(
+        calc_specifier_for_workspace_dep(
+            DeclaredSpecifiers { prev: None, bare: Some("^1.0.0") },
+            Some("my-lib"),
+            "my-lib",
+            Some("2.0.0-beta.1"),
+            SaveWorkspaceProtocol::On,
+            PinnedVersion::Major,
+        ),
+        "workspace:2.0.0-beta.1",
+    );
+}
+
+/// `Off` still renders a `workspace:` specifier — declining to use one
+/// at all is the caller's decision, not this function's.
+#[test]
+fn off_renders_the_pinned_shape() {
+    use SaveWorkspaceProtocol::Off;
+    assert_eq!(fresh("^1.0.0", Off), "workspace:^1.2.3");
+    assert_eq!(fresh("workspace:^1.0.0", Off), "workspace:^1.2.3");
+}
+
+/// An aliased dependency names its target inside the protocol, so the
+/// entry keeps pointing at the workspace package rather than at
+/// whatever shares the install name.
+#[test]
+fn an_alias_names_its_target_inside_the_protocol() {
+    let specifier = |protocol| {
+        calc_specifier_for_workspace_dep(
+            DeclaredSpecifiers { prev: None, bare: Some("workspace:^1.0.0") },
+            Some("lib-alias"),
+            "my-lib",
+            Some("1.2.3"),
+            protocol,
+            PinnedVersion::Major,
+        )
+    };
+    assert_eq!(specifier(SaveWorkspaceProtocol::Rolling), "workspace:my-lib@^");
+    assert_eq!(specifier(SaveWorkspaceProtocol::On), "workspace:my-lib@^1.2.3");
+}
+
+/// Without a resolved version there is nothing to pin to, so the pinned
+/// form falls back to the rolling shape rather than inventing one.
+#[test]
+fn a_missing_version_falls_back_to_the_rolling_shape() {
+    let specifier = |protocol| {
+        calc_specifier_for_workspace_dep(
+            DeclaredSpecifiers { prev: None, bare: Some("workspace:^") },
+            Some("my-lib"),
+            "my-lib",
+            None,
+            protocol,
+            PinnedVersion::Major,
+        )
+    };
+    assert_eq!(specifier(SaveWorkspaceProtocol::Rolling), "workspace:^");
+    assert_eq!(specifier(SaveWorkspaceProtocol::On), "workspace:^");
+}

--- a/pnpm/crates/resolving-npm-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/lib.rs
@@ -16,6 +16,7 @@
 //!   npm-resolved lockfile entry the install loads.
 
 mod calc_specifier;
+mod calc_specifier_for_workspace_dep;
 mod create_npm_resolution_verifier;
 mod errors;
 mod fetch_attestation_published_at;
@@ -38,6 +39,7 @@ mod which_version_is_pinned;
 mod workspace_pref_to_npm;
 
 pub use calc_specifier::calc_specifier;
+pub use calc_specifier_for_workspace_dep::{DeclaredSpecifiers, calc_specifier_for_workspace_dep};
 pub use create_npm_resolution_verifier::{
     CreateNpmResolutionVerifierOptions, DistStats, NpmResolutionVerifier, ObservedDistStats,
     create_npm_resolution_verifier, observed_dist_stats_sink,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -44,7 +44,7 @@ use crate::{
     pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
     resolve_from_workspace::{
-        ResolveFromWorkspaceError, ResolveFromWorkspaceOptions,
+        ResolveFromWorkspaceError, ResolveFromWorkspaceOptions, SavedSpecifierOptions,
         pick_matching_local_version_or_null, resolve_from_local_package,
         try_resolve_from_workspace, try_resolve_from_workspace_packages,
     },
@@ -164,6 +164,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
                 default_tag,
                 workspace_packages: opts.workspace_packages.as_ref(),
                 inject_workspace_packages: opts.inject_workspace_packages,
+                saved_specifier: saved_specifier_options(opts),
             };
             return try_resolve_from_workspace(wanted_dependency, &ws_opts)
                 .map_err(|err| Box::new(err) as ResolveError);
@@ -465,6 +466,7 @@ fn try_workspace_shadow(
             hard_link,
             project_dir,
             lockfile_dir,
+            saved_specifier_options(opts),
         ));
     }
 
@@ -481,6 +483,7 @@ fn try_workspace_shadow(
         hard_link,
         project_dir,
         lockfile_dir,
+        saved_specifier_options(opts),
     ))
 }
 
@@ -497,6 +500,17 @@ fn workspace_fallback_options(opts: &ResolveOptions) -> ResolveFromWorkspaceOpti
         default_tag: UNUSED,
         workspace_packages: opts.workspace_packages.as_ref(),
         inject_workspace_packages: opts.inject_workspace_packages,
+        saved_specifier: saved_specifier_options(opts),
+    }
+}
+
+/// Project the specifier-writing knobs out of [`ResolveOptions`] for the
+/// workspace entry point, which carries its own options struct.
+fn saved_specifier_options(opts: &ResolveOptions) -> SavedSpecifierOptions {
+    SavedSpecifierOptions {
+        calc_specifier: opts.calc_specifier,
+        pinned_version: opts.pinned_version,
+        save_workspace_protocol: opts.save_workspace_protocol,
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
@@ -12,7 +12,9 @@ use std::path::{Path, PathBuf};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::Version;
+use pacquet_config::SaveWorkspaceProtocol;
 use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
+use pacquet_registry::PinnedVersion;
 use pacquet_resolving_resolver_base::{
     PkgResolutionId, ResolveResult, WantedDependency, WorkspacePackage, WorkspacePackages,
     WorkspacePackagesByVersion,
@@ -20,6 +22,7 @@ use pacquet_resolving_resolver_base::{
 use pacquet_workspace_range_resolver::resolve_workspace_range;
 
 use crate::{
+    calc_specifier_for_workspace_dep::{DeclaredSpecifiers, calc_specifier_for_workspace_dep},
     parse_bare_specifier::parse_bare_specifier,
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
     workspace_pref_to_npm::{InvalidWorkspaceSpecError, workspace_pref_to_npm},
@@ -51,6 +54,27 @@ pub struct ResolveFromWorkspaceOptions<'a> {
     /// `inject-workspace-packages` config plus the per-dep `injected`
     /// toggle.
     pub inject_workspace_packages: bool,
+    /// How to write the manifest specifier for this pick, when the
+    /// caller wants one at all.
+    pub saved_specifier: SavedSpecifierOptions,
+}
+
+/// What [`resolve_from_local_package`] needs to produce a
+/// manifest-ready [`ResolveResult::normalized_bare_specifier`].
+///
+/// Mirrors the same-named fields of
+/// [`ResolveOptions`](pacquet_resolving_resolver_base::ResolveOptions);
+/// carried separately because the workspace entry point takes its own
+/// options struct.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SavedSpecifierOptions {
+    /// `false` suppresses the computation entirely — nothing below an
+    /// importer's direct dependencies is written to a manifest.
+    pub calc_specifier: bool,
+    /// Range operator to apply when the dependency declares none.
+    pub pinned_version: Option<PinnedVersion>,
+    /// The `saveWorkspaceProtocol` setting.
+    pub save_workspace_protocol: SaveWorkspaceProtocol,
 }
 
 /// Error envelope for [`try_resolve_from_workspace`]. The two error
@@ -190,6 +214,7 @@ pub(crate) fn try_resolve_from_workspace_packages(
         opts.inject_workspace_packages || wanted_dependency.injected.unwrap_or(false),
         opts.project_dir,
         opts.lockfile_dir,
+        opts.saved_specifier,
     ))
 }
 
@@ -214,16 +239,13 @@ pub(crate) fn pick_matching_local_version_or_null(
 }
 
 /// Build a `link:` / `file:` [`ResolveResult`] for a workspace package.
-///
-/// The `normalized_bare_specifier` field for the add / update paths
-/// stays `None` because pacquet doesn't carry the pinned-version /
-/// save-workspace-protocol config through to the resolver yet.
 pub(crate) fn resolve_from_local_package(
     local_package: &WorkspacePackage,
     wanted_dependency: &WantedDependency,
     hard_link_local_packages: bool,
     project_dir: &Path,
     lockfile_dir: &Path,
+    saved_specifier: SavedSpecifierOptions,
 ) -> ResolveResult {
     let local_dir = resolve_local_package_dir(local_package);
 
@@ -245,10 +267,34 @@ pub(crate) fn resolve_from_local_package(
         manifest: Some(std::sync::Arc::new(local_package.manifest.clone())),
         resolution: LockfileResolution::Directory(DirectoryResolution { directory }),
         resolved_via: "workspace".to_string(),
-        normalized_bare_specifier: None,
+        normalized_bare_specifier: saved_specifier
+            .calc_specifier
+            .then(|| workspace_specifier(local_package, wanted_dependency, saved_specifier))
+            .flatten(),
         alias: wanted_dependency.alias.clone(),
         policy_violation: None,
     }
+}
+
+/// The manifest specifier for a workspace pick, or `None` when the
+/// local manifest carries no name to write the protocol against.
+fn workspace_specifier(
+    local_package: &WorkspacePackage,
+    wanted_dependency: &WantedDependency,
+    saved_specifier: SavedSpecifierOptions,
+) -> Option<String> {
+    let manifest_field = |key| local_package.manifest.get(key).and_then(serde_json::Value::as_str);
+    Some(calc_specifier_for_workspace_dep(
+        DeclaredSpecifiers {
+            prev: wanted_dependency.prev_specifier.as_deref(),
+            bare: wanted_dependency.bare_specifier.as_deref(),
+        },
+        wanted_dependency.alias.as_deref(),
+        manifest_field("name")?,
+        manifest_field("version"),
+        saved_specifier.save_workspace_protocol,
+        saved_specifier.pinned_version.unwrap_or_default(),
+    ))
 }
 
 /// Honours `publishConfig.directory` when `publishConfig.linkDirectory`

--- a/pnpm/crates/resolving-npm-resolver/src/resolve_from_workspace/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/resolve_from_workspace/tests.rs
@@ -11,7 +11,10 @@ use pacquet_resolving_resolver_base::{
 };
 use serde_json::json;
 
-use super::{ResolveFromWorkspaceError, ResolveFromWorkspaceOptions, try_resolve_from_workspace};
+use super::{
+    ResolveFromWorkspaceError, ResolveFromWorkspaceOptions, SavedSpecifierOptions,
+    try_resolve_from_workspace,
+};
 
 fn build_packages() -> WorkspacePackages {
     let mut foo: WorkspacePackagesByVersion = BTreeMap::new();
@@ -53,6 +56,7 @@ fn opts(packages: &WorkspacePackages) -> ResolveFromWorkspaceOptions<'_> {
         default_tag: "latest",
         workspace_packages: Some(packages),
         inject_workspace_packages: false,
+        saved_specifier: SavedSpecifierOptions::default(),
     }
 }
 
@@ -116,6 +120,7 @@ fn workspace_self_dependency_renders_as_bare_link() {
         default_tag: "latest",
         workspace_packages: Some(&packages),
         inject_workspace_packages: false,
+        saved_specifier: SavedSpecifierOptions::default(),
     };
     let result = try_resolve_from_workspace(&wanted("self", "workspace:*"), &opts)
         .expect("ok")
@@ -221,6 +226,7 @@ fn publish_config_directory_overrides_root_when_link_directory_is_unset() {
         default_tag: "latest",
         workspace_packages: Some(&packages),
         inject_workspace_packages: false,
+        saved_specifier: SavedSpecifierOptions::default(),
     };
 
     let result = try_resolve_from_workspace(&wanted("foo", "workspace:*"), &opts)
@@ -253,6 +259,7 @@ fn publish_config_link_directory_false_keeps_root() {
         default_tag: "latest",
         workspace_packages: Some(&packages),
         inject_workspace_packages: false,
+        saved_specifier: SavedSpecifierOptions::default(),
     };
 
     let result = try_resolve_from_workspace(&wanted("foo", "workspace:*"), &opts)

--- a/pnpm/crates/resolving-resolver-base/src/resolve.rs
+++ b/pnpm/crates/resolving-resolver-base/src/resolve.rs
@@ -10,7 +10,7 @@ use std::{collections::BTreeMap, future::Future, path::PathBuf, pin::Pin, sync::
 
 use chrono::{DateTime, Utc};
 use derive_more::{Display, From};
-use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
+use pacquet_config::{SaveWorkspaceProtocol, TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgNameVer};
 use pacquet_registry::PinnedVersion;
 use serde::{Deserialize, Serialize};
@@ -331,6 +331,9 @@ pub struct ResolveOptions {
     /// `^`, `~` stays `~`, an exact pin stays exact). `None` leaves the
     /// choice to the resolver's own default.
     pub pinned_version: Option<PinnedVersion>,
+    /// How [`Self::calc_specifier`] writes a dependency that resolved to
+    /// a workspace package. The `saveWorkspaceProtocol` setting.
+    pub save_workspace_protocol: SaveWorkspaceProtocol,
     /// `minimumReleaseAge` cutoff. Versions published after this point
     /// are filtered out by the npm picker (or reported inline via
     /// [`ResolveResult::policy_violation`] when no mature pick exists).


### PR DESCRIPTION
## Summary

Makes `pnpm add <pkg>@workspace:…` honor `saveWorkspaceProtocol` in the Rust engine, and deduplicates the calculator it shares with `pnpm update --workspace`.

`add` was recording the specifier exactly as typed. Comparing the two stacks on the same workspace:

| request | setting | pnpm | pacquet (before) |
| --- | --- | --- | --- |
| `workspace:^1.2.3` | default | `workspace:^` | `workspace:^1.2.3` |
| `workspace:~1.2.3` | default | `workspace:~` | `workspace:~1.2.3` |
| `workspace:1.2.3` | default | `workspace:*` | `workspace:1.2.3` |

The rolling default matters: it writes a range with no version in it, so bumping a workspace package never has to touch its dependents' manifests. Saving the version defeats that.

> **Rebased onto `main` after pnpm/pnpm#13288 landed.** That PR added the `SaveWorkspaceProtocol` type, its `pnpm-workspace.yaml` field, and the parity row for `update --workspace`, so this PR no longer carries any of that. What's left is the `add` side, the missing env binding, and the dedupe.

### Commits

**1. `refactor(resolving-npm-resolver)`** — `update --workspace` had a private `workspace_specifier`; `add` needs the same rendering, so it moves to the npm-resolver crate and update.rs calls it. Also adds `PNPM_CONFIG_SAVE_WORKSPACE_PROTOCOL`, which was missing — pnpm exposes every setting through its env pass, and this one had a yaml field with no environment equivalent.

**2. `feat(add)`** — the `add`-side entry point, plus the integration test and changeset.

### Details worth a reviewer's eye

- **The shared calculator renders only; the decline is the caller's.** `update --workspace` is an explicit request for the protocol, so it writes a `workspace:` specifier even under `saveWorkspaceProtocol: false`; `add` falls back to a registry range there. Putting a `SaveWorkspaceProtocol::Off` early return inside the calculator would have silently changed `update`'s behavior — which is why the split is where it is. All nine `update --workspace` tests pass unchanged, which is the evidence the extraction preserved behavior.
- **The two shapes read the declared specifiers in different orders.** Rolling takes the previous entry then the typed one; pinned reads the previous entry only, falling back to the configured default — so `add <pkg>@workspace:~1.2.3` under `true` saves `workspace:^1.2.3`, not `~`. That asymmetry is pnpm's, and `DeclaredSpecifiers` keeps the two inputs separate so a caller can't collapse them by accident.
- **`resolved_version` is optional**, so a caller that hasn't enumerated the workspace still gets the rolling shape rather than an invented version.
- **The workspace is enumerated only for the shapes that carry a version.** The default `add` stays off the filesystem.
- **Indexing happens before the mutation loop** in `run_selected`, so a `workspace:` request resolves against the versions the projects declared on entry, not against a sibling the same command already rewrote.

Every row of the rolling / pinned / off matrix was checked against `pnpm11/pnpm/dist/pnpm.mjs` on identical fixtures — before the rebase and again after — including a pinned save resolving to the local `2.5.0` over a typed `^1.0.0`, and a prerelease written exactly. Those rows are the integration test.

### Not in scope

With `linkWorkspacePackages: true`, `pnpm add <ws-pkg>` (no explicit `workspace:`) resolves from the workspace in pnpm but fails with a registry 404 in pacquet — the resolver has no equivalent of pnpm's `tryResolveFromWorkspacePackages` fallback in its error path. Separate bug, separate fix; untouched here.

Related to pnpm/pnpm#12042.

## Squash Commit Body

```text
`pnpm add <pkg>@workspace:...` recorded the specifier exactly as typed,
so `workspace:^1.2.3` stayed pinned where pnpm writes `workspace:^` — a
range with no version in it, so bumping the workspace package never has
to touch its dependents' manifests.

`update --workspace` already had a private calculator for this. It moves
to the npm-resolver crate so both commands share it, and it renders
only: whether a dependency should be written under the protocol at all
stays with the caller, because the two differ. `update --workspace` is
an explicit request and writes a `workspace:` specifier even under
`saveWorkspaceProtocol: false`, while `add` falls back to a registry
range.

`add` needs its own entry point because it writes the manifest before
the install runs and so never reaches the resolver's `calc_specifier`
path. The workspace is enumerated only for the shapes that carry a
version; the rolling default reads nothing extra.

Also adds the missing `PNPM_CONFIG_SAVE_WORKSPACE_PROTOCOL` binding.

Related to pnpm/pnpm#12042.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (TypeScript already supports the setting; this is the pacquet side.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added/expanded support for the `saveWorkspaceProtocol` setting when adding and updating workspace dependencies.
  - Dependency specs written back to manifests now follow `workspace:` protocol rules, including rolling forms (e.g. `workspace:^`), versioned forms (e.g. `workspace:^2.5.0`), and preserved prereleases/aliases/range operators.
  - Added `SAVE_WORKSPACE_PROTOCOL` environment variable support for this behavior.
- **Bug Fixes**
  - Improved consistency of saved workspace specifiers between add, update, and resolver outcomes.
- **Tests**
  - Added end-to-end coverage for workspace protocol save behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->