### PR TITLE
fix(run): forward every argument after the script name verbatim

### DIFF
--- a/.changeset/pacquet-run-forwards-script-args.md
+++ b/.changeset/pacquet-run-forwards-script-args.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm run <script> <args>` now forwards every argument after the script name to the script verbatim, matching the behavior of the JavaScript implementation. Previously the `--` separator was dropped, so `pnpm run test -- --watch` reached the underlying program as `--watch` and failed whenever that program claimed the option itself; arguments spelled like `pnpm run`'s own flags (`-s`, `--if-present`) were also consumed by pnpm instead of reaching the script [#13295](https://github.com/pnpm/pnpm/issues/13295). Pass those flags before the script name (`pnpm run -s test`) to apply them to pnpm.

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -53,8 +53,7 @@ impl CleanArgs {
             && !script.is_empty()
         {
             return RunArgs {
-                command: Some(command_name.to_string()),
-                args: Vec::new(),
+                script: RunArgs::script(command_name, []),
                 if_present: false,
                 resume_from: None,
                 report_summary: false,

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -236,8 +236,7 @@ pub(super) fn install_test<'a>(
 ) -> miette::Result<CommandFuture<'a>> {
     let install_args = args.install_args;
     let run_args = super::run::RunArgs {
-        command: Some("test".to_string()),
-        args: args.args,
+        script: super::run::RunArgs::script("test", args.args),
         if_present: ctx.if_present,
         resume_from: ctx.recursive_resume_from.map(str::to_string),
         report_summary: ctx.recursive_report_summary,

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -54,10 +54,8 @@ pub(super) fn fallback<'a>(
     ctx: &RunCtx<'a>,
     command: Vec<String>,
 ) -> miette::Result<CommandFuture<'a>> {
-    let mut command = command.into_iter();
     let args = RunArgs {
-        command: command.next(),
-        args: command.collect(),
+        script: command,
         if_present: false,
         resume_from: None,
         report_summary: false,
@@ -126,8 +124,7 @@ pub(super) fn restart<'a>(
 
 fn run_args_for_script(command: &str, if_present: bool) -> RunArgs {
     RunArgs {
-        command: Some(command.to_string()),
-        args: Vec::new(),
+        script: RunArgs::script(command, []),
         if_present,
         resume_from: None,
         report_summary: false,

--- a/pnpm/crates/cli/src/cli_args/restart.rs
+++ b/pnpm/crates/cli/src/cli_args/restart.rs
@@ -26,8 +26,7 @@ impl RestartArgs {
 
         for script_name in ["stop", "restart", "start"] {
             RunArgs {
-                command: Some(script_name.to_string()),
-                args: args.clone(),
+                script: RunArgs::script(script_name, args.clone()),
                 if_present,
                 resume_from: None,
                 report_summary: false,

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -19,13 +19,18 @@ mod recursive;
 
 #[derive(Debug, Args)]
 pub struct RunArgs {
-    /// A pre-defined package script. When omitted, the available scripts
-    /// are listed.
-    pub command: Option<String>,
-
-    /// Arguments passed to the script after the script name.
+    /// A pre-defined package script followed by the arguments passed to
+    /// it. When empty, the available scripts are listed.
+    ///
+    /// One positional rather than a script name plus a separate argument
+    /// list, so parsing stops *at* the script name — pnpm puts `run` in
+    /// `SPECIALLY_ESCAPED_CMDS` to the same effect. Every later token
+    /// reaches the script verbatim, including a `--` separator and
+    /// anything shaped like a pnpm flag. Splitting the two lets clap keep
+    /// parsing past the script name, which swallows both
+    /// (pnpm/pnpm#13295). `exec` / `dlx` / `with` take the same shape.
     #[clap(trailing_var_arg = true, allow_hyphen_values = true)]
-    pub args: Vec<String>,
+    pub script: Vec<String>,
 
     /// Avoid exiting with a non-zero exit code when the script is undefined.
     #[clap(long)]
@@ -91,6 +96,26 @@ pub enum RunError {
 }
 
 impl RunArgs {
+    /// Build the positional from a script name and its arguments, for the
+    /// paths that synthesize a `run` rather than parsing one.
+    pub(super) fn script<Args>(name: &str, args: Args) -> Vec<String>
+    where
+        Args: IntoIterator<Item = String>,
+    {
+        std::iter::once(name.to_string()).chain(args).collect()
+    }
+
+    /// The script to run, or `None` when `run` was given no positional and
+    /// should list the available scripts instead.
+    pub(super) fn script_name(&self) -> Option<&str> {
+        self.script.first().map(String::as_str)
+    }
+
+    /// The arguments to forward to the script, verbatim.
+    pub(super) fn script_args(&self) -> &[String] {
+        self.script.get(1..).unwrap_or_default()
+    }
+
     /// Execute the subcommand in `dir`. `silent` suppresses the
     /// `$ <script>` echo (set when the reporter is `silent`).
     ///
@@ -120,12 +145,14 @@ impl RunArgs {
         // directory without a project skips the check instead of
         // spawning a doomed install (see check_deps_status_before_run_at).
         super::verify_deps::verify_deps_before_run(dir, config, silent)?;
-        let RunArgs { command, args, if_present, sequential, .. } = self;
-        let Some(script_name) = command else {
+        let RunArgs { script, if_present, sequential, .. } = self;
+        let mut script = script.into_iter();
+        let Some(script_name) = script.next() else {
             let manifest = read_project_manifest_only(dir).map_err(RunError::Manifest)?;
             println!("{}", render_project_commands(manifest.value()));
             return Ok(());
         };
+        let args: Vec<String> = script.collect();
         let manifest = match read_project_manifest_only(dir) {
             Ok(manifest) => manifest,
             Err(ReadProjectManifestOnlyError::NoImporterManifestFound { .. })

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -146,13 +146,11 @@ impl RunArgs {
         // spawning a doomed install (see check_deps_status_before_run_at).
         super::verify_deps::verify_deps_before_run(dir, config, silent)?;
         let RunArgs { script, if_present, sequential, .. } = self;
-        let mut script = script.into_iter();
-        let Some(script_name) = script.next() else {
+        let Some((script_name, args)) = script.split_first() else {
             let manifest = read_project_manifest_only(dir).map_err(RunError::Manifest)?;
             println!("{}", render_project_commands(manifest.value()));
             return Ok(());
         };
-        let args: Vec<String> = script.collect();
         let manifest = match read_project_manifest_only(dir) {
             Ok(manifest) => manifest,
             Err(ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
@@ -163,13 +161,13 @@ impl RunArgs {
             Err(err) => return Err(RunError::Manifest(err).into()),
         };
 
-        let mut specified = specified_scripts(manifest.value(), &script_name);
+        let mut specified = specified_scripts(manifest.value(), script_name);
 
         // Hidden scripts (names starting with `.`) can only be invoked
         // from within another script, detected by an inherited
         // `npm_lifecycle_event`.
         if env::var_os("npm_lifecycle_event").is_none() {
-            specified = throw_or_filter_hidden_scripts(specified, &script_name)?;
+            specified = throw_or_filter_hidden_scripts(specified, script_name)?;
         }
 
         if specified.is_empty() {
@@ -218,7 +216,7 @@ impl RunArgs {
             if args.is_empty() && main == "npx only-allow pnpm" {
                 continue;
             }
-            let status = run_stages(&ctx, name, &main, &args)?;
+            let status = run_stages(&ctx, name, &main, args)?;
             if !status.success() {
                 // A failing script sets the process exit code.
                 // `run_stage` already emitted the `[ELIFECYCLE]` line.
@@ -238,13 +236,13 @@ impl RunArgs {
 }
 
 fn exec_fallback(
-    script_name: String,
-    args: Vec<String>,
+    script_name: &str,
+    args: &[String],
     dir: &Path,
     config: &Config,
 ) -> miette::Result<()> {
     ExecArgs {
-        command: std::iter::once(script_name).chain(args).collect(),
+        command: RunArgs::script(script_name, args.iter().cloned()),
         shell_mode: false,
         resume_from: None,
         report_summary: false,

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -73,10 +73,10 @@ pub enum RecursiveRunError {
 /// `config.workspace_dir`, falling back to `dir` when no
 /// `pnpm-workspace.yaml` exists.
 pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Result<()> {
-    // `RunArgs::command` is optional so single-project `run` can list
+    // The script name is optional so single-project `run` can list
     // scripts; recursive mode has no such "list" behavior, so a missing
     // script name is a usage error (`ERR_PNPM_SCRIPT_NAME_IS_REQUIRED`).
-    let Some(script_name) = args.command.as_deref() else {
+    let Some(script_name) = args.script_name() else {
         return Err(RecursiveRunError::ScriptNameRequired.into());
     };
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
@@ -144,7 +144,9 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
             // Without these guards the recursive loop would fork a
             // useless shell per project and (for the npm guard) might
             // run the wrong-package-manager warning.
-            if script.is_empty() || (args.args.is_empty() && script == "npx only-allow pnpm") {
+            if script.is_empty()
+                || (args.script_args().is_empty() && script == "npx only-allow pnpm")
+            {
                 result[root].status = Status::Skipped;
                 continue;
             }
@@ -194,7 +196,7 @@ pub fn run_recursive(args: &RunArgs, config: &Config, dir: &Path) -> miette::Res
                 silent: true,
                 sequential: args.sequential,
             };
-            let status = run_stages(&ctx, script_name, script, &args.args)?;
+            let status = run_stages(&ctx, script_name, script, args.script_args())?;
             let duration = start.elapsed().as_secs_f64() * 1e3;
 
             if status.success() {

--- a/pnpm/crates/cli/src/cli_args/run/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/run/tests.rs
@@ -1,4 +1,5 @@
 use super::{RunError, render_project_commands, specified_scripts, throw_or_filter_hidden_scripts};
+use clap::Parser;
 use serde_json::json;
 
 #[test]
@@ -58,4 +59,66 @@ fn print_commands_empty_when_no_scripts() {
     let manifest = json!({ "name": "x" });
     let output = render_project_commands(&manifest);
     assert_eq!(output, "There are no scripts specified.");
+}
+
+/// Everything after the script name reaches the script verbatim, so a
+/// `--` separator survives and a pnpm-flag-shaped argument is not claimed
+/// by pnpm (pnpm/pnpm#13295). pnpm gets this by listing `run` in
+/// `SPECIALLY_ESCAPED_CMDS`; here it falls out of the single
+/// `trailing_var_arg` positional.
+#[test]
+fn run_forwards_every_token_after_the_script_name() {
+    for (argv, script_args) in [
+        (["run", "show", "--", "--other=1"].as_slice(), ["--", "--other=1"].as_slice()),
+        (&["run", "show", "--other=1"], &["--other=1"]),
+        (&["run", "show", "--", "-s"], &["--", "-s"]),
+        (&["run", "show", "--", "a", "b"], &["--", "a", "b"]),
+        (&["run", "show", "--", "--"], &["--", "--"]),
+        // `-s` / `--if-present` are pnpm's own `run` flags, but after the
+        // script name they belong to the script.
+        (&["run", "show", "-s"], &["-s"]),
+        (&["run", "show", "--if-present"], &["--if-present"]),
+        (&["run", "show"], &[]),
+    ] {
+        let args = run_args(argv);
+
+        assert_eq!(args.script_name(), Some("show"), "{argv:?}");
+        assert_eq!(args.script_args(), script_args, "{argv:?}");
+        assert!(!args.sequential, "{argv:?}: -s after the script name is not --sequential");
+        assert!(!args.if_present, "{argv:?}: --if-present after the script name is the script's");
+    }
+}
+
+/// The same flags ahead of the script name are still pnpm's.
+#[test]
+fn run_flags_before_the_script_name_are_pnpms() {
+    let sequential = run_args(&["run", "-s", "show"]);
+    assert!(sequential.sequential);
+    assert_eq!(sequential.script_name(), Some("show"));
+    assert!(sequential.script_args().is_empty());
+
+    let if_present = run_args(&["run", "--if-present", "show", "x"]);
+    assert!(if_present.if_present);
+    assert_eq!(if_present.script_name(), Some("show"));
+    assert_eq!(if_present.script_args(), ["x"]);
+}
+
+/// `run` with no positional lists the available scripts rather than
+/// running one.
+#[test]
+fn run_without_a_script_name_has_none() {
+    let args = run_args(&["run"]);
+    assert_eq!(args.script_name(), None);
+    assert!(args.script_args().is_empty());
+}
+
+fn run_args(argv: &[&str]) -> super::RunArgs {
+    let parsed = crate::cli_args::CliArgs::try_parse_from(
+        std::iter::once("pnpm").chain(argv.iter().copied()),
+    )
+    .unwrap_or_else(|error| panic!("{argv:?} should parse: {error}"));
+    match parsed.command {
+        crate::cli_args::cli_command::CliCommand::Run(args) => args,
+        other => panic!("{argv:?} should parse as run, got {other:?}"),
+    }
 }

--- a/pnpm/crates/cli/src/cli_args/stop.rs
+++ b/pnpm/crates/cli/src/cli_args/stop.rs
@@ -18,8 +18,7 @@ impl StopArgs {
     pub(crate) fn into_run_args(self) -> RunArgs {
         let StopArgs { args, if_present } = self;
         RunArgs {
-            command: Some("stop".to_string()),
-            args,
+            script: RunArgs::script("stop", args),
             if_present,
             resume_from: None,
             report_summary: false,

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -682,10 +682,13 @@ fn workspace_root_is_allowed_for_subcommands_without_global() {
     let (root, canonical) = workspace_fixture();
 
     for subcommand in [["install"].as_slice(), ["run", "build"].as_slice(), ["pack"].as_slice()] {
+        // Ahead of the subcommand: `run` forwards everything after the
+        // script name to the script, so a trailing `-w` would be the
+        // script's argument rather than pnpm's.
         let argv = std::iter::once("pacquet")
-            .chain(subcommand.iter().copied())
             .chain(["-w", "-C"])
-            .chain([root.path().to_str().expect("utf-8 tmp dir")]);
+            .chain([root.path().to_str().expect("utf-8 tmp dir")])
+            .chain(subcommand.iter().copied());
         let mut args = CliArgs::try_parse_from(argv).expect("parses");
         args.apply_workspace_root().unwrap_or_else(|error| {
             panic!("{subcommand:?} should accept -w: {error}");

--- a/pnpm/crates/cli/tests/run.rs
+++ b/pnpm/crates/cli/tests/run.rs
@@ -83,37 +83,70 @@ fn run_passes_extra_arguments_to_the_script() {
 
 /// `pnpm run <script> -- <args>` forwards the separator, so an argument
 /// shaped like an option of the script's own program reaches the script
-/// instead of being claimed by it (pnpm/pnpm#13295). Asserted on what the
-/// script received, not on the echoed command line.
+/// instead of being claimed by it (pnpm/pnpm#13295). Asserts what the
+/// script received rather than the echoed command line, and mirrors the
+/// TypeScript counterpart in `pnpm11/pnpm/test/run.ts` ("run: pass the
+/// args to the command that is specified in the build script"), down to
+/// only the main stage seeing the arguments.
 #[test]
 fn run_forwards_the_separator_and_option_shaped_arguments() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    let marker_path = workspace.join("args.json");
-    // `node -e` claims any option-shaped argument that reaches it before
-    // a `--`, exiting 9 with "bad option" — which is the failure this
-    // guards against, so the script has to be a program that would.
-    let script = format!(
-        r#"node -e "require('fs').writeFileSync({}, JSON.stringify(process.argv.slice(1)))""#,
-        serde_json::to_string(&marker_path.to_string_lossy().into_owned())
-            .expect("encode marker path")
-            .replace('"', "'"),
-    );
+    // A recorder file rather than an inlined `node -e` program, so no
+    // path has to survive quoting into a JS string literal on either
+    // platform. Same approach as the TypeScript test.
+    fs::write(
+        workspace.join("recordArgs.js"),
+        "require('fs').writeFileSync('args.json', \
+JSON.stringify(require('./args.json').concat([process.argv.slice(2)])), 'utf8')",
+    )
+    .expect("write recordArgs.js");
+    fs::write(workspace.join("args.json"), "[]").expect("seed args.json");
     fs::write(
         workspace.join("package.json"),
         json!({
             "name": "test",
             "version": "0.0.0",
-            "scripts": { "show": script },
+            "scripts": {
+                "prefoo": "node recordArgs",
+                "foo": "node recordArgs",
+                "postfoo": "node recordArgs",
+            },
         })
         .to_string(),
     )
     .expect("write package.json");
 
-    pacquet.with_args(["run", "show", "--", "--other=1", "-s", "--if-present"]).assert().success();
+    pacquet
+        .with_args([
+            "--config.enable-pre-post-scripts",
+            "run",
+            "foo",
+            "arg",
+            "--",
+            "--other=1",
+            "-s",
+            "--if-present",
+        ])
+        .assert()
+        .success();
 
-    let written = fs::read_to_string(&marker_path).expect("read marker");
-    let received: Vec<String> = serde_json::from_str(&written).expect("parse marker");
-    assert_eq!(received, ["--other=1", "-s", "--if-present"]);
+    let recorded: Vec<Vec<String>> =
+        serde_json::from_str(&fs::read_to_string(workspace.join("args.json")).expect("read args"))
+            .expect("parse args.json");
+    assert_eq!(
+        recorded,
+        vec![
+            Vec::<String>::new(),
+            vec![
+                "arg".to_string(),
+                "--".to_string(),
+                "--other=1".to_string(),
+                "-s".to_string(),
+                "--if-present".to_string(),
+            ],
+            Vec::<String>::new(),
+        ],
+    );
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/run.rs
+++ b/pnpm/crates/cli/tests/run.rs
@@ -81,6 +81,43 @@ fn run_passes_extra_arguments_to_the_script() {
     drop(root);
 }
 
+/// `pnpm run <script> -- <args>` forwards the separator, so an argument
+/// shaped like an option of the script's own program reaches the script
+/// instead of being claimed by it (pnpm/pnpm#13295). Asserted on what the
+/// script received, not on the echoed command line.
+#[test]
+fn run_forwards_the_separator_and_option_shaped_arguments() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker_path = workspace.join("args.json");
+    // `node -e` claims any option-shaped argument that reaches it before
+    // a `--`, exiting 9 with "bad option" — which is the failure this
+    // guards against, so the script has to be a program that would.
+    let script = format!(
+        r#"node -e "require('fs').writeFileSync({}, JSON.stringify(process.argv.slice(1)))""#,
+        serde_json::to_string(&marker_path.to_string_lossy().into_owned())
+            .expect("encode marker path")
+            .replace('"', "'"),
+    );
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "test",
+            "version": "0.0.0",
+            "scripts": { "show": script },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["run", "show", "--", "--other=1", "-s", "--if-present"]).assert().success();
+
+    let written = fs::read_to_string(&marker_path).expect("read marker");
+    let received: Vec<String> = serde_json::from_str(&written).expect("parse marker");
+    assert_eq!(received, ["--other=1", "-s", "--if-present"]);
+
+    drop(root);
+}
+
 /// Without `--if-present`, calling a script that does not exist fails
 /// with pnpm's `NO_SCRIPT` error.
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

`pnpm run <script> -- <args>` dropped the `--` separator on the Rust CLI, so a forwarded argument that looks like an option of the script's own program was claimed by that program:

```console
$ pnpm run show -- --other=1     # script is `node -e "…"`
$ node -e "…" --other=1
node: bad option: --other=1
[ELIFECYCLE] Command failed with exit code 9.
```

While reproducing pnpm/pnpm#13295 I found the separator is one of **six** divergences with the same root cause, so the fix covers all of them:

| command | pnpm v11.17.0 | pacquet before | after |
|---|---|---|---|
| `run show -- --other=1` | `-- --other=1` | `--other=1` | ✅ |
| `run show -- -s` | `-- -s` | `-s` | ✅ |
| `run show -- a b` | `-- a b` | `a b` | ✅ |
| `run show -- --` | `-- --` | `--` | ✅ |
| `run show -s` | `-s` | *(taken as `--sequential`)* | ✅ |
| `run show --if-present` | `--if-present` | *(taken as the flag)* | ✅ |

The last two mean a script could not receive an argument spelled like one of `pnpm run`'s own flags at all.

## Root cause

pnpm stops parsing **at the script name** — `run` is in `SPECIALLY_ESCAPED_CMDS`, so nopt escapes from `argv.remain[indexOfRunScriptName]` onward and every later token is verbatim.

pacquet let clap keep parsing, because `RunArgs` declared the script name as its own `Option<String>` positional *ahead of* the `trailing_var_arg` list. clap flips `trailing_values` only when a `trailing_var_arg` positional consumes its first value; with the name already taken by the earlier positional, the next `--` reached the escape branch and was discarded, and pnpm's flags kept matching.

`exec`, `dlx`, and `with` were unaffected because each uses a **single** `trailing_var_arg` vec, which puts the boundary in the right place. This change gives `run` the same shape.

## Behavior change worth noting

`-s` / `--sequential` and `--if-present` after the script name now go to the script. Applying them to pnpm requires putting them before the script name (`pnpm run -s test`), which is what pnpm itself requires. Verified against v11.17.0 — including that `pnpm run show -w` forwards `-w` rather than treating it as `--workspace-root`, which is why one test from pnpm/pnpm#13281 needed updating.

## Not fixed here

This is the clap layer only. pacquet also rewrites argv in two passes *before* clap, and those have the same missed boundary — filed as pnpm/pnpm#13302:

| command | pnpm | pacquet (with this PR) |
|---|---|---|
| `run show --config.foo=bar` | forwarded | swallowed by `ConfigOverrides::extract` |
| `run show --silent` | `--silent` | rewritten to `--reporter=silent` |
| `exec node show.js --config.foo=bar` | forwarded | swallowed |

They are a separate layer with a separate fix (one shared "where does parsing stop" helper for all pre-clap passes), and `exec` is affected too, so they are not folded in here. Everything reachable from the clap layer — the `--` separator and `run`'s own flags — is fixed by this PR.

## Verification

All ten cases in the matrix above now match the TypeScript CLI byte for byte, and 2207 `pacquet-cli` tests pass. The e2e regression test asserts what the script *received* (via a marker file) rather than the echoed command line, per the issue's request; I confirmed it fails when the separator is dropped again.

TypeScript CLI: no change needed — it is the reference here.

Closes pnpm/pnpm#13295

## Squash Commit Body

```text
pnpm stops parsing at the script name: `run` is in
`SPECIALLY_ESCAPED_CMDS`, so nopt is told to escape from
`argv.remain[indexOfRunScriptName]` onward and every later token reaches
the script untouched. pacquet instead let clap keep parsing, because
`RunArgs` declared the script name as its own `Option<String>` positional
ahead of the `trailing_var_arg` argument list. clap only flips
`trailing_values` when a `trailing_var_arg` positional takes its first
value, so with the name consumed by the earlier positional the next `--`
hit the escape branch and was discarded — and pnpm's own `run` flags kept
matching past the script name.

Six observable divergences, all from that one shape:

    command                       pnpm            pacquet
    run show -- --other=1         -- --other=1    --other=1
    run show -- -s                -- -s           -s
    run show -- a b               -- a b          a b
    run show -- --                -- --           --
    run show -s                   -s              (--sequential)
    run show --if-present         --if-present    (--if-present)

The dropped separator is the damaging one: `node`, `jest`, `tsc` and the
like then claim the forwarded option themselves, so `pnpm run test --
--watch` fails instead of running.

Collapse the two positionals into the single `trailing_var_arg` vec that
`exec` / `dlx` / `with` already use, which puts the escape boundary
exactly at the script name. Flags ahead of the script name still parse as
pnpm's.

Closes pnpm/pnpm#13295
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <sub>Rust-only: the TypeScript CLI is the reference behavior being matched.</sub>
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <sub>Parse-level table over the escape boundary, plus an e2e test asserting the arguments reach the script.</sub>

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm run` now forwards all arguments after the script name verbatim, including `--` and option-shaped arguments.
  * pnpm flags such as `-s` and `--if-present` are recognized as pnpm options only when placed before the script name.
  * Improved handling of script arguments across related commands, including `start`, `stop`, `restart`, `clean`, and `test`.

* **Tests**
  * Added coverage for argument forwarding, option placement, separators, and lifecycle scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->