### PR TITLE
fix(cli): forward the argument separator to the script

### DIFF
--- a/.changeset/pacquet-run-argument-separator.md
+++ b/.changeset/pacquet-run-argument-separator.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm run <script> -- <args>` now forwards the `--` separator to the script, matching the pnpm CLI. Previously it was dropped, so the program the script invokes read the following tokens as its own options — `pnpm run build -- --flag` against a `node`-based script failed with `node: bad option: --flag` instead of passing `--flag` to the script. `pnpm stop` and `pnpm restart` were affected the same way.

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -5,6 +5,7 @@ mod config_overrides;
 mod flag_relocation;
 mod github_actions;
 mod job_control;
+mod script_separator;
 mod shorthands;
 mod state;
 mod with_current;
@@ -64,6 +65,9 @@ fn run_cli() -> miette::Result<()> {
     // options written before the subcommand to after it so clap agrees.
     // See `flag_relocation`.
     let argv = relocate_pre_subcommand_flags(&command, argv);
+    // pnpm gives a script every token after its name, `--` included; clap
+    // would eat that `--` as its own escape. See `script_separator`.
+    let argv = script_separator::preserve_script_separator(&command, argv);
     let mut args = match command
         .try_get_matches_from(argv.clone())
         .and_then(|matches| CliArgs::from_arg_matches(&matches))

--- a/pnpm/crates/cli/src/script_separator.rs
+++ b/pnpm/crates/cli/src/script_separator.rs
@@ -1,0 +1,103 @@
+//! Preservation of the `--` that introduces a script's own arguments.
+//!
+//! pnpm hands every token after a script's name to the script, the `--`
+//! included: `pnpm run build -- --flag` runs the `build` script with
+//! `-- --flag` appended, so the program the script invokes reads `--flag`
+//! as an operand rather than as one of its own options. clap instead
+//! treats that `--` as its escape token and drops it, which quietly
+//! changes what the script receives — `node -e … --flag` fails with
+//! "bad option" where `node -e … -- --flag` succeeds.
+//!
+//! [`preserve_script_separator`] writes a second `--` in that position so
+//! the token clap consumes is the one this function added, leaving the
+//! user's own separator to reach the script.
+//!
+//! Only the *first* argument token needs this. Once a value has started
+//! filling the script's trailing arguments, clap keeps every later `--`
+//! as an ordinary value, so `pnpm run build x -- y` already matches pnpm.
+
+use crate::flag_relocation::{ArgTable, token_width};
+use clap::Command;
+use std::ffi::OsString;
+
+/// Commands whose trailing tokens are a script's argv. `test` and `start`
+/// belong to the same family but declare no trailing arguments yet, so
+/// they have no separator to preserve.
+const SCRIPT_COMMANDS: [&str; 3] = ["run", "stop", "restart"];
+
+/// The subcommands after which the script *name* is still to come, so the
+/// argument region starts one positional later.
+const TAKES_SCRIPT_NAME: [&str; 1] = ["run"];
+
+pub fn preserve_script_separator(cmd: &Command, mut argv: Vec<OsString>) -> Vec<OsString> {
+    let top_level = ArgTable::top_level(cmd);
+    let subcommand_union = ArgTable::subcommand_union(cmd);
+
+    let Some(subcommand_index) = next_token(&argv, 1, &top_level, &subcommand_union) else {
+        return argv;
+    };
+    let Some(subcommand) = argv[subcommand_index].to_str() else {
+        return argv;
+    };
+    if !SCRIPT_COMMANDS.contains(&subcommand) {
+        return argv;
+    }
+
+    let mut index = subcommand_index + 1;
+    if TAKES_SCRIPT_NAME.contains(&subcommand) {
+        let Some(script_name_index) = next_token(&argv, index, &top_level, &subcommand_union)
+            .filter(|&index| argv[index] != "--")
+        else {
+            return argv;
+        };
+        index = script_name_index + 1;
+    }
+
+    let Some(separator_index) = next_token(&argv, index, &top_level, &subcommand_union)
+        .filter(|&index| argv[index] == "--")
+    else {
+        return argv;
+    };
+    argv.insert(separator_index, OsString::from("--"));
+    argv
+}
+
+/// The index of the next token at or after `index` that is not an option
+/// (nor an option's value), including a `--` terminator — which
+/// [`crate::flag_relocation::find_positional`] deliberately reports as the
+/// end of the positionals instead of returning.
+fn next_token(
+    argv: &[OsString],
+    mut index: usize,
+    top_level: &ArgTable,
+    subcommand_union: &ArgTable,
+) -> Option<usize> {
+    loop {
+        let token = argv.get(index)?.to_str()?;
+        if token == "--" {
+            return Some(index);
+        }
+        if let Some(rest) = token.strip_prefix("--") {
+            let (name, has_inline_value) =
+                rest.split_once('=').map_or((rest, false), |(name, _)| (name, true));
+            let consumes_value = top_level
+                .long_consumes_value(name)
+                .or_else(|| subcommand_union.long_consumes_value(name))
+                .unwrap_or(false);
+            index += token_width(consumes_value, has_inline_value);
+        } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
+            let short = rest.chars().next().expect("checked non-empty");
+            let is_bare_short = rest.chars().count() == 1;
+            let consumes_value = top_level
+                .short_consumes_value(short)
+                .or_else(|| subcommand_union.short_consumes_value(short))
+                .unwrap_or(false);
+            index += token_width(consumes_value && is_bare_short, false);
+        } else {
+            return Some(index);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/script_separator/tests.rs
+++ b/pnpm/crates/cli/src/script_separator/tests.rs
@@ -1,0 +1,73 @@
+use super::preserve_script_separator;
+use crate::{boolean_negations::with_boolean_negations, cli_args::CliArgs};
+use clap::CommandFactory;
+use pretty_assertions::assert_eq;
+use std::ffi::OsString;
+
+fn preserve<Items: IntoIterator<Item = &'static str>>(items: Items) -> Vec<String> {
+    let command = with_boolean_negations(CliArgs::command());
+    let argv = items.into_iter().map(OsString::from).collect::<Vec<_>>();
+    preserve_script_separator(&command, argv)
+        .into_iter()
+        .map(|token| token.to_string_lossy().into_owned())
+        .collect()
+}
+
+#[test]
+fn a_leading_separator_is_doubled_so_the_script_still_receives_one() {
+    let argv = preserve(["pnpm", "run", "build", "--", "--flag"]);
+
+    assert_eq!(argv, ["pnpm", "run", "build", "--", "--", "--flag"]);
+}
+
+#[test]
+fn a_separator_after_the_first_argument_is_left_alone() {
+    // clap keeps this one, because the trailing arguments already started.
+    let argv = preserve(["pnpm", "run", "build", "x", "--", "y"]);
+
+    assert_eq!(argv, ["pnpm", "run", "build", "x", "--", "y"]);
+}
+
+#[test]
+fn options_between_the_script_name_and_the_separator_are_stepped_over() {
+    let argv = preserve(["pnpm", "run", "build", "--if-present", "--", "--flag"]);
+
+    assert_eq!(argv, ["pnpm", "run", "build", "--if-present", "--", "--", "--flag"]);
+}
+
+#[test]
+fn global_options_before_the_subcommand_are_stepped_over() {
+    let argv = preserve(["pnpm", "-C", "/tmp/project", "run", "build", "--", "--flag"]);
+
+    assert_eq!(argv, ["pnpm", "-C", "/tmp/project", "run", "build", "--", "--", "--flag"]);
+}
+
+#[test]
+fn the_script_shortcuts_that_take_arguments_are_covered() {
+    for command in ["stop", "restart"] {
+        let argv = preserve(["pnpm", command, "--", "--flag"]);
+        dbg!(command, &argv);
+        assert_eq!(argv, ["pnpm", command, "--", "--", "--flag"], "command: {command}");
+    }
+}
+
+#[test]
+fn a_run_without_a_script_name_is_left_alone() {
+    let argv = preserve(["pnpm", "run", "--", "--flag"]);
+
+    assert_eq!(argv, ["pnpm", "run", "--", "--flag"]);
+}
+
+#[test]
+fn commands_that_do_not_run_scripts_keep_their_separator_semantics() {
+    let argv = preserve(["pnpm", "exec", "--", "node", "--version"]);
+
+    assert_eq!(argv, ["pnpm", "exec", "--", "node", "--version"]);
+}
+
+#[test]
+fn argv_without_a_separator_is_unchanged() {
+    let argv = preserve(["pnpm", "run", "build", "--flag"]);
+
+    assert_eq!(argv, ["pnpm", "run", "build", "--flag"]);
+}

--- a/pnpm/crates/cli/tests/run.rs
+++ b/pnpm/crates/cli/tests/run.rs
@@ -662,3 +662,61 @@ fn run_start_fallback_uses_dir_for_server_js_probe() {
 
     drop(root);
 }
+
+/// pnpm appends every token after the script name to the script, the `--`
+/// separator included, so the program the script invokes reads what
+/// follows as operands instead of as its own options. Asserting on the
+/// arguments the script *receives* (rather than on the echoed command
+/// line) is what catches the separator going missing: without it,
+/// `node -e … --flag` fails with "bad option".
+#[cfg(unix)]
+#[test]
+fn run_forwards_the_argument_separator_to_the_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker = workspace.join("args.txt");
+    write_executable(
+        &workspace.join("record-args"),
+        &format!("#!/bin/sh\nprintf '%s' \"$*\" > \"{}\"\n", marker.display()),
+    );
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": { "record": "./record-args" },
+    })
+    .to_string();
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+
+    pacquet.with_args(["run", "record", "--", "--flag", "value"]).assert().success();
+
+    let written = fs::read_to_string(&marker).expect("read marker");
+    assert_eq!(written, "-- --flag value");
+
+    drop(root);
+}
+
+/// A separator that follows an argument is already an ordinary value, and
+/// must not be doubled.
+#[cfg(unix)]
+#[test]
+fn run_keeps_a_separator_that_follows_an_argument() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker = workspace.join("args.txt");
+    write_executable(
+        &workspace.join("record-args"),
+        &format!("#!/bin/sh\nprintf '%s' \"$*\" > \"{}\"\n", marker.display()),
+    );
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": { "record": "./record-args" },
+    })
+    .to_string();
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+
+    pacquet.with_args(["run", "record", "first", "--", "second"]).assert().success();
+
+    let written = fs::read_to_string(&marker).expect("read marker");
+    assert_eq!(written, "first -- second");
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

`pnpm run <script> -- <args>` dropped the `--`, so the program a script invokes read the following tokens as its own options. The reported case turns a working command into a hard failure:

```console
$ pnpm run show -- --other=1        # script: node -e "…"

pnpm:    $ node -e "…" -- --other=1   →  ARGS:["--other=1"]        exit 0
pacquet: $ node -e "…" --other=1      →  node: bad option: --other=1  exit 9
```

The loss is at parse time, not in the executor: clap treats the first `--` as its own escape token and removes it. `run` is exposed because its script name is a separate single-value positional — once that is consumed, clap is no longer mid-positional and the next `--` is taken as the escape. `exec` collects its whole command into one `trailing_var_arg` positional, which is why it was never affected, and why a separator that *follows* an argument (`pnpm run build x -- y`) already survived.

This restores it in argv space, where the neighbouring `shorthands` and `flag_relocation` passes already normalize argv for clap: write a second `--` at that position, so the token clap consumes is the inserted one and the user's own separator reaches the script.

`stop` and `restart` pass script arguments through the same shape and are covered too.

### Verified against the TypeScript CLI

Every form checked by running both binaries against a script that prints its own argv (`node args.js` → `OUT:[…]`):

| invocation | pnpm | pacquet before | pacquet after |
|---|---|---|---|
| `run mytask -- --other=1` | `["--","--other=1"]` | `["--other=1"]` | `["--","--other=1"]` |
| `run mytask -- -x a` | `["--","-x","a"]` | `["-x","a"]` | `["--","-x","a"]` |
| `run mytask x -- y` | `["x","--","y"]` | `["x","--","y"]` | `["x","--","y"]` |
| `run mytask -- x -- y` | `["--","x","--","y"]` | `["x","--","y"]` | `["--","x","--","y"]` |
| `run mytask a b` | `["a","b"]` | `["a","b"]` | `["a","b"]` |
| `mytask -- --other=1` | `["--","--other=1"]` | `["--","--other=1"]` | `["--","--other=1"]` |
| `stop -- --other=1` | `["--","--other=1"]` | `["--other=1"]` | `["--","--other=1"]` |
| `stop x -- y` | `["x","--","y"]` | `["x","--","y"]` | `["x","--","y"]` |

### Tests

Unit tests cover the argv transformation (leading separator doubled, non-leading left alone, options stepped over, non-script commands untouched, `pnpm run` with no script name untouched). Two integration tests assert on the arguments the script *receives* rather than on the echoed command line — that is what catches the separator going missing. I confirmed `run_forwards_the_argument_separator_to_the_script` fails when the pass is disabled, and that `run_keeps_a_separator_that_follows_an_argument` still passes then, so it genuinely pins the "don't double it" half.

### Not included

`pnpm test` and `pnpm start` accept no trailing arguments at all — `pnpm test --watch` fails with a usage error. That is a different defect (arguments not accepted, rather than the separator dropped) and is filed as pnpm/pnpm#13301. `script_separator.rs` notes the two commands so whoever implements it knows to extend the list.

Closes pnpm/pnpm#13295

## Squash Commit Body

```text
pnpm appends every token after a script's name to the script, the `--`
included, so the program the script invokes reads what follows as operands.
clap instead treats the first `--` as its own escape and drops it:

    $ pnpm run show -- --other=1
    pnpm:    node -e "…" -- --other=1   -> ARGS:["--other=1"]
    pacquet: node -e "…" --other=1      -> node: bad option: --other=1

Only the separator in the first argument position is affected. clap keeps
later ones as ordinary values, because a trailing-var-arg positional that
has started taking values no longer treats `--` as an escape — the same
reason `exec`, whose whole command is one such positional, never lost it.

Preserve it in argv space, the way the neighbouring shorthand and
flag-relocation passes already normalize argv for clap: write a second
`--` at that position so the token clap consumes is the inserted one.
`stop` and `restart` take script arguments through the same shape and are
covered too; `test` and `start` accept no trailing arguments at all, which
is pnpm/pnpm#13301.

Closes pnpm/pnpm#13295
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only bug: the TypeScript CLI already behaves correctly, and is the reference this was verified against. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787566191&installation_model_id=426870&pr_number=13303&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13303&signature=c104c3cb2c0e096f3caa734f69c7cad01b6dc1d4de664773d4e1bf6dd78014a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm run`, `pnpm stop`, and `pnpm restart` so `--` is correctly forwarded to the underlying script.
  * Arguments after `--` are no longer incorrectly interpreted as options by the package manager or executed command.
  * Preserved expected behavior when `--` appears as a regular script argument.

* **Tests**
  * Added coverage for argument forwarding across supported script commands and command-line layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->