### PR TITLE
fix(package-manager): stop nesting hoisted deps that won the root slot

### DIFF
--- a/.changeset/pacquet-hoisted-no-duplicate-root-version.md
+++ b/.changeset/pacquet-hoisted-no-duplicate-root-version.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+With `nodeLinker: hoisted`, a workspace project no longer gets its own copy of a dependency whose version already won the workspace-root slot. Only the versions that lost the root slot are nested, matching the pnpm CLI. Previously every project's direct dependency was materialized under that project as well, which gave lifecycle scripts a second copy to run in.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5163,7 +5163,7 @@ dependencies = [
  "command-extra",
  "dunce",
  "flate2",
- "junction",
+ "pacquet-fs",
  "pnpr",
  "pnpr-fixtures",
  "serde_json",

--- a/pnpm/crates/cli/tests/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/hoisted_node_linker.rs
@@ -549,6 +549,16 @@ fn run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker() {
             );
         }
     }
+    // Asserting the nested version too: a nested copy of the *root's*
+    // version would satisfy the build checks above while still being the
+    // wrong layout.
+    for project in &projects[2..] {
+        assert_eq!(
+            read_pkg_version(project, &format!("node_modules/{SCRIPTS}")),
+            "2.0.0",
+            "the nested copy must be the version that lost the root slot",
+        );
+    }
     // The projects whose version won the root slot reach it by walking
     // up, so they must not carry a second copy of their own.
     for project in &projects[..2] {
@@ -557,6 +567,58 @@ fn run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker() {
             "a project on the hoisted version must not nest its own copy",
         );
     }
+}
+
+/// A version that lost the root slot and later wins it must leave no
+/// nested copy behind: the stale entry would keep shadowing the root for
+/// that project, which is the duplication this layout avoids.
+#[test]
+fn a_nested_copy_is_removed_once_its_version_wins_the_root_slot() {
+    const SCRIPTS: &str = "@pnpm.e2e/pre-and-postinstall-scripts-example";
+    let fixture = WorkspaceFixture::new();
+    fixture.append_workspace_yaml(&format!(
+        "nodeLinker: hoisted\nallowBuilds:\n  '{SCRIPTS}': true\n",
+    ));
+    let loser = fixture.project(
+        "loser",
+        "loser",
+        ManifestDeps { prod: &[(SCRIPTS, "2")], ..Default::default() },
+    );
+    for dir in ["winner-a", "winner-b"] {
+        fixture.project(dir, dir, ManifestDeps { prod: &[(SCRIPTS, "1")], ..Default::default() });
+    }
+    fixture.run(["install"]);
+    assert_eq!(
+        read_pkg_version(&loser, &format!("node_modules/{SCRIPTS}")),
+        "2.0.0",
+        "the minority version starts out nested",
+    );
+
+    // Flip the majority so the formerly nested version wins the root slot.
+    for dir in ["winner-a", "winner-b"] {
+        fixture.project(dir, dir, ManifestDeps { prod: &[(SCRIPTS, "2")], ..Default::default() });
+    }
+    fixture.run(["install"]);
+
+    assert_eq!(
+        read_pkg_version(&fixture.workspace, &format!("node_modules/{SCRIPTS}")),
+        "2.0.0",
+        "the new majority version must hold the root slot",
+    );
+    assert!(
+        !loser.join("node_modules").join(SCRIPTS).exists(),
+        "the stale nested copy must not survive the transition",
+    );
+
+    // The same must hold for a link left behind by an install that did
+    // materialize the root-slot winner inside the project.
+    let stale = loser.join("node_modules").join(SCRIPTS);
+    fs::create_dir_all(stale.parent().expect("scope dir")).expect("create the scope dir");
+    std::os::unix::fs::symlink(fixture.workspace.join("node_modules").join(SCRIPTS), &stale)
+        .expect("plant a stale link");
+    fixture.run(["install"]);
+
+    assert!(!stale.exists(), "a stale project-local link must not survive a reinstall");
 }
 
 /// TS: `overwriting (…@3.0.0 with …@latest)`

--- a/pnpm/crates/cli/tests/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/hoisted_node_linker.rs
@@ -8,11 +8,6 @@
 //! then runs `pacquet install` so the fresh resolver builds the
 //! lockfile in memory and the hoisted linker materializes a flat
 //! `node_modules/` of **real directories**.
-//!
-//! Cases that depend on features pacquet hasn't built yet live in
-//! [`known_failures`] below with
-//! [`pacquet_testing_utils::allow_known_failure`] gating the assertion
-//! against the not-yet-implemented subject under test.
 
 #![cfg(unix)] // hoisted bin shims + real-dir-vs-junction checks are unix-shaped here.
 
@@ -545,17 +540,22 @@ fn run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker() {
             fixture.workspace.join("node_modules").join(SCRIPTS).join(generated).exists(),
             "the hoisted root copy must be built ({generated})",
         );
-        // Pacquet's hoisted linker materializes each project's direct
-        // dep under the project as well — upstream nests a copy only
-        // for the version that lost the root slot (see
-        // `known_failures::hoisted_workspace_layout_does_not_duplicate_root_version`).
-        // Every copy that is materialized must be built.
-        for project in &projects {
+        // Only the versions that lost the root slot are nested, and
+        // every nested copy must be built.
+        for project in &projects[2..] {
             assert!(
                 project.join("node_modules").join(SCRIPTS).join(generated).exists(),
-                "every materialized copy must be built ({generated})",
+                "every nested copy must be built ({generated})",
             );
         }
+    }
+    // The projects whose version won the root slot reach it by walking
+    // up, so they must not carry a second copy of their own.
+    for project in &projects[..2] {
+        assert!(
+            !project.join("node_modules").join(SCRIPTS).exists(),
+            "a project on the hoisted version must not nest its own copy",
+        );
     }
 }
 
@@ -866,40 +866,4 @@ fn lifecycle_scripts_do_not_fail_on_repeat_hoisted_install() {
     }
 
     drop((root, mock_instance));
-}
-
-mod known_failures {
-    //! Hoisted-node-linker cases blocked on features pacquet hasn't
-    //! built yet. Each stubs the not-yet-built subject through
-    //! [`pacquet_testing_utils::allow_known_failure`] so the test exits
-    //! early rather than masking a real bug. The `pnpm add` / update
-    //! manifest-mutation cases formerly stubbed here are real tests in
-    //! the parent module since the prune-stale-modules reconciliation
-    //! landed.
-
-    use pacquet_testing_utils::{
-        allow_known_failure,
-        known_failure::{KnownFailure, KnownResult},
-    };
-
-    fn hoisted_workspace_duplicate_materialization() -> KnownResult<()> {
-        Err(KnownFailure::new(
-            "Pacquet's hoisted linker materializes each workspace \
-             project's direct dependency under the project's own \
-             `node_modules` even when the same version already won the \
-             workspace-root slot. Upstream nests a copy only for \
-             versions that lost the root slot \
-             (`lifecycleScripts.ts:718` asserts the hoisted-version \
-             consumers have no nested copy).",
-        ))
-    }
-
-    /// The layout tail of TS `run pre/postinstall scripts in a
-    /// workspace that uses node-linker=hoisted`
-    /// (`lifecycleScripts.ts:718`); the script-execution half is the
-    /// real [`super::run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker`].
-    #[test]
-    fn hoisted_workspace_layout_does_not_duplicate_root_version() {
-        allow_known_failure!(hoisted_workspace_duplicate_materialization());
-    }
 }

--- a/pnpm/crates/cli/tests/install_filters.rs
+++ b/pnpm/crates/cli/tests/install_filters.rs
@@ -754,7 +754,10 @@ fn filtered_hoisted_install_materializes_full_shared_graph_but_links_only_select
             "hoisted shared graph is missing {dependency}",
         );
     }
-    assert!(selected.join("node_modules").join(HELLO).exists());
+    // The selected project's dependency won the workspace-root slot, so
+    // it resolves by walking up; nesting a second entry for it is what
+    // upstream avoids.
+    assert!(!selected.join("node_modules").join(HELLO).exists());
     assert!(!unselected.join("node_modules").exists());
     assert_full_wanted(&fixture.wanted(), &["packages/selected", "packages/unselected"]);
     let current = fixture.current();

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -75,6 +75,35 @@ fn relative_target_for(original: &Path, link: &Path) -> PathBuf {
     crate::relative_path(parent, original)
 }
 
+/// Whether `link` is a directory symlink or, on Windows, a junction —
+/// the two shapes [`symlink_dir`] can produce.
+///
+/// [`Path::is_symlink`] only reports the `IO_REPARSE_TAG_SYMLINK` shape,
+/// so a caller that cleans up after [`symlink_dir`] and tests with it
+/// alone misses every junction [`symlink_dir`] fell back to.
+pub fn is_symlink_or_junction(link: &Path) -> io::Result<bool> {
+    #[cfg(windows)]
+    {
+        // Check the symlink case first so a true symlink never reaches
+        // `junction::exists`.
+        if link.is_symlink() {
+            return Ok(true);
+        }
+        // `junction::exists` reports a path that is not a reparse point
+        // at all (a plain directory) as `ERROR_NOT_A_REPARSE_POINT`
+        // rather than `Ok(false)`; for this question that is a plain
+        // "no".
+        const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
+        return match junction::exists(link) {
+            Ok(is_junction) => Ok(is_junction),
+            Err(error) if error.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT) => Ok(false),
+            Err(error) => Err(error),
+        };
+    }
+    #[cfg(not(windows))]
+    Ok(link.is_symlink())
+}
+
 /// Remove a symlink (or junction on Windows) previously created with
 /// [`symlink_dir`].
 ///

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1831,16 +1831,6 @@ fn link_selected_hoisted_direct_dependencies(
             == pacquet_fs::lexical_normalize(lockfile_dir);
         let mut linked_names = Vec::new();
         for (alias, target) in direct_dependencies {
-            // A dependency that won the workspace-root slot is reached by
-            // walking up from the project, exactly as it is under pnpm.
-            // Repeating it inside the project would give a build a second
-            // copy to run lifecycle scripts in.
-            if !is_workspace_root
-                && pacquet_fs::lexical_normalize(target)
-                    == pacquet_fs::lexical_normalize(&root_modules_dir.join(alias))
-            {
-                continue;
-            }
             let link_path =
                 crate::safe_join_modules_dir::safe_join_modules_dir(&modules_dir, alias).map_err(
                     |source| {
@@ -1853,6 +1843,38 @@ fn link_selected_hoisted_direct_dependencies(
                         )
                     },
                 )?;
+            // A dependency that won the workspace-root slot is reached by
+            // walking up from the project, exactly as it is under pnpm.
+            // Repeating it inside the project would give a build a second
+            // copy to run lifecycle scripts in. Checked after `link_path`
+            // so an unusable alias still reports itself.
+            if !is_workspace_root
+                && pacquet_fs::lexical_normalize(target)
+                    == pacquet_fs::lexical_normalize(&root_modules_dir.join(alias))
+            {
+                // An install that predates this rule, or one where the
+                // version had lost the slot, leaves a link here. Left in
+                // place it keeps shadowing the root copy, which is the
+                // duplicate this skip exists to avoid. A real directory is
+                // the pruner's to remove, and only ever belongs to a
+                // version that lost the slot.
+                if link_path.is_symlink() {
+                    pacquet_fs::remove_symlink_dir(&link_path).map_err(|error| {
+                        HoistedLinkerError::SymlinkDirectDependencies(
+                            SymlinkDirectDependenciesError::SymlinkPackage {
+                                importer_id: importer_id.clone(),
+                                name: alias.clone(),
+                                source: SymlinkPackageError::SymlinkDir {
+                                    symlink_target: target.clone(),
+                                    symlink_path: link_path.clone(),
+                                    error,
+                                },
+                            },
+                        )
+                    })?;
+                }
+                continue;
+            }
             if pacquet_fs::lexical_normalize(&link_path) == pacquet_fs::lexical_normalize(target) {
                 linked_names.push(alias.clone());
                 continue;

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1818,14 +1818,29 @@ fn link_selected_hoisted_direct_dependencies(
 ) -> Result<(), HoistedLinkerError> {
     let modules_dir_name =
         config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
+    let root_modules_dir = pacquet_fs::lexical_normalize(&lockfile_dir.join(modules_dir_name));
     for (project_dir, _) in project_manifests {
         let importer_id = pacquet_workspace::importer_id_from_root_dir(lockfile_dir, project_dir);
         let Some(direct_dependencies) = direct_dependencies_by_importer_id.get(&importer_id) else {
             continue;
         };
         let modules_dir = project_dir.join(modules_dir_name);
+        // The workspace root owns the hoisted slot itself, so its own
+        // entries are the real directories rather than links to them.
+        let is_workspace_root = pacquet_fs::lexical_normalize(project_dir)
+            == pacquet_fs::lexical_normalize(lockfile_dir);
         let mut linked_names = Vec::new();
         for (alias, target) in direct_dependencies {
+            // A dependency that won the workspace-root slot is reached by
+            // walking up from the project, exactly as it is under pnpm.
+            // Repeating it inside the project would give a build a second
+            // copy to run lifecycle scripts in.
+            if !is_workspace_root
+                && pacquet_fs::lexical_normalize(target)
+                    == pacquet_fs::lexical_normalize(&root_modules_dir.join(alias))
+            {
+                continue;
+            }
             let link_path =
                 crate::safe_join_modules_dir::safe_join_modules_dir(&modules_dir, alias).map_err(
                     |source| {

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -1858,7 +1858,31 @@ fn link_selected_hoisted_direct_dependencies(
                 // duplicate this skip exists to avoid. A real directory is
                 // the pruner's to remove, and only ever belongs to a
                 // version that lost the slot.
-                if link_path.is_symlink() {
+                // `is_symlink_or_junction`, not `Path::is_symlink`: on
+                // Windows `symlink_dir` falls back to a junction when it
+                // cannot create a true symlink, and a junction is not a
+                // symlink to the stdlib.
+                let stale_link = match pacquet_fs::is_symlink_or_junction(&link_path) {
+                    Ok(is_link) => is_link,
+                    // Nothing to clean up — the common case, and the one
+                    // `junction::exists` reports as an error rather than
+                    // `Ok(false)`.
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+                    Err(error) => {
+                        return Err(HoistedLinkerError::SymlinkDirectDependencies(
+                            SymlinkDirectDependenciesError::SymlinkPackage {
+                                importer_id: importer_id.clone(),
+                                name: alias.clone(),
+                                source: SymlinkPackageError::SymlinkDir {
+                                    symlink_target: target.clone(),
+                                    symlink_path: link_path.clone(),
+                                    error,
+                                },
+                            },
+                        ));
+                    }
+                };
+                if stale_link {
                     pacquet_fs::remove_symlink_dir(&link_path).map_err(|error| {
                         HoistedLinkerError::SymlinkDirectDependencies(
                             SymlinkDirectDependenciesError::SymlinkPackage {

--- a/pnpm/crates/testing-utils/Cargo.toml
+++ b/pnpm/crates/testing-utils/Cargo.toml
@@ -27,6 +27,5 @@ text-block-macros = { workspace = true }
 pnpr-fixtures     = { workspace = true }
 pacquet-fs        = { workspace = true }
 
-
 [lints]
 workspace = true

--- a/pnpm/crates/testing-utils/Cargo.toml
+++ b/pnpm/crates/testing-utils/Cargo.toml
@@ -25,9 +25,8 @@ url               = { workspace = true }
 walkdir           = { workspace = true }
 text-block-macros = { workspace = true }
 pnpr-fixtures     = { workspace = true }
+pacquet-fs        = { workspace = true }
 
-[target.'cfg(windows)'.dependencies]
-junction = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/testing-utils/src/fs.rs
+++ b/pnpm/crates/testing-utils/src/fs.rs
@@ -45,32 +45,7 @@ pub fn get_all_files(root: &Path) -> Vec<String> {
 }
 
 pub fn is_symlink_or_junction(path: &Path) -> io::Result<bool> {
-    #[cfg(windows)]
-    {
-        // `pacquet_fs::symlink_dir` produces two reparse-tag shapes: a
-        // real symlink (`IO_REPARSE_TAG_SYMLINK`, seen by
-        // `Path::is_symlink` — true symlinks work on GitHub Actions
-        // Windows runners, which grant `SeCreateSymbolicLinkPrivilege`)
-        // or a junction (`IO_REPARSE_TAG_MOUNT_POINT`, seen by
-        // `junction::exists`). Check the symlink case first so a plain
-        // symlink never reaches `junction::exists`.
-        if path.is_symlink() {
-            return Ok(true);
-        }
-        // `junction::exists` reports a path that isn't a reparse point
-        // at all (a plain directory) as `ERROR_NOT_A_REPARSE_POINT`
-        // rather than `Ok(false)`; for "is this a symlink or junction?"
-        // that is a plain "no", so map it back to `false`.
-        const ERROR_NOT_A_REPARSE_POINT: i32 = 4390;
-        match junction::exists(path) {
-            Ok(is_junction) => Ok(is_junction),
-            Err(error) if error.raw_os_error() == Some(ERROR_NOT_A_REPARSE_POINT) => Ok(false),
-            Err(error) => Err(error),
-        }
-    }
-
-    #[cfg(not(windows))]
-    Ok(path.is_symlink())
+    pacquet_fs::is_symlink_or_junction(path)
 }
 
 /// Check if a file is executable.


### PR DESCRIPTION
## Summary

With `nodeLinker: hoisted`, pacquet gave every workspace project a link to each of its direct dependencies — including the ones already materialized in the workspace-root `node_modules`. Node resolution walks up from the project, so that entry is redundant, and it is a second copy for the build pass to run lifecycle scripts in.

pnpm nests a copy only for the versions that **lost** the root slot. Upstream's per-importer map is derived from the hoisting hierarchy, so a dependency the hoister moved to the root is simply absent from the importer's entry (`lockfileToHoistedDepGraph.ts` → `directDepsMap(Object.keys(nextHierarchy), graph)`); pacquet derives the same map from the importer's lockfile declarations, which keeps the winner in it, so the link pass has to recognize and skip it.

The workspace root is exempt — it owns the hoisted slot, and its entries are the real directories rather than links to them.

### Behavior

Upstream's fixture for this is `run pre/postinstall scripts in a workspace that uses node-linker=hoisted` (`installing/deps-installer/test/install/lifecycleScripts.ts:718`): four projects, two on `@1` and two on `@2`, asserting that the projects on the root-slot version have **no** nested copy while the other two do.

| location | before | after (= pnpm) |
|---|---|---|
| root `node_modules/<pkg>` (v1, root-slot winner) | real dir, built | unchanged |
| project-1, project-2 (`@1` — won the slot) | extra link to the root copy | **no entry** |
| project-3, project-4 (`@2` — lost the slot) | nested real dir, built | unchanged |

### Tests

This closes the known failure registered for exactly this divergence: `known_failures::hoisted_workspace_layout_does_not_duplicate_root_version` in `hoisted_node_linker.rs`, whose stub reason was

> Pacquet's hoisted linker materializes each workspace project's direct dependency under the project's own `node_modules` even when the same version already won the workspace-root slot. Upstream nests a copy only for versions that lost the root slot.

The stub is gone and the assertion is now real, inside `run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker` — the sibling test that was already carrying the fixture and had a comment explaining why it could not assert this yet. That leaves `hoisted_node_linker.rs` with no `known_failures` module at all.

One other test asserted the old shape: `install_filters.rs::filtered_hoisted_install_materializes_full_shared_graph_but_links_only_selected_projects` expected the selected project to nest a dependency that the same test also asserts is hoisted to the root. It now asserts the absence, for the same reason.

Full suite green (7003 tests), clippy and dylint clean.

### Note on the tracker

Picked up from pnpm/pnpm#13167, whose description is well out of date — it lists 34 unchecked plan items and 39 `allow_known_failure!` sites; the real numbers on `main` were 9 (7 of them deliberate "do not port" entries) and 2. Details in [this comment](https://github.com/pnpm/pnpm/issues/13167#issuecomment-5078106505). After this PR one stub remains, `importer_level_link_closure_divergence`, which is blocked on a cross-stack decision rather than on code.

Refs pnpm/pnpm#13167

## Squash Commit Body

```text
With nodeLinker=hoisted, every workspace project got a link to each of its
direct dependencies, including the ones already materialized in the
workspace-root node_modules. Node resolution walks up from the project, so
that second entry is redundant — and it is a second copy for the build
pass to run lifecycle scripts in.

pnpm nests a copy only for the versions that lost the root slot. Upstream's
map comes from the hoisting hierarchy, so a dependency the hoister moved to
the root is simply absent from the importer's entry; pacquet derives it from
the importer's lockfile declarations, which keeps the winner in the map, so
the link pass has to recognize and skip it.

The workspace root itself is exempt: it owns the hoisted slot, and its
entries are the real directories rather than links to them.

Two tests asserted the old shape and now pin the upstream rule, and the
known-failure stub registered for this divergence
(hoisted_workspace_duplicate_materialization) becomes a real assertion in
run_pre_and_postinstall_scripts_in_a_workspace_with_hoisted_linker.

Refs pnpm/pnpm#13167
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only divergence: the TypeScript CLI already produces this layout and is the reference the fix and its tests are written against. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787567404&installation_model_id=426870&pr_number=13306&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13306&signature=2e87f7223999a26bcce319ccdc2cc3b958f5ff790eb545a8811ba84abdb1866c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved hoisted workspace installation to deduplicate already-shared dependencies at the workspace root, matching pnpm CLI behavior.
  * Prevents lifecycle scripts from being triggered against duplicate dependency copies.
* **Bug Fixes**
  * Fixed hoisted direct dependency linking for filtered installs so selected projects don’t create redundant nested copies and resolve via the workspace-root location.
  * Automatically cleans up stale project-level links when the “winning” workspace-root version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->