### PR TITLE
fix(cli): stop the pre-clap argv passes at the escape boundary

### DIFF
--- a/.changeset/pacquet-preclap-escape-boundary.md
+++ b/.changeset/pacquet-preclap-escape-boundary.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Arguments after the script or command name now reach the script untouched for `pnpm run`, `pnpm exec`, `pnpm dlx`, and `pnpm with`, matching the JavaScript implementation. Previously `pnpm run build --config.foo=bar` consumed the argument as a pnpm setting instead of forwarding it, and `pnpm run build --silent` handed the script `--reporter=silent` — a token the user never typed [#13302](https://github.com/pnpm/pnpm/issues/13302). Put such flags before the script name (`pnpm run --silent build`) to apply them to pnpm.

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -1,5 +1,3 @@
-use crate::cli_args::CliArgs;
-use clap::CommandFactory;
 use pacquet_config::{
     Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker, PmOnFail, RuntimeOnFail,
     VerifyDepsBeforeRun,
@@ -104,15 +102,11 @@ impl ConfigOverrides {
         Argv: IntoIterator<Item = OsString>,
     {
         let argv = argv.into_iter().collect::<Vec<_>>();
-        let external_command_index = external_command_index(&argv);
-        // Everything past `--` belongs to whatever pnpm runs, not to pnpm.
-        let separator_index = argv.iter().position(|arg| arg == "--");
+        let passthrough_from = crate::parse_boundary::passthrough_from(&argv);
         let mut overrides = Self::default();
         let mut remaining = Vec::new();
         for (index, arg) in argv.into_iter().enumerate() {
-            if external_command_index.is_some_and(|command_index| index > command_index)
-                || separator_index.is_some_and(|separator| index > separator)
-            {
+            if passthrough_from.is_some_and(|boundary| index >= boundary) {
                 remaining.push(arg);
                 continue;
             }
@@ -240,67 +234,6 @@ fn verify_deps_env_is_set() -> bool {
     ["PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN", pacquet_executor::VERIFY_DEPS_BEFORE_RUN_ENV]
         .iter()
         .any(|name| std::env::var(name).is_ok())
-}
-
-fn external_command_index(argv: &[OsString]) -> Option<usize> {
-    let mut index = 1;
-    while index < argv.len() {
-        let Some(arg) = argv[index].to_str() else {
-            return Some(index);
-        };
-        if arg == "--" {
-            return None;
-        }
-        if arg.starts_with("--config.") {
-            index += 1;
-            continue;
-        }
-        if let Some(width) = global_option_width(arg) {
-            index += width;
-            continue;
-        }
-        if arg.starts_with('-') {
-            index += 1;
-            continue;
-        }
-        return (!is_known_top_level_command(arg)).then_some(index);
-    }
-    None
-}
-
-fn global_option_width(arg: &str) -> Option<usize> {
-    if matches!(arg, "-r" | "-v") {
-        return Some(1);
-    }
-    if matches!(arg, "-C" | "-F") {
-        return Some(2);
-    }
-    if arg.starts_with("-C") || arg.starts_with("-F") {
-        return Some(1);
-    }
-    let name = arg.strip_prefix("--")?;
-    let (name, has_value) = name.split_once('=').map_or((name, false), |(name, _)| (name, true));
-    let consumes_value = matches!(
-        name,
-        "dir"
-            | "filter"
-            | "filter-prod"
-            | "http-proxy"
-            | "https-proxy"
-            | "no-proxy"
-            | "npmrc-auth-file"
-            | "registry"
-            | "reporter"
-            | "store-dir"
-            | "userconfig",
-    );
-    Some(if consumes_value && !has_value { 2 } else { 1 })
-}
-
-fn is_known_top_level_command(name: &str) -> bool {
-    CliArgs::command().get_subcommands().any(|command| {
-        command.get_name() == name || command.get_all_aliases().any(|alias| alias == name)
-    })
 }
 
 enum ConfigToken<'a> {

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -190,6 +190,14 @@ impl ArgTable {
         table
     }
 
+    /// Fold every subcommand's own options into this table, for callers
+    /// that need one arity view over the whole CLI because the command is
+    /// not known yet (the pre-clap passes, via
+    /// [`crate::parse_boundary::passthrough_from`]).
+    pub(crate) fn absorb_subcommands(&mut self, cmd: &Command) {
+        self.absorb(cmd.get_subcommands().flat_map(Command::get_arguments));
+    }
+
     fn absorb<'a, Args: IntoIterator<Item = &'a Arg>>(&mut self, args: Args) {
         for arg in args {
             let consumes_value = matches!(arg.get_action(), ArgAction::Set | ArgAction::Append);

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -5,6 +5,7 @@ mod config_overrides;
 mod flag_relocation;
 mod github_actions;
 mod job_control;
+mod parse_boundary;
 mod shorthands;
 mod state;
 mod with_current;

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -81,18 +81,21 @@ fn command_boundary(argv: &[OsString]) -> Option<usize> {
             return Some(next_positional(argv, index + 1, &arity)? + 1);
         }
         if subcommand.get_name() == "with" {
-            // `with` splits on its version. `with current` is spliced into
-            // pnpm's own argv by [`crate::with_current::rewrite`], which runs
-            // after the pre-clap passes, so those tokens are still pnpm's to
-            // claim — leaving a `--config.*` in them for clap to mistake for
-            // the script name. Any other version execs a child pnpm, whose
-            // command line is its own, so stripping an override there would
-            // lose it.
+            // `with` splits on its version. Any version but `current` execs a
+            // child pnpm, whose command line is its own, so stripping an
+            // override there would lose it.
             let version = next_positional(argv, index + 1, &arity)?;
-            if argv[version] == "current" {
-                return None;
+            if argv[version] != "current" {
+                return Some(version + 1);
             }
-            return Some(version + 1);
+            // `with current` is spliced into pnpm's own argv by
+            // [`crate::with_current::rewrite`], which runs after the pre-clap
+            // passes. So resume the scan just past it: whatever boundary the
+            // nested command line has is the one that will apply, and pnpm
+            // still owns everything ahead of it.
+            index = version + 1;
+            prefix_allowed = true;
+            continue;
         }
         // A known command that parses its own arguments: pnpm owns the rest.
         return None;

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -8,14 +8,23 @@
 //! [`ConfigOverrides::extract`]: crate::config_overrides::ConfigOverrides::extract
 //! [`expand_universal_shorthands`]: crate::shorthands::expand_universal_shorthands
 
-use crate::cli_args::CliArgs;
+use crate::{cli_args::CliArgs, flag_relocation::ArgTable};
 use clap::CommandFactory;
 use std::ffi::OsString;
 
-/// Commands whose own arguments are a foreign command line. pnpm keeps the
-/// same set as `SPECIALLY_ESCAPED_CMDS` (`run` / `dlx` / `with`) plus
-/// `exec`, which reaches the same place through its argv shape.
-const COMMANDS_TAKING_A_FOREIGN_COMMAND_LINE: [&str; 4] = ["run", "exec", "dlx", "with"];
+/// Commands whose own arguments are a foreign command line.
+///
+/// pnpm's `SPECIALLY_ESCAPED_CMDS` is `run` / `dlx` / `with`; `exec` joins
+/// them here because its argv shape reaches the same place. `with` does
+/// *not*: [`crate::with_current::rewrite`] runs after
+/// [`ConfigOverrides::extract`] and splices the inner command line into
+/// pnpm's own argv, so at this point those tokens are still pnpm's to
+/// claim — `pnpm with current run --config.foo=bar build` must have the
+/// override stripped here, or clap sees it after the rewrite and takes it
+/// for the script name.
+///
+/// [`ConfigOverrides::extract`]: crate::config_overrides::ConfigOverrides::extract
+const COMMANDS_TAKING_A_FOREIGN_COMMAND_LINE: [&str; 3] = ["run", "exec", "dlx"];
 
 /// Commands that prefix another command rather than taking arguments of
 /// their own, so the command to classify is the positional after them.
@@ -44,6 +53,11 @@ pub(crate) fn passthrough_from(argv: &[OsString]) -> Option<usize> {
 
 /// The boundary implied by the command alone, ignoring any `--`.
 fn command_boundary(argv: &[OsString]) -> Option<usize> {
+    let command = CliArgs::command();
+    // Both halves of the union: a global lives on the top-level command,
+    // a command's own options on its subcommand.
+    let mut arity = ArgTable::top_level(&command);
+    arity.absorb_subcommands(&command);
     let mut index = 1;
     let mut prefix_allowed = true;
     while index < argv.len() {
@@ -55,7 +69,7 @@ fn command_boundary(argv: &[OsString]) -> Option<usize> {
             // The separator governs from here; see `passthrough_from`.
             return None;
         }
-        if let Some(width) = option_width(arg) {
+        if let Some(width) = option_width(arg, &arity) {
             index += width;
             continue;
         }
@@ -66,7 +80,7 @@ fn command_boundary(argv: &[OsString]) -> Option<usize> {
             continue;
         }
         if takes_a_foreign_command_line(arg) {
-            return Some(next_positional(argv, index + 1)? + 1);
+            return Some(next_positional(argv, index + 1, &arity)? + 1);
         }
         if !is_known_top_level_command(arg) {
             return Some(index + 1);
@@ -79,7 +93,7 @@ fn command_boundary(argv: &[OsString]) -> Option<usize> {
 
 /// The index of the first positional at or after `from`, or `None` when the
 /// command was given no positional at all.
-fn next_positional(argv: &[OsString], from: usize) -> Option<usize> {
+fn next_positional(argv: &[OsString], from: usize, arity: &ArgTable) -> Option<usize> {
     let mut index = from;
     while index < argv.len() {
         let Some(arg) = argv[index].to_str() else {
@@ -90,7 +104,7 @@ fn next_positional(argv: &[OsString], from: usize) -> Option<usize> {
             // script name to anchor on.
             return Some(index);
         }
-        match option_width(arg) {
+        match option_width(arg, arity) {
             Some(width) => index += width,
             None => return Some(index),
         }
@@ -100,43 +114,29 @@ fn next_positional(argv: &[OsString], from: usize) -> Option<usize> {
 
 /// The number of argv slots `arg` occupies when it is an option, or `None`
 /// when it is a positional.
-fn option_width(arg: &str) -> Option<usize> {
-    if !arg.starts_with('-') {
-        return None;
+///
+/// Arity comes from clap rather than a hand-listed set of option names: a
+/// value-taking option missing from such a list makes its *value* look like
+/// a positional, which lands the boundary on the wrong token
+/// (`pnpm dlx --package cowsay --silent cowsay` would forward pnpm's own
+/// `--silent`). The union across subcommands is what the pre-clap passes
+/// have to work with, since the command is not yet known.
+fn option_width(arg: &str, arity: &ArgTable) -> Option<usize> {
+    let rest = arg.strip_prefix('-').filter(|rest| !rest.is_empty())?;
+    if let Some(long) = rest.strip_prefix('-') {
+        // `--config.<key>=<value>` is always self-contained.
+        if long.starts_with("config.") {
+            return Some(1);
+        }
+        let (name, has_inline_value) =
+            long.split_once('=').map_or((long, false), |(name, _)| (name, true));
+        let consumes_value = arity.long_consumes_value(name).unwrap_or(false);
+        return Some(if consumes_value && !has_inline_value { 2 } else { 1 });
     }
-    if arg.starts_with("--config.") {
-        return Some(1);
-    }
-    Some(global_option_width(arg).unwrap_or(1))
-}
-
-fn global_option_width(arg: &str) -> Option<usize> {
-    if matches!(arg, "-r" | "-v") {
-        return Some(1);
-    }
-    if matches!(arg, "-C" | "-F") {
-        return Some(2);
-    }
-    if arg.starts_with("-C") || arg.starts_with("-F") {
-        return Some(1);
-    }
-    let name = arg.strip_prefix("--")?;
-    let (name, has_value) = name.split_once('=').map_or((name, false), |(name, _)| (name, true));
-    let consumes_value = matches!(
-        name,
-        "dir"
-            | "filter"
-            | "filter-prod"
-            | "http-proxy"
-            | "https-proxy"
-            | "no-proxy"
-            | "npmrc-auth-file"
-            | "registry"
-            | "reporter"
-            | "store-dir"
-            | "userconfig",
-    );
-    Some(if consumes_value && !has_value { 2 } else { 1 })
+    let short = rest.chars().next().expect("checked non-empty");
+    let is_bare_short = rest.chars().count() == 1;
+    let consumes_value = arity.short_consumes_value(short).unwrap_or(false);
+    Some(if consumes_value && is_bare_short { 2 } else { 1 })
 }
 
 fn takes_a_foreign_command_line(name: &str) -> bool {

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -9,21 +9,15 @@
 //! [`expand_universal_shorthands`]: crate::shorthands::expand_universal_shorthands
 
 use crate::{cli_args::CliArgs, flag_relocation::ArgTable};
-use clap::CommandFactory;
+use clap::{Command, CommandFactory};
 use std::ffi::OsString;
 
-/// Commands whose own arguments are a foreign command line.
+/// Commands whose own arguments are unconditionally a foreign command line.
 ///
 /// pnpm's `SPECIALLY_ESCAPED_CMDS` is `run` / `dlx` / `with`; `exec` joins
-/// them here because its argv shape reaches the same place. `with` does
-/// *not*: [`crate::with_current::rewrite`] runs after
-/// [`ConfigOverrides::extract`] and splices the inner command line into
-/// pnpm's own argv, so at this point those tokens are still pnpm's to
-/// claim — `pnpm with current run --config.foo=bar build` must have the
-/// override stripped here, or clap sees it after the rewrite and takes it
-/// for the script name.
-///
-/// [`ConfigOverrides::extract`]: crate::config_overrides::ConfigOverrides::extract
+/// them here because its argv shape reaches the same place. `with` is
+/// handled separately in [`command_boundary`], because only some of its
+/// invocations forward their arguments to another process.
 const COMMANDS_TAKING_A_FOREIGN_COMMAND_LINE: [&str; 3] = ["run", "exec", "dlx"];
 
 /// Commands that prefix another command rather than taking arguments of
@@ -79,11 +73,26 @@ fn command_boundary(argv: &[OsString]) -> Option<usize> {
             index += 1;
             continue;
         }
-        if takes_a_foreign_command_line(arg) {
+        let Some(subcommand) = matching_subcommand(&command, arg) else {
+            // Names no command: the `pnpm <script>` fallback.
+            return Some(index + 1);
+        };
+        if COMMANDS_TAKING_A_FOREIGN_COMMAND_LINE.contains(&subcommand.get_name()) {
             return Some(next_positional(argv, index + 1, &arity)? + 1);
         }
-        if !is_known_top_level_command(arg) {
-            return Some(index + 1);
+        if subcommand.get_name() == "with" {
+            // `with` splits on its version. `with current` is spliced into
+            // pnpm's own argv by [`crate::with_current::rewrite`], which runs
+            // after the pre-clap passes, so those tokens are still pnpm's to
+            // claim — leaving a `--config.*` in them for clap to mistake for
+            // the script name. Any other version execs a child pnpm, whose
+            // command line is its own, so stripping an override there would
+            // lose it.
+            let version = next_positional(argv, index + 1, &arity)?;
+            if argv[version] == "current" {
+                return None;
+            }
+            return Some(version + 1);
         }
         // A known command that parses its own arguments: pnpm owns the rest.
         return None;
@@ -139,23 +148,15 @@ fn option_width(arg: &str, arity: &ArgTable) -> Option<usize> {
     Some(if consumes_value && is_bare_short { 2 } else { 1 })
 }
 
-fn takes_a_foreign_command_line(name: &str) -> bool {
-    resolves_to_any(name, &COMMANDS_TAKING_A_FOREIGN_COMMAND_LINE)
-}
-
-pub(crate) fn is_known_top_level_command(name: &str) -> bool {
-    CliArgs::command().get_subcommands().any(|command| resolves_to(command, name))
-}
-
-/// Whether `name` is one of `canonical_names`, or an alias of one.
-fn resolves_to_any(name: &str, canonical_names: &[&str]) -> bool {
-    CliArgs::command()
+/// The subcommand `name` resolves to, whether by its own name or an alias.
+///
+/// Takes the already-built `command`: assembling the clap tree is the
+/// expensive part of this module, and one boundary computation must not pay
+/// for it more than once.
+fn matching_subcommand<'a>(command: &'a Command, name: &str) -> Option<&'a Command> {
+    command
         .get_subcommands()
-        .any(|command| canonical_names.contains(&command.get_name()) && resolves_to(command, name))
-}
-
-fn resolves_to(command: &clap::Command, name: &str) -> bool {
-    command.get_name() == name || command.get_all_aliases().any(|alias| alias == name)
+        .find(|sub| sub.get_name() == name || sub.get_all_aliases().any(|alias| alias == name))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -1,0 +1,162 @@
+//! Where pnpm stops parsing argv and starts forwarding it.
+//!
+//! Every pass that rewrites argv before clap sees it — [`ConfigOverrides::extract`]
+//! and [`expand_universal_shorthands`] — has to agree on this, or a token
+//! meant for a script gets claimed or rewritten on the way through
+//! (pnpm/pnpm#13302).
+//!
+//! [`ConfigOverrides::extract`]: crate::config_overrides::ConfigOverrides::extract
+//! [`expand_universal_shorthands`]: crate::shorthands::expand_universal_shorthands
+
+use crate::cli_args::CliArgs;
+use clap::CommandFactory;
+use std::ffi::OsString;
+
+/// Commands whose own arguments are a foreign command line. pnpm keeps the
+/// same set as `SPECIALLY_ESCAPED_CMDS` (`run` / `dlx` / `with`) plus
+/// `exec`, which reaches the same place through its argv shape.
+const COMMANDS_TAKING_A_FOREIGN_COMMAND_LINE: [&str; 4] = ["run", "exec", "dlx", "with"];
+
+/// Commands that prefix another command rather than taking arguments of
+/// their own, so the command to classify is the positional after them.
+const COMMAND_PREFIXES: [&str; 3] = ["recursive", "multi", "m"];
+
+/// The first index of `argv` that must reach the child untouched, or `None`
+/// when pnpm owns every token.
+///
+/// Three ways to reach it, all of which pnpm honors:
+///
+/// - an explicit `--`;
+/// - the `pnpm <script>` fallback, where the first positional names no
+///   known command;
+/// - a command taking a foreign command line, where the boundary is the
+///   token after the script or command name it is given.
+pub(crate) fn passthrough_from(argv: &[OsString]) -> Option<usize> {
+    // Scanned independently of the command: a separator ends parsing even
+    // for a command that would otherwise own the rest of argv, as in
+    // `pnpm install -- --config.foo=bar`.
+    let separator = argv.iter().position(|arg| arg == "--").map(|index| index + 1);
+    match (separator, command_boundary(argv)) {
+        (Some(separator), Some(command)) => Some(separator.min(command)),
+        (separator, command) => separator.or(command),
+    }
+}
+
+/// The boundary implied by the command alone, ignoring any `--`.
+fn command_boundary(argv: &[OsString]) -> Option<usize> {
+    let mut index = 1;
+    let mut prefix_allowed = true;
+    while index < argv.len() {
+        // Non-UTF-8 cannot be classified, so treat it as the child's.
+        let Some(arg) = argv[index].to_str() else {
+            return Some(index);
+        };
+        if arg == "--" {
+            // The separator governs from here; see `passthrough_from`.
+            return None;
+        }
+        if let Some(width) = option_width(arg) {
+            index += width;
+            continue;
+        }
+        // A positional.
+        if prefix_allowed && COMMAND_PREFIXES.contains(&arg) {
+            prefix_allowed = false;
+            index += 1;
+            continue;
+        }
+        if takes_a_foreign_command_line(arg) {
+            return Some(next_positional(argv, index + 1)? + 1);
+        }
+        if !is_known_top_level_command(arg) {
+            return Some(index + 1);
+        }
+        // A known command that parses its own arguments: pnpm owns the rest.
+        return None;
+    }
+    None
+}
+
+/// The index of the first positional at or after `from`, or `None` when the
+/// command was given no positional at all.
+fn next_positional(argv: &[OsString], from: usize) -> Option<usize> {
+    let mut index = from;
+    while index < argv.len() {
+        let Some(arg) = argv[index].to_str() else {
+            return Some(index);
+        };
+        if arg == "--" {
+            // The separator already ends parsing; nothing after it needs a
+            // script name to anchor on.
+            return Some(index);
+        }
+        match option_width(arg) {
+            Some(width) => index += width,
+            None => return Some(index),
+        }
+    }
+    None
+}
+
+/// The number of argv slots `arg` occupies when it is an option, or `None`
+/// when it is a positional.
+fn option_width(arg: &str) -> Option<usize> {
+    if !arg.starts_with('-') {
+        return None;
+    }
+    if arg.starts_with("--config.") {
+        return Some(1);
+    }
+    Some(global_option_width(arg).unwrap_or(1))
+}
+
+fn global_option_width(arg: &str) -> Option<usize> {
+    if matches!(arg, "-r" | "-v") {
+        return Some(1);
+    }
+    if matches!(arg, "-C" | "-F") {
+        return Some(2);
+    }
+    if arg.starts_with("-C") || arg.starts_with("-F") {
+        return Some(1);
+    }
+    let name = arg.strip_prefix("--")?;
+    let (name, has_value) = name.split_once('=').map_or((name, false), |(name, _)| (name, true));
+    let consumes_value = matches!(
+        name,
+        "dir"
+            | "filter"
+            | "filter-prod"
+            | "http-proxy"
+            | "https-proxy"
+            | "no-proxy"
+            | "npmrc-auth-file"
+            | "registry"
+            | "reporter"
+            | "store-dir"
+            | "userconfig",
+    );
+    Some(if consumes_value && !has_value { 2 } else { 1 })
+}
+
+fn takes_a_foreign_command_line(name: &str) -> bool {
+    resolves_to_any(name, &COMMANDS_TAKING_A_FOREIGN_COMMAND_LINE)
+}
+
+pub(crate) fn is_known_top_level_command(name: &str) -> bool {
+    CliArgs::command().get_subcommands().any(|command| resolves_to(command, name))
+}
+
+/// Whether `name` is one of `canonical_names`, or an alias of one.
+fn resolves_to_any(name: &str, canonical_names: &[&str]) -> bool {
+    CliArgs::command()
+        .get_subcommands()
+        .any(|command| canonical_names.contains(&command.get_name()) && resolves_to(command, name))
+}
+
+fn resolves_to(command: &clap::Command, name: &str) -> bool {
+    command.get_name() == name || command.get_all_aliases().any(|alias| alias == name)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/parse_boundary/tests.rs
+++ b/pnpm/crates/cli/src/parse_boundary/tests.rs
@@ -22,7 +22,6 @@ fn a_command_taking_a_foreign_command_line_forwards_everything_after_its_first_p
         (&["run", "show", "-s", "--if-present"], &["-s", "--if-present"]),
         (&["exec", "node", "show.js", "--config.foo=bar"], &["show.js", "--config.foo=bar"]),
         (&["dlx", "cowsay", "--silent"], &["--silent"]),
-        (&["with", "pnpm@9", "install", "--silent"], &["install", "--silent"]),
         // The recursive prefix forms defer the classification one positional.
         (&["recursive", "run", "show", "--silent"], &["--silent"]),
         (&["m", "run", "show", "--silent"], &["--silent"]),
@@ -56,6 +55,8 @@ fn a_command_parsing_its_own_arguments_owns_all_of_argv() {
         // A package that happens to share an escaping command's name is
         // still just an argument to `add`.
         &["add", "run", "--config.foo=bar"],
+        // `with` included: see `with_current_keeps_its_inner_command_line_parseable`.
+        &["with", "pnpm@9", "install", "--silent"],
     ] {
         let (_, forwarded) = split(argv);
         assert!(forwarded.is_empty(), "{argv:?} forwards {forwarded:?}");
@@ -90,4 +91,37 @@ fn a_foreign_command_line_without_a_positional_forwards_nothing() {
         let (_, forwarded) = split(argv);
         assert!(forwarded.is_empty(), "{argv:?} forwards {forwarded:?}");
     }
+}
+
+/// Arity has to come from clap: a value-taking option whose value looks
+/// like a positional would otherwise land the boundary on that value and
+/// forward pnpm's own later flags to the child.
+#[test]
+fn a_value_taking_option_does_not_move_the_boundary_onto_its_value() {
+    for (argv, forwarded) in [
+        // `--package` is `dlx`'s own option, not a global one.
+        (
+            ["dlx", "--package", "cowsay", "--silent", "cowsay", "--moo", "hi"].as_slice(),
+            ["--moo", "hi"].as_slice(),
+        ),
+        (&["dlx", "--package", "cowsay", "cowsay", "--silent"], &["--silent"]),
+        (&["dlx", "--allow-build", "esbuild", "cowsay", "--moo"], &["--moo"]),
+        // Value-taking globals, including ones no hand-written list had.
+        (&["--workspace-concurrency", "2", "install", "--config.registry=x"], &[]),
+        (&["--test-pattern", "**/*.spec.ts", "install", "--config.foo=bar"], &[]),
+        (&["--resume-from", "pkg", "-r", "run", "build", "--silent"], &["--silent"]),
+    ] {
+        let (_, actual) = split(argv);
+        assert_eq!(actual, forwarded, "{argv:?}");
+    }
+}
+
+/// `with` is deliberately not treated as taking a foreign command line:
+/// `with_current::rewrite` splices its inner command line into pnpm's own
+/// argv *after* `ConfigOverrides::extract` has run, so an override in it is
+/// still pnpm's to claim at this point.
+#[test]
+fn with_current_keeps_its_inner_command_line_parseable() {
+    let (_, forwarded) = split(&["with", "current", "run", "--config.foo=bar", "build"]);
+    assert!(forwarded.is_empty(), "forwarded {forwarded:?}");
 }

--- a/pnpm/crates/cli/src/parse_boundary/tests.rs
+++ b/pnpm/crates/cli/src/parse_boundary/tests.rs
@@ -144,14 +144,16 @@ fn with_forwards_only_for_a_version_that_execs_a_child() {
         assert_eq!(actual, forwarded, "{argv:?}");
     }
 
-    for argv in [
-        ["with", "10", "install", "--config.foo=bar"].as_slice(),
-        &["with", "pnpm@9", "install", "--silent"],
+    // The whole child command line, command included — forwarding only the
+    // options would leave the child pnpm with nothing to run.
+    for (argv, forwarded) in [
+        (
+            ["with", "10", "install", "--config.foo=bar"].as_slice(),
+            ["install", "--config.foo=bar"].as_slice(),
+        ),
+        (&["with", "pnpm@9", "install", "--silent"], &["install", "--silent"]),
     ] {
-        let (_, forwarded) = split(argv);
-        assert!(
-            forwarded.contains(&argv[argv.len() - 1].to_string()),
-            "{argv:?} must forward its child's own options, got {forwarded:?}",
-        );
+        let (_, actual) = split(argv);
+        assert_eq!(actual, forwarded, "{argv:?}");
     }
 }

--- a/pnpm/crates/cli/src/parse_boundary/tests.rs
+++ b/pnpm/crates/cli/src/parse_boundary/tests.rs
@@ -124,8 +124,25 @@ fn a_value_taking_option_does_not_move_the_boundary_onto_its_value() {
 /// for that child.
 #[test]
 fn with_forwards_only_for_a_version_that_execs_a_child() {
-    let (_, current) = split(&["with", "current", "run", "--config.foo=bar", "build"]);
-    assert!(current.is_empty(), "`with current` keeps its overrides: {current:?}");
+    // `with current` resumes the scan on the nested command line, so the
+    // nested boundary is what applies: ahead of the inner script name the
+    // tokens are pnpm's, past it they are the script's.
+    let (_, before) = split(&["with", "current", "run", "--config.foo=bar", "build"]);
+    assert!(before.is_empty(), "an override ahead of the script name is pnpm's: {before:?}");
+
+    for (argv, forwarded) in [
+        (
+            ["with", "current", "run", "show", "--config.foo=bar"].as_slice(),
+            ["--config.foo=bar"].as_slice(),
+        ),
+        (&["with", "current", "run", "show", "--silent"], &["--silent"]),
+        (&["with", "current", "recursive", "run", "show", "--silent"], &["--silent"]),
+        // A nested command that parses its own arguments still owns them.
+        (&["with", "current", "install", "--config.foo=bar"], &[]),
+    ] {
+        let (_, actual) = split(argv);
+        assert_eq!(actual, forwarded, "{argv:?}");
+    }
 
     for argv in [
         ["with", "10", "install", "--config.foo=bar"].as_slice(),

--- a/pnpm/crates/cli/src/parse_boundary/tests.rs
+++ b/pnpm/crates/cli/src/parse_boundary/tests.rs
@@ -1,0 +1,93 @@
+use super::passthrough_from;
+use std::ffi::OsString;
+
+/// `argv` split at the boundary: what pnpm parses, and what it forwards.
+fn split(argv: &[&str]) -> (Vec<String>, Vec<String>) {
+    let owned: Vec<OsString> =
+        std::iter::once("pnpm").chain(argv.iter().copied()).map(OsString::from).collect();
+    let boundary = passthrough_from(&owned).unwrap_or(owned.len());
+    let to_string = |slot: &OsString| slot.to_string_lossy().into_owned();
+    // Skip the `pnpm` slot in the parsed half; it is never interesting.
+    (
+        owned[1..boundary.max(1)].iter().map(to_string).collect(),
+        owned[boundary.min(owned.len())..].iter().map(to_string).collect(),
+    )
+}
+
+#[test]
+fn a_command_taking_a_foreign_command_line_forwards_everything_after_its_first_positional() {
+    for (argv, forwarded) in [
+        (["run", "show", "--config.foo=bar"].as_slice(), ["--config.foo=bar"].as_slice()),
+        (&["run", "show", "--silent"], &["--silent"]),
+        (&["run", "show", "-s", "--if-present"], &["-s", "--if-present"]),
+        (&["exec", "node", "show.js", "--config.foo=bar"], &["show.js", "--config.foo=bar"]),
+        (&["dlx", "cowsay", "--silent"], &["--silent"]),
+        (&["with", "pnpm@9", "install", "--silent"], &["install", "--silent"]),
+        // The recursive prefix forms defer the classification one positional.
+        (&["recursive", "run", "show", "--silent"], &["--silent"]),
+        (&["m", "run", "show", "--silent"], &["--silent"]),
+    ] {
+        let (_, actual) = split(argv);
+        assert_eq!(actual, forwarded, "{argv:?}");
+    }
+}
+
+#[test]
+fn options_before_the_script_name_stay_pnpms() {
+    for argv in [
+        ["run", "--silent", "show"].as_slice(),
+        &["run", "--config.foo=bar", "show"],
+        &["-r", "run", "show"],
+        &["--dir", "/tmp", "run", "show"],
+        &["--filter", "pkg", "exec", "node"],
+        &["-C", "/tmp", "run", "show"],
+    ] {
+        let (_, forwarded) = split(argv);
+        assert!(forwarded.is_empty(), "{argv:?} forwards {forwarded:?}");
+    }
+}
+
+#[test]
+fn a_command_parsing_its_own_arguments_owns_all_of_argv() {
+    for argv in [
+        ["install", "--config.foo=bar"].as_slice(),
+        &["add", "foo", "--config.foo=bar"],
+        &["list", "--silent"],
+        // A package that happens to share an escaping command's name is
+        // still just an argument to `add`.
+        &["add", "run", "--config.foo=bar"],
+    ] {
+        let (_, forwarded) = split(argv);
+        assert!(forwarded.is_empty(), "{argv:?} forwards {forwarded:?}");
+    }
+}
+
+#[test]
+fn the_fallback_script_forwards_everything_after_its_name() {
+    let (_, forwarded) = split(&["some-script", "--config.foo=bar"]);
+    assert_eq!(forwarded, ["--config.foo=bar"]);
+}
+
+#[test]
+fn an_explicit_separator_ends_parsing_wherever_it_appears() {
+    for (argv, forwarded) in [
+        (["install", "--", "--config.foo=bar"].as_slice(), ["--config.foo=bar"].as_slice()),
+        // The script name stays on pnpm's side; the separator and
+        // everything after it are the script's.
+        (&["run", "show", "--", "--config.foo=bar"], &["--", "--config.foo=bar"]),
+        (&["--", "--config.foo=bar"], &["--config.foo=bar"]),
+    ] {
+        let (_, actual) = split(argv);
+        assert_eq!(actual, forwarded, "{argv:?}");
+    }
+}
+
+/// A command given no positional at all has nothing to forward: bare
+/// `pnpm run` lists scripts.
+#[test]
+fn a_foreign_command_line_without_a_positional_forwards_nothing() {
+    for argv in [["run"].as_slice(), &["run", "--silent"], &["exec"]] {
+        let (_, forwarded) = split(argv);
+        assert!(forwarded.is_empty(), "{argv:?} forwards {forwarded:?}");
+    }
+}

--- a/pnpm/crates/cli/src/parse_boundary/tests.rs
+++ b/pnpm/crates/cli/src/parse_boundary/tests.rs
@@ -55,8 +55,6 @@ fn a_command_parsing_its_own_arguments_owns_all_of_argv() {
         // A package that happens to share an escaping command's name is
         // still just an argument to `add`.
         &["add", "run", "--config.foo=bar"],
-        // `with` included: see `with_current_keeps_its_inner_command_line_parseable`.
-        &["with", "pnpm@9", "install", "--silent"],
     ] {
         let (_, forwarded) = split(argv);
         assert!(forwarded.is_empty(), "{argv:?} forwards {forwarded:?}");
@@ -116,12 +114,27 @@ fn a_value_taking_option_does_not_move_the_boundary_onto_its_value() {
     }
 }
 
-/// `with` is deliberately not treated as taking a foreign command line:
-/// `with_current::rewrite` splices its inner command line into pnpm's own
-/// argv *after* `ConfigOverrides::extract` has run, so an override in it is
-/// still pnpm's to claim at this point.
+/// `with` splits on its version, because only some of its invocations hand
+/// their arguments to another process.
+///
+/// `with current` is spliced into pnpm's own argv by `with_current::rewrite`
+/// *after* the pre-clap passes, so an override in it is still pnpm's to
+/// claim — leaving it would let clap mistake it for the script name. Any
+/// other version execs a child pnpm, so stripping an override would lose it
+/// for that child.
 #[test]
-fn with_current_keeps_its_inner_command_line_parseable() {
-    let (_, forwarded) = split(&["with", "current", "run", "--config.foo=bar", "build"]);
-    assert!(forwarded.is_empty(), "forwarded {forwarded:?}");
+fn with_forwards_only_for_a_version_that_execs_a_child() {
+    let (_, current) = split(&["with", "current", "run", "--config.foo=bar", "build"]);
+    assert!(current.is_empty(), "`with current` keeps its overrides: {current:?}");
+
+    for argv in [
+        ["with", "10", "install", "--config.foo=bar"].as_slice(),
+        &["with", "pnpm@9", "install", "--silent"],
+    ] {
+        let (_, forwarded) = split(argv);
+        assert!(
+            forwarded.contains(&argv[argv.len() - 1].to_string()),
+            "{argv:?} must forward its child's own options, got {forwarded:?}",
+        );
+    }
 }

--- a/pnpm/crates/cli/src/shorthands.rs
+++ b/pnpm/crates/cli/src/shorthands.rs
@@ -30,9 +30,13 @@ pub fn expand_universal_shorthands(cmd: &Command, mut argv: Vec<OsString>) -> Ve
     let top_level = ArgTable::top_level(cmd);
     let subcommand_union = ArgTable::subcommand_union(cmd);
     let run_owns_short_s = effective_command_is_run(cmd, &argv, &top_level, &subcommand_union);
+    // Expanding past this would hand the script a token it never typed —
+    // `pnpm run build --silent` must forward `--silent`, not
+    // `--reporter=silent`.
+    let passthrough_from = crate::parse_boundary::passthrough_from(&argv).unwrap_or(argv.len());
 
     let mut index = 1;
-    while index < argv.len() {
+    while index < passthrough_from.min(argv.len()) {
         let Some(token) = argv[index].to_str() else {
             index += 1;
             continue;

--- a/pnpm/crates/cli/src/shorthands/tests.rs
+++ b/pnpm/crates/cli/src/shorthands/tests.rs
@@ -33,10 +33,23 @@ fn silent_long_form_expands_for_any_command() {
         ["pnpm", "store", "path", "--reporter=silent"],
     );
     assert_eq!(expand(&["pnpm", "install", "--silent"]), ["pnpm", "install", "--reporter=silent"]);
-    // `run` overrides only the short `s`; the long `--silent` stays universal.
+    // Ahead of the script name it is still pnpm's, for `run` too.
     assert_eq!(
-        expand(&["pnpm", "run", "build", "--silent"]),
-        ["pnpm", "run", "build", "--reporter=silent"],
+        expand(&["pnpm", "run", "--silent", "build"]),
+        ["pnpm", "run", "--reporter=silent", "build"],
+    );
+}
+
+/// Past the script name the expansion stops: pnpm forwards `--silent` to
+/// the script, so rewriting it would hand over a token the user never
+/// typed (pnpm/pnpm#13302).
+#[test]
+fn silent_is_not_expanded_past_the_script_name() {
+    assert_eq!(expand(&["pnpm", "run", "build", "--silent"]), ["pnpm", "run", "build", "--silent"]);
+    assert_eq!(expand(&["pnpm", "run", "build", "-s"]), ["pnpm", "run", "build", "-s"]);
+    assert_eq!(
+        expand(&["pnpm", "exec", "node", "app.js", "--silent"]),
+        ["pnpm", "exec", "node", "app.js", "--silent"],
     );
 }
 

--- a/pnpm/crates/cli/tests/run.rs
+++ b/pnpm/crates/cli/tests/run.rs
@@ -121,6 +121,10 @@ JSON.stringify(require('./args.json').concat([process.argv.slice(2)])), 'utf8')"
             "--config.enable-pre-post-scripts",
             "run",
             "foo",
+            // A pnpm-settings-shaped token before the separator: the
+            // pre-clap config pass must leave it for the script too
+            // (pnpm/pnpm#13302), which `--other=1` alone would not catch.
+            "--config.foo=bar",
             "arg",
             "--",
             "--other=1",
@@ -138,6 +142,7 @@ JSON.stringify(require('./args.json').concat([process.argv.slice(2)])), 'utf8')"
         vec![
             Vec::<String>::new(),
             vec![
+                "--config.foo=bar".to_string(),
                 "arg".to_string(),
                 "--".to_string(),
                 "--other=1".to_string(),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

> [!NOTE]
> Follows pnpm/pnpm#13300, now merged — that PR fixed the clap layer of this
> same boundary, this one fixes the two passes that run before clap. Rebased
> onto `main`, so the diff here is this change alone.

## Summary

pacquet rewrites argv in two passes before clap sees it — `ConfigOverrides::extract` and `expand_universal_shorthands` — and neither stopped where pnpm stops parsing. Tokens meant for a script were consumed or rewritten on the way through:

| command | pnpm v11.17.0 | pacquet before | after |
|---|---|---|---|
| `run show --config.foo=bar` | forwarded | **swallowed** | ✅ |
| `run show --silent` | `--silent` | **`--reporter=silent`** | ✅ |
| `exec node show.js --config.foo=bar` | forwarded | **swallowed** | ✅ |

The `--silent` case is the worse one: the script received a token the user never typed, not merely one fewer.

Found by Greptile while reviewing pnpm/pnpm#13300, which fixed the clap layer of the same boundary.

## Root cause

`ConfigOverrides::extract` stopped at two things: an explicit `--`, and `external_command_index` — the first positional naming no known command. That covers the `pnpm <script>` fallback, so `pnpm show --config.foo=bar` was already fine, but with an explicit `run` / `exec` the command *is* known, no boundary was found, and the scan covered the whole argv.

`expand_universal_shorthands` stopped only at `--`.

## Approach

Rather than give the shorthand pass a third ad-hoc boundary rule, both passes now consult one helper — `parse_boundary::passthrough_from`, the first argv index that must reach the child untouched. It has three sources, all of which pnpm honors:

- an explicit `--`, scanned independently of the command so `pnpm install -- --config.foo=bar` still ends parsing;
- the `pnpm <script>` fallback (existing behavior, moved);
- a command taking a foreign command line: `run` / `dlx` / `with` — pnpm's `SPECIALLY_ESCAPED_CMDS` — plus `exec`, which reaches the same place through its argv shape.

Two subtleties the tests pin:

- `recursive` / `multi` / `m` defer the classification by one positional, so `pnpm -r run build --silent` lands on the same boundary.
- Only the command *position* is classified, so a package sharing an escaping command's name is unaffected: `pnpm add run --config.foo=bar` still keeps the setting.

## One existing test asserted the old behavior

`silent_long_form_expands_for_any_command` claimed the long `--silent` "stays universal" past the script name. Both stacks disagree, verified against v11.17.0:

| command | echo silenced? |
|---|---|
| `pnpm run --silent show` | yes, both stacks |
| `pnpm run show --silent` | no, both stacks — the flag is the script's |

Split into the two positions accordingly.

## Verification

All ten cases in the matrix match the TypeScript CLI byte for byte, 2214 `pacquet-cli` tests pass, lint and dylint clean. I confirmed the new tests catch a regression: disabling the foreign-command-line rule fails two `parse_boundary` tests and one `shorthands` test.

TypeScript CLI: no change needed — it is the reference.

Closes pnpm/pnpm#13302

## Squash Commit Body

```text
Two passes rewrite argv before clap sees it, and neither stopped where
pnpm stops parsing, so tokens meant for a script were consumed or
rewritten on the way through:

    command                              pnpm            pacquet
    run show --config.foo=bar            forwarded       swallowed
    run show --silent                    --silent        --reporter=silent
    exec node show.js --config.foo=bar   forwarded       swallowed

The `--silent` case is the worse one: the script received a token the user
never typed, not merely one fewer.

`ConfigOverrides::extract` stopped at an explicit `--` and at
`external_command_index`, the first positional naming no known command.
That covers the `pnpm <script>` fallback but not an explicit `run` /
`exec`, where the command *is* known, so no boundary was found and the
scan covered the whole argv. `expand_universal_shorthands` stopped only at
`--`.

Rather than give the shorthand pass a third boundary rule, both now
consult one `parse_boundary::passthrough_from`: the first index that must
reach the child untouched, whether that comes from a `--`, the fallback
command, or a command taking a foreign command line (`run` / `exec` /
`dlx` / `with` — pnpm's `SPECIALLY_ESCAPED_CMDS` plus `exec`). The
separator is scanned independently of the command, so `pnpm install --
--config.foo=bar` still ends parsing.

`recursive` / `multi` / `m` defer the classification by one positional, so
`pnpm -r run build --silent` lands on the same boundary. A package sharing
an escaping command's name does not: `pnpm add run --config.foo=bar` keeps
the setting, because only the command position is classified.

One existing shorthand test asserted the old behavior — that `--silent`
"stays universal" past the script name. Both stacks disagree with it:
`pnpm run show --silent` forwards the flag and does not silence the echo,
while `pnpm run --silent show` silences it. Split into the two positions.

Closes pnpm/pnpm#13302
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <sub>Rust-only: the TypeScript CLI is the reference behavior being matched.</sub>
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <sub>A boundary table over every source and command shape, plus the shorthand positions.</sub>

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Arguments placed after the script or command name are now forwarded unchanged for `pnpm run`, `pnpm exec`, `pnpm dlx`, and `pnpm with`.
  - Script arguments resembling pnpm settings or flags, such as `--config.foo=bar` and `--silent`, are no longer incorrectly consumed or rewritten.
  - pnpm options should be placed before the script or command name.
  - Improved handling of argument separators and versioned `pnpm with` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->