### PR TITLE
fix(cli): accept -g for approve-builds

### DIFF
--- a/.changeset/pacquet-approve-builds-short-global.md
+++ b/.changeset/pacquet-approve-builds-short-global.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm approve-builds -g` is accepted again, reporting that the command is not supported with global packages rather than failing with `unexpected argument '-g' found`. `approve-builds` was the only command that declared `--global` without its `-g` short form [#13310](https://github.com/pnpm/pnpm/issues/13310).

--- a/pnpm/crates/cli/src/cli_args/approve_builds.rs
+++ b/pnpm/crates/cli/src/cli_args/approve_builds.rs
@@ -25,7 +25,7 @@ pub struct ApproveBuildsArgs {
     pub all: bool,
 
     /// Approve builds for globally installed packages (not supported yet).
-    #[clap(long)]
+    #[clap(short = 'g', long)]
     pub global: bool,
 }
 

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -658,22 +658,25 @@ const GLOBAL_SUBCOMMAND_ARGV: [&[&str]; 12] = [
 fn workspace_root_conflicts_with_global_for_every_subcommand() {
     let (root, _canonical) = workspace_fixture();
 
-    for subcommand in GLOBAL_SUBCOMMAND_ARGV {
-        let argv = std::iter::once("pacquet")
-            .chain(subcommand.iter().copied())
-            // The long form throughout: `approve-builds` declares
-            // `--global` without a `-g` short.
-            .chain(["-w", "--global", "-C"])
-            .chain([root.path().to_str().expect("utf-8 tmp dir")]);
-        let mut args = CliArgs::try_parse_from(argv).unwrap_or_else(|error| {
-            panic!("{subcommand:?} should parse with -w --global: {error}");
-        });
-        let error = args
-            .apply_workspace_root()
-            .expect_err(&format!("{subcommand:?} must reject -w with --global"));
+    // Both spellings: pnpm accepts `-g` wherever it accepts `--global`, so a
+    // subcommand declaring only the long form fails in the parser instead of
+    // reaching the conflict check (pnpm/pnpm#13310).
+    for global in ["--global", "-g"] {
+        for subcommand in GLOBAL_SUBCOMMAND_ARGV {
+            let argv = std::iter::once("pacquet")
+                .chain(subcommand.iter().copied())
+                .chain(["-w", global, "-C"])
+                .chain([root.path().to_str().expect("utf-8 tmp dir")]);
+            let mut args = CliArgs::try_parse_from(argv).unwrap_or_else(|error| {
+                panic!("{subcommand:?} should parse with -w {global}: {error}");
+            });
+            let error = args
+                .apply_workspace_root()
+                .expect_err(&format!("{subcommand:?} must reject -w with {global}"));
 
-        dbg!(subcommand, &error);
-        assert!(matches!(error, WorkspaceRootError::GlobalConflict), "{subcommand:?}");
+            dbg!(subcommand, global, &error);
+            assert!(matches!(error, WorkspaceRootError::GlobalConflict), "{subcommand:?} {global}");
+        }
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -674,8 +674,12 @@ fn workspace_root_conflicts_with_global_for_every_subcommand() {
                 .apply_workspace_root()
                 .expect_err(&format!("{subcommand:?} must reject -w with {global}"));
 
-            dbg!(subcommand, global, &error);
-            assert!(matches!(error, WorkspaceRootError::GlobalConflict), "{subcommand:?} {global}");
+            // The message carries what `dbg!` would, without 24 lines of it
+            // on the way past.
+            assert!(
+                matches!(error, WorkspaceRootError::GlobalConflict),
+                "{subcommand:?} {global}: {error:?}",
+            );
         }
     }
 }

--- a/pnpm/crates/cli/tests/approve_builds.rs
+++ b/pnpm/crates/cli/tests/approve_builds.rs
@@ -345,17 +345,22 @@ fn approve_builds_all_with_args_is_rejected() {
     drop(root);
 }
 
+/// Both spellings reach the same rejection. `-g` used to stop in the
+/// argument parser instead (pnpm/pnpm#13310), which the long form alone
+/// could not have caught.
 #[test]
 fn approve_builds_global_is_rejected() {
-    let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
-    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+    for global in ["--global", "-g"] {
+        let CommandTempCwd { workspace, root, .. } = CommandTempCwd::init();
+        fs::write(workspace.join("package.json"), "{}").expect("write package.json");
 
-    let assert = pacquet(&workspace).with_args(["approve-builds", "--global"]).assert().failure();
-    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
-    assert!(
-        stderr.contains("ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL"),
-        "stderr: {stderr}",
-    );
+        let assert = pacquet(&workspace).with_args(["approve-builds", global]).assert().failure();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+        assert!(
+            stderr.contains("ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL"),
+            "{global} stderr: {stderr}",
+        );
 
-    drop(root);
+        drop(root);
+    }
 }

--- a/pnpm/crates/cli/tests/approve_builds.rs
+++ b/pnpm/crates/cli/tests/approve_builds.rs
@@ -356,8 +356,14 @@ fn approve_builds_global_is_rejected() {
 
         let assert = pacquet(&workspace).with_args(["approve-builds", global]).assert().failure();
         let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
+        // Code and message both: the code alone would not catch the two
+        // spellings drifting to different user-facing text.
         assert!(
             stderr.contains("ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL"),
+            "{global} stderr: {stderr}",
+        );
+        assert!(
+            stderr.contains(r#""approve-builds" is not supported with global packages"#),
             "{global} stderr: {stderr}",
         );
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

`approve-builds` declared `--global` without the `-g` short form its ten peers all carry, so the short spelling failed in the argument parser instead of reaching pnpm's own error:

```console
$ pnpm approve-builds -g
# before
error: unexpected argument '-g' found

# after, and the TypeScript CLI v11.17.0
Error: ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL
```

pnpm accepts `-g` wherever it accepts `--global`. `approve-builds` was the only command out of eleven that did not.

## Test

The `--workspace-root` conflict table now runs over both spellings, which is the property that was actually missing. That table used the long form throughout *precisely because* this command rejected the short one — so the gap it had surfaced was never asserted. Dropping the short form again fails it, naming both the subcommand and the spelling:

```
["approve-builds"] should parse with -w -g: error: unexpected argument '-g' found
```

Verified against v11.17.0: both `-g` and `--global` now produce `ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL` on both stacks.

TypeScript CLI: no change needed — it is the reference.

Closes pnpm/pnpm#13310

## Squash Commit Body

```text
`approve-builds` declared `--global` without the `-g` short form its ten
peers all carry, so `pnpm approve-builds -g` died in the argument parser
instead of reaching pnpm's own
ERR_PNPM_APPROVE_BUILDS_NOT_SUPPORTED_WITH_GLOBAL. pnpm accepts `-g`
wherever it accepts `--global`.

The `--workspace-root` conflict table now runs over both spellings, which
is the property that was missing: it used the long form throughout
precisely because this one command rejected the short one, so the gap it
had surfaced went unasserted. Dropping the short form again fails the
table, naming the subcommand and the spelling.

Closes pnpm/pnpm#13310
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <sub>Rust-only: the TypeScript CLI is the reference behavior being matched.</sub>
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <sub>The existing `--global` conflict table, extended to both spellings.</sub>

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787571405&installation_model_id=426870&pr_number=13329&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13329&signature=3f2d8b8b722eac404a25294e5be529b43e443851b905ce3324b2b89e8dbb1b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored proper handling of the `-g` shorthand for `pnpm approve-builds`.
  * The command now consistently reports that global packages aren’t supported for both `--global` and `-g`.
  * Improved validation for conflicts between the workspace-root redirect and global options, covering both `--global` and `-g`.

* **Tests**
  * Expanded CLI and integration tests to cover both `--global` and `-g` spellings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->