### PR TITLE
fix(lockfile): read patchedDependencies written by pnpm 10

### DIFF
--- a/.changeset/read-pnpm-10-patched-dependencies.md
+++ b/.changeset/read-pnpm-10-patched-dependencies.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `ERR_PNPM_BROKEN_LOCKFILE` on a lockfile written by pnpm 10 that has a `patchedDependencies` section. pnpm 10 records each patched dependency as a `{hash, path}` mapping, while newer versions record the bare patch-file hash. Both shapes are now read, so such a lockfile installs unchanged and is normalized the next time it is written. See pnpm/pnpm#13307.
+Fixed `ERR_PNPM_BROKEN_LOCKFILE` when installing with a pnpm 10 lockfile that has a `patchedDependencies` section. See pnpm/pnpm#13307.

--- a/.changeset/read-pnpm-10-patched-dependencies.md
+++ b/.changeset/read-pnpm-10-patched-dependencies.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `ERR_PNPM_BROKEN_LOCKFILE` on a lockfile written by pnpm 10 that has a `patchedDependencies` section. pnpm 10 records each patched dependency as a `{hash, path}` mapping, while newer versions record the bare patch-file hash. Both shapes are now read, so such a lockfile installs unchanged and is normalized the next time it is written. See pnpm/pnpm#13307.

--- a/pnpm/crates/cli/tests/patch.rs
+++ b/pnpm/crates/cli/tests/patch.rs
@@ -482,7 +482,7 @@ fn install_reads_patched_dependencies_written_by_pnpm_10() {
     let pnpm_10_text = lockfile_text.replace(
         &format!("  is-positive@1.0.0: {patch_hash}\n"),
         &format!(
-            "  is-positive@1.0.0:\n    hash: {patch_hash}\n    path: patches/is-positive@1.0.0.patch\n"
+            "  is-positive@1.0.0:\n    hash: {patch_hash}\n    path: patches/is-positive@1.0.0.patch\n",
         ),
     );
     assert_ne!(pnpm_10_text, lockfile_text, "lockfile: {lockfile_text}");

--- a/pnpm/crates/cli/tests/patch.rs
+++ b/pnpm/crates/cli/tests/patch.rs
@@ -464,6 +464,60 @@ fn install_level_modified_patch_is_reapplied() {
     drop((root, mock_instance));
 }
 
+/// Regression test for <https://github.com/pnpm/pnpm/issues/13307>: a
+/// lockfile committed by pnpm 10 records each patched dependency as a
+/// `{hash, path}` mapping instead of the bare hash. Installing over it
+/// used to abort with `ERR_PNPM_BROKEN_LOCKFILE`, frozen or not.
+#[test]
+fn install_reads_patched_dependencies_written_by_pnpm_10() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1.0.0", "is-positive@1.0.0.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["install", "--reporter=silent"]).assert().success();
+
+    let patch_hash = patch_file_hash(&workspace, "is-positive@1.0.0.patch");
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile_text = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    let pnpm_10_text = lockfile_text.replace(
+        &format!("  is-positive@1.0.0: {patch_hash}\n"),
+        &format!(
+            "  is-positive@1.0.0:\n    hash: {patch_hash}\n    path: patches/is-positive@1.0.0.patch\n"
+        ),
+    );
+    assert_ne!(pnpm_10_text, lockfile_text, "lockfile: {lockfile_text}");
+    fs::write(&lockfile_path, &pnpm_10_text).expect("write the pnpm 10 lockfile");
+
+    remove_dir_if_exists(&workspace.join("node_modules"));
+    pacquet(&workspace, ["install", "--frozen-lockfile", "--reporter=silent"]).assert().success();
+    let frozen = read_installed_index(&workspace);
+    assert!(frozen.contains("// patched"), "frozen: {frozen}");
+    assert_eq!(
+        fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml"),
+        pnpm_10_text,
+        "a frozen install must leave the lockfile alone",
+    );
+
+    remove_dir_if_exists(&workspace.join("node_modules"));
+    let patch_path = workspace.join("patches/is-positive@1.0.0.patch");
+    let patch = fs::read_to_string(&patch_path).expect("read the patch file");
+    fs::write(&patch_path, patch.replace("// patched", "// edited patch"))
+        .expect("rewrite the patch file");
+    pacquet(&workspace, ["install", "--reporter=silent"]).assert().success();
+    let installed = read_installed_index(&workspace);
+    assert!(installed.contains("// edited patch"), "installed: {installed}");
+
+    let edited_hash = patch_file_hash(&workspace, "is-positive@1.0.0.patch");
+    let rewritten = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert_eq!(
+        rewritten,
+        lockfile_text.replace(&patch_hash, &edited_hash),
+        "an install that rewrites the lockfile normalizes the entry to the bare hash",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// TS: `patch package when the patched package has no dependencies and
 /// appears multiple times` (`patch.ts:475`). `is-not-positive` depends on
 /// `is-positive@^3.1.0`, which the override pins back onto the patched

--- a/pnpm/crates/cli/tests/patch.rs
+++ b/pnpm/crates/cli/tests/patch.rs
@@ -464,10 +464,7 @@ fn install_level_modified_patch_is_reapplied() {
     drop((root, mock_instance));
 }
 
-/// Regression test for <https://github.com/pnpm/pnpm/issues/13307>: a
-/// lockfile committed by pnpm 10 records each patched dependency as a
-/// `{hash, path}` mapping instead of the bare hash. Installing over it
-/// used to abort with `ERR_PNPM_BROKEN_LOCKFILE`, frozen or not.
+/// Regression test for <https://github.com/pnpm/pnpm/issues/13307>.
 #[test]
 fn install_reads_patched_dependencies_written_by_pnpm_10() {
     let (root, workspace, npmrc_info) =

--- a/pnpm/crates/lockfile/src/lib.rs
+++ b/pnpm/crates/lockfile/src/lib.rs
@@ -45,8 +45,8 @@ pub use snapshot_entry::*;
 pub use yaml_documents::*;
 
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::{BTreeMap, HashMap};
 
 /// Package key used by the `packages:` and `snapshots:` maps in a v9 lockfile.
 ///
@@ -147,9 +147,14 @@ pub struct Lockfile {
     /// `pnpmfileChecksum` and `importers` in the root-key order.
     /// A [`BTreeMap`] so the entries serialize sorted by key.
     ///
-    /// [`BTreeMap`]: std::collections::BTreeMap
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub patched_dependencies: Option<std::collections::BTreeMap<String, String>>,
+    /// Loading also accepts the `{hash, path}` shape pnpm 10 wrote,
+    /// collapsing it to the hash.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_patched_dependencies"
+    )]
+    pub patched_dependencies: Option<BTreeMap<String, String>>,
 
     #[serde(
         default,
@@ -266,4 +271,34 @@ fn is_local_tarball_path(path: &str) -> bool {
         lower.len() >= bytes.len() && lower[lower.len() - bytes.len()..].eq_ignore_ascii_case(bytes)
     };
     ends_with_ci(".tgz") || ends_with_ci(".tar.gz") || ends_with_ci(".tar")
+}
+
+/// Accepts both shapes a lockfile can carry for a `patchedDependencies`
+/// entry: the bare patch-file hash pnpm writes today, and the
+/// `{hash, path}` mapping pnpm 10 wrote. The mapping collapses to its
+/// hash — the path is redundant, since patch paths come from the
+/// project's `patchedDependencies` config — so a lockfile committed by
+/// pnpm 10 installs unchanged and normalizes the next time it is saved.
+fn deserialize_patched_dependencies<'de, Deser>(
+    deserializer: Deser,
+) -> Result<Option<BTreeMap<String, String>>, Deser::Error>
+where
+    Deser: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum PatchEntry {
+        Hash(String),
+        HashAndPath { hash: String },
+    }
+
+    let entries = Option::<BTreeMap<String, PatchEntry>>::deserialize(deserializer)?;
+    Ok(entries.map(|entries| {
+        entries
+            .into_iter()
+            .map(|(key, entry)| match entry {
+                PatchEntry::Hash(hash) | PatchEntry::HashAndPath { hash } => (key, hash),
+            })
+            .collect()
+    }))
 }

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use pacquet_diagnostics::miette::Diagnostic;
 use pretty_assertions::assert_eq;
+use std::collections::BTreeMap;
 use tempfile::tempdir;
 use text_block_macros::text_block;
 
@@ -227,6 +228,45 @@ snapshots:
     assert!(packages.contains_key(&key));
     let snapshots = lockfile.snapshots.as_ref().expect("snapshots present");
     assert!(snapshots.contains_key(&key));
+}
+
+/// Regression test for <https://github.com/pnpm/pnpm/issues/13307>.
+#[test]
+fn parses_pnpm_10_patched_dependencies_entries() {
+    let lockfile_text = text_block! {
+        "lockfileVersion: '9.0'"
+        ""
+        "patchedDependencies:"
+        "  is-odd@3.0.1:"
+        "    hash: 29572dfbe22f7337d5e2aeab404b7e889550d802c26fa7356730522dd98f4593"
+        "    path: patches/is-odd@3.0.1.patch"
+        "  is-positive@1.0.0: 6ceb8d5b9e4d6e2f8fca4d7d3f1e0c1b2a3948576d8e2f0c1a4b5d6e7f8091a2"
+        ""
+        "importers:"
+        ""
+        "  .: {}"
+    };
+    let tmp = write_lockfile(lockfile_text);
+    let virtual_store_dir = tmp.path().join("node_modules").join(".pacquet");
+
+    let lockfile = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
+        .expect("load lockfile with pnpm 10 patchedDependencies")
+        .expect("lockfile should be present");
+
+    let patched = lockfile.patched_dependencies.as_ref().expect("patchedDependencies present");
+    assert_eq!(
+        patched,
+        &BTreeMap::from([
+            (
+                "is-odd@3.0.1".to_string(),
+                "29572dfbe22f7337d5e2aeab404b7e889550d802c26fa7356730522dd98f4593".to_string(),
+            ),
+            (
+                "is-positive@1.0.0".to_string(),
+                "6ceb8d5b9e4d6e2f8fca4d7d3f1e0c1b2a3948576d8e2f0c1a4b5d6e7f8091a2".to_string(),
+            ),
+        ]),
+    );
 }
 
 /// Regression test for <https://github.com/pnpm/pnpm/issues/11775>.


### PR DESCRIPTION
## Summary

pnpm 10 serializes each `patchedDependencies` entry in `pnpm-lock.yaml` as a `{hash, path}` mapping, while pnpm 11 and later write the bare patch-file hash. pacquet typed `Lockfile::patched_dependencies` as `BTreeMap<String, String>`, so a lockfile committed by pnpm 10 failed to parse and *every* install — frozen and non-frozen alike — aborted with `ERR_PNPM_BROKEN_LOCKFILE` before it could regenerate anything. This is a hard upgrade blocker for any repository that patches a dependency and still has a pnpm-10-written lockfile committed (it blocks a cold frozen install of vercel/next.js).

The field now deserializes through an untagged entry accepting both shapes and collapsing the mapping to its hash, mirroring `migratePatchedDependencies` in `lockfile/fs/src/lockfileFormatConverters.ts`. The writer is unchanged, so such a lockfile installs as-is and normalizes to the bare-hash shape the next time it is written.

TypeScript CLI: no change needed — it already migrates the old shape at load time.

Closes pnpm/pnpm#13307

## Squash Commit Body

```text
pnpm 10 serializes each `patchedDependencies` entry as a `{hash, path}`
mapping, while pnpm 11 and later write the bare patch-file hash. The
`Lockfile::patched_dependencies` field typed the values as plain strings,
so a lockfile committed by pnpm 10 failed to parse and every install --
frozen and non-frozen alike -- aborted with ERR_PNPM_BROKEN_LOCKFILE
before it could regenerate anything.

Deserialize the field through an untagged entry that accepts both shapes
and collapses the mapping to its hash, mirroring
`migratePatchedDependencies` in the TypeScript CLI. The path is redundant
-- patch paths come from the project's `patchedDependencies` config -- and
the writer already emits the bare hash, so such a lockfile installs
unchanged and normalizes the next time it is written.

Closes pnpm/pnpm#13307
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: the TypeScript CLI already handles both shapes.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787571423&installation_model_id=426870&pr_number=13330&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13330&signature=2e7cd8549b35f8afbc90bd481bc242a3a046adcb6722fbd93788759f21513676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed frozen installs for lockfiles generated by pnpm 10 that include patched dependencies.
  * Added compatibility for both legacy and pnpm 10 patched-dependency formats.
  * Ensured patched packages install correctly, with stable lockfile handling and normalization on subsequent updates.
* **Tests**
  * Added regression coverage for pnpm 10 patched-dependencies lockfile shapes to prevent future lockfile parsing/install issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->