### PR TITLE
feat(update): name the workspace projects each interactive row came from

### DIFF
--- a/.changeset/interactive-update-workspace-column.md
+++ b/.changeset/interactive-update-workspace-column.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm update --interactive` run inside a workspace now shows a `Workspace` column naming the project each outdated dependency was found in, so the same package outdated in several projects can be told apart.

--- a/.changeset/interactive-update-workspace-labels.md
+++ b/.changeset/interactive-update-workspace-labels.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.inspection.outdated": patch
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+The `Workspace` column of `pnpm update --interactive` is more informative in two cases. A dependency outdated at the same version in several workspace projects is offered as one choice, since selecting it updates every project — that choice now names all of them instead of only the first. And a workspace project without a `name` is now labelled with its path rather than left blank, so several unnamed projects can be told apart.

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -189,6 +189,8 @@ async fn collect_outdated_for_importer_with_cache(
         .value()
         .get("name")
         .and_then(serde_json::Value::as_str)
+        // An empty name gives just as blank a label as no name at all.
+        .filter(|name| !name.is_empty())
         .map_or_else(|| importer_id.to_string(), str::to_string);
     let workspace = &workspace;
 

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -84,6 +84,11 @@ pub struct OutdatedPackage {
     /// `homepage` of the package, shown in the `--long` details column
     /// when the registry serves it.
     pub homepage: Option<String>,
+    /// Name of the workspace project this dependency was found in, shown
+    /// in the interactive update list's `Workspace` column. `None` for a
+    /// project without a `name`, and for entries that belong to no
+    /// project (GitHub Actions).
+    pub workspace: Option<String>,
 }
 
 impl From<github_actions::OutdatedGitHubAction> for OutdatedPackage {
@@ -98,6 +103,7 @@ impl From<github_actions::OutdatedGitHubAction> for OutdatedPackage {
             github_action: true,
             deprecated: None,
             homepage: Some(action.homepage),
+            workspace: None,
         }
     }
 }
@@ -174,6 +180,11 @@ async fn collect_outdated_for_importer_with_cache(
     let current_versions =
         current_versions_from_importer(lockfile, importer_id, query.include_direct);
     let current_versions = &current_versions;
+    // Recorded on every entry so the interactive update list can say
+    // which workspace project each outdated dependency came from.
+    let workspace =
+        manifest.value().get("name").and_then(serde_json::Value::as_str).map(str::to_string);
+    let workspace = &workspace;
 
     // Gather the lockfile-pinned direct dependencies to inspect, then
     // fetch their packuments concurrently — mirroring pnpm's
@@ -232,6 +243,7 @@ async fn collect_outdated_for_importer_with_cache(
                 github_action: false,
                 deprecated,
                 homepage: package.homepage.clone(),
+                workspace: workspace.clone(),
             }))
         });
 

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -181,9 +181,15 @@ async fn collect_outdated_for_importer_with_cache(
         current_versions_from_importer(lockfile, importer_id, query.include_direct);
     let current_versions = &current_versions;
     // Recorded on every entry so the interactive update list can say
-    // which workspace project each outdated dependency came from.
-    let workspace =
-        manifest.value().get("name").and_then(serde_json::Value::as_str).map(str::to_string);
+    // which workspace project each outdated dependency came from. A
+    // project is not required to declare a name, and an empty label
+    // leaves several unnamed projects indistinguishable, so fall back to
+    // the path that identifies the project in the lockfile.
+    let workspace = manifest
+        .value()
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .map_or_else(|| importer_id.to_string(), str::to_string);
     let workspace = &workspace;
 
     // Gather the lockfile-pinned direct dependencies to inspect, then
@@ -243,7 +249,7 @@ async fn collect_outdated_for_importer_with_cache(
                 github_action: false,
                 deprecated,
                 homepage: package.homepage.clone(),
-                workspace: workspace.clone(),
+                workspace: Some(workspace.clone()),
             }))
         });
 

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -29,6 +29,7 @@ fn pkg(name: &str, current: &str, target: &str, group: DependencyGroup) -> Outda
         github_action: false,
         deprecated: None,
         homepage: None,
+        workspace: None,
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -160,6 +160,9 @@ async fn collect_choices(
         )
     }))
     .await;
+    // Keyed by workspace as well, so an entry each project contributed
+    // survives to [`choices::update_choices`] — that is what lets a
+    // collapsed row name every project it covers instead of the first.
     let mut unique = HashSet::new();
     let mut collected = Vec::new();
     for choices in choices {
@@ -169,6 +172,7 @@ async fn collect_choices(
                 choice.package_name.clone(),
                 choice.current.to_string(),
                 choice.target.to_string(),
+                choice.workspace.clone(),
             );
             if unique.insert(key) {
                 collected.push(choice);

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -75,7 +75,7 @@ pub(crate) async fn select_packages<Reporter: self::Reporter>(
         )
         .await?;
     }
-    prompt_for_packages(&choices, options.latest)
+    prompt_for_packages(&choices, options.latest, config.workspace_dir.is_some())
 }
 
 pub(crate) async fn select_packages_for_projects<Reporter: self::Reporter>(
@@ -116,7 +116,7 @@ pub(crate) async fn select_packages_for_projects<Reporter: self::Reporter>(
         )
         .await?;
     }
-    prompt_for_packages(&choices, options.latest)
+    prompt_for_packages(&choices, options.latest, true)
 }
 
 async fn append_github_actions<Reporter: self::Reporter>(
@@ -181,6 +181,7 @@ async fn collect_choices(
 fn prompt_for_packages(
     choices: &[OutdatedPackage],
     latest: bool,
+    workspaces_enabled: bool,
 ) -> miette::Result<Option<Vec<String>>> {
     if choices.is_empty() {
         let message = if latest {
@@ -192,7 +193,7 @@ fn prompt_for_packages(
         return Ok(None);
     }
 
-    let groups = choices::update_choices(&choices.iter().collect::<Vec<_>>());
+    let groups = choices::update_choices(&choices.iter().collect::<Vec<_>>(), workspaces_enabled);
     let (labels, values) = flatten_groups(&groups);
 
     let selected_indices = MultiSelect::new()

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -8,6 +8,7 @@ use crate::cli_args::{
     outdated::{OutdatedPackage, colorize_target},
     sanitize::sanitize_inline,
 };
+use node_semver::Version;
 use pacquet_package_manifest::DependencyGroup;
 use std::collections::HashMap;
 
@@ -93,8 +94,8 @@ pub(crate) fn update_choices(
         let key = (
             package.alias.as_str(),
             package.package_name.as_str(),
-            package.current.to_string(),
-            package.target.to_string(),
+            &package.current,
+            &package.target,
             package.github_action,
         );
         let index = *seen.entry(key).or_insert_with(|| {
@@ -135,7 +136,7 @@ struct Choice<'a> {
     workspaces: Vec<String>,
 }
 
-type ChoiceKey<'a> = (&'a str, &'a str, String, String, bool);
+type ChoiceKey<'a> = (&'a str, &'a str, &'a Version, &'a Version, bool);
 
 /// The header row plus one row per offered dependency, padded so every
 /// column lines up within the group.

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -9,7 +9,7 @@ use crate::cli_args::{
     sanitize::sanitize_inline,
 };
 use pacquet_package_manifest::DependencyGroup;
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 /// One line of a [`ChoiceGroup`].
 #[derive(Debug, PartialEq, Eq)]
@@ -75,47 +75,71 @@ impl ChoiceGroupKind {
 /// A package that is outdated in more than one dependency type appears
 /// once, under whichever type came first: the deduplication key omits
 /// the dependency type. This matches pnpm, whose `uniqBy` runs before
-/// its `groupBy` over the same key.
+/// its `groupBy` over the same key. Collapsed entries keep every
+/// workspace project they came from, since selecting the row updates the
+/// package in all of them.
 pub(crate) fn update_choices(
     outdated: &[&OutdatedPackage],
     workspaces_enabled: bool,
 ) -> Vec<ChoiceGroup> {
-    let mut seen = HashSet::new();
-    let mut grouped: Vec<(ChoiceGroupKind, Vec<&OutdatedPackage>)> = Vec::new();
+    let mut seen: HashMap<ChoiceKey, usize> = HashMap::new();
+    let mut choices: Vec<Choice<'_>> = Vec::new();
+    let mut grouped: Vec<(ChoiceGroupKind, Vec<usize>)> = Vec::new();
     for package in outdated {
         // Keyed by alias as well as package name, because the alias is
         // what a selected row updates: two manifest entries aliasing one
         // package (`"a": "npm:foo@1"`, `"b": "npm:foo@1"`) are separate
         // dependencies and both have to be offered.
         let key = (
-            package.alias.as_str(),
-            package.package_name.as_str(),
+            package.alias.clone(),
+            package.package_name.clone(),
             package.current.to_string(),
             package.target.to_string(),
             package.github_action,
         );
-        if !seen.insert(key) {
-            continue;
-        }
-        let kind = ChoiceGroupKind::of(package);
-        match grouped.iter_mut().find(|(group, _)| *group == kind) {
-            Some((_, packages)) => packages.push(package),
-            None => grouped.push((kind, vec![*package])),
+        let index = *seen.entry(key).or_insert_with(|| {
+            let index = choices.len();
+            choices.push(Choice { package, workspaces: Vec::new() });
+            let kind = ChoiceGroupKind::of(package);
+            match grouped.iter_mut().find(|(group, _)| *group == kind) {
+                Some((_, indices)) => indices.push(index),
+                None => grouped.push((kind, vec![index])),
+            }
+            index
+        });
+        // Collect every project the collapsed entries came from, so the
+        // `Workspace` column names all of them rather than whichever was
+        // seen first — selecting the row updates the package in each.
+        if let Some(workspace) = &package.workspace
+            && !choices[index].workspaces.contains(workspace)
+        {
+            choices[index].workspaces.push(workspace.clone());
         }
     }
 
     grouped
         .into_iter()
-        .map(|(kind, packages)| ChoiceGroup {
+        .map(|(kind, indices)| ChoiceGroup {
             message: kind.message().to_string(),
-            rows: render_rows(&packages, workspaces_enabled),
+            rows: render_rows(
+                &indices.into_iter().map(|index| &choices[index]).collect::<Vec<_>>(),
+                workspaces_enabled,
+            ),
         })
         .collect()
 }
 
-/// The header row plus one row per package, padded so every column lines
-/// up within the group.
-fn render_rows(packages: &[&OutdatedPackage], workspaces_enabled: bool) -> Vec<ChoiceRow> {
+/// One offered dependency, with every workspace project it was found in.
+struct Choice<'a> {
+    package: &'a OutdatedPackage,
+    workspaces: Vec<String>,
+}
+
+type ChoiceKey = (String, String, String, String, bool);
+
+/// The header row plus one row per offered dependency, padded so every
+/// column lines up within the group.
+fn render_rows(choices: &[&Choice<'_>], workspaces_enabled: bool) -> Vec<ChoiceRow> {
     let mut header =
         vec!["Package".to_string(), "Current".to_string(), String::new(), "Target".to_string()];
     if workspaces_enabled {
@@ -124,8 +148,9 @@ fn render_rows(packages: &[&OutdatedPackage], workspaces_enabled: bool) -> Vec<C
     header.push("URL".to_string());
 
     let mut cells = vec![header];
-    for package in packages {
-        // The name, workspace, and homepage are read out of manifests
+    for choice in choices {
+        let package = choice.package;
+        // The name, workspaces, and homepage are read out of manifests
         // and registry metadata, so they are stripped of control
         // characters before reaching the terminal: an escape sequence
         // would corrupt the prompt's redraw, and a newline would break
@@ -138,7 +163,12 @@ fn render_rows(packages: &[&OutdatedPackage], workspaces_enabled: bool) -> Vec<C
         ];
         if workspaces_enabled {
             row.push(
-                package.workspace.as_deref().map(sanitize_inline).unwrap_or_default().into_owned(),
+                choice
+                    .workspaces
+                    .iter()
+                    .map(|workspace| sanitize_inline(workspace))
+                    .collect::<Vec<_>>()
+                    .join(", "),
             );
         }
         row.push(package.homepage.as_deref().map(sanitize_inline).unwrap_or_default().into_owned());
@@ -151,8 +181,10 @@ fn render_rows(packages: &[&OutdatedPackage], workspaces_enabled: bool) -> Vec<C
     let header = rows.next().expect("the header row is always pushed first");
     std::iter::once(header)
         .chain(
-            rows.zip(packages)
-                .map(|(row, package)| ChoiceRow { value: Some(package.alias.clone()), ..row }),
+            rows.zip(choices).map(|(row, choice)| ChoiceRow {
+                value: Some(choice.package.alias.clone()),
+                ..row
+            }),
         )
         .collect()
 }

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -76,7 +76,10 @@ impl ChoiceGroupKind {
 /// once, under whichever type came first: the deduplication key omits
 /// the dependency type. This matches pnpm, whose `uniqBy` runs before
 /// its `groupBy` over the same key.
-pub(crate) fn update_choices(outdated: &[&OutdatedPackage]) -> Vec<ChoiceGroup> {
+pub(crate) fn update_choices(
+    outdated: &[&OutdatedPackage],
+    workspaces_enabled: bool,
+) -> Vec<ChoiceGroup> {
     let mut seen = HashSet::new();
     let mut grouped: Vec<(ChoiceGroupKind, Vec<&OutdatedPackage>)> = Vec::new();
     for package in outdated {
@@ -105,35 +108,40 @@ pub(crate) fn update_choices(outdated: &[&OutdatedPackage]) -> Vec<ChoiceGroup> 
         .into_iter()
         .map(|(kind, packages)| ChoiceGroup {
             message: kind.message().to_string(),
-            rows: render_rows(&packages),
+            rows: render_rows(&packages, workspaces_enabled),
         })
         .collect()
 }
 
 /// The header row plus one row per package, padded so every column lines
 /// up within the group.
-fn render_rows(packages: &[&OutdatedPackage]) -> Vec<ChoiceRow> {
-    let header = vec![
-        "Package".to_string(),
-        "Current".to_string(),
-        String::new(),
-        "Target".to_string(),
-        "URL".to_string(),
-    ];
+fn render_rows(packages: &[&OutdatedPackage], workspaces_enabled: bool) -> Vec<ChoiceRow> {
+    let mut header =
+        vec!["Package".to_string(), "Current".to_string(), String::new(), "Target".to_string()];
+    if workspaces_enabled {
+        header.push("Workspace".to_string());
+    }
+    header.push("URL".to_string());
 
     let mut cells = vec![header];
     for package in packages {
-        // The name and homepage are registry metadata, so they are
-        // stripped of control characters before reaching the terminal:
-        // an escape sequence would corrupt the prompt's redraw, and a
-        // newline would break the row apart.
-        let row = vec![
+        // The name, workspace, and homepage are read out of manifests
+        // and registry metadata, so they are stripped of control
+        // characters before reaching the terminal: an escape sequence
+        // would corrupt the prompt's redraw, and a newline would break
+        // the row apart.
+        let mut row = vec![
             sanitize_inline(&package.package_name).into_owned(),
             package.current.to_string(),
             "❯".to_string(),
             colorize_target(package),
-            package.homepage.as_deref().map(sanitize_inline).unwrap_or_default().into_owned(),
         ];
+        if workspaces_enabled {
+            row.push(
+                package.workspace.as_deref().map(sanitize_inline).unwrap_or_default().into_owned(),
+            );
+        }
+        row.push(package.homepage.as_deref().map(sanitize_inline).unwrap_or_default().into_owned());
         cells.push(row);
     }
 

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -82,7 +82,7 @@ pub(crate) fn update_choices(
     outdated: &[&OutdatedPackage],
     workspaces_enabled: bool,
 ) -> Vec<ChoiceGroup> {
-    let mut seen: HashMap<ChoiceKey, usize> = HashMap::new();
+    let mut seen: HashMap<ChoiceKey<'_>, usize> = HashMap::new();
     let mut choices: Vec<Choice<'_>> = Vec::new();
     let mut grouped: Vec<(ChoiceGroupKind, Vec<usize>)> = Vec::new();
     for package in outdated {
@@ -91,8 +91,8 @@ pub(crate) fn update_choices(
         // package (`"a": "npm:foo@1"`, `"b": "npm:foo@1"`) are separate
         // dependencies and both have to be offered.
         let key = (
-            package.alias.clone(),
-            package.package_name.clone(),
+            package.alias.as_str(),
+            package.package_name.as_str(),
             package.current.to_string(),
             package.target.to_string(),
             package.github_action,
@@ -135,7 +135,7 @@ struct Choice<'a> {
     workspaces: Vec<String>,
 }
 
-type ChoiceKey = (String, String, String, String, bool);
+type ChoiceKey<'a> = (&'a str, &'a str, String, String, bool);
 
 /// The header row plus one row per offered dependency, padded so every
 /// column lines up within the group.

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
@@ -32,6 +32,7 @@ fn pkg(
         github_action: false,
         deprecated: None,
         homepage: None,
+        workspace: None,
     }
 }
 
@@ -49,7 +50,7 @@ fn groups_by_dependency_type_in_manifest_order() {
         pkg("qaz", "qaz", "1.0.1", "1.2.0", DependencyGroup::Optional),
     ];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     let rendered: Vec<(&str, Vec<&str>)> =
         groups.iter().map(|group| (group.message.as_str(), values(group))).collect();
@@ -69,7 +70,7 @@ fn groups_by_dependency_type_in_manifest_order() {
 fn each_group_opens_with_an_unselectable_header() {
     let packages = [pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod)];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     let header = &groups[0].rows[0];
     assert_eq!(header.value, None);
@@ -88,7 +89,7 @@ fn a_package_outdated_in_two_groups_is_offered_once() {
         pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Dev),
     ];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     assert_eq!(groups.len(), 1);
     assert_eq!(groups[0].message, "dependencies");
@@ -104,7 +105,7 @@ fn the_same_name_at_different_versions_is_offered_twice() {
         pkg("qaz", "foo", "1.0.1", "1.2.0", DependencyGroup::Dev),
     ];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     // The row is labelled by package name but selects by alias, so the
     // npm-aliased entry updates `qaz` rather than the name it resolves to.
@@ -120,7 +121,7 @@ fn github_actions_form_their_own_group() {
     action.github_action = true;
     let packages = [pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Dev), action];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     let rendered: Vec<(&str, Vec<&str>)> =
         groups.iter().map(|group| (group.message.as_str(), values(group))).collect();
@@ -143,7 +144,7 @@ fn a_long_version_keeps_the_row_on_one_line() {
         DependencyGroup::Dev,
     )];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     let row = &groups[0].rows[1];
     assert_eq!(row.value.as_deref(), Some("@typescript/native-preview"));
@@ -167,7 +168,7 @@ fn columns_line_up_within_a_group() {
         pkg("b", "b", "1.0.0", "2.0.0", DependencyGroup::Prod),
     ];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     let arrow_offsets: Vec<usize> = groups[0]
         .rows
@@ -181,7 +182,7 @@ fn columns_line_up_within_a_group() {
 /// Nothing outdated means nothing to choose from.
 #[test]
 fn an_empty_set_produces_no_groups() {
-    assert_eq!(update_choices(&[]), Vec::new());
+    assert_eq!(update_choices(&[], false), Vec::new());
 }
 
 /// Two manifest entries aliasing the same package are separate
@@ -194,7 +195,7 @@ fn two_aliases_of_one_package_are_both_offered() {
         pkg("b", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod),
     ];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     assert_eq!(values(&groups[0]), vec!["a", "b"]);
 }
@@ -208,10 +209,42 @@ fn control_characters_in_registry_metadata_are_stripped() {
     package.homepage = Some("https://example.test/\u{1b}[2J\nEVIL".to_string());
     let packages = [package];
 
-    let groups = update_choices(&packages.iter().collect::<Vec<_>>());
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     let row = &groups[0].rows[1];
     assert!(!row.label.contains('\u{1b}'), "escape survived: {:?}", row.label);
     assert!(!row.label.contains('\n'), "newline survived: {:?}", row.label);
     assert!(row.label.contains("https://example.test/"), "url lost: {:?}", row.label);
+}
+
+/// Inside a workspace the list gains a `Workspace` column naming the
+/// project each dependency was found in, so the same package outdated in
+/// two projects is tellable apart.
+#[test]
+fn a_workspace_run_names_the_project_each_row_came_from() {
+    let mut in_app = pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    in_app.workspace = Some("app".to_string());
+    let mut in_lib = pkg("foo", "foo", "1.1.0", "2.0.0", DependencyGroup::Prod);
+    in_lib.workspace = Some("lib".to_string());
+    let packages = [in_app, in_lib];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), true);
+
+    assert!(groups[0].rows[0].label.contains("Workspace"));
+    assert!(groups[0].rows[1].label.contains("app"), "{}", groups[0].rows[1].label);
+    assert!(groups[0].rows[2].label.contains("lib"), "{}", groups[0].rows[2].label);
+}
+
+/// Outside a workspace the column is absent, as upstream omits it when
+/// workspaces are not enabled.
+#[test]
+fn a_single_project_run_has_no_workspace_column() {
+    let mut package = pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    package.workspace = Some("solo".to_string());
+    let packages = [package];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
+
+    assert!(!groups[0].rows[0].label.contains("Workspace"));
+    assert!(!groups[0].rows[1].label.contains("solo"), "{}", groups[0].rows[1].label);
 }

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
@@ -218,8 +218,8 @@ fn control_characters_in_registry_metadata_are_stripped() {
 }
 
 /// Inside a workspace the list gains a `Workspace` column naming the
-/// project each dependency was found in, so the same package outdated in
-/// two projects is tellable apart.
+/// project each dependency was found in, so entries that differ by
+/// version are tellable apart.
 #[test]
 fn a_workspace_run_names_the_project_each_row_came_from() {
     let mut in_app = pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod);
@@ -247,4 +247,35 @@ fn a_single_project_run_has_no_workspace_column() {
 
     assert!(!groups[0].rows[0].label.contains("Workspace"));
     assert!(!groups[0].rows[1].label.contains("solo"), "{}", groups[0].rows[1].label);
+}
+
+/// Entries that differ only by the project they came from collapse into
+/// one row, because selecting it updates the package in every project —
+/// so the row has to name all of them rather than whichever came first.
+#[test]
+fn a_collapsed_row_names_every_project_it_covers() {
+    let mut in_web = pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    in_web.workspace = Some("web".to_string());
+    let mut in_tooling = pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    in_tooling.workspace = Some("tooling".to_string());
+    let packages = [in_web, in_tooling];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), true);
+
+    assert_eq!(values(&groups[0]), vec!["foo"]);
+    assert!(groups[0].rows[1].label.contains("web, tooling"), "{}", groups[0].rows[1].label);
+}
+
+/// A project appearing twice for one dependency is named once.
+#[test]
+fn a_repeated_project_is_named_once() {
+    let mut first = pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    first.workspace = Some("web".to_string());
+    let mut second = pkg("foo", "foo", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    second.workspace = Some("web".to_string());
+    let packages = [first, second];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), true);
+
+    assert!(!groups[0].rows[1].label.contains("web, web"), "{}", groups[0].rows[1].label);
 }

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -143,8 +143,8 @@ importers:
 #[tokio::test]
 async fn one_dependency_in_two_projects_keeps_both_workspaces() {
     let temp = tempfile::tempdir().expect("create temporary workspace");
-    let a = manifest_with_dependency(temp.path(), "packages/a", "foo");
-    let b = manifest_with_dependency(temp.path(), "packages/b", "foo");
+    let first = manifest_with_dependency(temp.path(), "packages/a", "foo");
+    let second = manifest_with_dependency(temp.path(), "packages/b", "foo");
     let lockfile: Lockfile = serde_saphyr::from_str(
         r"
 lockfileVersion: '9.0'
@@ -175,8 +175,8 @@ importers:
     let mut config = Config::new();
     config.registry = registry;
     let projects = [
-        InteractiveUpdateProject { manifest: &a, importer_id: "packages/a".to_string() },
-        InteractiveUpdateProject { manifest: &b, importer_id: "packages/b".to_string() },
+        InteractiveUpdateProject { manifest: &first, importer_id: "packages/a".to_string() },
+        InteractiveUpdateProject { manifest: &second, importer_id: "packages/b".to_string() },
     ];
 
     let choices = collect_choices(

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -204,16 +204,17 @@ importers:
     foo_mock.assert_async().await;
 }
 
-/// A project is allowed to omit its `name`, and an empty label would
-/// leave several such projects indistinguishable in the interactive
-/// list, so the entry falls back to the path identifying the project in
-/// the lockfile.
+/// A project may omit its `name` or declare it empty; either way the
+/// label would be blank, leaving several such projects indistinguishable
+/// in the interactive list, so the entry falls back to the path that
+/// identifies the project in the lockfile.
 #[tokio::test]
-async fn a_nameless_project_is_labelled_with_its_importer_path() {
-    let temp = tempfile::tempdir().expect("create temporary workspace");
-    let manifest = nameless_manifest_with_dependency(temp.path(), "packages/a", "foo");
-    let lockfile: Lockfile = serde_saphyr::from_str(
-        r"
+async fn a_project_without_a_usable_name_is_labelled_with_its_importer_path() {
+    for name in [None, Some("")] {
+        let temp = tempfile::tempdir().expect("create temporary workspace");
+        let manifest = manifest_without_usable_name(temp.path(), "packages/a", name);
+        let lockfile: Lockfile = serde_saphyr::from_str(
+            r"
 lockfileVersion: '9.0'
 importers:
   packages/a:
@@ -222,39 +223,43 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
 ",
-    )
-    .expect("parse workspace lockfile");
-    let mut server = mockito::Server::new_async().await;
-    let registry = format!("{}/", server.url());
-    let foo_mock = server
-        .mock("GET", "/foo")
-        .with_status(200)
-        .with_header("content-type", "application/json")
-        .with_body(package_body("foo", &registry))
-        .expect(1)
-        .create_async()
-        .await;
-    let mut config = Config::new();
-    config.registry = registry;
-    let projects =
-        [InteractiveUpdateProject { manifest: &manifest, importer_id: "packages/a".to_string() }];
+        )
+        .expect("parse workspace lockfile");
+        let mut server = mockito::Server::new_async().await;
+        let registry = format!("{}/", server.url());
+        let foo_mock = server
+            .mock("GET", "/foo")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(package_body("foo", &registry))
+            .expect(1)
+            .create_async()
+            .await;
+        let mut config = Config::new();
+        config.registry = registry;
+        let projects = [InteractiveUpdateProject {
+            manifest: &manifest,
+            importer_id: "packages/a".to_string(),
+        }];
 
-    let choices = collect_choices(
-        &projects,
-        Some(&lockfile),
-        &config,
-        &ThrottledClient::default(),
-        false,
-        &[DependencyGroup::Prod],
-    )
-    .await
-    .expect("collect interactive choices");
+        let choices = collect_choices(
+            &projects,
+            Some(&lockfile),
+            &config,
+            &ThrottledClient::default(),
+            false,
+            &[DependencyGroup::Prod],
+        )
+        .await
+        .expect("collect interactive choices");
 
-    assert_eq!(
-        choices.iter().map(|choice| choice.workspace.as_deref()).collect::<Vec<_>>(),
-        vec![Some("packages/a")],
-    );
-    foo_mock.assert_async().await;
+        assert_eq!(
+            choices.iter().map(|choice| choice.workspace.as_deref()).collect::<Vec<_>>(),
+            vec![Some("packages/a")],
+            "a {name:?} name should fall back to the importer path",
+        );
+        foo_mock.assert_async().await;
+    }
 }
 
 fn manifest_with_dependency(
@@ -286,18 +291,21 @@ fn manifest_with_dependency_spec(
     PackageManifest::from_path(manifest_path).expect("read project manifest")
 }
 
-/// A project manifest without a `name`, which a workspace project is
-/// allowed to omit.
-fn nameless_manifest_with_dependency(
+/// A project manifest whose `name` is absent, or present but empty —
+/// both shapes a workspace project's `package.json` can carry.
+fn manifest_without_usable_name(
     root: &std::path::Path,
     relative: &str,
-    dependency: &str,
+    name: Option<&str>,
 ) -> PackageManifest {
     let project_dir = root.join(relative);
     std::fs::create_dir_all(&project_dir).expect("create project directory");
     let manifest_path = project_dir.join("package.json");
-    std::fs::write(&manifest_path, json!({ "dependencies": { dependency: "^1.0.0" } }).to_string())
-        .expect("write project manifest");
+    let mut manifest = json!({ "dependencies": { "foo": "^1.0.0" } });
+    if let Some(name) = name {
+        manifest["name"] = json!(name);
+    }
+    std::fs::write(&manifest_path, manifest.to_string()).expect("write project manifest");
     PackageManifest::from_path(manifest_path).expect("read project manifest")
 }
 

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -137,6 +137,126 @@ importers:
     foo_mock.assert_async().await;
 }
 
+/// The same dependency at the same version in two projects has to reach
+/// [`super::choices::update_choices`] as two entries, or the collapsed
+/// row it renders can only name one of the projects.
+#[tokio::test]
+async fn one_dependency_in_two_projects_keeps_both_workspaces() {
+    let temp = tempfile::tempdir().expect("create temporary workspace");
+    let a = manifest_with_dependency(temp.path(), "packages/a", "foo");
+    let b = manifest_with_dependency(temp.path(), "packages/b", "foo");
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+importers:
+  packages/a:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+  packages/b:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+",
+    )
+    .expect("parse workspace lockfile");
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let foo_mock = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(package_body("foo", &registry))
+        .expect(2)
+        .create_async()
+        .await;
+    let mut config = Config::new();
+    config.registry = registry;
+    let projects = [
+        InteractiveUpdateProject { manifest: &a, importer_id: "packages/a".to_string() },
+        InteractiveUpdateProject { manifest: &b, importer_id: "packages/b".to_string() },
+    ];
+
+    let choices = collect_choices(
+        &projects,
+        Some(&lockfile),
+        &config,
+        &ThrottledClient::default(),
+        false,
+        &[DependencyGroup::Prod],
+    )
+    .await
+    .expect("collect interactive choices");
+
+    assert_eq!(
+        choices.iter().map(|choice| choice.workspace.as_deref()).collect::<Vec<_>>(),
+        vec![Some("packages-a"), Some("packages-b")],
+    );
+    // And they render as one row naming both.
+    let groups = super::choices::update_choices(&choices.iter().collect::<Vec<_>>(), true);
+    assert!(
+        groups[0].rows[1].label.contains("packages-a, packages-b"),
+        "{}",
+        groups[0].rows[1].label,
+    );
+    foo_mock.assert_async().await;
+}
+
+/// A project is allowed to omit its `name`, and an empty label would
+/// leave several such projects indistinguishable in the interactive
+/// list, so the entry falls back to the path identifying the project in
+/// the lockfile.
+#[tokio::test]
+async fn a_nameless_project_is_labelled_with_its_importer_path() {
+    let temp = tempfile::tempdir().expect("create temporary workspace");
+    let manifest = nameless_manifest_with_dependency(temp.path(), "packages/a", "foo");
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+importers:
+  packages/a:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+",
+    )
+    .expect("parse workspace lockfile");
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let foo_mock = server
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(package_body("foo", &registry))
+        .expect(1)
+        .create_async()
+        .await;
+    let mut config = Config::new();
+    config.registry = registry;
+    let projects =
+        [InteractiveUpdateProject { manifest: &manifest, importer_id: "packages/a".to_string() }];
+
+    let choices = collect_choices(
+        &projects,
+        Some(&lockfile),
+        &config,
+        &ThrottledClient::default(),
+        false,
+        &[DependencyGroup::Prod],
+    )
+    .await
+    .expect("collect interactive choices");
+
+    assert_eq!(
+        choices.iter().map(|choice| choice.workspace.as_deref()).collect::<Vec<_>>(),
+        vec![Some("packages/a")],
+    );
+    foo_mock.assert_async().await;
+}
+
 fn manifest_with_dependency(
     root: &std::path::Path,
     relative: &str,
@@ -163,6 +283,21 @@ fn manifest_with_dependency_spec(
         .to_string(),
     )
     .expect("write project manifest");
+    PackageManifest::from_path(manifest_path).expect("read project manifest")
+}
+
+/// A project manifest without a `name`, which a workspace project is
+/// allowed to omit.
+fn nameless_manifest_with_dependency(
+    root: &std::path::Path,
+    relative: &str,
+    dependency: &str,
+) -> PackageManifest {
+    let project_dir = root.join(relative);
+    std::fs::create_dir_all(&project_dir).expect("create project directory");
+    let manifest_path = project_dir.join("package.json");
+    std::fs::write(&manifest_path, json!({ "dependencies": { dependency: "^1.0.0" } }).to_string())
+        .expect("write project manifest");
     PackageManifest::from_path(manifest_path).expect("read project manifest")
 }
 

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -69,6 +69,12 @@ importers:
         choices.iter().map(|choice| choice.alias.as_str()).collect::<Vec<_>>(),
         vec!["foo", "bar"],
     );
+    // Each entry remembers the project it came from, which is what the
+    // interactive list's `Workspace` column shows.
+    assert_eq!(
+        choices.iter().map(|choice| choice.workspace.as_deref()).collect::<Vec<_>>(),
+        vec![Some("packages-a"), Some("packages-b")],
+    );
     foo_mock.assert_async().await;
     bar_mock.assert_async().await;
 }

--- a/pnpm11/deps/inspection/outdated/src/outdated.ts
+++ b/pnpm11/deps/inspection/outdated/src/outdated.ts
@@ -85,7 +85,9 @@ export async function outdated (
   // label leaves several unnamed projects indistinguishable in the
   // interactive update list, so fall back to the path that identifies
   // the project in the lockfile.
-  const workspace = opts.manifest.name ?? importerId
+  // `||` rather than `??`: a project that declares an empty name gives
+  // just as blank a label as one that declares none.
+  const workspace = opts.manifest.name || importerId
   const currentLockfile: LockfileObject = opts.currentLockfile ?? { lockfileVersion: LOCKFILE_VERSION, importers: { [importerId]: { specifiers: {} } } }
 
   const outdated: OutdatedPackage[] = []

--- a/pnpm11/deps/inspection/outdated/src/outdated.ts
+++ b/pnpm11/deps/inspection/outdated/src/outdated.ts
@@ -81,6 +81,11 @@ export async function outdated (
 
   const allDeps = getAllDependenciesFromManifest(await getOverriddenManifest())
   const importerId = getLockfileImporterId(opts.lockfileDir, opts.prefix)
+  // A workspace project is not required to declare a name, and an empty
+  // label leaves several unnamed projects indistinguishable in the
+  // interactive update list, so fall back to the path that identifies
+  // the project in the lockfile.
+  const workspace = opts.manifest.name ?? importerId
   const currentLockfile: LockfileObject = opts.currentLockfile ?? { lockfileVersion: LOCKFILE_VERSION, importers: { [importerId]: { specifiers: {} } } }
 
   const outdated: OutdatedPackage[] = []
@@ -152,7 +157,7 @@ export async function outdated (
                 latestManifest: undefined,
                 packageName,
                 wanted,
-                workspace: opts.manifest.name,
+                workspace,
               })
             }
             return
@@ -164,7 +169,7 @@ export async function outdated (
               latestManifest,
               packageName,
               wanted,
-              workspace: opts.manifest.name,
+              workspace,
             })
             return
           }
@@ -176,7 +181,7 @@ export async function outdated (
               latestManifest,
               packageName,
               wanted,
-              workspace: opts.manifest.name,
+              workspace,
             })
           }
         })

--- a/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
+++ b/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
@@ -1198,3 +1198,35 @@ test('outdated() does not list runtime that is already up to date', async () => 
 
   expect(outdatedPkgs).toStrictEqual([])
 })
+
+test.each([
+  ['absent', undefined],
+  ['empty', ''],
+])('outdated() labels a project with an %s name by its importer path', async (_case, name) => {
+  const lockfile = {
+    importers: {
+      ['packages/a' as ProjectId]: {
+        dependencies: { 'is-positive': '1.0.0' },
+        specifiers: { 'is-positive': '^1.0.0' },
+      },
+    },
+    lockfileVersion: LOCKFILE_VERSION,
+  }
+
+  const outdatedPkgs = await outdated({
+    currentLockfile: lockfile,
+    resolveLatest,
+    lockfileDir: 'project',
+    manifest: {
+      name,
+      version: '1.0.0',
+      dependencies: { 'is-positive': '^1.0.0' },
+    },
+    prefix: 'project/packages/a',
+    wantedLockfile: lockfile,
+  })
+
+  // Blank would leave two such projects indistinguishable in the
+  // interactive update list, so the lockfile importer path stands in.
+  expect(outdatedPkgs.map((pkg) => pkg.workspace)).toStrictEqual(['packages/a'])
+})

--- a/pnpm11/installing/commands/src/update/getUpdateChoices.ts
+++ b/pnpm11/installing/commands/src/update/getUpdateChoices.ts
@@ -128,20 +128,33 @@ function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled:
   const label = outdatedPkg.packageName
 
   const raw: string[] = [
-    label,
+    sanitizeCell(label),
     outdatedPkg.current ?? '',
     '❯',
+    // Not sanitized: `colorizeSemverDiff` puts the highlighting escapes
+    // in here deliberately.
     nextVersion,
   ]
   if (workspacesEnabled) {
-    raw.push(Array.from(workspaces ?? []).join(', '))
+    raw.push(Array.from(workspaces ?? []).map(sanitizeCell).join(', '))
   }
-  raw.push(getPkgUrl(outdatedPkg))
+  raw.push(sanitizeCell(getPkgUrl(outdatedPkg)))
 
   return {
     raw,
     name: outdatedPkg.packageName,
   }
+}
+
+/**
+ * Strip control characters from text that goes into a single-line table
+ * cell. Package names, workspace labels, and homepages come out of
+ * manifests and registry metadata, so an escape sequence there would
+ * corrupt the prompt's redraw and a newline would split the row.
+ */
+function sanitizeCell (text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/[\u0000-\u001F\u007F-\u009F]/g, '')
 }
 
 function getPkgUrl (pkg: OutdatedPackage): string {

--- a/pnpm11/installing/commands/src/update/getUpdateChoices.ts
+++ b/pnpm11/installing/commands/src/update/getUpdateChoices.ts
@@ -4,7 +4,7 @@ import { colorizeSemverDiff } from '@pnpm/colorize-semver-diff'
 import type { OutdatedPackage } from '@pnpm/deps.inspection.outdated'
 import { semverDiff } from '@pnpm/semver-diff'
 import { getBorderCharacters, table } from '@zkochan/table'
-import { and, groupBy, isEmpty, pickBy, pipe, pluck, uniqBy } from 'ramda'
+import { and, groupBy, isEmpty, pickBy, pluck } from 'ramda'
 
 export interface ChoiceRow {
   name: string
@@ -31,12 +31,29 @@ export function getUpdateChoices (outdatedPkgsOfProjects: UpdateChoiceDependency
     return JSON.stringify([outdatedPkg.packageName, outdatedPkg.latestManifest?.version, outdatedPkg.current, outdatedPkg.dependencyType])
   }
 
-  const dedupeAndGroupPkgs = pipe(
-    uniqBy((outdatedPkg: UpdateChoiceDependency) => pkgUniqueKey(outdatedPkg)),
-    groupBy((outdatedPkg: UpdateChoiceDependency) => outdatedPkg.dependencyType ?? outdatedPkg.belongsTo)
-  )
+  // Entries that differ only by the project they came from collapse into
+  // one choice, because selecting it updates the package in every
+  // project. Their workspaces are collected onto the survivor so the
+  // Workspace column names all of them rather than whichever came first.
+  const deduped: UpdateChoiceDependency[] = []
+  const workspacesByKey = new Map<string, Set<string>>()
+  for (const outdatedPkg of outdatedPkgsOfProjects) {
+    const key = pkgUniqueKey(outdatedPkg)
+    let workspaces = workspacesByKey.get(key)
+    if (workspaces == null) {
+      workspaces = new Set()
+      workspacesByKey.set(key, workspaces)
+      deduped.push(outdatedPkg)
+    }
+    if (outdatedPkg.workspace) {
+      workspaces.add(outdatedPkg.workspace)
+    }
+  }
 
-  const groupPkgsByType = dedupeAndGroupPkgs(outdatedPkgsOfProjects)
+  const groupPkgsByType = groupBy(
+    (outdatedPkg: UpdateChoiceDependency) => outdatedPkg.dependencyType ?? outdatedPkg.belongsTo,
+    deduped
+  )
 
   const headerRow = {
     Package: true,
@@ -58,7 +75,7 @@ export function getUpdateChoices (outdatedPkgsOfProjects: UpdateChoiceDependency
       // and entries from registries we cannot resolve against (no manifest).
       // We only want to show those dependencies that have a known newer version.
       if (choice.latestManifest != null && choice.latestManifest.version !== choice.current) {
-        rawChoices.push(buildPkgChoice(choice, workspacesEnabled))
+        rawChoices.push(buildPkgChoice(choice, workspacesEnabled, workspacesByKey.get(pkgUniqueKey(choice))))
       }
     }
     if (rawChoices.length === 0) continue
@@ -103,7 +120,7 @@ interface RawChoice {
   disabled?: boolean
 }
 
-function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled: boolean): RawChoice {
+function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled: boolean, workspaces?: Set<string>): RawChoice {
   const sdiff = semverDiff(outdatedPkg.wanted, outdatedPkg.latestManifest!.version)
   const nextVersion = sdiff.change === null
     ? outdatedPkg.latestManifest!.version
@@ -117,7 +134,7 @@ function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled:
     nextVersion,
   ]
   if (workspacesEnabled) {
-    raw.push(outdatedPkg.workspace ?? '')
+    raw.push(Array.from(workspaces ?? []).join(', '))
   }
   raw.push(getPkgUrl(outdatedPkg))
 

--- a/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
+++ b/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
@@ -197,3 +197,24 @@ test('getUpdateChoices() groups GitHub Actions separately', () => {
   expect(choices[0].message).toBe('GitHub Actions')
   expect(choices[0].choices[1]).toMatchObject({ name: 'actions/checkout', value: 'actions/checkout' })
 })
+
+test('getUpdateChoices() names every workspace a collapsed choice came from', () => {
+  const outdated = (workspace: string) => ({
+    alias: 'foo',
+    belongsTo: 'dependencies' as const,
+    current: '1.0.0',
+    latestManifest: { name: 'foo', version: '2.0.0' },
+    packageName: 'foo',
+    wanted: '1.0.0',
+    workspace,
+  })
+
+  const choices = getUpdateChoices([outdated('web'), outdated('tooling')], true)
+
+  // Selecting the choice updates the package in every project, so the two
+  // entries stay one row — but the row has to say which projects it covers.
+  expect(choices).toHaveLength(1)
+  expect(choices[0].choices).toHaveLength(2)
+  const dataRow = choices[0].choices[1] as { message: string }
+  expect(stripVTControlCharacters(dataRow.message)).toContain('web, tooling')
+})

--- a/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
+++ b/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
@@ -218,3 +218,31 @@ test('getUpdateChoices() names every workspace a collapsed choice came from', ()
   const dataRow = choices[0].choices[1] as { message: string }
   expect(stripVTControlCharacters(dataRow.message)).toContain('web, tooling')
 })
+
+test('getUpdateChoices() strips control characters from labels it renders', () => {
+  const choices = getUpdateChoices([
+    {
+      alias: 'foo',
+      belongsTo: 'dependencies' as const,
+      current: '1.0.0',
+      latestManifest: {
+        name: 'foo',
+        version: '2.0.0',
+        homepage: 'https://example.test/\u001b[2J\nEVIL',
+      },
+      packageName: 'foo',
+      wanted: '1.0.0',
+      workspace: 'web\u001b[31m\nEVIL',
+    },
+  ], true)
+
+  const dataRow = choices[0].choices[1] as { message: string }
+  // Once the escape byte is gone the remainder is inert text, so what
+  // matters is that no escape or newline reaches the prompt. The
+  // colorized target carries escapes of its own by design, hence the
+  // check on the workspace and URL cells rather than the whole row.
+  const cells = dataRow.message.split('❯')[1]
+  expect(cells).not.toContain('\u001b')
+  expect(dataRow.message).not.toContain('\n')
+  expect(dataRow.message).toContain('https://example.test/')
+})


### PR DESCRIPTION
## Summary

The remaining half of the interactive parity item in pnpm/pnpm#12101. #13298 grouped the list by dependency type; this adds the `Workspace` column upstream shows when workspaces are enabled.

Inside a workspace the list gave no way to tell which project an outdated dependency belonged to, so the same package outdated in two projects rendered as two indistinguishable rows. Every outdated entry now records the name of the project it was collected from:

```
dependencies
Package Current   Target Workspace URL
react    18.2.0 ❯ 19.1.0 web       https://react.dev/
devDependencies
Package    Current   Target Workspace URL
typescript   5.4.2 ❯ 5.4.5  tooling
```

The column is present only when workspaces are enabled, matching upstream's `workspacesEnabled` gate — the recursive entry point always runs inside one, the single-project entry point asks `config.workspace_dir`.

The name is read where `collect_outdated_for_importer` already has the manifest in hand, so no new parameter is threaded through, and it goes through `sanitize_inline` with the rest of the row.

Tests cover the column's presence and absence, that it names the right project per row, and — on the existing collector test, which already builds two fixture projects — that the field is actually populated end to end rather than only rendered.

## Also in this PR: two label fixes, in both stacks

Review raised two ways the column named a project poorly. Both were true of the TypeScript CLI as well, so both are fixed on each side rather than letting pacquet diverge.

**A collapsed row named only one project.** A dependency outdated at the same version in several projects is offered as a single choice, because selecting it updates the package in every one of them — that is how both stacks resolve the selection, which is a flat list of package names. The surviving row named whichever project was seen first, reading as though only that one was affected. Collapsed entries now contribute their projects to the row:

```
Package Current   Target Workspace    URL
foo      1.0.0 ❯ 2.0.0  web, tooling
```

**An unnamed project got a blank cell.** A workspace project need not declare a `name`, and both stacks took the name verbatim, so such a project rendered as an empty cell and several were indistinguishable. The label now falls back to the path that identifies the project in the lockfile — which pnpm already computes as `importerId`, and pacquet already has as `importer_id`.

The column itself remains a pacquet-only addition; the TypeScript CLI already had it.

## Squash Commit Body

```text
Inside a workspace the interactive update list showed no way to tell
which project an outdated dependency belonged to, so the same package
outdated in two projects rendered as two indistinguishable rows.

Every outdated entry now records the name of the project it was
collected from, and the interactive list gains the `Workspace` column
upstream shows when workspaces are enabled. The name is read where the
collector already has the manifest in hand, so nothing new is threaded
through; it is stripped of control characters with the rest of the row.

This completes the interactive parity item of pnpm/pnpm#12101, whose
remaining half after the grouping landed was this column.

Related to pnpm/pnpm#12101.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Workspace** column to interactive dependency updates in multi-project workspaces.
  * Identifies the project associated with each outdated dependency.
  * Consolidated choices now list all affected workspaces.
  * Unnamed workspace projects display their project path instead of appearing blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->