### PR TITLE
test(package-manager): stop the concurrency probes timing out under load

### DIFF
--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -118,7 +118,16 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
         active: usize,
         max_active: usize,
         started: usize,
+        /// Set once a handler gave up waiting for its peers. Later
+        /// handlers then skip the wait, so a genuine loss of concurrency
+        /// costs one timeout instead of one per selector.
+        barrier_expired: bool,
     }
+
+    // Only has to outlast the scheduling latency of a machine running
+    // the whole suite in parallel — the verdict comes from `max_active`,
+    // not from the deadline.
+    const OVERLAP_BARRIER_TIMEOUT: Duration = Duration::from_secs(15);
 
     let dir = tempdir().unwrap();
     let project_root = dir.path().join("project");
@@ -165,11 +174,15 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
                 requests.started += 1;
                 requests.max_active = requests.max_active.max(requests.active);
                 ready.notify_all();
-                let (mut requests, _) = ready
-                    .wait_timeout_while(requests, Duration::from_secs(2), |requests| {
-                        requests.started < packages.len()
+                let (mut requests, wait) = ready
+                    .wait_timeout_while(requests, OVERLAP_BARRIER_TIMEOUT, |requests| {
+                        requests.started < packages.len() && !requests.barrier_expired
                     })
                     .unwrap();
+                if wait.timed_out() {
+                    requests.barrier_expired = true;
+                    ready.notify_all();
+                }
                 drop(requests);
                 std::thread::sleep(Duration::from_millis(response_delay_ms));
                 requests = lock.lock().unwrap();
@@ -220,6 +233,10 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
 
     {
         let requests = request_state.0.lock().unwrap();
+        assert!(
+            !requests.barrier_expired,
+            "the selectors' latest requests never overlapped within {OVERLAP_BARRIER_TIMEOUT:?}",
+        );
         assert_eq!(
             requests.max_active,
             packages.len(),
@@ -432,7 +449,11 @@ async fn add_does_not_wait_for_a_slower_later_resolution_after_an_error() {
     let mut manifest = PackageManifest::create_if_needed(project_root.join("package.json"))
         .expect("create manifest");
 
-    let packages = [("first", "a", 100), ("second", "b", 3_000)];
+    // The gap between the two delays is what the deadline below reads:
+    // the failing selector must return well inside it while the slower
+    // peer is still sleeping, with enough slack that a loaded machine
+    // cannot push the fast path past the deadline.
+    let packages = [("first", "a", 100), ("second", "b", 20_000)];
     let mut config = Config::new();
     config.store_dir = dir.path().join("pacquet-store").into();
     config.modules_dir = modules_dir;
@@ -466,7 +487,7 @@ async fn add_does_not_wait_for_a_slower_later_resolution_after_an_error() {
     let http_client = ThrottledClient::default();
     let resolved_packages = ResolvedPackages::default();
     let result = tokio::time::timeout(
-        Duration::from_secs(2),
+        Duration::from_secs(5),
         Add {
             tarball_mem_cache: Arc::default(),
             resolved_packages: &resolved_packages,

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -124,9 +124,9 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
         barrier_expired: bool,
     }
 
-    // Only has to outlast the scheduling latency of a machine running
-    // the whole suite in parallel — the verdict comes from `max_active`,
-    // not from the deadline.
+    // Bounds the barrier so a lost overlap fails instead of hanging.
+    // Sized to outlast the scheduling latency of a machine running the
+    // whole suite in parallel, since expiry is itself a failure.
     const OVERLAP_BARRIER_TIMEOUT: Duration = Duration::from_secs(15);
 
     let dir = tempdir().unwrap();
@@ -179,6 +179,10 @@ async fn add_resolves_package_selectors_concurrently_and_reports_in_selector_ord
                         requests.started < packages.len() && !requests.barrier_expired
                     })
                     .unwrap();
+                // `wait_timeout_while` re-checks the predicate before it
+                // reports a timeout, so `timed_out()` means the peers were
+                // still missing when the budget ran out — never that the
+                // last one arrived on the deadline.
                 if wait.timed_out() {
                     requests.barrier_expired = true;
                     ready.notify_all();

--- a/pnpm/crates/package-manager/src/create_virtual_dir_by_snapshot/tests.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_dir_by_snapshot/tests.rs
@@ -25,6 +25,12 @@ pub(crate) struct LinkConcurrencyProbe {
     condvar: Condvar,
 }
 
+/// How long the first linker waits for a second one to join it. Only has
+/// to outlast the scheduling latency of a machine running the whole suite
+/// in parallel — the verdict comes from `max_concurrent`, not from the
+/// deadline.
+const OVERLAP_TIMEOUT: Duration = Duration::from_secs(15);
+
 impl LinkConcurrencyProbe {
     pub(crate) fn waiting_for_overlap() -> Self {
         Self { wait_for_overlap: true, ..Self::default() }
@@ -52,7 +58,7 @@ impl LinkConcurrencyProbe {
             let guard = self.mutex.lock().expect("lock link-concurrency probe");
             let _ = self
                 .condvar
-                .wait_timeout_while(guard, Duration::from_secs(2), |()| {
+                .wait_timeout_while(guard, OVERLAP_TIMEOUT, |()| {
                     self.max.load(Ordering::SeqCst) < 2
                 })
                 .expect("wait for overlapping link");


### PR DESCRIPTION
## Summary

`add_resolves_package_selectors_concurrently_and_reports_in_selector_order` failed intermittently during a full-suite run and passed on a re-run and in isolation, as reported in pnpm/pnpm#13328.

Its three mock `latest` handlers block on a condvar until all three requests have started, capped at 2 seconds, and the `wait_timeout_while` result was discarded. A timeout was therefore indistinguishable from "all three started": on a machine loaded enough that the third request was not dispatched within 2 s, the handlers unblocked early, `max_active` never reached 3, and the overlap assertion failed with nothing pointing at the real cause.

The assertion is worth keeping — it is what pins the concurrent-resolution behaviour from pnpm/pnpm#13097 — so only the deadline changes:

- The barrier now gets a budget that outlasts scheduling latency on a machine running the whole suite in parallel.
- The expiry is recorded rather than dropped. The first handler to give up marks the barrier dead, so its peers stop waiting — a genuine regression costs one timeout instead of one per selector — and the test now fails with "the selectors' latest requests never overlapped within 15s" instead of a bare count mismatch.

Verified by making the resolution loop sequential (`FuturesOrdered` replaced with await-in-loop): the test fails in 15.4 s with that message, and passes again once the implementation is restored.

Two more instances of the same fragile idiom, both flagged in the issue or found alongside it:

- `add_does_not_wait_for_a_slower_later_resolution_after_an_error` reads the gap between a fast failing selector and a slow peer through a wall-clock deadline. 100 ms against 3 s left only ~2 s of slack for the fast path; the peer moves to 20 s and the deadline to 5 s, which keeps the same claim with room for a loaded machine. The mock's sleep does not delay teardown — the test still completes in ~0.13 s — so the longer delay costs nothing.
- `LinkConcurrencyProbe` (behind `cold_batch_links_slots_in_parallel`) carried the same 2-second overlap barrier and gets the same budget.

No changeset: test-only, nothing published changes.

Closes pnpm/pnpm#13328

## Squash Commit Body

```text
add_resolves_package_selectors_concurrently_and_reports_in_selector_order
failed intermittently during a full-suite run and passed on a re-run. Its
mock handlers block on a condvar until all three latest requests have
started, capped at 2 seconds, and the wait result was discarded — so a
machine too loaded to dispatch the third request in time was
indistinguishable from a genuine loss of concurrency, and the overlap
assertion failed with nothing pointing at the real cause.

Give the barrier a budget that outlasts scheduling latency on a machine
running the whole suite in parallel, and record the expiry: the first
handler to give up marks the barrier dead so its peers stop waiting, which
keeps a real regression to one timeout instead of one per selector, and the
assertion now says the requests never overlapped instead of only reporting
a count mismatch. Verified by making the resolution loop sequential, which
fails with that message.

add_does_not_wait_for_a_slower_later_resolution_after_an_error reads the gap
between a fast failing selector and a slow peer through a wall-clock
deadline. 100 ms against 3 s left only ~2 s of slack for the fast path;
widening the peer to 20 s and the deadline to 5 s keeps the same claim with
room for a loaded machine. The mock's sleep does not delay teardown, so the
longer delay costs nothing.

LinkConcurrencyProbe carried the same 2-second barrier for
cold_batch_links_slots_in_parallel and gets the same treatment.

Closes pnpm/pnpm#13328
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- Rust-only test hardening; there is no TypeScript counterpart. -->
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787574274&installation_model_id=426870&pr_number=13339&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13339&signature=e5c6cac28c439ff791ddef2c30d760d60751e124352100e828c478c5edce15cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved concurrency test stability by adding an overlap barrier with a 15s timeout, ensuring deterministic behavior under scheduling latency.
  * Refined error-handling timing assertions by increasing the slower selector delay and extending the overall timeout window.
  * Updated link-concurrency overlap waiting to use an explicit 15s timeout to reduce intermittent timing-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->