### PR TITLE
fix(resolving-deps-resolver): hoist peers against the workspace root's deps

### DIFF
--- a/.changeset/optional-peer-prerelease-strictness.md
+++ b/.changeset/optional-peer-prerelease-strictness.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A missing optional peer dependency is no longer satisfied by a prerelease version that its declared range doesn't accept. `ts-jest`, which declares `@jest/transform` and `jest-util` as optional peers with `^29.0.0 || ^30.0.0`, was bound to `30.0.0-alpha.6` when a `jest` 30 prerelease was elsewhere in the graph, while `jest` itself stayed on 29.

--- a/.changeset/peer-hoist-reads-workspace-root-deps.md
+++ b/.changeset/peer-hoist-reads-workspace-root-deps.md
@@ -2,9 +2,4 @@
 "pacquet": patch
 ---
 
-Auto-installed peer dependencies are resolved correctly again in a workspace, so a peer that the workspace root already provides is no longer installed a second time.
-
-Two fixes to peer hoisting:
-
-- With `resolvePeersFromWorkspaceRoot` enabled (the default), a missing peer is matched against the **workspace root** project's dependencies. It was matched against the dependencies of whichever project was being resolved, so a project that didn't declare the peer itself resolved a second copy from the registry instead of reusing the root's. In [vercel/next.js](https://github.com/vercel/next.js), whose `overrides` pin `react` to a single canary build, this pulled in a second `react` and paired it with `react-dom` from the canary — a combination the pin exists to prevent.
-- A missing **optional** peer is no longer satisfied by a prerelease version that its declared range doesn't accept. `ts-jest`, which declares `@jest/transform` and `jest-util` as optional peers with `^29.0.0 || ^30.0.0`, was bound to `30.0.0-alpha.6` when a `jest` 30 prerelease was elsewhere in the graph, while `jest` itself stayed on 29.
+A peer dependency that the workspace root already provides is no longer installed a second time. With `resolvePeersFromWorkspaceRoot` enabled (the default), a missing peer is matched against the **workspace root** project's dependencies; it was matched against the dependencies of whichever project was being resolved, so a project that didn't declare the peer itself resolved its own copy from the registry. In [vercel/next.js](https://github.com/vercel/next.js), whose `overrides` pin `react` to a single canary build, this pulled in a second `react` and paired it with `react-dom` from the canary — a combination the pin exists to prevent.

--- a/.changeset/peer-hoist-reads-workspace-root-deps.md
+++ b/.changeset/peer-hoist-reads-workspace-root-deps.md
@@ -1,0 +1,10 @@
+---
+"pacquet": patch
+---
+
+Auto-installed peer dependencies are resolved correctly again in a workspace, so a peer that the workspace root already provides is no longer installed a second time.
+
+Two fixes to peer hoisting:
+
+- With `resolvePeersFromWorkspaceRoot` enabled (the default), a missing peer is matched against the **workspace root** project's dependencies. It was matched against the dependencies of whichever project was being resolved, so a project that didn't declare the peer itself resolved a second copy from the registry instead of reusing the root's. In [vercel/next.js](https://github.com/vercel/next.js), whose `overrides` pin `react` to a single canary build, this pulled in a second `react` and paired it with `react-dom` from the canary — a combination the pin exists to prevent.
+- A missing **optional** peer is no longer satisfied by a prerelease version that its declared range doesn't accept. `ts-jest`, which declares `@jest/transform` and `jest-util` as optional peers with `^29.0.0 || ^30.0.0`, was bound to `30.0.0-alpha.6` when a `jest` 30 prerelease was elsewhere in the graph, while `jest` itself stayed on 29.

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -149,6 +149,14 @@ pub fn get_hoistable_optional_peers(
     let mut optional_dependencies = BTreeMap::new();
     for (peer_name, ranges) in all_missing_optional_peers {
         let Some(selectors) = all_preferred_versions.get(peer_name) else { continue };
+        // Parsed once per peer, not once per candidate version. An
+        // unparsable range leaves no version satisfying every range, so
+        // bailing here matches checking and failing per candidate.
+        let Ok(parsed_ranges) =
+            ranges.iter().map(|range| range.parse::<Range>()).collect::<Result<Vec<_>, _>>()
+        else {
+            continue;
+        };
         let mut max_satisfying_version: Option<Version> = None;
         for (version_str, entry) in selectors {
             let selector_type = match entry {
@@ -167,10 +175,7 @@ pub fn get_hoistable_optional_peers(
             // `30.0.0-alpha.6` for `^29.0.0 || ^30.0.0` would split a
             // package family across release lines to satisfy a peer that
             // was fine left unresolved.
-            if !ranges
-                .iter()
-                .all(|range| range.parse::<Range>().is_ok_and(|parsed| parsed.satisfies(&version)))
-            {
+            if !parsed_ranges.iter().all(|parsed| parsed.satisfies(&version)) {
                 continue;
             }
             if max_satisfying_version.as_ref().is_none_or(|cur| version > *cur) {

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -133,8 +133,9 @@ pub fn hoist_peers(
 }
 
 /// Pick an installable version for each missing optional peer, but only
-/// when at least one preferred version satisfies *every* recorded range.
-/// Returns `peer_name → version`.
+/// when at least one preferred version satisfies *every* recorded range
+/// under strict semver — prereleases do not count against a range that
+/// carries none. Returns `peer_name → version`.
 ///
 /// Version selectors may be plain entries produced while resolving or
 /// weighted entries seeded from the wanted lockfile. Both are eligible
@@ -158,11 +159,18 @@ pub fn get_hoistable_optional_peers(
                 continue;
             }
             let Ok(version) = version_str.parse::<Version>() else { continue };
-            if !ranges.iter().all(|range| {
-                range
-                    .parse::<Range>()
-                    .is_ok_and(|parsed| satisfies_including_prerelease(&parsed, &version))
-            }) {
+            // Strict semver, unlike the required-peer picker above: a
+            // prerelease is not an acceptable stand-in for a range that
+            // didn't ask for one. An optional peer nobody declared is
+            // installed only to deduplicate onto something the graph
+            // already has, so silently binding it to, say,
+            // `30.0.0-alpha.6` for `^29.0.0 || ^30.0.0` would split a
+            // package family across release lines to satisfy a peer that
+            // was fine left unresolved.
+            if !ranges
+                .iter()
+                .all(|range| range.parse::<Range>().is_ok_and(|parsed| parsed.satisfies(&version)))
+            {
                 continue;
             }
             if max_satisfying_version.as_ref().is_none_or(|cur| version > *cur) {

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -134,8 +134,7 @@ pub fn hoist_peers(
 
 /// Pick an installable version for each missing optional peer, but only
 /// when at least one preferred version satisfies *every* recorded range
-/// under strict semver — prereleases do not count against a range that
-/// carries none. Returns `peer_name → version`.
+/// under strict semver. Returns `peer_name → version`.
 ///
 /// Version selectors may be plain entries produced while resolving or
 /// weighted entries seeded from the wanted lockfile. Both are eligible
@@ -149,9 +148,8 @@ pub fn get_hoistable_optional_peers(
     let mut optional_dependencies = BTreeMap::new();
     for (peer_name, ranges) in all_missing_optional_peers {
         let Some(selectors) = all_preferred_versions.get(peer_name) else { continue };
-        // Parsed once per peer, not once per candidate version. An
-        // unparsable range leaves no version satisfying every range, so
-        // bailing here matches checking and failing per candidate.
+        // An unparsable range is satisfied by nothing, so bailing on the
+        // peer matches failing the check per candidate.
         let Ok(parsed_ranges) =
             ranges.iter().map(|range| range.parse::<Range>()).collect::<Result<Vec<_>, _>>()
         else {
@@ -167,14 +165,10 @@ pub fn get_hoistable_optional_peers(
                 continue;
             }
             let Ok(version) = version_str.parse::<Version>() else { continue };
-            // Strict semver, unlike the required-peer picker above: a
-            // prerelease is not an acceptable stand-in for a range that
-            // didn't ask for one. An optional peer nobody declared is
-            // installed only to deduplicate onto something the graph
-            // already has, so silently binding it to, say,
-            // `30.0.0-alpha.6` for `^29.0.0 || ^30.0.0` would split a
-            // package family across release lines to satisfy a peer that
-            // was fine left unresolved.
+            // Strict, unlike the required-peer picker above: an optional
+            // peer nobody declared is installed only to deduplicate, so a
+            // prerelease its range rejects is not worth splitting a
+            // package family over.
             if !parsed_ranges.iter().all(|parsed| parsed.satisfies(&version)) {
                 continue;
             }

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
@@ -303,8 +303,6 @@ fn get_hoistable_optional_peers_rejects_prerelease_against_non_prerelease_range(
     assert_eq!(result, BTreeMap::new());
 }
 
-/// A prerelease inside the range's span is rejected too — the check is
-/// plain semver, not "reject only prereleases below the lower bound".
 #[test]
 fn get_hoistable_optional_peers_rejects_prerelease_within_the_range_span() {
     let preferred = preferred(&[(

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
@@ -294,13 +294,30 @@ fn hoist_peers_accepts_prerelease_against_non_prerelease_range() {
 }
 
 #[test]
-fn get_hoistable_optional_peers_accepts_prerelease_against_non_prerelease_range() {
+fn get_hoistable_optional_peers_rejects_prerelease_against_non_prerelease_range() {
     let preferred =
         preferred(&[("react", &[("18.0.0-rc.1", plain(VersionSelectorType::Version))])]);
     let mut missing = BTreeMap::new();
     missing.insert("react".to_string(), vec!["^18.0.0".to_string()]);
     let result = get_hoistable_optional_peers(&missing, &preferred);
+    assert_eq!(result, BTreeMap::new());
+}
+
+/// A prerelease inside the range's span is rejected too — the check is
+/// plain semver, not "reject only prereleases below the lower bound".
+#[test]
+fn get_hoistable_optional_peers_rejects_prerelease_within_the_range_span() {
+    let preferred = preferred(&[(
+        "jest-util",
+        &[
+            ("29.7.0", plain(VersionSelectorType::Version)),
+            ("30.0.0-alpha.6", plain(VersionSelectorType::Version)),
+        ],
+    )]);
+    let mut missing = BTreeMap::new();
+    missing.insert("jest-util".to_string(), vec!["^29.0.0 || ^30.0.0".to_string()]);
+    let result = get_hoistable_optional_peers(&missing, &preferred);
     let mut expected = BTreeMap::new();
-    expected.insert("react".to_string(), "18.0.0-rc.1".to_string());
+    expected.insert("jest-util".to_string(), "29.7.0".to_string());
     assert_eq!(result, expected);
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -2535,7 +2535,10 @@ fn pkgs_info_from_ids(
 /// [`fn@real_package_name_of`] it also yields the range and does not
 /// special-case the `npm:<range>` form, so the locked-entry check
 /// matches its TypeScript counterpart byte for byte.
-fn unwrap_package_name<'a>(alias: &'a str, bare_specifier: &'a str) -> (&'a str, &'a str) {
+pub(crate) fn unwrap_package_name<'a>(
+    alias: &'a str,
+    bare_specifier: &'a str,
+) -> (&'a str, &'a str) {
     let Some(rest) = bare_specifier.strip_prefix("npm:") else {
         return (alias, bare_specifier);
     };

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -296,9 +296,9 @@ pub(crate) struct ImporterHoistState {
     /// importer's initial wave has resolved, and shared unchanged by
     /// every importer for the rest of the install: the root's own
     /// hoisted peers must not become root-dep candidates for the
-    /// importers hoisted after it. Empty until then, and empty for good
-    /// when the install's importer set excludes the root (a filtered
-    /// install), matching pnpm's absent-root-importer case.
+    /// importers hoisted after it. Empty until the caller assigns it,
+    /// and empty for good for an importer set with no root at all,
+    /// matching pnpm's absent-root-importer case.
     workspace_root_deps: Arc<Vec<WorkspaceRootDep>>,
     /// `alias → bare_specifier` for the importer's own declared deps.
     /// The hoist picker wants the specifier a peer provider would be

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     resolve_dependency_tree::{
         ResolveDependencyTreeError, TreeCtx, WantedSpec, WorkspaceTreeCtx, extend_tree,
-        importer_direct_wanted_specs, record_changed_direct_deps,
+        importer_direct_wanted_specs, record_changed_direct_deps, unwrap_package_name,
     },
     resolve_peers::{ResolvePeersOptions, ResolvePeersResult, resolve_peers},
     resolved_tree::ResolvedTree,
@@ -62,11 +62,13 @@ pub struct ResolveImporterOptions {
     /// failure. This is the `autoInstallPeersFromHighestMatch` setting.
     pub auto_install_peers_from_highest_match: bool,
 
-    /// When true, the importer's direct deps are used as
-    /// `workspace_root_deps` for the hoist picker so a peer matching a
-    /// direct dep's alias / name short-circuits straight to that
-    /// dep's specifier. Single-importer pacquet treats the importer
-    /// as the root.
+    /// When true, the *workspace root* importer's direct deps are used
+    /// as `workspace_root_deps` for the hoist picker, so a peer matching
+    /// a root dep's alias / name short-circuits straight to that dep's
+    /// specifier. The caller supplies them through
+    /// [`ImporterHoistState::set_workspace_root_deps`]; on the
+    /// single-importer [`fn@resolve_importer`] path the importer is the
+    /// root, so it supplies its own.
     pub resolve_peers_from_workspace_root: bool,
 
     /// Threaded into [`ResolvePeersOptions::dedupe_peers`] on every
@@ -262,6 +264,9 @@ where
         workspace,
     )
     .await?;
+    // Single importer, so it *is* the workspace root.
+    let root_deps = Arc::new(state.hoistable_root_deps());
+    state.set_workspace_root_deps(root_deps);
     loop {
         state.run_required_round(resolver).await?;
         if !state.hoist_optional_round(resolver).await? {
@@ -284,6 +289,25 @@ pub(crate) struct ImporterHoistState {
     importer_id: String,
     ctx: TreeCtx,
     direct: Vec<DirectDep>,
+    /// The *workspace root* importer's direct deps, so a missing peer
+    /// whose name matches one of them short-circuits to that dep's
+    /// specifier — pnpm's `resolvePeersFromWorkspaceRoot`. Assigned by
+    /// the caller through [`Self::set_workspace_root_deps`] once every
+    /// importer's initial wave has resolved, and shared unchanged by
+    /// every importer for the rest of the install: the root's own
+    /// hoisted peers must not become root-dep candidates for the
+    /// importers hoisted after it. Empty until then, and empty for good
+    /// when the install's importer set excludes the root (a filtered
+    /// install), matching pnpm's absent-root-importer case.
+    workspace_root_deps: Arc<Vec<WorkspaceRootDep>>,
+    /// `alias → bare_specifier` for the importer's own declared deps.
+    /// The hoist picker wants the specifier a peer provider would be
+    /// installed from, and the resolver only reports a
+    /// `normalized_bare_specifier` for specs that needed normalizing
+    /// (npm aliases, `workspace:`, …) — a plain `"19.2.0"` arrives as
+    /// `None`. This is the fallback, and the source for deps the
+    /// resolver couldn't name at all.
+    wanted_specifier_by_alias: BTreeMap<String, String>,
     /// `NodeIds` appended to `direct` by
     /// [`Self::append_resolved_peer_providers`]. Threaded into
     /// [`ResolvePeersOptions::hoisted_peer_provider_node_ids`] so the
@@ -360,6 +384,10 @@ impl ImporterHoistState {
             .with_resolution_mode(pick_lowest_direct, subdep_published_by)
             .with_catalogs(catalogs);
         record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
+        let wanted_specifier_by_alias: BTreeMap<String, String> = initial_wanted
+            .iter()
+            .map(|(alias, range, ..)| (alias.clone(), range.clone()))
+            .collect();
         let direct = extend_tree(&ctx, resolver, initial_wanted, importer_id).await?;
         let parent_pkg_aliases: HashSet<String> =
             direct.iter().map(|dep| dep.alias.clone()).collect();
@@ -367,6 +395,8 @@ impl ImporterHoistState {
             importer_id: importer_id.to_string(),
             ctx,
             direct,
+            workspace_root_deps: Arc::default(),
+            wanted_specifier_by_alias,
             hoisted_peer_provider_node_ids: HashSet::new(),
             parent_pkg_aliases,
             all_missing_optional_peers: BTreeMap::new(),
@@ -381,6 +411,26 @@ impl ImporterHoistState {
             project_dir,
             modules_dir,
         })
+    }
+
+    /// This importer's id, for the caller's root-importer lookup.
+    pub(crate) fn importer_id(&self) -> &str {
+        &self.importer_id
+    }
+
+    /// The hoist-picker view of this importer's initial direct-dep wave.
+    /// The caller calls it on the root importer only, once, and feeds the
+    /// result to every importer's [`Self::set_workspace_root_deps`].
+    pub(crate) fn hoistable_root_deps(&self) -> Vec<WorkspaceRootDep> {
+        build_workspace_root_deps(
+            &self.direct,
+            &self.ctx.snapshot(self.direct.clone()),
+            &self.wanted_specifier_by_alias,
+        )
+    }
+
+    pub(crate) fn set_workspace_root_deps(&mut self, deps: Arc<Vec<WorkspaceRootDep>>) {
+        self.workspace_root_deps = deps;
     }
 
     fn peers_opts(&self) -> ResolvePeersOptions {
@@ -464,10 +514,11 @@ impl ImporterHoistState {
                 break;
             }
 
-            let workspace_root_deps = if self.resolve_peers_from_workspace_root {
-                build_workspace_root_deps(&self.direct, &snapshot)
+            let workspace_root_deps: &[WorkspaceRootDep] = if self.resolve_peers_from_workspace_root
+            {
+                &self.workspace_root_deps
             } else {
-                Vec::new()
+                &[]
             };
 
             let missing_as_pairs: Vec<(String, MissingPeerInfo)> =
@@ -476,7 +527,7 @@ impl ImporterHoistState {
                 &HoistPeersOptions {
                     auto_install_peers: self.auto_install_peers,
                     all_preferred_versions: &self.all_preferred_versions,
-                    workspace_root_deps: &workspace_root_deps,
+                    workspace_root_deps,
                 },
                 &missing_as_pairs,
             );
@@ -681,26 +732,45 @@ fn intersect_ranges(ranges: &[&str]) -> Option<String> {
 }
 
 /// Build the [`WorkspaceRootDep`] slice the hoist picker sees. Reads
-/// `direct` for the importer's slot names and `snapshot` for the
-/// resolved package each slot points at — `normalized_bare_specifier`
-/// passes through from the resolver verbatim.
+/// `direct` for the slot names and `snapshot` for the resolved package
+/// each slot points at, with `declared` supplying the specifier
+/// whenever the resolver reports no normalized one.
+///
+/// Deps the resolver couldn't name at resolution time still make it in
+/// through `declared`: `name_ver` is `None` for resolvers that learn
+/// the name from the manifest only after the fetch (git / tarball /
+/// local), and dropping them would hide a root peer provider declared
+/// that way from the picker.
 fn build_workspace_root_deps(
     direct: &[DirectDep],
     snapshot: &ResolvedTree,
+    declared: &BTreeMap<String, String>,
 ) -> Vec<WorkspaceRootDep> {
     let mut out = Vec::with_capacity(direct.len());
+    let mut named = HashSet::new();
     for dep in direct {
         let Some(pkg) = snapshot.packages.get(&dep.id) else { continue };
-        // `name_ver` is `None` for resolvers that learn the name from
-        // the manifest only after the fetch (git / tarball / local).
-        // Workspace-root short-circuit needs the resolution-time real
-        // name, so skip those — they fall through to the
-        // preferred-versions arm of `hoist_peers` instead.
         let Some(name_ver) = pkg.result.name_ver.as_ref() else { continue };
+        named.insert(dep.alias.as_str());
         out.push(WorkspaceRootDep {
             alias: dep.alias.clone(),
             pkg_name: name_ver.name.to_string(),
-            normalized_bare_specifier: pkg.result.normalized_bare_specifier.clone(),
+            normalized_bare_specifier: pkg
+                .result
+                .normalized_bare_specifier
+                .clone()
+                .or_else(|| declared.get(&dep.alias).cloned()),
+        });
+    }
+    for (alias, bare_specifier) in declared {
+        if named.contains(alias.as_str()) {
+            continue;
+        }
+        let (pkg_name, _) = unwrap_package_name(alias, bare_specifier);
+        out.push(WorkspaceRootDep {
+            alias: alias.clone(),
+            pkg_name: pkg_name.to_string(),
+            normalized_bare_specifier: Some(bare_specifier.clone()),
         });
     }
     out

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -740,9 +740,9 @@ fn cross_importer_specifier(spec: Option<String>) -> Option<String> {
 }
 
 /// Whether a specifier resolves against the consuming project's own
-/// directory — the `link:` / `file:` / `workspace:` protocols, same set
-/// [`fn@crate::resolve_dependency_tree::project_relative_cache_scope`]
-/// scopes its resolution cache by. A root dep declared this way is not
+/// directory — the `link:` / `file:` / `workspace:` protocols, the same
+/// set `project_relative_cache_scope` scopes its resolution cache by. A
+/// root dep declared this way is not
 /// a candidate for another importer's missing peer: hoisting the
 /// specifier verbatim would resolve it relative to *that* importer and
 /// reach a different path, or nothing at all. Dropping it leaves the

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -731,16 +731,51 @@ fn intersect_ranges(ranges: &[&str]) -> Option<String> {
     .map(|range| range.to_string())
 }
 
+/// Keep a specifier only if it means the same thing when resolved from
+/// an importer other than the root. Every candidate specifier passes
+/// through this one gate, whichever source it came from. See
+/// [`is_project_relative_specifier`] for what disqualifies one.
+fn cross_importer_specifier(spec: Option<String>) -> Option<String> {
+    spec.filter(|spec| !is_project_relative_specifier(spec))
+}
+
+/// Whether a specifier resolves against the consuming project's own
+/// directory — the `link:` / `file:` / `workspace:` protocols, same set
+/// [`fn@crate::resolve_dependency_tree::project_relative_cache_scope`]
+/// scopes its resolution cache by. A root dep declared this way is not
+/// a candidate for another importer's missing peer: hoisting the
+/// specifier verbatim would resolve it relative to *that* importer and
+/// reach a different path, or nothing at all. Dropping it leaves the
+/// peer to the preferred-versions arm, which is where such deps sat
+/// before they could be named at all.
+fn is_project_relative_specifier(spec: &str) -> bool {
+    spec.starts_with("link:") || spec.starts_with("file:") || spec.starts_with("workspace:")
+}
+
+/// The package's real name: the resolution-time `name_ver` when the
+/// resolver reported one, else the fetched manifest's `name`, which is
+/// the canonical source for the non-npm protocols that leave `name_ver`
+/// unset. `None` when neither is available — a git resolution reports
+/// no manifest until after the fetch, which is past the point the hoist
+/// picker runs.
+fn resolved_pkg_name(result: &pacquet_resolving_resolver_base::ResolveResult) -> Option<String> {
+    if let Some(name_ver) = result.name_ver.as_ref() {
+        return Some(name_ver.name.to_string());
+    }
+    result.manifest.as_deref()?.get("name").and_then(serde_json::Value::as_str).map(str::to_string)
+}
+
 /// Build the [`WorkspaceRootDep`] slice the hoist picker sees. Reads
 /// `direct` for the slot names and `snapshot` for the resolved package
 /// each slot points at, with `declared` supplying the specifier
 /// whenever the resolver reports no normalized one.
 ///
-/// Deps the resolver couldn't name at resolution time still make it in
-/// through `declared`: `name_ver` is `None` for resolvers that learn
-/// the name from the manifest only after the fetch (git / tarball /
-/// local), and dropping them would hide a root peer provider declared
-/// that way from the picker.
+/// The picker matches a peer against a root dep by alias *and* by real
+/// package name, so the name has to be the resolved one wherever it can
+/// be had — see [`resolved_pkg_name`]. A dep whose name can't be had at
+/// all still makes it in through `declared` under its alias: matching by
+/// alias alone beats dropping the root's provider entirely, and an alias
+/// usually *is* the package name.
 fn build_workspace_root_deps(
     direct: &[DirectDep],
     snapshot: &ResolvedTree,
@@ -750,20 +785,23 @@ fn build_workspace_root_deps(
     let mut named = HashSet::new();
     for dep in direct {
         let Some(pkg) = snapshot.packages.get(&dep.id) else { continue };
-        let Some(name_ver) = pkg.result.name_ver.as_ref() else { continue };
+        let Some(pkg_name) = resolved_pkg_name(&pkg.result) else { continue };
         named.insert(dep.alias.as_str());
         out.push(WorkspaceRootDep {
             alias: dep.alias.clone(),
-            pkg_name: name_ver.name.to_string(),
-            normalized_bare_specifier: pkg
-                .result
-                .normalized_bare_specifier
-                .clone()
-                .or_else(|| declared.get(&dep.alias).cloned()),
+            pkg_name,
+            normalized_bare_specifier: cross_importer_specifier(
+                pkg.result
+                    .normalized_bare_specifier
+                    .clone()
+                    .or_else(|| declared.get(&dep.alias).cloned()),
+            ),
         });
     }
     for (alias, bare_specifier) in declared {
-        if named.contains(alias.as_str()) {
+        if named.contains(alias.as_str())
+            || cross_importer_specifier(Some(bare_specifier.clone())).is_none()
+        {
             continue;
         }
         let (pkg_name, _) = unwrap_package_name(alias, bare_specifier);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -62,13 +62,10 @@ pub struct ResolveImporterOptions {
     /// failure. This is the `autoInstallPeersFromHighestMatch` setting.
     pub auto_install_peers_from_highest_match: bool,
 
-    /// When true, the *workspace root* importer's direct deps are used
-    /// as `workspace_root_deps` for the hoist picker, so a peer matching
-    /// a root dep's alias / name short-circuits straight to that dep's
-    /// specifier. [`fn@crate::resolve_workspace`] supplies the root's
-    /// deps to every importer; on the single-importer
-    /// [`fn@resolve_importer`] path the importer is the root, so it
-    /// supplies its own.
+    /// When true, a missing peer matching one of the *workspace root*
+    /// importer's direct deps is installed from that dep's specifier.
+    /// [`fn@crate::resolve_workspace`] supplies the root's deps; the
+    /// single-importer [`fn@resolve_importer`] path supplies its own.
     pub resolve_peers_from_workspace_root: bool,
 
     /// Threaded into [`ResolvePeersOptions::dedupe_peers`] on every
@@ -289,24 +286,12 @@ pub(crate) struct ImporterHoistState {
     importer_id: String,
     ctx: TreeCtx,
     direct: Vec<DirectDep>,
-    /// The *workspace root* importer's direct deps, so a missing peer
-    /// whose name matches one of them short-circuits to that dep's
-    /// specifier — pnpm's `resolvePeersFromWorkspaceRoot`. Assigned by
-    /// the caller through [`Self::set_workspace_root_deps`] once every
-    /// importer's initial wave has resolved, and shared unchanged by
-    /// every importer for the rest of the install: the root's own
-    /// hoisted peers must not become root-dep candidates for the
-    /// importers hoisted after it. Empty until the caller assigns it,
-    /// and empty for good for an importer set with no root at all,
-    /// matching pnpm's absent-root-importer case.
+    /// Empty until the caller assigns it; see
+    /// [`ResolveImporterOptions::resolve_peers_from_workspace_root`].
     workspace_root_deps: Arc<Vec<WorkspaceRootDep>>,
-    /// `alias → bare_specifier` for the importer's own declared deps.
-    /// The hoist picker wants the specifier a peer provider would be
-    /// installed from, and the resolver only reports a
-    /// `normalized_bare_specifier` for specs that needed normalizing
-    /// (npm aliases, `workspace:`, ...) — a plain `"19.2.0"` arrives as
-    /// `None`. This is the fallback, and the source for deps the
-    /// resolver couldn't name at all.
+    /// `alias → bare_specifier` as declared. Stands in wherever the
+    /// resolver reports no normalized form — a plain `"19.2.0"` arrives
+    /// as `None`.
     wanted_specifier_by_alias: BTreeMap<String, String>,
     /// `NodeIds` appended to `direct` by
     /// [`Self::append_resolved_peer_providers`]. Threaded into
@@ -413,14 +398,10 @@ impl ImporterHoistState {
         })
     }
 
-    /// This importer's id, for the caller's root-importer lookup.
     pub(crate) fn importer_id(&self) -> &str {
         &self.importer_id
     }
 
-    /// The hoist-picker view of this importer's initial direct-dep wave.
-    /// The caller calls it on the root importer only, once, and feeds the
-    /// result to every importer's [`Self::set_workspace_root_deps`].
     pub(crate) fn hoistable_root_deps(&self) -> Vec<WorkspaceRootDep> {
         build_workspace_root_deps(
             &self.direct,
@@ -731,33 +712,23 @@ fn intersect_ranges(ranges: &[&str]) -> Option<String> {
     .map(|range| range.to_string())
 }
 
-/// Keep a specifier only if it means the same thing when resolved from
-/// an importer other than the root. Every candidate specifier passes
-/// through this one gate, whichever source it came from. See
-/// [`is_project_relative_specifier`] for what disqualifies one.
+/// The one gate every candidate specifier passes through, whatever its
+/// source. See [`is_project_relative_specifier`].
 fn cross_importer_specifier(spec: Option<String>) -> Option<String> {
     spec.filter(|spec| !is_project_relative_specifier(spec))
 }
 
-/// Whether a specifier resolves against the consuming project's own
-/// directory — the `link:` / `file:` / `workspace:` protocols, the same
-/// set `project_relative_cache_scope` scopes its resolution cache by. A
-/// root dep declared this way is not
-/// a candidate for another importer's missing peer: hoisting the
-/// specifier verbatim would resolve it relative to *that* importer and
-/// reach a different path, or nothing at all. Dropping it leaves the
-/// peer to the preferred-versions arm, which is where such deps sat
-/// before they could be named at all.
+/// `link:` / `file:` / `workspace:` resolve against the consuming
+/// project's directory, so the root's copy of one can't stand in for
+/// another importer's peer — the same specifier would reach a different
+/// path there, or nothing. Same set `project_relative_cache_scope` uses.
 fn is_project_relative_specifier(spec: &str) -> bool {
     spec.starts_with("link:") || spec.starts_with("file:") || spec.starts_with("workspace:")
 }
 
-/// The package's real name: the resolution-time `name_ver` when the
-/// resolver reported one, else the fetched manifest's `name`, which is
-/// the canonical source for the non-npm protocols that leave `name_ver`
-/// unset. `None` when neither is available — a git resolution reports
-/// no manifest until after the fetch, which is past the point the hoist
-/// picker runs.
+/// `name_ver`, else the manifest — the canonical name for the protocols
+/// that leave `name_ver` unset. `None` for a git resolution, which has
+/// neither until it is fetched.
 fn resolved_pkg_name(result: &pacquet_resolving_resolver_base::ResolveResult) -> Option<String> {
     if let Some(name_ver) = result.name_ver.as_ref() {
         return Some(name_ver.name.to_string());
@@ -765,17 +736,9 @@ fn resolved_pkg_name(result: &pacquet_resolving_resolver_base::ResolveResult) ->
     result.manifest.as_deref()?.get("name").and_then(serde_json::Value::as_str).map(str::to_string)
 }
 
-/// Build the [`WorkspaceRootDep`] slice the hoist picker sees. Reads
-/// `direct` for the slot names and `snapshot` for the resolved package
-/// each slot points at, with `declared` supplying the specifier
-/// whenever the resolver reports no normalized one.
-///
-/// The picker matches a peer against a root dep by alias *and* by real
-/// package name, so the name has to be the resolved one wherever it can
-/// be had — see [`resolved_pkg_name`]. A dep whose name can't be had at
-/// all still makes it in through `declared` under its alias: matching by
-/// alias alone beats dropping the root's provider entirely, and an alias
-/// usually *is* the package name.
+/// The picker matches by alias *and* by real package name, so a dep
+/// [`resolved_pkg_name`] can't name still enters under its alias —
+/// usually the package name anyway, and better than no candidate.
 fn build_workspace_root_deps(
     direct: &[DirectDep],
     snapshot: &ResolvedTree,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -65,10 +65,10 @@ pub struct ResolveImporterOptions {
     /// When true, the *workspace root* importer's direct deps are used
     /// as `workspace_root_deps` for the hoist picker, so a peer matching
     /// a root dep's alias / name short-circuits straight to that dep's
-    /// specifier. The caller supplies them through
-    /// [`ImporterHoistState::set_workspace_root_deps`]; on the
-    /// single-importer [`fn@resolve_importer`] path the importer is the
-    /// root, so it supplies its own.
+    /// specifier. [`fn@crate::resolve_workspace`] supplies the root's
+    /// deps to every importer; on the single-importer
+    /// [`fn@resolve_importer`] path the importer is the root, so it
+    /// supplies its own.
     pub resolve_peers_from_workspace_root: bool,
 
     /// Threaded into [`ResolvePeersOptions::dedupe_peers`] on every
@@ -304,7 +304,7 @@ pub(crate) struct ImporterHoistState {
     /// The hoist picker wants the specifier a peer provider would be
     /// installed from, and the resolver only reports a
     /// `normalized_bare_specifier` for specs that needed normalizing
-    /// (npm aliases, `workspace:`, …) — a plain `"19.2.0"` arrives as
+    /// (npm aliases, `workspace:`, ...) — a plain `"19.2.0"` arrives as
     /// `None`. This is the fallback, and the source for deps the
     /// resolver couldn't name at all.
     wanted_specifier_by_alias: BTreeMap<String, String>,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -272,6 +272,21 @@ where
             .await?,
         );
     }
+    // Every importer hoists against the *root* importer's direct deps, not
+    // its own. Computed here — after the init barrier, so the root's initial
+    // wave has resolved — and shared unchanged for the rest of the install.
+    // An importer set that excludes the root leaves it empty, which turns the
+    // hoist picker's root short-circuit off for this install.
+    let root_deps = Arc::new(
+        states
+            .iter()
+            .find(|state| state.importer_id() == pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY)
+            .map(ImporterHoistState::hoistable_root_deps)
+            .unwrap_or_default(),
+    );
+    for state in &mut states {
+        state.set_workspace_root_deps(Arc::clone(&root_deps));
+    }
     loop {
         for state in &mut states {
             state.run_required_round(resolver).await?;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -275,8 +275,12 @@ where
     // Every importer hoists against the *root* importer's direct deps, not
     // its own. Computed here — after the init barrier, so the root's initial
     // wave has resolved — and shared unchanged for the rest of the install.
-    // An importer set that excludes the root leaves it empty, which turns the
-    // hoist picker's root short-circuit off for this install.
+    //
+    // The install layer passes every workspace project, `--filter` or not, so
+    // the root is normally present. The empty fallback covers an importer set
+    // that genuinely has no root, and matches pnpm, whose root-importer lookup
+    // is an unchecked index that yields `undefined` and an empty candidate
+    // list rather than an error.
     let root_deps = Arc::new(
         states
             .iter()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -272,15 +272,9 @@ where
             .await?,
         );
     }
-    // Every importer hoists against the *root* importer's direct deps, not
-    // its own. Computed here — after the init barrier, so the root's initial
-    // wave has resolved — and shared unchanged for the rest of the install.
-    //
-    // The install layer passes every workspace project, `--filter` or not, so
-    // the root is normally present. The empty fallback covers an importer set
-    // that genuinely has no root, and matches pnpm, whose root-importer lookup
-    // is an unchecked index that yields `undefined` and an empty candidate
-    // list rather than an error.
+    // Computed after the init barrier and shared unchanged: recomputing it
+    // per round would let the root's own hoisted peers become candidates for
+    // the importers hoisted after it.
     let root_deps = Arc::new(
         states
             .iter()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1695,8 +1695,8 @@ async fn fresh_resolved_parent_on_recorded_version_reuses_child_subtrees() {
 /// importer that pulls in a package with a `react` peer must get the
 /// root's `react`, even though the root's version doesn't satisfy the
 /// declared peer range — the setting exists to keep one copy across the
-/// workspace. Sourcing the picker from the hoisting importer instead
-/// left it with no candidate, and it resolved a second `react` from the
+/// workspace: if the picker were sourced from the hoisting importer, it
+/// would find no candidate there and resolve a second `react` from the
 /// range.
 #[tokio::test]
 async fn non_root_importer_hoists_the_root_importers_peer_provider() {
@@ -1761,4 +1761,175 @@ async fn non_root_importer_hoists_the_root_importers_peer_provider() {
     let app_deps = &result.peers.direct_dependencies_by_importer["app-b"];
     assert_eq!(app_deps["react"].as_str(), "react@19.2.0");
     assert_eq!(app_deps["lucide"].as_str(), "lucide@1.0.0(react@19.2.0)");
+}
+
+/// A tarball / git / local root dep is only recognizable as a peer
+/// provider by its *resolved* name: those resolvers leave `name_ver`
+/// unset, and the alias it was declared under need not match. Falling
+/// back to the fetched manifest's `name` keeps the picker able to match
+/// it — without that, the peer misses the root's copy and resolves its
+/// own from the registry.
+#[tokio::test]
+async fn root_dep_named_only_by_its_manifest_still_provides_the_peer() {
+    const TARBALL: &str = "https://tarballs.example/real-peer-1.0.0.tgz";
+    let (_root_tmp, root_manifest) = fake_manifest(serde_json::json!({ "aliased": TARBALL }));
+    let (_app_tmp, app_manifest) = fake_manifest(serde_json::json!({ "consumer": "1.0.0" }));
+    let importers = vec![
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "app-b".to_string(), manifest: &app_manifest },
+    ];
+    let mut unnamed = fake_result(
+        "real-peer",
+        "1.0.0",
+        None,
+        serde_json::json!({ "name": "real-peer", "version": "1.0.0" }),
+    );
+    unnamed.name_ver = None;
+    unnamed.id = pacquet_resolving_resolver_base::PkgResolutionId::from(TARBALL.to_string());
+    // Declared as `aliased`, so only the manifest reveals `real-peer`.
+    unnamed.alias = Some("aliased".to_string());
+    let resolver = RecordingResolver {
+        table: HashMap::from([
+            (("aliased".to_string(), TARBALL.to_string()), unnamed.clone()),
+            (("real-peer".to_string(), TARBALL.to_string()), unnamed),
+            // Only reachable when the picker fails to recognize the
+            // root's tarball dep as `real-peer`.
+            (
+                ("real-peer".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "real-peer",
+                    "1.9.9",
+                    None,
+                    serde_json::json!({ "name": "real-peer", "version": "1.9.9" }),
+                ),
+            ),
+            (
+                ("consumer".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "consumer",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "consumer",
+                        "version": "1.0.0",
+                        "peerDependencies": { "real-peer": "^1.0.0" },
+                    }),
+                ),
+            ),
+        ]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    opts.resolve_peers_from_workspace_root = true;
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            let mut importer_opts =
+                importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None);
+            importer_opts.resolve_peers_from_workspace_root = true;
+            importer_opts
+        })
+        .await
+        .expect("resolve workspace with a manifest-named root peer provider");
+
+    assert!(
+        !result.peers.graph.keys().any(|dep_path| dep_path.as_str().contains("1.9.9")),
+        "the peer must come from the root's tarball dep, not a second copy off the registry: {:?}",
+        result.peers.graph.keys().map(|k| k.as_str().to_string()).collect::<Vec<_>>(),
+    );
+}
+
+/// A `file:` root dep is not a peer-provider candidate: the specifier
+/// resolves against the consuming project's directory, so handing it to
+/// another importer would point at a path relative to *that* importer.
+/// The peer falls through to normal resolution instead.
+///
+/// Run for both shapes a local resolution can take, because they reach
+/// the guard by different routes: with a manifest the dep is nameable
+/// and carries the resolver's own specifier, without one it is named by
+/// its alias from the declared specifier.
+#[tokio::test]
+async fn a_project_relative_root_dep_is_not_offered_as_a_peer_provider() {
+    project_relative_root_dep_is_not_a_provider(ManifestAvailability::Absent).await;
+}
+
+#[tokio::test]
+async fn a_nameable_project_relative_root_dep_is_not_offered_as_a_peer_provider() {
+    project_relative_root_dep_is_not_a_provider(ManifestAvailability::Present).await;
+}
+
+#[derive(Clone, Copy)]
+enum ManifestAvailability {
+    Present,
+    Absent,
+}
+
+async fn project_relative_root_dep_is_not_a_provider(manifest: ManifestAvailability) {
+    const LOCAL: &str = "file:./vendor/real-peer.tgz";
+    let (_root_tmp, root_manifest) = fake_manifest(serde_json::json!({ "real-peer": LOCAL }));
+    let (_app_tmp, app_manifest) = fake_manifest(serde_json::json!({ "consumer": "1.0.0" }));
+    let importers = vec![
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "app-b".to_string(), manifest: &app_manifest },
+    ];
+    // A local tarball reports neither `name_ver` nor a manifest until it
+    // is fetched, so the declared specifier is all the picker could use.
+    let mut unnamed = fake_result(
+        "real-peer",
+        "1.0.0",
+        None,
+        serde_json::json!({ "name": "real-peer", "version": "1.0.0" }),
+    );
+    unnamed.name_ver = None;
+    if matches!(manifest, ManifestAvailability::Absent) {
+        unnamed.manifest = None;
+    }
+    unnamed.normalized_bare_specifier = Some(LOCAL.to_string());
+    unnamed.id = pacquet_resolving_resolver_base::PkgResolutionId::from(LOCAL.to_string());
+    let resolver = RecordingResolver {
+        table: HashMap::from([
+            (("real-peer".to_string(), LOCAL.to_string()), unnamed),
+            (
+                ("real-peer".to_string(), "^1.0.0".to_string()),
+                fake_result(
+                    "real-peer",
+                    "1.9.9",
+                    None,
+                    serde_json::json!({ "name": "real-peer", "version": "1.9.9" }),
+                ),
+            ),
+            (
+                ("consumer".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "consumer",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "consumer",
+                        "version": "1.0.0",
+                        "peerDependencies": { "real-peer": "^1.0.0" },
+                    }),
+                ),
+            ),
+        ]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    opts.resolve_peers_from_workspace_root = true;
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            let mut importer_opts =
+                importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None);
+            importer_opts.resolve_peers_from_workspace_root = true;
+            importer_opts
+        })
+        .await
+        .expect("resolve workspace with a project-relative root dep");
+
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["app-b"]["real-peer"].as_str(),
+        "real-peer@1.9.9",
+        "the `file:` specifier must not be hoisted into app-b",
+    );
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1690,14 +1690,9 @@ async fn fresh_resolved_parent_on_recorded_version_reuses_child_subtrees() {
     }
 }
 
-/// `resolvePeersFromWorkspaceRoot` reads the *root* importer's direct
-/// deps, not the deps of whichever importer is hoisting. A non-root
-/// importer that pulls in a package with a `react` peer must get the
-/// root's `react`, even though the root's version doesn't satisfy the
-/// declared peer range — the setting exists to keep one copy across the
-/// workspace: if the picker were sourced from the hoisting importer, it
-/// would find no candidate there and resolve a second `react` from the
-/// range.
+/// The root's `react` wins even though it doesn't satisfy `lucide-react`'s
+/// declared peer range: keeping one copy across the workspace is the point
+/// of the setting.
 #[tokio::test]
 async fn non_root_importer_hoists_the_root_importers_peer_provider() {
     let (_root_tmp, root_manifest) = fake_manifest(serde_json::json!({ "react": "19.2.0" }));
@@ -1717,8 +1712,6 @@ async fn non_root_importer_hoists_the_root_importers_peer_provider() {
                     serde_json::json!({ "name": "react", "version": "19.2.0" }),
                 ),
             ),
-            // Only reachable when the picker misses the root's `react`
-            // and falls back to resolving the peer range itself.
             (
                 ("react".to_string(), "^18.0.0".to_string()),
                 fake_result(
@@ -1763,12 +1756,8 @@ async fn non_root_importer_hoists_the_root_importers_peer_provider() {
     assert_eq!(app_deps["lucide"].as_str(), "lucide@1.0.0(react@19.2.0)");
 }
 
-/// A tarball / git / local root dep is only recognizable as a peer
-/// provider by its *resolved* name: those resolvers leave `name_ver`
-/// unset, and the alias it was declared under need not match. Falling
-/// back to the fetched manifest's `name` keeps the picker able to match
-/// it — without that, the peer misses the root's copy and resolves its
-/// own from the registry.
+/// A tarball / git / local root dep leaves `name_ver` unset, and the alias
+/// it was declared under need not be its name.
 #[tokio::test]
 async fn root_dep_named_only_by_its_manifest_still_provides_the_peer() {
     const TARBALL: &str = "https://tarballs.example/real-peer-1.0.0.tgz";
@@ -1786,14 +1775,11 @@ async fn root_dep_named_only_by_its_manifest_still_provides_the_peer() {
     );
     unnamed.name_ver = None;
     unnamed.id = pacquet_resolving_resolver_base::PkgResolutionId::from(TARBALL.to_string());
-    // Declared as `aliased`, so only the manifest reveals `real-peer`.
     unnamed.alias = Some("aliased".to_string());
     let resolver = RecordingResolver {
         table: HashMap::from([
             (("aliased".to_string(), TARBALL.to_string()), unnamed.clone()),
             (("real-peer".to_string(), TARBALL.to_string()), unnamed),
-            // Only reachable when the picker fails to recognize the
-            // root's tarball dep as `real-peer`.
             (
                 ("real-peer".to_string(), "^1.0.0".to_string()),
                 fake_result(
@@ -1839,15 +1825,10 @@ async fn root_dep_named_only_by_its_manifest_still_provides_the_peer() {
     );
 }
 
-/// A `file:` root dep is not a peer-provider candidate: the specifier
-/// resolves against the consuming project's directory, so handing it to
-/// another importer would point at a path relative to *that* importer.
-/// The peer falls through to normal resolution instead.
-///
-/// Run for both shapes a local resolution can take, because they reach
-/// the guard by different routes: with a manifest the dep is nameable
-/// and carries the resolver's own specifier, without one it is named by
-/// its alias from the declared specifier.
+/// Both shapes a local resolution can take reach the guard by different
+/// routes: with a manifest the dep is nameable and carries the resolver's
+/// own specifier, without one it is named by its alias from the declared
+/// specifier.
 #[tokio::test]
 async fn a_project_relative_root_dep_is_not_offered_as_a_peer_provider() {
     project_relative_root_dep_is_not_a_provider(ManifestAvailability::Absent).await;
@@ -1872,8 +1853,6 @@ async fn project_relative_root_dep_is_not_a_provider(manifest: ManifestAvailabil
         WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
         WorkspaceImporter { id: "app-b".to_string(), manifest: &app_manifest },
     ];
-    // A local tarball reports neither `name_ver` nor a manifest until it
-    // is fetched, so the declared specifier is all the picker could use.
     let mut unnamed = fake_result(
         "real-peer",
         "1.0.0",

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1689,3 +1689,76 @@ async fn fresh_resolved_parent_on_recorded_version_reuses_child_subtrees() {
         assert_eq!(graph_versions_of(&result, name), ["1.0.0"], "{name} must keep 1.0.0");
     }
 }
+
+/// `resolvePeersFromWorkspaceRoot` reads the *root* importer's direct
+/// deps, not the deps of whichever importer is hoisting. A non-root
+/// importer that pulls in a package with a `react` peer must get the
+/// root's `react`, even though the root's version doesn't satisfy the
+/// declared peer range — the setting exists to keep one copy across the
+/// workspace. Sourcing the picker from the hoisting importer instead
+/// left it with no candidate, and it resolved a second `react` from the
+/// range.
+#[tokio::test]
+async fn non_root_importer_hoists_the_root_importers_peer_provider() {
+    let (_root_tmp, root_manifest) = fake_manifest(serde_json::json!({ "react": "19.2.0" }));
+    let (_app_tmp, app_manifest) = fake_manifest(serde_json::json!({ "lucide": "1.0.0" }));
+    let importers = vec![
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "app-b".to_string(), manifest: &app_manifest },
+    ];
+    let resolver = RecordingResolver {
+        table: HashMap::from([
+            (
+                ("react".to_string(), "19.2.0".to_string()),
+                fake_result(
+                    "react",
+                    "19.2.0",
+                    None,
+                    serde_json::json!({ "name": "react", "version": "19.2.0" }),
+                ),
+            ),
+            // Only reachable when the picker misses the root's `react`
+            // and falls back to resolving the peer range itself.
+            (
+                ("react".to_string(), "^18.0.0".to_string()),
+                fake_result(
+                    "react",
+                    "18.3.1",
+                    None,
+                    serde_json::json!({ "name": "react", "version": "18.3.1" }),
+                ),
+            ),
+            (
+                ("lucide".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "lucide",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "lucide",
+                        "version": "1.0.0",
+                        "peerDependencies": { "react": "^18.0.0" },
+                    }),
+                ),
+            ),
+        ]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    opts.resolve_peers_from_workspace_root = true;
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            let mut importer_opts =
+                importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None);
+            importer_opts.resolve_peers_from_workspace_root = true;
+            importer_opts
+        })
+        .await
+        .expect("resolve workspace with a root-provided peer");
+
+    assert_eq!(graph_versions_of(&result, "react"), ["19.2.0"], "one react, the root's");
+    let app_deps = &result.peers.direct_dependencies_by_importer["app-b"];
+    assert_eq!(app_deps["react"].as_str(), "react@19.2.0");
+    assert_eq!(app_deps["lucide"].as_str(), "lucide@1.0.0(react@19.2.0)");
+}


### PR DESCRIPTION
## Summary

Two peer-resolution defects found while validating [vercel/next.js](https://github.com/vercel/next.js) for pnpm/pnpm#13305. Both are pacquet-only divergences from the TypeScript CLI — `hoist_peers.rs` is otherwise a faithful port of `hoistPeers` / `getHoistableOptionalPeers`, so there is no counterpart TypeScript change to land alongside this.

**1. `resolvePeersFromWorkspaceRoot` read the wrong importer's dependencies.** The hoist picker was fed `self.direct` — the deps of whichever importer was being resolved — instead of the workspace root's. A project that doesn't declare the peer itself therefore saw no candidate and resolved a second copy from the registry. The field doc admitted it (*"Single-importer pacquet treats the importer as the root"*), left over from before the multi-importer orchestrator existed; `WorkspaceResolveOptions` already documented the intended behavior correctly.

In next.js, whose `overrides` pin `react`/`react-dom`/`react-is`/`scheduler` to one canary build, `bench/heavy-npm-deps` (which declares `@mantine/core`, `lucide-react`, `next` and no `react`) pulled in a second `react@18.3.1` and bound the canary `react-dom` to it — violating that package's *exact* peer pin `react: 19.3.0-canary-28cd4bb0-20260723`, which is the runtime-breaking combination the pin exists to prevent. 38 references in the resolved lockfile, zero in pnpm 11's.

**2. The optional-peer picker accepted prereleases the declared range rejects.** `get_hoistable_optional_peers` used the prerelease-tolerant helper where the TypeScript counterpart uses a bare `semver.satisfies`. `ts-jest` declares `@jest/transform` and `jest-util` as optional peers with `^29.0.0 || ^30.0.0`; with a jest 30 prerelease elsewhere in the graph (dragged in by `overrides: { jest-snapshot: 30.0.0-alpha.6 }`) they bound to `30.0.0-alpha.6` — outside the declared range under strict semver — while `jest` itself stayed on 29.7.0.

### Effect on the next.js lockfile

Full re-resolution, both stacks run back to back on the same tree:

| | before | after |
| --- | --- | --- |
| `pnpm-lock.yaml` diff vs pnpm 11 | 638 lines | **445** |
| package keys resolved by one stack only | `react@18.3.1` | **none — the sets are identical** |
| `react@18.3.1` references | 38 | **0** |
| `ts-jest` peer suffix | 30-alpha transform + jest-util | **matches pnpm 11 exactly** |

The remaining 445 lines are a separate, unrelated `resolve_peers` provider-selection difference around `postcss`, discussed on pnpm/pnpm#13320; nothing is violated on either side there and it is not touched here.

### Not in this PR

- **Required-peer prerelease leniency** — `hoist_peers` is lenient in a *different* way to `getHoistableOptionalPeers`: pacquet strips the prerelease tag and retries against the base version, while TypeScript passes `includePrerelease: true`, which does not lower the range's bound. The two agree when the prerelease sits inside the range's span and disagree at the lower bound. Not implicated in any repository validated so far, and the Rust `node-semver` crate exposes no `includePrerelease`, so it needs real semver work. Filed as pnpm/pnpm#13341.

- **An aliased git workspace-root dependency** still can't satisfy a peer by its real package name. A git resolution reports neither `name_ver` nor a manifest before the hoist loop runs, so it is matched by alias only. Pre-existing — the previous code skipped such deps entirely, matching neither — and a missed deduplication rather than an incorrect graph. Filed as pnpm/pnpm#13351.

Related to pnpm/pnpm#13320, found via pnpm/pnpm#13305.

## Squash Commit Body

```text
`resolvePeersFromWorkspaceRoot` is meant to let any project satisfy a
missing peer from the workspace root's dependencies. The picker was fed
`self.direct` — the deps of whichever importer was being resolved — so a
project that didn't declare the peer itself saw no candidate and resolved
a second copy from the registry. The field doc said as much
("Single-importer pacquet treats the importer as the root"), left over
from before the multi-importer orchestrator existed.

`resolve_workspace` now builds the root importer's list once, after the
phase-1 init barrier, and shares it with every importer's hoist rounds;
computing it once also matches pnpm, where the root's own hoisted peers
never become root-dep candidates for the importers hoisted after it. An
importer set without the root leaves the list empty, mirroring pnpm's
absent-root-importer case.

`build_workspace_root_deps` also needed pnpm's two specifier sources to
be of any use: the resolver reports `normalized_bare_specifier` only for
specs that needed normalizing, so a plain "19.2.0" arrived as `None` and
the picker skipped the root dep entirely. Fall back to the declared
specifier, and include deps the resolver couldn't name at resolution
time (git / tarball / local), matching `getHoistableRootDeps`.

Separately, `get_hoistable_optional_peers` now checks ranges with plain
semver instead of the prerelease-tolerant helper, matching the bare
`semver.satisfies` in `getHoistableOptionalPeers`. A prerelease is not a
stand-in for a range that didn't ask for one: `ts-jest` declares
`@jest/transform` and `jest-util` as optional peers with
`^29.0.0 || ^30.0.0`, and a jest 30 prerelease elsewhere in the graph
was binding them to `30.0.0-alpha.6` while `jest` itself stayed on 29.

Both were found resolving vercel/next.js, whose `overrides` pin `react`
to one canary build: pnpm 12 produced a second `react@18.3.1` and paired
it with the canary `react-dom`, violating that package's exact peer pin.
The remaining required-peer prerelease divergence is pnpm/pnpm#13341.

Related to pnpm/pnpm#13320.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <br>Rust-only: both defects are pacquet diverging from TypeScript behavior that
  is already correct, so the TypeScript CLI needs no change.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
  <br>`non_root_importer_hoists_the_root_importers_peer_provider` covers the
  workspace-root sourcing; it was verified to fail against the old behavior
  (`["18.3.1", "19.2.0"]` where `["19.2.0"]` is expected). The optional-peer test
  that asserted the prerelease was accepted is inverted, plus a new case for a
  prerelease *inside* the range's span, which is the shape next.js hits and which
  a lower-bound check alone would miss.
- [x] Updated the documentation if needed.
  <br>No user-facing docs change; the stale `resolve_peers_from_workspace_root`
  field doc that described the bug is corrected.

### Verification

`just ready` green: 7020 tests passed, 0 failures; `cargo clippy --all-targets --workspace -D warnings` clean; `typos`, `cargo fmt`, `cargo check` clean. Pre-push gates run locally too: workspace `cargo doc` with `RUSTDOCFLAGS=-D warnings`, and `cargo dylint --all` clean. next.js frozen install re-checked after the change — exit 0, lockfile not rewritten, 3619 packages.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787575889&installation_model_id=426870&pr_number=13343&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13343&signature=a210d2f857757341a64355faac8832a4b62646e380345d0cd786a70aff147b1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace peer dependency resolution to reuse compatible dependencies provided by the workspace root, reducing duplicate installations.
  * Corrected optional peer handling so prerelease versions are not selected when they fall outside the declared peer range.
* **Tests**
  * Added coverage for workspace-root peer reuse and prerelease rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
