### PR TITLE
fix(package-manager): preserve scalar libc metadata

### DIFF
--- a/.changeset/pacquet-preserve-string-libc.md
+++ b/.changeset/pacquet-preserve-string-libc.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed generated lockfiles to preserve packages' scalar `libc` constraints.

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -597,13 +597,19 @@ fn build_package_metadata(
     }
 }
 
-/// Read a JSON array field off the resolver's manifest fragment and
-/// flatten it into a `Vec<String>`. `None` when the field is missing or
-/// not an array of strings — malformed metadata is silently dropped.
+/// Read a JSON string or array field off the resolver's manifest fragment and
+/// flatten it into a `Vec<String>`. `None` when the field is missing or has no
+/// string values — malformed metadata is silently dropped.
 fn read_string_list(manifest: Option<&Value>, key: &str) -> Option<Vec<String>> {
-    let arr = manifest?.get(key)?.as_array()?;
-    let out: Vec<String> = arr.iter().filter_map(Value::as_str).map(ToString::to_string).collect();
-    (!out.is_empty()).then_some(out)
+    match manifest?.get(key)? {
+        Value::String(value) if !value.is_empty() => Some(vec![value.clone()]),
+        Value::Array(items) => {
+            let out: Vec<String> =
+                items.iter().filter_map(Value::as_str).map(ToString::to_string).collect();
+            (!out.is_empty()).then_some(out)
+        }
+        _ => None,
+    }
 }
 
 /// `Some(true)` when the manifest declares a `bin` entry (string or

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -551,7 +551,7 @@ fn build_package_metadata(
 
     let cpu = read_string_list(manifest, "cpu");
     let os = read_string_list(manifest, "os");
-    let libc = read_string_list(manifest, "libc");
+    let libc = read_string_or_list(manifest, "libc");
 
     let deprecated =
         manifest.and_then(|m| m.get("deprecated")).and_then(Value::as_str).map(ToString::to_string);
@@ -597,17 +597,24 @@ fn build_package_metadata(
     }
 }
 
-/// Read a JSON string or array field off the resolver's manifest fragment and
-/// flatten it into a `Vec<String>`. `None` when the field is missing or has no
-/// string values — malformed metadata is silently dropped.
+/// Read a JSON array field off the resolver's manifest fragment and flatten it
+/// into a `Vec<String>`. `None` when the field is missing or has no string
+/// values — malformed metadata is silently dropped.
 fn read_string_list(manifest: Option<&Value>, key: &str) -> Option<Vec<String>> {
     match manifest?.get(key)? {
-        Value::String(value) if !value.is_empty() => Some(vec![value.clone()]),
         Value::Array(items) => {
             let out: Vec<String> =
                 items.iter().filter_map(Value::as_str).map(ToString::to_string).collect();
             (!out.is_empty()).then_some(out)
         }
+        _ => None,
+    }
+}
+
+fn read_string_or_list(manifest: Option<&Value>, key: &str) -> Option<Vec<String>> {
+    match manifest?.get(key)? {
+        Value::String(value) if !value.is_empty() => Some(vec![value.clone()]),
+        Value::Array(_) => read_string_list(manifest, key),
         _ => None,
     }
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -199,7 +199,7 @@ fn fresh_install_records_a_single_direct_dependency() {
 }
 
 #[test]
-fn fresh_install_records_string_libc_metadata() {
+fn fresh_install_records_string_libc_without_coercing_scalar_bundle_metadata() {
     let (_tmp, manifest) = write_manifest(json!({
         "name": "fixture",
         "version": "1.0.0",
@@ -214,6 +214,7 @@ fn fresh_install_records_string_libc_metadata() {
             "cpu": ["x64"],
             "os": ["linux"],
             "libc": "musl",
+            "bundledDependencies": "not-an-array",
         }),
         BTreeMap::new(),
         BTreeMap::new(),
@@ -231,10 +232,9 @@ fn fresh_install_records_string_libc_metadata() {
     ));
 
     let package_key: PackageKey = "sass-embedded-linux-musl-x64@1.100.0".parse().unwrap();
-    assert_eq!(
-        lockfile.packages.as_ref().expect("packages")[&package_key].libc.as_deref(),
-        Some(["musl".to_string()].as_slice()),
-    );
+    let metadata = &lockfile.packages.as_ref().expect("packages")[&package_key];
+    assert_eq!(metadata.libc.as_deref(), Some(["musl".to_string()].as_slice()));
+    assert!(metadata.bundled_dependencies.is_none());
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -199,6 +199,45 @@ fn fresh_install_records_a_single_direct_dependency() {
 }
 
 #[test]
+fn fresh_install_records_string_libc_metadata() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "sass-embedded-linux-musl-x64": "1.100.0" },
+    }));
+    let node = make_node(
+        "sass-embedded-linux-musl-x64",
+        "1.100.0",
+        json!({
+            "name": "sass-embedded-linux-musl-x64",
+            "version": "1.100.0",
+            "cpu": ["x64"],
+            "os": ["linux"],
+            "libc": "musl",
+        }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+    let mut graph = DependenciesGraph::new();
+    graph.insert(node.dep_path.clone(), node);
+    let direct = BTreeMap::from([(
+        "sass-embedded-linux-musl-x64".to_string(),
+        DepPath::from("sass-embedded-linux-musl-x64@1.100.0".to_string()),
+    )]);
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    let package_key: PackageKey = "sass-embedded-linux-musl-x64@1.100.0".parse().unwrap();
+    assert_eq!(
+        lockfile.packages.as_ref().expect("packages")[&package_key].libc.as_deref(),
+        Some(["musl".to_string()].as_slice()),
+    );
+}
+
+#[test]
 fn fresh_install_records_importer_manifest_metadata() {
     let (_tmp, manifest) = write_manifest(json!({
         "name": "fixture",


### PR DESCRIPTION
## Summary

- Preserve scalar `libc` constraints from registry manifests when pacquet generates a fresh lockfile.
- Accept string or array `libc` metadata in the dependency-graph conversion while keeping other list fields array-only.
- The TypeScript CLI already preserves this metadata, so no TypeScript change is required.

Closes pnpm/pnpm#13324.

## Squash Commit Body

```text
Registry package manifests may express `libc` as a plain string. Pacquet's
dependency-graph-to-lockfile conversion only accepted arrays, so fresh
lockfiles silently omitted those platform constraints.

Accept both string and array `libc` metadata in that conversion while keeping
other manifest list fields array-only. Cover the scalar form with a regression
test based on sass-embedded's Linux variants, including a check that malformed
scalar bundle metadata remains ignored.

Closes pnpm/pnpm#13324.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated lockfiles to preserve scalar `libc` constraints (for example, `"musl"`) instead of dropping them.
  * Improved handling of package metadata when fields are provided as either a single value or a list, ensuring correct recording in lockfiles.
* **Tests**
  * Added a fresh-install test to confirm `libc` is captured properly when declared as a string, and that non-array bundled dependency metadata is not serialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->