### PR TITLE
fix(pacquet): repair licenses command

### DIFF
--- a/.changeset/pacquet-licenses-global-store.md
+++ b/.changeset/pacquet-licenses-global-store.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm licenses list` and `pnpm licenses ls` parsing and license metadata discovery when using the global virtual store [pnpm/pnpm#13332](https://github.com/pnpm/pnpm/issues/13332) and [pnpm/pnpm#13333](https://github.com/pnpm/pnpm/issues/13333).

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info.rs
@@ -209,11 +209,15 @@ fn resolved_tarball_url(
 /// prefixed components are rejected by shape, not `is_absolute()`:
 /// on Windows a rooted-but-prefixless `\escape` (or a prefix-only
 /// `C:evil`) is not "absolute" yet still replaces the join base.
-fn is_unsafe_path_component(component: &str) -> bool {
-    component.contains("..")
-        || Path::new(component).components().any(|part| {
-            matches!(part, std::path::Component::RootDir | std::path::Component::Prefix(_))
-        })
+pub(crate) fn is_unsafe_path_component(component: &str) -> bool {
+    Path::new(component).components().any(|part| {
+        matches!(
+            part,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_),
+        )
+    })
 }
 
 /// Filesystem path of a package addressed by `dep_path`. For a local

--- a/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deps_tree/pkg_info/tests.rs
@@ -127,6 +127,7 @@ fn unsafe_path_components_are_detected_by_shape() {
     assert!(super::is_unsafe_path_component("../../escape"));
     assert!(super::is_unsafe_path_component("/etc"));
     assert!(!super::is_unsafe_path_component("lodash"));
+    assert!(!super::is_unsafe_path_component("foo..bar"));
     assert!(!super::is_unsafe_path_component("@scope/pkg"));
     // Rooted-but-prefixless and prefix-only components replace the
     // join base on Windows without being `is_absolute()`.

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -2,9 +2,13 @@ use crate::cli_args::recursive::{
     AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
 };
 use clap::Args;
-use miette::IntoDiagnostic;
+use derive_more::{Display, Error};
+use miette::{Diagnostic, IntoDiagnostic};
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, PackageKey, PkgName, ResolvedDependencyMap};
+use pacquet_package_manager::{
+    AllowBuildPolicy, validate_virtual_store_slot_containment, virtual_store_layout_for_lockfile,
+};
 use pacquet_package_manifest::{extract_author, extract_homepage, safe_read_package_json_from_dir};
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -22,6 +26,23 @@ pub struct LicensesArgs {
 
     #[clap(flatten)]
     pub dependency_options: LicensesDependencyOptions,
+
+    /// Subcommand and arguments.
+    pub params: Vec<String>,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+enum LicensesError {
+    #[display("Please specify the subcommand")]
+    #[diagnostic(
+        code(ERR_PNPM_LICENCES_NO_SUBCOMMAND),
+        help("Run `pnpm licenses --help` for available subcommands.")
+    )]
+    NoSubcommand,
+
+    #[display("This subcommand is not known")]
+    #[diagnostic(code(ERR_PNPM_LICENSES_UNKNOWN_SUBCOMMAND))]
+    UnknownSubcommand,
 }
 
 #[derive(Debug, Args)]
@@ -92,6 +113,12 @@ impl LicensesArgs {
         dir: &std::path::Path,
         recursive: bool,
     ) -> miette::Result<()> {
+        match self.params.first().map(String::as_str) {
+            Some("list" | "ls") => {}
+            Some(_) => return Err(LicensesError::UnknownSubcommand.into()),
+            None => return Err(LicensesError::NoSubcommand.into()),
+        }
+
         let lockfile_dir = config.workspace_dir.as_deref().unwrap_or(dir);
         let lockfile = Lockfile::load_wanted_from_dir(lockfile_dir).into_diagnostic()?;
         let Some(lockfile) = lockfile else {
@@ -200,14 +227,15 @@ impl LicensesArgs {
             }
         }
 
-        let project_root_dir = dir.to_path_buf();
-        let effective_vsd = config.effective_virtual_store_dir();
-        let virtual_store_dir = if effective_vsd.is_absolute() {
-            effective_vsd.to_path_buf()
-        } else {
-            project_root_dir.join(effective_vsd)
-        };
-        let virtual_store_dir_max_length = config.virtual_store_dir_max_length as usize;
+        let allow_build_policy = AllowBuildPolicy::from_config(config).into_diagnostic()?;
+        let layout = virtual_store_layout_for_lockfile(
+            config,
+            lockfile.snapshots.as_ref(),
+            lockfile.packages.as_ref(),
+            Some(&allow_build_policy),
+        );
+        validate_virtual_store_slot_containment(lockfile.snapshots.as_ref(), &layout)
+            .into_diagnostic()?;
 
         let mut results_by_license: BTreeMap<String, BTreeMap<String, LicenseInfo>> =
             BTreeMap::new();
@@ -224,13 +252,8 @@ impl LicensesArgs {
                 version.clone_from(v);
             }
 
-            let store_name = key.to_virtual_store_name(virtual_store_dir_max_length);
-
-            let pkg_dir = virtual_store_dir.join(&store_name).join("node_modules").join(&name);
-            let is_unsafe = store_name.contains("..")
-                || name.contains("..")
-                || std::path::Path::new(&store_name).is_absolute()
-                || std::path::Path::new(&name).is_absolute();
+            let pkg_dir = layout.slot_dir(&key).join("node_modules").join(&name);
+            let is_unsafe = name.contains("..") || std::path::Path::new(&name).is_absolute();
             let manifest = if is_unsafe {
                 None
             } else {

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -1,5 +1,6 @@
-use crate::cli_args::recursive::{
-    AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+use crate::cli_args::{
+    deps_tree::pkg_info::is_unsafe_path_component,
+    recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
 };
 use clap::Args;
 use derive_more::{Display, Error};
@@ -9,7 +10,10 @@ use pacquet_lockfile::{Lockfile, PackageKey, PkgName, ResolvedDependencyMap};
 use pacquet_package_manager::{
     AllowBuildPolicy, validate_virtual_store_slot_containment, virtual_store_layout_for_lockfile,
 };
-use pacquet_package_manifest::{extract_author, extract_homepage, safe_read_package_json_from_dir};
+use pacquet_package_manifest::{
+    extract_author, extract_homepage, node_version_from_engines_runtime,
+    safe_read_package_json_from_dir,
+};
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use tabled::{builder::Builder, settings::Style};
@@ -228,8 +232,14 @@ impl LicensesArgs {
         }
 
         let allow_build_policy = AllowBuildPolicy::from_config(config).into_diagnostic()?;
+        let project_manifest = safe_read_package_json_from_dir(dir).into_diagnostic()?;
+        let manifest_node_version =
+            project_manifest.as_ref().and_then(node_version_from_engines_runtime);
+        let effective_node_version =
+            config.node_version.as_deref().or(manifest_node_version.as_deref());
         let layout = virtual_store_layout_for_lockfile(
             config,
+            effective_node_version,
             lockfile.snapshots.as_ref(),
             lockfile.packages.as_ref(),
             Some(&allow_build_policy),
@@ -253,8 +263,7 @@ impl LicensesArgs {
             }
 
             let pkg_dir = layout.slot_dir(&key).join("node_modules").join(&name);
-            let is_unsafe = name.contains("..") || std::path::Path::new(&name).is_absolute();
-            let manifest = if is_unsafe {
+            let manifest = if is_unsafe_path_component(&name) {
                 None
             } else {
                 safe_read_package_json_from_dir(&pkg_dir).unwrap_or(None)

--- a/pnpm/crates/cli/src/cli_args/licenses/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/tests.rs
@@ -38,6 +38,7 @@ async fn test_empty_lockfile() {
             no_optional: false,
             optional: false,
         },
+        params: vec!["list".to_string()],
     };
 
     // An empty directory has no lockfile, so it should just print "{}" and exit ok

--- a/pnpm/crates/cli/src/cli_args/licenses/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/tests.rs
@@ -45,3 +45,23 @@ async fn test_empty_lockfile() {
     let res = args.run(&config, dir.path(), false).await;
     assert!(res.is_ok());
 }
+
+#[tokio::test]
+async fn test_no_subcommand_matches_pnpm_error_code() {
+    let dir = TempDir::new().unwrap();
+    let config = Config::default();
+    let args = LicensesArgs {
+        json: false,
+        long: false,
+        dependency_options: LicensesDependencyOptions {
+            prod: false,
+            dev: false,
+            no_optional: false,
+            optional: false,
+        },
+        params: vec![],
+    };
+
+    let err = args.run(&config, dir.path(), false).await.unwrap_err();
+    assert!(format!("{err:?}").contains("ERR_PNPM_LICENCES_NO_SUBCOMMAND"));
+}

--- a/pnpm/crates/cli/tests/licenses.rs
+++ b/pnpm/crates/cli/tests/licenses.rs
@@ -2,34 +2,51 @@ pub mod _utils;
 
 use _utils::{enable_gvs_in_workspace_yaml, pacquet_in};
 use assert_cmd::prelude::*;
-use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use serde_json::{Value, json};
 use std::{fs, path::Path};
 
 #[test]
-fn licenses_reads_package_metadata_from_the_global_virtual_store() {
+fn licenses_reads_global_store_metadata_with_a_manifest_selected_runtime() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let config_home = root.path().join("config");
+    fs::create_dir(&config_home).expect("create empty config home");
 
-    enable_gvs_in_workspace_yaml(&workspace, "");
+    enable_gvs_in_workspace_yaml(
+        &workspace,
+        "allowBuilds:\n  '@pnpm.e2e/install-script-example': true\n",
+    );
     fs::write(
         workspace.join("package.json"),
         json!({
+            "devEngines": {
+                "runtime": {
+                    "name": "node",
+                    "version": "1",
+                    "onFail": "ignore",
+                },
+            },
             "dependencies": {
-                "@pnpm.e2e/has-different-licenses": "1.0.0",
+                // This engine-constrained dependency makes installation resolve the GVS engine
+                // from the manifest-selected runtime instead of deferring to the host Node.
+                "@pnpm.e2e/for-legacy-node": "1.0.0",
+                "@pnpm.e2e/install-script-example": "1.0.0",
             },
         })
         .to_string(),
     )
     .expect("write package.json");
 
-    pacquet.with_arg("install").assert().success();
+    let mut pacquet = pacquet;
+    pacquet.env("XDG_CONFIG_HOME", &config_home).arg("install").assert().success();
 
     for subcommand in ["list", "ls"] {
-        let output = pacquet_in(&workspace)
-            .with_args(["licenses", subcommand, "--json"])
+        let mut licenses_command = pacquet_in(&workspace);
+        let output = licenses_command
+            .env("XDG_CONFIG_HOME", &config_home)
+            .args(["licenses", subcommand, "--json"])
             .output()
             .expect("spawn pacquet licenses");
         assert!(
@@ -41,7 +58,7 @@ fn licenses_reads_package_metadata_from_the_global_virtual_store() {
         let licenses: Value = serde_json::from_slice(&output.stdout).expect("parse licenses JSON");
         let packages = licenses["MIT"].as_array().expect("MIT license group");
         assert_eq!(packages.len(), 1);
-        assert_eq!(packages[0]["name"], "@pnpm.e2e/has-different-licenses");
+        assert_eq!(packages[0]["name"], "@pnpm.e2e/install-script-example");
         assert_eq!(packages[0]["versions"], json!(["1.0.0"]));
         assert!(
             packages[0]["paths"]

--- a/pnpm/crates/cli/tests/licenses.rs
+++ b/pnpm/crates/cli/tests/licenses.rs
@@ -1,0 +1,58 @@
+pub mod _utils;
+
+use _utils::{enable_gvs_in_workspace_yaml, pacquet_in};
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use serde_json::{Value, json};
+use std::{fs, path::Path};
+
+#[test]
+fn licenses_reads_package_metadata_from_the_global_virtual_store() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    enable_gvs_in_workspace_yaml(&workspace, "");
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "dependencies": {
+                "@pnpm.e2e/has-different-licenses": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    for subcommand in ["list", "ls"] {
+        let output = pacquet_in(&workspace)
+            .with_args(["licenses", subcommand, "--json"])
+            .output()
+            .expect("spawn pacquet licenses");
+        assert!(
+            output.status.success(),
+            "licenses {subcommand} should succeed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        let licenses: Value = serde_json::from_slice(&output.stdout).expect("parse licenses JSON");
+        let packages = licenses["MIT"].as_array().expect("MIT license group");
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0]["name"], "@pnpm.e2e/has-different-licenses");
+        assert_eq!(packages[0]["versions"], json!(["1.0.0"]));
+        assert!(
+            packages[0]["paths"]
+                .as_array()
+                .expect("package paths")
+                .iter()
+                .all(|path| Path::new(path.as_str().expect("path string")).exists()),
+            "reported package paths should exist: {}",
+            packages[0]["paths"],
+        );
+    }
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/package-manager/src/virtual_store_layout.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout.rs
@@ -285,17 +285,18 @@ impl VirtualStoreLayout {
     }
 }
 
-/// Build a lockfile's layout using the same runtime precedence as installation.
+/// Build a lockfile's layout using the runtime pin, effective Node version, then host.
 #[must_use]
 pub fn virtual_store_layout_for_lockfile(
     config: &Config,
+    effective_node_version: Option<&str>,
     snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
     packages: Option<&HashMap<PackageKey, PackageMetadata>>,
     allow_build_policy: Option<&AllowBuildPolicy>,
 ) -> VirtualStoreLayout {
     let engine = if config.enable_global_virtual_store {
         find_runtime_node_major(snapshots)
-            .or_else(|| config.node_version.as_deref().and_then(parse_major_from_version))
+            .or_else(|| effective_node_version.and_then(parse_major_from_version))
             .or_else(detect_node_major)
             .map(|major| engine_name(major, None, None))
     } else {

--- a/pnpm/crates/package-manager/src/virtual_store_layout.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout.rs
@@ -20,11 +20,16 @@
 //! [`PkgNameVerPeer::to_virtual_store_name`]: pacquet_lockfile::PkgNameVerPeer::to_virtual_store_name
 //! [`pacquet_graph_hasher::format_global_virtual_store_path`]: pacquet_graph_hasher::format_global_virtual_store_path
 
-use crate::{AllowBuildPolicy, install_frozen_lockfile::find_own_runtime_node_major};
+use crate::{
+    AllowBuildPolicy,
+    install_frozen_lockfile::{
+        find_own_runtime_node_major, find_runtime_node_major, parse_major_from_version,
+    },
+};
 use pacquet_config::Config;
 use pacquet_deps_path::get_pkg_id_with_patch_hash;
 use pacquet_graph_hasher::{
-    DepsGraphNode, DepsStateCache, calc_graph_node_hash, engine_name,
+    DepsGraphNode, DepsStateCache, calc_graph_node_hash, detect_node_major, engine_name,
     format_global_virtual_store_path, join_global_virtual_store_path,
 };
 use pacquet_lockfile::{
@@ -278,6 +283,25 @@ impl VirtualStoreLayout {
         // pushes it as a single component).
         join_global_virtual_store_path(&self.package_store_dir, &suffix)
     }
+}
+
+/// Build a lockfile's layout using the same runtime precedence as installation.
+#[must_use]
+pub fn virtual_store_layout_for_lockfile(
+    config: &Config,
+    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
+    packages: Option<&HashMap<PackageKey, PackageMetadata>>,
+    allow_build_policy: Option<&AllowBuildPolicy>,
+) -> VirtualStoreLayout {
+    let engine = if config.enable_global_virtual_store {
+        find_runtime_node_major(snapshots)
+            .or_else(|| config.node_version.as_deref().and_then(parse_major_from_version))
+            .or_else(detect_node_major)
+            .map(|major| engine_name(major, None, None))
+    } else {
+        None
+    };
+    VirtualStoreLayout::new(config, engine.as_deref(), snapshots, packages, allow_build_policy)
 }
 
 /// Map each injected `file:` project to the virtual-store package


### PR DESCRIPTION
## Summary

- accept the documented `pnpm licenses list` and `pnpm licenses ls` subcommands in pacquet, matching the TypeScript CLI
- resolve installed package manifests through pacquet.s canonical virtual-store layout, preserving lockfile and project-selected Node runtime precedence for hashed global virtual-store slots
- validate package-name components and computed slots before reading manifests, and cover both command spellings with a manifest-selected-runtime global-store integration test

Fixes pnpm/pnpm#13332.
Fixes pnpm/pnpm#13333.

## Squash Commit Body

```text
Pacquet parsed license options directly after `pnpm licenses`, so the documented `list` and `ls` subcommands were rejected. Accept those subcommands and report the same missing/unknown-subcommand error codes as the TypeScript CLI.

License discovery also reconstructed the legacy flat virtual-store path. Route it through the shared virtual-store layout instead, preserving lockfile pins and the effective project-selected Node runtime before falling back to the host, and validate package-name components plus slot containment before reading package manifests. This allows license metadata and reported paths to resolve correctly from hashed global virtual-store slots.

Fixes pnpm/pnpm#13332.
Fixes pnpm/pnpm#13333.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787576297&installation_model_id=426870&pr_number=13347&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13347&signature=28118daf9d85773417fc860f7331a8a4f0e7e00b327da38e893d4c27d6448711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `licenses list` and `licenses ls` parsing and license metadata discovery when using the global virtual store.
  * Improved reported package paths and license group JSON accuracy in global virtual store mode.
  * Added clearer, structured errors when the `licenses` command has no or an unsupported subcommand.
  * Strengthened detection of unsafe path components in dependency package info.

* **Tests**
  * Added/updated tests for JSON license output, package grouping, version checks, and filesystem path validity.
  * Added tests for missing-subcommand error messaging and improved empty-lockfile coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->