### PR TITLE
fix(package-manager): install git-hosted tarballs that pin no integrity

### DIFF
--- a/.changeset/install-tarballs-without-integrity.md
+++ b/.changeset/install-tarballs-without-integrity.md
@@ -1,0 +1,9 @@
+---
+"pacquet": patch
+---
+
+A lockfile entry for a git-hosted archive that records no `integrity` installs again instead of failing with `ERR_PNPM_MISSING_TARBALL_INTEGRITY`. Older pnpm versions wrote that shape for dependencies like `"ci-info": "watson/ci-info#f43f6a1c…"`, so any committed lockfile still carrying one could not be installed [#13308](https://github.com/pnpm/pnpm/issues/13308). The archive URL pins a full commit SHA, and pnpm fetches it without an integrity check.
+
+Every other remote tarball still has to carry an `integrity`, and the refusal now points at the repair: `pnpm clean --lockfile` followed by `pnpm install`.
+
+Error output no longer repeats the same message once per level of the internal error chain.

--- a/pnpm/crates/cli/src/cli_args/cat_index.rs
+++ b/pnpm/crates/cli/src/cli_args/cat_index.rs
@@ -162,7 +162,7 @@ fn request_matches_dependency(
 
 fn metadata_store_index_keys(pkg_id: &str, metadata: &PackageMetadata) -> Vec<String> {
     match &metadata.resolution {
-        LockfileResolution::Tarball(resolution) if resolution.git_hosted == Some(true) => {
+        LockfileResolution::Tarball(resolution) if resolution.is_git_hosted() => {
             git_store_index_keys(pkg_id)
         }
         LockfileResolution::Tarball(resolution) => resolution

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -16,12 +16,13 @@ use cli_args::CliArgs;
 use config_overrides::ConfigOverrides;
 use flag_relocation::relocate_pre_subcommand_flags;
 use miette::set_panic_hook;
-use pacquet_diagnostics::enable_tracing_by_env;
+use pacquet_diagnostics::{enable_tracing_by_env, install_report_handler};
 use state::State;
 use std::{ffi::OsString, future::Future, path::Path};
 
 pub fn main() -> miette::Result<()> {
     enable_tracing_by_env();
+    install_report_handler();
     set_panic_hook();
     // The synchronous startup in `run_cli` — building the negation-augmented
     // clap command (a recursive walk over every subcommand), relocating

--- a/pnpm/crates/cli/tests/tarball_url_dependency.rs
+++ b/pnpm/crates/cli/tests/tarball_url_dependency.rs
@@ -223,3 +223,71 @@ fn remote_tarball_reresolves_from_warm_store_without_refetch() {
 
     drop((root, mock_instance));
 }
+
+/// A `packages:` entry whose tarball resolution records no
+/// `integrity` is refused for a plain remote tarball: the bytes come
+/// off the network and nothing in the lockfile pins them. pnpm fails
+/// the same entry closed
+/// ([#13308](https://github.com/pnpm/pnpm/issues/13308)), and the
+/// message names the way out.
+///
+/// Git-host archive URLs are the exemption — they are what older pnpm
+/// versions wrote without an `integrity` — and that shape is covered
+/// by `unverified_fetch_is_allowed`'s unit tests, since no local
+/// server can answer for a git host.
+#[test]
+fn frozen_install_refuses_a_remote_tarball_without_integrity() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let tarball_path = "/pkg-from-tarball-1.0.0.tgz";
+    let mut tarball_server = mockito::Server::new();
+    let head_mock = tarball_server.mock("HEAD", tarball_path).with_status(200).create();
+    let get_mock = tarball_server
+        .mock("GET", tarball_path)
+        .with_status(200)
+        .with_body(minimal_tarball("pkg-from-tarball", "1.0.0"))
+        .create();
+    let tarball_url = format!("{}{tarball_path}", tarball_server.url());
+    let package_key = format!("pkg-from-tarball@{tarball_url}");
+    let manifest_path = workspace.join("package.json");
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+
+    fs::write(
+        &manifest_path,
+        serde_json::json!({ "dependencies": { "pkg-from-tarball": &tarball_url } }).to_string(),
+    )
+    .expect("write package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    let integrity = package_integrity(&lockfile, &package_key).unwrap_or_else(|| {
+        panic!("the fresh install must record an integrity for the tarball dep:\n{lockfile}")
+    });
+    let stripped = lockfile.replace(&format!("integrity: {integrity}, "), "");
+    assert!(
+        package_integrity(&stripped, &package_key).is_none(),
+        "the fixture must end up without an integrity:\n{stripped}",
+    );
+    fs::write(&lockfile_path, &stripped).expect("write pnpm-lock.yaml");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    let output = pacquet_at(&workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    // miette wraps the rendered message to the terminal width, so the
+    // sentences are matched against a single-spaced rendering.
+    let unwrapped = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        unwrapped.contains("ERR_PNPM_MISSING_TARBALL_INTEGRITY")
+            && unwrapped.contains("Run a fresh install to repair the lockfile"),
+        "the refusal must name the error code and the way out; got:\n{stderr}",
+    );
+
+    drop((root, mock_instance, head_mock, get_mock, tarball_server));
+}

--- a/pnpm/crates/diagnostics/src/collapsed_chain.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain.rs
@@ -1,0 +1,181 @@
+//! Report handler that renders each distinct cause once.
+//!
+//! pacquet's error enums wrap one another with
+//! `#[diagnostic(transparent)]` variants so `?` composes across crate
+//! boundaries. Such a variant displays as its inner error *and* keeps
+//! it as its `source`, so a leaf error four wrappers deep renders the
+//! same sentence at five levels of miette's `├─▶` cause chain. The
+//! handler here folds those levels away before delegating to miette's
+//! own renderer, which keeps every theme, width, and colour decision
+//! miette would otherwise make.
+
+use miette::{
+    Diagnostic, LabeledSpan, MietteHandler, MietteHandlerOpts, ReportHandler, Severity, SourceCode,
+};
+use std::{error::Error, fmt};
+
+/// Route [`miette::Report`] rendering through the collapsing handler.
+///
+/// A [`miette::Report`] captures the installed hook when it is built,
+/// so this has to run before the first one is created. A hook that is
+/// already installed is left alone — the first caller wins, and the
+/// only caller is the CLI entry point.
+pub fn install_report_handler() {
+    let _ = miette::set_hook(Box::new(|_| {
+        Box::new(CollapsingHandler { inner: MietteHandlerOpts::new().build() })
+    }));
+}
+
+struct CollapsingHandler {
+    inner: MietteHandler,
+}
+
+impl ReportHandler for CollapsingHandler {
+    fn debug(
+        &self,
+        diagnostic: &dyn Diagnostic,
+        formatter: &mut fmt::Formatter<'_>,
+    ) -> fmt::Result {
+        self.inner.debug(&Collapsed::new(diagnostic), formatter)
+    }
+}
+
+/// The reported error, with consecutive repeats of the same message
+/// dropped from its cause chain.
+///
+/// Every [`Diagnostic`] method delegates to the reported error itself,
+/// so its code, help, labels, and source snippet render unchanged.
+/// Only the chain below it is ours.
+struct Collapsed<'a> {
+    head: &'a dyn Diagnostic,
+    causes: Option<Box<Cause>>,
+}
+
+/// One surviving level below the head, holding its rendered message.
+///
+/// Owned rather than borrowed because [`Error::source`] hands the
+/// renderer a `&(dyn Error + 'static)`, which a chain borrowed from
+/// the report could not satisfy. A level's message is all miette
+/// prints for it — the causes below the head render as text, not as
+/// nested reports.
+#[derive(Debug)]
+struct Cause {
+    message: String,
+    next: Option<Box<Cause>>,
+}
+
+impl<'a> Collapsed<'a> {
+    fn new(head: &'a dyn Diagnostic) -> Self {
+        let mut messages = Vec::new();
+        let mut last = head.to_string();
+        let mut level = nested(Level::Diagnostic(head));
+        while let Some(current) = level {
+            let message = current.to_string();
+            if message != last {
+                messages.push(message.clone());
+                last = message;
+            }
+            level = nested(current);
+        }
+
+        let mut causes = None;
+        for message in messages.into_iter().rev() {
+            causes = Some(Box::new(Cause { message, next: causes }));
+        }
+        Collapsed { head, causes }
+    }
+}
+
+/// One level of the reported error's cause chain. miette walks a mix
+/// of [`Diagnostic`]s and plain [`Error`]s; both shapes descend
+/// differently, so both are tracked.
+#[derive(Clone, Copy)]
+enum Level<'a> {
+    Diagnostic(&'a dyn Diagnostic),
+    Error(&'a (dyn Error + 'static)),
+}
+
+/// The next level down, picked the way miette itself descends: a
+/// diagnostic source when the level offers one, its plain error source
+/// otherwise.
+fn nested(level: Level<'_>) -> Option<Level<'_>> {
+    match level {
+        Level::Diagnostic(diagnostic) => diagnostic
+            .diagnostic_source()
+            .map(Level::Diagnostic)
+            .or_else(|| diagnostic.source().map(Level::Error)),
+        Level::Error(error) => error.source().map(Level::Error),
+    }
+}
+
+impl fmt::Display for Level<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Level::Diagnostic(diagnostic) => fmt::Display::fmt(diagnostic, formatter),
+            Level::Error(error) => fmt::Display::fmt(error, formatter),
+        }
+    }
+}
+
+impl fmt::Display for Collapsed<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.head, formatter)
+    }
+}
+
+impl fmt::Debug for Collapsed<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.head, formatter)
+    }
+}
+
+impl Error for Collapsed<'_> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.causes.as_deref().map(|cause| cause as &(dyn Error + 'static))
+    }
+}
+
+impl Diagnostic for Collapsed<'_> {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        self.head.code()
+    }
+
+    fn severity(&self) -> Option<Severity> {
+        self.head.severity()
+    }
+
+    fn help(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        self.head.help()
+    }
+
+    fn url(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        self.head.url()
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        self.head.source_code()
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        self.head.labels()
+    }
+
+    fn related(&self) -> Option<Box<dyn Iterator<Item = &dyn Diagnostic> + '_>> {
+        self.head.related()
+    }
+}
+
+impl fmt::Display for Cause {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for Cause {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.next.as_deref().map(|cause| cause as &(dyn Error + 'static))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
@@ -1,5 +1,5 @@
-use super::Collapsed;
-use miette::Diagnostic;
+use super::{Collapsed, CollapsingHandler};
+use miette::{Diagnostic, MietteHandlerOpts, ReportHandler};
 use std::{error::Error, fmt};
 
 /// A `#[diagnostic(transparent)]` wrapper: displays as its inner error
@@ -108,4 +108,62 @@ fn the_head_keeps_its_diagnostic_code() {
     let collapsed = Collapsed::new(&wrapped);
 
     assert_eq!(collapsed.code().map(|code| code.to_string()), Some("ERR_PNPM_LEAF".to_string()));
+}
+
+/// A wrapper that offers its inner error as a *diagnostic* source.
+/// miette prefers that over the plain error source, so the fold has to
+/// descend it too.
+#[derive(Debug)]
+struct DiagnosticWrapper {
+    inner: Leaf,
+}
+
+impl fmt::Display for DiagnosticWrapper {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, formatter)
+    }
+}
+
+impl Error for DiagnosticWrapper {}
+
+impl Diagnostic for DiagnosticWrapper {
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        Some(&self.inner)
+    }
+}
+
+#[test]
+fn a_diagnostic_source_is_folded_like_an_error_source() {
+    let wrapped = DiagnosticWrapper {
+        inner: Leaf { message: "tarball server returned HTTP 404", source: None },
+    };
+
+    let collapsed = Collapsed::new(&wrapped);
+
+    assert_eq!(messages(&collapsed), vec!["tarball server returned HTTP 404".to_string()]);
+}
+
+/// Renders through the installed handler, which is the only thing the
+/// CLI ever calls. `format!("{:?}")` is how miette's `Report` reaches
+/// it.
+#[test]
+fn the_handler_renders_a_repeated_message_once() {
+    struct Rendered<'a>(&'a CollapsingHandler, &'a dyn Diagnostic);
+
+    impl fmt::Debug for Rendered<'_> {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.0.debug(self.1, formatter)
+        }
+    }
+
+    let handler = CollapsingHandler { inner: MietteHandlerOpts::new().build() };
+    let wrapped = Wrapper { inner: Wrapper { inner: Leaf { message: "boom", source: None } } };
+
+    let rendered = format!("{:?}", Rendered(&handler, &wrapped));
+
+    assert_eq!(
+        rendered.matches("boom").count(),
+        1,
+        "the message must be rendered once, got:\n{rendered}",
+    );
 }

--- a/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
@@ -1,0 +1,111 @@
+use super::Collapsed;
+use miette::Diagnostic;
+use std::{error::Error, fmt};
+
+/// A `#[diagnostic(transparent)]` wrapper: displays as its inner error
+/// and keeps it as the source.
+#[derive(Debug)]
+struct Wrapper<E> {
+    inner: E,
+}
+
+impl<E: fmt::Display> fmt::Display for Wrapper<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, formatter)
+    }
+}
+
+impl<E: Error + 'static> Error for Wrapper<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.inner)
+    }
+}
+
+impl<E: Diagnostic + 'static> Diagnostic for Wrapper<E> {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        self.inner.code()
+    }
+}
+
+#[derive(Debug)]
+struct Leaf {
+    message: &'static str,
+    source: Option<Box<Leaf>>,
+}
+
+impl fmt::Display for Leaf {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.message)
+    }
+}
+
+impl Error for Leaf {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_deref().map(|source| source as &(dyn Error + 'static))
+    }
+}
+
+impl Diagnostic for Leaf {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        Some(Box::new("ERR_PNPM_LEAF"))
+    }
+}
+
+/// Every line the renderer would print: the head, then one per
+/// surviving cause.
+fn messages(collapsed: &Collapsed<'_>) -> Vec<String> {
+    let mut messages = vec![collapsed.to_string()];
+    let mut source = collapsed.source();
+    while let Some(cause) = source {
+        messages.push(cause.to_string());
+        source = cause.source();
+    }
+    messages
+}
+
+#[test]
+fn transparent_wrappers_render_the_message_once() {
+    let leaf = Leaf { message: "tarball server returned HTTP 404", source: None };
+    let wrapped = Wrapper { inner: Wrapper { inner: Wrapper { inner: leaf } } };
+
+    let collapsed = Collapsed::new(&wrapped);
+
+    assert_eq!(messages(&collapsed), vec!["tarball server returned HTTP 404".to_string()]);
+}
+
+/// Only *consecutive* repeats fold: a wrapper that adds its own
+/// context, and a cause that genuinely repeats an earlier message
+/// further down the chain, both stay in the rendering.
+#[test]
+fn distinct_causes_survive() {
+    let leaf = Leaf {
+        message: "installing dependencies",
+        source: Some(Box::new(Leaf {
+            message: "tarball server returned HTTP 404",
+            source: Some(Box::new(Leaf { message: "installing dependencies", source: None })),
+        })),
+    };
+    let wrapped = Wrapper { inner: leaf };
+
+    let collapsed = Collapsed::new(&wrapped);
+
+    assert_eq!(
+        messages(&collapsed),
+        vec![
+            "installing dependencies".to_string(),
+            "tarball server returned HTTP 404".to_string(),
+            "installing dependencies".to_string(),
+        ],
+    );
+}
+
+/// The kept levels keep answering for themselves — the collapsed head
+/// still carries the code miette prints above the report.
+#[test]
+fn the_head_keeps_its_diagnostic_code() {
+    let wrapped = Wrapper { inner: Leaf { message: "boom", source: None } };
+
+    let collapsed = Collapsed::new(&wrapped);
+
+    assert_eq!(collapsed.code().map(|code| code.to_string()), Some("ERR_PNPM_LEAF".to_string()),);
+}

--- a/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
@@ -5,23 +5,23 @@ use std::{error::Error, fmt};
 /// A `#[diagnostic(transparent)]` wrapper: displays as its inner error
 /// and keeps it as the source.
 #[derive(Debug)]
-struct Wrapper<E> {
-    inner: E,
+struct Wrapper<Inner> {
+    inner: Inner,
 }
 
-impl<E: fmt::Display> fmt::Display for Wrapper<E> {
+impl<Inner: fmt::Display> fmt::Display for Wrapper<Inner> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.inner, formatter)
     }
 }
 
-impl<E: Error + 'static> Error for Wrapper<E> {
+impl<Inner: Error + 'static> Error for Wrapper<Inner> {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         Some(&self.inner)
     }
 }
 
-impl<E: Diagnostic + 'static> Diagnostic for Wrapper<E> {
+impl<Inner: Diagnostic + 'static> Diagnostic for Wrapper<Inner> {
     fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
         self.inner.code()
     }
@@ -107,5 +107,5 @@ fn the_head_keeps_its_diagnostic_code() {
 
     let collapsed = Collapsed::new(&wrapped);
 
-    assert_eq!(collapsed.code().map(|code| code.to_string()), Some("ERR_PNPM_LEAF".to_string()),);
+    assert_eq!(collapsed.code().map(|code| code.to_string()), Some("ERR_PNPM_LEAF".to_string()));
 }

--- a/pnpm/crates/diagnostics/src/lib.rs
+++ b/pnpm/crates/diagnostics/src/lib.rs
@@ -1,6 +1,8 @@
+mod collapsed_chain;
 mod local_tracing;
 
 pub use miette;
 pub use tracing;
 
+pub use collapsed_chain::install_report_handler;
 pub use local_tracing::enable_tracing_by_env;

--- a/pnpm/crates/env-installer/src/install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/install_config_deps.rs
@@ -182,7 +182,7 @@ async fn materialize<Reporter: self::Reporter>(
         store_index_writer: None,
         verify_store_integrity: opts.verify_store_integrity,
         verified_files_cache: SharedVerifiedFilesCache::default(),
-        package_integrity: integrity,
+        package_integrity: Some(integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: tarball,

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -30,6 +30,20 @@ pub struct TarballResolution {
     pub path: Option<String>,
 }
 
+impl TarballResolution {
+    /// Whether the tarball is a git-provider archive, and so needs the
+    /// prepare + packlist pass and the git-hosted store-index key.
+    ///
+    /// The recorded flag is a hint: pnpm's `classifyResolution` decides
+    /// from the URL alone, so an archive URL from a known git host
+    /// counts even when the lockfile omits the field (entries written
+    /// before it existed) or contradicts it.
+    #[must_use]
+    pub fn is_git_hosted(&self) -> bool {
+        self.git_hosted == Some(true) || is_git_hosted_tarball_url(&self.tarball)
+    }
+}
+
 /// For standard package specification, with package name and version range.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
@@ -330,8 +344,7 @@ impl LockfileResolution {
         let LockfileResolution::Tarball(tarball) = self else { return self.clone() };
         let Some(integrity) = tarball.integrity.as_ref() else { return self.clone() };
 
-        let git_hosted =
-            tarball.git_hosted == Some(true) || is_git_hosted_tarball_url(&tarball.tarball);
+        let git_hosted = tarball.is_git_hosted();
         // A standard registry tarball whose URL can be rebuilt from name+version+
         // registry is written as just `{integrity}` — pnpm derives the URL on
         // demand. Every other tarball must keep its URL or it can no longer be

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -198,6 +198,26 @@ fn is_git_hosted_tarball_url_rejects_false_positives() {
         "https://gitlab.com/api/v4/projects/foo%2Fbar/repository/archive.tar.gz",
     ));
     assert!(!is_git_hosted_tarball_url("https://bitbucket.org/foo/bar/get/main.tar.gz"));
+
+    // Host lookalikes. The authority is compared whole, so neither a
+    // `user@` prefix (where the real host is what follows the `@`) nor a
+    // subdomain of a git provider passes for the provider itself — the
+    // exemption from integrity checking rides on this.
+    assert!(!is_git_hosted_tarball_url(&format!(
+        "https://codeload.github.com@evil.example/foo/bar/tar.gz/{GIT_COMMIT}"
+    )));
+    assert!(!is_git_hosted_tarball_url(&format!(
+        "https://sub.codeload.github.com/foo/bar/tar.gz/{GIT_COMMIT}"
+    )));
+    assert!(!is_git_hosted_tarball_url(&format!(
+        "https://codeload.github.com.evil.example/foo/bar/tar.gz/{GIT_COMMIT}"
+    )));
+    assert!(!is_git_hosted_tarball_url(&format!(
+        "https://gitlab.com@evil.example/api/v4/projects/foo%2Fbar/repository/archive.tar.gz?ref={GIT_COMMIT}"
+    )));
+    assert!(!is_git_hosted_tarball_url(&format!(
+        "https://bitbucket.org@evil.example/foo/bar/get/{GIT_COMMIT}.tar.gz"
+    )));
 }
 
 #[test]

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -86,6 +86,34 @@ fn deserialize_tarball_resolution_with_git_hosted() {
     assert_eq!(received, expected);
 }
 
+/// The flag is a hint: the fetch dispatch and the store-index key
+/// follow the URL, so a git-host archive URL counts as git-hosted even
+/// when the lockfile says otherwise. A lockfile claiming `false` on
+/// one would otherwise skip the prepare + packlist pass and install the
+/// raw archive.
+#[test]
+fn is_git_hosted_follows_the_url_over_a_contradicting_flag() {
+    let git_hosted_url = format!("https://codeload.github.com/foo/bar/tar.gz/{GIT_COMMIT}");
+
+    for flag in [None, Some(false), Some(true)] {
+        let resolution = TarballResolution {
+            tarball: git_hosted_url.clone(),
+            integrity: None,
+            git_hosted: flag,
+            path: None,
+        };
+        assert!(resolution.is_git_hosted(), "a git-host archive URL is git-hosted, {flag:?}");
+    }
+
+    let plain = TarballResolution {
+        tarball: "https://example.com/pkg-1.0.0.tgz".to_string(),
+        integrity: None,
+        git_hosted: None,
+        path: None,
+    };
+    assert!(!plain.is_git_hosted());
+}
+
 #[test]
 fn deserialize_tarball_resolution_backfills_git_hosted() {
     eprintln!("CASE: codeload.github.com");

--- a/pnpm/crates/package-manager/src/create_virtual_store.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store.rs
@@ -1,6 +1,7 @@
 use crate::{
     CasPathsByPkgId, InstallPackageBySnapshot, InstallPackageBySnapshotError, SkippedSnapshots,
-    install_package_by_snapshot::runtime_platform_selector, store_init::init_store_dir_best_effort,
+    install_package_by_snapshot::{runtime_platform_selector, unverified_fetch_is_allowed},
+    store_init::init_store_dir_best_effort,
 };
 use derive_more::{Display, Error};
 use futures_util::future;
@@ -1242,6 +1243,16 @@ fn snapshot_cache_key(
     let pkg_id = metadata_key.to_string();
     match &metadata.resolution {
         LockfileResolution::Tarball(t) => {
+            // A tarball with no integrity that isn't one of the shapes
+            // exempt from verification never reaches the store: the
+            // fetch path refuses it. Give it no warm key at all, so a
+            // row already sitting at the shared `pkg_id\tbuilt` key
+            // (written for a git-hosted package of the same id) can't
+            // skip that refusal — pnpm likewise asserts fetchability
+            // before it consults the store.
+            if t.integrity.is_none() && !unverified_fetch_is_allowed(&t.tarball) {
+                return Ok(None);
+            }
             // Git-hosted tarballs land in the CAS via
             // `pacquet_git_fetcher::GitHostedTarballFetcher`, which
             // writes the row under `gitHostedStoreIndexKey(pkg_id,

--- a/pnpm/crates/package-manager/src/create_virtual_store.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store.rs
@@ -22,7 +22,7 @@ use pacquet_reporter::{
 };
 use pacquet_store_dir::{
     SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, git_hosted_store_index_key,
-    store_index_key,
+    pick_store_index_key, store_index_key,
 };
 use pacquet_tarball::{MemCache, PrefetchResult, SharedReportedProgressKeys, prefetch_cas_paths};
 use pipe_trait::Pipe;
@@ -1216,11 +1216,10 @@ fn link_slots_parallel<Reporter: self::Reporter>(
 
 /// Build the store-index cache key for a snapshot.
 ///
-/// Returns `Err` for any condition the install would fail on anyway
-/// (missing metadata, missing tarball integrity) so the orchestrator
-/// can short-circuit *before* the warm rayon batch runs; otherwise a
-/// malformed lockfile does up to ~6 s of warm-batch linking before the
-/// actual error fires.
+/// Returns `Err` for missing metadata — a condition the install would
+/// fail on anyway — so the orchestrator can short-circuit *before* the
+/// warm rayon batch runs; otherwise a malformed lockfile does up to
+/// ~6 s of warm-batch linking before the actual error fires.
 ///
 /// Shared by the upfront prefetch-keys loop and the warm/cold
 /// partition in [`CreateVirtualStore::run`], so a future change to
@@ -1242,30 +1241,23 @@ fn snapshot_cache_key(
     })?;
     let pkg_id = metadata_key.to_string();
     match &metadata.resolution {
-        LockfileResolution::Tarball(t) if t.git_hosted == Some(true) => {
-            // Git-hosted tarballs land in the CAS via
-            // `pacquet_git_fetcher::GitHostedTarballFetcher` and the
-            // row is written under `gitHostedStoreIndexKey(pkg_id,
-            // built)` rather than the integrity-based key. Use the
-            // same key shape here so the warm prefetch finds the
-            // row on a re-install. `built` tracks `!ignore_scripts`
-            // in lock-step with the dispatcher's write key, so the
-            // prefetch and write address the same slot.
-            Ok(Some(git_hosted_store_index_key(&pkg_id, !ignore_scripts)))
-        }
         LockfileResolution::Tarball(t) => {
-            let integrity = t
-                .integrity
-                .as_ref()
-                .ok_or_else(|| {
-                    CreateVirtualStoreError::InstallPackageBySnapshot(
-                        InstallPackageBySnapshotError::MissingTarballIntegrity {
-                            package_key: snapshot_key.to_string(),
-                        },
-                    )
-                })?
-                .to_string();
-            Ok(Some(store_index_key(&integrity, &pkg_id)))
+            // Git-hosted tarballs land in the CAS via
+            // `pacquet_git_fetcher::GitHostedTarballFetcher`, which
+            // writes the row under `gitHostedStoreIndexKey(pkg_id,
+            // built)` rather than the integrity-based key — and so
+            // does a tarball with no integrity to key a row by.
+            // `pick_store_index_key` picks the same shape pnpm picks,
+            // so the warm prefetch finds the row on a re-install.
+            // `built` tracks `!ignore_scripts` in lock-step with the
+            // dispatcher's write key, so the prefetch and the write
+            // address the same slot.
+            Ok(Some(pick_store_index_key(
+                t.integrity.as_ref().map(ToString::to_string).as_deref(),
+                t.git_hosted == Some(true),
+                &pkg_id,
+                !ignore_scripts,
+            )))
         }
         LockfileResolution::Registry(r) => {
             Ok(Some(store_index_key(&r.integrity.to_string(), &pkg_id)))

--- a/pnpm/crates/package-manager/src/create_virtual_store.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store.rs
@@ -1254,7 +1254,7 @@ fn snapshot_cache_key(
             // address the same slot.
             Ok(Some(pick_store_index_key(
                 t.integrity.as_ref().map(ToString::to_string).as_deref(),
-                t.git_hosted == Some(true),
+                t.is_git_hosted(),
                 &pkg_id,
                 !ignore_scripts,
             )))

--- a/pnpm/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store/tests.rs
@@ -1,7 +1,6 @@
 use super::{
-    CreateVirtualStore, CreateVirtualStoreError, InstallPackageBySnapshotError,
-    emit_warm_snapshot_progress, integrity_equal, removed_child_aliases, snapshot_cache_key,
-    snapshot_deps_equal,
+    CreateVirtualStore, emit_warm_snapshot_progress, integrity_equal, removed_child_aliases,
+    snapshot_cache_key, snapshot_deps_equal,
 };
 use crate::install_package_by_snapshot::host_platform_selector;
 use pacquet_lockfile::{
@@ -453,25 +452,20 @@ fn snapshot_cache_key_for_git_hosted_tarball_uses_git_hosted_key() {
     );
 }
 
-/// Failing closed at the cache-key site (rather than only at the
-/// install-side guard) is the whole point of the check duplication —
-/// otherwise a malformed lockfile burns the warm rayon batch before
-/// the install path fires the same error.
+/// Lockfile entries written before pnpm pinned a hash for git-host
+/// archives carry no `integrity`, and pnpm's `pickStoreIndexKey`
+/// addresses those by the git-hosted key shape rather than failing.
 #[test]
-fn snapshot_cache_key_rejects_tarball_without_integrity() {
+fn snapshot_cache_key_for_tarball_without_integrity_uses_git_hosted_key() {
     let pkg = key("foo", "1.0.0");
     let packages = HashMap::from([(pkg.clone(), tarball_metadata_without_integrity())]);
 
-    let err = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
-        .expect_err("missing integrity must reject upfront");
-    assert!(
-        matches!(
-            &err,
-            CreateVirtualStoreError::InstallPackageBySnapshot(
-                InstallPackageBySnapshotError::MissingTarballIntegrity { package_key },
-            ) if package_key == &pkg.to_string(),
-        ),
-        "expected MissingTarballIntegrity for `{pkg}`, got {err:?}",
+    let received = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
+        .expect("snapshot_cache_key must not error");
+    assert_eq!(
+        received,
+        Some(format!("{pkg}\tbuilt")),
+        "an integrity-less tarball must route through gitHostedStoreIndexKey",
     );
 }
 

--- a/pnpm/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store/tests.rs
@@ -399,7 +399,8 @@ fn git_metadata() -> PackageMetadata {
 fn git_hosted_tarball_metadata() -> PackageMetadata {
     PackageMetadata {
         resolution: LockfileResolution::Tarball(TarballResolution {
-            tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
+            tarball: "https://codeload.github.com/foo/bar/tar.gz/f43f6a1cefff47fb361c88cf4b943fdbcaafe540"
+                .to_string(),
             integrity: None,
             git_hosted: Some(true),
             path: None,
@@ -452,21 +453,19 @@ fn snapshot_cache_key_for_git_hosted_tarball_uses_git_hosted_key() {
     );
 }
 
-/// Lockfile entries written before pnpm pinned a hash for git-host
-/// archives carry no `integrity`, and pnpm's `pickStoreIndexKey`
-/// addresses those by the git-hosted key shape rather than failing.
+/// A plain remote tarball with no `integrity` is refused when the
+/// fetch path reaches it, so it gets no warm key: the git-hosted key
+/// shape `pickStoreIndexKey` would hand it is shared with every
+/// package of the same id, and a row sitting there would materialize
+/// the snapshot without the refusal ever running.
 #[test]
-fn snapshot_cache_key_for_tarball_without_integrity_uses_git_hosted_key() {
+fn snapshot_cache_key_for_a_refused_tarball_is_absent() {
     let pkg = key("foo", "1.0.0");
     let packages = HashMap::from([(pkg.clone(), tarball_metadata_without_integrity())]);
 
     let received = snapshot_cache_key(&pkg, &packages, false, &host_platform_selector())
         .expect("snapshot_cache_key must not error");
-    assert_eq!(
-        received,
-        Some(format!("{pkg}\tbuilt")),
-        "an integrity-less tarball must route through gitHostedStoreIndexKey",
-    );
+    assert_eq!(received, None, "a tarball the fetch path refuses must not warm-hit");
 }
 
 fn tarball_metadata_without_integrity() -> PackageMetadata {

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -13,7 +13,8 @@ use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use pacquet_hooks::custom_fetcher_adapter::CustomFetcherPicker;
 use pacquet_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, LockfileResolution,
-    PackageKey, PackageMetadata, PlatformSelector, SnapshotEntry, select_platform_variant,
+    PackageKey, PackageMetadata, PlatformSelector, SnapshotEntry, is_git_hosted_tarball_url,
+    select_platform_variant,
 };
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::{LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter};
@@ -144,10 +145,21 @@ pub enum InstallPackageBySnapshotError {
     #[diagnostic(transparent)]
     CreateVirtualDir(#[error(source)] CreateVirtualDirError),
 
+    /// A plain remote tarball the lockfile pins no `integrity` for.
+    /// Message and code mirror the TypeScript
+    /// `assertFetchableResolution` in
+    /// `pnpm11/installing/package-requester/src/packageRequester.ts`.
+    /// See [`unverified_fetch_is_allowed`] for the shapes that are
+    /// exempt.
     #[display(
-        "Package `{package_key}` has a tarball resolution without an `integrity` field; pnpm cannot verify the download and refuses to install it."
+        "Cannot fetch package \"{package_key}\" from the lockfile: it has no \"integrity\" field, so the downloaded tarball cannot be verified. Run a fresh install to repair the lockfile."
     )]
-    #[diagnostic(code(ERR_PNPM_MISSING_TARBALL_INTEGRITY))]
+    #[diagnostic(
+        code(ERR_PNPM_MISSING_TARBALL_INTEGRITY),
+        help(
+            "Re-resolving the entry is what records the missing hash: run `pnpm clean --lockfile` and then `pnpm install`."
+        )
+    )]
     MissingTarballIntegrity { package_key: String },
 
     #[display(
@@ -673,6 +685,14 @@ fn local_file_tarball_install_url<'a>(
 /// client — both sides must derive byte-identical URLs so the client's
 /// prefetch mem-cache keys line up.
 ///
+/// The integrity is `None` only for the shapes
+/// [`unverified_fetch_is_allowed`] exempts — every other tarball
+/// resolution that records none is refused here rather than fetched
+/// unchecked. See
+/// [`pacquet_tarball::DownloadTarballToStore::package_integrity`] for
+/// what an unverified fetch does; a registry resolution always carries
+/// an integrity.
+///
 /// # Panics
 ///
 /// On directory / git / binary / variations resolutions — callers gate
@@ -681,15 +701,17 @@ pub fn tarball_url_and_integrity<'a>(
     resolution: &'a LockfileResolution,
     package_key: &PackageKey,
     config: &'a Config,
-) -> Result<(Cow<'a, str>, &'a ssri::Integrity), InstallPackageBySnapshotError> {
+) -> Result<(Cow<'a, str>, Option<&'a ssri::Integrity>), InstallPackageBySnapshotError> {
     match resolution {
         LockfileResolution::Tarball(tarball_resolution) => {
-            let integrity = tarball_resolution.integrity.as_ref().ok_or_else(|| {
-                InstallPackageBySnapshotError::MissingTarballIntegrity {
+            let tarball_url = tarball_resolution.tarball.as_str();
+            let integrity = tarball_resolution.integrity.as_ref();
+            if integrity.is_none() && !unverified_fetch_is_allowed(tarball_url) {
+                return Err(InstallPackageBySnapshotError::MissingTarballIntegrity {
                     package_key: package_key.to_string(),
-                }
-            })?;
-            Ok((tarball_resolution.tarball.as_str().pipe(Cow::Borrowed), integrity))
+                });
+            }
+            Ok((tarball_url.pipe(Cow::Borrowed), integrity))
         }
         LockfileResolution::Registry(registry_resolution) => {
             let registries: HashMap<String, String> =
@@ -700,13 +722,11 @@ pub fn tarball_url_and_integrity<'a>(
             let version = package_key.suffix.version();
             let bare_name = package_key.name.bare.as_str();
             let tarball_url = format!("{registry}/{name}/-/{bare_name}-{version}.tgz");
-            Ok((Cow::Owned(tarball_url), &registry_resolution.integrity))
+            Ok((Cow::Owned(tarball_url), Some(&registry_resolution.integrity)))
         }
         // Caller (`run`) only invokes this helper for the tarball /
         // registry arms; git, directory, binary, variations, and
-        // custom resolutions never reach here. Return an
-        // unreachable-style error so a future caller that forgets to
-        // gate gets a clear panic in debug.
+        // custom resolutions never reach here.
         LockfileResolution::Directory(_)
         | LockfileResolution::Git(_)
         | LockfileResolution::Binary(_)
@@ -715,6 +735,24 @@ pub fn tarball_url_and_integrity<'a>(
             unreachable!("tarball_url_and_integrity called with non-tarball resolution");
         }
     }
+}
+
+/// Whether a tarball resolution that records no `integrity` may still
+/// be fetched.
+///
+/// pnpm exempts the two shapes it never recorded a hash for, keyed off
+/// the URL the way `classifyResolution` does — a lockfile's own
+/// `gitHosted` marker is only a hint:
+///
+/// - a git-host archive URL, which pins a full commit SHA (older pnpm
+///   versions wrote these without an `integrity`), and
+/// - a `file:` tarball, which is local to the project.
+///
+/// Every other remote tarball must carry one, so bytes fetched over
+/// the network for a package the lockfile claims to pin stay
+/// verifiable.
+fn unverified_fetch_is_allowed(tarball_url: &str) -> bool {
+    tarball_url.starts_with("file:") || is_git_hosted_tarball_url(tarball_url)
 }
 
 /// Build the host's [`PlatformSelector`] for runtime-variant
@@ -881,7 +919,7 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
             store_index_writer: store_index_writer.cloned(),
             verify_store_integrity: config.verify_store_integrity,
             verified_files_cache: Arc::clone(verified_files_cache),
-            package_integrity: &binary.integrity,
+            package_integrity: Some(&binary.integrity),
             package_unpacked_size: None,
             package_file_count: None,
             package_url: &binary.url,

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -437,7 +437,7 @@ impl InstallPackageBySnapshot<'_> {
                 // endpoint doesn't run `prepare`/`prepublish*` and
                 // the file set typically needs packlist filtering.
                 if let LockfileResolution::Tarball(t) = resolution
-                    && t.git_hosted == Some(true)
+                    && t.is_git_hosted()
                 {
                     // `built` tracks `!ignore_scripts`, in lock-step
                     // with the key shape `snapshot_cache_key` produces —

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -751,7 +751,7 @@ pub fn tarball_url_and_integrity<'a>(
 /// Every other remote tarball must carry one, so bytes fetched over
 /// the network for a package the lockfile claims to pin stay
 /// verifiable.
-fn unverified_fetch_is_allowed(tarball_url: &str) -> bool {
+pub(crate) fn unverified_fetch_is_allowed(tarball_url: &str) -> bool {
     tarball_url.starts_with("file:") || is_git_hosted_tarball_url(tarball_url)
 }
 

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -149,7 +149,7 @@ pub enum InstallPackageBySnapshotError {
     /// Message and code mirror the TypeScript
     /// `assertFetchableResolution` in
     /// `pnpm11/installing/package-requester/src/packageRequester.ts`.
-    /// See [`unverified_fetch_is_allowed`] for the shapes that are
+    /// See `unverified_fetch_is_allowed` for the shapes that are
     /// exempt.
     #[display(
         "Cannot fetch package \"{package_key}\" from the lockfile: it has no \"integrity\" field, so the downloaded tarball cannot be verified. Run a fresh install to repair the lockfile."
@@ -686,7 +686,7 @@ fn local_file_tarball_install_url<'a>(
 /// prefetch mem-cache keys line up.
 ///
 /// The integrity is `None` only for the shapes
-/// [`unverified_fetch_is_allowed`] exempts — every other tarball
+/// `unverified_fetch_is_allowed` exempts — every other tarball
 /// resolution that records none is refused here rather than fetched
 /// unchecked. See
 /// [`pacquet_tarball::DownloadTarballToStore::package_integrity`] for

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot/tests.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot/tests.rs
@@ -2,7 +2,7 @@ use super::{
     InstallPackageBySnapshotError, archive_filter_for, emit_progress_resolved,
     fetch_directory_resolution, host_platform_selector, local_file_tarball_install_url,
     node_extras_filter, render_variant_targets, runtime_platform_selector,
-    synthesize_runtime_manifest_bytes, tarball_url_and_integrity,
+    synthesize_runtime_manifest_bytes, tarball_url_and_integrity, unverified_fetch_is_allowed,
 };
 use pacquet_config::Config;
 use pacquet_directory_fetcher::DirectoryFetcherError;
@@ -10,6 +10,7 @@ use pacquet_graph_hasher::{host_arch, host_libc, host_platform};
 use pacquet_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, LockfileResolution,
     PackageKey, PlatformAssetResolution, PlatformAssetTarget, RegistryResolution,
+    TarballResolution,
 };
 use pacquet_package_is_installable::SupportedArchitectures;
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
@@ -56,10 +57,75 @@ fn registry_resolution_uses_scoped_registry_tarball_base() {
     let resolution = LockfileResolution::Registry(RegistryResolution { integrity });
     let package_key: PackageKey = "@private/foo@1.0.0".parse().expect("parse package key");
 
-    let (tarball_url, _) =
-        tarball_url_and_integrity(&resolution, &package_key, &config).expect("registry tarball");
+    let (tarball_url, _) = tarball_url_and_integrity(&resolution, &package_key, &config)
+        .expect("a registry resolution is always fetchable");
 
     assert_eq!(tarball_url.as_ref(), "https://private.example/npm/@private/foo/-/foo-1.0.0.tgz");
+}
+
+/// The exemption follows the URL, not the lockfile's `gitHosted`
+/// marker — the same call pnpm's `classifyResolution` makes.
+#[test]
+fn only_git_hosted_and_local_tarballs_may_be_fetched_unverified() {
+    assert!(unverified_fetch_is_allowed(
+        "https://codeload.github.com/watson/ci-info/tar.gz/f43f6a1cefff47fb361c88cf4b943fdbcaafe540",
+    ));
+    assert!(unverified_fetch_is_allowed("file:../vendor/pkg.tgz"));
+    assert!(!unverified_fetch_is_allowed("https://example.com/pkg-1.0.0.tgz"));
+    // A git host, but not one of its immutable archive URLs.
+    assert!(!unverified_fetch_is_allowed("https://codeload.github.com/watson/ci-info/tar.gz/main"));
+}
+
+/// A lockfile written before pnpm pinned a hash for git-host archives
+/// records the tarball without an `integrity`. pnpm downloads those
+/// unverified rather than refusing them, so the URL still resolves and
+/// only the integrity comes back empty.
+#[test]
+fn tarball_resolution_without_integrity_resolves_to_an_unverified_download() {
+    let config = Config::new();
+    let tarball = "https://codeload.github.com/watson/ci-info/tar.gz/f43f6a1cefff47fb361c88cf4b943fdbcaafe540";
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: tarball.to_string(),
+        integrity: None,
+        git_hosted: Some(true),
+        path: None,
+    });
+    let package_key: PackageKey = format!("ci-info@{tarball}").parse().expect("parse package key");
+
+    let (tarball_url, integrity) = tarball_url_and_integrity(&resolution, &package_key, &config)
+        .expect("a git-host archive is fetchable without an integrity");
+
+    assert_eq!(tarball_url.as_ref(), tarball);
+    assert!(integrity.is_none(), "an integrity-less resolution must not invent one");
+}
+
+/// The bytes of a plain remote tarball are whatever the server hands
+/// back, so a lockfile that pins no hash for one cannot be fetched
+/// from — pnpm's `assertFetchableResolution` refuses it too.
+#[test]
+fn remote_tarball_resolution_without_integrity_is_refused() {
+    let config = Config::new();
+    let tarball = "https://example.com/pkg-from-tarball-1.0.0.tgz";
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: tarball.to_string(),
+        integrity: None,
+        git_hosted: None,
+        path: None,
+    });
+    let package_key: PackageKey =
+        format!("pkg-from-tarball@{tarball}").parse().expect("parse package key");
+
+    let err = tarball_url_and_integrity(&resolution, &package_key, &config)
+        .expect_err("a remote tarball without an integrity is not fetchable");
+
+    assert!(
+        matches!(
+            &err,
+            InstallPackageBySnapshotError::MissingTarballIntegrity { package_key: reported }
+                if reported == &package_key.to_string(),
+        ),
+        "expected MissingTarballIntegrity for `{package_key}`, got {err:?}",
+    );
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/install_package_from_registry.rs
+++ b/pnpm/crates/package-manager/src/install_package_from_registry.rs
@@ -177,7 +177,7 @@ impl InstallPackageFromRegistry<'_> {
                 store_index_writer: store_index_writer.cloned(),
                 verify_store_integrity: config.verify_store_integrity,
                 verified_files_cache: SharedVerifiedFilesCache::clone(verified_files_cache),
-                package_integrity: &integrity,
+                package_integrity: Some(&integrity),
                 package_unpacked_size: unpacked_size,
                 package_file_count: file_count,
                 package_url: tarball_url,

--- a/pnpm/crates/package-manager/src/patch.rs
+++ b/pnpm/crates/package-manager/src/patch.rs
@@ -8,7 +8,7 @@ use node_semver::{Range, Version};
 use pacquet_config::{Config, PackageImportMethod, ScriptsPrependNodePath};
 use pacquet_executor::ScriptsPrependNodePath as ExecScriptsPrependNodePath;
 use pacquet_git_fetcher::{GitFetchOutput, GitFetcherError, GitHostedTarballFetcher};
-use pacquet_lockfile::{Lockfile, LockfileResolution, PackageKey, is_git_hosted_tarball_url};
+use pacquet_lockfile::{Lockfile, LockfileResolution, PackageKey};
 use pacquet_network::ThrottledClient;
 use pacquet_reporter::Reporter;
 use pacquet_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -355,10 +355,8 @@ async fn shutdown_store_index_writer_for_patch(
 
 fn git_tarball_url(resolution: &LockfileResolution) -> Option<String> {
     let LockfileResolution::Tarball(tarball) = resolution else { return None };
-    (tarball.git_hosted == Some(true)
-        || is_git_hosted_tarball_url(&tarball.tarball)
-        || tarball.tarball.starts_with("https://pkg.pr.new/"))
-    .then(|| tarball.tarball.clone())
+    (tarball.is_git_hosted() || tarball.tarball.starts_with("https://pkg.pr.new/"))
+        .then(|| tarball.tarball.clone())
 }
 
 fn executor_scripts_prepend_node_path(

--- a/pnpm/crates/package-manager/src/prefetching_resolver.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver.rs
@@ -324,7 +324,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
                 store_index_writer,
                 verify_store_integrity,
                 verified_files_cache,
-                package_integrity: &integrity,
+                package_integrity: Some(&integrity),
                 package_unpacked_size,
                 package_file_count,
                 package_url: &package_url,

--- a/pnpm/crates/package-manager/src/tarball_prefetch.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch.rs
@@ -119,7 +119,7 @@ pub(crate) fn spawn_tarball_download(download: TarballDownload) {
             store_index_writer,
             verify_store_integrity,
             verified_files_cache,
-            package_integrity: &integrity,
+            package_integrity: Some(&integrity),
             package_unpacked_size,
             package_file_count,
             package_url: &package_url,
@@ -300,9 +300,10 @@ impl TarballPrefetcher {
             }
             let (tarball_url, integrity) =
                 tarball_url_and_integrity(&metadata.resolution, package_key, config)
-                    .expect("registry resolutions always carry an integrity");
+                    .expect("registry resolutions are always fetchable");
             let package_id = package_key.without_peer().to_string();
-            let integrity = integrity.to_string();
+            let integrity =
+                integrity.expect("registry resolutions always carry an integrity").to_string();
             pending.push(PendingPrefetch {
                 store_key: store_index_key(&integrity, &package_id),
                 package_id,

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -1450,7 +1450,24 @@ pub struct DownloadTarballToStore<'a> {
     /// `Arc<DashSet<PathBuf>>` at install bootstrap and pass the same
     /// handle to every [`DownloadTarballToStore`].
     pub verified_files_cache: SharedVerifiedFilesCache,
-    pub package_integrity: &'a Integrity,
+    /// Expected hash of the tarball bytes. `None` for a lockfile entry
+    /// that records no `integrity` — the shape pnpm wrote for
+    /// git-host archives before it started pinning their hash. pnpm
+    /// downloads those without verifying (`getExpectedIntegrity`
+    /// returns `undefined` and the fetch proceeds), so pacquet does
+    /// too.
+    ///
+    /// An unverified fetch also neither reads nor writes an `index.db`
+    /// row, because the key pnpm addresses such a package by
+    /// (`pickStoreIndexKey`'s `pkg_id\tbuilt` fallback) is the one
+    /// `GitHostedTarballFetcher` writes the *prepared* file set to
+    /// after it runs `prepare` + packlist over this download. Claiming
+    /// that key here would leave the raw archive in the row whenever
+    /// the prepare pass failed. The git-hosted post-pass writes it
+    /// instead, so re-installs of the shape this arises from stay
+    /// warm; a plain remote tarball with no integrity re-downloads
+    /// each install.
+    pub package_integrity: Option<&'a Integrity>,
     pub package_unpacked_size: Option<usize>,
     /// `dist.fileCount` when the registry published one. Combined with
     /// `package_unpacked_size` into the download's queueing priority —
@@ -1461,7 +1478,7 @@ pub struct DownloadTarballToStore<'a> {
     pub package_url: &'a str,
     /// Stable identifier for the package, e.g. `"{name}@{version}"`. Paired
     /// with `package_integrity` to form the `SQLite` index key per pnpm v11's
-    /// `storeIndexKey`.
+    /// `storeIndexKey`, when there is an integrity to pair it with.
     pub package_id: &'a str,
     /// URL-keyed `Authorization` header lookup, built from the parsed
     /// `.npmrc` creds. Resolved per request so a tarball served from a
@@ -2130,9 +2147,8 @@ impl<'a> DownloadTarballToStore<'a> {
             requester,
             ..
         } = &self;
-        let cache_key = store_index_key(&package_integrity.to_string(), package_id);
-        let progress_key =
-            self.progress_reported.as_ref().map(|reported| (reported, cache_key.as_str()));
+        let cache_key = store_index_cache_key(package_integrity, package_id);
+        let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
 
         // Warm-cache fast path: when [`prefetch_cas_paths`] already
         // batched the `(integrity, pkg_id)` row in at install start,
@@ -2152,7 +2168,8 @@ impl<'a> DownloadTarballToStore<'a> {
         // normal path does with the result of
         // [`Self::run_without_mem_cache`].
         if let Some(prefetched) = prefetched_cas_paths
-            && let Some(cas_paths) = prefetched.get(&cache_key)
+            && let Some(cache_key) = cache_key.as_deref()
+            && let Some(cas_paths) = prefetched.get(cache_key)
         {
             tracing::info!(
                 target: "pacquet::download",
@@ -2331,9 +2348,8 @@ impl<'a> DownloadTarballToStore<'a> {
         // The lookup is best-effort. A missing `index.db`, a missing row,
         // an undecodable entry, or any CAFS file that has gone missing
         // from disk all fall through to the download path below.
-        let cache_key = store_index_key(&package_integrity.to_string(), package_id);
-        let progress_key =
-            self.progress_reported.as_ref().map(|reported| (reported, cache_key.as_str()));
+        let cache_key = store_index_cache_key(package_integrity, package_id);
+        let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
         // Hot path on warm installs: the install-scoped `prefetch_cas_paths`
         // task already ran one batched SELECT + integrity-check pass for
         // every (integrity, pkg_id) the lockfile mentions. If our key is
@@ -2354,7 +2370,8 @@ impl<'a> DownloadTarballToStore<'a> {
         // require a wider refactor of `DownloadTarballToStore`'s
         // return type.
         if let Some(prefetched) = prefetched_cas_paths
-            && let Some(cas_paths) = prefetched.get(&cache_key)
+            && let Some(cache_key) = cache_key.as_deref()
+            && let Some(cas_paths) = prefetched.get(cache_key)
         {
             tracing::info!(
                 target: "pacquet::download",
@@ -2365,14 +2382,15 @@ impl<'a> DownloadTarballToStore<'a> {
             emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
             return Ok((**cas_paths).clone());
         }
-        if let Some(cas_paths) = load_cached_cas_paths(
-            store_index,
-            store_dir,
-            cache_key.clone(),
-            verify_store_integrity,
-            verified_files_cache,
-        )
-        .await
+        if let Some(cache_key) = cache_key.clone()
+            && let Some(cas_paths) = load_cached_cas_paths(
+                store_index,
+                store_dir,
+                cache_key,
+                verify_store_integrity,
+                verified_files_cache,
+            )
+            .await
         {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping download");
             emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
@@ -2413,7 +2431,7 @@ impl<'a> DownloadTarballToStore<'a> {
             fetch_and_extract_with_retry::<Reporter>(
                 http_client,
                 package_url,
-                Some(package_integrity),
+                package_integrity,
                 package_unpacked_size,
                 download_priority(package_unpacked_size, package_file_count),
                 package_id,
@@ -2441,19 +2459,34 @@ impl<'a> DownloadTarballToStore<'a> {
         // writer failed to open or the caller handed us none — the row
         // is dropped with a `warn!` and the next install misses on this
         // cache key, matching the read path's stance.
-        let index_key = cache_key;
-        if let Some(writer) = store_index_writer {
-            writer.queue(index_key, pkg_files_idx);
-        } else {
-            tracing::warn!(
+        match (cache_key, store_index_writer) {
+            (Some(index_key), Some(writer)) => writer.queue(index_key, pkg_files_idx),
+            (Some(index_key), None) => tracing::warn!(
                 target: "pacquet::download",
                 ?index_key,
                 "no shared store-index writer; skipping index row for this tarball",
-            );
+            ),
+            (None, _) => tracing::debug!(
+                target: "pacquet::download",
+                ?package_url,
+                ?package_id,
+                "resolution carries no integrity; skipping index row for this tarball",
+            ),
         }
 
         Ok(cas_paths)
     }
+}
+
+/// Store-index key a tarball fetch reads and writes its
+/// [`PackageFilesIndex`] row at, or `None` when the resolution carries
+/// no integrity to address the row by. See
+/// [`DownloadTarballToStore::package_integrity`].
+fn store_index_cache_key(
+    package_integrity: Option<&Integrity>,
+    package_id: &str,
+) -> Option<String> {
+    package_integrity.map(|integrity| store_index_key(&integrity.to_string(), package_id))
 }
 
 /// Outcome of [`FetchTarballForResolution::run`]: the sha512 integrity

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -207,7 +207,7 @@ async fn packages_under_orgs_should_work() {
         store_index: None,
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &integrity("sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
+        package_integrity: Some(&integrity("sha512-dj7vjIn1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==")),
         package_unpacked_size: Some(16697),
         package_file_count: None,
         package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -272,7 +272,7 @@ async fn network_fetch_records_progress_key() {
         store_index: None,
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: Some(16697),
         package_file_count: None,
         package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -309,7 +309,7 @@ async fn should_throw_error_on_checksum_mismatch() {
         store_index: None,
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &integrity("sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w=="),
+        package_integrity: Some(&integrity("sha512-aaaan1Ar8sVXj2yAXiMNCJDmS9MQ9XMlIecX2dIzzhjSHCyKo4DdXjXMs7wKW2kj6yvVRSpuQjOZ3YLrh56w==")),
         package_unpacked_size: Some(16697),
         package_file_count: None,
         package_url: "https://registry.npmjs.org/@fastify/error/-/error-3.3.0.tgz",
@@ -389,7 +389,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         store_index: StoreIndex::shared_readonly_in(store_path),
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         // Any request that reaches the network here would fail the
@@ -461,7 +461,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
         store_index: None,
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -743,7 +743,7 @@ async fn falls_through_when_cafs_file_missing() {
         store_index: StoreIndex::shared_readonly_in(store_path),
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -805,7 +805,7 @@ async fn falls_through_when_digest_is_malformed() {
         store_index: StoreIndex::shared_readonly_in(store_path),
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -872,7 +872,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         store_index: StoreIndex::shared_readonly_in(store_path),
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -949,7 +949,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         store_index: StoreIndex::shared_readonly_in(store_path),
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: "http://127.0.0.1:1/unreachable.tgz",
@@ -1331,7 +1331,7 @@ async fn run_without_mem_cache_reads_local_file_tarball() {
         store_index: None,
         store_index_writer: None,
         verify_store_integrity: true,
-        package_integrity: &package_integrity,
+        package_integrity: Some(&package_integrity),
         package_unpacked_size: Some(16697),
         package_file_count: None,
         package_url: &package_url,
@@ -1351,6 +1351,57 @@ async fn run_without_mem_cache_reads_local_file_tarball() {
     .expect("local tarballs should be read from disk without network access");
 
     assert!(cas_paths.contains_key("package.json"));
+
+    drop((store_dir, local_dir));
+}
+
+/// A resolution that pins no integrity is downloaded unverified, and
+/// the fetch claims no store-index row: the key pnpm addresses such a
+/// package by (`pickStoreIndexKey`'s `pkg_id\tbuilt` fallback) belongs
+/// to the git-hosted prepare pass, which writes the *prepared* file set
+/// there.
+#[tokio::test]
+async fn run_without_mem_cache_fetches_unverified_and_writes_no_index_row() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("pkg.tgz");
+    std::fs::write(&tarball_path, FASTIFY_ERROR_TARBALL).unwrap();
+
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+    let package_url = format!("file:{}", tarball_path.display());
+    let client = fast_fail_client();
+    let (writer, writer_task) = StoreIndexWriter::spawn(store_path);
+    let cas_paths = DownloadTarballToStore {
+        http_client: &client,
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: Some(Arc::clone(&writer)),
+        verify_store_integrity: true,
+        package_integrity: None,
+        package_unpacked_size: None,
+        package_file_count: None,
+        package_url: &package_url,
+        package_id: "@fastify/error@3.3.0",
+        requester: "",
+        prefetched_cas_paths: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: true,
+        progress_reported: None,
+        append_manifest: None,
+    }
+    .run_without_mem_cache::<SilentReporter>()
+    .await
+    .expect("a resolution without an integrity should still be fetched");
+
+    assert!(cas_paths.contains_key("package.json"));
+
+    drop(writer);
+    writer_task.await.expect("writer task").expect("writer flushed");
+    let index = StoreIndex::open_in(store_path).expect("open store index");
+    let keys: Vec<String> = index.keys().expect("read index keys");
+    assert!(keys.is_empty(), "an unverified fetch must claim no index row: {keys:?}");
 
     drop((store_dir, local_dir));
 }
@@ -1872,7 +1923,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
                     store_index: None,
                     store_index_writer: None,
                     verify_store_integrity: true,
-                    package_integrity: pkg_integrity,
+                    package_integrity: Some(pkg_integrity),
                     package_unpacked_size: None,
                     package_file_count: None,
                     package_url: url,
@@ -2168,7 +2219,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         store_index_writer: None,
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &url,
@@ -2198,7 +2249,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         store_index_writer: None,
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &url,
@@ -2295,7 +2346,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
         store_index_writer: None,
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &url,
@@ -2334,7 +2385,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
         store_index_writer: None,
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &url,
@@ -2417,7 +2468,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
         store_index_writer: None,
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::default(),
-        package_integrity: pkg_integrity,
+        package_integrity: Some(pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: url,
@@ -2705,7 +2756,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         store_index_writer: Some(Arc::clone(&writer)),
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &url,
@@ -2746,7 +2797,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         store_index_writer: None,
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &url,
@@ -3134,7 +3185,7 @@ async fn offline_mode_skips_network_on_cache_miss() {
         store_index_writer: None,
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::default(),
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &url,
@@ -3207,7 +3258,7 @@ async fn offline_mode_still_uses_prefetched_cache() {
         store_index_writer: None,
         verify_store_integrity: true,
         verified_files_cache: SharedVerifiedFilesCache::default(),
-        package_integrity: &pkg_integrity,
+        package_integrity: Some(&pkg_integrity),
         package_unpacked_size: None,
         package_file_count: None,
         package_url: &url,

--- a/pnpm/tasks/micro-benchmark/src/main.rs
+++ b/pnpm/tasks/micro-benchmark/src/main.rs
@@ -44,7 +44,7 @@ fn bench_tarball(criterion: &mut Criterion, server: &mut ServerGuard, fixtures_f
                 store_index_writer: None,
                 verify_store_integrity: true,
                 verified_files_cache: pacquet_store_dir::SharedVerifiedFilesCache::default(),
-                package_integrity: &package_integrity,
+                package_integrity: Some(&package_integrity),
                 package_unpacked_size: Some(16697),
                 package_file_count: None,
                 package_url: url,

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -815,7 +815,10 @@ impl TarballRouter {
             ) {
                 continue;
             }
-            let Ok((tarball_url, integrity)) =
+            // A resolution that pins no integrity keeps its original URL:
+            // routing it through the endpoint would hand the client a
+            // mirrored tarball it has no hash to check.
+            let Ok((tarball_url, Some(integrity))) =
                 tarball_url_and_integrity(&metadata.resolution, package_key, config)
             else {
                 continue;
@@ -1010,7 +1013,9 @@ fn frozen_package_frames(
         ) {
             continue;
         }
-        let Ok((tarball_url, integrity)) =
+        // The frame carries the integrity the client prefetches against;
+        // an entry that pins none has no frame to announce.
+        let Ok((tarball_url, Some(integrity))) =
             tarball_url_and_integrity(&snapshot.resolution, package_key, config)
         else {
             continue;


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

pnpm 12 refused **every** tarball resolution that records no `integrity`, including the commit-pinned git-host archives older pnpm versions wrote without one. A committed lockfile carrying such an entry — for example `"ci-info": "watson/ci-info#f43f6a1c…"` in [vercel/next.js](https://github.com/vercel/next.js) — could not be installed at all, while pnpm 11 installs it. Fixes pnpm/pnpm#13308.

The refusal now follows the same classification pnpm makes:

| resolution shape | no `integrity` |
| --- | --- |
| git-host archive URL (full commit SHA) — `classifyResolution` → `gitHostedTarball` | fetched unverified |
| `file:` tarball — `localTarball` | fetched unverified |
| any other remote tarball | refused, `ERR_PNPM_MISSING_TARBALL_INTEGRITY` |

The classification keys off the URL (`is_git_hosted_tarball_url`), not the lockfile's `gitHosted` marker, matching `classifyResolution`'s "lockfile-provided flags are treated as hints".

**Security note.** This widens what pacquet will download without a hash, but only to the two shapes pnpm itself exempts, and only to the extent pnpm 11 already does: a git-host archive URL is pinned to a full commit SHA, so the bytes are as immutable as the host makes them, and a `file:` tarball is local. A plain `https://…/pkg.tgz` in a lockfile still has to carry an `integrity` — verified against pnpm 11, which fails the same fixture closed on both frozen and non-frozen installs.

**Two hardenings from review.** The prepare + packlist dispatch and the store-index key used to read the `gitHosted` field alone, so a lockfile recording `gitHosted: false` on a git-host archive URL could take the URL-based exemption and still skip the prepare pass; `TarballResolution::is_git_hosted()` now answers that from the flag *or* the URL, everywhere. And `snapshot_cache_key` no longer hands a refused shape the `pkg_id\tbuilt` warm key, which a pre-existing row could otherwise have used to materialize the snapshot before the refusal ran — pnpm asserts fetchability before consulting the store, and this gets to the same place. The exemption itself stays URL-only, so a lockfile can't buy an unverified fetch by writing `gitHosted: true`.

**Migration path.** The refusal is no longer a dead end. Its message mirrors pnpm's `assertFetchableResolution`, and a `help:` line names the repair, which was verified end to end: `pnpm clean --lockfile` then `pnpm install` re-resolves the entry and records the missing hash.

Also in this PR (the second half of the issue): every pacquet error printed its message once per level of the internal error chain, because `#[diagnostic(transparent)]` wrappers display as their inner error *and* keep it as their `source` — the reported 404 rendered six identical `├─▶` lines. A report handler in `pacquet-diagnostics` now folds consecutive repeats out of the cause chain and delegates the rendering to miette's own handler, so themes, widths, and colours are untouched.

**Verified manually** with the issue's reproduction (network-dependent, so not a test): the git-hosted `ci-info` entry with `integrity` and `gitHosted` stripped now installs cold, re-installs warm from the `pkg_id\tbuilt` store-index row the git-hosted prepare pass writes, and leaves the lockfile untouched.

**Parity gaps found while cross-checking both stacks, filed as follow-ups rather than fixed here:**

- pnpm/pnpm#13364 — pnpm reports the plain-remote-tarball refusal from its lockfile *verifier* (`createNpmResolutionVerifier`'s `MISSING_TARBALL_INTEGRITY` violation, batching every offending entry before anything is fetched); pacquet implements three of the four violation codes and raises this one from the fetch path instead. Same code, same outcome, later and one entry at a time.
- pnpm/pnpm#13365 — the store-index `pkgId` differs between the stacks for URL, git-host, and git dependencies (`tarball-pkg@http://…` vs `http://…`), so a store warmed by one is cold for the other on exactly those entries. Registry dependencies agree. Measured with both binaries into fresh stores.

## Squash Commit Body

```text
pnpm refused every tarball resolution without an `integrity`, including
the commit-pinned git-host archives older pnpm versions wrote without
one, so a committed lockfile carrying such an entry could not be
installed at all.

The exemption now follows pnpm's `classifyResolution`: a git-host
archive URL or a `file:` tarball may be fetched unverified, every other
remote tarball still has to pin a hash. The check keys off the URL
rather than the lockfile's `gitHosted` marker, which pnpm treats as a
hint. `DownloadTarballToStore::package_integrity` became
`Option<&Integrity>`; an unverified fetch also claims no `index.db`
row, because the key pnpm addresses such a package by
(`pickStoreIndexKey`'s `pkg_id\tbuilt` fallback) is the one the
git-hosted prepare pass writes the prepared file set to — the raw
archive must not land there. The warm-path key derivation now goes
through `pick_store_index_key`, so it agrees with that fallback.

The prepare + packlist dispatch and the warm-cache key follow the same
classification, from the flag or the URL, so an entry cannot be exempt
from verification while skipping preparation; and a shape the fetch
refuses gets no warm key at all, so a row already at the shared
`pkg_id\tbuilt` key cannot materialize it before the refusal runs.

The refusal that remains carries pnpm's message and a `help:` line
naming the repair (`pnpm clean --lockfile`, then `pnpm install`), which
re-resolves the entry and records the hash.

Closes pnpm/pnpm#13308.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: the TypeScript CLI already behaves this way
  (`getExpectedIntegrity`, `classifyResolution`, `pickStoreIndexKey`,
  `assertFetchableResolution`). -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).
