### PR TITLE
fix: repeat --frozen-lockfile install is a no-op again when an optional dependency was skipped

### DIFF
--- a/.changeset/frozen-noop-with-skipped-optionals.md
+++ b/.changeset/frozen-noop-with-skipped-optionals.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A repeat `pnpm install --frozen-lockfile` is a no-op again when the project has a platform-incompatible optional dependency. The skipped package is kept in `node_modules/.pnpm/lock.yaml` (`.modules.yaml` is what records the skip), so the install can once more recognize an unchanged tree instead of re-running every lifecycle and dependency build script [#13312](https://github.com/pnpm/pnpm/issues/13312).

--- a/pnpm/crates/cli/tests/current_lockfile.rs
+++ b/pnpm/crates/cli/tests/current_lockfile.rs
@@ -323,6 +323,55 @@ fn a_global_virtual_store_install_still_writes_the_current_lockfile() {
     drop((root, mock_instance));
 }
 
+/// A platform-incompatible optional dependency is skipped, but it stays
+/// recorded in the current lockfile — `.modules.yaml.skipped` is what
+/// carries the skip. Dropping it would leave the current lockfile
+/// permanently different from the wanted one, so a repeat
+/// `--frozen-lockfile` install could never take the "already up to date"
+/// short-circuit and would re-run every lifecycle script
+/// (<https://github.com/pnpm/pnpm/issues/13312>).
+#[test]
+fn a_skipped_optional_dependency_still_lets_a_repeat_frozen_install_be_a_no_op() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let package_json = serde_json::json!({
+        "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" },
+        "optionalDependencies": { "@pnpm.e2e/not-compatible-with-any-os": "*" },
+        "scripts": {
+            "postinstall": "node -e \"require('fs').appendFileSync('postinstall.log', 'x')\"",
+        },
+    });
+    fs::write(workspace.join("package.json"), package_json.to_string())
+        .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let wanted_text =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let wanted: pacquet_lockfile::Lockfile =
+        serde_saphyr::from_str(&wanted_text).expect("parse pnpm-lock.yaml");
+    assert_eq!(
+        read_current_lockfile(&workspace),
+        wanted,
+        "the skipped optional dependency must leave both lockfiles identical",
+    );
+
+    let log_path = workspace.join("postinstall.log");
+    assert_eq!(fs::read_to_string(&log_path).expect("read postinstall.log"), "x");
+
+    rerun(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    assert_eq!(
+        fs::read_to_string(&log_path).expect("read postinstall.log"),
+        "x",
+        "the repeat frozen install must short-circuit instead of re-running the postinstall",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// TS: `a broken private lockfile is ignored`
 /// (`deps-installer/test/lockfile.ts:1351`).
 #[test]

--- a/pnpm/crates/cli/tests/current_lockfile.rs
+++ b/pnpm/crates/cli/tests/current_lockfile.rs
@@ -340,7 +340,7 @@ fn a_skipped_optional_dependency_still_lets_a_repeat_frozen_install_be_a_no_op()
         "dependencies": { "@pnpm.e2e/pkg-with-1-dep": "100.0.0" },
         "optionalDependencies": { "@pnpm.e2e/not-compatible-with-any-os": "*" },
         "scripts": {
-            "postinstall": "node -e \"require('fs').appendFileSync('postinstall.log', 'x')\"",
+            "postinstall": r#"node -e "require('fs').appendFileSync('postinstall.log', 'x')""#,
         },
     });
     fs::write(workspace.join("package.json"), package_json.to_string())

--- a/pnpm/crates/cli/tests/current_lockfile.rs
+++ b/pnpm/crates/cli/tests/current_lockfile.rs
@@ -323,13 +323,9 @@ fn a_global_virtual_store_install_still_writes_the_current_lockfile() {
     drop((root, mock_instance));
 }
 
-/// A platform-incompatible optional dependency is skipped, but it stays
-/// recorded in the current lockfile — `.modules.yaml.skipped` is what
-/// carries the skip. Dropping it would leave the current lockfile
-/// permanently different from the wanted one, so a repeat
-/// `--frozen-lockfile` install could never take the "already up to date"
-/// short-circuit and would re-run every lifecycle script
-/// (<https://github.com/pnpm/pnpm/issues/13312>).
+/// The short-circuit gates on the two lockfiles being equal, so a
+/// current lockfile that dropped the skipped optional would disable it
+/// forever (<https://github.com/pnpm/pnpm/issues/13312>).
 #[test]
 fn a_skipped_optional_dependency_still_lets_a_repeat_frozen_install_be_a_no_op() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/package-manager/src/current_lockfile.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile.rs
@@ -3,14 +3,14 @@
 //!
 //! Rather than re-running the engine + `supportedArchitectures` +
 //! `skipped` checks at filter time, reuse the [`SkippedSnapshots`]
-//! set produced during install. The full set filters materialized
-//! snapshots; the package metadata map only drops user exclusions
-//! such as `--no-optional` and `--no-runtime`.
+//! set produced during install — its
+//! [transient subset][`SkippedSnapshots::transient_only`], since
+//! installability skips stay in the file.
 //!
 //! The output drives the **next** install's diff. Without this
 //! filter, pacquet's current lockfile recorded every snapshot the
-//! resolver imagined, including ones that `--no-optional` or
-//! installability dropped — so a follow-up install would think
+//! resolver imagined, including ones `--no-optional` or a failed
+//! optional fetch dropped — so a follow-up install would think
 //! those slots were already on disk and skip work that should
 //! actually run.
 
@@ -191,8 +191,13 @@ pub(crate) fn merge_filtered_current_lockfile(
     skipped: &SkippedSnapshots,
     workspace_root: &Path,
 ) -> Lockfile {
-    let selected =
-        materialization_closure(wanted, workspace_root, requested_importer_ids, included, skipped);
+    let selected = materialization_closure(
+        wanted,
+        workspace_root,
+        requested_importer_ids,
+        included,
+        &skipped.transient_only(),
+    );
     let Some(previous_current) = previous_current else {
         return selected.lockfile;
     };
@@ -331,10 +336,10 @@ fn lockfile_with_graph(
 /// Importers lose dep maps whose `include` flag is false; importer
 /// `optionalDependencies` lose entries whose resolved snapshot got
 /// skipped; the snapshot map is pruned to the transitive closure
-/// reachable from the surviving importer roots. The package metadata
-/// map preserves installability-skipped entries, matching pnpm's
-/// current-lockfile shape while `.modules.yaml.skipped` records the
-/// materialization skip.
+/// reachable from the surviving importer roots. Installability-skipped
+/// entries survive in both maps, matching pnpm's current-lockfile
+/// shape while `.modules.yaml.skipped` records the materialization
+/// skip — see [`SkippedSnapshots::transient_only`].
 #[must_use]
 pub fn filter_lockfile_for_current(
     lockfile: &Lockfile,
@@ -347,7 +352,14 @@ pub fn filter_lockfile_for_current(
     // resolve those links against. The empty root keeps the walk in the
     // lockfile-relative space importer IDs already use — `importer_root_dir("", id)`
     // is `id` — so link resolution stays correct rather than merely unused.
-    materialization_closure(lockfile, Path::new(""), &all_importer_ids, included, skipped).lockfile
+    materialization_closure(
+        lockfile,
+        Path::new(""),
+        &all_importer_ids,
+        included,
+        &skipped.transient_only(),
+    )
+    .lockfile
 }
 
 /// Per-importer filter: drop dep maps whose `include` flag is

--- a/pnpm/crates/package-manager/src/current_lockfile.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile.rs
@@ -336,10 +336,10 @@ fn lockfile_with_graph(
 /// Importers lose dep maps whose `include` flag is false; importer
 /// `optionalDependencies` lose entries whose resolved snapshot got
 /// skipped; the snapshot map is pruned to the transitive closure
-/// reachable from the surviving importer roots. Installability-skipped
-/// entries survive in both maps, matching pnpm's current-lockfile
-/// shape while `.modules.yaml.skipped` records the materialization
-/// skip — see [`SkippedSnapshots::transient_only`].
+/// reachable from the surviving importer roots. Only the transient
+/// skips prune: installability-skipped entries survive in both maps,
+/// matching pnpm's current-lockfile shape while `.modules.yaml.skipped`
+/// records the materialization skip.
 #[must_use]
 pub fn filter_lockfile_for_current(
     lockfile: &Lockfile,

--- a/pnpm/crates/package-manager/src/current_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile/tests.rs
@@ -308,10 +308,8 @@ fn user_excluded_packages_filtered_to_surviving_metadata_keys() {
     );
 }
 
-/// A platform-incompatible optional dependency stays in every section
-/// of the current lockfile, so a repeat `--frozen-lockfile` install can
-/// still match it against the wanted lockfile and short-circuit
-/// (<https://github.com/pnpm/pnpm/issues/13312>).
+/// Retaining them is what keeps the current lockfile comparable to the
+/// wanted one — see [`SkippedSnapshots::transient_only`].
 #[test]
 fn installability_skipped_entries_are_preserved() {
     let mut importers = HashMap::new();
@@ -353,8 +351,8 @@ fn installability_skipped_entries_are_preserved() {
     assert_eq!(filtered, lockfile);
 }
 
-/// A fetch failure is transient and recorded nowhere, so the snapshot
-/// has to leave the current lockfile for the next install to retry it.
+/// A fetch failure is recorded nowhere else, so dropping the snapshot
+/// here is what makes the next install retry it.
 #[test]
 fn fetch_failed_snapshot_is_pruned() {
     let mut importers = HashMap::new();
@@ -1163,9 +1161,8 @@ fn merge_filtered_current_lockfile_does_not_restore_a_skipped_selected_snapshot(
     assert!(packages.contains_key(&key("child", "1.0.0")));
 }
 
-/// The filtered-install merge keeps installability-skipped snapshots
-/// for the same reason [`super::filter_lockfile_for_current`] does
-/// (<https://github.com/pnpm/pnpm/issues/13312>).
+/// The filtered-install path has to agree with
+/// [`super::filter_lockfile_for_current`] here — it writes the same file.
 #[test]
 fn merge_filtered_current_lockfile_keeps_an_installability_skipped_snapshot() {
     let selected_id = "packages/selected".to_string();

--- a/pnpm/crates/package-manager/src/current_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile/tests.rs
@@ -308,8 +308,12 @@ fn user_excluded_packages_filtered_to_surviving_metadata_keys() {
     );
 }
 
+/// A platform-incompatible optional dependency stays in every section
+/// of the current lockfile, so a repeat `--frozen-lockfile` install can
+/// still match it against the wanted lockfile and short-circuit
+/// (<https://github.com/pnpm/pnpm/issues/13312>).
 #[test]
-fn installability_skipped_metadata_is_preserved() {
+fn installability_skipped_entries_are_preserved() {
     let mut importers = HashMap::new();
     importers.insert(
         ".".to_string(),
@@ -337,20 +341,49 @@ fn installability_skipped_metadata_is_preserved() {
         ..empty_lockfile()
     };
 
+    // The recorded skip set is the reachability closure of the direct
+    // skip, matching what `.modules.yaml.skipped` holds after an
+    // install that dropped `drop@1.0.0`.
     let mut skipped = SkippedSnapshots::new();
     skipped.insert_installability(key("drop", "1.0.0"));
+    skipped.insert_installability(key("child", "1.0.0"));
+
+    let filtered = super::filter_lockfile_for_current(&lockfile, include_all(), &skipped);
+
+    assert_eq!(filtered, lockfile);
+}
+
+/// A fetch failure is transient and recorded nowhere, so the snapshot
+/// has to leave the current lockfile for the next install to retry it.
+#[test]
+fn fetch_failed_snapshot_is_pruned() {
+    let mut importers = HashMap::new();
+    importers.insert(
+        ".".to_string(),
+        ProjectSnapshot {
+            dependencies: Some(importer_map(&[("keep", "1.0.0")])),
+            optional_dependencies: Some(importer_map(&[("drop", "1.0.0")])),
+            ..Default::default()
+        },
+    );
+
+    let mut snapshots = HashMap::new();
+    snapshots.insert(key("keep", "1.0.0"), SnapshotEntry::default());
+    snapshots.insert(key("drop", "1.0.0"), SnapshotEntry::default());
+
+    let lockfile = Lockfile { importers, snapshots: Some(snapshots), ..empty_lockfile() };
+
+    let mut skipped = SkippedSnapshots::new();
+    skipped.add_fetch_failed(key("drop", "1.0.0"));
 
     let filtered = super::filter_lockfile_for_current(&lockfile, include_all(), &skipped);
 
     let snaps = filtered.snapshots.as_ref().unwrap();
     assert!(snaps.contains_key(&key("keep", "1.0.0")));
     assert!(!snaps.contains_key(&key("drop", "1.0.0")));
-    assert!(!snaps.contains_key(&key("child", "1.0.0")));
-
-    let pkgs = filtered.packages.as_ref().unwrap();
-    assert!(pkgs.contains_key(&key("keep", "1.0.0")));
-    assert!(pkgs.contains_key(&key("drop", "1.0.0")));
-    assert!(pkgs.contains_key(&key("child", "1.0.0")));
+    assert!(
+        filtered.importers.get(".").unwrap().optional_dependencies.as_ref().unwrap().is_empty()
+    );
 }
 
 #[test]
@@ -1112,7 +1145,7 @@ fn merge_filtered_current_lockfile_does_not_restore_a_skipped_selected_snapshot(
         ..empty_lockfile()
     };
     let mut skipped = SkippedSnapshots::new();
-    skipped.insert_installability(key("parent", "1.0.0"));
+    skipped.add_fetch_failed(key("parent", "1.0.0"));
 
     let merged = super::merge_filtered_current_lockfile(
         Some(&previous),
@@ -1129,6 +1162,46 @@ fn merge_filtered_current_lockfile_does_not_restore_a_skipped_selected_snapshot(
     let packages = merged.packages.as_ref().unwrap();
     assert!(packages.contains_key(&key("parent", "1.0.0")));
     assert!(packages.contains_key(&key("child", "1.0.0")));
+}
+
+/// The filtered-install merge keeps installability-skipped snapshots
+/// for the same reason [`super::filter_lockfile_for_current`] does
+/// (<https://github.com/pnpm/pnpm/issues/13312>).
+#[test]
+fn merge_filtered_current_lockfile_keeps_an_installability_skipped_snapshot() {
+    let selected_id = "packages/selected".to_string();
+    let selected_importer = ProjectSnapshot {
+        optional_dependencies: Some(importer_map(&[("parent", "1.0.0")])),
+        ..Default::default()
+    };
+    let snapshots = HashMap::from([
+        (key("parent", "1.0.0"), snapshot_with_deps(&[("child", "1.0.0")])),
+        (key("child", "1.0.0"), SnapshotEntry::default()),
+    ]);
+    let packages = HashMap::from([
+        (key("parent", "1.0.0"), package_metadata("parent")),
+        (key("child", "1.0.0"), package_metadata("child")),
+    ]);
+    let wanted = Lockfile {
+        importers: HashMap::from([(selected_id.clone(), selected_importer)]),
+        snapshots: Some(snapshots),
+        packages: Some(packages),
+        ..empty_lockfile()
+    };
+    let mut skipped = SkippedSnapshots::new();
+    skipped.insert_installability(key("parent", "1.0.0"));
+    skipped.insert_installability(key("child", "1.0.0"));
+
+    let merged = super::merge_filtered_current_lockfile(
+        None,
+        &wanted,
+        &HashSet::from([selected_id]),
+        include_all(),
+        &skipped,
+        Path::new("/workspace"),
+    );
+
+    assert_eq!(merged, wanted);
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/current_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/current_lockfile/tests.rs
@@ -381,9 +381,8 @@ fn fetch_failed_snapshot_is_pruned() {
     let snaps = filtered.snapshots.as_ref().unwrap();
     assert!(snaps.contains_key(&key("keep", "1.0.0")));
     assert!(!snaps.contains_key(&key("drop", "1.0.0")));
-    assert!(
-        filtered.importers.get(".").unwrap().optional_dependencies.as_ref().unwrap().is_empty()
-    );
+    let imp = filtered.importers.get(".").unwrap();
+    assert!(imp.optional_dependencies.as_ref().unwrap().is_empty());
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2305,7 +2305,7 @@ where
             // Filter the wanted lockfile down to the snapshots that
             // were actually materialized: dep maps the user excluded
             // (`--no-optional`, `--no-dev`) plus snapshots the
-            // install-time skip set dropped (installability, fetch
+            // install-time skip set transiently dropped (a fetch
             // failure, `--no-optional`-only entries). The next install
             // diffs against this filtered shape so dropped snapshots
             // aren't mistaken for already-done work.

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -6216,10 +6216,7 @@ async fn fresh_install_skips_platform_incompatible_optional_dependency() {
         std::fs::read_to_string(&current_lockfile_path).expect("read current lockfile");
     let current_lockfile: Lockfile =
         serde_saphyr::from_str(&current_content).expect("parse current lockfile");
-    // `.modules.yaml.skipped` carries the skip, so the current lockfile
-    // keeps the entries and stays comparable to the wanted lockfile —
-    // what lets a repeat frozen install short-circuit
-    // (<https://github.com/pnpm/pnpm/issues/13312>).
+    // `.modules.yaml.skipped`, asserted above, is what carries the skip.
     assert_eq!(current_lockfile, lockfile);
 
     drop((dir, mock_instance));

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -6216,20 +6216,11 @@ async fn fresh_install_skips_platform_incompatible_optional_dependency() {
         std::fs::read_to_string(&current_lockfile_path).expect("read current lockfile");
     let current_lockfile: Lockfile =
         serde_saphyr::from_str(&current_content).expect("parse current lockfile");
-    assert!(
-        current_lockfile
-            .packages
-            .as_ref()
-            .is_some_and(|packages| packages.contains_key(&skipped_key.without_peer())),
-        "platform-incompatible optional dependency metadata must stay in current lockfile",
-    );
-    assert!(
-        !current_lockfile
-            .snapshots
-            .as_ref()
-            .is_some_and(|snapshots| snapshots.contains_key(&skipped_key)),
-        "platform-incompatible optional dependency must not be saved in current lockfile",
-    );
+    // `.modules.yaml.skipped` carries the skip, so the current lockfile
+    // keeps the entries and stays comparable to the wanted lockfile —
+    // what lets a repeat frozen install short-circuit
+    // (<https://github.com/pnpm/pnpm/issues/13312>).
+    assert_eq!(current_lockfile, lockfile);
 
     drop((dir, mock_instance));
 }

--- a/pnpm/crates/package-manager/src/installability.rs
+++ b/pnpm/crates/package-manager/src/installability.rs
@@ -174,6 +174,27 @@ impl SkippedSnapshots {
         self.optional_excluded.contains(key)
     }
 
+    /// The same set with the `installability` subset dropped — the
+    /// skips a written current lockfile has to reflect.
+    ///
+    /// `.modules.yaml.skipped` carries the installability subset from
+    /// one install to the next, so the current lockfile can keep those
+    /// entries and still describe what is on disk. It has to keep
+    /// them: pnpm's current lockfile does, and a repeat install's
+    /// "already up to date" comparison against the wanted lockfile
+    /// would otherwise never match again once a platform-incompatible
+    /// optional dependency was skipped. Fetch failures and
+    /// `--no-optional` exclusions are recorded nowhere else, so
+    /// leaving those out is what makes the next install redo them.
+    #[must_use]
+    pub(crate) fn transient_only(&self) -> Self {
+        Self {
+            installability: HashSet::new(),
+            fetch_failed: self.fetch_failed.clone(),
+            optional_excluded: self.optional_excluded.clone(),
+        }
+    }
+
     pub(crate) fn retain_installability_for_optional_snapshots(
         &mut self,
         snapshots: &HashMap<PackageKey, SnapshotEntry>,


### PR DESCRIPTION
## Summary

`pnpm install --frozen-lockfile` stopped being a no-op in pnpm 12 for any project with a skipped optional dependency — a platform-incompatible package such as `fsevents` on Linux. Every repeat invocation ran the full frozen path and re-ran the root project's lifecycle scripts plus any allowed dependency build script. On `vercel/next.js` that meant `@ast-grep/cli`'s `postinstall`, the root `postinstall` and `prepare` on every install, and a warm `--frozen-lockfile` about 3× slower than pnpm 11.

The cause was that pacquet's current lockfile (`node_modules/.pnpm/lock.yaml`) was written with the installability-skipped snapshots stripped out, while the frozen no-op short-circuit in `Install::run` gates on `wanted_lockfile == current`. Those two are mutually exclusive: the writer removed exactly what the comparison needs to be present, so once anything was skipped the gate could never pass again.

`.modules.yaml.skipped` is what carries an installability skip across installs, so the current lockfile can keep the entry and still describe the tree — which is what the TypeScript CLI already does via `filterLockfileByImportersAndEngine`. `SkippedSnapshots::transient_only` now feeds the current-lockfile filter, so only the transient skips (a failed optional fetch, `--no-optional`) prune. Nothing else records those, and the next install has to redo that work.

With the fix, the issue's reproduction matches pnpm 11: `pnpm-lock.yaml` and `node_modules/.pnpm/lock.yaml` are identical, and runs 2 and 3 short-circuit without re-running the `postinstall`.

Closes pnpm/pnpm#13312

## Squash Commit Body

```text
A platform-incompatible optional dependency was dropped from
`node_modules/.pnpm/lock.yaml` entirely, so the file could never again
equal `pnpm-lock.yaml`. The frozen no-op short-circuit in `Install::run`
gates on exactly that equality, which left every repeat
`pnpm install --frozen-lockfile` on such a project taking the full
frozen path and re-running the root lifecycle scripts and every allowed
dependency build script.

`.modules.yaml.skipped` is what records an installability skip across
installs, so the current lockfile can keep the entry and still describe
the tree — which is what the TypeScript CLI's
`filterLockfileByImportersAndEngine` does. Only the transient skips (a
failed optional fetch, `--no-optional`) are left out now, since nothing
else records them and the next install has to redo that work.

Retaining the entries is safe for materialization: the per-snapshot
"unchanged since the previous install" gate in `CreateVirtualStore` also
probes the slot directory, so a package that becomes installable after a
`supportedArchitectures` change still takes the cold path.

Closes pnpm/pnpm#13312
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(pacquet-only: the TypeScript CLI already behaves this way — this PR
  brings pacquet in line with it. No TS change needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787577411&installation_model_id=426870&pr_number=13350&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13350&signature=06684c1b3146329c5cacc2da466f3078dc475be1bd68e51033b39bf2dfe24d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->