### PR TITLE
fix(update): treat a whitespace-only project name as no name

### DIFF
--- a/.changeset/interactive-update-blank-workspace-name.md
+++ b/.changeset/interactive-update-blank-workspace-name.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.inspection.outdated": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+The `Workspace` column of `pnpm update --interactive` now falls back to the project's path when its `name` is only whitespace, as it already did for a missing or empty one — all three render an equally blank label otherwise.

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -189,7 +189,9 @@ async fn collect_outdated_for_importer_with_cache(
         .value()
         .get("name")
         .and_then(serde_json::Value::as_str)
-        // An empty name gives just as blank a label as no name at all.
+        // A name that is missing, empty, or only whitespace all give an
+        // equally blank label.
+        .map(str::trim)
         .filter(|name| !name.is_empty())
         .map_or_else(|| importer_id.to_string(), str::to_string);
     let workspace = &workspace;

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -210,7 +210,7 @@ importers:
 /// identifies the project in the lockfile.
 #[tokio::test]
 async fn a_project_without_a_usable_name_is_labelled_with_its_importer_path() {
-    for name in [None, Some("")] {
+    for name in [None, Some(""), Some("   ")] {
         let temp = tempfile::tempdir().expect("create temporary workspace");
         let manifest = manifest_without_usable_name(temp.path(), "packages/a", name);
         let lockfile: Lockfile = serde_saphyr::from_str(

--- a/pnpm11/deps/inspection/outdated/src/outdated.ts
+++ b/pnpm11/deps/inspection/outdated/src/outdated.ts
@@ -85,9 +85,9 @@ export async function outdated (
   // label leaves several unnamed projects indistinguishable in the
   // interactive update list, so fall back to the path that identifies
   // the project in the lockfile.
-  // `||` rather than `??`: a project that declares an empty name gives
-  // just as blank a label as one that declares none.
-  const workspace = opts.manifest.name || importerId
+  // Trimmed, and `||` rather than `??`: a name that is missing, empty, or
+  // only whitespace all give an equally blank label.
+  const workspace = opts.manifest.name?.trim() || importerId
   const currentLockfile: LockfileObject = opts.currentLockfile ?? { lockfileVersion: LOCKFILE_VERSION, importers: { [importerId]: { specifiers: {} } } }
 
   const outdated: OutdatedPackage[] = []

--- a/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
+++ b/pnpm11/deps/inspection/outdated/test/outdated.spec.ts
@@ -1202,6 +1202,7 @@ test('outdated() does not list runtime that is already up to date', async () => 
 test.each([
   ['absent', undefined],
   ['empty', ''],
+  ['whitespace-only', '   '],
 ])('outdated() labels a project with an %s name by its importer path', async (_case, name) => {
   const lockfile = {
     importers: {


### PR DESCRIPTION
## Summary

A one-line follow-up to pnpm/pnpm#13337, which landed the `Workspace` column of `pnpm update --interactive` along with its fallback for projects that declare no `name` or an empty one.

That fallback exists because a blank label leaves several projects indistinguishable in the list. A name of `"   "` is truthy and non-empty, so it slipped past the guard and rendered exactly as blank as the two shapes already handled. Both stacks now trim before deciding.

Raised in review of #13337; the fix arrived just after that PR was squash-merged, hence the separate PR.

The fallback tests now cover the three shapes together — `[None, Some(""), Some("   ")]` in Rust and a `test.each` over `[undefined, '', '   ']` in TypeScript — and the whitespace case fails against the current `main`.

## Squash Commit Body

```text
The `Workspace` column falls back to the project's lockfile path when a
workspace project declares no `name` or an empty one, because either
renders a blank label. A name of `"   "` is truthy and non-empty, so it
slipped past that guard and rendered just as blank.

Both stacks now trim before deciding, and the fallback tests cover the
absent, empty, and whitespace-only shapes together.

Follow-up to pnpm/pnpm#13337, which landed the column and the first two
shapes.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787579392&installation_model_id=426870&pr_number=13354&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13354&signature=8b77389f5c2ad41e7d82030aa5074d31c8f15c95a7bbeaf3ff9d3f4025e40c28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `pnpm update --interactive` workspace labels by treating whitespace-only project names as blank.
  - Projects without a usable name now consistently display their path as the workspace label.

- **Tests**
  - Added coverage for projects whose names contain only whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->