### PR TITLE
feat(cli): warn about install settings left under package.json's pnpm field

### DIFF
--- a/.changeset/pacquet-legacy-pnpm-field-warning.md
+++ b/.changeset/pacquet-legacy-pnpm-field-warning.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The Rust engine now warns when `package.json` still declares install settings under the `pnpm` field, which pnpm 10 moved to `pnpm-workspace.yaml`. A project that hasn't migrated its `pnpm.overrides` / `pnpm.packageExtensions` / `pnpm.patchedDependencies` previously saw the settings silently ignored, and only met the downstream symptom. Keys the `pnpm` field never owned are left alone.

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -31,6 +31,7 @@ pub mod import;
 pub mod install;
 pub mod install_test;
 pub mod lane;
+pub(crate) mod legacy_pnpm_field;
 pub mod licenses;
 pub mod link;
 pub mod list;

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -58,7 +58,7 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
         let cfg = config()?;
         args.apply_cli_config(cfg);
         let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir)
+            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
         apply_allow_build(cfg, &args.allow_build, &config_root)?;
         let pipeline = AddPipeline {
@@ -101,7 +101,7 @@ pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<C
     Ok(Box::pin(async move {
         let cfg = config()?;
         let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir)
+            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
         let pipeline = UpdatePipeline {
             args,
@@ -136,7 +136,7 @@ pub(super) fn remove<'a>(ctx: &RunCtx<'a>, args: RemoveArgs) -> miette::Result<C
     Ok(Box::pin(async move {
         let cfg = config()?;
         let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir)
+            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
         let pipeline = RemovePipeline {
             args,
@@ -193,7 +193,7 @@ pub(super) fn install<'a>(
             // for a single-package repo. Owned so it doesn't hold a
             // borrow of `cfg` across the `&mut` `updateConfig` pass.
             let (config_root, package_manager_to_sync) =
-                derive_config_root_and_package_manager_to_sync(cfg, dir)
+                derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                     .wrap_err("derive workspace root and package manager policy")?;
             // Resolve + install configurational dependencies, then
             // run their `updateConfig` plugin hooks, before the main
@@ -289,7 +289,7 @@ pub(super) fn deploy<'a>(ctx: &RunCtx<'a>, args: DeployArgs) -> miette::Result<C
             let cfg = config()?;
             apply_install_cli_config(cfg, &args.install_args);
             let (config_root, package_manager_to_sync) =
-                derive_config_root_and_package_manager_to_sync(cfg, dir)
+                derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                     .wrap_err("derive workspace root and package manager policy")?;
             let pipeline = DeployPipeline { args, cfg, config_root, package_manager_to_sync };
             match reporter {
@@ -316,7 +316,7 @@ pub(super) fn dedupe<'a>(ctx: &RunCtx<'a>, args: DedupeArgs) -> miette::Result<C
     Ok(Box::pin(async move {
         let cfg = config()?;
         let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir)
+            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
         let dedupe = DedupePipeline {
             args,
@@ -344,7 +344,7 @@ pub(super) fn prune<'a>(ctx: &RunCtx<'a>, args: PruneArgs) -> miette::Result<Com
     Ok(Box::pin(async move {
         let cfg = config()?;
         let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir)
+            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
         let pipeline = PrunePipeline {
             args,
@@ -423,7 +423,7 @@ pub(super) fn unlink<'a>(ctx: &RunCtx<'a>, args: UnlinkArgs) -> miette::Result<C
         // fresh resolution so the removed `link:` overrides re-resolve from
         // the registry.
         let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir)
+            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
                 .wrap_err("derive workspace root and package manager policy")?;
         let pipeline = InstallPipeline {
             args: InstallArgs::for_reresolving_install(),

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1,7 +1,8 @@
 use crate::{
     State,
     cli_args::{
-        pipelines::InstallFamilySelection, recursive::discover_workspace_projects,
+        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields, pipelines::InstallFamilySelection,
+        recursive::discover_workspace_projects,
         supported_architectures::SupportedArchitecturesArgs,
     },
 };
@@ -343,6 +344,11 @@ impl InstallArgs {
         }) else {
             return false;
         };
+        // Emitted from the deciding branch, not next to the config load
+        // above: every `return false` before this point hands the command
+        // to the full install path, which warns from
+        // `derive_config_root_and_package_manager_to_sync`.
+        warn_ignored_pnpm_manifest_fields(&config_root, emit);
         let prefix = workspace_root.to_string_lossy().into_owned();
         emit(&pacquet_reporter::LogEvent::Pnpm(pacquet_reporter::PnpmLog {
             level: pacquet_reporter::LogLevel::Info,

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -13,7 +13,14 @@ use super::{
     update::UpdateArgs,
     update_changeset::UpdateChangesetContext,
 };
-use crate::{State, config_deps};
+use crate::{
+    State,
+    cli_args::{
+        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields,
+        reporter::{ReporterType, reporter_emit},
+    },
+    config_deps,
+};
 use miette::Context;
 use pacquet_config::Config;
 use pacquet_reporter::Reporter;
@@ -600,8 +607,13 @@ async fn run_dedicated_lockfile_workspace_install<Reporter: self::Reporter + 'st
 pub(crate) fn derive_config_root_and_package_manager_to_sync(
     cfg: &Config,
     dir_ref: &Path,
+    reporter: ReporterType,
 ) -> miette::Result<(PathBuf, Option<PackageManagerToSync>)> {
     let config_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.to_path_buf());
+    // pnpm warns from config-reading, so the notice lands ahead of any
+    // install output. This is the install family's earliest point that
+    // knows the root manifest's directory.
+    warn_ignored_pnpm_manifest_fields(&config_root, reporter_emit(reporter));
     let package_manager_to_sync =
         package_manager_to_sync(&config_root.join("package.json"), &config_root)
             .wrap_err("read package manager policy")?;

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1725,6 +1725,55 @@ fn migrated_keys_are_reported_by_the_up_to_date_fast_path() {
     drop(root);
 }
 
+/// Both emit sites resolve the root manifest the way pnpm does — the
+/// workspace root when there is one, the current directory otherwise —
+/// so a run from a workspace package names the root's keys and never
+/// the package's own.
+#[test]
+fn migrated_keys_are_read_from_the_workspace_root() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "root",
+            "version": "1.0.0",
+            "private": true,
+            "pnpm": { "overrides": { "is-number": "6.0.0" } },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let package_dir = workspace.join("packages").join("leaf");
+    fs::create_dir_all(&package_dir).expect("create the workspace package");
+    fs::write(
+        package_dir.join("package.json"),
+        serde_json::json!({
+            "name": "leaf",
+            "version": "1.0.0",
+            "pnpm": { "neverBuiltDependencies": [] },
+        })
+        .to_string(),
+    )
+    .expect("write the workspace package's package.json");
+
+    let assert = pacquet_in(&package_dir).with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+
+    eprintln!("STDOUT:\n{stdout}");
+    assert!(
+        stdout.contains(r#"The following keys were ignored: "pnpm.overrides"."#),
+        "the root manifest's keys must be named; got:\n{stdout}",
+    );
+    assert!(
+        !stdout.contains("neverBuiltDependencies"),
+        "the workspace package's own `pnpm` field is not the root manifest; got:\n{stdout}",
+    );
+
+    drop(root);
+}
+
 /// The warning names only keys pnpm migrated, so a manifest carrying a
 /// `pnpm` field that third-party tooling owns stays quiet.
 #[test]

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1675,14 +1675,52 @@ fn migrated_keys_under_the_package_json_pnpm_field_are_reported() {
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
 
     eprintln!("STDOUT:\n{stdout}");
-    assert!(
-        stdout.contains(
+    let warning = stdout
+        .find(
             "The \"pnpm\" field in package.json is no longer read by pnpm. \
              The following keys were ignored: \"pnpm.overrides\". \
-             See https://pnpm.io/settings for the new home of each setting."
-        ),
-        "expected the ignored-field warning; got:\n{stdout}",
-    );
+             See https://pnpm.io/settings for the new home of each setting.",
+        )
+        .unwrap_or_else(|| panic!("expected the ignored-field warning; got:\n{stdout}"));
+    let footer = stdout
+        .find("Done in ")
+        .unwrap_or_else(|| panic!("expected the end-of-command footer; got:\n{stdout}"));
+    assert!(warning < footer, "the warning must precede the install output; got:\n{stdout}");
+
+    drop(root);
+}
+
+/// The up-to-date fast path finishes `install` before the pipeline that
+/// carries the warning ever runs, so it has to warn on its own: pnpm
+/// warns from config-reading and therefore keeps warning on a repeat
+/// install that has nothing to do.
+#[test]
+fn migrated_keys_are_reported_by_the_up_to_date_fast_path() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "root",
+            "version": "1.0.0",
+            "private": true,
+            "pnpm": { "overrides": { "is-number": "6.0.0" } },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+    let assert = pacquet_in(&workspace).with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+
+    eprintln!("STDOUT:\n{stdout}");
+    let warning = stdout.find("no longer read by pnpm").unwrap_or_else(|| {
+        panic!("the fast path must warn too; got:\n{stdout}");
+    });
+    let up_to_date = stdout
+        .find("Already up to date")
+        .unwrap_or_else(|| panic!("expected the fast path's own output; got:\n{stdout}"));
+    assert!(warning < up_to_date, "the warning must precede the install output; got:\n{stdout}");
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1645,3 +1645,65 @@ fn frozen_lockfile_setting_drives_the_headless_install() {
 
     drop((root, mock_instance));
 }
+
+/// pnpm 10 moved the install settings out of `package.json`'s `pnpm`
+/// field into `pnpm-workspace.yaml`, and warns about every migrated key
+/// a manifest still declares so the setting isn't silently dropped.
+/// A repository that hasn't migrated its `pnpm.overrides` would
+/// otherwise see only the downstream symptom.
+///
+/// The message is asserted verbatim: it is the same string pnpm emits,
+/// and `@pnpm/cli.default-reporter` renders it.
+#[test]
+fn migrated_keys_under_the_package_json_pnpm_field_are_reported() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "root",
+            "version": "1.0.0",
+            "private": true,
+            // `app` is not a key pnpm ever owned, so it must not be named.
+            "pnpm": { "overrides": { "is-number": "6.0.0" }, "app": {} },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let assert = pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    // The default reporter renders every warning into its stdout frame.
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+
+    eprintln!("STDOUT:\n{stdout}");
+    assert!(
+        stdout.contains(
+            "The \"pnpm\" field in package.json is no longer read by pnpm. \
+             The following keys were ignored: \"pnpm.overrides\". \
+             See https://pnpm.io/settings for the new home of each setting."
+        ),
+        "expected the ignored-field warning; got:\n{stdout}",
+    );
+
+    drop(root);
+}
+
+/// The warning names only keys pnpm migrated, so a manifest carrying a
+/// `pnpm` field that third-party tooling owns stays quiet.
+#[test]
+fn an_unmigrated_package_json_pnpm_field_is_not_reported() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "version": "1.0.0", "private": true, "pnpm": { "app": {} } })
+            .to_string(),
+    )
+    .expect("write package.json");
+
+    let assert = pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+
+    eprintln!("STDOUT:\n{stdout}");
+    assert!(!stdout.contains("no longer read by pnpm"), "must stay quiet; got:\n{stdout}");
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

Closes item 1 of pnpm/pnpm#13315 — pnpm 12 gave no warning when `package.json` still declared install settings under the `pnpm` field.

pnpm 10 moved those settings into `pnpm-workspace.yaml`, and pnpm 11 warns about every migrated key a manifest still carries so the setting is not silently dropped. pacquet ignored the field without a word, so a repository that had not migrated its `pnpm.overrides` met only the downstream symptom: a resolution that quietly disregarded the override. The issue calls this "the difference that matters most in practice" of the three it lists.

Using the fixture from the issue:

```
# before
Lockfile is up to date, resolution step is skipped
Packages: +2

# after — matching pnpm 11 byte for byte
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
Lockfile is up to date, resolution step is skipped
Packages: +2
```

## The port already existed — this wires it up

`pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs` was already in the tree with the same 19-key migrated list as `config/reader/src/index.ts` (I diffed the two sets: zero difference), the same message text, and unit tests for declaration order, an unowned key (`app`), and the absent / malformed / non-object manifest cases.

It was never declared as a module, so nothing compiled it and nothing called it. In the interest of full disclosure: it reached `main` through my own pnpm/pnpm#13299, where a `git add pnpm/crates` swept in two files that had nothing to do with that PR. It should have been reviewed as this change, so it is being reviewed as this change now.

## Where the warning is emitted

In `derive_config_root_and_package_manager_to_sync`, which:

- every install-family dispatch already calls (install, add, update, ci, remove, rebuild, install-test, and the three patch commands — one site covers all ten),
- computes the same directory pnpm reads the root manifest from (`workspaceDir ?? dir`, pnpm's `rootProjectManifestDir`),
- runs before any install output, so the warning lands first as it does in pnpm.

pnpm emits this from config-reading, so it fires for every command that loads config. The install family is where it is observable and where the issue reports it; extending it further can follow if it turns out to matter.

One install can finish without reaching that site: `finished_via_up_to_date_fast_path` completes a repeat `pnpm install` from `main`, before the async machinery exists, so an up-to-date project stayed silent (found in review). pnpm keeps warning on that run — it warns from config-reading, ahead of "Already up to date" — so the fast path now warns from its deciding branch, after `install_already_up_to_date` confirms it will finish and before its own output. Warning at its config-load site instead would double-print, since every earlier `return false` hands the command to the full install path.

The warning takes the parsed manifest rather than a directory (found in review). `derive_config_root_and_package_manager_to_sync` reads the root `package.json` once, through `read_manifest_json`, and hands the value to the warning and to `package_manager_to_sync` alike — one read where there were two, and the read strips a UTF-8 BOM, which a bare `serde_json::from_slice` had been choking on where pnpm warns. The fast path reads `config_root`'s manifest through that same reader rather than reusing the `dir/package.json` it already holds: those are the same file only by an invariant that lives in another function.

## Verification

Against the issue's own fixture, pnpm 11 and pacquet now produce an identical line. Also checked that a `pnpm` field holding only an unowned key (`app`), and a manifest with no `pnpm` field at all, both stay quiet — and that `pnpm add` warns too, since it shares the emit site.

Four end-to-end tests cover the warning, the silent case, the up-to-date fast path, and a run from inside a workspace package; the position tests assert the warning's *offset* relative to the command's own output, not just its presence. The workspace test discriminates by key — `overrides` at the root, `neverBuiltDependencies` in the package — so reading the wrong manifest fails it instead of producing a lookalike warning. I confirmed each of them genuinely catches its regression by breaking the subject and watching it fail. A unit test covers the BOM, checked against pnpm 11 on the same manifest.

`just ready` (7087 tests), `just dylint`, and the CI doc command are all clean.

### One thing noticed, not changed

pnpm 11 writes this warning to **stderr**; pacquet writes it to **stdout**. Filed as pnpm/pnpm#13361 rather than fixed here, since it needs a config-warning channel that bypasses the reporter.

Narrower than it first looks, and I initially described it too broadly: reporter warnings already agree between the stacks — `pnpm install --force` prints its warning on stdout in pnpm 11 too. The difference is confined to warnings pnpm raises while *reading config*, which it prints with `console.warn` (stderr) outside the reporter entirely. pacquet has no such channel, so this one goes through `LogEvent::Global` and lands in the reporter's stdout frame.

## Squash Commit Body

```text
pnpm 10 moved the install settings out of package.json's `pnpm` field
into pnpm-workspace.yaml, and pnpm warns about every migrated key a
manifest still declares so the setting is not silently dropped. pacquet
ignored the field without a word, so a project that had not migrated its
`pnpm.overrides` met only the downstream symptom.

`legacy_pnpm_field` already carried the port — the same 19-key migrated
list as config/reader/src/index.ts, the same message, and unit tests —
but was never declared as a module, so nothing compiled or called it.

The emit sits in `derive_config_root_and_package_manager_to_sync`, which
every install-family command already calls to resolve its root and which
computes the same directory pnpm reads the root manifest from. One site
covers all ten commands, and it runs before any install output so the
warning lands first, as in pnpm. The repeat-install fast path finishes
before that site is reached, so it warns from its deciding branch too.

The emit takes the parsed manifest, so that site reads the root
`package.json` once and shares it with `package_manager_to_sync`,
through the reader that strips a UTF-8 BOM.

Closes item 1 of pnpm/pnpm#13315.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (TypeScript already emits this warning; this is the pacquet side.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787579939&installation_model_id=426870&pr_number=13359&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13359&signature=4be1d769d41ba15f1ee71b15c3714a2a69ec9794e3967a43b50a25720225901f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added warnings when legacy `pnpm` settings in `package.json` are no longer read, directing users to migrate to `pnpm-workspace.yaml`.
- **Bug Fixes**
  - Ensures the warning is emitted on lockfile-only and “already up to date” flows (before the “Already up to date” message).
  - Correctly bases the warning on the workspace root manifest when running inside a workspace package.
  - Avoids reporting unrelated keys under the `pnpm` field.
- **Tests**
  - Added regression coverage for migrated, unrelated, workspace-scope, and lockfile-only scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


