### PR TITLE
test(package-manager): cover libc metadata shapes

### DIFF
--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     DependenciesGraphToLockfileError, GraphToLockfileOptions, ImporterLockfileInput,
-    dependencies_graph_to_lockfile as try_dependencies_graph_to_lockfile,
+    dependencies_graph_to_lockfile as try_dependencies_graph_to_lockfile, read_string_or_list,
 };
 use indexmap::IndexMap;
 use pacquet_deps_path::DepPath;
@@ -235,6 +235,18 @@ fn fresh_install_records_string_libc_without_coercing_scalar_bundle_metadata() {
     let metadata = &lockfile.packages.as_ref().expect("packages")[&package_key];
     assert_eq!(metadata.libc.as_deref(), Some(["musl".to_string()].as_slice()));
     assert!(metadata.bundled_dependencies.is_none());
+}
+
+#[test]
+fn string_or_list_metadata_accepts_arrays_and_rejects_other_values() {
+    let array_manifest = json!({ "libc": ["glibc", "musl"] });
+    assert_eq!(
+        read_string_or_list(Some(&array_manifest), "libc"),
+        Some(vec!["glibc".to_string(), "musl".to_string()]),
+    );
+
+    let object_manifest = json!({ "libc": { "name": "musl" } });
+    assert_eq!(read_string_or_list(Some(&object_manifest), "libc"), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Cover the array branch of the scalar-or-array `libc` metadata parser added in pnpm/pnpm#13346.
- Verify malformed non-string, non-array `libc` metadata remains ignored.
- Raise patch coverage for the merged fix without changing production behavior.

Follow-up to pnpm/pnpm#13346 and pnpm/pnpm#13324.

## Squash Commit Body

```text
The scalar libc regression test covered the string branch added in pnpm/pnpm#13346, while Codecov identified the array and invalid-value branches as uncovered.

Exercise both remaining shapes directly so the parser keeps accepting arrays and rejecting malformed metadata without changing production behavior.

Follow-up to pnpm/pnpm#13346.
```

## Checklist

- [x] The change is test-only and does not alter TypeScript or Rust CLI behavior.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787581231&installation_model_id=426870&pr_number=13367&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13367&signature=788aca762061eb1c58e68abfda4f94db3e5c9c2931a54dcdbb51e2233269a87a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify metadata values are correctly accepted when provided as arrays.
  * Added validation that unsupported object values are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->