### PR TITLE
fix(package-manager): derive global-virtual-store slots deterministically

### DIFF
--- a/.changeset/deterministic-gvs-hashes-for-cycles.md
+++ b/.changeset/deterministic-gvs-hashes-for-cycles.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install --frozen-lockfile` no longer re-imports a varying subset of packages on every repeat install of an unchanged project [#13316](https://github.com/pnpm/pnpm/issues/13316). The global-virtual-store directory of a package that takes part in a dependency cycle was derived from an order that changed from run to run, so those packages landed on a fresh slot each time; it is now derived deterministically and matches the directory pnpm itself computes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,6 +4427,7 @@ name = "pacquet-graph-hasher"
 version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
+ "indexmap 2.14.0",
  "pacquet-detect-libc",
  "pretty_assertions",
  "serde_json",

--- a/pnpm/crates/cli/tests/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/global_virtual_store.rs
@@ -64,6 +64,18 @@ fn sole_hash_dir(pkg_version_dir: &Path) -> PathBuf {
     pkg_version_dir.join(&hashes[0])
 }
 
+/// Replace a file the importer materialized with garbage, standing in
+/// for a slot left half-written by a crashed install.
+///
+/// Unlinking before writing matters: when the store and the slot sit on
+/// one filesystem the importer hardlinks, so truncating the slot's copy
+/// in place would rewrite the store's content-addressed file too — and
+/// then no re-import could ever restore the original bytes.
+fn corrupt_pristine_file(path: &Path) {
+    fs::remove_file(path).unwrap_or_else(|err| panic!("unlink {path:?}: {err}"));
+    fs::write(path, "{}").unwrap_or_else(|err| panic!("corrupt {path:?}: {err}"));
+}
+
 /// `<hash>/node_modules/<name>` — where the package's files actually live.
 fn pkg_in_slot(hash_dir: &Path, name: &str) -> PathBuf {
     hash_dir.join("node_modules").join(name)
@@ -722,7 +734,7 @@ fn needs_build_marker_triggers_reimport_on_next_install() {
     eprintln!("Simulating a crash after import but before the build...");
     fs::write(&marker, "").expect("write the incomplete-build marker");
     fs::remove_file(&postinstall_artifact).expect("remove the build artifact");
-    fs::write(&package_manifest, "{}").expect("corrupt a pristine package file");
+    corrupt_pristine_file(&package_manifest);
 
     eprintln!("Frozen reinstall with intact project links must rebuild the marked slot...");
     pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();

--- a/pnpm/crates/cli/tests/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/global_virtual_store.rs
@@ -1182,3 +1182,44 @@ fn approve_builds_updates_gvs_symlinks_and_runs_builds_at_the_new_hash_dir() {
 
     drop((root, mock_instance));
 }
+
+/// The GVS hash of a package inside a dependency cycle depends on the
+/// order the hasher walks the lockfile, so an install that walked the
+/// parsed `HashMap`s directly re-derived a *different* slot for the
+/// cycle on some fraction of its runs — and re-imported the packages
+/// that landed there. `pnpm install --frozen-lockfile` over an
+/// unchanged project must reuse the slots the previous run
+/// materialized ([pnpm/pnpm#13316](https://github.com/pnpm/pnpm/issues/13316)).
+#[test]
+fn repeat_installs_reuse_the_slots_of_circular_dependencies() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, &serde_json::json!({ "@pnpm.e2e/circular-deps-1-of-2": "1.0.2" }));
+    set_gvs_workspace_yaml(&workspace, "");
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dirs = [
+        pkg_version_dir(&store_dir, "@pnpm.e2e/circular-deps-1-of-2", "1.0.2"),
+        pkg_version_dir(&store_dir, "@pnpm.e2e/circular-deps-2-of-2", "1.0.2"),
+    ];
+    let slots_after_first: Vec<Vec<String>> =
+        version_dirs.iter().map(|dir| hash_dirs(dir)).collect();
+
+    // Each repeat is a fresh process, and therefore a fresh set of
+    // `HashMap` iteration orders.
+    for _ in 0..3 {
+        pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    }
+
+    for (version_dir, expected) in version_dirs.iter().zip(&slots_after_first) {
+        assert_eq!(
+            &hash_dirs(version_dir),
+            expected,
+            "a repeat install moved {version_dir:?} to a new slot",
+        );
+    }
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/graph-hasher/Cargo.toml
+++ b/pnpm/crates/graph-hasher/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace  = true
 
 [dependencies]
 base64              = { workspace = true }
+indexmap            = { workspace = true }
 pacquet-detect-libc = { workspace = true }
 serde_json          = { workspace = true }
 sha2                = { workspace = true }

--- a/pnpm/crates/graph-hasher/src/dep_state.rs
+++ b/pnpm/crates/graph-hasher/src/dep_state.rs
@@ -163,8 +163,14 @@ pub fn warm_deps_state_cache<'a, Key>(
 ) where
     Key: 'a + Clone + Eq + std::hash::Hash,
 {
+    // One `parents` set for the whole warm-up: each walk leaves it empty
+    // again, and a key that is already memoized needs no walk at all.
+    let mut parents = HashSet::new();
     for key in keys {
-        calc_dep_graph_hash(graph, cache, &mut HashSet::new(), key);
+        if cache.contains_key(key) {
+            continue;
+        }
+        calc_dep_graph_hash(graph, cache, &mut parents, key);
     }
 }
 

--- a/pnpm/crates/graph-hasher/src/dep_state.rs
+++ b/pnpm/crates/graph-hasher/src/dep_state.rs
@@ -1,4 +1,5 @@
 use crate::object_hasher::hash_object;
+use indexmap::IndexMap;
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
 
@@ -18,12 +19,21 @@ use std::collections::{HashMap, HashSet};
 /// `snapshots[].dependencies` + `optionalDependencies` flattened,
 /// with each value resolved to the snapshot key it points at.
 ///
+/// The map is insertion-ordered because iteration order is part of the
+/// hash contract: a node reached while one of its own ancestors is
+/// mid-walk hashes with its children truncated, so inside a dependency
+/// cycle the digest a node settles on depends on the order its parents
+/// were visited in. Upstream's node holds a plain JS object built by
+/// spreading `dependencies` then `optionalDependencies`, so callers must
+/// insert in that same order (each section in lockfile key order) for
+/// the digests to match.
+///
 /// Owns its strings so a caller building the graph from a lockfile
 /// doesn't have to keep a separate `String` arena alive for the
 /// duration of the hash walk.
 pub struct DepsGraphNode<Key> {
     pub full_pkg_id: String,
-    pub children: HashMap<String, Key>,
+    pub children: IndexMap<String, Key>,
 }
 
 /// Memoized per-depPath state cache: the result of `hash_object` for
@@ -81,6 +91,20 @@ where
 /// contribution becomes `""` (the "node not in graph" guard returns
 /// the empty string).
 ///
+/// **Visit order is part of the digest.** A node reached while one of
+/// its own ancestors is mid-walk hashes with its children truncated,
+/// and that truncated digest is what lands in `cache` until the
+/// outermost visit overwrites it — so inside a dependency cycle the
+/// digest a node ends up with depends on which node the walk entered
+/// the cycle from. Upstream is deterministic because JS objects
+/// iterate in insertion order; pacquet reproduces that by keeping
+/// [`DepsGraphNode::children`] insertion-ordered and by having callers
+/// drive the per-snapshot walks in lockfile key order (see
+/// [`crate::warm_deps_state_cache`]). Feeding this walk a
+/// `HashMap`-ordered graph instead would give the same lockfile a
+/// different global-virtual-store slot on every run, and each install
+/// would re-import whatever landed on a fresh slot path.
+///
 /// Exposed at `pub(crate)` so the global-virtual-store path hasher
 /// (`crate::global_virtual_store_path`) can share the same recursion
 /// and cache — both [`calc_dep_state`] and `calc_graph_node_hash` are
@@ -121,6 +145,29 @@ where
     cache.get(dep_path).expect("just inserted").clone()
 }
 
+/// Populate `cache` by walking `keys` in order, so that later lookups
+/// see the same digests no matter what order — or from how many
+/// threads — the callers ask for them.
+///
+/// [`calc_dep_state`] and [`crate::calc_graph_node_hash`] both memoize
+/// into a shared install-scoped cache, and for cyclic subgraphs the
+/// digest they store depends on the entry point that reached the node
+/// first (see [`DepsGraphNode::children`] for why). Callers that would
+/// otherwise enter the graph in an unordered — or concurrent — sequence
+/// prime the cache through here first, passing the snapshot keys in
+/// lockfile order.
+pub fn warm_deps_state_cache<'a, Key>(
+    graph: &HashMap<Key, DepsGraphNode<Key>>,
+    cache: &mut DepsStateCache<Key>,
+    keys: impl IntoIterator<Item = &'a Key>,
+) where
+    Key: 'a + Clone + Eq + std::hash::Hash,
+{
+    for key in keys {
+        calc_dep_graph_hash(graph, cache, &mut HashSet::new(), key);
+    }
+}
+
 /// Recursive helper used by [`crate::calc_graph_node_hash`] to decide
 /// whether a snapshot's engine string should contribute to its global-
 /// virtual-store hash.
@@ -143,7 +190,11 @@ where
 /// `false` *without* caching. The "false in this particular cycle
 /// rotation" answer isn't the canonical one — a sibling visit might
 /// still find a builder upstream, and caching `false` here would
-/// poison the next visit at the same key.
+/// poison the next visit at the same key. A `false` *derived* from
+/// such a hit is still cached though, so — as in
+/// [`calc_dep_graph_hash`] — the answer a cycle member settles on
+/// depends on visit order, and the caller has to supply a
+/// deterministic one.
 ///
 /// `cache` is install-scoped and threaded across every snapshot
 /// visited inside one [`crate::calc_graph_node_hash`] walk. `parents`

--- a/pnpm/crates/graph-hasher/src/dep_state/tests.rs
+++ b/pnpm/crates/graph-hasher/src/dep_state/tests.rs
@@ -1,4 +1,8 @@
-use super::{CalcDepStateOptions, DepsGraphNode, calc_dep_state, transitively_requires_build};
+use super::{
+    CalcDepStateOptions, DepsGraphNode, calc_dep_state, transitively_requires_build,
+    warm_deps_state_cache,
+};
+use indexmap::IndexMap;
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
 
@@ -43,7 +47,7 @@ fn dep_graph_hash_for_leaf_uses_id_and_empty_deps() {
         "leaf@1.0.0".to_string(),
         DepsGraphNode {
             full_pkg_id: "leaf@1.0.0:sha512-leaf".to_string(),
-            children: HashMap::new(),
+            children: IndexMap::new(),
         },
     );
     let mut cache = HashMap::new();
@@ -68,7 +72,7 @@ fn cache_makes_repeat_calls_byte_equal() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
     graph.insert(
         "leaf@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: IndexMap::new() },
     );
     let mut cache = HashMap::new();
     let opts = CalcDepStateOptions {
@@ -85,7 +89,7 @@ fn cache_makes_repeat_calls_byte_equal() {
 #[test]
 fn diamond_graph_resolves_consistently() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut root_children = HashMap::new();
+    let mut root_children = IndexMap::new();
     root_children.insert("a".to_string(), "a@1.0.0".to_string());
     root_children.insert("b".to_string(), "b@1.0.0".to_string());
     graph.insert(
@@ -95,13 +99,13 @@ fn diamond_graph_resolves_consistently() {
             children: root_children,
         },
     );
-    let mut a_children = HashMap::new();
+    let mut a_children = IndexMap::new();
     a_children.insert("c".to_string(), "c@1.0.0".to_string());
     graph.insert(
         "a@1.0.0".to_string(),
         DepsGraphNode { full_pkg_id: "a@1.0.0:sha512-a".to_string(), children: a_children },
     );
-    let mut b_children = HashMap::new();
+    let mut b_children = IndexMap::new();
     b_children.insert("c".to_string(), "c@1.0.0".to_string());
     graph.insert(
         "b@1.0.0".to_string(),
@@ -109,7 +113,7 @@ fn diamond_graph_resolves_consistently() {
     );
     graph.insert(
         "c@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "c@1.0.0:sha512-c".to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: "c@1.0.0:sha512-c".to_string(), children: IndexMap::new() },
     );
     let mut cache = HashMap::new();
     let result = calc_dep_state(
@@ -129,13 +133,13 @@ fn diamond_graph_resolves_consistently() {
 #[test]
 fn cyclic_graph_terminates_and_is_stable() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut a_children = HashMap::new();
+    let mut a_children = IndexMap::new();
     a_children.insert("b".to_string(), "b@1.0.0".to_string());
     graph.insert(
         "a@1.0.0".to_string(),
         DepsGraphNode { full_pkg_id: "a@1.0.0:sha512-a".to_string(), children: a_children },
     );
-    let mut b_children = HashMap::new();
+    let mut b_children = IndexMap::new();
     b_children.insert("a".to_string(), "a@1.0.0".to_string());
     graph.insert(
         "b@1.0.0".to_string(),
@@ -157,7 +161,7 @@ fn dep_graph_and_patch_concatenate_in_upstream_order() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
     graph.insert(
         "x@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "x@1.0.0:sha512-x".to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: "x@1.0.0:sha512-x".to_string(), children: IndexMap::new() },
     );
     let mut cache = HashMap::new();
     let result = calc_dep_state(
@@ -182,7 +186,7 @@ fn transitively_requires_build_self_in_built_set() {
         "builder@1.0.0".to_string(),
         DepsGraphNode {
             full_pkg_id: "builder@1.0.0:sha512-b".to_string(),
-            children: HashMap::new(),
+            children: IndexMap::new(),
         },
     );
     let built: std::collections::HashSet<String> =
@@ -202,7 +206,7 @@ fn transitively_requires_build_self_in_built_set() {
 #[test]
 fn transitively_requires_build_walks_to_descendant_builder() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut root_children = HashMap::new();
+    let mut root_children = IndexMap::new();
     root_children.insert("dep".to_string(), "builder@1.0.0".to_string());
     graph.insert(
         "root@1.0.0".to_string(),
@@ -212,7 +216,7 @@ fn transitively_requires_build_walks_to_descendant_builder() {
         "builder@1.0.0".to_string(),
         DepsGraphNode {
             full_pkg_id: "builder@1.0.0:sha512-b".to_string(),
-            children: HashMap::new(),
+            children: IndexMap::new(),
         },
     );
     let built: std::collections::HashSet<String> =
@@ -233,7 +237,7 @@ fn transitively_requires_build_walks_to_descendant_builder() {
 #[test]
 fn transitively_requires_build_returns_false_for_unrelated_tree() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut root_children = HashMap::new();
+    let mut root_children = IndexMap::new();
     root_children.insert("dep".to_string(), "leaf@1.0.0".to_string());
     graph.insert(
         "root@1.0.0".to_string(),
@@ -241,7 +245,7 @@ fn transitively_requires_build_returns_false_for_unrelated_tree() {
     );
     graph.insert(
         "leaf@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-l".to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-l".to_string(), children: IndexMap::new() },
     );
     let built: std::collections::HashSet<String> =
         std::iter::once("builder@9.9.9".to_string()).collect();
@@ -279,13 +283,13 @@ fn transitively_requires_build_caches_false_for_missing_node() {
 #[test]
 fn transitively_requires_build_cycle_terminates() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut a_children = HashMap::new();
+    let mut a_children = IndexMap::new();
     a_children.insert("b".to_string(), "b@1.0.0".to_string());
     graph.insert(
         "a@1.0.0".to_string(),
         DepsGraphNode { full_pkg_id: "a@1.0.0:sha512-a".to_string(), children: a_children },
     );
-    let mut b_children = HashMap::new();
+    let mut b_children = IndexMap::new();
     b_children.insert("a".to_string(), "a@1.0.0".to_string());
     graph.insert(
         "b@1.0.0".to_string(),
@@ -310,14 +314,14 @@ fn transitively_requires_build_cycle_terminates() {
 fn transitively_requires_build_cycle_does_not_mask_sibling_builder() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
     // Two children so child iteration order can take either path.
-    let mut a_children = HashMap::new();
+    let mut a_children = IndexMap::new();
     a_children.insert("b".to_string(), "b@1.0.0".to_string());
     a_children.insert("c".to_string(), "builder@1.0.0".to_string());
     graph.insert(
         "a@1.0.0".to_string(),
         DepsGraphNode { full_pkg_id: "a@1.0.0:sha512-a".to_string(), children: a_children },
     );
-    let mut b_children = HashMap::new();
+    let mut b_children = IndexMap::new();
     b_children.insert("a".to_string(), "a@1.0.0".to_string());
     graph.insert(
         "b@1.0.0".to_string(),
@@ -327,7 +331,7 @@ fn transitively_requires_build_cycle_does_not_mask_sibling_builder() {
         "builder@1.0.0".to_string(),
         DepsGraphNode {
             full_pkg_id: "builder@1.0.0:sha512-x".to_string(),
-            children: HashMap::new(),
+            children: IndexMap::new(),
         },
     );
     let built: std::collections::HashSet<String> =
@@ -341,4 +345,67 @@ fn transitively_requires_build_cycle_does_not_mask_sibling_builder() {
         &"a@1.0.0".to_string(),
         &mut parents
     ));
+}
+
+/// `a` sits in two cycles at once — `a` ↔ `b` and `a` ↔ `m` — so the
+/// digest each member settles on depends on which entry point the walk
+/// started from.
+fn entry_order_sensitive_graph() -> HashMap<String, DepsGraphNode<String>> {
+    fn node(id: &str, children: &[(&str, &str)]) -> DepsGraphNode<String> {
+        DepsGraphNode {
+            full_pkg_id: format!("{id}@1.0.0:sha512-{id}"),
+            children: children
+                .iter()
+                .map(|(alias, key)| ((*alias).to_string(), (*key).to_string()))
+                .collect(),
+        }
+    }
+    HashMap::from([
+        ("a".to_string(), node("a", &[("m", "m"), ("z", "z"), ("b", "b")])),
+        ("b".to_string(), node("b", &[("a", "a")])),
+        ("m".to_string(), node("m", &[("a", "a")])),
+        ("z".to_string(), node("z", &[])),
+    ])
+}
+
+fn dep_states(
+    graph: &HashMap<String, DepsGraphNode<String>>,
+    cache: &mut HashMap<String, String>,
+    query_order: &[&str],
+) -> Vec<(String, String)> {
+    let opts = CalcDepStateOptions {
+        engine_name: "darwin;arm64;node20",
+        patch_file_hash: None,
+        include_dep_graph_hash: true,
+    };
+    let mut states: Vec<(String, String)> = query_order
+        .iter()
+        .map(|key| ((*key).to_string(), calc_dep_state(graph, cache, &(*key).to_string(), &opts)))
+        .collect();
+    states.sort();
+    states
+}
+
+#[test]
+fn query_order_alone_decides_cyclic_dep_states() {
+    let graph = entry_order_sensitive_graph();
+    let forward = dep_states(&graph, &mut HashMap::new(), &["a", "b", "m", "z"]);
+    let backward = dep_states(&graph, &mut HashMap::new(), &["z", "m", "b", "a"]);
+    assert_ne!(forward, backward, "the cache is what `warm_deps_state_cache` exists to pin");
+}
+
+#[test]
+fn warming_makes_cyclic_dep_states_independent_of_query_order() {
+    let graph = entry_order_sensitive_graph();
+    let keys = ["a".to_string(), "b".to_string(), "m".to_string(), "z".to_string()];
+
+    let mut forward_cache = HashMap::new();
+    warm_deps_state_cache(&graph, &mut forward_cache, &keys);
+    let forward = dep_states(&graph, &mut forward_cache, &["a", "b", "m", "z"]);
+
+    let mut backward_cache = HashMap::new();
+    warm_deps_state_cache(&graph, &mut backward_cache, &keys);
+    let backward = dep_states(&graph, &mut backward_cache, &["z", "m", "b", "a"]);
+
+    assert_eq!(forward, backward);
 }

--- a/pnpm/crates/graph-hasher/src/dep_state/tests.rs
+++ b/pnpm/crates/graph-hasher/src/dep_state/tests.rs
@@ -1,10 +1,10 @@
 use super::{
-    CalcDepStateOptions, DepsGraphNode, calc_dep_state, transitively_requires_build,
-    warm_deps_state_cache,
+    CalcDepStateOptions, DepsGraphNode, calc_dep_graph_hash, calc_dep_state,
+    transitively_requires_build, warm_deps_state_cache,
 };
 use indexmap::IndexMap;
 use pretty_assertions::assert_eq;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[test]
 fn engine_only_key() {
@@ -408,4 +408,13 @@ fn warming_makes_cyclic_dep_states_independent_of_query_order() {
     let backward = dep_states(&graph, &mut backward_cache, &["z", "m", "b", "a"]);
 
     assert_eq!(forward, backward);
+
+    // The warm-up threads one `parents` set through every walk; that is
+    // only sound while each walk leaves it empty again, so hold it
+    // against walks that each start from a fresh set.
+    let mut per_key_cache = HashMap::new();
+    for key in &keys {
+        calc_dep_graph_hash(&graph, &mut per_key_cache, &mut HashSet::new(), key);
+    }
+    assert_eq!(forward_cache, per_key_cache);
 }

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
@@ -4,6 +4,7 @@ use super::{
     join_global_virtual_store_path,
 };
 use crate::dep_state::DepsGraphNode;
+use indexmap::IndexMap;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     path::{MAIN_SEPARATOR, Path},
@@ -48,7 +49,7 @@ fn identical_leaves_hash_identically() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
     graph.insert(
         "leaf@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: IndexMap::new() },
     );
     let mut cache_a = HashMap::new();
     let mut cache_b = HashMap::new();
@@ -79,7 +80,7 @@ fn engine_string_changes_hash() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
     graph.insert(
         "leaf@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: IndexMap::new() },
     );
     let mut cache = HashMap::new();
     let mut br = HashMap::new();
@@ -123,7 +124,7 @@ fn engine_agnostic_when_subtree_has_no_builders() {
         "pure-js@1.0.0".to_string(),
         DepsGraphNode {
             full_pkg_id: "pure-js@1.0.0:sha512-x".to_string(),
-            children: HashMap::new(),
+            children: IndexMap::new(),
         },
     );
     let built: HashSet<String> = std::iter::once("someone-else@1.0.0".to_string()).collect();
@@ -160,7 +161,7 @@ fn engine_included_when_self_in_built_set() {
         "native@1.0.0".to_string(),
         DepsGraphNode {
             full_pkg_id: "native@1.0.0:sha512-n".to_string(),
-            children: HashMap::new(),
+            children: IndexMap::new(),
         },
     );
     let built: HashSet<String> = std::iter::once("native@1.0.0".to_string()).collect();
@@ -190,7 +191,7 @@ fn engine_included_when_self_in_built_set() {
 #[test]
 fn engine_included_for_ancestor_of_builder() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut root_children = HashMap::new();
+    let mut root_children = IndexMap::new();
     root_children.insert("dep".to_string(), "native@1.0.0".to_string());
     graph.insert(
         "root@1.0.0".to_string(),
@@ -200,7 +201,7 @@ fn engine_included_for_ancestor_of_builder() {
         "native@1.0.0".to_string(),
         DepsGraphNode {
             full_pkg_id: "native@1.0.0:sha512-n".to_string(),
-            children: HashMap::new(),
+            children: IndexMap::new(),
         },
     );
     let built: HashSet<String> = std::iter::once("native@1.0.0".to_string()).collect();
@@ -234,7 +235,7 @@ fn none_built_dep_paths_disables_gating() {
         "pure-js@1.0.0".to_string(),
         DepsGraphNode {
             full_pkg_id: "pure-js@1.0.0:sha512-x".to_string(),
-            children: HashMap::new(),
+            children: IndexMap::new(),
         },
     );
     let mut cache_a = HashMap::new();
@@ -265,9 +266,9 @@ fn different_children_change_hash() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
     graph.insert(
         "leaf@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: IndexMap::new() },
     );
-    let mut root_a_children = HashMap::new();
+    let mut root_a_children = IndexMap::new();
     root_a_children.insert("a".to_string(), "leaf@1.0.0".to_string());
     graph.insert(
         "root@1.0.0(a)".to_string(),
@@ -275,7 +276,7 @@ fn different_children_change_hash() {
     );
     graph.insert(
         "root@1.0.0(b)".to_string(),
-        DepsGraphNode { full_pkg_id: "root@1.0.0:sha512-r".to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: "root@1.0.0:sha512-r".to_string(), children: IndexMap::new() },
     );
     let mut cache_a = HashMap::new();
     let mut br_a = HashMap::new();
@@ -306,7 +307,7 @@ fn leaf_matches_single_node_graph_hash() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
     graph.insert(
         "leaf@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: full.to_string(), children: HashMap::new() },
+        DepsGraphNode { full_pkg_id: full.to_string(), children: IndexMap::new() },
     );
     let mut cache = HashMap::new();
     let mut br = HashMap::new();

--- a/pnpm/crates/graph-hasher/src/lib.rs
+++ b/pnpm/crates/graph-hasher/src/lib.rs
@@ -16,7 +16,9 @@ mod engine_name;
 mod global_virtual_store_path;
 mod object_hasher;
 
-pub use dep_state::{CalcDepStateOptions, DepsGraphNode, DepsStateCache, calc_dep_state};
+pub use dep_state::{
+    CalcDepStateOptions, DepsGraphNode, DepsStateCache, calc_dep_state, warm_deps_state_cache,
+};
 pub use engine_name::{
     detect_node_major, detect_node_version, engine_name, host_arch, host_libc, host_platform,
 };

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -684,6 +684,21 @@ impl BuildModules<'_> {
         // the point of memoization.
         let deps_state_cache: Mutex<pacquet_graph_hasher::DepsStateCache<PackageKey>> =
             Mutex::new(pacquet_graph_hasher::DepsStateCache::new());
+        // Prime it in lockfile key order before any chunk runs. The
+        // chunk members race for the mutex, and a snapshot inside a
+        // dependency cycle takes the digest of whichever walk reached
+        // it first — so an unprimed cache would hand the same install
+        // a different side-effects-cache key on every run, and every
+        // repeat install would re-run the build it already has cached.
+        if let Some(graph) = &dep_graph {
+            let mut cache_guard =
+                deps_state_cache.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            pacquet_graph_hasher::warm_deps_state_cache(
+                graph,
+                &mut cache_guard,
+                crate::deps_graph::in_lockfile_order(graph).into_iter().map(|(key, _)| key),
+            );
+        }
 
         let chunks = build_sequence(&requires_build_map, patches, snapshots, importers, skipped);
 

--- a/pnpm/crates/package-manager/src/deps_graph.rs
+++ b/pnpm/crates/package-manager/src/deps_graph.rs
@@ -8,8 +8,11 @@
 //! derivation plus children-link wiring from `SnapshotEntry.dependencies`
 //! + `optional_dependencies`.
 
+use indexmap::IndexMap;
 use pacquet_graph_hasher::{DepsGraphNode, HashEncoding, hash_object_with_encoding};
-use pacquet_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
+use pacquet_lockfile::{
+    LockfileResolution, PackageKey, PackageMetadata, PkgName, SnapshotDepRef, SnapshotEntry,
+};
 use std::collections::HashMap;
 
 /// Build a `DepsGraph<PackageKey>` from a v9 lockfile's `snapshots`
@@ -117,23 +120,53 @@ fn full_pkg_id_for(pkg_key: &PackageKey, resolution: &LockfileResolution) -> Str
 /// Flatten `SnapshotEntry`'s `dependencies` + `optional_dependencies`
 /// into an `alias → PackageKey` map, using pacquet's already-typed
 /// `SnapshotDepRef`.
-fn build_children(snapshot: &SnapshotEntry) -> HashMap<String, PackageKey> {
-    let mut children = HashMap::new();
-    let dep_entries = snapshot
-        .dependencies
+///
+/// The result is ordered like upstream's
+/// `{...dependencies, ...optionalDependencies}` object: each section in
+/// lockfile key order, an alias in both sections keeping its position
+/// from `dependencies` while taking its value from
+/// `optionalDependencies`. Both sections are sorted on disk, so sorting
+/// them here restores the order the graph hasher's digests are defined
+/// in (see [`pacquet_graph_hasher::DepsGraphNode::children`]).
+pub(crate) fn build_children(snapshot: &SnapshotEntry) -> IndexMap<String, PackageKey> {
+    let mut children = IndexMap::new();
+    extend_children(&mut children, snapshot.dependencies.as_ref());
+    extend_children(&mut children, snapshot.optional_dependencies.as_ref());
+    children
+}
+
+fn extend_children(
+    children: &mut IndexMap<String, PackageKey>,
+    deps: Option<&HashMap<PkgName, SnapshotDepRef>>,
+) {
+    let Some(deps) = deps else { return };
+    let mut section: Vec<(String, PackageKey)> = deps
         .iter()
-        .flat_map(|m| m.iter())
-        .chain(snapshot.optional_dependencies.iter().flat_map(|m| m.iter()));
-    for (alias, dep_ref) in dep_entries {
         // `SnapshotDepRef::resolve` returns the `PkgNameVerPeer`
         // (= `PackageKey`) the alias points at in the `snapshots:`
         // map. `link:` deps don't have a snapshot key — skip them.
-        let Some(resolved) = dep_ref.resolve(alias) else {
-            continue;
-        };
-        children.insert(alias.to_string(), resolved);
-    }
-    children
+        .filter_map(|(alias, dep_ref)| Some((alias.to_string(), dep_ref.resolve(alias)?)))
+        .collect();
+    section.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    children.extend(section);
+}
+
+/// A snapshot map's entries in lockfile key order.
+///
+/// Pacquet parses the lockfile into `HashMap`s, so iterating one
+/// directly hands the graph hasher a different entry-point order on
+/// every run — and the digests it computes for cyclic subgraphs depend
+/// on that order (see
+/// [`pacquet_graph_hasher::DepsGraphNode::children`]). Sorting by the
+/// rendered snapshot key reproduces how pnpm writes — and therefore
+/// iterates — the `snapshots:` section.
+pub(crate) fn in_lockfile_order<Value>(
+    snapshots: &HashMap<PackageKey, Value>,
+) -> Vec<(&PackageKey, &Value)> {
+    let mut entries: Vec<(String, &PackageKey, &Value)> =
+        snapshots.iter().map(|(key, value)| (key.to_string(), key, value)).collect();
+    entries.sort_unstable_by(|(left, ..), (right, ..)| left.cmp(right));
+    entries.into_iter().map(|(_, key, value)| (key, value)).collect()
 }
 
 #[cfg(test)]

--- a/pnpm/crates/package-manager/src/virtual_store_layout.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout.rs
@@ -33,8 +33,8 @@ use pacquet_graph_hasher::{
     format_global_virtual_store_path, join_global_virtual_store_path,
 };
 use pacquet_lockfile::{
-    LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgName, PkgVerPeer,
-    SnapshotDepRef, SnapshotEntry, VersionPart,
+    LockfileResolution, PackageKey, PackageMetadata, PkgIdWithPatchHash, PkgVerPeer, SnapshotEntry,
+    VersionPart,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -207,7 +207,11 @@ impl VirtualStoreLayout {
         // when `built_dep_paths` is `None`.
         let mut build_required_cache: HashMap<PackageKey, bool> = HashMap::new();
         let mut gvs_suffixes: HashMap<PackageKey, String> = HashMap::with_capacity(snapshots.len());
-        for (snapshot_key, snapshot) in snapshots {
+        // Lockfile key order, not `HashMap` order: `calc_graph_node_hash`
+        // memoizes into `cache` / `build_required_cache`, and for a
+        // snapshot inside a dependency cycle the digest that lands there
+        // depends on which snapshot the walk reached it from.
+        for (snapshot_key, snapshot) in crate::deps_graph::in_lockfile_order(snapshots) {
             // Per-snapshot engine resolution: a snapshot that declares
             // its own `engines.runtime` carries the desugared
             // `dependencies.node: 'runtime:<version>'` pin, which has
@@ -431,7 +435,7 @@ fn lockfile_to_dep_graph(
     snapshots
         .iter()
         .map(|(snapshot_key, snapshot)| {
-            let children = collect_children(snapshot);
+            let children = crate::deps_graph::build_children(snapshot);
             let metadata_key = snapshot_key.without_peer();
             // The metadata-map key (peer- and patch-hash-stripped) is
             // derived via `without_peer` for the `packages:` lookup.
@@ -444,33 +448,6 @@ fn lockfile_to_dep_graph(
             (snapshot_key.clone(), DepsGraphNode { full_pkg_id, children })
         })
         .collect()
-}
-
-/// Combine a snapshot's `dependencies` and `optionalDependencies` into
-/// the graph's alias→key edges, equivalent to a
-/// `{...deps, ...optionalDeps}` spread.
-fn collect_children(snapshot: &SnapshotEntry) -> HashMap<String, PackageKey> {
-    let mut children = HashMap::new();
-    if let Some(deps) = &snapshot.dependencies {
-        merge_into_children(&mut children, deps);
-    }
-    if let Some(deps) = &snapshot.optional_dependencies {
-        merge_into_children(&mut children, deps);
-    }
-    children
-}
-
-fn merge_into_children(
-    children: &mut HashMap<String, PackageKey>,
-    deps: &HashMap<PkgName, SnapshotDepRef>,
-) {
-    for (alias, dep_ref) in deps {
-        // `link:` deps have no snapshot key — skip them.
-        let Some(resolved) = dep_ref.resolve(alias) else {
-            continue;
-        };
-        children.insert(alias.to_string(), resolved);
-    }
 }
 
 /// `variations` (cross-platform variant) resolutions don't exist in

--- a/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
@@ -585,7 +585,10 @@ fn cyclic_slot_suffixes() -> Vec<(String, String)> {
                 .strip_prefix("/tmp/store/links")
                 .expect("slot under the global virtual store")
                 .to_string_lossy()
-                .into_owned();
+                // `slot_dir` builds the tail from native components, so
+                // compare against the `/`-separated form the GVS path is
+                // canonically written in.
+                .replace('\\', "/");
             (snapshot_key.to_string(), suffix)
         })
         .collect();

--- a/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
@@ -522,3 +522,164 @@ fn collect_injected_deps_maps_file_snapshots_to_slots() {
     assert_eq!(injected_hoisted.len(), 1, "unplaced sources dropped: {injected_hoisted:?}");
     assert_eq!(injected_hoisted["comp2"], vec!["node_modules/@scope/comp2".to_string()]);
 }
+
+/// Digests taken from pnpm's own `iterateHashedGraphNodes` over the
+/// same graph. Both CLIs share one global virtual store, so a snapshot
+/// inside a dependency cycle has to land on the same slot whichever of
+/// them installed it.
+#[test]
+fn cyclic_gvs_slots_match_pnpm() {
+    let expected = [
+        ("a@1.0.0", "@/a/1.0.0/3bf76a728c7e155a17137e13ca7af820eb13a0ff4003fed5c39649aac0309905"),
+        ("b@1.0.0", "@/b/1.0.0/728ab1a600ca69780231a2630496c2e83a88c82e965d09ac193fa448c0148a6d"),
+        ("m@1.0.0", "@/m/1.0.0/d671219222f32dfed181f294115e23fc07805b7b78048002872f131f69c07983"),
+        ("n@1.0.0", "@/n/1.0.0/92dec6e2ee818106a34b91bea178347566cc47fe25208afa683831ca5d494605"),
+        ("p@1.0.0", "@/p/1.0.0/b666adb72829d0d822cf2005226985c0b19de632b569fcd75363adf141af3c41"),
+        ("q@1.0.0", "@/q/1.0.0/49a1cd21058b93255957e5accf04137fe74ef88364f96f4b1116e3ca75083b6a"),
+        ("x@1.0.0", "@/x/1.0.0/4230805547fe5208b58758d53b200bc13c5475e3324af75adc87538fcf247857"),
+        ("y@1.0.0", "@/y/1.0.0/4fba92559776b8cd9c4a541f07da9fcc95c8a8ea427f4116de7b2f0606f0f03d"),
+    ];
+    assert_eq!(
+        cyclic_slot_suffixes(),
+        expected
+            .iter()
+            .map(|(key, suffix)| ((*key).to_string(), (*suffix).to_string()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+/// The `HashMap`s a lockfile parses into iterate in a different order
+/// on every run, so a layout that walked them directly would move a
+/// cycle's slots around and make each repeat install re-import whatever
+/// landed on a fresh one ([pnpm/pnpm#13316](https://github.com/pnpm/pnpm/issues/13316)).
+#[test]
+fn cyclic_gvs_slots_are_stable_across_runs() {
+    let first = cyclic_slot_suffixes();
+    for _ in 0..64 {
+        assert_eq!(cyclic_slot_suffixes(), first);
+    }
+}
+
+fn cyclic_slot_suffixes() -> Vec<(String, String)> {
+    let config = make_config(
+        true,
+        PathBuf::from("/tmp/proj/node_modules/.pnpm"),
+        PathBuf::from("/tmp/store/links"),
+    );
+    let (snapshots, packages) = cyclic_snapshots();
+    // An empty policy allows no builds, which makes every snapshot hash
+    // engine-agnostically — the digests below then hold on any host.
+    let policy = crate::AllowBuildPolicy::default();
+    let layout = VirtualStoreLayout::new(
+        &config,
+        Some("darwin-arm64-node20"),
+        Some(&snapshots),
+        Some(&packages),
+        Some(&policy),
+    );
+    let mut suffixes: Vec<(String, String)> = snapshots
+        .keys()
+        .map(|snapshot_key| {
+            let slot = layout.slot_dir(snapshot_key);
+            let suffix = slot
+                .strip_prefix("/tmp/store/links")
+                .expect("slot under the global virtual store")
+                .to_string_lossy()
+                .into_owned();
+            (snapshot_key.to_string(), suffix)
+        })
+        .collect();
+    suffixes.sort();
+    suffixes
+}
+
+/// Two cyclic subgraphs whose digests only come out right when the
+/// hasher visits a snapshot's children the way pnpm's
+/// `{...dependencies, ...optionalDependencies}` object does.
+///
+/// `a` reaches the `p` ↔ `x` cycle through two regular dependencies —
+/// aliased `c` and `p` — so it pins the order *within* a section.
+/// `b` reaches the `n` ↔ `y` cycle through a regular `n` and an
+/// optional `c`, whose alias sorts first, so it pins that
+/// `optionalDependencies` still come last.
+fn cyclic_snapshots() -> (HashMap<PackageKey, SnapshotEntry>, HashMap<PackageKey, PackageMetadata>)
+{
+    let snapshots = HashMap::from([
+        (
+            key("a@1.0.0"),
+            SnapshotEntry {
+                dependencies: Some(HashMap::from([
+                    (alias("c"), SnapshotDepRef::Alias(key("q@1.0.0"))),
+                    (alias("p"), plain("1.0.0")),
+                ])),
+                ..Default::default()
+            },
+        ),
+        (
+            key("b@1.0.0"),
+            SnapshotEntry {
+                dependencies: Some(HashMap::from([(alias("n"), plain("1.0.0"))])),
+                optional_dependencies: Some(HashMap::from([(
+                    alias("c"),
+                    SnapshotDepRef::Alias(key("m@1.0.0")),
+                )])),
+                ..Default::default()
+            },
+        ),
+        (key("m@1.0.0"), depends_on("y")),
+        (key("n@1.0.0"), depends_on("y")),
+        (key("p@1.0.0"), depends_on("x")),
+        (key("q@1.0.0"), depends_on("x")),
+        (key("x@1.0.0"), depends_on("p")),
+        (key("y@1.0.0"), depends_on("n")),
+    ]);
+    let packages = snapshots
+        .keys()
+        .map(|snapshot_key| {
+            let lead = snapshot_key.name.to_string().to_uppercase();
+            (snapshot_key.clone(), registry_metadata(&lead))
+        })
+        .collect();
+    (snapshots, packages)
+}
+
+fn key(text: &str) -> PackageKey {
+    text.parse().expect("parse package key")
+}
+
+fn alias(text: &str) -> PkgName {
+    PkgName::parse(text).expect("parse alias")
+}
+
+fn plain(version: &str) -> SnapshotDepRef {
+    SnapshotDepRef::Plain(version.parse().expect("parse version"))
+}
+
+fn depends_on(name: &str) -> SnapshotEntry {
+    SnapshotEntry {
+        dependencies: Some(HashMap::from([(alias(name), plain("1.0.0"))])),
+        ..Default::default()
+    }
+}
+
+/// Registry metadata whose integrity starts with `lead`, so each
+/// package contributes a distinct `full_pkg_id` to the digests.
+fn registry_metadata(lead: &str) -> PackageMetadata {
+    let integrity = format!("sha512-{lead}{}", "A".repeat(91));
+    PackageMetadata {
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity.parse().expect("parse integrity"),
+        }),
+        version: None,
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13316 — pnpm 12 re-imported a varying subset of packages on every repeat frozen install of an unchanged project (reported on `mui/material-ui`, where `eslint`, `vitest`, `@vitest/*`, `@mui/internal-*` came back run after run).

**Root cause.** `calc_dep_graph_hash` breaks dependency cycles by hashing a node that re-enters through one of its own ancestors *with its children truncated*, and it memoizes that truncated digest until the outermost visit overwrites it. So the digest a cycle member ends up with depends on which node the walk entered the cycle from. pnpm's TypeScript CLI is deterministic here only because JS objects iterate in insertion order; pacquet drove the same walk from `HashMap`s — the lockfile's `snapshots` map and each node's `children` map — whose iteration order changes on every process. Every install therefore re-derived a *different* global-virtual-store hash, and thus a different slot path, for whichever packages happened to sit in a cycle. `CreateVirtualStore`'s current-lockfile skip gate then found no directory at the new path, emitted `pnpm:_broken_node_modules`, and re-imported them.

Only the packages caught in a cycle moved, and which ones moved changed per run — matching the issue's "varying subset" exactly.

**Fix.** Pin both iteration orders to the ones upstream's objects carry:

- `DepsGraphNode::children` becomes an `IndexMap`, and the single shared builder inserts `dependencies` before `optionalDependencies`, each in lockfile key order — upstream's `{...dependencies, ...optionalDependencies}` spread. `virtual_store_layout`'s private duplicate of that builder is gone.
- `VirtualStoreLayout::new` walks snapshots in lockfile key order instead of `HashMap` order, so the per-install memo is filled from the same entry points upstream uses.
- `BuildModules` shares one `DepsStateCache` across concurrently dispatched chunk members, which has the same entry-point sensitivity, so it now primes that cache in lockfile key order before the chunks run. Otherwise the side-effects-cache key of a builder inside a cycle moved between runs and its build re-ran on every install.

**Cross-stack parity.** The unit test pins the eight digests of a two-cycle fixture against the values pnpm's own `@pnpm/deps.graph-hasher` produces for the same graph (obtained by running the compiled TS package). The two CLIs share one global virtual store, so a cyclic package has to land on the same slot whichever of them installed it; the fixture is built so that both a plain alphabetical children merge and an `optionalDependencies`-first merge produce different digests, and either mistake fails the test.

**TypeScript side.** No change needed: the TS CLI's iteration orders are already fixed by insertion order. Worth noting as a follow-up (not fixed here, and not a regression): `building/after-install` computes side-effects-cache keys from a shared `depsStateCache` inside its concurrent chunk loop, so the key of a *cyclic* builder there is scheduling-dependent in the same way pacquet's was.

**Drive-by.** `needs_build_marker_triggers_reimport_on_next_install` corrupted a slot file with `fs::write`. When the store and the slot share a filesystem the importer hardlinks, so that rewrote the store's content-addressed file too and no re-import could restore the original bytes — the test failed locally on the very assertion it exists to make (it passes on CI, where the two land on different filesystems). It now unlinks before writing. Kept as its own commit.

## Squash Commit Body

```text
A frozen install of an unchanged project re-imported a varying subset of
its packages on every repeat run, instead of reusing the slots the
previous install materialized.

`calc_dep_graph_hash` breaks dependency cycles by hashing a node that
re-enters through one of its own ancestors with its children truncated —
and it memoizes that truncated digest until the outermost visit
overwrites it. The digest a cycle member ends up with therefore depends
on which node the walk entered the cycle from. Upstream is deterministic
because JS objects iterate in insertion order; pacquet drove the same
walk from `HashMap`s, whose iteration order differs per process, so every
install re-derived a different global-virtual-store hash — and a
different slot path — for the packages caught in a cycle. The
current-lockfile skip gate then found no directory at the new path and
re-imported them.

Both iteration orders are now pinned to the ones upstream's objects
carry:

- `DepsGraphNode::children` becomes an `IndexMap`, and the one shared
  builder inserts `dependencies` before `optionalDependencies`, each in
  lockfile key order — upstream's
  `{...dependencies, ...optionalDependencies}` spread.
  `virtual_store_layout`'s private copy of that builder is gone.
- `VirtualStoreLayout::new` walks the snapshots in lockfile key order
  rather than `HashMap` order, so the per-install memo is filled from the
  same entry points upstream uses.

`BuildModules` shares one `DepsStateCache` across concurrently dispatched
chunk members, which has the same entry-point sensitivity, so it primes
that cache in lockfile key order before the chunks run — otherwise the
side-effects-cache key of a cyclic builder moved between runs and the
build re-ran on every install.

The unit test pins the digests against the ones pnpm's own
`@pnpm/deps.graph-hasher` produces for the same graph: the two CLIs share
one global virtual store, so a cyclic package has to land on the same
slot whichever of them installed it.

Closes pnpm/pnpm#13316
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787586607&installation_model_id=426870&pr_number=13368&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13368&signature=d87c608058c7402c166542adfb123a868d9d8d93304523bb9f383b9019c40b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed repeated `--frozen-lockfile` installs re-importing an inconsistent subset of packages by making global virtual store slot assignment deterministic for dependency cycles.

- **Reliability**
  - Improved determinism in dependency graph hashing and virtual store layout generation, ensuring stable results across repeated runs and concurrent installation work.

- **Tests**
  - Added and strengthened regression tests to verify consistent frozen-install outcomes for cyclic dependency scenarios and to confirm stability regardless of query/evaluation order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->