### PR TITLE
fix(resolving-npm-resolver): report missing versions and packages with pnpm's error codes

### DIFF
--- a/.changeset/report-missing-versions-and-packages.md
+++ b/.changeset/report-missing-versions-and-packages.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolution failures now report the error pnpm defines for them. A well-formed range that the registry publishes nothing for fails with `ERR_PNPM_NO_MATCHING_VERSION` — naming the latest release, the other dist-tags, and the `pnpm view <pkg> versions` command that lists the rest — instead of `ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER`. A package the registry doesn't have fails with `ERR_PNPM_FETCH_404` and the "not in the npm registry, or you have no permission to fetch it" hint (plus which authorization header was sent, since a private registry often answers a permission failure with a 404) instead of a bare HTTP-client message. A wrapper that quotes its cause verbatim no longer prints the same sentence twice in the error report.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5073,9 +5073,11 @@ version = "0.0.1"
 dependencies = [
  "chrono",
  "derive_more",
+ "miette 7.6.0",
  "node-semver",
  "pacquet-config",
  "pacquet-lockfile",
+ "pacquet-network",
  "pacquet-registry",
  "serde",
  "serde_json",

--- a/pnpm/crates/cli/tests/_utils/mod.rs
+++ b/pnpm/crates/cli/tests/_utils/mod.rs
@@ -27,6 +27,17 @@ pub fn pacquet_in(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
+/// Strip whitespace and box-drawing glyphs out of a miette report so a
+/// substring assertion can't be broken by where the renderer chose to
+/// hard-wrap the message.
+#[must_use]
+pub fn flatten_report(report: &str) -> String {
+    report
+        .chars()
+        .filter(|ch| !ch.is_whitespace() && !matches!(ch, '│' | '├' | '╰' | '─' | '▶' | '×'))
+        .collect()
+}
+
 /// Flip the `enableGlobalVirtualStore` key in the `pnpm-workspace.yaml`
 /// that [`pacquet_testing_utils::bin::CommandTempCwd::add_mocked_registry`]
 /// populated with `storeDir` / `cacheDir` / `enableGlobalVirtualStore: false`.

--- a/pnpm/crates/cli/tests/auth.rs
+++ b/pnpm/crates/cli/tests/auth.rs
@@ -174,7 +174,12 @@ fn metadata_authorization_failure_is_reported() {
     let output = install_command(&workspace, root.path()).with_arg("install").output().unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("403 Forbidden"), "got {stderr}");
+    assert!(stderr.contains("ERR_PNPM_FETCH_403"), "got {stderr}");
+    assert!(stderr.contains("Forbidden - 403"), "got {stderr}");
+    assert!(
+        stderr.contains("No authorization header was set for the request."),
+        "the report must say which credential, if any, was sent: {stderr}",
+    );
 
     forbidden.assert();
 }

--- a/pnpm/crates/cli/tests/auth.rs
+++ b/pnpm/crates/cli/tests/auth.rs
@@ -184,6 +184,48 @@ fn metadata_authorization_failure_is_reported() {
     forbidden.assert();
 }
 
+/// A registry configured with inline `user:pass@` basic-auth must not
+/// leak either half into the fetch error, and the report must still name
+/// the credential that was sent — `AuthHeaders` derives a `Basic` header
+/// from that userinfo, so a hint computed against the redacted URL would
+/// claim no header was set.
+#[test]
+fn inline_registry_credentials_are_redacted_but_still_reported() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let authority = registry.url().replace("http://", "");
+    write_project_config(
+        root.path(),
+        &workspace,
+        &format!("http://basicuser:super-secret-password@{authority}"),
+        "",
+    );
+    let missing = registry
+        .mock("GET", "/private-pkg")
+        .with_status(404)
+        .with_body("Not Found")
+        .expect(1)
+        .create();
+    fs::write(workspace.join("package.json"), r#"{"dependencies":{"private-pkg":"1.0.0"}}"#)
+        .expect("write package.json");
+
+    let output = install_command(&workspace, root.path()).with_arg("install").output().unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("stderr={stderr}");
+    assert!(stderr.contains("ERR_PNPM_FETCH_404"), "got {stderr}");
+    assert!(
+        !stderr.contains("super-secret-password") && !stderr.contains("basicuser"),
+        "the inline credentials must not reach the terminal: {stderr}",
+    );
+    assert!(
+        stderr.contains("An authorization header was used: Basic "),
+        "the header derived from the inline credentials must still be reported: {stderr}",
+    );
+
+    missing.assert();
+}
+
 #[test]
 fn tarball_authorization_failure_is_reported() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1005,14 +1005,7 @@ fn install_surfaces_catalog_misconfiguration() {
     let output = pacquet.with_arg("install").assert().failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
     eprintln!("stderr={stderr}");
-    // The miette report hard-wraps the message and inserts a leading
-    // `│` on the wrapped line. Strip all whitespace and box-drawing
-    // characters before substring-matching so wrap position can't
-    // make the assertion brittle.
-    let flattened: String = stderr
-        .chars()
-        .filter(|ch| !ch.is_whitespace() && !matches!(ch, '│' | '├' | '╰' | '─' | '▶' | '×'))
-        .collect();
+    let flattened = flatten_report(&stderr);
     assert!(
         flattened.contains(
             "Nocatalogentry'@pnpm.e2e/hello-world-js-bin-parent'wasfoundforcatalog'default'.",
@@ -1022,6 +1015,89 @@ fn install_surfaces_catalog_misconfiguration() {
     assert!(
         stderr.contains("ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC"),
         "the catalog error must surface upstream's code, not the resolver chain's: {stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// A well-formed range that the registry publishes nothing for is
+/// `ERR_PNPM_NO_MATCHING_VERSION`, not the chain's
+/// `ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` — the specifier is
+/// supported, the version simply doesn't exist (pnpm/pnpm#13319). The
+/// report also names the latest published release and how to list the
+/// rest, the way the TypeScript CLI does.
+#[test]
+fn install_reports_a_missing_version_as_no_matching_version() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    eprintln!("Creating package.json that asks for a version nobody published...");
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/hello-world-js-bin-parent": "99.99.99",
+        },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    eprintln!("Executing command...");
+    let output = pacquet.with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    eprintln!("stderr={stderr}");
+    let flattened = flatten_report(&stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_NO_MATCHING_VERSION"),
+        "a missing version must not read as an unsupported specifier: {stderr}",
+    );
+    assert!(
+        flattened.contains("Nomatchingversionfoundfor@pnpm.e2e/hello-world-js-bin-parent@99.99.99"),
+        "stderr did not name the dependency that has no matching version: {stderr}",
+    );
+    assert!(
+        flattened.contains(r#"run"pnpmview@pnpm.e2e/hello-world-js-bin-parentversions""#),
+        "stderr did not say how to list the published versions: {stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// A package the registry has never heard of is `ERR_PNPM_FETCH_404`
+/// with pnpm's "not in the npm registry, or you have no permission"
+/// hint — not a bare HTTP-client message (pnpm/pnpm#13319).
+#[test]
+fn install_reports_an_unknown_package_as_fetch_404() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    eprintln!("Creating package.json that depends on a package nobody published...");
+    let manifest_path = workspace.join("package.json");
+    let package_json_content = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/definitely-not-a-published-package": "1.0.0",
+        },
+    });
+    fs::write(&manifest_path, package_json_content.to_string()).expect("write to package.json");
+
+    eprintln!("Executing command...");
+    let output = pacquet.with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    eprintln!("stderr={stderr}");
+    let flattened = flatten_report(&stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_FETCH_404"),
+        "a missing package must surface upstream's fetch code: {stderr}",
+    );
+    assert!(
+        flattened.contains("NotFound-404"),
+        "stderr did not report the registry's status: {stderr}",
+    );
+    assert!(
+        flattened.contains(
+            "@pnpm.e2e/definitely-not-a-published-packageisnotinthenpmregistry,oryouhavenopermissiontofetchit.",
+        ),
+        "stderr did not carry the missing-package hint: {stderr}",
     );
 
     drop((root, mock_instance));
@@ -1348,13 +1424,7 @@ fn frozen_store_with_a_pnpr_server_is_a_config_conflict() {
         .failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
     eprintln!("stderr={stderr}");
-    // The miette report hard-wraps the message and inserts box-drawing
-    // characters on wrapped lines; strip whitespace and those glyphs before
-    // substring-matching so wrap position can't make the assertion brittle.
-    let flattened: String = stderr
-        .chars()
-        .filter(|ch| !ch.is_whitespace() && !matches!(ch, '│' | '├' | '╰' | '─' | '▶' | '×'))
-        .collect();
+    let flattened = flatten_report(&stderr);
     assert!(
         flattened.contains("ERR_PNPM_FROZEN_STORE_INCOMPATIBLE_WITH_PNPR"),
         "stderr did not carry the frozen-store/pnpr conflict code: {stderr}",

--- a/pnpm/crates/diagnostics/src/collapsed_chain.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain.rs
@@ -73,7 +73,7 @@ impl<'a> Collapsed<'a> {
         let mut level = nested(Level::Diagnostic(head));
         while let Some(current) = level {
             let message = current.to_string();
-            if !last.ends_with(&message) {
+            if !restates(&last, &message) {
                 messages.push(message.clone());
                 last = message;
             }
@@ -86,6 +86,21 @@ impl<'a> Collapsed<'a> {
         }
         Collapsed { head, causes }
     }
+}
+
+/// Whether `outer` already says everything `inner` says: the two are equal, or
+/// `outer` is a wrapper that appended `inner` verbatim behind a separator
+/// ("Failed to resolve dependency tree: {inner}"). A cause level renders as its
+/// message and nothing else, so one whose whole message the line above already
+/// ends with adds no information.
+///
+/// The separator is what makes the tail a restatement rather than a
+/// coincidence: without it, a short cause ("0.1") would fold into any wrapper
+/// whose sentence happens to end with those characters ("resolved to 3.0.1"),
+/// dropping a distinct cause.
+fn restates(outer: &str, inner: &str) -> bool {
+    let Some(prefix) = outer.strip_suffix(inner) else { return false };
+    prefix.is_empty() || prefix.ends_with([' ', ':'])
 }
 
 /// One level of the reported error's cause chain. miette walks a mix

--- a/pnpm/crates/diagnostics/src/collapsed_chain.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain.rs
@@ -4,10 +4,12 @@
 //! `#[diagnostic(transparent)]` variants so `?` composes across crate
 //! boundaries. Such a variant displays as its inner error *and* keeps
 //! it as its `source`, so a leaf error four wrappers deep renders the
-//! same sentence at five levels of miette's `├─▶` cause chain. The
-//! handler here folds those levels away before delegating to miette's
-//! own renderer, which keeps every theme, width, and colour decision
-//! miette would otherwise make.
+//! same sentence at five levels of miette's `├─▶` cause chain. A
+//! wrapper that prefixes the inner message with context
+//! ("Failed to resolve dependency tree: {inner}") repeats it just as
+//! fully, one line above. The handler here folds those levels away
+//! before delegating to miette's own renderer, which keeps every theme,
+//! width, and colour decision miette would otherwise make.
 
 use miette::{
     Diagnostic, LabeledSpan, MietteHandler, MietteHandlerOpts, ReportHandler, Severity, SourceCode,
@@ -71,7 +73,7 @@ impl<'a> Collapsed<'a> {
         let mut level = nested(Level::Diagnostic(head));
         while let Some(current) = level {
             let message = current.to_string();
-            if message != last {
+            if !last.ends_with(&message) {
                 messages.push(message.clone());
                 last = message;
             }

--- a/pnpm/crates/diagnostics/src/collapsed_chain.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain.rs
@@ -42,8 +42,8 @@ impl ReportHandler for CollapsingHandler {
     }
 }
 
-/// The reported error, with consecutive repeats of the same message
-/// dropped from its cause chain.
+/// The reported error, with every cause the level above it already
+/// states in full dropped from its chain (see [`restates`]).
 ///
 /// Every [`Diagnostic`] method delegates to the reported error itself,
 /// so its code, help, labels, and source snippet render unchanged.

--- a/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
@@ -73,8 +73,8 @@ fn transparent_wrappers_render_the_message_once() {
     assert_eq!(messages(&collapsed), vec!["tarball server returned HTTP 404".to_string()]);
 }
 
-/// Only *consecutive* repeats fold: a wrapper that adds its own
-/// context, and a cause that genuinely repeats an earlier message
+/// Only *consecutive* restatements fold: a wrapper that says something
+/// of its own, and a cause that genuinely repeats an earlier message
 /// further down the chain, both stay in the rendering.
 #[test]
 fn distinct_causes_survive() {
@@ -95,6 +95,29 @@ fn distinct_causes_survive() {
             "installing dependencies".to_string(),
             "tarball server returned HTTP 404".to_string(),
             "installing dependencies".to_string(),
+        ],
+    );
+}
+
+/// A wrapper that prefixes its cause with context repeats it in full,
+/// so the cause folds into the wrapper's line.
+#[test]
+fn a_context_prefixed_wrapper_absorbs_its_cause() {
+    let leaf = Leaf {
+        message: "Failed to resolve dependency tree: No matching version found for is-odd@99.99.99",
+        source: Some(Box::new(Leaf {
+            message: "No matching version found for is-odd@99.99.99",
+            source: None,
+        })),
+    };
+
+    let collapsed = Collapsed::new(&leaf);
+
+    assert_eq!(
+        messages(&collapsed),
+        vec![
+            "Failed to resolve dependency tree: No matching version found for is-odd@99.99.99"
+                .to_string(),
         ],
     );
 }

--- a/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
+++ b/pnpm/crates/diagnostics/src/collapsed_chain/tests.rs
@@ -122,6 +122,24 @@ fn a_context_prefixed_wrapper_absorbs_its_cause() {
     );
 }
 
+/// A cause is only absorbed when the wrapper appended it behind a
+/// separator. A tail that matches mid-token is a coincidence, and the
+/// cause survives.
+#[test]
+fn a_coincidental_tail_match_is_not_a_restatement() {
+    let leaf = Leaf {
+        message: "the range resolved to 3.0.1",
+        source: Some(Box::new(Leaf { message: "0.1", source: None })),
+    };
+
+    let collapsed = Collapsed::new(&leaf);
+
+    assert_eq!(
+        messages(&collapsed),
+        vec!["the range resolved to 3.0.1".to_string(), "0.1".to_string()],
+    );
+}
+
 /// The kept levels keep answering for themselves — the collapsed head
 /// still carries the code miette prints above the report.
 #[test]

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -738,9 +738,16 @@ pub fn base64_encode(input: &str) -> String {
 /// The scheme survives so the reader can tell a `Bearer` token from `Basic`
 /// credentials, and a token long enough to be recognized by its owner keeps
 /// its first four characters; everything else becomes `[hidden]`.
+///
+/// Control characters are dropped first: the value comes from an untrusted
+/// `.npmrc` / environment variable and the masked result is printed to the
+/// terminal, so a token carrying raw escapes could otherwise inject terminal
+/// output through the characters masking leaves behind.
 #[must_use]
 pub fn hide_auth_information(auth_header_value: &str) -> String {
-    let mut parts = auth_header_value.split(' ');
+    let sanitized: String =
+        auth_header_value.chars().filter(|character| !character.is_control()).collect();
+    let mut parts = sanitized.split(' ');
     let auth_type = parts.next().unwrap_or_default();
     let Some(token) = parts.next() else {
         return "[hidden]".to_string();

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -734,6 +734,24 @@ pub fn base64_encode(input: &str) -> String {
     out
 }
 
+/// Mask an `Authorization` header value for display in an error message.
+/// The scheme survives so the reader can tell a `Bearer` token from `Basic`
+/// credentials, and a token long enough to be recognized by its owner keeps
+/// its first four characters; everything else becomes `[hidden]`.
+#[must_use]
+pub fn hide_auth_information(auth_header_value: &str) -> String {
+    let mut parts = auth_header_value.split(' ');
+    let auth_type = parts.next().unwrap_or_default();
+    let Some(token) = parts.next() else {
+        return "[hidden]".to_string();
+    };
+    if token.chars().count() < 20 {
+        return format!("{auth_type} [hidden]");
+    }
+    let prefix: String = token.chars().take(4).collect();
+    format!("{auth_type} {prefix}[hidden]")
+}
+
 /// Strip `user:pass@` (or `user@`) that appears right after a URL scheme in
 /// any message text, e.g. `… https://user:pass@host/pkg …` →
 /// `… https://host/pkg …`. A registry configured as `https://user:pass@host/`

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AuthHeaders, DEFAULT_REGISTRY_SCOPE, UpstreamRouteHook, base64_encode, nerf_dart,
-    redact_and_sanitize, redact_url_credentials,
+    AuthHeaders, DEFAULT_REGISTRY_SCOPE, UpstreamRouteHook, base64_encode, hide_auth_information,
+    nerf_dart, redact_and_sanitize, redact_url_credentials,
 };
 use crate::TokenHelperOutput;
 use pretty_assertions::assert_eq;
@@ -231,6 +231,29 @@ fn redact_and_sanitize_strips_credentials_and_control_chars() {
     // A control character inside the userinfo must not break the redaction:
     // controls are stripped first, then credentials are redacted.
     assert_eq!(redact_and_sanitize("https://user:pass\r@host/x"), "https://host/x");
+}
+
+#[test]
+fn hide_auth_information_keeps_the_scheme_and_masks_the_credential() {
+    // A token long enough to recognize keeps four characters.
+    assert_eq!(hide_auth_information("Bearer npm_0123456789abcdefghij"), "Bearer npm_[hidden]");
+    // A short token could be guessed from a prefix, so none of it survives.
+    assert_eq!(hide_auth_information("Bearer short-token"), "Bearer [hidden]");
+    assert_eq!(hide_auth_information("Basic Zm9vOmJhcg=="), "Basic [hidden]");
+    // No scheme to report — the whole value is a credential.
+    assert_eq!(hide_auth_information("bare-token"), "[hidden]");
+}
+
+#[test]
+fn hide_auth_information_strips_control_characters() {
+    // The masked value is printed to the terminal, so escapes carried by an
+    // untrusted `.npmrc` token must not survive masking.
+    let masked = hide_auth_information("Bea\u{1b}[31mrer \u{1b}[0m0123456789abcdefghijk\r\n");
+    dbg!(&masked);
+    assert!(
+        !masked.chars().any(char::is_control),
+        "no control character may reach the terminal: {masked:?}",
+    );
 }
 
 fn build(entries: &[(&str, &str)]) -> AuthHeaders {

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -10,7 +10,8 @@ mod token_helper;
 
 pub use auth::{
     AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, MetadataCacheScope, UpstreamRouteHook,
-    base64_encode, nerf_dart, normalize_auth_key, redact_and_sanitize, redact_url_credentials,
+    base64_encode, hide_auth_information, nerf_dart, normalize_auth_key, redact_and_sanitize,
+    redact_url_credentials,
 };
 pub use limited_body::{LimitedBody, read_limited_body};
 pub use token_helper::{TokenHelperOutput, TokenHelperRunner};

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -12,7 +12,8 @@ use pacquet_hooks::PnpmfileHooks;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest, engines_runtime_dependencies};
 use pacquet_patching::{PatchGroupRecord, PatchKeyConflictError, get_patch_info};
 use pacquet_resolving_resolver_base::{
-    PreferredVersionsOverlay, ResolveError, ResolveOptions, Resolver, WantedDependency,
+    NoMatchingVersionError, PreferredVersionsOverlay, RegistryResponseError, ResolveError,
+    ResolveOptions, Resolver, WantedDependency,
 };
 use pipe_trait::Pipe;
 use serde_json::Value;
@@ -270,6 +271,16 @@ pub enum ResolveDependencyTreeError {
     /// The inner error is the boxed type the resolver returned.
     #[display("Failed to resolve dependency: {_0}")]
     Resolve(#[error(not(source))] String),
+
+    /// The registry publishes the package but nothing the request accepts,
+    /// raised with the `ERR_PNPM_NO_MATCHING_VERSION` code.
+    #[diagnostic(transparent)]
+    NoMatchingVersion(#[error(source)] NoMatchingVersionError),
+
+    /// The registry answered the metadata request with a non-2xx status,
+    /// raised with the matching `ERR_PNPM_FETCH_<status>` code.
+    #[diagnostic(transparent)]
+    RegistryResponse(#[error(source)] RegistryResponseError),
 
     /// An optional dependency failed to resolve while the wanted
     /// lockfile still holds a package entry satisfying the wanted
@@ -1617,6 +1628,8 @@ where
             // keep aborting even for optional edges.
             Err(
                 err @ (ResolveDependencyTreeError::Resolve(_)
+                | ResolveDependencyTreeError::NoMatchingVersion(_)
+                | ResolveDependencyTreeError::RegistryResponse(_)
                 | ResolveDependencyTreeError::SpecNotSupported { .. }),
             ) if wanted.optional.unwrap_or(false) => {
                 if wanted_lockfile_contains_satisfying_entry(
@@ -2063,10 +2076,7 @@ where
     } else {
         opts
     };
-    let mut result = resolver
-        .resolve(wanted, opts)
-        .await
-        .map_err(|err: ResolveError| ResolveDependencyTreeError::Resolve(err.to_string()))?;
+    let mut result = resolver.resolve(wanted, opts).await.map_err(map_resolve_error)?;
     let Some(result_inner) = result.as_mut() else {
         return Err(ResolveDependencyTreeError::SpecNotSupported {
             specifier: render_specifier(wanted),
@@ -2121,6 +2131,24 @@ where
         .entry(cache_key)
         .or_insert_with(|| Arc::clone(&result));
     Ok(result)
+}
+
+/// Wrap a resolver-chain failure, keeping the pnpm error code of the ones
+/// that carry one. The chain hands back a type-erased
+/// [`ResolveError`], which drops the `miette::Diagnostic` facet, so the codes
+/// that are part of pnpm's public contract are recovered by downcast; every
+/// other failure keeps the generic envelope.
+fn map_resolve_error(err: ResolveError) -> ResolveDependencyTreeError {
+    let err = match err.downcast::<NoMatchingVersionError>() {
+        Ok(no_matching_version) => {
+            return ResolveDependencyTreeError::NoMatchingVersion(*no_matching_version);
+        }
+        Err(err) => err,
+    };
+    match err.downcast::<RegistryResponseError>() {
+        Ok(response) => ResolveDependencyTreeError::RegistryResponse(*response),
+        Err(err) => ResolveDependencyTreeError::Resolve(err.to_string()),
+    }
 }
 
 /// Speculatively warm a freshly-seeded node's children resolutions so

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -11,8 +11,9 @@ use chrono::{DateTime, TimeZone, Utc};
 use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
-    LatestQuery, PkgResolutionId, PreferredVersions, ResolveError, ResolveFuture,
-    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, WantedDependency,
+    LatestQuery, NoMatchingVersionError, PkgResolutionId, PreferredVersions, RegistryResponseError,
+    RegistryResponseErrorOptions, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
+    ResolveResult, Resolver, WantedDependency,
 };
 use pretty_assertions::assert_eq;
 
@@ -1028,6 +1029,40 @@ async fn shared_subtree_miss_unsatisfied_by_first_importer_still_hoists() {
 struct FailingAliasResolver {
     table: HashMap<(String, String), ResolveResult>,
     failing: std::collections::HashSet<String>,
+    failure: FailureShape,
+}
+
+/// How [`FailingAliasResolver`] fails. The tree walker recovers the coded
+/// shapes by downcasting the type-erased [`ResolveError`], so an optional
+/// dependency has to keep being skipped for each of them, not only for the
+/// plain string error every other resolver produces.
+#[derive(Clone, Copy)]
+enum FailureShape {
+    Plain,
+    NoMatchingVersion,
+    RegistryResponse,
+}
+
+impl FailureShape {
+    fn error(self, alias: &str, range: &str) -> ResolveError {
+        match self {
+            FailureShape::Plain => format!("No matching version found for {alias}@{range}").into(),
+            FailureShape::NoMatchingVersion => Box::new(NoMatchingVersionError {
+                dep: format!("{alias}@{range}"),
+                registry: "https://registry.example/".to_string(),
+                published_versions: format!(r#"The latest release of {alias} is "2.0.0"."#),
+            }),
+            FailureShape::RegistryResponse => {
+                Box::new(RegistryResponseError::new(RegistryResponseErrorOptions {
+                    url: &format!("https://registry.example/{alias}"),
+                    status: 404,
+                    status_text: "Not Found",
+                    pkg_name: alias,
+                    auth_header_value: None,
+                }))
+            }
+        }
+    }
 }
 
 impl Resolver for FailingAliasResolver {
@@ -1039,10 +1074,11 @@ impl Resolver for FailingAliasResolver {
         let alias = wanted.alias.clone().unwrap_or_default();
         let range = wanted.bare_specifier.clone().unwrap_or_default();
         let failing = self.failing.contains(&alias);
+        let failure = self.failure;
         let result = self.table.get(&(alias.clone(), range.clone())).cloned();
         Box::pin(async move {
             if failing {
-                return Err(format!("No matching version found for {alias}@{range}").into());
+                return Err(failure.error(&alias, &range));
             }
             Ok::<_, ResolveError>(result)
         })
@@ -1059,7 +1095,9 @@ impl Resolver for FailingAliasResolver {
 
 /// One importer whose manifest carries a resolvable regular dep
 /// (`kept`) and an optional dep (`broken`) whose resolution fails.
-fn optional_failure_fixture() -> (tempfile::TempDir, PackageManifest, FailingAliasResolver) {
+fn optional_failure_fixture(
+    failure: FailureShape,
+) -> (tempfile::TempDir, PackageManifest, FailingAliasResolver) {
     let tmp = tempfile::tempdir().expect("tempdir");
     let path = tmp.path().join("package.json");
     let json = serde_json::json!({
@@ -1081,6 +1119,7 @@ fn optional_failure_fixture() -> (tempfile::TempDir, PackageManifest, FailingAli
             ),
         )]),
         failing: std::collections::HashSet::from(["broken".to_string()]),
+        failure,
     };
     (tmp, manifest, resolver)
 }
@@ -1127,7 +1166,7 @@ fn lockfile_with_package(key: &str) -> pacquet_lockfile::Lockfile {
 
 #[tokio::test]
 async fn skips_an_optional_dependency_whose_resolution_fails_with_no_locked_entry() {
-    let (_tmp, manifest, resolver) = optional_failure_fixture();
+    let (_tmp, manifest, resolver) = optional_failure_fixture(FailureShape::Plain);
     let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
     let skipped = std::sync::Arc::new(Mutex::new(Vec::new()));
     let mut opts = workspace_opts(false, false);
@@ -1171,7 +1210,7 @@ async fn skips_an_optional_dependency_whose_resolution_fails_with_no_locked_entr
 // loudly instead of silently dropping the locked entries.
 #[tokio::test]
 async fn fails_on_an_optional_dependency_that_cannot_be_resolved_with_a_satisfying_locked_entry() {
-    let (_tmp, manifest, resolver) = optional_failure_fixture();
+    let (_tmp, manifest, resolver) = optional_failure_fixture(FailureShape::Plain);
     let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
     let mut opts = workspace_opts(false, false);
     opts.wanted_lockfile = Some(std::sync::Arc::new(lockfile_with_package("broken@1.2.0")));
@@ -1200,7 +1239,7 @@ async fn fails_on_an_optional_dependency_that_cannot_be_resolved_with_a_satisfyi
 
 #[tokio::test]
 async fn skips_an_optional_dependency_when_the_locked_entry_does_not_satisfy_the_wanted_range() {
-    let (_tmp, manifest, resolver) = optional_failure_fixture();
+    let (_tmp, manifest, resolver) = optional_failure_fixture(FailureShape::Plain);
     let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
     let mut opts = workspace_opts(false, false);
     opts.wanted_lockfile = Some(std::sync::Arc::new(lockfile_with_package("broken@0.9.0")));
@@ -1217,6 +1256,70 @@ async fn skips_an_optional_dependency_when_the_locked_entry_does_not_satisfy_the
 
     let direct = &result.peers.direct_dependencies_by_importer["."];
     assert!(!direct.contains_key("broken"), "the failing optional edge is dropped: {direct:?}");
+}
+
+/// The coded resolver failures arrive as their own error variants rather
+/// than the generic `Resolve` envelope, so each has to stay in the
+/// optional-dependency skip arm: an optional dependency the registry has
+/// no version of — or no package for — must keep dropping its edge
+/// instead of failing the install.
+#[tokio::test]
+async fn skips_an_optional_dependency_for_every_coded_resolver_failure() {
+    for failure in [FailureShape::NoMatchingVersion, FailureShape::RegistryResponse] {
+        let (_tmp, manifest, resolver) = optional_failure_fixture(failure);
+        let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+        let skipped = std::sync::Arc::new(Mutex::new(Vec::new()));
+        let mut opts = workspace_opts(false, false);
+        opts.skipped_optional_log = Some(std::sync::Arc::new({
+            let skipped = std::sync::Arc::clone(&skipped);
+            move |notification| skipped.lock().unwrap().push(notification)
+        }));
+        let result = resolve_workspace(
+            &resolver,
+            &importers,
+            &[DependencyGroup::Prod, DependencyGroup::Optional],
+            opts,
+            |_| importer_opts(std::path::PathBuf::from("/repo"), None),
+        )
+        .await
+        .expect("a coded resolution failure of an optional dependency is skipped");
+
+        let direct = &result.peers.direct_dependencies_by_importer["."];
+        assert!(direct.contains_key("kept"), "the regular dep resolves: {direct:?}");
+        assert!(!direct.contains_key("broken"), "the failing optional edge is dropped: {direct:?}");
+        let skipped = skipped.lock().unwrap();
+        assert_eq!(skipped.len(), 1);
+        assert_eq!(skipped[0].name.as_deref(), Some("broken"));
+    }
+}
+
+/// The loud-failure path for a locked optional dependency has to cover
+/// the coded failures too, for the same reason as the skip arm.
+#[tokio::test]
+async fn fails_loudly_on_a_locked_optional_dependency_for_every_coded_resolver_failure() {
+    for failure in [FailureShape::NoMatchingVersion, FailureShape::RegistryResponse] {
+        let (_tmp, manifest, resolver) = optional_failure_fixture(failure);
+        let importers = [WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+        let mut opts = workspace_opts(false, false);
+        opts.wanted_lockfile = Some(std::sync::Arc::new(lockfile_with_package("broken@1.2.0")));
+        opts.update_reuse_scope = crate::UpdateReuseScope::None;
+        let result = resolve_workspace(
+            &resolver,
+            &importers,
+            &[DependencyGroup::Prod, DependencyGroup::Optional],
+            opts,
+            |_| importer_opts(std::path::PathBuf::from("/repo"), None),
+        )
+        .await;
+
+        let Err(crate::ResolveImporterError::Resolve(err)) = result else {
+            panic!("a locked optional dependency must fail loudly");
+        };
+        assert!(
+            matches!(err, crate::ResolveDependencyTreeError::LockedOptionalResolutionFailure(_)),
+            "unexpected error: {err}",
+        );
+    }
 }
 
 /// A newly-resolved package whose manifest carries `deprecated` is

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry_resolver.rs
@@ -28,8 +28,8 @@ use pacquet_resolving_resolver_base::{
 
 use crate::{
     npm_resolver::{
-        BuildResolveResult, PickFromRegistryOptions, PickedFromRegistry, build_resolve_result,
-        pick_from_registry_with_guard,
+        BuildResolveResult, PickFromRegistryOptions, RegistryPick, build_resolve_result,
+        no_matching_version, pick_from_registry_with_guard, swallowed_as_no_latest,
     },
     parse_bare_specifier::{
         NamedRegistryPackageSpec, parse_named_registry_specifier_to_registry_package_spec,
@@ -139,8 +139,11 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
         };
 
         let optional = wanted_dependency.optional.unwrap_or(false);
-        let Some(picked) = self.pick_from_registry(registry, &spec, opts, optional).await? else {
-            return Ok(None);
+        let picked = match self.pick_from_registry(registry, &spec, opts, optional).await? {
+            RegistryPick::Picked(picked) => picked,
+            RegistryPick::NoMatchingVersion(meta) => {
+                return Err(no_matching_version(wanted_dependency, registry, &meta));
+            }
         };
 
         let result = build_resolve_result(BuildResolveResult {
@@ -177,7 +180,13 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
         if !query.compatible {
             resolve_opts.update = UpdateBehavior::Latest;
         }
-        let result = self.resolve_impl(&wanted, &resolve_opts).await?;
+        let result = match self.resolve_impl(&wanted, &resolve_opts).await {
+            Ok(result) => result,
+            Err(err) if swallowed_as_no_latest(&err, opts) => {
+                return Ok(Some(LatestInfo { latest_manifest: None }));
+            }
+            Err(err) => return Err(err),
+        };
         let Some(result) = result else {
             return Ok(None);
         };
@@ -197,7 +206,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
         spec: &RegistryPackageSpec,
         opts: &ResolveOptions,
         optional: bool,
-    ) -> Result<Option<PickedFromRegistry>, ResolveError> {
+    ) -> Result<RegistryPick, ResolveError> {
         let overlay_selectors =
             crate::preferred_overlay::overlay_merged_selectors(opts, &spec.name);
         let base_selectors =
@@ -233,7 +242,7 @@ impl<Cache: PackageMetaCache + 'static> NamedRegistryResolver<Cache> {
             },
         )
         .await?;
-        if let Some(picked) = &picked {
+        if let RegistryPick::Picked(picked) = &picked {
             crate::preferred_overlay::warn_once_on_held_back_update(
                 opts,
                 spec,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -29,7 +29,7 @@ use chrono::{DateTime, Utc};
 use node_semver::Version;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_and_sanitize};
 use pacquet_registry::{Package, PackageVersion, PinnedVersion};
 use pacquet_resolving_resolver_base::{
     LatestInfo, LatestQuery, NoMatchingVersionError, PackageVersionGuardDecision,
@@ -459,7 +459,7 @@ pub(crate) fn no_matching_version(
         }
         None => wanted_dependency.bare_specifier.clone().unwrap_or_default(),
     };
-    Box::new(NoMatchingVersionError::new(dep, registry.to_string(), meta))
+    Box::new(NoMatchingVersionError::new(dep, redact_and_sanitize(registry), meta))
 }
 
 /// Registry pick was unavailable (no matching version or fetch
@@ -720,10 +720,14 @@ fn map_pick_error<Cache: PackageMetaCache>(
     let Some(status) = registry_response_status(&error) else {
         return Box::new(error);
     };
-    let url = redact_url_credentials(&to_registry_url(opts.registry, &opts.spec.name));
+    let url = to_registry_url(opts.registry, &opts.spec.name);
+    // Look the credential up with the URL the fetch itself used. An inline
+    // `user:pass@` is exactly what `AuthHeaders` turns into a Basic header, so
+    // redacting before the lookup would report "no authorization header was
+    // set" for the registries that most certainly carry one.
     let auth_header_value = ctx.auth_headers.for_url_with_package(&url, Some(&opts.spec.name));
     Box::new(RegistryResponseError::new(RegistryResponseErrorOptions {
-        url: &url,
+        url: &redact_and_sanitize(&url),
         status: status.as_u16(),
         status_text: status.canonical_reason().unwrap_or_default(),
         pkg_name: &opts.spec.name,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -29,10 +29,11 @@ use chrono::{DateTime, Utc};
 use node_semver::Version;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
-use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient};
+use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials};
 use pacquet_registry::{Package, PackageVersion, PinnedVersion};
 use pacquet_resolving_resolver_base::{
-    LatestInfo, LatestQuery, PackageVersionGuardDecision, ResolutionPolicyViolation, ResolveError,
+    LatestInfo, LatestQuery, NoMatchingVersionError, PackageVersionGuardDecision,
+    RegistryResponseError, RegistryResponseErrorOptions, ResolutionPolicyViolation, ResolveError,
     ResolveFuture, ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior,
     WantedDependency, WorkspacePackages, parse_packument_timestamp,
 };
@@ -41,8 +42,11 @@ use crate::{
     errors::{AllVersionsBlockedError, GuardRepickLimitError},
     named_registry::pick_registry_for_package,
     parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
-    pick_package::{PackageMetaCache, PickPackageContext, PickPackageOptions, pick_package},
+    pick_package::{
+        PackageMetaCache, PickPackageContext, PickPackageError, PickPackageOptions, pick_package,
+    },
     pick_package_from_meta::{RegistryPackageSpec, RegistryPackageSpecType},
+    registry_url::to_registry_url,
     resolve_from_workspace::{
         ResolveFromWorkspaceError, ResolveFromWorkspaceOptions, SavedSpecifierOptions,
         pick_matching_local_version_or_null, resolve_from_local_package,
@@ -214,8 +218,8 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
 
         let pick_result = self.pick_from_registry(&registry, &spec, opts, optional).await;
         let picked = match pick_result {
-            Ok(Some(picked)) => picked,
-            Ok(None) => {
+            Ok(RegistryPick::Picked(picked)) => picked,
+            Ok(RegistryPick::NoMatchingVersion(meta)) => {
                 return match workspace_packages_active.map(|workspace_packages| {
                     try_workspace_fallback(workspace_packages, &spec, wanted_dependency, opts)
                 }) {
@@ -229,7 +233,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
                             ..
                         },
                     )) => Err(Box::new(ws_err)),
-                    _ => Ok(None),
+                    _ => Err(no_matching_version(wanted_dependency, &registry, &meta)),
                 };
             }
             Err(err) => {
@@ -307,10 +311,12 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
         let registry = self.registries.get("@jsr").map_or(DEFAULT_JSR_REGISTRY, String::as_str);
 
         let optional = wanted_dependency.optional.unwrap_or(false);
-        let Some(picked) =
-            self.pick_from_registry(registry, &jsr_spec.spec, opts, optional).await?
-        else {
-            return Ok(None);
+        let picked = match self.pick_from_registry(registry, &jsr_spec.spec, opts, optional).await?
+        {
+            RegistryPick::Picked(picked) => picked,
+            RegistryPick::NoMatchingVersion(meta) => {
+                return Err(no_matching_version(wanted_dependency, registry, &meta));
+            }
         };
 
         let result = build_resolve_result(BuildResolveResult {
@@ -334,16 +340,14 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
     }
 
     /// Common picker invocation shared by [`Self::resolve_impl`] and
-    /// [`Self::resolve_jsr_impl`]. Returns `Ok(None)` when the picker
-    /// finds no matching version so each caller can fold that into
-    /// its own `Ok(None)` short-circuit.
+    /// [`Self::resolve_jsr_impl`].
     async fn pick_from_registry(
         &self,
         registry: &str,
         spec: &RegistryPackageSpec,
         opts: &ResolveOptions,
         optional: bool,
-    ) -> Result<Option<PickedFromRegistry>, ResolveError> {
+    ) -> Result<RegistryPick, ResolveError> {
         let overlay_selectors =
             crate::preferred_overlay::overlay_merged_selectors(opts, &spec.name);
         let base_selectors =
@@ -379,7 +383,7 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
             },
         )
         .await?;
-        if let Some(picked) = &picked {
+        if let RegistryPick::Picked(picked) = &picked {
             crate::preferred_overlay::warn_once_on_held_back_update(
                 opts,
                 spec,
@@ -413,7 +417,13 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
         if !query.compatible {
             resolve_opts.update = UpdateBehavior::Latest;
         }
-        let result = self.resolve_impl(&wanted, &resolve_opts).await?;
+        let result = match self.resolve_impl(&wanted, &resolve_opts).await {
+            Ok(result) => result,
+            Err(err) if swallowed_as_no_latest(&err, opts) => {
+                return Ok(Some(LatestInfo { latest_manifest: None }));
+            }
+            Err(err) => return Err(err),
+        };
         let Some(result) = result else {
             return Ok(None);
         };
@@ -426,6 +436,30 @@ impl<Cache: PackageMetaCache + 'static> NpmResolver<Cache> {
         }
         Ok(Some(LatestInfo { latest_manifest: result.manifest }))
     }
+}
+
+/// Whether a latest-version lookup should report "no latest" instead of
+/// failing. `minimumReleaseAge` filters the packument before the pick, so
+/// every published version can be too young to match — a policy outcome the
+/// caller renders as "nothing to update to", not an error.
+pub(crate) fn swallowed_as_no_latest(err: &ResolveError, opts: &ResolveOptions) -> bool {
+    opts.published_by.is_some() && err.is::<NoMatchingVersionError>()
+}
+
+/// The `ERR_PNPM_NO_MATCHING_VERSION` error for a registry that publishes the
+/// package but nothing the request accepts.
+pub(crate) fn no_matching_version(
+    wanted_dependency: &WantedDependency,
+    registry: &str,
+    meta: &Package,
+) -> ResolveError {
+    let dep = match wanted_dependency.alias.as_deref() {
+        Some(alias) => {
+            format!("{alias}@{}", wanted_dependency.bare_specifier.as_deref().unwrap_or_default())
+        }
+        None => wanted_dependency.bare_specifier.clone().unwrap_or_default(),
+    };
+    Box::new(NoMatchingVersionError::new(dep, registry.to_string(), meta))
 }
 
 /// Registry pick was unavailable (no matching version or fetch
@@ -533,6 +567,15 @@ pub(crate) struct PickedFromRegistry {
     pub(crate) version: std::sync::Arc<PackageVersion>,
 }
 
+/// Outcome of a registry pick.
+pub(crate) enum RegistryPick {
+    Picked(PickedFromRegistry),
+    /// The registry served the packument but no published version satisfied
+    /// the request. The packument comes along because
+    /// [`NoMatchingVersionError`] reports what *is* published.
+    NoMatchingVersion(std::sync::Arc<Package>),
+}
+
 pub(crate) struct PickFromRegistryOptions<'a> {
     pub registry: &'a str,
     pub spec: &'a RegistryPackageSpec,
@@ -556,7 +599,7 @@ const GUARD_REPICK_LIMIT: usize = 1000;
 pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
     ctx: &PickPackageContext<'_, Cache>,
     opts: PickFromRegistryOptions<'_>,
-) -> Result<Option<PickedFromRegistry>, ResolveError> {
+) -> Result<RegistryPick, ResolveError> {
     let mut blocked_versions = std::collections::HashSet::new();
     let mut last_rejection: Option<String> = None;
     loop {
@@ -574,27 +617,32 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
         };
         let pick_result = pick_package(ctx, opts.spec, &pick_opts)
             .await
-            .map_err(|err| Box::new(err) as ResolveError)?;
+            .map_err(|err| map_pick_error(ctx, &opts, err))?;
 
         let Some(version) = pick_result.picked_package else {
             // No candidate left. With no prior guard rejection this is the
-            // ordinary "no matching version" outcome the resolver folds into
-            // Ok(None); once the guard has rejected every match, surface that
-            // as a distinct error instead of letting it read as an
-            // unsupported spec downstream.
+            // ordinary "no matching version" outcome; once the guard has
+            // rejected every match, surface that as a distinct error rather
+            // than blaming the range the user wrote.
             return match last_rejection {
                 Some(reason) => Err(all_versions_blocked(opts.spec, reason)),
-                None => Ok(None),
+                None => Ok(RegistryPick::NoMatchingVersion(pick_result.meta)),
             };
         };
         let Some(guard) = opts.package_version_guard else {
-            return Ok(Some(PickedFromRegistry { meta: pick_result.meta, version }));
+            return Ok(RegistryPick::Picked(PickedFromRegistry {
+                meta: pick_result.meta,
+                version,
+            }));
         };
 
         let version_str = version.version.to_string();
         match guard.check(&opts.spec.name, &version_str).await? {
             PackageVersionGuardDecision::Allow => {
-                return Ok(Some(PickedFromRegistry { meta: pick_result.meta, version }));
+                return Ok(RegistryPick::Picked(PickedFromRegistry {
+                    meta: pick_result.meta,
+                    version,
+                }));
             }
             PackageVersionGuardDecision::Reject { reason } => {
                 tracing::debug!(
@@ -657,6 +705,30 @@ fn blocked_packument_key(
 
 fn all_versions_blocked(spec: &RegistryPackageSpec, reason: String) -> ResolveError {
     Box::new(AllVersionsBlockedError { name: spec.name.clone(), reason })
+}
+
+/// Box a picker failure for the resolver chain, restating a non-2xx registry
+/// answer as [`RegistryResponseError`]. Without that the transport-level
+/// message ("HTTP status client error (404 Not Found) for url ...") is all the
+/// user sees: no `ERR_PNPM_FETCH_404`, and no hint that a 404 from a private
+/// registry is often really an authorization failure.
+fn map_pick_error<Cache: PackageMetaCache>(
+    ctx: &PickPackageContext<'_, Cache>,
+    opts: &PickFromRegistryOptions<'_>,
+    error: PickPackageError,
+) -> ResolveError {
+    let Some(status) = registry_response_status(&error) else {
+        return Box::new(error);
+    };
+    let url = redact_url_credentials(&to_registry_url(opts.registry, &opts.spec.name));
+    let auth_header_value = ctx.auth_headers.for_url_with_package(&url, Some(&opts.spec.name));
+    Box::new(RegistryResponseError::new(RegistryResponseErrorOptions {
+        url: &url,
+        status: status.as_u16(),
+        status_text: status.canonical_reason().unwrap_or_default(),
+        pkg_name: &opts.spec.name,
+        auth_header_value: auth_header_value.as_deref(),
+    }))
 }
 
 /// Input bundle for [`build_resolve_result`]. Grouped so the
@@ -841,18 +913,30 @@ fn detect_min_release_age_violation(
     })
 }
 
-/// Whether any error in the source chain is a reqwest `404 Not Found`.
+/// Whether the registry answered "no such package" for this pick.
 fn is_not_found_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    registry_response_status(err) == Some(reqwest::StatusCode::NOT_FOUND)
+}
+
+/// The HTTP status a registry answered with, recovered from anywhere in the
+/// error chain. Both shapes occur: the picker's raw `reqwest` failure, and the
+/// [`RegistryResponseError`] [`map_pick_error`] restates it as.
+fn registry_response_status(
+    err: &(dyn std::error::Error + 'static),
+) -> Option<reqwest::StatusCode> {
     let mut current = Some(err);
     while let Some(err) = current {
+        if let Some(response_err) = err.downcast_ref::<RegistryResponseError>() {
+            return reqwest::StatusCode::from_u16(response_err.status).ok();
+        }
         if let Some(reqwest_err) = err.downcast_ref::<reqwest::Error>()
-            && reqwest_err.status() == Some(reqwest::StatusCode::NOT_FOUND)
+            && let Some(status) = reqwest_err.status()
         {
-            return true;
+            return Some(status);
         }
         current = err.source();
     }
-    false
+    None
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-resolver-base/Cargo.toml
+++ b/pnpm/crates/resolving-resolver-base/Cargo.toml
@@ -13,10 +13,12 @@ repository.workspace  = true
 [dependencies]
 pacquet-config   = { workspace = true }
 pacquet-lockfile = { workspace = true }
+pacquet-network  = { workspace = true }
 pacquet-registry = { workspace = true }
 
 chrono      = { workspace = true }
 derive_more = { workspace = true }
+miette      = { workspace = true }
 node-semver = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }

--- a/pnpm/crates/resolving-resolver-base/src/errors.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors.rs
@@ -1,0 +1,224 @@
+//! Resolver failures that carry a pnpm error code.
+//!
+//! [`ResolveError`](crate::ResolveError) type-erases a resolver failure to
+//! `Box<dyn Error>`, which drops its [`miette::Diagnostic`] facet — and with
+//! it the `ERR_PNPM_*` code that is part of pnpm's public contract. The types
+//! here are the exception: a caller that has to keep the code (the dependency
+//! tree walker) recovers it by downcasting the box. A resolver therefore has
+//! to box them *outermost*, never nested inside another error, or the
+//! downcast misses them.
+
+use std::fmt::{self, Write as _};
+
+use chrono::{Local, TimeDelta, Utc};
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use pacquet_network::hide_auth_information;
+use pacquet_registry::Package;
+
+/// `ERR_PNPM_NO_MATCHING_VERSION`: the registry served the package's
+/// packument, but none of the published versions satisfied the request.
+///
+/// Distinct from `ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER`, which means
+/// no resolver understood the specifier's shape. A well-formed range that
+/// simply matches nothing belongs here (<https://github.com/pnpm/pnpm/issues/13319>).
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("No matching version found for {dep} while fetching it from {registry}")]
+#[diagnostic(code(ERR_PNPM_NO_MATCHING_VERSION), help("{published_versions}"))]
+pub struct NoMatchingVersionError {
+    /// The dependency as declared — `<alias>@<bare specifier>`, or the bare
+    /// specifier alone when it has no alias.
+    #[error(not(source))]
+    pub dep: String,
+    pub registry: String,
+    /// What the registry *does* publish: the latest release, the other
+    /// dist-tags, and how to list every version.
+    pub published_versions: String,
+}
+
+impl NoMatchingVersionError {
+    #[must_use]
+    pub fn new(dep: String, registry: String, meta: &Package) -> Self {
+        Self { dep, registry, published_versions: describe_published_versions(meta) }
+    }
+}
+
+/// The registry-metadata appendix pnpm prints under a no-matching-version
+/// error: the latest release and when it went out, the other dist-tags, and
+/// the `pnpm view` invocation that lists every published version.
+fn describe_published_versions(meta: &Package) -> String {
+    let mut out = String::new();
+    if let Some(latest) = meta.dist_tags.get("latest") {
+        write!(out, r#"The latest release of {} is "{latest}"."#, meta.name).unwrap();
+        if let Some(published_at) = meta.published_at(latest).and_then(stringify_date) {
+            write!(out, " Published at {published_at}").unwrap();
+        }
+        out.push('\n');
+    }
+    // The tags arrive in a `HashMap`, so they are sorted to keep the message
+    // stable across runs rather than left in iteration order.
+    let mut other_tags: Vec<_> =
+        meta.dist_tags.iter().filter(|(tag, _)| tag.as_str() != "latest").collect();
+    other_tags.sort_by_key(|(tag, _)| *tag);
+    if !other_tags.is_empty() {
+        out.push_str("\nOther releases are:\n");
+        for (tag, version) in other_tags {
+            write!(out, "  * {tag}: {version}").unwrap();
+            if let Some(published_at) = meta.published_at(version).and_then(stringify_date) {
+                write!(out, " published at {published_at}").unwrap();
+            }
+            out.push('\n');
+        }
+    }
+    write!(
+        out,
+        "\nIf you need the full list of all {} published versions run \"pnpm view {} versions\".",
+        meta.versions.len(),
+        meta.name,
+    )
+    .unwrap();
+    out
+}
+
+/// Render a packument publish timestamp the way pnpm reports it: the date on
+/// its own, with the time of day appended while the release is less than a
+/// day old. `None` when the registry served a timestamp that doesn't parse.
+fn stringify_date(timestamp: &str) -> Option<String> {
+    let parsed = crate::parse_packument_timestamp(timestamp)?;
+    let local = parsed.with_timezone(&Local);
+    if Utc::now() - parsed < TimeDelta::days(1) {
+        return Some(local.format("%-m/%-d/%Y %-I:%M:%S %p").to_string());
+    }
+    Some(local.format("%-m/%-d/%Y").to_string())
+}
+
+/// `ERR_PNPM_FETCH_<status>`: the registry answered a request with a non-2xx
+/// status. Carries pnpm's hint for the statuses that deny access, so a 404
+/// that is really an authorization failure is recognizable as one.
+///
+/// [`Diagnostic`] is implemented by hand because the code embeds the status.
+#[derive(Debug, Display, Error)]
+#[display("GET {url}: {status_text} - {status}")]
+pub struct RegistryResponseError {
+    #[error(not(source))]
+    pub url: String,
+    pub status: u16,
+    pub status_text: String,
+    pub hint: Option<String>,
+}
+
+impl Diagnostic for RegistryResponseError {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        Some(Box::new(format!("ERR_PNPM_FETCH_{}", self.status)))
+    }
+
+    fn help(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        self.hint.as_ref().map(|hint| Box::new(hint) as Box<dyn fmt::Display + '_>)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RegistryResponseErrorOptions<'a> {
+    /// The requested URL, with any inline credentials already redacted.
+    pub url: &'a str,
+    pub status: u16,
+    /// The status' reason phrase, e.g. `Not Found` for a 404.
+    pub status_text: &'a str,
+    pub pkg_name: &'a str,
+    /// The `Authorization` header value sent with the request. Masked by
+    /// [`hide_auth_information`] before it reaches the hint.
+    pub auth_header_value: Option<&'a str>,
+}
+
+impl RegistryResponseError {
+    #[must_use]
+    pub fn new(opts: RegistryResponseErrorOptions<'_>) -> Self {
+        let RegistryResponseErrorOptions { url, status, status_text, pkg_name, auth_header_value } =
+            opts;
+        let mut hint = String::new();
+        if status == 404 {
+            write!(
+                hint,
+                "{pkg_name} is not in the npm registry, or you have no permission to fetch it.",
+            )
+            .unwrap();
+            if let Some(without_version) = strip_trailing_semver_suffix(pkg_name) {
+                write!(hint, " Did you mean {without_version}?").unwrap();
+            }
+        }
+        // Some registries answer an authentication failure with a 404 rather
+        // than disclosing that the package exists, so the authorization line
+        // is printed for that status too.
+        if matches!(status, 401 | 403 | 404) {
+            if !hint.is_empty() {
+                hint.push_str("\n\n");
+            }
+            match auth_header_value {
+                Some(value) => write!(
+                    hint,
+                    "An authorization header was used: {}",
+                    hide_auth_information(value),
+                )
+                .unwrap(),
+                None => hint.push_str("No authorization header was set for the request."),
+            }
+        }
+        Self {
+            url: url.to_string(),
+            status,
+            status_text: status_text.to_string(),
+            hint: (!hint.is_empty()).then_some(hint),
+        }
+    }
+}
+
+/// Detect a package name that accidentally carries a `<version>` suffix
+/// (`lodash@4.17.21`, `lodash4.17.21`) and return the part before it, so the
+/// 404 hint can suggest the name the user meant. `None` when the name carries
+/// no trailing version.
+fn strip_trailing_semver_suffix(pkg_name: &str) -> Option<&str> {
+    // Common case: `name@version`. A leading `@` (the scope of `@scope/foo`)
+    // is not a separator, hence the `index > 0`.
+    if let Some(index) = pkg_name.rfind('@')
+        && index > 0
+        && is_semver(&pkg_name[index + 1..])
+    {
+        return Some(&pkg_name[..index]);
+    }
+    // Fallback: a version appended with no separator at all (`foo1.0.0`).
+    // Walk backwards over three dot-separated digit blocks.
+    let bytes = pkg_name.as_bytes();
+    let mut end = consume_trailing_digits(bytes, bytes.len());
+    if end == bytes.len() || end == 0 || bytes[end - 1] != b'.' {
+        return None;
+    }
+    end -= 1;
+    let before_patch = end;
+    end = consume_trailing_digits(bytes, end);
+    if end == before_patch || end == 0 || bytes[end - 1] != b'.' {
+        return None;
+    }
+    end -= 1;
+    let before_minor = end;
+    end = consume_trailing_digits(bytes, end);
+    if end == before_minor || end == 0 || !is_semver(&pkg_name[end..]) {
+        return None;
+    }
+    let prefix = pkg_name[..end].strip_suffix('@').unwrap_or(&pkg_name[..end]);
+    (!prefix.is_empty()).then_some(prefix)
+}
+
+fn consume_trailing_digits(bytes: &[u8], end: usize) -> usize {
+    let mut index = end;
+    while index > 0 && bytes[index - 1].is_ascii_digit() {
+        index -= 1;
+    }
+    index
+}
+
+fn is_semver(candidate: &str) -> bool {
+    candidate.parse::<node_semver::Version>().is_ok()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
+use chrono::{TimeDelta, Utc};
 use miette::Diagnostic;
 use pacquet_registry::{Package, PackageDistribution, PackageVersion};
 
 use super::{
-    NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions,
+    NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions, stringify_date,
     strip_trailing_semver_suffix,
 };
 
@@ -165,6 +166,30 @@ fn registry_response_error_leaves_a_500_without_a_hint() {
     });
 
     assert!(error.hint.is_none(), "{:?}", error.hint);
+}
+
+#[test]
+fn a_release_older_than_a_day_is_dated_without_a_time_of_day() {
+    let rendered = stringify_date("2024-03-15T09:42:13Z").expect("a parsable timestamp");
+    dbg!(&rendered);
+    assert!(rendered.starts_with("3/1"), "expected a month/day/year date, got {rendered:?}");
+    assert!(!rendered.contains(':'), "an old release carries no time of day: {rendered:?}");
+}
+
+#[test]
+fn a_release_published_within_the_day_carries_its_time_of_day() {
+    let an_hour_ago = Utc::now() - TimeDelta::hours(1);
+    let rendered = stringify_date(&an_hour_ago.to_rfc3339()).expect("a parsable timestamp");
+    dbg!(&rendered);
+    assert!(
+        rendered.ends_with(" AM") || rendered.ends_with(" PM"),
+        "a fresh release carries its time of day: {rendered:?}",
+    );
+}
+
+#[test]
+fn an_unparsable_timestamp_is_dropped_rather_than_echoed() {
+    assert_eq!(stringify_date("last tuesday"), None);
 }
 
 #[test]

--- a/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
@@ -103,7 +103,7 @@ fn no_matching_version_help_lists_the_other_dist_tags_in_a_stable_order() {
     dbg!(&help);
     assert!(
         help.contains("Other releases are:\n  * legacy: 1.0.0\n  * next: 4.0.0-beta.1\n"),
-        "{help}"
+        "{help}",
     );
 }
 
@@ -117,7 +117,7 @@ fn registry_response_error_codes_the_status_and_hints_at_the_missing_package() {
         auth_header_value: None,
     });
 
-    assert_eq!(error.to_string(), "GET https://registry.npmjs.org/@repro%2Fpkg-a: Not Found - 404",);
+    assert_eq!(error.to_string(), "GET https://registry.npmjs.org/@repro%2Fpkg-a: Not Found - 404");
     assert_eq!(error.code().map(|code| code.to_string()).as_deref(), Some("ERR_PNPM_FETCH_404"));
     assert_eq!(
         rendered_help(&error),

--- a/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
@@ -1,0 +1,183 @@
+use std::collections::HashMap;
+
+use miette::Diagnostic;
+use pacquet_registry::{Package, PackageDistribution, PackageVersion};
+
+use super::{
+    NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions,
+    strip_trailing_semver_suffix,
+};
+
+fn make_package(name: &str, versions: &[&str], dist_tags: &[(&str, &str)]) -> Package {
+    Package {
+        name: name.to_string(),
+        dist_tags: dist_tags
+            .iter()
+            .map(|(tag, version)| ((*tag).to_string(), (*version).to_string()))
+            .collect(),
+        versions: versions
+            .iter()
+            .map(|version| {
+                (
+                    (*version).to_string(),
+                    PackageVersion {
+                        name: name.to_string(),
+                        version: version.parse().expect("parse semver"),
+                        dist: PackageDistribution::default(),
+                        dependencies: None,
+                        dev_dependencies: None,
+                        peer_dependencies: None,
+                        optional_dependencies: None,
+                        peer_dependencies_meta: None,
+                        other: HashMap::default(),
+                        npm_user: None,
+                        deprecated: None,
+                    },
+                )
+            })
+            .collect(),
+        time: None,
+        modified: None,
+        etag: None,
+        homepage: None,
+        mutex: std::sync::Arc::default(),
+    }
+}
+
+fn rendered_help(error: &dyn Diagnostic) -> String {
+    error.help().map(|help| help.to_string()).unwrap_or_default()
+}
+
+#[test]
+fn no_matching_version_reports_the_upstream_code_and_message() {
+    let meta = make_package("is-odd", &["1.0.0", "3.0.1"], &[("latest", "3.0.1")]);
+    let error = NoMatchingVersionError::new(
+        "is-odd@99.99.99".to_string(),
+        "https://registry.npmjs.org/".to_string(),
+        &meta,
+    );
+
+    assert_eq!(
+        error.to_string(),
+        "No matching version found for is-odd@99.99.99 while fetching it from https://registry.npmjs.org/",
+    );
+    assert_eq!(
+        error.code().map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_NO_MATCHING_VERSION"),
+    );
+}
+
+#[test]
+fn no_matching_version_help_lists_the_latest_release_and_how_to_see_the_rest() {
+    let meta = make_package("is-odd", &["1.0.0", "2.0.0", "3.0.1"], &[("latest", "3.0.1")]);
+    let error = NoMatchingVersionError::new(
+        "is-odd@99.99.99".to_string(),
+        "https://registry.npmjs.org/".to_string(),
+        &meta,
+    );
+
+    let help = rendered_help(&error);
+    dbg!(&help);
+    assert!(help.contains(r#"The latest release of is-odd is "3.0.1"."#), "{help}");
+    assert!(
+        help.contains(r#"If you need the full list of all 3 published versions run "pnpm view is-odd versions"."#),
+        "{help}",
+    );
+    assert!(!help.contains("Other releases are:"), "{help}");
+}
+
+#[test]
+fn no_matching_version_help_lists_the_other_dist_tags_in_a_stable_order() {
+    let meta = make_package(
+        "is-odd",
+        &["1.0.0", "3.0.1", "4.0.0-beta.1"],
+        &[("latest", "3.0.1"), ("next", "4.0.0-beta.1"), ("legacy", "1.0.0")],
+    );
+    let error = NoMatchingVersionError::new(
+        "is-odd@99.99.99".to_string(),
+        "https://registry.npmjs.org/".to_string(),
+        &meta,
+    );
+
+    let help = rendered_help(&error);
+    dbg!(&help);
+    assert!(
+        help.contains("Other releases are:\n  * legacy: 1.0.0\n  * next: 4.0.0-beta.1\n"),
+        "{help}"
+    );
+}
+
+#[test]
+fn registry_response_error_codes_the_status_and_hints_at_the_missing_package() {
+    let error = RegistryResponseError::new(RegistryResponseErrorOptions {
+        url: "https://registry.npmjs.org/@repro%2Fpkg-a",
+        status: 404,
+        status_text: "Not Found",
+        pkg_name: "@repro/pkg-a",
+        auth_header_value: None,
+    });
+
+    assert_eq!(error.to_string(), "GET https://registry.npmjs.org/@repro%2Fpkg-a: Not Found - 404",);
+    assert_eq!(error.code().map(|code| code.to_string()).as_deref(), Some("ERR_PNPM_FETCH_404"));
+    assert_eq!(
+        rendered_help(&error),
+        "@repro/pkg-a is not in the npm registry, or you have no permission to fetch it.\n\nNo authorization header was set for the request.",
+    );
+}
+
+#[test]
+fn registry_response_error_masks_the_authorization_header() {
+    let error = RegistryResponseError::new(RegistryResponseErrorOptions {
+        url: "https://registry.npmjs.org/private-pkg",
+        status: 404,
+        status_text: "Not Found",
+        pkg_name: "private-pkg",
+        auth_header_value: Some("Bearer npm_0123456789abcdefghij"),
+    });
+
+    let help = rendered_help(&error);
+    dbg!(&help);
+    assert!(help.ends_with("An authorization header was used: Bearer npm_[hidden]"), "{help}");
+}
+
+#[test]
+fn registry_response_error_hints_only_at_authorization_for_a_403() {
+    let error = RegistryResponseError::new(RegistryResponseErrorOptions {
+        url: "https://registry.npmjs.org/private-pkg",
+        status: 403,
+        status_text: "Forbidden",
+        pkg_name: "private-pkg",
+        auth_header_value: None,
+    });
+
+    assert_eq!(error.code().map(|code| code.to_string()).as_deref(), Some("ERR_PNPM_FETCH_403"));
+    assert_eq!(rendered_help(&error), "No authorization header was set for the request.");
+}
+
+#[test]
+fn registry_response_error_leaves_a_500_without_a_hint() {
+    let error = RegistryResponseError::new(RegistryResponseErrorOptions {
+        url: "https://registry.npmjs.org/pkg",
+        status: 500,
+        status_text: "Internal Server Error",
+        pkg_name: "pkg",
+        auth_header_value: Some("Bearer token"),
+    });
+
+    assert!(error.hint.is_none(), "{:?}", error.hint);
+}
+
+#[test]
+fn a_name_carrying_a_version_suffix_suggests_the_bare_name() {
+    assert_eq!(strip_trailing_semver_suffix("lodash@4.17.21"), Some("lodash"));
+    assert_eq!(strip_trailing_semver_suffix("lodash4.17.21"), Some("lodash"));
+    assert_eq!(strip_trailing_semver_suffix("@scope/pkg@1.0.0"), Some("@scope/pkg"));
+}
+
+#[test]
+fn a_plain_name_suggests_nothing() {
+    assert_eq!(strip_trailing_semver_suffix("lodash"), None);
+    assert_eq!(strip_trailing_semver_suffix("@scope/pkg"), None);
+    assert_eq!(strip_trailing_semver_suffix("is-odd@latest"), None);
+    assert_eq!(strip_trailing_semver_suffix("4.17.21"), None);
+}

--- a/pnpm/crates/resolving-resolver-base/src/lib.rs
+++ b/pnpm/crates/resolving-resolver-base/src/lib.rs
@@ -17,11 +17,13 @@
 //! (a verifier needs [`pacquet_lockfile::LockfileResolution`]; a
 //! resolver result *also* carries one).
 
+mod errors;
 mod peer_range;
 mod publish_time;
 mod resolve;
 mod verifier;
 
+pub use errors::{NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions};
 pub use peer_range::{get_peer_version_range, is_acceptable_peer_spec, is_valid_peer_range};
 pub use publish_time::parse_packument_timestamp;
 pub use resolve::{


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13319.

Three reporting bugs on the pacquet resolution path, all visible from the issue's repro:

**A version that doesn't exist.** `pick_from_registry` folded "the registry publishes this package but nothing matching the range" into `Ok(None)`, so the dispatcher ran out of resolvers and reported `ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` — "pnpm doesn't understand this specifier", which is the wrong diagnosis for a perfectly ordinary `99.99.99`. It now raises `NoMatchingVersionError` (`ERR_PNPM_NO_MATCHING_VERSION`) with the registry-metadata appendix the TypeScript CLI prints: latest release (and when it was published), the other dist-tags, and the `pnpm view <pkg> versions` pointer. Raised on all three registry paths — npm, `jsr:`, and named registries — matching `resolveNpm` / `pickFromSimpleRegistry` upstream.

```
Error: ERR_PNPM_NO_MATCHING_VERSION

  × installing dependencies
  ╰─▶ Failed to resolve dependency tree: No matching version found for is-
      odd@99.99.99 while fetching it from https://registry.npmjs.org/
  help: The latest release of is-odd is "3.0.1".

        If you need the full list of all 7 published versions run "pnpm view
        is-odd versions".
```

**A package that doesn't exist.** A non-2xx metadata response surfaced as raw transport text with no code at all. It now becomes `RegistryResponseError` (`ERR_PNPM_FETCH_<status>`), carrying pnpm's `GET <url>: <reason> - <status>` message, the "not in the npm registry, or you have no permission to fetch it" hint (with upstream's "Did you mean …?" for a name that carries a version suffix), and — for 401/403/404, since a private registry commonly answers a permission failure with a 404 — which authorization header was sent, masked the way `@pnpm/error`'s `FetchError` masks it.

```
Error: ERR_PNPM_FETCH_404

  × installing dependencies
  ╰─▶ Failed to resolve dependency tree: GET https://registry.npmjs.org/
      @repro%2Fpkg-a: Not Found - 404
  help: @repro/pkg-a is not in the npm registry, or you have no permission
        to fetch it.

        An authorization header was used: Bearer npm_[hidden]
```

**The repeated diagnostic chain.** The collapsing report handler folded only *identical* consecutive messages, so a wrapper that quotes its cause verbatim behind a prefix ("Failed to resolve dependency tree: `<msg>`") still printed `<msg>` again one line below. It now folds a level whose message the level above already ends with.

### Note on scope

pnpm 11 also prints `This error happened while installing a direct dependency of <dir>`. In the TypeScript stack that line comes from `@pnpm/cli.default-reporter`'s `reportError`, which decorates *every* `ERR_PNPM_*` with the declaring project and the `pkgsStack`. pacquet renders install errors straight through miette with no equivalent layer, so adding it is a change to the whole error surface rather than to these two codes — left out of this PR deliberately.

`pnpm view`'s own `ViewError::Fetch404` still builds its 404 without the hint; the shared `RegistryResponseError` is now available to it, but converting it is a separate change.

## Squash Commit Body

```text
A well-formed semver range that the registry publishes nothing for was
folded into `Ok(None)`, so the resolver chain ran out and reported
`ERR_PNPM_SPEC_NOT_SUPPORTED_BY_ANY_RESOLVER` — "pnpm doesn't understand
this specifier", which is the wrong diagnosis and drops the latest
release, the other dist-tags, and the `pnpm view <pkg> versions` pointer.
The npm, jsr, and named-registry paths now raise `NoMatchingVersionError`
(`ERR_PNPM_NO_MATCHING_VERSION`) with that appendix, the way
`pickFromSimpleRegistry` and `resolveNpm` do upstream.

A non-2xx registry answer reached the user as raw transport text with no
code at all. Metadata responses now become `RegistryResponseError`
(`ERR_PNPM_FETCH_<status>`) carrying pnpm's `GET <url>: <reason> -
<status>` message, the "not in the npm registry, or you have no
permission to fetch it" hint, and — for 401/403/404, since a private
registry often answers a permission failure with a 404 — which
authorization header was sent, masked.

`ResolveError` erases a resolver failure to `Box<dyn Error>`, dropping
the `Diagnostic` facet the codes live on, so both types are recovered by
downcast in the tree walker and re-surfaced through transparent variants.
Optional dependencies keep skipping on either of them.

The report renderer also folds a cause whose message its wrapper already
quotes in full, so "Failed to resolve dependency tree: <msg>" no longer
prints <msg> again on the line below.

Closes pnpm/pnpm#13319
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(pacquet-only: the TypeScript CLI already raises both codes with these
  messages — this PR brings pacquet up to it, so there is nothing to port
  back.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787590833&installation_model_id=426870&pr_number=13371&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13371&signature=bd190d02724c471bb34ffc2bc244c7041830563213536454cc0d84e9fde772f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved install and resolution error reporting for unpublished versions and unknown packages, with clearer pnpm error codes and guidance.
  * Enhanced registry failure messages (including 404/403 handling) to provide more actionable context.
  * Improved authorization diagnostics by masking sensitive tokens and reporting whether an authorization header was sent.
  * Reduced duplicated nested error text for clearer, less repetitive output.
  * Better latest-version behavior when no matching release is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->