### PR TITLE
fix(package-manager): keep peer-only aliases out of importers without auto-install-peers

### DIFF
--- a/.changeset/optional-peers-stay-out-of-importers.md
+++ b/.changeset/optional-peers-stay-out-of-importers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+With `autoInstallPeers: false`, a package's own optional peer dependencies are no longer added to its importer entry in `pnpm-lock.yaml` (and no longer linked into its `node_modules`) when another workspace project happens to resolve a matching version [#13325](https://github.com/pnpm/pnpm/issues/13325).

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -276,6 +276,15 @@ fn optional_peer_stays_out_of_the_importer_without_auto_install_peers() {
         !a_section.contains("'@pnpm.e2e/peer-c':"),
         "optional peer added to pkg-a under `autoInstallPeers: false`\n{lockfile}",
     );
+    // The optional peer is still deduplicated into the dependent's peer
+    // context — the same entry the TypeScript CLI writes for this
+    // workspace. Its counterpart lives in `peerDependencies.ts`, in
+    // `an optional peer declared by a workspace project is not added to
+    // its own importer, when auto-install-peers is off`.
+    assert!(
+        a_section.contains("version: 1.0.0(@pnpm.e2e/peer-c@1.0.0)"),
+        "pkg-a lost the deduplicated optional-peer context\n{lockfile}",
+    );
     assert!(
         !workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c").exists(),
         "optional peer linked into pkg-a under `autoInstallPeers: false`",

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -231,6 +231,61 @@ fn frozen_install_accepts_auto_installed_workspace_peer() {
     drop((root, mock_instance));
 }
 
+/// Regression for [#13325](https://github.com/pnpm/pnpm/issues/13325):
+/// with `autoInstallPeers: false`, an optional peer that a sibling
+/// importer's resolution makes available must not turn into a direct
+/// dependency of the importer that only declares it as an optional
+/// peer.
+#[test]
+fn optional_peer_stays_out_of_the_importer_without_auto_install_peers() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } = two_project_workspace(
+        &serde_json::json!({
+            "name": "pkg-a",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/abc-optional-peers": "1.0.0" },
+            "peerDependencies": { "@pnpm.e2e/peer-c": "^1.0.0" },
+            "peerDependenciesMeta": { "@pnpm.e2e/peer-c": { "optional": true } },
+        }),
+        &serde_json::json!({
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/peer-c": "1.0.0" },
+        }),
+    );
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    workspace_yaml.push_str("autoInstallPeers: false\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let a_section = lockfile
+        .split("  pkg-a:\n")
+        .nth(1)
+        .and_then(|tail| tail.split("\n  pkg-b:").next())
+        .expect("pnpm-lock.yaml missing pkg-a importer section");
+    eprintln!("pkg-a importer section:\n{a_section}");
+    // The peer-suffixed version of `abc-optional-peers` names `peer-c`
+    // too, so match the importer entry's own key.
+    assert!(
+        !a_section.contains("'@pnpm.e2e/peer-c':"),
+        "optional peer added to pkg-a under `autoInstallPeers: false`\n{lockfile}",
+    );
+    assert!(
+        !workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c").exists(),
+        "optional peer linked into pkg-a under `autoInstallPeers: false`",
+    );
+
+    pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn changed_workspace_importer_invalidates_lockfile() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } = two_project_workspace(

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -13,12 +13,15 @@
 
 pub mod _utils;
 
+use _utils::{importer, importer_version, read_lockfile};
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pacquet_lockfile::PkgName;
 use pacquet_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::is_symlink_or_junction,
 };
+use pretty_assertions::assert_eq;
 use std::{fs, path::Path, process::Command};
 
 fn pacquet_at(workspace: &Path) -> Command {
@@ -262,32 +265,28 @@ fn optional_peer_stays_out_of_the_importer_without_auto_install_peers() {
 
     pacquet_at(&workspace).with_arg("install").assert().success();
 
-    let lockfile =
-        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
-    let a_section = lockfile
-        .split("  pkg-a:\n")
-        .nth(1)
-        .and_then(|tail| tail.split("\n  pkg-b:").next())
-        .expect("pnpm-lock.yaml missing pkg-a importer section");
-    eprintln!("pkg-a importer section:\n{a_section}");
-    // The peer-suffixed version of `abc-optional-peers` names `peer-c`
-    // too, so match the importer entry's own key.
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    let pkg_a = importer(&lockfile, "pkg-a");
+    dbg!(pkg_a);
+    let peer_c: PkgName = "@pnpm.e2e/peer-c".parse().expect("parse peer name");
+    for group in [&pkg_a.dependencies, &pkg_a.dev_dependencies, &pkg_a.optional_dependencies] {
+        assert!(
+            !group.as_ref().is_some_and(|dependencies| dependencies.contains_key(&peer_c)),
+            "optional peer added to pkg-a under `autoInstallPeers: false`",
+        );
+    }
     assert!(
-        !a_section.contains("'@pnpm.e2e/peer-c':"),
-        "optional peer added to pkg-a under `autoInstallPeers: false`\n{lockfile}",
+        !workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c").exists(),
+        "optional peer linked into pkg-a under `autoInstallPeers: false`",
     );
     // The optional peer is still deduplicated into the dependent's peer
     // context — the same entry the TypeScript CLI writes for this
     // workspace. Its counterpart lives in `peerDependencies.ts`, in
     // `an optional peer declared by a workspace project is not added to
     // its own importer, when auto-install-peers is off`.
-    assert!(
-        a_section.contains("version: 1.0.0(@pnpm.e2e/peer-c@1.0.0)"),
-        "pkg-a lost the deduplicated optional-peer context\n{lockfile}",
-    );
-    assert!(
-        !workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c").exists(),
-        "optional peer linked into pkg-a under `autoInstallPeers: false`",
+    assert_eq!(
+        importer_version(&lockfile, "pkg-a", "@pnpm.e2e/abc-optional-peers"),
+        "1.0.0(@pnpm.e2e/peer-c@1.0.0)",
     );
 
     pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -41,6 +41,14 @@ pub struct ImporterLockfileInput<'a> {
     pub direct_dependencies_by_alias: BTreeMap<String, DepPath>,
 }
 
+/// The install-wide settings [`build_importer`] reads. Both decide
+/// which direct dependencies reach the importer entry, so they travel
+/// together instead of as two adjacent `bool` parameters.
+struct ImporterLockfileFlags {
+    exclude_links_from_lockfile: bool,
+    auto_install_peers: bool,
+}
+
 /// Options threaded into [`dependencies_graph_to_lockfile`].
 pub struct GraphToLockfileOptions<'a> {
     /// One entry per workspace project being installed. Keyed by the
@@ -164,7 +172,14 @@ pub fn dependencies_graph_to_lockfile(
     let mut importers: HashMap<String, ProjectSnapshot> =
         HashMap::with_capacity(importer_inputs.len());
     for (id, input) in &importer_inputs {
-        importers.insert(id.clone(), build_importer(input, graph, exclude_links_from_lockfile)?);
+        importers.insert(
+            id.clone(),
+            build_importer(
+                input,
+                graph,
+                &ImporterLockfileFlags { exclude_links_from_lockfile, auto_install_peers },
+            )?,
+        );
     }
 
     let catalog_snapshots = build_catalog_snapshots(&importers, catalogs);
@@ -252,8 +267,9 @@ fn importer_resolved_version(importer: &ProjectSnapshot, alias: &str) -> Option<
 fn build_importer(
     input: &ImporterLockfileInput<'_>,
     graph: &DependenciesGraph,
-    exclude_links_from_lockfile: bool,
+    flags: &ImporterLockfileFlags,
 ) -> Result<ProjectSnapshot, DependenciesGraphToLockfileError> {
+    let ImporterLockfileFlags { exclude_links_from_lockfile, auto_install_peers } = *flags;
     let manifest = input.manifest;
     let direct = &input.direct_dependencies_by_alias;
 
@@ -275,7 +291,9 @@ fn build_importer(
         // snapshots graph below. Writing them here would carry specifiers
         // the manifest can't satisfy through `satisfies_package_manifest`
         // and force every later install onto the fresh-resolve path.
-        let Some(specifier) = read_manifest_specifier(manifest, alias) else { continue };
+        let Some(specifier) = read_manifest_specifier(manifest, alias, auto_install_peers) else {
+            continue;
+        };
         // Workspace-link nodes don't enter the graph (the resolver
         // short-circuits them at `depth = -1`); resolve the importer
         // version directly from the `link:` depPath instead. Non-link
@@ -349,18 +367,23 @@ fn manifest_alias_to_group(manifest: &PackageManifest) -> HashMap<String, Depend
 }
 
 /// Look up the user-written specifier for `alias` in the manifest's
-/// `optionalDependencies` / `dependencies` / `devDependencies` /
-/// `peerDependencies` maps, in that precedence order. Returns `None` for
-/// a peer-only entry that was auto-installed but isn't recorded as a
-/// direct dep in the manifest — such entries don't go into the
-/// importer's `specifiers` map.
-fn read_manifest_specifier(manifest: &PackageManifest, alias: &str) -> Option<String> {
-    for group in [
-        DependencyGroup::Optional,
-        DependencyGroup::Prod,
-        DependencyGroup::Dev,
-        DependencyGroup::Peer,
-    ] {
+/// `optionalDependencies` / `dependencies` / `devDependencies` maps —
+/// plus `peerDependencies` when `auto_install_peers` materializes those
+/// into the importer's dependencies. Returns `None` for an alias the
+/// manifest doesn't declare in any of those groups, including a peer the
+/// hoist installed while `autoInstallPeers` is off: such entries stay out
+/// of the importer's `specifiers` map and are only reachable through the
+/// snapshots graph.
+fn read_manifest_specifier(
+    manifest: &PackageManifest,
+    alias: &str,
+    auto_install_peers: bool,
+) -> Option<String> {
+    let materialized_peers = auto_install_peers.then_some(DependencyGroup::Peer);
+    for group in [DependencyGroup::Optional, DependencyGroup::Prod, DependencyGroup::Dev]
+        .into_iter()
+        .chain(materialized_peers)
+    {
         let group_key: &str = group.into();
         if let Some(map) = manifest.value().get(group_key).and_then(Value::as_object)
             && let Some(spec) = map.get(alias).and_then(Value::as_str)

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -2013,3 +2013,83 @@ fn same_name_injected_dep_serializes_as_plain_file_ref() {
         "renamed aliases must keep the <name>@<ref> form: {renamed:?}",
     );
 }
+
+/// Regression for <https://github.com/pnpm/pnpm/issues/13325>: a peer
+/// the hoist installed for the importer is a direct dependency of the
+/// resolved tree either way, but it only belongs in the importer's
+/// lockfile entry when `autoInstallPeers` materializes the manifest's
+/// `peerDependencies` into its dependencies.
+#[test]
+fn importer_records_a_peer_only_alias_only_under_auto_install_peers() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "consumer": "1.0.0" },
+        "peerDependencies": { "peer": "^1.0.0" },
+        "peerDependenciesMeta": { "peer": { "optional": true } },
+    }));
+    let peer = make_node(
+        "peer",
+        "1.0.0",
+        json!({ "name": "peer", "version": "1.0.0" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+    let consumer = make_node(
+        "consumer",
+        "1.0.0",
+        json!({
+            "name": "consumer",
+            "version": "1.0.0",
+            "peerDependencies": { "peer": "^1.0.0" },
+            "peerDependenciesMeta": { "peer": { "optional": true } },
+        }),
+        BTreeMap::from([("peer".to_string(), peer.dep_path.clone())]),
+        BTreeMap::from([(
+            "peer".to_string(),
+            PeerDep { version: "^1.0.0".to_string(), optional: true },
+        )]),
+        HashSet::new(),
+    );
+    let mut graph = DependenciesGraph::new();
+    for node in [peer, consumer] {
+        graph.insert(node.dep_path.clone(), node);
+    }
+    let direct = BTreeMap::from([
+        ("consumer".to_string(), DepPath::from("consumer@1.0.0".to_string())),
+        ("peer".to_string(), DepPath::from("peer@1.0.0".to_string())),
+    ]);
+
+    let peer_key = PkgName::parse("peer").unwrap();
+    let without_auto_install = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest,
+        &graph,
+        direct.clone(),
+        false,
+        false,
+        None,
+        None,
+    ));
+    let importer = without_auto_install.root_project().expect("root importer exists");
+    dbg!(&importer.dependencies);
+    assert!(
+        !importer.dependencies.as_ref().is_some_and(|deps| deps.contains_key(&peer_key)),
+        "a peer-only alias must stay out of the importer entry under `autoInstallPeers: false`",
+    );
+    assert!(
+        !importer.specifiers.as_ref().is_some_and(|specs| specs.contains_key("peer")),
+        "a peer-only alias must stay out of the importer specifiers under `autoInstallPeers: false`",
+    );
+
+    let with_auto_install = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, true, false, None, None,
+    ));
+    let importer = with_auto_install.root_project().expect("root importer exists");
+    let entry = importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(&peer_key))
+        .expect("auto-installed peer entry");
+    assert_eq!(entry.specifier, "^1.0.0");
+}

--- a/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
@@ -1581,6 +1581,12 @@ test('an optional peer declared by a workspace project is not added to its own i
   const lockfile = readYamlFileSync<LockfileFile>(path.resolve(WANTED_LOCKFILE))
   expect(lockfile.importers!['project-1'].dependencies).not.toHaveProperty(['@pnpm.e2e/peer-c'])
   expect(fs.existsSync(path.resolve('project-1/node_modules/@pnpm.e2e/peer-c'))).toBeFalsy()
+  // The optional peer is still deduplicated into the dependent's peer context.
+  // pacquet writes the identical entry; its counterpart is
+  // `optional_peer_stays_out_of_the_importer_without_auto_install_peers` in
+  // pnpm/crates/cli/tests/workspace_install.rs.
+  expect(lockfile.importers!['project-1'].dependencies!['@pnpm.e2e/abc-optional-peers'].version)
+    .toBe('1.0.0(@pnpm.e2e/peer-c@1.0.0)')
 })
 
 test('resolve peer dependencies from aliased subdependencies if they are dependencies of a parent package', async () => {

--- a/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
@@ -1536,6 +1536,53 @@ test('deduplicate packages that have peers, when adding new dependency in a work
   expect(depPaths).toContain(`@pnpm.e2e/abc-parent-with-ab@1.0.0${createPeerDepGraphHash([{ name: '@pnpm.e2e/peer-c', version: '1.0.0' }])}`)
 })
 
+test('an optional peer declared by a workspace project is not added to its own importer, when auto-install-peers is off', async () => {
+  // Regression test for https://github.com/pnpm/pnpm/issues/13325
+  // project-1 declares @pnpm.e2e/peer-c only as an optional peer, and a sibling
+  // project resolves that very version. The optional peer may be deduplicated
+  // into the peer context of project-1's dependency, but it must not become a
+  // direct dependency of project-1 itself.
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+
+  const manifest1 = {
+    name: 'project-1',
+    dependencies: {
+      '@pnpm.e2e/abc-optional-peers': '1.0.0',
+    },
+    peerDependencies: {
+      '@pnpm.e2e/peer-c': '^1.0.0',
+    },
+    peerDependenciesMeta: {
+      '@pnpm.e2e/peer-c': { optional: true },
+    },
+  }
+  const manifest2 = {
+    name: 'project-2',
+    dependencies: {
+      '@pnpm.e2e/peer-c': '1.0.0',
+    },
+  }
+  preparePackages([
+    { location: 'project-1', package: manifest1 },
+    { location: 'project-2', package: manifest2 },
+  ])
+
+  const importers: MutatedProject[] = [
+    { mutation: 'install', rootDir: path.resolve('project-1') as ProjectRootDir },
+    { mutation: 'install', rootDir: path.resolve('project-2') as ProjectRootDir },
+  ]
+  const allProjects = [
+    { buildIndex: 0, manifest: manifest1, rootDir: path.resolve('project-1') as ProjectRootDir },
+    { buildIndex: 0, manifest: manifest2, rootDir: path.resolve('project-2') as ProjectRootDir },
+  ]
+  await mutateModules(importers, testDefaults({ allProjects, autoInstallPeers: false }))
+
+  const lockfile = readYamlFileSync<LockfileFile>(path.resolve(WANTED_LOCKFILE))
+  expect(lockfile.importers!['project-1'].dependencies).not.toHaveProperty(['@pnpm.e2e/peer-c'])
+  expect(fs.existsSync(path.resolve('project-1/node_modules/@pnpm.e2e/peer-c'))).toBeFalsy()
+})
+
 test('resolve peer dependencies from aliased subdependencies if they are dependencies of a parent package', async () => {
   prepareEmpty()
   await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })


### PR DESCRIPTION
## Summary

With `autoInstallPeers: false`, pacquet added a project's own optional peer dependencies to that project's importer entry in `pnpm-lock.yaml` (and linked them into its `node_modules`) as soon as some other part of the workspace resolved a matching version. Reported for vite in pnpm/pnpm#13325, where `packages/vite` gained `jiti`, `tsx` and `yaml` — the optional peers of `postcss-load-config` that `packages/vite` re-declares as its own optional peers.

The peer hoist itself is not the divergence: both stacks hoist an optional peer into the importer's resolved direct dependencies when a satisfying version is already in scope, which is what produces the `(@pnpm.e2e/peer-c@1.0.0)` peer context on the dependent. The difference is what reaches the lockfile importer entry. The TypeScript CLI folds `peerDependencies` into an importer's dependencies only under `autoInstallPeers` (`getAllDependenciesFromManifest(manifest, { autoInstallPeers })` in `pnpm11/installing/deps-resolver/src/index.ts`), so with the setting off a hoisted peer stays reachable only through the snapshots graph. pacquet's `read_manifest_specifier` consulted `peerDependencies` unconditionally; it now applies the same gate — which also lines it up with pacquet's own lockfile freshness check, whose peer fold is already gated on `auto_install_peers`.

Verified against the TypeScript CLI with a two-project fixture on the mocked registry: before the fix pacquet wrote `'@pnpm.e2e/peer-c': { specifier: ^1.0.0, version: 1.0.0 }` into `pkg-a` while pnpm v11.17.0 wrote nothing; after the fix the two lockfiles are byte-identical (modulo the `settings:` block), and so is `pkg-a/node_modules`. `autoInstallPeers: true` still materializes the peer in both stacks.

Closes pnpm/pnpm#13325

## Squash Commit Body

```text
An importer's lockfile entry was built from every hoisted direct
dependency the manifest declared anywhere, `peerDependencies` included.
The peer hoist runs whenever a missing peer can be satisfied from a
version already resolved in the workspace, so with
`autoInstallPeers: false` a project's own optional peer became a direct
dependency of its importer as soon as a sibling project resolved a
matching version, and got linked into that project's `node_modules`.

The TypeScript CLI folds `peerDependencies` into an importer's
dependencies only under `autoInstallPeers`
(`getAllDependenciesFromManifest(manifest, { autoInstallPeers })` in
`installing/deps-resolver/src/index.ts`); peers hoisted with the setting
off never reach the importer entry and stay reachable only through the
snapshots graph. `read_manifest_specifier` now applies the same gate,
which also matches pacquet's lockfile freshness check — its peer fold is
already gated on the same setting, so the two now agree on which
importer entries a manifest is expected to have.

The fix is pacquet-only: the TypeScript CLI already behaves this way, and
gets a regression test for the same scenario.

Closes pnpm/pnpm#13325
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- The bug is pacquet-only; the TypeScript CLI already behaves correctly
  and gets a matching regression test. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787591516&installation_model_id=426870&pr_number=13372&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13372&signature=c2a89e8d81bba1ecf9242e387c4b576cc9c5c30c7955e63517d42632a2fee606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When automatic peer installation is disabled (`autoInstallPeers: false`), optional peer dependencies are no longer added to a project’s lockfile importer or installed into its `node_modules`.
  * Lockfiles produced with this setting work correctly with frozen installs.
  * Behavior remains unchanged when automatic peer installation is enabled.
* **Tests**
  * Added regression coverage for optional-peer handling (issue `#13325`) across CLI and installer scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->