### PR TITLE
fix(deps-resolver): close two Astro lockfile divergences

### DIFF
--- a/.changeset/astro-lockfile-resolution-parity.md
+++ b/.changeset/astro-lockfile-resolution-parity.md
@@ -1,0 +1,8 @@
+---
+"pacquet": patch
+---
+
+Two `pnpm install` resolution fixes that made large workspaces such as [Astro](https://github.com/withastro/astro) produce a different `pnpm-lock.yaml` than pnpm 11 [#13334](https://github.com/pnpm/pnpm/issues/13334):
+
+- A scoped workspace package referenced through the `file:` protocol (`"@test/pkg": "file:./pkg"`) is recorded as a `link:` again instead of being copied in as a `file:` snapshot.
+- `bundledDependencies` / `bundleDependencies` are no longer resolved as dependencies of their own. npm ships them inside the package's tarball, so installing them again added packages the lockfile should not contain (for example `napi-wasm` under `@parcel/watcher-wasm`).

--- a/pnpm/crates/resolving-deps-resolver/src/dedupe_injected_deps.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dedupe_injected_deps.rs
@@ -129,16 +129,17 @@ fn child_matches_target(
 /// The resolver's `pkg.id` for a `file:<path>` workspace pick is
 /// emitted as `<name>@file:<path>` once the manifest name is in scope
 /// (see `build_pkg_id_with_patch_hash`) and as the bare `file:<path>`
-/// before that — accept both shapes.
+/// before that — accept both shapes. Splitting on the whole `@file:`
+/// separator rather than on `@` alone keeps scoped names
+/// (`@scope/name@file:<path>`) matching, whose leading `@` would
+/// otherwise be taken for the separator.
 fn injected_workspace_target(
     node: &crate::dependencies_graph::DependenciesGraphNode,
     workspace_project_ids: &HashSet<String>,
 ) -> Option<String> {
     let raw = node.resolved_package_id.as_str();
-    let path = raw.strip_prefix("file:").or_else(|| {
-        let after_at = raw.split_once('@').map(|(_, rest)| rest)?;
-        after_at.strip_prefix("file:")
-    })?;
+    let path =
+        raw.strip_prefix("file:").or_else(|| raw.split_once("@file:").map(|(_, path)| path))?;
     workspace_project_ids.contains(path).then(|| path.to_string())
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/dedupe_injected_deps/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dedupe_injected_deps/tests.rs
@@ -63,6 +63,36 @@ fn rewrites_childless_injected_dep_to_link() {
     assert!(graph.is_empty(), "unreachable file: snapshot should be pruned");
 }
 
+// Regression test for pnpm/pnpm#13334: the resolver prefixes a `file:`
+// workspace pick with the manifest name, so a scoped package's id reads
+// `@scope/name@file:<path>`. Its leading `@` must not be mistaken for the
+// name/id separator, or the dep never dedupes back to `link:`.
+#[test]
+fn rewrites_scoped_injected_dep_to_link() {
+    let lockfile_dir = PathBuf::from("/ws");
+    let host_root = lockfile_dir.join("fixtures/host");
+    let pkg_root = host_root.join("pkg");
+
+    let mut graph: DependenciesGraph = std::collections::HashMap::new();
+    let injected = DepPath::from("@test/pkg@file:fixtures/host/pkg".to_string());
+    graph.insert(injected.clone(), make_node("@test/pkg@file:fixtures/host/pkg", BTreeMap::new()));
+
+    let mut direct: DirectByImporter = BTreeMap::new();
+    direct
+        .insert("fixtures/host".to_string(), BTreeMap::from([("@test/pkg".to_string(), injected)]));
+    direct.insert("fixtures/host/pkg".to_string(), BTreeMap::new());
+
+    let mut roots = BTreeMap::new();
+    roots.insert("fixtures/host".to_string(), host_root);
+    roots.insert("fixtures/host/pkg".to_string(), pkg_root);
+
+    dedupe_injected_deps(&mut graph, &mut direct, &roots, &lockfile_dir);
+
+    let after = direct.get("fixtures/host").unwrap().get("@test/pkg").unwrap();
+    assert_eq!(after.as_str(), "link:pkg");
+    assert!(graph.is_empty(), "unreachable file: snapshot should be pruned");
+}
+
 #[test]
 fn leaves_injected_dep_when_children_differ() {
     let lockfile_dir = PathBuf::from("/ws");

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -3064,25 +3064,52 @@ fn render_specifier(wanted: &WantedDependency) -> String {
 /// `optionalDependencies`. The walker propagates this through
 /// `current_is_optional` so [`ResolvedPackage::optional`] reflects
 /// whether every path to the node went through an optional edge.
+///
+/// Names the manifest bundles are dropped: npm ships them inside the
+/// package's own tarball, so resolving them again would install a
+/// second copy the package never loads.
 fn extract_children(
     result: &pacquet_resolving_resolver_base::ResolveResult,
 ) -> Result<Vec<ChildSpec>, ResolveDependencyTreeError> {
     let Some(manifest) = result.manifest.as_ref() else { return Ok(Vec::new()) };
     let parent = render_parent(result);
+    let bundled = bundled_dependency_names(manifest);
     let mut out = Vec::new();
-    collect_deps(manifest, "dependencies", false, &parent, &mut out)?;
-    collect_deps(manifest, "optionalDependencies", true, &parent, &mut out)?;
+    collect_deps(manifest, "dependencies", false, &parent, &bundled, &mut out)?;
+    collect_deps(manifest, "optionalDependencies", true, &parent, &bundled, &mut out)?;
     for (name, specifier) in engines_runtime_dependencies(manifest, "engines", "dependencies") {
         out.push((name.to_string(), specifier, false));
     }
     Ok(out)
 }
 
+/// The dependency names a manifest declares as bundled, read from
+/// `bundledDependencies` with `bundleDependencies` as the fallback
+/// spelling. `true` stands for "every entry in `dependencies`".
+fn bundled_dependency_names(manifest: &Value) -> HashSet<&str> {
+    let bundled = ["bundledDependencies", "bundleDependencies"]
+        .into_iter()
+        .find_map(|key| manifest.get(key).filter(|value| !value.is_null()));
+    match bundled {
+        Some(Value::Bool(true)) => manifest
+            .get("dependencies")
+            .and_then(Value::as_object)
+            .map(|map| map.keys().map(String::as_str).collect())
+            .unwrap_or_default(),
+        Some(Value::Array(names)) => names.iter().filter_map(Value::as_str).collect(),
+        _ => HashSet::new(),
+    }
+}
+
+/// Dependency names are validated before the bundled filter runs, so a
+/// manifest with an unusable alias is rejected whether or not the
+/// package bundles that alias.
 fn collect_deps(
     manifest: &Value,
     key: &str,
     optional: bool,
     parent: &str,
+    bundled: &HashSet<&str>,
     out: &mut Vec<ChildSpec>,
 ) -> Result<(), ResolveDependencyTreeError> {
     let Some(map) = manifest.get(key).and_then(Value::as_object) else { return Ok(()) };
@@ -3093,6 +3120,9 @@ fn collect_deps(
                     parent: parent.to_string(),
                     alias: name.clone(),
                 });
+            }
+            if bundled.contains(name.as_str()) {
+                continue;
             }
             out.push((name.clone(), range_str.to_string(), optional));
         }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -41,6 +41,88 @@ fn dependency_engines_runtime_is_walked_as_a_runtime_dependency() {
     );
 }
 
+fn manifest_result(manifest: serde_json::Value) -> ResolveResult {
+    ResolveResult {
+        id: PkgResolutionId::from("parent@1.0.0"),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: Some(std::sync::Arc::new(manifest)),
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: "parent".to_string(),
+        }),
+        resolved_via: "npm-registry".to_string(),
+        normalized_bare_specifier: None,
+        alias: Some("parent".to_string()),
+        policy_violation: None,
+    }
+}
+
+// Regression test for pnpm/pnpm#13334: npm ships bundled dependencies
+// inside the package's own tarball, so they must not be resolved as
+// edges of their own.
+#[test]
+fn bundled_dependencies_are_not_walked() {
+    let result = manifest_result(serde_json::json!({
+        "name": "parent",
+        "version": "1.0.0",
+        "dependencies": { "bundled-dep": "^1.0.0", "regular-dep": "^2.0.0" },
+        "optionalDependencies": { "bundled-optional": "^3.0.0" },
+        "bundledDependencies": ["bundled-dep", "bundled-optional"],
+    }));
+    assert_eq!(
+        extract_children(&result).unwrap(),
+        vec![("regular-dep".to_string(), "^2.0.0".to_string(), false)],
+    );
+}
+
+#[test]
+fn bundle_dependencies_spelling_is_honored() {
+    let result = manifest_result(serde_json::json!({
+        "name": "parent",
+        "version": "1.0.0",
+        "dependencies": { "bundled-dep": "^1.0.0", "regular-dep": "^2.0.0" },
+        "bundleDependencies": ["bundled-dep"],
+    }));
+    assert_eq!(
+        extract_children(&result).unwrap(),
+        vec![("regular-dep".to_string(), "^2.0.0".to_string(), false)],
+    );
+}
+
+#[test]
+fn bundled_dependencies_true_bundles_every_dependency() {
+    let result = manifest_result(serde_json::json!({
+        "name": "parent",
+        "version": "1.0.0",
+        "dependencies": { "one": "^1.0.0", "two": "^2.0.0" },
+        "optionalDependencies": { "three": "^3.0.0" },
+        "bundledDependencies": true,
+    }));
+    assert_eq!(
+        extract_children(&result).unwrap(),
+        vec![("three".to_string(), "^3.0.0".to_string(), true)],
+    );
+}
+
+// `bundledDependencies: true` names the `dependencies` keys, and upstream
+// filters the merged `{...optionalDependencies, ...dependencies}` map, so an
+// alias listed in both groups is dropped from both.
+#[test]
+fn bundled_dependencies_true_also_drops_the_optional_duplicate() {
+    let result = manifest_result(serde_json::json!({
+        "name": "parent",
+        "version": "1.0.0",
+        "dependencies": { "both": "^1.0.0" },
+        "optionalDependencies": { "both": "^1.0.0", "optional-only": "^3.0.0" },
+        "bundledDependencies": true,
+    }));
+    assert_eq!(
+        extract_children(&result).unwrap(),
+        vec![("optional-only".to_string(), "^3.0.0".to_string(), true)],
+    );
+}
+
 fn key(raw: &str) -> PkgNameVerPeer {
     raw.parse().expect("parse snapshot key")
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#13334.

I reproduced the report against `main` (`0754566903`) with pnpm 11.17.0 as the reference: same Astro checkout, same `trustPolicy` removal, `pnpm install --lockfile-only` with each CLI. The diff is now **306 lines**, not the 957 the issue recorded on `12.0.0-alpha.21` — most of the peer-context examples in the report (the `supports-color@10.2.2` contexts, `sharp` × `@types/node`, `@testing-library/svelte` × `vitest`) already resolve identically on `main`.

Of what is left, three independent bugs accounted for 149 lines. One of them — a project's own `peerDependencies` reaching its lockfile importer entry without `autoInstallPeers` — landed separately as pnpm/pnpm#13372 while this was in review, so this PR now carries the other two (143 lines). With #13372 on `main`, the diff drops to **157 lines**.

**1. A scoped workspace package referenced as `file:` is never deduped back to `link:`.**
`injected_workspace_target` recovers the `file:` payload from a resolved package id by splitting on the first `@`. pacquet prefixes the manifest name onto a `file:` workspace pick, so a scoped id reads `@test/pkg@file:packages/…` — the leading `@` was taken for the separator and the `file:` strip failed. Every one of Astro's nested fixture packages is scoped, so all of them were recorded as root-relative `file:` snapshots (plus five spurious `packages:` / `snapshots:` rows) where pnpm 11 records `link:pkg`. Splitting on the whole `@file:` separator fixes it. This is pacquet-only: upstream's `dedupeInjectedDeps` reads a bare `file:<path>` id, so it has no name to strip.

**2. `bundledDependencies` are resolved as if they were regular dependencies.**
npm ships bundled deps inside the package's own tarball, and pnpm's `getNonDevWantedDependencies` filters them out of the wanted set before resolution. pacquet's `extract_children` had no such filter, so `napi-wasm` was installed under `@parcel/watcher-wasm` (and the whole `@napi-rs` / `@emnapi` / `@tybys` set under `@tailwindcss/oxide-wasm32-wasi`), adding packages the lockfile should not contain. Both spellings are honored and `true` means "every entry of `dependencies`", as upstream. Alias validation still runs over bundled entries, so an unusable alias is rejected either way — also as upstream.

**3. ~~A project's own `peerDependencies` leak into its lockfile importer entry.~~** Landed independently as pnpm/pnpm#13372 (closing pnpm/pnpm#13325) while this PR was in review — same root cause, same gate on `autoInstallPeers`. Dropped from this branch in favour of the version on `main`.

Both are pacquet-only — the TypeScript CLI is the reference and already behaves correctly here, so there is nothing to mirror.

### What is still divergent (157 lines), and why it is not in this PR

Both remaining causes need design work rather than a targeted fix, so I left them for the issue rather than guessing:

- **The `parentPkgAliases` arm of upstream's peer-shadowed-dependency omission.** When a package declares the same name in both `dependencies` and `peerDependencies`, upstream drops it from `dependencies` — under `autoInstallPeers` always, and otherwise only when the name is already visible in the resolving parent's alias scope. pacquet models the first arm (`omit_peer_shadowed_dependencies`) and documents the second as unmodeled. That is what drops the `wrangler` peer from `@cloudflare/vite-plugin` and the `@atcute/lexicons` peer from `@atcute/identity`, which then cascades into duplicate `@cloudflare/vite-plugin` variants and an extra `@cloudflare/workers-types` entry in `@flue/cli`'s `transitivePeerDependencies`. Modeling it means threading a parent-alias set into a decision that pacquet currently memoizes per package id under a deterministic-owner rule, so "first occurrence wins" (upstream's effective behavior) would have to be re-derived without reintroducing order dependence.
- **Local `file:*.tgz` tarballs.** The local resolver's file branch returns no manifest, so the resolved id stays the bare `file:<path>.tgz` with no name prefix. That fails to parse as a `PackageKey`, and `build_packages_and_snapshots` silently skips it — `fake-data-pkg` is referenced from an importer but has no `packages:` / `snapshots:` row. This is not Astro-specific: a bare `pnpm add ./pkg-1.0.0.tgz` reproduces it, and the install leaves a dangling symlink into an empty virtual-store directory, so local tarball deps do not install at all today. Fixing it needs both a manifest at resolve time (extracting the tarball, as the remote-tarball resolver does) and a local-file arm in the fetch path.

- **`@standard-community/standard-json` / `standard-openapi` peer contexts.** These packages declare no dependencies at all, so this is not the shadowing bug. pacquet produces two extra variants that upstream's `dedupePeerDependents` would collapse; pacquet's `collapsed_target_matches_parent` guard — added in #12372 to compensate for a peer-resolution divergence — blocks the child-edge rewrite that would orphan them. Removing the guard would regress pnpm/pnpm#12330, so this belongs with the peer-resolution design work above.

## Squash Commit Body

```text
Resolving the Astro workspace with pacquet produced a `pnpm-lock.yaml`
that differed from pnpm 11's by 306 lines. Two independent bugs account
for 143 of them.

`dedupe_injected_deps` splits a resolved package id into its name and
its `file:` payload on the first `@`. A scoped id
(`@test/pkg@file:packages/…`) starts with `@`, so the split returned the
scope tail and the `file:` strip failed — the injected workspace dep was
never recognized and stayed a `file:` snapshot where pnpm records
`link:`. Split on the whole `@file:` separator instead.

`extract_children` walked every entry of `dependencies` and
`optionalDependencies`, including the ones the manifest declares as
bundled. npm ships those inside the package's own tarball, and pnpm's
`getNonDevWantedDependencies` filters them out before resolution; the
missing filter pulled extra packages into the lockfile (`napi-wasm`
under `@parcel/watcher-wasm`, the whole `@napi-rs`/`@emnapi` set under
`@tailwindcss/oxide-wasm32-wasi`). Both spellings are honored, and
`true` means every entry of `dependencies`, matching npm. The bundled
set is computed once and shared by both `collect_deps` calls, so an
alias declared in both groups is dropped from both — upstream filters
the merged `{...optionalDependencies, ...dependencies}` map and reaches
the same result. The alias validation still runs over bundled entries
so an unusable alias is rejected either way, as it is upstream.

A third divergence from the same reproduction — a project's own
`peerDependencies` reaching its lockfile importer entry without
`autoInstallPeers` — landed separately as pnpm/pnpm#13372 while this was
in review, so it is no longer part of this change.

The remaining divergences — the `parentPkgAliases` arm of upstream's
peer-shadowed-dependency omission, and local `file:*.tgz` tarballs
resolving without a manifest — are described in the issue; both need
design work beyond this change.

Related to pnpm/pnpm#13334.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (pacquet-only bugs; the TypeScript CLI is the reference and already correct.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).
