### PR TITLE
fix(fs): distinguish an unavailable lock from a busy one

### DIFF
--- a/.changeset/engine-lock-failure-is-reported.md
+++ b/.changeset/engine-lock-failure-is-reported.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+When the pinned `packageManager` engine install cannot take its lock because the store cannot be written to, pnpm now reports that instead of quietly installing without the lock. A lock another process holds is unchanged — it is still waited for.

--- a/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -160,10 +160,6 @@ async fn install_pnpm_from_env_with_config<Reporter: self::Reporter + 'static>(
 /// when it can't be taken. Losing the lock is not a reason to refuse to
 /// run: the install below is the same one every other process is racing
 /// to perform, so proceeding unserialized is exactly today's behavior.
-///
-/// A lock that could not be *established* is warned about instead:
-/// running unserialized is survivable, but doing it because the store
-/// could not be written would otherwise hide why the race came back.
 fn engine_install_lock<Reporter: self::Reporter>(
     config: &Config,
     package_name: &str,

--- a/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -16,7 +16,7 @@ use pacquet_graph_hasher::{detect_node_major, engine_name};
 use pacquet_lockfile::{EnvLockfile, PackageKey};
 use pacquet_package_manager::{AllowBuildPolicy, VirtualStoreLayout};
 use pacquet_package_manifest::parse_manifest;
-use pacquet_reporter::Reporter;
+use pacquet_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pacquet_store_dir::StoreDir;
 use serde_json::Value;
 use std::{
@@ -102,7 +102,7 @@ async fn install_pnpm_from_env_with_config<Reporter: self::Reporter + 'static>(
     // all of which reach this point together on a cold cache; without the
     // lock, one clears the slot out from under another and the loser dies
     // looking for a binary that no longer exists.
-    let _lock = engine_install_lock(config, package_name, version);
+    let _lock = engine_install_lock::<Reporter>(config, package_name, version);
     // The wait may have been for a process that installed the very engine
     // we want, so ask the cache again before paying for the download.
     if let Some(slot) = compute_engine_slot(config, env, package_name, version) {
@@ -161,10 +161,14 @@ async fn install_pnpm_from_env_with_config<Reporter: self::Reporter + 'static>(
 /// run: the install below is the same one every other process is racing
 /// to perform, so proceeding unserialized is exactly today's behavior.
 ///
-/// A lock that could not be taken because the mechanism itself failed is
-/// warned about — running unserialized is survivable, but silently doing
-/// it because the store is unwritable would hide why the race came back.
-fn engine_install_lock(config: &Config, package_name: &str, version: &str) -> Option<DirLock> {
+/// A lock that could not be *established* is warned about instead:
+/// running unserialized is survivable, but doing it because the store
+/// could not be written would otherwise hide why the race came back.
+fn engine_install_lock<Reporter: self::Reporter>(
+    config: &Config,
+    package_name: &str,
+    version: &str,
+) -> Option<DirLock> {
     /// Long enough for a cold install of the engine over a slow link,
     /// short enough that a wedged host isn't hung on indefinitely.
     const WAIT: Duration = Duration::from_mins(5);
@@ -174,17 +178,22 @@ fn engine_install_lock(config: &Config, package_name: &str, version: &str) -> Op
 
     let name = format!("{}@{version}.lock", package_name.replace('/', "+"));
     let path = config.store_dir.tmp().join("engine-locks").join(name);
-    match DirLock::acquire(path.clone(), WAIT, ABANDONED_AFTER) {
-        Ok(lock) => lock,
-        Err(error) => {
-            tracing::warn!(
-                ?error,
-                lock = %path.display(),
-                "could not take the engine install lock; installing unserialized",
-            );
-            None
-        }
-    }
+    let error = match DirLock::acquire(path.clone(), WAIT, ABANDONED_AFTER) {
+        Ok(lock) => return lock,
+        Err(error) => error,
+    };
+    // Through the reporter rather than `tracing`, which is only wired to
+    // a subscriber when `TRACE` is set and would drop this on every
+    // ordinary run.
+    Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+        level: LogLevel::Warn,
+        message: format!(
+            "Could not lock the pnpm engine install at {}: {error}. Installing without it, which is unsafe if another pnpm is installing the same version.",
+            path.display(),
+        ),
+        prefix: String::new(),
+    }));
+    None
 }
 
 fn package_manager_engine_config(config: &Config) -> miette::Result<Config> {

--- a/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -160,6 +160,10 @@ async fn install_pnpm_from_env_with_config<Reporter: self::Reporter + 'static>(
 /// when it can't be taken. Losing the lock is not a reason to refuse to
 /// run: the install below is the same one every other process is racing
 /// to perform, so proceeding unserialized is exactly today's behavior.
+///
+/// A lock that could not be taken because the mechanism itself failed is
+/// warned about — running unserialized is survivable, but silently doing
+/// it because the store is unwritable would hide why the race came back.
 fn engine_install_lock(config: &Config, package_name: &str, version: &str) -> Option<DirLock> {
     /// Long enough for a cold install of the engine over a slow link,
     /// short enough that a wedged host isn't hung on indefinitely.
@@ -170,7 +174,17 @@ fn engine_install_lock(config: &Config, package_name: &str, version: &str) -> Op
 
     let name = format!("{}@{version}.lock", package_name.replace('/', "+"));
     let path = config.store_dir.tmp().join("engine-locks").join(name);
-    DirLock::acquire(path, WAIT, ABANDONED_AFTER).ok().flatten()
+    match DirLock::acquire(path.clone(), WAIT, ABANDONED_AFTER) {
+        Ok(lock) => lock,
+        Err(error) => {
+            tracing::warn!(
+                ?error,
+                lock = %path.display(),
+                "could not take the engine install lock; installing unserialized",
+            );
+            None
+        }
+    }
 }
 
 fn package_manager_engine_config(config: &Config) -> miette::Result<Config> {

--- a/pnpm/crates/fs/src/dir_lock.rs
+++ b/pnpm/crates/fs/src/dir_lock.rs
@@ -47,12 +47,9 @@ impl DirLock {
     /// take, or a slow holder gets its lock stolen — which is why it is
     /// the caller's to choose and not tied to `wait`.
     ///
-    /// `Ok(None)` means the lock is held by someone else. An `Err` means
-    /// the locking mechanism itself failed — the parent directory or the
-    /// owner record could not be written — which is a different thing
-    /// entirely, and the caller should say so rather than quietly running
-    /// unserialized as though it had merely lost a race. Losing the race
-    /// is what the wait is for.
+    /// `Ok(None)` is a lock someone else holds; `Err` is one that could
+    /// not be established at all. Callers that degrade rather than fail
+    /// need to tell those apart.
     pub fn acquire(
         path: PathBuf,
         wait: Duration,
@@ -110,13 +107,8 @@ impl Drop for DirLock {
 }
 
 /// Record this process as the owner of a lock directory it just created.
-///
-/// Without its owner record a lock cannot tell, at release time, whether
-/// it is still the one it took, so an unwritable record hands the
-/// directory back rather than holding an unidentifiable lock. That is
-/// reported as an error, not as a busy lock: a store this process cannot
-/// write is not the same as one another process is using, and the caller
-/// should be able to say which happened.
+/// A lock that cannot be recorded is given back, since [`Drop`] would
+/// have no way to tell at release time whether it is still ours.
 fn claim(path: PathBuf) -> io::Result<DirLock> {
     let token = mint_token();
     if let Err(error) = fs::write(path.join(OWNER_FILE), &token) {

--- a/pnpm/crates/fs/src/dir_lock.rs
+++ b/pnpm/crates/fs/src/dir_lock.rs
@@ -64,25 +64,9 @@ impl DirLock {
         let deadline = SystemTime::now() + wait;
         loop {
             match fs::create_dir(&path) {
-                Ok(()) => {
-                    let token = mint_token();
-                    return match fs::write(path.join(OWNER_FILE), &token) {
-                        Ok(()) => Ok(Some(DirLock { path, token })),
-                        // Without its owner record this lock cannot tell,
-                        // at release time, whether it is still the one it
-                        // took, so hand the directory back rather than
-                        // hold an unidentifiable lock. Reported as an
-                        // error, not as a busy lock: a store this process
-                        // cannot write is not the same as one another
-                        // process is using, and the caller should be able
-                        // to say which happened.
-                        Err(error) => {
-                            let _ = fs::remove_dir_all(&path);
-                            Err(error)
-                        }
-                    };
-                }
+                Ok(()) => return claim(path).map(Some),
                 Err(error) if error.kind() != io::ErrorKind::AlreadyExists => return Err(error),
+                // Held by someone else: fall through to the wait below.
                 Err(_) => {}
             }
             if is_abandoned(&path, abandoned_after) {
@@ -123,6 +107,23 @@ impl Drop for DirLock {
         }
         let _ = fs::remove_dir_all(&self.path);
     }
+}
+
+/// Record this process as the owner of a lock directory it just created.
+///
+/// Without its owner record a lock cannot tell, at release time, whether
+/// it is still the one it took, so an unwritable record hands the
+/// directory back rather than holding an unidentifiable lock. That is
+/// reported as an error, not as a busy lock: a store this process cannot
+/// write is not the same as one another process is using, and the caller
+/// should be able to say which happened.
+fn claim(path: PathBuf) -> io::Result<DirLock> {
+    let token = mint_token();
+    if let Err(error) = fs::write(path.join(OWNER_FILE), &token) {
+        let _ = fs::remove_dir_all(&path);
+        return Err(error);
+    }
+    Ok(DirLock { path, token })
 }
 
 /// A value no concurrent acquisition shares. The clock supplies

--- a/pnpm/crates/fs/src/dir_lock.rs
+++ b/pnpm/crates/fs/src/dir_lock.rs
@@ -47,8 +47,12 @@ impl DirLock {
     /// take, or a slow holder gets its lock stolen — which is why it is
     /// the caller's to choose and not tied to `wait`.
     ///
-    /// Errors are limited to creating the lock's parent directory;
-    /// everything else is a lost race, which is what the wait is for.
+    /// `Ok(None)` means the lock is held by someone else. An `Err` means
+    /// the locking mechanism itself failed — the parent directory or the
+    /// owner record could not be written — which is a different thing
+    /// entirely, and the caller should say so rather than quietly running
+    /// unserialized as though it had merely lost a race. Losing the race
+    /// is what the wait is for.
     pub fn acquire(
         path: PathBuf,
         wait: Duration,
@@ -62,18 +66,21 @@ impl DirLock {
             match fs::create_dir(&path) {
                 Ok(()) => {
                     let token = mint_token();
-                    if fs::write(path.join(OWNER_FILE), &token).is_ok() {
-                        return Ok(Some(DirLock { path, token }));
-                    }
-                    // Without its owner record this lock cannot tell, at
-                    // release time, whether it is still the one it took.
-                    // Rather than hold an unidentifiable lock, give the
-                    // directory back and report the lock as not taken —
-                    // the caller's documented degradation is to proceed
-                    // unserialized, which is no worse than not having
-                    // tried.
-                    let _ = fs::remove_dir_all(&path);
-                    return Ok(None);
+                    return match fs::write(path.join(OWNER_FILE), &token) {
+                        Ok(()) => Ok(Some(DirLock { path, token })),
+                        // Without its owner record this lock cannot tell,
+                        // at release time, whether it is still the one it
+                        // took, so hand the directory back rather than
+                        // hold an unidentifiable lock. Reported as an
+                        // error, not as a busy lock: a store this process
+                        // cannot write is not the same as one another
+                        // process is using, and the caller should be able
+                        // to say which happened.
+                        Err(error) => {
+                            let _ = fs::remove_dir_all(&path);
+                            Err(error)
+                        }
+                    };
                 }
                 Err(error) if error.kind() != io::ErrorKind::AlreadyExists => return Err(error),
                 Err(_) => {}

--- a/pnpm/crates/fs/src/dir_lock/tests.rs
+++ b/pnpm/crates/fs/src/dir_lock/tests.rs
@@ -87,3 +87,16 @@ fn a_stale_holder_does_not_release_its_successors_lock() {
     drop(successor);
     assert!(!path.exists(), "the successor releases it on its own drop");
 }
+
+#[test]
+fn claiming_a_directory_that_cannot_hold_the_record_fails() {
+    let root = tempdir().expect("create tempdir");
+    // Nothing at this path, so writing the owner record inside it fails —
+    // standing in for the unwritable store the real caller hits.
+    let path = root.path().join("missing").join("engine.lock");
+
+    let error = super::claim(path.clone()).expect_err("an unrecordable lock is not taken");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+    assert!(!path.exists(), "no lock is left behind");
+}

--- a/pnpm/crates/fs/src/dir_lock/tests.rs
+++ b/pnpm/crates/fs/src/dir_lock/tests.rs
@@ -91,12 +91,13 @@ fn a_stale_holder_does_not_release_its_successors_lock() {
 #[test]
 fn claiming_a_directory_that_cannot_hold_the_record_fails() {
     let root = tempdir().expect("create tempdir");
-    // Nothing at this path, so writing the owner record inside it fails —
-    // standing in for the unwritable store the real caller hits.
-    let path = root.path().join("missing").join("engine.lock");
+    let path = root.path().join("engine.lock");
+    // A directory where the owner record belongs: the lock directory is
+    // real, so the cleanup assertion below has something to observe, and
+    // writing the record into it still fails.
+    fs::create_dir_all(path.join("owner")).expect("block the owner record");
 
     let error = super::claim(path.clone()).expect_err("an unrecordable lock is not taken");
 
-    assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
-    assert!(!path.exists(), "no lock is left behind");
+    assert!(!path.exists(), "the lock directory is given back: {error}");
 }


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13375. This was raised in review there (by Qodo) after the PR had already merged, so it lands on its own.

`DirLock::acquire` folded a failure to write the lock's owner record into `Ok(None)` — the same answer it gives when another process holds the lock. Those are different situations. One is the wait doing its job; the other means the locking mechanism itself is broken and the caller is about to run without the lock and without knowing why. That distinction matters most at the engine install, which is exactly where the lock exists to keep concurrent destructive installs out of a shared global-virtual-store slot.

The write failure now propagates as `Err`, alongside the parent-directory failure that already did. The engine-install caller still proceeds — a lock it cannot take is not a reason to refuse to run — but logs what happened instead of silently reverting to the racy behavior that pnpm/pnpm#13375 set out to fix.

### Notes for reviewers

- **No test.** Making `create_dir` succeed while a write inside it fails needs a filesystem fault-injection seam `pacquet-fs` does not have. `pnpm/AGENTS.md` sanctions the `Sys` seam for exactly this kind of error-kind branch, but adding one to `DirLock` for a single assertion costs more than the signature change is worth. The existing four `dir_lock` tests still cover acquire/release, contention, takeover, and the stale-successor case.
- The behavior on the busy path is unchanged — a lock another process holds is still waited for, then reported as `Ok(None)`.

## Squash Commit Body

```text
`DirLock::acquire` folded a failure to write the owner record into
`Ok(None)`, which is the same answer it gives when another process holds
the lock. Those are different situations: one is the wait doing its job,
the other means the locking mechanism itself is broken and the caller is
about to run without the lock and without knowing why. That matters most
at the engine install, where the lock exists to keep concurrent
destructive installs out of a shared store slot.

The write failure now propagates as `Err`, alongside the parent-directory
failure that already did. The engine-install caller still proceeds — a
lock it cannot take is not a reason to refuse to run — but logs what
happened rather than silently reverting to the racy behavior.

Follow-up to pnpm/pnpm#13375, raised in review there after it merged.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: `DirLock` has no TypeScript counterpart.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests. (See "Notes for reviewers".)

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787610278&installation_model_id=426870&pr_number=13377&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13377&signature=28ee8bf2559ca3e0c5ca3254dcd9eed7a7f551a844d8cc2ca7a66e9c7ab566d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned package manager installations now emit a warning when the install lock can’t be acquired (e.g., unwritable store or lock mechanism failures), including the lock path and underlying error.
  * Lock acquisition failures are no longer silently ignored; installs proceed without the lock, while waiting on locks held by other processes is unchanged.
* **Documentation**
  * Updated lock acquisition documentation to clarify the difference between lock contention and lock mechanism failures.
* **Tests**
  * Added a unit test covering failure to claim the lock directory when the owner record can’t be written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->