### PR TITLE
test(cli): tighten the optional-peer node_modules and failure output

### DIFF
--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -274,9 +274,14 @@ fn optional_peer_stays_out_of_the_importer_without_auto_install_peers() {
             "optional peer added to pkg-a under `autoInstallPeers: false`: {pkg_a:?}",
         );
     }
-    // `symlink_metadata` so a dangling link counts as linked too.
+    // `symlink_metadata` so a dangling link counts as linked too, and
+    // `NotFound` specifically so an unreadable directory isn't mistaken
+    // for an absent link.
     assert!(
-        fs::symlink_metadata(workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c")).is_err(),
+        matches!(
+            fs::symlink_metadata(workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c")),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound
+        ),
         "optional peer linked into pkg-a under `autoInstallPeers: false`",
     );
     // The optional peer is still deduplicated into the dependent's peer

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -267,16 +267,16 @@ fn optional_peer_stays_out_of_the_importer_without_auto_install_peers() {
 
     let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
     let pkg_a = importer(&lockfile, "pkg-a");
-    dbg!(pkg_a);
     let peer_c: PkgName = "@pnpm.e2e/peer-c".parse().expect("parse peer name");
     for group in [&pkg_a.dependencies, &pkg_a.dev_dependencies, &pkg_a.optional_dependencies] {
         assert!(
             !group.as_ref().is_some_and(|dependencies| dependencies.contains_key(&peer_c)),
-            "optional peer added to pkg-a under `autoInstallPeers: false`",
+            "optional peer added to pkg-a under `autoInstallPeers: false`: {pkg_a:?}",
         );
     }
+    // `symlink_metadata` so a dangling link counts as linked too.
     assert!(
-        !workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c").exists(),
+        fs::symlink_metadata(workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c")).is_err(),
         "optional peer linked into pkg-a under `autoInstallPeers: false`",
     );
     // The optional peer is still deduplicated into the dependent's peer


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13372, which merged while the last review round was still being addressed — this is the commit that missed the merge.

Two test-only refinements to `optional_peer_stays_out_of_the_importer_without_auto_install_peers`:

- `Path::exists` follows the link, so a *dangling* `@pnpm.e2e/peer-c` link in `pkg-a/node_modules` would have read as "not linked" and passed the check. `fs::symlink_metadata` fails only when nothing is at that path at all, and still catches a Windows junction.
- The importer snapshot moves out of an unconditional `dbg!` into the assertion message, so it is printed when a check fails rather than on every run.

No behavior change and no changeset: the regression this test guards is already fixed on main by pnpm/pnpm#13372.

## Squash Commit Body

```text
`Path::exists` follows the link, so a dangling `peer-c` link in pkg-a's
`node_modules` would have read as "not linked" and passed the check;
`symlink_metadata` fails only when nothing is there at all.

The importer snapshot moves from an unconditional `dbg!` into the
assertion message, so it is printed when a check fails rather than on
every run.

Follow-up to pnpm/pnpm#13372, which merged before this commit landed.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787610330&installation_model_id=426870&pr_number=13378&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13378&signature=45e0e92c03a7afa2a097cec217058f0a0ae78f470a18f1866cd2977c45d5ccd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened the regression test coverage for optional peer dependencies when automatic peer installation is disabled.
  * Enhanced failure diagnostics by including full package debug state when unexpected peer dependencies are detected.
  * Updated the on-disk verification to more precisely distinguish missing paths from dangling symlinks (dangling symlinks are treated as linked).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->