### PR TITLE
fix(cli): read the root manifest once, and through the BOM

### DIFF
--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1,7 +1,7 @@
 use crate::{
     State,
     cli_args::{
-        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields, pipelines::InstallFamilySelection,
+        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields_in, pipelines::InstallFamilySelection,
         recursive::discover_workspace_projects,
         supported_architectures::SupportedArchitecturesArgs,
     },
@@ -348,7 +348,7 @@ impl InstallArgs {
         // above: every `return false` before this point hands the command
         // to the full install path, which warns from
         // `derive_config_root_and_package_manager_to_sync`.
-        warn_ignored_pnpm_manifest_fields(&config_root, emit);
+        warn_ignored_pnpm_manifest_fields_in(&config_root, emit);
         let prefix = workspace_root.to_string_lossy().into_owned();
         emit(&pacquet_reporter::LogEvent::Pnpm(pacquet_reporter::PnpmLog {
             level: pacquet_reporter::LogLevel::Info,

--- a/pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs
+++ b/pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs
@@ -3,7 +3,9 @@
 //! that still carries one of the migrated keys gets a warning naming it,
 //! so the setting isn't silently dropped.
 
+use super::package_manager::read_manifest_json;
 use pacquet_reporter::{GlobalLog, LogEvent, LogLevel};
+use serde_json::Value;
 use std::path::Path;
 
 /// Keys pnpm reads from `pnpm-workspace.yaml` and never from the `pnpm`
@@ -35,11 +37,11 @@ const MIGRATED_PNPM_FIELD_KEYS: &[&str] = &[
 ];
 
 /// Warn about every migrated key the root project manifest still
-/// declares under `pnpm`. An unreadable or malformed manifest is not
-/// this function's problem — the install path reports it with far more
-/// context — so it simply produces no warning.
-pub(crate) fn warn_ignored_pnpm_manifest_fields(root_dir: &Path, emit: fn(&LogEvent)) {
-    let ignored = ignored_pnpm_field_keys(root_dir);
+/// declares under `pnpm`. A manifest that could not be read is not this
+/// function's problem — the install path reports it with far more
+/// context — so `None` simply produces no warning.
+pub(crate) fn warn_ignored_pnpm_manifest_fields(manifest: Option<&Value>, emit: fn(&LogEvent)) {
+    let ignored = ignored_pnpm_field_keys(manifest);
     if ignored.is_empty() {
         return;
     }
@@ -54,14 +56,20 @@ pub(crate) fn warn_ignored_pnpm_manifest_fields(root_dir: &Path, emit: fn(&LogEv
     }));
 }
 
-fn ignored_pnpm_field_keys(root_dir: &Path) -> Vec<String> {
-    let Ok(bytes) = std::fs::read(root_dir.join("package.json")) else {
-        return Vec::new();
-    };
-    let Ok(manifest) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
-        return Vec::new();
-    };
-    let Some(legacy_field) = manifest.get("pnpm").and_then(serde_json::Value::as_object) else {
+/// [`warn_ignored_pnpm_manifest_fields`] for a caller that has not read
+/// the root manifest yet.
+pub(crate) fn warn_ignored_pnpm_manifest_fields_in(root_dir: &Path, emit: fn(&LogEvent)) {
+    warn_ignored_pnpm_manifest_fields(root_manifest(root_dir).as_ref(), emit);
+}
+
+fn root_manifest(root_dir: &Path) -> Option<Value> {
+    read_manifest_json(&root_dir.join("package.json")).ok().flatten()
+}
+
+fn ignored_pnpm_field_keys(manifest: Option<&Value>) -> Vec<String> {
+    let Some(legacy_field) =
+        manifest.and_then(|manifest| manifest.get("pnpm")).and_then(Value::as_object)
+    else {
         return Vec::new();
     };
     legacy_field

--- a/pnpm/crates/cli/src/cli_args/legacy_pnpm_field/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/legacy_pnpm_field/tests.rs
@@ -1,8 +1,12 @@
-use super::ignored_pnpm_field_keys;
-use std::fs;
+use super::{ignored_pnpm_field_keys, root_manifest};
+use std::{fs, path::Path};
 
-fn write_manifest(dir: &std::path::Path, contents: &str) {
+fn write_manifest(dir: &Path, contents: &str) {
     fs::write(dir.join("package.json"), contents).expect("write package.json");
+}
+
+fn keys_in(dir: &Path) -> Vec<String> {
+    ignored_pnpm_field_keys(root_manifest(dir).as_ref())
 }
 
 #[test]
@@ -13,7 +17,7 @@ fn reports_migrated_keys_in_declaration_order() {
         r#"{"pnpm":{"onlyBuiltDependencies":["a"],"app":{},"overrides":{"x":"1"}}}"#,
     );
     assert_eq!(
-        ignored_pnpm_field_keys(dir.path()),
+        keys_in(dir.path()),
         vec!["onlyBuiltDependencies".to_string(), "overrides".to_string()],
     );
 }
@@ -22,7 +26,17 @@ fn reports_migrated_keys_in_declaration_order() {
 fn ignores_manifests_without_a_migrated_key() {
     let dir = tempfile::tempdir().expect("create temp dir");
     write_manifest(dir.path(), r#"{"pnpm":{"app":{}},"name":"x"}"#);
-    assert!(ignored_pnpm_field_keys(dir.path()).is_empty());
+    assert!(keys_in(dir.path()).is_empty());
+}
+
+/// An editor-written manifest may open with a UTF-8 BOM, which every
+/// other manifest read in the CLI strips. The warning has to see the
+/// same keys those reads do.
+#[test]
+fn reports_migrated_keys_through_a_utf8_bom() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    write_manifest(dir.path(), "\u{feff}{\"pnpm\":{\"overrides\":{\"x\":\"1\"}}}");
+    assert_eq!(keys_in(dir.path()), vec!["overrides".to_string()]);
 }
 
 /// A non-object `pnpm` field belongs to some other tool; there is
@@ -31,11 +45,11 @@ fn ignores_manifests_without_a_migrated_key() {
 #[test]
 fn tolerates_absent_malformed_and_non_object_manifests() {
     let dir = tempfile::tempdir().expect("create temp dir");
-    assert!(ignored_pnpm_field_keys(dir.path()).is_empty(), "no manifest");
+    assert!(keys_in(dir.path()).is_empty(), "no manifest");
 
     write_manifest(dir.path(), "{ not json");
-    assert!(ignored_pnpm_field_keys(dir.path()).is_empty(), "malformed manifest");
+    assert!(keys_in(dir.path()).is_empty(), "malformed manifest");
 
     write_manifest(dir.path(), r#"{"pnpm":"11.0.0"}"#);
-    assert!(ignored_pnpm_field_keys(dir.path()).is_empty(), "non-object pnpm field");
+    assert!(keys_in(dir.path()).is_empty(), "non-object pnpm field");
 }

--- a/pnpm/crates/cli/src/cli_args/package_manager.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager.rs
@@ -25,30 +25,23 @@ pub(crate) struct PackageManagerToSync {
 }
 
 pub(crate) fn package_manager_to_sync(
-    manifest_path: &Path,
+    manifest: &Value,
     root_dir: &Path,
-) -> miette::Result<Option<PackageManagerToSync>> {
-    let Some(manifest) = read_manifest_json(manifest_path)? else {
-        return Ok(None);
-    };
-    let Some(pm) = wanted_package_manager(&manifest) else {
-        return Ok(None);
-    };
-    let Some(wanted_version) = pm.version.as_deref() else {
-        return Ok(None);
-    };
+) -> Option<PackageManagerToSync> {
+    let pm = wanted_package_manager(manifest)?;
+    let wanted_version = pm.version.as_deref()?;
     if pm.name != "pnpm" || !should_persist_package_manager_lockfile(&pm) {
-        return Ok(None);
+        return None;
     }
     let source_version = current_source_pnpm_version().or_else(|| pnpm_version_from(root_dir));
     if let Some(version) =
         source_version.filter(|version| version_satisfies(version, wanted_version))
     {
-        return Ok(Some(PackageManagerToSync { specifier: wanted_version.to_string(), version }));
+        return Some(PackageManagerToSync { specifier: wanted_version.to_string(), version });
     }
-    Ok(exact_version(wanted_version)
+    exact_version(wanted_version)
         .filter(|version| version_satisfies(version, wanted_version))
-        .map(|version| PackageManagerToSync { specifier: wanted_version.to_string(), version }))
+        .map(|version| PackageManagerToSync { specifier: wanted_version.to_string(), version })
 }
 
 pub(crate) fn read_manifest_json(path: &Path) -> miette::Result<Option<Value>> {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -3,7 +3,7 @@ use super::{
     dedupe::{self, DedupeArgs},
     deploy::DeployArgs,
     install::{InstallArgs, resolve_bool_override},
-    package_manager::{PackageManagerToSync, package_manager_to_sync},
+    package_manager::{PackageManagerToSync, package_manager_to_sync, read_manifest_json},
     prune::PruneArgs,
     recursive::{
         AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
@@ -610,13 +610,14 @@ pub(crate) fn derive_config_root_and_package_manager_to_sync(
     reporter: ReporterType,
 ) -> miette::Result<(PathBuf, Option<PackageManagerToSync>)> {
     let config_root = cfg.workspace_dir.clone().unwrap_or_else(|| dir_ref.to_path_buf());
+    let root_manifest = read_manifest_json(&config_root.join("package.json"))
+        .wrap_err("read package manager policy")?;
     // pnpm warns from config-reading, so the notice lands ahead of any
     // install output. This is the install family's earliest point that
     // knows the root manifest's directory.
-    warn_ignored_pnpm_manifest_fields(&config_root, reporter_emit(reporter));
+    warn_ignored_pnpm_manifest_fields(root_manifest.as_ref(), reporter_emit(reporter));
     let package_manager_to_sync =
-        package_manager_to_sync(&config_root.join("package.json"), &config_root)
-            .wrap_err("read package manager policy")?;
+        root_manifest.as_ref().and_then(|manifest| package_manager_to_sync(manifest, &config_root));
     Ok((config_root, package_manager_to_sync))
 }
 

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -6,6 +6,7 @@ use super::{
     list::RecursionLimit,
     package_manager::{
         current_source_pnpm_version, package_manager_to_sync, parse_package_manager,
+        read_manifest_json,
     },
 };
 use clap::Parser;
@@ -550,9 +551,9 @@ fn package_manager_to_sync_preserves_dev_engine_specifier() {
     )
     .expect("write manifest");
 
-    let package_manager = package_manager_to_sync(&manifest_path, root.path())
-        .expect("read policy")
-        .expect("sync package manager");
+    let manifest = read_manifest_json(&manifest_path).expect("read manifest").expect("manifest");
+    let package_manager =
+        package_manager_to_sync(&manifest, root.path()).expect("sync package manager");
 
     assert_eq!(package_manager.specifier, ">=0.0.0");
     assert_eq!(

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1828,7 +1828,8 @@ fn migrated_keys_are_read_from_the_workspace_root() {
     )
     .expect("write the workspace package's package.json");
 
-    let assert = pacquet_in(&package_dir).with_arg("install").assert().success();
+    let assert =
+        pacquet_in(&package_dir).with_args(["install", "--lockfile-only"]).assert().success();
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
 
     eprintln!("STDOUT:\n{stdout}");

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1795,6 +1795,46 @@ fn migrated_keys_are_reported_by_the_up_to_date_fast_path() {
     drop(root);
 }
 
+/// Each emit site reads the root manifest on its own, and an editor may
+/// leave a UTF-8 BOM at its head. A reader that trips over one drops the
+/// warning without a trace, so both sites are exercised: the install
+/// pipeline on the first run, the up-to-date fast path on the second.
+#[test]
+fn migrated_keys_are_reported_through_a_utf8_bom() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest = serde_json::json!({
+        "name": "root",
+        "version": "1.0.0",
+        "private": true,
+        "pnpm": { "overrides": { "is-number": "6.0.0" } },
+    });
+    fs::write(workspace.join("package.json"), format!("\u{feff}{manifest}"))
+        .expect("write package.json");
+
+    let assert = pacquet.with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+
+    eprintln!("STDOUT:\n{stdout}");
+    assert!(
+        stdout.contains("no longer read by pnpm"),
+        "the BOM must not swallow the warning; got:\n{stdout}",
+    );
+
+    let assert = pacquet_in(&workspace).with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+
+    eprintln!("STDOUT:\n{stdout}");
+    let warning = stdout.find("no longer read by pnpm").unwrap_or_else(|| {
+        panic!("the fast path reads the manifest on its own; got:\n{stdout}");
+    });
+    let up_to_date = stdout
+        .find("Already up to date")
+        .unwrap_or_else(|| panic!("expected the fast path's own output; got:\n{stdout}"));
+    assert!(warning < up_to_date, "the warning must precede the install output; got:\n{stdout}");
+
+    drop(root);
+}
+
 /// Both emit sites resolve the root manifest the way pnpm does — the
 /// workspace root when there is one, the current directory otherwise —
 /// so a run from a workspace package names the root's keys and never


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13359, which added the "the `pnpm` field in package.json is no longer read" warning to pacquet. Two things came out of that PR's review after it had already been squash-merged, so they land here instead. The feature's changeset is still pending in `.changeset/pacquet-legacy-pnpm-field-warning.md`, so this corrects it before it ever ships — no second release note.

**The warning missed manifests that open with a UTF-8 BOM.** It parsed `package.json` with a bare `serde_json::from_slice`, which fails on the BOM an editor may leave at the head of the file, and a failed parse means no warning. Every other manifest read in pacquet goes through `parse_manifest` / `parse_manifest_bytes`, which strip it, so a BOM-prefixed project got the install it asked for and none of the warning. pnpm warns:

```
$ pnpm install     # pacquet, before
Done in 208ms using pnpm v12.0.0-alpha.21

$ pnpm install     # pnpm 11, same manifest
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
```

**It also read the root manifest twice.** The warning read and parsed `package.json`, then `package_manager_to_sync` read and parsed the same file, on every install-family dispatch.

Both followed from the helper doing its own IO, so it now takes the parsed manifest. `derive_config_root_and_package_manager_to_sync` reads the file once through `read_manifest_json` — the crate's BOM-stripping reader, which is what fixes the first problem at that site — and hands the value to the warning and to the package-manager policy alike. `package_manager_to_sync` no longer reads anything, which leaves it infallible and drops a `Result` from its signature.

The up-to-date fast path keeps a read of its own, through `warn_ignored_pnpm_manifest_fields_in`. It holds a parsed `dir/package.json` already, but the warning has to read `workspaceDir ?? dir` — the same directory pnpm resolves the root manifest from. Those are the same path today only because `promote_recursive_by_default` flips `recursive` whenever a workspace root is found and the fast path bails on recursive installs. Anchoring the emit to an invariant enforced in another function would mean that relaxing the promotion rule later silently starts naming a workspace package's keys, so the fast path pays for one small read on a path that already reads the lockfile, `.modules.yaml`, and the workspace manifest.

## Verification

Against a BOM-prefixed manifest declaring `pnpm.overrides`, pnpm 11 and pacquet now emit the same line — on a fresh install and on the repeat that takes the fast path. `reports_migrated_keys_through_a_utf8_bom` pins the reader as a unit test. Each emit site reads the manifest on its own, so `migrated_keys_are_reported_through_a_utf8_bom` covers both through the binary: the first `install` goes through the pipeline's emit, the repeat through the fast path's, where it also asserts the warning still precedes `Already up to date`. Both fail with `strip_utf8_bom` returning its input unchanged.

`cargo nextest run -p pacquet-cli` (2258 tests), clippy, `cargo doc` with `-D warnings`, and `cargo dylint` are clean.

## Squash Commit Body

```text
The warning parsed `package.json` with a bare `serde_json::from_slice`,
which chokes on the UTF-8 BOM an editor may leave at the head of the
file — pnpm strips it and warns, pacquet stayed silent. It also read and
parsed the manifest a second time, immediately before
`package_manager_to_sync` read and parsed the very same file.

Both follow from the helper doing its own IO. It now takes the parsed
manifest, so `derive_config_root_and_package_manager_to_sync` reads the
file once through `read_manifest_json` (the crate's BOM-stripping
reader) and hands it to the warning and to the package-manager policy
alike. `package_manager_to_sync` no longer reads anything, which leaves
it infallible.

The up-to-date fast path keeps its own read, one directory removed from
the manifest it already holds, and goes through the same reader via
`warn_ignored_pnpm_manifest_fields_in`: the two paths coincide only by
an invariant that lives in another function.

Follow-up to pnpm/pnpm#13359, whose changeset is still pending, so the
fix ships with the feature.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (TypeScript already strips the BOM and warns; this is the pacquet side.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  (The feature's changeset from pnpm/pnpm#13359 is still unreleased and covers this.)
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787610771&installation_model_id=426870&pr_number=13380&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13380&signature=ad2dea9010414b4bde37c942295c3c0a33b56adf65e6cc17916c23564078bdea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy `pnpm` settings in `package.json`, ensuring migrated-field warnings are emitted consistently, including when installs finish via the “already up to date” path.
  * Enhanced manifest parsing so warnings are still shown correctly with UTF-8 BOMs and tolerate malformed or non-object `pnpm` fields.

* **Tests**
  * Added a regression test for UTF-8 BOM behavior.
  * Updated and expanded install coverage to include workspace and lockfile-only scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
