### PR TITLE
fix(deps-resolver): gate peer hoisting on dedupePeerDependents too

### DIFF
--- a/.changeset/gate-peer-hoist-on-dedupe-peer-dependents.md
+++ b/.changeset/gate-peer-hoist-on-dedupe-peer-dependents.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Setting both `autoInstallPeers: false` and `dedupePeerDependents: false` now leaves missing peers alone, instead of still installing the ones a version elsewhere in the workspace could satisfy.

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -294,6 +294,47 @@ fn optional_peer_stays_out_of_the_importer_without_auto_install_peers() {
     drop((root, mock_instance));
 }
 
+/// Companion to
+/// [`optional_peer_stays_out_of_the_importer_without_auto_install_peers`]:
+/// peers are hoisted for `autoInstallPeers` *or* `dedupePeerDependents`,
+/// so with both off the sibling's version is left alone and the
+/// dependent keeps an unsuffixed snapshot.
+#[test]
+fn no_peer_is_hoisted_when_auto_install_peers_and_dedupe_peer_dependents_are_off() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } = two_project_workspace(
+        &serde_json::json!({
+            "name": "pkg-a",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/abc-optional-peers": "1.0.0" },
+        }),
+        &serde_json::json!({
+            "name": "pkg-b",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/peer-c": "1.0.0" },
+        }),
+    );
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    workspace_yaml.push_str("autoInstallPeers: false\ndedupePeerDependents: false\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    assert_eq!(importer_version(&lockfile, "pkg-a", "@pnpm.e2e/abc-optional-peers"), "1.0.0");
+    assert!(
+        fs::symlink_metadata(workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c")).is_err(),
+        "optional peer linked into pkg-a with both hoist settings off",
+    );
+
+    pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn changed_workspace_importer_invalidates_lockfile() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } = two_project_workspace(

--- a/pnpm/crates/cli/tests/workspace_install.rs
+++ b/pnpm/crates/cli/tests/workspace_install.rs
@@ -326,7 +326,10 @@ fn no_peer_is_hoisted_when_auto_install_peers_and_dedupe_peer_dependents_are_off
     let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
     assert_eq!(importer_version(&lockfile, "pkg-a", "@pnpm.e2e/abc-optional-peers"), "1.0.0");
     assert!(
-        fs::symlink_metadata(workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c")).is_err(),
+        matches!(
+            fs::symlink_metadata(workspace.join("pkg-a/node_modules/@pnpm.e2e/peer-c")),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound
+        ),
         "optional peer linked into pkg-a with both hoist settings off",
     );
 

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1426,6 +1426,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                         .auto_install_peers_from_highest_match,
                     resolve_peers_from_workspace_root: config.resolve_peers_from_workspace_root,
                     dedupe_peers: config.dedupe_peers,
+                    dedupe_peer_dependents: config.dedupe_peer_dependents,
                     // The per-importer hoist loop mutates its own copy, so
                     // clone the shared seed's map here (deref past the `Arc`).
                     all_preferred_versions: importer_preferred_versions.as_ref().clone(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -73,6 +73,15 @@ pub struct ResolveImporterOptions {
     /// See the field doc on [`ResolvePeersOptions`] for the behavior.
     pub dedupe_peers: bool,
 
+    /// The `dedupePeerDependents` setting (default `true`). Together
+    /// with [`Self::auto_install_peers`] it decides whether the hoist
+    /// rounds run at all — a peer nothing asked to install is still
+    /// hoisted to collapse peer-suffixed variants, so turning both off
+    /// leaves every missing peer missing. The cross-importer collapse
+    /// itself lives in [`fn@crate::resolve_peers_workspace`] and reads
+    /// the setting separately.
+    pub dedupe_peer_dependents: bool,
+
     /// Seed for the preferred-versions tie-break table. The
     /// orchestrator extends this in place as packages are walked —
     /// each newly-resolved `name@version` lands as a plain
@@ -167,6 +176,7 @@ impl std::fmt::Debug for ResolveImporterOptions {
             )
             .field("resolve_peers_from_workspace_root", &self.resolve_peers_from_workspace_root)
             .field("dedupe_peers", &self.dedupe_peers)
+            .field("dedupe_peer_dependents", &self.dedupe_peer_dependents)
             .field("all_preferred_versions", &self.all_preferred_versions)
             .field(
                 "override_bare_specifier",
@@ -311,6 +321,11 @@ pub(crate) struct ImporterHoistState {
     all_missing_optional_peers: BTreeMap<String, Vec<String>>,
     all_preferred_versions: PreferredVersions,
     override_bare_specifier: Option<Arc<DependencyOverrider>>,
+    /// `auto_install_peers || dedupe_peer_dependents` — upstream's
+    /// `hoistPeers`. Both hoist rounds no-op when it is `false`, so a
+    /// missing peer stays missing and the packages that declare it keep
+    /// an unsuffixed snapshot.
+    hoist_peers: bool,
     auto_install_peers: bool,
     auto_install_peers_from_highest_match: bool,
     resolve_peers_from_workspace_root: bool,
@@ -343,6 +358,7 @@ impl ImporterHoistState {
             auto_install_peers_from_highest_match,
             resolve_peers_from_workspace_root,
             dedupe_peers,
+            dedupe_peer_dependents,
             all_preferred_versions,
             override_bare_specifier,
             patched_dependencies,
@@ -397,6 +413,7 @@ impl ImporterHoistState {
             all_missing_optional_peers: BTreeMap::new(),
             all_preferred_versions,
             override_bare_specifier,
+            hoist_peers: auto_install_peers || dedupe_peer_dependents,
             auto_install_peers,
             auto_install_peers_from_highest_match,
             resolve_peers_from_workspace_root,
@@ -441,7 +458,9 @@ impl ImporterHoistState {
 
     /// Resolve the importer's missing *required* peers to a fixpoint,
     /// rebuilding the missing-*optional* buckets the round's
-    /// [`Self::hoist_optional_round`] consumes.
+    /// [`Self::hoist_optional_round`] consumes. No-op when nothing may
+    /// be hoisted (see [`ImporterHoistState::hoist_peers`]); the final
+    /// peer pass still reports every unmet peer as a warning.
     pub(crate) async fn run_required_round<Chain>(
         &mut self,
         resolver: &Chain,
@@ -449,6 +468,9 @@ impl ImporterHoistState {
     where
         Chain: Resolver + ?Sized,
     {
+        if !self.hoist_peers {
+            return Ok(());
+        }
         // Both hoists read the run-extended preferred-versions map:
         // every resolved package's version is folded into
         // `all_preferred_versions` and consulted for the optional hoist
@@ -583,7 +605,8 @@ impl ImporterHoistState {
     }
 
     /// Hoist this round's missing optional peers; `true` when any were
-    /// installed (the workspace runs another round).
+    /// installed (the workspace runs another round). No-op when nothing
+    /// may be hoisted (see [`ImporterHoistState::hoist_peers`]).
     pub(crate) async fn hoist_optional_round<Chain>(
         &mut self,
         resolver: &Chain,
@@ -591,7 +614,7 @@ impl ImporterHoistState {
     where
         Chain: Resolver + ?Sized,
     {
-        if self.all_missing_optional_peers.is_empty() {
+        if !self.hoist_peers || self.all_missing_optional_peers.is_empty() {
             return Ok(false);
         }
         let workspace_root_deps: &[WorkspaceRootDep] =

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -97,6 +97,7 @@ fn default_opts() -> ResolveImporterOptions {
         auto_install_peers_from_highest_match: false,
         resolve_peers_from_workspace_root: false,
         dedupe_peers: false,
+        dedupe_peer_dependents: true,
         all_preferred_versions: PreferredVersions::new(),
         override_bare_specifier: None,
         patched_dependencies: None,
@@ -1472,4 +1473,74 @@ mod resolution_mode {
         assert_eq!(resolver.opts_for("direct"), (true, Some(maximum)));
         assert_eq!(resolver.opts_for("sub"), (false, Some(cutoff)));
     }
+}
+
+/// `hoistPeers` is `autoInstallPeers || dedupePeerDependents`: with both
+/// off, a missing optional peer stays missing even though a preferred
+/// version is in scope, so the packages that declare it keep an
+/// unsuffixed snapshot.
+#[tokio::test]
+async fn both_hoist_settings_off_leaves_the_optional_peer_missing() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("abc".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "abc",
+            "1.0.0",
+            serde_json::json!({
+                "name": "abc",
+                "version": "1.0.0",
+                "peerDependencies": { "peer-c": "^1.0.0" },
+                "peerDependenciesMeta": { "peer-c": { "optional": true } },
+            }),
+        ),
+    );
+    table.insert(
+        ("peer-c".to_string(), "1.0.0".to_string()),
+        fake_result("peer-c", "1.0.0", serde_json::json!({ "name": "peer-c", "version": "1.0.0" })),
+    );
+    let (_tmp, manifest) = fake_manifest(serde_json::json!({ "abc": "1.0.0" }));
+
+    // A sibling importer already resolved the peer, so the optional
+    // hoist would have a version to pick.
+    let seeded_preferred_versions = || {
+        let mut selectors = VersionSelectors::new();
+        selectors
+            .insert("1.0.0".to_string(), VersionSelectorEntry::Plain(VersionSelectorType::Version));
+        PreferredVersions::from([("peer-c".to_string(), selectors)])
+    };
+
+    let hoisting_off = ResolveImporterOptions {
+        auto_install_peers: false,
+        dedupe_peer_dependents: false,
+        all_preferred_versions: seeded_preferred_versions(),
+        ..default_opts()
+    };
+    let resolver = StubResolver { table: table.clone(), calls: Mutex::new(Vec::new()) };
+    let result = resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], hoisting_off)
+        .await
+        .unwrap();
+    let direct: Vec<&str> =
+        result.peers_result.direct_dependencies_by_alias.keys().map(String::as_str).collect();
+    assert_eq!(direct, ["abc"]);
+    assert_eq!(
+        result.peers_result.direct_dependencies_by_alias.get("abc"),
+        Some(&DepPath::from("abc@1.0.0".to_string())),
+    );
+
+    // `dedupePeerDependents` alone still hoists it, without
+    // `autoInstallPeers`.
+    let dedupe_only = ResolveImporterOptions {
+        auto_install_peers: false,
+        dedupe_peer_dependents: true,
+        all_preferred_versions: seeded_preferred_versions(),
+        ..default_opts()
+    };
+    let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+    let result =
+        resolve_importer(&resolver, &manifest, [DependencyGroup::Prod], dedupe_only).await.unwrap();
+    assert_eq!(
+        result.peers_result.direct_dependencies_by_alias.get("abc"),
+        Some(&DepPath::from("abc@1.0.0(peer-c@1.0.0)".to_string())),
+    );
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -215,15 +215,16 @@ where
 
     // Build every importer's options up front so the `time-based`
     // pre-pass and the resolve loop see the same per-importer wiring.
-    // `auto_install_peers` is workspace-wide (one setting per install),
-    // so the workspace-level value overrides whatever the per-importer
-    // callback set — the importer hoist loop and the tree walk's shadow
-    // pruning must agree.
+    // `auto_install_peers` and `dedupe_peer_dependents` are
+    // workspace-wide (one setting per install), so the workspace-level
+    // values override whatever the per-importer callback set — the
+    // importer hoist loop and the tree walk's shadow pruning must agree.
     let importer_opts: Vec<ResolveImporterOptions> = importers
         .iter()
         .map(&mut per_importer_options)
         .map(|mut opts| {
             opts.auto_install_peers = auto_install_peers;
+            opts.dedupe_peer_dependents = dedupe_peer_dependents;
             opts
         })
         .collect();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -174,6 +174,7 @@ fn importer_opts(
         auto_install_peers_from_highest_match: false,
         resolve_peers_from_workspace_root: false,
         dedupe_peers: false,
+        dedupe_peer_dependents: true,
         all_preferred_versions: PreferredVersions::new(),
         override_bare_specifier: None,
         patched_dependencies: None,

--- a/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
@@ -1591,8 +1591,8 @@ test('an optional peer declared by a workspace project is not added to its own i
 
 test('no peer is hoisted when auto-install-peers and dedupe-peer-dependents are both off', async () => {
   // Peers are hoisted for either setting, so with both off the sibling's
-  // @pnpm.e2e/peer-c is left alone and the dependent keeps an unsuffixed
-  // snapshot. pacquet's counterpart is
+  // @pnpm.e2e/peer-c is left alone and the dependent keeps a snapshot with
+  // no peer suffix. pacquet's counterpart is
   // `no_peer_is_hoisted_when_auto_install_peers_and_dedupe_peer_dependents_are_off`
   // in pnpm/crates/cli/tests/workspace_install.rs.
   await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })

--- a/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
+++ b/pnpm11/installing/deps-installer/test/install/peerDependencies.ts
@@ -1589,6 +1589,51 @@ test('an optional peer declared by a workspace project is not added to its own i
     .toBe('1.0.0(@pnpm.e2e/peer-c@1.0.0)')
 })
 
+test('no peer is hoisted when auto-install-peers and dedupe-peer-dependents are both off', async () => {
+  // Peers are hoisted for either setting, so with both off the sibling's
+  // @pnpm.e2e/peer-c is left alone and the dependent keeps an unsuffixed
+  // snapshot. pacquet's counterpart is
+  // `no_peer_is_hoisted_when_auto_install_peers_and_dedupe_peer_dependents_are_off`
+  // in pnpm/crates/cli/tests/workspace_install.rs.
+  await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })
+  await addDistTag({ package: '@pnpm.e2e/peer-c', version: '1.0.0', distTag: 'latest' })
+
+  const manifest1 = {
+    name: 'project-1',
+    dependencies: {
+      '@pnpm.e2e/abc-optional-peers': '1.0.0',
+    },
+  }
+  const manifest2 = {
+    name: 'project-2',
+    dependencies: {
+      '@pnpm.e2e/peer-c': '1.0.0',
+    },
+  }
+  preparePackages([
+    { location: 'project-1', package: manifest1 },
+    { location: 'project-2', package: manifest2 },
+  ])
+
+  const importers: MutatedProject[] = [
+    { mutation: 'install', rootDir: path.resolve('project-1') as ProjectRootDir },
+    { mutation: 'install', rootDir: path.resolve('project-2') as ProjectRootDir },
+  ]
+  const allProjects = [
+    { buildIndex: 0, manifest: manifest1, rootDir: path.resolve('project-1') as ProjectRootDir },
+    { buildIndex: 0, manifest: manifest2, rootDir: path.resolve('project-2') as ProjectRootDir },
+  ]
+  await mutateModules(importers, testDefaults({
+    allProjects,
+    autoInstallPeers: false,
+    dedupePeerDependents: false,
+  }))
+
+  const lockfile = readYamlFileSync<LockfileFile>(path.resolve(WANTED_LOCKFILE))
+  expect(lockfile.importers!['project-1'].dependencies!['@pnpm.e2e/abc-optional-peers'].version).toBe('1.0.0')
+  expect(fs.existsSync(path.resolve('project-1/node_modules/@pnpm.e2e/peer-c'))).toBeFalsy()
+})
+
 test('resolve peer dependencies from aliased subdependencies if they are dependencies of a parent package', async () => {
   prepareEmpty()
   await addDistTag({ package: '@pnpm.e2e/peer-a', version: '1.0.0', distTag: 'latest' })

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@reflink/reflink": "catalog:",
-    "node-gyp": "^12.3.0",
+    "node-gyp": "^12.4.0",
     "v8-compile-cache": "2.4.0"
   },
   "devDependencies": {

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@reflink/reflink": "catalog:",
-    "node-gyp": "^12.4.0",
+    "node-gyp": "^12.3.0",
     "v8-compile-cache": "2.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Second divergence found while fixing pnpm/pnpm#13325, in the same area but independent of it: pacquet ran the peer hoist rounds on every install, so a missing peer that some version elsewhere in the workspace could satisfy was installed even with `autoInstallPeers: false` **and** `dedupePeerDependents: false`. The dependent then carried a peer context the TypeScript CLI never writes.

Upstream derives one flag from the two settings — `hoistPeers = autoInstallPeers || dedupePeerDependents` in `pnpm11/installing/deps-resolver/src/resolveDependencyTree.ts` — and `resolveRootDependencies` returns before the hoist loop when it is false: hoisting a peer nobody asked to install only pays off when peer-suffixed variants are being collapsed. `ImporterHoistState` now carries the same derived flag, and both hoist rounds no-op when it is unset. The final peer pass is untouched, so unmet peers are still reported as warnings.

Verified against the TypeScript CLI (`node pnpm11/pnpm/dist/pnpm.mjs`, v11.17.0) on a two-project workspace where `pkg-b` resolves `@pnpm.e2e/peer-c@1.0.0` and `pkg-a` depends on `@pnpm.e2e/abc-optional-peers`, which declares it as an optional peer:

| `autoInstallPeers` | `dedupePeerDependents` | before | after |
| --- | --- | --- | --- |
| `false` | `true` (default) | identical | identical |
| `true` | `false` | identical | identical |
| `true` | `true` | identical | identical |
| `false` | `false` | **`abc-optional-peers@1.0.0(@pnpm.e2e/peer-c@1.0.0)` vs `abc-optional-peers@1.0.0`** | identical |

Both stacks get a regression test for the newly-fixed combination, next to the pnpm/pnpm#13325 pair they complement.

## Squash Commit Body

```text
The hoist rounds ran on every install, so a missing peer that some
version elsewhere in the workspace could satisfy was installed even with
`autoInstallPeers: false` and `dedupePeerDependents: false` — the
dependent then carried a peer context the TypeScript CLI never writes.

Upstream derives one flag from the two settings —
`hoistPeers = autoInstallPeers || dedupePeerDependents` in
`installing/deps-resolver/src/resolveDependencyTree.ts` — and
`resolveRootDependencies` returns before the hoist loop when it is
false: hoisting a peer nobody asked to install only pays off if
peer-suffixed variants are being collapsed. `ImporterHoistState` now
carries the same derived flag and both rounds no-op when it is unset,
which leaves the peer missing and the dependent's snapshot free of a
peer suffix. The final peer pass is untouched, so unmet peers are still
reported.

Verified against the TypeScript CLI on a two-project workspace: all four
`autoInstallPeers` x `dedupePeerDependents` combinations now produce
byte-identical lockfiles, where the both-off combination previously
diverged.

Follow-up to pnpm/pnpm#13372.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- The bug is pacquet-only; the TypeScript CLI already gates its hoist on
  the same two settings and gets a matching regression test. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787612045&installation_model_id=426870&pr_number=13381&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13381&signature=bb58d52a8a6b66b494a22843e594a2adba5e3b969a205c808e3531d5aa3e36c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When both peer auto-installation and peer deduplication are disabled, missing peer dependencies are no longer hoisted or installed unexpectedly.
  * Workspace installations now consistently preserve this configuration across packages.
  * Frozen-lockfile installations continue to succeed with the corrected behavior.

* **Tests**
  * Added coverage for optional peer handling and workspace installation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->