### PR TITLE
fix(cli): record packageManagerDependencies from every command

### DIFF
--- a/.changeset/sync-package-manager-deps-on-every-command.md
+++ b/.changeset/sync-package-manager-deps-on-every-command.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A project that pins pnpm through `devEngines.packageManager` (or a v12+ `packageManager` field) now gets its `packageManagerDependencies` recorded in `pnpm-lock.yaml` by every command, not just by the install-family ones [#13348](https://github.com/pnpm/pnpm/issues/13348). Running `pnpm list` (or any other command) in a freshly cloned project no longer leaves the lockfile without the pinned version. The `pmOnFail` setting now also decides whether the pin is recorded: `--pm-on-fail=ignore` keeps it out of the lockfile even when the manifest asks for a stricter policy, and vice versa.

--- a/pnpm/crates/cli/src/cli_args/package_manager.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager.rs
@@ -1,4 +1,5 @@
 use miette::IntoDiagnostic;
+use pacquet_config::PmOnFail;
 use pacquet_package_manifest::parse_manifest;
 use serde_json::Value;
 use std::{fs, io::ErrorKind, path::Path};
@@ -24,11 +25,20 @@ pub(crate) struct PackageManagerToSync {
     pub(crate) version: String,
 }
 
+/// The pnpm version to record under the env lockfile's
+/// `packageManagerDependencies`, or `None` when the project doesn't pin pnpm
+/// in a way that persists (see [`should_persist_package_manager_lockfile`]).
+/// `on_fail` is the effective policy — the `pmOnFail` setting when it is set,
+/// which overrides the manifest's own `onFail`.
 pub(crate) fn package_manager_to_sync(
     manifest: &Value,
     root_dir: &Path,
+    on_fail: Option<PmOnFail>,
 ) -> Option<PackageManagerToSync> {
-    let pm = wanted_package_manager(manifest)?;
+    let mut pm = wanted_package_manager(manifest)?;
+    if let Some(on_fail) = on_fail {
+        pm.on_fail = Some(on_fail.as_str().to_string());
+    }
     let wanted_version = pm.version.as_deref()?;
     if pm.name != "pnpm" || !should_persist_package_manager_lockfile(&pm) {
         return None;

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -616,8 +616,9 @@ pub(crate) fn derive_config_root_and_package_manager_to_sync(
     // install output. This is the install family's earliest point that
     // knows the root manifest's directory.
     warn_ignored_pnpm_manifest_fields(root_manifest.as_ref(), reporter_emit(reporter));
-    let package_manager_to_sync =
-        root_manifest.as_ref().and_then(|manifest| package_manager_to_sync(manifest, &config_root));
+    let package_manager_to_sync = root_manifest
+        .as_ref()
+        .and_then(|manifest| package_manager_to_sync(manifest, &config_root, cfg.pm_on_fail));
     Ok((config_root, package_manager_to_sync))
 }
 

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -2,6 +2,8 @@
 //! manager and the pinned runtimes are reconciled with what is actually
 //! running. A pnpm pin with `onFail: "download"` switches the CLI to the
 //! wanted version; every other pin is validated in place and fails or warns.
+//! A pin that persists to the lockfile is also recorded there, whatever the
+//! command — see [`env_lockfile_sync`].
 //!
 //! Mirrors the block at the top of pnpm's `pnpm/src/main.ts`.
 
@@ -11,8 +13,9 @@ use super::{
     cli_command::{CliArgs, CliCommand},
     config::ConfigSubcommand,
     package_manager::{
-        PACKAGE_MANAGER_SWITCH_ENV_VARS, WantedPackageManager, read_manifest_json,
-        should_persist_package_manager_lockfile, version_satisfies, wanted_package_manager,
+        PACKAGE_MANAGER_SWITCH_ENV_VARS, PackageManagerToSync, WantedPackageManager,
+        package_manager_to_sync, read_manifest_json, should_persist_package_manager_lockfile,
+        version_satisfies, wanted_package_manager,
     },
     reporter::reporter_emit,
     sanitize::sanitize_inline,
@@ -28,6 +31,7 @@ use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_config::{Config, Host, PNPM_VERSION, PmOnFail};
 use pacquet_default_reporter::DefaultReporter;
+use pacquet_env_installer::is_package_manager_resolved;
 use pacquet_lockfile::{EnvLockfile, LockfileResolution, PackageKey, PackageMetadata, VersionPart};
 use pacquet_package_manifest::{apply_runtime_on_fail_override, is_runtime_alias};
 use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter, SilentReporter};
@@ -39,13 +43,13 @@ use std::{
 };
 use system_runtime_version::system_runtime_version;
 
-/// Run the pre-command checks and return the version switch they ask for,
-/// if any. The checks themselves report through `args.reporter` and fail
-/// the command by returning an error.
+/// Run the pre-command checks and return the work they ask for, if any. The
+/// checks themselves report through `args.reporter` and fail the command by
+/// returning an error.
 pub(crate) fn pre_command_plan(
     args: &CliArgs,
     config_overrides: &ConfigOverrides,
-) -> miette::Result<Option<SwitchPlan>> {
+) -> miette::Result<Option<PreCommandPlan>> {
     if should_skip_command(&args.command) {
         return Ok(None);
     }
@@ -54,6 +58,7 @@ pub(crate) fn pre_command_plan(
             switch: SwitchInput::from_cli_args(args),
             global: is_global(&args.command),
             check_runtimes: true,
+            syncs_env_lockfile_in_pipeline: syncs_env_lockfile_in_pipeline(&args.command),
             emit: reporter_emit(args.reporter),
         },
         config_overrides,
@@ -68,12 +73,15 @@ pub(crate) fn pre_command_plan(
 pub(crate) fn pre_command_plan_for_version_flag(
     argv: &[OsString],
     config_overrides: &ConfigOverrides,
-) -> miette::Result<Option<SwitchPlan>> {
+) -> miette::Result<Option<PreCommandPlan>> {
     pre_command_plan_from_input(
         &PreCommandInput {
             switch: SwitchInput::from_version_argv(argv),
             global: false,
             check_runtimes: false,
+            // No install pipeline runs behind `--version`, so nothing else
+            // would record the pin.
+            syncs_env_lockfile_in_pipeline: false,
             emit: DefaultReporter::emit,
         },
         config_overrides,
@@ -81,11 +89,31 @@ pub(crate) fn pre_command_plan_for_version_flag(
     )
 }
 
-#[expect(clippy::exit, reason = "delegated pnpm must preserve the child exit code")]
-pub(crate) async fn execute_switch(
-    plan: SwitchPlan,
+/// Carry out what the pre-command checks planned. Returns whether the command
+/// has already been run by a delegated pnpm, in which case the caller is done.
+pub(crate) async fn execute_plan(
+    plan: PreCommandPlan,
     child_argv: &[OsString],
 ) -> miette::Result<bool> {
+    match plan {
+        PreCommandPlan::Switch(plan) => execute_switch(plan, child_argv).await,
+        PreCommandPlan::SyncEnvLockfile(sync) => {
+            let EnvLockfileSync { config, root_dir, package_manager } = sync;
+            config_deps::sync_package_manager_dependencies(
+                &config,
+                &root_dir,
+                &package_manager.specifier,
+                &package_manager.version,
+                false,
+            )
+            .await?;
+            Ok(false)
+        }
+    }
+}
+
+#[expect(clippy::exit, reason = "delegated pnpm must preserve the child exit code")]
+async fn execute_switch(plan: SwitchPlan, child_argv: &[OsString]) -> miette::Result<bool> {
     let SwitchPlan { config, target } = plan;
     let SwitchTarget { spec, source } = target;
     let config = Config::leak(config);
@@ -130,7 +158,7 @@ fn pre_command_plan_from_input(
     input: &PreCommandInput,
     config_overrides: &ConfigOverrides,
     process_state: SwitchProcessState,
-) -> miette::Result<Option<SwitchPlan>> {
+) -> miette::Result<Option<PreCommandPlan>> {
     let switch = &input.switch;
     if switch.command.as_deref().is_some_and(should_skip_command_name) {
         return Ok(None);
@@ -148,7 +176,10 @@ fn pre_command_plan_from_input(
     let root_dir = config.workspace_dir.clone().unwrap_or_else(|| dir.clone());
     let manifest = read_manifest_json(&root_dir.join("package.json"))?;
 
-    if let Some(pm) = manifest.as_ref().and_then(wanted_package_manager) {
+    let mut package_manager_to_sync = None;
+    if let Some(root_manifest) = manifest.as_ref()
+        && let Some(pm) = wanted_package_manager(root_manifest)
+    {
         let on_fail = effective_on_fail(&config, &pm);
         let switch_wanted = pm.name == "pnpm" && on_fail == PmOnFail::Download;
         // Turning `manage-package-manager-versions` off is the user taking
@@ -159,10 +190,24 @@ fn pre_command_plan_from_input(
         let unmanaged_pin = switch_wanted && process_state.package_manager_switch_disabled;
         if on_fail != PmOnFail::Ignore && !unmanaged_pin {
             if switch_wanted && !process_state.executed_by_corepack {
-                if let Some(target) = switch_target(&config, &root_dir)?
-                    && !version_satisfies(PNPM_VERSION, &target.spec)
-                {
-                    return Ok(Some(SwitchPlan { config, target }));
+                if let Some(target) = switch_target(&config, &root_dir)? {
+                    if !version_satisfies(PNPM_VERSION, &target.spec) {
+                        return Ok(Some(PreCommandPlan::Switch(SwitchPlan { config, target })));
+                    }
+                    // The running pnpm already satisfies the pin, so there is
+                    // nothing to switch to — but the pin still has to reach
+                    // the lockfile, which the switch would otherwise have
+                    // written on its way to the wanted version.
+                    package_manager_to_sync = env_lockfile_sync(
+                        root_manifest,
+                        &root_dir,
+                        on_fail,
+                        input,
+                        match &target.source {
+                            SwitchSource::LockedEnv { env, .. } => ReadEnvLockfile::Already(env),
+                            SwitchSource::Resolve { .. } => ReadEnvLockfile::NotYet,
+                        },
+                    )?;
                 }
             } else if input.global {
                 global_warn(
@@ -171,6 +216,13 @@ fn pre_command_plan_from_input(
                 );
             } else {
                 check_package_manager(&pm, on_fail, process_state, input.emit)?;
+                package_manager_to_sync = env_lockfile_sync(
+                    root_manifest,
+                    &root_dir,
+                    on_fail,
+                    input,
+                    ReadEnvLockfile::NotYet,
+                )?;
             }
         }
     }
@@ -181,7 +233,69 @@ fn pre_command_plan_from_input(
     {
         check_runtimes(manifest, &config, input.emit)?;
     }
-    Ok(None)
+    Ok(package_manager_to_sync.map(|package_manager| {
+        PreCommandPlan::SyncEnvLockfile(EnvLockfileSync { config, root_dir, package_manager })
+    }))
+}
+
+/// pnpm's `syncEnvLockfile`: the pnpm version a project pins is recorded in
+/// the env lockfile's `packageManagerDependencies` by every command, not only
+/// by the install family, so the entry is the same whichever command a
+/// contributor happens to run first.
+///
+/// `None` when the project doesn't pin a persisting pnpm version, when the
+/// lockfile already records one that satisfies the pin, or when the command's
+/// own pipeline syncs it — the install family passes its `frozen-lockfile`
+/// value to the sync, and a frozen install must fail on an out-of-date
+/// `packageManagerDependencies` rather than have it repaired here first.
+fn env_lockfile_sync(
+    root_manifest: &Value,
+    root_dir: &Path,
+    on_fail: PmOnFail,
+    input: &PreCommandInput,
+    read_lockfile: ReadEnvLockfile<'_>,
+) -> miette::Result<Option<PackageManagerToSync>> {
+    if input.syncs_env_lockfile_in_pipeline {
+        return Ok(None);
+    }
+    let Some(package_manager) = package_manager_to_sync(root_manifest, root_dir, Some(on_fail))
+    else {
+        return Ok(None);
+    };
+    let read;
+    let env_lockfile = match read_lockfile {
+        ReadEnvLockfile::Already(env_lockfile) => Some(env_lockfile),
+        ReadEnvLockfile::NotYet => {
+            read = read_env_lockfile(root_dir)?;
+            read.as_ref()
+        }
+    };
+    if env_lockfile.is_some_and(|env_lockfile| {
+        is_package_manager_resolved(
+            env_lockfile,
+            &package_manager.specifier,
+            &package_manager.version,
+        )
+    }) {
+        return Ok(None);
+    }
+    Ok(Some(package_manager))
+}
+
+/// Whether the caller already holds the parsed env lockfile. The download
+/// path reads it to look for a version to switch to, and `pnpm-lock.yaml`
+/// is read whole, so reading it a second time to answer the same question
+/// would double the cost of every command in a pinned project.
+#[derive(Clone, Copy)]
+enum ReadEnvLockfile<'a> {
+    Already(&'a EnvLockfile),
+    NotYet,
+}
+
+fn read_env_lockfile(root_dir: &Path) -> miette::Result<Option<EnvLockfile>> {
+    EnvLockfile::read(root_dir).map_err(miette::Report::new).wrap_err_with(|| {
+        format!("read the package-manager env lockfile in {}", root_dir.display())
+    })
 }
 
 /// pnpm's `checkPackageManager`. `on_fail` is already resolved against the
@@ -370,7 +484,29 @@ struct PreCommandInput {
     switch: SwitchInput,
     global: bool,
     check_runtimes: bool,
+    syncs_env_lockfile_in_pipeline: bool,
     emit: fn(&LogEvent),
+}
+
+/// The install-family commands that sync `packageManagerDependencies` from
+/// their own pipeline, where the effective `frozen-lockfile` value is known —
+/// the commands whose dispatch calls
+/// `pipelines::derive_config_root_and_package_manager_to_sync`.
+/// See [`env_lockfile_sync`].
+fn syncs_env_lockfile_in_pipeline(command: &CliCommand) -> bool {
+    matches!(
+        command,
+        CliCommand::Add(_)
+            | CliCommand::Ci(_)
+            | CliCommand::Dedupe(_)
+            | CliCommand::Deploy(_)
+            | CliCommand::Install(_)
+            | CliCommand::InstallTest(_)
+            | CliCommand::Prune(_)
+            | CliCommand::Remove(_)
+            | CliCommand::Unlink(_)
+            | CliCommand::Update(_),
+    )
 }
 
 /// pnpm treats `--global` as an opt-out of the project's package manager
@@ -417,14 +553,11 @@ fn switch_target(config: &Config, root_dir: &Path) -> miette::Result<Option<Swit
     if on_fail != PmOnFail::Download {
         return Ok(None);
     }
-    pm.on_fail = Some(on_fail_str(on_fail).to_string());
+    pm.on_fail = Some(on_fail.as_str().to_string());
 
     let persist_lockfile = should_persist_package_manager_lockfile(&pm);
     if persist_lockfile
-        && let Some(env) =
-            EnvLockfile::read(root_dir).map_err(miette::Report::new).wrap_err_with(|| {
-                format!("read the package-manager env lockfile in {}", root_dir.display())
-            })?
+        && let Some(env) = read_env_lockfile(root_dir)?
         && let Some(version) = locked_package_manager_version(&env, &spec)?
     {
         return Ok(Some(SwitchTarget { spec, source: SwitchSource::LockedEnv { env, version } }));
@@ -585,15 +718,6 @@ fn effective_on_fail(config: &Config, pm: &WantedPackageManager) -> PmOnFail {
     })
 }
 
-fn on_fail_str(on_fail: PmOnFail) -> &'static str {
-    match on_fail {
-        PmOnFail::Download => "download",
-        PmOnFail::Error => "error",
-        PmOnFail::Warn => "warn",
-        PmOnFail::Ignore => "ignore",
-    }
-}
-
 /// The commands pnpm marks with `skipPackageManagerCheck`, plus `setup` —
 /// they either predate the project's pins (`setup`), inspect pnpm itself
 /// (`store`, `doctor`, and so on), or run something that is not the project
@@ -671,6 +795,20 @@ struct SwitchTarget {
 pub(crate) struct SwitchPlan {
     config: Config,
     target: SwitchTarget,
+}
+
+/// The asynchronous work the (synchronous) pre-command checks scheduled.
+#[derive(Debug)]
+pub(crate) enum PreCommandPlan {
+    Switch(SwitchPlan),
+    SyncEnvLockfile(EnvLockfileSync),
+}
+
+#[derive(Debug)]
+pub(crate) struct EnvLockfileSync {
+    config: Config,
+    root_dir: PathBuf,
+    package_manager: PackageManagerToSync,
 }
 
 #[derive(Debug)]

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -1,9 +1,9 @@
 use super::{
-    PreCommandInput, SwitchInput, SwitchProcessState, SwitchSource, pre_command_plan_from_input,
-    switch_target,
+    PackageManagerToSync, PreCommandInput, PreCommandPlan, SwitchInput, SwitchProcessState,
+    SwitchSource, pre_command_plan_from_input, switch_target,
 };
 use crate::config_overrides::ConfigOverrides;
-use pacquet_config::{Config, PmOnFail};
+use pacquet_config::{Config, PNPM_VERSION, PmOnFail};
 use pacquet_reporter::{Reporter, SilentReporter};
 use std::{
     ffi::OsString,
@@ -170,15 +170,161 @@ fn pre_command_plan_skips_the_runtime_check_for_global_commands() {
     assert!(plan.is_none(), "unexpected switch plan");
 }
 
+#[test]
+fn pre_command_plan_records_a_pin_the_running_pnpm_already_satisfies() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), PNPM_VERSION);
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    // No switch is needed, but the pin still has to reach the lockfile.
+    let Some(PreCommandPlan::SyncEnvLockfile(sync)) = plan else {
+        panic!("expected an env lockfile sync, got {plan:?}");
+    };
+    assert_eq!(
+        sync.package_manager,
+        PackageManagerToSync {
+            specifier: PNPM_VERSION.to_string(),
+            version: PNPM_VERSION.to_string(),
+        },
+    );
+}
+
+#[test]
+fn pre_command_plan_records_a_pin_that_only_warns() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(
+        root.path(),
+        &format!(
+            r#"{{"devEngines":{{"packageManager":{{"name":"pnpm","version":"{PNPM_VERSION}","onFail":"warn"}}}}}}"#,
+        ),
+    );
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(
+        matches!(plan, Some(PreCommandPlan::SyncEnvLockfile(_))),
+        "expected an env lockfile sync, got {plan:?}",
+    );
+}
+
+#[test]
+fn pre_command_plan_leaves_the_env_lockfile_sync_to_the_install_pipeline() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), PNPM_VERSION);
+
+    let plan = pre_command_plan_from_input(
+        &PreCommandInput { syncs_env_lockfile_in_pipeline: true, ..pre_command_input(root.path()) },
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
+}
+
+#[test]
+fn pre_command_plan_skips_the_env_lockfile_sync_when_the_lockfile_is_up_to_date() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), PNPM_VERSION);
+    write_lockfile(root.path(), &locked_package_manager(PNPM_VERSION, PNPM_VERSION));
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
+}
+
+#[test]
+fn pre_command_plan_records_a_pin_whose_specifier_the_lockfile_no_longer_matches() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), PNPM_VERSION);
+    // The locked version still satisfies the pin — so there is nothing to
+    // switch to, and the lockfile the switch lookup already read is the one
+    // the sync decision reuses — but it was resolved from a wider specifier.
+    write_lockfile(root.path(), &locked_package_manager(">=0.0.0", PNPM_VERSION));
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(
+        matches!(plan, Some(PreCommandPlan::SyncEnvLockfile(_))),
+        "expected an env lockfile sync, got {plan:?}",
+    );
+}
+
+#[test]
+fn pre_command_plan_records_a_pin_the_pm_on_fail_setting_reactivated() {
+    let root = TempDir::new().expect("tmp dir");
+    write_manifest(
+        root.path(),
+        &format!(
+            r#"{{"devEngines":{{"packageManager":{{"name":"pnpm","version":"{PNPM_VERSION}","onFail":"ignore"}}}}}}"#,
+        ),
+    );
+
+    // `pmOnFail` overrides the manifest's own `onFail`, so the pin the
+    // manifest asked to ignore is enforced — and recorded — after all.
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &config_overrides(&["--config.pm-on-fail=warn"]),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(
+        matches!(plan, Some(PreCommandPlan::SyncEnvLockfile(_))),
+        "expected an env lockfile sync, got {plan:?}",
+    );
+}
+
+#[test]
+fn pre_command_plan_does_not_record_a_pin_the_pm_on_fail_setting_turned_off() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), PNPM_VERSION);
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &config_overrides(&["--config.pm-on-fail=ignore"]),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
+}
+
+fn config_overrides(argv: &[&str]) -> ConfigOverrides {
+    ConfigOverrides::extract(argv.iter().copied().map(OsString::from)).0
+}
+
 fn pre_command_input(dir: &Path) -> PreCommandInput {
     PreCommandInput {
         switch: SwitchInput {
             dir: dir.to_path_buf(),
             npmrc_auth_file: None,
-            command: Some("install".to_string()),
+            command: Some("run".to_string()),
         },
         global: false,
         check_runtimes: true,
+        syncs_env_lockfile_in_pipeline: false,
         emit: SilentReporter::emit,
     }
 }
@@ -364,6 +510,43 @@ fn write_manifest(root: &Path, content: &str) {
 
 fn write_lockfile(root: &Path, content: &str) {
     fs::write(root.join("pnpm-lock.yaml"), content).expect("write lockfile");
+}
+
+/// An env lockfile whose `packageManagerDependencies` record `version`,
+/// resolved from the registry, against `specifier`.
+fn locked_package_manager(specifier: &str, version: &str) -> String {
+    format!(
+        r"---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {{}}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: '{specifier}'
+        version: {version}
+      pnpm:
+        specifier: '{specifier}'
+        version: {version}
+
+packages:
+
+  '@pnpm/exe@{version}':
+    resolution: {{integrity: sha512-di6YvqPO/2jvih6kCJ8r0ySzQNjQWrBXPEfqEHtrmwOamuNALnfASwhFBwEtMjWmaA8QG7TqAg2qEvAe+8cBkQ==}}
+
+  pnpm@{version}:
+    resolution: {{integrity: sha512-QVocwll0cx51RVwUaDcb50xapft2IbUNQFbSIkUWCfEUEvI/1gLmFp8eBgRmZB95hZfhvpYaEGiINqZ7FlaUmQ==}}
+
+snapshots:
+
+  '@pnpm/exe@{version}': {{}}
+
+  pnpm@{version}: {{}}
+---
+",
+    )
 }
 
 fn switch_target_error(root: &Path) -> miette::Report {

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -553,7 +553,7 @@ fn package_manager_to_sync_preserves_dev_engine_specifier() {
 
     let manifest = read_manifest_json(&manifest_path).expect("read manifest").expect("manifest");
     let package_manager =
-        package_manager_to_sync(&manifest, root.path()).expect("sync package manager");
+        package_manager_to_sync(&manifest, root.path(), None).expect("sync package manager");
 
     assert_eq!(package_manager.specifier, ">=0.0.0");
     assert_eq!(

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -81,7 +81,7 @@ fn run_cli() -> miette::Result<()> {
                 cli_args::pre_command::pre_command_plan_for_version_flag(&argv, &config_overrides)?
                 && block_on_runtime(
                     "pacquet-pre-command",
-                    cli_args::pre_command::execute_switch(plan, &child_argv),
+                    cli_args::pre_command::execute_plan(plan, &child_argv),
                 )?
             {
                 return Ok(());
@@ -100,7 +100,7 @@ fn run_cli() -> miette::Result<()> {
     if let Some(plan) = cli_args::pre_command::pre_command_plan(&args, &config_overrides)?
         && block_on_runtime(
             "pacquet-pre-command",
-            cli_args::pre_command::execute_switch(plan, &child_argv),
+            cli_args::pre_command::execute_plan(plan, &child_argv),
         )?
     {
         return Ok(());

--- a/pnpm/crates/cli/tests/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/package_manager_check.rs
@@ -187,6 +187,23 @@ fn dev_engines_package_manager_array_defaults_on_fail_to_ignore_before_the_last_
     assert_success(&output);
 }
 
+/// The pinned pnpm belongs in the lockfile whichever command records it, so
+/// a project's first pacquet command being something other than an install
+/// must not leave `packageManagerDependencies` unwritten.
+#[test]
+fn a_command_outside_the_install_family_records_the_pinned_package_manager() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_dev_engines_package_manager(&workspace, "pnpm", pacquet_config::PNPM_VERSION, None);
+
+    let output = run(pacquet, root.path(), &EXEC_NODE_VERSION);
+
+    assert_success(&output);
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read the written lockfile");
+    assert_contains(&lockfile, "packageManagerDependencies:");
+    assert_contains(&lockfile, &format!("pnpm@{}", pacquet_config::PNPM_VERSION));
+}
+
 #[test]
 fn the_pm_on_fail_hint_can_be_followed_as_a_bare_flag() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/version.rs
+++ b/pnpm/crates/cli/tests/version.rs
@@ -1,4 +1,5 @@
 use command_extra::CommandExtra;
+use pacquet_lockfile::EnvLockfile;
 use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use pretty_assertions::assert_eq;
 use std::{
@@ -53,6 +54,44 @@ fn version_flag_switches_to_project_package_manager_version() {
     dbg!(&output);
     assert!(output.status.success(), "pacquet --version should succeed");
     assert_eq!(String::from_utf8_lossy(&output.stdout), "9.3.0\n");
+
+    drop((root, mock_instance));
+}
+
+/// `--version` runs the pre-command checks — that is what lets it switch to
+/// the pinned pnpm above. A pin the running pnpm already satisfies has nothing
+/// to switch to, but it is still recorded, so the entry does not depend on
+/// which command the project saw first.
+#[test]
+fn version_flag_records_a_pinned_package_manager_it_does_not_need_to_switch_to() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let pinned = pacquet_config::PNPM_VERSION;
+    fs::write(
+        workspace.join("package.json"),
+        format!(r#"{{"devEngines":{{"packageManager":{{"name":"pnpm","version":"{pinned}"}}}}}}"#),
+    )
+    .expect("write package.json");
+
+    let output = test_command(pacquet, root.path())
+        .env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .args(["--version"])
+        .output()
+        .expect("run pacquet --version");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet --version should succeed");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), format!("{pinned}\n"));
+
+    let env_lockfile = EnvLockfile::read(&workspace)
+        .expect("read the written env lockfile")
+        .expect("the env lockfile should have been written");
+    let recorded = env_lockfile.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .package_manager_dependencies
+        .as_ref()
+        .expect("packageManagerDependencies should be recorded");
+    assert_eq!(recorded["pnpm"].specifier, pinned);
+    assert_eq!(recorded["pnpm"].version, pinned);
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -139,6 +139,18 @@ pub enum PmOnFail {
     Ignore,
 }
 
+impl PmOnFail {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Download => "download",
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Ignore => "ignore",
+        }
+    }
+}
+
 /// What to do when a runtime declared through `devEngines.runtime` or
 /// `engines.runtime` does not match the current process.
 ///


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13348.

pnpm records the pinned pnpm version under `packageManagerDependencies` from its
pre-command block, so **every** command writes it. pacquet only did so from the
install-family pipelines, so a project whose first pacquet command was `pnpm
list` (or `run`, `exec`, `why`, …) got no lockfile at all.

The issue lists three ways out. This PR takes the first one — **keep pacquet's
extra strictness and gate the pre-command sync** — because the alternative
(dropping `FrozenLockfileOutdated` for package-manager deps to match pnpm
exactly) gives up a real guard against a lockfile silently changing under
`--frozen-lockfile` in CI, and the third (record the divergence) leaves the
lockfile dependent on which command ran first.

The gate is the command itself rather than the effective `frozen-lockfile`
value: the install family (`install`, `ci`, `add`, `update`, `remove`, `dedupe`,
`prune`, `deploy`, `unlink`, `install-test`) already syncs from its own
pipeline, where the `frozen-lockfile` value is known, so the pre-command block
skips those and covers everything else. A frozen install therefore still fails
on an out-of-date `packageManagerDependencies` instead of having it repaired
first, and `pacquet install`'s up-to-date fast path keeps its zero-network
startup.

Two more spots the pre-command block now mirrors pnpm:

- The `download` policy with a pin the running pnpm already satisfies. pnpm gets
  there through `switchCliVersion`, which resolves and saves before it decides
  no switch is needed; pacquet returned early and wrote nothing. This is the
  issue's reproduction.
- `pmOnFail`. pnpm resolves `wantedPackageManager.onFail` against the setting
  before `shouldPersistLockfile` reads it, so `--pm-on-fail=ignore` keeps the
  pin out of the lockfile and `--pm-on-fail=warn` puts a manifest-ignored pin
  back in. `package_manager_to_sync` now takes the effective policy, which fixes
  the install family too.

Rebased onto `main` after pnpm/pnpm#13380 landed the same "pass the parsed
manifest" refactor of `package_manager_to_sync`, which shrank this diff to just
the `on_fail` parameter on that function.

pacquet-only: the TypeScript CLI already behaves this way, and nothing about its
behavior changes here.

## Squash Commit Body

```text
pnpm's pre-command block calls syncEnvLockfile for every command that isn't
in skipPackageManagerCheckForCommand, so a project pinning pnpm through
devEngines.packageManager (or a v12+ packageManager field) gets its
packageManagerDependencies recorded whatever the user ran. pacquet synced
only from the install-family pipelines, so `pnpm list` in a fresh clone left
no lockfile behind.

pre_command_plan now returns a PreCommandPlan — either the version switch it
already planned, or the env-lockfile sync it needs — and lib.rs runs whichever
came back on the pre-command runtime. The sync is planned in the same two
places pnpm reaches syncEnvLockfile: after checkPackageManager on the
warn/error/corepack path, and on the download path when the running pnpm
already satisfies the pin (where pnpm's switchCliVersion still resolves and
saves before returning).

The install family is excluded, because it passes its own frozen-lockfile
value to the sync and pacquet — unlike pnpm — fails a frozen install whose
packageManagerDependencies are out of date. Syncing those commands from the
pre-command block would repair the lockfile before the pipeline could refuse
to. Excluding them also keeps the up-to-date install fast path free of the
lockfile read.

The plan is skipped without touching the network whenever the env lockfile
already records a version satisfying the pin. That answer needs the lockfile,
but the download path has already read it looking for a version to switch to,
and `pnpm-lock.yaml` is read whole — so the parsed lockfile is threaded into
the sync decision rather than read a second time. A warm pinned project pays
one lockfile read per command, the same as before.

package_manager_to_sync now takes the effective pmOnFail rather than reading
the manifest's own onFail, matching how pnpm resolves
wantedPackageManager.onFail before shouldPersistLockfile sees it.

Closes pnpm/pnpm#13348
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pinned pnpm versions from `devEngines.packageManager` are now recorded in `pnpm-lock.yaml` for every pnpm command, including commands outside the install family.
  * The `--version` flow now records the pinned package manager when it matches the current pinned pnpm.
* **Bug Fixes**
  * Lockfile synchronization now consistently follows `pmOnFail` (warn vs ignore), and avoids updating `pnpm-lock.yaml` when it’s already up to date.
* **Tests**
  * Added coverage for recording behavior across pinned versions and `pmOnFail` settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->