### PR TITLE
fix(deps-graph-hasher): give local directory deps their own global-virtual-store slot

### DIFF
--- a/.changeset/gvs-local-directory-deps.md
+++ b/.changeset/gvs-local-directory-deps.md
@@ -5,6 +5,7 @@
 "@pnpm/building.after-install": patch
 "@pnpm/engine.pm.commands": patch
 "pnpm": patch
+"pacquet": patch
 ---
 
 Installing a local `file:` directory dependency with the global virtual store enabled no longer fails with `TypeError: Cannot read properties of undefined (reading 'split')` [#13335](https://github.com/pnpm/pnpm/issues/13335).

--- a/.changeset/gvs-local-directory-deps.md
+++ b/.changeset/gvs-local-directory-deps.md
@@ -1,0 +1,12 @@
+---
+"@pnpm/deps.graph-hasher": patch
+"@pnpm/deps.graph-builder": patch
+"@pnpm/installing.deps-resolver": patch
+"@pnpm/building.after-install": patch
+"@pnpm/engine.pm.commands": patch
+"pnpm": patch
+---
+
+Installing a local `file:` directory dependency with the global virtual store enabled no longer fails with `TypeError: Cannot read properties of undefined (reading 'split')` [#13335](https://github.com/pnpm/pnpm/issues/13335).
+
+Local directory dependencies — `file:` directories and injected workspace packages — now get a global-virtual-store slot of their own per project. They used to share one slot across every project that depended on a directory of the same name, so a project could end up linked to another project's copy of the dependency.

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -243,6 +243,7 @@ impl LicensesArgs {
             lockfile.snapshots.as_ref(),
             lockfile.packages.as_ref(),
             Some(&allow_build_policy),
+            Some(lockfile_dir),
         );
         validate_virtual_store_slot_containment(lockfile.snapshots.as_ref(), &layout)
             .into_diagnostic()?;

--- a/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -235,6 +235,11 @@ fn compute_engine_slot(
         Some(&env.snapshots),
         Some(&env.packages),
         Some(&policy),
+        // No lockfile directory: this lockfile only ever holds the pnpm
+        // package and its registry dependencies, and the install that
+        // materializes the slot runs from a throwaway directory that
+        // differs on every self-update.
+        None,
     );
     Some(layout.slot_dir(&key))
 }

--- a/pnpm/crates/cli/tests/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/global_virtual_store.rs
@@ -767,6 +767,50 @@ fn needs_build_marker_triggers_reimport_on_next_install() {
     drop((root, mock_instance));
 }
 
+/// TS: `local directory dependency works with global virtual store`
+/// (`globalVirtualStore.ts`).
+///
+/// The lockfile records no version for a directory snapshot while the
+/// resolver reads one off the manifest, so both install paths have to
+/// agree on the anchored `directory` segment or the reinstall would
+/// relocate the package. Upstream additionally crashed here — see
+/// <https://github.com/pnpm/pnpm/issues/13335>.
+#[test]
+fn local_directory_dependency_works_with_global_virtual_store() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    set_gvs_workspace_yaml(&workspace, "");
+    write_manifest(&workspace, &serde_json::json!({ "dep": "file:dep" }));
+    fs::create_dir_all(workspace.join("dep")).expect("mkdir dep");
+    fs::write(
+        workspace.join("dep/package.json"),
+        serde_json::json!({ "name": "dep", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write dep/package.json");
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir = pkg_version_dir(&store_dir, "@/dep", "directory");
+    let slot_after_install = sole_hash_dir(&version_dir);
+    assert!(
+        pkg_in_slot(&slot_after_install, "dep").join("package.json").exists(),
+        "the local directory dependency must be materialized in its GVS slot",
+    );
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    assert_eq!(
+        sole_hash_dir(&version_dir),
+        slot_after_install,
+        "the frozen reinstall must land on the slot the first install created",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// TS: `injected local packages work with global virtual store`
 /// (`globalVirtualStore.ts:461`).
 ///

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path.rs
@@ -51,6 +51,12 @@ use std::{
 ///   every snapshot in the install. Untouched when `built_dep_paths`
 ///   is `None`; callers that don't care can hold a throwaway
 ///   `let mut cache = HashMap::new();` and pass `&mut cache`.
+///
+/// `project` scopes the slot to one project instead of sharing it
+/// across every project in the store. Callers pass `Some(lockfile_dir)`
+/// for a snapshot resolved from a local directory and `None` for
+/// everything else — see
+/// [`local_directory_scope`](../../../../package-manager/src/virtual_store_layout.rs).
 pub fn calc_graph_node_hash<Key>(
     graph: &HashMap<Key, DepsGraphNode<Key>>,
     cache: &mut DepsStateCache<Key>,
@@ -58,6 +64,7 @@ pub fn calc_graph_node_hash<Key>(
     engine: Option<&str>,
     built_dep_paths: Option<&HashSet<Key>>,
     build_required_cache: &mut HashMap<Key, bool>,
+    project: Option<&str>,
 ) -> String
 where
     Key: Clone + Eq + std::hash::Hash,
@@ -81,10 +88,10 @@ where
         Value::Null
     };
     let deps_hash = calc_dep_graph_hash(graph, cache, &mut HashSet::new(), dep_path);
-    let payload = json!({
-        "engine": engine_value,
-        "deps": deps_hash,
-    });
+    let payload = match project {
+        None => json!({ "engine": engine_value, "deps": deps_hash }),
+        Some(project) => json!({ "engine": engine_value, "deps": deps_hash, "project": project }),
+    };
     hash_object_without_sorting(&payload, HashEncoding::Hex)
 }
 

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
@@ -62,6 +62,7 @@ fn identical_leaves_hash_identically() {
         Some("darwin-arm64-node20"),
         None,
         &mut br_a,
+        None,
     );
     let second = calc_graph_node_hash(
         &graph,
@@ -70,6 +71,7 @@ fn identical_leaves_hash_identically() {
         Some("darwin-arm64-node20"),
         None,
         &mut br_b,
+        None,
     );
     assert_eq!(first, second, "deterministic for same input");
     assert_eq!(first.len(), 64, "sha256 hex digest is 64 chars");
@@ -91,6 +93,7 @@ fn engine_string_changes_hash() {
         Some("darwin-arm64-node20"),
         None,
         &mut br,
+        None,
     );
     let mut cache_other = HashMap::new();
     let mut br_other = HashMap::new();
@@ -101,6 +104,7 @@ fn engine_string_changes_hash() {
         Some("linux-x64-node22"),
         None,
         &mut br_other,
+        None,
     );
     let mut cache_null = HashMap::new();
     let mut br_null = HashMap::new();
@@ -111,6 +115,7 @@ fn engine_string_changes_hash() {
         None,
         None,
         &mut br_null,
+        None,
     );
     assert_ne!(with_engine, with_other_engine);
     assert_ne!(with_engine, with_null);
@@ -137,6 +142,7 @@ fn engine_agnostic_when_subtree_has_no_builders() {
         Some("darwin-arm64-node20"),
         Some(&built),
         &mut br_a,
+        None,
     );
     let mut cache_b = HashMap::new();
     let mut br_b = HashMap::new();
@@ -147,6 +153,7 @@ fn engine_agnostic_when_subtree_has_no_builders() {
         Some("linux-x64-node22"),
         Some(&built),
         &mut br_b,
+        None,
     );
     assert_eq!(
         darwin, linux,
@@ -174,6 +181,7 @@ fn engine_included_when_self_in_built_set() {
         Some("darwin-arm64-node20"),
         Some(&built),
         &mut br_a,
+        None,
     );
     let mut cache_b = HashMap::new();
     let mut br_b = HashMap::new();
@@ -184,6 +192,7 @@ fn engine_included_when_self_in_built_set() {
         Some("linux-x64-node22"),
         Some(&built),
         &mut br_b,
+        None,
     );
     assert_ne!(darwin, linux, "builder must partition by engine string");
 }
@@ -214,6 +223,7 @@ fn engine_included_for_ancestor_of_builder() {
         Some("darwin-arm64-node20"),
         Some(&built),
         &mut br_a,
+        None,
     );
     let mut cache_b = HashMap::new();
     let mut br_b = HashMap::new();
@@ -224,6 +234,7 @@ fn engine_included_for_ancestor_of_builder() {
         Some("linux-x64-node22"),
         Some(&built),
         &mut br_b,
+        None,
     );
     assert_ne!(darwin, linux, "ancestor of a builder must partition by engine string");
 }
@@ -247,6 +258,7 @@ fn none_built_dep_paths_disables_gating() {
         Some("darwin-arm64-node20"),
         None,
         &mut br_a,
+        None,
     );
     let mut cache_b = HashMap::new();
     let mut br_b = HashMap::new();
@@ -257,6 +269,7 @@ fn none_built_dep_paths_disables_gating() {
         Some("linux-x64-node22"),
         None,
         &mut br_b,
+        None,
     );
     assert_ne!(darwin, linux, "without builtDepPaths gating, engine is always part of the hash");
 }
@@ -287,6 +300,7 @@ fn different_children_change_hash() {
         Some("darwin-arm64-node20"),
         None,
         &mut br_a,
+        None,
     );
     let mut cache_b = HashMap::new();
     let mut br_b = HashMap::new();
@@ -297,6 +311,7 @@ fn different_children_change_hash() {
         Some("darwin-arm64-node20"),
         None,
         &mut br_b,
+        None,
     );
     assert_ne!(with_dep, without_dep, "same root, different children must not collide on GVS hash");
 }
@@ -311,8 +326,15 @@ fn leaf_matches_single_node_graph_hash() {
     );
     let mut cache = HashMap::new();
     let mut br = HashMap::new();
-    let digest =
-        calc_graph_node_hash(&graph, &mut cache, &"leaf@1.0.0".to_string(), None, None, &mut br);
+    let digest = calc_graph_node_hash(
+        &graph,
+        &mut cache,
+        &"leaf@1.0.0".to_string(),
+        None,
+        None,
+        &mut br,
+        None,
+    );
     assert_eq!(
         calc_leaf_global_virtual_store_path(full, "leaf", "1.0.0"),
         format_global_virtual_store_path("leaf", "1.0.0", &digest),

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -1298,7 +1298,7 @@ fn gvs_layout(dir: &Path) -> &'static VirtualStoreLayout {
     config.global_virtual_store_dir = dir.join("store/links");
     config.virtual_store_dir = dir.join("node_modules/.pacquet");
     let config = config.leak();
-    Box::leak(Box::new(VirtualStoreLayout::new(config, None, None, None, None)))
+    Box::leak(Box::new(VirtualStoreLayout::new(config, None, None, None, None, None)))
 }
 
 /// Run [`BuildModules`] over a single patched `is-positive@1.0.0`
@@ -2581,7 +2581,7 @@ fn pkg_root_for_key_isolated_uses_layout() {
     config.modules_dir = dir.path().join("node_modules");
     config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
     let config = config.leak();
-    let layout = VirtualStoreLayout::new(config, None, None, None, None);
+    let layout = VirtualStoreLayout::new(config, None, None, None, None, None);
 
     let key: PackageKey = "is-positive@1.0.0".parse().expect("parse key");
     let result = super::pkg_root_for_key(&layout, None, &key).expect("isolated lookup hits");
@@ -2606,7 +2606,7 @@ fn pkg_root_for_key_hoisted_uses_override() {
     config.modules_dir = dir.path().join("node_modules");
     config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
     let config = config.leak();
-    let layout = VirtualStoreLayout::new(config, None, None, None, None);
+    let layout = VirtualStoreLayout::new(config, None, None, None, None, None);
 
     let key: PackageKey = "is-positive@1.0.0".parse().expect("parse key");
     let hoisted_dir = PathBuf::from("/repo/node_modules/is-positive");
@@ -2628,7 +2628,7 @@ fn pkg_root_for_key_hoisted_missing_returns_none() {
     config.modules_dir = dir.path().join("node_modules");
     config.virtual_store_dir = dir.path().join("node_modules/.pacquet");
     let config = config.leak();
-    let layout = VirtualStoreLayout::new(config, None, None, None, None);
+    let layout = VirtualStoreLayout::new(config, None, None, None, None, None);
 
     let key: PackageKey = "absent@1.0.0".parse().expect("parse key");
     let map: HashMap<PackageKey, Vec<PathBuf>> = HashMap::new();

--- a/pnpm/crates/package-manager/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store/tests.rs
@@ -159,6 +159,7 @@ async fn cold_batch_links_slots_in_parallel() {
         Some(&snapshots),
         Some(&packages),
         Some(&allow_build_policy),
+        None,
     );
     let skipped = SkippedSnapshots::new();
     let logged_methods = AtomicU8::new(0);

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -3730,7 +3730,15 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<P
     }
     if gvs_build_markers_may_require_recovery(config) {
         let wanted = lockfile.get().ok().flatten()?;
-        if gvs_build_marker_present(wanted, config, &workspace_root) {
+        // `workspace_root` above is the workspace-state root, which stays the
+        // discovered workspace dir even under `sharedWorkspaceLockfile: false`.
+        // The slot lookup needs the lockfile dir instead — `run_inner`'s
+        // `lockfileDir = sharedWorkspaceLockfile ? workspaceDir : projectDir` —
+        // or this fast path would probe a directory dep's slot under a project
+        // that does not own it and miss the marker it is looking for.
+        let lockfile_dir =
+            if config.shared_workspace_lockfile { workspace_root.as_path() } else { manifest_dir };
+        if gvs_build_marker_present(wanted, config, lockfile_dir) {
             return None;
         }
     }

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1003,7 +1003,7 @@ where
             // swallowed read error.
             let marker_safe = if gvs_build_markers_may_require_recovery(config) {
                 match lockfile.get() {
-                    Ok(Some(wanted)) => !gvs_build_marker_present(wanted, config),
+                    Ok(Some(wanted)) => !gvs_build_marker_present(wanted, config, &workspace_root),
                     Ok(None) => true,
                     Err(_) => false,
                 }
@@ -1631,7 +1631,7 @@ where
             // project-state input checked above. Let materialization inspect
             // buildable and patched GVS slots instead of declaring the local
             // tree complete from importer links alone.
-            && !gvs_build_marker_present(wanted_lockfile, config)
+            && !gvs_build_marker_present(wanted_lockfile, config, &workspace_root)
             // An explicit `pacquet rebuild` always re-runs the build phase,
             // so it never short-circuits here.
             && rebuild.is_none()
@@ -2115,6 +2115,7 @@ where
                 current.snapshots.as_ref(),
                 current.packages.as_ref(),
                 Some(&allow_build_policy),
+                Some(workspace_root.as_path()),
             );
             crate::package_map::write_package_map(
                 current,
@@ -2875,7 +2876,7 @@ fn gvs_build_markers_may_require_recovery(config: &Config) -> bool {
 /// marker for this lockfile. Hash directories are enumerated rather than
 /// recomputed because buildable slots include the runtime engine in their
 /// graph hash, which the pre-runtime fast path deliberately has not resolved.
-fn gvs_build_marker_present(wanted: &Lockfile, config: &Config) -> bool {
+fn gvs_build_marker_present(wanted: &Lockfile, config: &Config, lockfile_dir: &Path) -> bool {
     if !gvs_build_markers_may_require_recovery(config) {
         return false;
     }
@@ -2888,6 +2889,7 @@ fn gvs_build_marker_present(wanted: &Lockfile, config: &Config) -> bool {
         wanted.snapshots.as_ref(),
         wanted.packages.as_ref(),
         Some(&policy),
+        Some(lockfile_dir),
     );
     if crate::validate_virtual_store_slot_containment(wanted.snapshots.as_ref(), &layout).is_err() {
         return true;
@@ -3728,7 +3730,7 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<P
     }
     if gvs_build_markers_may_require_recovery(config) {
         let wanted = lockfile.get().ok().flatten()?;
-        if gvs_build_marker_present(wanted, config) {
+        if gvs_build_marker_present(wanted, config, &workspace_root) {
             return None;
         }
     }

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -924,6 +924,7 @@ where
             snapshots,
             packages,
             Some(&allow_build_policy),
+            Some(workspace_root),
         );
 
         // Reject a lockfile whose dependency names, aliases, or

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1934,6 +1934,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             initial_materialization_lockfile.snapshots.as_ref(),
             initial_materialization_lockfile.packages.as_ref(),
             Some(&allow_build_policy),
+            Some(lockfile_dir),
         );
         if config.enable_global_virtual_store {
             tracing::info!(

--- a/pnpm/crates/package-manager/src/package_map/tests.rs
+++ b/pnpm/crates/package-manager/src/package_map/tests.rs
@@ -143,7 +143,7 @@ fn lockfile_package_map_uses_global_virtual_store_layout() {
         HashMap::from([("dep1@1.0.0".parse::<PackageKey>().unwrap(), SnapshotEntry::default())]);
     // GVS precomputes a `<name>/<version>/<hash>` slot per snapshot; the
     // package map must read those locations rather than the flat depPath name.
-    let layout = VirtualStoreLayout::new(&config, None, Some(&snapshots), None, None);
+    let layout = VirtualStoreLayout::new(&config, None, Some(&snapshots), None, None, None);
 
     let root_manifest = manifest("root");
     let project_manifests = vec![(cwd.clone(), &root_manifest)];

--- a/pnpm/crates/package-manager/src/validate_lockfile_paths/tests.rs
+++ b/pnpm/crates/package-manager/src/validate_lockfile_paths/tests.rs
@@ -37,7 +37,7 @@ fn rejects_a_global_virtual_store_version_escape() {
 
     let mut snapshots = HashMap::new();
     snapshots.insert(key.clone(), SnapshotEntry::default());
-    let layout = VirtualStoreLayout::new(&config, None, Some(&snapshots), None, None);
+    let layout = VirtualStoreLayout::new(&config, None, Some(&snapshots), None, None, None);
     assert!(
         !pacquet_fs::is_subdir(layout.package_store_dir(), &layout.slot_dir(&key)),
         "the crafted slot must actually escape the store for this test to be meaningful",

--- a/pnpm/crates/package-manager/src/virtual_store_layout.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout.rs
@@ -236,8 +236,7 @@ impl VirtualStoreLayout {
             let snapshot_engine = own_engine.as_deref().or(engine);
             let metadata_key = snapshot_key.without_peer();
             let metadata = packages.and_then(|map| map.get(&metadata_key));
-            let resolution = metadata.map(|meta| &meta.resolution);
-            let project = local_directory_scope(resolution, lockfile_dir);
+            let project = local_directory_scope(metadata, &metadata_key.suffix, lockfile_dir);
             let hex_digest = calc_graph_node_hash(
                 &graph,
                 &mut cache,
@@ -431,15 +430,12 @@ pub fn collect_injected_deps(
 /// here would put a `:` (and embedded `/`) into the slot path —
 /// rejected on Windows with `ERROR_INVALID_NAME`.
 fn gvs_version_segment(metadata: Option<&PackageMetadata>, suffix: &PkgVerPeer) -> String {
-    if matches!(metadata.map(|meta| &meta.resolution), Some(LockfileResolution::Directory(_))) {
+    if is_local_directory(metadata, suffix) {
         return LOCAL_DIRECTORY_SEGMENT.to_string();
     }
-    if let Some(version) = metadata.and_then(|meta| meta.version.as_deref()) {
-        return version.to_string();
-    }
-    match suffix.version() {
-        VersionPart::File(_) => LOCAL_DIRECTORY_SEGMENT.to_string(),
-        VersionPart::Semver(_) | VersionPart::NonSemver(_) => suffix.version().to_string(),
+    match metadata.and_then(|meta| meta.version.as_deref()) {
+        Some(version) => version.to_string(),
+        None => suffix.version().to_string(),
     }
 }
 
@@ -447,10 +443,35 @@ fn gvs_version_segment(metadata: Option<&PackageMetadata>, suffix: &PkgVerPeer) 
 /// directory — see [`gvs_version_segment`].
 const LOCAL_DIRECTORY_SEGMENT: &str = "directory";
 
-/// Extra hash input that keeps a snapshot resolved from a local
-/// directory — a `file:` directory dependency or an injected workspace
-/// package — on a slot of its own. Returns `None` for every other
-/// resolution, which then hashes exactly as it did before.
+/// Whether the snapshot is a package taken from a local directory — a
+/// `file:` directory dependency or an injected workspace package.
+///
+/// Both the version segment and the project scope below are derived
+/// from this one answer. Deciding it twice is what lets a snapshot take
+/// the anchored segment while missing the scope, which is the collision
+/// the scope exists to prevent.
+///
+/// Without a `packages:` entry the resolution is unavailable and the
+/// snapshot key's `file:` version part is the only signal left. Reading
+/// it as a directory is the safe way to be wrong: the slot stays scoped,
+/// and the segment stays a legal path component (the raw `file:<path>`
+/// carries a `:` and a `/`, which Windows rejects with
+/// `ERROR_INVALID_NAME`).
+fn is_local_directory(metadata: Option<&PackageMetadata>, suffix: &PkgVerPeer) -> bool {
+    if let Some(metadata) = metadata {
+        if matches!(metadata.resolution, LockfileResolution::Directory(_)) {
+            return true;
+        }
+        if metadata.version.is_some() {
+            return false;
+        }
+    }
+    matches!(suffix.version(), VersionPart::File(_))
+}
+
+/// Extra hash input that keeps a snapshot taken from a local directory
+/// on a slot of its own. `None` for every other snapshot, which then
+/// hashes exactly as it did before.
 ///
 /// A directory resolution is the one resolution with no integrity: it
 /// is a path relative to the lockfile, so `file:dep` hashes identically
@@ -460,19 +481,18 @@ const LOCAL_DIRECTORY_SEGMENT: &str = "directory";
 /// the install re-imports it every time — so the projects would go on
 /// overwriting each other's dependency.
 fn local_directory_scope(
-    resolution: Option<&LockfileResolution>,
+    metadata: Option<&PackageMetadata>,
+    suffix: &PkgVerPeer,
     lockfile_dir: Option<&Path>,
 ) -> Option<String> {
-    match resolution {
-        Some(LockfileResolution::Directory(_)) => {
-            // Lossy on purpose: the TypeScript CLI hashes the same slot from a
-            // JS string, and Node decodes a path as UTF-8 with replacement, so
-            // this is the identical input. Hashing the raw bytes instead would
-            // give the two stacks different slots for the same project.
-            lockfile_dir.map(|dir| dir.to_string_lossy().into_owned())
-        }
-        _ => None,
+    if !is_local_directory(metadata, suffix) {
+        return None;
     }
+    // Lossy on purpose: the TypeScript CLI hashes the same slot from a JS
+    // string, and Node decodes a path as UTF-8 with replacement, so this is
+    // the identical input. Hashing the raw bytes instead would give the two
+    // stacks different slots for the same project.
+    lockfile_dir.map(|dir| dir.to_string_lossy().into_owned())
 }
 
 /// Build the dependency graph from the lockfile's `snapshots` /

--- a/pnpm/crates/package-manager/src/virtual_store_layout.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout.rs
@@ -200,6 +200,14 @@ impl VirtualStoreLayout {
             };
         };
         let graph = lockfile_to_dep_graph(snapshots, packages);
+        // One conversion for the whole lockfile: the same string scopes every
+        // local directory snapshot in it.
+        //
+        // Lossy on purpose: the TypeScript CLI hashes the same slot from a JS
+        // string, and Node decodes a path as UTF-8 with replacement, so this is
+        // the identical input. Hashing the raw bytes instead would give the two
+        // stacks different slots for the same project.
+        let project_scope = lockfile_dir.map(|dir| dir.to_string_lossy());
         // Build the engine-agnostic gating set once per install.
         // `None` here disables gating so every snapshot still hashes
         // with its engine string.
@@ -236,7 +244,8 @@ impl VirtualStoreLayout {
             let snapshot_engine = own_engine.as_deref().or(engine);
             let metadata_key = snapshot_key.without_peer();
             let metadata = packages.and_then(|map| map.get(&metadata_key));
-            let project = local_directory_scope(metadata, &metadata_key.suffix, lockfile_dir);
+            let project =
+                local_directory_scope(metadata, &metadata_key.suffix, project_scope.as_deref());
             let hex_digest = calc_graph_node_hash(
                 &graph,
                 &mut cache,
@@ -244,7 +253,7 @@ impl VirtualStoreLayout {
                 snapshot_engine,
                 built_dep_paths.as_ref(),
                 &mut build_required_cache,
-                project.as_deref(),
+                project,
             );
             let name = metadata_key.name.to_string();
             let version = gvs_version_segment(metadata, &metadata_key.suffix);
@@ -480,19 +489,12 @@ fn is_local_directory(metadata: Option<&PackageMetadata>, suffix: &PkgVerPeer) -
 /// project installed first, and because the source directory is mutable
 /// the install re-imports it every time — so the projects would go on
 /// overwriting each other's dependency.
-fn local_directory_scope(
+fn local_directory_scope<'a>(
     metadata: Option<&PackageMetadata>,
     suffix: &PkgVerPeer,
-    lockfile_dir: Option<&Path>,
-) -> Option<String> {
-    if !is_local_directory(metadata, suffix) {
-        return None;
-    }
-    // Lossy on purpose: the TypeScript CLI hashes the same slot from a JS
-    // string, and Node decodes a path as UTF-8 with replacement, so this is
-    // the identical input. Hashing the raw bytes instead would give the two
-    // stacks different slots for the same project.
-    lockfile_dir.map(|dir| dir.to_string_lossy().into_owned())
+    lockfile_dir: Option<&'a str>,
+) -> Option<&'a str> {
+    is_local_directory(metadata, suffix).then_some(lockfile_dir).flatten()
 }
 
 /// Build the dependency graph from the lockfile's `snapshots` /

--- a/pnpm/crates/package-manager/src/virtual_store_layout.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout.rs
@@ -465,6 +465,10 @@ fn local_directory_scope(
 ) -> Option<String> {
     match resolution {
         Some(LockfileResolution::Directory(_)) => {
+            // Lossy on purpose: the TypeScript CLI hashes the same slot from a
+            // JS string, and Node decodes a path as UTF-8 with replacement, so
+            // this is the identical input. Hashing the raw bytes instead would
+            // give the two stacks different slots for the same project.
             lockfile_dir.map(|dir| dir.to_string_lossy().into_owned())
         }
         _ => None,

--- a/pnpm/crates/package-manager/src/virtual_store_layout.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout.rs
@@ -155,12 +155,22 @@ impl VirtualStoreLayout {
     /// `engine = null` so their GVS directories survive Node.js
     /// upgrades. When `None`, every snapshot keeps the engine in
     /// its hash payload.
+    ///
+    /// `lockfile_dir` scopes the slots of snapshots resolved from a
+    /// local directory to the project that owns them: a directory
+    /// resolution is a lockfile-relative path with no integrity, so
+    /// `file:dep` otherwise hashes identically in every project that
+    /// depends on a directory of that name, and they all link to
+    /// whichever project installed first. `None` leaves them on that
+    /// shared slot, which is only safe for a lockfile known to have no
+    /// directory resolutions.
     pub fn new(
         config: &Config,
         engine: Option<&str>,
         snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
         packages: Option<&HashMap<PackageKey, PackageMetadata>>,
         allow_build_policy: Option<&AllowBuildPolicy>,
+        lockfile_dir: Option<&Path>,
     ) -> Self {
         // Pacquet keeps `virtual_store_dir` and `global_virtual_store_dir`
         // as two separate fields (see
@@ -224,6 +234,10 @@ impl VirtualStoreLayout {
             let own_engine =
                 find_own_runtime_node_major(snapshot).map(|major| engine_name(major, None, None));
             let snapshot_engine = own_engine.as_deref().or(engine);
+            let metadata_key = snapshot_key.without_peer();
+            let metadata = packages.and_then(|map| map.get(&metadata_key));
+            let resolution = metadata.map(|meta| &meta.resolution);
+            let project = local_directory_scope(resolution, lockfile_dir);
             let hex_digest = calc_graph_node_hash(
                 &graph,
                 &mut cache,
@@ -231,10 +245,10 @@ impl VirtualStoreLayout {
                 snapshot_engine,
                 built_dep_paths.as_ref(),
                 &mut build_required_cache,
+                project.as_deref(),
             );
-            let metadata_key = snapshot_key.without_peer();
             let name = metadata_key.name.to_string();
-            let version = gvs_version_segment(&metadata_key.suffix);
+            let version = gvs_version_segment(metadata, &metadata_key.suffix);
             let suffix = format_global_virtual_store_path(&name, &version, &hex_digest);
             gvs_suffixes.insert(snapshot_key.clone(), suffix);
         }
@@ -297,6 +311,7 @@ pub fn virtual_store_layout_for_lockfile(
     snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
     packages: Option<&HashMap<PackageKey, PackageMetadata>>,
     allow_build_policy: Option<&AllowBuildPolicy>,
+    lockfile_dir: Option<&Path>,
 ) -> VirtualStoreLayout {
     let engine = if config.enable_global_virtual_store {
         find_runtime_node_major(snapshots)
@@ -306,7 +321,14 @@ pub fn virtual_store_layout_for_lockfile(
     } else {
         None
     };
-    VirtualStoreLayout::new(config, engine.as_deref(), snapshots, packages, allow_build_policy)
+    VirtualStoreLayout::new(
+        config,
+        engine.as_deref(),
+        snapshots,
+        packages,
+        allow_build_policy,
+        lockfile_dir,
+    )
 }
 
 /// Map each injected `file:` project to the virtual-store package
@@ -401,16 +423,51 @@ pub fn collect_injected_deps(
 /// the version as `pkgSnapshot.version ?? pkgInfo.version`, then feeds
 /// it into the global-virtual-store path format.
 ///
-/// An injected `file:` workspace dep carries no `version` field in the
-/// lockfile, and its depPath version is non-semver, so the version
-/// derivation returns `undefined` and the path format stringifies it to
-/// the literal segment `undefined`. Emitting the raw `file:<path>` here
-/// instead would put a `:` (and embedded `/`) into the slot path —
+/// A snapshot resolved from a local directory gets the fixed
+/// [`LOCAL_DIRECTORY_SEGMENT`] instead: the lockfile records no version
+/// for one, and the install path that resolves from manifests does know
+/// the version, so anchoring the segment is what keeps a re-install on
+/// the slot the first install created. Emitting the raw `file:<path>`
+/// here would put a `:` (and embedded `/`) into the slot path —
 /// rejected on Windows with `ERROR_INVALID_NAME`.
-fn gvs_version_segment(suffix: &PkgVerPeer) -> String {
+fn gvs_version_segment(metadata: Option<&PackageMetadata>, suffix: &PkgVerPeer) -> String {
+    if matches!(metadata.map(|meta| &meta.resolution), Some(LockfileResolution::Directory(_))) {
+        return LOCAL_DIRECTORY_SEGMENT.to_string();
+    }
+    if let Some(version) = metadata.and_then(|meta| meta.version.as_deref()) {
+        return version.to_string();
+    }
     match suffix.version() {
-        VersionPart::File(_) => "undefined".to_string(),
+        VersionPart::File(_) => LOCAL_DIRECTORY_SEGMENT.to_string(),
         VersionPart::Semver(_) | VersionPart::NonSemver(_) => suffix.version().to_string(),
+    }
+}
+
+/// Stands in for the version of a snapshot resolved from a local
+/// directory — see [`gvs_version_segment`].
+const LOCAL_DIRECTORY_SEGMENT: &str = "directory";
+
+/// Extra hash input that keeps a snapshot resolved from a local
+/// directory — a `file:` directory dependency or an injected workspace
+/// package — on a slot of its own. Returns `None` for every other
+/// resolution, which then hashes exactly as it did before.
+///
+/// A directory resolution is the one resolution with no integrity: it
+/// is a path relative to the lockfile, so `file:dep` hashes identically
+/// in every project that happens to depend on a directory of that name.
+/// Sharing the slot would hand one project the files of whichever
+/// project installed first, and because the source directory is mutable
+/// the install re-imports it every time — so the projects would go on
+/// overwriting each other's dependency.
+fn local_directory_scope(
+    resolution: Option<&LockfileResolution>,
+    lockfile_dir: Option<&Path>,
+) -> Option<String> {
+    match resolution {
+        Some(LockfileResolution::Directory(_)) => {
+            lockfile_dir.map(|dir| dir.to_string_lossy().into_owned())
+        }
+        _ => None,
     }
 }
 

--- a/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
@@ -7,7 +7,8 @@ use pacquet_lockfile::{
 use pretty_assertions::{assert_eq, assert_ne};
 use std::{
     collections::{HashMap, HashSet},
-    path::PathBuf,
+    ffi::OsStr,
+    path::{Path, PathBuf},
 };
 
 /// Build a `Config` test-double with the GVS-relevant fields
@@ -508,7 +509,7 @@ fn directory_deps_get_a_slot_per_project() {
             Some(&snapshots),
             Some(&packages),
             None,
-            Some(std::path::Path::new(lockfile_dir)),
+            Some(Path::new(lockfile_dir)),
         )
         .slot_dir(&key)
     };
@@ -516,8 +517,12 @@ fn directory_deps_get_a_slot_per_project() {
     let in_project_a = slot_in("/home/user/a");
     let in_project_b = slot_in("/home/user/b");
     assert_ne!(in_project_a, in_project_b);
-    assert!(
-        in_project_a.to_string_lossy().contains("dep/directory/"),
+    // The slot is `<root>/@/dep/<version>/<hash>`, so the version segment is
+    // the hash directory's parent. Compared as a component rather than a
+    // substring: the separator is native, `\` on Windows.
+    assert_eq!(
+        in_project_a.parent().and_then(Path::file_name),
+        Some(OsStr::new("directory")),
         "directory deps take the anchored version segment; got {in_project_a:?}",
     );
 }

--- a/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
@@ -480,6 +480,39 @@ fn gvs_version_segment_anchors_directory_deps() {
     assert_eq!(super::gvs_version_segment(Some(&tarball_metadata), &tarball_dep.suffix), "0.0.0");
 }
 
+/// A lockfile that keeps a `file:` snapshot but drops or mismatches its
+/// `packages:` entry leaves no resolution to read. The segment and the
+/// project scope have to reach the same verdict from what is left, or
+/// the snapshot takes the anchored segment while missing the scope —
+/// which is the collision the scope exists to prevent.
+#[test]
+fn a_file_snapshot_without_metadata_is_still_scoped() {
+    let dir_dep: PackageKey = "b@file:packages/b".parse().unwrap();
+
+    assert_eq!(super::gvs_version_segment(None, &dir_dep.suffix), "directory");
+    assert_eq!(
+        super::local_directory_scope(None, &dir_dep.suffix, Some(Path::new("/home/user/a"))),
+        Some("/home/user/a".to_string()),
+    );
+
+    // The same holds when the entry is present but carries neither a
+    // directory resolution nor a version to fall back on.
+    let bare = package_metadata(
+        LockfileResolution::Tarball(TarballResolution {
+            tarball: "file:packages/b".to_string(),
+            integrity: None,
+            git_hosted: None,
+            path: None,
+        }),
+        None,
+    );
+    assert_eq!(super::gvs_version_segment(Some(&bare), &dir_dep.suffix), "directory");
+    assert_eq!(
+        super::local_directory_scope(Some(&bare), &dir_dep.suffix, Some(Path::new("/home/user/a"))),
+        Some("/home/user/a".to_string()),
+    );
+}
+
 /// Two unrelated projects that both depend on a `./dep` directory
 /// resolve to the same snapshot key, name, and (absent) version — only
 /// the lockfile directory tells their slots apart.

--- a/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
@@ -491,8 +491,8 @@ fn a_file_snapshot_without_metadata_is_still_scoped() {
 
     assert_eq!(super::gvs_version_segment(None, &dir_dep.suffix), "directory");
     assert_eq!(
-        super::local_directory_scope(None, &dir_dep.suffix, Some(Path::new("/home/user/a"))),
-        Some("/home/user/a".to_string()),
+        super::local_directory_scope(None, &dir_dep.suffix, Some("/home/user/a")),
+        Some("/home/user/a"),
     );
 
     // The same holds when the entry is present but carries neither a
@@ -508,8 +508,8 @@ fn a_file_snapshot_without_metadata_is_still_scoped() {
     );
     assert_eq!(super::gvs_version_segment(Some(&bare), &dir_dep.suffix), "directory");
     assert_eq!(
-        super::local_directory_scope(Some(&bare), &dir_dep.suffix, Some(Path::new("/home/user/a"))),
-        Some("/home/user/a".to_string()),
+        super::local_directory_scope(Some(&bare), &dir_dep.suffix, Some("/home/user/a")),
+        Some("/home/user/a"),
     );
 }
 

--- a/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/package-manager/src/virtual_store_layout/tests.rs
@@ -2,7 +2,7 @@ use super::VirtualStoreLayout;
 use pacquet_config::Config;
 use pacquet_lockfile::{
     DirectoryResolution, LockfileResolution, PackageKey, PackageMetadata, PkgName,
-    RegistryResolution, SnapshotDepRef, SnapshotEntry,
+    RegistryResolution, SnapshotDepRef, SnapshotEntry, TarballResolution,
 };
 use pretty_assertions::{assert_eq, assert_ne};
 use std::{
@@ -22,6 +22,24 @@ fn make_config(gvs: bool, virtual_store_dir: PathBuf, gvs_dir: PathBuf) -> Confi
     config
 }
 
+/// [`PackageMetadata`] carrying only the fields the layout reads.
+fn package_metadata(resolution: LockfileResolution, version: Option<&str>) -> PackageMetadata {
+    PackageMetadata {
+        resolution,
+        version: version.map(str::to_string),
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
 #[test]
 fn slot_dir_uses_flat_name_when_gvs_off() {
     let config = make_config(
@@ -29,7 +47,7 @@ fn slot_dir_uses_flat_name_when_gvs_off() {
         PathBuf::from("/tmp/proj/node_modules/.pnpm"),
         PathBuf::from("/tmp/store/links"),
     );
-    let layout = VirtualStoreLayout::new(&config, Some("ignored"), None, None, None);
+    let layout = VirtualStoreLayout::new(&config, Some("ignored"), None, None, None, None);
     let key: PackageKey = "@scope/foo@1.2.3".parse().unwrap();
     assert_eq!(
         layout.slot_dir(&key),
@@ -74,6 +92,7 @@ fn slot_dir_uses_gvs_layout_when_gvs_on() {
         Some("darwin-arm64-node20"),
         Some(&snapshots),
         Some(&packages),
+        None,
         None,
     );
     let slot = layout.slot_dir(&key);
@@ -128,6 +147,7 @@ fn slot_dir_prefixes_unscoped_with_at_slash_under_gvs() {
         Some(&snapshots),
         Some(&packages),
         None,
+        None,
     );
     let slot = layout.slot_dir(&key);
     let _ = slot
@@ -174,6 +194,7 @@ fn slot_dir_engine_agnostic_with_empty_allow_build_policy() {
         Some(&snapshots),
         Some(&packages),
         Some(&policy),
+        None,
     )
     .slot_dir(&key);
     let linux = VirtualStoreLayout::new(
@@ -182,6 +203,7 @@ fn slot_dir_engine_agnostic_with_empty_allow_build_policy() {
         Some(&snapshots),
         Some(&packages),
         Some(&policy),
+        None,
     )
     .slot_dir(&key);
     assert_eq!(
@@ -231,6 +253,7 @@ fn slot_dir_engine_specific_when_snapshot_is_built() {
         Some(&snapshots),
         Some(&packages),
         Some(&policy),
+        None,
     )
     .slot_dir(&key);
     let linux = VirtualStoreLayout::new(
@@ -239,6 +262,7 @@ fn slot_dir_engine_specific_when_snapshot_is_built() {
         Some(&snapshots),
         Some(&packages),
         Some(&policy),
+        None,
     )
     .slot_dir(&key);
     assert_ne!(darwin, linux, "builder snapshot must partition GVS slot by engine string");
@@ -263,6 +287,7 @@ fn missing_metadata_keeps_source_dep_path_untrusted_for_gvs() {
         Some(&snapshots),
         Some(&packages),
         Some(&policy),
+        None,
     )
     .slot_dir(&key);
     let linux = VirtualStoreLayout::new(
@@ -271,6 +296,7 @@ fn missing_metadata_keeps_source_dep_path_untrusted_for_gvs() {
         Some(&snapshots),
         Some(&packages),
         Some(&policy),
+        None,
     )
     .slot_dir(&key);
     assert_eq!(darwin, linux, "source depPath with missing metadata must not be name-allowed");
@@ -377,6 +403,7 @@ fn cross_pinning_siblings_get_distinct_slots() {
         Some(&snapshots),
         Some(&packages),
         Some(&policy),
+        None,
     );
     let slot_22 = layout.slot_dir(&pins_22);
     let slot_20 = layout.slot_dir(&pins_20);
@@ -423,12 +450,76 @@ fn full_pkg_id_keeps_patch_hash_when_present() {
 }
 
 #[test]
-fn gvs_version_segment_renders_file_deps_as_undefined() {
+fn gvs_version_segment_anchors_directory_deps() {
     let semver: PackageKey = "foo@1.2.3".parse().unwrap();
-    assert_eq!(super::gvs_version_segment(&semver.suffix), "1.2.3");
+    assert_eq!(super::gvs_version_segment(None, &semver.suffix), "1.2.3");
 
-    let file_dep: PackageKey = "b@file:packages/b".parse().unwrap();
-    assert_eq!(super::gvs_version_segment(&file_dep.suffix), "undefined");
+    // The lockfile records no version for a directory snapshot, and the
+    // install path that resolves from manifests does know it — so the
+    // segment has to be the same either way, or a re-install would
+    // relocate the package.
+    let dir_dep: PackageKey = "b@file:packages/b".parse().unwrap();
+    let dir_metadata = package_metadata(
+        LockfileResolution::Directory(DirectoryResolution { directory: "packages/b".to_string() }),
+        None,
+    );
+    assert_eq!(super::gvs_version_segment(Some(&dir_metadata), &dir_dep.suffix), "directory");
+
+    // A local tarball is content-addressed and does carry a version.
+    let tarball_dep: PackageKey = "tar-dep@file:vendor/dep.tgz".parse().unwrap();
+    let tarball_metadata = package_metadata(
+        LockfileResolution::Tarball(TarballResolution {
+            tarball: "file:vendor/dep.tgz".to_string(),
+            integrity: None,
+            git_hosted: None,
+            path: None,
+        }),
+        Some("0.0.0"),
+    );
+    assert_eq!(super::gvs_version_segment(Some(&tarball_metadata), &tarball_dep.suffix), "0.0.0");
+}
+
+/// Two unrelated projects that both depend on a `./dep` directory
+/// resolve to the same snapshot key, name, and (absent) version — only
+/// the lockfile directory tells their slots apart.
+#[test]
+fn directory_deps_get_a_slot_per_project() {
+    let key: PackageKey = "dep@file:dep".parse().unwrap();
+    let mut snapshots = HashMap::new();
+    snapshots.insert(key.clone(), SnapshotEntry::default());
+    let mut packages = HashMap::new();
+    packages.insert(
+        key.without_peer(),
+        package_metadata(
+            LockfileResolution::Directory(DirectoryResolution { directory: "dep".to_string() }),
+            None,
+        ),
+    );
+
+    let config = make_config(
+        true,
+        PathBuf::from("/tmp/proj/node_modules/.pnpm"),
+        PathBuf::from("/tmp/store/links"),
+    );
+    let slot_in = |lockfile_dir: &str| {
+        super::VirtualStoreLayout::new(
+            &config,
+            None,
+            Some(&snapshots),
+            Some(&packages),
+            None,
+            Some(std::path::Path::new(lockfile_dir)),
+        )
+        .slot_dir(&key)
+    };
+
+    let in_project_a = slot_in("/home/user/a");
+    let in_project_b = slot_in("/home/user/b");
+    assert_ne!(in_project_a, in_project_b);
+    assert!(
+        in_project_a.to_string_lossy().contains("dep/directory/"),
+        "directory deps take the anchored version segment; got {in_project_a:?}",
+    );
 }
 
 /// `collect_injected_deps` maps each `file:` snapshot's source path to
@@ -576,6 +667,7 @@ fn cyclic_slot_suffixes() -> Vec<(String, String)> {
         Some(&snapshots),
         Some(&packages),
         Some(&policy),
+        None,
     );
     let mut suffixes: Vec<(String, String)> = snapshots
         .keys()

--- a/pnpm11/building/after-install/src/index.ts
+++ b/pnpm11/building/after-install/src/index.ts
@@ -378,9 +378,12 @@ async function _rebuild (
     for (const { hash, pkgMeta } of iterateHashedGraphNodes(
       depGraph,
       iteratePkgMeta(ctx.currentLockfile, depGraph),
-      _allowBuild,
-      opts.supportedArchitectures,
-      nodeVersion
+      {
+        allowBuild: _allowBuild,
+        supportedArchitectures: opts.supportedArchitectures,
+        nodeVersion,
+        lockfileDir: opts.lockfileDir,
+      }
     )) {
       const preferredGvsDir = path.join(globalVirtualStoreDir, hash)
       gvsDirByDepPath.set(pkgMeta.depPath, fs.existsSync(preferredGvsDir)

--- a/pnpm11/deps/graph-builder/src/iteratePkgsForVirtualStore.ts
+++ b/pnpm11/deps/graph-builder/src/iteratePkgsForVirtualStore.ts
@@ -5,6 +5,7 @@ import {
   type DepsGraph,
   type DepsStateCache,
   findRuntimeNodeVersion,
+  type GraphNodeHashOptions,
   type HashedDepPath,
   iterateHashedGraphNodes,
   iteratePkgMeta,
@@ -26,6 +27,7 @@ interface PkgSnapshotWithLocation {
 export function * iteratePkgsForVirtualStore (lockfile: LockfileObject, opts: {
   allowBuild?: AllowBuild
   enableGlobalVirtualStore?: boolean
+  lockfileDir: string
   virtualStoreDirMaxLength: number
   virtualStoreDir: string
   globalVirtualStoreDir: string
@@ -43,6 +45,7 @@ export function * iteratePkgsForVirtualStore (lockfile: LockfileObject, opts: {
       allowBuild: opts.allowBuild,
       supportedArchitectures: opts.supportedArchitectures,
       nodeVersion,
+      lockfileDir: opts.lockfileDir,
     })) {
       yield {
         dirInVirtualStore: path.join(opts.globalVirtualStoreDir, hash),
@@ -50,7 +53,7 @@ export function * iteratePkgsForVirtualStore (lockfile: LockfileObject, opts: {
       }
     }
   } else if (lockfile.packages) {
-    let graphNodeHashOpts: { graph: DepsGraph<DepPath>, cache: DepsStateCache, supportedArchitectures?: SupportedArchitectures, nodeVersion?: string } | undefined
+    let graphNodeHashOpts: { graph: DepsGraph<DepPath>, cache: DepsStateCache, supportedArchitectures?: SupportedArchitectures, nodeVersion?: string, lockfileDir: string } | undefined
     for (const depPath in lockfile.packages) {
       if (!Object.hasOwn(lockfile.packages, depPath)) {
         continue
@@ -71,6 +74,7 @@ export function * iteratePkgsForVirtualStore (lockfile: LockfileObject, opts: {
           graph: lockfileToDepGraph(lockfile, opts.supportedArchitectures),
           supportedArchitectures: opts.supportedArchitectures,
           nodeVersion,
+          lockfileDir: opts.lockfileDir,
         }
         const hash = calcGraphNodeHash(graphNodeHashOpts, pkgMeta)
         dirInVirtualStore = path.join(opts.globalVirtualStoreDir, hash)
@@ -87,16 +91,8 @@ export function * iteratePkgsForVirtualStore (lockfile: LockfileObject, opts: {
 
 function hashDependencyPaths (
   lockfile: LockfileObject,
-  {
-    allowBuild,
-    supportedArchitectures,
-    nodeVersion,
-  }: {
-    allowBuild?: AllowBuild
-    supportedArchitectures?: SupportedArchitectures
-    nodeVersion?: string
-  }
+  opts: GraphNodeHashOptions
 ): IterableIterator<HashedDepPath<PkgMetaAndSnapshot>> {
-  const graph = lockfileToDepGraph(lockfile, supportedArchitectures)
-  return iterateHashedGraphNodes(graph, iteratePkgMeta(lockfile, graph), allowBuild, supportedArchitectures, nodeVersion)
+  const graph = lockfileToDepGraph(lockfile, opts.supportedArchitectures)
+  return iterateHashedGraphNodes(graph, iteratePkgMeta(lockfile, graph), opts)
 }

--- a/pnpm11/deps/graph-hasher/src/index.ts
+++ b/pnpm11/deps/graph-hasher/src/index.ts
@@ -192,8 +192,8 @@ export interface GraphNodeHashOptions {
   /**
    * Directory the lockfile lives in. Scopes the slots of local directory
    * dependencies to the project that owns them — see
-   * {@link localDirectoryScope}. Omitting it leaves those packages on a shared
-   * slot, which is only safe for a lockfile known to have no directory
+   * {@link isLocalDirectoryResolution}. Omitting it leaves those packages on a
+   * shared slot, which is only safe for a lockfile known to have no directory
    * dependencies.
    */
   lockfileDir?: string
@@ -260,11 +260,15 @@ export function calcGraphNodeHash<T extends PkgMeta> (
   const ownPin = readSnapshotRuntimePin(graph[depPath]?.children)
   const engine = includeEngine ? engineName(ownPin ?? nodeVersion) : null
   const deps = calcDepGraphHash(graph, cache, new Set(), depPath, supportedArchitectures)
-  const project = localDirectoryScope(graph[depPath]?.resolution, lockfileDir)
+  const isLocalDirectory = isLocalDirectoryResolution(graph[depPath]?.resolution)
+  // Scoping the slot needs the project's identity; the segment only needs to
+  // know that the package is a local directory, so a caller that leaves
+  // `lockfileDir` out still gets a well-formed path.
+  const project = isLocalDirectory ? lockfileDir : undefined
   const hexDigest = project == null
     ? hashObjectWithoutSorting({ engine, deps }, { encoding: 'hex' })
     : hashObjectWithoutSorting({ engine, deps, project }, { encoding: 'hex' })
-  return formatGlobalVirtualStorePath(name, project == null ? version : LOCAL_DIRECTORY_SEGMENT, hexDigest)
+  return formatGlobalVirtualStorePath(name, isLocalDirectory ? LOCAL_DIRECTORY_SEGMENT : version, hexDigest)
 }
 
 /**
@@ -278,26 +282,19 @@ export function calcGraphNodeHash<T extends PkgMeta> (
 const LOCAL_DIRECTORY_SEGMENT = 'directory'
 
 /**
- * Extra hash input that keeps a package resolved from a local directory —
- * a `file:` directory dependency or an injected workspace package — on a slot
- * of its own. Returns `undefined` for every other resolution, which then hashes
- * exactly as before.
+ * Whether the package came from a local directory — a `file:` directory
+ * dependency or an injected workspace package.
  *
- * A directory resolution is the one resolution with no integrity: it is a path
- * relative to the lockfile, so `file:dep` hashes identically in every project
- * that happens to depend on a directory of that name. Sharing the slot would
- * hand one project the files of whichever project installed first, and because
- * the source directory is mutable pnpm re-imports it on every install — so the
- * projects would go on overwriting each other's dependency.
+ * Such a package needs a slot of its own per project. A directory resolution is
+ * the one resolution with no integrity: it is a path relative to the lockfile,
+ * so `file:dep` hashes identically in every project that happens to depend on a
+ * directory of that name. Sharing the slot would hand one project the files of
+ * whichever project installed first, and because the source directory is
+ * mutable pnpm re-imports it on every install — so the projects would go on
+ * overwriting each other's dependency.
  */
-function localDirectoryScope (
-  resolution: LockfileResolution | undefined,
-  lockfileDir: string | undefined
-): string | undefined {
-  if (lockfileDir == null || resolution == null || !('type' in resolution) || resolution.type !== 'directory') {
-    return undefined
-  }
-  return lockfileDir
+function isLocalDirectoryResolution (resolution: LockfileResolution | undefined): boolean {
+  return resolution != null && 'type' in resolution && resolution.type === 'directory'
 }
 
 export function calcLeafGlobalVirtualStorePath (fullPkgId: string, name: string, version: string): string {

--- a/pnpm11/deps/graph-hasher/src/index.ts
+++ b/pnpm11/deps/graph-hasher/src/index.ts
@@ -173,11 +173,9 @@ export interface HashedDepPath<T extends PkgMeta> {
   hash: string
 }
 
-export function * iterateHashedGraphNodes<T extends PkgMeta> (
-  graph: DepsGraph<DepPath>,
-  pkgMetaIterator: PkgMetaIterator<T>,
-  allowBuild?: AllowBuild,
-  supportedArchitectures?: SupportedArchitectures,
+export interface GraphNodeHashOptions {
+  allowBuild?: AllowBuild
+  supportedArchitectures?: SupportedArchitectures
   /**
    * Install-wide fallback `engines.runtime` / `devEngines.runtime`
    * Node version. Used only for snapshots that don't pin their own
@@ -191,12 +189,26 @@ export function * iterateHashedGraphNodes<T extends PkgMeta> (
    * `process.version` as a last resort).
    */
   nodeVersion?: string
+  /**
+   * Directory the lockfile lives in. Scopes the slots of local directory
+   * dependencies to the project that owns them — see
+   * {@link localDirectoryScope}. Omitting it leaves those packages on a shared
+   * slot, which is only safe for a lockfile known to have no directory
+   * dependencies.
+   */
+  lockfileDir?: string
+}
+
+export function * iterateHashedGraphNodes<T extends PkgMeta> (
+  graph: DepsGraph<DepPath>,
+  pkgMetaIterator: PkgMetaIterator<T>,
+  opts: GraphNodeHashOptions = {}
 ): IterableIterator<HashedDepPath<T>> {
   let builtDepPaths: Set<DepPath> | undefined
   let entries: Iterable<T>
-  if (allowBuild != null) {
+  if (opts.allowBuild != null) {
     const pkgMetaList = Array.from(pkgMetaIterator)
-    builtDepPaths = computeBuiltDepPaths(pkgMetaList, allowBuild)
+    builtDepPaths = computeBuiltDepPaths(pkgMetaList, opts.allowBuild)
     entries = pkgMetaList
   } else {
     entries = pkgMetaIterator
@@ -206,8 +218,9 @@ export function * iterateHashedGraphNodes<T extends PkgMeta> (
     cache: {},
     builtDepPaths,
     buildRequiredCache: builtDepPaths !== undefined ? {} : undefined,
-    supportedArchitectures,
-    nodeVersion,
+    supportedArchitectures: opts.supportedArchitectures,
+    nodeVersion: opts.nodeVersion,
+    lockfileDir: opts.lockfileDir,
   }
   for (const pkgMeta of entries) {
     yield {
@@ -218,14 +231,16 @@ export function * iterateHashedGraphNodes<T extends PkgMeta> (
 }
 
 export function calcGraphNodeHash<T extends PkgMeta> (
-  { graph, cache, builtDepPaths, buildRequiredCache, supportedArchitectures, nodeVersion }: {
+  { graph, cache, builtDepPaths, buildRequiredCache, supportedArchitectures, nodeVersion, lockfileDir }: {
     graph: DepsGraph<DepPath>
     cache: DepsStateCache
     builtDepPaths?: Set<DepPath>
     buildRequiredCache?: Record<string, boolean>
     supportedArchitectures?: SupportedArchitectures
-    /** See [`iterateHashedGraphNodes`]'s `nodeVersion` parameter. */
+    /** See {@link GraphNodeHashOptions.nodeVersion}. */
     nodeVersion?: string
+    /** See {@link GraphNodeHashOptions.lockfileDir}. */
+    lockfileDir?: string
   },
   pkgMeta: T
 ): string {
@@ -245,8 +260,44 @@ export function calcGraphNodeHash<T extends PkgMeta> (
   const ownPin = readSnapshotRuntimePin(graph[depPath]?.children)
   const engine = includeEngine ? engineName(ownPin ?? nodeVersion) : null
   const deps = calcDepGraphHash(graph, cache, new Set(), depPath, supportedArchitectures)
-  const hexDigest = hashObjectWithoutSorting({ engine, deps }, { encoding: 'hex' })
-  return formatGlobalVirtualStorePath(name, version, hexDigest)
+  const project = localDirectoryScope(graph[depPath]?.resolution, lockfileDir)
+  const hexDigest = project == null
+    ? hashObjectWithoutSorting({ engine, deps }, { encoding: 'hex' })
+    : hashObjectWithoutSorting({ engine, deps, project }, { encoding: 'hex' })
+  return formatGlobalVirtualStorePath(name, project == null ? version : LOCAL_DIRECTORY_SEGMENT, hexDigest)
+}
+
+/**
+ * Slot segment that stands in for the version of a package resolved from a
+ * local directory. pnpm omits the version from a directory snapshot, so the
+ * lockfile has none to offer — and the resolver, which does know it from the
+ * manifest, must agree with the lockfile or a re-install would relocate the
+ * package. The segment is decoration in a store listing; the digest that
+ * follows it is what identifies the slot.
+ */
+const LOCAL_DIRECTORY_SEGMENT = 'directory'
+
+/**
+ * Extra hash input that keeps a package resolved from a local directory —
+ * a `file:` directory dependency or an injected workspace package — on a slot
+ * of its own. Returns `undefined` for every other resolution, which then hashes
+ * exactly as before.
+ *
+ * A directory resolution is the one resolution with no integrity: it is a path
+ * relative to the lockfile, so `file:dep` hashes identically in every project
+ * that happens to depend on a directory of that name. Sharing the slot would
+ * hand one project the files of whichever project installed first, and because
+ * the source directory is mutable pnpm re-imports it on every install — so the
+ * projects would go on overwriting each other's dependency.
+ */
+function localDirectoryScope (
+  resolution: LockfileResolution | undefined,
+  lockfileDir: string | undefined
+): string | undefined {
+  if (lockfileDir == null || resolution == null || !('type' in resolution) || resolution.type !== 'directory') {
+    return undefined
+  }
+  return lockfileDir
 }
 
 export function calcLeafGlobalVirtualStorePath (fullPkgId: string, name: string, version: string): string {
@@ -339,6 +390,7 @@ export function lockfileToDepGraph (
       })
       graph[depPath as DepPath] = {
         children,
+        resolution: pkgSnapshot.resolution,
         fullPkgId: createFullPkgId(getPkgIdWithPatchHash(depPath as DepPath), pkgSnapshot.resolution, supportedArchitectures),
       }
     }

--- a/pnpm11/deps/graph-hasher/test/allowBuildIdentity.test.ts
+++ b/pnpm11/deps/graph-hasher/test/allowBuildIdentity.test.ts
@@ -34,7 +34,7 @@ it('gates built dep paths through the allowBuild policy by depPath', () => {
         version: '1.0.0',
       },
     ].values(),
-    allowBuild
+    { allowBuild }
   ))
 
   expect(checkedDepPaths).toStrictEqual([registryDepPath, directTarballDepPath])

--- a/pnpm11/deps/graph-hasher/test/calcGraphNodeHash.test.ts
+++ b/pnpm11/deps/graph-hasher/test/calcGraphNodeHash.test.ts
@@ -521,6 +521,15 @@ describe('calcGraphNodeHash', () => {
       expect(inProjectA).not.toBe(inProjectB)
     })
 
+    it('keeps the segment when the caller supplies no lockfile directory', () => {
+      // A caller that hashes a lockfile it knows has no directory deps may
+      // leave `lockfileDir` out; one that slips through must still produce a
+      // path rather than dereference the missing version.
+      const result = calcGraphNodeHash({ graph, cache: {} }, pkgMeta)
+
+      expect(result).toMatch(/^@\/dep\/directory\/[a-f0-9]+$/)
+    })
+
     it('leaves packages resolved from the registry unscoped', () => {
       const registryGraph: DepsGraph<DepPath> = {
         ['foo@1.0.0' as DepPath]: {

--- a/pnpm11/deps/graph-hasher/test/calcGraphNodeHash.test.ts
+++ b/pnpm11/deps/graph-hasher/test/calcGraphNodeHash.test.ts
@@ -475,6 +475,73 @@ describe('calcGraphNodeHash', () => {
     expect(hash20.startsWith('@/pins-20/1.0.0/')).toBe(true)
   })
 
+  describe('local directory dependencies', () => {
+    const graph: DepsGraph<DepPath> = {
+      ['dep@file:dep' as DepPath]: {
+        children: {},
+        resolution: { directory: 'dep', type: 'directory' },
+        fullPkgId: 'dep@file:dep:hash',
+      },
+    }
+
+    // The lockfile omits the version of a directory snapshot, so
+    // `nameVerFromPkgSnapshot` hands the hasher `undefined`.
+    // See https://github.com/pnpm/pnpm/issues/13335.
+    const pkgMeta = {
+      depPath: 'dep@file:dep' as DepPath,
+      name: 'dep',
+      version: undefined as unknown as string,
+    }
+
+    it('stands in a fixed segment for the version the lockfile does not record', () => {
+      const result = calcGraphNodeHash({ graph, cache: {}, lockfileDir: '/home/user/project' }, pkgMeta)
+
+      expect(result).toMatch(/^@\/dep\/directory\/[a-f0-9]+$/)
+    })
+
+    it('uses the same segment when the resolver knows the version', () => {
+      // The resolver reads the version off the manifest, so it would
+      // otherwise place the package on a different slot than the
+      // headless install that follows it.
+      const fromResolver = calcGraphNodeHash(
+        { graph, cache: {}, lockfileDir: '/home/user/project' },
+        { ...pkgMeta, version: '1.0.0' }
+      )
+
+      expect(fromResolver).toBe(calcGraphNodeHash({ graph, cache: {}, lockfileDir: '/home/user/project' }, pkgMeta))
+    })
+
+    it('gives each project its own slot', () => {
+      // Two unrelated projects that both depend on a `./dep` directory
+      // resolve to the same dep path, name, and (absent) version — only
+      // the lockfile directory tells them apart.
+      const inProjectA = calcGraphNodeHash({ graph, cache: {}, lockfileDir: '/home/user/a' }, pkgMeta)
+      const inProjectB = calcGraphNodeHash({ graph, cache: {}, lockfileDir: '/home/user/b' }, pkgMeta)
+
+      expect(inProjectA).not.toBe(inProjectB)
+    })
+
+    it('leaves packages resolved from the registry unscoped', () => {
+      const registryGraph: DepsGraph<DepPath> = {
+        ['foo@1.0.0' as DepPath]: {
+          children: {},
+          resolution: { integrity: 'sha512-abc' },
+          fullPkgId: 'foo@1.0.0:sha512-abc',
+        },
+      }
+      const registryPkgMeta: PkgMeta = {
+        depPath: 'foo@1.0.0' as DepPath,
+        name: 'foo',
+        version: '1.0.0',
+      }
+
+      const inProjectA = calcGraphNodeHash({ graph: registryGraph, cache: {}, lockfileDir: '/home/user/a' }, registryPkgMeta)
+      const inProjectB = calcGraphNodeHash({ graph: registryGraph, cache: {}, lockfileDir: '/home/user/b' }, registryPkgMeta)
+
+      expect(inProjectA).toBe(inProjectB)
+    })
+  })
+
   it('should handle prerelease versions', () => {
     const graph: DepsGraph<DepPath> = {
       ['pkg@1.0.0-beta.1' as DepPath]: {

--- a/pnpm11/deps/graph-hasher/test/lockfileToDepGraph.test.ts
+++ b/pnpm11/deps/graph-hasher/test/lockfileToDepGraph.test.ts
@@ -38,6 +38,7 @@ test('lockfileToDepGraph', () => {
       children: {
         qar: 'qar@1.0.0',
       },
+      resolution: { integrity: '1' },
       fullPkgId: 'bar@1.0.0:1',
     },
     'foo@1.0.0': {
@@ -45,10 +46,12 @@ test('lockfileToDepGraph', () => {
         bar: 'bar@1.0.0',
         qar: 'qar@1.0.0',
       },
+      resolution: { integrity: '0' },
       fullPkgId: 'foo@1.0.0:0',
     },
     'qar@1.0.0': {
       children: {},
+      resolution: { integrity: '2' },
       fullPkgId: 'qar@1.0.0:2',
     },
   })

--- a/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
+++ b/pnpm11/engine/pm/commands/src/self-updater/installPnpm.ts
@@ -185,7 +185,10 @@ function findPnpmGvsPath (
   const graph = lockfileToDepGraph(lockfile)
   const pkgMetaIterator = iteratePkgMeta(lockfile, graph)
   const allowBuild = createAllowBuildFunction({ allowBuilds })
-  for (const { hash, pkgMeta } of iterateHashedGraphNodes(graph, pkgMetaIterator, allowBuild)) {
+  // No `lockfileDir`: this lockfile only ever holds the pnpm package and its
+  // registry dependencies, and the install that materializes the slot runs from
+  // a throwaway directory that differs on every self-update.
+  for (const { hash, pkgMeta } of iterateHashedGraphNodes(graph, pkgMetaIterator, { allowBuild })) {
     if (pkgMeta.name === pkgName) {
       return path.join(globalVirtualStoreDir, hash)
     }

--- a/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
+++ b/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
@@ -536,6 +536,73 @@ test('injected local packages work with global virtual store', async () => {
   expect(fs.existsSync(path.join(injectedDepLocation!, 'foo.js'))).toBeTruthy()
 })
 
+// The lockfile records no version for a directory snapshot, so a headless
+// install used to crash while building the slot path.
+// See https://github.com/pnpm/pnpm/issues/13335.
+test('local directory dependency works with global virtual store', async () => {
+  const project = prepareEmpty()
+  fs.mkdirSync('dep')
+  fs.writeFileSync('dep/package.json', JSON.stringify({ name: 'dep', version: '1.0.0' }), 'utf8')
+
+  const globalVirtualStoreDir = path.resolve('links')
+  const manifest = {
+    dependencies: {
+      dep: 'file:dep',
+    },
+  }
+  const opts = testDefaults({
+    enableGlobalVirtualStore: true,
+    virtualStoreDir: globalVirtualStoreDir,
+  })
+  await install(manifest, opts)
+
+  project.has('dep')
+  const slotBeforeReinstall = fs.realpathSync(path.resolve('node_modules/dep'))
+  expect(slotBeforeReinstall.startsWith(globalVirtualStoreDir)).toBeTruthy()
+
+  rimrafSync('node_modules')
+  await install(manifest, { ...opts, frozenLockfile: true })
+
+  project.has('dep')
+  // The resolver reads the version off the manifest and the headless install
+  // reads it off the lockfile, where there is none — both have to land on the
+  // same slot or the reinstall would relocate the package.
+  expect(fs.realpathSync(path.resolve('node_modules/dep'))).toBe(slotBeforeReinstall)
+})
+
+test('two projects with a same-named local directory dependency get separate global virtual store slots', async () => {
+  preparePackages([
+    { location: 'project-1', package: { name: 'project-1', version: '1.0.0' } },
+    { location: 'project-2', package: { name: 'project-2', version: '1.0.0' } },
+  ])
+  const globalVirtualStoreDir = path.resolve('links')
+
+  // The second install has to see what the first one left in the shared store,
+  // so the two run one after the other.
+  const slotOfProject1 = await installLocalDirectoryDependency('project-1', globalVirtualStoreDir)
+  const slotOfProject2 = await installLocalDirectoryDependency('project-2', globalVirtualStoreDir)
+
+  // Both resolve to `dep@file:dep` with no recorded version — only the project
+  // they belong to tells the two slots apart.
+  expect(slotOfProject1).not.toBe(slotOfProject2)
+  expect(fs.readFileSync(path.resolve('project-1/node_modules/dep/index.js'), 'utf8')).toBe("module.exports = 'project-1'")
+  expect(fs.readFileSync(path.resolve('project-2/node_modules/dep/index.js'), 'utf8')).toBe("module.exports = 'project-2'")
+})
+
+/** Installs a `./dep` directory dependency into `project` and returns its slot. */
+async function installLocalDirectoryDependency (project: string, globalVirtualStoreDir: string): Promise<string> {
+  fs.mkdirSync(path.resolve(project, 'dep'))
+  fs.writeFileSync(path.resolve(project, 'dep/package.json'), JSON.stringify({ name: 'dep', version: '1.0.0' }), 'utf8')
+  fs.writeFileSync(path.resolve(project, 'dep/index.js'), `module.exports = '${project}'`, 'utf8')
+  await install({ dependencies: { dep: 'file:dep' } }, testDefaults({
+    dir: path.resolve(project),
+    lockfileDir: path.resolve(project),
+    enableGlobalVirtualStore: true,
+    virtualStoreDir: globalVirtualStoreDir,
+  }))
+  return fs.realpathSync(path.resolve(project, 'node_modules/dep'))
+}
+
 test('virtualStoreOnly populates standard virtual store without importer symlinks', async () => {
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
   prepareEmpty()

--- a/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
+++ b/pnpm11/installing/deps-installer/test/install/globalVirtualStore.ts
@@ -536,8 +536,8 @@ test('injected local packages work with global virtual store', async () => {
   expect(fs.existsSync(path.join(injectedDepLocation!, 'foo.js'))).toBeTruthy()
 })
 
-// The lockfile records no version for a directory snapshot, so a headless
-// install used to crash while building the slot path.
+// The lockfile records no version for a directory snapshot, so the headless
+// install has none to put in the slot path.
 // See https://github.com/pnpm/pnpm/issues/13335.
 test('local directory dependency works with global virtual store', async () => {
   const project = prepareEmpty()

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -595,6 +595,7 @@ function extendGraph (
     allowBuild?: AllowBuild
     globalVirtualStoreDir: string
     enableGlobalVirtualStore?: boolean
+    lockfileDir: string
     supportedArchitectures?: SupportedArchitectures
   }
 ): DependenciesGraph {
@@ -609,7 +610,12 @@ function extendGraph (
   // `process.version` instead of the script-runner Node, splitting
   // the cache between pinned and non-pinned installs on the same host.
   const nodeVersion = findRuntimeNodeVersion(Object.keys(graph))
-  for (const { pkgMeta: { depPath }, hash } of iterateHashedGraphNodes(graph, pkgMetaIter, allowBuild, opts.supportedArchitectures, nodeVersion)) {
+  for (const { pkgMeta: { depPath }, hash } of iterateHashedGraphNodes(graph, pkgMetaIter, {
+    allowBuild,
+    supportedArchitectures: opts.supportedArchitectures,
+    nodeVersion,
+    lockfileDir: opts.lockfileDir,
+  })) {
     const modules = path.join(opts.globalVirtualStoreDir, hash, 'node_modules')
     const node = graph[depPath]
     Object.assign(node, {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13335.

Installing a `file:` directory dependency with the global virtual store enabled crashed the headless install:

```text
TypeError: Cannot read properties of undefined (reading 'split')
    at assertNoPathTraversal
    at formatGlobalVirtualStorePath
    at calcGraphNodeHash
```

pnpm deliberately omits `version` from a directory snapshot (`toLockfileDependency` skips it for `type: 'directory'`), so `nameVerFromPkgSnapshot` hands the hasher `undefined`, and the traversal guard added in pnpm/pnpm#12872 dereferences it. Directory snapshots now use a fixed `directory` segment in place of the version.

While reproducing that, I found a second, quieter defect underneath it. A directory resolution is the one resolution with no integrity — it is a path relative to the lockfile — so `file:dep` hashed identically in **every** project depending on a directory of that name, and they all shared one global-virtual-store slot:

```console
$ # two unrelated projects, each with its own ./dep
$ cd projectA && pnpm install --config.enable-global-virtual-store=true
$ cd ../projectB && pnpm install --config.enable-global-virtual-store=true
$ cat projectA/node_modules/dep/index.js
content-B          # <- projectA is now linked to projectB's files
```

Both resolved to `<store>/v11/links/@/dep/1.0.0/28c8453e…`. Because the source directory is mutable, pnpm re-imports directory deps on every install, so the two projects went on overwriting each other's copy. The lockfile directory now joins the hash payload for directory resolutions, giving each project its own slot; every other resolution hashes exactly as before.

Fixing the version segment also settles a disagreement between the two install paths: the resolver reads the version off the manifest and the headless install reads it off the lockfile, where there is none, so the same package used to land on two different slots depending on which path ran.

### Notes for reviewers

- **Why not keep directory deps out of the global virtual store entirely?** That is the cleaner semantics, but when GVS is on `virtualStoreDir` *is* the global store (`extendInstallOptions`), so there is no project-local virtual store left to fall back to. Scoping the slot achieves the same isolation without introducing a second virtual-store root. Directory deps take the cold re-import path on every install anyway, so they never benefited from a shared slot.
- Old `.../undefined/<hash>` slots left by earlier pnpm 11 versions become unreachable and are collected by the existing mark-and-sweep `pruneGlobalVirtualStore`.
- `iterateHashedGraphNodes` takes an options object now — it was already up to five positional parameters, and this change would have added a sixth.

### pacquet

The Rust port had both defects and is fixed in the same PR, so the two stacks derive the same slot:

- `gvs_version_segment` rendered the literal `undefined` for every `file:` dep — what the TypeScript side produced before its traversal guard turned the missing version into a crash. It now anchors a directory resolution to the `directory` segment, and prefers `PackageMetadata::version`, so a local *tarball* (content-addressed, and carrying a version in the lockfile) no longer shares the directory dep's fallback. That last part was an existing divergence from the TypeScript CLI.
- `VirtualStoreLayout::new` took no resolution into account when inserting a slot suffix, so directory deps collided across projects the same way. It takes the lockfile directory now and folds it into the hash payload for directory resolutions, via a new `project` argument on `calc_graph_node_hash`.
- Added `local_directory_dependency_works_with_global_virtual_store` (`pnpm/crates/cli/tests/global_virtual_store.rs`) and `directory_deps_get_a_slot_per_project` (`virtual_store_layout/tests.rs`) — there was no coverage for a plain, non-injected `file:` directory dependency under GVS.

## Squash Commit Body

```text
Installing a `file:` directory dependency with the global virtual store
enabled crashed the headless install:

    TypeError: Cannot read properties of undefined (reading 'split')
        at assertNoPathTraversal
        at formatGlobalVirtualStorePath
        at calcGraphNodeHash

pnpm omits `version` from a directory snapshot, so `nameVerFromPkgSnapshot`
hands the hasher `undefined` and the traversal guard added in
pnpm/pnpm#12872 dereferences it. Directory snapshots now use a fixed
`directory` segment in place of the version. That also settles a
disagreement between the two install paths: the resolver reads the version
off the manifest and the headless install off the lockfile, where there is
none, so the same package landed on two different slots.

The crash hid a worse defect. A directory resolution is the one resolution
with no integrity — it is a path relative to the lockfile — so `file:dep`
hashed identically in every project that depended on a directory of that
name, and all of them linked to whichever project installed first. Since
the source directory is mutable, pnpm re-imports it on every install, so
the projects went on overwriting each other's copy. The lockfile directory
now joins the hash payload for directory resolutions, giving each project
its own slot; every other resolution hashes exactly as before.

`iterateHashedGraphNodes` takes an options object now — it was up to five
positional parameters before this change added a sixth.

Closes pnpm/pnpm#13335
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation issues for local `file:` directory dependencies when Global Virtual Store is enabled.
  * Improved frozen-lockfile reinstalls to reuse the same Global Virtual Store slot reliably.
  * Scopes hashing so `file:` directory dependencies get deterministic, project-specific slots and don’t collide across projects with the same dependency name.
* **Tests**
  * Added integration and end-to-end coverage for stable reinstalls and project-specific isolation for local directory dependencies with Global Virtual Store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->