### PR TITLE
fix(resolving-deps-resolver): resolve nested file: deps against the declaring manifest

### DIFF
--- a/.changeset/nested-file-dep-declaring-manifest.md
+++ b/.changeset/nested-file-dep-declaring-manifest.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A `file:` dependency declared by a package that was itself installed from a local directory is now resolved relative to that package's directory, not to the importer's [#13323](https://github.com/pnpm/pnpm/issues/13323). Installing a project whose local dependency depends on a sibling directory (`file:../child`) no longer fails with `Could not install from "…" as it does not exist`, and the snapshot entry for such a dependency is now written as `file:<path>` instead of `<name>@file:<path>`, matching the lockfile pnpm writes.

--- a/pnpm/crates/cli/tests/nested_file_dependencies.rs
+++ b/pnpm/crates/cli/tests/nested_file_dependencies.rs
@@ -3,9 +3,7 @@
 //!
 //! Such a specifier is relative to the manifest that declares it, not to
 //! the importer that pulled the chain in — pnpm's `parentPkg.rootDir`.
-//! Regression tests for pnpm/pnpm#13323, where the nested specifier was
-//! resolved against the importer and produced a directory that doesn't
-//! exist.
+//! Covers pnpm/pnpm#13323.
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
@@ -17,10 +15,10 @@ fn write_manifest(dir: &Path, manifest: &serde_json::Value) {
     fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
 }
 
-/// `parent` sits next to `child` inside the importer, so the buggy
-/// resolution (`<importer>/../child`) escapes the workspace entirely
-/// while the correct one (`<importer>/parent/../child`) lands on
-/// `child`.
+/// `parent` sits next to `child` inside the importer, so the two
+/// candidate bases disagree: `file:../child` lands on `child` from the
+/// declaring manifest's directory, and outside the workspace from the
+/// importer's.
 #[test]
 fn nested_file_dep_resolves_against_the_declaring_manifest() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/nested_file_dependencies.rs
+++ b/pnpm/crates/cli/tests/nested_file_dependencies.rs
@@ -1,0 +1,133 @@
+//! End-to-end coverage for `file:` dependencies declared by a package
+//! that was itself resolved from a local directory.
+//!
+//! Such a specifier is relative to the manifest that declares it, not to
+//! the importer that pulled the chain in — pnpm's `parentPkg.rootDir`.
+//! Regression tests for pnpm/pnpm#13323, where the nested specifier was
+//! resolved against the importer and produced a directory that doesn't
+//! exist.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path};
+
+fn write_manifest(dir: &Path, manifest: &serde_json::Value) {
+    fs::create_dir_all(dir).expect("create the package directory");
+    fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
+}
+
+/// `parent` sits next to `child` inside the importer, so the buggy
+/// resolution (`<importer>/../child`) escapes the workspace entirely
+/// while the correct one (`<importer>/parent/../child`) lands on
+/// `child`.
+#[test]
+fn nested_file_dep_resolves_against_the_declaring_manifest() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "name": "root",
+            "version": "1.0.0",
+            "private": true,
+            "dependencies": { "nested-parent": "file:./parent" },
+        }),
+    );
+    write_manifest(
+        &workspace.join("parent"),
+        &serde_json::json!({
+            "name": "nested-parent",
+            "version": "1.0.0",
+            "dependencies": { "nested-child": "file:../child" },
+        }),
+    );
+    write_manifest(
+        &workspace.join("child"),
+        &serde_json::json!({ "name": "nested-child", "version": "1.0.0" }),
+    );
+
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("nested-child@file:child:"),
+        "pnpm-lock.yaml should resolve file:../child against parent/:\n{lockfile}",
+    );
+
+    let installed = workspace.join(
+        "node_modules/.pnpm/nested-parent@file+parent/node_modules/nested-child/package.json",
+    );
+    assert!(
+        installed.is_file(),
+        "nested-child should be installed into nested-parent's virtual-store slot at {}",
+        installed.display(),
+    );
+
+    drop((root, mock_instance));
+}
+
+/// The vite layout from pnpm/pnpm#13323: a workspace project depends on
+/// a sibling directory that in turn depends on another one a level up.
+/// Both the resolved directory and the snapshot's reference to it must
+/// match what pnpm writes — the reference drops the `<name>@` prefix
+/// because the alias equals the package's own name.
+#[test]
+fn nested_file_dep_of_a_workspace_project_matches_the_pnpm_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "name": "ws-root", "version": "0.0.0", "private": true }),
+    );
+
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    if !workspace_yaml.ends_with('\n') {
+        workspace_yaml.push('\n');
+    }
+    workspace_yaml.push_str("packages:\n  - 'packages/*'\n");
+    fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
+
+    write_manifest(
+        &workspace.join("packages/license"),
+        &serde_json::json!({
+            "name": "license",
+            "version": "1.0.0",
+            "dependencies": { "nested-parent": "file:./parent" },
+        }),
+    );
+    write_manifest(
+        &workspace.join("packages/license/parent"),
+        &serde_json::json!({
+            "name": "nested-parent",
+            "version": "1.0.0",
+            "dependencies": { "nested-child": "file:../child" },
+        }),
+    );
+    write_manifest(
+        &workspace.join("packages/license/child"),
+        &serde_json::json!({ "name": "nested-child", "version": "1.0.0" }),
+    );
+
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("{directory: packages/license/child, type: directory}"),
+        "pnpm-lock.yaml should keep the license/ path component of the nested dep:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("nested-child: file:packages/license/child"),
+        "the snapshot should reference the nested dep without a self-alias prefix:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -423,31 +423,39 @@ fn importer_dep_version(
     let parsed = dep_path_str.parse::<ImporterDepVersion>()?;
     // An injected workspace dep reaches this point as its full peered
     // dep path, `<name>@file:<path>(peers)` — the bare `file:` strip
-    // above only matches peerless dep paths, and `real_name` is unset
-    // for directory resolutions (they learn their name from the
-    // manifest). pnpm v11 reserves the `<name>@<ref>` alias form for
-    // *renamed* deps and writes the plain `file:<path>(peers)` ref when
-    // the alias equals the package name; a self-aliased ref would
-    // double-prefix every consumer that composes `alias@version` into a
-    // snapshot key (v11 readers, Bit's graph converter).
+    // above only matches peerless dep paths.
     if let ImporterDepVersion::Alias(parsed_alias) = &parsed
-        && match parsed_alias.name.scope.as_deref() {
-            Some(scope) => {
-                alias.strip_prefix('@').and_then(|unscoped| unscoped.split_once('/')).is_some_and(
-                    |(alias_scope, bare)| alias_scope == scope && bare == parsed_alias.name.bare,
-                )
-            }
-            None => alias == parsed_alias.name.bare,
-        }
-        && matches!(parsed_alias.suffix.version(), VersionPart::File(_))
+        && let Some(ver) = self_aliased_file_ver(alias, parsed_alias)
     {
-        let suffix = parsed_alias.suffix.to_string();
+        let suffix = ver.to_string();
         let payload = suffix
             .strip_prefix("file:")
             .expect("a File version part always displays with the file: scheme");
         return Ok(ImporterDepVersion::File(payload.to_string()));
     }
     Ok(parsed)
+}
+
+/// `Some(version)` when `key` names a `file:` package aliased to its own
+/// name. pnpm reserves the `<name>@<ref>` alias form for *renamed* deps
+/// and writes the plain `file:<path>(peers)` ref when the alias equals
+/// the package name; a self-aliased ref would double-prefix every
+/// consumer that composes `alias@version` into a snapshot key (v11
+/// readers, Bit's graph converter).
+///
+/// The dep path is the only place the name is available for these:
+/// [`real_name`] is unset for directory resolutions, which learn their
+/// name from the fetched manifest.
+fn self_aliased_file_ver<'a>(alias: &str, key: &'a PkgNameVerPeer) -> Option<&'a PkgVerPeer> {
+    let aliased_to_own_name = match key.name.scope.as_deref() {
+        Some(scope) => alias
+            .strip_prefix('@')
+            .and_then(|unscoped| unscoped.split_once('/'))
+            .is_some_and(|(alias_scope, bare)| alias_scope == scope && bare == key.name.bare),
+        None => alias == key.name.bare,
+    };
+    (aliased_to_own_name && matches!(key.suffix.version(), VersionPart::File(_)))
+        .then_some(&key.suffix)
 }
 
 /// `Some(real_name)` when the resolver produced a structured name; `None`
@@ -468,10 +476,9 @@ fn real_name(result: &ResolveResult) -> Option<String> {
     // - a git dep with no host archive (`<name>@git+<repo>#<commit>` ->
     //   `version: git+<repo>#<commit>`), the shape every non-host repo
     //   resolves to (ssh, self-hosted, `file:`).
-    // `file:` resolutions are deliberately left to the `None` path so
-    // their importer entries keep pacquet's current prefixed shape —
-    // bringing those in line is separate from
-    // <https://github.com/pnpm/pnpm/issues/12053>.
+    // `file:` resolutions stay on the `None` path: both callers strip
+    // their `<name>@` prefix from the parsed dep path instead, via
+    // [`self_aliased_file_ver`].
     let reads_name_from_manifest = match &result.resolution {
         LockfileResolution::Variations(_) | LockfileResolution::Git(_) => true,
         LockfileResolution::Tarball(tarball) => is_remote_http_tarball(&tarball.tarball),
@@ -866,7 +873,11 @@ fn snapshot_dep_ref(
             return Some(SnapshotDepRef::Plain(parsed));
         }
     }
-    dep_path_str.parse::<PkgNameVerPeer>().ok().map(SnapshotDepRef::Alias)
+    let key = dep_path_str.parse::<PkgNameVerPeer>().ok()?;
+    if let Some(ver) = self_aliased_file_ver(alias, &key) {
+        return Some(SnapshotDepRef::Plain(ver.clone()));
+    }
+    Some(SnapshotDepRef::Alias(key))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -1460,6 +1460,73 @@ fn workspace_link_child_renders_as_snapshot_link() {
     }
 }
 
+/// Build a fake `DependenciesGraphNode` for a package resolved from a
+/// local directory (`file:<dir>`). The local resolver keys these by
+/// `<name>@file:<dir>` and leaves `name_ver` as `None` — the name lives
+/// in the fetched manifest only.
+fn make_file_node(name: &str, directory: &str) -> DependenciesGraphNode {
+    let id_text = format!("file:{directory}");
+    let dep_path = DepPath::from(format!("{name}@{id_text}"));
+    let resolve_result = ResolveResult {
+        id: PkgResolutionId::from(id_text),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: Some(Arc::new(json!({ "name": name, "version": "1.0.0" }))),
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: directory.to_string(),
+        }),
+        resolved_via: "local-filesystem".to_string(),
+        normalized_bare_specifier: None,
+        alias: None,
+        policy_violation: None,
+    };
+    DependenciesGraphNode {
+        resolved_package_id: dep_path.to_string(),
+        dep_path,
+        resolve_result: Arc::new(resolve_result),
+        children: BTreeMap::new(),
+        optional_children: HashSet::new(),
+        peer_dependencies: BTreeMap::new(),
+        transitive_peer_dependencies: HashSet::new(),
+        resolved_peer_names: HashSet::new(),
+        depth: 1,
+        installable: true,
+        is_pure: true,
+        optional: false,
+    }
+}
+
+#[test]
+fn file_dep_child_renders_as_bare_file_ref() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "app",
+        "version": "1.0.0",
+        "dependencies": { "nested-parent": "file:./parent" },
+    }));
+
+    let child = make_file_node("nested-child", "child");
+    let mut parent = make_file_node("nested-parent", "parent");
+    parent.children.insert("nested-child".to_string(), child.dep_path.clone());
+
+    let mut graph = DependenciesGraph::new();
+    let parent_dep_path = parent.dep_path.clone();
+    graph.insert(parent_dep_path.clone(), parent);
+    graph.insert(child.dep_path.clone(), child);
+
+    let direct = BTreeMap::from([("nested-parent".to_string(), parent_dep_path)]);
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    let snapshots = lockfile.snapshots.as_ref().expect("snapshots map");
+    let parent_key: PackageKey = "nested-parent@file:parent".parse().unwrap();
+    let deps = snapshots[&parent_key].dependencies.as_ref().expect("nested-parent dependencies");
+    let child_ref = deps.get(&PkgName::parse("nested-child").unwrap()).expect("nested-child child");
+    assert_eq!(dbg!(child_ref).to_string(), "file:child");
+}
+
 #[test]
 fn snapshot_link_uses_lockfile_root_while_importer_link_uses_project_root() {
     let (_tmp, manifest) = write_manifest(json!({

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -600,12 +600,17 @@ fn project_relative_cache_scope(
 
 /// The directory the `file:` dependencies declared by a resolved
 /// package resolve against — pnpm's `parentPkg.rootDir`. A package
-/// fetched from a local directory declares them relative to its own
+/// copied from a local directory declares them relative to its own
 /// directory; every other resolution has no directory of its own, so
 /// its `file:` children stay on the consuming importer's.
 ///
-/// Directory resolutions record their path relative to the lockfile
-/// root, except for `link:`-shaped ones, which record it absolute.
+/// Only `file:`-shaped directory resolutions qualify. They record
+/// their directory relative to the lockfile root (absolute under
+/// `preserveAbsolutePaths`), whereas a `link:`-shaped one records it
+/// relative to the consuming importer (workspace links) or absolute
+/// (the local resolver). Nothing asks for a linked node's directory:
+/// a linked project resolves its own dependencies as a separate
+/// importer, so the walk never descends into one.
 fn declaring_manifest_dir(
     ctx: &TreeCtx,
     result: &pacquet_resolving_resolver_base::ResolveResult,
@@ -613,6 +618,9 @@ fn declaring_manifest_dir(
     let pacquet_lockfile::LockfileResolution::Directory(resolution) = &result.resolution else {
         return None;
     };
+    if !result.id.as_str().starts_with("file:") {
+        return None;
+    }
     let directory = Path::new(&resolution.directory);
     let absolute = if directory.is_absolute() {
         pacquet_fs::lexical_normalize(directory)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -598,6 +598,48 @@ fn project_relative_cache_scope(
     .then(|| opts.project_dir.clone())
 }
 
+/// The directory the `file:` dependencies declared by a resolved
+/// package resolve against — pnpm's `parentPkg.rootDir`. A package
+/// fetched from a local directory declares them relative to its own
+/// directory; every other resolution has no directory of its own, so
+/// its `file:` children stay on the consuming importer's.
+///
+/// Directory resolutions record their path relative to the lockfile
+/// root, except for `link:`-shaped ones, which record it absolute.
+fn declaring_manifest_dir(
+    ctx: &TreeCtx,
+    result: &pacquet_resolving_resolver_base::ResolveResult,
+) -> Option<Arc<Path>> {
+    let pacquet_lockfile::LockfileResolution::Directory(resolution) = &result.resolution else {
+        return None;
+    };
+    let directory = Path::new(&resolution.directory);
+    let absolute = if directory.is_absolute() {
+        pacquet_fs::lexical_normalize(directory)
+    } else {
+        pacquet_fs::lexical_normalize(&ctx.lockfile_dir.join(directory))
+    };
+    Some(Arc::from(absolute))
+}
+
+/// Point a `file:` specifier at the directory of the manifest that
+/// declares it ([`declaring_manifest_dir`]) instead of the consuming
+/// importer's. Every other specifier keeps the caller's options.
+fn opts_relative_to_declaring_manifest<'a>(
+    opts: &'a ResolveOptions,
+    wanted: &WantedDependency,
+    parent_dir: Option<&Path>,
+) -> Cow<'a, ResolveOptions> {
+    match parent_dir {
+        Some(parent_dir)
+            if wanted.bare_specifier.as_deref().is_some_and(|spec| spec.starts_with("file:")) =>
+        {
+            Cow::Owned(ResolveOptions { project_dir: parent_dir.to_path_buf(), ..opts.clone() })
+        }
+        _ => Cow::Borrowed(opts),
+    }
+}
+
 /// One spec carried through [`extend_tree`] and the importer-side
 /// orchestrator: `(alias, range, optional, injected)`. `injected`
 /// reflects the importer manifest's `dependenciesMeta[alias].injected`
@@ -1352,9 +1394,18 @@ where
                     ..WantedDependency::default()
                 };
                 let base_overlay = ctx.base_opts.preferred_versions_overlay.clone();
-                let seed =
-                    resolve_node_seed(ctx, resolver, wanted, &[], 0, false, reuse, base_overlay)
-                        .await?;
+                let seed = resolve_node_seed(
+                    ctx,
+                    resolver,
+                    wanted,
+                    &[],
+                    0,
+                    false,
+                    reuse,
+                    base_overlay,
+                    None,
+                )
+                .await?;
                 warm_children_resolutions(ctx, resolver, &seed).await;
                 Ok::<NodeSeed, ResolveDependencyTreeError>(seed)
             }
@@ -1418,6 +1469,7 @@ where
         parent_optional,
         reuse,
         base_overlay.clone(),
+        None,
     )
     .await?
     {
@@ -1478,6 +1530,10 @@ struct PendingNode {
 /// map omits the cycled child. Without this, two nodes for the same id
 /// race each other into `graph.insert`, and an empty-children entry for
 /// the cycled occurrence can overwrite the real one.
+///
+/// `parent_dir` is the directory of the manifest that declares this
+/// edge, when that manifest is a package resolved from a local
+/// directory — see [`declaring_manifest_dir`].
 #[expect(
     clippy::too_many_arguments,
     reason = "internal walker helper threading per-node context through the recursion"
@@ -1492,6 +1548,7 @@ async fn resolve_node_seed<Chain>(
     parent_optional: bool,
     reuse: ReuseSource,
     pick_overlay: Option<Arc<PreferredVersionsOverlay>>,
+    parent_dir: Option<&Path>,
 ) -> Result<NodeSeed, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
@@ -1567,6 +1624,8 @@ where
         }
         None => opts,
     };
+    let opts_for_file_dep = opts_relative_to_declaring_manifest(opts, &wanted, parent_dir);
+    let opts = opts_for_file_dep.as_ref();
     // Project-relative resolutions (`link:`/`file:`/`workspace:`) are
     // keyed by the consuming importer so one importer's relative path
     // is never reused by another. See [`WantedKey`]. The prior key
@@ -1856,6 +1915,7 @@ where
         let direct_versions = lock_recoverable(&ctx.workspace.direct_dep_versions)
             .get(&ctx.importer_id)
             .map(Arc::clone);
+        let declaring_dir = declaring_manifest_dir(ctx, &result);
         let child_seeds = child_specs
             .iter()
             .map(|(child_name, child_range, child_optional)| {
@@ -1888,6 +1948,7 @@ where
                 }
                 let next_ancestors = Arc::clone(&next_ancestors);
                 let pick_overlay = children_overlay.clone();
+                let declaring_dir = declaring_dir.clone();
                 async move {
                     let seed = resolve_node_seed(
                         ctx,
@@ -1898,6 +1959,7 @@ where
                         current_is_optional,
                         ReuseSource::Transitive { key: child_prior },
                         pick_overlay,
+                        declaring_dir.as_deref(),
                     )
                     .await?;
                     warm_children_resolutions(ctx, resolver, &seed).await;
@@ -2179,6 +2241,7 @@ where
     }
     let Ok(specs) = extract_children(&pending.result) else { return };
     let opts = ctx.opts_for_depth(pending.depth + 1);
+    let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
     specs
         .iter()
         .map(|(name, range, optional)| {
@@ -2188,7 +2251,9 @@ where
                 optional: Some(*optional),
                 ..WantedDependency::default()
             };
+            let opts = opts_relative_to_declaring_manifest(opts, &wanted, declaring_dir.as_deref());
             async move {
+                let opts = opts.as_ref();
                 // Warm through the same per-wanted dedup cache, under
                 // the empty-overlay-view key: when the real pick's
                 // view is empty too (the overwhelmingly common case)


### PR DESCRIPTION
## Summary

A `file:` specifier is relative to the directory of the manifest that declares it — pnpm's `parentPkg.rootDir`. Pacquet's tree walk threaded the importer's `project_dir` through every depth, so a `file:` dependency of a package that was itself installed from a local directory got resolved against the importer. In the reported layout, `file:../child` declared by `packages/license/parent` resolved to `packages/child` and the install failed with `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`.

The children walk now derives the declaring package's directory from its directory resolution and hands it to each `file:` child's resolve options. It joins the per-wanted dedup key through `project_relative_cache_scope`, so two parents declaring the same relative specifier no longer share one resolution.

Fixing resolution exposed a second divergence in the same scenario: the snapshot reference. Pacquet wrote `<name>@file:<path>` where pnpm writes the bare `file:<path>` whenever the alias equals the package's own name. The importer side already stripped that self-alias, so the strip is now shared with the snapshot side. Without it, `pnpm dedupe --check` on `vitejs/vite` would still report a diff against the committed lockfile.

Verified against pnpm 11.17.0 by running both stacks over vite's `packages/vite/src/node/__tests__/plugins/fixtures/license` shape: the lockfiles are now byte-identical, as they are for three other layouts (single project, `packages/*`, `packages/**`).

pnpm 11 already resolves these correctly and covers the shape with its `deep local` test in `installing/deps-installer/test/install/local.ts`, so this is pacquet-only — no TypeScript change is needed.

Closes pnpm/pnpm#13323

## Squash Commit Body

```text
A `file:` specifier is relative to the directory of the manifest that
declares it — pnpm's `parentPkg.rootDir`. The tree walk threaded the
importer's `project_dir` through every depth, so a `file:` dependency of
a package installed from a local directory was resolved against the
importer instead. A `file:../child` in `packages/license/parent` landed
on `packages/child` and the install failed with
`ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`.

The children walk now derives the declaring package's directory from its
directory resolution (relative to the lockfile root, absolute for
`link:`-shaped ones) and hands it to each `file:` child's resolve
options. It joins the per-wanted dedup key through
`project_relative_cache_scope`, so two parents that declare the same
relative specifier no longer share a resolution. The speculative
children warm-up applies the same override, both to keep it from
resolving a path that doesn't exist and so it warms the key the real
resolve reads back.

Once resolution was correct, the snapshot the lockfile writes for such a
dependency still diverged: pacquet wrote `<name>@file:<path>` where pnpm
writes the bare `file:<path>` whenever the alias equals the package's own
name. The importer side already stripped that self-alias; the strip is
now shared with the snapshot side, so a workspace with nested `file:`
deps (vite's license fixtures) round-trips through `pnpm dedupe --check`
against a pnpm-written lockfile.

pnpm 11 already resolves these correctly and covers the shape with its
`deep local` test, so no TypeScript change is needed.

Closes pnpm/pnpm#13323
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787612899&installation_model_id=426870&pr_number=13384&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13384&signature=f06217599d2aea62bb7bdc5f767503112b3ce72e09f66fed7cc422574ff95f6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->