### PR TITLE
fix(lockfile): fail a frozen install when a recorded setting drifts

### DIFF
--- a/.changeset/frozen-install-checks-drifted-settings.md
+++ b/.changeset/frozen-install-checks-drifted-settings.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A frozen install now fails when `autoInstallPeers`, `dedupePeers`, or `excludeLinksFromLockfile` has changed since `pnpm-lock.yaml` was written, instead of installing against a lockfile that no longer matches the settings. The error names the drifted setting, as `pnpm install --frozen-lockfile` has always done.

--- a/pnpm/crates/cli/tests/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/lockfile_only.rs
@@ -6,6 +6,9 @@
 //! `--frozen-lockfile --lockfile-only` combination still validates the
 //! on-disk lockfile against the manifest and fails when it is stale.
 
+pub mod _utils;
+pub use _utils::append_workspace_yaml_key;
+
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_testing_utils::{
@@ -125,10 +128,7 @@ fn frozen_lockfile_only_rejects_a_drifted_setting() {
 
     pacquet.with_args(["install", "--lockfile-only"]).assert().success();
 
-    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
-    let yaml = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
-    fs::write(&workspace_yaml, format!("{yaml}autoInstallPeers: false\n"))
-        .expect("flip autoInstallPeers");
+    append_workspace_yaml_key(&workspace, "autoInstallPeers", false);
 
     let output = pacquet_at(&workspace)
         .with_args(["install", "--frozen-lockfile", "--lockfile-only"])

--- a/pnpm/crates/cli/tests/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/lockfile_only.rs
@@ -106,6 +106,53 @@ fn writes_lockfile_without_downloading_or_linking() {
     drop((root, mock_instance));
 }
 
+/// A `settings.*` key the lockfile records is part of the frozen
+/// contract too: flipping one after the lockfile was written makes the
+/// recorded resolution unreproducible, so pnpm refuses the install and
+/// names the drifted setting. Pinned end to end because the code and
+/// the quoted name are what CI logs show.
+#[test]
+fn frozen_lockfile_only_rejects_a_drifted_setting() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "is-positive": "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let yaml = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml, format!("{yaml}autoInstallPeers: false\n"))
+        .expect("flip autoInstallPeers");
+
+    let output = pacquet_at(&workspace)
+        .with_args(["install", "--frozen-lockfile", "--lockfile-only"])
+        .output()
+        .expect("spawn pacquet install");
+
+    assert!(
+        !output.status.success(),
+        "a drifted setting must fail the frozen install (stderr: {})",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("ERR_PNPM_LOCKFILE_CONFIG_MISMATCH"),
+        "stderr must name the config-mismatch diagnostic; got:\n{stderr}",
+    );
+    assert!(
+        stderr.contains(r#""settings.autoInstallPeers""#),
+        "stderr must quote the drifted setting; got:\n{stderr}",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// `--frozen-lockfile --lockfile-only` keeps frozen semantics: it
 /// validates the on-disk `pnpm-lock.yaml` against the manifest and
 /// fails when the manifest has drifted, never rewriting the lockfile.

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -162,8 +162,8 @@ pub enum StalenessReason {
 
     /// The lockfile's `settings.autoInstallPeers` differs from the
     /// current install's `Config::auto_install_peers`. Only checked when
-    /// the lockfile records a `settings` block: a lockfile that never
-    /// carried one says nothing about the setting it was written under.
+    /// the lockfile records a `settings` block, which is the only place
+    /// the value it was written under is preserved.
     #[display(
         "`autoInstallPeers` in the lockfile ({lockfile}) doesn't match the current config ({config})"
     )]
@@ -394,9 +394,9 @@ pub fn check_lockfile_settings(
         });
     }
 
-    // A lockfile with no `settings` block predates the field and says
-    // nothing about the setting it was written under, so it can't drift
-    // — pnpm's `lockfile.settings?.autoInstallPeers != null` guard.
+    // A lockfile with no `settings` block records nothing about the
+    // setting it was written under, so there is nothing to compare —
+    // pnpm's `lockfile.settings?.autoInstallPeers != null` guard.
     if let Some(settings) = lockfile.settings.as_ref()
         && settings.auto_install_peers != auto_install_peers
     {

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -27,6 +27,9 @@ pub struct LockfileSettingsCheck<'a> {
     pub package_extensions_checksum: Option<&'a str>,
     pub ignored_optional_dependencies: Option<&'a [String]>,
     pub patched_dependencies: Option<&'a BTreeMap<String, String>>,
+    pub auto_install_peers: bool,
+    pub dedupe_peers: bool,
+    pub exclude_links_from_lockfile: bool,
     pub inject_workspace_packages: bool,
     pub peers_suffix_max_length: u64,
 }
@@ -156,6 +159,35 @@ pub enum StalenessReason {
         lockfile: BTreeMap<String, String>,
         config: BTreeMap<String, String>,
     },
+
+    /// The lockfile's `settings.autoInstallPeers` differs from the
+    /// current install's `Config::auto_install_peers`. Only checked when
+    /// the lockfile records a `settings` block: a lockfile that never
+    /// carried one says nothing about the setting it was written under.
+    #[display(
+        "`autoInstallPeers` in the lockfile ({lockfile}) doesn't match the current config ({config})"
+    )]
+    AutoInstallPeersChanged { lockfile: bool, config: bool },
+
+    /// The lockfile's `settings.dedupePeers` differs from the current
+    /// install's `Config::dedupe_peers`. The key is written only while
+    /// the setting is on, so both sides normalize to a boolean and an
+    /// absent key equals `false`.
+    #[display(
+        "`dedupePeers` in the lockfile ({lockfile}) doesn't match the current config ({config})"
+    )]
+    DedupePeersChanged { lockfile: bool, config: bool },
+
+    /// The lockfile's `settings.excludeLinksFromLockfile` differs from
+    /// the current install's `Config::exclude_links_from_lockfile`. The
+    /// setting decides whether `link:` deps are recorded at all, so a
+    /// flip invalidates every importer snapshot. Like
+    /// [`Self::AutoInstallPeersChanged`], only checked when the lockfile
+    /// records a `settings` block.
+    #[display(
+        "`excludeLinksFromLockfile` in the lockfile ({lockfile}) doesn't match the current config ({config})"
+    )]
+    ExcludeLinksFromLockfileChanged { lockfile: bool, config: bool },
 }
 
 impl StalenessReason {
@@ -181,6 +213,11 @@ impl StalenessReason {
                 Some("ignoredOptionalDependencies")
             }
             StalenessReason::PatchedDependenciesChanged { .. } => Some("patchedDependencies"),
+            StalenessReason::AutoInstallPeersChanged { .. } => Some("settings.autoInstallPeers"),
+            StalenessReason::DedupePeersChanged { .. } => Some("settings.dedupePeers"),
+            StalenessReason::ExcludeLinksFromLockfileChanged { .. } => {
+                Some("settings.excludeLinksFromLockfile")
+            }
             StalenessReason::PeersSuffixMaxLengthChanged { .. } => {
                 Some("settings.peersSuffixMaxLength")
             }
@@ -272,46 +309,21 @@ impl SpecDiff {
 }
 
 /// Verify that lockfile-level settings the install pipeline reads
-/// from `pnpm-workspace.yaml` haven't drifted since the lockfile
-/// was written. Today this covers `catalogs`, `overrides`,
-/// `packageExtensionsChecksum`, `ignoredOptionalDependencies`,
-/// `patchedDependencies`, and the relevant `settings.*` keys (umbrella
-/// [#434] slice 7); the variants below will grow as more settings land
-/// (`pnpmfileChecksum`, etc.).
+/// from `pnpm-workspace.yaml` haven't drifted since the lockfile was
+/// written: `catalogs`, `overrides`, `packageExtensionsChecksum`,
+/// `ignoredOptionalDependencies`, `patchedDependencies`,
+/// and the relevant `settings.*` keys (umbrella
+/// [#434] slice 7).
 ///
 /// Drift in any of these settings would otherwise require a full
 /// resolution; pacquet has no resolver, so the matching action is to
-/// abort the frozen install with `OutdatedLockfile`. The check ordering
-/// is deterministic so the *first* drifted field is reported — which
-/// matters for tests and for CI logs that quote the reason verbatim.
+/// abort the frozen install with `OutdatedLockfile`. The fields are
+/// compared in the order pnpm's `getOutdatedLockfileSetting` compares
+/// them, because only the *first* drifted field is reported and both
+/// stacks must name the same one.
 ///
 /// [#434]: https://github.com/pnpm/pacquet/issues/434
 pub fn check_lockfile_settings(
-    lockfile: &Lockfile,
-    overrides: Option<&HashMap<String, String>>,
-    package_extensions_checksum: Option<&str>,
-    ignored_optional_dependencies: Option<&[String]>,
-    patched_dependencies: Option<&BTreeMap<String, String>>,
-    inject_workspace_packages: bool,
-    peers_suffix_max_length: u64,
-) -> Result<(), StalenessReason> {
-    check_lockfile_settings_with_catalogs(
-        lockfile,
-        LockfileSettingsCheck {
-            catalogs: &Catalogs::new(),
-            overrides,
-            package_extensions_checksum,
-            ignored_optional_dependencies,
-            patched_dependencies,
-            inject_workspace_packages,
-            peers_suffix_max_length,
-        },
-    )
-}
-
-/// Catalog-aware variant of [`check_lockfile_settings`] used by install paths
-/// that have already loaded `pnpm-workspace.yaml`.
-pub fn check_lockfile_settings_with_catalogs(
     lockfile: &Lockfile,
     check: LockfileSettingsCheck<'_>,
 ) -> Result<(), StalenessReason> {
@@ -321,6 +333,9 @@ pub fn check_lockfile_settings_with_catalogs(
         package_extensions_checksum,
         ignored_optional_dependencies,
         patched_dependencies,
+        auto_install_peers,
+        dedupe_peers,
+        exclude_links_from_lockfile,
         inject_workspace_packages,
         peers_suffix_max_length,
     } = check;
@@ -379,12 +394,33 @@ pub fn check_lockfile_settings_with_catalogs(
         });
     }
 
-    let lockfile_inject =
-        lockfile.settings.as_ref().is_some_and(|settings| settings.inject_workspace_packages);
-    if lockfile_inject != inject_workspace_packages {
-        return Err(StalenessReason::InjectWorkspacePackagesChanged {
-            lockfile: lockfile_inject,
-            config: inject_workspace_packages,
+    // A lockfile with no `settings` block predates the field and says
+    // nothing about the setting it was written under, so it can't drift
+    // — pnpm's `lockfile.settings?.autoInstallPeers != null` guard.
+    if let Some(settings) = lockfile.settings.as_ref()
+        && settings.auto_install_peers != auto_install_peers
+    {
+        return Err(StalenessReason::AutoInstallPeersChanged {
+            lockfile: settings.auto_install_peers,
+            config: auto_install_peers,
+        });
+    }
+
+    let lockfile_dedupe_peers =
+        lockfile.settings.as_ref().and_then(|settings| settings.dedupe_peers).unwrap_or(false);
+    if lockfile_dedupe_peers != dedupe_peers {
+        return Err(StalenessReason::DedupePeersChanged {
+            lockfile: lockfile_dedupe_peers,
+            config: dedupe_peers,
+        });
+    }
+
+    if let Some(settings) = lockfile.settings.as_ref()
+        && settings.exclude_links_from_lockfile != exclude_links_from_lockfile
+    {
+        return Err(StalenessReason::ExcludeLinksFromLockfileChanged {
+            lockfile: settings.exclude_links_from_lockfile,
+            config: exclude_links_from_lockfile,
         });
     }
 
@@ -397,6 +433,15 @@ pub fn check_lockfile_settings_with_catalogs(
         return Err(StalenessReason::PeersSuffixMaxLengthChanged {
             lockfile: lockfile_peers_suffix_max_length,
             config: peers_suffix_max_length,
+        });
+    }
+
+    let lockfile_inject =
+        lockfile.settings.as_ref().is_some_and(|settings| settings.inject_workspace_packages);
+    if lockfile_inject != inject_workspace_packages {
+        return Err(StalenessReason::InjectWorkspacePackagesChanged {
+            lockfile: lockfile_inject,
+            config: inject_workspace_packages,
         });
     }
 

--- a/pnpm/crates/lockfile/src/freshness/tests.rs
+++ b/pnpm/crates/lockfile/src/freshness/tests.rs
@@ -1325,8 +1325,8 @@ fn check_settings_returns_drift_when_auto_install_peers_differs() {
     assert_eq!(err.setting_name(), Some("settings.autoInstallPeers"));
 }
 
-/// A lockfile with no `settings` block predates the field, so it can't
-/// disagree with the config about it.
+/// A lockfile with no `settings` block records no value to disagree
+/// with.
 #[test]
 fn check_settings_ignores_auto_install_peers_without_a_settings_block() {
     let lockfile: Lockfile = serde_saphyr::from_str(text_block! {

--- a/pnpm/crates/lockfile/src/freshness/tests.rs
+++ b/pnpm/crates/lockfile/src/freshness/tests.rs
@@ -916,7 +916,7 @@ fn check_settings_passes_when_both_sides_empty() {
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok());
     assert!(
         check_lockfile_settings(
             &lockfile,
@@ -1004,7 +1004,7 @@ fn check_settings_passes_when_overrides_both_empty() {
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok());
 
     let empty: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     assert!(
@@ -1177,7 +1177,7 @@ fn check_settings_returns_ok_when_no_package_extensions_checksum_on_either_side(
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok());
 }
 
 #[test]
@@ -1415,7 +1415,7 @@ fn check_settings_passes_when_inject_workspace_packages_both_false() {
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok());
 }
 
 #[test]
@@ -1492,7 +1492,7 @@ fn check_settings_passes_when_peers_suffix_max_length_unset_and_config_is_defaul
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok());
 }
 
 /// Lockfile carries no `settings.peersSuffixMaxLength` (writer used
@@ -1539,7 +1539,7 @@ fn check_settings_passes_when_explicit_peers_suffix_max_length_matches() {
                 ..settings_check(&Catalogs::new())
             }
         )
-        .is_ok()
+        .is_ok(),
     );
 }
 

--- a/pnpm/crates/lockfile/src/freshness/tests.rs
+++ b/pnpm/crates/lockfile/src/freshness/tests.rs
@@ -1,6 +1,5 @@
 use super::{
-    LockfileSettingsCheck, StalenessReason, check_lockfile_settings,
-    check_lockfile_settings_with_catalogs, satisfies_package_manifest,
+    LockfileSettingsCheck, StalenessReason, check_lockfile_settings, satisfies_package_manifest,
 };
 use crate::Lockfile;
 use pacquet_catalogs_types::Catalogs;
@@ -29,6 +28,9 @@ fn settings_check(catalogs: &Catalogs) -> LockfileSettingsCheck<'_> {
         package_extensions_checksum: None,
         ignored_optional_dependencies: None,
         patched_dependencies: None,
+        auto_install_peers: true,
+        dedupe_peers: false,
+        exclude_links_from_lockfile: false,
         inject_workspace_packages: false,
         peers_suffix_max_length: crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
     }
@@ -815,7 +817,7 @@ fn check_settings_passes_when_catalog_snapshot_matches_config() {
         "default".to_string(),
         BTreeMap::from([("react".to_string(), "^18.2.0".to_string())]),
     )]);
-    assert!(check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs)).is_ok());
+    assert!(check_lockfile_settings(&lockfile, settings_check(&catalogs)).is_ok());
 }
 
 #[test]
@@ -836,7 +838,7 @@ fn check_settings_accepts_equivalent_git_catalog_specifiers() {
             "github:kevva/is-positive#97edff6".to_string(),
         )]),
     )]);
-    check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs))
+    check_lockfile_settings(&lockfile, settings_check(&catalogs))
         .expect("equivalent git catalog specifiers must be current");
 }
 
@@ -850,7 +852,7 @@ fn check_settings_ignores_catalog_config_entries_absent_from_snapshot() {
         "default".to_string(),
         BTreeMap::from([("react".to_string(), "^18.2.0".to_string())]),
     )]);
-    assert!(check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs)).is_ok());
+    assert!(check_lockfile_settings(&lockfile, settings_check(&catalogs)).is_ok());
 }
 
 #[test]
@@ -868,7 +870,7 @@ fn check_settings_returns_drift_when_catalog_snapshot_specifier_changes() {
         "default".to_string(),
         BTreeMap::from([("react".to_string(), "^19.0.0".to_string())]),
     )]);
-    let err = check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs))
+    let err = check_lockfile_settings(&lockfile, settings_check(&catalogs))
         .expect_err("changed catalog entry must surface drift");
     let StalenessReason::CatalogsChanged { lockfile: snapshot, config } = err else {
         panic!("expected CatalogsChanged");
@@ -899,7 +901,7 @@ fn check_settings_returns_drift_when_catalog_snapshot_entry_is_removed_from_conf
     })
     .expect("parse lockfile with catalogs");
     let catalogs = Catalogs::from([("default".to_string(), BTreeMap::new())]);
-    let err = check_lockfile_settings_with_catalogs(&lockfile, settings_check(&catalogs))
+    let err = check_lockfile_settings(&lockfile, settings_check(&catalogs))
         .expect_err("removed catalog entry must surface drift");
     assert!(matches!(err, StalenessReason::CatalogsChanged { .. }));
 }
@@ -914,27 +916,14 @@ fn check_settings_passes_when_both_sides_empty() {
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
     assert!(
         check_lockfile_settings(
             &lockfile,
-            None,
-            None,
-            None,
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH
-        )
-        .is_ok(),
-    );
-    assert!(
-        check_lockfile_settings(
-            &lockfile,
-            None,
-            None,
-            Some(&[]),
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH
+            LockfileSettingsCheck {
+                ignored_optional_dependencies: Some(&[]),
+                ..settings_check(&Catalogs::new())
+            }
         )
         .is_ok(),
     );
@@ -953,12 +942,10 @@ fn check_settings_passes_when_sets_match_regardless_of_order() {
     assert!(
         check_lockfile_settings(
             &lockfile,
-            None,
-            None,
-            Some(&config_set),
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+            LockfileSettingsCheck {
+                ignored_optional_dependencies: Some(&config_set),
+                ..settings_check(&Catalogs::new())
+            }
         )
         .is_ok(),
     );
@@ -975,12 +962,10 @@ fn check_settings_returns_drift_when_sets_differ() {
     let config_set = ["bar".to_string()];
     let err = check_lockfile_settings(
         &lockfile,
-        None,
-        None,
-        Some(&config_set),
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck {
+            ignored_optional_dependencies: Some(&config_set),
+            ..settings_check(&Catalogs::new())
+        },
     )
     .expect_err("set drift must surface as IgnoredOptionalDependenciesChanged");
     assert_eq!(
@@ -1000,16 +985,8 @@ fn check_settings_returns_drift_when_lockfile_has_set_but_config_does_not() {
         "  - foo"
     })
     .expect("parse lockfile with ignoredOptionalDependencies");
-    let err = check_lockfile_settings(
-        &lockfile,
-        None,
-        None,
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
-    )
-    .expect_err("removing a set in config while lockfile has it must surface drift");
+    let err = check_lockfile_settings(&lockfile, settings_check(&Catalogs::new()))
+        .expect_err("removing a set in config while lockfile has it must surface drift");
     let StalenessReason::IgnoredOptionalDependenciesChanged { lockfile: l, config: c } = err else {
         panic!("expected IgnoredOptionalDependenciesChanged");
     };
@@ -1027,29 +1004,13 @@ fn check_settings_passes_when_overrides_both_empty() {
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    assert!(
-        check_lockfile_settings(
-            &lockfile,
-            None,
-            None,
-            None,
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH
-        )
-        .is_ok(),
-    );
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
 
     let empty: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     assert!(
         check_lockfile_settings(
             &lockfile,
-            Some(&empty),
-            None,
-            None,
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+            LockfileSettingsCheck { overrides: Some(&empty), ..settings_check(&Catalogs::new()) }
         )
         .is_ok(),
     );
@@ -1070,12 +1031,7 @@ fn check_settings_passes_when_overrides_match_regardless_of_order() {
     assert!(
         check_lockfile_settings(
             &lockfile,
-            Some(&config),
-            None,
-            None,
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+            LockfileSettingsCheck { overrides: Some(&config), ..settings_check(&Catalogs::new()) }
         )
         .is_ok(),
     );
@@ -1093,12 +1049,7 @@ fn check_settings_returns_drift_on_overrides_value_change() {
     config.insert("foo".to_string(), "2.0.0".to_string());
     let err = check_lockfile_settings(
         &lockfile,
-        Some(&config),
-        None,
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck { overrides: Some(&config), ..settings_check(&Catalogs::new()) },
     )
     .expect_err("changed override value must surface drift");
     let StalenessReason::OverridesChanged { lockfile: l, config: c } = err else {
@@ -1116,16 +1067,8 @@ fn check_settings_returns_drift_when_lockfile_has_overrides_but_config_does_not(
         "  foo: 1.0.0"
     })
     .expect("parse lockfile with overrides");
-    let err = check_lockfile_settings(
-        &lockfile,
-        None,
-        None,
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
-    )
-    .expect_err("dropped override must surface drift");
+    let err = check_lockfile_settings(&lockfile, settings_check(&Catalogs::new()))
+        .expect_err("dropped override must surface drift");
     let StalenessReason::OverridesChanged { lockfile: l, config: c } = err else {
         panic!("expected OverridesChanged");
     };
@@ -1143,12 +1086,7 @@ fn check_settings_returns_drift_when_config_has_overrides_but_lockfile_does_not(
     config.insert("foo".to_string(), "1.0.0".to_string());
     let err = check_lockfile_settings(
         &lockfile,
-        Some(&config),
-        None,
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck { overrides: Some(&config), ..settings_check(&Catalogs::new()) },
     )
     .expect_err("added override must surface drift");
     let StalenessReason::OverridesChanged { lockfile: l, config: c } = err else {
@@ -1177,12 +1115,10 @@ fn check_settings_passes_when_patched_dependencies_match() {
     assert!(
         check_lockfile_settings(
             &lockfile,
-            None,
-            None,
-            None,
-            Some(&config),
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+            LockfileSettingsCheck {
+                patched_dependencies: Some(&config),
+                ..settings_check(&Catalogs::new())
+            }
         )
         .is_ok(),
     );
@@ -1205,12 +1141,10 @@ fn check_settings_returns_drift_when_patch_hash_changes() {
     )]);
     let err = check_lockfile_settings(
         &lockfile,
-        None,
-        None,
-        None,
-        Some(&config),
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck {
+            patched_dependencies: Some(&config),
+            ..settings_check(&Catalogs::new())
+        },
     )
     .expect_err("changed patch hash must surface drift");
     let StalenessReason::PatchedDependenciesChanged { lockfile: l, config: c } = err else {
@@ -1228,16 +1162,8 @@ fn check_settings_returns_drift_when_patch_removed_from_config() {
         "  graceful-fs@4.2.11: abc123"
     })
     .expect("parse lockfile with patchedDependencies");
-    let err = check_lockfile_settings(
-        &lockfile,
-        None,
-        None,
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
-    )
-    .expect_err("dropped patch must surface drift");
+    let err = check_lockfile_settings(&lockfile, settings_check(&Catalogs::new()))
+        .expect_err("dropped patch must surface drift");
     let StalenessReason::PatchedDependenciesChanged { lockfile: l, config: c } = err else {
         panic!("expected PatchedDependenciesChanged, got {err:?}");
     };
@@ -1251,18 +1177,7 @@ fn check_settings_returns_ok_when_no_package_extensions_checksum_on_either_side(
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    assert!(
-        check_lockfile_settings(
-            &lockfile,
-            None,
-            None,
-            None,
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
-        )
-        .is_ok(),
-    );
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
 }
 
 #[test]
@@ -1275,12 +1190,12 @@ fn check_settings_returns_ok_when_package_extensions_checksum_matches() {
     assert!(
         check_lockfile_settings(
             &lockfile,
-            None,
-            Some("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="),
-            None,
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+            LockfileSettingsCheck {
+                package_extensions_checksum: Some(
+                    "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                ),
+                ..settings_check(&Catalogs::new())
+            }
         )
         .is_ok(),
     );
@@ -1297,12 +1212,12 @@ fn check_settings_returns_drift_on_package_extensions_checksum_value_change() {
     .expect("parse lockfile");
     let err = check_lockfile_settings(
         &lockfile,
-        None,
-        Some("sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB="),
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck {
+            package_extensions_checksum: Some(
+                "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=",
+            ),
+            ..settings_check(&Catalogs::new())
+        },
     )
     .expect_err("changed checksum must surface drift");
     let StalenessReason::PackageExtensionsChecksumChanged { lockfile: l, config: c } = err else {
@@ -1319,16 +1234,8 @@ fn check_settings_returns_drift_when_lockfile_has_checksum_but_config_does_not()
         "packageExtensionsChecksum: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
     })
     .expect("parse lockfile");
-    let err = check_lockfile_settings(
-        &lockfile,
-        None,
-        None,
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
-    )
-    .expect_err("dropped extensions must surface drift");
+    let err = check_lockfile_settings(&lockfile, settings_check(&Catalogs::new()))
+        .expect_err("dropped extensions must surface drift");
     let StalenessReason::PackageExtensionsChecksumChanged { lockfile: l, config: c } = err else {
         panic!("expected PackageExtensionsChecksumChanged, got {err:?}");
     };
@@ -1344,12 +1251,12 @@ fn check_settings_returns_drift_when_config_has_checksum_but_lockfile_does_not()
     .expect("parse minimal lockfile");
     let err = check_lockfile_settings(
         &lockfile,
-        None,
-        Some("sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="),
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck {
+            package_extensions_checksum: Some(
+                "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            ),
+            ..settings_check(&Catalogs::new())
+        },
     )
     .expect_err("added extensions must surface drift");
     let StalenessReason::PackageExtensionsChecksumChanged { lockfile: l, config: c } = err else {
@@ -1374,12 +1281,11 @@ fn check_settings_reports_overrides_before_ignored_optional() {
     let ignored: [String; 0] = [];
     let err = check_lockfile_settings(
         &lockfile,
-        Some(&config),
-        None,
-        Some(&ignored),
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck {
+            overrides: Some(&config),
+            ignored_optional_dependencies: Some(&ignored),
+            ..settings_check(&Catalogs::new())
+        },
     )
     .expect_err("both drifted; expect OverridesChanged surfaced");
     assert!(
@@ -1397,8 +1303,32 @@ fn check_settings_reports_overrides_before_ignored_optional() {
 /// `settings.injectWorkspacePackages` key when `false`, so a lockfile
 /// missing the field entirely deserializes to `false` and compares
 /// equal to a config that also has it off.
+/// pnpm refuses a frozen install when `settings.autoInstallPeers`
+/// drifts: the setting decides whether peers are folded into the
+/// importer snapshot, so the recorded resolution isn't reproducible
+/// under the other value.
 #[test]
-fn check_settings_passes_when_inject_workspace_packages_both_false() {
+fn check_settings_returns_drift_when_auto_install_peers_differs() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "settings:"
+        "  autoInstallPeers: true"
+        "  excludeLinksFromLockfile: false"
+    })
+    .expect("parse lockfile with settings");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck { auto_install_peers: false, ..settings_check(&Catalogs::new()) },
+    )
+    .expect_err("a flipped autoInstallPeers must surface drift");
+    assert_eq!(err, StalenessReason::AutoInstallPeersChanged { lockfile: true, config: false });
+    assert_eq!(err.setting_name(), Some("settings.autoInstallPeers"));
+}
+
+/// A lockfile with no `settings` block predates the field, so it can't
+/// disagree with the config about it.
+#[test]
+fn check_settings_ignores_auto_install_peers_without_a_settings_block() {
     let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
         "lockfileVersion: '9.0'"
     })
@@ -1406,15 +1336,86 @@ fn check_settings_passes_when_inject_workspace_packages_both_false() {
     assert!(
         check_lockfile_settings(
             &lockfile,
-            None,
-            None,
-            None,
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+            LockfileSettingsCheck { auto_install_peers: false, ..settings_check(&Catalogs::new()) },
         )
         .is_ok(),
     );
+}
+
+/// `dedupePeers` is written only while it is on, so an absent key reads
+/// as `false` and turning the setting on is drift.
+#[test]
+fn check_settings_returns_drift_when_dedupe_peers_is_enabled() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "settings:"
+        "  autoInstallPeers: true"
+        "  excludeLinksFromLockfile: false"
+    })
+    .expect("parse lockfile with settings");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck { dedupe_peers: true, ..settings_check(&Catalogs::new()) },
+    )
+    .expect_err("enabling dedupePeers must surface drift");
+    assert_eq!(err, StalenessReason::DedupePeersChanged { lockfile: false, config: true });
+    assert_eq!(err.setting_name(), Some("settings.dedupePeers"));
+}
+
+#[test]
+fn check_settings_returns_drift_when_exclude_links_from_lockfile_differs() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "settings:"
+        "  autoInstallPeers: true"
+        "  excludeLinksFromLockfile: false"
+    })
+    .expect("parse lockfile with settings");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck {
+            exclude_links_from_lockfile: true,
+            ..settings_check(&Catalogs::new())
+        },
+    )
+    .expect_err("a flipped excludeLinksFromLockfile must surface drift");
+    assert_eq!(
+        err,
+        StalenessReason::ExcludeLinksFromLockfileChanged { lockfile: false, config: true },
+    );
+    assert_eq!(err.setting_name(), Some("settings.excludeLinksFromLockfile"));
+}
+
+/// Only the first drifted field is reported, and pnpm's
+/// `getOutdatedLockfileSetting` reports them in a fixed order — with
+/// both `overrides` and `settings.autoInstallPeers` drifted, both
+/// stacks must name `overrides`.
+#[test]
+fn check_settings_reports_the_field_pnpm_reports_first() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "settings:"
+        "  autoInstallPeers: true"
+        "  excludeLinksFromLockfile: false"
+        "overrides:"
+        "  is-number: 6.0.0"
+    })
+    .expect("parse lockfile with overrides and settings");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck { auto_install_peers: false, ..settings_check(&Catalogs::new()) },
+    )
+    .expect_err("both fields drifted");
+    assert_eq!(err.setting_name(), Some("overrides"));
+}
+
+#[test]
+fn check_settings_passes_when_inject_workspace_packages_both_false() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+    })
+    .expect("parse minimal lockfile");
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
 }
 
 #[test]
@@ -1430,12 +1431,11 @@ fn check_settings_passes_when_inject_workspace_packages_both_true() {
     assert!(
         check_lockfile_settings(
             &lockfile,
-            None,
-            None,
-            None,
-            None,
-            true,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+            LockfileSettingsCheck {
+                auto_install_peers: false,
+                inject_workspace_packages: true,
+                ..settings_check(&Catalogs::new())
+            }
         )
         .is_ok(),
     );
@@ -1449,12 +1449,10 @@ fn check_settings_returns_drift_when_config_enables_inject_workspace_packages() 
     .expect("parse minimal lockfile");
     let err = check_lockfile_settings(
         &lockfile,
-        None,
-        None,
-        None,
-        None,
-        true,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck {
+            inject_workspace_packages: true,
+            ..settings_check(&Catalogs::new())
+        },
     )
     .expect_err("enabling inject must surface drift");
     assert_eq!(
@@ -1475,12 +1473,7 @@ fn check_settings_returns_drift_when_config_disables_inject_workspace_packages()
     .expect("parse lockfile with inject on");
     let err = check_lockfile_settings(
         &lockfile,
-        None,
-        None,
-        None,
-        None,
-        false,
-        crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        LockfileSettingsCheck { auto_install_peers: false, ..settings_check(&Catalogs::new()) },
     )
     .expect_err("disabling inject must surface drift");
     assert_eq!(
@@ -1499,18 +1492,7 @@ fn check_settings_passes_when_peers_suffix_max_length_unset_and_config_is_defaul
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    assert!(
-        check_lockfile_settings(
-            &lockfile,
-            None,
-            None,
-            None,
-            None,
-            false,
-            crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH
-        )
-        .is_ok(),
-    );
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok(),);
 }
 
 /// Lockfile carries no `settings.peersSuffixMaxLength` (writer used
@@ -1524,8 +1506,11 @@ fn check_settings_returns_drift_when_lockfile_implicit_default_differs_from_conf
         "lockfileVersion: '9.0'"
     })
     .expect("parse minimal lockfile");
-    let err = check_lockfile_settings(&lockfile, None, None, None, None, false, 10)
-        .expect_err("config != default must surface drift when lockfile is unset");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck { peers_suffix_max_length: 10, ..settings_check(&Catalogs::new()) },
+    )
+    .expect_err("config != default must surface drift when lockfile is unset");
     assert_eq!(
         err,
         StalenessReason::PeersSuffixMaxLengthChanged {
@@ -1545,7 +1530,17 @@ fn check_settings_passes_when_explicit_peers_suffix_max_length_matches() {
         "  peersSuffixMaxLength: 10"
     })
     .expect("parse lockfile with settings");
-    assert!(check_lockfile_settings(&lockfile, None, None, None, None, false, 10).is_ok());
+    assert!(
+        check_lockfile_settings(
+            &lockfile,
+            LockfileSettingsCheck {
+                auto_install_peers: false,
+                peers_suffix_max_length: 10,
+                ..settings_check(&Catalogs::new())
+            }
+        )
+        .is_ok()
+    );
 }
 
 /// An explicit `settings.peersSuffixMaxLength` in the lockfile that
@@ -1560,8 +1555,15 @@ fn check_settings_returns_drift_when_explicit_peers_suffix_max_length_differs() 
         "  peersSuffixMaxLength: 10"
     })
     .expect("parse lockfile with settings");
-    let err = check_lockfile_settings(&lockfile, None, None, None, None, false, 100)
-        .expect_err("changed peersSuffixMaxLength must surface drift");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck {
+            auto_install_peers: false,
+            peers_suffix_max_length: 100,
+            ..settings_check(&Catalogs::new())
+        },
+    )
+    .expect_err("changed peersSuffixMaxLength must surface drift");
     assert_eq!(err, StalenessReason::PeersSuffixMaxLengthChanged { lockfile: 10, config: 100 });
 }
 

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2544,7 +2544,7 @@ pub(crate) fn check_lockfile_settings_drift(
     // from what the lockfile recorded.
     let patched_dependency_hashes =
         config.patched_dependency_hashes().map_err(FreshnessCheckError::CalcPatchHashes)?;
-    pacquet_lockfile::check_lockfile_settings_with_catalogs(
+    pacquet_lockfile::check_lockfile_settings(
         lockfile,
         pacquet_lockfile::LockfileSettingsCheck {
             catalogs,
@@ -2552,6 +2552,9 @@ pub(crate) fn check_lockfile_settings_drift(
             package_extensions_checksum: package_extensions_checksum.as_deref(),
             ignored_optional_dependencies: config.ignored_optional_dependencies.as_deref(),
             patched_dependencies: patched_dependency_hashes.as_ref(),
+            auto_install_peers: config.auto_install_peers,
+            dedupe_peers: config.dedupe_peers,
+            exclude_links_from_lockfile: config.exclude_links_from_lockfile,
             inject_workspace_packages: config.inject_workspace_packages,
             peers_suffix_max_length: config.peers_suffix_max_length,
         },

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -248,6 +248,31 @@ const TOO_MANY_CONFIGS_MESSAGE: &str = "too many distinct registry configuration
 /// `128 KiB` is far above any real registry/overrides configuration.
 const MAX_CONFIG_KEY_BYTES: usize = 128 * 1024;
 
+/// The slice of an input lockfile's `settings` block that
+/// [`intern_config`] adopts, and the only part of it the interning key
+/// carries. Keying on the whole block would let a caller mint an
+/// unbounded number of distinct configs out of the fields the config
+/// never reads (`peersSuffixMaxLength` alone is a `u64`) and exhaust
+/// [`MAX_INTERNED_CONFIGS`], after which no caller gets a config at all.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AdoptedLockfileSettings {
+    auto_install_peers: bool,
+    dedupe_peers: bool,
+    exclude_links_from_lockfile: bool,
+}
+
+impl From<&pacquet_lockfile::LockfileSettings> for AdoptedLockfileSettings {
+    fn from(settings: &pacquet_lockfile::LockfileSettings) -> Self {
+        AdoptedLockfileSettings {
+            auto_install_peers: settings.auto_install_peers,
+            // Written only while the setting is on, so an absent key is `false`.
+            dedupe_peers: settings.dedupe_peers.unwrap_or(false),
+            exclude_links_from_lockfile: settings.exclude_links_from_lockfile,
+        }
+    }
+}
+
 /// Build + leak a `&'static Config` for a request's registry
 /// configuration, interned by its canonical JSON so repeat requests reuse
 /// it. Returns `None` when the config can't be safely interned:
@@ -289,8 +314,11 @@ fn intern_config(
     // client would; leaving the server's own defaults in place would make
     // the frozen path reject a lockfile that is valid for its owner, since
     // the freshness gate compares these against the config.
-    let lockfile_settings =
-        request.lockfile.as_ref().and_then(|lockfile| lockfile.settings.as_ref());
+    let lockfile_settings = request
+        .lockfile
+        .as_ref()
+        .and_then(|lockfile| lockfile.settings.as_ref())
+        .map(AdoptedLockfileSettings::from);
 
     let key = serde_json::json!({
         "registry": registry,
@@ -340,8 +368,7 @@ fn intern_config(
     config.trust_policy_ignore_after = request.trust_policy_ignore_after;
     if let Some(settings) = lockfile_settings {
         config.auto_install_peers = settings.auto_install_peers;
-        // Written only while the setting is on, so an absent key is `false`.
-        config.dedupe_peers = settings.dedupe_peers.unwrap_or(false);
+        config.dedupe_peers = settings.dedupe_peers;
         config.exclude_links_from_lockfile = settings.exclude_links_from_lockfile;
     }
     let config: &'static PacquetConfig = config.leak();

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -309,15 +309,22 @@ fn intern_config(
         .map(|overrides| overrides.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect());
 
     // The protocol carries no `autoInstallPeers` / `dedupePeers` /
-    // `excludeLinksFromLockfile`, but an input lockfile records the values
-    // it was written under. Adopting them makes the server resolve as the
-    // client would; leaving the server's own defaults in place would make
-    // the frozen path reject a lockfile that is valid for its owner, since
-    // the freshness gate compares these against the config.
+    // `excludeLinksFromLockfile`, so the server's own defaults would
+    // otherwise decide them. On a frozen request the input lockfile is the
+    // contract — nothing is re-resolved, and the freshness gate compares
+    // these three against the config — so its recorded values are the ones
+    // to honor; the server's defaults would reject a lockfile that is
+    // valid for its owner.
+    //
+    // A request that may update resolutions keeps the server defaults: the
+    // lockfile records what the *last* install used, which is stale exactly
+    // when the client has just changed one of these. Neither value is the
+    // client's current setting, and only the protocol can carry that
+    // ([pnpm/pnpm#13389](https://github.com/pnpm/pnpm/issues/13389)).
     let lockfile_settings = request
-        .lockfile
-        .as_ref()
-        .and_then(|lockfile| lockfile.settings.as_ref())
+        .frozen_lockfile
+        .then(|| request.lockfile.as_ref()?.settings.as_ref())
+        .flatten()
         .map(AdoptedLockfileSettings::from);
 
     let key = serde_json::json!({

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -283,8 +283,18 @@ fn intern_config(
         .as_ref()
         .map(|overrides| overrides.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect());
 
+    // The protocol carries no `autoInstallPeers` / `dedupePeers` /
+    // `excludeLinksFromLockfile`, but an input lockfile records the values
+    // it was written under. Adopting them makes the server resolve as the
+    // client would; leaving the server's own defaults in place would make
+    // the frozen path reject a lockfile that is valid for its owner, since
+    // the freshness gate compares these against the config.
+    let lockfile_settings =
+        request.lockfile.as_ref().and_then(|lockfile| lockfile.settings.as_ref());
+
     let key = serde_json::json!({
         "registry": registry,
+        "lockfileSettings": lockfile_settings,
         "namedRegistries": request.named_registries,
         "overrides": overrides_key,
         "minimumReleaseAge": request.minimum_release_age,
@@ -328,6 +338,12 @@ fn intern_config(
     config.trust_policy = request.trust_policy;
     config.trust_policy_exclude.clone_from(&request.trust_policy_exclude);
     config.trust_policy_ignore_after = request.trust_policy_ignore_after;
+    if let Some(settings) = lockfile_settings {
+        config.auto_install_peers = settings.auto_install_peers;
+        // Written only while the setting is on, so an absent key is `false`.
+        config.dedupe_peers = settings.dedupe_peers.unwrap_or(false);
+        config.exclude_links_from_lockfile = settings.exclude_links_from_lockfile;
+    }
     let config: &'static PacquetConfig = config.leak();
     configs.insert(key, config);
     Some(config)

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -12,8 +12,11 @@ use std::{
 };
 
 use dashmap::DashMap;
+use pacquet_catalogs_types::Catalogs;
 use pacquet_config::{Config, NodeLinker};
-use pacquet_lockfile::{Lockfile, check_lockfile_settings, satisfies_package_manifest};
+use pacquet_lockfile::{
+    Lockfile, LockfileSettingsCheck, check_lockfile_settings, satisfies_package_manifest,
+};
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manager::{Install, ResolutionObserver, ResolvedPackages};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
@@ -270,12 +273,18 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
     let lockfile = request.lockfile.as_ref()?;
     check_lockfile_settings(
         lockfile,
-        None,
-        None,
-        None,
-        None,
-        config.inject_workspace_packages,
-        config.peers_suffix_max_length,
+        LockfileSettingsCheck {
+            catalogs: &Catalogs::new(),
+            overrides: None,
+            package_extensions_checksum: None,
+            ignored_optional_dependencies: None,
+            patched_dependencies: None,
+            auto_install_peers: config.auto_install_peers,
+            dedupe_peers: config.dedupe_peers,
+            exclude_links_from_lockfile: config.exclude_links_from_lockfile,
+            inject_workspace_packages: config.inject_workspace_packages,
+            peers_suffix_max_length: config.peers_suffix_max_length,
+        },
     )
     .ok()?;
 

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -271,10 +271,15 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
     }
 
     let lockfile = request.lockfile.as_ref()?;
+    // The request's catalogs are the effective ones — they are what the
+    // install below resolves `catalog:` specifiers against. Checking the
+    // lockfile's snapshot against an empty set instead would call every
+    // catalog-bearing lockfile stale and cost them this short-circuit.
+    let no_catalogs = Catalogs::new();
     check_lockfile_settings(
         lockfile,
         LockfileSettingsCheck {
-            catalogs: &Catalogs::new(),
+            catalogs: request.catalogs.as_ref().unwrap_or(&no_catalogs),
             overrides: None,
             package_extensions_checksum: None,
             ignored_optional_dependencies: None,

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -1084,6 +1084,43 @@ fn intern_config_adopts_the_input_lockfile_settings() {
     assert!(!defaults.exclude_links_from_lockfile);
 }
 
+/// Only the three adopted fields may reach the interning key. The rest of
+/// the `settings` block doesn't change the config, and keying on it would
+/// let a caller mint a distinct leaked config per value —
+/// `peersSuffixMaxLength` is a `u64` — until `MAX_INTERNED_CONFIGS` is
+/// spent and every caller is refused.
+#[test]
+fn intern_config_ignores_lockfile_settings_it_does_not_adopt() {
+    use super::intern_config;
+    use pacquet_store_dir::StoreDir;
+    use std::{collections::HashMap, path::PathBuf, sync::Mutex};
+
+    let configs = Mutex::new(HashMap::new());
+    let store_dir = StoreDir::new(PathBuf::from("/tmp/pnpr-unadopted-settings-store"));
+    let cache_dir = PathBuf::from("/tmp/pnpr-unadopted-settings-cache");
+    let request = |peers_suffix_max_length: u64| ResolveRequest {
+        registry: Some("https://a.test/".to_string()),
+        lockfile: Some(Lockfile {
+            settings: Some(pacquet_lockfile::LockfileSettings {
+                peers_suffix_max_length: Some(peers_suffix_max_length),
+                ..pacquet_lockfile::LockfileSettings::default()
+            }),
+            ..lockfile("1.0.0")
+        }),
+        ..ResolveRequest::default()
+    };
+    // A cap of one: a second distinct key would be refused outright.
+    let intern = |request: &ResolveRequest| {
+        intern_config(&configs, &store_dir, &cache_dir, request, 1, usize::MAX)
+    };
+
+    assert!(intern(&request(1000)).is_some());
+    assert!(
+        intern(&request(10)).is_some(),
+        "a field the config never reads must not mint a second interned config",
+    );
+}
+
 #[test]
 fn intern_config_caps_distinct_leaked_configs_but_keeps_serving_known_ones() {
     use super::intern_config;

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -1040,6 +1040,50 @@ fn tarball_url_version_extracts_conventional_names_only() {
     assert_eq!(tarball_url_version("https://r/foo/-/foo.tgz", "foo"), None);
 }
 
+/// The resolve protocol carries no `autoInstallPeers` / `dedupePeers` /
+/// `excludeLinksFromLockfile`, so a request's config would otherwise
+/// resolve — and compare its frozen lockfile — under the server's
+/// defaults. The input lockfile records what its owner used, and the
+/// freshness gate rejects a lockfile whose settings disagree, so those
+/// values have to reach the config.
+#[test]
+fn intern_config_adopts_the_input_lockfile_settings() {
+    use super::intern_config;
+    use pacquet_store_dir::StoreDir;
+    use std::{collections::HashMap, path::PathBuf, sync::Mutex};
+
+    let configs = Mutex::new(HashMap::new());
+    let store_dir = StoreDir::new(PathBuf::from("/tmp/pnpr-lockfile-settings-store"));
+    let cache_dir = PathBuf::from("/tmp/pnpr-lockfile-settings-cache");
+    let request = |settings: Option<pacquet_lockfile::LockfileSettings>| ResolveRequest {
+        registry: Some("https://a.test/".to_string()),
+        lockfile: Some(Lockfile { settings, ..lockfile("1.0.0") }),
+        ..ResolveRequest::default()
+    };
+    let intern = |request: &ResolveRequest| {
+        intern_config(&configs, &store_dir, &cache_dir, request, 10, usize::MAX)
+            .expect("intern config")
+    };
+
+    let client_settings = pacquet_lockfile::LockfileSettings {
+        auto_install_peers: false,
+        dedupe_peers: Some(true),
+        exclude_links_from_lockfile: true,
+        ..pacquet_lockfile::LockfileSettings::default()
+    };
+    let adopted = intern(&request(Some(client_settings)));
+    assert!(!adopted.auto_install_peers);
+    assert!(adopted.dedupe_peers);
+    assert!(adopted.exclude_links_from_lockfile);
+
+    // A lockfile with no `settings` block says nothing, so the server's
+    // own defaults stand — and the two must not share an interned config.
+    let defaults = intern(&request(None));
+    assert!(defaults.auto_install_peers);
+    assert!(!defaults.dedupe_peers);
+    assert!(!defaults.exclude_links_from_lockfile);
+}
+
 #[test]
 fn intern_config_caps_distinct_leaked_configs_but_keeps_serving_known_ones() {
     use super::intern_config;

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -1058,6 +1058,7 @@ fn intern_config_adopts_the_input_lockfile_settings() {
     let request = |settings: Option<pacquet_lockfile::LockfileSettings>| ResolveRequest {
         registry: Some("https://a.test/".to_string()),
         lockfile: Some(Lockfile { settings, ..lockfile("1.0.0") }),
+        frozen_lockfile: true,
         ..ResolveRequest::default()
     };
     let intern = |request: &ResolveRequest| {
@@ -1084,6 +1085,40 @@ fn intern_config_adopts_the_input_lockfile_settings() {
     assert!(!defaults.exclude_links_from_lockfile);
 }
 
+/// A request that may update resolutions resolves under the server's
+/// settings, not the lockfile's: the lockfile records what the last
+/// install used, which is stale precisely when the client has just
+/// changed one. Nothing in the request carries the client's current
+/// value, so the frozen contract is the only place adoption is sound.
+#[test]
+fn intern_config_adopts_lockfile_settings_only_for_a_frozen_request() {
+    use super::intern_config;
+    use pacquet_store_dir::StoreDir;
+    use std::{collections::HashMap, path::PathBuf, sync::Mutex};
+
+    let configs = Mutex::new(HashMap::new());
+    let store_dir = StoreDir::new(PathBuf::from("/tmp/pnpr-update-settings-store"));
+    let cache_dir = PathBuf::from("/tmp/pnpr-update-settings-cache");
+    let request = ResolveRequest {
+        registry: Some("https://a.test/".to_string()),
+        lockfile: Some(Lockfile {
+            settings: Some(pacquet_lockfile::LockfileSettings {
+                auto_install_peers: false,
+                exclude_links_from_lockfile: true,
+                ..pacquet_lockfile::LockfileSettings::default()
+            }),
+            ..lockfile("1.0.0")
+        }),
+        frozen_lockfile: false,
+        ..ResolveRequest::default()
+    };
+
+    let config = intern_config(&configs, &store_dir, &cache_dir, &request, 10, usize::MAX)
+        .expect("intern config");
+    assert!(config.auto_install_peers);
+    assert!(!config.exclude_links_from_lockfile);
+}
+
 /// Only the three adopted fields may reach the interning key. The rest of
 /// the `settings` block doesn't change the config, and keying on it would
 /// let a caller mint a distinct leaked config per value —
@@ -1100,6 +1135,7 @@ fn intern_config_ignores_lockfile_settings_it_does_not_adopt() {
     let cache_dir = PathBuf::from("/tmp/pnpr-unadopted-settings-cache");
     let request = |peers_suffix_max_length: u64| ResolveRequest {
         registry: Some("https://a.test/".to_string()),
+        frozen_lockfile: true,
         lockfile: Some(Lockfile {
             settings: Some(pacquet_lockfile::LockfileSettings {
                 peers_suffix_max_length: Some(peers_suffix_max_length),


### PR DESCRIPTION
## Summary

Closes the error-code half of item 1 of pnpm/pnpm#13315 — with one field left over, filed as pnpm/pnpm#13385.

pnpm's `getOutdatedLockfileSetting` names eleven fields whose drift makes a lockfile unreproducible, and refuses a frozen install with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` naming the first one that drifted. pacquet compared seven of them. Three of the four it skipped are checkable with what the freshness gate already has:

```sh
# lockfile written with the defaults, then the setting flipped
printf 'packages: []\nautoInstallPeers: false\n' > pnpm-workspace.yaml

$ pnpm@11 install --frozen-lockfile
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation. The current "settings.autoInstallPeers" configuration doesn't match the value found in the lockfile

$ pnpm@12 install --frozen-lockfile     # before
Done in 228ms using pnpm v12.0.0-alpha.21
```

Same for `dedupePeers` and `excludeLinksFromLockfile`. The install went ahead against a lockfile whose recorded resolution no longer matched the settings that produced it — `autoInstallPeers` decides whether peers are folded into the importer snapshot, and `excludeLinksFromLockfile` decides whether `link:` deps are recorded at all.

Each comparison follows pnpm's exactly: `autoInstallPeers` and `excludeLinksFromLockfile` are checked only when the lockfile records a `settings` block, since a lockfile written before the field says nothing about it, while `dedupePeers` is written only while it is on, so an absent key reads as `false`.

### Order matters too

Only the first drifted field is reported, so the comparison order decides which name the user sees. pacquet checked `injectWorkspacePackages` where pnpm checks `autoInstallPeers`, and pnpm checks `injectWorkspacePackages` last. The fields are now compared in pnpm's order, and a test pins the case where two fields drift at once.

### Not in this PR

`pnpmfileChecksum`, the eleventh field, stays unchecked. pnpm records it only when a loaded pnpmfile exports a `hooks` object, so telling "no pnpmfile" from "a pnpmfile with no hooks" means evaluating it through the Node worker — on `check_lockfile_settings_drift`, which is sync and is also what the repeat-install fast path calls to stay cheap. Wiring `None` there instead would fail every frozen install in a project that has a pnpmfile, so it needs its own decision about loading the pnpmfile on those paths. Filed as pnpm/pnpm#13385 with the repro.

### The pnpr side (added in review)

The resolve protocol carries none of these three settings, so pnpr's per-request config kept the server's own defaults for them — and once the freshness gate compares them, a frozen request whose lockfile was written under any non-default value would be rejected against settings its owner never chose. On a frozen request the input lockfile is the contract (nothing is re-resolved, and the gate checks it against the config), so `intern_config` adopts the values it records.

Update-capable requests keep the server's defaults, unchanged by this PR: there the lockfile records what the *last* install used, which is stale exactly when the client has just changed one of these, and the server would keep resolving under the old value. Neither is the client's current setting — only the protocol can carry that, filed as pnpm/pnpm#13389.

Two follow-ups from review on that: the interning key carries only the three adopted fields (keying on the whole `settings` block would let a caller mint a distinct leaked config per `peersSuffixMaxLength` value and exhaust `MAX_INTERNED_CONFIGS`, after which no caller gets a config at all), and the frozen short-circuit now checks the lockfile's `catalogs` snapshot against the request's catalogs instead of an empty set — a pre-existing bug that cost every catalog-bearing lockfile its short-circuit.

### One cleanup

`check_lockfile_settings` now takes the options struct its catalog-aware twin took, and the twin is gone. The two had drifted into different field sets, and that is precisely what let `catalogs` be added to one of them while pnpr's call site kept passing the older, shorter list.

## Verification

pnpm 11 and pacquet now produce the same line for each of the three, naming the same setting. A pacquet-written lockfile still passes its own `--frozen-lockfile` install, which is the regression this class of check risks.

Unit tests cover each new comparison, the "no `settings` block can't drift" case, and the report-order case; a CLI test pins the diagnostic code and the quoted setting name end to end. Breaking the `autoInstallPeers` comparison fails it.

`cargo nextest run` over `pacquet-lockfile` (252), `pacquet-package-manager` (800), `pacquet-cli` + `pnpr` (2925), plus clippy, `cargo doc`, and dylint: clean.

## Squash Commit Body

```text
`getOutdatedLockfileSetting` names eleven fields whose drift makes the
lockfile unreproducible; pacquet compared seven. A project that flipped
`autoInstallPeers`, `dedupePeers`, or `excludeLinksFromLockfile` after
writing its lockfile got a clean `--frozen-lockfile` install from
pacquet and `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` from pnpm — the install
proceeded against a lockfile whose recorded resolution no longer
matched the settings that produced it.

Each comparison follows pnpm's: `autoInstallPeers` and
`excludeLinksFromLockfile` are checked only when the lockfile records a
`settings` block, since one written before the field says nothing about
it, while `dedupePeers` is written only while it is on, so an absent key
reads as `false`.

The fields are now compared in pnpm's order too. Only the first drifted
field is reported, so the order decides which name a user sees, and
`injectWorkspacePackages` sat where pnpm checks `autoInstallPeers`.

`pnpmfileChecksum`, the eleventh field, is still unchecked: it needs the
pnpmfile's hooks gate, which means loading the pnpmfile through the Node
worker on a path that deliberately avoids it. Filed as pnpm/pnpm#13385.

`check_lockfile_settings` takes the same options struct its catalog-aware
twin took, and the twin is gone — the two had drifted into different
field sets, which is what let the new fields be added to one and missed
at the other's call site.

Closes the error-code half of item 1 of pnpm/pnpm#13315.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (TypeScript already refuses these installs; this is the pacquet side.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787613634&installation_model_id=426870&pr_number=13386&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13386&signature=12919e72a6c01b8f38c960105fdf99ada3ab11c7970de18dc49e13f0a11867df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Frozen installs now detect changes to `autoInstallPeers`, `dedupePeers`, and `excludeLinksFromLockfile`.
  * Error messages identify the specific setting that differs from the lockfile.
  * Lockfile settings are consistently respected during frozen installation checks.
* **Tests**
  * Added coverage for settings drift, detection precedence, and lockfile-only frozen installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

