### PR TITLE
fix(deps-resolver): close the peer-context divergences on large workspaces

### DIFF
--- a/.changeset/peer-shadowed-deps-in-parent-scope.md
+++ b/.changeset/peer-shadowed-deps-in-parent-scope.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer nests a copy of a dependency that the package also declares as a peer, when the parent already supplies that name. This is what pnpm 11 does with `autoInstallPeers` disabled, and the divergence showed up in large workspaces such as [Astro](https://github.com/withastro/astro) as duplicated peer-suffixed variants in `pnpm-lock.yaml` [#13334](https://github.com/pnpm/pnpm/issues/13334).

--- a/.changeset/peer-shadowed-deps-in-parent-scope.md
+++ b/.changeset/peer-shadowed-deps-in-parent-scope.md
@@ -2,4 +2,7 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer nests a copy of a dependency that the package also declares as a peer, when the parent already supplies that name. This is what pnpm 11 does with `autoInstallPeers` disabled, and the divergence showed up in large workspaces such as [Astro](https://github.com/withastro/astro) as duplicated peer-suffixed variants in `pnpm-lock.yaml` [#13334](https://github.com/pnpm/pnpm/issues/13334).
+Two `pnpm install` peer-resolution fixes that made large workspaces such as [Astro](https://github.com/withastro/astro) produce a different `pnpm-lock.yaml` than pnpm 11 [#13334](https://github.com/pnpm/pnpm/issues/13334):
+
+- A package that declares the same name in both `dependencies` and `peerDependencies` no longer gets a nested copy of it when the parent already supplies that name, which is what pnpm does with `autoInstallPeers` disabled. The nested copy hid the peer, so the package was recorded without the peer context it resolves in.
+- A duplicate peer-suffixed variant that collapses into a larger, compatible one now collapses everywhere it is referenced. A variant kept alive by a single consumer's edge no longer lingers in the lockfile.

--- a/pnpm/crates/resolving-deps-resolver/src/dedupe_peer_dependents.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dedupe_peer_dependents.rs
@@ -20,12 +20,12 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use pacquet_deps_path::{DepPath, index_of_dep_path_suffix};
+use pacquet_deps_path::DepPath;
 
 use crate::{
     dedupe_injected_deps::{DirectByImporter, prune_unreachable},
     dep_path_compatibility::{is_compatible_and_has_more_deps, node_deps_count},
-    dependencies_graph::{DependenciesGraph, DependenciesGraphNode},
+    dependencies_graph::DependenciesGraph,
 };
 
 /// Collapse peer-dependent duplicate variants in `graph` into their
@@ -88,17 +88,9 @@ fn deduplicate_all(
     if remaining_duplicates.len() == duplicates_count {
         return dep_paths_map;
     }
-    let collapsed_target_peer_info = collapsed_target_peer_info(graph, dep_paths_map.values());
     for node in graph.values_mut() {
-        let parent_peer_names = compatible_peer_names_for_parent(node);
         for child_dep_path in node.children.values_mut() {
-            if let Some(target) = dep_paths_map.get(child_dep_path)
-                && collapsed_target_matches_parent(
-                    &collapsed_target_peer_info,
-                    target,
-                    &parent_peer_names,
-                )
-            {
+            if let Some(target) = dep_paths_map.get(child_dep_path) {
                 *child_dep_path = target.clone();
             }
         }
@@ -164,136 +156,6 @@ fn deduplicate_dep_paths(
     }
 
     (dep_paths_map, remaining_duplicates)
-}
-
-fn collapsed_target_matches_parent(
-    collapsed_target_peer_info: &HashMap<DepPath, CollapsedTargetPeerInfo>,
-    target: &DepPath,
-    parent_peer_names: &HashSet<String>,
-) -> bool {
-    let Some(info) = collapsed_target_peer_info.get(target) else {
-        return true;
-    };
-    info.peer_names.iter().all(|name| {
-        parent_peer_names.contains(name)
-            || info.transitive_peer_dependencies.contains(name)
-            || info.peer_child_is_compatible_with_parent(name, parent_peer_names)
-    })
-}
-
-fn collapsed_target_peer_info<'a>(
-    graph: &DependenciesGraph,
-    targets: impl Iterator<Item = &'a DepPath>,
-) -> HashMap<DepPath, CollapsedTargetPeerInfo> {
-    targets
-        .filter_map(|target| {
-            let node = graph.get(target)?;
-            Some((
-                target.clone(),
-                CollapsedTargetPeerInfo {
-                    package_name: package_name_from_pkg_id(&node.resolved_package_id),
-                    peer_names: dep_path_peer_names(target),
-                    transitive_peer_dependencies: node.transitive_peer_dependencies.clone(),
-                    child_peer_names: child_peer_names(node),
-                },
-            ))
-        })
-        .collect()
-}
-
-struct CollapsedTargetPeerInfo {
-    package_name: String,
-    peer_names: HashSet<String>,
-    transitive_peer_dependencies: HashSet<String>,
-    child_peer_names: HashMap<String, HashSet<String>>,
-}
-
-impl CollapsedTargetPeerInfo {
-    fn peer_child_is_compatible_with_parent(
-        &self,
-        name: &str,
-        parent_peer_names: &HashSet<String>,
-    ) -> bool {
-        self.child_peer_names.get(name).is_some_and(|peer_names| {
-            peer_names.is_empty()
-                || (peer_names.contains(&self.package_name)
-                    && peer_names.iter().all(|peer_name| {
-                        peer_name == &self.package_name
-                            || parent_peer_names.contains(peer_name)
-                            || self.transitive_peer_dependencies.contains(peer_name)
-                    }))
-        })
-    }
-}
-
-fn child_peer_names(node: &DependenciesGraphNode) -> HashMap<String, HashSet<String>> {
-    node.children.iter().map(|(alias, child)| (alias.clone(), dep_path_peer_names(child))).collect()
-}
-
-fn compatible_peer_names_for_parent(node: &DependenciesGraphNode) -> HashSet<String> {
-    let mut names = dep_path_peer_names(&node.dep_path);
-    names.insert(package_name_from_pkg_id(&node.resolved_package_id));
-    names
-}
-
-fn package_name_from_pkg_id(pkg_id: &str) -> String {
-    pkg_id.rfind('@').map_or_else(|| pkg_id.to_string(), |index| pkg_id[..index].to_string())
-}
-
-fn dep_path_peer_names(dep_path: &DepPath) -> HashSet<String> {
-    let mut names = HashSet::new();
-    collect_peer_names(dep_path.as_str(), &mut names);
-    names
-}
-
-fn collect_peer_names(raw: &str, names: &mut HashSet<String>) {
-    let suffix = index_of_dep_path_suffix(raw);
-    let Some(peers_index) = suffix.peers_index else { return };
-    let Some(segments) = split_peer_suffix_segments(&raw[peers_index..]) else {
-        return;
-    };
-    for segment in segments {
-        if let Some(name) = peer_segment_name(&segment) {
-            names.insert(name.to_string());
-        }
-        collect_peer_names(&segment, names);
-    }
-}
-
-fn split_peer_suffix_segments(suffix: &str) -> Option<Vec<String>> {
-    let bytes = suffix.as_bytes();
-    let mut segments = Vec::new();
-    let mut depth = 0i32;
-    let mut start = None;
-    for (idx, byte) in bytes.iter().enumerate() {
-        match byte {
-            b'(' => {
-                if depth == 0 {
-                    start = Some(idx + 1);
-                }
-                depth += 1;
-            }
-            b')' => {
-                depth -= 1;
-                if depth < 0 {
-                    return None;
-                }
-                if depth == 0 {
-                    let start = start.take()?;
-                    segments.push(suffix[start..idx].to_string());
-                }
-            }
-            _ => {}
-        }
-    }
-    (depth == 0).then_some(segments)
-}
-
-fn peer_segment_name(segment: &str) -> Option<&str> {
-    let head_end = segment.find('(').unwrap_or(segment.len());
-    let head = &segment[..head_end];
-    let version_at = head.rfind('@')?;
-    (version_at > 0).then_some(&head[..version_at])
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/dedupe_peer_dependents/tests.rs
@@ -1,4 +1,4 @@
-use super::{DirectByImporter, dedupe_peer_dependents, deduplicate_dep_paths, dep_path_peer_names};
+use super::{DirectByImporter, dedupe_peer_dependents, deduplicate_dep_paths};
 use crate::dependencies_graph::{DependenciesGraph, DependenciesGraphNode};
 use pacquet_deps_path::DepPath;
 use pacquet_lockfile::{DirectoryResolution, LockfileResolution};
@@ -10,26 +10,6 @@ use std::{
 
 fn dp(raw: &str) -> DepPath {
     DepPath::from(raw.to_string())
-}
-
-#[test]
-fn collects_peer_names_after_patch_hash() {
-    let dep_path = dp(concat!(
-        "@medusajs/workflows-sdk@2.13.3",
-        "(patch_hash=248195172cff27c28650c005b6aa0aa3b2f2976f9739544b360b81668f2d8b59)",
-        "(@types/node@20.19.17)",
-        "(better-sqlite3@12.8.0)",
-        "(express@4.21.2)",
-    ));
-
-    assert_eq!(
-        dep_path_peer_names(&dep_path),
-        HashSet::from([
-            "@types/node".to_string(),
-            "better-sqlite3".to_string(),
-            "express".to_string(),
-        ]),
-    );
 }
 
 fn make_node(
@@ -189,8 +169,13 @@ fn does_not_collapse_across_incompatible_peer_versions() {
     assert_eq!(direct["project3"]["foo"], direct["project4"]["foo"]);
 }
 
+/// Every reference to a collapsed variant is rewritten, including a
+/// consumer's child edge whose own peer suffix names the collapsed
+/// variant — pnpm's `deduplicateAll` rewrites `node.children`
+/// unconditionally, and leaving one edge behind keeps the collapsed
+/// variant alive in the lockfile.
 #[test]
-fn direct_dep_collapses_but_parent_edge_keeps_incompatible_peer_variant() {
+fn a_consumers_child_edge_follows_the_collapse() {
     let subset = "foo@1.0.0(bar@1.0.0)";
     let larger = "foo@1.0.0(bar@1.0.0)(baz@1.0.0)";
     let baz = "baz@1.0.0(qux@1.0.0)";
@@ -228,8 +213,8 @@ fn direct_dep_collapses_but_parent_edge_keeps_incompatible_peer_variant() {
 
     assert_eq!(direct["project-subset"]["foo"], dp(larger));
     assert_eq!(direct["project-larger"]["foo"], dp(larger));
-    assert_eq!(graph[&dp(consumer)].children["foo"], dp(subset));
-    assert!(graph.contains_key(&dp(subset)));
+    assert_eq!(graph[&dp(consumer)].children["foo"], dp(larger));
+    assert!(!graph.contains_key(&dp(subset)), "the collapsed variant has no reference left");
     assert!(graph.contains_key(&dp(larger)));
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lib.rs
@@ -68,6 +68,7 @@ mod dependencies_graph;
 mod hoist_peers;
 mod lockfile_reuse;
 mod node_id;
+mod parent_pkg_aliases;
 mod resolve_dependency_tree;
 mod resolve_importer;
 mod resolve_peers;
@@ -85,6 +86,7 @@ pub use hoist_peers::{
 };
 pub use node_id::NodeId;
 pub use pacquet_deps_path::DepPath;
+pub use parent_pkg_aliases::ParentPkgAliases;
 pub use resolve_dependency_tree::{
     Deprecation, DeprecationLogFn, ManifestHook, ResolveDependencyTreeError,
     ResolveDependencyTreeOptions, SkippedOptionalDependency, SkippedOptionalDependencyParent,

--- a/pnpm/crates/resolving-deps-resolver/src/parent_pkg_aliases.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/parent_pkg_aliases.rs
@@ -1,0 +1,81 @@
+//! The dependency names visible in a resolving parent's scope.
+//!
+//! pnpm's `options.parentPkgAliases` (`resolveDependencies.ts`) is the
+//! union of every alias resolved at the levels *above* the one being
+//! resolved: the importer's wanted dependencies, then each level's
+//! resolved children as the walk descends. A package whose
+//! `peerDependencies` name is already in that scope drops the
+//! same-named entry from its own `dependencies`, so the peer edge —
+//! satisfied from an ancestor — supplies the package instead of a
+//! nested copy.
+//!
+//! Upstream rebuilds the whole map per level (`{ ...parentPkgAliases,
+//! ...currentParentPkgAliases }`). Here the levels are chained instead,
+//! so extending a scope costs one level's aliases rather than a copy of
+//! everything above it; only membership is ever asked of it.
+
+use serde_json::Value;
+use std::{collections::HashSet, sync::Arc};
+
+/// One level's aliases, chained onto the levels above it.
+#[derive(Debug, Default)]
+pub struct ParentPkgAliases {
+    names: HashSet<String>,
+    parent: Option<Arc<ParentPkgAliases>>,
+}
+
+impl ParentPkgAliases {
+    /// The scope an importer's own direct dependencies resolve in: the
+    /// aliases it declares. pnpm seeds `parentPkgAliases` from the
+    /// importer's wanted dependencies and keeps adding to it — resolved
+    /// direct deps, then every hoisted peer — as the hoist rounds run.
+    #[must_use]
+    pub fn root(names: HashSet<String>) -> Arc<Self> {
+        Arc::new(ParentPkgAliases { names, parent: None })
+    }
+
+    /// The scope the children of `self`'s level resolve in.
+    #[must_use]
+    pub fn extend(self: &Arc<Self>, names: HashSet<String>) -> Arc<Self> {
+        Arc::new(ParentPkgAliases { names, parent: Some(Arc::clone(self)) })
+    }
+
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        let mut level = Some(self);
+        while let Some(current) = level {
+            if current.names.contains(name) {
+                return true;
+            }
+            level = current.parent.as_deref();
+        }
+        false
+    }
+}
+
+/// The `dependencies` entries of `manifest` that its own
+/// `peerDependencies` shadow, and that the peer edge therefore supplies
+/// instead. Under `auto_install_peers` every shadowed name is dropped
+/// (the peer is auto-installed at the importer, so it always resolves);
+/// otherwise only the names already resolvable from
+/// `parent_pkg_aliases`, since dropping a peer nothing in scope
+/// provides would leave it unsatisfied.
+pub(crate) fn peer_shadowed_dependencies(
+    manifest: Option<&Value>,
+    parent_pkg_aliases: &ParentPkgAliases,
+    auto_install_peers: bool,
+) -> HashSet<String> {
+    let Some(manifest) = manifest else { return HashSet::new() };
+    let object = |key| manifest.get(key).and_then(Value::as_object);
+    let (Some(peers), Some(deps)) = (object("peerDependencies"), object("dependencies")) else {
+        return HashSet::new();
+    };
+    deps.keys()
+        .filter(|name| peers.contains_key(*name))
+        .filter(|name| auto_install_peers || parent_pkg_aliases.contains(name))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/resolving-deps-resolver/src/parent_pkg_aliases/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/parent_pkg_aliases/tests.rs
@@ -1,0 +1,56 @@
+use std::collections::HashSet;
+
+use super::{ParentPkgAliases, peer_shadowed_dependencies};
+
+fn names<const COUNT: usize>(names: [&str; COUNT]) -> HashSet<String> {
+    names.into_iter().map(str::to_string).collect()
+}
+
+#[test]
+fn a_level_sees_every_alias_above_it() {
+    let root = ParentPkgAliases::root(names(["root-dep"]));
+    let level1 = root.extend(names(["child"]));
+    let level2 = level1.extend(names(["grandchild"]));
+
+    assert!(level2.contains("root-dep"));
+    assert!(level2.contains("child"));
+    assert!(level2.contains("grandchild"));
+    assert!(!level2.contains("unrelated"));
+    assert!(!root.contains("child"), "a level's aliases stay out of the scopes above it");
+}
+
+#[test]
+fn only_in_scope_peers_shadow_the_own_dependency() {
+    let manifest = serde_json::json!({
+        "dependencies": { "in-scope": "^1.0.0", "out-of-scope": "^1.0.0", "not-a-peer": "^1.0.0" },
+        "peerDependencies": { "in-scope": "*", "out-of-scope": "*" },
+    });
+    let scope = ParentPkgAliases::root(names(["in-scope"]));
+
+    assert_eq!(peer_shadowed_dependencies(Some(&manifest), &scope, false), names(["in-scope"]));
+}
+
+#[test]
+fn auto_install_peers_shadows_every_own_dependency() {
+    let manifest = serde_json::json!({
+        "dependencies": { "in-scope": "^1.0.0", "out-of-scope": "^1.0.0" },
+        "peerDependencies": { "in-scope": "*", "out-of-scope": "*" },
+    });
+    let scope = ParentPkgAliases::root(names(["in-scope"]));
+
+    assert_eq!(
+        peer_shadowed_dependencies(Some(&manifest), &scope, true),
+        names(["in-scope", "out-of-scope"]),
+    );
+}
+
+#[test]
+fn a_manifest_without_both_sections_shadows_nothing() {
+    let scope = ParentPkgAliases::root(names(["dep"]));
+    let peers_only = serde_json::json!({ "peerDependencies": { "dep": "*" } });
+    let deps_only = serde_json::json!({ "dependencies": { "dep": "^1.0.0" } });
+
+    assert!(peer_shadowed_dependencies(None, &scope, true).is_empty());
+    assert!(peer_shadowed_dependencies(Some(&peers_only), &scope, true).is_empty());
+    assert!(peer_shadowed_dependencies(Some(&deps_only), &scope, true).is_empty());
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1842,6 +1842,11 @@ where
     let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
+    // The claim is taken while holding the `packages` lock so claims and
+    // envelope writes stay in the same order: an occurrence that lost the
+    // claim in between would otherwise leave its peer set on an envelope
+    // whose children the winning occurrence walked.
+    let mut packages = lock_recoverable(&ctx.workspace.packages);
     let children_owner = claim_children_owner(
         ctx,
         &id,
@@ -1853,13 +1858,11 @@ where
             ctx.workspace.auto_install_peers,
         ),
     );
-
     let peer_dependencies = if is_link {
         BTreeMap::new()
     } else {
         extract_peer_dependencies(&result, &children_owner.peer_shadowed)
     };
-    let mut packages = lock_recoverable(&ctx.workspace.packages);
     if let Some(existing) = packages.get_mut(&id) {
         existing.optional = existing.optional && current_is_optional;
         // A fresh claim can shadow a different set of dependencies than

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -40,6 +40,7 @@ use crate::{
         current_pkg_from_lockfile, prior_child_key, reusable_importer_dep, synthesize_reused_result,
     },
     node_id::NodeId,
+    parent_pkg_aliases::{ParentPkgAliases, peer_shadowed_dependencies},
     resolved_tree::{DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree},
 };
 use pacquet_lockfile::{
@@ -411,8 +412,16 @@ where
         wanted.push((name.to_string(), range.to_string(), optional, injected));
     }
     record_changed_direct_deps(&ctx, pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY, &wanted);
-    let direct =
-        extend_tree(&ctx, resolver, wanted, pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY).await?;
+    let parent_pkg_aliases =
+        ParentPkgAliases::root(wanted.iter().map(|(alias, ..)| alias.clone()).collect());
+    let direct = extend_tree(
+        &ctx,
+        resolver,
+        wanted,
+        pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY,
+        &parent_pkg_aliases,
+    )
+    .await?;
     Ok(ctx.into_resolved_tree(direct))
 }
 
@@ -689,6 +698,21 @@ impl ChildrenOwner {
     }
 }
 
+/// What the current children owner of a `pkgIdWithPatchHash` decided
+/// for it. Both halves are per-occurrence inputs the walk has to settle
+/// on one answer for, so they are claimed together, under one lock.
+#[derive(Debug, Clone)]
+struct ChildrenOwnerEntry {
+    owner: ChildrenOwner,
+    /// The owner occurrence's peer-shadowed `dependencies` (see
+    /// [`peer_shadowed_dependencies`]). Which names are shadowed
+    /// depends on the parent scope, which differs per occurrence;
+    /// pnpm lets the first occurrence to resolve decide, which is
+    /// arrival-ordered. The deterministic children owner decides here
+    /// instead, so the same graph always yields the same lockfile.
+    peer_shadowed: Arc<HashSet<String>>,
+}
+
 /// Workspace-shared maps. Every per-importer [`TreeCtx`] in a
 /// multi-importer install holds an `Arc<WorkspaceTreeCtx>` so the
 /// resolver's per-`pkgIdWithPatchHash` dedup (`packages`,
@@ -711,7 +735,7 @@ pub struct WorkspaceTreeCtx {
         Mutex<HashMap<WantedKey, Arc<pacquet_resolving_resolver_base::ResolveResult>>>,
     children_specs_by_id: Mutex<HashMap<String, Arc<Vec<ChildSpec>>>>,
     children_by_id: Mutex<HashMap<String, Arc<Vec<crate::resolved_tree::ChildEdge>>>>,
-    children_owner_by_id: Mutex<HashMap<String, ChildrenOwner>>,
+    children_owner_by_id: Mutex<HashMap<String, ChildrenOwnerEntry>>,
     node_parent_ids_by_id: Mutex<HashMap<NodeId, Arc<Vec<String>>>>,
     manifest_hook: Option<ManifestHook>,
     /// The previous `pnpm-lock.yaml` the install started from, when one
@@ -756,11 +780,9 @@ pub struct WorkspaceTreeCtx {
     /// Re-emits when the same package appears at a shallower depth so a
     /// direct dependency is never misclassified as transitive.
     deprecation_depths: Mutex<HashMap<String, i32>>,
-    /// The install's `autoInstallPeers` setting. When `true`,
-    /// [`fn@resolve_node`] drops a resolved package's `dependencies`
-    /// entries that are shadowed by its own `peerDependencies`, so the
-    /// peer edge supplies the package instead. See
-    /// [`omit_peer_shadowed_dependencies`].
+    /// The install's `autoInstallPeers` setting. It widens which of a
+    /// resolved package's `dependencies` its own `peerDependencies`
+    /// shadow — see [`peer_shadowed_dependencies`].
     auto_install_peers: bool,
     /// Resolved registry map (`"default"` + per-scope) used to
     /// materialize a prior `Registry` lockfile resolution back into its
@@ -908,7 +930,7 @@ impl WorkspaceTreeCtx {
     ) {
         let owners = lock_recoverable(&self.children_owner_by_id).clone();
         let mut record = lock_recoverable(&self.first_walk_missing_by_pkg);
-        for (pkg_id, owner) in &owners {
+        for (pkg_id, ChildrenOwnerEntry { owner, .. }) in &owners {
             if owner.importer_id != importer_id {
                 continue;
             }
@@ -925,7 +947,7 @@ impl WorkspaceTreeCtx {
             }
         }
         for (pkg_id, names) in missing_by_pkg {
-            if owners.get(pkg_id).is_none_or(|owner| owner.importer_id != importer_id) {
+            if owners.get(pkg_id).is_none_or(|entry| entry.owner.importer_id != importer_id) {
                 record.entry(pkg_id.clone()).or_insert_with(|| OwnerMissingRecord {
                     recorded_by: None,
                     names: names.clone(),
@@ -1364,6 +1386,7 @@ pub async fn extend_tree<Chain>(
     resolver: &Chain,
     wanted: Vec<WantedSpec>,
     importer_id: &str,
+    parent_pkg_aliases: &Arc<ParentPkgAliases>,
 ) -> Result<Vec<DirectDep>, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
@@ -1412,6 +1435,7 @@ where
                     reuse,
                     base_overlay,
                     None,
+                    parent_pkg_aliases,
                 )
                 .await?;
                 warm_children_resolutions(ctx, resolver, &seed).await;
@@ -1430,16 +1454,18 @@ where
         ctx.base_opts.preferred_versions_overlay.clone(),
         direct_versions,
     );
+    let children_pkg_aliases = parent_pkg_aliases.extend(level_aliases(&seeds));
     // Phase 2: walk each direct dep's children with the level overlay.
     let results = seeds
         .into_iter()
         .map(|seed| {
             let overlay = children_overlay.clone();
+            let pkg_aliases = Arc::clone(&children_pkg_aliases);
             async move {
                 match seed {
                     NodeSeed::Done(dep) => Ok(dep),
                     NodeSeed::Pending(pending) => {
-                        walk_node_children(ctx, resolver, *pending, overlay).await
+                        walk_node_children(ctx, resolver, *pending, overlay, pkg_aliases).await
                     }
                 }
             }
@@ -1454,6 +1480,17 @@ where
 /// [`fn@walk_node_children`]. Used where per-level preference folding
 /// does not apply — the lockfile-reuse subtree walk, whose versions
 /// are exact pins.
+///
+/// The node's children resolve in the same `parent_pkg_aliases` scope
+/// as the node itself, without this level's own aliases folded in: a
+/// reused subtree takes its children from the lockfile snapshot rather
+/// than from a manifest, so no shadowed dependency can be dropped
+/// inside it, and the narrower scope only ever means one omission
+/// fewer where an edge falls back to a fresh resolve.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "internal walker helper threading per-node context through the recursion"
+)]
 #[async_recursion]
 async fn resolve_node<Chain>(
     ctx: &TreeCtx,
@@ -1463,6 +1500,7 @@ async fn resolve_node<Chain>(
     depth: i32,
     parent_optional: bool,
     reuse: ReuseSource,
+    parent_pkg_aliases: &Arc<ParentPkgAliases>,
 ) -> Result<Option<DirectDep>, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
@@ -1478,12 +1516,20 @@ where
         reuse,
         base_overlay.clone(),
         None,
+        parent_pkg_aliases,
     )
     .await?
     {
         NodeSeed::Done(dep) => Ok(dep),
         NodeSeed::Pending(pending) => {
-            walk_node_children(ctx, resolver, *pending, base_overlay).await
+            walk_node_children(
+                ctx,
+                resolver,
+                *pending,
+                base_overlay,
+                Arc::clone(parent_pkg_aliases),
+            )
+            .await
         }
     }
 }
@@ -1511,6 +1557,8 @@ struct PendingNode {
     /// The deterministic children-ownership claim taken at seed time;
     /// the walk phase re-checks it before recording the children, so
     /// a better-placed occurrence seeded after this one still wins.
+    /// It also carries the peer-shadowed dependency names the walk
+    /// phase filters this package's children by.
     children_owner: ChildrenOwnerClaim,
     depth: i32,
     current_is_optional: bool,
@@ -1542,6 +1590,10 @@ struct PendingNode {
 /// `parent_dir` is the directory of the manifest that declares this
 /// edge, when that manifest is a package resolved from a local
 /// directory — see [`declaring_manifest_dir`].
+///
+/// `parent_pkg_aliases` is the scope this edge's level resolves in; it
+/// decides which of the resolved package's `dependencies` its own
+/// `peerDependencies` shadow (see [`peer_shadowed_dependencies`]).
 #[expect(
     clippy::too_many_arguments,
     reason = "internal walker helper threading per-node context through the recursion"
@@ -1557,6 +1609,7 @@ async fn resolve_node_seed<Chain>(
     reuse: ReuseSource,
     pick_overlay: Option<Arc<PreferredVersionsOverlay>>,
     parent_dir: Option<&Path>,
+    parent_pkg_aliases: &Arc<ParentPkgAliases>,
 ) -> Result<NodeSeed, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
@@ -1594,6 +1647,7 @@ where
             depth,
             current_is_optional,
             reused,
+            parent_pkg_aliases,
         )
         .await
         .map(NodeSeed::Done);
@@ -1765,9 +1819,10 @@ where
     // Build (or look up) the ResolvedPackage envelope. The first
     // visitor populates it; later visitors AND-fold the `optional`
     // flag so a single non-optional path flips it back to `false`.
-    // Child traversal is claimed separately below, so a later
-    // deterministically-better occurrence can replace the shared
-    // `children_by_id` entry without rewriting the package envelope.
+    // Child traversal is claimed first, and a later
+    // deterministically-better occurrence replaces the shared
+    // `children_by_id` entry — plus, since the two are two halves of
+    // one manifest reading, the envelope's peer dependencies.
     // Leaves (no deps / optional deps / peers / peerDependenciesMeta)
     // reuse the package id as their `NodeId`, collapsing every parent
     // edge onto one tree node. Non-leaves still get a fresh per-
@@ -1787,18 +1842,35 @@ where
     let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
+    let children_owner = claim_children_owner(
+        ctx,
+        &id,
+        depth,
+        ancestor_ids,
+        peer_shadowed_dependencies(
+            result.manifest.as_deref(),
+            parent_pkg_aliases,
+            ctx.workspace.auto_install_peers,
+        ),
+    );
+
+    let peer_dependencies = if is_link {
+        BTreeMap::new()
+    } else {
+        extract_peer_dependencies(&result, &children_owner.peer_shadowed)
+    };
     let mut packages = lock_recoverable(&ctx.workspace.packages);
     if let Some(existing) = packages.get_mut(&id) {
         existing.optional = existing.optional && current_is_optional;
-    } else {
-        let peer_dependencies =
-            if is_link { BTreeMap::new() } else { extract_peer_dependencies(&result) };
-        {
-            let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
-            for name in peer_dependencies.keys() {
-                all_peers.insert(name.clone());
-            }
+        // A fresh claim can shadow a different set of dependencies than
+        // the occurrence that populated the envelope did, which moves
+        // names between the package's children and its peers.
+        if children_owner.owns_children && existing.peer_dependencies != peer_dependencies {
+            register_peer_dep_names(ctx, &peer_dependencies);
+            existing.peer_dependencies = peer_dependencies;
         }
+    } else {
+        register_peer_dep_names(ctx, &peer_dependencies);
         packages.insert(
             id.clone(),
             ResolvedPackage {
@@ -1810,13 +1882,13 @@ where
             },
         );
     }
+    drop(packages);
 
     emit_deprecation_if_needed(ctx, &result, &id, depth);
 
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
     let next_ancestors = Arc::new(next_ancestors);
-    let children_owner = claim_children_owner(ctx, &id, depth, ancestor_ids);
 
     Ok(NodeSeed::Pending(Box::new(PendingNode {
         result,
@@ -1836,6 +1908,9 @@ where
 /// overlay covering this node's own level (built by the caller from
 /// every sibling seed); the grandchildren's overlay layers this
 /// node's resolved children on top, extending the per-level fold.
+/// `children_pkg_aliases` follows the same shape: the caller folds this
+/// node's whole level into the scope, and the grandchildren's scope
+/// layers this node's resolved children on top.
 ///
 /// Only the deterministic children owner walks this package's
 /// manifest children. Other occurrences stay lazy and expand from
@@ -1846,6 +1921,7 @@ async fn walk_node_children<Chain>(
     resolver: &Chain,
     pending: PendingNode,
     children_overlay: Option<Arc<PreferredVersionsOverlay>>,
+    children_pkg_aliases: Arc<ParentPkgAliases>,
 ) -> Result<Option<DirectDep>, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
@@ -1886,6 +1962,21 @@ where
                 .or_insert_with(|| Arc::clone(&specs));
             specs
         };
+        // The specs are cached unfiltered because which of them the
+        // package's own `peerDependencies` shadow is a property of the
+        // owner occurrence, not of the manifest.
+        let peer_shadowed = &children_owner.peer_shadowed;
+        let child_specs: Cow<'_, [ChildSpec]> = if peer_shadowed.is_empty() {
+            Cow::Borrowed(child_specs.as_slice())
+        } else {
+            Cow::Owned(
+                child_specs
+                    .iter()
+                    .filter(|(name, _, optional)| *optional || !peer_shadowed.contains(name))
+                    .cloned()
+                    .collect(),
+            )
+        };
         let child_specs =
             if result.resolved_via == "workspace" && result.id.as_str().starts_with("file:") {
                 Cow::Owned(
@@ -1898,7 +1989,7 @@ where
                         .collect::<Result<Vec<_>, _>>()?,
                 )
             } else {
-                Cow::Borrowed(child_specs.as_slice())
+                child_specs
             };
         // An *updated* parent (one that landed on a different version
         // than the lockfile recorded, or a new dep) discards its
@@ -1957,6 +2048,7 @@ where
                 let next_ancestors = Arc::clone(&next_ancestors);
                 let pick_overlay = children_overlay.clone();
                 let declaring_dir = declaring_dir.clone();
+                let parent_pkg_aliases = &children_pkg_aliases;
                 async move {
                     let seed = resolve_node_seed(
                         ctx,
@@ -1968,6 +2060,7 @@ where
                         ReuseSource::Transitive { key: child_prior },
                         pick_overlay,
                         declaring_dir.as_deref(),
+                        parent_pkg_aliases,
                     )
                     .await?;
                     warm_children_resolutions(ctx, resolver, &seed).await;
@@ -1980,17 +2073,19 @@ where
             children_overlay.clone(),
             level_versions(ctx, &child_seeds),
         );
+        let grandchild_pkg_aliases = children_pkg_aliases.extend(level_aliases(&child_seeds));
         // Phase 2: walk each child's own children with the extended
         // overlay.
         let child_results = child_seeds
             .into_iter()
             .map(|seed| {
                 let overlay = grandchild_overlay.clone();
+                let pkg_aliases = Arc::clone(&grandchild_pkg_aliases);
                 async move {
                     match seed {
                         NodeSeed::Done(dep) => Ok(dep),
                         NodeSeed::Pending(pending) => {
-                            walk_node_children(ctx, resolver, *pending, overlay).await
+                            walk_node_children(ctx, resolver, *pending, overlay, pkg_aliases).await
                         }
                     }
                 }
@@ -2185,12 +2280,6 @@ where
         result_inner.manifest = Some(updated);
     }
 
-    if ctx.workspace.auto_install_peers
-        && let Some(manifest) = result_inner.manifest.take()
-    {
-        result_inner.manifest = Some(omit_peer_shadowed_dependencies(manifest));
-    }
-
     let result = result.expect("Some-guarded above");
     // Wrap in `Arc` once so the cache, the per-id
     // `ResolvedPackage` envelope, and the later peer-resolved
@@ -2252,6 +2341,9 @@ where
     let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
     specs
         .iter()
+        .filter(|(name, _, optional)| {
+            *optional || !pending.children_owner.peer_shadowed.contains(name)
+        })
         .map(|(name, range, optional)| {
             let wanted = WantedDependency {
                 alias: Some(name.clone()),
@@ -2289,6 +2381,21 @@ where
         })
         .pipe(future::join_all)
         .await;
+}
+
+/// The install aliases one resolved level contributes to its
+/// children's [`ParentPkgAliases`] scope. An edge the walk dropped (a
+/// cycle re-entry, a skipped optional) contributes nothing, matching
+/// pnpm's fold over the level's resolved addresses.
+fn level_aliases(seeds: &[NodeSeed]) -> HashSet<String> {
+    seeds
+        .iter()
+        .filter_map(|seed| match seed {
+            NodeSeed::Pending(pending) => Some(pending.alias.clone()),
+            NodeSeed::Done(Some(dep)) => Some(dep.alias.clone()),
+            NodeSeed::Done(None) => None,
+        })
+        .collect()
 }
 
 /// The `(name → versions)` additions one resolved level contributes
@@ -2458,13 +2565,21 @@ struct ReusedNode {
 struct ChildrenOwnerClaim {
     owner: ChildrenOwner,
     owns_children: bool,
+    /// The shadowed-dependency set in force for the package id — this
+    /// occurrence's when it won the claim, the standing owner's when it
+    /// lost. See [`ChildrenOwnerEntry::peer_shadowed`].
+    peer_shadowed: Arc<HashSet<String>>,
 }
 
+/// `peer_shadowed` is this occurrence's own set; it is installed as the
+/// package id's set only when the occurrence wins the claim, so the
+/// losing occurrences of a concurrent claim all read back the winner's.
 fn claim_children_owner(
     ctx: &TreeCtx,
     pkg_id: &str,
     depth: i32,
     ancestor_ids: &[String],
+    peer_shadowed: HashSet<String>,
 ) -> ChildrenOwnerClaim {
     let owner = ChildrenOwner {
         update_active: !matches!(ctx.update_reuse_scope(), UpdateReuseScope::All),
@@ -2473,13 +2588,22 @@ fn claim_children_owner(
         parent_path: ancestor_ids.to_vec(),
         importer_id: ctx.importer_id.clone(),
     };
-    let owns_children = {
+    let (owns_children, peer_shadowed) = {
         let mut owners = lock_recoverable(&ctx.workspace.children_owner_by_id);
         match owners.get(pkg_id) {
-            Some(existing) if !owner.wins_over(existing) => false,
+            Some(existing) if !owner.wins_over(&existing.owner) => {
+                (false, Arc::clone(&existing.peer_shadowed))
+            }
             _ => {
-                owners.insert(pkg_id.to_string(), owner.clone());
-                true
+                let peer_shadowed = Arc::new(peer_shadowed);
+                owners.insert(
+                    pkg_id.to_string(),
+                    ChildrenOwnerEntry {
+                        owner: owner.clone(),
+                        peer_shadowed: Arc::clone(&peer_shadowed),
+                    },
+                );
+                (true, peer_shadowed)
             }
         }
     };
@@ -2487,13 +2611,22 @@ fn claim_children_owner(
         lock_recoverable(&ctx.workspace.first_importer_by_pkg)
             .insert(pkg_id.to_string(), owner.importer_id.clone());
     }
-    ChildrenOwnerClaim { owner, owns_children }
+    ChildrenOwnerClaim { owner, owns_children, peer_shadowed }
+}
+
+/// Seed the peer-walker's `parentPkgs` filter with the names a
+/// resolved package declares as peers.
+fn register_peer_dep_names(ctx: &TreeCtx, peer_dependencies: &BTreeMap<String, PeerDep>) {
+    let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
+    for name in peer_dependencies.keys() {
+        all_peers.insert(name.clone());
+    }
 }
 
 fn is_current_children_owner(ctx: &TreeCtx, pkg_id: &str, owner: &ChildrenOwner) -> bool {
     lock_recoverable(&ctx.workspace.children_owner_by_id)
         .get(pkg_id)
-        .is_some_and(|current| current == owner)
+        .is_some_and(|current| current.owner == *owner)
 }
 
 fn remember_node_parent_ids(ctx: &TreeCtx, node_id: &NodeId, parent_ids: Arc<Vec<String>>) {
@@ -2808,6 +2941,10 @@ fn subtree_children_reusable(
 /// [`fn@resolve_node`], specialized for a node whose subtree
 /// [`fn@try_reuse_node`] already confirmed reusable.
 #[async_recursion]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "internal walker helper threading per-node context through the recursion"
+)]
 async fn resolve_reused_node<Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
@@ -2816,6 +2953,7 @@ async fn resolve_reused_node<Chain>(
     depth: i32,
     current_is_optional: bool,
     reused: ReusedNode,
+    parent_pkg_aliases: &Arc<ParentPkgAliases>,
 ) -> Result<Option<DirectDep>, ResolveDependencyTreeError>
 where
     Chain: Resolver + ?Sized,
@@ -2858,7 +2996,10 @@ where
         .as_ref()
         .and_then(|lockfile| lockfile.snapshots.as_ref())
         .and_then(|snaps| snaps.get(&key));
-    let peer_dependencies = extract_peer_dependencies(&result);
+    // A reused node's children come from the snapshot rather than from
+    // a manifest, so no `dependencies` entry of its synthesized
+    // manifest can be peer-shadowed.
+    let peer_dependencies = extract_peer_dependencies(&result, &HashSet::new());
     let child_refs = snapshot_child_refs(snapshot, &peer_dependencies);
     let is_leaf = child_refs.is_empty() && peer_dependencies.is_empty();
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
@@ -2892,7 +3033,7 @@ where
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
     let next_ancestors = Arc::new(next_ancestors);
-    let children_owner = claim_children_owner(ctx, &id, depth, ancestor_ids);
+    let children_owner = claim_children_owner(ctx, &id, depth, ancestor_ids, HashSet::new());
 
     let children = if children_owner.owns_children {
         let child_results = child_refs
@@ -2918,6 +3059,7 @@ where
                         depth + 1,
                         current_is_optional,
                         ReuseSource::Transitive { key: Some(child_key) },
+                        parent_pkg_aliases,
                     )
                     .await
                 }
@@ -3243,28 +3385,28 @@ fn render_parent(result: &pacquet_resolving_resolver_base::ResolveResult) -> Str
 /// `peerDependenciesMeta[name].optional` folded onto each entry. The
 /// package's own name plus names also present in `dependencies` or
 /// `optionalDependencies` are skipped because those edges already
-/// supply the same package directly. Under `autoInstallPeers`,
-/// [`omit_peer_shadowed_dependencies`] has already dropped
-/// peer-shadowed names from `dependencies`, so those peers survive
-/// here. A `peerDependenciesMeta` entry without a matching
-/// `peerDependencies` entry only counts when `optional: true` — it is
-/// treated as an optional `"*"` peer exactly like an explicitly
-/// declared one, and non-optional meta-only entries are ignored.
+/// supply the same package directly — except for the `peer_shadowed`
+/// names, whose own-dependency edge the walk drops in favor of the peer
+/// (see [`peer_shadowed_dependencies`]). A `peerDependenciesMeta` entry
+/// without a matching `peerDependencies` entry only counts when
+/// `optional: true` — it is treated as an optional `"*"` peer exactly
+/// like an explicitly declared one, and non-optional meta-only entries
+/// are ignored.
 fn extract_peer_dependencies(
     result: &pacquet_resolving_resolver_base::ResolveResult,
+    peer_shadowed: &HashSet<String>,
 ) -> BTreeMap<String, PeerDep> {
     let Some(manifest) = result.manifest.as_ref() else { return BTreeMap::new() };
     let mut peers: BTreeMap<String, PeerDep> = BTreeMap::new();
 
-    let mut own_deps: HashSet<String> = ["dependencies", "optionalDependencies"]
-        .iter()
-        .flat_map(|key| {
-            manifest
-                .get(*key)
-                .and_then(Value::as_object)
-                .into_iter()
-                .flat_map(|map| map.keys().cloned())
-        })
+    let dep_names = |key| {
+        manifest.get(key).and_then(Value::as_object).into_iter().flat_map(|map| map.keys().cloned())
+    };
+    // Only `dependencies` are shadowed, so an entry that is *also* an
+    // optional dependency still supplies the name itself.
+    let mut own_deps: HashSet<String> = dep_names("dependencies")
+        .filter(|name| !peer_shadowed.contains(name))
+        .chain(dep_names("optionalDependencies"))
         .collect();
     if let Some(name) = manifest.get("name").and_then(Value::as_str) {
         own_deps.insert(name.to_string());
@@ -3299,36 +3441,6 @@ fn extract_peer_dependencies(
     }
 
     peers
-}
-
-/// Drop a resolved package's `dependencies` entries that are shadowed
-/// by its own `peerDependencies`, so the peer edge (satisfied from an
-/// ancestor or auto-installed at the importer) supplies the package
-/// instead of a nested copy. Only applies under `autoInstallPeers`.
-/// (Without `autoInstallPeers`, only peers resolvable from the parent
-/// scope would be omitted; pacquet's per-package children cache has no
-/// parent context, so that arm is not modeled and the own dependency
-/// keeps winning, which is correct whenever the peer is not in scope.)
-fn omit_peer_shadowed_dependencies(manifest: Arc<Value>) -> Arc<Value> {
-    let shadowed: Vec<String> = {
-        let Some(peers) = manifest.get("peerDependencies").and_then(Value::as_object) else {
-            return manifest;
-        };
-        let Some(deps) = manifest.get("dependencies").and_then(Value::as_object) else {
-            return manifest;
-        };
-        deps.keys().filter(|name| peers.contains_key(*name)).cloned().collect()
-    };
-    if shadowed.is_empty() {
-        return manifest;
-    }
-    let mut updated = (*manifest).clone();
-    if let Some(deps) = updated.get_mut("dependencies").and_then(Value::as_object_mut) {
-        for name in &shadowed {
-            deps.remove(name);
-        }
-    }
-    Arc::new(updated)
 }
 
 /// `true` when the package has no `dependencies`, `optionalDependencies`,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -249,8 +249,11 @@ fn matches_a_name_prefixed_file_id() {
 
 #[test]
 fn owner_missing_record_is_written_once_per_generation() {
-    use super::{ChildrenOwner, WorkspaceTreeCtx, lock_recoverable};
-    use std::collections::{HashMap, HashSet};
+    use super::{ChildrenOwner, ChildrenOwnerEntry, WorkspaceTreeCtx, lock_recoverable};
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+    };
 
     let ctx = WorkspaceTreeCtx::default();
     let owner = ChildrenOwner {
@@ -260,7 +263,12 @@ fn owner_missing_record_is_written_once_per_generation() {
         parent_path: vec!["root-dep@1.0.0".to_string()],
         importer_id: ".".to_string(),
     };
-    lock_recoverable(&ctx.children_owner_by_id).insert("pkg@1.0.0".to_string(), owner.clone());
+    let entry = |owner: ChildrenOwner| ChildrenOwnerEntry {
+        owner,
+        peer_shadowed: Arc::new(HashSet::new()),
+    };
+    lock_recoverable(&ctx.children_owner_by_id)
+        .insert("pkg@1.0.0".to_string(), entry(owner.clone()));
 
     let miss = |names: &[&str]| {
         let mut map: HashMap<String, HashSet<String>> = HashMap::new();
@@ -286,7 +294,7 @@ fn owner_missing_record_is_written_once_per_generation() {
     );
 
     let new_owner = ChildrenOwner { depth: 0, ..owner };
-    lock_recoverable(&ctx.children_owner_by_id).insert("pkg@1.0.0".to_string(), new_owner);
+    lock_recoverable(&ctx.children_owner_by_id).insert("pkg@1.0.0".to_string(), entry(new_owner));
     ctx.record_first_walk_missing(".", &miss(&[]));
     assert_eq!(
         ctx.first_walk_missing_by_pkg().get("pkg@1.0.0").map(HashSet::len),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -28,6 +28,7 @@ use crate::{
         DependencyOverrider, HoistPeersOptions, MissingPeerInfo, WorkspaceRootDep,
         get_hoistable_optional_peers, hoist_peers,
     },
+    parent_pkg_aliases::ParentPkgAliases,
     resolve_dependency_tree::{
         ResolveDependencyTreeError, TreeCtx, WantedSpec, WorkspaceTreeCtx, extend_tree,
         importer_direct_wanted_specs, record_changed_direct_deps, unwrap_package_name,
@@ -399,9 +400,22 @@ impl ImporterHoistState {
             .iter()
             .map(|(alias, range, ..)| (alias.clone(), range.clone()))
             .collect();
-        let direct = extend_tree(&ctx, resolver, initial_wanted, importer_id).await?;
-        let parent_pkg_aliases: HashSet<String> =
-            direct.iter().map(|dep| dep.alias.clone()).collect();
+        // pnpm seeds `parentPkgAliases` from the importer's wanted
+        // dependencies, before any of them resolve, so a direct dep's
+        // own peer-shadowed dependency is dropped even when the
+        // shadowing sibling is still resolving — and stays seeded even
+        // when the sibling drops out (a skipped optional).
+        let mut parent_pkg_aliases: HashSet<String> =
+            initial_wanted.iter().map(|(alias, ..)| alias.clone()).collect();
+        let direct = extend_tree(
+            &ctx,
+            resolver,
+            initial_wanted,
+            importer_id,
+            &ParentPkgAliases::root(parent_pkg_aliases.clone()),
+        )
+        .await?;
+        parent_pkg_aliases.extend(direct.iter().map(|dep| dep.alias.clone()));
         Ok(ImporterHoistState {
             importer_id: importer_id.to_string(),
             ctx,
@@ -565,8 +579,14 @@ impl ImporterHoistState {
             // wanted dependency without threading the per-dep meta.
             let new_wanted: Vec<WantedSpec> =
                 hoisted.into_iter().map(|(name, range)| (name, range, false, false)).collect();
-            let new_direct =
-                extend_tree(&self.ctx, resolver, new_wanted, &self.importer_id).await?;
+            let new_direct = extend_tree(
+                &self.ctx,
+                resolver,
+                new_wanted,
+                &self.importer_id,
+                &ParentPkgAliases::root(self.parent_pkg_aliases.clone()),
+            )
+            .await?;
             self.direct.extend(new_direct);
             update_preferred_versions_with_ctx(&self.ctx, &mut self.all_preferred_versions);
         }
@@ -637,7 +657,14 @@ impl ImporterHoistState {
         // also defaults to `false` for the same reason.
         let new_wanted: Vec<WantedSpec> =
             hoisted_optional.into_iter().map(|(name, range)| (name, range, false, false)).collect();
-        let new_direct = extend_tree(&self.ctx, resolver, new_wanted, &self.importer_id).await?;
+        let new_direct = extend_tree(
+            &self.ctx,
+            resolver,
+            new_wanted,
+            &self.importer_id,
+            &ParentPkgAliases::root(self.parent_pkg_aliases.clone()),
+        )
+        .await?;
         self.direct.extend(new_direct);
         update_preferred_versions_with_ctx(&self.ctx, &mut self.all_preferred_versions);
         Ok(true)

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -2805,6 +2805,22 @@ mod peer_own_dep_shadowing {
         table
     }
 
+    /// [`parser_table`] plus the higher `types` an importer can hold as
+    /// a direct dependency of its own.
+    fn shadowing_table() -> HashMap<(String, String), pacquet_resolving_resolver_base::ResolveResult>
+    {
+        let mut table = parser_table();
+        table.insert(
+            ("types".to_string(), "^2.0.0".to_string()),
+            fake_result(
+                "types",
+                "2.0.0",
+                serde_json::json!({ "name": "types", "version": "2.0.0" }),
+            ),
+        );
+        table
+    }
+
     #[tokio::test]
     async fn auto_install_peers_keeps_the_peer_and_drops_the_own_dep() {
         let resolver = StubResolver { table: parser_table(), calls: Mutex::new(Vec::new()) };
@@ -2842,6 +2858,65 @@ mod peer_own_dep_shadowing {
             "the peer is dropped when the package supplies the name itself",
         );
         assert!(tree.packages.contains_key("types@1.0.0"), "the own dependency is walked");
+    }
+
+    /// `types` is a direct dependency of the importer, so it is in
+    /// `parser`'s parent scope and the peer edge resolves against it
+    /// instead of `parser` nesting its own copy — pnpm's
+    /// `parentPkgAliases` arm of the omission, which applies with
+    /// `autoInstallPeers` off.
+    #[tokio::test]
+    async fn a_peer_in_the_parent_scope_shadows_the_own_dep() {
+        let resolver = StubResolver { table: shadowing_table(), calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) =
+            fake_manifest(serde_json::json!({ "parser": "^1.0.0", "types": "^2.0.0" }));
+
+        let tree =
+            resolve_dependency_tree(&resolver, &manifest, [DependencyGroup::Prod], opts(false))
+                .await
+                .unwrap();
+
+        let parser = tree.packages.get("parser@1.0.0").expect("parser resolved");
+        assert!(
+            parser.peer_dependencies.contains_key("types"),
+            "the peer survives when the parent scope already supplies the name",
+        );
+        assert!(
+            !tree.packages.contains_key("types@1.0.0"),
+            "the shadowed own dependency is not walked as a child",
+        );
+        assert!(tree.packages.contains_key("types@2.0.0"), "the parent's copy is the one resolved");
+    }
+
+    /// The scope accumulates level by level: `types` is the importer's
+    /// direct dependency and `parser` sits two levels below it.
+    #[tokio::test]
+    async fn the_parent_scope_reaches_every_level_below_it() {
+        let mut table = shadowing_table();
+        table.insert(
+            ("wrapper".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "wrapper",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "wrapper",
+                    "version": "1.0.0",
+                    "dependencies": { "parser": "^1.0.0" },
+                }),
+            ),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) =
+            fake_manifest(serde_json::json!({ "wrapper": "^1.0.0", "types": "^2.0.0" }));
+
+        let tree =
+            resolve_dependency_tree(&resolver, &manifest, [DependencyGroup::Prod], opts(false))
+                .await
+                .unwrap();
+
+        let parser = tree.packages.get("parser@1.0.0").expect("parser resolved");
+        assert!(parser.peer_dependencies.contains_key("types"));
+        assert!(!tree.packages.contains_key("types@1.0.0"));
     }
 
     #[tokio::test]

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -2917,6 +2917,10 @@ mod peer_own_dep_shadowing {
         let parser = tree.packages.get("parser@1.0.0").expect("parser resolved");
         assert!(parser.peer_dependencies.contains_key("types"));
         assert!(!tree.packages.contains_key("types@1.0.0"));
+        assert!(
+            tree.packages.contains_key("types@2.0.0"),
+            "the importer's copy is the one resolved",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes the two peer-context divergences pnpm/pnpm#13334 tracks, both pacquet-only — the TypeScript CLI is the reference and already behaves this way.

**1. A peer shadowed by a same-named dependency.** pnpm drops a resolved package's `dependencies` entry when the package also declares that name as a peer and the name is already resolvable from the level the package resolved in (`options.parentPkgAliases` in `installing/deps-resolver/src/resolveDependencies.ts`) — always under `autoInstallPeers`, otherwise only for the names in scope. pacquet modeled the first arm only, so with `autoInstallPeers` off it nested a copy of the dependency and the peer never surfaced.

The scope is now threaded down the walk the same way the preferred-versions overlay already is: each level folds its resolved aliases into the scope its children resolve against, chained rather than copied so a level costs its own aliases instead of a copy of everything above it.

Which names a package sheds is therefore a property of the *occurrence*, while its children and its peer set are shared per `pkgIdWithPatchHash`. pnpm lets the occurrence that happens to resolve first decide, which is arrival-ordered; pacquet gives the decision to the deterministic children owner, which already picks one occurrence's children for the whole graph, so the same input can never produce two different lockfiles.

**2. Variants that should collapse but don't.** pnpm's `deduplicateAll` rewrites every child edge pointing at a collapsed variant. pacquet gated that rewrite on `collapsed_target_matches_parent`, a guard with no upstream counterpart added in pnpm/pnpm#12372 to compensate for a peer-resolution divergence (pnpm/pnpm#12330): a consumer whose own peer suffix named the collapsed variant kept its edge, which kept the variant reachable and in the lockfile.

That divergence is gone, so the guard is dropped along with the dep-path peer-name parsing it needed. **This is the risky half of the PR** — it undoes a deliberate compensation, so it is a separate commit and can be dropped on its own. The evidence that it is safe: pnpm/pnpm#12372's own regression coverage passes without it — `transitive_pending_peer_uses_provider_final_suffix_in_lockfile`, `fresh_install_uses_final_peer_suffix_for_transitive_pending_peer`, and the resolver-level peer tests that PR added — and so does the rest of the suite (`just ready`, 7195 tests). The one test that fails is the synthetic unit test written to encode the guard, whose expectation is inverted here to the upstream one.

### Measured on the reproduction

Astro at `b01a6921cd`, `trustPolicy: no-downgrade` removed, `pnpm install --lockfile-only` against pnpm 11.17.0 as the reference:

| Build | `diff -U0` lines vs pnpm 11.17.0 |
|---|---|
| `main` (063094d271) | 124 |
| \+ commit 1 (peer-shadowed deps) | 86 |
| \+ commit 2 (collapse on every edge) | 59 |

Re-measured after the rebase onto `01dc5ac4c8` (which brought in pnpm/pnpm#13381, pnpm/pnpm#13384 and pnpm/pnpm#13386) against a freshly generated pnpm 11.17.0 reference: still 59 lines, still the same two causes below.

The `wrangler` peer of `@cloudflare/vite-plugin`, the `@atcute/lexicons` peer of `@atcute/identity`, the duplicate `@cloudflare/vite-plugin` variants, the extra `@cloudflare/workers-types` entry in `@flue/cli`'s `transitivePeerDependencies`, and the two extra `@standard-community` variants are all gone.

The remaining 59 lines are two things this issue does not cover:

- the local `file:*.tgz` gap split out to pnpm/pnpm#13379 (`fake-data-pkg`);
- one `sharp` × `@types/node` optional-peer version pick (pnpm 11 hoists `24.13.3`, pacquet `22.20.1`) that diverges on `main` too, with or without these commits. It is not the divergence the issue reported for `sharp` — that one (pacquet `24`, pnpm `22`) had already resolved itself, and `@types/node@24.13.3` has been published since. Worth its own issue; I did not chase it here.

## Squash Commit Body

```text
Two peer-context divergences from pnpm, both in the resolver's tree walk.

pnpm drops a resolved package's `dependencies` entry when the package
also declares that name as a peer and the name is already resolvable
from the level the package resolved in (`options.parentPkgAliases`) —
always under `autoInstallPeers`, and otherwise only for the names in
scope. pacquet modeled the first arm only, so with `autoInstallPeers`
off it nested a copy of the dependency instead of resolving the peer
from the parent. The scope is now threaded down the walk the way the
preferred-versions overlay already is, chained per level rather than
copied. Which names a package sheds is a property of the occurrence
while its children and peers are shared per `pkgIdWithPatchHash`, so
the deterministic children owner decides for the id — pnpm lets the
first occurrence to resolve decide, which is arrival-ordered.

pnpm also rewrites every child edge that points at a collapsed peer
variant. pacquet gated that on `collapsed_target_matches_parent`, a
guard with no upstream counterpart added in pnpm/pnpm#12372 to
compensate for a peer-resolution divergence (pnpm/pnpm#12330), which
left a collapsed variant reachable from a consumer whose own peer
suffix named it. That divergence is gone — the regression coverage from
that PR passes without the guard — so the guard and the dep-path
peer-name parsing it needed are dropped.

Astro's lockfile is now 59 diff lines from pnpm 11.17.0's, down from
124. What is left is one `sharp` × `@types/node` peer-version pick that
diverges without these changes too, and pnpm/pnpm#13379.

Closes pnpm/pnpm#13334
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: the TypeScript CLI is the reference behavior here. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).
