### PR TITLE
test(cli): cover an aliased git root dep providing another importer's peer

### DIFF
--- a/pnpm/crates/cli/tests/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/git_hosted_install.rs
@@ -604,8 +604,8 @@ fn registry_dependency_can_alias_a_git_dependency_that_provides_a_peer() {
 /// A git specifier names a repository, not a package, so the name the
 /// peer is matched on lives only in the repo's own manifest — read
 /// during resolution, early enough for the hoist that
-/// `resolvePeersFromWorkspaceRoot` runs. Reported as broken in
-/// `pnpm/pnpm#13351`.
+/// `resolvePeersFromWorkspaceRoot` runs
+/// (<https://github.com/pnpm/pnpm/issues/13351>).
 #[test]
 fn an_aliased_git_root_dependency_provides_another_importers_peer() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -637,7 +637,8 @@ fn an_aliased_git_root_dependency_provides_another_importers_peer() {
 
     pacquet.with_args(["install"]).assert().success();
 
-    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = read_lockfile(&lockfile_path);
     let git_key = format!("@scoped/peer@{spec}");
     assert_eq!(importer_version(&lockfile, ".", "vendored-peer"), git_key);
     assert_eq!(
@@ -648,6 +649,16 @@ fn an_aliased_git_root_dependency_provides_another_importers_peer() {
         sole_package(&lockfile, "@scoped/peer").0,
         git_key,
         "the peer must be the root's git dep, not a second copy off the registry",
+    );
+
+    // Every install after the first re-resolves with the prior lockfile
+    // in hand, which is the shape a real workspace spends its life in.
+    let first_install = fs::read(&lockfile_path).expect("read the lockfile");
+    pnpm_at(&workspace).with_args(["install", "--no-prefer-frozen-lockfile"]).assert().success();
+    assert_eq!(
+        fs::read(&lockfile_path).expect("reread the lockfile"),
+        first_install,
+        "re-resolving against the recorded lockfile must not move the peer",
     );
 
     drop((root, npmrc_info));

--- a/pnpm/crates/cli/tests/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/git_hosted_install.rs
@@ -601,6 +601,60 @@ fn registry_dependency_can_alias_a_git_dependency_that_provides_a_peer() {
     drop((root, npmrc_info));
 }
 
+/// A workspace-root git dependency installed under an alias satisfies
+/// another importer's peer of the package's *real* name
+/// (`pnpm/pnpm#13351`). A git specifier names a repository, not a
+/// package, so that name lives only in the repo's own manifest, which
+/// the resolver reads during resolution — early enough for the hoist
+/// `resolvePeersFromWorkspaceRoot` runs, which matches a root dep by
+/// alias and by package name.
+#[test]
+fn an_aliased_git_root_dependency_provides_another_importers_peer() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "scoped-peer");
+    repo.write_file("package.json", r#"{"name":"@scoped/peer","version":"1.0.0"}"#);
+    let commit = repo.commit("init");
+    let spec = repo.git_url_at(&commit);
+    write_manifest_value(
+        &workspace,
+        &json!({
+            "name": "root",
+            "version": "1.0.0",
+            "private": true,
+            "dependencies": { "vendored-peer": spec },
+        }),
+    );
+    let app = workspace.join("app");
+    fs::create_dir(&app).expect("create the app project");
+    write_manifest_value(
+        &app,
+        &json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "@having/scoped-peer": "1.0.0" },
+        }),
+    );
+    append_workspace_yaml_key(&workspace, "packages", "[app]");
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    let git_key = format!("@scoped/peer@{spec}");
+    assert_eq!(importer_version(&lockfile, ".", "vendored-peer"), git_key);
+    assert_eq!(
+        importer_version(&lockfile, "app", "@having/scoped-peer"),
+        format!("1.0.0({git_key})"),
+    );
+    assert_eq!(
+        sole_package(&lockfile, "@scoped/peer").0,
+        git_key,
+        "the peer must be the root's git dep, not a second copy off the registry",
+    );
+
+    drop((root, npmrc_info));
+}
+
 // TS: `updating package that has a github-hosted dependency`
 // (`lockfile.ts:600`).
 #[test]

--- a/pnpm/crates/cli/tests/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/git_hosted_install.rs
@@ -601,13 +601,11 @@ fn registry_dependency_can_alias_a_git_dependency_that_provides_a_peer() {
     drop((root, npmrc_info));
 }
 
-/// A workspace-root git dependency installed under an alias satisfies
-/// another importer's peer of the package's *real* name
-/// (`pnpm/pnpm#13351`). A git specifier names a repository, not a
-/// package, so that name lives only in the repo's own manifest, which
-/// the resolver reads during resolution — early enough for the hoist
-/// `resolvePeersFromWorkspaceRoot` runs, which matches a root dep by
-/// alias and by package name.
+/// A git specifier names a repository, not a package, so the name the
+/// peer is matched on lives only in the repo's own manifest — read
+/// during resolution, early enough for the hoist that
+/// `resolvePeersFromWorkspaceRoot` runs. Reported as broken in
+/// `pnpm/pnpm#13351`.
 #[test]
 fn an_aliased_git_root_dependency_provides_another_importers_peer() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -766,11 +766,12 @@ fn is_project_relative_specifier(spec: &str) -> bool {
 }
 
 /// `name_ver`, else the manifest — the canonical name for the protocols
-/// that leave `name_ver` unset. The git and remote-tarball resolvers read
-/// the package's own manifest during resolution, so those arrive named
-/// too. `None` only for a package with no manifest name at all — a
-/// repository without a `package.json` — where the alias is the only
-/// name anywhere in the graph.
+/// that leave `name_ver` unset. The git and remote-tarball resolvers fill
+/// `manifest` from the package's own `package.json` during resolution
+/// whenever they hold a fetch context, which every install path wires, so
+/// those arrive named too. `None` when no manifest name is available: a
+/// repository with no `package.json`, or the resolve-only chain that
+/// wires no fetch context — and hoists no peers.
 fn resolved_pkg_name(result: &pacquet_resolving_resolver_base::ResolveResult) -> Option<String> {
     if let Some(name_ver) = result.name_ver.as_ref() {
         return Some(name_ver.name.to_string());

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -766,8 +766,11 @@ fn is_project_relative_specifier(spec: &str) -> bool {
 }
 
 /// `name_ver`, else the manifest — the canonical name for the protocols
-/// that leave `name_ver` unset. `None` for a git resolution, which has
-/// neither until it is fetched.
+/// that leave `name_ver` unset. The git and remote-tarball resolvers read
+/// the package's own manifest during resolution, so those arrive named
+/// too. `None` only for a package with no manifest name at all — a
+/// repository without a `package.json` — where the alias is the only
+/// name anywhere in the graph.
 fn resolved_pkg_name(result: &pacquet_resolving_resolver_base::ResolveResult) -> Option<String> {
     if let Some(name_ver) = result.name_ver.as_ref() {
         return Some(name_ver.name.to_string());


### PR DESCRIPTION
## Summary

pnpm/pnpm#13351 reports that a workspace-root dependency installed from git under an alias cannot satisfy another importer's peer of the package's real name, so `resolvePeersFromWorkspaceRoot` silently resolves a second copy from the registry. **It does not reproduce.** This PR pins the working behavior with an end-to-end test and corrects the doc comment the report was reading.

### What was actually checked

A two-importer workspace — root declares the git package under a different alias, a sibling project depends on something that peers on the package's real name — resolved against a locally built binary:

| shape | result |
| --- | --- |
| `git+file://` repository (`type: git` resolution) | one copy, the root's; sibling's peer bound to the git key |
| `github:` host archive (`gitHosted: true` tarball) | same |
| repeat install (re-resolve with the prior lockfile) | lockfile byte-identical, still one copy |
| TypeScript CLI, same fixture | **byte-identical lockfile** |

### Why the report read the other way

It quotes `build_resolve_result` in `git_resolver.rs`, which does set `name_ver: None` and `manifest: None`. But `resolve_impl` then calls `read_package_metadata`, which fills `manifest` from the package's own `package.json` — a git host's archive is downloaded and read, a repository with no archive endpoint gets a throwaway checkout (pnpm/pnpm#13059). So `resolved_pkg_name` names a git dependency well before the hoist loop reads it, and the alias-only match the issue describes never happens. The bare shape belongs to the no-fetch-context path used by unit tests and the resolve-only NAPI entry point, neither of which hoists peers. The lockfile-reuse path carries a name of its own too — `synthesize_reused_result` reconstructs the manifest from the recorded `<name>@<url>` snapshot key — though a *direct* git dep does not reach it on re-resolution: `--no-prefer-frozen-lockfile` re-resolves it against the repository, which is where the name comes from again.

That means option 1 in the issue (read the name from the wanted lockfile) is unnecessary, and the first-install gap it would have left does not exist either.

The one genuinely nameless case is a repository with no `package.json`, where the alias is the only name anywhere in the graph — the `with-non-package-dep` fixture shape, and identical in both stacks.

Closes pnpm/pnpm#13351.

## Squash Commit Body

```text
pnpm/pnpm#13351 reported that a workspace-root dependency installed from
git under an alias could not satisfy another importer's peer of the
package's real name, so `resolvePeersFromWorkspaceRoot` silently resolved
a second copy from the registry. It does not reproduce: both git shapes
(a `type: git` repository and a `gitHosted: true` host archive) dedupe
onto the root's dependency, and the TypeScript CLI produces a
byte-identical lockfile for the same fixture.

The report read `build_resolve_result` in `git_resolver.rs`, which sets
`name_ver: None` and `manifest: None`, and concluded a git resolution
reaches the hoist loop unnamed. `resolve_impl` then calls
`read_package_metadata`, which fills `manifest` from the package's own
`package.json` — a host archive is downloaded and read, a repository with
no archive endpoint gets a throwaway checkout — so `resolved_pkg_name`
names the dependency before the hoist loop ever sees it. The bare shape
belongs to the no-fetch-context path used by unit tests and the
resolve-only NAPI entry point, neither of which hoists peers. Lockfile
reuse is named too: `synthesize_reused_result` reconstructs the manifest
from the recorded snapshot key.

The doc on `resolved_pkg_name` claimed the opposite, and is what the
report was reading; it now describes what the resolvers actually deliver.
The new end-to-end test pins the behavior against a local git repository
whose package name differs from the alias the root installs it under; it
was verified to fail — with the duplicate registry copy the issue
describes — when `resolved_pkg_name`'s manifest fallback is removed.

Closes pnpm/pnpm#13351.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <br>No behavior changes in either stack. The TypeScript CLI was run against the
  same fixture and produces a byte-identical lockfile, so there is nothing to
  port; the new coverage lives on the pacquet side, where the defect was reported.
- [ ] ~~Added a changeset~~ — nothing user-visible changes: a test and a doc comment.
- [x] Added or updated tests.
  <br>`an_aliased_git_root_dependency_provides_another_importers_peer` in
  `pnpm/crates/cli/tests/git_hosted_install.rs`. Verified to catch the reported
  regression: with `resolved_pkg_name`'s manifest fallback removed it fails with
  `1.0.0(@scoped/peer@1.0.0)` — the second registry copy — instead of the git key.
  It also re-installs under `--no-prefer-frozen-lockfile` and asserts the lockfile
  is byte-identical, covering the shape every install after the first takes.
  <br>Not covered here: the `gitHosted: true` archive locator needs a real git
  host, and every test in this file is deliberately network-free over
  `git+file://` (see the module doc); that shape is pinned at the resolver level
  in `pacquet-resolving-git-resolver`. It was verified by hand against
  `github:kevva/is-negative#1d7e288` — it dedupes onto the root's dep identically.
- [x] Updated the documentation if needed.
  <br>The `resolved_pkg_name` doc no longer claims a git resolution reaches the
  hoist loop unnamed.

### Verification

`just ready` green on the final state: 7217 tests passed, 0 failures; `cargo clippy --locked --workspace --all-targets -- --deny warnings` clean; `typos`, `cargo fmt`, `cargo check` clean.

The **Pacquet Code Coverage** check is red, and is unrelated to this PR: the same job is failing on `main` and on every sibling branch in the same window, with no job logs retained.

---
Written by an agent (Claude Code, claude-opus-5).
