### PR TITLE
ci(codecov): free runner disk before the coverage build

### DIFF
--- a/.github/workflows/pacquet-codecov.yml
+++ b/.github/workflows/pacquet-codecov.yml
@@ -27,12 +27,39 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Build the instrumented artifacts with line-tables-only debug info, as
+    # `Rust CI / Test` does. Coverage regions live in the binary's own
+    # `__llvm_covmap`/`__llvm_covfun` sections, so llvm-cov needs no DWARF at
+    # all, while the full `--all-targets` debug build of the whole workspace
+    # (~70 crates plus heavy C deps like aws-lc-sys, ring, libsql-ffi and
+    # tree-sitter) is what pushes target/ over the runner's free disk. Line
+    # tables keep panic backtraces file:line-accurate. Set here in CI rather
+    # than in Cargo.toml so a local `just codecov` keeps full debug info.
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+    # A coverage run compiles the workspace from cold and then runs every
+    # test; the healthy runtime is ~8 minutes. Without this a wedged job
+    # would sit on the default 360-minute limit.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true # Pull submodules for `cargo coverage`
           persist-credentials: false
+
+      # The instrumented build holds a full set of debug artifacts in
+      # target/llvm-cov-target, on top of a profraw file per test process and
+      # the merged profdata. That no longer fits in the runner's free disk:
+      # the job dies with "No space left on device" — often while the runner
+      # itself is writing its diagnostic log, so the failure lands with no
+      # step output at all. Drop the preinstalled toolchains this job never
+      # uses (~25 GB) before compiling anything.
+      - name: Free up runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
 
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
@@ -81,6 +108,10 @@ jobs:
           unset XDG_DATA_HOME
 
           cargo codecov --lcov --output-path lcov.info
+
+      - name: Report disk usage
+        if: always()
+        run: df -h /
 
       - name: Upload Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary

`Pacquet Code Coverage` has been failing on `main` and on every PR. The runs
report a failure with no step output at all, and the job log 404s, so the
signature looks like infrastructure flake — but `gh run view <id>` shows the
real cause under `ANNOTATIONS`:

```
System.IO.IOException: No space left on device : '/home/runner/_diag/Worker_20260726-002653-utc.log'
```

The runner ran out of disk and died while writing its own diagnostic log,
which is why nothing else survives.

The coverage job compiles the whole workspace with coverage instrumentation
and `--all-targets`, keeps a profraw file per test process for all 7167 tests,
and then merges them — but unlike `Rust CI / Test`, `Test` and `build-pnpr`, it
never dropped the preinstalled toolchains it doesn't use. This reclaims the
same ~25 GB before anything is compiled, and builds the instrumented artifacts
with line-tables-only debug info.

Measured on the `blacksmith-4vcpu-ubuntu-2404` runner (145 GB disk) in
[run 30182035153](https://github.com/pnpm/pnpm/actions/runs/30182035153):
97 GB free after the cleanup step, and the full instrumented run peaks at
81 GB used / 57 GB free — a green run, both jobs, with the report uploaded to
codecov.

Dropping the DWARF does not change what is reported: llvm-cov reads its
regions from the binary's `__llvm_covmap`/`__llvm_covfun` sections. Comparing
the `lcov.info` artifacts of the last green pre-change run against this run's:
540 files / 92662 lines / 87.26% before, 542 files / 93155 lines / 87.32%
after (the two extra files are new code on the newer commit).

## Squash Commit Body

```text
The Pacquet Code Coverage job has been failing on main and on every PR
with `System.IO.IOException: No space left on device`, thrown while the
runner worker writes its own diagnostic log — so the run reports a
failure with no step output at all.

The job compiles the whole workspace with coverage instrumentation and
`--all-targets`, keeps a profraw file per test process for all 7167
tests, and then merges them, but it never dropped the preinstalled
toolchains the way `Rust CI / Test`, `Test` and `build-pnpr` do. Reclaim
the same ~25 GB before anything is compiled, and build the instrumented
artifacts with line-tables-only debug info: llvm-cov reads its regions
from the binary's `__llvm_covmap`/`__llvm_covfun` sections, so the DWARF
that dominates the debug build buys the report nothing.

Also report the free disk after the run and cap the job at 60 minutes,
so the next disk regression shows up as a number instead of a silent
worker death.
```

## Checklist

- [x] Added or updated tests. (CI-only change; verified by dispatching the
  workflow on this branch and diffing the coverage artifact — see above.)

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787619867&installation_model_id=426870&pr_number=13396&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13396&signature=c4d068f0bde6c661689944471b6be0a66dc64e07a7f41e22c0f4fa2cebd45cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code coverage workflow reliability by reducing debug data generated during Rust builds.
  * Added runner disk cleanup and disk usage reporting to help prevent storage-related coverage failures.
  * Ensured disk usage is captured even when earlier workflow steps fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->