### PR TITLE
fix(resolving-deps-resolver): key a peer edge to the provider's own depPath

### DIFF
--- a/.changeset/peer-edge-keeps-the-providers-suffix.md
+++ b/.changeset/peer-edge-keeps-the-providers-suffix.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+A peer dependency is now recorded in the lockfile at the version and peer suffix the peer provider actually resolved to. Peers whose provider carried peer suffixes of its own could be recorded against a package instance that no importer installs, leaving an unreachable entry in `snapshots:` and a peer bound to the wrong instance [#13320](https://github.com/pnpm/pnpm/issues/13320).

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -755,7 +755,6 @@ struct NodeRecord {
     /// edges) but holding `NodeIds`, so the rebuild can map each edge to
     /// its final depPath.
     edges: BTreeMap<String, NodeId>,
-    peer_edges: HashSet<String>,
     optional_child_aliases: HashSet<String>,
     transitive_peer_dependencies: HashSet<String>,
     depth: i32,
@@ -1339,14 +1338,12 @@ impl Walker<'_> {
             record_edges.insert(peer_alias.clone(), peer_node_id.clone());
         }
         let optional_child_aliases = self.optional_child_aliases(&pkg.id, &record_edges);
-        let peer_edges = own_resolved_peers.keys().cloned().collect();
         let record_order = self.next_record_order;
         self.next_record_order += 1;
         self.node_records.insert(
             node_id.clone(),
             NodeRecord {
                 edges: record_edges,
-                peer_edges,
                 optional_child_aliases: optional_child_aliases.clone(),
                 transitive_peer_dependencies: transitive_peer_dependencies.clone(),
                 depth: tree_node.depth,
@@ -1999,6 +1996,13 @@ impl Walker<'_> {
     /// `depth`, like the inline build); nodes whose suffix was
     /// previously collapsed by the cycle fallback now split into
     /// distinct entries.
+    ///
+    /// Every edge — a regular child or a resolved peer — points at the
+    /// depPath the edge's own node resolved to, matching upstream's
+    /// `resolveChildren`, which maps each `childrenNodeIds` entry
+    /// through `pathsByNodeId`. A peer provider therefore keeps its own
+    /// peer suffix even where the consumer resolved none of those peers
+    /// itself.
     fn build_final_graph(&self, final_dep_paths: &HashMap<NodeId, DepPath>) -> DependenciesGraph {
         // Minimum tree depth across *every* occurrence that resolves to a
         // given final depPath. `pure_pkgs` / `find_hit` revisits
@@ -2019,41 +2023,19 @@ impl Walker<'_> {
         }
 
         let mut record_dep_paths: HashMap<NodeId, DepPath> = HashMap::new();
-        let mut record_resolved_peer_names: HashMap<NodeId, HashSet<String>> = HashMap::new();
-        let mut variants_by_pkg_id: HashMap<String, Vec<(DepPath, HashSet<String>)>> =
-            HashMap::new();
         let mut transitive_peer_dependencies_by_dep_path: HashMap<DepPath, HashSet<String>> =
             HashMap::new();
         for (node_id, record) in &self.node_records {
             let dep_path = self.final_dep_path_of(node_id, final_dep_paths);
-            let pkg_id = self.tree.dependencies_tree[node_id].resolved_package_id.clone();
-            let resolved_peer_names: HashSet<String> = self
-                .node_external_peers
-                .get(node_id)
-                .map(|peers| peers.keys().cloned().collect())
-                .unwrap_or_default();
-            record_dep_paths.insert(node_id.clone(), dep_path.clone());
-            record_resolved_peer_names.insert(node_id.clone(), resolved_peer_names.clone());
-            let variant_peer_names: HashSet<String> =
-                peer_segment_names(&dep_path).unwrap_or_default().into_iter().collect();
-            variants_by_pkg_id.entry(pkg_id).or_default().push((dep_path, variant_peer_names));
             transitive_peer_dependencies_by_dep_path
-                .entry(record_dep_paths[node_id].clone())
+                .entry(dep_path.clone())
                 .or_default()
                 .extend(record.transitive_peer_dependencies.iter().cloned());
-        }
-        for variants in variants_by_pkg_id.values_mut() {
-            variants.sort_by(|(left_dep_path, left_peers), (right_dep_path, right_peers)| {
-                right_peers
-                    .len()
-                    .cmp(&left_peers.len())
-                    .then_with(|| left_dep_path.cmp(right_dep_path))
-            });
+            record_dep_paths.insert(node_id.clone(), dep_path);
         }
 
         let mut graph = DependenciesGraph::new();
         let mut graph_order: HashMap<DepPath, u64> = HashMap::new();
-        let mut synthetic_nodes: HashMap<DepPath, DependenciesGraphNode> = HashMap::new();
         for (node_id, record) in &self.node_records {
             let dep_path = record_dep_paths[node_id].clone();
             let depth = min_depth.get(&dep_path).copied().unwrap_or(record.depth);
@@ -2061,30 +2043,14 @@ impl Walker<'_> {
             let pkg = &self.tree.packages[&pkg_id];
             let mut children: BTreeMap<String, DepPath> = BTreeMap::new();
             for (alias, edge_node_id) in &record.edges {
-                let is_peer_edge =
-                    record.peer_edges.contains(alias) || pkg.peer_dependencies.contains_key(alias);
-                let (edge_dep_path, synthetic_node) = if is_peer_edge {
-                    self.final_peer_edge_dep_path(
-                        node_id,
-                        edge_node_id,
-                        final_dep_paths,
-                        &record_resolved_peer_names,
-                        &variants_by_pkg_id,
-                    )
-                } else {
-                    (self.final_dep_path_of(edge_node_id, final_dep_paths), None)
-                };
-                if let Some(node) = synthetic_node {
-                    transitive_peer_dependencies_by_dep_path
-                        .entry(node.dep_path.clone())
-                        .or_default()
-                        .extend(node.transitive_peer_dependencies.iter().cloned());
-                    synthetic_nodes.entry(node.dep_path.clone()).or_insert(node);
-                }
-                children.insert(alias.clone(), edge_dep_path);
+                children
+                    .insert(alias.clone(), self.final_dep_path_of(edge_node_id, final_dep_paths));
             }
-            let resolved_peer_names =
-                record_resolved_peer_names.get(node_id).cloned().unwrap_or_default();
+            let resolved_peer_names: HashSet<String> = self
+                .node_external_peers
+                .get(node_id)
+                .map(|peers| peers.keys().cloned().collect())
+                .unwrap_or_default();
             let mut candidate = DependenciesGraphNode {
                 dep_path: dep_path.clone(),
                 resolved_package_id: pkg_id.clone(),
@@ -2139,128 +2105,7 @@ impl Walker<'_> {
                 }
             }
         }
-        for (dep_path, node) in synthetic_nodes {
-            graph.entry(dep_path).or_insert(node);
-        }
         graph
-    }
-
-    fn final_peer_edge_dep_path(
-        &self,
-        consumer_node_id: &NodeId,
-        provider_node_id: &NodeId,
-        final_dep_paths: &HashMap<NodeId, DepPath>,
-        record_resolved_peer_names: &HashMap<NodeId, HashSet<String>>,
-        variants_by_pkg_id: &HashMap<String, Vec<(DepPath, HashSet<String>)>>,
-    ) -> (DepPath, Option<DependenciesGraphNode>) {
-        let original = self.final_dep_path_of(provider_node_id, final_dep_paths);
-        let Some(provider_tree_node) = self.tree.dependencies_tree.get(provider_node_id) else {
-            return (original, None);
-        };
-        let Some(consumer_tree_node) = self.tree.dependencies_tree.get(consumer_node_id) else {
-            return (original, None);
-        };
-        let Some(consumer_pkg) = self.tree.packages.get(&consumer_tree_node.resolved_package_id)
-        else {
-            return (original, None);
-        };
-        let mut available_peer_names = HashSet::new();
-        if let Some(consumer_record) = self.node_records.get(consumer_node_id) {
-            available_peer_names.extend(consumer_record.peer_edges.iter().cloned());
-            for alias in consumer_record.edges.keys() {
-                if self.tree.all_peer_dep_names.contains(alias) {
-                    available_peer_names.insert(alias.clone());
-                }
-            }
-        }
-        available_peer_names.insert(pkg_name_version(&consumer_pkg.result).0);
-
-        let Some(variants) = variants_by_pkg_id.get(&provider_tree_node.resolved_package_id) else {
-            return (original, None);
-        };
-        if variants
-            .iter()
-            .find(|(dep_path, _)| dep_path == &original)
-            .is_some_and(|(_, peer_names)| peer_names.is_subset(&available_peer_names))
-        {
-            return (original, None);
-        }
-        let unavailable = unavailable_peer_segment_names(&original, &available_peer_names);
-        if unavailable.is_some_and(|names| {
-            !names.is_empty()
-                && self.node_records.get(provider_node_id).is_some_and(|record| {
-                    names.iter().all(|name| record.transitive_peer_dependencies.contains(name))
-                })
-        }) {
-            return (original, None);
-        }
-        if let Some(trimmed) = dep_path_with_allowed_peer_segments(&original, &available_peer_names)
-        {
-            if variants.iter().any(|(dep_path, _)| dep_path == &trimmed) {
-                return (trimmed, None);
-            }
-            if let Some(node) = self.synthetic_peer_variant_node(
-                provider_node_id,
-                trimmed.clone(),
-                &available_peer_names,
-                final_dep_paths,
-                record_resolved_peer_names,
-            ) {
-                return (trimmed, Some(node));
-            }
-        }
-        variants
-            .iter()
-            .find(|(_, peer_names)| peer_names.is_subset(&available_peer_names))
-            .map(|(dep_path, _)| (dep_path.clone(), None))
-            .unwrap_or((original, None))
-    }
-
-    fn synthetic_peer_variant_node(
-        &self,
-        provider_node_id: &NodeId,
-        dep_path: DepPath,
-        available_peer_names: &HashSet<String>,
-        final_dep_paths: &HashMap<NodeId, DepPath>,
-        record_resolved_peer_names: &HashMap<NodeId, HashSet<String>>,
-    ) -> Option<DependenciesGraphNode> {
-        let record = self.node_records.get(provider_node_id)?;
-        let tree_node = self.tree.dependencies_tree.get(provider_node_id)?;
-        let pkg = self.tree.packages.get(&tree_node.resolved_package_id)?;
-        let mut children = BTreeMap::new();
-        for (alias, edge_node_id) in &record.edges {
-            if record.peer_edges.contains(alias) && !available_peer_names.contains(alias) {
-                continue;
-            }
-            children.insert(alias.clone(), self.final_dep_path_of(edge_node_id, final_dep_paths));
-        }
-        let optional_children = record
-            .optional_child_aliases
-            .iter()
-            .filter(|alias| children.contains_key(*alias))
-            .cloned()
-            .collect();
-        let resolved_peer_names: HashSet<String> = record_resolved_peer_names
-            .get(provider_node_id)
-            .into_iter()
-            .flat_map(|names| names.iter())
-            .filter(|name| available_peer_names.contains(*name))
-            .cloned()
-            .collect();
-        Some(DependenciesGraphNode {
-            dep_path,
-            resolved_package_id: tree_node.resolved_package_id.clone(),
-            resolve_result: Arc::clone(&pkg.result),
-            children,
-            optional_children,
-            peer_dependencies: pkg.peer_dependencies.clone(),
-            transitive_peer_dependencies: record.transitive_peer_dependencies.clone(),
-            resolved_peer_names,
-            depth: record.depth,
-            installable: record.installable,
-            is_pure: false,
-            optional: pkg.optional,
-        })
     }
 
     fn optional_child_aliases(
@@ -2771,41 +2616,6 @@ fn unavailable_non_transitive_peer_segment_names(
             })
             .collect(),
     )
-}
-
-fn dep_path_with_allowed_peer_segments(
-    dep_path: &DepPath,
-    allowed_peer_names: &HashSet<String>,
-) -> Option<DepPath> {
-    let raw = dep_path.as_str();
-    let suffix = index_of_dep_path_suffix(raw);
-    let peers_index = suffix.peers_index?;
-    let segments = split_peer_suffix_segments(&raw[peers_index..])?;
-    let mut kept = Vec::new();
-    for segment in &segments {
-        let name = peer_segment_name(segment)?;
-        if allowed_peer_names.contains(name) {
-            kept.push(segment.as_str());
-        }
-    }
-    if kept.is_empty() || kept.len() == segments.len() {
-        return None;
-    }
-    let mut out = raw[..peers_index].to_string();
-    for segment in kept {
-        out.push('(');
-        out.push_str(segment);
-        out.push(')');
-    }
-    Some(DepPath::from(out))
-}
-
-fn unavailable_peer_segment_names(
-    dep_path: &DepPath,
-    available_peer_names: &HashSet<String>,
-) -> Option<Vec<String>> {
-    let names = peer_segment_names(dep_path)?;
-    Some(names.into_iter().filter(|name| !available_peer_names.contains(name)).collect())
 }
 
 fn peer_segment_names(dep_path: &DepPath) -> Option<Vec<String>> {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,7 +1,6 @@
 use super::{
-    ImporterPeerInput, NodeRecord, ResolvePeersOptions, Walker,
-    dep_path_with_allowed_peer_segments, importer_relative_link_dep_path, peer_segment_names,
-    resolve_peers, resolve_peers_workspace, satisfies_with_prereleases,
+    ImporterPeerInput, NodeRecord, ResolvePeersOptions, Walker, importer_relative_link_dep_path,
+    peer_segment_names, resolve_peers, resolve_peers_workspace, satisfies_with_prereleases,
 };
 use crate::{
     dependencies_graph::{DependenciesGraph, PeerDependencyIssues},
@@ -67,17 +66,6 @@ fn parses_peer_suffix_after_patch_hash() {
     assert_eq!(
         peer_segment_names(&dep_path),
         Some(vec!["@types/node".to_string(), "better-sqlite3".to_string(), "express".to_string(),]),
-    );
-
-    let allowed = HashSet::from(["@types/node".to_string(), "express".to_string()]);
-    assert_eq!(
-        dep_path_with_allowed_peer_segments(&dep_path, &allowed),
-        Some(DepPath::from(concat!(
-            "@medusajs/workflows-sdk@2.13.3",
-            "(patch_hash=248195172cff27c28650c005b6aa0aa3b2f2976f9739544b360b81668f2d8b59)",
-            "(@types/node@20.19.17)",
-            "(express@4.21.2)",
-        ))),
     );
 }
 
@@ -921,7 +909,6 @@ fn final_graph_keeps_first_equal_depth_payload_and_unions_transitive_peers() {
         second.clone(),
         NodeRecord {
             edges: BTreeMap::from([("peer".to_string(), second_child)]),
-            peer_edges: HashSet::new(),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::from(["debug".to_string()]),
             depth: 1,
@@ -934,7 +921,6 @@ fn final_graph_keeps_first_equal_depth_payload_and_unions_transitive_peers() {
         first.clone(),
         NodeRecord {
             edges: BTreeMap::from([("peer".to_string(), first_child)]),
-            peer_edges: HashSet::new(),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 1,
@@ -990,7 +976,6 @@ fn final_graph_duplicate_parent_prefers_child_variant_matching_parent_peers() {
         first.clone(),
         NodeRecord {
             edges: BTreeMap::from([("webpack-cli".to_string(), first_child.clone())]),
-            peer_edges: HashSet::new(),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 1,
@@ -1003,7 +988,6 @@ fn final_graph_duplicate_parent_prefers_child_variant_matching_parent_peers() {
         second.clone(),
         NodeRecord {
             edges: BTreeMap::from([("webpack-cli".to_string(), second_child.clone())]),
-            peer_edges: HashSet::new(),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 1,
@@ -1024,7 +1008,7 @@ fn final_graph_duplicate_parent_prefers_child_variant_matching_parent_peers() {
 }
 
 #[test]
-fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers() {
+fn final_graph_peer_edge_keeps_the_providers_own_peer_suffix() {
     let provider_analyzer = NodeId::next();
     let provider_bare = NodeId::next();
     let consumer = NodeId::next();
@@ -1032,7 +1016,7 @@ fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers()
     let provider_analyzer_dep_path = DepPath::from(
         "webpack-cli@6.0.1(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.2)(webpack@5.107.2)",
     );
-    let provider_middle_dep_path =
+    let trimmed_dep_path =
         DepPath::from("webpack-cli@6.0.1(webpack-dev-server@5.2.2)(webpack@5.107.2)");
     let provider_bare_dep_path = DepPath::from("webpack-cli@6.0.1(webpack@5.107.2)");
     let consumer_dep_path = DepPath::from(
@@ -1085,7 +1069,6 @@ fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers()
         provider_analyzer.clone(),
         NodeRecord {
             edges: BTreeMap::new(),
-            peer_edges: HashSet::new(),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 0,
@@ -1098,7 +1081,6 @@ fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers()
         provider_bare.clone(),
         NodeRecord {
             edges: BTreeMap::new(),
-            peer_edges: HashSet::new(),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 0,
@@ -1111,7 +1093,6 @@ fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers()
         consumer.clone(),
         NodeRecord {
             edges: BTreeMap::from([("webpack-cli".to_string(), provider_analyzer.clone())]),
-            peer_edges: HashSet::from(["webpack-dev-server".to_string(), "webpack".to_string()]),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 1,
@@ -1143,15 +1124,16 @@ fn final_graph_peer_edge_uses_provider_variant_without_unavailable_extra_peers()
     );
 
     let graph = walker.build_final_graph(&HashMap::from([
-        (provider_analyzer, provider_analyzer_dep_path),
+        (provider_analyzer, provider_analyzer_dep_path.clone()),
         (provider_bare, provider_bare_dep_path),
         (consumer, consumer_dep_path.clone()),
     ]));
 
     assert_eq!(
         graph[&consumer_dep_path].children.get("webpack-cli"),
-        Some(&provider_middle_dep_path),
+        Some(&provider_analyzer_dep_path),
     );
+    assert!(!graph.contains_key(&trimmed_dep_path), "no variant is fabricated for the edge");
 }
 
 #[test]
@@ -1216,7 +1198,6 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
         provider.clone(),
         NodeRecord {
             edges: BTreeMap::new(),
-            peer_edges: HashSet::new(),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::from([
                 "bufferutil".to_string(),
@@ -1233,11 +1214,6 @@ fn final_graph_peer_edge_keeps_provider_transitive_peer_suffixes() {
         consumer.clone(),
         NodeRecord {
             edges: BTreeMap::from([("webpack-dev-server".to_string(), provider.clone())]),
-            peer_edges: HashSet::from([
-                "webpack".to_string(),
-                "webpack-bundle-analyzer".to_string(),
-                "webpack-dev-server".to_string(),
-            ]),
             optional_child_aliases: HashSet::new(),
             transitive_peer_dependencies: HashSet::new(),
             depth: 0,
@@ -1575,6 +1551,148 @@ fn workspace_importers_get_distinct_instances_for_different_peer_versions() {
         result.direct_dependencies_by_importer["project-b"]["consumer"],
         DepPath::from("consumer@1.0.0(peer@2.0.0)"),
     );
+}
+
+#[test]
+fn a_shared_consumer_keeps_the_first_importers_peer_provider_variant() {
+    let plugin_v1 = NodeId::next();
+    let plugin_v2 = NodeId::next();
+    let utils_root = NodeId::next();
+    let utils_app = NodeId::next();
+    let resolver_root = NodeId::next();
+    let resolver_app = NodeId::next();
+    let parser = NodeId::leaf("parser@1.0.0");
+
+    let importers = [
+        ImporterPeerInput {
+            id: ".".to_string(),
+            direct: vec![
+                DirectDep {
+                    alias: "plugin".to_string(),
+                    node_id: plugin_v1.clone(),
+                    id: "plugin@1.0.0".to_string(),
+                },
+                DirectDep {
+                    alias: "parser".to_string(),
+                    node_id: parser.clone(),
+                    id: "parser@1.0.0".to_string(),
+                },
+                DirectDep {
+                    alias: "resolver".to_string(),
+                    node_id: resolver_root.clone(),
+                    id: "resolver@1.0.0".to_string(),
+                },
+            ],
+            root_dir: std::path::PathBuf::from("/repo"),
+            modules_dir: None,
+        },
+        ImporterPeerInput {
+            id: "app".to_string(),
+            direct: vec![
+                DirectDep {
+                    alias: "plugin".to_string(),
+                    node_id: plugin_v2.clone(),
+                    id: "plugin@2.0.0".to_string(),
+                },
+                DirectDep {
+                    alias: "resolver".to_string(),
+                    node_id: resolver_app.clone(),
+                    id: "resolver@1.0.0".to_string(),
+                },
+            ],
+            root_dir: std::path::PathBuf::from("/repo/app"),
+            modules_dir: None,
+        },
+    ];
+
+    let mut tree = ResolvedTree {
+        direct: Vec::new(),
+        packages: HashMap::from([
+            ("plugin@1.0.0".to_string(), package("plugin", "1.0.0", &[("parser", "*")], false)),
+            ("plugin@2.0.0".to_string(), package("plugin", "2.0.0", &[("parser", "*")], false)),
+            (
+                "utils@1.0.0".to_string(),
+                package("utils", "1.0.0", &[("resolver", "*"), ("parser", "*")], false),
+            ),
+            ("resolver@1.0.0".to_string(), package("resolver", "1.0.0", &[("plugin", "*")], false)),
+            ("parser@1.0.0".to_string(), package("parser", "1.0.0", &[], true)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (
+                plugin_v1,
+                tree_node(
+                    "plugin@1.0.0",
+                    BTreeMap::from([("utils".to_string(), utils_root.clone())]),
+                    0,
+                ),
+            ),
+            (
+                plugin_v2,
+                tree_node(
+                    "plugin@2.0.0",
+                    BTreeMap::from([("utils".to_string(), utils_app.clone())]),
+                    0,
+                ),
+            ),
+            (utils_root, tree_node("utils@1.0.0", BTreeMap::new(), 1)),
+            (utils_app, tree_node("utils@1.0.0", BTreeMap::new(), 1)),
+            (resolver_root, tree_node("resolver@1.0.0", BTreeMap::new(), 0)),
+            (resolver_app, tree_node("resolver@1.0.0", BTreeMap::new(), 0)),
+            (parser, tree_node("parser@1.0.0", BTreeMap::new(), 0)),
+        ]),
+        all_peer_dep_names: HashSet::from([
+            "plugin".to_string(),
+            "resolver".to_string(),
+            "parser".to_string(),
+        ]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+
+    let result = resolve_peers_workspace(
+        &mut tree,
+        &importers,
+        std::path::Path::new("/repo"),
+        false,
+        false,
+        true,
+        ResolvePeersOptions::default(),
+    );
+
+    // Both `utils` occurrences collapse onto one depPath because the
+    // `resolver` peer id collapses on the plugin/resolver peer cycle, so
+    // exactly one of them supplies the graph node's edges.
+    let utils = result.graph.keys().filter(|dep_path| dep_path.as_str().starts_with("utils@"));
+    assert_eq!(utils.count(), 1, "one utils entry: {:?}", result.graph.keys().collect::<Vec<_>>());
+    let utils_dep_path = result
+        .graph
+        .keys()
+        .find(|dep_path| dep_path.as_str().starts_with("utils@"))
+        .expect("utils entry")
+        .clone();
+    assert_eq!(
+        result.graph[&utils_dep_path].children.get("resolver"),
+        Some(&DepPath::from("resolver@1.0.0(plugin@1.0.0)")),
+    );
+    // Trimming a peer segment off the edge would key it to a variant no
+    // importer reaches, leaving an orphan entry in the lockfile —
+    // https://github.com/pnpm/pnpm/issues/13320.
+    let mut reachable: HashSet<DepPath> = HashSet::new();
+    let mut queue: Vec<DepPath> = result
+        .direct_dependencies_by_importer
+        .values()
+        .flat_map(|direct| direct.values().cloned())
+        .collect();
+    while let Some(dep_path) = queue.pop() {
+        if !reachable.insert(dep_path.clone()) {
+            continue;
+        }
+        queue.extend(result.graph[&dep_path].children.values().cloned());
+    }
+    let orphans: Vec<_> =
+        result.graph.keys().filter(|dep_path| !reachable.contains(*dep_path)).collect();
+    assert!(orphans.is_empty(), "every graph entry is reachable from an importer: {orphans:?}");
 }
 
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1677,7 +1677,7 @@ fn a_shared_consumer_keeps_the_first_importers_peer_provider_variant() {
     );
     // Trimming a peer segment off the edge would key it to a variant no
     // importer reaches, leaving an orphan entry in the lockfile —
-    // https://github.com/pnpm/pnpm/issues/13320.
+    // <https://github.com/pnpm/pnpm/issues/13320>.
     let mut reachable: HashSet<DepPath> = HashSet::new();
     let mut queue: Vec<DepPath> = result
         .direct_dependencies_by_importer


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13320 — the last item on it, the three `snapshots:` keys pacquet emitted for `vercel/next.js` that the TypeScript CLI does not.

One of the three (`@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)`) was already fixed on `main` by pnpm/pnpm#13374 — it came from walking `@tailwindcss/oxide-wasm32-wasi`'s bundled dependencies. The other two traced to `build_final_graph`, which rewrote a resolved-peer edge whenever the provider's depPath carried a peer segment the consumer had not resolved itself: it looked for a variant of the provider without those segments, and fabricated one when none existed. The TypeScript CLI does no such thing — `resolveChildren` maps every `childrenNodeIds` entry through `pathsByNodeId`, so an edge always names the instance the provider node resolved to.

On next.js the rewrite hit the single shared `eslint-module-utils` instance: its `eslint-import-resolver-typescript` edge was trimmed to a fabricated variant, which `dedupe_peer_dependents` then collapsed into the *other* importer's resolver instance. The lockfile came out with the peer bound to the wrong instance, plus an orphan `snapshots:` entry nothing referenced.

Minimal reproduction (a two-importer workspace where the root has `eslint-plugin-import@2.31.0` + `@typescript-eslint/parser` and a package has `eslint-plugin-import@^2.32.0` + `eslint-import-resolver-typescript`) diverged the same way and now matches.

Verification, all against the same registry state:

| | before | after |
| --- | --- | --- |
| `vercel/next.js@dcf242a1` full re-resolution vs the TypeScript CLI | 6 diff lines, 3 pacquet-only `snapshots:` keys | **byte-identical, 0 diff lines** |
| `n8n@5339b5e4` (separate divergence, pnpm/pnpm#13322) | 1371 diff lines | 1251 diff lines |
| `webpack` + `webpack-cli` + `webpack-dev-server` + `webpack-bundle-analyzer` (the case the removed code was written for) | identical | identical |

Full pacquet suite green (7270 tests), `just ready` clean.

TypeScript side: no counterpart. The rewrite was pacquet-only, and this removes it in favour of what the TypeScript CLI already does.

## Squash Commit Body

```text
The final-graph rebuild rewrote a resolved-peer edge whenever the
provider's depPath carried a peer segment the consumer had not resolved
itself: it looked for a variant of the provider without those segments,
and fabricated one when none existed. Upstream does no such thing —
`resolveChildren` maps every `childrenNodeIds` entry through
`pathsByNodeId`, so an edge always names the instance the provider node
resolved to.

That rewrite is what was left of pnpm/pnpm#13320 on vercel/next.js. The
workspace resolves two `eslint-plugin-import` versions, and the single
shared `eslint-module-utils` instance had its
`eslint-import-resolver-typescript` edge trimmed to a fabricated
variant, which the peer-dependent dedupe then collapsed into the *other*
importer's resolver instance. The lockfile came out with the peer bound
to the wrong instance and an orphan `snapshots:` entry nothing
referenced.

Dropping the rewrite makes a full re-resolution of vercel/next.js
byte-identical to the TypeScript CLI's lockfile, and narrows the
separate n8n divergence (pnpm/pnpm#13322) from 1371 to 1251 lines.
`NodeRecord::peer_edges` only existed to classify edges for the rewrite,
so it goes with it.

Closes pnpm/pnpm#13320.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787646959&installation_model_id=426870&pr_number=13401&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13401&signature=eed4c3a75a0e7ba5b6bf62762ea638cdb6b0c44c85a93e3b9f54ba4ae92a0ee5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed peer dependency resolution so lockfiles reference the provider version and peer suffix actually selected.
  * Prevented dependencies from being linked to incorrect package variants.
  * Removed unreachable dependency entries from lockfiles in complex workspace scenarios.
  * Improved consistency when shared dependencies are resolved across multiple projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->