### PR TITLE
fix(config): resolve `$dep-name` self-references in overrides

### DIFF
--- a/.changeset/resolve-override-version-references.md
+++ b/.changeset/resolve-override-version-references.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`$dep-name` self-references in `overrides` are now resolved against the root manifest's direct dependencies, so an override such as `rolldown: $rolldown` records the concrete specifier in `pnpm-lock.yaml` and no longer fails a frozen install with `ERR_PNPM_OUTDATED_LOCKFILE` [#13314](https://github.com/pnpm/pnpm/issues/13314). A reference to a package that is not a direct dependency fails with `ERR_PNPM_CANNOT_RESOLVE_OVERRIDE_VERSION`, and the deprecated syntax now warns, pointing at catalogs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4113,6 +4113,7 @@ dependencies = [
  "pacquet-env-replace",
  "pacquet-network",
  "pacquet-package-is-installable",
+ "pacquet-package-manifest",
  "pacquet-patching",
  "pacquet-store-dir",
  "pacquet-testing-utils",

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -38,6 +38,7 @@ pub mod list;
 pub mod login;
 pub mod logout;
 pub mod outdated;
+pub(crate) mod override_version_references;
 pub mod owner;
 pub mod pack;
 pub mod pack_app;

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1,8 +1,9 @@
 use crate::{
     State,
     cli_args::{
-        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields_in, pipelines::InstallFamilySelection,
-        recursive::discover_workspace_projects,
+        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields_in,
+        override_version_references::warn_deprecated_override_version_references,
+        pipelines::InstallFamilySelection, recursive::discover_workspace_projects,
         supported_architectures::SupportedArchitecturesArgs,
     },
 };
@@ -350,6 +351,7 @@ impl InstallArgs {
         // to the full install path, which warns from
         // `derive_config_root_and_package_manager_to_sync`.
         warn_ignored_pnpm_manifest_fields_in(&config_root, emit);
+        warn_deprecated_override_version_references(config, emit);
         // The scope covers the same projects the full install path would
         // report; an up-to-date run says so too rather than going quiet
         // about what it just decided was current.

--- a/pnpm/crates/cli/src/cli_args/override_version_references.rs
+++ b/pnpm/crates/cli/src/cli_args/override_version_references.rs
@@ -1,0 +1,38 @@
+//! The `$dep-name` self-reference syntax in `overrides` — a value that
+//! copies the specifier the root manifest declares for that dependency —
+//! is deprecated in favor of catalogs. pnpm still honors it, and warns
+//! once per command about every selector still using it.
+
+use pacquet_config::Config;
+use pacquet_reporter::{GlobalLog, LogEvent, LogLevel};
+use serde_json::Value;
+
+/// Warn about the `overrides` selectors whose configured value is a
+/// `$dep-name` reference.
+///
+/// The values [`Config::overrides`] carries are already resolved, so
+/// the raw ones are read back from [`Config::explicit_settings`], the
+/// record of what each config source set.
+pub(crate) fn warn_deprecated_override_version_references(config: &Config, emit: fn(&LogEvent)) {
+    let Some(overrides) = config.explicit_settings.get("overrides").and_then(Value::as_object)
+    else {
+        return;
+    };
+    let selectors = overrides
+        .iter()
+        .filter(|(_, spec)| spec.as_str().is_some_and(|spec| spec.starts_with('$')))
+        .map(|(selector, _)| selector.as_str())
+        .collect::<Vec<_>>();
+    if selectors.is_empty() {
+        return;
+    }
+    emit(&LogEvent::Global(GlobalLog {
+        level: LogLevel::Warn,
+        message: format!(
+            "The \"$\" version reference syntax in overrides is deprecated (used by: {}). \
+             Define the version in a catalog and reference it with the \"catalog:\" protocol \
+             instead. See https://pnpm.io/catalogs",
+            selectors.join(", "),
+        ),
+    }));
+}

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -17,6 +17,7 @@ use crate::{
     State,
     cli_args::{
         legacy_pnpm_field::warn_ignored_pnpm_manifest_fields,
+        override_version_references::warn_deprecated_override_version_references,
         reporter::{ReporterType, reporter_emit},
     },
     config_deps,
@@ -653,6 +654,7 @@ pub(crate) fn derive_config_root_and_package_manager_to_sync(
     // install output. This is the install family's earliest point that
     // knows the root manifest's directory.
     warn_ignored_pnpm_manifest_fields(root_manifest.as_ref(), reporter_emit(reporter));
+    warn_deprecated_override_version_references(cfg, reporter_emit(reporter));
     let package_manager_to_sync = root_manifest
         .as_ref()
         .and_then(|manifest| package_manager_to_sync(manifest, &config_root, cfg.pm_on_fail));

--- a/pnpm/crates/cli/tests/override_version_references.rs
+++ b/pnpm/crates/cli/tests/override_version_references.rs
@@ -1,0 +1,113 @@
+//! `$dep-name` self-references in `overrides` end to end: the reference
+//! resolves against the root manifest's direct dependencies, and the
+//! resolved specifier — not the raw `$dep-name` — is what the lockfile
+//! records and what a later frozen install compares against.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_lockfile::Lockfile;
+use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use pretty_assertions::assert_eq;
+use std::{fs, path::Path, process::Command};
+
+const DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+
+/// Append an `overrides` block to the `pnpm-workspace.yaml` the mocked
+/// registry already wrote (it carries `storeDir`/`cacheDir`, so the
+/// tests must extend it rather than overwrite it).
+fn add_overrides(workspace: &Path, block: &str) {
+    let path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&path).unwrap_or_default();
+    if !yaml.is_empty() && !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str(block);
+    fs::write(&path, yaml).expect("update pnpm-workspace.yaml");
+}
+
+fn write_manifest(workspace: &Path, dep_spec: &str) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "override-self-reference",
+            "version": "1.0.0",
+            "dependencies": { DEP: dep_spec },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+}
+
+fn lockfile_overrides(workspace: &Path) -> Vec<(String, String)> {
+    let text = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    let lockfile: Lockfile = serde_saphyr::from_str(&text).expect("parse pnpm-lock.yaml");
+    lockfile
+        .overrides
+        .iter()
+        .flatten()
+        .map(|(selector, spec)| (selector.clone(), spec.clone()))
+        .collect()
+}
+
+#[test]
+fn install_resolves_a_reference_and_a_frozen_install_accepts_the_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, "^100.0.0");
+    add_overrides(&workspace, &format!("overrides:\n  \"{DEP}\": ${DEP}\n"));
+
+    let output = pacquet.with_arg("install").assert().success();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout).into_owned();
+    eprintln!("STDOUT:\n{stdout}\n");
+
+    assert_eq!(lockfile_overrides(&workspace), vec![(DEP.to_string(), "^100.0.0".to_string())]);
+    assert!(
+        stdout.contains(&format!(
+            "The \"$\" version reference syntax in overrides is deprecated (used by: {DEP}). \
+             Define the version in a catalog and reference it with the \"catalog:\" protocol \
+             instead. See https://pnpm.io/catalogs"
+        )),
+        "{stdout}",
+    );
+
+    // The freshness check compares the lockfile's `overrides` against
+    // the configured ones, so an unresolved `$dep-name` here would fail
+    // the install as outdated.
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .assert()
+        .success();
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn install_rejects_a_reference_to_a_package_that_is_not_a_direct_dependency() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, "^100.0.0");
+    add_overrides(&workspace, &format!("overrides:\n  \"{DEP}\": $is-odd\n"));
+
+    let output = pacquet.with_arg("install").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
+    eprintln!("STDERR:\n{stderr}\n");
+
+    assert!(stderr.contains("ERR_PNPM_CANNOT_RESOLVE_OVERRIDE_VERSION"), "{stderr}");
+    // miette wraps the message across terminal-width lines, so compare
+    // against a whitespace-collapsed rendering.
+    let unwrapped = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(
+        unwrapped.contains(
+            r#"Cannot resolve version $is-odd in overrides. The direct dependencies don't have dependency "is-odd"."#
+        ),
+        "{stderr}",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/config/Cargo.toml
+++ b/pnpm/crates/config/Cargo.toml
@@ -17,6 +17,7 @@ pacquet-detect-libc            = { workspace = true }
 pacquet-env-replace            = { workspace = true }
 pacquet-network                = { workspace = true }
 pacquet-package-is-installable = { workspace = true }
+pacquet-package-manifest       = { workspace = true }
 pacquet-patching               = { workspace = true }
 pacquet-store-dir              = { workspace = true }
 pacquet-versioning             = { workspace = true }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -6,6 +6,7 @@ mod global_bin_check;
 pub mod matcher;
 pub mod naming_cases;
 mod npmrc_auth;
+mod override_version_references;
 pub mod property_path;
 pub mod protected_settings;
 mod store_path;
@@ -2544,6 +2545,16 @@ impl Config {
                 }
                 collect_explicit_settings(&mut self.explicit_settings, &settings);
                 settings.apply_to(&mut self, &base_dir);
+                // `overrides` reaches `Config` only from the workspace
+                // yaml (the global config.yaml is stripped of the key,
+                // and no `PNPM_CONFIG_*` var carries a map), so the
+                // `$dep-name` values it may hold are resolved here,
+                // against the workspace root's manifest.
+                if let Some(overrides) = self.overrides.as_mut() {
+                    crate::override_version_references::resolve_version_references(
+                        overrides, &base_dir,
+                    )?;
+                }
             }
         }
 

--- a/pnpm/crates/config/src/override_version_references.rs
+++ b/pnpm/crates/config/src/override_version_references.rs
@@ -12,7 +12,7 @@
 
 use crate::workspace_yaml::LoadWorkspaceYamlError;
 use indexmap::IndexMap;
-use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use std::{collections::HashMap, path::Path};
 
 /// The dependency groups a `$dep-name` reference may point at, in
@@ -24,9 +24,10 @@ const REFERENCEABLE_GROUPS: [DependencyGroup; 3] =
 /// Replace every `$dep-name` value in `overrides` with the specifier
 /// the manifest at `root_dir` declares for that dependency.
 ///
-/// A root manifest that is missing or unreadable contributes no
-/// dependencies, so every reference in it fails to resolve — the install
-/// path reports the unreadable manifest itself with far more context.
+/// A workspace root without a manifest declares no dependencies, so
+/// every reference then fails to resolve. A manifest that exists but
+/// cannot be read or parsed propagates its own error instead — the
+/// unreadable file is what the user has to fix.
 pub(crate) fn resolve_version_references(
     overrides: &mut IndexMap<String, String>,
     root_dir: &Path,
@@ -34,7 +35,13 @@ pub(crate) fn resolve_version_references(
     if !overrides.values().any(|spec| spec.starts_with('$')) {
         return Ok(());
     }
-    let root_manifest = PackageManifest::from_path(root_dir.join("package.json")).ok();
+    let root_manifest = match PackageManifest::from_path(root_dir.join("package.json")) {
+        Ok(manifest) => Some(manifest),
+        Err(PackageManifestError::NoImporterManifestFound(_)) => None,
+        Err(source) => {
+            return Err(LoadWorkspaceYamlError::ReadRootManifest { source: Box::new(source) });
+        }
+    };
     let direct_dependencies: HashMap<&str, &str> = root_manifest
         .as_ref()
         .map(|manifest| manifest.dependencies(REFERENCEABLE_GROUPS).collect())

--- a/pnpm/crates/config/src/override_version_references.rs
+++ b/pnpm/crates/config/src/override_version_references.rs
@@ -1,0 +1,57 @@
+//! `$dep-name` self-references in `overrides`.
+//!
+//! An override value of `$foo` means "whatever specifier the root
+//! manifest declares for `foo`". The reference is resolved while config
+//! is read, so every downstream consumer — the read-package hook that
+//! rewrites manifests, the `overrides:` map written to
+//! `pnpm-lock.yaml`, and the lockfile freshness check that compares the
+//! two — works with the concrete specifier.
+//!
+//! The syntax is deprecated in favor of catalogs, but pnpm still
+//! honors it.
+
+use crate::workspace_yaml::LoadWorkspaceYamlError;
+use indexmap::IndexMap;
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use std::{collections::HashMap, path::Path};
+
+/// The dependency groups a `$dep-name` reference may point at, in
+/// merge order: a name declared in more than one of them resolves to
+/// the last group's specifier. `peerDependencies` is not referenceable.
+const REFERENCEABLE_GROUPS: [DependencyGroup; 3] =
+    [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional];
+
+/// Replace every `$dep-name` value in `overrides` with the specifier
+/// the manifest at `root_dir` declares for that dependency.
+///
+/// A root manifest that is missing or unreadable contributes no
+/// dependencies, so every reference in it fails to resolve — the install
+/// path reports the unreadable manifest itself with far more context.
+pub(crate) fn resolve_version_references(
+    overrides: &mut IndexMap<String, String>,
+    root_dir: &Path,
+) -> Result<(), LoadWorkspaceYamlError> {
+    if !overrides.values().any(|spec| spec.starts_with('$')) {
+        return Ok(());
+    }
+    let root_manifest = PackageManifest::from_path(root_dir.join("package.json")).ok();
+    let direct_dependencies: HashMap<&str, &str> = root_manifest
+        .as_ref()
+        .map(|manifest| manifest.dependencies(REFERENCEABLE_GROUPS).collect())
+        .unwrap_or_default();
+    for spec in overrides.values_mut() {
+        let Some(dependency_name) = spec.strip_prefix('$') else { continue };
+        let Some(resolved) = direct_dependencies.get(dependency_name) else {
+            return Err(LoadWorkspaceYamlError::CannotResolveOverrideVersion {
+                spec: spec.clone(),
+                dependency_name: dependency_name.to_string(),
+            });
+        };
+        let resolved = (*resolved).to_string();
+        *spec = resolved;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/config/src/override_version_references/tests.rs
+++ b/pnpm/crates/config/src/override_version_references/tests.rs
@@ -105,6 +105,21 @@ fn a_reference_without_a_root_manifest_is_rejected() {
     );
 }
 
+#[test]
+fn a_malformed_root_manifest_reports_itself() {
+    let root = tempdir().expect("create a temporary workspace root");
+    fs::write(root.path().join("package.json"), "{ not json").expect("write the root package.json");
+    let mut overrides = overrides_map(&[("is-odd", "$is-odd")]);
+
+    let error = resolve_version_references(&mut overrides, root.path())
+        .expect_err("the unparsable manifest is the problem to report");
+
+    assert!(
+        matches!(&error, LoadWorkspaceYamlError::ReadRootManifest { .. }),
+        "unexpected error: {error:?}",
+    );
+}
+
 /// The read is skipped entirely when no value carries a reference, so a
 /// workspace root without a manifest is not an error for everyone else.
 #[test]

--- a/pnpm/crates/config/src/override_version_references/tests.rs
+++ b/pnpm/crates/config/src/override_version_references/tests.rs
@@ -1,0 +1,128 @@
+use super::resolve_version_references;
+use crate::workspace_yaml::LoadWorkspaceYamlError;
+use indexmap::IndexMap;
+use pretty_assertions::assert_eq;
+use std::{fs, path::Path};
+use tempfile::{TempDir, tempdir};
+
+fn root_with_manifest(manifest: &serde_json::Value) -> TempDir {
+    let root = tempdir().expect("create a temporary workspace root");
+    fs::write(root.path().join("package.json"), manifest.to_string())
+        .expect("write the root package.json");
+    root
+}
+
+fn overrides_map(entries: &[(&str, &str)]) -> IndexMap<String, String> {
+    entries.iter().map(|(selector, spec)| ((*selector).to_string(), (*spec).to_string())).collect()
+}
+
+#[test]
+fn a_reference_resolves_to_the_specifier_of_a_direct_dependency() {
+    let root = root_with_manifest(&serde_json::json!({
+        "name": "root",
+        "dependencies": { "is-odd": "3.0.1" },
+        "devDependencies": { "rolldown": "~1.2.0" },
+        "optionalDependencies": { "fsevents": "^2.3.0" },
+    }));
+    let mut overrides = overrides_map(&[
+        ("is-odd", "$is-odd"),
+        ("rolldown", "$rolldown"),
+        ("fsevents", "$fsevents"),
+    ]);
+
+    resolve_version_references(&mut overrides, root.path()).expect("resolve the references");
+
+    assert_eq!(
+        overrides,
+        overrides_map(&[("is-odd", "3.0.1"), ("rolldown", "~1.2.0"), ("fsevents", "^2.3.0")]),
+    );
+}
+
+/// The selector a reference is attached to is irrelevant — `$name`
+/// names the dependency to copy the specifier from, not the dependency
+/// being overridden.
+#[test]
+fn a_reference_may_name_a_dependency_other_than_the_overridden_one() {
+    let root = root_with_manifest(&serde_json::json!({
+        "name": "root",
+        "dependencies": { "is-odd": "3.0.1" },
+    }));
+    let mut overrides = overrides_map(&[("is-even>is-odd", "$is-odd")]);
+
+    resolve_version_references(&mut overrides, root.path()).expect("resolve the reference");
+
+    assert_eq!(overrides, overrides_map(&[("is-even>is-odd", "3.0.1")]));
+}
+
+#[test]
+fn values_without_a_reference_are_left_alone() {
+    let root = root_with_manifest(&serde_json::json!({ "name": "root" }));
+    let mut overrides =
+        overrides_map(&[("is-odd", "3.0.1"), ("is-even", "catalog:"), ("foo", "-")]);
+    let untouched = overrides.clone();
+
+    resolve_version_references(&mut overrides, root.path()).expect("leave the values alone");
+
+    assert_eq!(overrides, untouched);
+}
+
+#[test]
+fn a_reference_to_a_missing_dependency_is_rejected() {
+    let root = root_with_manifest(&serde_json::json!({
+        "name": "root",
+        "peerDependencies": { "is-odd": "3.0.1" },
+    }));
+    let mut overrides = overrides_map(&[("is-odd", "$is-odd")]);
+
+    let error = resolve_version_references(&mut overrides, root.path())
+        .expect_err("a peer dependency is not referenceable");
+
+    assert!(
+        matches!(
+            &error,
+            LoadWorkspaceYamlError::CannotResolveOverrideVersion { spec, dependency_name }
+                if spec == "$is-odd" && dependency_name == "is-odd",
+        ),
+        "unexpected error: {error:?}",
+    );
+    assert_eq!(
+        error.to_string(),
+        r#"Cannot resolve version $is-odd in overrides. The direct dependencies don't have dependency "is-odd"."#,
+    );
+}
+
+#[test]
+fn a_reference_without_a_root_manifest_is_rejected() {
+    let root = tempdir().expect("create a temporary workspace root");
+    let mut overrides = overrides_map(&[("is-odd", "$is-odd")]);
+
+    let error = resolve_version_references(&mut overrides, root.path())
+        .expect_err("nothing can be referenced without a root manifest");
+
+    assert!(
+        matches!(&error, LoadWorkspaceYamlError::CannotResolveOverrideVersion { .. }),
+        "unexpected error: {error:?}",
+    );
+}
+
+/// The read is skipped entirely when no value carries a reference, so a
+/// workspace root without a manifest is not an error for everyone else.
+#[test]
+fn a_missing_root_manifest_is_fine_without_references() {
+    let root = tempdir().expect("create a temporary workspace root");
+    let mut overrides = overrides_map(&[("is-odd", "3.0.1")]);
+
+    resolve_version_references(&mut overrides, root.path()).expect("no reference to resolve");
+
+    assert_eq!(overrides, overrides_map(&[("is-odd", "3.0.1")]));
+}
+
+#[test]
+fn an_empty_override_map_needs_no_root_manifest() {
+    let mut empty = IndexMap::new();
+
+    resolve_version_references(&mut empty, Path::new("/nonexistent"))
+        .expect("no reference to resolve");
+
+    assert!(empty.is_empty());
+}

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -748,6 +748,14 @@ pub enum LoadWorkspaceYamlError {
         )
     )]
     TokenHelperUnsupportedCharacter { character: char },
+    /// The root manifest a `$dep-name` self-reference in `overrides`
+    /// resolves against exists but could not be read or parsed.
+    /// Boxed so the returned `Result` stays small.
+    #[display("Failed to read the root package.json: {source}")]
+    ReadRootManifest {
+        #[error(source)]
+        source: Box<pacquet_package_manifest::PackageManifestError>,
+    },
     /// An `overrides` value used the `$dep-name` self-reference syntax,
     /// but the root manifest declares no such direct dependency.
     #[display(

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -748,6 +748,13 @@ pub enum LoadWorkspaceYamlError {
         )
     )]
     TokenHelperUnsupportedCharacter { character: char },
+    /// An `overrides` value used the `$dep-name` self-reference syntax,
+    /// but the root manifest declares no such direct dependency.
+    #[display(
+        r#"Cannot resolve version {spec} in overrides. The direct dependencies don't have dependency "{dependency_name}"."#
+    )]
+    #[diagnostic(code(ERR_PNPM_CANNOT_RESOLVE_OVERRIDE_VERSION))]
+    CannotResolveOverrideVersion { spec: String, dependency_name: String },
 }
 
 impl WorkspaceSettings {
@@ -1171,9 +1178,10 @@ impl WorkspaceSettings {
         if let Some(v) = self.ignored_optional_dependencies {
             config.ignored_optional_dependencies = Some(v);
         }
-        // `$dep-name` self-reference resolution happens elsewhere (the
-        // resolver chain), since it needs the workspace's root manifest
-        // and that isn't in scope here.
+        // `$dep-name` self-references are resolved by
+        // [`crate::override_version_references::resolve_version_references`]
+        // once the cascade knows the workspace root, whose manifest
+        // carries the direct dependencies they point at.
         if let Some(v) = self.overrides {
             config.overrides = (!v.is_empty()).then_some(v);
         }


### PR DESCRIPTION
## Summary

`overrides` values may use the `$dep-name` self-reference syntax — `rolldown: $rolldown` means "whatever specifier the root manifest declares for `rolldown`". pacquet copied the raw map onto `Config::overrides`, so the reference reached the read-package hook, `pnpm-lock.yaml#overrides`, and the lockfile freshness check verbatim. A lockfile written by pnpm 11 (which records the resolved specifier) then failed a frozen install:

```
Error: ERR_PNPM_OUTDATED_LOCKFILE
  `overrides` in the lockfile ({"is-odd": "3.0.1"}) doesn't match the
  current config ({"is-odd": "$is-odd"})
```

This PR resolves the references while config is read, so every consumer downstream of `Config` (including the `.modules.yaml` settings record) sees the concrete specifier, as in pnpm 11. A reference to a package that is not a direct dependency now fails with `ERR_PNPM_CANNOT_RESOLVE_OVERRIDE_VERSION`, and the install family warns about the deprecated syntax and points at catalogs — both matching pnpm 11's wording (`getOptionsFromPnpmSettings`).

The TypeScript CLI already resolves these references, so it needs no change; this is a pacquet-only fix.

Closes pnpm/pnpm#13314

## Squash Commit Body

```text
An `overrides` value of `$foo` means "whatever specifier the root
manifest declares for `foo`". pacquet copied the raw map onto
`Config::overrides` instead, so the reference reached the read-package
hook, `pnpm-lock.yaml#overrides`, and the lockfile freshness check
verbatim. A lockfile written by pnpm 11 — which records the resolved
specifier — then failed a frozen install with ERR_PNPM_OUTDATED_LOCKFILE
(`overrides` in the lockfile `{"is-odd":"3.0.1"}` vs the config's
`{"is-odd":"$is-odd"}`), which is what blocked validating vitejs/vite.

Resolve the references while config is read: `pnpm-workspace.yaml` is
the only source that can set `overrides` (the global config.yaml is
stripped of the key and no `PNPM_CONFIG_*` var carries a map), and the
cascade knows the workspace root at that point, so the root manifest's
`dependencies` / `devDependencies` / `optionalDependencies` are in
reach. Every consumer downstream of `Config` — including the
`.modules.yaml` settings record — therefore sees the concrete
specifier, as it does in pnpm 11.

A reference to a package that is not a direct dependency fails with
ERR_PNPM_CANNOT_RESOLVE_OVERRIDE_VERSION, and the install family warns
about the deprecated syntax and points at catalogs, both matching
pnpm 11's wording.

TypeScript CLI: no change needed, it already resolves the references.

Closes pnpm/pnpm#13314
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787652324&installation_model_id=426870&pr_number=13404&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13404&signature=270a3a40d794f4f75979afc84d982c20489f87524fb19a64c95155b85bc6c291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `$dep-name` override version references are now resolved using the root manifest’s direct dependencies.
  * Resolved override specifiers are written to `pnpm-lock.yaml`, so `--frozen-lockfile` installs no longer fail for these cases.
  * Invalid `$...` references now fail with a clearer `ERR_PNPM_CANNOT_RESOLVE_OVERRIDE_VERSION` message when the dependency isn’t a direct dependency.

* **Warnings**
  * Deprecated `$`-style override version references now emit a deprecation warning pointing to the `catalog:` protocol, including during fast-path installs.

* **Documentation**
  * Updated documented behavior and error semantics for deprecated override syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->