### PR TITLE
fix(package-manager): record and honor bundledDependencies

### DIFF
--- a/.changeset/bundled-dependencies-true.md
+++ b/.changeset/bundled-dependencies-true.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Executables that a package ships inside its own tarball (`bundledDependencies`) are linked again into that package's `node_modules/.bin`, under both the isolated and the hoisted node linker. A package that declares `bundleDependencies: true` instead of a list of names is now recorded in `pnpm-lock.yaml` the way pnpm 11 records it, and such a lockfile can be read back.

--- a/pnpm/crates/cli/tests/bundled_dependencies.rs
+++ b/pnpm/crates/cli/tests/bundled_dependencies.rs
@@ -4,7 +4,7 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_lockfile::{BundledDependencies, Lockfile, PackageMetadata};
-use pacquet_testing_utils::{bin::CommandTempCwd, fs::is_path_executable};
+use pacquet_testing_utils::bin::CommandTempCwd;
 use std::{fs, path::Path};
 
 pub mod _utils;
@@ -17,12 +17,9 @@ fn bundled_dependencies_are_kept_out_of_the_lockfile() {
 
     pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0"]).assert().success();
 
-    assert!(
-        is_path_executable(&workspace.join(
-            "node_modules/@pnpm.e2e/pkg-with-bundled-dependencies/node_modules/.bin/hello-world-js-bin"
-        )),
-        "the bundled dependency's bin must be linked inside the bundling package",
-    );
+    assert_bin_linked(&workspace.join(
+        "node_modules/@pnpm.e2e/pkg-with-bundled-dependencies/node_modules/.bin/hello-world-js-bin",
+    ));
 
     let lockfile = read_wanted_lockfile(&workspace);
     assert_eq!(
@@ -44,12 +41,9 @@ fn bundle_dependencies_spelling_is_kept_out_of_the_lockfile() {
 
     pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundle-dependencies@1.0.0"]).assert().success();
 
-    assert!(
-        is_path_executable(&workspace.join(
-            "node_modules/@pnpm.e2e/pkg-with-bundle-dependencies/node_modules/.bin/hello-world-js-bin"
-        )),
-        "the bundled dependency's bin must be linked inside the bundling package",
-    );
+    assert_bin_linked(&workspace.join(
+        "node_modules/@pnpm.e2e/pkg-with-bundle-dependencies/node_modules/.bin/hello-world-js-bin",
+    ));
 
     let lockfile = read_wanted_lockfile(&workspace);
     assert_eq!(
@@ -84,13 +78,13 @@ fn bundle_dependencies_true_is_recorded_as_true() {
     let bundled_bin = workspace.join(
         "node_modules/@pnpm.e2e/pkg-with-bundle-dependencies-true/node_modules/.bin/hello-world-js-bin",
     );
-    assert!(is_path_executable(&bundled_bin));
+    assert_bin_linked(&bundled_bin);
 
     // The boolean form has to survive a round trip through the lockfile,
     // both to parse at all and to keep driving the bundled-bin linking.
     fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
     pacquet_in(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
-    assert!(is_path_executable(&bundled_bin));
+    assert_bin_linked(&bundled_bin);
 
     drop((root, npmrc_info)); // cleanup
 }
@@ -104,12 +98,9 @@ fn bundled_bins_are_linked_under_the_hoisted_linker() {
 
     pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0"]).assert().success();
 
-    assert!(
-        is_path_executable(&workspace.join(
-            "node_modules/@pnpm.e2e/pkg-with-bundled-dependencies/node_modules/.bin/hello-world-js-bin"
-        )),
-        "the hoisted tree keeps the bundled dependency's bin inside the bundling package",
-    );
+    assert_bin_linked(&workspace.join(
+        "node_modules/@pnpm.e2e/pkg-with-bundled-dependencies/node_modules/.bin/hello-world-js-bin",
+    ));
 
     drop((root, npmrc_info)); // cleanup
 }
@@ -133,6 +124,17 @@ fn bundle_dependencies_false_is_not_recorded() {
     );
 
     drop((root, npmrc_info)); // cleanup
+}
+
+/// Windows has no executable bit — `link_bins_of_packages` writes `.cmd` and
+/// `.ps1` siblings there instead — so only the shim's existence is portable.
+fn assert_bin_linked(shim: &Path) {
+    assert!(shim.exists(), "the bundled dependency's bin must be linked at {shim:?}");
+    #[cfg(unix)]
+    assert!(
+        pacquet_testing_utils::fs::is_path_executable(shim),
+        "the bundled dependency's bin shim at {shim:?} must be executable",
+    );
 }
 
 fn read_wanted_lockfile(workspace: &Path) -> Lockfile {

--- a/pnpm/crates/cli/tests/bundled_dependencies.rs
+++ b/pnpm/crates/cli/tests/bundled_dependencies.rs
@@ -4,7 +4,7 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pacquet_lockfile::{BundledDependencies, Lockfile, PackageMetadata};
-use pacquet_testing_utils::bin::CommandTempCwd;
+use pacquet_testing_utils::{bin::CommandTempCwd, fs::is_symlink_or_junction};
 use std::{fs, path::Path};
 
 pub mod _utils;
@@ -111,12 +111,16 @@ fn bundled_bins_are_linked_under_the_hoisted_linker() {
     for bundling_pkg in
         ["@pnpm.e2e/pkg-with-bundled-dependencies", "@pnpm.e2e/pkg-with-bundle-dependencies-true"]
     {
-        assert_bin_linked(
-            &workspace
-                .join("node_modules")
-                .join(bundling_pkg)
-                .join("node_modules/.bin/hello-world-js-bin"),
+        let pkg_dir = workspace.join("node_modules").join(bundling_pkg);
+        // The hoisted linker materializes a real directory where the isolated
+        // one leaves a symlink into the virtual store, so this is what proves
+        // the `nodeLinker` key took effect and the other linker is not what
+        // linked the bin below.
+        assert!(
+            pkg_dir.is_dir() && !is_symlink_or_junction(&pkg_dir).expect("stat the package dir"),
+            "{bundling_pkg} must be a real directory under the hoisted linker",
         );
+        assert_bin_linked(&pkg_dir.join("node_modules/.bin/hello-world-js-bin"));
     }
 
     drop((root, npmrc_info)); // cleanup

--- a/pnpm/crates/cli/tests/bundled_dependencies.rs
+++ b/pnpm/crates/cli/tests/bundled_dependencies.rs
@@ -1,0 +1,140 @@
+//! Ports of the TypeScript `bundledDependencies` install suite
+//! (`installing/deps-installer/test/install/bundledDependencies.ts`).
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pacquet_lockfile::{BundledDependencies, Lockfile, PackageMetadata};
+use pacquet_testing_utils::{bin::CommandTempCwd, fs::is_path_executable};
+use std::{fs, path::Path};
+
+pub mod _utils;
+pub use _utils::pacquet_in;
+
+#[test]
+fn bundled_dependencies_are_kept_out_of_the_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0"]).assert().success();
+
+    assert!(
+        is_path_executable(&workspace.join(
+            "node_modules/@pnpm.e2e/pkg-with-bundled-dependencies/node_modules/.bin/hello-world-js-bin"
+        )),
+        "the bundled dependency's bin must be linked inside the bundling package",
+    );
+
+    let lockfile = read_wanted_lockfile(&workspace);
+    assert_eq!(
+        package(&lockfile, "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0").bundled_dependencies,
+        Some(BundledDependencies::Names(vec!["@pnpm.e2e/hello-world-js-bin".to_string()])),
+    );
+    assert!(
+        !has_package(&lockfile, "@pnpm.e2e/hello-world-js-bin@1.0.0"),
+        "a bundled dependency ships inside the tarball and must not get a lockfile entry",
+    );
+
+    drop((root, npmrc_info)); // cleanup
+}
+
+#[test]
+fn bundle_dependencies_spelling_is_kept_out_of_the_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundle-dependencies@1.0.0"]).assert().success();
+
+    assert!(
+        is_path_executable(&workspace.join(
+            "node_modules/@pnpm.e2e/pkg-with-bundle-dependencies/node_modules/.bin/hello-world-js-bin"
+        )),
+        "the bundled dependency's bin must be linked inside the bundling package",
+    );
+
+    let lockfile = read_wanted_lockfile(&workspace);
+    assert_eq!(
+        package(&lockfile, "@pnpm.e2e/pkg-with-bundle-dependencies@1.0.0").bundled_dependencies,
+        Some(BundledDependencies::Names(vec!["@pnpm.e2e/hello-world-js-bin".to_string()])),
+        "the lockfile records the `bundleDependencies` spelling under `bundledDependencies`",
+    );
+    assert!(!has_package(&lockfile, "@pnpm.e2e/hello-world-js-bin@1.0.0"));
+
+    drop((root, npmrc_info)); // cleanup
+}
+
+#[test]
+fn bundle_dependencies_true_is_recorded_as_true() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    pacquet
+        .with_args(["add", "@pnpm.e2e/pkg-with-bundle-dependencies-true@1.0.0"])
+        .assert()
+        .success();
+
+    let lockfile = read_wanted_lockfile(&workspace);
+    assert_eq!(
+        package(&lockfile, "@pnpm.e2e/pkg-with-bundle-dependencies-true@1.0.0")
+            .bundled_dependencies,
+        Some(BundledDependencies::Boolean(true)),
+        "`bundleDependencies: true` is recorded verbatim, and drives bundled-bin linking",
+    );
+    assert!(!has_package(&lockfile, "@pnpm.e2e/hello-world-js-bin@1.0.0"));
+
+    let bundled_bin = workspace.join(
+        "node_modules/@pnpm.e2e/pkg-with-bundle-dependencies-true/node_modules/.bin/hello-world-js-bin",
+    );
+    assert!(is_path_executable(&bundled_bin));
+
+    // The boolean form has to survive a round trip through the lockfile,
+    // both to parse at all and to keep driving the bundled-bin linking.
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    pacquet_in(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert!(is_path_executable(&bundled_bin));
+
+    drop((root, npmrc_info)); // cleanup
+}
+
+#[test]
+fn bundle_dependencies_false_is_not_recorded() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundle-dependencies-false"]).assert().success();
+
+    let lockfile = read_wanted_lockfile(&workspace);
+    assert_eq!(
+        package(&lockfile, "@pnpm.e2e/pkg-with-bundle-dependencies-false@1.0.0")
+            .bundled_dependencies,
+        None,
+    );
+    assert!(
+        has_package(&lockfile, "@pnpm.e2e/hello-world-js-bin@1.0.0"),
+        "`bundleDependencies: false` bundles nothing, so the dependency is resolved normally",
+    );
+
+    drop((root, npmrc_info)); // cleanup
+}
+
+fn read_wanted_lockfile(workspace: &Path) -> Lockfile {
+    let text =
+        fs::read_to_string(workspace.join(Lockfile::FILE_NAME)).expect("read pnpm-lock.yaml");
+    serde_saphyr::from_str(&text).expect("parse pnpm-lock.yaml")
+}
+
+fn package<'a>(lockfile: &'a Lockfile, key: &str) -> &'a PackageMetadata {
+    lockfile
+        .packages
+        .as_ref()
+        .expect("lockfile has packages")
+        .iter()
+        .find_map(|(candidate, metadata)| (candidate.to_string() == key).then_some(metadata))
+        .unwrap_or_else(|| panic!("the lockfile must record {key}"))
+}
+
+fn has_package(lockfile: &Lockfile, key: &str) -> bool {
+    lockfile
+        .packages
+        .as_ref()
+        .is_some_and(|packages| packages.keys().any(|candidate| candidate.to_string() == key))
+}

--- a/pnpm/crates/cli/tests/bundled_dependencies.rs
+++ b/pnpm/crates/cli/tests/bundled_dependencies.rs
@@ -96,11 +96,28 @@ fn bundled_bins_are_linked_under_the_hoisted_linker() {
 
     append_workspace_yaml_key(&workspace, "nodeLinker", "hoisted");
 
-    pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0"]).assert().success();
+    // Both declaration shapes, because the hoisted linker reaches the bundling
+    // signal through `DependenciesGraphNode::has_bundled_dependencies` rather
+    // than the lockfile row the isolated linker reads.
+    pacquet
+        .with_args([
+            "add",
+            "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0",
+            "@pnpm.e2e/pkg-with-bundle-dependencies-true@1.0.0",
+        ])
+        .assert()
+        .success();
 
-    assert_bin_linked(&workspace.join(
-        "node_modules/@pnpm.e2e/pkg-with-bundled-dependencies/node_modules/.bin/hello-world-js-bin",
-    ));
+    for bundling_pkg in
+        ["@pnpm.e2e/pkg-with-bundled-dependencies", "@pnpm.e2e/pkg-with-bundle-dependencies-true"]
+    {
+        assert_bin_linked(
+            &workspace
+                .join("node_modules")
+                .join(bundling_pkg)
+                .join("node_modules/.bin/hello-world-js-bin"),
+        );
+    }
 
     drop((root, npmrc_info)); // cleanup
 }

--- a/pnpm/crates/cli/tests/bundled_dependencies.rs
+++ b/pnpm/crates/cli/tests/bundled_dependencies.rs
@@ -8,7 +8,7 @@ use pacquet_testing_utils::{bin::CommandTempCwd, fs::is_path_executable};
 use std::{fs, path::Path};
 
 pub mod _utils;
-pub use _utils::pacquet_in;
+pub use _utils::{append_workspace_yaml_key, pacquet_in};
 
 #[test]
 fn bundled_dependencies_are_kept_out_of_the_lockfile() {
@@ -91,6 +91,25 @@ fn bundle_dependencies_true_is_recorded_as_true() {
     fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
     pacquet_in(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
     assert!(is_path_executable(&bundled_bin));
+
+    drop((root, npmrc_info)); // cleanup
+}
+
+#[test]
+fn bundled_bins_are_linked_under_the_hoisted_linker() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    append_workspace_yaml_key(&workspace, "nodeLinker", "hoisted");
+
+    pacquet.with_args(["add", "@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0"]).assert().success();
+
+    assert!(
+        is_path_executable(&workspace.join(
+            "node_modules/@pnpm.e2e/pkg-with-bundled-dependencies/node_modules/.bin/hello-world-js-bin"
+        )),
+        "the hoisted tree keeps the bundled dependency's bin inside the bundling package",
+    );
 
     drop((root, npmrc_info)); // cleanup
 }

--- a/pnpm/crates/cli/tests/bundled_dependencies.rs
+++ b/pnpm/crates/cli/tests/bundled_dependencies.rs
@@ -143,8 +143,10 @@ fn bundle_dependencies_false_is_not_recorded() {
     drop((root, npmrc_info)); // cleanup
 }
 
-/// Windows has no executable bit — `link_bins_of_packages` writes `.cmd` and
-/// `.ps1` siblings there instead — so only the shim's existence is portable.
+/// A linked bin means something different per platform: Unix has the
+/// executable bit on the extensionless shim, while Windows has no such bit and
+/// instead relies on the `.cmd` / `.ps1` launchers written next to it. Assert
+/// whichever of the two actually makes the bin invocable on the host.
 fn assert_bin_linked(shim: &Path) {
     assert!(shim.exists(), "the bundled dependency's bin must be linked at {shim:?}");
     #[cfg(unix)]
@@ -152,6 +154,14 @@ fn assert_bin_linked(shim: &Path) {
         pacquet_testing_utils::fs::is_path_executable(shim),
         "the bundled dependency's bin shim at {shim:?} must be executable",
     );
+    #[cfg(windows)]
+    for extension in ["cmd", "ps1"] {
+        let launcher = shim.with_file_name(format!(
+            "{}.{extension}",
+            shim.file_name().expect("bin shim has a file name").to_string_lossy(),
+        ));
+        assert!(launcher.exists(), "the bin shim at {shim:?} needs its {extension} launcher");
+    }
 }
 
 fn read_wanted_lockfile(workspace: &Path) -> Lockfile {

--- a/pnpm/crates/env-installer/src/manifest_lockfile.rs
+++ b/pnpm/crates/env-installer/src/manifest_lockfile.rs
@@ -1,4 +1,4 @@
-use pacquet_lockfile::{PackageMetadata, PeerDependencyMeta};
+use pacquet_lockfile::{BundledDependencies, PackageMetadata, PeerDependencyMeta};
 use pacquet_resolving_resolver_base::ResolveResult;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -29,8 +29,7 @@ pub(crate) fn package_metadata(
             .map(ToString::to_string),
         has_bin: manifest_has_bin(manifest),
         prepare: None,
-        bundled_dependencies: read_string_list(manifest, "bundledDependencies")
-            .or_else(|| read_string_list(manifest, "bundleDependencies")),
+        bundled_dependencies: BundledDependencies::from_manifest(manifest),
         peer_dependencies: read_string_map(manifest, "peerDependencies"),
         peer_dependencies_meta: read_peer_dependencies_meta(manifest),
     }

--- a/pnpm/crates/lockfile/src/package_metadata.rs
+++ b/pnpm/crates/lockfile/src/package_metadata.rs
@@ -41,7 +41,7 @@ pub struct PackageMetadata {
     pub prepare: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bundled_dependencies: Option<Vec<String>>,
+    pub bundled_dependencies: Option<BundledDependencies>,
     #[serde(
         skip_serializing_if = "Option::is_none",
         serialize_with = "crate::serialize_yaml::sorted_map_opt"
@@ -52,6 +52,43 @@ pub struct PackageMetadata {
         serialize_with = "crate::serialize_yaml::sorted_map_opt"
     )]
     pub peer_dependencies_meta: Option<HashMap<String, PeerDependencyMeta>>,
+}
+
+/// What a package bundles inside its own tarball, as pnpm records it: the
+/// bundled names, or the boolean form that covers every entry of
+/// `dependencies`. Both manifest spellings (`bundledDependencies` and
+/// `bundleDependencies`) land here under the `bundledDependencies` key.
+///
+/// The presence of the field — whatever its shape — is what tells the
+/// installer to link the bins the tarball ships in its own `node_modules`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BundledDependencies {
+    Boolean(bool),
+    Names(Vec<String>),
+}
+
+impl BundledDependencies {
+    /// Read the declaration off a package manifest. Only a list or `true` is
+    /// recorded; anything else (including `false`) falls through to the legacy
+    /// `bundleDependencies` spelling and then to `None`, because a package that
+    /// bundles nothing must not look like one that does.
+    #[must_use]
+    pub fn from_manifest(manifest: Option<&serde_json::Value>) -> Option<Self> {
+        ["bundledDependencies", "bundleDependencies"].into_iter().find_map(|key| {
+            match manifest?.get(key)? {
+                serde_json::Value::Array(items) => Some(BundledDependencies::Names(
+                    items
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(ToString::to_string)
+                        .collect(),
+                )),
+                serde_json::Value::Bool(true) => Some(BundledDependencies::Boolean(true)),
+                _ => None,
+            }
+        })
+    }
 }
 
 // Some packages declare `libc` as a plain string in `package.json`; pnpm writes

--- a/pnpm/crates/lockfile/src/package_metadata/tests.rs
+++ b/pnpm/crates/lockfile/src/package_metadata/tests.rs
@@ -1,4 +1,4 @@
-use super::PackageMetadata;
+use super::{BundledDependencies, PackageMetadata};
 use crate::serialize_yaml;
 use text_block_macros::text_block;
 
@@ -41,4 +41,91 @@ fn libc_string_roundtrip() {
     let serialized = serialize_yaml::to_string(&metadata).unwrap();
     let reparsed: PackageMetadata = serde_saphyr::from_str(&serialized).unwrap();
     assert_eq!(metadata.libc, reparsed.libc);
+}
+
+#[test]
+fn bundled_dependencies_from_a_name_list() {
+    let manifest = serde_json::json!({ "bundledDependencies": ["a", "b"] });
+    assert_eq!(
+        BundledDependencies::from_manifest(Some(&manifest)),
+        Some(BundledDependencies::Names(vec!["a".to_string(), "b".to_string()])),
+    );
+}
+
+#[test]
+fn bundled_dependencies_from_the_legacy_spelling() {
+    let manifest = serde_json::json!({ "bundleDependencies": ["a"] });
+    assert_eq!(
+        BundledDependencies::from_manifest(Some(&manifest)),
+        Some(BundledDependencies::Names(vec!["a".to_string()])),
+    );
+}
+
+// Upstream writes whichever of the two keys holds a list or `true`, preferring
+// `bundledDependencies` — so a `false` under the preferred key does not veto
+// the legacy one.
+#[test]
+fn bundled_dependencies_falls_through_a_false_to_the_legacy_spelling() {
+    let manifest = serde_json::json!({ "bundledDependencies": false, "bundleDependencies": ["a"] });
+    assert_eq!(
+        BundledDependencies::from_manifest(Some(&manifest)),
+        Some(BundledDependencies::Names(vec!["a".to_string()])),
+    );
+}
+
+#[test]
+fn bundled_dependencies_true_is_kept() {
+    let manifest = serde_json::json!({ "bundleDependencies": true });
+    assert_eq!(
+        BundledDependencies::from_manifest(Some(&manifest)),
+        Some(BundledDependencies::Boolean(true)),
+    );
+}
+
+#[test]
+fn bundled_dependencies_false_is_dropped() {
+    let manifest = serde_json::json!({ "bundleDependencies": false });
+    assert_eq!(BundledDependencies::from_manifest(Some(&manifest)), None);
+}
+
+// pnpm records an empty list verbatim (`Array.isArray([])` passes its gate),
+// and `pnpm install` on a package declaring `"bundledDependencies": []` writes
+// `bundledDependencies: []` into `pnpm-lock.yaml`. Dropping it here would make
+// pacquet's lockfile differ from pnpm's for that package.
+#[test]
+fn bundled_dependencies_keeps_an_empty_list() {
+    let manifest = serde_json::json!({ "bundledDependencies": [] });
+    assert_eq!(
+        BundledDependencies::from_manifest(Some(&manifest)),
+        Some(BundledDependencies::Names(Vec::new())),
+    );
+}
+
+#[test]
+fn bundled_dependencies_absent() {
+    let manifest = serde_json::json!({ "name": "foo" });
+    assert_eq!(BundledDependencies::from_manifest(Some(&manifest)), None);
+}
+
+#[test]
+fn bundled_dependencies_boolean_roundtrip() {
+    let yaml = format!("{}\nbundledDependencies: true\n", make_metadata(""));
+    let metadata: PackageMetadata = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(metadata.bundled_dependencies, Some(BundledDependencies::Boolean(true)));
+    let serialized = serialize_yaml::to_string(&metadata).unwrap();
+    let reparsed: PackageMetadata = serde_saphyr::from_str(&serialized).unwrap();
+    assert_eq!(metadata.bundled_dependencies, reparsed.bundled_dependencies);
+}
+
+#[test]
+fn bundled_dependencies_name_list_roundtrip() {
+    let yaml = format!("{}\nbundledDependencies:\n  - a\n", make_metadata(""));
+    let metadata: PackageMetadata = serde_saphyr::from_str(&yaml).unwrap();
+    assert_eq!(
+        metadata.bundled_dependencies,
+        Some(BundledDependencies::Names(vec!["a".to_string()])),
+    );
+    let serialized = serialize_yaml::to_string(&metadata).unwrap();
+    let reparsed: PackageMetadata = serde_saphyr::from_str(&serialized).unwrap();
+    assert_eq!(metadata.bundled_dependencies, reparsed.bundled_dependencies);
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -13,10 +13,11 @@ use indexmap::IndexMap;
 use pacquet_catalogs_protocol_parser::parse_catalog_protocol;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_lockfile::{
-    CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile, LockfileResolution, LockfileSettings,
-    LockfileVersion, PackageKey, PackageMetadata, ParseImporterDepVersionError, PeerDependencyMeta,
-    PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot, ResolvedCatalogEntry,
-    ResolvedDependencyMap, ResolvedDependencySpec, SnapshotDepRef, SnapshotEntry, VersionPart,
+    BundledDependencies, CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile,
+    LockfileResolution, LockfileSettings, LockfileVersion, PackageKey, PackageMetadata,
+    ParseImporterDepVersionError, PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer,
+    ProjectSnapshot, ResolvedCatalogEntry, ResolvedDependencyMap, ResolvedDependencySpec,
+    SnapshotDepRef, SnapshotEntry, VersionPart,
 };
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_deps_resolver::{DepPath, DependenciesGraph, DependenciesGraphNode};
@@ -588,8 +589,7 @@ fn build_package_metadata(
 
     let has_bin = manifest_has_bin(manifest);
 
-    let bundled_dependencies = read_string_list(manifest, "bundledDependencies")
-        .or_else(|| read_string_list(manifest, "bundleDependencies"));
+    let bundled_dependencies = BundledDependencies::from_manifest(manifest);
 
     let (peer_dependencies, peer_dependencies_meta) = build_peer_dep_blocks(node);
 

--- a/pnpm/crates/package-manager/src/link_bins.rs
+++ b/pnpm/crates/package-manager/src/link_bins.rs
@@ -379,10 +379,11 @@ impl LinkVirtualStoreBins<'_> {
         } = self;
         if let Some(snapshots) = snapshots {
             let has_bin_set = build_has_bin_set(packages);
+            let bundling_set = build_bundling_set(packages);
             run_lockfile_driven::<Sys>(
                 layout,
                 snapshots,
-                has_bin_set.as_ref(),
+                BinSlotSets { has_bin: has_bin_set.as_ref(), bundling: &bundling_set },
                 package_manifests,
                 skipped,
                 extra_node_paths,
@@ -436,10 +437,38 @@ fn build_has_bin_set(
     )
 }
 
+/// Pre-compute the set of package keys that ship dependencies inside their
+/// own tarball. Presence of the lockfile's `bundledDependencies` field is
+/// the signal, whatever its shape — a name list and the `true` form both
+/// mean the package carries a populated `node_modules` of its own.
+///
+/// Unlike [`build_has_bin_set`] there is no "metadata absent" case to
+/// distinguish: without a `packages:` section no slot can be known to
+/// bundle, and probing every slot's package directory for a `node_modules`
+/// that almost never exists would cost a `read_dir` per slot.
+fn build_bundling_set(
+    packages: Option<&HashMap<PackageKey, PackageMetadata>>,
+) -> HashSet<PackageKey> {
+    packages
+        .into_iter()
+        .flatten()
+        .filter(|(_, meta)| meta.bundled_dependencies.is_some())
+        .map(|(key, _)| key.clone())
+        .collect()
+}
+
+/// The two lockfile-derived slot classifications [`run_lockfile_driven`]
+/// consults before doing any per-slot work, from [`build_has_bin_set`] and
+/// [`build_bundling_set`] respectively.
+struct BinSlotSets<'a> {
+    has_bin: Option<&'a HashSet<PackageKey>>,
+    bundling: &'a HashSet<PackageKey>,
+}
+
 /// Walk the lockfile's `snapshots:` map, build each slot's bin output
 /// directory lexically, and link every child's bins into it. The
 /// child set comes from `snapshot.dependencies` +
-/// `snapshot.optional_dependencies`, filtered by `has_bin_set` so
+/// `snapshot.optional_dependencies`, filtered by `sets.has_bin` so
 /// packages that don't declare a bin never make it into the
 /// per-slot path-building or manifest-lookup work. The corresponding
 /// manifest comes from [`PackageManifests`] (no disk read) or, for
@@ -449,13 +478,14 @@ fn build_has_bin_set(
 fn run_lockfile_driven<Sys>(
     layout: &crate::VirtualStoreLayout,
     snapshots: &HashMap<PackageKey, SnapshotEntry>,
-    has_bin_set: Option<&HashSet<PackageKey>>,
+    sets: BinSlotSets<'_>,
     package_manifests: &PackageManifests,
     skipped: &SkippedSnapshots,
     extra_node_paths: &[String],
 ) -> Result<(), LinkVirtualStoreBinsError>
 where
-    Sys: FsReadFile
+    Sys: FsReadDir
+        + FsReadFile
         + FsReadToString
         + FsReadHead
         + FsCreateDirAll
@@ -464,6 +494,7 @@ where
         + FsSetExecutable
         + FsEnsureExecutableBits,
 {
+    let BinSlotSets { has_bin: has_bin_set, bundling: bundling_set } = sets;
     // `has_bin_set` is `Some` exactly when the lockfile's `packages:`
     // section was present at install start — in which case the set
     // is authoritative and every slot is filtered through it (an
@@ -538,7 +569,8 @@ where
             // costs at most one `package.json` read.
             None => true,
         };
-        if with_bin.is_empty() && !self_has_bin {
+        let self_bundles = bundling_set.contains(&self_metadata_key);
+        if with_bin.is_empty() && !self_has_bin && !self_bundles {
             return Ok(());
         }
 
@@ -581,6 +613,17 @@ where
                     Err(error) => return Err(LinkVirtualStoreBinsError::LinkBins(error)),
                 }
             }
+        }
+
+        // Packages the tarball ships in its own `node_modules` are not
+        // lockfile children, so nothing above sees them; their bins are
+        // reachable only from inside the bundling package and have to be
+        // shimmed straight from disk.
+        if self_bundles {
+            bin_sources.extend(
+                collect_packages_in_modules_dir::<Sys>(&self_pkg_dir.join("node_modules"))
+                    .map_err(LinkVirtualStoreBinsError::LinkBins)?,
+            );
         }
 
         // Self-bin source (slot's own package), when its lockfile row

--- a/pnpm/crates/package-manager/src/link_bins.rs
+++ b/pnpm/crates/package-manager/src/link_bins.rs
@@ -460,6 +460,7 @@ fn build_bundling_set(
 /// The two lockfile-derived slot classifications [`run_lockfile_driven`]
 /// consults before doing any per-slot work, from [`build_has_bin_set`] and
 /// [`build_bundling_set`] respectively.
+#[derive(Clone, Copy)]
 struct BinSlotSets<'a> {
     has_bin: Option<&'a HashSet<PackageKey>>,
     bundling: &'a HashSet<PackageKey>,

--- a/pnpm/crates/package-manager/src/link_hoisted_modules.rs
+++ b/pnpm/crates/package-manager/src/link_hoisted_modules.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
-use pacquet_cmd_shim::LinkBinsError;
+use pacquet_cmd_shim::{Host, LinkBinsError, link_bins};
 use pacquet_config::PackageImportMethod;
 use pacquet_lockfile::PkgIdWithPatchHash;
 use pacquet_reporter::{LogEvent, LogLevel, Reporter, StatsLog, StatsMessage};
@@ -249,6 +249,20 @@ fn link_all_pkgs_in_order<Reporter: self::Reporter>(
         // pnpm gates `extraNodePaths` on the isolated linker, so
         // hoisted-tree shims never carry `NODE_PATH`.
         link_direct_dep_bins(&modules_dir, &dep_names, &[])
+            .map_err(LinkHoistedModulesError::LinkBins)?;
+    }
+
+    // Packages the tarball ships in its own `node_modules` are not graph
+    // nodes, so the pass above never sees them; their bins are reachable
+    // only from inside the bundling package.
+    for child_dir in hierarchy.0.keys() {
+        let bundles = opts.graph.get(child_dir).is_some_and(|node| node.has_bundled_dependencies);
+        if !bundles {
+            continue;
+        }
+        let bundled_modules_dir = child_dir.join("node_modules");
+        let bins_dir = bundled_modules_dir.join(".bin");
+        link_bins::<Host>(&bundled_modules_dir, &bins_dir, &[])
             .map_err(LinkHoistedModulesError::LinkBins)?;
     }
 

--- a/pnpm/plans/TEST_PORTING.md
+++ b/pnpm/plans/TEST_PORTING.md
@@ -467,6 +467,11 @@ Supporting tests:
 - [x] `TypeScript repo: installing/deps-installer/test/install/misc.ts:1130` `installing with no symlinks with PnP` verifies `.bin` exists with no symlink layout — ported as `pnp_install_without_symlinks_still_writes_modules_manifest_and_bin_directory` in `crates/cli/tests/install_state.rs`.
 - [x] `TypeScript repo: installing/deps-installer/test/hoistedNodeLinker/install.ts:187` `run pre/postinstall scripts. bin files should be linked in a hoisted node_modules`. Ported as `run_pre_and_postinstall_scripts_and_link_bins` in `crates/cli/tests/hoisted_node_linker.rs`.
 - [x] `TypeScript repo: installing/deps-installer/test/hoistedNodeLinker/install.ts:264` `linking bins of local projects when node-linker is set to hoisted`. Ported as `linking_bins_of_local_projects`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/bundledDependencies.ts:10` `bundledDependencies (pkg-with-bundled-dependencies@1.0.0)` — ported as `bundled_dependencies_are_kept_out_of_the_lockfile` in `crates/cli/tests/bundled_dependencies.rs`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/bundledDependencies.ts:64` `bundleDependencies (pkg-with-bundle-dependencies@1.0.0)` — ported as `bundle_dependencies_spelling_is_kept_out_of_the_lockfile`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/bundledDependencies.ts:79` `installing a package with bundleDependencies set to false` — ported as `bundle_dependencies_false_is_not_recorded`.
+- [x] `TypeScript repo: installing/deps-installer/test/install/bundledDependencies.ts:89` `installing a package with bundleDependencies set to true` — ported as `bundle_dependencies_true_is_recorded_as_true`, extended with the lockfile round trip the boolean form needs. Pacquet also keeps `bundled_bins_are_linked_under_the_hoisted_linker` for the `nodeLinker: hoisted` counterpart, which upstream reaches only through `linkAllBins`.
+- [ ] `TypeScript repo: installing/deps-installer/test/install/bundledDependencies.ts:29` `local tarball with bundledDependencies` and `:46` `local tarball with bundledDependencies true` (covering <https://github.com/pnpm/pnpm/issues/7411>) — need `.tgz` fixtures on the Rust side.
 
 Rust port notes:
 


### PR DESCRIPTION
## Summary

While investigating pnpm/pnpm#13326 I found the reported divergence was already fixed — but the audit of the code that fixed it turned up two gaps in the same area that it did not cover, plus a whole upstream test suite with no pnpm 12 counterpart.

**What pnpm/pnpm#13326 turned out to be.** The issue reports that pnpm 12 resolves the dependency subtree of a platform-incompatible optional package (`@tailwindcss/oxide-wasm32-wasi` and six transitive packages). Running its exact reproduction against pnpm `11.17.0` and a HEAD build of pnpm 12 now produces byte-identical `pnpm-lock.yaml`; the fix was `eab73b3994` (pnpm/pnpm#13374), which taught `extract_children` to drop names a manifest declares in `bundledDependencies` — and `@tailwindcss/oxide-wasm32-wasi` bundles exactly those six.

The issue's stated expectation — that pnpm 11 skips resolving the subtree of a platform-incompatible optional package — does not hold. On Linux x64, pnpm 11 resolves the full 36-package subtree of the `darwin`-only `dmg-license@1.0.11`, and records `@img/sharp-darwin-arm64@0.34.4` with its `@img/sharp-libvips-darwin-arm64` edge; pnpm 12 matches both exactly. A 12-package sweep of the platform-heavy ecosystem (esbuild, rollup, `@parcel/watcher`, lightningcss, oxide, sharp, `@swc/core`, unrs-resolver, oxc-parser, `@napi-rs/canvas`, dmg-license, `@sentry/profiling-node`) is identical between the two stacks both natively and under `supportedArchitectures: {os: [darwin], cpu: [arm64]}`. So this PR does **not** add a platform gate to the resolver — that would be a new divergence, and it would fail the existing `skip_optional_dependency_that_does_not_support_the_current_os` test.

**What this PR does fix**, both found by porting the upstream `bundledDependencies` suite:

1. **`bundleDependencies: true` was dropped from the lockfile.** A manifest may declare the boolean form instead of a name list, which npm and pnpm both read as "every entry of `dependencies` ships inside this tarball". pacquet's writer only understood the list form, and `PackageMetadata::bundled_dependencies` was typed `Option<Vec<String>>` — so the boolean could not even be represented, and a `pnpm-lock.yaml` written by pnpm 11 for such a package failed to parse. The field is now modelled as the `string[] | boolean` union pnpm records, read through one shared `BundledDependencies::from_manifest` used by both the install writer and the env-installer writer.

2. **Bundled bins were never linked.** The field's presence is what tells the installer a package carries a populated `node_modules` of its own whose bins belong in that package's `node_modules/.bin` (upstream: `linkBinsOfPackages` + the `hasBundledDependencies` branch in `building/during-install` and `deps-restorer`). Bundled packages are not lockfile children, so neither pacquet linker ever saw them: the isolated path's per-slot bin walk iterates `snapshot.dependencies`, and the hoisted path iterates graph nodes — `has_bundled_dependencies` was computed and stored on every hoisted node but had no reader at all. Both paths now get the second bin pass over the package's own `node_modules`.

Installing `@pnpm.e2e/pkg-with-bundled-dependencies@1.0.0` on `main` produces no `.bin` directory inside the package; pnpm 11 writes `node_modules/@pnpm.e2e/pkg-with-bundled-dependencies/node_modules/.bin/hello-world-js-bin`.

**Tests.** `installing/deps-installer/test/install/bundledDependencies.ts` had no pnpm 12 counterpart, which is why neither gap was caught. It is ported as `pnpm/crates/cli/tests/bundled_dependencies.rs`, covering both manifest spellings, `false`, and the boolean form across a frozen reinstall (which is what exercises the lockfile round trip), plus a pacquet-only `nodeLinker: hoisted` case. Each test was verified to fail against the unfixed implementation. The two local-tarball cases from that suite still need `.tgz` fixtures and are listed as unported in `plans/TEST_PORTING.md`.

Related to pnpm/pnpm#13326

## Squash Commit Body

```text
Investigating pnpm/pnpm#13326 showed its reproduction already matches
pnpm 11 byte for byte, fixed by eab73b3994 (pnpm/pnpm#13374) filtering
bundled names out of `extract_children`. Porting the upstream
`bundledDependencies` install suite — which had no pacquet counterpart,
and is why the original defect shipped — surfaced two gaps that fix did
not cover.

A manifest may declare `bundleDependencies: true` instead of a name
list, which npm and pnpm both read as "every entry of `dependencies`
ships inside this tarball". The lockfile writer only understood the list
form, and `PackageMetadata::bundled_dependencies` was typed
`Option<Vec<String>>`, so the boolean could neither be written nor read
back — a `pnpm-lock.yaml` written by pnpm 11 for such a package failed
to parse. Model the field as the `string[] | boolean` union pnpm
records, behind one shared `BundledDependencies::from_manifest` that
both the install and env-installer writers call.

The field's presence is also what tells the installer a package carries
a populated `node_modules` of its own whose bins belong in that
package's `node_modules/.bin`. Bundled packages are not lockfile
children, so neither linker reached them: the isolated path's per-slot
walk iterates `snapshot.dependencies`, and the hoisted path iterates
graph nodes — `has_bundled_dependencies` was computed and stored on
every hoisted node but had no reader. Both paths now run the second bin
pass upstream's `linkAllBins` and `building/during-install` run.

No platform gate is added to the resolver. The issue asks for one, but
pnpm 11 resolves the subtree of a platform-incompatible optional package
too (`dmg-license@1.0.11` on Linux, `@img/sharp-darwin-arm64`'s libvips
edge), and `skip_optional_dependency_that_does_not_support_the_current_os`
already asserts pacquet matches that.

Related to pnpm/pnpm#13326
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(pacquet-only: the TypeScript CLI already records the boolean form and
  links bundled bins. No TS change needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787691457&installation_model_id=426870&pr_number=13406&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13406&signature=e4f12f342505b5e41e3d0130edcf4b013e8ba37348e3cc04657da4d11942e224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of `bundledDependencies` / `bundleDependencies` in package metadata and lockfile output (including boolean `true` form and alternate spelling).

- **Bug Fixes**
  - Bundled packages now link bundled dependency executables into the bundling package’s `.bin` directory correctly for both isolated and hoisted installs, including when a package includes its own `node_modules`.

- **Tests**
  - Added/expanded end-to-end and lockfile metadata parsing/round-trip coverage for boolean, list, and disabled bundled-dependency cases.

- **Documentation**
  - Updated bundled-dependency test porting-status notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->