### PR TITLE
fix(update-interactive): measure the choice table in terminal columns

### DIFF
--- a/.changeset/interactive-update-wide-character-columns.md
+++ b/.changeset/interactive-update-wide-character-columns.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm update --interactive` now measures its table in terminal columns rather than in characters. A package name, workspace name, or version containing wide characters (CJK, most emoji) no longer knocks its row's columns out of line with the rest of the group, and a wide character in a version no longer aborts the command with `Subject parameter value width cannot be greater than the container width` [#13357](https://github.com/pnpm/pnpm/issues/13357).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,6 +3986,7 @@ dependencies = [
  "chrono",
  "clap",
  "command-extra",
+ "console",
  "derive_more",
  "dialoguer",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ base64 = { version = "0.22.1" }
 bcrypt = { version = "0.19.1" }
 bytes = { version = "1.11.0" }
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }
+console = { version = "0.16.3" }
 crossterm = { version = "0.29.0" }
 dashmap = { version = "6.2.1" }
 derive_more = { version = "2.1.1", features = ["full"] }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,7 +268,7 @@ catalogs:
       specifier: ^4.0.10
       version: 4.0.10
     '@types/node':
-      specifier: ^22.19.19
+      specifier: ^22.20.1
       version: 22.20.1
     '@types/normalize-package-data':
       specifier: ^2.4.4
@@ -616,7 +616,7 @@ catalogs:
       specifier: 10.0.4
       version: 10.0.4
     npm-registry-fetch:
-      specifier: ^19.0.0
+      specifier: ^19.1.1
       version: 19.1.1
     object-hash:
       specifier: 3.0.0
@@ -774,6 +774,9 @@ catalogs:
     string-length:
       specifier: ^7.0.1
       version: 7.0.1
+    string-width:
+      specifier: ^8.2.2
+      version: 8.2.2
     strip-bom:
       specifier: ^5.0.0
       version: 5.0.0
@@ -814,7 +817,7 @@ catalogs:
       specifier: ^8.65.0
       version: 8.65.0
     undici:
-      specifier: ^7.27.2
+      specifier: ^7.29.0
       version: 7.29.0
     unified:
       specifier: ^11.0.5
@@ -5389,6 +5392,9 @@ importers:
       render-help:
         specifier: 'catalog:'
         version: 2.0.0
+      string-width:
+        specifier: 'catalog:'
+        version: 8.2.2
       version-selector-type:
         specifier: 'catalog:'
         version: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,7 +268,7 @@ catalogs:
       specifier: ^4.0.10
       version: 4.0.10
     '@types/node':
-      specifier: ^22.20.1
+      specifier: ^22.19.19
       version: 22.20.1
     '@types/normalize-package-data':
       specifier: ^2.4.4
@@ -616,7 +616,7 @@ catalogs:
       specifier: 10.0.4
       version: 10.0.4
     npm-registry-fetch:
-      specifier: ^19.1.1
+      specifier: ^19.0.0
       version: 19.1.1
     object-hash:
       specifier: 3.0.0
@@ -817,7 +817,7 @@ catalogs:
       specifier: ^8.65.0
       version: 8.65.0
     undici:
-      specifier: ^7.29.0
+      specifier: ^7.27.2
       version: 7.29.0
     unified:
       specifier: ^11.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,7 +72,7 @@ versioning:
   # The Rust CLI wrapper and its NAPI addon always release in lockstep at one
   # shared version.
   fixed:
-    - ['pacquet', '@pnpm/napi']
+    - [ 'pacquet', '@pnpm/napi' ]
   # The Rust products release as `X.Y.Z-alpha.N` prereleases (published under the
   # `next` dist-tag) while the TypeScript CLI keeps releasing stable versions on
   # the main lane. `pnpm lane main --filter …` graduates a product to stable.
@@ -152,7 +152,7 @@ catalog:
   '@types/micromatch': ^4.0.10
   # Kept on 22.x to match pnpm's minimum supported Node.js version (>=22.13);
   # newer majors would type APIs that don't exist on the supported floor.
-  '@types/node': ^22.19.19
+  '@types/node': ^22.20.1
   '@types/normalize-package-data': ^2.4.4
   '@types/normalize-path': ^3.0.2
   '@types/npm-registry-fetch': ^8.0.9
@@ -287,7 +287,7 @@ catalog:
   npm-packlist: 10.0.4
   # npm-registry-fetch 20.x requires Node.js ^22.22.2 || ^24.15.0 || >=26.0.0,
   # above pnpm's supported floor of Node.js >=22.13.
-  npm-registry-fetch: ^19.0.0
+  npm-registry-fetch: ^19.1.1
   object-hash: 3.0.0
   open: ^11.0.0
   openpgp: ^6.3.1
@@ -343,6 +343,7 @@ catalog:
   ssri: 13.0.1
   stacktracey: ^2.2.0
   string-length: ^7.0.1
+  string-width: ^8.2.2
   strip-bom: ^5.0.0
   strip-comments-strings: 1.2.0
   symlink-dir: ^10.0.1
@@ -364,7 +365,7 @@ catalog:
   typescript-eslint: ^8.65.0
   # undici 8.x requires Node.js >=22.19.0, above pnpm's supported floor of
   # Node.js >=22.13.
-  undici: ^7.27.2
+  undici: ^7.29.0
   unified: ^11.0.5
   # validate-npm-package-name 8.x requires Node.js ^22.22.2 || ^24.15.0 ||
   # >=26.0.0, above pnpm's supported floor of Node.js >=22.13.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,7 +72,7 @@ versioning:
   # The Rust CLI wrapper and its NAPI addon always release in lockstep at one
   # shared version.
   fixed:
-    - [ 'pacquet', '@pnpm/napi' ]
+    - ['pacquet', '@pnpm/napi']
   # The Rust products release as `X.Y.Z-alpha.N` prereleases (published under the
   # `next` dist-tag) while the TypeScript CLI keeps releasing stable versions on
   # the main lane. `pnpm lane main --filter …` graduates a product to stable.
@@ -152,7 +152,7 @@ catalog:
   '@types/micromatch': ^4.0.10
   # Kept on 22.x to match pnpm's minimum supported Node.js version (>=22.13);
   # newer majors would type APIs that don't exist on the supported floor.
-  '@types/node': ^22.20.1
+  '@types/node': ^22.19.19
   '@types/normalize-package-data': ^2.4.4
   '@types/normalize-path': ^3.0.2
   '@types/npm-registry-fetch': ^8.0.9
@@ -287,7 +287,7 @@ catalog:
   npm-packlist: 10.0.4
   # npm-registry-fetch 20.x requires Node.js ^22.22.2 || ^24.15.0 || >=26.0.0,
   # above pnpm's supported floor of Node.js >=22.13.
-  npm-registry-fetch: ^19.1.1
+  npm-registry-fetch: ^19.0.0
   object-hash: 3.0.0
   open: ^11.0.0
   openpgp: ^6.3.1
@@ -365,7 +365,7 @@ catalog:
   typescript-eslint: ^8.65.0
   # undici 8.x requires Node.js >=22.19.0, above pnpm's supported floor of
   # Node.js >=22.13.
-  undici: ^7.29.0
+  undici: ^7.27.2
   unified: ^11.0.5
   # validate-npm-package-name 8.x requires Node.js ^22.22.2 || ^24.15.0 ||
   # >=26.0.0, above pnpm's supported floor of Node.js >=22.13.

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -63,6 +63,7 @@ pacquet-workspace-state                   = { workspace = true }
 
 chrono               = { workspace = true }
 clap                 = { workspace = true }
+console              = { workspace = true }
 derive_more          = { workspace = true }
 dialoguer            = { workspace = true }
 dunce                = { workspace = true }

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -8,6 +8,7 @@ use crate::cli_args::{
     outdated::{OutdatedPackage, colorize_target},
     sanitize::sanitize_inline,
 };
+use console::measure_text_width;
 use node_semver::Version;
 use pacquet_package_manifest::DependencyGroup;
 use std::collections::HashMap;
@@ -190,8 +191,9 @@ fn render_rows(choices: &[&Choice<'_>], workspaces_enabled: bool) -> Vec<ChoiceR
         .collect()
 }
 
-/// The width of each column, measured on the printable text so the
-/// colour escapes `colorize_target` embeds do not inflate the padding.
+/// The width of each column, measured in terminal columns so the colour
+/// escapes `colorize_target` embeds do not inflate the padding and a name
+/// made of wide characters is not measured as narrower than it renders.
 fn column_widths(cells: &[Vec<String>]) -> Vec<usize> {
     let column_count = cells.iter().map(Vec::len).max().unwrap_or_default();
     (0..column_count)
@@ -199,7 +201,7 @@ fn column_widths(cells: &[Vec<String>]) -> Vec<usize> {
             cells
                 .iter()
                 .filter_map(|row| row.get(column))
-                .map(|cell| printable_width(cell))
+                .map(|cell| measure_text_width(cell))
                 .max()
                 .unwrap_or_default()
         })
@@ -217,7 +219,7 @@ fn pad_row(row: &[String], widths: &[usize]) -> String {
             line.push(' ');
         }
         let padding =
-            widths.get(index).copied().unwrap_or_default().saturating_sub(printable_width(cell));
+            widths.get(index).copied().unwrap_or_default().saturating_sub(measure_text_width(cell));
         if index == CURRENT_COLUMN {
             line.extend(std::iter::repeat_n(' ', padding));
             line.push_str(cell);
@@ -231,31 +233,6 @@ fn pad_row(row: &[String], widths: &[usize]) -> String {
         }
     }
     line.trim_end().to_string()
-}
-
-/// The column width of `text`, skipping the SGR escapes that colour it.
-///
-/// Only the colouring this module applies through [`colorize_target`]
-/// reaches here — every other cell is stripped of control characters by
-/// [`sanitize_inline`] first — so this handles the `ESC [ … m` sequences
-/// `owo_colors` emits rather than ANSI in general. Width is counted in
-/// characters, which matches column width for the ASCII that package
-/// names and semver versions are made of.
-fn printable_width(text: &str) -> usize {
-    let mut width = 0;
-    let mut chars = text.chars();
-    while let Some(character) = chars.next() {
-        if character == '\u{1b}' {
-            for escape in chars.by_ref() {
-                if escape == 'm' {
-                    break;
-                }
-            }
-            continue;
-        }
-        width += 1;
-    }
-    width
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
@@ -6,7 +6,7 @@
 //! the user sees: which groups appear, in what order, which packages sit
 //! in each, and that every column lines up.
 
-use super::{ChoiceGroup, update_choices};
+use super::{ChoiceGroup, column_widths, pad_row, update_choices};
 use crate::cli_args::outdated::OutdatedPackage;
 use console::measure_text_width;
 use node_semver::Version;
@@ -186,19 +186,40 @@ fn columns_line_up_within_a_group() {
 }
 
 /// Padding is counted in terminal columns rather than in `char`s, so a
-/// name made of double-width characters does not push the rest of its row
-/// out of line with its neighbours'.
+/// name made of double-width characters — CJK, most emoji — does not push
+/// the rest of its row out of line with its neighbours'.
 #[test]
 fn a_wide_name_does_not_shift_its_row() {
     let packages = [
         pkg("中文包名字", "中文包名字", "1.0.0", "2.0.0", DependencyGroup::Prod),
+        pkg("party-🎉-pkg", "party-🎉-pkg", "1.0.0", "2.0.0", DependencyGroup::Prod),
         pkg("b", "b", "1.0.0", "2.0.0", DependencyGroup::Prod),
     ];
 
     let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
     let offsets = arrow_offsets(&groups[0]);
-    assert_eq!(offsets[0], offsets[1]);
+    assert_eq!(offsets, vec![offsets[0]; 3]);
+}
+
+/// The escapes colouring the target are not printed, so they must not
+/// count toward its cell's width: a coloured cell would otherwise be
+/// measured as wider than it renders and push the columns after it out.
+///
+/// [`colorize_target`] emits nothing when colour is off, which is how it
+/// runs under test, so this drives the padding directly.
+#[test]
+fn colour_escapes_do_not_count_toward_a_cells_width() {
+    let coloured = vec!["\u{1b}[31m2.0.0\u{1b}[0m".to_string(), "web".to_string()];
+    let plain = vec!["2.0.0".to_string(), "web".to_string()];
+
+    let widths = column_widths(&[coloured.clone(), plain.clone()]);
+
+    assert_eq!(widths[0], "2.0.0".len());
+    assert_eq!(
+        measure_text_width(&pad_row(&coloured, &widths)),
+        measure_text_width(&pad_row(&plain, &widths)),
+    );
 }
 
 /// Nothing outdated means nothing to choose from.

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
@@ -6,8 +6,9 @@
 //! the user sees: which groups appear, in what order, which packages sit
 //! in each, and that every column lines up.
 
-use super::{ChoiceGroup, printable_width, update_choices};
+use super::{ChoiceGroup, update_choices};
 use crate::cli_args::outdated::OutdatedPackage;
+use console::measure_text_width;
 use node_semver::Version;
 use pacquet_package_manifest::DependencyGroup;
 
@@ -39,6 +40,16 @@ fn pkg(
 /// The package each selectable row of a group updates, in order.
 fn values(group: &ChoiceGroup) -> Vec<&str> {
     group.rows.iter().filter_map(|row| row.value.as_deref()).collect()
+}
+
+/// The terminal column each selectable row's `❯` starts at, in order.
+fn arrow_offsets(group: &ChoiceGroup) -> Vec<usize> {
+    group
+        .rows
+        .iter()
+        .skip(1)
+        .map(|row| measure_text_width(row.label.split('❯').next().expect("row has an arrow")))
+        .collect()
 }
 
 #[test]
@@ -170,13 +181,24 @@ fn columns_line_up_within_a_group() {
 
     let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
 
-    let arrow_offsets: Vec<usize> = groups[0]
-        .rows
-        .iter()
-        .skip(1)
-        .map(|row| printable_width(row.label.split('❯').next().expect("row has an arrow")))
-        .collect();
-    assert_eq!(arrow_offsets[0], arrow_offsets[1]);
+    let offsets = arrow_offsets(&groups[0]);
+    assert_eq!(offsets[0], offsets[1]);
+}
+
+/// Padding is counted in terminal columns rather than in `char`s, so a
+/// name made of double-width characters does not push the rest of its row
+/// out of line with its neighbours'.
+#[test]
+fn a_wide_name_does_not_shift_its_row() {
+    let packages = [
+        pkg("中文包名字", "中文包名字", "1.0.0", "2.0.0", DependencyGroup::Prod),
+        pkg("b", "b", "1.0.0", "2.0.0", DependencyGroup::Prod),
+    ];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
+
+    let offsets = arrow_offsets(&groups[0]);
+    assert_eq!(offsets[0], offsets[1]);
 }
 
 /// Nothing outdated means nothing to choose from.

--- a/pnpm11/installing/commands/package.json
+++ b/pnpm11/installing/commands/package.json
@@ -103,6 +103,7 @@
     "p-limit": "catalog:",
     "ramda": "catalog:",
     "render-help": "catalog:",
+    "string-width": "catalog:",
     "version-selector-type": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm11/installing/commands/src/update/getUpdateChoices.ts
+++ b/pnpm11/installing/commands/src/update/getUpdateChoices.ts
@@ -1,10 +1,9 @@
-import { stripVTControlCharacters } from 'node:util'
-
 import { colorizeSemverDiff } from '@pnpm/colorize-semver-diff'
 import type { OutdatedPackage } from '@pnpm/deps.inspection.outdated'
 import { semverDiff } from '@pnpm/semver-diff'
 import { getBorderCharacters, table } from '@zkochan/table'
 import { and, groupBy, isEmpty, pickBy, pluck } from 'ramda'
+import stringWidth from 'string-width'
 
 export interface ChoiceRow {
   name: string
@@ -194,9 +193,18 @@ function alignColumns (rows: string[][]): string[] {
   ).split('\n')
 }
 
+/**
+ * The width the column has to be given so that none of its cells wrap.
+ *
+ * Measured in terminal columns rather than in code units, matching how
+ * `@zkochan/table` lays the cell out: a cell that renders wider than the
+ * width it is given wraps, which splits the row and shifts every choice
+ * after it. `stringWidth` also discards the highlighting escapes
+ * `colorizeSemverDiff` puts in the target column.
+ */
 function getColumnWidth (rows: string[][], columnIndex: number, minWidth: number): number {
   return rows.reduce((max, row) => {
     if (row[columnIndex] == null) return max
-    return Math.max(max, stripVTControlCharacters(row[columnIndex]).length)
+    return Math.max(max, stringWidth(row[columnIndex]))
   }, minWidth)
 }

--- a/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
+++ b/pnpm11/installing/commands/test/update/getUpdateChoices.test.ts
@@ -2,6 +2,7 @@ import { stripVTControlCharacters } from 'node:util'
 
 import { expect, test } from '@jest/globals'
 import chalk from 'chalk'
+import stringWidth from 'string-width'
 
 import { getUpdateChoices } from '../../lib/update/getUpdateChoices.js'
 
@@ -176,6 +177,29 @@ test('getUpdateChoices() handles long version strings without wrapping', () => {
   // within the version string, which would break a plain substring match
   // when chalk has colors enabled.
   expect(stripVTControlCharacters(dataRow.message)).toContain('7.0.0-dev.20251214.1')
+})
+
+test('getUpdateChoices() sizes the version columns by their rendered width', () => {
+  const outdated = (alias: string, current: string) => ({
+    alias,
+    belongsTo: 'dependencies' as const,
+    current,
+    latestManifest: { name: alias, version: '2.0.0' },
+    packageName: alias,
+    wanted: current,
+  })
+
+  // A version made of double-width characters occupies twice the columns
+  // its code units suggest. Sizing the column by code units leaves the
+  // cell wider than the column it is laid out in, which wraps the row.
+  const choices = getUpdateChoices([outdated('a', '1.0.0-中文中文中文中文中文'), outdated('b', '1.0.0')], false)
+
+  const rows = choices[0].choices.map((choice) => stripVTControlCharacters((choice as { message: string }).message))
+  for (const row of rows) {
+    expect(row).not.toContain('\n')
+  }
+  const arrowColumns = rows.slice(1).map((row) => stringWidth(row.split('❯')[0]))
+  expect(arrowColumns[0]).toBe(arrowColumns[1])
 })
 
 test('getUpdateChoices() groups GitHub Actions separately', () => {


### PR DESCRIPTION
## Summary

`pnpm update --interactive` sized and padded its choice table by counting characters. That is the rendered width only for the ASCII most package names and versions are made of — a cell holding wide characters (CJK, most emoji) measures narrower than it renders, so its row's columns stopped lining up with its neighbours'.

Both stacks are fixed:

- **pacquet** — the hand-rolled `printable_width` in `pnpm/crates/cli/src/cli_args/update_interactive/choices.rs` gives way to `console::measure_text_width`, which strips the SGR escapes `colorize_target` embeds *and* measures the rest against the East Asian width tables. `console` was already in `Cargo.lock` through `dialoguer`; per `pnpm/AGENTS.md` it is now declared in `[workspace.dependencies]` and pulled into the `cli` crate from there.
- **TypeScript CLI** — `@zkochan/table` measures with `string-width`, so wide package, workspace and URL columns were already placed correctly. `getUpdateChoices`' own `getColumnWidth` was not: it sized the two version columns with `stripVTControlCharacters(...).length`. This was worse than cosmetic — a version wider than the width it computed made `@zkochan/table` reject the cell outright, so the command aborted with `Subject parameter value width cannot be greater than the container width` instead of printing the list. It now measures with `string-width` as well (added to the catalog and to `@pnpm/installing.commands`).

### Tests

Three regression tests, each checked against the unfixed implementation rather than just added green:

| Test | Fails without the fix as |
| --- | --- |
| `a_wide_name_does_not_shift_its_row` (Rust) — a CJK name, an emoji name and an ASCII name in one group | arrow offsets `[25, 21, 20]` instead of `[25, 25, 25]` |
| `colour_escapes_do_not_count_toward_a_cells_width` (Rust) — drives `column_widths` / `pad_row` with a cell carrying `ESC [ … m` | the coloured cell measures 14 columns instead of 5 |
| `getUpdateChoices() sizes the version columns by their rendered width` (TS) | `Subject parameter value width cannot be greater than the container width` |

The escape test has to go in below `update_choices`, because `colorize_target` emits nothing when colour is off — which is how it runs under test. On the TypeScript side the ANSI half is already covered: the existing assertions pin exact padded rows built with live `chalk` escapes.

Closes pnpm/pnpm#13357

## Squash Commit Body

```text
`pnpm update --interactive` sized and padded its table by counting
characters, which is only the rendered width for the ASCII most package
names and versions are made of. A cell holding wide characters — CJK,
most emoji — measures narrower than it renders, so its row's columns
stopped lining up with its neighbours'.

pacquet's hand-rolled `printable_width` gives way to
`console::measure_text_width`, which strips the SGR escapes
`colorize_target` embeds and measures the rest against the East Asian
width tables. `console` is already in `Cargo.lock` through `dialoguer`;
it is now declared in `[workspace.dependencies]`.

The TypeScript CLI lays the table out with `@zkochan/table`, which
measures with `string-width` and so already placed wide package and
workspace names correctly. Its own `getColumnWidth` did not: it sized
the two version columns with `stripVTControlCharacters(...).length`, and
a version wider than the width it computed made `@zkochan/table` reject
the cell outright — `pnpm update --interactive` aborted with "Subject
parameter value width cannot be greater than the container width"
instead of printing the list. It now measures with `string-width` too.

Closes pnpm/pnpm#13357
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).
