### PR TITLE
fix(cli): print config-load warnings to stderr

### DIFF
--- a/.changeset/config-warnings-stderr.md
+++ b/.changeset/config-warnings-stderr.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Config-load warnings, such as the warning about install settings left under the `pnpm` field of `package.json`, are printed to stderr instead of stdout [#13361](https://github.com/pnpm/pnpm/issues/13361).

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -13,6 +13,7 @@ pub mod ci;
 pub mod clean;
 pub mod completion;
 pub mod config;
+pub(crate) mod config_warnings;
 pub mod create;
 pub mod dedupe;
 pub mod deploy;

--- a/pnpm/crates/cli/src/cli_args/config_warnings.rs
+++ b/pnpm/crates/cli/src/cli_args/config_warnings.rs
@@ -1,0 +1,21 @@
+//! The stderr channel for config-load warnings.
+//!
+//! pnpm collects the warnings raised while reading config and prints them
+//! with `console.warn` — to stderr, outside the reporter, on every command
+//! and under every reporter — so they never mix into the stdout a script
+//! captures. Warnings emitted through the reporter stay on stdout; only
+//! config-load warnings belong here.
+
+use pacquet_default_reporter::colors::Colors;
+use std::io::IsTerminal;
+
+/// Write a `[WARN]`-labelled config-load warning to stderr.
+pub(crate) fn emit_config_warning(message: &str) {
+    // Styling is keyed off stdout, not stderr: pnpm's `formatWarn` colors
+    // with chalk's default (stdout-probing) instance even though
+    // `console.warn` writes to stderr.
+    let colors = Colors {
+        enabled: std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none(),
+    };
+    eprintln!("{} {message}", colors.warn_label());
+}

--- a/pnpm/crates/cli/src/cli_args/config_warnings.rs
+++ b/pnpm/crates/cli/src/cli_args/config_warnings.rs
@@ -7,9 +7,12 @@
 //! config-load warnings belong here.
 
 use pacquet_default_reporter::colors::Colors;
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 
-/// Write a `[WARN]`-labelled config-load warning to stderr.
+/// Write a `[WARN]`-labelled config-load warning to stderr. Best-effort:
+/// a warning must never abort the command, so a failed write (a closed
+/// stderr, a consumer that exited) is discarded, as the reporter sinks
+/// discard theirs.
 pub(crate) fn emit_config_warning(message: &str) {
     // Styling is keyed off stdout, not stderr: pnpm's `formatWarn` colors
     // with chalk's default (stdout-probing) instance even though
@@ -17,5 +20,5 @@ pub(crate) fn emit_config_warning(message: &str) {
     let colors = Colors {
         enabled: std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none(),
     };
-    eprintln!("{} {message}", colors.warn_label());
+    let _ = writeln!(std::io::stderr(), "{} {message}", colors.warn_label());
 }

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -350,7 +350,7 @@ impl InstallArgs {
         // above: every `return false` before this point hands the command
         // to the full install path, which warns from
         // `derive_config_root_and_package_manager_to_sync`.
-        warn_ignored_pnpm_manifest_fields_in(&config_root, emit);
+        warn_ignored_pnpm_manifest_fields_in(&config_root);
         warn_deprecated_override_version_references(config, emit);
         // The scope covers the same projects the full install path would
         // report; an up-to-date run says so too rather than going quiet

--- a/pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs
+++ b/pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs
@@ -3,8 +3,7 @@
 //! that still carries one of the migrated keys gets a warning naming it,
 //! so the setting isn't silently dropped.
 
-use super::package_manager::read_manifest_json;
-use pacquet_reporter::{GlobalLog, LogEvent, LogLevel};
+use super::{config_warnings::emit_config_warning, package_manager::read_manifest_json};
 use serde_json::Value;
 use std::path::Path;
 
@@ -37,29 +36,28 @@ const MIGRATED_PNPM_FIELD_KEYS: &[&str] = &[
 ];
 
 /// Warn about every migrated key the root project manifest still
-/// declares under `pnpm`. A manifest that could not be read is not this
-/// function's problem — the install path reports it with far more
-/// context — so `None` simply produces no warning.
-pub(crate) fn warn_ignored_pnpm_manifest_fields(manifest: Option<&Value>, emit: fn(&LogEvent)) {
+/// declares under `pnpm`. This is a config-load warning, so it goes to
+/// stderr through [`emit_config_warning`] rather than the reporter. A
+/// manifest that could not be read is not this function's problem — the
+/// install path reports it with far more context — so `None` simply
+/// produces no warning.
+pub(crate) fn warn_ignored_pnpm_manifest_fields(manifest: Option<&Value>) {
     let ignored = ignored_pnpm_field_keys(manifest);
     if ignored.is_empty() {
         return;
     }
     let keys = ignored.iter().map(|key| format!(r#""pnpm.{key}""#)).collect::<Vec<_>>().join(", ");
-    emit(&LogEvent::Global(GlobalLog {
-        level: LogLevel::Warn,
-        message: format!(
-            "The \"pnpm\" field in package.json is no longer read by pnpm. \
-             The following keys were ignored: {keys}. \
-             See https://pnpm.io/settings for the new home of each setting.",
-        ),
-    }));
+    emit_config_warning(&format!(
+        "The \"pnpm\" field in package.json is no longer read by pnpm. \
+         The following keys were ignored: {keys}. \
+         See https://pnpm.io/settings for the new home of each setting.",
+    ));
 }
 
 /// [`warn_ignored_pnpm_manifest_fields`] for a caller that has not read
 /// the root manifest yet.
-pub(crate) fn warn_ignored_pnpm_manifest_fields_in(root_dir: &Path, emit: fn(&LogEvent)) {
-    warn_ignored_pnpm_manifest_fields(root_manifest(root_dir).as_ref(), emit);
+pub(crate) fn warn_ignored_pnpm_manifest_fields_in(root_dir: &Path) {
+    warn_ignored_pnpm_manifest_fields(root_manifest(root_dir).as_ref());
 }
 
 fn root_manifest(root_dir: &Path) -> Option<Value> {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -653,7 +653,7 @@ pub(crate) fn derive_config_root_and_package_manager_to_sync(
     // pnpm warns from config-reading, so the notice lands ahead of any
     // install output. This is the install family's earliest point that
     // knows the root manifest's directory.
-    warn_ignored_pnpm_manifest_fields(root_manifest.as_ref(), reporter_emit(reporter));
+    warn_ignored_pnpm_manifest_fields(root_manifest.as_ref());
     warn_deprecated_override_version_references(cfg, reporter_emit(reporter));
     let package_manager_to_sync = root_manifest
         .as_ref()

--- a/pnpm/crates/cli/tests/custom_resolvers.rs
+++ b/pnpm/crates/cli/tests/custom_resolvers.rs
@@ -142,7 +142,11 @@ fn failing_should_refresh_resolution_aborts_the_install() {
 
     let output = pacquet_at(&workspace).with_arg("install").assert().failure();
     let stderr = String::from_utf8_lossy(&output.get_output().stderr).into_owned();
-    assert!(stderr.contains("refresh check crashed"), "stderr: {stderr}");
+    // miette wraps the report at the terminal width, and where the wrap
+    // falls depends on the temp-dir path length in the message, so the
+    // phrase is matched with the wrapping collapsed.
+    let unwrapped = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
+    assert!(unwrapped.contains("refresh check crashed"), "stderr: {stderr}");
 
     drop((root, mock_instance)); // cleanup
 }

--- a/pnpm/crates/cli/tests/install.rs
+++ b/pnpm/crates/cli/tests/install.rs
@@ -1722,8 +1722,10 @@ fn frozen_lockfile_setting_drives_the_headless_install() {
 /// A repository that hasn't migrated its `pnpm.overrides` would
 /// otherwise see only the downstream symptom.
 ///
-/// The message is asserted verbatim: it is the same string pnpm emits,
-/// and `@pnpm/cli.default-reporter` renders it.
+/// The message is asserted verbatim, `[WARN]` label included: it is the
+/// same string pnpm's `getConfig` prints with `console.warn`. Config-load
+/// warnings go to stderr, outside the reporter, so a script capturing
+/// stdout never sees them mixed into the command's own output.
 #[test]
 fn migrated_keys_under_the_package_json_pnpm_field_are_reported() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -1741,21 +1743,22 @@ fn migrated_keys_under_the_package_json_pnpm_field_are_reported() {
     .expect("write package.json");
 
     let assert = pacquet.with_args(["install", "--lockfile-only"]).assert().success();
-    // The default reporter renders every warning into its stdout frame.
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
 
-    eprintln!("STDOUT:\n{stdout}");
-    let warning = stdout
-        .find(
-            "The \"pnpm\" field in package.json is no longer read by pnpm. \
+    eprintln!("STDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+    assert!(
+        stderr.contains(
+            "[WARN] The \"pnpm\" field in package.json is no longer read by pnpm. \
              The following keys were ignored: \"pnpm.overrides\". \
              See https://pnpm.io/settings for the new home of each setting.",
-        )
-        .unwrap_or_else(|| panic!("expected the ignored-field warning; got:\n{stdout}"));
-    let footer = stdout
-        .find("Done in ")
-        .unwrap_or_else(|| panic!("expected the end-of-command footer; got:\n{stdout}"));
-    assert!(warning < footer, "the warning must precede the install output; got:\n{stdout}");
+        ),
+        "expected the ignored-field warning on stderr; got:\n{stderr}",
+    );
+    assert!(
+        !stdout.contains("no longer read by pnpm"),
+        "the warning must stay out of stdout; got:\n{stdout}",
+    );
 
     drop(root);
 }
@@ -1782,15 +1785,17 @@ fn migrated_keys_are_reported_by_the_up_to_date_fast_path() {
     pacquet.with_arg("install").assert().success();
     let assert = pacquet_in(&workspace).with_arg("install").assert().success();
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
 
-    eprintln!("STDOUT:\n{stdout}");
-    let warning = stdout.find("no longer read by pnpm").unwrap_or_else(|| {
-        panic!("the fast path must warn too; got:\n{stdout}");
-    });
-    let up_to_date = stdout
-        .find("Already up to date")
-        .unwrap_or_else(|| panic!("expected the fast path's own output; got:\n{stdout}"));
-    assert!(warning < up_to_date, "the warning must precede the install output; got:\n{stdout}");
+    eprintln!("STDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+    assert!(
+        stderr.contains("no longer read by pnpm"),
+        "the fast path must warn too; got:\n{stderr}",
+    );
+    assert!(
+        stdout.contains("Already up to date"),
+        "expected the fast path's own output; got:\n{stdout}",
+    );
 
     drop(root);
 }
@@ -1812,25 +1817,27 @@ fn migrated_keys_are_reported_through_a_utf8_bom() {
         .expect("write package.json");
 
     let assert = pacquet.with_arg("install").assert().success();
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
 
-    eprintln!("STDOUT:\n{stdout}");
+    eprintln!("STDERR:\n{stderr}");
     assert!(
-        stdout.contains("no longer read by pnpm"),
-        "the BOM must not swallow the warning; got:\n{stdout}",
+        stderr.contains("no longer read by pnpm"),
+        "the BOM must not swallow the warning; got:\n{stderr}",
     );
 
     let assert = pacquet_in(&workspace).with_arg("install").assert().success();
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
 
-    eprintln!("STDOUT:\n{stdout}");
-    let warning = stdout.find("no longer read by pnpm").unwrap_or_else(|| {
-        panic!("the fast path reads the manifest on its own; got:\n{stdout}");
-    });
-    let up_to_date = stdout
-        .find("Already up to date")
-        .unwrap_or_else(|| panic!("expected the fast path's own output; got:\n{stdout}"));
-    assert!(warning < up_to_date, "the warning must precede the install output; got:\n{stdout}");
+    eprintln!("STDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+    assert!(
+        stderr.contains("no longer read by pnpm"),
+        "the fast path reads the manifest on its own; got:\n{stderr}",
+    );
+    assert!(
+        stdout.contains("Already up to date"),
+        "expected the fast path's own output; got:\n{stdout}",
+    );
 
     drop(root);
 }
@@ -1870,16 +1877,16 @@ fn migrated_keys_are_read_from_the_workspace_root() {
 
     let assert =
         pacquet_in(&package_dir).with_args(["install", "--lockfile-only"]).assert().success();
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
 
-    eprintln!("STDOUT:\n{stdout}");
+    eprintln!("STDERR:\n{stderr}");
     assert!(
-        stdout.contains(r#"The following keys were ignored: "pnpm.overrides"."#),
-        "the root manifest's keys must be named; got:\n{stdout}",
+        stderr.contains(r#"The following keys were ignored: "pnpm.overrides"."#),
+        "the root manifest's keys must be named; got:\n{stderr}",
     );
     assert!(
-        !stdout.contains("neverBuiltDependencies"),
-        "the workspace package's own `pnpm` field is not the root manifest; got:\n{stdout}",
+        !stderr.contains("neverBuiltDependencies"),
+        "the workspace package's own `pnpm` field is not the root manifest; got:\n{stderr}",
     );
 
     drop(root);
@@ -1899,9 +1906,13 @@ fn an_unmigrated_package_json_pnpm_field_is_not_reported() {
 
     let assert = pacquet.with_args(["install", "--lockfile-only"]).assert().success();
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
 
-    eprintln!("STDOUT:\n{stdout}");
-    assert!(!stdout.contains("no longer read by pnpm"), "must stay quiet; got:\n{stdout}");
+    eprintln!("STDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+    assert!(
+        !stdout.contains("no longer read by pnpm") && !stderr.contains("no longer read by pnpm"),
+        "must stay quiet; got stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
 
     drop(root);
 }


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13361.

pnpm 11 prints config-load warnings to **stderr** (`getConfig` collects them while reading config and prints them with `console.warn`), while pacquet routed its one config-load warning — the "install settings left under `package.json`'s `pnpm` field" warning from pnpm/pnpm#13359 — through `LogEvent::Global` into the default reporter's **stdout** frame. A script capturing stdout got the warning mixed into the command's own output.

This PR gives pacquet a config-warning channel (`cli_args::config_warnings::emit_config_warning`) that writes a `[WARN]`-labelled line straight to stderr, outside the reporter, and emits the ignored-field warning through it:

- The channel prints unconditionally — on every reporter, matching `console.warn` in the TypeScript CLI's `getConfig`.
- Color styling is keyed off stdout's TTY-ness (not stderr's), matching `formatWarn`'s use of chalk's default, stdout-probing instance.
- Future config-load warnings (the global-config settings warning, the `workspaces`-field warning) inherit the stderr routing by going through the same channel, which is why the fix lands in a channel rather than at the single call site.

Warnings emitted through the reporter stay on stdout, where the two stacks already agree — in particular the `$`-override deprecation warning keeps its reporter routing, because pnpm emits it through `globalWarn`, not the config-warnings array.

This is a pacquet-only fix: the TypeScript CLI already prints config-load warnings to stderr, so no parity work is needed on that side.

Verified against the issue's repro: `pnpm install --lockfile-only 2>/dev/null` now prints nothing (warning went to stderr), matching pnpm 11.

## Squash Commit Body

```text
pnpm collects warnings raised while reading config and prints them with
console.warn — to stderr, outside the reporter — while pacquet routed its
one config-load warning (the ignored `pnpm` field of package.json)
through LogEvent::Global into the default reporter's stdout frame. A
script capturing stdout got the warning mixed into the command's own
output.

Add a config-warning channel (cli_args::config_warnings) that writes a
[WARN]-labelled line straight to stderr, and emit the ignored-field
warning through it. Reporter-emitted warnings stay on stdout, where the
two stacks already agree; the $-override deprecation warning keeps its
reporter routing because pnpm emits it through globalWarn, not the
config-warnings array. Future config-load warnings inherit the stderr
routing by going through the same channel.

Closes pnpm/pnpm#13361
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (pacquet-only fix — the TypeScript CLI already prints config-load
  warnings to stderr.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (No documentation changes needed.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787735978&installation_model_id=426870&pr_number=13416&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13416&signature=ed048e5e29f077cd3741901ed4b12087641ad7a3340d24647cad5bc197eab4e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration-load warnings (including ignored legacy `pnpm` settings) are now printed to **stderr** instead of **stdout**.
  * Warnings use a consistent **`[WARN]`** label and remain readable even when output wraps by terminal width.
  * When no relevant legacy settings are present (or the root manifest can’t be read), these warnings no longer appear.

* **Tests**
  * Updated installation tests to assert stderr/stdout separation, labeling, and quiet cases across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->