### PR TITLE
fix(store-dir): key non-registry store-index rows by the bare resolution id

### DIFF
--- a/.changeset/store-index-keys-non-registry-deps-by-resolution-id.md
+++ b/.changeset/store-index-keys-non-registry-deps-by-resolution-id.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The store index now keys URL, git-host, and `type: git` dependencies by their bare resolution id, matching the key pnpm 11 writes [#13365](https://github.com/pnpm/pnpm/issues/13365). Previously these rows carried a `<name>@` prefix, so a store warmed by one pnpm major was cold for the other and every non-registry dependency was re-downloaded, re-extracted, and re-imported on a switch. A remote tarball also occupied two index rows instead of one, doubling its extraction work.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4481,6 +4481,7 @@ dependencies = [
  "node-semver",
  "pacquet-catalogs-types",
  "pacquet-crypto-hash",
+ "pacquet-deps-path",
  "pacquet-diagnostics",
  "pacquet-fs",
  "pacquet-package-manifest",

--- a/pnpm/crates/cli/src/cli_args/cat_index.rs
+++ b/pnpm/crates/cli/src/cli_args/cat_index.rs
@@ -105,8 +105,8 @@ fn lockfile_store_index_keys(
         let Some(dependency) = find_dependency(importer, &alias_name) else { continue };
         let Some(snapshot_key) = dependency.version.resolved_key(&alias_name) else { continue };
         let metadata_key = snapshot_key.without_peer();
-        let pkg_id = metadata_key.to_string();
-        if !request_matches_dependency(alias, requested_bare, dependency, &pkg_id) {
+        if !request_matches_dependency(alias, requested_bare, dependency, &metadata_key.to_string())
+        {
             continue;
         }
         let Some(metadata) =
@@ -114,7 +114,7 @@ fn lockfile_store_index_keys(
         else {
             continue;
         };
-        for key in metadata_store_index_keys(&pkg_id, metadata) {
+        for key in metadata_store_index_keys(&metadata_key.pkg_id(), metadata) {
             if seen.insert(key.clone()) {
                 keys.push(key);
             }
@@ -154,10 +154,10 @@ fn request_matches_dependency(
     alias: &str,
     requested_bare: Option<&str>,
     dependency: &ResolvedDependencySpec,
-    pkg_id: &str,
+    lockfile_key: &str,
 ) -> bool {
     let Some(requested_bare) = requested_bare else { return true };
-    dependency.specifier == requested_bare || pkg_id == format!("{alias}@{requested_bare}")
+    dependency.specifier == requested_bare || lockfile_key == format!("{alias}@{requested_bare}")
 }
 
 fn metadata_store_index_keys(pkg_id: &str, metadata: &PackageMetadata) -> Vec<String> {

--- a/pnpm/crates/cli/tests/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/git_hosted_install.rs
@@ -683,6 +683,39 @@ fn updating_a_registry_package_that_has_a_git_dependency() {
     drop((root, npmrc_info));
 }
 
+/// A git dependency installed under an alias is gated on its *manifest*
+/// name, not the alias: `allowBuilds` has to name `<manifest name>@<spec>`
+/// for `prepare` to run.
+///
+/// The lockfile keys the package the same way, and pnpm's
+/// `preparePackage` builds the identity it checks from the fetched
+/// `package.json` too, so the alias never enters the build policy.
+#[test]
+fn an_aliased_git_dependency_is_gated_on_its_manifest_name() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "hi");
+    repo.write_file(
+        "package.json",
+        r#"{"name":"hi","version":"1.0.0","files":["package.json","prepare.txt"],"scripts":{"prepare":"node -e \"require('fs').writeFileSync('prepare.txt', 'prepared')\""}}"#,
+    );
+    let commit = repo.commit("init");
+    let spec = repo.git_url_at(&commit);
+    write_dependencies(&workspace, &[("say-hi", &spec)]);
+    allow_builds(&workspace, &[&format!("hi@{spec}")]);
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    assert_eq!(importer_version(&lockfile, ".", "say-hi"), format!("hi@{spec}"));
+    assert!(
+        workspace.join("node_modules/say-hi/prepare.txt").exists(),
+        "the manifest-name allowBuilds entry must let `prepare` run under the alias",
+    );
+
+    drop((root, npmrc_info));
+}
+
 /// The store index is shared with the TypeScript CLI, which keys a git
 /// dependency's row by the bare `git+…#<commit>` resolution id. Keying
 /// it by the lockfile's `<name>@git+…` form instead leaves a store

--- a/pnpm/crates/cli/tests/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/git_hosted_install.rs
@@ -683,6 +683,38 @@ fn updating_a_registry_package_that_has_a_git_dependency() {
     drop((root, npmrc_info));
 }
 
+/// The store index is shared with the TypeScript CLI, which keys a git
+/// dependency's row by the bare `git+…#<commit>` resolution id. Keying
+/// it by the lockfile's `<name>@git+…` form instead leaves a store
+/// warmed by one stack cold for the other
+/// ([#13365](https://github.com/pnpm/pnpm/issues/13365)).
+#[test]
+fn a_git_dependency_is_indexed_under_the_bare_resolution_id() {
+    let fixture = CommandTempCwd::init();
+    let (repo, commit) = say_hi_repo(fixture.root.path());
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } = fixture.add_mocked_registry();
+    write_dependencies(&workspace, &[("hi", &repo.git_url_at(&commit))]);
+
+    pacquet.with_args(["install"]).assert().success();
+
+    let store_dir = pacquet_store_dir::StoreDir::from(npmrc_info.store_dir.clone());
+    let keys = pacquet_store_dir::StoreIndex::open_readonly_in(&store_dir)
+        .expect("open the store index")
+        .keys()
+        .expect("read the store index keys");
+    let pkg_id = repo.git_url_at(&commit);
+    assert!(
+        keys.iter().any(|key| key == &format!("{pkg_id}\tbuilt")),
+        "no store-index row keyed by the bare resolution id {pkg_id:?}: {keys:?}",
+    );
+    assert!(
+        !keys.iter().any(|key| key.starts_with("hi@")),
+        "the lockfile-shaped `<name>@<id>` key must not reach the store index: {keys:?}",
+    );
+
+    drop((root, npmrc_info));
+}
+
 /// Append an `allowBuilds` block to the `pnpm-workspace.yaml` the
 /// harness wrote, opting the listed `<name>@<specifier>` keys into
 /// running lifecycle scripts.

--- a/pnpm/crates/cli/tests/tarball_url_dependency.rs
+++ b/pnpm/crates/cli/tests/tarball_url_dependency.rs
@@ -324,10 +324,8 @@ fn frozen_install_refuses_a_remote_tarball_without_integrity() {
 /// warmed by one stack stays warm for the other
 /// ([#13365](https://github.com/pnpm/pnpm/issues/13365)).
 ///
-/// Two rows appeared here before: the resolve-time fetch keyed its row by
-/// the manifest's `name@version` while the install pass keyed one by the
-/// lockfile's `name@<url>`, so one tarball cost two index entries and two
-/// extractions.
+/// One row, not two: the resolve-time fetch and the install pass address
+/// the same key, so a tarball costs one index entry and one extraction.
 #[test]
 fn a_remote_tarball_is_indexed_once_under_the_bare_url() {
     let CommandTempCwd { workspace, root, npmrc_info, .. } =
@@ -366,4 +364,69 @@ fn a_remote_tarball_is_indexed_once_under_the_bare_url() {
     );
 
     drop((head_mock, get_mock, root, mock_instance, tarball_server));
+}
+
+/// A tarball whose host answers the preflight with an immutable redirect
+/// is still reused from a warm store on re-resolution.
+///
+/// The lockfile records the *post-redirect* URL in `resolution.tarball`
+/// while the entry's `pkg_id` — its key, and the store-index row it
+/// lands at — stays the bare specifier the manifest asked for. A
+/// re-resolve looks the warm entry up by that specifier, before any
+/// preflight has revealed the redirect, so both sides have to agree on
+/// it. The proof is the same as
+/// [`remote_tarball_reresolves_from_warm_store_without_refetch`]: tear
+/// the host down, then re-resolve.
+#[test]
+fn remote_tarball_behind_an_immutable_redirect_reuses_the_warm_store() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let requested_path = "/pkg-from-tarball.tgz";
+    let canonical_path = "/cdn/pkg-from-tarball-1.0.0.tgz";
+    let mut tarball_server = mockito::Server::new();
+    let canonical_url = format!("{}{canonical_path}", tarball_server.url());
+    let redirect_mock = tarball_server
+        .mock("HEAD", requested_path)
+        .with_status(302)
+        .with_header("location", &canonical_url)
+        .create();
+    let head_mock = tarball_server
+        .mock("HEAD", canonical_path)
+        .with_status(200)
+        .with_header("cache-control", "immutable")
+        .create();
+    let get_mock = tarball_server
+        .mock("GET", canonical_path)
+        .with_status(200)
+        .with_body(minimal_tarball("pkg-from-tarball", "1.0.0"))
+        .create();
+    let requested_url = format!("{}{requested_path}", tarball_server.url());
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "pkg-from-tarball": &requested_url } }).to_string(),
+    )
+    .expect("write package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read the lockfile");
+    assert!(
+        lockfile.contains(&canonical_url),
+        "the lockfile must record the post-redirect URL:\n{lockfile}",
+    );
+    let package_key = format!("pkg-from-tarball@{requested_url}");
+    package_integrity(&lockfile, &package_key).unwrap_or_else(|| {
+        panic!("the entry must be keyed by the requested URL and carry an integrity:\n{lockfile}")
+    });
+
+    drop((redirect_mock, head_mock, get_mock, tarball_server));
+
+    pacquet_at(&workspace).with_arg("update").assert().success();
+
+    let after = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read the lockfile");
+    assert_eq!(after, lockfile, "a warm re-resolve must not rewrite the entry");
+
+    drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/tarball_url_dependency.rs
+++ b/pnpm/crates/cli/tests/tarball_url_dependency.rs
@@ -318,3 +318,52 @@ fn frozen_install_refuses_a_remote_tarball_without_integrity() {
 
     drop((root, mock_instance, tarball_server));
 }
+
+/// A remote tarball lands in the store index under exactly one row, keyed
+/// by the bare URL — the `pkgId` the TypeScript CLI writes, so a store
+/// warmed by one stack stays warm for the other
+/// ([#13365](https://github.com/pnpm/pnpm/issues/13365)).
+///
+/// Two rows appeared here before: the resolve-time fetch keyed its row by
+/// the manifest's `name@version` while the install pass keyed one by the
+/// lockfile's `name@<url>`, so one tarball cost two index entries and two
+/// extractions.
+#[test]
+fn a_remote_tarball_is_indexed_once_under_the_bare_url() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let store_dir = pacquet_store_dir::StoreDir::from(npmrc_info.store_dir.clone());
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let tarball_path = "/pkg-from-tarball-1.0.0.tgz";
+    let mut tarball_server = mockito::Server::new();
+    let head_mock = tarball_server.mock("HEAD", tarball_path).with_status(200).create();
+    let get_mock = tarball_server
+        .mock("GET", tarball_path)
+        .with_status(200)
+        .with_body(minimal_tarball("pkg-from-tarball", "1.0.0"))
+        .create();
+    let tarball_url = format!("{}{tarball_path}", tarball_server.url());
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "pkg-from-tarball": &tarball_url } }).to_string(),
+    )
+    .expect("write package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let keys = pacquet_store_dir::StoreIndex::open_readonly_in(&store_dir)
+        .expect("open the store index")
+        .keys()
+        .expect("read the store index keys");
+    let rows: Vec<&String> =
+        keys.iter().filter(|key| key.contains("pkg-from-tarball")).collect::<Vec<_>>();
+    assert_eq!(rows.len(), 1, "one tarball dependency must occupy one store-index row: {keys:?}");
+    assert!(
+        rows[0].ends_with(&format!("\t{tarball_url}")),
+        "the store-index row must be keyed by the bare tarball URL: {:?}",
+        rows[0],
+    );
+
+    drop((head_mock, get_mock, root, mock_instance, tarball_server));
+}

--- a/pnpm/crates/deps-path/src/try_get_package_id.rs
+++ b/pnpm/crates/deps-path/src/try_get_package_id.rs
@@ -13,10 +13,12 @@ use crate::suffix_index::index_of_dep_path_suffix;
 ///    `runtime:` engine entries — those carry their name in the
 ///    pkgId by design.
 ///
-/// The result is a borrowed slice of `dep_path` when neither transform
-/// applies, or an owned [`String`] when the second transform (name
-/// prefix strip) runs. Callers that always need ownership can
-/// `.to_string()`.
+/// The result is a borrowed slice of `dep_path` when the second
+/// transform doesn't run, or an owned [`String`] when it does. A
+/// borrowed result is always a *prefix* of `dep_path` — the whole of it,
+/// or everything ahead of the suffix — so a caller holding an owned
+/// input can truncate it in place instead of re-allocating. Callers that
+/// always need ownership can `.to_string()`.
 #[must_use]
 pub fn try_get_package_id(dep_path: &str) -> std::borrow::Cow<'_, str> {
     let suffix_index = index_of_dep_path_suffix(dep_path);

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -53,8 +53,10 @@ pub struct GitFetcher<'a> {
     pub node_execpath: Option<&'a Path>,
     pub npm_execpath: Option<&'a Path>,
     pub store_dir: &'a StoreDir,
-    /// Used in log lines; matches the `package_id` the rest of the
-    /// install dispatcher uses (`<name>@<version>(<peer-suffix>)`).
+    /// Used in log lines, and as the resolution id
+    /// [`crate::prepare_package`] synthesizes its gated dep path from.
+    /// Matches the `package_id` the rest of the install dispatcher uses
+    /// — for a git dep, the bare `git+…#<commit>` id.
     pub package_id: &'a str,
     pub requester: &'a str,
     /// Install-scoped store-index writer. When provided, the fetcher
@@ -118,7 +120,7 @@ impl GitFetcher<'_> {
         let empty_env: HashMap<String, String> = HashMap::new();
         let prepare_opts = PreparePackageOptions {
             allow_build: Box::new(|dep_path| (self.allow_build)(dep_path)),
-            dep_path: self.package_id,
+            pkg_resolution_id: self.package_id,
             ignore_scripts: self.ignore_scripts,
             unsafe_perm: self.unsafe_perm,
             user_agent: self.user_agent,

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -54,7 +54,7 @@ pub struct GitFetcher<'a> {
     pub npm_execpath: Option<&'a Path>,
     pub store_dir: &'a StoreDir,
     /// Used in log lines, and as the resolution id
-    /// [`crate::prepare_package`] synthesizes its gated dep path from.
+    /// [`crate::prepare_package()`] synthesizes its gated dep path from.
     /// Matches the `package_id` the rest of the install dispatcher uses
     /// — for a git dep, the bare `git+…#<commit>` id.
     pub package_id: &'a str,

--- a/pnpm/crates/git-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher/tests.rs
@@ -691,7 +691,8 @@ async fn fetcher_runs_prepare_when_allow_build_returns_true() {
     // Targeted allow_build that returns true for *this* package only —
     // catches a regression where the gate ignores the dep path and
     // falls through to default-allow or default-deny.
-    let allow_x_only: AllowBuildRef<'_> = &|dep_path| dep_path == "x@1.0.0";
+    let allow_x_only: AllowBuildRef<'_> =
+        &|dep_path| dep_path == "x@git+file:///tmp/repo.git#abc123";
 
     let received = GitFetcher {
         repo: &repo_url,
@@ -707,10 +708,10 @@ async fn fetcher_runs_prepare_when_allow_build_returns_true() {
         node_execpath: None,
         npm_execpath: None,
         store_dir: &store_dir,
-        package_id: "x@1.0.0",
+        package_id: "git+file:///tmp/repo.git#abc123",
         requester: "/test",
         store_index_writer: None,
-        files_index_file: "x@1.0.0\tbuilt",
+        files_index_file: "git+file:///tmp/repo.git#abc123\tbuilt",
         git_bin: None,
     }
     .run::<SilentReporter>()
@@ -754,10 +755,10 @@ async fn fetcher_rejects_untrusted_manifest_identity() {
         node_execpath: None,
         npm_execpath: None,
         store_dir: &store_dir,
-        package_id: "x@git+file:///tmp/repo.git#abc123",
+        package_id: "git+file:///tmp/repo.git#abc123",
         requester: "/test",
         store_index_writer: None,
-        files_index_file: "x@git+file:///tmp/repo.git#abc123\tbuilt",
+        files_index_file: "git+file:///tmp/repo.git#abc123\tbuilt",
         git_bin: None,
     }
     .run::<SilentReporter>()
@@ -786,8 +787,9 @@ async fn fetcher_allows_untrusted_manifest_identity_by_dep_path() {
     let store_root = tempdir().unwrap();
     let store_dir = StoreDir::from(store_root.path().to_path_buf());
     let repo_url = format!("file://{}", bare.display());
-    let package_id = "x@git+file:///tmp/repo.git#abc123";
-    let allow_dep_path: AllowBuildRef<'_> = &|dep_path| dep_path == package_id;
+    let package_id = "git+file:///tmp/repo.git#abc123";
+    let allow_dep_path: AllowBuildRef<'_> =
+        &|dep_path| dep_path == "x@git+file:///tmp/repo.git#abc123";
 
     let received = GitFetcher {
         repo: &repo_url,
@@ -806,7 +808,7 @@ async fn fetcher_allows_untrusted_manifest_identity_by_dep_path() {
         package_id,
         requester: "/test",
         store_index_writer: None,
-        files_index_file: "x@git+file:///tmp/repo.git#abc123\tbuilt",
+        files_index_file: "git+file:///tmp/repo.git#abc123\tbuilt",
         git_bin: None,
     }
     .run::<SilentReporter>()

--- a/pnpm/crates/git-fetcher/src/prepare_package.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package.rs
@@ -41,7 +41,11 @@ pub type AllowBuildRef<'a> = &'a (dyn Fn(&str) -> bool + Send + Sync);
 /// Caller-supplied context for [`prepare_package`].
 pub struct PreparePackageOptions<'a> {
     pub allow_build: AllowBuildFn<'a>,
-    pub dep_path: &'a str,
+    /// The package's resolution id — the bare `git+…#<commit>` or
+    /// archive URL. The gated dep path is synthesized from it and the
+    /// fetched manifest's name, so the policy sees the same
+    /// `<name>@<id>` key a lockfile would record.
+    pub pkg_resolution_id: &'a str,
     pub ignore_scripts: bool,
     pub unsafe_perm: bool,
     pub user_agent: Option<&'a str>,
@@ -91,11 +95,14 @@ pub fn prepare_package<Reporter: self::Reporter>(
 
     // `allowBuild` check before any spawn. A dep path that isn't
     // allowed throws ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED. The manifest comes
-    // from the fetched artifact itself, so its name and version only
-    // feed the error message; the dep path is the gated identity.
+    // from the fetched artifact itself, so its version only feeds the
+    // error message; the synthesized dep path is the gated identity.
+    // Resolution ids of git and tarball artifacts are never
+    // semver-shaped, so the policy derives an untrusted package
+    // identity from it and name-only rules can't approve the build.
     let name = manifest.get("name").and_then(Value::as_str).unwrap_or("");
     let version = manifest.get("version").and_then(Value::as_str).unwrap_or("");
-    if !(opts.allow_build)(opts.dep_path) {
+    if !(opts.allow_build)(&format!("{name}@{}", opts.pkg_resolution_id)) {
         return Err(PreparePackageError::NotAllowed {
             name: name.to_string(),
             version: version.to_string(),

--- a/pnpm/crates/git-fetcher/src/prepare_package/tests.rs
+++ b/pnpm/crates/git-fetcher/src/prepare_package/tests.rs
@@ -24,7 +24,7 @@ fn opts<'a>(allow: bool, ignore_scripts: bool) -> PreparePackageOptions<'a> {
     static EMPTY_BIN_PATHS: &[std::path::PathBuf] = &[];
     PreparePackageOptions {
         allow_build: Box::new(move |_dep_path| allow),
-        dep_path: "x@https://example.com/x.tgz",
+        pkg_resolution_id: "https://example.com/x.tgz",
         ignore_scripts,
         unsafe_perm: true,
         user_agent: None,
@@ -41,7 +41,7 @@ fn opts_allow_registry_artifacts_only<'a>() -> PreparePackageOptions<'a> {
     static EMPTY_BIN_PATHS: &[std::path::PathBuf] = &[];
     PreparePackageOptions {
         allow_build: Box::new(move |dep_path| !dep_path.contains("://")),
-        dep_path: "x@https://example.com/x.tgz",
+        pkg_resolution_id: "https://example.com/x.tgz",
         ignore_scripts: false,
         unsafe_perm: true,
         user_agent: None,
@@ -54,11 +54,14 @@ fn opts_allow_registry_artifacts_only<'a>() -> PreparePackageOptions<'a> {
     }
 }
 
-fn opts_allow_dep_path(dep_path: &str) -> PreparePackageOptions<'_> {
+fn opts_allow_dep_path<'a>(
+    dep_path: &'a str,
+    pkg_resolution_id: &'a str,
+) -> PreparePackageOptions<'a> {
     static EMPTY_BIN_PATHS: &[std::path::PathBuf] = &[];
     PreparePackageOptions {
         allow_build: Box::new(move |actual_dep_path| actual_dep_path == dep_path),
-        dep_path,
+        pkg_resolution_id,
         ignore_scripts: false,
         unsafe_perm: true,
         user_agent: None,
@@ -204,10 +207,16 @@ fn prepare_allows_untrusted_manifest_identity_by_dep_path() {
         }),
     );
 
-    let dep_path = "trusted-name@git+https://example.com/org/repo.git#abc123";
-    let result =
-        prepare_package::<SilentReporter>(&opts_allow_dep_path(dep_path), dir.path(), None)
-            .expect("depPath-specific allow should permit prepare");
+    // The policy sees `<manifest name>@<resolution id>` — the key a
+    // lockfile would record — not the bare resolution id.
+    let pkg_resolution_id = "git+https://example.com/org/repo.git#abc123";
+    let dep_path = format!("trusted-name@{pkg_resolution_id}");
+    let result = prepare_package::<SilentReporter>(
+        &opts_allow_dep_path(&dep_path, pkg_resolution_id),
+        dir.path(),
+        None,
+    )
+    .expect("depPath-specific allow should permit prepare");
 
     assert!(result.should_be_built);
     assert!(dir.path().join("built.txt").exists());

--- a/pnpm/crates/git-fetcher/src/tarball_fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/tarball_fetcher.rs
@@ -68,7 +68,8 @@ pub struct GitHostedTarballFetcher<'a> {
     pub node_execpath: Option<&'a Path>,
     pub npm_execpath: Option<&'a Path>,
     pub store_dir: &'a StoreDir,
-    /// Used in log lines.
+    /// Used in log lines; see the matching field on
+    /// [`crate::GitFetcher`] for its other role.
     pub package_id: &'a str,
     pub requester: &'a str,
     /// Install-scoped store-index writer; see the matching field on
@@ -104,7 +105,7 @@ impl GitHostedTarballFetcher<'_> {
         let empty_env: HashMap<String, String> = HashMap::new();
         let prepare_opts = PreparePackageOptions {
             allow_build: Box::new(|dep_path| (self.allow_build)(dep_path)),
-            dep_path: self.package_id,
+            pkg_resolution_id: self.package_id,
             ignore_scripts: self.ignore_scripts,
             unsafe_perm: self.unsafe_perm,
             user_agent: self.user_agent,

--- a/pnpm/crates/lockfile/Cargo.toml
+++ b/pnpm/crates/lockfile/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace  = true
 [dependencies]
 pacquet-catalogs-types                    = { workspace = true }
 pacquet-crypto-hash                       = { workspace = true }
+pacquet-deps-path                         = { workspace = true }
 pacquet-diagnostics                       = { workspace = true }
 pacquet-fs                                = { workspace = true }
 pacquet-package-manifest                  = { workspace = true }

--- a/pnpm/crates/lockfile/src/pkg_name_ver_peer.rs
+++ b/pnpm/crates/lockfile/src/pkg_name_ver_peer.rs
@@ -62,7 +62,20 @@ impl PkgNameVerPeer {
     /// TypeScript CLI, which keys those rows by the bare id.
     #[must_use]
     pub fn pkg_id(&self) -> String {
-        pacquet_deps_path::try_get_package_id(&self.to_string()).into_owned()
+        let mut rendered = self.to_string();
+        // A borrowed result is a prefix of the rendered key — the whole
+        // of it, or everything ahead of the peer / patch-hash suffix — so
+        // truncating reuses this allocation. Only dropping the `name@`
+        // prefix yields an owned string.
+        let pkg_id_len = match pacquet_deps_path::try_get_package_id(&rendered) {
+            std::borrow::Cow::Borrowed(pkg_id) => {
+                debug_assert!(rendered.starts_with(pkg_id));
+                pkg_id.len()
+            }
+            std::borrow::Cow::Owned(pkg_id) => return pkg_id,
+        };
+        rendered.truncate(pkg_id_len);
+        rendered
     }
 }
 

--- a/pnpm/crates/lockfile/src/pkg_name_ver_peer.rs
+++ b/pnpm/crates/lockfile/src/pkg_name_ver_peer.rs
@@ -47,13 +47,12 @@ impl PkgNameVerPeer {
     }
 
     /// The package id pnpm addresses this package by outside the
-    /// lockfile: the store-index row key
-    /// ([`pacquet_store_dir::store_index_key`] /
-    /// [`pacquet_store_dir::git_hosted_store_index_key`] — named in
-    /// prose because `pacquet-lockfile` deliberately does not depend on
+    /// lockfile: the store-index row key (`store_index_key` /
+    /// `git_hosted_store_index_key` — referenced as plain text because
+    /// `pacquet-lockfile` deliberately does not depend on
     /// `pacquet-store-dir`), the `packageId` of a `pnpm:progress`
-    /// event, and the argument the git fetchers hand to the
-    /// `allowBuild` policy.
+    /// event, and the resolution id the git fetchers build their
+    /// `allowBuild` dep path from.
     ///
     /// For a registry package this is the peer-stripped key itself
     /// (`name@version`). For a non-registry resolution — a URL tarball,

--- a/pnpm/crates/lockfile/src/pkg_name_ver_peer.rs
+++ b/pnpm/crates/lockfile/src/pkg_name_ver_peer.rs
@@ -63,15 +63,11 @@ impl PkgNameVerPeer {
     #[must_use]
     pub fn pkg_id(&self) -> String {
         let mut rendered = self.to_string();
-        // A borrowed result is a prefix of the rendered key — the whole
-        // of it, or everything ahead of the peer / patch-hash suffix — so
-        // truncating reuses this allocation. Only dropping the `name@`
-        // prefix yields an owned string.
+        // `try_get_package_id` borrows a prefix of its input unless it
+        // drops the `name@` prefix, so truncating reuses this allocation
+        // rather than cloning the slice into a second one.
         let pkg_id_len = match pacquet_deps_path::try_get_package_id(&rendered) {
-            std::borrow::Cow::Borrowed(pkg_id) => {
-                debug_assert!(rendered.starts_with(pkg_id));
-                pkg_id.len()
-            }
+            std::borrow::Cow::Borrowed(pkg_id) => pkg_id.len(),
             std::borrow::Cow::Owned(pkg_id) => return pkg_id,
         };
         rendered.truncate(pkg_id_len);

--- a/pnpm/crates/lockfile/src/pkg_name_ver_peer.rs
+++ b/pnpm/crates/lockfile/src/pkg_name_ver_peer.rs
@@ -45,6 +45,26 @@ impl PkgNameVerPeer {
     pub fn without_peer(&self) -> PkgNameVerPeer {
         PkgNameVerPeer::new(self.name.clone(), self.suffix.without_peer())
     }
+
+    /// The package id pnpm addresses this package by outside the
+    /// lockfile: the store-index row key
+    /// ([`pacquet_store_dir::store_index_key`] /
+    /// [`pacquet_store_dir::git_hosted_store_index_key`] — named in
+    /// prose because `pacquet-lockfile` deliberately does not depend on
+    /// `pacquet-store-dir`), the `packageId` of a `pnpm:progress`
+    /// event, and the argument the git fetchers hand to the
+    /// `allowBuild` policy.
+    ///
+    /// For a registry package this is the peer-stripped key itself
+    /// (`name@version`). For a non-registry resolution — a URL tarball,
+    /// a git-host archive, a `type: git` dependency — it is the bare
+    /// resolution id, without the `name@` prefix the lockfile key
+    /// carries. The store index is a contract shared with the
+    /// TypeScript CLI, which keys those rows by the bare id.
+    #[must_use]
+    pub fn pkg_id(&self) -> String {
+        pacquet_deps_path::try_get_package_id(&self.to_string()).into_owned()
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/lockfile/src/pkg_name_ver_peer/tests.rs
+++ b/pnpm/crates/lockfile/src/pkg_name_ver_peer/tests.rs
@@ -223,3 +223,33 @@ fn to_virtual_store_name_shortens_user_reported_vitest_case() {
     assert_eq!(hash.len(), 32);
     assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
 }
+
+/// The store index is a contract shared with the TypeScript CLI, which
+/// keys a registry package by `name@version` and every non-registry
+/// shape by the bare resolution id. `pkg_id` reproduces both.
+#[test]
+fn pkg_id_strips_the_name_prefix_from_non_registry_keys() {
+    fn case(input: &'static str, expected: &str) {
+        eprintln!("CASE: {input:?}");
+        let key: PkgNameVerPeer = input.parse().expect("parse package key");
+        assert_eq!(key.pkg_id(), expected);
+    }
+
+    case("is-positive@1.0.0", "is-positive@1.0.0");
+    case("@foo/bar@1.0.0", "@foo/bar@1.0.0");
+    case("react-dom@17.0.2(react@17.0.2)", "react-dom@17.0.2");
+    case("foo@1.0.0(patch_hash=0000)(bar@2.0.0)", "foo@1.0.0");
+    case(
+        "tarball-pkg@http://127.0.0.1:8791/tarball-pkg-1.0.0.tgz",
+        "http://127.0.0.1:8791/tarball-pkg-1.0.0.tgz",
+    );
+    case(
+        "ci-info@https://codeload.github.com/watson/ci-info/tar.gz/f43f6a1c",
+        "https://codeload.github.com/watson/ci-info/tar.gz/f43f6a1c",
+    );
+    case("hi@git+file:///tmp/repo#a0c17e86", "git+file:///tmp/repo#a0c17e86");
+    case("hi@git+ssh://git@github.com/foo/hi#a0c17e86", "git+ssh://git@github.com/foo/hi#a0c17e86");
+    // A runtime entry carries its name in the id by design, so pnpm
+    // keeps the prefix there.
+    case("node@runtime:22.0.0", "node@runtime:22.0.0");
+}

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -1277,7 +1277,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
         && let Some(integrity) = metadata.resolution.integrity()
     {
         let files_index_file =
-            pacquet_store_dir::store_index_key(&integrity.to_string(), &metadata_key.to_string());
+            pacquet_store_dir::store_index_key(&integrity.to_string(), &metadata_key.pkg_id());
         if let Err(err) =
             pacquet_store_dir::upload(store, &pkg_dir, &files_index_file, cache_key, writer)
         {

--- a/pnpm/crates/package-manager/src/create_virtual_store.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store.rs
@@ -770,7 +770,7 @@ impl CreateVirtualStore<'_> {
             // hits — the link work just happens later, in
             // `link_hoisted_modules`.
             for (snapshot_key, _, _, cache_key, _) in &warm {
-                let package_id = snapshot_key.without_peer().to_string();
+                let package_id = snapshot_key.pkg_id();
                 emit_warm_snapshot_progress::<Reporter>(
                     &package_id,
                     requester,
@@ -1157,7 +1157,7 @@ fn link_slots_parallel<Reporter: self::Reporter>(
     let phase_start = std::time::Instant::now();
     let link_work = || {
         slots.par_iter().try_for_each(|slot| {
-            let package_id = slot.snapshot_key.without_peer().to_string();
+            let package_id = slot.snapshot_key.pkg_id();
             if let Some(cache_key) = slot.warm_cache_key {
                 emit_warm_snapshot_progress::<Reporter>(
                     &package_id,
@@ -1240,7 +1240,7 @@ fn snapshot_cache_key(
             metadata_key: metadata_key.to_string(),
         }
     })?;
-    let pkg_id = metadata_key.to_string();
+    let pkg_id = metadata_key.pkg_id();
     match &metadata.resolution {
         LockfileResolution::Tarball(t) => {
             // A tarball with no integrity that isn't one of the shapes

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -399,19 +399,16 @@ impl InstallPackageBySnapshot<'_> {
                 // keeps its by-value contract.
                 //
                 // Restricted to registry resolutions: those are the only
-                // ones the background prefetchers populate under a key
-                // this pass also writes — the pnpr `TarballPrefetcher` and
-                // the resolve-time `PrefetchingResolver` both key by
-                // `name@version`, matching the materialization store-index
-                // row. A remote tarball, by contrast, resolves with no
-                // `name_ver`, so the prefetcher skips it; its only
-                // mem-cache entry comes from the resolver's
-                // download-to-resolve, keyed by `name@version`, whereas the
-                // lockfile (and this pass) address it by `name@<url>`.
-                // Reusing that entry would skip writing the `name@<url>`
-                // store-index row a later re-resolve needs to reuse the
-                // warm store, so remote tarballs must take the standalone
-                // path.
+                // ones the background prefetchers populate — the pnpr
+                // `TarballPrefetcher` and the resolve-time
+                // `PrefetchingResolver` both key by `name@version`, and a
+                // remote tarball resolves with no `name_ver`, so they skip
+                // it. Its only mem-cache entry comes from the resolver's
+                // download-to-resolve, and a hit on that entry returns the
+                // extraction without touching the store index. Taking the
+                // standalone path instead keeps this pass reconciling the
+                // row itself, so a later re-resolve finds the warm store
+                // whatever the resolver did or didn't write.
                 let raw_cas_paths = match tarball_mem_cache {
                     Some(mem_cache) if matches!(resolution, LockfileResolution::Registry(_)) => {
                         // `clone()` is cheap (refs + `Arc`s) and lets us

--- a/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/package-manager/src/install_package_by_snapshot.rs
@@ -298,7 +298,7 @@ impl InstallPackageBySnapshot<'_> {
         } = self;
 
         // TODO: skip when already exists in store?
-        let package_id = package_key.without_peer().to_string();
+        let package_id = package_key.pkg_id();
         emit_progress_resolved::<Reporter>(&package_id, requester);
 
         // Adapter shared between the `Git` arm below and the
@@ -904,7 +904,7 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
     requester: &str,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<HashMap<String, PathBuf>, InstallPackageBySnapshotError> {
-    let package_id = package_key.without_peer().to_string();
+    let package_id = package_key.pkg_id();
 
     // Synthesize the `package.json` runtime archives (Node.js / Bun /
     // Deno) don't ship, and hand it to the fetcher as `append_manifest`.

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -41,7 +41,7 @@ use pacquet_resolving_npm_resolver::{
     merge_named_registries, shared_packument_fetch_locker, shared_picked_manifest_cache,
 };
 use pacquet_resolving_resolver_base::{ResolveOptions, Resolver};
-use pacquet_resolving_tarball_resolver::{TarballFetchContext, TarballResolver};
+use pacquet_resolving_tarball_resolver::{PriorTarballEntry, TarballFetchContext, TarballResolver};
 use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
 use pacquet_tarball::{MemCache, SharedReportedProgressKeys};
 use std::{
@@ -866,14 +866,20 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // the materializing and `--lockfile-only` paths: the lockfile
         // needs the integrity regardless of whether `node_modules` is
         // built.
-        // Map every remote-tarball URL the prior lockfile recorded (with an
+        // Map every remote tarball the prior lockfile recorded (with an
         // integrity) to its `<integrity>\t<pkg_id>` store-index key, keyed
         // exactly as `snapshot_cache_key` / the install pass address the row.
         // The `TarballResolver` uses it to reuse a warm store entry instead
         // of re-downloading on re-resolution. Git-hosted tarballs are skipped
         // (they key by `gitHostedStoreIndexKey`, not the integrity) and just
         // re-fetch as before. Empty on a first install.
-        let prior_tarball_entries: HashMap<String, (ssri::Integrity, String)> = wanted_lockfile
+        //
+        // The map is keyed by `pkg_id` — the bare specifier — rather than
+        // `resolution.tarball`, because that is what the resolver looks a
+        // dependency up by. The two differ once an immutable response has
+        // redirected: the lockfile then records the post-redirect URL while
+        // the id stays the specifier the manifest asked for.
+        let prior_tarball_entries: HashMap<String, PriorTarballEntry> = wanted_lockfile
             .and_then(|lockfile| lockfile.packages.as_ref())
             .map(|packages| {
                 packages
@@ -881,8 +887,16 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                     .filter_map(|(key, metadata)| match &metadata.resolution {
                         LockfileResolution::Tarball(t) if t.git_hosted != Some(true) => {
                             let integrity = t.integrity.clone()?;
-                            let cache_key = store_index_key(&integrity.to_string(), &key.pkg_id());
-                            Some((t.tarball.clone(), (integrity, cache_key)))
+                            let pkg_id = key.pkg_id();
+                            let store_index_key = store_index_key(&integrity.to_string(), &pkg_id);
+                            Some((
+                                pkg_id,
+                                PriorTarballEntry {
+                                    integrity,
+                                    store_index_key,
+                                    tarball_url: t.tarball.clone(),
+                                },
+                            ))
                         }
                         _ => None,
                     })

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -881,8 +881,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                     .filter_map(|(key, metadata)| match &metadata.resolution {
                         LockfileResolution::Tarball(t) if t.git_hosted != Some(true) => {
                             let integrity = t.integrity.clone()?;
-                            let cache_key =
-                                store_index_key(&integrity.to_string(), &key.to_string());
+                            let cache_key = store_index_key(&integrity.to_string(), &key.pkg_id());
                             Some((t.tarball.clone(), (integrity, cache_key)))
                         }
                         _ => None,
@@ -2651,10 +2650,9 @@ fn is_partial_workspace_selection(
 /// install.
 ///
 /// Skips nodes whose resolver result isn't a non-git-hosted tarball
-/// with an `integrity` and a resolvable `name@version` (from `name_ver`
-/// or, for remote-tarball direct deps, the fetched manifest):
-/// git-hosted tarballs and directory / git / binary resolutions use a
-/// different key shape (`pkg_id`-only) and route through the cold path.
+/// with an `integrity`: git-hosted tarballs and directory / git /
+/// binary resolutions use a different key shape (`pkg_id`-only) and
+/// route through the cold path.
 fn collect_prefetch_cache_keys_from_graph(
     graph: &pacquet_resolving_deps_resolver::DependenciesGraph,
 ) -> Vec<String> {
@@ -2670,18 +2668,12 @@ fn collect_prefetch_cache_keys_from_graph(
                 return None;
             }
             let integrity = tarball.integrity.as_ref()?.to_string();
-            // `name_ver` when the resolver produced one (npm registry);
-            // otherwise the manifest's `name@version` — remote-tarball
-            // direct deps learn both from `package.json`, and the
-            // resolve-time fetch keyed the store-index row the same way.
-            let pkg_id = if let Some(name_ver) = node.resolve_result.name_ver.as_ref() {
-                format!("{}@{}", name_ver.name, name_ver.suffix)
-            } else {
-                let manifest = node.resolve_result.manifest.as_deref()?;
-                let name = manifest.get("name")?.as_str()?;
-                let version = manifest.get("version")?.as_str()?;
-                format!("{name}@{version}")
-            };
+            // The node's dep path carries the same `name@<id>` shape the
+            // lockfile records, so stripping it yields the `pkg_id` the
+            // install pass and the resolve-time fetch address the row by
+            // — `name@version` for a registry package, the bare URL for a
+            // remote tarball.
+            let pkg_id = pacquet_deps_path::try_get_package_id(node.dep_path.as_str());
             Some(pacquet_store_dir::store_index_key(&integrity, &pkg_id))
         })
         .collect();

--- a/pnpm/crates/package-manager/src/patch.rs
+++ b/pnpm/crates/package-manager/src/patch.rs
@@ -209,7 +209,7 @@ impl WritePackageForPatch<'_> {
         let (tarball_url, integrity) =
             tarball_url_and_integrity(&metadata.resolution, &target.package_key, config)
                 .map_err(WritePackageForPatchError::TarballResolution)?;
-        let package_id = format!("{}@{}", target.alias, target.version);
+        let package_id = target.package_key.pkg_id();
 
         validate_patch_destination(dest)?;
 

--- a/pnpm/crates/package-manager/src/tarball_prefetch.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch.rs
@@ -301,7 +301,7 @@ impl TarballPrefetcher {
             let (tarball_url, integrity) =
                 tarball_url_and_integrity(&metadata.resolution, package_key, config)
                     .expect("registry resolutions are always fetchable");
-            let package_id = package_key.without_peer().to_string();
+            let package_id = package_key.pkg_id();
             let integrity =
                 integrity.expect("registry resolutions always carry an integrity").to_string();
             pending.push(PendingPrefetch {

--- a/pnpm/crates/resolving-tarball-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-tarball-resolver/src/lib.rs
@@ -24,4 +24,4 @@
 
 mod tarball_resolver;
 
-pub use tarball_resolver::{TarballFetchContext, TarballResolver};
+pub use tarball_resolver::{PriorTarballEntry, TarballFetchContext, TarballResolver};

--- a/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -169,9 +169,12 @@ impl TarballResolver {
             store_dir: ctx.store_dir,
             store_index_writer: ctx.store_index_writer.clone(),
             package_url: &resolved_url,
-            // A direct https tarball has no resolver-known name@version, so the URL is the
-            // only identifier; such tarballs carry no scoped-registry auth.
-            package_id: &resolved_url,
+            // The bare specifier — not `resolved_url` — is this
+            // dependency's `pkg_id`: it is what the lockfile key carries
+            // and therefore what the install pass keys the store-index
+            // row by. The two differ when an immutable response
+            // redirects. Such tarballs carry no scoped-registry auth.
+            package_id: &normalized_bare_specifier,
             auth_headers: &ctx.auth_headers,
             retry_opts: ctx.retry_opts,
             // A plain tarball is the package; its manifest is at the root.

--- a/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -38,11 +38,27 @@ pub struct TarballFetchContext {
     pub store_index: Option<SharedReadonlyStoreIndex>,
     pub verify_store_integrity: bool,
     pub verified_files_cache: SharedVerifiedFilesCache,
-    /// Tarball URL → `(integrity, "<integrity>\t<pkg_id>" store-index key)`
-    /// for every remote-tarball entry the prior lockfile recorded. Lets a
-    /// re-resolve reuse the already-extracted store content instead of
-    /// re-downloading. Empty on a first install.
-    pub prior_tarball_entries: Arc<HashMap<String, (Integrity, String)>>,
+    /// What the prior lockfile recorded for each remote-tarball entry,
+    /// keyed by `pkg_id`. Lets a re-resolve reuse the already-extracted
+    /// store content instead of re-downloading. Empty on a first install.
+    ///
+    /// A remote tarball's `pkg_id` is its normalized bare specifier, so
+    /// [`TarballResolver::reuse_from_warm_store`] can look an entry up
+    /// before the preflight that would reveal a redirect.
+    pub prior_tarball_entries: Arc<HashMap<String, PriorTarballEntry>>,
+}
+
+/// One remote-tarball entry carried over from the prior lockfile.
+#[derive(Debug, Clone)]
+pub struct PriorTarballEntry {
+    pub integrity: Integrity,
+    /// `<integrity>\t<pkg_id>` — the store-index row holding the
+    /// extracted content.
+    pub store_index_key: String,
+    /// The URL the lockfile recorded. An immutable redirect moves this
+    /// off the bare specifier, so a warm reuse replays it rather than
+    /// re-deriving one and churning the lockfile.
+    pub tarball_url: String,
 }
 
 /// Resolves `http://...` / `https://...` tarball URLs from a project's
@@ -193,20 +209,21 @@ impl TarballResolver {
         )))
     }
 
-    /// Reuse an already-extracted store entry for `tarball_url` when the
-    /// prior lockfile recorded it with an integrity and the store still
-    /// holds the content + its bundled manifest. Returns `None` (caller
-    /// downloads) when there's no fetch context, no prior entry for the
-    /// URL, or the store-index lookup misses — never on a wrong-content
-    /// risk, since the key embeds the integrity and the CAFS is
-    /// content-addressed.
+    /// Reuse an already-extracted store entry for the dependency whose
+    /// `pkg_id` is `normalized_bare_specifier`, when the prior lockfile
+    /// recorded it with an integrity and the store still holds the
+    /// content + its bundled manifest. Returns `None` (caller downloads)
+    /// when there's no fetch context, no prior entry for the id, or the
+    /// store-index lookup misses — never on a wrong-content risk, since
+    /// the key embeds the integrity and the CAFS is content-addressed.
     async fn reuse_from_warm_store(
         &self,
         wanted_dependency: &WantedDependency,
-        tarball_url: &str,
+        normalized_bare_specifier: &str,
     ) -> Option<ResolveResult> {
         let ctx = self.fetch_context.as_ref()?;
-        let (integrity, cache_key) = ctx.prior_tarball_entries.get(tarball_url)?;
+        let prior = ctx.prior_tarball_entries.get(normalized_bare_specifier)?;
+        let cache_key = &prior.store_index_key;
         let PrefetchResult { cas_paths, manifests, .. } = prefetch_cas_paths(
             ctx.store_index.clone(),
             ctx.store_dir,
@@ -224,9 +241,9 @@ impl TarballResolver {
         let manifest = manifests.get(cache_key)?;
         Some(Self::head_only_result(
             wanted_dependency,
-            tarball_url.to_string(),
-            tarball_url.to_string(),
-            Some(integrity.clone()),
+            normalized_bare_specifier.to_string(),
+            prior.tarball_url.clone(),
+            Some(prior.integrity.clone()),
             Some(Arc::clone(manifest)),
         ))
     }

--- a/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -43,8 +43,8 @@ pub struct TarballFetchContext {
     /// store content instead of re-downloading. Empty on a first install.
     ///
     /// A remote tarball's `pkg_id` is its normalized bare specifier, so
-    /// [`TarballResolver::reuse_from_warm_store`] can look an entry up
-    /// before the preflight that would reveal a redirect.
+    /// the resolver can look an entry up before the preflight that would
+    /// reveal a redirect.
     pub prior_tarball_entries: Arc<HashMap<String, PriorTarballEntry>>,
 }
 

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -2548,8 +2548,11 @@ pub struct FetchTarballForResolution<'a> {
     pub store_dir: &'static StoreDir,
     pub store_index_writer: Option<Arc<StoreIndexWriter>>,
     pub package_url: &'a str,
-    /// Package identity used for scoped auth lookup and the intermediate
-    /// store-index cache key.
+    /// Package identity used for scoped auth lookup and for the
+    /// store-index row this fetch writes. Must be the `pkg_id` the
+    /// install pass derives from the lockfile entry — the bare URL for a
+    /// remote tarball — or the two passes file the same content under
+    /// two rows.
     pub package_id: &'a str,
     pub auth_headers: &'a AuthHeaders,
     pub retry_opts: RetryOpts,
@@ -2620,15 +2623,13 @@ impl FetchTarballForResolution<'_> {
         // `prepare` over it, and both the graph prefetch and the
         // warm-store reuse map skip git-hosted entries.
         if manifest_subdir.is_none() {
-            // Scope the store-index row by the package's canonical
-            // `name@version`, matching what the install pass derives from
-            // the same manifest. Fall back to the URL when the tarball has
-            // no usable `package.json` name (degraded, but keeps the row
-            // addressable).
-            let package_id =
-                manifest_package_id(manifest.as_ref()).unwrap_or_else(|| package_url.to_string());
-
-            let index_key = store_index_key(&integrity.to_string(), &package_id);
+            // Key the row by the caller's `package_id` — the same
+            // `pkg_id` the install pass derives from the lockfile entry.
+            // Deriving a `name@version` from the bundled manifest instead
+            // would file a remote tarball under a key nothing ever reads,
+            // leaving the install pass to write a second row for the same
+            // content.
+            let index_key = store_index_key(&integrity.to_string(), package_id);
             if let Some(writer) = store_index_writer {
                 writer.queue(index_key, pkg_files_idx);
             } else {
@@ -2786,14 +2787,6 @@ fn read_bundled_manifest(
         TarballError::ParseBundledManifest { tarball: tarball_path.to_string(), source }
     })?;
     Ok((normalize_bundled_manifest(&parsed), true))
-}
-
-/// `name@version` from a bundled manifest, when both fields are present.
-fn manifest_package_id(manifest: Option<&serde_json::Value>) -> Option<String> {
-    let manifest = manifest?;
-    let name = manifest.get("name")?.as_str()?;
-    let version = manifest.get("version")?.as_str()?;
-    Some(format!("{name}@{version}"))
 }
 
 /// Run one full zip-archive fetch attempt: hit the network, drain the


### PR DESCRIPTION
## Summary

Fixes the store-index `pkgId` divergence reported in pnpm/pnpm#13365: for every **non-registry** dependency, the TypeScript CLI keys its `index.db` row by the bare resolution id while pacquet keyed it by the lockfile-shaped `<name>@<id>`. Registry entries already agreed exactly.

| dependency shape | before (pacquet) | after |
| --- | --- | --- |
| remote tarball URL | `sha512-…\ttarball-pkg@http://…/tarball-pkg-1.0.0.tgz` | `sha512-…\thttp://…/tarball-pkg-1.0.0.tgz` |
| git-host archive | `ci-info@https://codeload.github.com/…\tbuilt` | `https://codeload.github.com/…\tbuilt` |
| `type: git` | `hi@git+file:///…/repo#a0c17e86…\tbuilt` | `git+file:///…/repo#a0c17e86…\tbuilt` |

Verified end to end by installing the same `git+file://` dependency with `pnpm@11.17.0` and with this build into separate stores: both now write the byte-identical key, and a pacquet install against the TS-warmed store reuses the row instead of adding a second one.

The second finding in the issue is fixed too: a remote tarball occupied **two** rows because the resolve-time fetch keyed by the bundled manifest's `name@version` while the install pass keyed by `name@<url>`. It now occupies one.

Closes pnpm/pnpm#13365

Review also surfaced a neighbouring gap in the side-effects cache: git-hosted tarballs upload to a row the warm path never reads, and `type: git` never uploads at all. That changes which key *shape* a package is filed under rather than the `pkgId` inside a key, so it is tracked separately in pnpm/pnpm#13420.

## Squash Commit Body

```text
The v11 store index is an on-disk contract shared between the TypeScript
CLI and pacquet, but the two stacks disagreed on `pkgId` for every
non-registry dependency: pnpm writes the bare resolution id (the tarball
URL, the git-host archive URL, the `git+…#<commit>` spec) while pacquet
wrote the lockfile-shaped `<name>@<id>`. Registry entries — the
overwhelming majority — already agreed. The cost was reuse: a store
warmed by one stack was cold for the other for every URL / git
dependency, so switching between pnpm 11 and pnpm 12 re-downloaded,
re-extracted, and re-imported all of them, and `cat-index` in one stack
could not see the other's rows.

`PkgNameVerPeer::pkg_id` now derives that id from a lockfile key, reusing
`pacquet_deps_path::try_get_package_id` (pnpm's `tryGetPackageId`), and
every store-index keying site goes through it — the install dispatcher,
the warm-key prefetch in `create_virtual_store`, the fresh-lockfile
reuse map and graph prefetch, the side-effects upload, `pnpm patch`, and
`pnpm cat-index`.

A remote tarball also occupied two rows rather than one: the resolve-time
fetch keyed its row by the bundled manifest's `name@version` while the
install pass keyed one by `name@<url>`. `FetchTarballForResolution` now
keys by the caller's `package_id`, and the tarball resolver passes the
normalized bare specifier (the id the lockfile records) rather than the
post-redirect URL, so both passes address one row.

The git fetchers hand `prepare_package` a resolution id now, so it
synthesizes the `<name>@<id>` dep path it gates on from the fetched
manifest's name — exactly what pnpm's `preparePackage` does, keeping the
`allowBuilds` identity unchanged while the store key moves.

Closes pnpm/pnpm#13365
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: the TypeScript side already writes the correct key; this
  PR is the parity fix. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787736358&installation_model_id=426870&pr_number=13417&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13417&signature=2e5d604d80d008c107f3b69c0bd05290413d8a1b424bbc0919f88d64e2d19e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared-store compatibility across pnpm versions by normalizing store index keys for non-registry Git/URL dependencies (so warmed stores don’t get invalidated across versions).
  * Fixed warm-store reuse for remote tarballs to ensure stable store index entries (including immutable redirect scenarios) and avoid duplicated indexing/extraction.
  * Corrected build/allow-build gating for aliased Git dependencies to use the dependency’s manifest identity consistently.
* **Tests**
  * Added integration coverage for Git hosted alias/manifest gating and bare-resolution-id indexing.
  * Added end-to-end tests for remote tarball single-entry store indexing and immutable redirect lockfile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
