### PR TITLE
fix(package-manager): validate pnpmfile checksum

### DIFF
--- a/.changeset/frozen-pnpmfile-checksum.md
+++ b/.changeset/frozen-pnpmfile-checksum.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reject frozen installs when the current pnpmfile does not match the lockfile's `pnpmfileChecksum`.

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -251,6 +251,33 @@ pub trait CustomResolver: Send + Sync {
     ) -> Result<bool, HookError>;
 }
 
+/// The `pnpmfileChecksum` an install through `hooks` would record in
+/// `pnpm-lock.yaml`, for comparison against the `recorded` value in the
+/// lockfile a freshness gate is checking.
+///
+/// [`PnpmfileHooks::calculate_pnpmfile_checksum`] evaluates the
+/// pnpmfile to answer whether it exports hooks, which costs a Node
+/// worker. `recorded` settles the comparison without it whenever the
+/// lockfile already holds a checksum: a pnpmfile whose bytes still hash
+/// to that value is the same module that produced it and still exports
+/// hooks, while one that hashes differently is drift whether or not it
+/// exports any. Only a lockfile that records no checksum needs the
+/// pnpmfile evaluated, to tell "no pnpmfile" from "a pnpmfile that
+/// exports none".
+pub async fn current_pnpmfile_checksum(
+    hooks: Option<&Arc<dyn PnpmfileHooks>>,
+    recorded: Option<&str>,
+) -> Option<String> {
+    let hooks = hooks?;
+    if recorded.is_some()
+        && let Some(file) = hooks.source_path()
+        && let Ok(hash) = pacquet_crypto_hash::create_hash_from_file(file)
+    {
+        return Some(hash);
+    }
+    hooks.calculate_pnpmfile_checksum().await
+}
+
 /// A no-op implementation of [`PnpmfileHooks`].
 pub struct NoopHooks;
 

--- a/pnpm/crates/hooks/tests/node_hooks.rs
+++ b/pnpm/crates/hooks/tests/node_hooks.rs
@@ -50,6 +50,57 @@ async fn calculate_pnpmfile_checksum_is_none_when_no_hooks_exported() {
     assert_eq!(hooks.calculate_pnpmfile_checksum().await, None);
 }
 
+/// No pnpmfile means no checksum, so a lockfile that records one is
+/// drift — the removal itself is what the gate must see.
+#[tokio::test]
+async fn current_pnpmfile_checksum_is_none_without_a_pnpmfile() {
+    assert_eq!(pacquet_hooks::current_pnpmfile_checksum(None, Some("sha256-abc")).await, None);
+}
+
+#[tokio::test]
+async fn current_pnpmfile_checksum_hashes_the_pnpmfile_that_exports_hooks() {
+    let tmp = TempDir::new().expect("temp dir");
+    let src = "module.exports = { hooks: { readPackage: (pkg) => pkg } }\n";
+    std::fs::write(tmp.path().join(".pnpmfile.cjs"), src).expect("write pnpmfile");
+
+    let hooks = finder::load_pnpmfile(tmp.path());
+    assert_eq!(
+        pacquet_hooks::current_pnpmfile_checksum(hooks.as_ref(), None).await,
+        Some(pacquet_crypto_hash::create_hash(src)),
+    );
+}
+
+/// pnpm records no checksum for a pnpmfile that exports no `hooks`
+/// object, so neither may pacquet — otherwise every install in a
+/// project with a resolvers-only pnpmfile would report drift.
+#[tokio::test]
+async fn current_pnpmfile_checksum_is_none_when_the_pnpmfile_exports_no_hooks() {
+    let tmp = TempDir::new().expect("temp dir");
+    std::fs::write(tmp.path().join(".pnpmfile.cjs"), "module.exports = {}\n")
+        .expect("write pnpmfile");
+
+    let hooks = finder::load_pnpmfile(tmp.path());
+    assert_eq!(pacquet_hooks::current_pnpmfile_checksum(hooks.as_ref(), None).await, None);
+}
+
+/// A lockfile that already records a checksum settles the comparison
+/// by hash alone. Pinned with a pnpmfile that exports no hooks —
+/// evaluating it would answer `None` and call an unchanged project
+/// drifted.
+#[tokio::test]
+async fn current_pnpmfile_checksum_trusts_the_hash_when_the_lockfile_records_one() {
+    let tmp = TempDir::new().expect("temp dir");
+    let src = "module.exports = {}\n";
+    std::fs::write(tmp.path().join(".pnpmfile.cjs"), src).expect("write pnpmfile");
+
+    let hooks = finder::load_pnpmfile(tmp.path());
+    let recorded = pacquet_crypto_hash::create_hash(src);
+    assert_eq!(
+        pacquet_hooks::current_pnpmfile_checksum(hooks.as_ref(), Some(&recorded)).await,
+        Some(recorded),
+    );
+}
+
 #[test]
 fn test_find_pnpmfile_none_when_missing() {
     let tmp = TempDir::new().expect("temp dir");

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -32,6 +32,27 @@ pub struct LockfileSettingsCheck<'a> {
     pub exclude_links_from_lockfile: bool,
     pub inject_workspace_packages: bool,
     pub peers_suffix_max_length: u64,
+    pub pnpmfile_checksum: PnpmfileChecksumCheck<'a>,
+}
+
+/// What [`check_lockfile_settings`] compares the lockfile's
+/// `pnpmfileChecksum` against.
+///
+/// The value is not a plain config read: pnpm records a checksum only
+/// when a loaded pnpmfile exports a `hooks` object, so computing it can
+/// mean evaluating the pnpmfile. Callers that already know the
+/// pnpmfiles are unchanged — or that have no pnpmfile to speak of —
+/// say so with [`PnpmfileChecksumCheck::Skip`] instead of inventing a
+/// value, since passing `Current(None)` would fail every install in a
+/// project whose lockfile legitimately records one.
+#[derive(Clone, Copy)]
+pub enum PnpmfileChecksumCheck<'a> {
+    /// The checksum the current install would record: the hash of the
+    /// pnpmfiles that export hooks, `None` when none do.
+    Current(Option<&'a str>),
+
+    /// Leave `pnpmfileChecksum` uncompared.
+    Skip,
 }
 
 /// Why an importer's lockfile entry doesn't satisfy the on-disk
@@ -188,6 +209,17 @@ pub enum StalenessReason {
         "`excludeLinksFromLockfile` in the lockfile ({lockfile}) doesn't match the current config ({config})"
     )]
     ExcludeLinksFromLockfileChanged { lockfile: bool, config: bool },
+
+    /// The lockfile's `pnpmfileChecksum` doesn't match the checksum the
+    /// current install would record: a pnpmfile was added, edited, or
+    /// removed since the lockfile was written, so the manifests the
+    /// recorded resolution was built from are no longer the ones this
+    /// install would see. Both values are the prefixed `sha256-…`
+    /// strings, absent when no pnpmfile exports hooks.
+    #[display(
+        "`pnpmfileChecksum` in the lockfile ({lockfile:?}) doesn't match the current pnpmfile ({config:?})"
+    )]
+    PnpmfileChecksumChanged { lockfile: Option<String>, config: Option<String> },
 }
 
 impl StalenessReason {
@@ -221,6 +253,7 @@ impl StalenessReason {
             StalenessReason::PeersSuffixMaxLengthChanged { .. } => {
                 Some("settings.peersSuffixMaxLength")
             }
+            StalenessReason::PnpmfileChecksumChanged { .. } => Some("pnpmfileChecksum"),
             StalenessReason::InjectWorkspacePackagesChanged { .. } => {
                 Some("settings.injectWorkspacePackages")
             }
@@ -312,7 +345,7 @@ impl SpecDiff {
 /// from `pnpm-workspace.yaml` haven't drifted since the lockfile was
 /// written: `catalogs`, `overrides`, `packageExtensionsChecksum`,
 /// `ignoredOptionalDependencies`, `patchedDependencies`,
-/// and the relevant `settings.*` keys (umbrella
+/// `pnpmfileChecksum`, and the relevant `settings.*` keys (umbrella
 /// [#434] slice 7).
 ///
 /// Drift in any of these settings would otherwise require a full
@@ -338,6 +371,7 @@ pub fn check_lockfile_settings(
         exclude_links_from_lockfile,
         inject_workspace_packages,
         peers_suffix_max_length,
+        pnpmfile_checksum,
     } = check;
 
     if !all_catalogs_are_up_to_date(catalogs, lockfile.catalogs.as_ref()) {
@@ -433,6 +467,15 @@ pub fn check_lockfile_settings(
         return Err(StalenessReason::PeersSuffixMaxLengthChanged {
             lockfile: lockfile_peers_suffix_max_length,
             config: peers_suffix_max_length,
+        });
+    }
+
+    if let PnpmfileChecksumCheck::Current(pnpmfile_checksum) = pnpmfile_checksum
+        && lockfile.pnpmfile_checksum.as_deref() != pnpmfile_checksum
+    {
+        return Err(StalenessReason::PnpmfileChecksumChanged {
+            lockfile: lockfile.pnpmfile_checksum.clone(),
+            config: pnpmfile_checksum.map(str::to_string),
         });
     }
 

--- a/pnpm/crates/lockfile/src/freshness/tests.rs
+++ b/pnpm/crates/lockfile/src/freshness/tests.rs
@@ -1,5 +1,6 @@
 use super::{
-    LockfileSettingsCheck, StalenessReason, check_lockfile_settings, satisfies_package_manifest,
+    LockfileSettingsCheck, PnpmfileChecksumCheck, StalenessReason, check_lockfile_settings,
+    satisfies_package_manifest,
 };
 use crate::Lockfile;
 use pacquet_catalogs_types::Catalogs;
@@ -33,6 +34,7 @@ fn settings_check(catalogs: &Catalogs) -> LockfileSettingsCheck<'_> {
         exclude_links_from_lockfile: false,
         inject_workspace_packages: false,
         peers_suffix_max_length: crate::DEFAULT_PEERS_SUFFIX_MAX_LENGTH,
+        pnpmfile_checksum: PnpmfileChecksumCheck::Current(None),
     }
 }
 
@@ -1565,6 +1567,169 @@ fn check_settings_returns_drift_when_explicit_peers_suffix_max_length_differs() 
     )
     .expect_err("changed peersSuffixMaxLength must surface drift");
     assert_eq!(err, StalenessReason::PeersSuffixMaxLengthChanged { lockfile: 10, config: 100 });
+}
+
+// ---------------------------------------------------------------------------
+// `pnpmfileChecksum` drift — an added, edited, or removed pnpmfile
+// ---------------------------------------------------------------------------
+
+/// A lockfile written without a pnpmfile, checked by an install that
+/// still has none.
+#[test]
+fn check_settings_passes_when_neither_side_has_a_pnpmfile() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+    })
+    .expect("parse minimal lockfile");
+    assert!(check_lockfile_settings(&lockfile, settings_check(&Catalogs::new())).is_ok());
+}
+
+#[test]
+fn check_settings_passes_when_pnpmfile_checksum_matches() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "pnpmfileChecksum: sha256-abc"
+    })
+    .expect("parse lockfile with a pnpmfile checksum");
+    assert!(
+        check_lockfile_settings(
+            &lockfile,
+            LockfileSettingsCheck {
+                pnpmfile_checksum: PnpmfileChecksumCheck::Current(Some("sha256-abc")),
+                ..settings_check(&Catalogs::new())
+            },
+        )
+        .is_ok(),
+    );
+}
+
+/// An edited pnpmfile hashes differently, so the lockfile no longer
+/// describes what this install's `readPackage` hooks would produce.
+#[test]
+fn check_settings_returns_drift_when_pnpmfile_checksum_differs() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "pnpmfileChecksum: sha256-abc"
+    })
+    .expect("parse lockfile with a pnpmfile checksum");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck {
+            pnpmfile_checksum: PnpmfileChecksumCheck::Current(Some("sha256-def")),
+            ..settings_check(&Catalogs::new())
+        },
+    )
+    .expect_err("an edited pnpmfile must surface drift");
+    assert_eq!(
+        err,
+        StalenessReason::PnpmfileChecksumChanged {
+            lockfile: Some("sha256-abc".to_string()),
+            config: Some("sha256-def".to_string()),
+        },
+    );
+    assert_eq!(err.setting_name(), Some("pnpmfileChecksum"));
+}
+
+/// The reproduction from pnpm/pnpm#13385: a hooks-exporting pnpmfile
+/// added after the lockfile was written.
+#[test]
+fn check_settings_returns_drift_when_a_pnpmfile_appeared() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+    })
+    .expect("parse minimal lockfile");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck {
+            pnpmfile_checksum: PnpmfileChecksumCheck::Current(Some("sha256-abc")),
+            ..settings_check(&Catalogs::new())
+        },
+    )
+    .expect_err("a new pnpmfile must surface drift");
+    assert_eq!(
+        err,
+        StalenessReason::PnpmfileChecksumChanged {
+            lockfile: None,
+            config: Some("sha256-abc".to_string()),
+        },
+    );
+}
+
+#[test]
+fn check_settings_returns_drift_when_the_pnpmfile_was_removed() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "pnpmfileChecksum: sha256-abc"
+    })
+    .expect("parse lockfile with a pnpmfile checksum");
+    let err = check_lockfile_settings(&lockfile, settings_check(&Catalogs::new()))
+        .expect_err("a removed pnpmfile must surface drift");
+    assert_eq!(
+        err,
+        StalenessReason::PnpmfileChecksumChanged {
+            lockfile: Some("sha256-abc".to_string()),
+            config: None,
+        },
+    );
+}
+
+/// A caller that can't produce the checksum leaves the field alone
+/// rather than reading its absence as "no pnpmfile", which would fail
+/// every lockfile that legitimately records one.
+#[test]
+fn check_settings_skips_the_pnpmfile_checksum_on_request() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "pnpmfileChecksum: sha256-abc"
+    })
+    .expect("parse lockfile with a pnpmfile checksum");
+    assert!(
+        check_lockfile_settings(
+            &lockfile,
+            LockfileSettingsCheck {
+                pnpmfile_checksum: PnpmfileChecksumCheck::Skip,
+                ..settings_check(&Catalogs::new())
+            },
+        )
+        .is_ok(),
+    );
+}
+
+/// pnpm compares `pnpmfileChecksum` after `settings.peersSuffixMaxLength`
+/// and before `settings.injectWorkspacePackages`, and only the first
+/// drifted field is reported.
+#[test]
+fn check_settings_reports_pnpmfile_checksum_between_its_pnpm_neighbors() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "pnpmfileChecksum: sha256-abc"
+        "settings:"
+        "  autoInstallPeers: true"
+        "  excludeLinksFromLockfile: false"
+        "  peersSuffixMaxLength: 10"
+    })
+    .expect("parse lockfile with a checksum and settings");
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck {
+            peers_suffix_max_length: 100,
+            inject_workspace_packages: true,
+            ..settings_check(&Catalogs::new())
+        },
+    )
+    .expect_err("all three fields drifted");
+    assert_eq!(err.setting_name(), Some("settings.peersSuffixMaxLength"));
+
+    let err = check_lockfile_settings(
+        &lockfile,
+        LockfileSettingsCheck {
+            peers_suffix_max_length: 10,
+            inject_workspace_packages: true,
+            ..settings_check(&Catalogs::new())
+        },
+    )
+    .expect_err("the checksum and injectWorkspacePackages drifted");
+    assert_eq!(err.setting_name(), Some("pnpmfileChecksum"));
 }
 
 /// Once `check_lockfile_settings` passes, `satisfies_package_manifest`

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -19,8 +19,8 @@ use pacquet_executor::{
     run_dev_preinstall_hook, run_project_lifecycle_scripts,
 };
 use pacquet_lockfile::{
-    LazyLockfile, LoadLockfileError, Lockfile, MaybeLazyLockfile, SaveLockfileError,
-    StalenessReason, VersionPart, satisfies_package_manifest,
+    LazyLockfile, LoadLockfileError, Lockfile, MaybeLazyLockfile, PnpmfileChecksumCheck,
+    SaveLockfileError, StalenessReason, VersionPart, satisfies_package_manifest,
 };
 use pacquet_lockfile_verification::{
     VerifyError, VerifyLockfileResolutionsOptions, record_lockfile_verified,
@@ -1164,6 +1164,15 @@ where
             emit_initial_package_manifest::<Reporter>(manifest);
         }
 
+        // The pnpmfile whose checksum the freshness gates compare
+        // against a lockfile's `pnpmfileChecksum`, resolved the way the
+        // install that records one resolves it. Building the handle
+        // costs a `stat`. The Node worker only starts if a gate has to
+        // ask whether the pnpmfile exports hooks. The handle is handed to
+        // the resolve path below so an install spawns at most one.
+        let pnpmfile_hook = pnpmfile_hook_override
+            .or_else(|| pacquet_hooks::finder::load_pnpmfile(&workspace_root));
+
         // Load the *current* lockfile that records what the previous
         // install actually materialized in `<virtual_store_dir>/lock.yaml`.
         // The frozen-lockfile path diffs each wanted snapshot against
@@ -1193,23 +1202,23 @@ where
         // when `pnpm-lock.yaml` is absent and the materialized snapshot still
         // satisfies the manifest. The install then skips resolution and
         // regenerates `pnpm-lock.yaml` from the synthesized object.
-        let synthesized_lockfile: Option<Lockfile> =
-            if lockfile.is_none() && !frozen_lockfile && prefer_frozen_lockfile {
-                current_lockfile.as_ref().and_then(|current| {
-                    check_lockfile_freshness(
-                        current,
-                        &manifest_freshness_inputs,
-                        config,
-                        &catalogs,
-                        ignore_manifest_check,
-                        true,
-                    )
-                    .ok()
-                    .map(|()| current.clone())
-                })
-            } else {
-                None
-            };
+        let synthesized_lockfile: Option<Lockfile> = match current_lockfile.as_ref() {
+            Some(current) if lockfile.is_none() && !frozen_lockfile && prefer_frozen_lockfile => {
+                check_lockfile_freshness(
+                    current,
+                    &manifest_freshness_inputs,
+                    config,
+                    &catalogs,
+                    pnpmfile_hook.as_ref(),
+                    ignore_manifest_check,
+                    true,
+                )
+                .await
+                .ok()
+                .map(|()| current.clone())
+            }
+            _ => None,
+        };
         let lockfile_synthesized_from_current = synthesized_lockfile.is_some();
         // The dry-run diff baseline is the actual on-disk `pnpm-lock.yaml`
         // (`None` when it is absent), captured before the synthesized-from-
@@ -1390,9 +1399,11 @@ where
                 &manifest_freshness_inputs,
                 config,
                 &catalogs,
+                pnpmfile_hook.as_ref(),
                 ignore_manifest_check,
                 false,
             )
+            .await
             .map_err(InstallError::from)?;
             true
         } else if update_checksums {
@@ -1411,9 +1422,12 @@ where
                     &manifest_freshness_inputs,
                     config,
                     &catalogs,
+                    pnpmfile_hook.as_ref(),
                     ignore_manifest_check,
                     true,
-                ) {
+                )
+                .await
+                {
                     // Even an up-to-date lockfile may not go frozen: a
                     // custom resolver's `shouldRefreshResolution` can
                     // force the fresh-resolve path. The hook's verdict
@@ -2076,7 +2090,7 @@ where
                 auth_override,
                 resolution_observer,
                 peer_issues_sink: peer_issues_sink.clone(),
-                pnpmfile_hook_override,
+                pnpmfile_hook_override: pnpmfile_hook,
                 real_importer_ids: requested_importer_ids.as_ref().map(|_| &real_importer_ids),
                 selected_importer_ids: requested_importer_ids.as_ref(),
                 current_lockfile: current_lockfile.as_ref(),
@@ -2612,16 +2626,33 @@ where
 /// `package.json` to disk, so the freshness check would always fire
 /// on `pnpm up` / `add` / `remove`. Settings drift (`overrides`,
 /// `ignoredOptionalDependencies`) still runs.
-fn check_lockfile_freshness(
+///
+/// `pnpmfile_hook` is the pnpmfile an install of this project would
+/// load, whose checksum the settings gate compares against
+/// `lockfile.pnpmfileChecksum` (see
+/// [`pacquet_hooks::current_pnpmfile_checksum`]).
+async fn check_lockfile_freshness(
     lockfile: &Lockfile,
     manifest_freshness_inputs: &[(String, &PackageManifest)],
     config: &Config,
     catalogs: &Catalogs,
+    pnpmfile_hook: Option<&Arc<dyn pacquet_hooks::PnpmfileHooks>>,
     ignore_manifest_check: bool,
     allow_missing_dependency_free_importers: bool,
 ) -> Result<(), FreshnessCheckError> {
     let parsed_overrides_opt = parse_config_overrides(config, catalogs)?;
-    check_lockfile_settings_drift(lockfile, config, catalogs, parsed_overrides_opt.as_deref())?;
+    let pnpmfile_checksum = pacquet_hooks::current_pnpmfile_checksum(
+        pnpmfile_hook,
+        lockfile.pnpmfile_checksum.as_deref(),
+    )
+    .await;
+    check_lockfile_settings_drift(
+        lockfile,
+        config,
+        catalogs,
+        parsed_overrides_opt.as_deref(),
+        PnpmfileChecksumCheck::Current(pnpmfile_checksum.as_deref()),
+    )?;
 
     if ignore_manifest_check {
         return Ok(());
@@ -2672,11 +2703,16 @@ pub(crate) fn parse_config_overrides(
 /// `packageExtensionsChecksum` drift between the lockfile-recorded
 /// values and the current config before the per-importer specifier
 /// check.
+///
+/// `pnpmfile_checksum` is the one input the config doesn't carry.
+/// callers that can't produce it pass
+/// [`PnpmfileChecksumCheck::Skip`].
 pub(crate) fn check_lockfile_settings_drift(
     lockfile: &Lockfile,
     config: &Config,
     catalogs: &Catalogs,
     parsed_overrides: Option<&[pacquet_config_parse_overrides::VersionOverride]>,
+    pnpmfile_checksum: PnpmfileChecksumCheck<'_>,
 ) -> Result<(), FreshnessCheckError> {
     let overrides_map: Option<std::collections::HashMap<String, String>> =
         parsed_overrides.map(pacquet_config_parse_overrides::create_overrides_map_from_parsed);
@@ -2701,6 +2737,7 @@ pub(crate) fn check_lockfile_settings_drift(
             exclude_links_from_lockfile: config.exclude_links_from_lockfile,
             inject_workspace_packages: config.inject_workspace_packages,
             peers_suffix_max_length: config.peers_suffix_max_length,
+            pnpmfile_checksum,
         },
     )
     .map_err(FreshnessCheckError::Stale)

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -9251,6 +9251,74 @@ async fn frozen_lockfile_errors_when_package_extensions_drift_from_lockfile() {
     drop(dir);
 }
 
+#[tokio::test]
+async fn frozen_lockfile_errors_when_pnpmfile_checksum_drifts() {
+    let dir = tempdir().unwrap();
+    let project_root = dir.path().join("project");
+    let modules_dir = project_root.join("node_modules");
+    std::fs::create_dir_all(&project_root).unwrap();
+    let manifest = PackageManifest::create_if_needed(project_root.join("package.json")).unwrap();
+
+    let mut config = Config::new();
+    config.store_dir = dir.path().join("pacquet-store").into();
+    config.modules_dir = modules_dir.clone();
+    config.virtual_store_dir = modules_dir.join(".pacquet");
+    let config = config.leak();
+
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .: {}"
+    })
+    .expect("parse minimal lockfile");
+
+    std::fs::write(
+        project_root.join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { readPackage: pkg => pkg } }\n",
+    )
+    .unwrap();
+
+    let result = Install {
+        tarball_mem_cache: Default::default(),
+        http_client: &Default::default(),
+        http_client_arc: std::sync::Arc::new(Default::default()),
+        config,
+        manifest: &manifest,
+        emit_initial_manifest: true,
+        lockfile: MaybeLazyLockfile::Loaded(Some(&lockfile)),
+        lockfile_path: None,
+        dependency_groups: [DependencyGroup::Prod],
+        frozen_lockfile: true,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: false,
+        trust_lockfile: false,
+        update_checksums: false,
+        mutation: ProjectMutation::InstallWorkspace,
+        installs_only: true,
+        resolved_packages: &Default::default(),
+        supported_architectures: None,
+        node_linker: pacquet_config::NodeLinker::default(),
+        lockfile_only: false,
+        dry_run: false,
+        update_seed_policy: crate::UpdateSeedPolicy::KeepAll,
+        auth_override: None,
+        resolution_observer: None,
+        peer_issues_sink: None,
+        catalogs_override: None,
+        disable_optimistic_repeat_install: false,
+        pnpmfile_hook_override: None,
+        workspace_projects_override: None,
+    }
+    .run::<SilentReporter>()
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(InstallError::LockfileConfigMismatch { setting: "pnpmfileChecksum" })
+    ));
+}
+
 /// Runs a fresh install in `root` with `root_deps` as direct prod
 /// dependencies and `pnpmfile_src` written to `<root>/.pnpmfile.cjs`, so the
 /// pnpmfile hooks are discovered and run during resolution.

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -732,6 +732,12 @@ fn modified_manifests_match_lockfile(
         config,
         catalogs,
         parsed_overrides.as_deref(),
+        // `pnpmfileChecksum` needs no comparison here: reaching this
+        // point means `pnpmfiles_modified_since` already proved the
+        // pnpmfile list and contents are what the install that wrote
+        // this lockfile saw. Computing the checksum instead would cost
+        // a Node worker on the path that exists to avoid starting one.
+        pacquet_lockfile::PnpmfileChecksumCheck::Skip,
     ) {
         tracing::debug!(target: "pacquet::install", %error, "repeat-install content check: lockfile settings drift");
         return Err("a lockfile setting drifted from the current configuration");

--- a/pnpr/crates/pnpr/src/resolver/resolve.rs
+++ b/pnpr/crates/pnpr/src/resolver/resolve.rs
@@ -15,7 +15,8 @@ use dashmap::DashMap;
 use pacquet_catalogs_types::Catalogs;
 use pacquet_config::{Config, NodeLinker};
 use pacquet_lockfile::{
-    Lockfile, LockfileSettingsCheck, check_lockfile_settings, satisfies_package_manifest,
+    Lockfile, LockfileSettingsCheck, PnpmfileChecksumCheck, check_lockfile_settings,
+    satisfies_package_manifest,
 };
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_package_manager::{Install, ProjectMutation, ResolutionObserver, ResolvedPackages};
@@ -289,6 +290,12 @@ pub fn fresh_frozen_input_lockfile(config: &Config, request: &ResolveRequest) ->
             exclude_links_from_lockfile: config.exclude_links_from_lockfile,
             inject_workspace_packages: config.inject_workspace_packages,
             peers_suffix_max_length: config.peers_suffix_max_length,
+            // A `pnpmfileChecksum` in the request's lockfile records the
+            // client's pnpmfile, which ran client-side and has no
+            // counterpart here. The server resolves without one, so it
+            // has nothing to compare and would reject every lockfile
+            // written by a project that has one.
+            pnpmfile_checksum: PnpmfileChecksumCheck::Skip,
         },
     )
     .ok()?;


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#13385.

Pacquet now compares the current pnpmfile against `pnpmfileChecksum` before accepting a frozen or preferred-frozen lockfile. It evaluates a newly discovered pnpmfile to preserve pnpm’s hooks-only checksum rule, but directly hashes the file when the lockfile already records a checksum. The optimistic repeat-install path remains worker-free because its workspace-state gate has already verified that the pnpmfile list and contents are unchanged.

The TypeScript CLI already implements this behavior, so no TypeScript change is needed. The pnpr resolver explicitly skips this client-local setting because it cannot access the client’s pnpmfile.

## Squash Commit Body

```text
Compare the pnpmfile loaded for an install with the checksum recorded in the lockfile before using frozen resolution. Evaluate the module only when no checksum is recorded, which distinguishes a pnpmfile that exports hooks from one that does not without adding Node startup to the common matching-checksum case.

Keep optimistic repeat installs worker-free because workspace-state validation has already established that the pnpmfile is unchanged. Skip the comparison in pnpr because the resolver service has no access to the client-local pnpmfile.

Fixes pnpm/pnpm#13385.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787739106&installation_model_id=426870&pr_number=13418&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13418&signature=92de7eff07981f88760e7c41ab505651490746ae8f7733d610c2126fd1e30edd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Frozen installs now verify that the active pnpmfile matches the checksum recorded in the lockfile.
  - Added clear lockfile mismatch reporting when the pnpmfile has changed.

- **Bug Fixes**
  - Prevented frozen and preferred-frozen installs from proceeding with an outdated pnpmfile.
  - Improved checksum handling for missing, added, or modified pnpmfiles.

- **Tests**
  - Added coverage for checksum changes, missing checksums, and skipped validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->