### PR TITLE
fix(add): resolve bare workspace packages

### DIFF
--- a/.changeset/resolve-bare-workspace-adds.md
+++ b/.changeset/resolve-bare-workspace-adds.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm add <workspace-package>` to resolve the local package when `linkWorkspacePackages` is enabled.

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -1161,6 +1161,21 @@ fn save_workspace_protocol_decides_the_saved_workspace_range() {
     }
 }
 
+#[test]
+fn a_bare_workspace_add_uses_the_local_package_and_saved_protocol_setting() {
+    const LIB: &str = "@pnpm.e2e/ws-bare";
+    for (setting, expected) in
+        [(None, "workspace:^"), (Some("true"), "workspace:^1.2.3"), (Some("false"), "^1.2.3")]
+    {
+        let (root, app_dir) =
+            workspace_with_lib(setting, &[(LIB, "1.2.3")], "packages/app/package.json");
+        add_in(&app_dir, LIB);
+
+        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some(expected));
+        drop(root);
+    }
+}
+
 /// `workspace:<target>@<range>` installs `<target>` under the name the
 /// selector gave, so the saved specifier has to keep naming the target —
 /// dropping it would leave a `workspace:` entry pointing at the install

--- a/pnpm/crates/cli/tests/add.rs
+++ b/pnpm/crates/cli/tests/add.rs
@@ -1107,28 +1107,29 @@ fn add_with_save_settings(args: &[&str]) -> (TempDir, PathBuf, TestRegistry) {
 fn save_workspace_protocol_decides_the_saved_workspace_range() {
     const LIB: &str = "@pnpm.e2e/ws-lib";
     let cases = [
-        (None, "workspace:^1.2.3", "1.2.3", "workspace:^"),
-        (None, "workspace:~1.2.3", "1.2.3", "workspace:~"),
-        (None, "workspace:1.2.3", "1.2.3", "workspace:*"),
-        (None, "workspace:*", "1.2.3", "workspace:*"),
-        (Some("true"), "workspace:^1.2.3", "1.2.3", "workspace:^1.2.3"),
+        (None, "workspace:^1.2.3", "1.2.3", true, "workspace:^"),
+        (None, "workspace:^1.2.3", "1.2.3", false, "workspace:^"),
+        (None, "workspace:~1.2.3", "1.2.3", true, "workspace:~"),
+        (None, "workspace:1.2.3", "1.2.3", true, "workspace:*"),
+        (None, "workspace:*", "1.2.3", true, "workspace:*"),
+        (Some("true"), "workspace:^1.2.3", "1.2.3", true, "workspace:^1.2.3"),
         // The typed `~` loses to the default `^`: the pinned form reads
         // its operator off the previous entry, and there is none here.
-        (Some("true"), "workspace:~1.2.3", "1.2.3", "workspace:^1.2.3"),
+        (Some("true"), "workspace:~1.2.3", "1.2.3", true, "workspace:^1.2.3"),
         // The local version wins over the typed range.
-        (Some("true"), "workspace:^1.0.0", "2.5.0", "workspace:^2.5.0"),
+        (Some("true"), "workspace:^1.0.0", "2.5.0", true, "workspace:^2.5.0"),
         // A range over a prerelease would not match it, so it is exact.
-        (Some("true"), "workspace:^1.0.0", "2.0.0-beta.1", "workspace:2.0.0-beta.1"),
-        (Some("false"), "workspace:^1.2.3", "1.2.3", "workspace:^1.2.3"),
+        (Some("true"), "workspace:^1.0.0", "2.0.0-beta.1", true, "workspace:2.0.0-beta.1"),
+        (Some("false"), "workspace:^1.2.3", "1.2.3", true, "workspace:^1.2.3"),
     ];
 
-    for (setting, requested, lib_version, expected) in cases {
+    for (setting, requested, lib_version, link_workspace_packages, expected) in cases {
         let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
         let protocol_line = setting
             .map(|setting| format!("saveWorkspaceProtocol: {setting}\n"))
             .unwrap_or_default();
         let yaml = format!(
-            "{HERMETIC_STORE_YAML}packages:\n  - packages/*\nlinkWorkspacePackages: true\n{protocol_line}",
+            "{HERMETIC_STORE_YAML}packages:\n  - packages/*\nlinkWorkspacePackages: {link_workspace_packages}\n{protocol_line}",
         );
         std::fs::write(workspace.join("pnpm-workspace.yaml"), yaml).expect("write workspace yaml");
         write_json(&workspace.join("package.json"), &serde_json::json!({ "name": "root" }));

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -1003,6 +1003,9 @@ fn workspace_save_specifier(
             if !config.link_workspace_packages.enabled_at_depth(0) {
                 return None;
             }
+            if explicit_spec.is_some_and(|specifier| specifier.starts_with("npm:")) {
+                return None;
+            }
             let registries: std::collections::HashMap<String, String> =
                 config.resolved_registries().into_iter().collect();
             let registry = pick_registry_for_package(&registries, package_name, explicit_spec);

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -1016,15 +1016,14 @@ fn workspace_save_specifier(
                 return None;
             }
             let versions = workspace_packages?.get(package_name)?;
-            let resolved_version = pick_matching_local_version_or_null(versions, &parsed);
-            (package_name.to_string(), resolved_version)
+            let resolved_version = pick_matching_local_version_or_null(versions, &parsed)?;
+            (package_name.to_string(), Some(resolved_version))
         };
-    let resolved_version = resolved_version?;
     let workspace_specifier = calc_specifier_for_workspace_dep(
         DeclaredSpecifiers { prev: prev_specifier, bare: explicit_spec },
         Some(package_name),
         &target_name,
-        Some(&resolved_version),
+        resolved_version.as_deref(),
         config.save_workspace_protocol,
         pinned_version,
     );

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -30,8 +30,9 @@ use pacquet_resolving_git_resolver::{
 };
 use pacquet_resolving_npm_resolver::{
     DeclaredSpecifiers, InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageError,
-    PickPackageOptions, calc_specifier_for_workspace_dep, parse_bare_specifier, pick_package,
-    pick_registry_for_package, shared_packument_fetch_locker, which_version_is_pinned,
+    PickPackageOptions, calc_specifier_for_workspace_dep, parse_bare_specifier,
+    pick_matching_local_version_or_null, pick_package, pick_registry_for_package,
+    shared_packument_fetch_locker, which_version_is_pinned,
 };
 use pacquet_resolving_resolver_base::WorkspacePackages;
 use pacquet_tarball::MemCache;
@@ -186,11 +187,8 @@ where
         let meta_cache = std::sync::Arc::new(InMemoryPackageMetaCache::default());
         let fetch_locker = shared_packument_fetch_locker();
         let catalog_ctx = read_catalog_ctx(manifest, config)?;
-        // The rolling default writes a range with no version in it, so
-        // the workspace only has to be enumerated for the shapes that
-        // carry the local package's actual version. Skipping the walk
-        // otherwise keeps the default `add` off the filesystem.
-        let workspace_packages = (config.save_workspace_protocol != SaveWorkspaceProtocol::Rolling)
+        let workspace_packages = (config.link_workspace_packages.enabled_at_depth(0)
+            || config.save_workspace_protocol != SaveWorkspaceProtocol::Rolling)
             .then(|| workspace_packages_for_add(config))
             .flatten();
         let updated_catalogs = prepare_manifest::<Reporter>(
@@ -706,7 +704,7 @@ async fn resolve_added_dependency<'a>(
         package_name,
         explicit_spec,
         prev_specifier.as_deref(),
-        config.save_workspace_protocol,
+        config,
         pinned_version,
         workspace_packages,
     ) {
@@ -978,49 +976,64 @@ fn workspace_packages_for_add(config: &Config) -> Option<WorkspacePackages> {
 /// The `workspace:` specifier to save for `package_name`, or `None`
 /// when this add isn't a workspace dependency.
 ///
-/// Only an explicit `workspace:` request is rewritten. pnpm also
-/// rewrites a bare-semver request once it resolves to a local package,
-/// but pacquet's resolver has no workspace fallback for that case yet
-/// (it fails against the registry first), so there is nothing here to
-/// rewrite.
-///
 /// A relative `workspace:./pkg` is left alone: it names a directory, not
 /// a range, so there is no operator to roll.
 fn workspace_save_specifier(
     package_name: &str,
     explicit_spec: Option<&str>,
     prev_specifier: Option<&str>,
-    save_workspace_protocol: SaveWorkspaceProtocol,
+    config: &Config,
     pinned_version: PinnedVersion,
     workspace_packages: Option<&WorkspacePackages>,
 ) -> Option<String> {
-    let spec = WorkspaceSpec::parse(explicit_spec?)?;
-    if spec.version.starts_with('.') {
-        return None;
-    }
-    // `workspace:<target>@<range>` installs `<target>` under the name
-    // the selector gave, so the target — not the install name — is what
-    // the workspace is searched for and what the saved specifier names.
-    let target_name = spec.alias.as_deref().unwrap_or(package_name);
-    let resolved_version =
-        workspace_packages.and_then(|packages| packages.get(target_name)).and_then(|versions| {
-            let available: Vec<String> = versions.keys().cloned().collect();
-            // The highest local version, semver-aware, so a workspace
-            // holding both `9.0.0` and `10.0.0` does not pin to the
-            // lexicographically greater `9.0.0`. Deliberately not
-            // filtered by the requested range: pnpm pins whatever the
-            // workspace holds, leaving a genuine mismatch for the
-            // install to report as `NO_MATCHING_VERSION_INSIDE_WORKSPACE`.
-            resolve_workspace_range("*", &available)
-        });
-    Some(calc_specifier_for_workspace_dep(
+    let (target_name, resolved_version) =
+        if let Some(spec) = explicit_spec.and_then(WorkspaceSpec::parse) {
+            if spec.version.starts_with('.') {
+                return None;
+            }
+            let target_name = spec.alias.unwrap_or_else(|| package_name.to_string());
+            let resolved_version = workspace_packages
+                .and_then(|packages| packages.get(&target_name))
+                .and_then(|versions| {
+                    let available: Vec<String> = versions.keys().cloned().collect();
+                    resolve_workspace_range("*", &available)
+                });
+            (target_name, resolved_version)
+        } else {
+            if !config.link_workspace_packages.enabled_at_depth(0) {
+                return None;
+            }
+            let registries: std::collections::HashMap<String, String> =
+                config.resolved_registries().into_iter().collect();
+            let registry = pick_registry_for_package(&registries, package_name, explicit_spec);
+            let parsed = parse_bare_specifier(
+                explicit_spec.unwrap_or("latest"),
+                Some(package_name),
+                "latest",
+                &registry,
+            )?;
+            if parsed.name != package_name || parsed.normalized_bare_specifier.is_some() {
+                return None;
+            }
+            let versions = workspace_packages?.get(package_name)?;
+            let resolved_version = pick_matching_local_version_or_null(versions, &parsed);
+            (package_name.to_string(), resolved_version)
+        };
+    let resolved_version = resolved_version?;
+    let workspace_specifier = calc_specifier_for_workspace_dep(
         DeclaredSpecifiers { prev: prev_specifier, bare: explicit_spec },
         Some(package_name),
-        target_name,
-        resolved_version.as_deref(),
-        save_workspace_protocol,
+        &target_name,
+        Some(&resolved_version),
+        config.save_workspace_protocol,
         pinned_version,
-    ))
+    );
+    if config.save_workspace_protocol == SaveWorkspaceProtocol::Off
+        && !explicit_spec.is_some_and(|specifier| specifier.starts_with("workspace:"))
+    {
+        return workspace_specifier.strip_prefix("workspace:").map(str::to_string);
+    }
+    Some(workspace_specifier)
 }
 
 /// Split a `pacquet add` argument into its package name and optional

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -1,9 +1,10 @@
 use super::{
     Add, AddError, node_runtime_version_spec, normalized_save_specifier,
     persist_selected_manifests, prepare_selected_manifests, selected_project_indices,
+    workspace_save_specifier,
 };
 use crate::ResolvedPackages;
-use pacquet_config::Config;
+use pacquet_config::{Config, LinkWorkspacePackages};
 use pacquet_network::ThrottledClient;
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_registry::PinnedVersion;
@@ -18,6 +19,24 @@ use std::{
 use tempfile::tempdir;
 
 const SCOPED_TEST_INTEGRITY: &str = "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==";
+
+#[test]
+fn explicit_npm_specifier_is_not_rewritten_as_a_workspace_dependency() {
+    let mut config = Config::new();
+    config.link_workspace_packages = LinkWorkspacePackages::DirectOnly;
+
+    assert_eq!(
+        workspace_save_specifier(
+            "foo",
+            Some("npm:foo@^1.0.0"),
+            None,
+            &config,
+            PinnedVersion::Major,
+            None,
+        ),
+        None,
+    );
+}
 
 #[tokio::test]
 async fn add_routes_scoped_packages_to_configured_scoped_registry() {

--- a/pnpm/crates/resolving-npm-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/lib.rs
@@ -76,7 +76,8 @@ pub use pick_package_from_meta::{
 };
 pub use registry_url::to_registry_url;
 pub use resolve_from_workspace::{
-    ResolveFromWorkspaceError, ResolveFromWorkspaceOptions, try_resolve_from_workspace,
+    ResolveFromWorkspaceError, ResolveFromWorkspaceOptions, pick_matching_local_version_or_null,
+    try_resolve_from_workspace,
 };
 pub use trust_checks::{
     TrustCheckOptions, TrustEvidence, TrustViolation, fail_if_trust_downgraded, get_trust_evidence,

--- a/pnpm/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/resolve_from_workspace.rs
@@ -219,7 +219,8 @@ pub(crate) fn try_resolve_from_workspace_packages(
 }
 
 /// Pick the local workspace version that satisfies `spec`, or `None`.
-pub(crate) fn pick_matching_local_version_or_null(
+#[must_use]
+pub fn pick_matching_local_version_or_null(
     versions: &WorkspacePackagesByVersion,
     spec: &RegistryPackageSpec,
 ) -> Option<String> {


### PR DESCRIPTION
## Summary

Fixes pacquet `pnpm add <workspace-package>` so a bare request resolves an available local workspace package when `linkWorkspacePackages` is enabled, instead of querying the registry first and failing on a 404. The add preparation path reuses the resolver's workspace version selection and feeds the selected version into the existing `saveWorkspaceProtocol` renderer.

The TypeScript CLI already has this behavior; this restores pacquet parity.

Closes pnpm/pnpm#13336.

## Squash Commit Body

```text
Pacquet prepared package.json changes before running the install resolver. For a bare new dependency, that preparation always queried the registry for latest, so a workspace-only package failed with a 404 even though the npm resolver already supported workspace fallback.

Index workspace packages during add when direct workspace linking is enabled, select the local version with the resolver's existing matching helper, and pass it through the shared workspace specifier renderer. Keep the add-specific saveWorkspaceProtocol=false behavior in the add layer so update --workspace continues to write an explicit workspace specifier.

Cover rolling, pinned, and disabled saveWorkspaceProtocol modes with an end-to-end regression test.

Closes pnpm/pnpm#13336.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787743083&installation_model_id=426870&pr_number=13424&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13424&signature=60b5d4ec1228476dd2e268ad8f6aa630e5666acd41ac0ac81d2dedf420266bb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm add <workspace-package>` and bare local package names to resolve and save the correct local workspace dependency when workspace linking is enabled.
  - Improved workspace specifier rewriting to properly ignore `workspace:./...`, honor `saveWorkspaceProtocol`, and strip `workspace:` when `saveWorkspaceProtocol` is `Off`.
  - Prevented rewriting of explicit `npm:...` dependency specifiers into workspace dependencies.

- **Tests**
  - Expanded regression coverage for `linkWorkspacePackages` and `saveWorkspaceProtocol` combinations, including new scenarios for bare adds and explicit `npm:` inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->