### PR TITLE
test(cli): cover skipped optional lockfile reconstruction

### DIFF
--- a/pnpm/crates/cli/tests/current_lockfile.rs
+++ b/pnpm/crates/cli/tests/current_lockfile.rs
@@ -28,6 +28,23 @@ fn package_names(lockfile: &pacquet_lockfile::Lockfile) -> Vec<String> {
     names
 }
 
+fn assert_skipped_optional_is_retained(lockfile: &pacquet_lockfile::Lockfile) {
+    dbg!(lockfile);
+    assert!(
+        importer_has_group_dependency(
+            lockfile,
+            pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY,
+            "optionalDependencies",
+            "@pnpm.e2e/not-compatible-with-any-os",
+        ),
+        "the root importer must retain the platform-skipped optional dependency",
+    );
+    assert!(
+        has_snapshot(lockfile, "@pnpm.e2e/not-compatible-with-any-os", "1.0.0"),
+        "the platform-skipped optional dependency must retain its snapshot",
+    );
+}
+
 /// TS: `installing a simple project` (`deps-restorer/test/index.ts:54`),
 /// the current-lockfile half.
 #[test]
@@ -132,6 +149,9 @@ fn a_deleted_wanted_lockfile_is_regenerated_from_the_current_one() {
     let current = read_current_lockfile(&workspace);
     let wanted_lockfile =
         serde_saphyr::from_str(&wanted).expect("parse the original pnpm-lock.yaml");
+    assert_skipped_optional_is_retained(&wanted_lockfile);
+    assert_skipped_optional_is_retained(&current);
+    dbg!(&current, &wanted_lockfile);
     assert_eq!(
         current, wanted_lockfile,
         "the current lockfile must retain the platform-skipped optional dependency",
@@ -149,12 +169,19 @@ fn a_deleted_wanted_lockfile_is_regenerated_from_the_current_one() {
         .assert()
         .success();
 
+    let regenerated =
+        fs::read_to_string(&wanted_path).expect("read the regenerated pnpm-lock.yaml");
+    eprintln!("original pnpm-lock.yaml:\n{wanted}\nregenerated pnpm-lock.yaml:\n{regenerated}");
     assert_eq!(
-        fs::read_to_string(&wanted_path).expect("read the regenerated pnpm-lock.yaml"),
-        wanted,
+        regenerated, wanted,
         "the wanted lockfile must be rebuilt from the current one, not re-resolved",
     );
-    assert_eq!(read_current_lockfile(&workspace), current);
+    let regenerated_lockfile =
+        serde_saphyr::from_str(&regenerated).expect("parse the regenerated pnpm-lock.yaml");
+    assert_skipped_optional_is_retained(&regenerated_lockfile);
+    let regenerated_current = read_current_lockfile(&workspace);
+    dbg!(&regenerated_current, &current);
+    assert_eq!(regenerated_current, current);
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/current_lockfile.rs
+++ b/pnpm/crates/cli/tests/current_lockfile.rs
@@ -117,14 +117,25 @@ fn a_deleted_wanted_lockfile_is_regenerated_from_the_current_one() {
             "@pnpm.e2e/pkg-with-1-dep": "^100.0.0",
             "@pnpm.e2e/foo": "^100.0.0",
         },
+        "optionalDependencies": {
+            "@pnpm.e2e/not-compatible-with-any-os": "*",
+        },
     });
     fs::write(workspace.join("package.json"), package_json.to_string())
         .expect("write package.json");
 
-    pacquet.with_arg("install").assert().success();
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
     let wanted_path = workspace.join("pnpm-lock.yaml");
     let wanted = fs::read_to_string(&wanted_path).expect("read pnpm-lock.yaml");
-    let current = package_names(&read_current_lockfile(&workspace));
+
+    rerun(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    let current = read_current_lockfile(&workspace);
+    let wanted_lockfile =
+        serde_saphyr::from_str(&wanted).expect("parse the original pnpm-lock.yaml");
+    assert_eq!(
+        current, wanted_lockfile,
+        "the current lockfile must retain the platform-skipped optional dependency",
+    );
 
     fs::remove_file(&wanted_path).expect("remove pnpm-lock.yaml");
     // The harness writes a `pnpm-workspace.yaml` for storeDir/cacheDir, so
@@ -133,14 +144,17 @@ fn a_deleted_wanted_lockfile_is_regenerated_from_the_current_one() {
     fs::remove_file(workspace.join("node_modules/.pnpm-workspace-state-v1.json"))
         .expect("remove the workspace state file");
 
-    rerun(&workspace).with_arg("install").assert().success();
+    rerun(&workspace)
+        .with_args(["install", "--lockfile-only", "--prefer-frozen-lockfile"])
+        .assert()
+        .success();
 
     assert_eq!(
         fs::read_to_string(&wanted_path).expect("read the regenerated pnpm-lock.yaml"),
         wanted,
         "the wanted lockfile must be rebuilt from the current one, not re-resolved",
     );
-    assert_eq!(package_names(&read_current_lockfile(&workspace)), current);
+    assert_eq!(read_current_lockfile(&workspace), current);
 
     drop((root, mock_instance));
 }


### PR DESCRIPTION
## Summary

Extends the deleted-wanted-lockfile reconstruction test with a platform-incompatible optional dependency and the exact lockfile-only reconstruction sequence from pnpm/pnpm#13317.

The production fix landed on `main` in pnpm/pnpm#13350 because pnpm/pnpm#13312 had the same root cause. This follow-up verifies that `node_modules/.pnpm/lock.yaml` retains the skipped optional importer entry and snapshots, and that deleting `pnpm-lock.yaml` reconstructs it byte-for-byte.

Closes pnpm/pnpm#13317

## Squash Commit Body

```text
Exercise deleted wanted-lockfile reconstruction with an optional dependency
that is incompatible on every OS. Assert that the frozen install retains the
complete graph in the current lockfile before deleting pnpm-lock.yaml, then
verify lockfile-only reconstruction reproduces the original file.

The production fix landed with pnpm/pnpm#13350 for the same root cause as
pnpm/pnpm#13312. This test pins its reconstruction consequence.

Closes pnpm/pnpm#13317
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Test-only pacquet follow-up; the TypeScript CLI already behaves correctly.)
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787743272&installation_model_id=426870&pr_number=13425&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13425&signature=2d4737a0a9522bbac15c44286137757edf9316d7fa279d8a1bba742302d967ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockfile regeneration to correctly preserve platform-skipped optional dependencies when re-generating from an existing setup.
  * Added stronger validation that regenerated `pnpm-lock.yaml` and the resulting “current” lockfile remain consistent, including optional dependency entries and related snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->