### PR TITLE
fix(package-manager): reuse git side-effects cache keys

### DIFF
--- a/.changeset/fix-git-side-effects-cache-index-key.md
+++ b/.changeset/fix-git-side-effects-cache-index-key.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed warm side-effects cache reuse for git dependencies.

--- a/pnpm/crates/cli/tests/git_hosted_install.rs
+++ b/pnpm/crates/cli/tests/git_hosted_install.rs
@@ -426,6 +426,46 @@ fn run_prepare_script_for_git_hosted_dependencies() {
 }
 
 #[test]
+fn type_git_dependency_reuses_side_effects_on_warm_install() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let repo = GitRepoFixture::init(root.path(), "git-side-effects");
+    let lifecycle_log = root.path().join("git-side-effects-builds.log");
+    let script = format!(
+        r"require('fs').appendFileSync({}, 'built\n')",
+        serde_json::to_string(&lifecycle_log).expect("serialize lifecycle log path"),
+    );
+    repo.write_file(
+        "package.json",
+        &json!({
+            "name": "git-side-effects",
+            "version": "1.0.0",
+            "scripts": { "postinstall": format!("node -e {script:?}") },
+        })
+        .to_string(),
+    );
+    let commit = repo.commit("init");
+    let spec = repo.git_url_at(&commit);
+    write_dependencies(&workspace, &[("git-side-effects", &spec)]);
+    allow_builds(&workspace, &[&format!("git-side-effects@{spec}")]);
+
+    pacquet.with_arg("install").assert().success();
+    let builds_after_cold_install =
+        fs::read_to_string(&lifecycle_log).expect("read cold-install lifecycle log");
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    pnpm_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    assert_eq!(
+        fs::read_to_string(&lifecycle_log).expect("read warm-install lifecycle log"),
+        builds_after_cold_install,
+        "the warm install must materialize cached side effects without rerunning postinstall",
+    );
+
+    drop((root, npmrc_info));
+}
+
+#[test]
 fn git_dependency_is_built_on_isolated_reinstall() {
     assert_git_dependency_is_built_on_reinstall(None);
 }

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -1,7 +1,7 @@
 use crate::{
     ImportIndexedDirError, ImportIndexedDirOpts, NEEDS_BUILD_MARKER, SkippedSnapshots,
     build_sequence::build_sequence,
-    import_indexed_dir,
+    import_indexed_dir, store_index_key_for_resolution,
     version_policy::{VersionPolicyError, expand_package_version_specs},
 };
 use derive_more::{Display, Error};
@@ -1258,10 +1258,8 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     // subsequent installs hit the cache.
     //
     // The other preconditions: cache_key composable (engine + graph
-    // present), `packages` map available for the integrity lookup,
-    // and the metadata row carries an integrity (registry / tarball
-    // resolutions — git / directory have no integrity, so those
-    // aren't cached).
+    // present), `packages` map available for store-index key selection,
+    // and the resolution has a store-backed key.
     //
     // All errors are swallowed with a `tracing::warn!`. A failed
     // upload doesn't fail the install: the next install re-runs the
@@ -1274,20 +1272,20 @@ fn build_one_snapshot<Reporter: self::Reporter>(
         && let Some(cache_key) = cache_key.as_deref()
         && let Some(packages) = packages
         && let Some(metadata) = packages.get(&metadata_key)
-        && let Some(integrity) = metadata.resolution.integrity()
-    {
-        let files_index_file =
-            pacquet_store_dir::store_index_key(&integrity.to_string(), &metadata_key.pkg_id());
-        if let Err(err) =
+        && let Some(files_index_file) = store_index_key_for_resolution(
+            &metadata.resolution,
+            &metadata_key.pkg_id(),
+            !ignore_scripts,
+        )
+        && let Err(err) =
             pacquet_store_dir::upload(store, &pkg_dir, &files_index_file, cache_key, writer)
-        {
-            tracing::warn!(
-                target: "pacquet::build",
-                ?err,
-                dep_path = %snapshot_key,
-                "side-effects cache upload failed; build proceeds",
-            );
-        }
+    {
+        tracing::warn!(
+            target: "pacquet::build",
+            ?err,
+            dep_path = %snapshot_key,
+            "side-effects cache upload failed; build proceeds",
+        );
     }
 
     Ok(())

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -6,7 +6,9 @@ use super::{
 // unconditionally would be an unused import on Windows.
 #[cfg(unix)]
 use super::RebuildOptions;
-use crate::{RequiresBuildBySnapshot, SkippedSnapshots, VirtualStoreLayout};
+use crate::{
+    RequiresBuildBySnapshot, SkippedSnapshots, VirtualStoreLayout, store_index_key_for_resolution,
+};
 use pacquet_config::{Config, PackageImportMethod};
 use pacquet_executor::ScriptsPrependNodePath;
 use pacquet_lockfile::{
@@ -68,6 +70,39 @@ fn parse_key_without_leading_slash() {
     let (name, version) = parse_name_version_from_key("express@4.18.1");
     assert_eq!(name, "express");
     assert_eq!(version, "4.18.1");
+}
+
+#[test]
+fn side_effects_key_for_git_hosted_tarball_matches_warm_lookup() {
+    let integrity = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    let pkg_id = "https://codeload.github.com/pnpm/pnpm/tar.gz/abcdef";
+    let resolution =
+        pacquet_lockfile::LockfileResolution::Tarball(pacquet_lockfile::TarballResolution {
+            tarball: pkg_id.to_string(),
+            integrity: Some(integrity.parse().expect("parse integrity")),
+            git_hosted: Some(true),
+            path: None,
+        });
+
+    assert_eq!(
+        store_index_key_for_resolution(&resolution, pkg_id, true),
+        Some(pacquet_store_dir::git_hosted_store_index_key(pkg_id, true)),
+    );
+}
+
+#[test]
+fn side_effects_key_for_git_resolution_does_not_require_integrity() {
+    let pkg_id = "git+file:///tmp/repo#abcdef";
+    let resolution = pacquet_lockfile::LockfileResolution::Git(pacquet_lockfile::GitResolution {
+        repo: "file:///tmp/repo".to_string(),
+        commit: "abcdef".to_string(),
+        path: None,
+    });
+
+    assert_eq!(
+        store_index_key_for_resolution(&resolution, pkg_id, true),
+        Some(pacquet_store_dir::git_hosted_store_index_key(pkg_id, true)),
+    );
 }
 
 // Policy-logic tests below drive `AllowBuildPolicy::new` directly with

--- a/pnpm/crates/package-manager/src/create_virtual_store.rs
+++ b/pnpm/crates/package-manager/src/create_virtual_store.rs
@@ -1,6 +1,7 @@
 use crate::{
     CasPathsByPkgId, InstallPackageBySnapshot, InstallPackageBySnapshotError, SkippedSnapshots,
     install_package_by_snapshot::{runtime_platform_selector, unverified_fetch_is_allowed},
+    store_index_key_for_resolution,
     store_init::init_store_dir_best_effort,
 };
 use derive_more::{Display, Error};
@@ -21,10 +22,7 @@ use pacquet_reporter::{
     BrokenModulesLog, LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter, StatsLog,
     StatsMessage,
 };
-use pacquet_store_dir::{
-    SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, git_hosted_store_index_key,
-    pick_store_index_key, store_index_key,
-};
+use pacquet_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
 use pacquet_tarball::{MemCache, PrefetchResult, SharedReportedProgressKeys, prefetch_cas_paths};
 use pipe_trait::Pipe;
 use std::{
@@ -1263,12 +1261,7 @@ fn snapshot_cache_key(
             // `built` tracks `!ignore_scripts` in lock-step with the
             // dispatcher's write key, so the prefetch and the write
             // address the same slot.
-            Ok(Some(pick_store_index_key(
-                t.integrity.as_ref().map(ToString::to_string).as_deref(),
-                t.is_git_hosted(),
-                &pkg_id,
-                !ignore_scripts,
-            )))
+            Ok(store_index_key_for_resolution(&metadata.resolution, &pkg_id, !ignore_scripts))
         }
         LockfileResolution::Registry(r) => {
             Ok(Some(store_index_key(&r.integrity.to_string(), &pkg_id)))
@@ -1296,7 +1289,7 @@ fn snapshot_cache_key(
             // whether the snapshot is already in `index.db`. `built`
             // tracks `!ignore_scripts` to match the dispatcher's
             // write key.
-            Ok(Some(git_hosted_store_index_key(&pkg_id, !ignore_scripts)))
+            Ok(store_index_key_for_resolution(&metadata.resolution, &pkg_id, !ignore_scripts))
         }
         // Runtime artifacts (Node.js / Bun / Deno): the per-archive
         // integrity is the warm-cache key, same shape as the

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -131,6 +131,29 @@ pub(crate) const DIRECT_GROUPS: [pacquet_package_manifest::DependencyGroup; 3] =
 
 pub(crate) const NEEDS_BUILD_MARKER: &str = ".pnpm-needs-build";
 
+pub(crate) fn store_index_key_for_resolution(
+    resolution: &pacquet_lockfile::LockfileResolution,
+    pkg_id: &str,
+    built: bool,
+) -> Option<String> {
+    match resolution {
+        pacquet_lockfile::LockfileResolution::Tarball(tarball) => {
+            Some(pacquet_store_dir::pick_store_index_key(
+                tarball.integrity.as_ref().map(ToString::to_string).as_deref(),
+                tarball.is_git_hosted(),
+                pkg_id,
+                built,
+            ))
+        }
+        pacquet_lockfile::LockfileResolution::Git(_) => {
+            Some(pacquet_store_dir::git_hosted_store_index_key(pkg_id, built))
+        }
+        _ => resolution
+            .integrity()
+            .map(|integrity| pacquet_store_dir::store_index_key(&integrity.to_string(), pkg_id)),
+    }
+}
+
 pub(crate) fn snapshot_has_patch(snapshot_key: &pacquet_lockfile::PackageKey) -> bool {
     pacquet_deps_path::index_of_dep_path_suffix(&snapshot_key.to_string())
         .patch_hash_index


### PR DESCRIPTION
## Summary

Fixes pacquet side-effects-cache uploads for git dependencies by deriving the upload row from the same resolution-aware helper as warm lookups. Git-hosted tarballs now upload to their built/not-built row, and `type: git` resolutions upload without requiring integrity. Ordinary registry and remote-tarball keys remain integrity-based.

The TypeScript CLI already computes and reuses one `pickStoreIndexKey`, so this is a pacquet-only parity correction.

Closes pnpm/pnpm#13420

## Squash Commit Body

```text
Pacquet selected side-effects upload rows from resolution integrity, while warm lookup selected git-hosted built/not-built rows. Hosted tarballs therefore wrote cache data to a row warm installs never read, and type: git resolutions never uploaded because they have no integrity.

Centralize resolution-aware store-index key selection in the package manager and use it for both warm lookup and side-effects upload. Keep integrity keys for ordinary packages while selecting git-hosted built/not-built rows for hosted tarballs and bare git resolutions.

Add key-shape regressions for both git resolution forms and an end-to-end git+file warm-install test proving lifecycle scripts are not rerun.

Closes pnpm/pnpm#13420
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787743363&installation_model_id=426870&pr_number=13426&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13426&signature=a0ef217a079dde6ba1da9353c4e4c204a874748d591e2b8806284777f05624bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed warm side-effects cache reuse for Git dependencies.
  * Reinstalling a Git dependency with a warm cache now correctly reuses previously built results instead of rerunning lifecycle scripts unnecessarily.
  * Improved consistency when identifying cached package builds across supported resolution types.

* **Release**
  * Included in a patch release of `pacquet`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->