### PR TITLE
feat(update): select global groups interactively

### DIFF
--- a/.changeset/friendly-global-groups.md
+++ b/.changeset/friendly-global-groups.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/global.commands": minor
+"@pnpm/global.packages": patch
 "@pnpm/installing.commands": minor
 "pnpm": minor
 "pacquet": minor

--- a/.changeset/friendly-global-groups.md
+++ b/.changeset/friendly-global-groups.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/global.commands": minor
+"@pnpm/installing.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Added interactive group selection to `pnpm update --global --interactive`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5276,6 +5276,9 @@ importers:
       '@pnpm/global.commands':
         specifier: workspace:*
         version: link:../../global/commands
+      '@pnpm/global.packages':
+        specifier: workspace:*
+        version: link:../../global/packages
       '@pnpm/hooks.pnpmfile':
         specifier: workspace:*
         version: link:../../hooks/pnpmfile

--- a/pnpm/crates/cli/src/cli_args/global.rs
+++ b/pnpm/crates/cli/src/cli_args/global.rs
@@ -175,6 +175,7 @@ pub async fn handle_global_add<Reporter: self::Reporter + 'static>(
 pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
     base_config: &'static Config,
     params: &[String],
+    selected_hashes: Option<&HashSet<String>>,
     latest: bool,
     range_spec_style: RangeSpecStyle,
     supported_architectures: Option<SupportedArchitectures>,
@@ -189,7 +190,7 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
         println!("No global packages found");
         return Ok(());
     }
-    let to_update: Vec<GlobalPackageInfo> = if params.is_empty() {
+    let mut to_update: Vec<GlobalPackageInfo> = if params.is_empty() {
         all
     } else {
         let filtered: Vec<GlobalPackageInfo> =
@@ -200,6 +201,9 @@ pub async fn handle_global_update<Reporter: self::Reporter + 'static>(
         }
         filtered
     };
+    if let Some(selected_hashes) = selected_hashes {
+        to_update.retain(|pkg| selected_hashes.contains(&pkg.hash));
+    }
 
     for pkg in &to_update {
         let selectors: Vec<String> = pkg

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -698,6 +698,11 @@ impl OutdatedArgs {
         let mut isolated_config = config.clone();
         isolated_config.workspace_dir = None;
         isolated_config.shared_workspace_lockfile = false;
+        // A group's lockfile is written unconditionally (`run_group_install`
+        // forces it) because it is where the installed versions are recorded,
+        // so reading it back must not depend on the caller's `lockfile`
+        // setting.
+        isolated_config.lockfile = true;
         let config = Config::leak(isolated_config);
 
         let include = self.dependency_options.include();

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -15,7 +15,7 @@ use pacquet_package_manager::{Update, build_workspace_packages_map};
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_registry::RangeSpecStyle;
 use pacquet_reporter::Reporter;
-use std::path::Path;
+use std::{collections::HashSet, path::Path};
 
 /// The `--prod`, `--dev`, and `--no-optional` flags that select which
 /// dependency groups to update.
@@ -381,11 +381,20 @@ impl UpdateArgs {
         config: &'static Config,
     ) -> miette::Result<()> {
         self.check_workspace_option(None)?;
-        if self.interactive {
-            return Err(miette::miette!(
-                "`pnpm update --global --interactive` is not supported yet."
-            ));
-        }
+        let selected_hashes: Option<HashSet<String>> = if self.interactive {
+            match crate::cli_args::update_interactive::select_global_package_groups(
+                config,
+                &self.packages,
+                self.latest,
+            )
+            .await?
+            {
+                Some(selected) => Some(selected),
+                None => return Ok(()),
+            }
+        } else {
+            None
+        };
         let supported_architectures =
             self.supported_architectures.apply_to(config.supported_architectures.clone());
         let range_spec_style = RangeSpecStyle::from_save_options(
@@ -395,6 +404,7 @@ impl UpdateArgs {
         Box::pin(crate::cli_args::global::handle_global_update::<Reporter>(
             config,
             &self.packages,
+            selected_hashes.as_ref(),
             self.latest,
             range_spec_style,
             supported_architectures,

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -55,6 +55,10 @@ pub(crate) async fn select_global_package_groups(
     let mut config = base_config.clone();
     config.workspace_dir = None;
     config.shared_workspace_lockfile = false;
+    // A group's lockfile is written unconditionally (`run_group_install`
+    // forces it) because it is where the installed versions are recorded, so
+    // reading it back must not depend on the caller's `lockfile` setting.
+    config.lockfile = true;
     let config = Config::leak(config);
     let query = OutdatedQuery {
         target_version: if latest { TargetVersion::Latest } else { TargetVersion::WithinRange },

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -43,6 +43,90 @@ pub(crate) struct InteractiveUpdateOptions<'a> {
     pub include_github_actions: bool,
 }
 
+pub(crate) async fn select_global_package_groups(
+    base_config: &'static Config,
+    packages: &[String],
+    latest: bool,
+) -> miette::Result<Option<HashSet<String>>> {
+    let global_pkg_dir = base_config.global_pkg_dir.clone().ok_or_else(|| {
+        miette!(code = "ERR_PNPM_NO_GLOBAL_BIN_DIR", "Unable to find the global packages directory")
+    })?;
+    let mut config = base_config.clone();
+    config.workspace_dir = None;
+    config.shared_workspace_lockfile = false;
+    let config = Config::leak(config);
+    let matcher = (!packages.is_empty()).then(|| pacquet_config::matcher::create_matcher(packages));
+    let query = OutdatedQuery {
+        target_version: if latest { TargetVersion::Latest } else { TargetVersion::WithinRange },
+        include_direct: &[DependencyGroup::Prod],
+        match_names: matcher.as_ref(),
+        include_deprecated: false,
+    };
+    let mut labels = Vec::new();
+    let mut hashes = Vec::new();
+    let global_packages = pacquet_global::scan_global_packages(&global_pkg_dir)
+        .map_err(|err| miette!("failed to scan global packages: {err}"))?;
+    if global_packages.is_empty() {
+        println!("No global packages found");
+        return Ok(None);
+    }
+    for pkg in global_packages {
+        let state = crate::State::init(pkg.install_dir.join("package.json"), config, false)
+            .map_err(|err| miette::Report::new(err).wrap_err("initialize global state"))?;
+        let lockfile = state
+            .lockfile
+            .get()
+            .map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?;
+        let outdated = collect_outdated_for_importer(
+            &state.manifest,
+            lockfile,
+            pacquet_lockfile::Lockfile::ROOT_IMPORTER_KEY,
+            config,
+            &state.http_client,
+            &query,
+        )
+        .await?;
+        if outdated.is_empty() {
+            continue;
+        }
+        labels.push(
+            outdated
+                .iter()
+                .map(|package| {
+                    format!("{} {} → {}", package.alias, package.current, package.target)
+                })
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
+        hashes.push(pkg.hash);
+    }
+    if labels.is_empty() {
+        let message = if latest {
+            "All of your dependencies are already up to date"
+        } else {
+            "All of your dependencies are already up to date inside the specified ranges. Use the --latest option to update the ranges in package.json"
+        };
+        println!("{message}");
+        return Ok(None);
+    }
+    let selected_indices = MultiSelect::new()
+        .with_prompt(
+            "Choose which global package groups to update (space to select, enter to confirm)",
+        )
+        .items(&labels)
+        .interact()
+        .into_diagnostic()
+        .map_err(|err| miette!("interactive update selection failed: {err}"))?;
+    let selected = selected_indices
+        .into_iter()
+        .filter_map(|index| hashes.get(index).cloned())
+        .collect::<HashSet<_>>();
+    if selected.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(selected))
+}
+
 /// Gather outdated direct dependencies, prompt the user, and return the
 /// selected package names. `Ok(None)` means "nothing to do" — either no
 /// dependency has an update available or the prompt was answered with an

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -19,6 +19,7 @@ use crate::{
     cli_args::{
         outdated::{OutdatedPackage, OutdatedQuery, TargetVersion, collect_outdated_for_importer},
         pipelines::InstallFamilySelection,
+        sanitize::sanitize_inline,
     },
     github_actions,
 };
@@ -93,7 +94,12 @@ pub(crate) async fn select_global_package_groups(
             outdated
                 .iter()
                 .map(|package| {
-                    format!("{} {} → {}", package.alias, package.current, package.target)
+                    format!(
+                        "{} {} → {}",
+                        sanitize_inline(&package.alias),
+                        package.current,
+                        package.target,
+                    )
                 })
                 .collect::<Vec<_>>()
                 .join(", "),

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -56,11 +56,10 @@ pub(crate) async fn select_global_package_groups(
     config.workspace_dir = None;
     config.shared_workspace_lockfile = false;
     let config = Config::leak(config);
-    let matcher = (!packages.is_empty()).then(|| pacquet_config::matcher::create_matcher(packages));
     let query = OutdatedQuery {
         target_version: if latest { TargetVersion::Latest } else { TargetVersion::WithinRange },
         include_direct: &[DependencyGroup::Prod],
-        match_names: matcher.as_ref(),
+        match_names: None,
         include_deprecated: false,
     };
     let mut labels = Vec::new();
@@ -71,7 +70,22 @@ pub(crate) async fn select_global_package_groups(
         println!("No global packages found");
         return Ok(None);
     }
-    for pkg in global_packages {
+    // A global group is always updated as a whole, so the params select groups
+    // rather than dependencies, the same way `handle_global_update` reads them.
+    let matched_packages = if packages.is_empty() {
+        global_packages
+    } else {
+        let matched = global_packages
+            .into_iter()
+            .filter(|pkg| packages.iter().any(|param| pkg.has_alias(param)))
+            .collect::<Vec<_>>();
+        if matched.is_empty() {
+            println!("No matching global packages found");
+            return Ok(None);
+        }
+        matched
+    };
+    for pkg in matched_packages {
         let state = crate::State::init(pkg.install_dir.join("package.json"), config, false)
             .map_err(|err| miette::Report::new(err).wrap_err("initialize global state"))?;
         let lockfile = state

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -542,6 +542,66 @@ fn global_interactive_update_empty() {
     drop(root);
 }
 
+/// A global group records its installed versions in its own lockfile, which
+/// the install writes whatever the caller configured, so reading those
+/// versions back must survive `lockfile=false`.
+#[cfg(unix)]
+#[test]
+fn global_commands_read_group_lockfiles_when_the_lockfile_setting_is_off() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    let pnpm_home = root.path().join("pnpm-home");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+    fs::write(
+        pnpm_home.join("pnpm-workspace.yaml"),
+        format!(
+            "storeDir: {}\ncacheDir: {}\nenableGlobalVirtualStore: false\nlockfile: false\n",
+            npmrc_info.store_dir.display(),
+            npmrc_info.cache_dir.display(),
+        ),
+    )
+    .expect("disable the lockfile setting");
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["add", "-g", "@pnpm.e2e/pkg-with-1-dep@100.0.0"])
+        .assert()
+        .success();
+
+    let global_pkg_dir = pnpm_home.join("global/v11");
+    let links = symlink_entries(&global_pkg_dir);
+    let install_dir = fs::canonicalize(&links[0]).expect("resolve global install-group link");
+    assert!(
+        install_dir.join("pnpm-lock.yaml").is_file(),
+        "a global install writes its group lockfile even with lockfile=false",
+    );
+
+    let output = global_command(&workspace, &pnpm_home)
+        .with_args(["outdated", "-g", "--format", "json"])
+        .output()
+        .expect("run outdated -g");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let report: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|err| panic!("parse outdated -g JSON: {err}; stdout: {stdout}"));
+    assert_eq!(report["@pnpm.e2e/pkg-with-1-dep"]["current"], "100.0.0");
+
+    let output = global_command(&workspace, &pnpm_home)
+        .with_args(["update", "-g", "-i", "--latest"])
+        .output()
+        .expect("run interactive global update");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("already up to date"),
+        "the outdated group must reach the prompt, got: {stdout}",
+    );
+
+    drop((root, npmrc_info));
+}
+
 /// The params of `update -g -i` select whole groups, exactly as they do
 /// without `-i`, so a name no group holds stops before the prompt.
 #[cfg(unix)]

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -593,10 +593,15 @@ fn global_commands_read_group_lockfiles_when_the_lockfile_setting_is_off() {
         .output()
         .expect("run interactive global update");
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Reaching the prompt is the proof that the group's versions were read.
+    // The test has no TTY, so `dialoguer` cannot render it and the command
+    // fails with that specific error; an unread group would instead exit 0
+    // after printing that everything is up to date.
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stdout.contains("already up to date"),
-        "the outdated group must reach the prompt, got: {stdout}",
+        stderr.contains("interactive update selection failed"),
+        "the outdated group must reach the prompt; stdout: {}; stderr: {stderr}",
+        String::from_utf8_lossy(&output.stdout),
     );
 
     drop((root, npmrc_info));

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -542,6 +542,43 @@ fn global_interactive_update_empty() {
     drop(root);
 }
 
+/// The params of `update -g -i` select whole groups, exactly as they do
+/// without `-i`, so a name no group holds stops before the prompt.
+#[cfg(unix)]
+#[test]
+fn global_interactive_update_without_a_matching_group() {
+    use assert_cmd::assert::OutputAssertExt;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let pnpm_home = root.path().join("pnpm-home");
+    prepare_global_home(&pnpm_home, &npmrc_info);
+
+    global_command(&workspace, &pnpm_home)
+        .with_args(["add", "-g", "@foo/touch-file-one-bin"])
+        .assert()
+        .success();
+
+    let output = global_command(&workspace, &pnpm_home)
+        .with_args(["update", "-g", "-i", "@pnpm.e2e/multi-version-a"])
+        .output()
+        .expect("run interactive global update");
+
+    assert!(
+        output.status.success(),
+        "interactive global update should succeed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No matching global packages found"),
+        "expected the no-match message, got: {stdout}",
+    );
+
+    drop(npmrc_info);
+    drop(root);
+}
+
 /// `pacquet add -g pnpm` is rejected — pnpm is managed via `self-update`.
 #[test]
 fn global_add_pnpm_is_rejected() {

--- a/pnpm/crates/cli/tests/global.rs
+++ b/pnpm/crates/cli/tests/global.rs
@@ -517,6 +517,31 @@ fn global_list_empty() {
     drop(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn global_interactive_update_empty() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let pnpm_home = root.path().join("pnpm-home");
+    fs::create_dir_all(pnpm_home.join("bin")).expect("create global bin dir");
+
+    let output = global_command(&workspace, &pnpm_home)
+        .with_args(["update", "-g", "-i"])
+        .output()
+        .expect("run interactive global update");
+
+    assert!(
+        output.status.success(),
+        "interactive global update should succeed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("not supported yet"),
+        "interactive global update should use the selection path",
+    );
+
+    drop(root);
+}
+
 /// `pacquet add -g pnpm` is rejected — pnpm is managed via `self-update`.
 #[test]
 fn global_add_pnpm_is_rejected() {

--- a/pnpm11/global/commands/src/globalAdd.ts
+++ b/pnpm11/global/commands/src/globalAdd.ts
@@ -184,8 +184,8 @@ export function shouldReplaceExistingGlobalInstall (
   aliases: string[],
   replacementAliases: string[]
 ): boolean {
-  if (aliases.some((alias) => alias in pkg.dependencies)) return true
-  return isPnpmCliOnlyGroup(pkg) && replacementAliases.some((alias) => alias in pkg.dependencies)
+  if (aliases.some((alias) => Object.hasOwn(pkg.dependencies, alias))) return true
+  return isPnpmCliOnlyGroup(pkg) && replacementAliases.some((alias) => Object.hasOwn(pkg.dependencies, alias))
 }
 
 function isPnpmCliOnlyGroup (pkg: GlobalPackageInfo): boolean {

--- a/pnpm11/global/commands/src/globalUpdate.ts
+++ b/pnpm11/global/commands/src/globalUpdate.ts
@@ -54,7 +54,7 @@ export async function handleGlobalUpdate (
   let packagesToUpdate: GlobalPackageInfo[]
   if (params.length > 0) {
     packagesToUpdate = allPackages.filter((pkg) =>
-      params.some((p) => p in pkg.dependencies)
+      params.some((p) => Object.hasOwn(pkg.dependencies, p))
     )
     if (packagesToUpdate.length === 0) {
       return 'No matching global packages found'

--- a/pnpm11/global/commands/src/globalUpdate.ts
+++ b/pnpm11/global/commands/src/globalUpdate.ts
@@ -33,6 +33,7 @@ export type GlobalUpdateOptions = CreateStoreControllerOptions & {
   rootProjectManifest?: unknown
   handleResolutionPolicyViolations?: (violations: readonly ResolutionPolicyViolation[]) => Promise<void>
   updateResolutionPolicyManifest?: (violations: readonly ResolutionPolicyViolation[], dir: string) => Promise<void>
+  selectedPackageHashes?: Set<string>
 }
 
 export async function handleGlobalUpdate (
@@ -60,6 +61,10 @@ export async function handleGlobalUpdate (
     }
   } else {
     packagesToUpdate = allPackages
+  }
+  const selectedPackageHashes = opts.selectedPackageHashes
+  if (selectedPackageHashes) {
+    packagesToUpdate = packagesToUpdate.filter(({ hash }) => selectedPackageHashes.has(hash))
   }
 
   // Update each package group sequentially to avoid overwhelming the system

--- a/pnpm11/global/commands/test/globalUpdate.test.ts
+++ b/pnpm11/global/commands/test/globalUpdate.test.ts
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals'
+import { beforeEach, expect, jest, test } from '@jest/globals'
 
 const linkBinsOfPackages = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
 const removeBin = jest.fn<() => Promise<void>>().mockResolvedValue(undefined)
@@ -33,6 +33,10 @@ jest.unstable_mockModule('../src/promptApproveGlobalBuilds.js', () => ({ promptA
 jest.unstable_mockModule('../src/readInstalledPackages.js', () => ({ readInstalledPackages }))
 
 const { handleGlobalUpdate } = await import('../src/globalUpdate.js')
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 test('global update emits a single summary after updating all isolated groups', async () => {
   createInstallDir
@@ -80,4 +84,33 @@ test('global update emits a single summary after updating all isolated groups', 
   )
   expect(summaryDebug).toHaveBeenCalledTimes(1)
   expect(summaryDebug).toHaveBeenCalledWith({ prefix: '/global/v11' })
+})
+
+test('global update only updates interactively selected groups', async () => {
+  createInstallDir.mockReturnValue('/global/v11/install-1')
+  getHashLink.mockReturnValue('/global/v11/hash-foo')
+  scanGlobalPackages.mockReturnValue([
+    {
+      dependencies: { foo: '^1.0.0' },
+      hash: 'hash-foo',
+      installDir: '/global/v11/old-foo',
+    },
+    {
+      dependencies: { bar: '^2.0.0' },
+      hash: 'hash-bar',
+      installDir: '/global/v11/old-bar',
+    },
+  ])
+
+  await handleGlobalUpdate({
+    bin: '/global/bin',
+    globalPkgDir: '/global/v11',
+    selectedPackageHashes: new Set(['hash-foo']),
+  } as any, [], {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  expect(installGlobalPackages).toHaveBeenCalledTimes(1)
+  expect(installGlobalPackages).toHaveBeenCalledWith(
+    expect.objectContaining({ dir: '/global/v11/install-1' }),
+    ['foo@^1.0.0']
+  )
 })

--- a/pnpm11/global/packages/src/scanGlobalPackages.ts
+++ b/pnpm11/global/packages/src/scanGlobalPackages.ts
@@ -95,7 +95,7 @@ export function scanGlobalPackages (globalDir: string): GlobalPackageInfo[] {
 
 export function findGlobalPackage (globalDir: string, alias: string): GlobalPackageInfo | null {
   const packages = scanGlobalPackages(globalDir)
-  return packages.find((pkg) => alias in pkg.dependencies) ?? null
+  return packages.find((pkg) => Object.hasOwn(pkg.dependencies, alias)) ?? null
 }
 
 export async function getGlobalPackageDetails (info: GlobalPackageInfo): Promise<InstalledGlobalPackage[]> {

--- a/pnpm11/installing/commands/package.json
+++ b/pnpm11/installing/commands/package.json
@@ -58,6 +58,7 @@
     "@pnpm/fs.graceful-fs": "workspace:*",
     "@pnpm/fs.read-modules-dir": "workspace:*",
     "@pnpm/global.commands": "workspace:*",
+    "@pnpm/global.packages": "workspace:*",
     "@pnpm/hooks.pnpmfile": "workspace:*",
     "@pnpm/installing.context": "workspace:*",
     "@pnpm/installing.dedupe.check": "workspace:*",

--- a/pnpm11/installing/commands/src/update/getUpdateChoices.ts
+++ b/pnpm11/installing/commands/src/update/getUpdateChoices.ts
@@ -102,7 +102,7 @@ export function getUpdateChoices (outdatedPkgsOfProjects: UpdateChoiceDependency
         name: outdatedPkg.name,
         message: renderedTable[i],
         value: outdatedPkg.name,
-        short: sanitizeCell(outdatedPkg.name),
+        short: sanitizeUpdateChoiceText(outdatedPkg.name),
       }
     })
 
@@ -130,7 +130,7 @@ function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled:
   const label = outdatedPkg.packageName
 
   const raw: string[] = [
-    sanitizeCell(label),
+    sanitizeUpdateChoiceText(label),
     outdatedPkg.current ?? '',
     '❯',
     // Not sanitized: `colorizeSemverDiff` puts the highlighting escapes
@@ -138,9 +138,9 @@ function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled:
     nextVersion,
   ]
   if (workspacesEnabled) {
-    raw.push(Array.from(workspaces ?? []).map(sanitizeCell).join(', '))
+    raw.push(Array.from(workspaces ?? []).map(sanitizeUpdateChoiceText).join(', '))
   }
-  raw.push(sanitizeCell(getPkgUrl(outdatedPkg)))
+  raw.push(sanitizeUpdateChoiceText(getPkgUrl(outdatedPkg)))
 
   return {
     raw,
@@ -152,7 +152,7 @@ function buildPkgChoice (outdatedPkg: UpdateChoiceDependency, workspacesEnabled:
  * Strip control and formatting characters from text that goes into a
  * single-line table cell.
  */
-function sanitizeCell (text: string): string {
+export function sanitizeUpdateChoiceText (text: string): string {
   // eslint-disable-next-line no-control-regex
   return text.replace(/[\u0000-\u001F\u007F-\u009F\u00AD\u0600-\u0605\u061C\u06DD\u070F\u0890\u0891\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB\u{110BD}\u{110CD}\u{13430}-\u{1343F}\u{1BCA0}-\u{1BCA3}\u{1D173}-\u{1D17A}\u{E0001}\u{E0020}-\u{E007F}]/gu, '')
 }

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -231,7 +231,7 @@ async function selectGlobalPackageGroups (
   // rather than dependencies, the same way `handleGlobalUpdate()` reads them.
   const matchedPackages = input.length === 0
     ? globalPackages
-    : globalPackages.filter((pkg) => input.some((param) => param in pkg.dependencies))
+    : globalPackages.filter((pkg) => input.some((param) => Object.hasOwn(pkg.dependencies, param)))
   if (matchedPackages.length === 0) return 'No matching global packages found'
   const outdatedPerGroup = await Promise.all(matchedPackages.map(async (pkg) => {
     const project = {

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -26,7 +26,7 @@ import { createVulnerabilityUpdateMatching, installDeps } from '../installDeps.j
 import { parseUpdateParam } from '../recursive.js'
 import { createGlobalPolicyCallbacks } from '../resolutionPolicyManifest.js'
 import { captureUpdateChangesetContext, generateUpdateChangeset } from './generateUpdateChangeset.js'
-import { getUpdateChoices } from './getUpdateChoices.js'
+import { getUpdateChoices, sanitizeUpdateChoiceText } from './getUpdateChoices.js'
 export function rcOptionsTypes (): Record<string, unknown> {
   return pick([
     'cache-dir',
@@ -254,7 +254,9 @@ async function selectGlobalPackageGroups (
     .map(({ pkg, outdated }) => ({
       name: outdated
         .map(({ alias, current, wanted, latestManifest }) =>
-          `${alias} ${current ?? 'missing'} → ${opts.latest ? latestManifest?.version ?? wanted : wanted}`
+          [alias, current ?? 'missing', '→', opts.latest ? latestManifest?.version ?? wanted : wanted]
+            .map(sanitizeUpdateChoiceText)
+            .join(' ')
         )
         .join(', '),
       value: pkg.hash,

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -1,3 +1,5 @@
+import util from 'node:util'
+
 import { checkbox, Separator } from '@inquirer/prompts'
 import type { CommandHandler, CommandHandlerMap, CompletionFunc } from '@pnpm/cli.command'
 import { FILTERING, OPTIONS, UNIVERSAL_OPTIONS } from '@pnpm/cli.common-cli-options-help'
@@ -225,12 +227,18 @@ async function selectGlobalPackageGroups (
 ): Promise<Set<string> | string> {
   const globalPackages = scanGlobalPackages(opts.globalPkgDir!)
   if (globalPackages.length === 0) return 'No global packages found'
-  const outdatedPerGroup = await Promise.all(globalPackages.map(async (pkg) => {
+  // A global group is always updated as a whole, so the params select groups
+  // rather than dependencies, the same way `handleGlobalUpdate()` reads them.
+  const matchedPackages = input.length === 0
+    ? globalPackages
+    : globalPackages.filter((pkg) => input.some((param) => param in pkg.dependencies))
+  if (matchedPackages.length === 0) return 'No matching global packages found'
+  const outdatedPerGroup = await Promise.all(matchedPackages.map(async (pkg) => {
     const project = {
       rootDir: pkg.installDir as ProjectRootDir,
       manifest: await readProjectManifestOnly(pkg.installDir, opts),
     }
-    const [outdated] = await outdatedDepsOfProjects([project], input, {
+    const [outdated] = await outdatedDepsOfProjects([project], [], {
       ...opts,
       compatible: opts.latest !== true,
       ignoreDependencies: opts.updateConfig?.ignoreDependencies,
@@ -266,11 +274,11 @@ async function selectGlobalPackageGroups (
       ? 'All of your dependencies are already up to date'
       : 'All of your dependencies are already up to date inside the specified ranges. Use the --latest option to update the ranges in package.json'
   }
-  return new Set(await checkbox({
+  return new Set(await runUpdatePrompt(() => checkbox({
     choices,
     message: 'Choose which global package groups to update (space to select, enter to confirm)',
     pageSize: Math.min(choices.length, interactivePromptPageSize()),
-  }))
+  })))
 }
 
 async function interactiveUpdate (
@@ -357,36 +365,43 @@ async function interactiveUpdate (
     `(Press ${chalk.cyan('<space>')} to select, ` +
     `${chalk.cyan('<a>')} to toggle all, ` +
     `${chalk.cyan('<i>')} to invert selection)\n\nEnter to start updating. Ctrl-c to cancel.`
-  let updatePkgNames: string[]
+  const updatePkgNames = await runUpdatePrompt(() => checkbox({
+    choices: flatChoices,
+    pageSize: interactivePromptPageSize(),
+    message,
+    required: true,
+    validate: (values) => {
+      if (values.length === 0) {
+        return 'You must choose at least one dependency.'
+      }
+      return true
+    },
+    theme: {
+      icon: { checked: '●', unchecked: '○', cursor: '❯' },
+      style: {
+        highlight: (text: string) => text,
+      },
+      keybindings: ['vim'],
+    },
+  }))
+
+  return update(updatePkgNames, opts, rebuildHandler) as Promise<undefined>
+}
+
+/**
+ * Cancelling a prompt with Ctrl-c is how the user declines to update, not an
+ * error: report it and leave with a success status.
+ */
+async function runUpdatePrompt<T> (prompt: () => Promise<T>): Promise<T> {
   try {
-    updatePkgNames = await checkbox({
-      choices: flatChoices,
-      pageSize: interactivePromptPageSize(),
-      message,
-      required: true,
-      validate: (values) => {
-        if (values.length === 0) {
-          return 'You must choose at least one dependency.'
-        }
-        return true
-      },
-      theme: {
-        icon: { checked: '●', unchecked: '○', cursor: '❯' },
-        style: {
-          highlight: (text: string) => text,
-        },
-        keybindings: ['vim'],
-      },
-    })
-  } catch (err) {
-    if (err instanceof Error && err.name === 'ExitPromptError') {
+    return await prompt()
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && err.name === 'ExitPromptError') {
       globalInfo('Update canceled')
       process.exit(0)
     }
     throw err
   }
-
-  return update(updatePkgNames, opts, rebuildHandler) as Promise<undefined>
 }
 
 async function update (

--- a/pnpm11/installing/commands/src/update/index.ts
+++ b/pnpm11/installing/commands/src/update/index.ts
@@ -13,6 +13,7 @@ import { findOutdatedGitHubActions, isGitHubActionSelector, normalizeGitHubActio
 import { outdatedDepsOfProjects } from '@pnpm/deps.inspection.outdated'
 import { PnpmError } from '@pnpm/error'
 import { handleGlobalUpdate } from '@pnpm/global.commands'
+import { scanGlobalPackages } from '@pnpm/global.packages'
 import type { UpdateMatchingFunction } from '@pnpm/installing.deps-installer'
 import { globalInfo } from '@pnpm/logger'
 import type { IncludedDependencies, PackageVulnerabilityAudit, ProjectRootDir } from '@pnpm/types'
@@ -200,9 +201,15 @@ export async function handler (
         hint: 'Run "pnpm setup" to create it automatically, or set the global-bin-dir setting, or the PNPM_HOME env variable. The global bin directory should be in the PATH.',
       })
     }
+    const selection = opts.interactive
+      ? await selectGlobalPackageGroups(params, opts)
+      : undefined
+    if (typeof selection === 'string') return selection
+    if (selection?.size === 0) return undefined
     return handleGlobalUpdate({
       ...opts,
       ...createGlobalPolicyCallbacks(opts),
+      selectedPackageHashes: selection,
     }, params, commands ?? {})
   }
   const rebuildHandler = commands?.rebuild
@@ -210,6 +217,58 @@ export async function handler (
     return interactiveUpdate(params, opts, rebuildHandler)
   }
   return update(params, opts, rebuildHandler) as Promise<undefined>
+}
+
+async function selectGlobalPackageGroups (
+  input: string[],
+  opts: UpdateCommandOptions
+): Promise<Set<string> | string> {
+  const globalPackages = scanGlobalPackages(opts.globalPkgDir!)
+  if (globalPackages.length === 0) return 'No global packages found'
+  const outdatedPerGroup = await Promise.all(globalPackages.map(async (pkg) => {
+    const project = {
+      rootDir: pkg.installDir as ProjectRootDir,
+      manifest: await readProjectManifestOnly(pkg.installDir, opts),
+    }
+    const [outdated] = await outdatedDepsOfProjects([project], input, {
+      ...opts,
+      compatible: opts.latest !== true,
+      ignoreDependencies: opts.updateConfig?.ignoreDependencies,
+      include: {
+        dependencies: true,
+        devDependencies: false,
+        optionalDependencies: true,
+      },
+      retry: {
+        factor: opts.fetchRetryFactor,
+        maxTimeout: opts.fetchRetryMaxtimeout,
+        minTimeout: opts.fetchRetryMintimeout,
+        retries: opts.fetchRetries,
+      },
+      timeout: opts.fetchTimeout,
+    })
+    return { pkg, outdated }
+  }))
+  const choices = outdatedPerGroup
+    .filter(({ outdated }) => outdated.length > 0)
+    .map(({ pkg, outdated }) => ({
+      name: outdated
+        .map(({ alias, current, wanted, latestManifest }) =>
+          `${alias} ${current ?? 'missing'} → ${opts.latest ? latestManifest?.version ?? wanted : wanted}`
+        )
+        .join(', '),
+      value: pkg.hash,
+    }))
+  if (choices.length === 0) {
+    return opts.latest
+      ? 'All of your dependencies are already up to date'
+      : 'All of your dependencies are already up to date inside the specified ranges. Use the --latest option to update the ranges in package.json'
+  }
+  return new Set(await checkbox({
+    choices,
+    message: 'Choose which global package groups to update (space to select, enter to confirm)',
+    pageSize: Math.min(choices.length, interactivePromptPageSize()),
+  }))
 }
 
 async function interactiveUpdate (

--- a/pnpm11/installing/commands/test/update/interactive.ts
+++ b/pnpm11/installing/commands/test/update/interactive.ts
@@ -62,6 +62,20 @@ const DEFAULT_OPTIONS = {
   virtualStoreDirMaxLength: process.platform === 'win32' ? 60 : 120,
 }
 
+test('global interactive update handles an empty global directory', async () => {
+  const globalDir = path.resolve('global')
+
+  await expect(update.handler({
+    ...DEFAULT_OPTIONS,
+    bin: path.resolve('bin'),
+    dir: process.cwd(),
+    global: true,
+    globalPkgDir: globalDir,
+    interactive: true,
+  } as any)).resolves.toBe('No global packages found') // eslint-disable-line @typescript-eslint/no-explicit-any
+  expect(mockCheckbox).not.toHaveBeenCalled()
+})
+
 test('interactively update', async () => {
   const project = prepare({
     dependencies: {

--- a/pnpm11/installing/commands/test/update/interactive.ts
+++ b/pnpm11/installing/commands/test/update/interactive.ts
@@ -151,6 +151,32 @@ test('global interactive update reports when no group has the requested package'
   expect(mockCheckbox).not.toHaveBeenCalled()
 })
 
+// pacquet reads only the wanted lockfile, which its global install writes
+// whatever `lockfile` is set to; here the current lockfile carries the
+// versions instead. Both stacks must keep reporting them.
+test('global interactive update reads current versions when the lockfile setting is off', async () => {
+  prepare()
+  const options = { ...globalOptions(), useLockfile: false }
+
+  await add.handler(options as any, ['@pnpm.e2e/multi-version-a@1.0.0']) // eslint-disable-line @typescript-eslint/no-explicit-any
+  await addDistTag({ package: '@pnpm.e2e/multi-version-a', version: '2.1.0', distTag: 'latest' })
+  mockCheckbox.mockClear()
+  mockCheckbox.mockResolvedValue([])
+
+  await update.handler({
+    ...options,
+    interactive: true,
+    latest: true,
+  } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  expect(mockCheckbox).toHaveBeenCalledWith(expect.objectContaining({
+    choices: [{
+      name: '@pnpm.e2e/multi-version-a 1.0.0 → 2.1.0',
+      value: expect.any(String),
+    }],
+  }))
+})
+
 test('global interactive update does not match a group on an inherited Object key', async () => {
   prepare()
   const options = globalOptions()

--- a/pnpm11/installing/commands/test/update/interactive.ts
+++ b/pnpm11/installing/commands/test/update/interactive.ts
@@ -63,7 +63,7 @@ const DEFAULT_OPTIONS = {
 }
 
 test('global interactive update handles an empty global directory', async () => {
-  const globalDir = path.resolve('global')
+  const globalDir = path.resolve('empty-global')
 
   await expect(update.handler({
     ...DEFAULT_OPTIONS,
@@ -74,6 +74,41 @@ test('global interactive update handles an empty global directory', async () => 
     interactive: true,
   } as any)).resolves.toBe('No global packages found') // eslint-disable-line @typescript-eslint/no-explicit-any
   expect(mockCheckbox).not.toHaveBeenCalled()
+})
+
+test('global interactive update reads current versions from the global virtual store', async () => {
+  prepare()
+  const globalDir = path.resolve('global')
+  const storeDir = path.resolve('pnpm-store')
+  const options = {
+    ...DEFAULT_OPTIONS,
+    allowBuilds: {},
+    bin: path.resolve('bin'),
+    cacheDir: path.resolve('cache'),
+    dir: process.cwd(),
+    enableGlobalVirtualStore: true,
+    global: true,
+    globalPkgDir: globalDir,
+    pnpmHomeDir: '',
+    storeDir,
+  }
+
+  await add.handler(options as any, ['@pnpm.e2e/multi-version-a@1.0.0']) // eslint-disable-line @typescript-eslint/no-explicit-any
+  await addDistTag({ package: '@pnpm.e2e/multi-version-a', version: '2.1.0', distTag: 'latest' })
+  mockCheckbox.mockResolvedValue([])
+
+  await update.handler({
+    ...options,
+    interactive: true,
+    latest: true,
+  } as any) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  expect(mockCheckbox).toHaveBeenCalledWith(expect.objectContaining({
+    choices: [{
+      name: '@pnpm.e2e/multi-version-a 1.0.0 → 2.1.0',
+      value: expect.any(String),
+    }],
+  }))
 })
 
 test('interactively update', async () => {

--- a/pnpm11/installing/commands/test/update/interactive.ts
+++ b/pnpm11/installing/commands/test/update/interactive.ts
@@ -111,6 +111,90 @@ test('global interactive update reads current versions from the global virtual s
   }))
 })
 
+test('global interactive update offers a matching group even when the requested package is current', async () => {
+  prepare()
+  const options = globalOptions()
+
+  await addDistTag({ package: '@pnpm.e2e/multi-version-b', version: '3.1.0', distTag: 'latest' })
+  // One comma-joined param installs both packages into a single group.
+  await add.handler(options as any, ['@pnpm.e2e/multi-version-a@1.0.0,@pnpm.e2e/multi-version-b@3.1.0']) // eslint-disable-line @typescript-eslint/no-explicit-any
+  await addDistTag({ package: '@pnpm.e2e/multi-version-a', version: '2.1.0', distTag: 'latest' })
+  mockCheckbox.mockClear()
+  mockCheckbox.mockResolvedValue([])
+
+  await update.handler({
+    ...options,
+    interactive: true,
+    latest: true,
+  } as any, ['@pnpm.e2e/multi-version-b']) // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  expect(mockCheckbox).toHaveBeenCalledWith(expect.objectContaining({
+    choices: [{
+      name: '@pnpm.e2e/multi-version-a 1.0.0 → 2.1.0',
+      value: expect.any(String),
+    }],
+  }))
+})
+
+test('global interactive update reports when no group has the requested package', async () => {
+  prepare()
+  const options = globalOptions()
+
+  await add.handler(options as any, ['@pnpm.e2e/multi-version-a@1.0.0']) // eslint-disable-line @typescript-eslint/no-explicit-any
+  mockCheckbox.mockClear()
+
+  await expect(update.handler({
+    ...options,
+    interactive: true,
+    latest: true,
+  } as any, ['@pnpm.e2e/multi-version-c'])).resolves.toBe('No matching global packages found') // eslint-disable-line @typescript-eslint/no-explicit-any
+  expect(mockCheckbox).not.toHaveBeenCalled()
+})
+
+test('global interactive update leaves without an error when the prompt is canceled', async () => {
+  prepare()
+  const options = globalOptions()
+
+  await add.handler(options as any, ['@pnpm.e2e/multi-version-a@1.0.0']) // eslint-disable-line @typescript-eslint/no-explicit-any
+  await addDistTag({ package: '@pnpm.e2e/multi-version-a', version: '2.1.0', distTag: 'latest' })
+  const canceled = new Error('User force closed the prompt')
+  canceled.name = 'ExitPromptError'
+  mockCheckbox.mockClear()
+  mockCheckbox.mockRejectedValue(canceled)
+  // `process.exit()` never returns in production, so the spy throws to stop
+  // the handler where the real call would.
+  const exited = new Error('process.exit')
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {
+    throw exited
+  })
+
+  try {
+    await expect(update.handler({
+      ...options,
+      interactive: true,
+      latest: true,
+    } as any)).rejects.toBe(exited) // eslint-disable-line @typescript-eslint/no-explicit-any
+    expect(exitSpy).toHaveBeenCalledWith(0)
+  } finally {
+    exitSpy.mockRestore()
+    mockCheckbox.mockReset()
+  }
+})
+
+function globalOptions (): Record<string, unknown> {
+  return {
+    ...DEFAULT_OPTIONS,
+    allowBuilds: {},
+    bin: path.resolve('bin'),
+    cacheDir: path.resolve('cache'),
+    dir: process.cwd(),
+    global: true,
+    globalPkgDir: path.resolve('global'),
+    pnpmHomeDir: '',
+    storeDir: path.resolve('pnpm-store'),
+  }
+}
+
 test('interactively update', async () => {
   const project = prepare({
     dependencies: {

--- a/pnpm11/installing/commands/test/update/interactive.ts
+++ b/pnpm11/installing/commands/test/update/interactive.ts
@@ -151,6 +151,21 @@ test('global interactive update reports when no group has the requested package'
   expect(mockCheckbox).not.toHaveBeenCalled()
 })
 
+test('global interactive update does not match a group on an inherited Object key', async () => {
+  prepare()
+  const options = globalOptions()
+
+  await add.handler(options as any, ['@pnpm.e2e/multi-version-a@1.0.0']) // eslint-disable-line @typescript-eslint/no-explicit-any
+  mockCheckbox.mockClear()
+
+  await expect(update.handler({
+    ...options,
+    interactive: true,
+    latest: true,
+  } as any, ['constructor'])).resolves.toBe('No matching global packages found') // eslint-disable-line @typescript-eslint/no-explicit-any
+  expect(mockCheckbox).not.toHaveBeenCalled()
+})
+
 test('global interactive update leaves without an error when the prompt is canceled', async () => {
   prepare()
   const options = globalOptions()

--- a/pnpm11/installing/commands/tsconfig.json
+++ b/pnpm11/installing/commands/tsconfig.json
@@ -100,6 +100,9 @@
       "path": "../../global/commands"
     },
     {
+      "path": "../../global/packages"
+    },
+    {
       "path": "../../hooks/pnpmfile"
     },
     {


### PR DESCRIPTION
## Summary

Adds support for `pnpm update --global --interactive` in both the TypeScript CLI and the Rust pnpm port.

Global install groups are presented as the selection unit. Each option summarizes the outdated packages in that group, and only selected groups are updated. Empty global stores and empty selections exit without changing anything.

Prompt labels are sanitized before rendering so local or registry metadata cannot inject terminal control characters.

Also makes the concurrent selector-resolution test tolerate the valid case where an auxiliary packument request is skipped.

Closes pnpm/pnpm#13360.

## Squash Commit Body

```text
Scan global install groups and calculate their outdated dependencies before a
global interactive update. Present each group as one selectable item so packages
that share a global installation remain an atomic update unit, then restrict the
global update to the selected group hashes.

Implement the same selection and filtering behavior in the TypeScript CLI and
the Rust pnpm port, including clean no-op behavior for empty stores and empty
selections. Sanitize metadata-derived prompt labels before rendering them. Add
focused tests and release metadata for both implementations.

Closes pnpm/pnpm#13360.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive selection for `pnpm update --global`.
  * Displays outdated global package groups with installed and available versions.
  * Updates only the package groups selected by the user.
  * Handles empty installations, unmatched packages, and up-to-date packages gracefully.

* **Bug Fixes**
  * Removed the unsupported-operation error for interactive global updates.
  * Improved handling of cancelled interactive prompts.
  * Ensured global lockfiles are read correctly during update checks.
  * Prevented inherited properties from being treated as package dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->