### PR TITLE
fix(pacquet): align MUI resolution and dedupe

### DIFF
--- a/.changeset/mui-optional-peer-parity.md
+++ b/.changeset/mui-optional-peer-parity.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Resolve optional peers from versions provided by local workspace packages and omit empty deprecation messages from generated lockfiles.
+Resolve optional peers from versions provided by local workspace packages, omit empty deprecation messages from generated lockfiles, and preserve valid lockfile pins in `pnpm dedupe --check`.

--- a/.changeset/mui-optional-peer-parity.md
+++ b/.changeset/mui-optional-peer-parity.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Resolve optional peers from versions provided by local workspace packages and omit empty deprecation messages from generated lockfiles.

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -72,7 +72,7 @@ impl DedupeArgs {
             node_linker: config.node_linker,
             lockfile_only: true,
             dry_run: false,
-            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::drop_all(),
+            update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAllResolveAll,
             auth_override: None,
             resolution_observer: None,
             peer_issues_sink: None,

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -75,6 +75,43 @@ fn dedupe_check_does_not_materialize_nor_write_lockfile() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn dedupe_check_keeps_valid_lockfile_pins() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let manifest_path = workspace.join("package.json");
+    let manifest = |version: &str| {
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/dep-of-pkg-with-1-dep": version,
+            },
+        })
+        .to_string()
+    };
+    fs::write(&manifest_path, manifest("100.0.0")).expect("write package.json");
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    fs::write(&manifest_path, manifest("^100.0.0")).expect("rewrite package.json");
+    let lockfile_before = lockfile.replacen("specifier: 100.0.0", "specifier: ^100.0.0", 1);
+    fs::write(&lockfile_path, &lockfile_before).expect("rewrite lockfile specifier");
+
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["dedupe", "--check"])
+        .assert()
+        .success();
+
+    let lockfile_after = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert_eq!(lockfile_before, lockfile_after, "dedupe must preserve a valid existing pin");
+
+    drop((root, mock_instance));
+}
+
 /// pnpm's dedupe points at `pnpm peers check` when the install it runs
 /// leaves peer-dependency issues behind, so the two commands agree.
 #[test]

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -613,8 +613,11 @@ fn build_package_metadata(
     let os = read_string_list(manifest, "os");
     let libc = read_string_or_list(manifest, "libc");
 
-    let deprecated =
-        manifest.and_then(|m| m.get("deprecated")).and_then(Value::as_str).map(ToString::to_string);
+    let deprecated = manifest
+        .and_then(|m| m.get("deprecated"))
+        .and_then(Value::as_str)
+        .filter(|deprecated| !deprecated.is_empty())
+        .map(ToString::to_string);
 
     let has_bin = manifest_has_bin(manifest);
 

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -199,6 +199,33 @@ fn fresh_install_records_a_single_direct_dependency() {
 }
 
 #[test]
+fn empty_deprecation_message_is_not_written_to_the_lockfile() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": { "legacy": "1.0.0" },
+    }));
+    let node = make_node(
+        "legacy",
+        "1.0.0",
+        json!({ "name": "legacy", "version": "1.0.0", "deprecated": "" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::new(),
+    );
+    let mut graph = DependenciesGraph::new();
+    graph.insert(node.dep_path.clone(), node);
+    let mut direct = BTreeMap::new();
+    direct.insert("legacy".to_string(), DepPath::from("legacy@1.0.0".to_string()));
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, true, false, None, None,
+    ));
+    let package_key: PackageKey = "legacy@1.0.0".parse().expect("package key");
+    assert_eq!(lockfile.packages.as_ref().expect("packages")[&package_key].deprecated, None);
+}
+
+#[test]
 fn fresh_install_records_string_libc_without_coercing_scalar_bundle_metadata() {
     let (_tmp, manifest) = write_manifest(json!({
         "name": "fixture",

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -246,6 +246,10 @@ pub enum UpdateSeedPolicy {
     /// Seed every lockfile pin. `pacquet install` / `pacquet add`.
     #[default]
     KeepAll,
+    /// Seed every lockfile pin but re-resolve every dependency edge.
+    /// `pacquet dedupe` uses this to preserve valid pins while rebuilding
+    /// the graph around the fewest compatible versions.
+    KeepAllResolveAll,
     /// Withhold every lockfile pin. `pacquet update` with no package
     /// selectors — the whole graph re-resolves to highest-in-range.
     DropAll {
@@ -275,7 +279,9 @@ impl UpdateSeedPolicy {
 
     fn max_depth(&self) -> UpdateDepth {
         match self {
-            UpdateSeedPolicy::KeepAll => UpdateDepth::UNLIMITED,
+            UpdateSeedPolicy::KeepAll | UpdateSeedPolicy::KeepAllResolveAll => {
+                UpdateDepth::UNLIMITED
+            }
             UpdateSeedPolicy::DropAll { max_depth }
             | UpdateSeedPolicy::DropOnly { max_depth, .. }
             | UpdateSeedPolicy::ByImporter { max_depth, .. } => *max_depth,
@@ -299,6 +305,7 @@ fn update_reuse_scopes(
 
     match policy {
         UpdateSeedPolicy::KeepAll => (UpdateReuseScope::All, BTreeMap::new()),
+        UpdateSeedPolicy::KeepAllResolveAll => (UpdateReuseScope::None, BTreeMap::new()),
         UpdateSeedPolicy::DropAll { .. } => (UpdateReuseScope::None, BTreeMap::new()),
         UpdateSeedPolicy::DropOnly { names, .. } => {
             (UpdateReuseScope::Except(names.clone()), BTreeMap::new())
@@ -1189,7 +1196,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // else keeps its pin. Manifest preferences remain workspace-wide.
         let lockfile_snapshots = wanted_lockfile.and_then(|lockfile| lockfile.snapshots.as_ref());
         let all_preferred_versions = match &update_seed_policy {
-            UpdateSeedPolicy::KeepAll | UpdateSeedPolicy::ByImporter { .. } => {
+            UpdateSeedPolicy::KeepAll
+            | UpdateSeedPolicy::KeepAllResolveAll
+            | UpdateSeedPolicy::ByImporter { .. } => {
                 pacquet_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests(
                     lockfile_snapshots,
                     manifests_for_preferred.as_slice(),

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -855,6 +855,9 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
             pacquet_workspace::importer_id_from_root_dir(workspace_root, &projects[index].root_dir);
         match prepared.seed_policy {
             UpdateSeedPolicy::KeepAll => {}
+            UpdateSeedPolicy::KeepAllResolveAll => {
+                unreachable!("update never uses the dedupe seed policy")
+            }
             UpdateSeedPolicy::DropAll { .. } => {
                 seed_policies.insert(importer_id, ImporterUpdateSeedPolicy::DropAll);
             }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -727,6 +727,7 @@ struct ChildrenOwnerEntry {
 /// without colliding.
 pub struct WorkspaceTreeCtx {
     packages: Mutex<HashMap<String, ResolvedPackage>>,
+    workspace_package_versions: Mutex<HashSet<(String, String)>>,
     dependencies_tree: Mutex<HashMap<NodeId, DependenciesTreeNode>>,
     all_peer_dep_names: Mutex<HashSet<String>>,
     policy_violations: Mutex<Vec<pacquet_resolving_resolver_base::ResolutionPolicyViolation>>,
@@ -837,6 +838,7 @@ impl Default for WorkspaceTreeCtx {
     fn default() -> Self {
         WorkspaceTreeCtx {
             packages: Mutex::new(HashMap::new()),
+            workspace_package_versions: Mutex::new(HashSet::new()),
             dependencies_tree: Mutex::new(HashMap::new()),
             all_peer_dep_names: Mutex::new(HashSet::new()),
             policy_violations: Mutex::new(Vec::new()),
@@ -1359,13 +1361,18 @@ impl TreeCtx {
     /// resolved.
     #[must_use]
     pub fn resolved_versions(&self) -> Vec<(String, String)> {
-        lock_recoverable(&self.workspace.packages)
+        let mut versions: Vec<_> = lock_recoverable(&self.workspace.packages)
             .values()
             .filter_map(|pkg| {
-                let name_ver = pkg.result.name_ver.as_ref()?;
-                Some((name_ver.name.to_string(), name_ver.suffix.to_string()))
+                pkg.result
+                    .name_ver
+                    .as_ref()
+                    .map(|name_ver| (name_ver.name.to_string(), name_ver.suffix.to_string()))
             })
-            .collect()
+            .collect();
+        versions
+            .extend(lock_recoverable(&self.workspace.workspace_package_versions).iter().cloned());
+        versions
     }
 }
 
@@ -1796,6 +1803,20 @@ where
                 .unwrap_or_default(),
             resolved_via: result.resolved_via.clone(),
         });
+    }
+
+    if result.name_ver.is_none()
+        && wanted.bare_specifier.as_deref().is_some_and(|specifier| {
+            specifier.starts_with("workspace:") && !specifier.starts_with("workspace:.")
+        })
+        && let Some(manifest) = result.manifest.as_deref()
+        && let (Some(name), Some(version)) = (
+            manifest.get("name").and_then(Value::as_str),
+            manifest.get("version").and_then(Value::as_str),
+        )
+    {
+        lock_recoverable(&ctx.workspace.workspace_package_versions)
+            .insert((name.to_string(), version.to_string()));
     }
 
     let id = build_pkg_id_with_patch_hash(ctx, &result).await?;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -1355,13 +1355,10 @@ impl TreeCtx {
         self.workspace.snapshot(direct)
     }
 
-    /// Iterate over every `(name, version)` pair the walk has resolved
-    /// so far. Used by the orchestrator to keep `allPreferredVersions`
-    /// in sync, pushing each resolved version as the dependency is
-    /// resolved.
+    /// Return every registry version resolved so far.
     #[must_use]
     pub fn resolved_versions(&self) -> Vec<(String, String)> {
-        let mut versions: Vec<_> = lock_recoverable(&self.workspace.packages)
+        lock_recoverable(&self.workspace.packages)
             .values()
             .filter_map(|pkg| {
                 pkg.result
@@ -1369,10 +1366,18 @@ impl TreeCtx {
                     .as_ref()
                     .map(|name_ver| (name_ver.name.to_string(), name_ver.suffix.to_string()))
             })
-            .collect();
-        versions
-            .extend(lock_recoverable(&self.workspace.workspace_package_versions).iter().cloned());
-        versions
+            .collect()
+    }
+
+    pub(crate) fn newly_seen_workspace_package_versions(
+        &self,
+        seen: &mut HashSet<(String, String)>,
+    ) -> Vec<(String, String)> {
+        lock_recoverable(&self.workspace.workspace_package_versions)
+            .iter()
+            .filter(|version| seen.insert((*version).clone()))
+            .cloned()
+            .collect()
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -336,6 +336,7 @@ pub(crate) struct ImporterHoistState {
     parent_pkg_aliases: HashSet<String>,
     all_missing_optional_peers: BTreeMap<String, Vec<String>>,
     all_preferred_versions: PreferredVersions,
+    seen_workspace_package_versions: HashSet<(String, String)>,
     override_bare_specifier: Option<Arc<DependencyOverrider>>,
     /// `auto_install_peers || dedupe_peer_dependents` — upstream's
     /// `hoistPeers`. Both hoist rounds no-op when it is `false`, so a
@@ -441,6 +442,7 @@ impl ImporterHoistState {
             parent_pkg_aliases,
             all_missing_optional_peers: BTreeMap::new(),
             all_preferred_versions,
+            seen_workspace_package_versions: HashSet::new(),
             override_bare_specifier,
             hoist_peers: auto_install_peers || dedupe_peer_dependents,
             auto_install_peers,
@@ -509,7 +511,11 @@ impl ImporterHoistState {
         // `all_preferred_versions` and consulted for the optional hoist
         // after each wave. Refreshed per round so it carries every
         // importer's versions, not just this importer's.
-        update_preferred_versions_with_ctx(&self.ctx, &mut self.all_preferred_versions);
+        update_preferred_versions_with_ctx(
+            &self.ctx,
+            &mut self.all_preferred_versions,
+            &mut self.seen_workspace_package_versions,
+        );
         // The hoist input must not see missing peers declared inside a
         // subtree owned by another importer's shared children context —
         // the owner walk's children report is reused there, so those
@@ -607,7 +613,11 @@ impl ImporterHoistState {
             )
             .await?;
             self.direct.extend(new_direct);
-            update_preferred_versions_with_ctx(&self.ctx, &mut self.all_preferred_versions);
+            update_preferred_versions_with_ctx(
+                &self.ctx,
+                &mut self.all_preferred_versions,
+                &mut self.seen_workspace_package_versions,
+            );
         }
         Ok(())
     }
@@ -685,7 +695,11 @@ impl ImporterHoistState {
         )
         .await?;
         self.direct.extend(new_direct);
-        update_preferred_versions_with_ctx(&self.ctx, &mut self.all_preferred_versions);
+        update_preferred_versions_with_ctx(
+            &self.ctx,
+            &mut self.all_preferred_versions,
+            &mut self.seen_workspace_package_versions,
+        );
         Ok(true)
     }
 
@@ -933,8 +947,16 @@ fn build_workspace_root_deps(
 /// Add every newly-resolved `name@version` from `ctx` to
 /// `preferred` as a plain [`VersionSelectorType::Version`] entry.
 /// Idempotent: only inserts when no entry exists for `(name, version)`.
-fn update_preferred_versions_with_ctx(ctx: &TreeCtx, preferred: &mut PreferredVersions) {
-    for (name, version) in ctx.resolved_versions() {
+fn update_preferred_versions_with_ctx(
+    ctx: &TreeCtx,
+    preferred: &mut PreferredVersions,
+    seen_workspace_package_versions: &mut HashSet<(String, String)>,
+) {
+    for (name, version) in ctx
+        .resolved_versions()
+        .into_iter()
+        .chain(ctx.newly_seen_workspace_package_versions(seen_workspace_package_versions))
+    {
         let bucket = preferred.entry(name).or_default();
         bucket.entry(version).or_insert(VersionSelectorEntry::Plain(VersionSelectorType::Version));
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1025,6 +1025,69 @@ async fn shared_subtree_miss_unsatisfied_by_first_importer_still_hoists() {
     }
 }
 
+#[tokio::test]
+async fn local_workspace_package_version_can_satisfy_another_importers_optional_peer() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("needs-opt".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "needs-opt",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "needs-opt",
+                "version": "1.0.0",
+                "peerDependencies": { "opt": "^1.0.0" },
+                "peerDependenciesMeta": { "opt": { "optional": true } },
+            }),
+        ),
+    );
+    let mut local_opt =
+        fake_result("opt", "1.0.0", None, serde_json::json!({ "name": "opt", "version": "1.0.0" }));
+    local_opt.id = PkgResolutionId::from("link:packages/opt".to_string());
+    local_opt.name_ver = None;
+    local_opt.resolution = LockfileResolution::Directory(DirectoryResolution {
+        directory: "packages/opt".to_string(),
+    });
+    local_opt.resolved_via = "local-filesystem".to_string();
+    table.insert(("opt".to_string(), "workspace:*".to_string()), local_opt);
+    table.insert(
+        ("opt".to_string(), "1.0.0".to_string()),
+        fake_result("opt", "1.0.0", None, serde_json::json!({ "name": "opt", "version": "1.0.0" })),
+    );
+    let resolver = RecordingResolver { table, seen: Mutex::new(HashMap::new()) };
+    let (tmp_root, root_manifest) = fake_manifest(serde_json::json!({ "opt": "workspace:*" }));
+    let (tmp_a, a_manifest) = fake_manifest(serde_json::json!({ "needs-opt": "1.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "pkg-a".to_string(), manifest: &a_manifest },
+    ];
+    let dirs = [tmp_root.path(), tmp_a.path()];
+
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    let mut next = 0;
+    let result = resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        let dir = dirs[next].to_path_buf();
+        next += 1;
+        let mut opts = importer_opts(dir, None);
+        opts.auto_install_peers = true;
+        opts
+    })
+    .await
+    .unwrap();
+
+    let direct = result.peers.direct_dependencies_by_importer.get("pkg-a").expect("pkg-a");
+    assert_eq!(
+        direct.get("needs-opt").map(std::string::ToString::to_string),
+        Some("needs-opt@1.0.0(opt@1.0.0)".to_string()),
+    );
+    assert_eq!(
+        direct.get("opt").map(std::string::ToString::to_string),
+        Some("opt@1.0.0".to_string()),
+    );
+}
+
 /// Resolver fed from a `(alias, range)` → `ResolveResult` table whose
 /// chain fails for the aliases in `failing`, mimicking a registry
 /// whose packument no longer serves any satisfying version.


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13430.

Align pacquet's MUI resolution and dedupe behavior with TypeScript pnpm:

- seed preferred versions from workspace package identities so optional peers can reuse them;
- omit empty deprecation messages from generated lockfiles;
- let dedupe re-resolve dependency edges while retaining valid lockfile pins as preferences.

MUI validation used TypeScript pnpm 11.17.0 and pacquet 12.0.0-alpha.21 with package-manager switching disabled. Fresh lockfiles were byte-identical, both implementations reported the same dedupe changes on a fresh lockfile, and both accepted MUI's committed deduped lockfile.

## Squash Commit Body

```text
Seed preferred versions from workspace package identities so optional peers can reuse local workspace versions during cross-importer resolution.

Omit empty deprecation messages from generated lockfiles. Separate dedupe's resolution-reuse policy from its preferred-version seed policy so it rebuilds dependency edges without unnecessarily replacing valid pins.

Closes pnpm/pnpm#13430.
```

## Checklist

- [x] The TypeScript CLI already has the intended behavior; this aligns the Rust `pnpm/` port with it.
- [x] Added a changeset for `pacquet`.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787747531&installation_model_id=426870&pr_number=13431&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13431&signature=59e2811a2867c433a7fc8b5614a10104bd823593cd9ca93b206b26835578447d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optional peer dependencies can now resolve correctly against compatible versions provided by local workspace packages.
  * `pnpm dedupe --check` preserves valid existing lockfile pins without rewriting `pnpm-lock.yaml`.
  * Dependencies with an empty `deprecated` field no longer write an empty deprecation entry to the generated lockfile.
  * Improved seed/update behavior during dedupe’s lockfile-only install flow.
* **Tests**
  * Added integration and regression coverage for workspace optional peers, dedupe lockfile preservation, and empty deprecation omission.
* **Chores**
  * Added a patch release note for these improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->