### PR TITLE
fix(pacquet): align n8n lockfile with pnpm 11

### DIFF
--- a/.changeset/git-hosted-lockfile-resolution.md
+++ b/.changeset/git-hosted-lockfile-resolution.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Do not write archive integrity for commit-addressed git-hosted dependencies.

--- a/.changeset/libc-lockfile-scalar.md
+++ b/.changeset/libc-lockfile-scalar.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Write single-value `libc` package metadata in the same scalar form as pnpm.

--- a/.changeset/shared-peer-owner-barrier.md
+++ b/.changeset/shared-peer-owner-barrier.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Prevented optional peers from being selected from an unrelated workspace package's shared dependency context.

--- a/pnpm/crates/lockfile/src/package_metadata.rs
+++ b/pnpm/crates/lockfile/src/package_metadata.rs
@@ -30,7 +30,8 @@ pub struct PackageMetadata {
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_string_or_vec"
+        deserialize_with = "deserialize_string_or_vec",
+        serialize_with = "serialize_string_or_vec"
     )]
     pub libc: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -112,6 +113,25 @@ where
         StringOrVec::String(item) => vec![item],
         StringOrVec::Vec(items) => items,
     }))
+}
+
+#[expect(
+    clippy::ref_option,
+    reason = "serde serialize_with requires a reference to the field type"
+)]
+fn serialize_string_or_vec<Value, Ser>(
+    value: &Option<Vec<Value>>,
+    serializer: Ser,
+) -> Result<Ser::Ok, Ser::Error>
+where
+    Value: Serialize,
+    Ser: serde::Serializer,
+{
+    match value.as_deref() {
+        Some([item]) => item.serialize(serializer),
+        Some(items) => items.serialize(serializer),
+        None => serializer.serialize_none(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/pnpm/crates/lockfile/src/package_metadata/tests.rs
+++ b/pnpm/crates/lockfile/src/package_metadata/tests.rs
@@ -44,6 +44,15 @@ fn libc_string_roundtrip() {
 }
 
 #[test]
+fn singleton_libc_is_written_as_a_string() {
+    let metadata: PackageMetadata =
+        serde_saphyr::from_str(&make_metadata("libc: [glibc]\n")).unwrap();
+    let yaml = serde_saphyr::to_string(&metadata).unwrap();
+
+    assert!(yaml.contains("libc: glibc\n"), "{yaml}");
+}
+
+#[test]
 fn bundled_dependencies_from_a_name_list() {
     let manifest = serde_json::json!({ "bundledDependencies": ["a", "b"] });
     assert_eq!(

--- a/pnpm/crates/lockfile/src/package_metadata/tests.rs
+++ b/pnpm/crates/lockfile/src/package_metadata/tests.rs
@@ -47,9 +47,13 @@ fn libc_string_roundtrip() {
 fn singleton_libc_is_written_as_a_string() {
     let metadata: PackageMetadata =
         serde_saphyr::from_str(&make_metadata("libc: [glibc]\n")).unwrap();
-    let yaml = serde_saphyr::to_string(&metadata).unwrap();
+    let yaml = serialize_yaml::to_string(&metadata).unwrap();
 
-    assert!(yaml.contains("libc: glibc\n"), "{yaml}");
+    assert_eq!(
+        yaml.lines().filter(|line| line.trim_start().starts_with("libc:")).collect::<Vec<_>>(),
+        ["libc: glibc"],
+        "{yaml}",
+    );
 }
 
 #[test]

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -351,9 +351,15 @@ impl LockfileResolution {
         include_tarball_url: bool,
     ) -> LockfileResolution {
         let LockfileResolution::Tarball(tarball) = self else { return self.clone() };
-        let Some(integrity) = tarball.integrity.as_ref() else { return self.clone() };
-
         let git_hosted = tarball.is_git_hosted();
+        let Some(integrity) = tarball.integrity.as_ref() else {
+            if git_hosted && tarball.git_hosted != Some(true) {
+                let mut normalized = tarball.clone();
+                normalized.git_hosted = Some(true);
+                return LockfileResolution::Tarball(normalized);
+            }
+            return self.clone();
+        };
         // A standard registry tarball whose URL can be rebuilt from name+version+
         // registry is written as just `{integrity}` — pnpm derives the URL on
         // demand. Every other tarball must keep its URL or it can no longer be

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -341,7 +341,8 @@ impl LockfileResolution {
     /// `include_tarball_url` is set, when it is a `file:` tarball, when it is
     /// git-hosted, or when it does not match the derived URL (e.g. private
     /// registries with non-standard tarball paths). Non-tarball resolutions and
-    /// integrity-less tarballs pass through unchanged.
+    /// integrity-less tarballs pass through unchanged, except that a recognized
+    /// git-hosted archive is normalized with `git_hosted: Some(true)`.
     #[must_use]
     pub fn to_lockfile_form(
         &self,

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -727,10 +727,15 @@ fn to_lockfile_form_records_git_hosted_for_integrityless_archive() {
         path: None,
     });
     let actual = resolution.to_lockfile_form("foo", "1.0.0", "https://registry.npmjs.org/", false);
-    let LockfileResolution::Tarball(actual) = actual else {
-        panic!("expected tarball resolution");
-    };
-    assert_eq!(actual.git_hosted, Some(true));
+    assert_eq!(
+        actual,
+        LockfileResolution::Tarball(TarballResolution {
+            tarball: format!("https://codeload.github.com/foo/bar/tar.gz/{GIT_COMMIT}"),
+            integrity: None,
+            git_hosted: Some(true),
+            path: None,
+        }),
+    );
 }
 
 /// `include_tarball_url` takes the same kept-URL branch, so it must keep

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -718,6 +718,21 @@ fn to_lockfile_form_keeps_git_hosted_subdirectory_path() {
     assert_eq!(actual, resolution);
 }
 
+#[test]
+fn to_lockfile_form_records_git_hosted_for_integrityless_archive() {
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: format!("https://codeload.github.com/foo/bar/tar.gz/{GIT_COMMIT}"),
+        integrity: None,
+        git_hosted: None,
+        path: None,
+    });
+    let actual = resolution.to_lockfile_form("foo", "1.0.0", "https://registry.npmjs.org/", false);
+    let LockfileResolution::Tarball(actual) = actual else {
+        panic!("expected tarball resolution");
+    };
+    assert_eq!(actual.git_hosted, Some(true));
+}
+
 /// `include_tarball_url` takes the same kept-URL branch, so it must keep
 /// `path` too.
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -21,10 +21,7 @@ use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::{
-        Arc, Mutex, MutexGuard,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, Mutex, MutexGuard},
 };
 
 /// Acquire a [`Mutex`] guard, recovering from poisoning the same way
@@ -800,7 +797,6 @@ pub struct WorkspaceTreeCtx {
     /// reuses the owner occurrence's children and missing-peer report. Consumed via
     /// [`crate::HoistMissingScope`].
     first_importer_by_pkg: Mutex<HashMap<String, String>>,
-    cross_importer_children_reuse: AtomicBool,
     /// Per package: the missing-peer names reported by the *initial*
     /// peer walk of the current children-owner generation, plus the
     /// owner that recorded them (`None` while only a non-owner's
@@ -865,7 +861,6 @@ impl Default for WorkspaceTreeCtx {
             auto_install_peers: false,
             registries: HashMap::new(),
             first_importer_by_pkg: Mutex::new(HashMap::new()),
-            cross_importer_children_reuse: AtomicBool::new(false),
             first_walk_missing_by_pkg: Mutex::new(HashMap::new()),
             changed_direct_deps: Mutex::new(HashMap::new()),
             direct_dep_versions: Mutex::new(HashMap::new()),
@@ -921,11 +916,6 @@ impl WorkspaceTreeCtx {
     #[must_use]
     pub fn first_importer_by_pkg(&self) -> HashMap<String, String> {
         lock_recoverable(&self.first_importer_by_pkg).clone()
-    }
-
-    #[must_use]
-    pub fn has_cross_importer_children_reuse(&self) -> bool {
-        self.cross_importer_children_reuse.load(Ordering::Relaxed)
     }
 
     /// Record a walk's per-package missing-peer names. The owning
@@ -2661,12 +2651,6 @@ fn claim_children_owner(
     };
     let (owns_children, peer_shadowed) = {
         let mut owners = lock_recoverable(&ctx.workspace.children_owner_by_id);
-        if owners
-            .get(pkg_id)
-            .is_some_and(|existing| existing.owner.importer_id != owner.importer_id)
-        {
-            ctx.workspace.cross_importer_children_reuse.store(true, Ordering::Relaxed);
-        }
         match owners.get(pkg_id) {
             Some(existing) if !owner.wins_over(&existing.owner) => {
                 (false, Arc::clone(&existing.peer_shadowed))

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -21,7 +21,10 @@ use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, MutexGuard},
+    sync::{
+        Arc, Mutex, MutexGuard,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 /// Acquire a [`Mutex`] guard, recovering from poisoning the same way
@@ -797,6 +800,7 @@ pub struct WorkspaceTreeCtx {
     /// reuses the owner occurrence's children and missing-peer report. Consumed via
     /// [`crate::HoistMissingScope`].
     first_importer_by_pkg: Mutex<HashMap<String, String>>,
+    cross_importer_children_reuse: AtomicBool,
     /// Per package: the missing-peer names reported by the *initial*
     /// peer walk of the current children-owner generation, plus the
     /// owner that recorded them (`None` while only a non-owner's
@@ -861,6 +865,7 @@ impl Default for WorkspaceTreeCtx {
             auto_install_peers: false,
             registries: HashMap::new(),
             first_importer_by_pkg: Mutex::new(HashMap::new()),
+            cross_importer_children_reuse: AtomicBool::new(false),
             first_walk_missing_by_pkg: Mutex::new(HashMap::new()),
             changed_direct_deps: Mutex::new(HashMap::new()),
             direct_dep_versions: Mutex::new(HashMap::new()),
@@ -916,6 +921,11 @@ impl WorkspaceTreeCtx {
     #[must_use]
     pub fn first_importer_by_pkg(&self) -> HashMap<String, String> {
         lock_recoverable(&self.first_importer_by_pkg).clone()
+    }
+
+    #[must_use]
+    pub fn has_cross_importer_children_reuse(&self) -> bool {
+        self.cross_importer_children_reuse.load(Ordering::Relaxed)
     }
 
     /// Record a walk's per-package missing-peer names. The owning
@@ -2651,6 +2661,12 @@ fn claim_children_owner(
     };
     let (owns_children, peer_shadowed) = {
         let mut owners = lock_recoverable(&ctx.workspace.children_owner_by_id);
+        if owners
+            .get(pkg_id)
+            .is_some_and(|existing| existing.owner.importer_id != owner.importer_id)
+        {
+            ctx.workspace.cross_importer_children_reuse.store(true, Ordering::Relaxed);
+        }
         match owners.get(pkg_id) {
             Some(existing) if !owner.wins_over(&existing.owner) => {
                 (false, Arc::clone(&existing.peer_shadowed))

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -33,7 +33,10 @@ use crate::{
         ResolveDependencyTreeError, TreeCtx, WantedSpec, WorkspaceTreeCtx, extend_tree,
         importer_direct_wanted_specs, record_changed_direct_deps, unwrap_package_name,
     },
-    resolve_peers::{ResolvePeersOptions, ResolvePeersResult, resolve_peers},
+    resolve_peers::{
+        HoistMissingScope, ResolvePeersOptions, ResolvePeersResult, apply_hoist_missing_scope,
+        resolve_peers,
+    },
     resolved_tree::ResolvedTree,
 };
 use chrono::{DateTime, Utc};
@@ -353,6 +356,12 @@ pub(crate) struct ImporterHoistState {
     modules_dir: Option<std::path::PathBuf>,
 }
 
+pub(crate) struct RequiredRound {
+    snapshot: ResolvedTree,
+    original_node_ids: HashSet<crate::NodeId>,
+    peers_result: ResolvePeersResult,
+}
+
 impl ImporterHoistState {
     /// Resolve the importer's initial direct-dependency wave and set
     /// up the hoist-round state.
@@ -504,6 +513,41 @@ impl ImporterHoistState {
         if !self.hoist_peers {
             return Ok(());
         }
+        self.begin_required_round();
+        self.complete_required_round(resolver, None).await
+    }
+
+    pub(crate) fn prepare_initial_required_round(&mut self) -> Option<RequiredRound> {
+        if !self.hoist_peers {
+            return None;
+        }
+        self.begin_required_round();
+        Some(self.resolve_required_round(None))
+    }
+
+    pub(crate) fn apply_owner_missing_scope(&self, round: &mut RequiredRound) {
+        apply_hoist_missing_scope(
+            &mut round.peers_result,
+            &HoistMissingScope {
+                importer_id: self.importer_id.clone(),
+                first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
+                first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
+            },
+        );
+    }
+
+    pub(crate) async fn complete_initial_required_round<Chain>(
+        &mut self,
+        resolver: &Chain,
+        round: RequiredRound,
+    ) -> Result<(), ResolveImporterError>
+    where
+        Chain: Resolver + ?Sized,
+    {
+        self.complete_required_round(resolver, Some(round)).await
+    }
+
+    fn begin_required_round(&mut self) {
         // Both hoists read the run-extended preferred-versions map:
         // every resolved package's version is folded into
         // `all_preferred_versions` and consulted for the optional hoist
@@ -516,26 +560,43 @@ impl ImporterHoistState {
         // peers never reach a non-owner importer's hoist. The final peer
         // pass keeps the unscoped options so warnings stay complete.
         self.all_missing_optional_peers.clear();
+    }
+
+    fn resolve_required_round(
+        &self,
+        hoist_missing_scope: Option<Arc<HoistMissingScope>>,
+    ) -> RequiredRound {
+        let mut snapshot = self.ctx.snapshot(self.direct.clone());
+        let original_node_ids: HashSet<crate::NodeId> =
+            snapshot.dependencies_tree.keys().cloned().collect();
+        let peers_result = {
+            let mut opts = self.peers_opts();
+            opts.hoist_missing_scope = hoist_missing_scope;
+            resolve_peers(&mut snapshot, opts)
+        };
+        self.ctx
+            .workspace()
+            .record_first_walk_missing(&self.importer_id, &peers_result.missing_names_by_pkg);
+        RequiredRound { snapshot, original_node_ids, peers_result }
+    }
+
+    async fn complete_required_round<Chain>(
+        &mut self,
+        resolver: &Chain,
+        mut first_round: Option<RequiredRound>,
+    ) -> Result<(), ResolveImporterError>
+    where
+        Chain: Resolver + ?Sized,
+    {
         loop {
-            let mut snapshot = self.ctx.snapshot(self.direct.clone());
-            let original_node_ids: HashSet<crate::NodeId> =
-                snapshot.dependencies_tree.keys().cloned().collect();
-            let peers_result = {
-                let mut opts = self.peers_opts();
-                // Re-snapshotted per peer pass because auto-hoisting
-                // can extend the tree and move children ownership to a
-                // shallower occurrence.
-                opts.hoist_missing_scope =
-                    Some(Arc::new(crate::resolve_peers::HoistMissingScope {
+            let RequiredRound { snapshot, original_node_ids, peers_result } =
+                first_round.take().unwrap_or_else(|| {
+                    self.resolve_required_round(Some(Arc::new(HoistMissingScope {
                         importer_id: self.importer_id.clone(),
                         first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
                         first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
-                    }));
-                resolve_peers(&mut snapshot, opts)
-            };
-            self.ctx
-                .workspace()
-                .record_first_walk_missing(&self.importer_id, &peers_result.missing_names_by_pkg);
+                    })))
+                });
 
             let (missing_required, fresh_optional) = partition_missing_peers(
                 &peers_result.peer_dependency_issues.missing,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -276,6 +276,7 @@ pub struct ResolvePeersResult {
     /// the importer's hidden direct-dep set.
     pub resolved_peer_providers_by_alias: BTreeMap<String, NodeId>,
     pub peer_dependency_issues: PeerDependencyIssues,
+    missing_ancestor_pkg_ids: HashMap<String, Vec<Vec<String>>>,
     /// Per resolved package: the union of missing-peer names its
     /// occurrences' children reported in this walk. The hoist loop
     /// persists the owner-context map per package so non-owner importers
@@ -345,6 +346,7 @@ pub fn resolve_peers(tree: &mut ResolvedTree, opts: ResolvePeersOptions) -> Reso
         opts,
         graph: DependenciesGraph::new(),
         issues: PeerDependencyIssues::default(),
+        missing_ancestor_pkg_ids: HashMap::new(),
         node_dep_paths: HashMap::new(),
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
@@ -361,6 +363,23 @@ pub fn resolve_peers(tree: &mut ResolvedTree, opts: ResolvePeersOptions) -> Reso
         current_provider_sources,
     };
     walker.walk()
+}
+
+pub(crate) fn apply_hoist_missing_scope(
+    result: &mut ResolvePeersResult,
+    scope: &HoistMissingScope,
+) {
+    result.peer_dependency_issues.missing.retain(|peer_name, issues| {
+        let ancestor_chains = result.missing_ancestor_pkg_ids.remove(peer_name).unwrap_or_default();
+        *issues = std::mem::take(issues)
+            .into_iter()
+            .zip(ancestor_chains)
+            .filter_map(|(issue, ancestor_pkg_ids)| {
+                (!scope.suppresses(&ancestor_pkg_ids, peer_name)).then_some(issue)
+            })
+            .collect();
+        !issues.is_empty()
+    });
 }
 
 /// The current-provider sources visible while walking `importer`: its
@@ -436,6 +455,7 @@ pub fn resolve_peers_workspace(
         opts,
         graph: DependenciesGraph::new(),
         issues: PeerDependencyIssues::default(),
+        missing_ancestor_pkg_ids: HashMap::new(),
         node_dep_paths: HashMap::new(),
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),
@@ -622,6 +642,7 @@ struct Walker<'tree> {
     opts: ResolvePeersOptions,
     graph: DependenciesGraph,
     issues: PeerDependencyIssues,
+    missing_ancestor_pkg_ids: HashMap<String, Vec<Vec<String>>>,
     /// `NodeId → DepPath` once a node has been walked. Lets repeated
     /// visits (an importer-direct dep that's also reached transitively)
     /// reuse the already-computed depPath.
@@ -873,6 +894,7 @@ impl Walker<'_> {
             direct_dependencies_by_alias: direct_by_alias,
             resolved_peer_providers_by_alias,
             peer_dependency_issues: self.issues,
+            missing_ancestor_pkg_ids: self.missing_ancestor_pkg_ids,
             missing_names_by_pkg,
             paths_by_node_id,
         }
@@ -1160,12 +1182,16 @@ impl Walker<'_> {
                     if self.missing_issue_suppressed(&chain_with_self, peer_name) {
                         continue;
                     }
-                    self.issues.missing.entry(peer_name.clone()).or_default().push(MissingPeer {
-                        wanted_range: get_peer_version_range(&info.range),
-                        raw_range: info.range.clone(),
-                        optional: info.optional,
-                        parents: parents_from_chain(parent_chain_names, &pkg_name),
-                    });
+                    self.record_missing_issue(
+                        peer_name,
+                        MissingPeer {
+                            wanted_range: get_peer_version_range(&info.range),
+                            raw_range: info.range.clone(),
+                            optional: info.optional,
+                            parents: parents_from_chain(parent_chain_names, &pkg_name),
+                        },
+                        &chain_with_self,
+                    );
                 }
             }
             self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
@@ -1561,6 +1587,19 @@ impl Walker<'_> {
         scope.suppresses(ancestor_pkg_ids, peer_name)
     }
 
+    fn record_missing_issue(
+        &mut self,
+        peer_name: &str,
+        issue: MissingPeer,
+        ancestor_pkg_ids: &[String],
+    ) {
+        self.issues.missing.entry(peer_name.to_string()).or_default().push(issue);
+        self.missing_ancestor_pkg_ids
+            .entry(peer_name.to_string())
+            .or_default()
+            .push(ancestor_pkg_ids.to_vec());
+    }
+
     #[expect(
         clippy::too_many_arguments,
         reason = "internal walker helper threading per-node context, mirrors the resolve_node parameter set"
@@ -1593,13 +1632,15 @@ impl Walker<'_> {
                     MissingPeerInfo { range: range_for_match.to_string(), optional },
                 );
                 if !self.missing_issue_suppressed(ancestor_pkg_ids, peer_name) {
-                    self.issues.missing.entry(peer_name.to_string()).or_default().push(
+                    self.record_missing_issue(
+                        peer_name,
                         MissingPeer {
                             wanted_range: range_for_satisfies,
                             raw_range: range_for_match.to_string(),
                             optional,
                             parents: parents_from_chain(chain, pkg_name),
                         },
+                        ancestor_pkg_ids,
                     );
                 }
             }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -2023,6 +2023,7 @@ fn walker_for_tests(tree: &mut ResolvedTree) -> Walker<'_> {
         opts: ResolvePeersOptions::default(),
         graph: DependenciesGraph::new(),
         issues: PeerDependencyIssues::default(),
+        missing_ancestor_pkg_ids: HashMap::new(),
         node_dep_paths: HashMap::new(),
         node_external_peers: HashMap::new(),
         node_missing_peers: HashMap::new(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -292,7 +292,7 @@ where
         for state in &mut states {
             state.run_required_round(resolver).await?;
         }
-        if !owner_missing_sets_initialized {
+        if !owner_missing_sets_initialized && states.len() > 1 {
             // A non-owner importer can be visited before the importer that owns
             // a shared package's children. Refresh every hoist input after all
             // owners have published their missing-peer sets so foreign

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -287,9 +287,21 @@ where
     for state in &mut states {
         state.set_workspace_root_deps(Arc::clone(&root_deps));
     }
+    let mut owner_missing_sets_initialized = false;
     loop {
         for state in &mut states {
             state.run_required_round(resolver).await?;
+        }
+        if !owner_missing_sets_initialized {
+            // A non-owner importer can be visited before the importer that owns
+            // a shared package's children. Refresh every hoist input after all
+            // owners have published their missing-peer sets so foreign
+            // subtrees are filtered against their owner context before optional
+            // peers are added.
+            for state in &mut states {
+                state.run_required_round(resolver).await?;
+            }
+            owner_missing_sets_initialized = true;
         }
         let mut any_hoisted = false;
         for state in &mut states {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -292,7 +292,7 @@ where
         for state in &mut states {
             state.run_required_round(resolver).await?;
         }
-        if !owner_missing_sets_initialized && states.len() > 1 {
+        if !owner_missing_sets_initialized && workspace.has_cross_importer_children_reuse() {
             // A non-owner importer can be visited before the importer that owns
             // a shared package's children. Refresh every hoist input after all
             // owners have published their missing-peer sets so foreign

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -287,28 +287,28 @@ where
     for state in &mut states {
         state.set_workspace_root_deps(Arc::clone(&root_deps));
     }
-    let mut owner_missing_sets_initialized = false;
+    let mut initial_required_rounds: Vec<_> =
+        states.iter_mut().map(ImporterHoistState::prepare_initial_required_round).collect();
+    for (state, round) in states.iter().zip(&mut initial_required_rounds) {
+        if let Some(round) = round {
+            state.apply_owner_missing_scope(round);
+        }
+    }
+    for (state, round) in states.iter_mut().zip(initial_required_rounds) {
+        if let Some(round) = round {
+            state.complete_initial_required_round(resolver, round).await?;
+        }
+    }
     loop {
-        for state in &mut states {
-            state.run_required_round(resolver).await?;
-        }
-        if !owner_missing_sets_initialized && workspace.has_cross_importer_children_reuse() {
-            // A non-owner importer can be visited before the importer that owns
-            // a shared package's children. Refresh every hoist input after all
-            // owners have published their missing-peer sets so foreign
-            // subtrees are filtered against their owner context before optional
-            // peers are added.
-            for state in &mut states {
-                state.run_required_round(resolver).await?;
-            }
-            owner_missing_sets_initialized = true;
-        }
         let mut any_hoisted = false;
         for state in &mut states {
             any_hoisted |= state.hoist_optional_round(resolver).await?;
         }
         if !any_hoisted {
             break;
+        }
+        for state in &mut states {
+            state.run_required_round(resolver).await?;
         }
     }
     let mut per_importer_inputs: Vec<ImporterPeerInput> = Vec::with_capacity(importers.len());

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -935,6 +935,116 @@ async fn shared_subtree_owner_context_suppresses_later_optional_hoist() {
     );
 }
 
+#[tokio::test]
+async fn shared_subtree_owner_context_is_available_before_optional_hoisting() {
+    let resolver = RecordingResolver {
+        table: HashMap::from([
+            (
+                ("wrapper".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "wrapper",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "wrapper",
+                        "version": "1.0.0",
+                        "dependencies": { "shared": "1.0.0" },
+                    }),
+                ),
+            ),
+            (
+                ("shared".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "shared",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "shared",
+                        "version": "1.0.0",
+                        "dependencies": { "mid": "1.0.0" },
+                    }),
+                ),
+            ),
+            (
+                ("mid".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "mid",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "mid",
+                        "version": "1.0.0",
+                        "peerDependencies": { "opt": "*" },
+                        "peerDependenciesMeta": { "opt": { "optional": true } },
+                    }),
+                ),
+            ),
+            (
+                ("carrier".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "carrier",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "carrier",
+                        "version": "1.0.0",
+                        "dependencies": { "opt": "25.0.0" },
+                    }),
+                ),
+            ),
+            (
+                ("opt".to_string(), "18.0.0".to_string()),
+                fake_result(
+                    "opt",
+                    "18.0.0",
+                    None,
+                    serde_json::json!({ "name": "opt", "version": "18.0.0" }),
+                ),
+            ),
+            (
+                ("opt".to_string(), "25.0.0".to_string()),
+                fake_result(
+                    "opt",
+                    "25.0.0",
+                    None,
+                    serde_json::json!({ "name": "opt", "version": "25.0.0" }),
+                ),
+            ),
+        ]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let (tmp_nested, nested_manifest) =
+        fake_manifest(serde_json::json!({ "wrapper": "1.0.0", "carrier": "1.0.0" }));
+    let (tmp_owner, owner_manifest) =
+        fake_manifest(serde_json::json!({ "shared": "1.0.0", "opt": "18.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: "nested".to_string(), manifest: &nested_manifest },
+        WorkspaceImporter { id: "owner".to_string(), manifest: &owner_manifest },
+    ];
+    let dirs = [tmp_nested.path(), tmp_owner.path()];
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    let mut next = 0;
+
+    let result = resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        let dir = dirs[next].to_path_buf();
+        next += 1;
+        let mut opts = importer_opts(dir, None);
+        opts.auto_install_peers = true;
+        opts
+    })
+    .await
+    .unwrap();
+
+    let nested =
+        result.peers.direct_dependencies_by_importer.get("nested").expect("nested importer");
+    assert_eq!(
+        nested.get("wrapper").map(std::string::ToString::to_string),
+        Some("wrapper@1.0.0".to_string()),
+        "the importer visited before the shared-subtree owner must not hoist the owner's peer",
+    );
+}
+
 /// The reverse of the sharing case above: when the first importer's
 /// walk could NOT satisfy the optional peer either (it only hoisted it
 /// later), the miss stays visible to every importer — each hoists its

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -25,17 +25,14 @@ use crate::{
 /// Store/network handles [`GitResolver`] needs to read a git dep's
 /// identity out of the package itself during resolution.
 ///
-/// A git dep's specifier names a repo, not a package, so its name —
-/// and, for a host archive, its integrity — live only in the package's
-/// own `package.json`. pacquet builds the lockfile before the
-/// install/fetch pass runs, so they have to be read here. Mirrors the
-/// tarball resolver's remote-tarball fetch, which fills the same fields
-/// for the same reason.
+/// A git dep's specifier names a repo, not a package, so its name lives
+/// only in the package's own `package.json`. pacquet builds the lockfile
+/// before the install/fetch pass runs, so it has to be read here.
 ///
 /// Two shapes, by resolution:
 ///
 /// - a git *host* (`github:` / `gitlab:` / `bitbucket:`) serves an
-///   archive, which is downloaded and hashed;
+///   archive, which is downloaded;
 /// - any other repo (ssh, self-hosted, `file:`) has no archive
 ///   endpoint, so a throwaway checkout is the cheapest read.
 ///
@@ -66,7 +63,7 @@ pub struct GitFetchContext {
 /// install dispatcher) into a single owner.
 ///
 /// When `fetch_context` is `Some`, the package is read during
-/// resolution to fill `manifest` (and `integrity`, for a host archive)
+/// resolution to fill `manifest`
 /// — see [`GitFetchContext`]. `None` (unit tests, and the resolve-only
 /// NAPI entry point) keeps the manifest-less shape.
 pub struct GitResolver<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> {
@@ -125,8 +122,7 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
         Ok(Some(result))
     }
 
-    /// Fill `manifest` — and, for an archive, the resolution's
-    /// `integrity` — from the package the git dep points at. No-op
+    /// Fill `manifest` from the package the git dep points at. No-op
     /// without a fetch context (unit tests / resolve-only callers).
     async fn read_package_metadata(&self, result: &mut ResolveResult) -> Result<(), ResolveError> {
         let Some(ctx) = self.fetch_context.as_ref() else { return Ok(()) };
@@ -159,15 +155,6 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
                 .map_err(|err| Box::new(err) as ResolveError)?;
 
                 result.manifest = resolved.manifest.map(Arc::new);
-                if let LockfileResolution::Tarball(tarball) = &mut result.resolution {
-                    // A git host's archive carries no integrity of its
-                    // own, and the install pass refuses a tarball
-                    // resolution without one
-                    // (`tarball_url_and_integrity`). The bytes were
-                    // just hashed to extract them, so record that —
-                    // same field upstream writes for a git dep.
-                    tarball.integrity = Some(resolved.integrity);
-                }
             }
             LockfileResolution::Git(git) => {
                 // No archive endpoint to read, so the working tree is

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
@@ -129,6 +129,7 @@ async fn github_shortcut_full_commit_returns_tarball() {
                 "https://codeload.github.com/zkochan/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99",
             );
             assert_eq!(t.git_hosted, Some(true));
+            assert!(t.integrity.is_none());
             assert!(t.path.is_none());
         }
         other => panic!("expected Tarball, got {other:?}"),

--- a/pnpm/crates/resolving-git-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-git-resolver/src/lib.rs
@@ -16,9 +16,8 @@
 //!   commit, and emits either a `Tarball{gitHosted: true}` or `Git`
 //!   resolution. Given a [`GitFetchContext`], it also reads the
 //!   package's name from its `package.json` — out of the host archive,
-//!   or out of a checkout for a repo that serves no archive — plus the
-//!   archive's integrity. See that type for why resolution is where
-//!   that has to happen.
+//!   or out of a checkout for a repo that serves no archive. See that
+//!   type for why resolution is where that has to happen.
 //!
 //! Out of scope:
 //!


### PR DESCRIPTION
## Summary

Aligns Rust pnpm lockfile generation with pnpm 11 for the n8n workspace validation tracked by pnpm/pnpm#13305.

The Rust implementation now:

- waits for every shared-subtree owner to publish its initial missing-peer context before optional-peer hoisting;
- writes singleton `libc` metadata as a scalar;
- omits archive integrity for commit-addressed git-hosted dependencies and normalizes recognized integrity-less git archives.

No TypeScript change is needed: pnpm 11 produced the correct reference shapes in all three cases. Fresh back-to-back resolutions of n8n produced byte-identical lockfiles: 77 importers, 3,795 package entries, and 3,884 snapshots.

Related to pnpm/pnpm#13305.

## Squash Commit Body

```text
Synchronize every workspace importer through an initial required-peer pass
before optional peers are selected. This ensures a non-owner occurrence of a
shared subtree uses the missing-peer context published by that subtree owner,
rather than selecting a provider from an unrelated importer.

Preserve pnpm lockfile serialization conventions for singleton libc metadata
and commit-addressed git-hosted archives. These corrections make fresh n8n
lockfiles generated by pnpm 11 and Rust pnpm byte-identical.

Related to pnpm/pnpm#13305.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787749534&installation_model_id=426870&pr_number=13432&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13432&signature=0b95465db6766adaab863989d14432f7e4ffb9342a3ddab24e6118e81a28868c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Git-hosted dependencies addressed by commit no longer receive archive integrity data in lockfiles.
  - Git-hosted archive resolutions are now correctly identified and recorded.
  - Single-value `libc` metadata is serialized in pnpm-compatible scalar format.
  - Optional peer dependencies are no longer incorrectly selected from unrelated shared dependency contexts.

- **Tests**
  - Added coverage for git-hosted lockfile output, scalar `libc` serialization, and shared peer-resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->