### PR TITLE
test(benchmark): cover concurrent integrity extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4541,6 +4541,8 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "criterion",
+ "flate2",
+ "futures-util",
  "mockito",
  "node-semver",
  "pacquet-lockfile",
@@ -4553,6 +4555,7 @@ dependencies = [
  "project-root",
  "serde_json",
  "ssri",
+ "tar",
  "tempfile",
  "tokio",
 ]

--- a/pnpm/tasks/micro-benchmark/Cargo.toml
+++ b/pnpm/tasks/micro-benchmark/Cargo.toml
@@ -24,12 +24,15 @@ pacquet-lockfile  = { workspace = true }
 
 clap         = { workspace = true }
 criterion    = { workspace = true }
+flate2       = { workspace = true }
+futures-util = { workspace = true }
 mockito      = { workspace = true }
 tokio        = { workspace = true }
 tempfile     = { workspace = true }
 pipe-trait   = { workspace = true }
 project-root = { workspace = true }
 ssri         = { workspace = true }
+tar          = { workspace = true }
 node-semver  = { workspace = true }
 serde_json   = { workspace = true }
 

--- a/pnpm/tasks/micro-benchmark/src/main.rs
+++ b/pnpm/tasks/micro-benchmark/src/main.rs
@@ -1,7 +1,9 @@
-use std::{fs, hint::black_box, path::Path};
+use std::{fs, hint::black_box, path::Path, time::Duration};
 
 use clap::Parser;
 use criterion::{Criterion, Throughput};
+use flate2::{Compression, write::GzEncoder};
+use futures_util::future;
 use mockito::ServerGuard;
 use pacquet_network::{AuthHeaders, ThrottledClient};
 use pacquet_registry::Package;
@@ -10,7 +12,11 @@ use pacquet_tarball::{DownloadTarballToStore, RetryOpts};
 use pipe_trait::Pipe;
 use project_root::get_project_root;
 use ssri::Integrity;
+use tar::{Builder, Header};
 use tempfile::tempdir;
+
+const BATCH_TARBALL_COUNT: usize = 256;
+const BATCH_FILES_PER_TARBALL: usize = 64;
 
 #[derive(Debug, Parser)]
 struct CliArgs {
@@ -66,6 +72,102 @@ fn bench_tarball(criterion: &mut Criterion, server: &mut ServerGuard, fixtures_f
     });
 
     group.finish();
+}
+
+fn bench_concurrent_tarballs(criterion: &mut Criterion, server: &mut ServerGuard) {
+    let packages = (0..BATCH_TARBALL_COUNT)
+        .map(|package_index| {
+            let tarball = create_benchmark_tarball(package_index);
+            let path = format!("/batch-package-{package_index}.tgz");
+            server.mock("GET", path.as_str()).with_status(200).with_body(tarball.clone()).create();
+            BatchPackage {
+                id: format!("batch-package-{package_index}@1.0.0"),
+                integrity: Integrity::from(tarball.as_slice()),
+                unpacked_size: BATCH_FILES_PER_TARBALL * benchmark_file(package_index, 0).len(),
+                url: format!("{}{path}", server.url()),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let rt = tokio::runtime::Builder::new_multi_thread().enable_all().build().unwrap();
+    let mut group = criterion.benchmark_group("tarball_batch");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(20));
+    group.throughput(Throughput::Elements(
+        u64::try_from(BATCH_TARBALL_COUNT * BATCH_FILES_PER_TARBALL)
+            .expect("benchmark file count fits u64"),
+    ));
+    group.bench_function("cold_store_many_medium_tarballs", |bencher| {
+        bencher.to_async(&rt).iter(|| async {
+            let dir = tempdir().unwrap();
+            let store_dir =
+                dir.path().to_path_buf().pipe(StoreDir::from).pipe(Box::new).pipe(Box::leak);
+            let http_client = ThrottledClient::new_for_installs();
+            future::try_join_all(packages.iter().map(|package| async {
+                let auth_headers = AuthHeaders::default();
+                DownloadTarballToStore {
+                    http_client: &http_client,
+                    store_dir,
+                    store_index: None,
+                    store_index_writer: None,
+                    verify_store_integrity: true,
+                    verified_files_cache: pacquet_store_dir::SharedVerifiedFilesCache::default(),
+                    package_integrity: Some(&package.integrity),
+                    package_unpacked_size: Some(package.unpacked_size),
+                    package_file_count: Some(BATCH_FILES_PER_TARBALL),
+                    package_url: &package.url,
+                    package_id: &package.id,
+                    requester: "",
+                    prefetched_cas_paths: None,
+                    retry_opts: RetryOpts::default(),
+                    auth_headers: &auth_headers,
+                    ignore_file_pattern: None,
+                    offline: false,
+                    progress_reported: None,
+                    append_manifest: None,
+                }
+                .run_without_mem_cache::<pacquet_reporter::SilentReporter>()
+                .await
+            }))
+            .await
+            .unwrap()
+            .iter()
+            .map(std::collections::HashMap::len)
+            .sum::<usize>()
+        });
+    });
+    group.finish();
+}
+
+struct BatchPackage {
+    id: String,
+    integrity: Integrity,
+    unpacked_size: usize,
+    url: String,
+}
+
+fn create_benchmark_tarball(package_index: usize) -> Vec<u8> {
+    let encoder = GzEncoder::new(Vec::new(), Compression::fast());
+    let mut archive = Builder::new(encoder);
+    for file_index in 0..BATCH_FILES_PER_TARBALL {
+        let content = benchmark_file(package_index, file_index);
+        let mut header = Header::new_gnu();
+        header.set_path(format!("package/files/file-{file_index}.txt")).unwrap();
+        header.set_size(u64::try_from(content.len()).expect("benchmark file size fits u64"));
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive.append(&header, content.as_slice()).unwrap();
+    }
+    let encoder = archive.into_inner().unwrap();
+    encoder.finish().unwrap()
+}
+
+fn benchmark_file(package_index: usize, file_index: usize) -> Vec<u8> {
+    let prefix = format!("package={package_index};file={file_index};").into_bytes();
+    let mut content =
+        vec![u8::try_from((package_index + file_index) % 251).expect("value is below 251"); 128];
+    content[..prefix.len()].copy_from_slice(&prefix);
+    content
 }
 
 /// Isolate pacquet's resolve-time metadata parse: deserialize a registry
@@ -125,6 +227,7 @@ pub fn main() -> Result<(), String> {
     let lockfile_dir = root.join("pnpm/tasks/integrated-benchmark/src/fixtures");
 
     bench_tarball(&mut criterion, &mut server, &fixtures_folder);
+    bench_concurrent_tarballs(&mut criterion, &mut server);
     bench_packument(&mut criterion, &packument);
     bench_lockfile(&mut criterion, &lockfile_dir);
 


### PR DESCRIPTION
## Summary

Adds a Criterion benchmark for the integrity and extraction workload exposed by https://github.com/pnpm/pnpm/issues/13305.

The benchmark downloads 256 concurrent tarballs into cold stores. Each tarball contains 64 files, crossing the per-tarball parallel extraction threshold that is not exercised by the existing single-package integrity benchmark.

This is benchmark-only infrastructure and does not change either CLI implementation or a published package.

## Squash Commit Body

```text
Add a concurrent cold-store tarball benchmark alongside the existing single-package integrity benchmark.

The workload covers many file-heavy tarballs in flight at once, matching the extraction shape that made the Rust engine slower than the TypeScript CLI on the Next.js workspace in pnpm/pnpm#13305.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787750611&installation_model_id=426870&pr_number=13433&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13433&signature=8d55780f989eaeb817cce48e28b10f51c3d73a8662765cf396d0b771504e0b06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a benchmark for downloading and storing multiple tarballs concurrently.
  * Added support for generating and testing batches of compressed package archives.

* **Performance**
  * Expanded benchmark coverage to measure concurrent package download workflows alongside existing single-package benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->