### PR TITLE
fix(pacquet): preserve libc metadata shape

### DIFF
--- a/.changeset/quiet-wolves-remember.md
+++ b/.changeset/quiet-wolves-remember.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Preserve whether package `libc` metadata uses a string or an array when writing the lockfile.

--- a/pnpm/crates/env-installer/src/install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/install_config_deps.rs
@@ -450,7 +450,7 @@ fn read_optional_subdeps(
             tarball,
             os: pkg.os.clone(),
             cpu: pkg.cpu.clone(),
-            libc: pkg.libc.clone(),
+            libc: pkg.libc.as_deref().map(<[String]>::to_vec),
         });
     }
     Ok(subdeps)

--- a/pnpm/crates/env-installer/src/manifest_lockfile.rs
+++ b/pnpm/crates/env-installer/src/manifest_lockfile.rs
@@ -1,4 +1,4 @@
-use pacquet_lockfile::{BundledDependencies, PackageMetadata, PeerDependencyMeta};
+use pacquet_lockfile::{BundledDependencies, PackageMetadata, PeerDependencyMeta, StringOrList};
 use pacquet_resolving_resolver_base::ResolveResult;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -22,7 +22,7 @@ pub(crate) fn package_metadata(
         engines: read_engines(manifest),
         cpu: read_string_list(manifest, "cpu"),
         os: read_string_list(manifest, "os"),
-        libc: read_string_list(manifest, "libc"),
+        libc: read_string_or_list(manifest, "libc"),
         deprecated: manifest
             .and_then(|m| m.get("deprecated"))
             .and_then(Value::as_str)
@@ -79,6 +79,14 @@ fn read_string_list(manifest: Option<&Value>, key: &str) -> Option<Vec<String>> 
                 items.iter().filter_map(Value::as_str).map(ToString::to_string).collect();
             (!out.is_empty()).then_some(out)
         }
+        _ => None,
+    }
+}
+
+fn read_string_or_list(manifest: Option<&Value>, key: &str) -> Option<StringOrList> {
+    match manifest?.get(key)? {
+        Value::String(value) if !value.is_empty() => Some(StringOrList::String(value.clone())),
+        Value::Array(_) => read_string_list(manifest, key).map(StringOrList::List),
         _ => None,
     }
 }

--- a/pnpm/crates/lockfile/src/package_metadata.rs
+++ b/pnpm/crates/lockfile/src/package_metadata.rs
@@ -1,6 +1,6 @@
 use crate::LockfileResolution;
-use serde::{Deserialize, Deserializer, Serialize};
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, ops::Deref};
 
 /// Metadata for one resolved package version, as stored in the v9
 /// `packages:` map. This is the per-version data that does not vary by
@@ -27,13 +27,8 @@ pub struct PackageMetadata {
     pub cpu: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os: Option<Vec<String>>,
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "deserialize_string_or_vec",
-        serialize_with = "serialize_string_or_vec"
-    )]
-    pub libc: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub libc: Option<StringOrList>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -92,45 +87,37 @@ impl BundledDependencies {
     }
 }
 
-// Some packages declare `libc` as a plain string in `package.json`; pnpm writes
-// that string as-is into the lockfile.
-fn deserialize_string_or_vec<'de, Value, Deser>(
-    deserializer: Deser,
-) -> Result<Option<Vec<Value>>, Deser::Error>
-where
-    Value: Deserialize<'de>,
-    Deser: Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum StringOrVec<Value> {
-        String(Value),
-        Vec(Vec<Value>),
-    }
-
-    let opt = Option::<StringOrVec<Value>>::deserialize(deserializer)?;
-    Ok(opt.map(|value| match value {
-        StringOrVec::String(item) => vec![item],
-        StringOrVec::Vec(items) => items,
-    }))
+/// A package-manifest field that accepts either one string or a list.
+///
+/// pnpm preserves this distinction in the lockfile, so retaining only the
+/// normalized values is insufficient for byte-identical serialization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum StringOrList {
+    String(String),
+    List(Vec<String>),
 }
 
-#[expect(
-    clippy::ref_option,
-    reason = "serde serialize_with requires a reference to the field type"
-)]
-fn serialize_string_or_vec<Value, Ser>(
-    value: &Option<Vec<Value>>,
-    serializer: Ser,
-) -> Result<Ser::Ok, Ser::Error>
-where
-    Value: Serialize,
-    Ser: serde::Serializer,
-{
-    match value.as_deref() {
-        Some([item]) => item.serialize(serializer),
-        Some(items) => items.serialize(serializer),
-        None => serializer.serialize_none(),
+impl Deref for StringOrList {
+    type Target = [String];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            StringOrList::String(value) => std::slice::from_ref(value),
+            StringOrList::List(values) => values,
+        }
+    }
+}
+
+impl From<Vec<String>> for StringOrList {
+    fn from(values: Vec<String>) -> Self {
+        StringOrList::List(values)
+    }
+}
+
+impl FromIterator<String> for StringOrList {
+    fn from_iter<Values: IntoIterator<Item = String>>(iter: Values) -> Self {
+        StringOrList::List(iter.into_iter().collect())
     }
 }
 

--- a/pnpm/crates/lockfile/src/package_metadata/tests.rs
+++ b/pnpm/crates/lockfile/src/package_metadata/tests.rs
@@ -1,4 +1,4 @@
-use super::{BundledDependencies, PackageMetadata};
+use super::{BundledDependencies, PackageMetadata, StringOrList};
 use crate::serialize_yaml;
 use text_block_macros::text_block;
 
@@ -17,14 +17,14 @@ fn make_metadata(libc_yaml: &str) -> String {
 fn libc_as_string() {
     let yaml = make_metadata("libc: glibc\n");
     let metadata: PackageMetadata = serde_saphyr::from_str(&yaml).unwrap();
-    assert_eq!(metadata.libc, Some(vec!["glibc".to_string()]));
+    assert_eq!(metadata.libc, Some(StringOrList::String("glibc".to_string())));
 }
 
 #[test]
 fn libc_as_array() {
     let yaml = make_metadata("libc: [glibc]\n");
     let metadata: PackageMetadata = serde_saphyr::from_str(&yaml).unwrap();
-    assert_eq!(metadata.libc, Some(vec!["glibc".to_string()]));
+    assert_eq!(metadata.libc, Some(StringOrList::List(vec!["glibc".to_string()])));
 }
 
 #[test]
@@ -44,16 +44,12 @@ fn libc_string_roundtrip() {
 }
 
 #[test]
-fn singleton_libc_is_written_as_a_string() {
-    let metadata: PackageMetadata =
-        serde_saphyr::from_str(&make_metadata("libc: [glibc]\n")).unwrap();
-    let yaml = serialize_yaml::to_string(&metadata).unwrap();
-
-    assert_eq!(
-        yaml.lines().filter(|line| line.trim_start().starts_with("libc:")).collect::<Vec<_>>(),
-        ["libc: glibc"],
-        "{yaml}",
-    );
+fn libc_shape_is_preserved() {
+    for input in ["libc: glibc\n", "libc: [glibc]\n"] {
+        let metadata: PackageMetadata = serde_saphyr::from_str(&make_metadata(input)).unwrap();
+        let yaml = serialize_yaml::to_string(&metadata).unwrap();
+        assert!(yaml.lines().any(|line| line.trim_start() == input.trim()), "{yaml}");
+    }
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -673,10 +673,17 @@ fn read_string_list(manifest: Option<&Value>, key: &str) -> Option<Vec<String>> 
     }
 }
 
-fn read_string_or_list(manifest: Option<&Value>, key: &str) -> Option<Vec<String>> {
+fn read_string_or_list(
+    manifest: Option<&Value>,
+    key: &str,
+) -> Option<pacquet_lockfile::StringOrList> {
     match manifest?.get(key)? {
-        Value::String(value) if !value.is_empty() => Some(vec![value.clone()]),
-        Value::Array(_) => read_string_list(manifest, key),
+        Value::String(value) if !value.is_empty() => {
+            Some(pacquet_lockfile::StringOrList::String(value.clone()))
+        }
+        Value::Array(_) => {
+            read_string_list(manifest, key).map(pacquet_lockfile::StringOrList::List)
+        }
         _ => None,
     }
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -308,11 +308,10 @@ fn generated_lockfile_preserves_libc_manifest_shape() {
         &manifest, &graph, direct, false, false, None, None,
     ));
 
-    assert_eq!(
-        lockfile.to_yaml_string().expect("serialize generated lockfile"),
-        format!(
-            "{}\n",
-            text_block! {
+    let yaml = lockfile.to_yaml_string().expect("serialize generated lockfile");
+    let expected = format!(
+        "{}\n",
+        text_block! {
                 "lockfileVersion: '9.0'"
                 ""
                 "settings:"
@@ -345,9 +344,10 @@ fn generated_lockfile_preserves_libc_manifest_shape() {
                 "  list-libc@1.0.0: {}"
                 ""
                 "  scalar-libc@1.0.0: {}"
-            }
-        ),
+        },
     );
+    eprintln!("GENERATED LOCKFILE:\n{yaml}\n");
+    assert_eq!(yaml, expected);
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -269,7 +269,7 @@ fn string_or_list_metadata_accepts_arrays_and_rejects_other_values() {
     let array_manifest = json!({ "libc": ["glibc", "musl"] });
     assert_eq!(
         read_string_or_list(Some(&array_manifest), "libc"),
-        Some(vec!["glibc".to_string(), "musl".to_string()]),
+        Some(vec!["glibc".to_string(), "musl".to_string()].into()),
     );
 
     let object_manifest = json!({ "libc": { "name": "musl" } });

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -23,6 +23,7 @@ use std::{
     sync::Arc,
 };
 use tempfile::TempDir;
+use text_block_macros::text_block;
 
 fn dependencies_graph_to_lockfile(opts: GraphToLockfileOptions<'_>) -> pacquet_lockfile::Lockfile {
     try_dependencies_graph_to_lockfile(opts).expect("convert dependency graph to lockfile")
@@ -274,6 +275,79 @@ fn string_or_list_metadata_accepts_arrays_and_rejects_other_values() {
 
     let object_manifest = json!({ "libc": { "name": "musl" } });
     assert_eq!(read_string_or_list(Some(&object_manifest), "libc"), None);
+}
+
+#[test]
+fn generated_lockfile_preserves_libc_manifest_shape() {
+    let (_tmp, manifest) = write_manifest(json!({
+        "name": "fixture",
+        "version": "1.0.0",
+        "dependencies": {
+            "list-libc": "1.0.0",
+            "scalar-libc": "1.0.0",
+        },
+    }));
+    let mut graph = DependenciesGraph::new();
+    for (name, libc) in [("list-libc", json!(["glibc"])), ("scalar-libc", json!("musl"))] {
+        let node = make_node(
+            name,
+            "1.0.0",
+            json!({ "name": name, "version": "1.0.0", "libc": libc }),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            HashSet::new(),
+        );
+        graph.insert(node.dep_path.clone(), node);
+    }
+    let direct = BTreeMap::from([
+        ("list-libc".to_string(), DepPath::from("list-libc@1.0.0".to_string())),
+        ("scalar-libc".to_string(), DepPath::from("scalar-libc@1.0.0".to_string())),
+    ]);
+
+    let lockfile = dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest, &graph, direct, false, false, None, None,
+    ));
+
+    assert_eq!(
+        lockfile.to_yaml_string().expect("serialize generated lockfile"),
+        format!(
+            "{}\n",
+            text_block! {
+                "lockfileVersion: '9.0'"
+                ""
+                "settings:"
+                "  autoInstallPeers: false"
+                "  excludeLinksFromLockfile: false"
+                ""
+                "importers:"
+                ""
+                "  .:"
+                "    dependencies:"
+                "      list-libc:"
+                "        specifier: 1.0.0"
+                "        version: 1.0.0"
+                "      scalar-libc:"
+                "        specifier: 1.0.0"
+                "        version: 1.0.0"
+                ""
+                "packages:"
+                ""
+                "  list-libc@1.0.0:"
+                "    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==}"
+                "    libc: [glibc]"
+                ""
+                "  scalar-libc@1.0.0:"
+                "    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==}"
+                "    libc: musl"
+                ""
+                "snapshots:"
+                ""
+                "  list-libc@1.0.0: {}"
+                ""
+                "  scalar-libc@1.0.0: {}"
+            }
+        ),
+    );
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/hoisted_dep_graph.rs
+++ b/pnpm/crates/package-manager/src/hoisted_dep_graph.rs
@@ -729,7 +729,7 @@ fn manifest_for_installability(
         engines,
         cpu: metadata.cpu.clone(),
         os: metadata.os.clone(),
-        libc: metadata.libc.clone(),
+        libc: metadata.libc.as_deref().map(<[String]>::to_vec),
     }
 }
 

--- a/pnpm/crates/package-manager/src/installability.rs
+++ b/pnpm/crates/package-manager/src/installability.rs
@@ -895,7 +895,7 @@ fn manifest_from_metadata(
         }),
         cpu: metadata.cpu.clone(),
         os: metadata.os.clone(),
-        libc: metadata.libc.clone(),
+        libc: metadata.libc.as_deref().map(<[String]>::to_vec),
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13435 by preserving whether package `libc` metadata was declared as a string or an array when pacquet writes `pnpm-lock.yaml`.

TypeScript pnpm already preserves this distinction. With this change, clean lockfile-only installs of `withastro/astro` at `112d3ea14cf997218239fd8a436707e56a3815fb` produce byte-identical TypeScript and Rust lockfiles with SHA-256 `2d5f4badfb12ef4ca3ea692ef9c8415298556a054b1c24585e617e91ad6416d8`.

## Squash Commit Body

```text
Represent libc metadata as an untagged string-or-list value in the Rust lockfile model. Preserve the source manifest shape when building package metadata, while exposing a normalized slice to installability consumers.

This keeps scalar libc declarations scalar and singleton arrays as arrays, matching TypeScript pnpm's lockfile serialization.

Fixes pnpm/pnpm#13435.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787772875&installation_model_id=426870&pr_number=13436&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13436&signature=59372bc2906ce91a1992e748682ab97f84d9dabd22283e8d9e7d3969f65e0942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Lockfiles now preserve the original `libc` shape from the manifest (scalar vs list) when writing `libc` into `PackageMetadata`.
  - Improved handling of optional `libc` values so the same representation is propagated through lockfile generation and installability checks.
- **Tests**
  - Updated `libc` parsing/serialization assertions to match shape preservation.
  - Added coverage that generated lockfiles reproduce scalar and list forms exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->