### PR TITLE
fix(pacquet): restore git tarball integrity

### DIFF
--- a/.changeset/git-hosted-lockfile-resolution.md
+++ b/.changeset/git-hosted-lockfile-resolution.md
@@ -1,5 +1,0 @@
----
-"pacquet": patch
----
-
-Do not write archive integrity for commit-addressed git-hosted dependencies.

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -341,8 +341,7 @@ impl LockfileResolution {
     /// `include_tarball_url` is set, when it is a `file:` tarball, when it is
     /// git-hosted, or when it does not match the derived URL (e.g. private
     /// registries with non-standard tarball paths). Non-tarball resolutions and
-    /// integrity-less tarballs pass through unchanged, except that a recognized
-    /// git-hosted archive is normalized with `git_hosted: Some(true)`.
+    /// integrity-less tarballs pass through unchanged.
     #[must_use]
     pub fn to_lockfile_form(
         &self,
@@ -352,15 +351,9 @@ impl LockfileResolution {
         include_tarball_url: bool,
     ) -> LockfileResolution {
         let LockfileResolution::Tarball(tarball) = self else { return self.clone() };
+        let Some(integrity) = tarball.integrity.as_ref() else { return self.clone() };
+
         let git_hosted = tarball.is_git_hosted();
-        let Some(integrity) = tarball.integrity.as_ref() else {
-            if git_hosted && tarball.git_hosted != Some(true) {
-                let mut normalized = tarball.clone();
-                normalized.git_hosted = Some(true);
-                return LockfileResolution::Tarball(normalized);
-            }
-            return self.clone();
-        };
         // A standard registry tarball whose URL can be rebuilt from name+version+
         // registry is written as just `{integrity}` — pnpm derives the URL on
         // demand. Every other tarball must keep its URL or it can no longer be

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -718,26 +718,6 @@ fn to_lockfile_form_keeps_git_hosted_subdirectory_path() {
     assert_eq!(actual, resolution);
 }
 
-#[test]
-fn to_lockfile_form_records_git_hosted_for_integrityless_archive() {
-    let resolution = LockfileResolution::Tarball(TarballResolution {
-        tarball: format!("https://codeload.github.com/foo/bar/tar.gz/{GIT_COMMIT}"),
-        integrity: None,
-        git_hosted: None,
-        path: None,
-    });
-    let actual = resolution.to_lockfile_form("foo", "1.0.0", "https://registry.npmjs.org/", false);
-    assert_eq!(
-        actual,
-        LockfileResolution::Tarball(TarballResolution {
-            tarball: format!("https://codeload.github.com/foo/bar/tar.gz/{GIT_COMMIT}"),
-            integrity: None,
-            git_hosted: Some(true),
-            path: None,
-        }),
-    );
-}
-
 /// `include_tarball_url` takes the same kept-URL branch, so it must keep
 /// `path` too.
 #[test]

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -25,14 +25,17 @@ use crate::{
 /// Store/network handles [`GitResolver`] needs to read a git dep's
 /// identity out of the package itself during resolution.
 ///
-/// A git dep's specifier names a repo, not a package, so its name lives
-/// only in the package's own `package.json`. pacquet builds the lockfile
-/// before the install/fetch pass runs, so it has to be read here.
+/// A git dep's specifier names a repo, not a package, so its name —
+/// and, for a host archive, its integrity — live only in the package's
+/// own `package.json`. pacquet builds the lockfile before the
+/// install/fetch pass runs, so they have to be read here. Mirrors the
+/// tarball resolver's remote-tarball fetch, which fills the same fields
+/// for the same reason.
 ///
 /// Two shapes, by resolution:
 ///
 /// - a git *host* (`github:` / `gitlab:` / `bitbucket:`) serves an
-///   archive, which is downloaded;
+///   archive, which is downloaded and hashed;
 /// - any other repo (ssh, self-hosted, `file:`) has no archive
 ///   endpoint, so a throwaway checkout is the cheapest read.
 ///
@@ -63,7 +66,7 @@ pub struct GitFetchContext {
 /// install dispatcher) into a single owner.
 ///
 /// When `fetch_context` is `Some`, the package is read during
-/// resolution to fill `manifest`
+/// resolution to fill `manifest` (and `integrity`, for a host archive)
 /// — see [`GitFetchContext`]. `None` (unit tests, and the resolve-only
 /// NAPI entry point) keeps the manifest-less shape.
 pub struct GitResolver<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> {
@@ -122,7 +125,8 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
         Ok(Some(result))
     }
 
-    /// Fill `manifest` from the package the git dep points at. No-op
+    /// Fill `manifest` — and, for an archive, the resolution's
+    /// `integrity` — from the package the git dep points at. No-op
     /// without a fetch context (unit tests / resolve-only callers).
     async fn read_package_metadata(&self, result: &mut ResolveResult) -> Result<(), ResolveError> {
         let Some(ctx) = self.fetch_context.as_ref() else { return Ok(()) };
@@ -155,6 +159,15 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
                 .map_err(|err| Box::new(err) as ResolveError)?;
 
                 result.manifest = resolved.manifest.map(Arc::new);
+                if let LockfileResolution::Tarball(tarball) = &mut result.resolution {
+                    // A git host's archive carries no integrity of its
+                    // own, and the install pass refuses a tarball
+                    // resolution without one
+                    // (`tarball_url_and_integrity`). The bytes were
+                    // just hashed to extract them, so record that —
+                    // same field upstream writes for a git dep.
+                    tarball.integrity = Some(resolved.integrity);
+                }
             }
             LockfileResolution::Git(git) => {
                 // No archive endpoint to read, so the working tree is

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -25,12 +25,12 @@ use crate::{
 /// Store/network handles [`GitResolver`] needs to read a git dep's
 /// identity out of the package itself during resolution.
 ///
-/// A git dep's specifier names a repo, not a package, so its name —
-/// and, for a host archive, its integrity — live only in the package's
-/// own `package.json`. pacquet builds the lockfile before the
-/// install/fetch pass runs, so they have to be read here. Mirrors the
-/// tarball resolver's remote-tarball fetch, which fills the same fields
-/// for the same reason.
+/// A git dep's specifier names a repo, not a package, so its package name
+/// lives only in the package's own `package.json`. For a host archive,
+/// integrity is computed from the fetched bytes and stored on the resolution.
+/// pacquet builds the lockfile before the install/fetch pass runs, so both
+/// fields have to be filled here. Mirrors the tarball resolver's
+/// remote-tarball fetch, which fills the same fields for the same reason.
 ///
 /// Two shapes, by resolution:
 ///
@@ -125,9 +125,9 @@ impl<Probe: GitProbe + 'static, Runner: GitCommandRunner + 'static> GitResolver<
         Ok(Some(result))
     }
 
-    /// Fill `manifest` — and, for an archive, the resolution's
-    /// `integrity` — from the package the git dep points at. No-op
-    /// without a fetch context (unit tests / resolve-only callers).
+    /// Fill `manifest` from the package the git dep points at and compute an
+    /// archive resolution's `integrity` from its fetched bytes. No-op without
+    /// a fetch context (unit tests / resolve-only callers).
     async fn read_package_metadata(&self, result: &mut ResolveResult) -> Result<(), ResolveError> {
         let Some(ctx) = self.fetch_context.as_ref() else { return Ok(()) };
         match &result.resolution {

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver/tests.rs
@@ -129,7 +129,6 @@ async fn github_shortcut_full_commit_returns_tarball() {
                 "https://codeload.github.com/zkochan/is-negative/tar.gz/163360a8d3ae6bee9524541043197ff356f8ed99",
             );
             assert_eq!(t.git_hosted, Some(true));
-            assert!(t.integrity.is_none());
             assert!(t.path.is_none());
         }
         other => panic!("expected Tarball, got {other:?}"),

--- a/pnpm/crates/resolving-git-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-git-resolver/src/lib.rs
@@ -16,8 +16,9 @@
 //!   commit, and emits either a `Tarball{gitHosted: true}` or `Git`
 //!   resolution. Given a [`GitFetchContext`], it also reads the
 //!   package's name from its `package.json` — out of the host archive,
-//!   or out of a checkout for a repo that serves no archive. See that
-//!   type for why resolution is where that has to happen.
+//!   or out of a checkout for a repo that serves no archive — plus the
+//!   archive's integrity. See that type for why resolution is where
+//!   that has to happen.
 //!
 //! Out of scope:
 //!


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Restore Rust pnpm's integrity propagation for commit-addressed git-hosted
tarballs. TypeScript pnpm intentionally records this hash so later installs
reject tarball bytes that differ from the artifact resolved initially.

This reverts only the git integrity portion of pnpm/pnpm#13432. Its peer
resolution and `libc` serialization changes remain intact. The contradictory,
unreleased changeset from that PR is removed.

## Squash Commit Body

```text
Restore the integrity hash collected while resolving commit-addressed
git-hosted archives. This keeps Rust pnpm aligned with the TypeScript security
behavior that pins downloaded archive bytes in the lockfile.

Revert only the git integrity portion of pnpm/pnpm#13432; retain its peer
resolution and libc serialization changes.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

The TypeScript implementation already pins git-hosted tarball integrity. This
restores the matching Rust behavior. The unreleased changeset that announced
the opposite behavior is removed instead of adding a second release note.

Validation: `just ready` passed, including all 7,381 Rust tests, workspace
checks, formatting, typos, and Clippy.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787773718&installation_model_id=426870&pr_number=13439&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13439&signature=afe862f303ddec3b4f6114a93ac8be45984ebc83c14fe46e7cdb6287ba57fe02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of Git-hosted archive (tarball) resolutions when integrity is missing, so integrity-less tarballs are preserved instead of being modified.
  * Ensure archive integrity is recorded for Git resolutions when it is available.
  * Updated lockfile resolution behavior to keep existing tarball resolution details consistent.
* **Documentation**
  * Clarified how archive integrity is handled during Git dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->