### PR TITLE
fix(cli): list scripts for filtered run

### DIFF
--- a/.changeset/calm-pugs-list.md
+++ b/.changeset/calm-pugs-list.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm --filter <package> run` to list the selected package's scripts when no script name is specified.

--- a/.changeset/calm-pugs-list.md
+++ b/.changeset/calm-pugs-list.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm --filter <package> run` to list the selected package's scripts when no script name is specified.
+Fixed `pnpm --filter <package> run` to list the selected package's scripts and root workspace scripts when no script name is specified.

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -154,7 +154,7 @@ impl RunArgs {
         let RunArgs { script, if_present, sequential, .. } = self;
         let Some((script_name, args)) = script.split_first() else {
             let manifest = read_project_manifest_only(dir).map_err(RunError::Manifest)?;
-            println!("{}", render_project_commands(manifest.value()));
+            println!("{}", render_project_commands(manifest.value(), None));
             return Ok(());
         };
         let manifest = match read_project_manifest_only(dir) {
@@ -579,9 +579,8 @@ fn throw_or_filter_hidden_scripts(
 }
 
 /// Render the script listing printed when `pnpm run` is called without a
-/// script name. The workspace-root section is omitted because pacquet's
-/// run has no workspace context yet.
-fn render_project_commands(manifest: &Value) -> String {
+/// script name.
+fn render_project_commands(manifest: &Value, root_manifest: Option<&Value>) -> String {
     let scripts = manifest.get("scripts").and_then(Value::as_object);
     let mut lifecycle = Vec::new();
     let mut other = Vec::new();
@@ -614,6 +613,27 @@ fn render_project_commands(manifest: &Value) -> String {
         }
         write!(output, "Commands available via \"pnpm run\":\n{}", render_commands(&other))
             .unwrap();
+    }
+    let root_scripts = root_manifest
+        .and_then(|manifest| manifest.get("scripts"))
+        .and_then(Value::as_object)
+        .map(|scripts| {
+            scripts
+                .iter()
+                .filter_map(|(name, script)| Some((name.as_str(), script.as_str()?)))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if !root_scripts.is_empty() {
+        if !output.is_empty() {
+            output.push_str("\n\n");
+        }
+        write!(
+            output,
+            "Commands of the root workspace project (to run them, use \"pnpm -w run\"):\n{}",
+            render_commands(&root_scripts),
+        )
+        .unwrap();
     }
     output
 }

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -10,7 +10,7 @@
 //! auto-exclusion of the workspace root is applied via
 //! [`AutoExcludeRoot::Enabled`].
 
-use super::{RunArgs, RunContext, ScriptSelector, run_stages};
+use super::{RunArgs, RunContext, ScriptSelector, render_project_commands, run_stages};
 use crate::cli_args::recursive::{
     AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
     get_resumed_package_chunks, select_recursive_projects, sort_filtered_projects,
@@ -79,12 +79,6 @@ pub fn run_recursive(
     dir: &Path,
     emit: fn(&LogEvent),
 ) -> miette::Result<()> {
-    // The script name is optional so single-project `run` can list
-    // scripts; recursive mode has no such "list" behavior, so a missing
-    // script name is a usage error (`ERR_PNPM_SCRIPT_NAME_IS_REQUIRED`).
-    let Some(script_name) = args.script_name() else {
-        return Err(RecursiveRunError::ScriptNameRequired.into());
-    };
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
 
     let (projects, patterns) = discover_workspace_projects(workspace_root)?;
@@ -95,6 +89,24 @@ pub fn run_recursive(
         AutoExcludeRoot::Enabled { workspace_patterns: patterns.as_deref() },
     )?;
     let graph = &selection.selected;
+    let Some(script_name) = args.script_name() else {
+        if graph.len() != 1 {
+            return Err(RecursiveRunError::ScriptNameRequired.into());
+        }
+        let project = graph.values().next().expect("graph contains exactly one project");
+        let root_manifest = projects
+            .iter()
+            .find(|candidate| {
+                candidate.root_dir == workspace_root
+                    && candidate.root_dir != project.package.project.root_dir
+            })
+            .map(|project| project.manifest.value());
+        println!(
+            "{}",
+            render_project_commands(project.package.project.manifest.value(), root_manifest),
+        );
+        return Ok(());
+    };
     // Report what the `--filter` selection resolved to before running a
     // single script, so the user can confirm it covers what they meant.
     emit(&LogEvent::Scope(ScopeLog {

--- a/pnpm/crates/cli/src/cli_args/run/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/run/tests.rs
@@ -106,7 +106,7 @@ fn print_commands_groups_lifecycle_and_other() {
     let manifest = json!({
         "scripts": { "test": "jest", "build": "tsc", ".hidden": "secret" },
     });
-    let output = render_project_commands(&manifest);
+    let output = render_project_commands(&manifest, None);
     assert!(output.contains("Lifecycle scripts:"), "lifecycle header:\n{output}");
     assert!(output.contains("  test\n    jest"), "test under lifecycle:\n{output}");
     assert!(output.contains(r#"Commands available via "pnpm run":"#), "other header:\n{output}");
@@ -117,7 +117,7 @@ fn print_commands_groups_lifecycle_and_other() {
 #[test]
 fn print_commands_empty_when_no_scripts() {
     let manifest = json!({ "name": "x" });
-    let output = render_project_commands(&manifest);
+    let output = render_project_commands(&manifest, None);
     assert_eq!(output, "There are no scripts specified.");
 }
 

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -1351,7 +1351,13 @@ fn recursive_run_recursion_guard_skips_originating_project() {
 #[test]
 fn recursive_run_without_script_name_errors_with_script_name_is_required() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    write_workspace(&workspace, &[("project-1", build_writes_marker("project-1"))]);
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", build_writes_marker("project-1")),
+            ("project-2", build_writes_marker("project-2")),
+        ],
+    );
 
     let output = pacquet.with_arg("-r").with_arg("run").output().expect("spawn pacquet");
     assert!(!output.status.success(), "missing script name in recursive mode must fail");
@@ -1360,6 +1366,56 @@ fn recursive_run_without_script_name_errors_with_script_name_is_required() {
         stderr.contains("ERR_PNPM_SCRIPT_NAME_IS_REQUIRED"),
         "stderr should carry the script-name-required code, got: {stderr}",
     );
+
+    drop(root);
+}
+
+#[test]
+fn filtered_run_without_script_name_lists_selected_and_root_scripts() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "workspace-root",
+            "version": "1.0.0",
+            "scripts": { "root-build": "echo root" },
+        })
+        .to_string(),
+    )
+    .expect("write root package.json");
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "project-1",
+                json!({
+                    "name": "project-1",
+                    "version": "1.0.0",
+                    "scripts": {
+                        "build": "echo project",
+                        "test": "echo tested",
+                    },
+                }),
+            ),
+            ("project-2", build_writes_marker("project-2")),
+        ],
+    );
+
+    let output = pacquet
+        .with_arg("--filter")
+        .with_arg("project-1")
+        .with_arg("run")
+        .output()
+        .expect("spawn pacquet");
+    assert!(output.status.success(), "filtered script listing must succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+    assert!(stdout.contains("Lifecycle scripts:\n  test\n    echo tested"));
+    assert!(stdout.contains("Commands available via \"pnpm run\":\n  build\n    echo project"));
+    assert!(stdout.contains(
+        "Commands of the root workspace project (to run them, use \"pnpm -w run\"):\n  root-build\n    echo root",
+    ));
+    assert!(!stdout.contains("touch ran.txt"), "unselected project scripts must not be listed");
 
     drop(root);
 }


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13437.

When `pnpm --filter <package> run` selects exactly one workspace package and no script name is provided, pacquet now lists that package’s scripts and the root workspace scripts instead of returning `ERR_PNPM_SCRIPT_NAME_IS_REQUIRED`. The TypeScript CLI already has this behavior, so this PR restores Rust parity without changing the TypeScript implementation. Multi-project recursive runs without a script name continue to return the existing error.

## Squash Commit Body

```text
Select the filtered workspace graph before requiring a script name. When exactly one project is selected, render its scripts and the root workspace scripts through the normal listing path; retain the recursive missing-script error for larger selections.

Add an integration regression test covering the filtered command and keep coverage for the multi-project recursive error.

Fixes pnpm/pnpm#13437.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787774480&installation_model_id=426870&pr_number=13440&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13440&signature=6a9f9f4dfe701415fd2b72639ae56981a13604d575b2ea94cd005f48d9580bf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `run` without a script name so filtered executions correctly list commands for the selected package.
  * Updated command listings to include scripts from the workspace root when appropriate.
  * Kept the “script name required” behavior when multiple packages are selected without specifying a script.
* **Tests**
  * Added and updated coverage to verify selected-package and workspace-root scripts are shown, while unselected packages’ scripts are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->