### PR TITLE
fix(pacquet): align licenses with TypeScript pnpm

### DIFF
--- a/.changeset/fuzzy-dodos-report.md
+++ b/.changeset/fuzzy-dodos-report.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm licenses list` to report dependencies from every workspace project, exclude unsupported platform packages, and mark development dependencies.

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -1,6 +1,7 @@
 use crate::cli_args::{
     deps_tree::pkg_info::is_unsafe_path_component,
     recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
+    sanitize::{sanitize, sanitize_inline},
 };
 use clap::Args;
 use derive_more::{Display, Error};
@@ -285,7 +286,8 @@ impl LicensesArgs {
         all_packages.sort_by(|a, b| a.name.cmp(&b.name));
 
         for info in all_packages {
-            let mut row = vec![render_package_name(info), info.license.clone()];
+            let mut row =
+                vec![render_package_name(info), sanitize_inline(&info.license).into_owned()];
             if self.long {
                 let mut details = Vec::new();
                 if let Some(author) = &info.author {
@@ -297,7 +299,7 @@ impl LicensesArgs {
                 if let Some(home) = &info.homepage {
                     details.push(home.clone());
                 }
-                row.push(details.join("\n"));
+                row.push(sanitize(&details.join("\n")).into_owned());
             }
             builder.push_record(row);
         }
@@ -312,7 +314,7 @@ impl LicensesArgs {
 
 fn collect_dependencies(
     lockfile: &Lockfile,
-    importer_ids: impl IntoIterator<Item = String>,
+    importer_ids: impl IntoIterator<Item = impl AsRef<str>>,
     include: Include,
     supported_architectures: Option<&SupportedArchitectures>,
     current_os: &str,
@@ -323,7 +325,9 @@ fn collect_dependencies(
     let mut stack: Vec<(PackageKey, BelongsTo)> = Vec::new();
 
     for id in importer_ids {
-        let Some(importer) = lockfile.importers.get(&id).or_else(|| lockfile.root_project()) else {
+        let Some(importer) =
+            lockfile.importers.get(id.as_ref()).or_else(|| lockfile.root_project())
+        else {
             continue;
         };
         let mut queue_deps = |deps: Option<&ResolvedDependencyMap>, kind: BelongsTo| {
@@ -367,7 +371,10 @@ fn collect_dependencies(
                     cpu: package.cpu.as_deref(),
                     libc: package.libc.as_deref(),
                 };
-                let inferred = inferred_platform(&key.name.to_string(), declared);
+                let inferred =
+                    (declared.os.is_none() || declared.cpu.is_none() || declared.libc.is_none())
+                        .then(|| key.name.to_string())
+                        .and_then(|name| inferred_platform(&name, declared));
                 let wanted = inferred.as_ref().map_or(declared, |platform| WantedPlatformRef {
                     os: platform.os.as_deref(),
                     cpu: platform.cpu.as_deref(),
@@ -410,11 +417,12 @@ fn collect_dependencies(
 }
 
 fn render_package_name(info: &LicenseInfo) -> String {
+    let name = sanitize_inline(&info.name);
     let suffix = match info.belongs_to {
-        BelongsTo::Prod | BelongsTo::Optional => return info.name.clone(),
+        BelongsTo::Prod | BelongsTo::Optional => return name.into_owned(),
         BelongsTo::Dev => "(dev)",
     };
-    format!("{} {}", info.name, suffix.if_supports_color(Stream::Stdout, |text| text.dimmed()))
+    format!("{} {}", name, suffix.if_supports_color(Stream::Stdout, |text| text.dimmed()))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -5,8 +5,13 @@ use crate::cli_args::{
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Diagnostic, IntoDiagnostic};
+use owo_colors::{OwoColorize, Stream};
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, PackageKey, PkgName, ResolvedDependencyMap};
+use pacquet_package_is_installable::{
+    SupportedArchitectures, WantedPlatform, WantedPlatformRef, inferred_platform,
+    platform_is_supported,
+};
 use pacquet_package_manager::{
     AllowBuildPolicy, validate_virtual_store_slot_containment, virtual_store_layout_for_lockfile,
 };
@@ -15,7 +20,7 @@ use pacquet_package_manifest::{
     safe_read_package_json_from_dir,
 };
 use serde::Serialize;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use tabled::{builder::Builder, settings::Style};
 
 #[derive(Debug, Args)]
@@ -102,6 +107,8 @@ pub struct LicenseInfo {
     pub versions: Vec<String>,
     pub paths: Vec<String>,
     pub license: String,
+    #[serde(skip)]
+    belongs_to: BelongsTo,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -132,9 +139,8 @@ impl LicensesArgs {
             return Ok(());
         };
 
-        let mut importer_ids = Vec::new();
-
-        if recursive {
+        let importer_ids = if recursive {
+            let mut importer_ids = Vec::new();
             let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
             let (projects, _) = discover_workspace_projects(workspace_root)?;
             let selection =
@@ -152,85 +158,21 @@ impl LicensesArgs {
                 };
                 importer_ids.push(id);
             }
+            importer_ids
         } else {
-            let importer_id = if dir == lockfile_dir {
-                ".".to_string()
-            } else {
-                dir.strip_prefix(lockfile_dir)
-                    .ok()
-                    .map(|rel| rel.to_string_lossy().replace('\\', "/"))
-                    .filter(|id| !id.is_empty())
-                    .unwrap_or_else(|| ".".to_string())
-            };
-            importer_ids.push(importer_id);
-        }
+            lockfile.importers.keys().cloned().collect()
+        };
 
         let include = self.dependency_options.include();
-        let mut belongs_to: HashMap<PackageKey, BelongsTo> = HashMap::new();
-        let mut stack: Vec<(PackageKey, BelongsTo)> = Vec::new();
-
-        for id in importer_ids {
-            let Some(importer) = lockfile.importers.get(&id).or_else(|| lockfile.root_project())
-            else {
-                continue;
-            };
-            let mut queue_deps = |deps: Option<&ResolvedDependencyMap>, kind: BelongsTo| {
-                if let Some(deps) = deps {
-                    for (alias, spec) in deps {
-                        if let Some(key) = spec.version.resolved_key(alias) {
-                            stack.push((key, kind));
-                        }
-                    }
-                }
-            };
-
-            if include.dependencies {
-                queue_deps(importer.dependencies.as_ref(), BelongsTo::Prod);
-            }
-            if include.dev_dependencies {
-                queue_deps(importer.dev_dependencies.as_ref(), BelongsTo::Dev);
-            }
-            if include.optional_dependencies {
-                queue_deps(importer.optional_dependencies.as_ref(), BelongsTo::Optional);
-            }
-        }
-
-        let empty_snapshots = HashMap::new();
-        let snapshots = lockfile.snapshots.as_ref().unwrap_or(&empty_snapshots);
-        let mut seen = HashSet::new();
-
-        while let Some((key, kind)) = stack.pop() {
-            if let Some(existing) = belongs_to.get(&key)
-                && *existing <= kind
-            {
-                continue;
-            }
-
-            belongs_to.insert(key.clone(), kind);
-
-            if !seen.insert((key.clone(), kind)) {
-                continue;
-            }
-
-            if let Some(snapshot) = snapshots.get(&key) {
-                let mut queue_children =
-                    |deps: Option<&HashMap<PkgName, pacquet_lockfile::SnapshotDepRef>>| {
-                        if let Some(deps) = deps {
-                            for (name, dep_ref) in deps {
-                                if let Some(child_key) = dep_ref.resolve(name) {
-                                    stack.push((child_key, kind));
-                                }
-                            }
-                        }
-                    };
-
-                queue_children(snapshot.dependencies.as_ref());
-                if include.optional_dependencies {
-                    queue_children(snapshot.optional_dependencies.as_ref());
-                }
-            }
-        }
-
+        let belongs_to = collect_dependencies(
+            &lockfile,
+            importer_ids,
+            include,
+            config.supported_architectures.as_ref(),
+            pacquet_detect_libc::host_platform(),
+            pacquet_detect_libc::host_arch(),
+            pacquet_graph_hasher::host_libc(),
+        );
         let allow_build_policy = AllowBuildPolicy::from_config(config).into_diagnostic()?;
         let project_manifest = safe_read_package_json_from_dir(dir).into_diagnostic()?;
         let manifest_node_version =
@@ -253,7 +195,7 @@ impl LicensesArgs {
 
         let pkgs = lockfile.packages.as_ref();
 
-        for (key, _kind) in belongs_to {
+        for (key, kind) in belongs_to {
             let name = key.name.to_string();
             let mut version = key.suffix.version().to_string();
             if let Some(pkgs) = pkgs
@@ -291,11 +233,13 @@ impl LicensesArgs {
                 versions: Vec::new(),
                 paths: Vec::new(),
                 license,
+                belongs_to: kind,
                 author,
                 homepage,
                 description,
             });
 
+            info.belongs_to = info.belongs_to.min(kind);
             if !info.versions.contains(&version) {
                 info.versions.push(version);
             }
@@ -342,7 +286,7 @@ impl LicensesArgs {
         all_packages.sort_by(|a, b| a.name.cmp(&b.name));
 
         for info in all_packages {
-            let mut row = vec![info.name.clone(), info.license.clone()];
+            let mut row = vec![render_package_name(info), info.license.clone()];
             if self.long {
                 let mut details = Vec::new();
                 if let Some(author) = &info.author {
@@ -365,6 +309,116 @@ impl LicensesArgs {
 
         Ok(())
     }
+}
+
+fn collect_dependencies(
+    lockfile: &Lockfile,
+    importer_ids: impl IntoIterator<Item = String>,
+    include: Include,
+    supported_architectures: Option<&SupportedArchitectures>,
+    current_os: &str,
+    current_cpu: &str,
+    current_libc: &str,
+) -> HashMap<PackageKey, BelongsTo> {
+    let mut belongs_to: HashMap<PackageKey, BelongsTo> = HashMap::new();
+    let mut stack: Vec<(PackageKey, BelongsTo)> = Vec::new();
+
+    for id in importer_ids {
+        let Some(importer) = lockfile.importers.get(&id).or_else(|| lockfile.root_project()) else {
+            continue;
+        };
+        let mut queue_deps = |deps: Option<&ResolvedDependencyMap>, kind: BelongsTo| {
+            if let Some(deps) = deps {
+                for (alias, spec) in deps {
+                    if let Some(key) = spec.version.resolved_key(alias) {
+                        stack.push((key, kind));
+                    }
+                }
+            }
+        };
+
+        if include.dependencies {
+            queue_deps(importer.dependencies.as_ref(), BelongsTo::Prod);
+        }
+        if include.dev_dependencies {
+            queue_deps(importer.dev_dependencies.as_ref(), BelongsTo::Dev);
+        }
+        if include.optional_dependencies {
+            queue_deps(importer.optional_dependencies.as_ref(), BelongsTo::Optional);
+        }
+    }
+
+    let empty_snapshots = HashMap::new();
+    let snapshots = lockfile.snapshots.as_ref().unwrap_or(&empty_snapshots);
+
+    while let Some((key, kind)) = stack.pop() {
+        if let Some(existing) = belongs_to.get(&key)
+            && *existing <= kind
+        {
+            continue;
+        }
+
+        let snapshot = snapshots.get(&key);
+        let package =
+            lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()));
+        if package.is_some_and(|package| {
+            let declared = WantedPlatformRef {
+                os: package.os.as_deref(),
+                cpu: package.cpu.as_deref(),
+                libc: package.libc.as_deref(),
+            };
+            let inferred: Option<WantedPlatform>;
+            let wanted = if snapshot.is_some_and(|snapshot| snapshot.optional) {
+                inferred = inferred_platform(&key.name.to_string(), declared);
+                inferred.as_ref().map_or(declared, |platform| WantedPlatformRef {
+                    os: platform.os.as_deref(),
+                    cpu: platform.cpu.as_deref(),
+                    libc: platform.libc.as_deref(),
+                })
+            } else {
+                declared
+            };
+            !platform_is_supported(
+                wanted,
+                supported_architectures,
+                current_os,
+                current_cpu,
+                current_libc,
+            )
+        }) {
+            continue;
+        }
+
+        belongs_to.insert(key.clone(), kind);
+
+        if let Some(snapshot) = snapshot {
+            let mut queue_children =
+                |deps: Option<&HashMap<PkgName, pacquet_lockfile::SnapshotDepRef>>| {
+                    if let Some(deps) = deps {
+                        for (name, dep_ref) in deps {
+                            if let Some(child_key) = dep_ref.resolve(name) {
+                                stack.push((child_key, kind));
+                            }
+                        }
+                    }
+                };
+
+            queue_children(snapshot.dependencies.as_ref());
+            if include.optional_dependencies {
+                queue_children(snapshot.optional_dependencies.as_ref());
+            }
+        }
+    }
+
+    belongs_to
+}
+
+fn render_package_name(info: &LicenseInfo) -> String {
+    let suffix = match info.belongs_to {
+        BelongsTo::Prod | BelongsTo::Optional => return info.name.clone(),
+        BelongsTo::Dev => "(dev)",
+    };
+    format!("{} {}", info.name, suffix.if_supports_color(Stream::Stdout, |text| text.dimmed()))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -9,8 +9,7 @@ use owo_colors::{OwoColorize, Stream};
 use pacquet_config::Config;
 use pacquet_lockfile::{Lockfile, PackageKey, PkgName, ResolvedDependencyMap};
 use pacquet_package_is_installable::{
-    SupportedArchitectures, WantedPlatform, WantedPlatformRef, inferred_platform,
-    platform_is_supported,
+    SupportedArchitectures, WantedPlatformRef, inferred_platform, platform_is_supported,
 };
 use pacquet_package_manager::{
     AllowBuildPolicy, validate_virtual_store_slot_containment, virtual_store_layout_for_lockfile,
@@ -361,31 +360,28 @@ fn collect_dependencies(
         let snapshot = snapshots.get(&key);
         let package =
             lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()));
-        if package.is_some_and(|package| {
-            let declared = WantedPlatformRef {
-                os: package.os.as_deref(),
-                cpu: package.cpu.as_deref(),
-                libc: package.libc.as_deref(),
-            };
-            let inferred: Option<WantedPlatform>;
-            let wanted = if snapshot.is_some_and(|snapshot| snapshot.optional) {
-                inferred = inferred_platform(&key.name.to_string(), declared);
-                inferred.as_ref().map_or(declared, |platform| WantedPlatformRef {
+        if snapshot.is_some_and(|snapshot| snapshot.optional)
+            && package.is_some_and(|package| {
+                let declared = WantedPlatformRef {
+                    os: package.os.as_deref(),
+                    cpu: package.cpu.as_deref(),
+                    libc: package.libc.as_deref(),
+                };
+                let inferred = inferred_platform(&key.name.to_string(), declared);
+                let wanted = inferred.as_ref().map_or(declared, |platform| WantedPlatformRef {
                     os: platform.os.as_deref(),
                     cpu: platform.cpu.as_deref(),
                     libc: platform.libc.as_deref(),
-                })
-            } else {
-                declared
-            };
-            !platform_is_supported(
-                wanted,
-                supported_architectures,
-                current_os,
-                current_cpu,
-                current_libc,
-            )
-        }) {
+                });
+                !platform_is_supported(
+                    wanted,
+                    supported_architectures,
+                    current_os,
+                    current_cpu,
+                    current_libc,
+                )
+            })
+        {
             continue;
         }
 

--- a/pnpm/crates/cli/src/cli_args/licenses/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/tests.rs
@@ -139,7 +139,7 @@ snapshots:
 
     let dependencies = collect_dependencies(
         &lockfile,
-        lockfile.importers.keys().cloned(),
+        lockfile.importers.keys(),
         include,
         None,
         "linux",
@@ -168,5 +168,7 @@ fn renders_dev_classification() {
         description: None,
     };
 
-    assert_eq!(render_package_name(&info), "dev-only (dev)");
+    let rendered = render_package_name(&info);
+    assert!(rendered.starts_with("dev-only "));
+    assert!(rendered.contains("(dev)"));
 }

--- a/pnpm/crates/cli/src/cli_args/licenses/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/tests.rs
@@ -92,6 +92,9 @@ importers:
       prod-only:
         specifier: 1.0.0
         version: 1.0.0
+      required-darwin:
+        specifier: 1.0.0
+        version: 1.0.0
 packages:
   '@esbuild/darwin-arm64@1.0.0':
     resolution: {integrity: sha512-inferred-darwin}
@@ -104,6 +107,11 @@ packages:
     resolution: {integrity: sha512-hidden}
   prod-only@1.0.0:
     resolution: {integrity: sha512-prod}
+  required-child@1.0.0:
+    resolution: {integrity: sha512-required-child}
+  required-darwin@1.0.0:
+    resolution: {integrity: sha512-required-darwin}
+    os: [darwin]
   visible-child@1.0.0:
     resolution: {integrity: sha512-visible}
 snapshots:
@@ -118,6 +126,10 @@ snapshots:
   prod-only@1.0.0:
     dependencies:
       visible-child: 1.0.0
+  required-child@1.0.0: {}
+  required-darwin@1.0.0:
+    dependencies:
+      required-child: 1.0.0
   visible-child@1.0.0: {}
 ",
     )
@@ -135,9 +147,11 @@ snapshots:
         "glibc",
     );
 
-    assert_eq!(dependencies.len(), 3);
+    assert_eq!(dependencies.len(), 5);
     assert_eq!(dependencies[&"dev-only@1.0.0".parse().unwrap()], BelongsTo::Dev);
     assert_eq!(dependencies[&"prod-only@1.0.0".parse().unwrap()], BelongsTo::Prod);
+    assert_eq!(dependencies[&"required-child@1.0.0".parse().unwrap()], BelongsTo::Prod);
+    assert_eq!(dependencies[&"required-darwin@1.0.0".parse().unwrap()], BelongsTo::Prod);
     assert_eq!(dependencies[&"visible-child@1.0.0".parse().unwrap()], BelongsTo::Prod);
 }
 

--- a/pnpm/crates/cli/src/cli_args/licenses/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/tests.rs
@@ -1,4 +1,8 @@
-use super::{Config, LicensesArgs, LicensesDependencyOptions};
+use super::{
+    BelongsTo, Config, Include, LicenseInfo, LicensesArgs, LicensesDependencyOptions,
+    collect_dependencies, render_package_name,
+};
+use pacquet_lockfile::Lockfile;
 use tempfile::TempDir;
 
 #[test]
@@ -64,4 +68,91 @@ async fn test_no_subcommand_matches_pnpm_error_code() {
 
     let err = args.run(&config, dir.path(), false).await.unwrap_err();
     assert!(format!("{err:?}").contains("ERR_PNPM_LICENCES_NO_SUBCOMMAND"));
+}
+
+#[test]
+fn collects_every_importer_and_filters_unsupported_subtrees() {
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    devDependencies:
+      dev-only:
+        specifier: 1.0.0
+        version: 1.0.0
+      darwin-only:
+        specifier: 1.0.0
+        version: 1.0.0
+      '@esbuild/darwin-arm64':
+        specifier: 1.0.0
+        version: 1.0.0
+  packages/a:
+    dependencies:
+      prod-only:
+        specifier: 1.0.0
+        version: 1.0.0
+packages:
+  '@esbuild/darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-inferred-darwin}
+  dev-only@1.0.0:
+    resolution: {integrity: sha512-dev}
+  darwin-only@1.0.0:
+    resolution: {integrity: sha512-darwin}
+    os: [darwin]
+  hidden-child@1.0.0:
+    resolution: {integrity: sha512-hidden}
+  prod-only@1.0.0:
+    resolution: {integrity: sha512-prod}
+  visible-child@1.0.0:
+    resolution: {integrity: sha512-visible}
+snapshots:
+  '@esbuild/darwin-arm64@1.0.0':
+    optional: true
+  dev-only@1.0.0: {}
+  darwin-only@1.0.0:
+    optional: true
+    dependencies:
+      hidden-child: 1.0.0
+  hidden-child@1.0.0: {}
+  prod-only@1.0.0:
+    dependencies:
+      visible-child: 1.0.0
+  visible-child@1.0.0: {}
+",
+    )
+    .unwrap();
+    let include =
+        Include { dependencies: true, dev_dependencies: true, optional_dependencies: true };
+
+    let dependencies = collect_dependencies(
+        &lockfile,
+        lockfile.importers.keys().cloned(),
+        include,
+        None,
+        "linux",
+        "x64",
+        "glibc",
+    );
+
+    assert_eq!(dependencies.len(), 3);
+    assert_eq!(dependencies[&"dev-only@1.0.0".parse().unwrap()], BelongsTo::Dev);
+    assert_eq!(dependencies[&"prod-only@1.0.0".parse().unwrap()], BelongsTo::Prod);
+    assert_eq!(dependencies[&"visible-child@1.0.0".parse().unwrap()], BelongsTo::Prod);
+}
+
+#[test]
+fn renders_dev_classification() {
+    let info = LicenseInfo {
+        name: "dev-only".to_string(),
+        versions: vec!["1.0.0".to_string()],
+        paths: Vec::new(),
+        license: "MIT".to_string(),
+        belongs_to: BelongsTo::Dev,
+        author: None,
+        homepage: None,
+        description: None,
+    };
+
+    assert_eq!(render_package_name(&info), "dev-only (dev)");
 }


### PR DESCRIPTION
## Summary

- scan every importer in a workspace for `pnpm licenses list`, matching the TypeScript CLI's default scope
- exclude optional packages that do not support the effective host or configured `supportedArchitectures`, including constraints inferred from platform package names
- render the `(dev)` classification for development-only dependencies
- verify the reported Prisma lockfile produces the same 1,177 normalized package names as TypeScript pnpm

Fixes pnpm/pnpm#13438.

## Squash Commit Body

```text
Pacquet's licenses command scanned only the active workspace importer unless recursive mode was explicitly selected. TypeScript pnpm scans every lockfile importer by default, so large workspaces lost dependencies that were reachable only from other projects.

Collect dependencies from every importer in the default mode and filter unsupported optional package subtrees with the same declared and package-name-inferred platform constraints used during installation. Preserve dependency-group priority while walking the graph and render development-only packages with the same `(dev)` suffix as TypeScript pnpm.

Fixes pnpm/pnpm#13438.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787774815&installation_model_id=426870&pr_number=13441&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13441&signature=a912f08b72cddd6160a00d63e955b8ed3acae89a3b4c60d3cf313cae90185b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm licenses list` to aggregate dependencies from every workspace project and label each entry by dependency type (prod, optional, dev).
  * Excluded license entries for packages not supported on the current platform and improved how dev-only items are displayed in table output.
  * Sanitized long-form “Details” output for cleaner, safer rendering.
* **Tests**
  * Added tests covering dependency collection, dependency-type classification, and dev-only package name formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->