### PR TITLE
fix(pacquet): read legacy license fields

### DIFF
--- a/.changeset/wise-wolves-report.md
+++ b/.changeset/wise-wolves-report.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm licenses list` to read licenses from legacy package manifest fields.

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -16,7 +16,7 @@ use pacquet_package_manager::{
     AllowBuildPolicy, validate_virtual_store_slot_containment, virtual_store_layout_for_lockfile,
 };
 use pacquet_package_manifest::{
-    extract_author, extract_homepage, node_version_from_engines_runtime,
+    extract_author, extract_homepage, extract_license, node_version_from_engines_runtime,
     safe_read_package_json_from_dir,
 };
 use serde::Serialize;
@@ -214,10 +214,8 @@ impl LicensesArgs {
 
             let license = manifest
                 .as_ref()
-                .and_then(|m| m.get("license"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("Unknown")
-                .to_string();
+                .and_then(extract_license)
+                .unwrap_or_else(|| "Unknown".to_string());
             let author = manifest.as_ref().and_then(extract_author);
             let homepage = manifest.as_ref().and_then(extract_homepage);
             let description = manifest

--- a/pnpm/crates/cli/tests/licenses.rs
+++ b/pnpm/crates/cli/tests/licenses.rs
@@ -33,6 +33,7 @@ fn licenses_reads_global_store_metadata_with_a_manifest_selected_runtime() {
                 // from the manifest-selected runtime instead of deferring to the host Node.
                 "@pnpm.e2e/for-legacy-node": "1.0.0",
                 "@pnpm.e2e/install-script-example": "1.0.0",
+                "@pnpm.e2e/legacy-license": "1.0.0",
             },
         })
         .to_string(),
@@ -57,18 +58,25 @@ fn licenses_reads_global_store_metadata_with_a_manifest_selected_runtime() {
 
         let licenses: Value = serde_json::from_slice(&output.stdout).expect("parse licenses JSON");
         let packages = licenses["MIT"].as_array().expect("MIT license group");
-        assert_eq!(packages.len(), 1);
-        assert_eq!(packages[0]["name"], "@pnpm.e2e/install-script-example");
-        assert_eq!(packages[0]["versions"], json!(["1.0.0"]));
-        assert!(
-            packages[0]["paths"]
-                .as_array()
-                .expect("package paths")
+        assert_eq!(
+            packages
                 .iter()
-                .all(|path| Path::new(path.as_str().expect("path string")).exists()),
-            "reported package paths should exist: {}",
-            packages[0]["paths"],
+                .map(|package| package["name"].as_str().expect("package name"))
+                .collect::<Vec<_>>(),
+            ["@pnpm.e2e/install-script-example", "@pnpm.e2e/legacy-license"],
         );
+        for package in packages {
+            assert_eq!(package["versions"], json!(["1.0.0"]));
+            assert!(
+                package["paths"]
+                    .as_array()
+                    .expect("package paths")
+                    .iter()
+                    .all(|path| Path::new(path.as_str().expect("path string")).exists()),
+                "reported package paths should exist: {}",
+                package["paths"],
+            );
+        }
     }
 
     drop((root, mock_instance));

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -931,3 +931,44 @@ pub fn extract_author(manifest: &serde_json::Value) -> Option<String> {
 pub fn extract_homepage(manifest: &serde_json::Value) -> Option<String> {
     manifest.get("homepage").and_then(|v| v.as_str()).map(ToString::to_string)
 }
+
+/// Extracts the license from either the modern `license` field or the legacy
+/// `licenses` field.
+pub fn extract_license(manifest: &serde_json::Value) -> Option<String> {
+    manifest
+        .get("license")
+        .and_then(extract_license_field)
+        .or_else(|| manifest.get("licenses").and_then(extract_license_field))
+}
+
+fn extract_license_field(field: &serde_json::Value) -> Option<String> {
+    if let Some(license) = field.as_str() {
+        return (!license.is_empty()).then(|| license.to_string());
+    }
+    if let Some(entries) = field.as_array() {
+        let licenses: Vec<&str> = entries.iter().filter_map(extract_license_type).collect();
+        return match licenses.as_slice() {
+            [] => None,
+            [license] => Some((*license).to_string()),
+            licenses => Some(format!("({})", licenses.join(" OR "))),
+        };
+    }
+    extract_license_type(field).map(ToString::to_string)
+}
+
+fn extract_license_type(entry: &serde_json::Value) -> Option<&str> {
+    entry.as_str().filter(|license| !license.is_empty()).or_else(|| {
+        entry.as_object().and_then(|entry| {
+            entry
+                .get("type")
+                .and_then(serde_json::Value::as_str)
+                .filter(|license| !license.is_empty())
+                .or_else(|| {
+                    entry
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .filter(|license| !license.is_empty())
+                })
+        })
+    })
+}

--- a/pnpm/crates/package-manifest/src/tests.rs
+++ b/pnpm/crates/package-manifest/src/tests.rs
@@ -8,7 +8,8 @@ use tempfile::{NamedTempFile, tempdir};
 use super::{
     BundleDependencies, PackageManifest, PackageManifestError, apply_runtime_on_fail_override,
     convert_dependencies_to_engines_runtime, convert_engines_runtime_to_dependencies,
-    node_version_from_engines_runtime, parse_manifest_bytes, safe_read_package_json_from_dir,
+    extract_license, node_version_from_engines_runtime, parse_manifest_bytes,
+    safe_read_package_json_from_dir,
 };
 use crate::DependencyGroup;
 use serde_json::json;
@@ -1120,6 +1121,44 @@ fn safe_read_package_json_from_dir_reads_a_manifest_that_starts_with_a_utf8_bom(
 
     let manifest = safe_read_package_json_from_dir(dir.path()).unwrap().unwrap();
     assert_eq!(manifest.get("name").unwrap(), &json!("fixture"));
+}
+
+#[test]
+fn extracts_license_from_modern_and_legacy_manifest_fields() {
+    assert_eq!(extract_license(&json!({ "license": "MIT" })), Some("MIT".to_string()));
+    assert_eq!(
+        extract_license(&json!({ "license": { "type": "Apache-2.0" } })),
+        Some("Apache-2.0".to_string()),
+    );
+    assert_eq!(
+        extract_license(&json!({ "licenses": [{ "type": "MIT" }] })),
+        Some("MIT".to_string()),
+    );
+    assert_eq!(
+        extract_license(&json!({
+            "licenses": [{ "type": "MIT" }, { "name": "Apache-2.0" }]
+        })),
+        Some("(MIT OR Apache-2.0)".to_string()),
+    );
+}
+
+#[test]
+fn modern_license_takes_priority_and_invalid_values_fall_back() {
+    assert_eq!(
+        extract_license(&json!({
+            "license": "BSD-3-Clause",
+            "licenses": [{ "type": "MIT" }]
+        })),
+        Some("BSD-3-Clause".to_string()),
+    );
+    assert_eq!(
+        extract_license(&json!({
+            "license": "",
+            "licenses": [{ "type": "MIT" }]
+        })),
+        Some("MIT".to_string()),
+    );
+    assert_eq!(extract_license(&json!({ "license": 42, "licenses": [] })), None);
 }
 
 /// A BOM is only stripped where a document may legitimately start, so a

--- a/pnpr/.fixtures/packages/@pnpm.e2e/legacy-license/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/legacy-license/1.0.0/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@pnpm.e2e/legacy-license",
+  "version": "1.0.0",
+  "licenses": [
+    {
+      "type": "MIT"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Aligns the Rust `pnpm licenses list` license values with TypeScript pnpm by reading both the modern `license` field and legacy `licenses` manifest forms. This completes the remaining license-value parity work for pnpm/pnpm#13438.

Adds parser coverage for precedence, object, array, and multi-license forms, plus a CLI integration fixture that verifies a legacy license is reported under `MIT`.

## Squash Commit Body

```text
TypeScript pnpm resolves package licenses from both the modern `license` field and the deprecated `licenses` field. Pacquet only accepted a string `license`, causing packages such as `exit`, `prettysize`, and `seq-queue` to be reported as `Unknown`.

Add a shared package-manifest extractor matching TypeScript precedence and legacy-field handling, and use it in `pnpm licenses list`. Cover the parser directly and verify the CLI result with a registry fixture.

Closes pnpm/pnpm#13438.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787778740&installation_model_id=426870&pr_number=13446&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13446&signature=9a0df5313dda6fb1ead290f21d883f25e6580485576e1a1adb716449b64b239c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm licenses list` so packages using legacy license metadata are recognized correctly.
  * Added support for license declarations in strings, arrays, and structured entries.
  * Multiple distinct licenses are now displayed together using an “OR” format.
  * Packages with invalid or empty modern license fields can fall back to valid legacy metadata.
* **Tests**
  * Expanded coverage for legacy license formats and license reporting output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->