### PR TITLE
fix(config): derive public hoisting from shamefullyHoist

### DIFF
--- a/.changeset/shamefully-hoist-root-links.md
+++ b/.changeset/shamefully-hoist-root-links.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `shamefullyHoist: true` to create public root dependency links.

--- a/pnpm/crates/cli/tests/dedupe_direct_deps.rs
+++ b/pnpm/crates/cli/tests/dedupe_direct_deps.rs
@@ -587,12 +587,9 @@ fn dedupes_direct_dep_against_publicly_hoisted_root_dep() {
     drop((root, mock_instance));
 }
 
-/// With `publicHoistPattern: ['*']` (the explicit form of
-/// `shamefullyHoist: true` — pacquet doesn't bridge the legacy flag to
-/// the pattern, see [`hoist::shamefully_hoist_legacy_publicly_hoists_everything`]),
-/// every transitive lands at the workspace root's `node_modules/`. A
-/// non-root importer's direct dep that also lands at root via hoist
-/// gets deduped from the importer.
+/// With `shamefullyHoist: true`, every transitive lands at the workspace
+/// root's `node_modules/`. A non-root importer's direct dep that also lands
+/// at root via hoist gets deduped from the importer.
 ///
 /// Runs through pacquet's fresh-install path (single `pacquet install`,
 /// no `--frozen-lockfile`), exercising the hoist pass that fresh
@@ -624,9 +621,7 @@ fn dedupe_under_shamefully_hoist() {
     workspace_yaml.push_str(
         "packages:\n  - 'packages/*'\n\
          dedupeDirectDeps: true\n\
-         shamefullyHoist: true\n\
-         hoistPattern: []\n\
-         publicHoistPattern:\n  - '*'\n",
+         shamefullyHoist: true\n",
     );
     fs::write(&workspace_yaml_path, workspace_yaml).expect("write pnpm-workspace.yaml");
 

--- a/pnpm/crates/cli/tests/hoist.rs
+++ b/pnpm/crates/cli/tests/hoist.rs
@@ -247,7 +247,7 @@ fn both_patterns_empty_produces_no_hoist_symlinks() {
 
 /// `shamefullyHoist: true` is the legacy alias for
 /// `publicHoistPattern: ["*"]`, translated in
-/// `WorkspaceSettings::apply_to`.
+/// the final merged config.
 #[test]
 fn shamefully_hoist_legacy_publicly_hoists_everything() {
     let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info, .. } =
@@ -259,10 +259,7 @@ fn shamefully_hoist_legacy_publicly_hoists_everything() {
         serde_json::json!({ "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0" }),
     );
     generate_lockfile(pnpm);
-    write_workspace_yaml(
-        &workspace,
-        "shamefullyHoist: true\nhoistPattern: []\npublicHoistPattern:\n  - '*'\n",
-    );
+    write_workspace_yaml(&workspace, "shamefullyHoist: true\n");
 
     pacquet.with_args(["install", "--frozen-lockfile"]).assert().success();
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2069,6 +2069,19 @@ impl Config {
         self.public_hoist_pattern = Some(Vec::new());
     }
 
+    /// Apply the legacy `shamefullyHoist` setting to the public hoist pattern.
+    ///
+    /// This runs after all config sources have been merged because an explicit
+    /// `shamefullyHoist` value takes precedence over `publicHoistPattern`
+    /// regardless of which source supplied either setting.
+    fn apply_shamefully_hoist_derivation(&mut self) {
+        match self.explicit_settings.get("shamefullyHoist").and_then(serde_json::Value::as_bool) {
+            Some(true) => self.public_hoist_pattern = Some(vec!["*".to_string()]),
+            Some(false) => self.public_hoist_pattern = None,
+            None => {}
+        }
+    }
+
     /// Restore the smart default store after a higher-precedence config
     /// source explicitly clears `storeDir`.
     pub fn reset_store_dir_to_default<Sys>(&mut self, start_dir: &Path)
@@ -2640,6 +2653,7 @@ impl Config {
             global_virtual_store_dir_explicit,
         );
 
+        self.apply_shamefully_hoist_derivation();
         self.apply_virtual_store_only_derivation();
 
         // Resolve the global install directories:

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2661,6 +2661,17 @@ pub fn shamefully_hoist_false_disables_public_hoisting() {
 }
 
 #[test]
+pub fn unset_shamefully_hoist_preserves_the_public_hoist_pattern() {
+    let tmp = tempdir().unwrap();
+    fs::write(tmp.path().join("pnpm-workspace.yaml"), "publicHoistPattern:\n  - eslint\n")
+        .expect("write to pnpm-workspace.yaml");
+
+    let config = Config::new().current::<HostNoHome>(tmp.path()).expect("loads");
+
+    assert_eq!(config.public_hoist_pattern, Some(vec!["eslint".to_string()]));
+}
+
+#[test]
 pub fn virtual_store_dir_max_length_matches_pnpm_default() {
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostNoHome>(tmp.path()).expect("loads");

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2633,6 +2633,34 @@ pub fn pnpm_config_hoist_false_clears_hoist_pattern() {
 }
 
 #[test]
+pub fn shamefully_hoist_derives_the_public_hoist_pattern() {
+    let tmp = tempdir().unwrap();
+    fs::write(
+        tmp.path().join("pnpm-workspace.yaml"),
+        "shamefullyHoist: true\npublicHoistPattern:\n  - eslint\n",
+    )
+    .expect("write to pnpm-workspace.yaml");
+
+    let config = Config::new().current::<HostNoHome>(tmp.path()).expect("loads");
+
+    assert_eq!(config.public_hoist_pattern, Some(vec!["*".to_string()]));
+}
+
+#[test]
+pub fn shamefully_hoist_false_disables_public_hoisting() {
+    let tmp = tempdir().unwrap();
+    fs::write(
+        tmp.path().join("pnpm-workspace.yaml"),
+        "shamefullyHoist: false\npublicHoistPattern:\n  - eslint\n",
+    )
+    .expect("write to pnpm-workspace.yaml");
+
+    let config = Config::new().current::<HostNoHome>(tmp.path()).expect("loads");
+
+    assert_eq!(config.public_hoist_pattern, None);
+}
+
+#[test]
 pub fn virtual_store_dir_max_length_matches_pnpm_default() {
     let tmp = tempdir().unwrap();
     let config = Config::new().current::<HostNoHome>(tmp.path()).expect("loads");


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13444.

The Rust CLI parsed `shamefullyHoist` but did not derive the corresponding
public hoist pattern, so `shamefullyHoist: true` could leave dependencies
missing from the root `node_modules`.

Apply the derivation after all configuration sources are merged:

- `true` sets `publicHoistPattern` to `["*"]`
- `false` disables public hoisting
- an unset value preserves an explicitly configured public hoist pattern

The TypeScript CLI already applies this derivation, so no TypeScript change is
needed. The Rust config and CLI regression tests now cover the behavior, and a
patch changeset is included for `pacquet`.

Validation:

- `just ready`
- reproduced the reported Slidev installation with the built Rust CLI and
  verified the previously missing root links are created
- repository pre-push checks

## Squash Commit Body

```text
The Rust CLI accepted shamefullyHoist without translating it into the public
hoist pattern used by installation. This left packages absent from the root
node_modules even though shameful hoisting was enabled.

Derive publicHoistPattern after all configuration sources are merged so an
explicit shamefullyHoist value has the same precedence and behavior as in the
TypeScript CLI. Cover both enabled and disabled values in config tests and make
the CLI regression tests rely on shamefullyHoist alone.

Fixes pnpm/pnpm#13444.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787779733&installation_model_id=426870&pr_number=13447&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13447&signature=387d814466da2a96305745db623e680a3e92394612f023d37ccf0b010743c8d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `shamefullyHoist: true` so public dependency links are created at the project root as expected.
  * Ensured `shamefullyHoist: false` reliably disables public hoisting, even when `publicHoistPattern` is set.
  * Improved behavior when `shamefullyHoist` is merged with other hoisting-related settings.

* **Tests**
  * Added coverage for how `shamefullyHoist` affects the derived `publicHoistPattern` when set to `true`, `false`, or left unset.
  * Updated hoisting-related test setups and scenarios to validate the final merged configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->