### PR TITLE
fix(cli): support parallel recursive runs

### DIFF
--- a/.changeset/rust-parallel-recursive-run.md
+++ b/.changeset/rust-parallel-recursive-run.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `--parallel` being treated as the script name when placed before `run` in a recursive command.

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -59,6 +59,7 @@ impl CleanArgs {
                 report_summary: false,
                 no_bail: false,
                 sort: true,
+                parallel: false,
                 sequential: false,
             }
             .run(ctx.dir, config, matches!(ctx.reporter, ReporterType::Silent));

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -207,6 +207,11 @@ pub struct CliArgs {
     #[clap(long = "workspace-concurrency", global = true)]
     pub workspace_concurrency: Option<i32>,
 
+    /// Run scripts in every selected workspace project concurrently,
+    /// disregarding topological sorting.
+    #[clap(long, global = true)]
+    pub parallel: bool,
+
     /// Recursive only: resume execution from the given package.
     #[clap(long = "resume-from", global = true, hide = true)]
     pub resume_from: Option<String>,
@@ -242,6 +247,9 @@ impl CliArgs {
         if self.if_present {
             self.validate_if_present_top_level_option()?;
         }
+        if self.parallel {
+            self.validate_parallel_global_option()?;
+        }
         Ok(())
     }
 
@@ -256,6 +264,15 @@ impl CliArgs {
     pub fn promote_recursive_for_filter(&mut self) {
         if !self.filter.is_empty() || !self.filter_prod.is_empty() {
             self.recursive = true;
+        }
+    }
+
+    /// Apply the recursive-run settings represented by pnpm's
+    /// `--parallel` shorthand.
+    pub fn apply_parallel_run_options(&mut self) {
+        if self.parallel {
+            self.recursive = true;
+            self.no_sort = true;
         }
     }
 
@@ -350,6 +367,20 @@ impl CliArgs {
             return Ok(());
         }
         self.validate_run_scoped_global_option("--no-bail")
+    }
+
+    fn validate_parallel_global_option(&self) -> Result<(), clap::Error> {
+        if matches!(
+            self.command,
+            CliCommand::Run(_)
+                | CliCommand::External(_)
+                | CliCommand::Test(_)
+                | CliCommand::Start(_)
+                | CliCommand::Stop(_),
+        ) {
+            return Ok(());
+        }
+        Err(Self::unexpected_argument_error("--parallel"))
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -36,6 +36,7 @@ pub(crate) struct RunCtx<'a> {
     pub(crate) recursive_report_summary: bool,
     pub(crate) recursive_no_bail: bool,
     pub(crate) recursive_sort: bool,
+    pub(crate) recursive_parallel: bool,
     /// The top-level `--if-present` spelling (`pnpm --if-present test`);
     /// merged with the flag the script subcommands declare themselves.
     pub(crate) if_present: bool,
@@ -178,6 +179,7 @@ impl CliArgs {
             sort: _,
             no_sort,
             workspace_concurrency,
+            parallel,
             resume_from,
             report_summary,
             no_bail,
@@ -323,6 +325,7 @@ impl CliArgs {
             recursive_report_summary: report_summary,
             recursive_no_bail: no_bail,
             recursive_sort: !no_sort,
+            recursive_parallel: parallel,
             if_present,
             config: &config,
             global_config: &global_config,

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -242,6 +242,7 @@ pub(super) fn install_test<'a>(
         report_summary: ctx.recursive_report_summary,
         no_bail: ctx.recursive_no_bail,
         sort: ctx.recursive_sort,
+        parallel: ctx.recursive_parallel,
         sequential: false,
     };
 

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -64,6 +64,7 @@ pub(super) fn fallback<'a>(
         report_summary: false,
         no_bail: false,
         sort: true,
+        parallel: false,
         sequential: false,
     };
     let args = with_recursive_run_options(ctx, args);
@@ -90,6 +91,7 @@ fn with_recursive_run_options(ctx: &RunCtx<'_>, mut args: RunArgs) -> RunArgs {
     args.report_summary = ctx.recursive_report_summary;
     args.no_bail = ctx.recursive_no_bail;
     args.sort = ctx.recursive_sort;
+    args.parallel = ctx.recursive_parallel;
     args.if_present |= ctx.if_present;
     args
 }

--- a/pnpm/crates/cli/src/cli_args/restart.rs
+++ b/pnpm/crates/cli/src/cli_args/restart.rs
@@ -32,6 +32,7 @@ impl RestartArgs {
                 report_summary: false,
                 no_bail: false,
                 sort: true,
+                parallel: false,
                 sequential: false,
             }
             .run(dir, config, silent)?;

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -61,6 +61,10 @@ pub struct RunArgs {
     #[clap(skip = true)]
     pub sort: bool,
 
+    /// Start scripts in all selected projects concurrently.
+    #[clap(skip = true)]
+    pub parallel: bool,
+
     /// Run the specified scripts one by one.
     #[clap(long, short = 's')]
     pub sequential: bool,

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -4,17 +4,17 @@
 //! `config.filter` / `config.filter_prod` (`--filter` / `--filter-prod`,
 //! include and exclude selectors) narrow the selected set via
 //! [`select_recursive_projects`]; the selection is then sorted
-//! topologically by default, or kept in workspace order under `--no-sort`,
-//! and run sequentially. `--reverse` and `--workspace-concurrency`
-//! parallelism are not supported yet. The main-dispatch
-//! auto-exclusion of the workspace root is applied via
+//! topologically by default, or kept in workspace order under `--no-sort`.
+//! `--parallel` starts every selected project concurrently. `--reverse`
+//! and bounded `--workspace-concurrency` parallelism are not supported yet.
+//! The main-dispatch auto-exclusion of the workspace root is applied via
 //! [`AutoExcludeRoot::Enabled`].
 
 use super::{RunArgs, RunContext, ScriptSelector, render_project_commands, run_stages};
 use crate::cli_args::recursive::{
-    AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
-    get_resumed_package_chunks, select_recursive_projects, sort_filtered_projects,
-    write_recursive_summary,
+    AutoExcludeRoot, ExecutionStatus, GraphPkg, Status, count_failures,
+    discover_workspace_projects, get_resumed_package_chunks, select_recursive_projects,
+    sort_filtered_projects, write_recursive_summary,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -22,6 +22,7 @@ use miette::Diagnostic;
 use pacquet_config::Config;
 use pacquet_package_manager::{make_node_package_map_option, package_map_path_for_execution};
 use pacquet_reporter::{LogEvent, LogLevel, ScopeLog};
+use pacquet_workspace_projects_graph::ProjectGraph;
 use std::{
     collections::HashMap,
     env,
@@ -162,114 +163,72 @@ pub fn run_recursive(
         );
     }
 
-    for chunk in &chunks {
-        for root in chunk {
-            let manifest = &graph[root].package.project.manifest;
-            let specified = selector.select(manifest.value());
-            if specified.is_empty() {
-                result[root].status = Status::Skipped;
-                continue;
+    if args.parallel {
+        let roots = chunks.iter().flatten().collect::<Vec<_>>();
+        let executions = std::thread::scope(|scope| {
+            roots
+                .iter()
+                .map(|root| {
+                    scope.spawn(|| {
+                        run_project(RunProjectOptions {
+                            root,
+                            graph,
+                            selector: &selector,
+                            args,
+                            init_cwd: &init_cwd,
+                            config,
+                            extra_env: &extra_env,
+                            bail,
+                        })
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(|handle| {
+                    handle.join().unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+                })
+                .collect::<miette::Result<Vec<_>>>()
+        })?;
+        for (root, execution) in roots.into_iter().zip(executions) {
+            has_command += execution.has_command;
+            result.insert(root.clone(), execution.status);
+        }
+        if bail
+            && let Some((root, _)) =
+                result.iter().find(|(_, execution)| execution.status == Status::Failure)
+        {
+            if args.report_summary {
+                write_recursive_summary(workspace_root, &result)?;
             }
-            // A `/pattern/` selector can match several scripts in one
-            // project, but the summary carries a single status per
-            // project and `count_failures` derives the exit code from
-            // it. Once one of them has failed, nothing a later script
-            // does may overwrite that.
-            let mut project_failed = false;
-            for selected in &specified {
-                let Some(script) = manifest.script(selected, true)? else {
-                    continue;
-                };
-                // Per-stage no-ops: an empty body (`!scripts[name]`) is
-                // treated as absent → skip, and a stage whose post-args
-                // command is exactly `npx only-allow pnpm` is skipped.
-                // Without these guards the recursive loop would fork a
-                // useless shell per project and (for the npm guard) might
-                // run the wrong-package-manager warning.
-                // A no-op among several selected scripts leaves the
-                // project's status alone: it says nothing about the
-                // scripts that did run, and overwriting a recorded
-                // `Passed` (or `Failure`) with `Skipped` would misreport
-                // them. A project where *nothing* matched is marked
-                // skipped above, before this loop.
-                if script.is_empty()
-                    || (args.script_args().is_empty() && script == "npx only-allow pnpm")
-                {
-                    continue;
-                }
-                // Recursion guard: skip a project when `npm_lifecycle_event`
-                // matches the requested script AND `PNPM_SCRIPT_SRC_DIR`
-                // matches the project root — i.e. this very project is
-                // already executing this very script and we're now inside its
-                // child invocation. Without this, a `build` script that itself
-                // calls `pacquet -r run build` from within a workspace project
-                // recurses without bound (every child sees the same env and
-                // walks the workspace again). Status stays Queued.
-                if env::var_os("npm_lifecycle_event").is_some_and(|event| event == **selected)
-                    && env::var_os("PNPM_SCRIPT_SRC_DIR")
-                        .is_some_and(|src_dir| Path::new(&src_dir) == root)
-                {
-                    continue;
-                }
-                // Hidden-script gate, checked *after* the truthy-body skip
-                // above so a hidden name that no project defines surfaces as
-                // `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` rather than
-                // `ERR_PNPM_HIDDEN_SCRIPT` — preserving the error precedence.
-                if selected.starts_with('.') && env::var_os("npm_lifecycle_event").is_none() {
-                    return Err(super::RunError::HiddenScript { script: selected.clone() }.into());
-                }
-
-                if !project_failed {
-                    result[root].status = Status::Running;
-                }
-                has_command += 1;
-                let start = Instant::now();
-                // Per-project pre/main/post via the same machinery
-                // single-project `run` uses. The outer manifest /
-                // empty-body / `npx only-allow pnpm` guards above
-                // discharge `run_stages`' precondition (non-empty body
-                // that isn't the args-less npx no-op), so the main stage
-                // is guaranteed to run and `run_stages` returns a plain
-                // `ExitStatus`. Pre/post scripts run with
-                // `enablePrePostScripts`. The per-package failure surface
-                // comes from the `ExecutionStatus` summary, not the
-                // `$ <script>` echo.
-                let ctx = RunContext {
-                    manifest,
-                    dir: root,
+            return Err(RecursiveRunError::RecursiveRunFirstFail {
+                prefix: root.to_string_lossy().into_owned(),
+            }
+            .into());
+        }
+    } else {
+        for chunk in &chunks {
+            for root in chunk {
+                let execution = run_project(RunProjectOptions {
+                    root,
+                    graph,
+                    selector: &selector,
+                    args,
                     init_cwd: &init_cwd,
                     config,
                     extra_env: &extra_env,
-                    silent: true,
-                    sequential: args.sequential,
-                };
-                let status = run_stages(&ctx, selected, script, args.script_args())?;
-                let duration = start.elapsed().as_secs_f64() * 1e3;
-
-                if status.success() {
-                    if !project_failed {
-                        let entry = &mut result[root];
-                        entry.status = Status::Passed;
-                        entry.duration = Some(duration);
+                    bail,
+                })?;
+                has_command += execution.has_command;
+                let failed = execution.status.status == Status::Failure;
+                result.insert(root.clone(), execution.status);
+                if bail && failed {
+                    if args.report_summary {
+                        write_recursive_summary(workspace_root, &result)?;
                     }
-                } else {
-                    project_failed = true;
-                    let prefix = root.to_string_lossy().into_owned();
-                    let entry = &mut result[root];
-                    entry.status = Status::Failure;
-                    entry.duration = Some(duration);
-                    entry.message = Some(format!(
-                        "command failed with exit code {}",
-                        status.code().unwrap_or(1),
-                    ));
-                    entry.prefix = Some(prefix.clone());
-
-                    if bail {
-                        if args.report_summary {
-                            write_recursive_summary(workspace_root, &result)?;
-                        }
-                        return Err(RecursiveRunError::RecursiveRunFirstFail { prefix }.into());
+                    return Err(RecursiveRunError::RecursiveRunFirstFail {
+                        prefix: root.to_string_lossy().into_owned(),
                     }
+                    .into());
                 }
             }
         }
@@ -298,4 +257,87 @@ pub fn run_recursive(
         return Err(RecursiveRunError::RecursiveFail { count: failures }.into());
     }
     Ok(())
+}
+
+struct ProjectExecution {
+    status: ExecutionStatus,
+    has_command: usize,
+}
+
+#[derive(Clone, Copy)]
+struct RunProjectOptions<'a, 'project> {
+    root: &'a Path,
+    graph: &'a ProjectGraph<GraphPkg<'project>>,
+    selector: &'a ScriptSelector<'a>,
+    args: &'a RunArgs,
+    init_cwd: &'a Path,
+    config: &'a Config,
+    extra_env: &'a HashMap<String, String>,
+    bail: bool,
+}
+
+fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExecution> {
+    let RunProjectOptions { root, graph, selector, args, init_cwd, config, extra_env, bail } =
+        options;
+    let manifest = &graph[root].package.project.manifest;
+    let specified = selector.select(manifest.value());
+    if specified.is_empty() {
+        let mut status = ExecutionStatus::queued();
+        status.status = Status::Skipped;
+        return Ok(ProjectExecution { status, has_command: 0 });
+    }
+
+    let mut execution = ProjectExecution { status: ExecutionStatus::queued(), has_command: 0 };
+    let mut project_failed = false;
+    for selected in &specified {
+        let Some(script) = manifest.script(selected, true)? else {
+            continue;
+        };
+        if script.is_empty() || (args.script_args().is_empty() && script == "npx only-allow pnpm") {
+            continue;
+        }
+        if env::var_os("npm_lifecycle_event").is_some_and(|event| event == **selected)
+            && env::var_os("PNPM_SCRIPT_SRC_DIR").is_some_and(|src_dir| Path::new(&src_dir) == root)
+        {
+            continue;
+        }
+        if selected.starts_with('.') && env::var_os("npm_lifecycle_event").is_none() {
+            return Err(super::RunError::HiddenScript { script: selected.clone() }.into());
+        }
+
+        if !project_failed {
+            execution.status.status = Status::Running;
+        }
+        execution.has_command += 1;
+        let start = Instant::now();
+        let ctx = RunContext {
+            manifest,
+            dir: root,
+            init_cwd,
+            config,
+            extra_env,
+            silent: true,
+            sequential: args.sequential,
+        };
+        let status = run_stages(&ctx, selected, script, args.script_args())?;
+        let duration = start.elapsed().as_secs_f64() * 1e3;
+
+        if status.success() {
+            if !project_failed {
+                execution.status.status = Status::Passed;
+                execution.status.duration = Some(duration);
+            }
+        } else {
+            project_failed = true;
+            execution.status.status = Status::Failure;
+            execution.status.duration = Some(duration);
+            execution.status.message =
+                Some(format!("command failed with exit code {}", status.code().unwrap_or(1)));
+            execution.status.prefix = Some(root.to_string_lossy().into_owned());
+            if bail {
+                break;
+            }
+        }
+    }
+    Ok(execution)
 }

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -18,7 +18,7 @@ use crate::cli_args::recursive::{
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
-use miette::Diagnostic;
+use miette::{Diagnostic, IntoDiagnostic, WrapErr};
 use pacquet_config::Config;
 use pacquet_package_manager::{make_node_package_map_option, package_map_path_for_execution};
 use pacquet_reporter::{LogEvent, LogLevel, ScopeLog};
@@ -165,24 +165,30 @@ pub fn run_recursive(
 
     if args.parallel {
         let roots = chunks.iter().flatten().collect::<Vec<_>>();
-        let executions = std::thread::scope(|scope| {
-            roots
+        let executions = std::thread::scope(|scope| -> miette::Result<Vec<_>> {
+            let handles = roots
                 .iter()
                 .map(|root| {
-                    scope.spawn(|| {
-                        run_project(RunProjectOptions {
-                            root,
-                            graph,
-                            selector: &selector,
-                            args,
-                            init_cwd: &init_cwd,
-                            config,
-                            extra_env: &extra_env,
-                            bail,
+                    std::thread::Builder::new()
+                        .spawn_scoped(scope, || {
+                            run_project(RunProjectOptions {
+                                root,
+                                graph,
+                                selector: &selector,
+                                args,
+                                init_cwd: &init_cwd,
+                                config,
+                                extra_env: &extra_env,
+                                bail,
+                            })
                         })
-                    })
+                        .into_diagnostic()
+                        .wrap_err_with(|| {
+                            format!("failed to start parallel script runner for {}", root.display())
+                        })
                 })
-                .collect::<Vec<_>>()
+                .collect::<miette::Result<Vec<_>>>()?;
+            handles
                 .into_iter()
                 .map(|handle| {
                     handle.join().unwrap_or_else(|panic| std::panic::resume_unwind(panic))

--- a/pnpm/crates/cli/src/cli_args/script_shortcut.rs
+++ b/pnpm/crates/cli/src/cli_args/script_shortcut.rs
@@ -27,6 +27,7 @@ impl ScriptShortcutArgs {
             report_summary: false,
             no_bail: false,
             sort: true,
+            parallel: false,
             sequential: false,
         }
     }

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -173,6 +173,37 @@ fn recursive_run_flags_parse_before_fallback_command() {
 }
 
 #[test]
+fn parallel_before_run_is_a_recursive_unsorted_run_option() {
+    let mut parsed = CliArgs::try_parse_from([
+        "pacquet",
+        "-r",
+        "--filter=./packages/**",
+        "--parallel",
+        "run",
+        "build",
+    ])
+    .expect("parses --parallel before run");
+    assert!(parsed.parallel);
+    parsed.validate_command_scoped_global_options().expect("run accepts --parallel");
+    parsed.apply_parallel_run_options();
+    assert!(parsed.recursive);
+    assert!(parsed.no_sort);
+    assert!(
+        matches!(&parsed.command, CliCommand::Run(args) if args.script.as_slice() == ["build"]),
+    );
+}
+
+#[test]
+fn parallel_after_run_script_is_forwarded_to_the_script() {
+    let parsed = CliArgs::try_parse_from(["pacquet", "run", "build", "--parallel"])
+        .expect("parses --parallel as a script argument");
+    assert!(!parsed.parallel);
+    assert!(
+        matches!(&parsed.command, CliCommand::Run(args) if args.script.as_slice() == ["build", "--parallel"]),
+    );
+}
+
+#[test]
 fn script_scoped_global_flags_parse_before_script_commands() {
     for argv in [
         ["pacquet", "--report-summary", "run", "build"].as_slice(),

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -174,16 +174,10 @@ fn recursive_run_flags_parse_before_fallback_command() {
 
 #[test]
 fn parallel_before_run_is_a_recursive_unsorted_run_option() {
-    let mut parsed = CliArgs::try_parse_from([
-        "pacquet",
-        "-r",
-        "--filter=./packages/**",
-        "--parallel",
-        "run",
-        "build",
-    ])
-    .expect("parses --parallel before run");
+    let mut parsed = CliArgs::try_parse_from(["pacquet", "--parallel", "run", "build"])
+        .expect("parses --parallel before run");
     assert!(parsed.parallel);
+    assert!(!parsed.recursive);
     parsed.validate_command_scoped_global_options().expect("run accepts --parallel");
     parsed.apply_parallel_run_options();
     assert!(parsed.recursive);

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -94,6 +94,7 @@ fn run_cli() -> miette::Result<()> {
     if let Err(err) = args.validate_command_scoped_global_options() {
         err.exit();
     }
+    args.apply_parallel_run_options();
     args.promote_recursive_for_filter();
     args.apply_workspace_root()?;
     args.promote_recursive_by_default();

--- a/pnpm/crates/cli/tests/run_recursive.rs
+++ b/pnpm/crates/cli/tests/run_recursive.rs
@@ -107,6 +107,54 @@ fn recursive_run_executes_script_in_every_project() {
 }
 
 #[test]
+fn parallel_before_run_starts_selected_projects_concurrently() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let waits_for_peer = |name: &str, peer: &str| {
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "scripts": {
+                "build": format!(
+                    "touch ../{name}.started; \
+                     attempts=0; \
+                     while [ ! -f ../{peer}.started ] && [ \"$attempts\" -lt 100 ]; do \
+                       sleep 0.01; attempts=$((attempts + 1)); \
+                     done; \
+                     test -f ../{peer}.started"
+                ),
+            },
+        })
+    };
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", waits_for_peer("project-1", "project-2")),
+            ("project-2", waits_for_peer("project-2", "project-1")),
+        ],
+    );
+
+    pacquet
+        .with_arg("-r")
+        .with_arg("--filter=./project-*")
+        .with_arg("--parallel")
+        .with_arg("run")
+        .with_arg("build")
+        .assert()
+        .success();
+
+    assert!(
+        workspace.join("project-1.started").exists(),
+        "project-1 should start while project-2 is waiting",
+    );
+    assert!(
+        workspace.join("project-2.started").exists(),
+        "project-2 should start while project-1 is waiting",
+    );
+
+    drop(root);
+}
+
+#[test]
 fn top_level_fallback_enters_recursive_run() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let commitlint_writes_marker = |name: &str| {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#13443.

The Rust CLI now recognizes `--parallel` before recursive `run` commands instead of passing it through as the script name. It applies pnpm's recursive and no-sort shorthand settings, then starts every selected project's script concurrently.

The TypeScript CLI already has this behavior, so no TypeScript implementation change is needed.

Parser tests cover both sides of the forwarding boundary: `--parallel` before `run` is a pnpm option, while the same token after the script name is forwarded unchanged. The recursive-run regression test synchronizes two projects so it fails under sequential execution.

## Squash Commit Body

```text
Recognize `--parallel` as a recursive-run option in the Rust CLI instead
of forwarding it as the script name.

Apply the shorthand's recursive and no-sort settings during CLI
normalization, thread the parallel mode into recursive script dispatch,
and start all selected projects concurrently. Project results are
collected in selection order so summaries and failure reporting remain
deterministic.

Add parser-boundary coverage and a synchronization-based concurrency
regression test. The TypeScript CLI already implements this behavior.

Closes pnpm/pnpm#13443
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787779871&installation_model_id=426870&pr_number=13448&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13448&signature=8df08f946b4c73602baa430aeca02275db0ed4937c3dd399a6d107b66f5bc11b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global `--parallel` flag for run-like script commands to start scripts concurrently across selected projects (recursive, unsorted).
* **Bug Fixes**
  * Fixed `--parallel` being misread as a script name when placed before `run` in recursive commands.
  * Ensured `--parallel` placed after the script name is treated as a script argument.
  * Kept `clean`/`purge` and restart flows non-parallel, and propagated parallel behavior through recursive execution.
* **Tests**
  * Added parsing and integration coverage verifying concurrent startup and correct `--parallel` placement/handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->