### PR TITLE
fix(dedupe): sort check snapshot changes

### DIFF
--- a/.changeset/calm-dedupes-report.md
+++ b/.changeset/calm-dedupes-report.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.dedupe.check": patch
+"pnpm": patch
+---
+
+Sort `pnpm dedupe --check` snapshot changes for stable output across pnpm implementations.

--- a/.changeset/calm-dedupes-report.md
+++ b/.changeset/calm-dedupes-report.md
@@ -1,5 +1,6 @@
 ---
 "@pnpm/installing.dedupe.check": patch
+"@pnpm/installing.dedupe.issues-renderer": patch
 "pnpm": patch
 ---
 

--- a/pnpm11/installing/dedupe/check/src/dedupeDiffCheck.ts
+++ b/pnpm11/installing/dedupe/check/src/dedupeDiffCheck.ts
@@ -105,7 +105,13 @@ function diffSnapshots<TSnapshot> (
 
   const added = (Object.keys(next) as DepPath[]).filter(id => prev[id] == null)
 
-  return { added, removed, updated }
+  added.sort()
+  removed.sort()
+  const sortedUpdated = Object.fromEntries(
+    Object.entries(updated).sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+  )
+
+  return { added, removed, updated: sortedUpdated }
 }
 
 function getResolutionUpdates (prev: ResolvedDependencies, next: ResolvedDependencies): ResolutionChangesByAlias {

--- a/pnpm11/installing/dedupe/check/src/dedupeDiffCheck.ts
+++ b/pnpm11/installing/dedupe/check/src/dedupeDiffCheck.ts
@@ -107,9 +107,7 @@ function diffSnapshots<TSnapshot> (
 
   added.sort()
   removed.sort()
-  const sortedUpdated = Object.fromEntries(
-    Object.entries(updated).sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-  )
+  const sortedUpdated = sortRecord(updated)
 
   return { added, removed, updated: sortedUpdated }
 }
@@ -134,7 +132,13 @@ function getResolutionUpdates (prev: ResolvedDependencies, next: ResolvedDepende
     updates[alias] = { type: 'added', next: nextResolution }
   }
 
-  return updates
+  return sortRecord(updates)
+}
+
+function sortRecord<T> (record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record).sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+  )
 }
 
 export function countChangedSnapshots (snapshotChanges: SnapshotsChanges): number {

--- a/pnpm11/installing/dedupe/check/src/dedupeDiffCheck.ts
+++ b/pnpm11/installing/dedupe/check/src/dedupeDiffCheck.ts
@@ -99,7 +99,7 @@ function diffSnapshots<TSnapshot> (
     }
 
     if (Object.keys(updates).length > 0) {
-      updated[id] = sortRecord(updates)
+      updated[id] = updates
     }
   }
 
@@ -107,9 +107,8 @@ function diffSnapshots<TSnapshot> (
 
   added.sort()
   removed.sort()
-  const sortedUpdated = sortRecord(updated)
 
-  return { added, removed, updated: sortedUpdated }
+  return { added, removed, updated }
 }
 
 function getResolutionUpdates (prev: ResolvedDependencies, next: ResolvedDependencies): ResolutionChangesByAlias {
@@ -133,12 +132,6 @@ function getResolutionUpdates (prev: ResolvedDependencies, next: ResolvedDepende
   }
 
   return updates
-}
-
-function sortRecord<T> (record: Record<string, T>): Record<string, T> {
-  return Object.fromEntries(
-    Object.entries(record).sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
-  )
 }
 
 export function countChangedSnapshots (snapshotChanges: SnapshotsChanges): number {

--- a/pnpm11/installing/dedupe/check/src/dedupeDiffCheck.ts
+++ b/pnpm11/installing/dedupe/check/src/dedupeDiffCheck.ts
@@ -99,7 +99,7 @@ function diffSnapshots<TSnapshot> (
     }
 
     if (Object.keys(updates).length > 0) {
-      updated[id] = updates
+      updated[id] = sortRecord(updates)
     }
   }
 
@@ -132,7 +132,7 @@ function getResolutionUpdates (prev: ResolvedDependencies, next: ResolvedDepende
     updates[alias] = { type: 'added', next: nextResolution }
   }
 
-  return sortRecord(updates)
+  return updates
 }
 
 function sortRecord<T> (record: Record<string, T>): Record<string, T> {

--- a/pnpm11/installing/dedupe/check/test/dedupeDiffCheck.ts
+++ b/pnpm11/installing/dedupe/check/test/dedupeDiffCheck.ts
@@ -131,6 +131,8 @@ describe('dedupeDiffCheck', () => {
           resolution: { integrity: 'sha512-a' },
           dependencies: {
             zDependency: '1.0.0',
+          },
+          optionalDependencies: {
             aDependency: '1.0.0',
           },
         },
@@ -160,6 +162,8 @@ describe('dedupeDiffCheck', () => {
           resolution: { integrity: 'sha512-a' },
           dependencies: {
             zDependency: '2.0.0',
+          },
+          optionalDependencies: {
             aDependency: '2.0.0',
           },
         },

--- a/pnpm11/installing/dedupe/check/test/dedupeDiffCheck.ts
+++ b/pnpm11/installing/dedupe/check/test/dedupeDiffCheck.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@jest/globals'
-import { DedupeCheckIssuesError, dedupeDiffCheck } from '@pnpm/installing.dedupe.check'
+import {
+  calcDedupeCheckIssues,
+  DedupeCheckIssuesError,
+  dedupeDiffCheck,
+} from '@pnpm/installing.dedupe.check'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import type { DepPath, ProjectId } from '@pnpm/types'
 
@@ -110,5 +114,68 @@ describe('dedupeDiffCheck', () => {
         updated: {},
       },
     }))
+  })
+
+  it('sorts snapshot changes independently of resolution order', () => {
+    const before: LockfileObject = {
+      importers: {
+        ['.' as ProjectId]: {
+          specifiers: {},
+        },
+      },
+      packages: {
+        ['z@1.0.0' as DepPath]: {
+          resolution: { integrity: 'sha512-z' },
+        },
+        ['a@1.0.0' as DepPath]: {
+          resolution: { integrity: 'sha512-a' },
+          dependencies: {
+            dependency: '1.0.0',
+          },
+        },
+      },
+      lockfileVersion: 'testLockfileVersion',
+    }
+    const after: LockfileObject = {
+      importers: {
+        ['.' as ProjectId]: {
+          specifiers: {},
+        },
+      },
+      packages: {
+        ['z-new@1.0.0' as DepPath]: {
+          resolution: { integrity: 'sha512-z-new' },
+        },
+        ['a-new@1.0.0' as DepPath]: {
+          resolution: { integrity: 'sha512-a-new' },
+        },
+        ['z@1.0.0' as DepPath]: {
+          resolution: { integrity: 'sha512-z' },
+          dependencies: {
+            dependency: '2.0.0',
+          },
+        },
+        ['a@1.0.0' as DepPath]: {
+          resolution: { integrity: 'sha512-a' },
+          dependencies: {
+            dependency: '2.0.0',
+          },
+        },
+      },
+      lockfileVersion: 'testLockfileVersion',
+    }
+
+    expect(calcDedupeCheckIssues(before, after).packageIssuesByDepPath).toEqual({
+      added: ['a-new@1.0.0', 'z-new@1.0.0'],
+      removed: [],
+      updated: {
+        'a@1.0.0': {
+          dependency: { type: 'updated', prev: '1.0.0', next: '2.0.0' },
+        },
+        'z@1.0.0': {
+          dependency: { type: 'added', next: '2.0.0' },
+        },
+      },
+    })
   })
 })

--- a/pnpm11/installing/dedupe/check/test/dedupeDiffCheck.ts
+++ b/pnpm11/installing/dedupe/check/test/dedupeDiffCheck.ts
@@ -130,7 +130,8 @@ describe('dedupeDiffCheck', () => {
         ['a@1.0.0' as DepPath]: {
           resolution: { integrity: 'sha512-a' },
           dependencies: {
-            dependency: '1.0.0',
+            zDependency: '1.0.0',
+            aDependency: '1.0.0',
           },
         },
       },
@@ -158,7 +159,8 @@ describe('dedupeDiffCheck', () => {
         ['a@1.0.0' as DepPath]: {
           resolution: { integrity: 'sha512-a' },
           dependencies: {
-            dependency: '2.0.0',
+            zDependency: '2.0.0',
+            aDependency: '2.0.0',
           },
         },
       },
@@ -170,7 +172,8 @@ describe('dedupeDiffCheck', () => {
       removed: [],
       updated: {
         'a@1.0.0': {
-          dependency: { type: 'updated', prev: '1.0.0', next: '2.0.0' },
+          aDependency: { type: 'updated', prev: '1.0.0', next: '2.0.0' },
+          zDependency: { type: 'updated', prev: '1.0.0', next: '2.0.0' },
         },
         'z@1.0.0': {
           dependency: { type: 'added', next: '2.0.0' },

--- a/pnpm11/installing/dedupe/issues-renderer/src/index.ts
+++ b/pnpm11/installing/dedupe/issues-renderer/src/index.ts
@@ -31,17 +31,21 @@ export function renderDedupeCheckIssues (dedupeCheckIssues: DedupeCheckIssues): 
  */
 function report (snapshotChanges: SnapshotsChanges): string {
   return [
-    ...Object.entries(snapshotChanges.updated).map(([alias, updates]) => renderTree(toArchy(alias, updates))),
-    ...snapshotChanges.added.map((id) => `${chalk.green('+')} ${id}`),
-    ...snapshotChanges.removed.map((id) => `${chalk.red('-')} ${id}`),
+    ...sortEntries(snapshotChanges.updated).map(([alias, updates]) => renderTree(toArchy(alias, updates))),
+    ...[...snapshotChanges.added].sort().map((id) => `${chalk.green('+')} ${id}`),
+    ...[...snapshotChanges.removed].sort().map((id) => `${chalk.red('-')} ${id}`),
   ].join('\n')
 }
 
 function toArchy (name: string, issue: ResolutionChangesByAlias): TreeNode {
   return {
     label: name,
-    nodes: Object.entries(issue).map(([alias, change]) => toArchyResolution(alias, change)),
+    nodes: sortEntries(issue).map(([alias, change]) => toArchyResolution(alias, change)),
   }
+}
+
+function sortEntries<T> (record: Record<string, T>): Array<[string, T]> {
+  return Object.entries(record).sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
 }
 
 function toArchyResolution (alias: string, change: ResolutionChange): TreeNode {

--- a/pnpm11/installing/dedupe/issues-renderer/test/index.ts
+++ b/pnpm11/installing/dedupe/issues-renderer/test/index.ts
@@ -84,4 +84,39 @@ describe('renderDedupeCheckIssues', () => {
       },
     }))).toMatchSnapshot()
   })
+
+  test('sorts integer-like snapshot and alias keys lexically', () => {
+    const output = stripAnsi(renderDedupeCheckIssues({
+      importerIssuesByImporterId: {
+        added: [],
+        removed: [],
+        updated: {},
+      },
+      packageIssuesByDepPath: {
+        added: [],
+        removed: [],
+        updated: {
+          2: {
+            2: { type: 'added', next: '2.0.0' },
+            10: { type: 'added', next: '10.0.0' },
+          },
+          10: {
+            dependency: { type: 'added', next: '1.0.0' },
+          },
+        },
+      },
+    }))
+
+    expect(output.split('\n')).toEqual([
+      'Packages',
+      '10',
+      '└── + dependency 1.0.0',
+      '',
+      '2',
+      '├── + 10 10.0.0',
+      '└── + 2 2.0.0',
+      '',
+      '',
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

Sort snapshot additions, removals, and updates in the TypeScript `pnpm dedupe --check` diff. The Rust CLI already emits canonical lockfile-key order, so this makes the two implementations report the same deterministic result on large workspaces such as `novuhq/novu`.

Related to pnpm/pnpm#13305.

The Novu lockfiles written by the available TypeScript baseline and the branch-built Rust CLI were byte-identical. A full branch-built TypeScript Novu run remains blocked because the workspace references the private `@taskforcesh/bullmq-pro` package and the registry returns 404 without project credentials.

## Squash Commit Body

```text
Sort dedupe check snapshot changes before rendering them so output does not depend on resolver insertion order. This aligns the TypeScript report with Rust pnpm, which already reports canonical lockfile-key order.

Related to pnpm/pnpm#13305.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5.6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787784744&installation_model_id=426870&pr_number=13451&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13451&signature=779efde25fb11cdac767220b378b60f893d6b7cb37ce35a10f41ec4505846089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm dedupe --check` snapshot diff consistency by producing deterministic results regardless of lockfile ordering.
* **Tests**
  * Added Jest coverage to verify dedupe check issue reporting remains correctly structured and stably sorted across input variations.
* **Releases**
  * Prepared patch releases for the deduplication checking package and pnpm.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->