### PR TITLE
fix: preserve node_modules during dedupe checks

### DIFF
--- a/.changeset/tidy-donkeys-check.md
+++ b/.changeset/tidy-donkeys-check.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Prevented `pnpm dedupe --check` from removing an incompatible `node_modules` directory.

--- a/pnpm11/installing/commands/test/dedupe.ts
+++ b/pnpm11/installing/commands/test/dedupe.ts
@@ -174,16 +174,23 @@ async function testFixture (fixtureName: string) {
   // unmodified after a regular install.
   await install.handler(opts)
   expect(readProjectLockfile()).toEqual(originalLockfile)
+  const modulesFilePath = path.join(project.dir(), 'node_modules/.modules.yaml')
+  const originalModulesFile = fs.readFileSync(modulesFilePath, 'utf8')
 
   let dedupeCheckError: DedupeCheckIssuesError | undefined
   try {
-    await dedupe.handler({ ...opts, check: true })
+    await dedupe.handler({
+      ...opts,
+      check: true,
+      storeDir: path.join(project.dir(), 'different-store'),
+    })
   } catch (err: unknown) {
     expect(err).toBeInstanceOf(DedupeCheckIssuesError)
     dedupeCheckError = err as DedupeCheckIssuesError
   } finally {
     // The dedupe check option should never change the lockfile.
     expect(readProjectLockfile()).toEqual(originalLockfile)
+    expect(fs.readFileSync(modulesFilePath, 'utf8')).toBe(originalModulesFile)
   }
 
   if (dedupeCheckError == null) {

--- a/pnpm11/installing/commands/test/dedupe.ts
+++ b/pnpm11/installing/commands/test/dedupe.ts
@@ -176,6 +176,8 @@ async function testFixture (fixtureName: string) {
   expect(readProjectLockfile()).toEqual(originalLockfile)
   const modulesFilePath = path.join(project.dir(), 'node_modules/.modules.yaml')
   const originalModulesFile = fs.readFileSync(modulesFilePath, 'utf8')
+  const virtualStoreDir = path.join(project.dir(), 'node_modules/.pnpm')
+  const originalVirtualStoreEntries = fs.readdirSync(virtualStoreDir).sort()
 
   let dedupeCheckError: DedupeCheckIssuesError | undefined
   try {
@@ -191,6 +193,7 @@ async function testFixture (fixtureName: string) {
     // The dedupe check option should never change the lockfile.
     expect(readProjectLockfile()).toEqual(originalLockfile)
     expect(fs.readFileSync(modulesFilePath, 'utf8')).toBe(originalModulesFile)
+    expect(fs.readdirSync(virtualStoreDir).sort()).toEqual(originalVirtualStoreEntries)
   }
 
   if (dedupeCheckError == null) {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -349,7 +349,7 @@ export async function mutateModules (
 
   let ctx = await getContext(opts)
 
-  if (!opts.lockfileOnly && ctx.modulesFile != null) {
+  if (!opts.lockfileOnly && !isCheckOnlyInstall(opts) && ctx.modulesFile != null) {
     const { purged } = await validateModules(ctx.modulesFile, Object.values(ctx.projects), {
       forceNewModules: installsOnly,
       include: opts.include,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#13450.

`pnpm dedupe --check` now skips `node_modules` compatibility validation. That validation may purge an incompatible modules directory, which violates the check-only contract and left n8n without its virtual store when the effective store directory differed.

The Rust CLI already preserves installed state during this check, so no pacquet change is needed.

## Squash Commit Body

```text
Check-only installs are intended to resolve and compare lockfiles without
writing to disk. The modules compatibility validation ran before the existing
check-only guards, however, and could purge node_modules when settings such as
the store directory differed.

Skip compatibility validation for check-only installs and verify that
dedupe --check preserves the modules manifest while still reporting lockfile
dedupe opportunities.

Fixes pnpm/pnpm#13450.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787785293&installation_model_id=426870&pr_number=13452&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13452&signature=693d07d0ba85e8d736c162896421087ba39563106d11a37c8edeae0fa8f53063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm dedupe --check` now preserves an incompatible `node_modules` directory instead of removing it.
  * Check-only operations now leave the lockfile, `node_modules/.modules.yaml`, and virtual store entries unchanged.
* **Tests**
  * Expanded dedupe `--check` assertions to verify immutability of the lockfile and `node_modules` metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->