### PR TITLE
fix(package-manager): honor scriptShell for lifecycle scripts

### DIFF
--- a/.changeset/script-shell-for-lifecycle-scripts.md
+++ b/.changeset/script-shell-for-lifecycle-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`scriptShell` now selects the shell for lifecycle scripts too — dependency build scripts and a project's own `preinstall`/`install`/`postinstall`/`prepare` and `pnpm:devPreinstall` — not only for `pnpm run` and `pnpm exec`. A workspace that configures a shell was still getting the platform default (`sh` / `cmd`) for everything the install itself spawns.

--- a/pnpm/crates/cli/tests/lifecycle_scripts.rs
+++ b/pnpm/crates/cli/tests/lifecycle_scripts.rs
@@ -2255,3 +2255,100 @@ mod project_scripts_in_a_workspace {
         drop((root, anchor));
     }
 }
+
+/// `scriptShell` selects the shell every lifecycle script is spawned
+/// under, not only the one `pnpm run` uses. Unix-only: the probe is a
+/// shell shim, and `select_shell` rejects `.cmd`/`.bat` shims on
+/// Windows anyway.
+#[cfg(unix)]
+mod script_shell {
+    use super::workspace_yaml::{allow_builds, append_workspace_yaml_key};
+    use assert_cmd::prelude::*;
+    use command_extra::CommandExtra;
+    use pacquet_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+    use std::{fs, os::unix::fs::PermissionsExt, path::Path};
+
+    /// Install a shell shim that appends each script it is asked to run
+    /// to `log`, then hands the script to the real `/bin/sh`, and point
+    /// `scriptShell` at it. Every spawn that honors the setting shows up
+    /// in the log; every spawn that ignores it silently does not.
+    fn install_probe_shell(workspace: &Path) -> std::path::PathBuf {
+        let log = workspace.join("shell-invocations.txt");
+        let shim = workspace.join("probe-shell.sh");
+        fs::write(
+            &shim,
+            format!("#!/bin/sh\nprintf '%s\\n' \"$2\" >> {log:?}\nexec /bin/sh -c \"$2\"\n"),
+        )
+        .expect("write the probe shell");
+        fs::set_permissions(&shim, fs::Permissions::from_mode(0o755))
+            .expect("make the probe shell executable");
+        append_workspace_yaml_key(workspace, "scriptShell", shim.display());
+        log
+    }
+
+    fn logged_scripts(log: &Path) -> Vec<String> {
+        fs::read_to_string(log)
+            .expect("read the probe shell's log")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn runs_the_projects_own_scripts_and_dev_preinstall_under_it() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        let package_json = serde_json::json!({
+            "name": "project-with-a-configured-shell",
+            "version": "1.0.0",
+            "scripts": {
+                "pnpm:devPreinstall": "echo dev-preinstall-marker",
+                "postinstall": "echo postinstall-marker",
+            },
+        });
+        fs::write(workspace.join("package.json"), package_json.to_string())
+            .expect("write package.json");
+        let log = install_probe_shell(&workspace);
+
+        pacquet.with_arg("install").assert().success();
+
+        let scripts = logged_scripts(&log);
+        assert!(
+            scripts.iter().any(|script| script.contains("dev-preinstall-marker")),
+            "pnpm:devPreinstall should run under the configured shell, got {scripts:?}",
+        );
+        assert!(
+            scripts.iter().any(|script| script.contains("postinstall-marker")),
+            "the project's postinstall should run under the configured shell, got {scripts:?}",
+        );
+
+        drop((root, mock_instance));
+    }
+
+    #[test]
+    fn runs_dependency_build_scripts_under_it() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+        let package_json = serde_json::json!({
+            "dependencies": { "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" },
+        });
+        fs::write(workspace.join("package.json"), package_json.to_string())
+            .expect("write package.json");
+        allow_builds(&workspace, &[("@pnpm.e2e/pre-and-postinstall-scripts-example", true)]);
+        let log = install_probe_shell(&workspace);
+
+        pacquet.with_arg("install").assert().success();
+
+        let scripts = logged_scripts(&log);
+        assert!(
+            scripts.iter().any(|script| script.contains("generated-by-preinstall")),
+            "a dependency's build scripts should run under the configured shell, got {scripts:?}",
+        );
+
+        drop((root, mock_instance));
+    }
+}

--- a/pnpm/crates/cli/tests/lifecycle_scripts.rs
+++ b/pnpm/crates/cli/tests/lifecycle_scripts.rs
@@ -2269,15 +2269,20 @@ mod script_shell {
     use std::{fs, os::unix::fs::PermissionsExt, path::Path};
 
     /// Install a shell shim that appends each script it is asked to run
-    /// to `log`, then hands the script to the real `/bin/sh`, and point
-    /// `scriptShell` at it. Every spawn that honors the setting shows up
-    /// in the log; every spawn that ignores it silently does not.
+    /// to a log beside itself, then hands the script to the real
+    /// `/bin/sh`, and point `scriptShell` at it. Every spawn that honors
+    /// the setting shows up in the log; every spawn that ignores it
+    /// silently does not.
+    ///
+    /// The shim derives the log path from its own location rather than
+    /// having it interpolated in, so nothing from the temp directory's
+    /// name is ever parsed as shell source.
     fn install_probe_shell(workspace: &Path) -> std::path::PathBuf {
         let log = workspace.join("shell-invocations.txt");
         let shim = workspace.join("probe-shell.sh");
         fs::write(
             &shim,
-            format!("#!/bin/sh\nprintf '%s\\n' \"$2\" >> {log:?}\nexec /bin/sh -c \"$2\"\n"),
+            "#!/bin/sh\nprintf '%s\\n' \"$2\" >> \"$(dirname \"$0\")/shell-invocations.txt\"\nexec /bin/sh -c \"$2\"\n",
         )
         .expect("write the probe shell");
         fs::set_permissions(&shim, fs::Permissions::from_mode(0o755))

--- a/pnpm/crates/package-manager/src/build_modules.rs
+++ b/pnpm/crates/package-manager/src/build_modules.rs
@@ -462,6 +462,11 @@ pub struct BuildModules<'a> {
     /// [`RunPostinstallHooks::scripts_prepend_node_path`] for each
     /// spawned lifecycle script. Default [`ScriptsPrependNodePath::Never`].
     pub scripts_prepend_node_path: ScriptsPrependNodePath,
+    /// Mirrors `config.script_shell`. Threaded through to
+    /// [`RunPostinstallHooks::script_shell`], so a workspace that
+    /// configures a shell gets it for build scripts too, not only for
+    /// `pnpm run`. `None` selects the platform default.
+    pub script_shell: Option<&'a Path>,
     pub extra_env: &'a HashMap<String, String>,
     /// Mirrors `config.user_agent`, stamped into each build script's
     /// `npm_config_user_agent`.
@@ -594,6 +599,7 @@ impl BuildModules<'_> {
             store_index_writer,
             patches,
             scripts_prepend_node_path,
+            script_shell,
             extra_env,
             user_agent,
             unsafe_perm,
@@ -759,6 +765,7 @@ impl BuildModules<'_> {
                         extra_env,
                         user_agent,
                         scripts_prepend_node_path,
+                        script_shell,
                         unsafe_perm,
                         frozen_store,
                         ignore_scripts,
@@ -839,6 +846,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
     extra_env: &HashMap<String, String>,
     user_agent: &str,
     scripts_prepend_node_path: ScriptsPrependNodePath,
+    script_shell: Option<&Path>,
     unsafe_perm: bool,
     frozen_store: bool,
     ignore_scripts: bool,
@@ -1196,7 +1204,7 @@ fn build_one_snapshot<Reporter: self::Reporter>(
             unsafe_perm,
             node_gyp_bin: None,
             scripts_prepend_node_path,
-            script_shell: None,
+            script_shell,
             optional,
         });
 

--- a/pnpm/crates/package-manager/src/build_modules/tests.rs
+++ b/pnpm/crates/package-manager/src/build_modules/tests.rs
@@ -391,6 +391,8 @@ fn build_modules_collects_ignored_builds() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -458,6 +460,8 @@ fn ignore_scripts_skips_build_without_collecting_ignored() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -514,6 +518,8 @@ fn cached_requires_build_false_skips_package_dir_probe() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -590,6 +596,8 @@ fn build_modules_collects_ignored_builds_under_concurrency() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -658,6 +666,8 @@ fn build_modules_excludes_explicit_deny_from_ignored() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -743,6 +753,8 @@ fn do_not_fail_on_optional_dep_with_failing_postinstall() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -905,6 +917,8 @@ fn using_side_effects_cache_skips_rebuild() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -1032,6 +1046,8 @@ fn corrupt_side_effects_cache_falls_back_to_rebuild() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -1150,6 +1166,8 @@ fn materialization_failure_on_incomplete_slot_is_fatal() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -1218,6 +1236,8 @@ fn side_effects_cache_disabled_bypasses_the_gate() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -1284,6 +1304,8 @@ fn fail_when_failing_postinstall_is_required() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -1374,6 +1396,8 @@ fn frozen_backstop_run(
         patches: Some(&patches),
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -1696,6 +1720,8 @@ async fn write_path_populates_side_effects_row() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -1817,6 +1843,8 @@ async fn write_path_disabled_skips_upload() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -1910,6 +1938,8 @@ async fn frozen_store_skips_side_effects_upload() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -2052,6 +2082,8 @@ async fn upload_error_does_not_interrupt_install() {
         patches: None,
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -2308,6 +2340,8 @@ new file mode 100644
         patches: Some(&patches),
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -2422,6 +2456,8 @@ new file mode 100644
         patches: Some(&patches),
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -2508,6 +2544,8 @@ async fn missing_patch_file_path_errors_with_diagnostic() {
         patches: Some(&patches),
 
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,
@@ -2768,6 +2806,7 @@ fn rebuild_selection_runs_only_selected_scripts() {
         store_index_writer: None,
         patches: None,
         scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
         extra_env: &HashMap::new(),
         user_agent: "pnpm/test",
         unsafe_perm: true,

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -3810,7 +3810,7 @@ fn run_dev_preinstall<Reporter: self::Reporter>(
         unsafe_perm: config.unsafe_perm,
         node_gyp_bin: None,
         scripts_prepend_node_path: exec_scripts_prepend_node_path(config),
-        script_shell: None,
+        script_shell: config.script_shell.as_deref().map(Path::new),
         optional: false,
     })
     .map(drop)
@@ -3864,7 +3864,7 @@ fn run_projects_lifecycle_scripts<Reporter: self::Reporter>(
                 unsafe_perm: config.unsafe_perm,
                 node_gyp_bin: None,
                 scripts_prepend_node_path,
-                script_shell: None,
+                script_shell: config.script_shell.as_deref().map(Path::new),
                 optional: false,
             })
             .map_err(InstallError::ProjectLifecycleScript)?;

--- a/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_frozen_lockfile.rs
@@ -516,6 +516,7 @@ pub(crate) fn run_build_phase<Reporter: self::Reporter>(
         store_index_writer: Some(store_index_writer),
         patches: patches.as_ref(),
         scripts_prepend_node_path,
+        script_shell: config.script_shell.as_deref().map(Path::new),
         extra_env,
         user_agent: &config.user_agent,
         unsafe_perm: config.unsafe_perm,


### PR DESCRIPTION
## Summary

`scriptShell` reached only `pnpm run` / `pnpm exec` (and `pnpm version`). Every lifecycle script the *install* spawns passed `script_shell: None` and so ran under the platform default — `sh` on POSIX, `cmd` on Windows — however the workspace had configured its shell. The TypeScript CLI threads `scriptShell` into the same runs through `scriptsOpts`, so a workspace whose scripts assume its configured shell worked there and silently did not here.

This threads `config.script_shell` to the three contexts that spawn scripts during an install:

| context | site |
| --- | --- |
| dependency build scripts | `build_modules.rs` (via a new `BuildModules::script_shell`) |
| a project's own `preinstall`/`install`/`postinstall`/`prepare` | `install.rs` `run_projects_lifecycle_scripts` |
| `pnpm:devPreinstall` | `install.rs` `run_dev_preinstall` |

Found while reviewing pnpm/pnpm#13403, where a reviewer flagged the missing `scriptShell` on the new `pnpm:devPreinstall` call. It was not specific to that hook — every lifecycle call site had it — so it was left for its own change rather than fixed for one stage and not the rest.

### Deliberately unchanged

Not every `script_shell: None` is a gap. These stay as they are because the TypeScript CLI does not pass `scriptShell` there either, and matching it is the whole point:

- **git-hosted dependency preparation** (`install_package_by_snapshot.rs`, `patch.rs`) — the counterpart, `exec/prepare-package`, builds its `RunLifecycleHookOptions` with `depPath` / `pkgRoot` / `rootModulesDir` / `unsafePerm` / `userAgent` and no `scriptShell`.
- **`pack` and `publish` scripts** — `publish.ts` binds `runScriptsIfPresent` with the same field set, likewise without it.

Changing those would be a unilateral divergence, not a fix.

### Testing

The tests point `scriptShell` at a shell shim that appends every script it is handed to a log, then execs the real `/bin/sh`. A context that ignores the setting never appears in the log, so the test fails rather than silently passing on a default-shell fallback. I confirmed both tests fail with the three wirings reverted to `None`.

Unix-only (`#[cfg(unix)]`): the probe is a shell script, and `select_shell` already rejects `.cmd` / `.bat` shims on Windows.

Related to pnpm/pnpm#12042, whose checklist marks `scriptShell` as done — accurate for `pnpm run`, which is presumably what was verified, but not for lifecycle scripts.

## Squash Commit Body

```text
`scriptShell` reached only `pnpm run` / `pnpm exec` (and `pnpm version`).
Every lifecycle script the install spawns passed `script_shell: None` and
so ran under the platform default, `sh` or `cmd`, however the workspace
had configured its shell. The TypeScript CLI threads `scriptShell` into
the same runs through `scriptsOpts`, so a workspace whose scripts assume
its configured shell worked there and not here.

Thread `config.script_shell` to the three contexts that spawn scripts
during an install: dependency build scripts, a project's own lifecycle
scripts, and `pnpm:devPreinstall`.

Deliberately unchanged, because the TypeScript CLI does not pass
`scriptShell` there either and matching it is the point:

- git-hosted dependency preparation (`install_package_by_snapshot`,
  `patch`), whose counterpart `exec/prepare-package` builds its
  `RunLifecycleHookOptions` without the field.
- `pack` and `publish` lifecycle scripts, likewise.

The tests spawn through a shell shim that records each script it is
handed, so a context that ignores the setting fails rather than silently
falling back to the default shell. Unix-only: the probe is a shell
script, and `select_shell` rejects `.cmd` / `.bat` shims on Windows.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- pacquet-only: the TypeScript CLI already honors scriptShell in all
  three contexts. This brings pacquet up to it. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.
  <!-- No doc change: scriptShell is already documented as applying to
  scripts; this makes the implementation match. -->

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787785387&installation_model_id=426870&pr_number=13453&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13453&signature=4804006bc7c2127753e4940ef6b9f698c2599380a4558addddd8b064600ac77b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Honored configured `scriptShell` when running dependency build scripts and project lifecycle scripts during installation.
  * Lifecycle hooks (`preinstall`, `install`, `postinstall`, `prepare`, and `pnpm:devPreinstall`) now consistently use the selected shell.

* **Tests**
  * Added Unix-only regression tests to verify `scriptShell` is applied beyond `pnpm run`, including for dependency build and lifecycle markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->