### PR TITLE
fix(pacquet): complete licenses report parity

### DIFF
--- a/.changeset/tidy-moles-list.md
+++ b/.changeset/tidy-moles-list.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm licenses list` to detect licenses from license files and preserve the latest package version's development classification.

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -103,7 +103,11 @@ wax                  = { workspace = true }
 # children (lifecycle scripts and their descendants) to pacquet's. See
 # `src/job_control.rs`.
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { workspace = true, features = [
+  "Win32_Storage_FileSystem",
+  "Win32_UI_Shell",
+  "Win32_UI_WindowsAndMessaging",
+] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -1,5 +1,8 @@
 use crate::cli_args::{
-    deps_tree::pkg_info::is_unsafe_path_component,
+    deps_tree::{
+        dep_types::{DepType, detect_dep_types},
+        pkg_info::is_unsafe_path_component,
+    },
     recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
     sanitize::{sanitize, sanitize_inline},
 };
@@ -22,6 +25,8 @@ use pacquet_package_manifest::{
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap};
 use tabled::{builder::Builder, settings::Style};
+
+mod license_resolver;
 
 #[derive(Debug, Args)]
 pub struct LicensesArgs {
@@ -109,6 +114,8 @@ pub struct LicenseInfo {
     pub license: String,
     #[serde(skip)]
     belongs_to: BelongsTo,
+    #[serde(skip)]
+    selected_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -212,10 +219,20 @@ impl LicensesArgs {
                 safe_read_package_json_from_dir(&pkg_dir).unwrap_or(None)
             };
 
-            let license = manifest
-                .as_ref()
-                .and_then(extract_license)
-                .unwrap_or_else(|| "Unknown".to_string());
+            let license = match manifest.as_ref() {
+                Some(manifest) => match extract_license(manifest) {
+                    Some(license) if !license.to_ascii_lowercase().contains("see license") => {
+                        license
+                    }
+                    manifest_license => {
+                        license_resolver::resolve_license_from_dir(manifest_license, &pkg_dir)
+                            .await
+                            .into_diagnostic()?
+                            .unwrap_or_else(|| "Unknown".to_string())
+                    }
+                },
+                None => "Unknown".to_string(),
+            };
             let author = manifest.as_ref().and_then(extract_author);
             let homepage = manifest.as_ref().and_then(extract_homepage);
             let description = manifest
@@ -232,12 +249,17 @@ impl LicensesArgs {
                 paths: Vec::new(),
                 license,
                 belongs_to: kind,
-                author,
-                homepage,
-                description,
+                selected_version: version.clone(),
+                author: author.clone(),
+                homepage: homepage.clone(),
+                description: description.clone(),
             });
 
-            info.belongs_to = info.belongs_to.min(kind);
+            if select_newer_version(info, &version, kind) {
+                info.author = author;
+                info.homepage = homepage;
+                info.description = description;
+            }
             if !info.versions.contains(&version) {
                 info.versions.push(version);
             }
@@ -411,7 +433,36 @@ fn collect_dependencies(
         }
     }
 
+    let dep_types = detect_dep_types(lockfile);
+    for (key, belongs_to) in &mut belongs_to {
+        *belongs_to = if dep_types.get(key) == Some(&DepType::DevOnly) {
+            BelongsTo::Dev
+        } else {
+            BelongsTo::Prod
+        };
+    }
+
     belongs_to
+}
+
+fn version_is_newer(candidate: &str, selected: &str) -> bool {
+    match (node_semver::Version::parse(candidate), node_semver::Version::parse(selected)) {
+        (Ok(candidate), Ok(selected)) => candidate > selected,
+        _ => candidate > selected,
+    }
+}
+
+fn select_newer_version(
+    info: &mut LicenseInfo,
+    candidate_version: &str,
+    candidate_belongs_to: BelongsTo,
+) -> bool {
+    if !version_is_newer(candidate_version, &info.selected_version) {
+        return false;
+    }
+    info.belongs_to = candidate_belongs_to;
+    info.selected_version = candidate_version.to_string();
+    true
 }
 
 fn render_package_name(info: &LicenseInfo) -> String {

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -227,7 +227,6 @@ impl LicensesArgs {
                     manifest_license => {
                         license_resolver::resolve_license_from_dir(manifest_license, &pkg_dir)
                             .await
-                            .into_diagnostic()?
                             .unwrap_or_else(|| "Unknown".to_string())
                     }
                 },

--- a/pnpm/crates/cli/src/cli_args/licenses/license_resolver.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/license_resolver.rs
@@ -92,14 +92,14 @@ async fn read_first_license_file(dir: &Path) -> Option<Vec<u8>> {
             Ok(_) | Err(_) => continue,
         };
         if metadata.len() > MAX_LICENSE_FILE_SIZE as u64 {
-            return Some(Vec::new());
+            continue;
         }
         let mut contents = Vec::with_capacity(metadata.len() as usize);
         if file.take((MAX_LICENSE_FILE_SIZE + 1) as u64).read_to_end(&mut contents).await.is_err() {
             continue;
         }
         if contents.len() > MAX_LICENSE_FILE_SIZE {
-            contents.clear();
+            continue;
         }
         return Some(contents);
     }

--- a/pnpm/crates/cli/src/cli_args/licenses/license_resolver.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/license_resolver.rs
@@ -1,0 +1,120 @@
+use regex::Regex;
+use std::{
+    collections::HashSet,
+    io::{self, ErrorKind},
+    path::Path,
+    sync::OnceLock,
+};
+
+const LICENSE_FILES: &[&str] = &[
+    "LICENSE",
+    "LICENCE",
+    "LICENSE.md",
+    "LICENCE.md",
+    "LICENSE.txt",
+    "LICENCE.txt",
+    "MIT-LICENSE.txt",
+    "MIT-LICENSE.md",
+    "MIT-LICENSE",
+];
+
+const LICENSE_NAMES: &[&str] = &[
+    "Apache1_1",
+    "Apache-1.1",
+    "Apache 1.1",
+    "Apache2",
+    "Apache-2.0",
+    "Apache 2.0",
+    "BSD",
+    "BSD-4-Clause",
+    "CC01",
+    "CC0-1.0",
+    "CC0 1.0",
+    "CDDL1",
+    "CDDL-1.0",
+    "Common Development and Distribution License 1.0",
+    "EPL1",
+    "EPL-1.0",
+    "Eclipse Public License 1.0",
+    "GPLv2",
+    "GPL-2.0-only",
+    "GPLv3",
+    "GPL-3.0-only",
+    "ISC",
+    "LGPL",
+    "LGPL-3.0-only",
+    "LGPL2_1",
+    "LGPL-2.1-only",
+    "MIT",
+    "MPL1_1",
+    "MPL-1.1",
+    "Mozilla Public License 1.1",
+    "MPL2",
+    "MPL-2.0",
+    "Mozilla Public License 2.0",
+    "NewBSD",
+    "BSD-3-Clause",
+    "New BSD",
+    "OFL",
+    "OFL-1.1",
+    "SIL OPEN FONT LICENSE Version 1.1",
+    "Python",
+    "PSF-2.0",
+    "Python Software Foundation License",
+    "Ruby",
+    "SimplifiedBSD",
+    "BSD-2-Clause",
+    "Simplified BSD",
+    "WTFPL",
+    "0BSD",
+    "BSD Zero Clause License",
+    "Zlib",
+    "zlib/libpng license",
+];
+
+pub(super) async fn resolve_license_from_dir(
+    manifest_license: Option<String>,
+    dir: &Path,
+) -> io::Result<Option<String>> {
+    let Some(license_path) = first_license_path(dir).await? else {
+        return Ok(manifest_license);
+    };
+    let contents = tokio::fs::read(license_path).await?;
+    Ok(Some(
+        detect_license_from_text(&String::from_utf8_lossy(&contents))
+            .unwrap_or_else(|| "Unknown".to_string()),
+    ))
+}
+
+async fn first_license_path(dir: &Path) -> io::Result<Option<std::path::PathBuf>> {
+    for name in LICENSE_FILES {
+        let path = dir.join(name);
+        match tokio::fs::symlink_metadata(&path).await {
+            Ok(metadata) if metadata.is_file() => return Ok(Some(path)),
+            Ok(_) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(None)
+}
+
+fn detect_license_from_text(contents: &str) -> Option<String> {
+    static LICENSE_PATTERN: OnceLock<Regex> = OnceLock::new();
+    let pattern = LICENSE_PATTERN.get_or_init(|| {
+        let alternatives =
+            LICENSE_NAMES.iter().map(|name| regex::escape(name)).collect::<Vec<_>>().join("|");
+        Regex::new(&format!(r"(?i)\b({alternatives})\b"))
+            .expect("license names form a valid regular expression")
+    });
+    let mut seen = HashSet::new();
+    let matches = pattern
+        .find_iter(contents)
+        .map(|matched| matched.as_str())
+        .filter(|matched| seen.insert(*matched))
+        .collect::<Vec<_>>();
+    (!matches.is_empty()).then(|| matches.join(" OR "))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/licenses/license_resolver.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/license_resolver.rs
@@ -1,10 +1,8 @@
 use regex::Regex;
-use std::{
-    collections::HashSet,
-    io::{self, ErrorKind},
-    path::Path,
-    sync::OnceLock,
-};
+use std::{collections::HashSet, path::Path, sync::OnceLock};
+use tokio::io::AsyncReadExt;
+
+const MAX_LICENSE_FILE_SIZE: usize = 1024 * 1024;
 
 const LICENSE_FILES: &[&str] = &[
     "LICENSE",
@@ -75,28 +73,47 @@ const LICENSE_NAMES: &[&str] = &[
 pub(super) async fn resolve_license_from_dir(
     manifest_license: Option<String>,
     dir: &Path,
-) -> io::Result<Option<String>> {
-    let Some(license_path) = first_license_path(dir).await? else {
-        return Ok(manifest_license);
+) -> Option<String> {
+    let Some(contents) = read_first_license_file(dir).await else {
+        return manifest_license;
     };
-    let contents = tokio::fs::read(license_path).await?;
-    Ok(Some(
+    Some(
         detect_license_from_text(&String::from_utf8_lossy(&contents))
             .unwrap_or_else(|| "Unknown".to_string()),
-    ))
+    )
 }
 
-async fn first_license_path(dir: &Path) -> io::Result<Option<std::path::PathBuf>> {
+async fn read_first_license_file(dir: &Path) -> Option<Vec<u8>> {
     for name in LICENSE_FILES {
         let path = dir.join(name);
-        match tokio::fs::symlink_metadata(&path).await {
-            Ok(metadata) if metadata.is_file() => return Ok(Some(path)),
-            Ok(_) => {}
-            Err(error) if error.kind() == ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
+        let Ok(file) = open_no_follow(&path).await else { continue };
+        let metadata = match file.metadata().await {
+            Ok(metadata) if metadata.is_file() => metadata,
+            Ok(_) | Err(_) => continue,
+        };
+        if metadata.len() > MAX_LICENSE_FILE_SIZE as u64 {
+            return Some(Vec::new());
         }
+        let mut contents = Vec::with_capacity(metadata.len() as usize);
+        if file.take((MAX_LICENSE_FILE_SIZE + 1) as u64).read_to_end(&mut contents).await.is_err() {
+            continue;
+        }
+        if contents.len() > MAX_LICENSE_FILE_SIZE {
+            contents.clear();
+        }
+        return Some(contents);
     }
-    Ok(None)
+    None
+}
+
+async fn open_no_follow(path: &Path) -> std::io::Result<tokio::fs::File> {
+    let mut options = tokio::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    #[cfg(windows)]
+    options.custom_flags(windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OPEN_REPARSE_POINT);
+    options.open(path).await
 }
 
 fn detect_license_from_text(contents: &str) -> Option<String> {

--- a/pnpm/crates/cli/src/cli_args/licenses/license_resolver/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/license_resolver/tests.rs
@@ -1,4 +1,4 @@
-use super::{detect_license_from_text, resolve_license_from_dir};
+use super::{MAX_LICENSE_FILE_SIZE, detect_license_from_text, resolve_license_from_dir};
 use tempfile::TempDir;
 
 #[test]
@@ -16,19 +16,15 @@ async fn resolves_license_file_when_manifest_has_no_license() {
     let dir = TempDir::new().unwrap();
     tokio::fs::write(dir.path().join("LICENSE"), "(The MIT License)").await.unwrap();
 
-    assert_eq!(resolve_license_from_dir(None, dir.path()).await.unwrap(), Some("MIT".to_string()));
+    assert_eq!(resolve_license_from_dir(None, dir.path()).await, Some("MIT".to_string()));
     assert_eq!(
-        resolve_license_from_dir(Some("SEE LICENSE IN LICENSE".to_string()), dir.path())
-            .await
-            .unwrap(),
+        resolve_license_from_dir(Some("SEE LICENSE IN LICENSE".to_string()), dir.path()).await,
         Some("MIT".to_string()),
     );
 
     tokio::fs::write(dir.path().join("LICENSE"), "custom terms").await.unwrap();
     assert_eq!(
-        resolve_license_from_dir(Some("SEE LICENSE IN LICENSE".to_string()), dir.path())
-            .await
-            .unwrap(),
+        resolve_license_from_dir(Some("SEE LICENSE IN LICENSE".to_string()), dir.path()).await,
         Some("Unknown".to_string()),
     );
 }
@@ -39,5 +35,29 @@ async fn skips_non_file_license_candidates() {
     tokio::fs::create_dir(dir.path().join("LICENSE")).await.unwrap();
     tokio::fs::write(dir.path().join("LICENCE"), "(The MIT License)").await.unwrap();
 
-    assert_eq!(resolve_license_from_dir(None, dir.path()).await.unwrap(), Some("MIT".to_string()));
+    assert_eq!(resolve_license_from_dir(None, dir.path()).await, Some("MIT".to_string()));
+}
+
+#[tokio::test]
+async fn bounds_license_file_reads() {
+    let dir = TempDir::new().unwrap();
+    tokio::fs::write(dir.path().join("LICENSE"), vec![b'M'; MAX_LICENSE_FILE_SIZE + 1])
+        .await
+        .unwrap();
+
+    assert_eq!(resolve_license_from_dir(None, dir.path()).await, Some("Unknown".to_string()));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn does_not_follow_license_file_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    tokio::fs::write(outside.path().join("LICENSE"), "(The MIT License)").await.unwrap();
+    symlink(outside.path().join("LICENSE"), dir.path().join("LICENSE")).unwrap();
+    tokio::fs::write(dir.path().join("LICENCE"), "Apache-2.0").await.unwrap();
+
+    assert_eq!(resolve_license_from_dir(None, dir.path()).await, Some("Apache-2.0".to_string()));
 }

--- a/pnpm/crates/cli/src/cli_args/licenses/license_resolver/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/license_resolver/tests.rs
@@ -1,0 +1,43 @@
+use super::{detect_license_from_text, resolve_license_from_dir};
+use tempfile::TempDir;
+
+#[test]
+fn detects_known_license_names_in_text() {
+    assert_eq!(detect_license_from_text("(The MIT License)"), Some("MIT".to_string()));
+    assert_eq!(
+        detect_license_from_text("Apache-2.0 or MIT"),
+        Some("Apache-2.0 OR MIT".to_string()),
+    );
+    assert_eq!(detect_license_from_text("custom terms"), None);
+}
+
+#[tokio::test]
+async fn resolves_license_file_when_manifest_has_no_license() {
+    let dir = TempDir::new().unwrap();
+    tokio::fs::write(dir.path().join("LICENSE"), "(The MIT License)").await.unwrap();
+
+    assert_eq!(resolve_license_from_dir(None, dir.path()).await.unwrap(), Some("MIT".to_string()));
+    assert_eq!(
+        resolve_license_from_dir(Some("SEE LICENSE IN LICENSE".to_string()), dir.path())
+            .await
+            .unwrap(),
+        Some("MIT".to_string()),
+    );
+
+    tokio::fs::write(dir.path().join("LICENSE"), "custom terms").await.unwrap();
+    assert_eq!(
+        resolve_license_from_dir(Some("SEE LICENSE IN LICENSE".to_string()), dir.path())
+            .await
+            .unwrap(),
+        Some("Unknown".to_string()),
+    );
+}
+
+#[tokio::test]
+async fn skips_non_file_license_candidates() {
+    let dir = TempDir::new().unwrap();
+    tokio::fs::create_dir(dir.path().join("LICENSE")).await.unwrap();
+    tokio::fs::write(dir.path().join("LICENCE"), "(The MIT License)").await.unwrap();
+
+    assert_eq!(resolve_license_from_dir(None, dir.path()).await.unwrap(), Some("MIT".to_string()));
+}

--- a/pnpm/crates/cli/src/cli_args/licenses/license_resolver/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/license_resolver/tests.rs
@@ -44,8 +44,9 @@ async fn bounds_license_file_reads() {
     tokio::fs::write(dir.path().join("LICENSE"), vec![b'M'; MAX_LICENSE_FILE_SIZE + 1])
         .await
         .unwrap();
+    tokio::fs::write(dir.path().join("LICENCE"), "Apache-2.0").await.unwrap();
 
-    assert_eq!(resolve_license_from_dir(None, dir.path()).await, Some("Unknown".to_string()));
+    assert_eq!(resolve_license_from_dir(None, dir.path()).await, Some("Apache-2.0".to_string()));
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/cli/src/cli_args/licenses/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     BelongsTo, Config, Include, LicenseInfo, LicensesArgs, LicensesDependencyOptions,
-    collect_dependencies, render_package_name,
+    collect_dependencies, render_package_name, select_newer_version,
 };
 use pacquet_lockfile::Lockfile;
 use tempfile::TempDir;
@@ -163,6 +163,7 @@ fn renders_dev_classification() {
         paths: Vec::new(),
         license: "MIT".to_string(),
         belongs_to: BelongsTo::Dev,
+        selected_version: "1.0.0".to_string(),
         author: None,
         homepage: None,
         description: None,
@@ -171,4 +172,25 @@ fn renders_dev_classification() {
     let rendered = render_package_name(&info);
     assert!(rendered.starts_with("dev-only "));
     assert!(rendered.contains("(dev)"));
+}
+
+#[test]
+fn selects_latest_version_classification_with_semver_precedence() {
+    let mut info = LicenseInfo {
+        name: "multiple-versions".to_string(),
+        versions: vec!["2.0.0".to_string()],
+        paths: Vec::new(),
+        license: "MIT".to_string(),
+        belongs_to: BelongsTo::Prod,
+        selected_version: "2.0.0".to_string(),
+        author: None,
+        homepage: None,
+        description: None,
+    };
+
+    assert!(select_newer_version(&mut info, "10.0.0", BelongsTo::Dev));
+    assert_eq!(info.belongs_to, BelongsTo::Dev);
+    assert_eq!(info.selected_version, "10.0.0");
+    assert!(!select_newer_version(&mut info, "3.0.0", BelongsTo::Prod));
+    assert_eq!(info.belongs_to, BelongsTo::Dev);
 }

--- a/pnpm/crates/cli/tests/licenses.rs
+++ b/pnpm/crates/cli/tests/licenses.rs
@@ -63,7 +63,11 @@ fn licenses_reads_global_store_metadata_with_a_manifest_selected_runtime() {
                 .iter()
                 .map(|package| package["name"].as_str().expect("package name"))
                 .collect::<Vec<_>>(),
-            ["@pnpm.e2e/install-script-example", "@pnpm.e2e/legacy-license"],
+            [
+                "@pnpm.e2e/for-legacy-node",
+                "@pnpm.e2e/install-script-example",
+                "@pnpm.e2e/legacy-license",
+            ],
         );
         for package in packages {
             assert_eq!(package["versions"], json!(["1.0.0"]));


### PR DESCRIPTION
## Summary

Complete the remaining Rust `pnpm licenses list` parity work for pnpm/pnpm#13438.

- Detect licenses from conventional license files when the manifest has no
  usable license value.
- Classify packages using lockfile-wide dependency types.
- Preserve the latest version's classification and details when output
  deduplicates package versions into one row.

TypeScript pnpm already has these behaviors. This PR aligns the Rust port, so
no TypeScript changes are needed.

## Squash Commit Body

```text
Resolve missing manifest licenses from conventional license files, using the
same recognized names as TypeScript pnpm.

Classify dependencies with lockfile-wide dependency types. When output
deduplicates versions into one row, preserve classification and details from
the latest version.

Closes pnpm/pnpm#13438.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787785505&installation_model_id=426870&pr_number=13454&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13454&signature=b4d25b6169955c82bfa69ebd17f2e22d8e424f9665c31cc2ee3be2194adfe215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `pnpm licenses list` to detect licenses from license files, including resolving “see license” references, with a safe maximum file-size read and symlink-safe behavior.
  - When multiple versions exist, it now selects the latest version with semver-aware precedence and preserves the latest version’s dev/prod classification and related metadata.
- **Tests**
  - Expanded coverage for text-based and filesystem-based license detection, fallback-to-`Unknown`, oversized license handling, symlink non-following, and “newer version” selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->