### PR TITLE
fix(licenses): preserve aliased package versions

### DIFF
--- a/.changeset/brave-pandas-list.md
+++ b/.changeset/brave-pandas-list.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/deps.compliance.license-scanner": patch
+"pnpm": patch
+---
+
+Fixed `pnpm licenses list` to report every version when the same package is installed under multiple aliases [pnpm/pnpm#13438](https://github.com/pnpm/pnpm/issues/13438).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3041,9 +3041,6 @@ importers:
       path-absolute:
         specifier: 'catalog:'
         version: 2.0.0
-      ramda:
-        specifier: 'catalog:'
-        version: '@pnpm/ramda@0.28.1'
       semver:
         specifier: 'catalog:'
         version: 7.8.5

--- a/pnpm11/deps/compliance/license-scanner/package.json
+++ b/pnpm11/deps/compliance/license-scanner/package.json
@@ -47,7 +47,6 @@
     "@pnpm/types": "workspace:*",
     "p-limit": "catalog:",
     "path-absolute": "catalog:",
-    "ramda": "catalog:",
     "semver": "catalog:"
   },
   "peerDependencies": {

--- a/pnpm11/deps/compliance/license-scanner/src/licenses.ts
+++ b/pnpm11/deps/compliance/license-scanner/src/licenses.ts
@@ -43,8 +43,8 @@ function getDependenciesFromLicenseNode (
   }
 
   let dependencies: LicensePackage[] = []
-  for (const dependencyName in licenseNode.dependencies) {
-    const dependencyNode = licenseNode.dependencies[dependencyName]
+  for (const dependencyKey in licenseNode.dependencies) {
+    const dependencyNode = licenseNode.dependencies[dependencyKey]
     const dependenciesOfNode = getDependenciesFromLicenseNode(dependencyNode)
 
     dependencies = [
@@ -53,7 +53,7 @@ function getDependenciesFromLicenseNode (
       {
         belongsTo: dependencyNode.dev ? 'devDependencies' : 'dependencies',
         version: dependencyNode.version as string,
-        name: dependencyName,
+        name: dependencyNode.name as string,
         license: dependencyNode.license as string,
         licenseContents: dependencyNode.licenseContents,
         author: dependencyNode.author as string,

--- a/pnpm11/deps/compliance/license-scanner/src/licenses.ts
+++ b/pnpm11/deps/compliance/license-scanner/src/licenses.ts
@@ -38,34 +38,30 @@ export interface LicensePackage {
 function getDependenciesFromLicenseNode (
   licenseNode: LicenseNode
 ): LicensePackage[] {
-  if (!licenseNode.dependencies) {
-    return []
-  }
-
-  let dependencies: LicensePackage[] = []
-  for (const dependencyKey in licenseNode.dependencies) {
-    const dependencyNode = licenseNode.dependencies[dependencyKey]
-    const dependenciesOfNode = getDependenciesFromLicenseNode(dependencyNode)
-
-    dependencies = [
-      ...dependencies,
-      ...dependenciesOfNode,
-      {
-        belongsTo: dependencyNode.dev ? 'devDependencies' : 'dependencies',
-        version: dependencyNode.version as string,
-        name: dependencyNode.name as string,
-        license: dependencyNode.license as string,
-        licenseContents: dependencyNode.licenseContents,
-        author: dependencyNode.author as string,
-        homepage: dependencyNode.homepage as string,
-        description: dependencyNode.description,
-        repository: dependencyNode.repository as string,
-        path: dependencyNode.dir,
-      },
-    ]
-  }
-
+  const dependencies: LicensePackage[] = []
+  appendDependenciesFromLicenseNode(licenseNode, dependencies)
   return dependencies
+}
+
+function appendDependenciesFromLicenseNode (
+  licenseNode: LicenseNode,
+  dependencies: LicensePackage[]
+): void {
+  for (const dependencyNode of Object.values(licenseNode.dependencies ?? {})) {
+    appendDependenciesFromLicenseNode(dependencyNode, dependencies)
+    dependencies.push({
+      belongsTo: dependencyNode.dev ? 'devDependencies' : 'dependencies',
+      version: dependencyNode.version as string,
+      name: dependencyNode.name as string,
+      license: dependencyNode.license as string,
+      licenseContents: dependencyNode.licenseContents,
+      author: dependencyNode.author as string,
+      homepage: dependencyNode.homepage as string,
+      description: dependencyNode.description,
+      repository: dependencyNode.repository as string,
+      path: dependencyNode.dir,
+    })
+  }
 }
 
 export async function findDependencyLicenses (opts: {

--- a/pnpm11/deps/compliance/license-scanner/src/lockfileToLicenseNodeTree.ts
+++ b/pnpm11/deps/compliance/license-scanner/src/lockfileToLicenseNodeTree.ts
@@ -8,7 +8,6 @@ import {
 } from '@pnpm/lockfile.walker'
 import { StoreIndex } from '@pnpm/store.index'
 import type { DependenciesField, ProjectId, Registries, SupportedArchitectures } from '@pnpm/types'
-import { map as mapValues } from 'ramda'
 
 import { getPkgInfo } from './getPkgInfo.js'
 
@@ -24,7 +23,7 @@ export interface LicenseNode {
   repository?: string
   integrity?: string
   requires?: Record<string, string>
-  dependencies?: { [name: string]: LicenseNode }
+  dependencies?: Record<string, LicenseNode>
   dev: boolean
 }
 
@@ -113,7 +112,7 @@ export async function lockfileToLicenseNode (
       }
 
       // If the package details could be fetched, we consider it part of the tree
-      return [name, dep]
+      return [depPath, dep]
     }))).filter(Boolean) as Array<[string, LicenseNode]>
   )
 
@@ -178,6 +177,9 @@ export async function lockfileToLicenseNodeTree (
   return licenseNodeTree
 }
 
-function toRequires (licenseNodesByDepName: Record<string, LicenseNode>): Record<string, string> {
-  return mapValues((licenseNode) => licenseNode.version!, licenseNodesByDepName)
+function toRequires (licenseNodes: Record<string, LicenseNode>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(licenseNodes)
+      .map(([key, licenseNode]) => [licenseNode.name ?? key, licenseNode.version!])
+  )
 }

--- a/pnpm11/deps/compliance/license-scanner/test/licenses.spec.ts
+++ b/pnpm11/deps/compliance/license-scanner/test/licenses.spec.ts
@@ -312,4 +312,55 @@ describe('licences', () => {
       },
     ] as LicensePackage[])
   })
+
+  test('findDependencyLicenses lists versions installed under different aliases', async () => {
+    const lockfile: LockfileObject = {
+      importers: {
+        ['.' as ProjectId]: {
+          dependencies: {
+            prettier: '3.6.2',
+            prettier2: 'prettier@2.8.8',
+          },
+          specifiers: {
+            prettier: '3.6.2',
+            prettier2: 'npm:prettier@2.8.8',
+          },
+        },
+      },
+      lockfileVersion: LOCKFILE_VERSION,
+      packages: {
+        ['prettier@2.8.8' as DepPath]: {
+          resolution: {
+            integrity: 'prettier2-integrity',
+          },
+        },
+        ['prettier@3.6.2' as DepPath]: {
+          resolution: {
+            integrity: 'prettier3-integrity',
+          },
+        },
+      },
+    }
+
+    const licensePackages = await findDependencyLicenses({
+      lockfileDir: '/opt/pnpm',
+      manifest: {} as ProjectManifest,
+      virtualStoreDir: '/.pnpm',
+      registries: {} as Registries,
+      wantedLockfile: lockfile,
+      storeDir: tmpStoreDir,
+      virtualStoreDirMaxLength: 120,
+    })
+
+    expect(licensePackages.map(({ name, version }) => ({ name, version }))).toEqual([
+      {
+        name: 'prettier',
+        version: '2.8.8',
+      },
+      {
+        name: 'prettier',
+        version: '3.6.2',
+      },
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13438.

The TypeScript license scanner keyed dependency nodes by resolved package name. When multiple aliases resolved to different versions of the same package, later nodes overwrote earlier ones. The scanner now keys internal nodes by depPath while rendering the real package name from package metadata.

Pacquet already preserved every version, so no Rust change is needed. On the original Prisma reproduction, both implementations now produce the same 1,180 canonical license rows, including `prettier (dev)`.

## Squash Commit Body

```text
Key license tree nodes by depPath so aliases resolving to the same package
name do not overwrite each other. Keep report names sourced from package
metadata and preserve the existing requires shape.

Closes pnpm/pnpm#13438.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787790924&installation_model_id=426870&pr_number=13456&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13456&signature=5deab8c986276bd960bb51f95e2786cb1daa78b86a6c291009c97078cca38009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm licenses list` to report every installed version when the same package is present under multiple aliases.

* **Tests**
  * Added coverage to ensure license reporting includes aliased packages with multiple versions.

* **Chores**
  * Updated the license-scanner package’s dependency set used for the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->