### PR TITLE
chore(release): move pacquet to the beta lane

### DIFF
--- a/.changeset/pacquet-beta-release.md
+++ b/.changeset/pacquet-beta-release.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The Rust implementation of pnpm has moved from alpha to beta releases.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,12 +73,13 @@ versioning:
   # shared version.
   fixed:
     - ['pacquet', '@pnpm/napi']
-  # The Rust products release as `X.Y.Z-alpha.N` prereleases (published under the
-  # `next` dist-tag) while the TypeScript CLI keeps releasing stable versions on
-  # the main lane. `pnpm lane main --filter …` graduates a product to stable.
+  # The Rust CLI and its NAPI addon release as `X.Y.Z-beta.N` prereleases, while
+  # pnpr remains on `X.Y.Z-alpha.N`. Both are published under the `next` dist-tag
+  # while the TypeScript CLI keeps releasing stable versions on the main lane.
+  # `pnpm lane main --filter …` graduates a product to stable.
   lanes:
-    pacquet: alpha
-    '@pnpm/napi': alpha
+    pacquet: beta
+    '@pnpm/napi': beta
     '@pnpm/pnpr': alpha
 
 allowBuilds:

--- a/pnpm/npm/pnpm/package.json
+++ b/pnpm/npm/pnpm/package.json
@@ -5,7 +5,7 @@
     "name": "pnpm"
   },
   "version": "12.0.0-alpha.21",
-  "description": "Fast, disk space efficient package manager — the Rust port of pnpm (alpha, not production-ready)",
+  "description": "Fast, disk space efficient package manager — the Rust port of pnpm (beta, not production-ready)",
   "keywords": [
     "pnpm",
     "package manager",

--- a/pnpm/npm/pnpm/package.json
+++ b/pnpm/npm/pnpm/package.json
@@ -5,7 +5,7 @@
     "name": "pnpm"
   },
   "version": "12.0.0-alpha.21",
-  "description": "Fast, disk space efficient package manager — the Rust port of pnpm (beta, not production-ready)",
+  "description": "Fast, disk space efficient package manager",
   "keywords": [
     "pnpm",
     "package manager",


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Move the pacquet and `@pnpm/napi` fixed group from the `alpha` release lane to `beta`.
- Keep `@pnpm/pnpr` on its existing `alpha` lane and clarify the workspace configuration comment.
- Update pacquet's package description and add a release note for the beta transition.

The native release-plan dry run confirms that the next release changes both fixed-group packages from `12.0.0-alpha.21` to `12.0.0-beta.0`.

## Squash Commit Body

```text
Move pacquet and its NAPI addon to the beta release lane while leaving pnpr on alpha.

Changing the lane identifier resets the prerelease counter, so the next native versioning run will release the fixed group as 12.0.0-beta.0. Update the package metadata and release note to describe the new maturity level.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787791471&installation_model_id=426870&pr_number=13458&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13458&signature=4354cdb7b8629962f6e7b679049f593944baeeb165a43f74e01ac4f0dd2c1866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated release channels for the Rust-based pnpm implementation from alpha to beta.
  * `pacquet` and `@pnpm/napi` now publish beta prereleases under the `next` channel.
  * Refreshed release metadata, including updated package descriptions, to reflect the beta status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->