### PR TITLE
fix(pacquet): preserve locked peers during dedupe

### DIFF
--- a/.changeset/pacquet-dedupe-locked-peers.md
+++ b/.changeset/pacquet-dedupe-locked-peers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Preserve optional peer providers recorded in peer suffixes when `pnpm dedupe` rebuilds a workspace lockfile.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -795,21 +795,48 @@ fn locked_peer_names(
     preferred_versions: &PreferredVersions,
     wanted_lockfile: Option<&pacquet_lockfile::Lockfile>,
 ) -> HashSet<String> {
-    let peer_suffixes: Vec<&str> = wanted_lockfile
-        .and_then(|lockfile| lockfile.snapshots.as_ref())
-        .into_iter()
-        .flat_map(|snapshots| snapshots.keys())
-        .map(|key| key.suffix.peer())
-        .filter(|peer| !peer.is_empty())
-        .collect();
-    preferred_versions
-        .keys()
-        .filter(|name| {
-            let marker = format!("({name}@");
-            peer_suffixes.iter().any(|suffix| suffix.contains(&marker))
-        })
-        .cloned()
-        .collect()
+    let Some(lockfile) = wanted_lockfile else {
+        return HashSet::new();
+    };
+    let mut names = HashSet::new();
+    for (key, snapshot) in lockfile.snapshots.iter().flatten() {
+        let peer_suffix = key.suffix.peer();
+        if peer_suffix.is_empty() {
+            continue;
+        }
+        names.extend(
+            preferred_versions
+                .keys()
+                .filter(|name| {
+                    let marker = format!("({name}@");
+                    peer_suffix.contains(&marker)
+                })
+                .cloned(),
+        );
+        if is_hashed_peer_suffix(peer_suffix)
+            && let Some(metadata) =
+                lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
+        {
+            let missing =
+                snapshot.transitive_peer_dependencies.iter().flatten().collect::<HashSet<_>>();
+            names.extend(
+                metadata
+                    .peer_dependencies
+                    .iter()
+                    .flatten()
+                    .map(|(name, _)| name)
+                    .filter(|name| !missing.contains(name))
+                    .cloned(),
+            );
+        }
+    }
+    preferred_versions.keys().filter(|name| names.contains(*name)).cloned().collect()
+}
+
+fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {
+    peer_suffix.rsplit_once('(').and_then(|(_, tail)| tail.strip_suffix(')')).is_some_and(|hash| {
+        hash.len() == 32 && hash.chars().all(|character| character.is_ascii_hexdigit())
+    })
 }
 
 /// Split the missing-peer report into the inputs the inner and outer

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -804,15 +804,20 @@ fn locked_peer_names(wanted_lockfile: Option<&pacquet_lockfile::Lockfile>) -> Ha
             && let Some(metadata) =
                 lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
         {
-            let missing =
-                snapshot.transitive_peer_dependencies.iter().flatten().collect::<HashSet<_>>();
+            let resolved_names = snapshot
+                .dependencies
+                .iter()
+                .chain(snapshot.optional_dependencies.iter())
+                .flatten()
+                .map(|(name, _)| name.to_string())
+                .collect::<HashSet<_>>();
             names.extend(
                 metadata
                     .peer_dependencies
                     .iter()
                     .flatten()
                     .map(|(name, _)| name)
-                    .filter(|name| !missing.contains(name))
+                    .filter(|name| resolved_names.contains(*name))
                     .cloned(),
             );
         }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -534,6 +534,10 @@ impl ImporterHoistState {
                 importer_id: self.importer_id.clone(),
                 first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
                 first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
+                locked_peer_names: locked_peer_names(
+                    &self.all_preferred_versions,
+                    self.ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
+                ),
             },
         );
     }
@@ -601,6 +605,10 @@ impl ImporterHoistState {
                         importer_id: self.importer_id.clone(),
                         first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
                         first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
+                        locked_peer_names: locked_peer_names(
+                            &self.all_preferred_versions,
+                            self.ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
+                        ),
                     })))
                 });
 
@@ -781,6 +789,27 @@ impl ImporterHoistState {
         let peers_result = resolve_peers(&mut resolved_tree, peers_opts);
         ResolveImporterResult { resolved_tree, peers_result }
     }
+}
+
+fn locked_peer_names(
+    preferred_versions: &PreferredVersions,
+    wanted_lockfile: Option<&pacquet_lockfile::Lockfile>,
+) -> HashSet<String> {
+    let peer_suffixes: Vec<&str> = wanted_lockfile
+        .and_then(|lockfile| lockfile.snapshots.as_ref())
+        .into_iter()
+        .flat_map(|snapshots| snapshots.keys())
+        .map(|key| key.suffix.peer())
+        .filter(|peer| !peer.is_empty())
+        .collect();
+    preferred_versions
+        .keys()
+        .filter(|name| {
+            let marker = format!("({name}@");
+            peer_suffixes.iter().any(|suffix| suffix.contains(&marker))
+        })
+        .cloned()
+        .collect()
 }
 
 /// Split the missing-peer report into the inputs the inner and outer

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -339,6 +339,7 @@ pub(crate) struct ImporterHoistState {
     parent_pkg_aliases: HashSet<String>,
     all_missing_optional_peers: BTreeMap<String, Vec<String>>,
     all_preferred_versions: PreferredVersions,
+    locked_peer_names: Arc<HashSet<String>>,
     seen_workspace_package_versions: HashSet<(String, String)>,
     override_bare_specifier: Option<Arc<DependencyOverrider>>,
     /// `auto_install_peers || dedupe_peer_dependents` — upstream's
@@ -420,6 +421,8 @@ impl ImporterHoistState {
             .with_patched_dependencies(patched_dependencies)
             .with_resolution_mode(pick_lowest_direct, subdep_published_by)
             .with_catalogs(catalogs);
+        let locked_peer_names =
+            Arc::new(locked_peer_names(ctx.workspace().wanted_lockfile().map(AsRef::as_ref)));
         record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
         let wanted_specifier_by_alias: BTreeMap<String, String> = initial_wanted
             .iter()
@@ -451,6 +454,7 @@ impl ImporterHoistState {
             parent_pkg_aliases,
             all_missing_optional_peers: BTreeMap::new(),
             all_preferred_versions,
+            locked_peer_names,
             seen_workspace_package_versions: HashSet::new(),
             override_bare_specifier,
             hoist_peers: auto_install_peers || dedupe_peer_dependents,
@@ -534,10 +538,7 @@ impl ImporterHoistState {
                 importer_id: self.importer_id.clone(),
                 first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
                 first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
-                locked_peer_names: locked_peer_names(
-                    &self.all_preferred_versions,
-                    self.ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
-                ),
+                locked_peer_names: Arc::clone(&self.locked_peer_names),
             },
         );
     }
@@ -605,10 +606,7 @@ impl ImporterHoistState {
                         importer_id: self.importer_id.clone(),
                         first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
                         first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
-                        locked_peer_names: locked_peer_names(
-                            &self.all_preferred_versions,
-                            self.ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
-                        ),
+                        locked_peer_names: Arc::clone(&self.locked_peer_names),
                     })))
                 });
 
@@ -791,10 +789,7 @@ impl ImporterHoistState {
     }
 }
 
-fn locked_peer_names(
-    preferred_versions: &PreferredVersions,
-    wanted_lockfile: Option<&pacquet_lockfile::Lockfile>,
-) -> HashSet<String> {
+fn locked_peer_names(wanted_lockfile: Option<&pacquet_lockfile::Lockfile>) -> HashSet<String> {
     let Some(lockfile) = wanted_lockfile else {
         return HashSet::new();
     };
@@ -804,15 +799,7 @@ fn locked_peer_names(
         if peer_suffix.is_empty() {
             continue;
         }
-        names.extend(
-            preferred_versions
-                .keys()
-                .filter(|name| {
-                    let marker = format!("({name}@");
-                    peer_suffix.contains(&marker)
-                })
-                .cloned(),
-        );
+        names.extend(peer_suffix_names(peer_suffix));
         if is_hashed_peer_suffix(peer_suffix)
             && let Some(metadata) =
                 lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
@@ -830,7 +817,15 @@ fn locked_peer_names(
             );
         }
     }
-    preferred_versions.keys().filter(|name| names.contains(*name)).cloned().collect()
+    names
+}
+
+fn peer_suffix_names(peer_suffix: &str) -> impl Iterator<Item = String> + '_ {
+    peer_suffix.match_indices('(').filter_map(|(start, _)| {
+        let segment = peer_suffix[start + 1..].split(['(', ')']).next()?;
+        let (name, _) = segment.rsplit_once('@')?;
+        (!name.is_empty()).then(|| name.to_string())
+    })
 }
 
 fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -21,18 +21,6 @@ use crate::{
 fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {
     use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion, PkgNameVerPeer, SnapshotEntry};
 
-    let mut selectors = VersionSelectors::new();
-    selectors.insert(
-        "1.0.0".to_string(),
-        VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
-            selector_type: VersionSelectorType::Version,
-            weight: EXISTING_VERSION_SELECTOR_WEIGHT,
-        }),
-    );
-    let preferred = PreferredVersions::from([
-        ("peer".to_string(), selectors.clone()),
-        ("unrelated".to_string(), selectors),
-    ]);
     let lockfile = Lockfile {
         lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
         settings: None,
@@ -44,13 +32,30 @@ fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {
         patched_dependencies: None,
         importers: HashMap::new(),
         packages: None,
-        snapshots: Some(HashMap::from([(
-            PkgNameVerPeer::from_str("consumer@1.0.0(peer@1.0.0)").unwrap(),
-            SnapshotEntry::default(),
-        )])),
+        snapshots: Some(HashMap::from([
+            (
+                PkgNameVerPeer::from_str("consumer@1.0.0(peer@1.0.0)").unwrap(),
+                SnapshotEntry::default(),
+            ),
+            (
+                PkgNameVerPeer::from_str(
+                    "other@1.0.0(@types/node@24.0.0)(provider@1.0.0(nested@2.0.0))",
+                )
+                .unwrap(),
+                SnapshotEntry::default(),
+            ),
+        ])),
     };
 
-    assert_eq!(locked_peer_names(&preferred, Some(&lockfile)), HashSet::from(["peer".to_string()]));
+    assert_eq!(
+        locked_peer_names(Some(&lockfile)),
+        HashSet::from([
+            "@types/node".to_string(),
+            "nested".to_string(),
+            "peer".to_string(),
+            "provider".to_string(),
+        ]),
+    );
 }
 
 #[test]
@@ -60,17 +65,6 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
         PackageMetadata, PkgNameVerPeer, SnapshotEntry,
     };
 
-    let selectors = VersionSelectors::from([(
-        "1.0.0".to_string(),
-        VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
-            selector_type: VersionSelectorType::Version,
-            weight: EXISTING_VERSION_SELECTOR_WEIGHT,
-        }),
-    )]);
-    let preferred = PreferredVersions::from([
-        ("peer".to_string(), selectors.clone()),
-        ("missing".to_string(), selectors),
-    ]);
     let package_key = PkgNameVerPeer::from_str("consumer@1.0.0").unwrap();
     let snapshot_key =
         PkgNameVerPeer::from_str("consumer@1.0.0(0123456789abcdef0123456789abcdef)").unwrap();
@@ -115,7 +109,7 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
         )])),
     };
 
-    assert_eq!(locked_peer_names(&preferred, Some(&lockfile)), HashSet::from(["peer".to_string()]));
+    assert_eq!(locked_peer_names(Some(&lockfile)), HashSet::from(["peer".to_string()]));
 }
 
 struct StubResolver {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -62,7 +62,7 @@ fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {
 fn hashed_peer_suffix_uses_package_peer_metadata() {
     use pacquet_lockfile::{
         ComVer, DirectoryResolution, Lockfile, LockfileResolution, LockfileVersion,
-        PackageMetadata, PkgNameVerPeer, SnapshotEntry,
+        PackageMetadata, PkgName, PkgNameVerPeer, PkgVerPeer, SnapshotDepRef, SnapshotEntry,
     };
 
     let package_key = PkgNameVerPeer::from_str("consumer@1.0.0").unwrap();
@@ -103,7 +103,10 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
         snapshots: Some(HashMap::from([(
             snapshot_key,
             SnapshotEntry {
-                transitive_peer_dependencies: Some(vec!["missing".to_string()]),
+                dependencies: Some(HashMap::from([(
+                    PkgName::parse("peer").unwrap(),
+                    SnapshotDepRef::Plain(PkgVerPeer::from_str("1.0.0").unwrap()),
+                )])),
                 ..SnapshotEntry::default()
             },
         )])),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -53,6 +53,71 @@ fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {
     assert_eq!(locked_peer_names(&preferred, Some(&lockfile)), HashSet::from(["peer".to_string()]));
 }
 
+#[test]
+fn hashed_peer_suffix_uses_package_peer_metadata() {
+    use pacquet_lockfile::{
+        ComVer, DirectoryResolution, Lockfile, LockfileResolution, LockfileVersion,
+        PackageMetadata, PkgNameVerPeer, SnapshotEntry,
+    };
+
+    let selectors = VersionSelectors::from([(
+        "1.0.0".to_string(),
+        VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
+            selector_type: VersionSelectorType::Version,
+            weight: EXISTING_VERSION_SELECTOR_WEIGHT,
+        }),
+    )]);
+    let preferred = PreferredVersions::from([
+        ("peer".to_string(), selectors.clone()),
+        ("missing".to_string(), selectors),
+    ]);
+    let package_key = PkgNameVerPeer::from_str("consumer@1.0.0").unwrap();
+    let snapshot_key =
+        PkgNameVerPeer::from_str("consumer@1.0.0(0123456789abcdef0123456789abcdef)").unwrap();
+    let lockfile = Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: HashMap::new(),
+        packages: Some(HashMap::from([(
+            package_key,
+            PackageMetadata {
+                resolution: LockfileResolution::Directory(DirectoryResolution {
+                    directory: "consumer".to_string(),
+                }),
+                version: None,
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: Some(HashMap::from([
+                    ("peer".to_string(), "*".to_string()),
+                    ("missing".to_string(), "*".to_string()),
+                ])),
+                peer_dependencies_meta: None,
+            },
+        )])),
+        snapshots: Some(HashMap::from([(
+            snapshot_key,
+            SnapshotEntry {
+                transitive_peer_dependencies: Some(vec!["missing".to_string()]),
+                ..SnapshotEntry::default()
+            },
+        )])),
+    };
+
+    assert_eq!(locked_peer_names(&preferred, Some(&lockfile)), HashSet::from(["peer".to_string()]));
+}
+
 struct StubResolver {
     table: HashMap<(String, String), ResolveResult>,
     calls: Mutex<Vec<(String, String)>>,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, str::FromStr, sync::Mutex};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    sync::Mutex,
+};
 
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
@@ -10,8 +14,44 @@ use pretty_assertions::assert_eq;
 
 use crate::{
     DepPath, ResolveDependencyTreeError, resolve_importer,
-    resolve_importer::{ResolveImporterError, ResolveImporterOptions},
+    resolve_importer::{ResolveImporterError, ResolveImporterOptions, locked_peer_names},
 };
+
+#[test]
+fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {
+    use pacquet_lockfile::{ComVer, Lockfile, LockfileVersion, PkgNameVerPeer, SnapshotEntry};
+
+    let mut selectors = VersionSelectors::new();
+    selectors.insert(
+        "1.0.0".to_string(),
+        VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
+            selector_type: VersionSelectorType::Version,
+            weight: EXISTING_VERSION_SELECTOR_WEIGHT,
+        }),
+    );
+    let preferred = PreferredVersions::from([
+        ("peer".to_string(), selectors.clone()),
+        ("unrelated".to_string(), selectors),
+    ]);
+    let lockfile = Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: HashMap::new(),
+        packages: None,
+        snapshots: Some(HashMap::from([(
+            PkgNameVerPeer::from_str("consumer@1.0.0(peer@1.0.0)").unwrap(),
+            SnapshotEntry::default(),
+        )])),
+    };
+
+    assert_eq!(locked_peer_names(&preferred, Some(&lockfile)), HashSet::from(["peer".to_string()]));
+}
 
 struct StubResolver {
     table: HashMap<(String, String), ResolveResult>,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -231,7 +231,7 @@ pub struct HoistMissingScope {
     pub first_walk_missing_by_pkg: HashMap<String, std::collections::HashSet<String>>,
     /// Peers represented by the wanted lockfile must remain eligible
     /// for importer-local hoisting during lockfile re-resolution.
-    pub locked_peer_names: std::collections::HashSet<String>,
+    pub locked_peer_names: Arc<std::collections::HashSet<String>>,
 }
 
 impl HoistMissingScope {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -229,12 +229,18 @@ pub struct HoistMissingScope {
     /// satisfy stay visible to every importer (and each hoists its
     /// own copy).
     pub first_walk_missing_by_pkg: HashMap<String, std::collections::HashSet<String>>,
+    /// Peers represented by the wanted lockfile must remain eligible
+    /// for importer-local hoisting during lockfile re-resolution.
+    pub locked_peer_names: std::collections::HashSet<String>,
 }
 
 impl HoistMissingScope {
     /// `true` when a miss of `peer_name` declared under the given
     /// ancestor chain is covered by another importer's shared walk.
     fn suppresses(&self, ancestor_pkg_ids: &[String], peer_name: &str) -> bool {
+        if self.locked_peer_names.contains(peer_name) {
+            return false;
+        }
         ancestor_pkg_ids.iter().any(|pkg_id| {
             self.first_importer_by_pkg.get(pkg_id).is_some_and(|owner| {
                 *owner != self.importer_id

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -933,6 +933,55 @@ async fn shared_subtree_owner_context_suppresses_later_optional_hoist() {
         Some("shared@1.0.0".to_string()),
         "pkg-a must not hoist opt, but it also must not reuse root's opt provider",
     );
+
+    let (tmp_root, root_manifest) = fake_manifest(
+        serde_json::json!({ "shared": "1.0.0", "opt": "18.0.0", "carrier": "1.0.0" }),
+    );
+    let (tmp_a, a_manifest) = fake_manifest(serde_json::json!({ "shared": "1.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "pkg-a".to_string(), manifest: &a_manifest },
+    ];
+    let dirs = [tmp_root.path(), tmp_a.path()];
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    opts.wanted_lockfile = Some(std::sync::Arc::new(pacquet_lockfile::Lockfile {
+        lockfile_version: pacquet_lockfile::LockfileVersion::<9>::try_from(
+            pacquet_lockfile::ComVer::new(9, 0),
+        )
+        .unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: HashMap::new(),
+        packages: None,
+        snapshots: Some(HashMap::from([(
+            pacquet_lockfile::PkgNameVerPeer::from_str("shared@1.0.0(opt@25.0.0)").unwrap(),
+            pacquet_lockfile::SnapshotEntry::default(),
+        )])),
+    }));
+    let mut next = 0;
+    let result = resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        let dir = dirs[next].to_path_buf();
+        next += 1;
+        let mut opts = importer_opts(dir, None);
+        opts.auto_install_peers = true;
+        opts
+    })
+    .await
+    .unwrap();
+
+    let a_direct =
+        result.peers.direct_dependencies_by_importer.get("pkg-a").expect("pkg-a importer");
+    assert_eq!(
+        a_direct.get("shared").map(std::string::ToString::to_string),
+        Some("shared@1.0.0(opt@25.0.0)".to_string()),
+        "a locked peer provider must remain eligible for importer-local hoisting",
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

During `pnpm dedupe --check` on the n8n workspace, pacquet suppressed importer-local optional peer hoisting when another importer had already traversed the same package. That removed optional peer providers already represented in the wanted lockfile's peer suffixes, producing many `bufferutil` and `utf-8-validate` peer-context differences from the TypeScript CLI.

Keep preferred versions that occur in wanted-lockfile peer suffixes eligible for importer-local hoisting. This brings the affected jsdom and vitest peer contexts in n8n in line with the TypeScript CLI.

The n8n comparison still exposes two independent parity gaps outside this fix: applying the `@browserbasehq/stagehand` override during dedupe, and adding integrity for the git-hosted `wa-sqlite` tarball.

Related to pnpm/pnpm#13305.

## Squash Commit Body

```text
Pacquet's cross-importer missing-peer suppression treated all preferred
versions alike. During lockfile re-resolution, this could suppress optional
peer providers that were already encoded in peer suffixes in the wanted
lockfile.

Derive the names of locked peer providers from wanted-lockfile snapshot
suffixes and exempt those names from cross-importer suppression. This keeps
importer-local peer contexts stable during dedupe and aligns the affected n8n
jsdom and vitest variants with the TypeScript CLI.

Related to pnpm/pnpm#13305.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787816889&installation_model_id=426870&pr_number=13459&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13459&signature=c40431bfb6e4a7fe682d9dbf291626ddc641535e30fa5f9bd6cd91c57cc71f92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved optional peer providers from “peer suffix” lockfile entries when rebuilding a workspace lockfile via deduplication.
  * Prevented locked peers from being incorrectly suppressed during required-peer hoisting by honoring lockfile-derived locked peer names.
* **Tests**
  * Added unit tests covering locked peer name derivation, including missing and hashed peer-suffix scenarios.
  * Updated workspace hoisting coverage so optional peer providers remain eligible when an existing lockfile entry is present.
* **Chores**
  * Added release metadata for a `pacquet` patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->