### PR TITLE
fix(pacquet): align license report metadata

### DIFF
--- a/.changeset/calm-cats-report.md
+++ b/.changeset/calm-cats-report.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Aligned `pnpm licenses list --json` package metadata and license-group ordering with the TypeScript CLI.

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -211,7 +211,11 @@ impl LicensesArgs {
             })
             .collect::<Vec<_>>();
         dependencies.sort_by(|left, right| {
-            left.2.cmp(&right.2).then_with(|| compare_versions(&left.3, &right.3))
+            left.2
+                .cmp(&right.2)
+                .then_with(|| compare_versions(&left.3, &right.3))
+                .then_with(|| left.0.to_string().cmp(&right.0.to_string()))
+                .then_with(|| left.1.cmp(&right.1))
         });
 
         let mut results_by_license: IndexMap<String, BTreeMap<String, LicenseInfo>> =

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -8,6 +8,7 @@ use crate::cli_args::{
 };
 use clap::Args;
 use derive_more::{Display, Error};
+use indexmap::IndexMap;
 use miette::{Diagnostic, IntoDiagnostic};
 use owo_colors::{OwoColorize, Stream};
 use pacquet_config::Config;
@@ -19,9 +20,9 @@ use pacquet_package_manager::{
     AllowBuildPolicy, validate_virtual_store_slot_containment, virtual_store_layout_for_lockfile,
 };
 use pacquet_package_manifest::{
-    extract_author, extract_homepage, extract_license, node_version_from_engines_runtime,
-    safe_read_package_json_from_dir,
+    extract_license, node_version_from_engines_runtime, safe_read_package_json_from_dir,
 };
+use pacquet_resolving_git_resolver::HostedGit;
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap};
 use tabled::{builder::Builder, settings::Style};
@@ -197,21 +198,26 @@ impl LicensesArgs {
         validate_virtual_store_slot_containment(lockfile.snapshots.as_ref(), &layout)
             .into_diagnostic()?;
 
-        let mut results_by_license: BTreeMap<String, BTreeMap<String, LicenseInfo>> =
-            BTreeMap::new();
-
         let pkgs = lockfile.packages.as_ref();
+        let mut dependencies = belongs_to
+            .into_iter()
+            .map(|(key, kind)| {
+                let name = key.name.to_string();
+                let version = pkgs
+                    .and_then(|packages| packages.get(&key.without_peer()))
+                    .and_then(|meta| meta.version.clone())
+                    .unwrap_or_else(|| key.suffix.version().to_string());
+                (key, kind, name, version)
+            })
+            .collect::<Vec<_>>();
+        dependencies.sort_by(|left, right| {
+            left.2.cmp(&right.2).then_with(|| compare_versions(&left.3, &right.3))
+        });
 
-        for (key, kind) in belongs_to {
-            let name = key.name.to_string();
-            let mut version = key.suffix.version().to_string();
-            if let Some(pkgs) = pkgs
-                && let Some(meta) = pkgs.get(&key.without_peer())
-                && let Some(v) = &meta.version
-            {
-                version.clone_from(v);
-            }
+        let mut results_by_license: IndexMap<String, BTreeMap<String, LicenseInfo>> =
+            IndexMap::new();
 
+        for (key, kind, name, version) in dependencies {
             let pkg_dir = layout.slot_dir(&key).join("node_modules").join(&name);
             let manifest = if is_unsafe_path_component(&name) {
                 None
@@ -232,8 +238,8 @@ impl LicensesArgs {
                 },
                 None => "Unknown".to_string(),
             };
-            let author = manifest.as_ref().and_then(extract_author);
-            let homepage = manifest.as_ref().and_then(extract_homepage);
+            let author = manifest.as_ref().and_then(extract_license_author);
+            let homepage = manifest.as_ref().and_then(extract_license_homepage);
             let description = manifest
                 .as_ref()
                 .and_then(|m| m.get("description"))
@@ -275,7 +281,7 @@ impl LicensesArgs {
         }
 
         if self.json {
-            let mut json_output: BTreeMap<String, Vec<&LicenseInfo>> = BTreeMap::new();
+            let mut json_output: IndexMap<String, Vec<&LicenseInfo>> = IndexMap::new();
             for (lic, group) in &results_by_license {
                 let mut infos: Vec<&LicenseInfo> = group.values().collect();
                 infos.sort_by(|a, b| a.name.cmp(&b.name));
@@ -445,9 +451,13 @@ fn collect_dependencies(
 }
 
 fn version_is_newer(candidate: &str, selected: &str) -> bool {
-    match (node_semver::Version::parse(candidate), node_semver::Version::parse(selected)) {
-        (Ok(candidate), Ok(selected)) => candidate > selected,
-        _ => candidate > selected,
+    compare_versions(candidate, selected).is_gt()
+}
+
+fn compare_versions(left: &str, right: &str) -> std::cmp::Ordering {
+    match (node_semver::Version::parse(left), node_semver::Version::parse(right)) {
+        (Ok(left), Ok(right)) => left.cmp(&right),
+        _ => left.cmp(right),
     }
 }
 
@@ -471,6 +481,44 @@ fn render_package_name(info: &LicenseInfo) -> String {
         BelongsTo::Dev => "(dev)",
     };
     format!("{} {}", name, suffix.if_supports_color(Stream::Stdout, |text| text.dimmed()))
+}
+
+fn extract_license_author(manifest: &serde_json::Value) -> Option<String> {
+    match manifest.get("author")? {
+        serde_json::Value::String(author) => {
+            if author.is_empty() {
+                return Some(String::new());
+            }
+            let name_end = author.find(['(', '<']).unwrap_or(author.len());
+            let name = author[..name_end].trim();
+            (!name.is_empty()).then(|| name.to_string())
+        }
+        serde_json::Value::Object(author) => {
+            author.get("name").and_then(serde_json::Value::as_str).map(ToString::to_string)
+        }
+        _ => None,
+    }
+}
+
+fn extract_license_homepage(manifest: &serde_json::Value) -> Option<String> {
+    if let Some(homepage) =
+        manifest.get("homepage").and_then(serde_json::Value::as_str).filter(|url| !url.is_empty())
+    {
+        return Some(if url::Url::parse(homepage).is_ok() {
+            homepage.to_string()
+        } else {
+            format!("http://{homepage}")
+        });
+    }
+
+    let repository = match manifest.get("repository")? {
+        serde_json::Value::String(repository) => repository,
+        serde_json::Value::Object(repository) => {
+            repository.get("url").and_then(serde_json::Value::as_str)?
+        }
+        _ => return None,
+    };
+    HostedGit::package_docs_url(repository)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/licenses/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/tests.rs
@@ -1,8 +1,10 @@
 use super::{
     BelongsTo, Config, Include, LicenseInfo, LicensesArgs, LicensesDependencyOptions,
-    collect_dependencies, render_package_name, select_newer_version,
+    collect_dependencies, extract_license_author, extract_license_homepage, render_package_name,
+    select_newer_version,
 };
 use pacquet_lockfile::Lockfile;
+use serde_json::json;
 use tempfile::TempDir;
 
 #[test]
@@ -193,4 +195,33 @@ fn selects_latest_version_classification_with_semver_precedence() {
     assert_eq!(info.selected_version, "10.0.0");
     assert!(!select_newer_version(&mut info, "3.0.0", BelongsTo::Prod));
     assert_eq!(info.belongs_to, BelongsTo::Dev);
+}
+
+#[test]
+fn normalizes_author_for_license_reports() {
+    assert_eq!(
+        extract_license_author(&json!({
+            "author": "The Babel Team <team@babel.dev> (https://babel.dev/team)"
+        })),
+        Some("The Babel Team".to_string()),
+    );
+    assert_eq!(
+        extract_license_author(&json!({ "author": { "name": "The Babel Team" } })),
+        Some("The Babel Team".to_string()),
+    );
+    assert_eq!(extract_license_author(&json!({ "author": "" })), Some(String::new()));
+}
+
+#[test]
+fn normalizes_homepage_for_license_reports() {
+    assert_eq!(
+        extract_license_homepage(&json!({ "homepage": "babel.dev" })),
+        Some("http://babel.dev".to_string()),
+    );
+    assert_eq!(
+        extract_license_homepage(&json!({
+            "repository": "git+https://github.com/babel/babel.git"
+        })),
+        Some("https://github.com/babel/babel#readme".to_string()),
+    );
 }

--- a/pnpm/crates/cli/tests/licenses.rs
+++ b/pnpm/crates/cli/tests/licenses.rs
@@ -7,6 +7,88 @@ use serde_json::{Value, json};
 use std::{fs, path::Path};
 
 #[test]
+fn licenses_normalizes_metadata_and_orders_groups_by_package() {
+    let workspace = tempfile::tempdir().expect("create workspace");
+    fs::write(
+        workspace.path().join("package.json"),
+        json!({
+            "dependencies": {
+                "alpha": "1.0.0",
+                "zeta": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.path().join("pnpm-lock.yaml"),
+        r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      alpha:
+        specifier: 1.0.0
+        version: 1.0.0
+      zeta:
+        specifier: 1.0.0
+        version: 1.0.0
+packages:
+  alpha@1.0.0:
+    resolution: {integrity: sha512-alpha}
+  zeta@1.0.0:
+    resolution: {integrity: sha512-zeta}
+snapshots:
+  alpha@1.0.0: {}
+  zeta@1.0.0: {}
+",
+    )
+    .expect("write lockfile");
+    let virtual_store = workspace.path().join("node_modules/.pnpm");
+    let alpha_dir = virtual_store.join("alpha@1.0.0/node_modules/alpha");
+    let zeta_dir = virtual_store.join("zeta@1.0.0/node_modules/zeta");
+    fs::create_dir_all(&alpha_dir).expect("create alpha directory");
+    fs::create_dir_all(&zeta_dir).expect("create zeta directory");
+    fs::write(
+        alpha_dir.join("package.json"),
+        json!({
+            "name": "alpha",
+            "version": "1.0.0",
+            "license": "Zlib",
+            "author": "Alpha Team <alpha@example.com> (https://example.com/team)",
+            "repository": "github:example/alpha",
+        })
+        .to_string(),
+    )
+    .expect("write alpha manifest");
+    fs::write(
+        zeta_dir.join("package.json"),
+        json!({
+            "name": "zeta",
+            "version": "1.0.0",
+            "license": "MIT",
+        })
+        .to_string(),
+    )
+    .expect("write zeta manifest");
+
+    let output = pacquet_in(workspace.path())
+        .args(["licenses", "list", "--json"])
+        .output()
+        .expect("run licenses");
+    assert!(
+        output.status.success(),
+        "licenses should succeed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let report: Value = serde_json::from_slice(&output.stdout).expect("parse licenses JSON");
+    assert_eq!(report.as_object().unwrap().keys().collect::<Vec<_>>(), ["Zlib", "MIT"]);
+    assert_eq!(report["Zlib"][0]["author"], "Alpha Team");
+    assert_eq!(report["Zlib"][0]["homepage"], "https://github.com/example/alpha#readme");
+}
+
+#[test]
 fn licenses_reads_global_store_metadata_with_a_manifest_selected_runtime() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/resolving-git-resolver/src/hosted_git.rs
+++ b/pnpm/crates/resolving-git-resolver/src/hosted_git.rs
@@ -271,7 +271,7 @@ impl HostedGit {
             && let Some((_, tree_path)) = giturl.split_once("/tree/")
             && let Some(committish) = tree_path.split(['/', '#', '?']).next()
         {
-            hosted.committish = Some(committish.to_string());
+            hosted.committish = Some(percent_decode(committish));
         }
         Some(hosted.docs())
     }

--- a/pnpm/crates/resolving-git-resolver/src/hosted_git.rs
+++ b/pnpm/crates/resolving-git-resolver/src/hosted_git.rs
@@ -12,9 +12,7 @@
 //!   form; pacquet uses the override, not the raw template.
 //! - The `gist` host is not implemented. The test suite never
 //!   exercises it and the install path has no gist-shaped store key.
-//! - `browse` / `bugs` / `docs` / `file` / `git` templates are not
-//!   implemented — only `https` / `ssh` / `sshurl` / `tarball` /
-//!   `shortcut` are used by the resolver.
+//! - `browse` / `bugs` / `file` / `git` templates are not implemented.
 
 use pacquet_network::encode_uri_component;
 use std::fmt;
@@ -263,6 +261,41 @@ impl HostedGit {
             out = stripped.to_string();
         }
         Some(out)
+    }
+
+    /// Package documentation URL matching normalize-package-data.
+    #[must_use]
+    pub fn package_docs_url(giturl: &str) -> Option<String> {
+        let mut hosted = Self::from_url(giturl)?;
+        if hosted.host_type == HostedGitType::Github
+            && let Some((_, tree_path)) = giturl.split_once("/tree/")
+            && let Some(committish) = tree_path.split(['/', '#', '?']).next()
+        {
+            hosted.committish = Some(committish.to_string());
+        }
+        Some(hosted.docs())
+    }
+
+    fn docs(&self) -> String {
+        if let Some(committish) = &self.committish {
+            let separator = match self.host_type {
+                HostedGitType::Github | HostedGitType::Gitlab => "tree",
+                HostedGitType::Bitbucket => "src",
+            };
+            return format!(
+                "https://{domain}/{user}/{project}/{separator}/{committish}#readme",
+                domain = self.host_type.domain(),
+                user = self.user,
+                project = self.project,
+                committish = encode_uri_component(committish),
+            );
+        }
+        format!(
+            "https://{domain}/{user}/{project}#readme",
+            domain = self.host_type.domain(),
+            user = self.user,
+            project = self.project,
+        )
     }
 
     /// `git@<domain>:<user>/<project>.git[#committish]`. Mirrors

--- a/pnpm/crates/resolving-git-resolver/src/hosted_git/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/hosted_git/tests.rs
@@ -122,6 +122,10 @@ fn docs_render() {
         Some("https://github.com/pugjs/pug/tree/master#readme".to_string()),
     );
     assert_eq!(
+        HostedGit::package_docs_url("https://github.com/user/repo/tree/feature%2Ffoo"),
+        Some("https://github.com/user/repo/tree/feature%2Ffoo#readme".to_string()),
+    );
+    assert_eq!(
         HostedGit::package_docs_url("github:user/repo#feature/foo"),
         Some("https://github.com/user/repo/tree/feature%2Ffoo#readme".to_string()),
     );

--- a/pnpm/crates/resolving-git-resolver/src/hosted_git/tests.rs
+++ b/pnpm/crates/resolving-git-resolver/src/hosted_git/tests.rs
@@ -112,6 +112,22 @@ fn https_render_with_commit() {
 }
 
 #[test]
+fn docs_render() {
+    assert_eq!(
+        HostedGit::package_docs_url("gitlab:pnpmjs/git-resolver"),
+        Some("https://gitlab.com/pnpmjs/git-resolver#readme".to_string()),
+    );
+    assert_eq!(
+        HostedGit::package_docs_url("https://github.com/pugjs/pug/tree/master/packages/pug-attrs"),
+        Some("https://github.com/pugjs/pug/tree/master#readme".to_string()),
+    );
+    assert_eq!(
+        HostedGit::package_docs_url("github:user/repo#feature/foo"),
+        Some("https://github.com/user/repo/tree/feature%2Ffoo#readme".to_string()),
+    );
+}
+
+#[test]
 fn ssh_render() {
     let hosted = HostedGit::from_url("foo/bar").expect("ok");
     assert_eq!(hosted.ssh(HostedOpts::default()).unwrap(), "git@github.com:foo/bar.git");


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

- Normalize pacquet license-report authors like the TypeScript CLI.
- Derive missing homepages from hosted Git repository metadata.
- Preserve license groups in package-first order instead of sorting license names.
- Add unit and end-to-end coverage and a pacquet patch changeset.

This addresses item 1 of pnpm/pnpm#13457. The TypeScript CLI already defines the expected behavior, so no TypeScript implementation change is required.

## Squash Commit Body

```text
Normalize author strings and derive repository-based homepages when pacquet
builds license reports. Preserve the license-group insertion order produced by
the TypeScript CLI's package-first traversal.

Addresses item 1 of pnpm/pnpm#13457.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787819384&installation_model_id=426870&pr_number=13461&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13461&signature=21bac6daa983dcc5a4a6e14dd9500db14b38f49f9ad04bd56cfa92c5bca3c749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Made `licenses list --json` output more consistent by deterministically ordering license groups and package entries.
  * Improved license metadata normalization, including author name and homepage link derivation.
  * Added/extended generation of package documentation links for GitHub, GitLab, and Bitbucket, including proper `#readme` handling for branches and subdirectories.
* **Bug Fixes**
  * Corrected inconsistencies between the license report output and the TypeScript CLI output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->