### PR TITLE
fix(cli): align dedupe check reporting

### DIFF
--- a/.changeset/friendly-dedupes-report.md
+++ b/.changeset/friendly-dedupes-report.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Aligned `pnpm dedupe --check` progress and error output with the TypeScript CLI.

--- a/pnpm/crates/cli/src/bin/main.rs
+++ b/pnpm/crates/cli/src/bin/main.rs
@@ -1,3 +1,3 @@
-pub fn main() -> miette::Result<()> {
+fn main() -> std::process::ExitCode {
     pacquet_cli::main()
 }

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -1,6 +1,8 @@
 use std::{
     io::Write,
+    marker::PhantomData,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use crate::{
@@ -17,10 +19,15 @@ use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_lockfile::Lockfile;
 use pacquet_package_manager::{
-    ImporterDiffKey, Install, LockfileDiff, ProjectMutation, SnapshotDiff, diff_lockfiles,
+    ImporterDiffKey, Install, LockfileDiff, ProjectMutation, ResolutionObserver,
+    ResolvedPackageHint, SnapshotDiff, diff_lockfiles,
 };
 use pacquet_package_manifest::DependencyGroup;
-use pacquet_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
+use pacquet_reporter::{
+    DedupeCheckLog, GlobalLog, LogEvent, LogLevel, PnpmErrorLog, ProgressLog, ProgressMessage,
+    Reporter,
+};
+use serde_json::{Map, Value, json};
 use tempfile::NamedTempFile;
 
 #[derive(Debug, Args)]
@@ -74,7 +81,14 @@ impl DedupeArgs {
             dry_run: false,
             update_seed_policy: pacquet_package_manager::UpdateSeedPolicy::KeepAllResolveAll,
             auth_override: None,
-            resolution_observer: None,
+            resolution_observer: Some(Arc::new(DedupeResolutionReporter::<Reporter> {
+                requester: lockfile_path
+                    .parent()
+                    .unwrap_or_else(|| Path::new("."))
+                    .display()
+                    .to_string(),
+                reporter: PhantomData,
+            })),
             peer_issues_sink: None,
             catalogs_override: None,
             disable_optimistic_repeat_install: false,
@@ -106,12 +120,12 @@ impl DedupeArgs {
                 guard.disarm();
                 Ok(())
             } else {
-                let report = render_dedupe_check_issues(&diff_lockfiles(
+                let diff = diff_lockfiles(
                     parse_snapshot(existing.as_deref(), lockfile_path).as_ref(),
                     deduped.as_ref(),
                     ImporterDiffKey::Version,
-                ));
-                eprintln!("{report}");
+                );
+                emit_dedupe_check_error::<Reporter>(&diff);
                 Err(DedupeError::CheckIssues.into())
             }
         } else {
@@ -123,11 +137,36 @@ impl DedupeArgs {
 #[derive(Debug, Display, Error, Diagnostic)]
 enum DedupeError {
     #[display("Dedupe --check found changes to the lockfile")]
-    #[diagnostic(
-        code(ERR_PNPM_DEDUPE_CHECK_ISSUES),
-        help("Run `pnpm dedupe` to apply the changes above.")
-    )]
+    #[diagnostic(code(ERR_PNPM_DEDUPE_CHECK_ISSUES))]
     CheckIssues,
+}
+
+struct DedupeResolutionReporter<Reporter> {
+    requester: String,
+    reporter: PhantomData<fn() -> Reporter>,
+}
+
+impl<Reporter: self::Reporter> ResolutionObserver for DedupeResolutionReporter<Reporter> {
+    fn on_resolved(&self, hint: ResolvedPackageHint<'_>) {
+        Reporter::emit(&LogEvent::Progress(ProgressLog {
+            level: LogLevel::Debug,
+            message: ProgressMessage::Resolved {
+                package_id: hint.id.to_string(),
+                requester: self.requester.clone(),
+            },
+        }));
+    }
+}
+
+fn emit_dedupe_check_error<Reporter: self::Reporter>(diff: &LockfileDiff) {
+    let message = "Dedupe --check found changes to the lockfile".to_string();
+    Reporter::emit(&LogEvent::DedupeCheck(DedupeCheckLog {
+        level: LogLevel::Error,
+        message: message.clone(),
+        err: PnpmErrorLog { code: "ERR_PNPM_DEDUPE_CHECK_ISSUES".to_string(), message },
+        dedupe_check_issues: dedupe_check_issues_json(diff),
+        rendered: render_dedupe_check_error(diff),
+    }));
 }
 
 /// Parse one side of the `--check` diff. A snapshot that does not parse —
@@ -164,6 +203,49 @@ fn render_dedupe_check_issues(diff: &LockfileDiff) -> String {
     .flatten()
     .collect::<Vec<_>>()
     .join("\n")
+}
+
+fn render_dedupe_check_error(diff: &LockfileDiff) -> String {
+    format!(
+        "[ERR_PNPM_DEDUPE_CHECK_ISSUES] Dedupe --check found changes to the lockfile\n\n{}\nRun pnpm dedupe to apply the changes above.",
+        render_dedupe_check_issues(diff).trim_end(),
+    )
+}
+
+fn dedupe_check_issues_json(diff: &LockfileDiff) -> Value {
+    json!({
+        "importerIssuesByImporterId": snapshots_changes_json(&diff.importers, &[], &[]),
+        "packageIssuesByDepPath": snapshots_changes_json(
+            &diff.updated_packages,
+            &diff.added_packages,
+            &diff.removed_packages,
+        ),
+    })
+}
+
+fn snapshots_changes_json(updated: &[SnapshotDiff], added: &[String], removed: &[String]) -> Value {
+    let updated = updated
+        .iter()
+        .map(|snapshot| {
+            let changes = snapshot
+                .added
+                .iter()
+                .map(|(alias, next)| (alias.clone(), json!({ "type": "added", "next": next })))
+                .chain(snapshot.removed.iter().map(|(alias, prev)| {
+                    (alias.clone(), json!({ "type": "removed", "prev": prev }))
+                }))
+                .chain(snapshot.updated.iter().map(|(alias, prev, next)| {
+                    (alias.clone(), json!({ "type": "updated", "prev": prev, "next": next }))
+                }))
+                .collect::<Map<_, _>>();
+            (snapshot.id.clone(), Value::Object(changes))
+        })
+        .collect::<Map<_, _>>();
+    json!({
+        "added": added,
+        "removed": removed,
+        "updated": updated,
+    })
 }
 
 fn render_section(

--- a/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
@@ -1,6 +1,12 @@
-use pacquet_package_manager::{LockfileDiff, SnapshotDiff};
+use std::{marker::PhantomData, sync::Mutex};
 
-use super::render_dedupe_check_issues;
+use pacquet_package_manager::{LockfileDiff, SnapshotDiff};
+use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
+
+use super::{
+    DedupeResolutionReporter, emit_dedupe_check_error, render_dedupe_check_error,
+    render_dedupe_check_issues,
+};
 
 #[test]
 fn a_resolution_free_rewrite_says_so() {
@@ -8,6 +14,91 @@ fn a_resolution_free_rewrite_says_so() {
     assert_eq!(
         report,
         "The lockfile would be rewritten, but no dependency resolution would change.",
+    );
+}
+
+#[test]
+fn check_error_matches_pnpm_reporter_format() {
+    let report = render_dedupe_check_error(&LockfileDiff::default());
+    assert_eq!(
+        report,
+        "\
+[ERR_PNPM_DEDUPE_CHECK_ISSUES] Dedupe --check found changes to the lockfile
+
+The lockfile would be rewritten, but no dependency resolution would change.
+Run pnpm dedupe to apply the changes above.",
+    );
+}
+
+#[test]
+fn check_error_emits_the_structured_pnpm_event() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    emit_dedupe_check_error::<RecordingReporter>(&LockfileDiff::default());
+
+    let captured = EVENTS.lock().unwrap();
+    assert!(
+        matches!(
+            captured.as_slice(),
+            [LogEvent::DedupeCheck(log)]
+                if log.err.code == "ERR_PNPM_DEDUPE_CHECK_ISSUES"
+                    && log.dedupe_check_issues["importerIssuesByImporterId"]["updated"]
+                        == serde_json::json!({})
+        ),
+        "unexpected events: {captured:?}",
+    );
+}
+
+#[test]
+fn resolution_observer_emits_resolved_progress() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let observer = DedupeResolutionReporter::<RecordingReporter> {
+        requester: "/project".to_string(),
+        reporter: PhantomData,
+    };
+    pacquet_package_manager::ResolutionObserver::on_resolved(
+        &observer,
+        pacquet_package_manager::ResolvedPackageHint {
+            id: "dep@2.0.0",
+            name: "dep",
+            version: "2.0.0",
+            integrity: "sha512-test",
+            tarball_url: "https://registry.example/dep/-/dep-2.0.0.tgz",
+            unpacked_size: None,
+            file_count: None,
+            from_registry: true,
+        },
+    );
+
+    let captured = EVENTS.lock().unwrap();
+    assert!(
+        matches!(
+            captured.as_slice(),
+            [LogEvent::Progress(log)]
+                if matches!(
+                    &log.message,
+                    ProgressMessage::Resolved { package_id, requester }
+                        if package_id == "dep@2.0.0" && requester == "/project"
+                )
+        ),
+        "unexpected events: {captured:?}",
     );
 }
 

--- a/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
@@ -20,6 +20,7 @@ fn a_resolution_free_rewrite_says_so() {
 #[test]
 fn check_error_matches_pnpm_reporter_format() {
     let report = render_dedupe_check_error(&LockfileDiff::default());
+    eprintln!("REPORT:\n{report}\n");
     assert_eq!(
         report,
         "\

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -71,6 +71,7 @@ impl CliArgs {
             &dir,
             self.command.default_reporter_summary_scope(),
             self.command.reports_scope(self.recursive),
+            matches!(self.command, CliCommand::Dedupe(_)),
         );
     }
 

--- a/pnpm/crates/cli/src/cli_args/reporter.rs
+++ b/pnpm/crates/cli/src/cli_args/reporter.rs
@@ -38,10 +38,12 @@ pub(crate) fn configure_default_reporter(
     dir: &Path,
     summary_scope: SummaryScope,
     reports_scope: bool,
+    hide_added_pkgs_progress: bool,
 ) {
     pacquet_default_reporter::set_cwd(dir.to_string_lossy().into_owned());
     pacquet_default_reporter::set_summary_scope(summary_scope);
     pacquet_default_reporter::set_reports_scope(reports_scope);
+    pacquet_default_reporter::set_hide_added_pkgs_progress(hide_added_pkgs_progress);
     if matches!(reporter, ReporterType::AppendOnly) {
         pacquet_default_reporter::force_append_only();
     }

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -19,9 +19,9 @@ use flag_relocation::relocate_pre_subcommand_flags;
 use miette::set_panic_hook;
 use pacquet_diagnostics::{enable_tracing_by_env, install_report_handler};
 use state::State;
-use std::{ffi::OsString, future::Future, path::Path};
+use std::{ffi::OsString, future::Future, path::Path, process::ExitCode};
 
-pub fn main() -> miette::Result<()> {
+pub fn main() -> ExitCode {
     enable_tracing_by_env();
     install_report_handler();
     set_panic_hook();
@@ -32,7 +32,19 @@ pub fn main() -> miette::Result<()> {
     // 8 MiB). `block_on_runtime` already moves the command body onto a
     // roomy thread; run the parsing startup that precedes it on one too so
     // the whole path has uniform headroom.
-    run_on_big_stack(run_cli)
+    match run_on_big_stack(run_cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            if !is_reported_error(&error) {
+                eprintln!("Error: {error:?}");
+            }
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn is_reported_error(error: &miette::Report) -> bool {
+    error.code().is_some_and(|code| code.to_string() == "ERR_PNPM_DEDUPE_CHECK_ISSUES")
 }
 
 /// Build the CLI, parse argv, take any early-return fast path, then execute

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -185,21 +185,71 @@ fn dedupe_check_reports_the_lockfile_diff() {
         .expect("run pnpm dedupe --check");
 
     assert_eq!(output.status.code(), Some(1), "a would-change lockfile must exit 1: {output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
     let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
-    assert!(stderr.contains("ERR_PNPM_DEDUPE_CHECK_ISSUES"), "stderr:\n{stderr}");
-    assert!(stderr.contains("Dedupe --check found changes to the lockfile"), "stderr:\n{stderr}");
+    eprintln!("STDOUT:\n{stdout}");
+    assert!(stderr.is_empty(), "stderr:\n{stderr}");
     assert!(
-        stderr.contains("Importers")
-            && stderr.contains("@pnpm.e2e/dep-of-pkg-with-1-dep 100.0.0 → 100.1.0"),
-        "the importer's resolved version change must be rendered; stderr:\n{stderr}",
+        stdout.contains("Progress: resolved 1, reused 0, downloaded 0, done"),
+        "stdout:\n{stdout}",
+    );
+    assert!(stdout.contains("ERR_PNPM_DEDUPE_CHECK_ISSUES"), "stdout:\n{stdout}");
+    assert!(stdout.contains("Dedupe --check found changes to the lockfile"), "stdout:\n{stdout}");
+    assert!(
+        stdout.contains("Importers")
+            && stdout.contains("@pnpm.e2e/dep-of-pkg-with-1-dep 100.0.0 → 100.1.0"),
+        "the importer's resolved version change must be rendered; stdout:\n{stdout}",
     );
     assert!(
-        stderr.contains("Packages")
-            && stderr.contains("+ @pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0")
-            && stderr.contains("- @pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0"),
-        "the added and removed snapshots must be rendered; stderr:\n{stderr}",
+        stdout.contains("Packages")
+            && stdout.contains("+ @pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0")
+            && stdout.contains("- @pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0"),
+        "the added and removed snapshots must be rendered; stdout:\n{stdout}",
     );
-    assert!(stderr.contains("Run `pnpm dedupe` to apply the changes above."), "stderr:\n{stderr}");
+    assert!(stdout.contains("Run pnpm dedupe to apply the changes above."), "stdout:\n{stdout}");
+    assert!(stdout.ends_with("Run pnpm dedupe to apply the changes above.\n"), "stdout:\n{stdout}");
+
+    let ndjson_output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["dedupe", "--check", "--reporter=ndjson"])
+        .output()
+        .expect("run pnpm dedupe --check with the ndjson reporter");
+    assert_eq!(ndjson_output.status.code(), Some(1), "ndjson check: {ndjson_output:?}");
+    assert!(ndjson_output.stdout.is_empty(), "ndjson stdout: {ndjson_output:?}");
+    let ndjson_stderr = String::from_utf8(ndjson_output.stderr).expect("stderr is UTF-8");
+    let ndjson_records = ndjson_stderr
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("valid NDJSON"))
+        .collect::<Vec<_>>();
+    assert!(
+        ndjson_records.iter().any(|record| {
+            record["name"] == "pnpm:progress"
+                && record["status"] == "resolved"
+                && record["packageId"] == "@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"
+        }),
+        "ndjson stderr:\n{ndjson_stderr}",
+    );
+    assert!(
+        ndjson_records.iter().any(|record| {
+            record["name"] == "pnpm"
+                && record["level"] == "error"
+                && record["err"]["code"] == "ERR_PNPM_DEDUPE_CHECK_ISSUES"
+                && record["dedupeCheckIssues"]["packageIssuesByDepPath"]["added"]
+                    == serde_json::json!(["@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"])
+        }),
+        "ndjson stderr:\n{ndjson_stderr}",
+    );
+
+    let silent_output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["dedupe", "--check", "--reporter=silent"])
+        .output()
+        .expect("run pnpm dedupe --check with the silent reporter");
+    assert_eq!(silent_output.status.code(), Some(1), "silent check: {silent_output:?}");
+    assert!(silent_output.stdout.is_empty(), "silent stdout: {silent_output:?}");
+    assert!(silent_output.stderr.is_empty(), "silent stderr: {silent_output:?}");
 
     let lockfile_after = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
     assert_eq!(lockfile_before, lockfile_after, "dedupe --check must not modify pnpm-lock.yaml");

--- a/pnpm/crates/default-reporter/src/lib.rs
+++ b/pnpm/crates/default-reporter/src/lib.rs
@@ -83,6 +83,9 @@ pub fn set_reports_scope(reports_scope: bool) {
 }
 
 /// Configure whether dependency progress includes the materialization count.
+///
+/// This must be called before the reporter is initialized. Only the first
+/// configured value is retained.
 pub fn set_hide_added_pkgs_progress(hide_added_pkgs_progress: bool) {
     let _ = HIDE_ADDED_PKGS_PROGRESS.set(hide_added_pkgs_progress);
 }

--- a/pnpm/crates/default-reporter/src/lib.rs
+++ b/pnpm/crates/default-reporter/src/lib.rs
@@ -37,6 +37,7 @@ static PACKAGE_VERSION: OnceLock<String> = OnceLock::new();
 static FORCE_APPEND_ONLY: OnceLock<bool> = OnceLock::new();
 static SUMMARY_SCOPE: OnceLock<SummaryScope> = OnceLock::new();
 static REPORTS_SCOPE: OnceLock<bool> = OnceLock::new();
+static HIDE_ADDED_PKGS_PROGRESS: OnceLock<bool> = OnceLock::new();
 
 /// Which prefixes contribute to the packages-diff summary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,6 +80,11 @@ pub fn set_summary_scope(scope: SummaryScope) {
 /// the first event; ignored if already set.
 pub fn set_reports_scope(reports_scope: bool) {
     let _ = REPORTS_SCOPE.set(reports_scope);
+}
+
+/// Configure whether dependency progress includes the materialization count.
+pub fn set_hide_added_pkgs_progress(hide_added_pkgs_progress: bool) {
+    let _ = HIDE_ADDED_PKGS_PROGRESS.set(hide_added_pkgs_progress);
 }
 
 fn cwd() -> String {
@@ -147,6 +153,7 @@ impl Sink {
                 append_only,
                 summary_scope: SUMMARY_SCOPE.get().copied().unwrap_or(SummaryScope::CurrentPrefix),
                 reports_scope: REPORTS_SCOPE.get().copied().unwrap_or(false),
+                hide_added_pkgs_progress: HIDE_ADDED_PKGS_PROGRESS.get().copied().unwrap_or(false),
                 ..state::ReporterOptions::default()
             },
         );

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -12,7 +12,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use pacquet_reporter::{
-    AddedRoot, ContextLog, DependencyType, DeprecationLog, ExecutionTimeLog,
+    AddedRoot, ContextLog, DedupeCheckLog, DependencyType, DeprecationLog, ExecutionTimeLog,
     FetchingProgressMessage, HookLog, IgnoredScriptsLog, InstallingConfigDepsLog,
     InstallingConfigDepsStatus, LifecycleMessage, LifecycleStdio, LockfileVerificationMessage,
     LogEvent, LogLevel, PackageImportMethod, PackageManifestMessage, ProgressMessage, RemovedRoot,
@@ -412,6 +412,7 @@ impl ReporterState {
             LogEvent::LockfileVerification(log) => self.on_lockfile_verification(&log.message),
             LogEvent::RequestRetry(log) => self.on_request_retry(log),
             LogEvent::Pnpm(log) => self.on_pnpm(log.level, &log.message, &log.prefix),
+            LogEvent::DedupeCheck(log) => self.on_dedupe_check(log),
             // `pnpm:global` shares the "other" log stream with the `pnpm`
             // channel but carries no prefix, so it always renders (the
             // empty-prefix path in `on_pnpm`).
@@ -1139,6 +1140,10 @@ impl ReporterState {
                 }
             }
         }
+    }
+
+    fn on_dedupe_check(&mut self, log: &DedupeCheckLog) {
+        self.push_block(log.rendered.clone());
     }
 
     fn on_execution_time(&mut self, log: &ExecutionTimeLog) {

--- a/pnpm/crates/reporter/src/lib.rs
+++ b/pnpm/crates/reporter/src/lib.rs
@@ -167,6 +167,14 @@ pub enum LogEvent {
     #[serde(rename = "pnpm")]
     Pnpm(PnpmLog),
 
+    /// The `ERR_PNPM_DEDUPE_CHECK_ISSUES` error (`name: "pnpm"`).
+    ///
+    /// This keeps the structured diff on the wire for NDJSON consumers
+    /// while carrying the terminal rendering used by the in-process default
+    /// reporter.
+    #[serde(rename = "pnpm")]
+    DedupeCheck(DedupeCheckLog),
+
     /// Global-logger message (`name: "pnpm:global"`). Written to a
     /// `bole('pnpm:global')` logger with just a message string — no
     /// `prefix`, unlike [`LogEvent::Pnpm`]. The interactive
@@ -788,6 +796,25 @@ pub struct PnpmLog {
     pub level: LogLevel,
     pub message: String,
     pub prefix: String,
+}
+
+/// The error payload bole serializes under `err`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PnpmErrorLog {
+    pub code: String,
+    pub message: String,
+}
+
+/// `pnpm dedupe --check` failure payload.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DedupeCheckLog {
+    pub level: LogLevel,
+    pub message: String,
+    pub err: PnpmErrorLog,
+    pub dedupe_check_issues: serde_json::Value,
+    #[serde(skip)]
+    pub rendered: String,
 }
 
 /// `pnpm:scope` payload: how many workspace projects the command

--- a/pnpm/crates/reporter/src/lib.rs
+++ b/pnpm/crates/reporter/src/lib.rs
@@ -805,7 +805,8 @@ pub struct PnpmErrorLog {
     pub message: String,
 }
 
-/// `pnpm dedupe --check` failure payload.
+/// Keeps the structured dedupe diff on the wire while retaining a
+/// terminal-only rendering for the in-process default reporter.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DedupeCheckLog {

--- a/pnpm/crates/reporter/src/tests.rs
+++ b/pnpm/crates/reporter/src/tests.rs
@@ -5,15 +5,15 @@ use pretty_assertions::assert_eq;
 use serde_json::Value;
 
 use crate::{
-    AddedRoot, BrokenModulesLog, ContextLog, DependencyType, DeprecationLog, Envelope,
-    FetchingProgressLog, FetchingProgressMessage, GetHostName, GlobalLog, HookLog, Host,
+    AddedRoot, BrokenModulesLog, ContextLog, DedupeCheckLog, DependencyType, DeprecationLog,
+    Envelope, FetchingProgressLog, FetchingProgressMessage, GetHostName, GlobalLog, HookLog, Host,
     IgnoredScriptsLog, LifecycleLog, LifecycleMessage, LifecycleStdio, LockfileVerificationLog,
     LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog,
-    PackageManifestLog, PackageManifestMessage, PnpmLog, ProgressLog, ProgressMessage,
-    PromptAction, PromptLog, RemovedRoot, Reporter, RequestRetryError, RequestRetryLog, RootLog,
-    RootMessage, SilentReporter, SkippedOptionalDependencyLog, SkippedOptionalPackage,
-    SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage,
-    SummaryLog,
+    PackageManifestLog, PackageManifestMessage, PnpmErrorLog, PnpmLog, ProgressLog,
+    ProgressMessage, PromptAction, PromptLog, RemovedRoot, Reporter, RequestRetryError,
+    RequestRetryLog, RootLog, RootMessage, SilentReporter, SkippedOptionalDependencyLog,
+    SkippedOptionalPackage, SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog,
+    StatsLog, StatsMessage, SummaryLog,
 };
 
 #[test]
@@ -135,6 +135,43 @@ fn pnpm_event_matches_pnpm_wire_shape() {
     assert_eq!(json["level"], "info");
     assert_eq!(json["message"], "Lockfile is up to date, resolution step is skipped");
     assert_eq!(json["prefix"], "/some/project");
+}
+
+#[test]
+fn dedupe_check_event_matches_pnpm_wire_shape() {
+    let event = LogEvent::DedupeCheck(DedupeCheckLog {
+        level: LogLevel::Error,
+        message: "Dedupe --check found changes to the lockfile".to_string(),
+        err: PnpmErrorLog {
+            code: "ERR_PNPM_DEDUPE_CHECK_ISSUES".to_string(),
+            message: "Dedupe --check found changes to the lockfile".to_string(),
+        },
+        dedupe_check_issues: serde_json::json!({
+            "importerIssuesByImporterId": {
+                "added": [],
+                "removed": [],
+                "updated": {},
+            },
+            "packageIssuesByDepPath": {
+                "added": ["dep@2.0.0"],
+                "removed": ["dep@1.0.0"],
+                "updated": {},
+            },
+        }),
+        rendered: "terminal-only rendering".to_string(),
+    });
+    let envelope = Envelope { time: 1_700_000_000_000, hostname: "host", pid: 4242, event: &event };
+    let json: Value = envelope
+        .pipe_ref(serde_json::to_string)
+        .expect("serialize envelope")
+        .pipe_as_ref(serde_json::from_str)
+        .expect("parse JSON");
+
+    assert_eq!(json["name"], "pnpm");
+    assert_eq!(json["level"], "error");
+    assert_eq!(json["err"]["code"], "ERR_PNPM_DEDUPE_CHECK_ISSUES");
+    assert_eq!(json["dedupeCheckIssues"]["packageIssuesByDepPath"]["added"][0], "dep@2.0.0");
+    assert!(json.get("rendered").is_none(), "terminal rendering must stay off the wire: {json:?}");
 }
 
 /// Global-channel (`name: "pnpm:global"`) log carries the


### PR DESCRIPTION
## Summary

Aligns the Rust pnpm implementation’s `dedupe --check` reporting with the TypeScript CLI:

- emits resolution progress for the lockfile-only dedupe pass without an added-packages count;
- routes the check failure through the reporter so the default output matches pnpm and avoids a second Miette diagnostic;
- preserves the structured diff in NDJSON output and keeps the silent reporter silent.

The TypeScript CLI already has the desired behavior, so this change only updates the Rust implementation. Related to item 2 of pnpm/pnpm#13457.

## Squash Commit Body

```text
The Rust lockfile-only dedupe path bypassed both ordinary resolution progress and pnpm-style error reporting. Attach a lightweight resolution observer to emit resolved-package progress, then report check failures as a structured pnpm event that each reporter can handle appropriately.

This makes default, NDJSON, and silent output match the TypeScript CLI while retaining the existing exit status and leaving the lockfile untouched.

Related to item 2 of pnpm/pnpm#13457.
```

## Checklist

- [x] The TypeScript CLI already provides the target behavior; the Rust `pnpm/` port is aligned by this PR.
- [x] Added a `pacquet` patch changeset.
- [x] Added or updated tests for default, NDJSON, silent, and structured reporter output.
- [x] Documentation updates are not needed for this output-parity fix.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787820108&installation_model_id=426870&pr_number=13462&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13462&signature=d494e33fed2823de9c5ebd1dde0dd8a4b7b6d1bc0cdb6451fb677af9fe85233c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Aligned `pnpm dedupe --check` progress and error reporting with the TypeScript CLI.
  - Improved output stream handling for lockfile-diff results (and ensured stderr is empty where applicable).
  - Standardized the failure exit code and reduced duplicate error text for dedupe-check issues.
- **New Features**
  - Added structured NDJSON reporting for `pnpm dedupe --check`, including machine-readable error details and diff payloads.
  - Added/strengthened “silent” reporting mode behavior.
  - Improved resolution progress events during deduplication.
  - Added an option to hide “added packages” progress materialization counts in the default reporter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->