### PR TITLE
fix(pacquet): verify dependencies before run

### DIFF
--- a/.changeset/quiet-dodos-verify.md
+++ b/.changeset/quiet-dodos-verify.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Run dependency verification consistently after regenerating a lockfile with `dedupePeers` enabled.

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -129,6 +129,11 @@ pub struct InstallArgs {
     #[clap(long = "no-prefer-frozen-lockfile", overrides_with = "prefer_frozen_lockfile")]
     pub no_prefer_frozen_lockfile: bool,
 
+    /// Run the install already requested by `verifyDepsBeforeRun` without
+    /// independently short-circuiting it as up to date.
+    #[clap(long, hide = true)]
+    pub verify_deps_before_run_install: bool,
+
     /// Skip the check that `pnpm-lock.yaml` is up to date with
     /// `package.json` under `--frozen-lockfile`. For callers that just
     /// wrote the lockfile themselves and know the manifest is about to
@@ -257,6 +262,7 @@ impl InstallArgs {
             force: false,
             prefer_frozen_lockfile: false,
             no_prefer_frozen_lockfile: true,
+            verify_deps_before_run_install: false,
             ignore_manifest_check: false,
             no_runtime: false,
             ignore_scripts: false,
@@ -305,6 +311,7 @@ impl InstallArgs {
         if self.effective_frozen_lockfile(config)
             || self.lockfile_only
             || self.force
+            || self.verify_deps_before_run_install
             || self.pnpr_server.is_some()
         {
             return false;
@@ -420,6 +427,7 @@ impl InstallArgs {
             force: _,
             prefer_frozen_lockfile,
             no_prefer_frozen_lockfile,
+            verify_deps_before_run_install,
             ignore_manifest_check,
             no_runtime,
             // The `ignore_scripts` / `offline` / `frozen_store` /
@@ -453,7 +461,9 @@ impl InstallArgs {
         // mutual `overrides_with` collapses both spellings to the
         // last-specified, so at most one is set and the precedence here
         // is straightforward.
-        let prefer_frozen_lockfile = if prefer_frozen_lockfile {
+        let prefer_frozen_lockfile = if verify_deps_before_run_install {
+            Some(false)
+        } else if prefer_frozen_lockfile {
             Some(true)
         } else if no_prefer_frozen_lockfile {
             Some(false)
@@ -551,7 +561,7 @@ impl InstallArgs {
             resolution_observer: None,
             peer_issues_sink: None,
             catalogs_override: None,
-            disable_optimistic_repeat_install: false,
+            disable_optimistic_repeat_install: verify_deps_before_run_install,
             pnpmfile_hook_override: None,
             workspace_projects_override: None,
         };

--- a/pnpm/crates/cli/src/cli_args/verify_deps.rs
+++ b/pnpm/crates/cli/src/cli_args/verify_deps.rs
@@ -91,12 +91,17 @@ pub(crate) fn verify_deps_before_run(
 /// Re-run the kind of install the workspace state recorded, in-place
 /// and with inherited stdio, the way pnpm's `runDepsStatusCheck` spawns
 /// `pnpm install` through `runPnpmCli`. The spawned install never
-/// re-enters this gate: only `run` / `exec` consult it.
+/// re-enters this gate: only `run` / `exec` consult it. Its up-to-date
+/// shortcuts are bypassed because the pre-run check has already decided
+/// that an install is required.
 #[expect(clippy::exit, reason = "a failed spawned install must preserve the child exit code")]
 fn spawn_install(dir: &Path, install_args: &[String], silent: bool) -> miette::Result<()> {
     let exe = std::env::current_exe().into_diagnostic()?;
     let mut command = Command::new(exe);
-    command.arg("install").args(install_args).current_dir(dir);
+    command
+        .args(["install", "--verify-deps-before-run-install"])
+        .args(install_args)
+        .current_dir(dir);
     if silent {
         command.arg("--reporter=silent");
     }

--- a/pnpm/crates/cli/tests/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/verify_deps_before_run.rs
@@ -59,7 +59,7 @@ fn dedupe_peers_lockfile_regeneration_installs_before_running_the_script() {
                 "@pnpm.e2e/foo": "100.0.0",
             },
             "scripts": {
-                "hello": r#"node -e "require('fs').writeFileSync('marker.txt', '')""#,
+                "hello": r#"node -e "require('fs').appendFileSync('postinstall.log', 'h')""#,
                 "postinstall": r#"node -e "require('fs').appendFileSync('postinstall.log', 'x')""#,
             },
         })
@@ -78,10 +78,15 @@ fn dedupe_peers_lockfile_regeneration_installs_before_running_the_script() {
     bump_mtime(&workspace.join("pnpm-lock.yaml"));
 
     pacquet_in(&workspace).with_args(["run", "hello"]).assert().success();
-    assert!(workspace.join("marker.txt").exists(), "the script must run after the install");
     assert_eq!(
         fs::read_to_string(workspace.join("postinstall.log")).expect("read postinstall log"),
-        "xx",
+        "xxh",
+    );
+
+    pacquet_in(&workspace).with_args(["run", "hello"]).assert().success();
+    assert_eq!(
+        fs::read_to_string(workspace.join("postinstall.log")).expect("read postinstall log"),
+        "xxhh",
     );
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/verify_deps_before_run.rs
@@ -8,7 +8,10 @@ pub use _utils::*;
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pacquet_testing_utils::{bin::CommandTempCwd, fs::bump_mtime};
+use pacquet_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fs::bump_mtime,
+};
 use serde_json::json;
 use std::{fs, path::Path};
 
@@ -39,6 +42,49 @@ fn default_install_action_installs_before_running_the_script() {
     assert!(workspace.join("node_modules").exists(), "the gate must have spawned an install first");
 
     drop(root);
+}
+
+#[test]
+fn dedupe_peers_lockfile_regeneration_installs_before_running_the_script() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    append_workspace_yaml_key(&workspace, "dedupePeers", true);
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "verify-deps-project",
+            "version": "0.0.0",
+            "dependencies": {
+                "@pnpm.e2e/foo": "100.0.0",
+            },
+            "scripts": {
+                "hello": r#"node -e "require('fs').writeFileSync('marker.txt', '')""#,
+                "postinstall": r#"node -e "require('fs').appendFileSync('postinstall.log', 'x')""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+    assert_eq!(
+        fs::read_to_string(workspace.join("postinstall.log")).expect("read postinstall log"),
+        "x",
+    );
+
+    fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
+    pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    bump_mtime(&workspace.join("pnpm-lock.yaml"));
+
+    pacquet_in(&workspace).with_args(["run", "hello"]).assert().success();
+    assert!(workspace.join("marker.txt").exists(), "the script must run after the install");
+    assert_eq!(
+        fs::read_to_string(workspace.join("postinstall.log")).expect("read postinstall log"),
+        "xx",
+    );
+
+    drop((root, mock_instance));
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2650,8 +2650,11 @@ async fn check_lockfile_freshness(
         lockfile,
         config,
         catalogs,
-        parsed_overrides_opt.as_deref(),
-        PnpmfileChecksumCheck::Current(pnpmfile_checksum.as_deref()),
+        CheckLockfileSettingsDriftOptions {
+            parsed_overrides: parsed_overrides_opt.as_deref(),
+            pnpmfile_checksum: PnpmfileChecksumCheck::Current(pnpmfile_checksum.as_deref()),
+            dedupe_peers: config.dedupe_peers,
+        },
     )?;
 
     if ignore_manifest_check {
@@ -2707,13 +2710,21 @@ pub(crate) fn parse_config_overrides(
 /// `pnpmfile_checksum` is the one input the config doesn't carry.
 /// callers that can't produce it pass
 /// [`PnpmfileChecksumCheck::Skip`].
+#[derive(Clone, Copy)]
+pub(crate) struct CheckLockfileSettingsDriftOptions<'a> {
+    pub parsed_overrides: Option<&'a [pacquet_config_parse_overrides::VersionOverride]>,
+    pub pnpmfile_checksum: PnpmfileChecksumCheck<'a>,
+    pub dedupe_peers: bool,
+}
+
 pub(crate) fn check_lockfile_settings_drift(
     lockfile: &Lockfile,
     config: &Config,
     catalogs: &Catalogs,
-    parsed_overrides: Option<&[pacquet_config_parse_overrides::VersionOverride]>,
-    pnpmfile_checksum: PnpmfileChecksumCheck<'_>,
+    opts: CheckLockfileSettingsDriftOptions<'_>,
 ) -> Result<(), FreshnessCheckError> {
+    let CheckLockfileSettingsDriftOptions { parsed_overrides, pnpmfile_checksum, dedupe_peers } =
+        opts;
     let overrides_map: Option<std::collections::HashMap<String, String>> =
         parsed_overrides.map(pacquet_config_parse_overrides::create_overrides_map_from_parsed);
     let package_extensions_checksum =
@@ -2733,7 +2744,7 @@ pub(crate) fn check_lockfile_settings_drift(
             ignored_optional_dependencies: config.ignored_optional_dependencies.as_deref(),
             patched_dependencies: patched_dependency_hashes.as_ref(),
             auto_install_peers: config.auto_install_peers,
-            dedupe_peers: config.dedupe_peers,
+            dedupe_peers,
             exclude_links_from_lockfile: config.exclude_links_from_lockfile,
             inject_workspace_packages: config.inject_workspace_packages,
             peers_suffix_max_length: config.peers_suffix_max_length,

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -303,7 +303,8 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
     // than just the modified ones.
     let projects_to_check: Vec<&ManifestStat<'_>> =
         if lockfile_modified { manifest_stats.iter().collect() } else { modified };
-    match modified_manifests_match_lockfile(check, &state, &projects_to_check) {
+    match modified_manifests_match_lockfile(check, &state, &projects_to_check, config.dedupe_peers)
+    {
         Ok(loaded_current) => {
             if let Err(reason) = regenerate_wanted_lockfile_if_missing(check, loaded_current) {
                 return Decision::Skipped { reason };
@@ -647,6 +648,7 @@ fn modified_manifests_match_lockfile(
     check: &OptimisticRepeatInstallCheck<'_>,
     state: &WorkspaceState,
     modified: &[&ManifestStat<'_>],
+    dedupe_peers: bool,
 ) -> Result<Option<Lockfile>, &'static str> {
     let &OptimisticRepeatInstallCheck {
         workspace_root,
@@ -731,13 +733,16 @@ fn modified_manifests_match_lockfile(
         wanted,
         config,
         catalogs,
-        parsed_overrides.as_deref(),
-        // `pnpmfileChecksum` needs no comparison here: reaching this
-        // point means `pnpmfiles_modified_since` already proved the
-        // pnpmfile list and contents are what the install that wrote
-        // this lockfile saw. Computing the checksum instead would cost
-        // a Node worker on the path that exists to avoid starting one.
-        pacquet_lockfile::PnpmfileChecksumCheck::Skip,
+        crate::install::CheckLockfileSettingsDriftOptions {
+            parsed_overrides: parsed_overrides.as_deref(),
+            // `pnpmfileChecksum` needs no comparison here: reaching this
+            // point means `pnpmfiles_modified_since` already proved the
+            // pnpmfile list and contents are what the install that wrote
+            // this lockfile saw. Computing the checksum instead would cost
+            // a Node worker on the path that exists to avoid starting one.
+            pnpmfile_checksum: pacquet_lockfile::PnpmfileChecksumCheck::Skip,
+            dedupe_peers,
+        },
     ) {
         tracing::debug!(target: "pacquet::install", %error, "repeat-install content check: lockfile settings drift");
         return Err("a lockfile setting drifted from the current configuration");
@@ -1799,7 +1804,10 @@ pub fn check_deps_status_before_run(
 
     let projects_to_check: Vec<&ManifestStat<'_>> =
         if lockfile_modified { manifest_stats.iter().collect() } else { modified };
-    match modified_manifests_match_lockfile(check, state, &projects_to_check) {
+    // The TypeScript run/exec handler does not forward `dedupePeers`
+    // into `checkDepsStatus`, so its pre-run lockfile check uses the
+    // false default even when the workspace setting is true.
+    match modified_manifests_match_lockfile(check, state, &projects_to_check, false) {
         Ok(_) => {
             if let Err(reason) = missing_wanted_lockfile_stand_in_ok(check) {
                 return outdated(reason);


### PR DESCRIPTION
## Summary

Fixes the pacquet parity gap described in item 4 of pnpm/pnpm#13457.

When `dedupePeers` is enabled and an identical wanted lockfile is regenerated with `install --lockfile-only`, pacquet now follows TypeScript pnpm and treats the pre-run dependency state as stale. The verifier-triggered install bypasses only its independent up-to-date shortcuts, allowing the install and root lifecycle scripts to finish before the requested script starts.

This is Rust-only because the TypeScript CLI already has the target behavior.

## Squash Commit Body

```text
Align pacquet with the TypeScript dependency-status check used by run and exec. The TypeScript handler does not forward dedupePeers, so a regenerated lockfile with that setting is considered stale and triggers install before the script.

Carry that verifier-specific setting comparison into pacquet and prevent the spawned install from independently short-circuiting after the verifier has requested it. This preserves normal package reuse while ensuring project lifecycle scripts run before the requested command.

Fixes item 4 of pnpm/pnpm#13457.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787821074&installation_model_id=426870&pr_number=13463&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13463&signature=5360705fb1fd61fae9040c968c9d7fd75e082921765454bea2f90db70e59f1cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency verification before running scripts, ensuring the install step is re-entered with the correct verification behavior.
  * Fixed lockfile “settings drift” detection so it properly accounts for peer de-duplication settings when evaluating lockfile freshness.
  * Improved handling when lockfiles are regenerated, ensuring post-install actions are recognized consistently.

* **Tests**
  * Added E2E coverage for `verify-deps-before-run` with peer de-duplication enabled and lockfile regeneration (including `pnpm-lock.yaml` deletion scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->