### PR TITLE
fix(catalogs): preserve valid resolutions during dedupe

### DIFF
--- a/.changeset/quiet-catalogs-dedupe.md
+++ b/.changeset/quiet-catalogs-dedupe.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Fixed `pnpm dedupe` updating valid catalog resolutions when another matching version exists in the lockfile.

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1272,11 +1272,6 @@ function forgetResolutionsOfAllPrevWantedDeps (wantedLockfile: LockfileObject): 
       ({ dependencies: _dependencies, optionalDependencies: _optionalDependencies, ...rest }) => rest,
       wantedLockfile.packages)
   }
-
-  // Also clear the resolutions in catalogs so they're re-resolved and deduped.
-  if ((wantedLockfile.catalogs != null) && !isEmpty(wantedLockfile.catalogs)) {
-    wantedLockfile.catalogs = undefined
-  }
 }
 
 /**

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1112,7 +1112,7 @@ test('catalogs work when inject-workspace-packages=true', async () => {
 })
 
 describe('dedupe', () => {
-  test('catalogs are deduped when running pnpm dedupe', async () => {
+  test('valid catalog resolutions are preserved when running pnpm dedupe', async () => {
     const { options, projects, readLockfile } = preparePackagesAndReturnObjects([
       {
         name: 'project1',
@@ -1166,7 +1166,7 @@ describe('dedupe', () => {
     expect(Object.keys(lockfile.packages)).toEqual(['@pnpm.e2e/foo@100.0.0', '@pnpm.e2e/foo@100.1.0'])
     expect(lockfile.catalogs.default['@pnpm.e2e/foo'].version).toBe('100.0.0')
 
-    // Perform a dedupe and expect the catalog version to update.
+    // Perform a dedupe and expect the valid catalog version to be preserved.
     await mutateModules(installProjects(projects), {
       ...options,
       dedupe: true,
@@ -1174,8 +1174,8 @@ describe('dedupe', () => {
       catalogs,
     })
     const dedupedLockfile = readLockfile()
-    expect(Object.keys(dedupedLockfile.packages)).toEqual(['@pnpm.e2e/foo@100.1.0'])
-    expect(dedupedLockfile.catalogs.default['@pnpm.e2e/foo'].version).toBe('100.1.0')
+    expect(Object.keys(dedupedLockfile.packages)).toEqual(['@pnpm.e2e/foo@100.0.0', '@pnpm.e2e/foo@100.1.0'])
+    expect(dedupedLockfile.catalogs.default['@pnpm.e2e/foo'].version).toBe('100.0.0')
   })
 })
 

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1166,7 +1166,6 @@ describe('dedupe', () => {
     expect(Object.keys(lockfile.packages)).toEqual(['@pnpm.e2e/foo@100.0.0', '@pnpm.e2e/foo@100.1.0'])
     expect(lockfile.catalogs.default['@pnpm.e2e/foo'].version).toBe('100.0.0')
 
-    // Perform a dedupe and expect the valid catalog version to be preserved.
     await mutateModules(installProjects(projects), {
       ...options,
       dedupe: true,


### PR DESCRIPTION
## Summary

Fixes `pnpm dedupe` so a catalog version already recorded in the lockfile remains selected while it satisfies the catalog range, even when a newer matching version is also present.

The dedupe pass still rebuilds importer and package dependency edges, but it no longer discards the catalog snapshot that provides the catalog-specific preferred version. Pacquet already preserves this valid pin, so no Rust change is needed.

Closes pnpm/pnpm#13465.

## Squash Commit Body

```text
Keep catalog snapshots available while dedupe rebuilds importer and package dependency edges. The resolver validates that the recorded catalog specifier still matches before reusing its version, so changed catalog ranges continue to re-resolve while valid pins remain stable.

Closes pnpm/pnpm#13465.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5.6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787832890&installation_model_id=426870&pr_number=13468&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13468&signature=8bbfe5712643671e0da44a402c48cdc4b7b343b5db868ac34308bed9bc9f762e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm dedupe` to preserve valid catalog resolutions when matching package versions exist in the lockfile.
  * Prevented dedupe from incorrectly resetting catalog resolution data or removing valid resolved versions from the lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->