### PR TITLE
fix(pacquet): preserve lockfile before scripts

### DIFF
--- a/.changeset/calm-wolves-reuse-lockfile.md
+++ b/.changeset/calm-wolves-reuse-lockfile.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Prevented dependency verification before scripts from rewriting an up-to-date lockfile.

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -461,9 +461,7 @@ impl InstallArgs {
         // mutual `overrides_with` collapses both spellings to the
         // last-specified, so at most one is set and the precedence here
         // is straightforward.
-        let prefer_frozen_lockfile = if verify_deps_before_run_install {
-            Some(false)
-        } else if prefer_frozen_lockfile {
+        let prefer_frozen_lockfile = if prefer_frozen_lockfile {
             Some(true)
         } else if no_prefer_frozen_lockfile {
             Some(false)

--- a/pnpm/crates/cli/tests/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/verify_deps_before_run.rs
@@ -76,8 +76,25 @@ fn dedupe_peers_lockfile_regeneration_installs_before_running_the_script() {
     fs::remove_file(workspace.join("pnpm-lock.yaml")).expect("remove pnpm-lock.yaml");
     pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
     bump_mtime(&workspace.join("pnpm-lock.yaml"));
+    let regenerated_lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read regenerated lockfile");
 
-    pacquet_in(&workspace).with_args(["run", "hello"]).assert().success();
+    let output = pacquet_in(&workspace)
+        .with_args(["run", "hello"])
+        .output()
+        .expect("run script after lockfile regeneration");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+    assert!(output.status.success(), "the script must run successfully");
+    assert!(
+        stdout.contains("Lockfile is up to date, resolution step is skipped"),
+        "the verifier install must reuse the regenerated lockfile:\n{stdout}",
+    );
+    assert_eq!(
+        fs::read_to_string(workspace.join("pnpm-lock.yaml"))
+            .expect("read lockfile after verifier install"),
+        regenerated_lockfile,
+    );
     assert_eq!(
         fs::read_to_string(workspace.join("postinstall.log")).expect("read postinstall log"),
         "xxh",

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -343,11 +343,11 @@ where
     /// catalog bump drives resolution even under `--no-save`, where the
     /// bumped entry is intentionally not persisted to disk.
     pub catalogs_override: Option<Catalogs>,
-    /// When `true`, the optimistic repeat-install fast path is
-    /// disabled so the full install pipeline always runs. `pacquet
-    /// prune` sets this because the fast path short-circuits before
-    /// the virtual-store sweep, meaning extraneous packages can
-    /// survive a prune when the lockfile hasn't changed.
+    /// When `true`, repeat-install fast paths are disabled so the full
+    /// install pipeline always runs. `pacquet prune` sets this because
+    /// a fast path can short-circuit before the virtual-store sweep,
+    /// meaning extraneous packages can survive a prune when the lockfile
+    /// hasn't changed.
     pub disable_optimistic_repeat_install: bool,
     /// In-process `readPackage` / `afterAllResolved` hooks supplied by an
     /// embedder (the Node API binding) instead of a `.pnpmfile.cjs` on disk.
@@ -1731,6 +1731,7 @@ where
 
         if take_frozen_path
             && !filtered_install
+            && !disable_optimistic_repeat_install
             // `--force` reinstalls everything, so an up-to-date tree
             // must not short-circuit the materialization.
             && !config.force


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13466.

Verifier-triggered installs now keep the configured `preferFrozenLockfile` behavior, so an up-to-date regenerated wanted lockfile is reused instead of freshly resolving its peer graph. The verifier mode still bypasses repeat-install exits, which ensures the required install and root lifecycle scripts finish before the requested script starts.

The regression test asserts that resolution is skipped, the lockfile remains byte-identical, and `postinstall` runs before the requested script. The pinned Vue reproduction also retains the original lockfile SHA-256 (`3090fe80629d31be0f459ce3eb29d4d1fd87ba19df57d0f92ae1c5b7fee26f55`) after `pnpm run lint`.

This is Rust-only because the TypeScript CLI already has the target behavior.

## Squash Commit Body

```text
Keep verifier-triggered installs on the normal prefer-frozen dispatch path. A regenerated lockfile that is fresh for the current configuration can then be materialized without re-resolving and rewriting its peer graph.

Continue bypassing both optimistic and frozen repeat-install exits for this mode so root lifecycle scripts still run before the requested command.

Fixes pnpm/pnpm#13466.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787833100&installation_model_id=426870&pr_number=13469&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13469&signature=1d9ed8b30fbada71586a418e5f929c3113f41bb835f8ee45a938207deed3553a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency verification when install scripts run after lockfile regeneration.
  - Prevented unnecessary lockfile updates when the lockfile is already current.
  - Ensured scripts complete successfully while preserving the regenerated lockfile.
  - Corrected handling of frozen-lockfile preferences so configured behavior is respected.
  - Added support for forcing a complete install instead of using the repeat-install shortcut when configured.

- **Documentation**
  - Clarified the setting that disables optimistic repeat-install behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->