### PR TITLE
fix(pacquet): align remaining parity output

### DIFF
--- a/.changeset/neat-taxis-report.md
+++ b/.changeset/neat-taxis-report.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Aligned license reports, `dedupe --check` progress and spacing, and dependency-verification output with pnpm.

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     io::Write,
     marker::PhantomData,
     path::{Path, PathBuf},
@@ -17,7 +18,8 @@ use crate::{
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
-use pacquet_lockfile::Lockfile;
+use pacquet_lockfile::{Lockfile, PkgNameVerPeer};
+use pacquet_modules_yaml::{Host, read_modules_manifest};
 use pacquet_package_manager::{
     ImporterDiffKey, Install, LockfileDiff, ProjectMutation, ResolutionObserver,
     ResolvedPackageHint, SnapshotDiff, diff_lockfiles,
@@ -27,6 +29,7 @@ use pacquet_reporter::{
     DedupeCheckLog, GlobalLog, LogEvent, LogLevel, PnpmErrorLog, ProgressLog, ProgressMessage,
     Reporter,
 };
+use pacquet_store_dir::{SharedReadonlyStoreIndex, StoreIndex, store_index_key};
 use serde_json::{Map, Value, json};
 use tempfile::NamedTempFile;
 
@@ -50,6 +53,25 @@ impl DedupeArgs {
     ) -> miette::Result<()> {
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
+        let lockfile_packages =
+            lockfile.get().into_diagnostic()?.and_then(|lockfile| lockfile.packages.as_ref());
+        let reusable_skipped_package_ids = read_modules_manifest::<Host>(&config.modules_dir)
+            .into_diagnostic()?
+            .into_iter()
+            .flat_map(|modules| modules.skipped)
+            .filter_map(|package_id| {
+                let package_key = package_id.parse::<PkgNameVerPeer>().ok()?.without_peer();
+                let metadata = lockfile_packages?.get(&package_key)?;
+                (metadata.cpu.is_none()
+                    && metadata.os.is_none()
+                    && metadata.libc.is_none()
+                    && !config
+                        .ignored_optional_dependencies
+                        .as_ref()
+                        .is_some_and(|ignored| ignored.contains(&package_key.name.to_string())))
+                .then(|| package_key.pkg_id())
+            })
+            .collect();
 
         Install {
             tarball_mem_cache: std::sync::Arc::clone(tarball_mem_cache),
@@ -87,6 +109,12 @@ impl DedupeArgs {
                     .unwrap_or_else(|| Path::new("."))
                     .display()
                     .to_string(),
+                store_index: if config.frozen_store {
+                    StoreIndex::shared_immutable_in(&config.store_dir)
+                } else {
+                    StoreIndex::shared_readonly_in(&config.store_dir)
+                },
+                reusable_skipped_package_ids,
                 reporter: PhantomData,
             })),
             peer_issues_sink: None,
@@ -143,6 +171,8 @@ enum DedupeError {
 
 struct DedupeResolutionReporter<Reporter> {
     requester: String,
+    store_index: Option<SharedReadonlyStoreIndex>,
+    reusable_skipped_package_ids: HashSet<String>,
     reporter: PhantomData<fn() -> Reporter>,
 }
 
@@ -155,6 +185,25 @@ impl<Reporter: self::Reporter> ResolutionObserver for DedupeResolutionReporter<R
                 requester: self.requester.clone(),
             },
         }));
+        let package_key = store_index_key(hint.integrity, hint.id);
+        let found_in_store = self.reusable_skipped_package_ids.contains(hint.id)
+            || self.store_index.as_ref().is_some_and(|store_index| {
+                store_index
+                    .lock()
+                    .ok()
+                    .and_then(|index| index.get(&package_key).ok())
+                    .flatten()
+                    .is_some()
+            });
+        if found_in_store {
+            Reporter::emit(&LogEvent::Progress(ProgressLog {
+                level: LogLevel::Debug,
+                message: ProgressMessage::FoundInStore {
+                    package_id: hint.id.to_string(),
+                    requester: self.requester.clone(),
+                },
+            }));
+        }
     }
 }
 
@@ -206,9 +255,16 @@ fn render_dedupe_check_issues(diff: &LockfileDiff) -> String {
 }
 
 fn render_dedupe_check_error(diff: &LockfileDiff) -> String {
+    let issues = render_dedupe_check_issues(diff);
+    let recommendation_separator = if issues.ends_with("\n\n") {
+        ""
+    } else if issues.ends_with('\n') {
+        "\n"
+    } else {
+        "\n\n"
+    };
     format!(
-        "[ERR_PNPM_DEDUPE_CHECK_ISSUES] Dedupe --check found changes to the lockfile\n\n{}\nRun pnpm dedupe to apply the changes above.",
-        render_dedupe_check_issues(diff).trim_end(),
+        "[ERR_PNPM_DEDUPE_CHECK_ISSUES] Dedupe --check found changes to the lockfile\n\n{issues}{recommendation_separator}Run pnpm dedupe to apply the changes above.\n",
     )
 }
 
@@ -281,8 +337,6 @@ fn render_snapshot_diff(diff: &SnapshotDiff) -> String {
         .map(|label| TreeNode::with_children(label, Vec::new()))
         .collect();
     render_archy(&TreeNode::with_children(plain(&diff.id), nodes))
-        .trim_end_matches('\n')
-        .to_string()
 }
 
 /// Atomically write `content` to `path` via temp-file + rename, so the write

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -21,8 +21,9 @@ use miette::{Context, Diagnostic, IntoDiagnostic};
 use pacquet_lockfile::{Lockfile, PkgNameVerPeer};
 use pacquet_modules_yaml::{Host, read_modules_manifest};
 use pacquet_package_manager::{
-    ImporterDiffKey, Install, LockfileDiff, ProjectMutation, ResolutionObserver,
-    ResolvedPackageHint, SnapshotDiff, diff_lockfiles,
+    ImporterDiffKey, Install, InstallabilityHost, LockfileDiff, ProjectMutation,
+    ResolutionObserver, ResolvedPackageHint, SnapshotDiff, diff_lockfiles,
+    package_metadata_is_installable,
 };
 use pacquet_package_manifest::DependencyGroup;
 use pacquet_reporter::{
@@ -55,23 +56,27 @@ impl DedupeArgs {
             &state;
         let lockfile_packages =
             lockfile.get().into_diagnostic()?.and_then(|lockfile| lockfile.packages.as_ref());
-        let reusable_skipped_package_ids = read_modules_manifest::<Host>(&config.modules_dir)
-            .ok()
-            .flatten()
+        let modules_manifest =
+            read_modules_manifest::<Host>(&config.modules_dir).into_diagnostic()?;
+        let mut installability_host =
+            InstallabilityHost::detect_with(config.engine_strict, config.node_version.clone());
+        installability_host.supported_architectures = config.supported_architectures.clone();
+        let reusable_skipped_package_ids = modules_manifest
             .into_iter()
             .flat_map(|modules| modules.skipped)
             .filter_map(|package_id| {
                 let package_key = package_id.parse::<PkgNameVerPeer>().ok()?.without_peer();
                 let metadata = lockfile_packages?.get(&package_key)?;
-                (metadata.cpu.is_none()
-                    && metadata.os.is_none()
-                    && metadata.libc.is_none()
-                    && !config
-                        .ignored_optional_dependencies
-                        .as_ref()
-                        .is_some_and(|ignored| ignored.contains(&package_key.name.to_string())))
-                .then(|| package_key.pkg_id())
+                Some(reusable_skipped_package_id(
+                    &package_key,
+                    metadata,
+                    &installability_host,
+                    config.ignored_optional_dependencies.as_deref(),
+                ))
             })
+            .collect::<miette::Result<Vec<_>>>()?
+            .into_iter()
+            .flatten()
             .collect();
 
         Install {
@@ -192,9 +197,8 @@ impl<Reporter: self::Reporter> ResolutionObserver for DedupeResolutionReporter<R
                 store_index
                     .lock()
                     .ok()
-                    .and_then(|index| index.get(&package_key).ok())
-                    .flatten()
-                    .is_some()
+                    .and_then(|index| index.contains_key(&package_key).ok())
+                    .unwrap_or(false)
             });
         if found_in_store {
             Reporter::emit(&LogEvent::Progress(ProgressLog {
@@ -206,6 +210,22 @@ impl<Reporter: self::Reporter> ResolutionObserver for DedupeResolutionReporter<R
             }));
         }
     }
+}
+
+fn reusable_skipped_package_id(
+    package_key: &PkgNameVerPeer,
+    metadata: &pacquet_lockfile::PackageMetadata,
+    installability_host: &InstallabilityHost,
+    ignored_optional_dependencies: Option<&[String]>,
+) -> miette::Result<Option<String>> {
+    if ignored_optional_dependencies
+        .is_some_and(|ignored| ignored.contains(&package_key.name.to_string()))
+    {
+        return Ok(None);
+    }
+    Ok(package_metadata_is_installable(package_key, metadata, installability_host)
+        .into_diagnostic()?
+        .then(|| package_key.pkg_id()))
 }
 
 fn emit_dedupe_check_error<Reporter: self::Reporter>(diff: &LockfileDiff) {

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -56,7 +56,8 @@ impl DedupeArgs {
         let lockfile_packages =
             lockfile.get().into_diagnostic()?.and_then(|lockfile| lockfile.packages.as_ref());
         let reusable_skipped_package_ids = read_modules_manifest::<Host>(&config.modules_dir)
-            .into_diagnostic()?
+            .ok()
+            .flatten()
             .into_iter()
             .flat_map(|modules| modules.skipped)
             .filter_map(|package_id| {

--- a/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
@@ -1,7 +1,9 @@
-use std::{marker::PhantomData, sync::Mutex};
+use std::{collections::HashSet, marker::PhantomData, sync::Mutex};
 
 use pacquet_package_manager::{LockfileDiff, SnapshotDiff};
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
+use pacquet_store_dir::{PackageFilesIndex, StoreDir, StoreIndex, store_index_key};
+use tempfile::TempDir;
 
 use super::{
     DedupeResolutionReporter, emit_dedupe_check_error, render_dedupe_check_error,
@@ -27,7 +29,9 @@ fn check_error_matches_pnpm_reporter_format() {
 [ERR_PNPM_DEDUPE_CHECK_ISSUES] Dedupe --check found changes to the lockfile
 
 The lockfile would be rewritten, but no dependency resolution would change.
-Run pnpm dedupe to apply the changes above.",
+
+Run pnpm dedupe to apply the changes above.
+",
     );
 }
 
@@ -72,21 +76,11 @@ fn resolution_observer_emits_resolved_progress() {
 
     let observer = DedupeResolutionReporter::<RecordingReporter> {
         requester: "/project".to_string(),
+        store_index: None,
+        reusable_skipped_package_ids: HashSet::new(),
         reporter: PhantomData,
     };
-    pacquet_package_manager::ResolutionObserver::on_resolved(
-        &observer,
-        pacquet_package_manager::ResolvedPackageHint {
-            id: "dep@2.0.0",
-            name: "dep",
-            version: "2.0.0",
-            integrity: "sha512-test",
-            tarball_url: "https://registry.example/dep/-/dep-2.0.0.tgz",
-            unpacked_size: None,
-            file_count: None,
-            from_registry: true,
-        },
-    );
+    pacquet_package_manager::ResolutionObserver::on_resolved(&observer, resolved_dep_hint());
 
     let captured = EVENTS.lock().unwrap();
     assert!(
@@ -101,6 +95,95 @@ fn resolution_observer_emits_resolved_progress() {
         ),
         "unexpected events: {captured:?}",
     );
+}
+
+#[test]
+fn resolution_observer_reports_packages_found_in_store() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let root = TempDir::new().unwrap();
+    let store_dir = StoreDir::new(root.path());
+    std::fs::create_dir_all(store_dir.root()).unwrap();
+    StoreIndex::open_in(&store_dir)
+        .unwrap()
+        .set(&store_index_key("sha512-test", "dep@2.0.0"), &PackageFilesIndex::default())
+        .unwrap();
+    let observer = DedupeResolutionReporter::<RecordingReporter> {
+        requester: "/project".to_string(),
+        store_index: StoreIndex::shared_readonly_in(&store_dir),
+        reusable_skipped_package_ids: HashSet::new(),
+        reporter: PhantomData,
+    };
+
+    pacquet_package_manager::ResolutionObserver::on_resolved(&observer, resolved_dep_hint());
+
+    let captured = EVENTS.lock().unwrap();
+    assert!(
+        matches!(
+            captured.as_slice(),
+            [
+                LogEvent::Progress(resolved),
+                LogEvent::Progress(found_in_store),
+            ] if matches!(&resolved.message, ProgressMessage::Resolved { .. })
+                && matches!(&found_in_store.message, ProgressMessage::FoundInStore { .. })
+        ),
+        "unexpected events: {captured:?}",
+    );
+}
+
+#[test]
+fn resolution_observer_reports_skipped_packages_as_reused() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let observer = DedupeResolutionReporter::<RecordingReporter> {
+        requester: "/project".to_string(),
+        store_index: None,
+        reusable_skipped_package_ids: HashSet::from(["dep@2.0.0".to_string()]),
+        reporter: PhantomData,
+    };
+    pacquet_package_manager::ResolutionObserver::on_resolved(&observer, resolved_dep_hint());
+
+    let captured = EVENTS.lock().unwrap();
+    assert!(
+        matches!(
+            captured.as_slice(),
+            [
+                LogEvent::Progress(resolved),
+                LogEvent::Progress(found_in_store),
+            ] if matches!(&resolved.message, ProgressMessage::Resolved { .. })
+                && matches!(&found_in_store.message, ProgressMessage::FoundInStore { .. })
+        ),
+        "unexpected events: {captured:?}",
+    );
+}
+
+fn resolved_dep_hint() -> pacquet_package_manager::ResolvedPackageHint<'static> {
+    pacquet_package_manager::ResolvedPackageHint {
+        id: "dep@2.0.0",
+        name: "dep",
+        version: "2.0.0",
+        integrity: "sha512-test",
+        tarball_url: "https://registry.example/dep/-/dep-2.0.0.tgz",
+        unpacked_size: None,
+        file_count: None,
+        from_registry: true,
+    }
 }
 
 /// The report pnpm's `renderDedupeCheckIssues` produces: a tree per changed
@@ -135,10 +218,12 @@ Importers
 .
 └── @babel/core 7.26.10 → 7.26.10(supports-color@9.4.0)
 
+
 Packages
 chalk@5.3.0
 ├── + supports-color 9.4.0
 └── - debug 4.3.4
+
 + supports-color@9.4.0
 - ws@8.14.2
 ",

--- a/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
@@ -1,13 +1,14 @@
 use std::{collections::HashSet, marker::PhantomData, sync::Mutex};
 
-use pacquet_package_manager::{LockfileDiff, SnapshotDiff};
+use pacquet_lockfile::PackageMetadata;
+use pacquet_package_manager::{InstallabilityHost, LockfileDiff, SnapshotDiff};
 use pacquet_reporter::{LogEvent, ProgressMessage, Reporter};
 use pacquet_store_dir::{PackageFilesIndex, StoreDir, StoreIndex, store_index_key};
 use tempfile::TempDir;
 
 use super::{
     DedupeResolutionReporter, emit_dedupe_check_error, render_dedupe_check_error,
-    render_dedupe_check_issues,
+    render_dedupe_check_issues, reusable_skipped_package_id,
 };
 
 #[test]
@@ -171,6 +172,32 @@ fn resolution_observer_reports_skipped_packages_as_reused() {
         ),
         "unexpected events: {captured:?}",
     );
+}
+
+#[test]
+fn engine_incompatible_skipped_packages_are_not_reported_as_reused() {
+    let package_key = "engine-constrained@1.0.0".parse().unwrap();
+    let metadata: PackageMetadata = serde_json::from_value(serde_json::json!({
+        "resolution": {
+            "integrity": "sha512-dGVzdA==",
+        },
+        "engines": {
+            "node": "<1",
+        },
+    }))
+    .unwrap();
+    let host = InstallabilityHost {
+        node_version: "22.0.0".to_string(),
+        node_detected: true,
+        os: "linux",
+        cpu: "x64",
+        libc: "glibc",
+        supported_architectures: None,
+        engine_strict: false,
+    };
+
+    let reusable = reusable_skipped_package_id(&package_key, &metadata, &host, None).unwrap();
+    assert!(reusable.is_none());
 }
 
 fn resolved_dep_hint() -> pacquet_package_manager::ResolvedPackageHint<'static> {

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -71,7 +71,7 @@ impl CliArgs {
             &dir,
             self.command.default_reporter_summary_scope(),
             self.command.reports_scope(self.recursive),
-            matches!(self.command, CliCommand::Dedupe(_)),
+            false,
         );
     }
 

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -305,7 +305,7 @@ impl LicensesArgs {
 
         let mut all_packages: Vec<&LicenseInfo> =
             results_by_license.values().flat_map(|g| g.values()).collect();
-        all_packages.sort_by(|a, b| a.name.cmp(&b.name));
+        all_packages.sort_by(|a, b| compare_package_names(&a.name, &b.name));
 
         for info in all_packages {
             let mut row =

--- a/pnpm/crates/cli/src/cli_args/licenses.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses.rs
@@ -24,7 +24,10 @@ use pacquet_package_manifest::{
 };
 use pacquet_resolving_git_resolver::HostedGit;
 use serde::Serialize;
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, HashMap},
+};
 use tabled::{builder::Builder, settings::Style};
 
 mod license_resolver;
@@ -211,8 +214,7 @@ impl LicensesArgs {
             })
             .collect::<Vec<_>>();
         dependencies.sort_by(|left, right| {
-            left.2
-                .cmp(&right.2)
+            compare_package_names(&left.2, &right.2)
                 .then_with(|| compare_versions(&left.3, &right.3))
                 .then_with(|| left.0.to_string().cmp(&right.0.to_string()))
                 .then_with(|| left.1.cmp(&right.1))
@@ -271,16 +273,7 @@ impl LicensesArgs {
             }
             if !info.versions.contains(&version) {
                 info.versions.push(version);
-            }
-            if !info.paths.contains(&path_str) {
                 info.paths.push(path_str);
-            }
-        }
-
-        for group in results_by_license.values_mut() {
-            for info in group.values_mut() {
-                info.versions.sort();
-                info.paths.sort();
             }
         }
 
@@ -288,7 +281,7 @@ impl LicensesArgs {
             let mut json_output: IndexMap<String, Vec<&LicenseInfo>> = IndexMap::new();
             for (lic, group) in &results_by_license {
                 let mut infos: Vec<&LicenseInfo> = group.values().collect();
-                infos.sort_by(|a, b| a.name.cmp(&b.name));
+                infos.sort_by(|a, b| compare_package_names(&a.name, &b.name));
                 json_output.insert(lic.clone(), infos);
             }
 
@@ -462,6 +455,38 @@ fn compare_versions(left: &str, right: &str) -> std::cmp::Ordering {
     match (node_semver::Version::parse(left), node_semver::Version::parse(right)) {
         (Ok(left), Ok(right)) => left.cmp(&right),
         _ => left.cmp(right),
+    }
+}
+
+fn compare_package_names(left: &str, right: &str) -> Ordering {
+    left.bytes()
+        .map(package_name_collation_weight)
+        .cmp(right.bytes().map(package_name_collation_weight))
+        .then_with(|| {
+            left.bytes()
+                .zip(right.bytes())
+                .find_map(|(left, right)| {
+                    if left == right || !left.eq_ignore_ascii_case(&right) {
+                        None
+                    } else if left.is_ascii_lowercase() {
+                        Some(Ordering::Less)
+                    } else {
+                        Some(Ordering::Greater)
+                    }
+                })
+                .unwrap_or_else(|| left.cmp(right))
+        })
+}
+
+fn package_name_collation_weight(byte: u8) -> u8 {
+    match byte {
+        b'_' => 0,
+        b'-' => 1,
+        b'.' => 2,
+        b'@' => 3,
+        b'/' => 4,
+        b'~' => 5,
+        byte => byte.to_ascii_lowercase().saturating_add(6),
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/licenses/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/licenses/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     BelongsTo, Config, Include, LicenseInfo, LicensesArgs, LicensesDependencyOptions,
-    collect_dependencies, extract_license_author, extract_license_homepage, render_package_name,
-    select_newer_version,
+    collect_dependencies, compare_package_names, extract_license_author, extract_license_homepage,
+    render_package_name, select_newer_version,
 };
 use pacquet_lockfile::Lockfile;
 use serde_json::json;
@@ -195,6 +195,40 @@ fn selects_latest_version_classification_with_semver_precedence() {
     assert_eq!(info.selected_version, "10.0.0");
     assert!(!select_newer_version(&mut info, "3.0.0", BelongsTo::Prod));
     assert_eq!(info.belongs_to, BelongsTo::Dev);
+}
+
+#[test]
+fn compares_package_names_like_javascript_locale_compare() {
+    let mut names = [
+        "string-width",
+        "stringify-object",
+        "string_decoder",
+        "a~b",
+        "a/b",
+        "a.b",
+        "a-b",
+        "a_b",
+        "a0b",
+        "aab",
+        "ab",
+    ];
+    names.sort_by(|left, right| compare_package_names(left, right));
+    assert_eq!(
+        names,
+        [
+            "a_b",
+            "a-b",
+            "a.b",
+            "a/b",
+            "a~b",
+            "a0b",
+            "aab",
+            "ab",
+            "string_decoder",
+            "string-width",
+            "stringify-object",
+        ],
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -76,7 +76,7 @@ fn dedupe_check_does_not_materialize_nor_write_lockfile() {
 }
 
 #[test]
-fn dedupe_check_ignores_a_malformed_modules_manifest() {
+fn dedupe_check_rejects_a_malformed_modules_manifest() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
@@ -103,7 +103,7 @@ fn dedupe_check_ignores_a_malformed_modules_manifest() {
         .with_current_dir(&workspace)
         .with_args(["dedupe", "--check"])
         .assert()
-        .success();
+        .failure();
 
     let lockfile_after = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
     assert_eq!(lockfile_before, lockfile_after);

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -109,7 +109,8 @@ fn dedupe_check_rejects_a_malformed_modules_manifest() {
     assert!(
         stderr.contains("Failed to parse")
             && stderr.contains("workspace/node_modules/.modules.yaml")
-            && stderr.contains("line 1 column 6"),
+            && stderr.contains("line 1")
+            && stderr.contains("column 6"),
         "dedupe check must report the malformed modules manifest:\n{stderr}",
     );
 

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -108,7 +108,8 @@ fn dedupe_check_rejects_a_malformed_modules_manifest() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Failed to parse")
-            && stderr.contains("node_modules/.modules.yaml")
+            && stderr.contains("node_modules")
+            && stderr.contains(".modules.yaml")
             && stderr.contains("line 1")
             && stderr.contains("column 6"),
         "dedupe check must report the malformed modules manifest:\n{stderr}",

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -108,7 +108,7 @@ fn dedupe_check_rejects_a_malformed_modules_manifest() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("Failed to parse")
-            && stderr.contains("workspace/node_modules/.modules.yaml")
+            && stderr.contains("node_modules/.modules.yaml")
             && stderr.contains("line 1")
             && stderr.contains("column 6"),
         "dedupe check must report the malformed modules manifest:\n{stderr}",

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -110,8 +110,7 @@ fn dedupe_check_rejects_a_malformed_modules_manifest() {
         stderr.contains("Failed to parse")
             && stderr.contains("node_modules")
             && stderr.contains(".modules.yaml")
-            && stderr.contains("line 1")
-            && stderr.contains("column 6"),
+            && stderr.contains("<input>:1:6"),
         "dedupe check must report the malformed modules manifest:\n{stderr}",
     );
 

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -98,12 +98,20 @@ fn dedupe_check_rejects_a_malformed_modules_manifest() {
     fs::write(workspace.join("node_modules/.modules.yaml"), "not: [valid")
         .expect("corrupt modules manifest");
 
-    Command::cargo_bin("pnpm")
+    let output = Command::cargo_bin("pnpm")
         .expect("find the pnpm binary")
         .with_current_dir(&workspace)
         .with_args(["dedupe", "--check"])
-        .assert()
-        .failure();
+        .output()
+        .expect("run dedupe check");
+    assert!(!output.status.success(), "dedupe check must reject malformed .modules.yaml");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to parse")
+            && stderr.contains("workspace/node_modules/.modules.yaml")
+            && stderr.contains("line 1 column 6"),
+        "dedupe check must report the malformed modules manifest:\n{stderr}",
+    );
 
     let lockfile_after = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
     assert_eq!(lockfile_before, lockfile_after);

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -190,7 +190,7 @@ fn dedupe_check_reports_the_lockfile_diff() {
     eprintln!("STDOUT:\n{stdout}");
     assert!(stderr.is_empty(), "stderr:\n{stderr}");
     assert!(
-        stdout.contains("Progress: resolved 1, reused 0, downloaded 0, done"),
+        stdout.contains("Progress: resolved 1, reused 0, downloaded 0, added 0, done"),
         "stdout:\n{stdout}",
     );
     assert!(stdout.contains("ERR_PNPM_DEDUPE_CHECK_ISSUES"), "stdout:\n{stdout}");
@@ -207,7 +207,10 @@ fn dedupe_check_reports_the_lockfile_diff() {
         "the added and removed snapshots must be rendered; stdout:\n{stdout}",
     );
     assert!(stdout.contains("Run pnpm dedupe to apply the changes above."), "stdout:\n{stdout}");
-    assert!(stdout.ends_with("Run pnpm dedupe to apply the changes above.\n"), "stdout:\n{stdout}");
+    assert!(
+        stdout.ends_with("Run pnpm dedupe to apply the changes above.\n\n"),
+        "stdout:\n{stdout}",
+    );
 
     let ndjson_output = Command::cargo_bin("pnpm")
         .expect("find the pnpm binary")

--- a/pnpm/crates/cli/tests/dedupe.rs
+++ b/pnpm/crates/cli/tests/dedupe.rs
@@ -76,6 +76,42 @@ fn dedupe_check_does_not_materialize_nor_write_lockfile() {
 }
 
 #[test]
+fn dedupe_check_ignores_a_malformed_modules_manifest() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile_before = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    fs::write(workspace.join("node_modules/.modules.yaml"), "not: [valid")
+        .expect("corrupt modules manifest");
+
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["dedupe", "--check"])
+        .assert()
+        .success();
+
+    let lockfile_after = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert_eq!(lockfile_before, lockfile_after);
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn dedupe_check_keeps_valid_lockfile_pins() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/licenses.rs
+++ b/pnpm/crates/cli/tests/licenses.rs
@@ -13,6 +13,8 @@ fn licenses_normalizes_metadata_and_orders_groups_by_package() {
         workspace.path().join("package.json"),
         json!({
             "dependencies": {
+                "a-b": "1.0.0",
+                "a_b": "1.0.0",
                 "alpha": "1.0.0",
                 "zeta": "1.0.0",
             },
@@ -27,6 +29,12 @@ lockfileVersion: '9.0'
 importers:
   .:
     dependencies:
+      a-b:
+        specifier: 1.0.0
+        version: 1.0.0
+      a_b:
+        specifier: 1.0.0
+        version: 1.0.0
       alpha:
         specifier: 1.0.0
         version: 1.0.0
@@ -34,21 +42,43 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
 packages:
+  a-b@1.0.0:
+    resolution: {integrity: sha512-a-b}
+  a_b@1.0.0:
+    resolution: {integrity: sha512-a_b}
   alpha@1.0.0:
     resolution: {integrity: sha512-alpha}
   zeta@1.0.0:
     resolution: {integrity: sha512-zeta}
 snapshots:
+  a-b@1.0.0: {}
+  a_b@1.0.0: {}
   alpha@1.0.0: {}
   zeta@1.0.0: {}
 ",
     )
     .expect("write lockfile");
     let virtual_store = workspace.path().join("node_modules/.pnpm");
+    let a_dash_b_dir = virtual_store.join("a-b@1.0.0/node_modules/a-b");
+    let a_underscore_b_dir = virtual_store.join("a_b@1.0.0/node_modules/a_b");
     let alpha_dir = virtual_store.join("alpha@1.0.0/node_modules/alpha");
     let zeta_dir = virtual_store.join("zeta@1.0.0/node_modules/zeta");
+    fs::create_dir_all(&a_dash_b_dir).expect("create a-b directory");
+    fs::create_dir_all(&a_underscore_b_dir).expect("create a_b directory");
     fs::create_dir_all(&alpha_dir).expect("create alpha directory");
     fs::create_dir_all(&zeta_dir).expect("create zeta directory");
+    for (directory, name) in [(&a_dash_b_dir, "a-b"), (&a_underscore_b_dir, "a_b")] {
+        fs::write(
+            directory.join("package.json"),
+            json!({
+                "name": name,
+                "version": "1.0.0",
+                "license": "MIT",
+            })
+            .to_string(),
+        )
+        .expect("write collation fixture manifest");
+    }
     fs::write(
         alpha_dir.join("package.json"),
         json!({
@@ -83,9 +113,22 @@ snapshots:
     );
 
     let report: Value = serde_json::from_slice(&output.stdout).expect("parse licenses JSON");
-    assert_eq!(report.as_object().unwrap().keys().collect::<Vec<_>>(), ["Zlib", "MIT"]);
+    assert_eq!(report.as_object().unwrap().keys().collect::<Vec<_>>(), ["MIT", "Zlib"]);
     assert_eq!(report["Zlib"][0]["author"], "Alpha Team");
     assert_eq!(report["Zlib"][0]["homepage"], "https://github.com/example/alpha#readme");
+
+    let output =
+        pacquet_in(workspace.path()).args(["licenses", "list"]).output().expect("run licenses");
+    assert!(
+        output.status.success(),
+        "licenses should succeed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let table = String::from_utf8(output.stdout).expect("licenses table is UTF-8");
+    assert!(
+        table.find("a_b").expect("a_b row") < table.find("a-b").expect("a-b row"),
+        "table should use JavaScript-compatible package collation:\n{table}",
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/verify_deps_before_run.rs
@@ -90,6 +90,19 @@ fn dedupe_peers_lockfile_regeneration_installs_before_running_the_script() {
         stdout.contains("Lockfile is up to date, resolution step is skipped"),
         "the verifier install must reuse the regenerated lockfile:\n{stdout}",
     );
+    let policy_verdict = stdout
+        .find("Lockfile passes supply-chain policies")
+        .expect("the verifier must report its lockfile policy verdict");
+    let frozen_install = stdout
+        .find("Lockfile is up to date, resolution step is skipped")
+        .expect("the verifier must report the frozen install");
+    let up_to_date = stdout
+        .find("Already up to date")
+        .expect("the verifier must report that no packages changed");
+    assert!(
+        policy_verdict < frozen_install && frozen_install < up_to_date,
+        "the verifier messages must match pnpm's order:\n{stdout}",
+    );
     assert_eq!(
         fs::read_to_string(workspace.join("pnpm-lock.yaml"))
             .expect("read lockfile after verifier install"),

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -428,7 +428,16 @@ impl ReporterState {
             // Debug-only / non-rendered channels in pnpm's default reporter.
             LogEvent::BrokenModules(_) => {}
         }
-        if matches!(event, LogEvent::LockfileVerification(_)) {
+        if matches!(
+            event,
+            LogEvent::LockfileVerification(log)
+                if matches!(
+                    &log.message,
+                    LockfileVerificationMessage::Cached { .. }
+                        | LockfileVerificationMessage::Done { .. }
+                        | LockfileVerificationMessage::Failed { .. }
+                ),
+        ) {
             self.flush_pending_lockfile_message();
         }
         self.finish()

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -391,7 +391,7 @@ impl ReporterState {
     }
 
     pub fn handle(&mut self, event: &LogEvent) -> Output {
-        if !matches!(event, LogEvent::LockfileVerification(_)) {
+        if matches!(event, LogEvent::Stats(_) | LogEvent::Summary(_) | LogEvent::ExecutionTime(_)) {
             self.flush_pending_lockfile_message();
         }
         match event {

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -273,6 +273,7 @@ pub struct ReporterState {
 
     config_deps_slot: BlockSlot,
     lockfile_verification_slot: BlockSlot,
+    pending_lockfile_message: Option<String>,
     exec_slot: BlockSlot,
 
     warnings_counter: usize,
@@ -379,6 +380,7 @@ impl ReporterState {
             big: HashMap::new(),
             config_deps_slot: BlockSlot::default(),
             lockfile_verification_slot: BlockSlot::default(),
+            pending_lockfile_message: None,
             exec_slot: BlockSlot::default(),
             warnings_counter: 0,
             collapsed_warn_slot: BlockSlot::default(),
@@ -389,6 +391,9 @@ impl ReporterState {
     }
 
     pub fn handle(&mut self, event: &LogEvent) -> Output {
+        if !matches!(event, LogEvent::LockfileVerification(_)) {
+            self.flush_pending_lockfile_message();
+        }
         match event {
             LogEvent::Context(log) => self.on_context(log),
             // Prompt lifetime is handled by `Sink` before state folding.
@@ -422,6 +427,9 @@ impl ReporterState {
             LogEvent::Deprecation(log) => self.on_deprecation(log),
             // Debug-only / non-rendered channels in pnpm's default reporter.
             LogEvent::BrokenModules(_) => {}
+        }
+        if matches!(event, LogEvent::LockfileVerification(_)) {
+            self.flush_pending_lockfile_message();
         }
         self.finish()
     }
@@ -622,8 +630,9 @@ impl ReporterState {
         let added = self.stats_added.take().unwrap_or(0);
         let removed = self.stats_removed.take().unwrap_or(0);
         if added == 0 && removed == 0 {
-            // The "Already up to date" line is emitted by pacquet as a
-            // `pnpm` log; rendering it here too would duplicate it.
+            let mut slot = std::mem::take(&mut self.stats_slot);
+            self.frame.emit(&mut slot, "Already up to date".to_string(), false);
+            self.stats_slot = slot;
             return;
         }
         let mut msg = String::from("Packages:");
@@ -1136,14 +1145,24 @@ impl ReporterState {
             LogLevel::Error => self.push_block(message.to_string()),
             LogLevel::Info => {
                 if prefix.is_empty() || prefix == self.cwd {
-                    self.push_block(message.to_string());
+                    if message == "Lockfile is up to date, resolution step is skipped" {
+                        self.pending_lockfile_message = Some(message.to_string());
+                    } else {
+                        self.push_block(message.to_string());
+                    }
                 }
             }
         }
     }
 
+    fn flush_pending_lockfile_message(&mut self) {
+        if let Some(message) = self.pending_lockfile_message.take() {
+            self.push_block(message);
+        }
+    }
+
     fn on_dedupe_check(&mut self, log: &DedupeCheckLog) {
-        self.push_block(log.rendered.clone());
+        self.push_block(format!("\n{}", log.rendered));
     }
 
     fn on_execution_time(&mut self, log: &ExecutionTimeLog) {

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -733,6 +733,7 @@ fn install_summary_flushes_the_frozen_message_without_a_policy_verdict() {
     let summary = reporter.handle(&summary());
     match summary {
         Output::Lines(lines) => {
+            dbg!(&lines);
             assert_eq!(lines, ["Lockfile is up to date, resolution step is skipped"]);
         }
         _ => panic!("the install summary should flush the frozen message"),

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -653,6 +653,11 @@ fn lockfile_policy_verdict_precedes_the_frozen_install_message() {
                 message: "Lockfile is up to date, resolution step is skipped".to_string(),
                 prefix: CWD.to_string(),
             }),
+            LogEvent::Stage(StageLog {
+                level: LogLevel::Debug,
+                prefix: CWD.to_string(),
+                stage: Stage::ImportingDone,
+            }),
             LogEvent::LockfileVerification(LockfileVerificationLog {
                 level: LogLevel::Debug,
                 message: LockfileVerificationMessage::Cached {
@@ -711,6 +716,26 @@ fn append_only_waits_for_a_terminal_lockfile_policy_verdict() {
             ],
         ),
         _ => panic!("completed verification should emit its verdict before the frozen message"),
+    }
+}
+
+#[test]
+fn install_summary_flushes_the_frozen_message_without_a_policy_verdict() {
+    let mut reporter =
+        state_with_options(ReporterOptions { append_only: true, ..ReporterOptions::default() });
+    let pending = reporter.handle(&LogEvent::Pnpm(PnpmLog {
+        level: LogLevel::Info,
+        message: "Lockfile is up to date, resolution step is skipped".to_string(),
+        prefix: CWD.to_string(),
+    }));
+    assert!(matches!(pending, Output::None));
+
+    let summary = reporter.handle(&summary());
+    match summary {
+        Output::Lines(lines) => {
+            assert_eq!(lines, ["Lockfile is up to date, resolution step is skipped"]);
+        }
+        _ => panic!("the install summary should flush the frozen message"),
     }
 }
 

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -12,10 +12,11 @@ use pacquet_default_reporter::{
 use pacquet_reporter::{
     AddedRoot, ContextLog, DependencyType, DeprecationLog, ExecutionTimeLog, FetchingProgressLog,
     FetchingProgressMessage, GlobalLog, HookLog, LifecycleLog, LifecycleMessage, LifecycleStdio,
-    LogEvent, LogLevel, PackageImportMethod, PackageImportMethodLog, PackageManifestLog,
-    PackageManifestMessage, PnpmLog, ProgressLog, ProgressMessage, RootLog, RootMessage, ScopeLog,
-    SkippedOptionalDependencyLog, SkippedOptionalPackage, SkippedOptionalParent,
-    SkippedOptionalReason, Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
+    LockfileVerificationLog, LockfileVerificationMessage, LogEvent, LogLevel, PackageImportMethod,
+    PackageImportMethodLog, PackageManifestLog, PackageManifestMessage, PnpmLog, ProgressLog,
+    ProgressMessage, RootLog, RootMessage, ScopeLog, SkippedOptionalDependencyLog,
+    SkippedOptionalPackage, SkippedOptionalParent, SkippedOptionalReason, Stage, StageLog,
+    StatsLog, StatsMessage, SummaryLog,
 };
 
 const CWD: &str = "/repo";
@@ -637,6 +638,52 @@ fn already_up_to_date_pnpm_log_renders() {
             message: "Already up to date".to_string(),
             prefix: CWD.to_string(),
         })],
+    );
+    assert_eq!(frame, "Already up to date");
+}
+
+#[test]
+fn lockfile_policy_verdict_precedes_the_frozen_install_message() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            LogEvent::Pnpm(PnpmLog {
+                level: LogLevel::Info,
+                message: "Lockfile is up to date, resolution step is skipped".to_string(),
+                prefix: CWD.to_string(),
+            }),
+            LogEvent::LockfileVerification(LockfileVerificationLog {
+                level: LogLevel::Debug,
+                message: LockfileVerificationMessage::Cached {
+                    verified_at: None,
+                    lockfile_path: None,
+                },
+            }),
+        ],
+    );
+    assert_eq!(
+        frame,
+        "✓ Lockfile passes supply-chain policies (previously verified)\n\
+Lockfile is up to date, resolution step is skipped",
+    );
+}
+
+#[test]
+fn zero_install_stats_render_already_up_to_date() {
+    let mut reporter = state(false);
+    let frame = render(
+        &mut reporter,
+        vec![
+            LogEvent::Stats(StatsLog {
+                level: LogLevel::Debug,
+                message: StatsMessage::Added { added: 0, prefix: CWD.to_string() },
+            }),
+            LogEvent::Stats(StatsLog {
+                level: LogLevel::Debug,
+                message: StatsMessage::Removed { removed: 0, prefix: CWD.to_string() },
+            }),
+        ],
     );
     assert_eq!(frame, "Already up to date");
 }

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -670,6 +670,51 @@ Lockfile is up to date, resolution step is skipped",
 }
 
 #[test]
+fn append_only_waits_for_a_terminal_lockfile_policy_verdict() {
+    let mut reporter =
+        state_with_options(ReporterOptions { append_only: true, ..ReporterOptions::default() });
+    let pending = reporter.handle(&LogEvent::Pnpm(PnpmLog {
+        level: LogLevel::Info,
+        message: "Lockfile is up to date, resolution step is skipped".to_string(),
+        prefix: CWD.to_string(),
+    }));
+    assert!(matches!(pending, Output::None));
+
+    let started = reporter.handle(&LogEvent::LockfileVerification(LockfileVerificationLog {
+        level: LogLevel::Debug,
+        message: LockfileVerificationMessage::Started { entries: 2, lockfile_path: None },
+    }));
+    match started {
+        Output::Lines(lines) => {
+            assert_eq!(
+                lines,
+                ["? Verifying lockfile against supply-chain policies (2 entries)..."],
+            );
+        }
+        _ => panic!("started verification should emit only its progress line"),
+    }
+
+    let done = reporter.handle(&LogEvent::LockfileVerification(LockfileVerificationLog {
+        level: LogLevel::Debug,
+        message: LockfileVerificationMessage::Done {
+            entries: 2,
+            elapsed_ms: 100,
+            lockfile_path: None,
+        },
+    }));
+    match done {
+        Output::Lines(lines) => assert_eq!(
+            lines,
+            [
+                "✓ Lockfile passes supply-chain policies (2 entries in 100ms)",
+                "Lockfile is up to date, resolution step is skipped",
+            ],
+        ),
+        _ => panic!("completed verification should emit its verdict before the frozen message"),
+    }
+}
+
+#[test]
 fn zero_install_stats_render_already_up_to_date() {
     let mut reporter = state(false);
     let frame = render(

--- a/pnpm/crates/package-manager/src/installability.rs
+++ b/pnpm/crates/package-manager/src/installability.rs
@@ -663,6 +663,25 @@ fn cached_check(
     Ok(verdict)
 }
 
+pub fn package_metadata_is_installable(
+    metadata_key: &PackageKey,
+    metadata: &PackageMetadata,
+    host: &InstallabilityHost,
+) -> Result<bool, Box<InstallabilityError>> {
+    let manifest = manifest_from_metadata(metadata_key, metadata);
+    let options = InstallabilityOptions {
+        engine_strict: host.engine_strict,
+        optional: true,
+        current_node_version: host.node_version.as_str(),
+        pnpm_version: None,
+        current_os: host.os,
+        current_cpu: host.cpu,
+        current_libc: host.libc,
+        supported_architectures: host.supported_architectures.as_ref(),
+    };
+    Ok(check_installability(&metadata_key.to_string(), &manifest, &options)?.is_none())
+}
+
 /// Edge classification produced by [`walk_lockfile_edges`].
 struct LockfileEdgeReach<'lock> {
     /// Snapshots reachable from any importer through any edge chain,

--- a/pnpm/crates/package-manager/src/installability.rs
+++ b/pnpm/crates/package-manager/src/installability.rs
@@ -663,6 +663,11 @@ fn cached_check(
     Ok(verdict)
 }
 
+/// Checks lockfile package metadata as an optional dependency on the current host.
+///
+/// Returns `Ok(true)` when the package is compatible, `Ok(false)` for an
+/// unsupported engine or platform, and propagates an invalid configured Node.js
+/// version as [`InstallabilityError::InvalidNodeVersion`].
 pub fn package_metadata_is_installable(
     metadata_key: &PackageKey,
     metadata: &PackageMetadata,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#13457.

Aligns the remaining pacquet-only output differences with the TypeScript CLI:

- orders license packages, versions, and paths like JavaScript `localeCompare`,
  and records one path for each package version;
- reports `dedupe --check` store reuse and zero added packages, with matching
  tree and error spacing;
- orders lockfile-policy output before the frozen-install message and reports
  `Already up to date` for a zero-change verification install.

The TypeScript CLI already provides the expected behavior, so no TypeScript
implementation change is needed. Against `vuejs/core` at
`b5f8518379b77c3b62a7a9d2b52f6c76cda09bd5`, the license JSON is byte-identical
after normalizing only the checkout path and dedupe finishes with
`resolved 618, reused 503, downloaded 0, added 0`.

## Squash Commit Body

```text
Finish the strict output-parity work for pacquet's license, dedupe, and
pre-run verification commands.

Use pnpm-compatible package-name collation and keep license versions aligned
with their single representative paths. Teach dedupe progress to account for
the store and reusable skipped optional subdependencies, restore the added
counter, and preserve pnpm's report spacing. Buffer the frozen-lockfile status
until the lockfile-policy verdict and render zero-change stats as already up to
date.

Closes pnpm/pnpm#13457.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787838950&installation_model_id=426870&pr_number=13472&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13472&signature=700866c201e13b34a7c81746c793593918974b894b300b0a02a29b5d977c5e77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm dedupe --check` now reports when resolved packages are found in the store by reusing previously skipped entries to improve progress feedback.
* **Improvements**
  * License output ordering is now consistent with pnpm-aligned collation for both JSON and table formats.
  * Lockfile verification and dedupe output formatting have clearer newline/spacing behavior, including an explicit “Already up to date” line and more consistent progress sequencing.
* **Tests**
  * Added/updated coverage for malformed modules manifests, “found in store”/reused-skipped behavior, license ordering, and reporter rendering/progress output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->