### PR TITLE
fix(pacquet): preserve locked peer contexts during dedupe

### DIFF
--- a/.changeset/pacquet-dedupe-importer-peer-pins.md
+++ b/.changeset/pacquet-dedupe-importer-peer-pins.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Preserve each importer's locked optional peer versions during `pnpm dedupe`.
+Preserve each direct dependency's locked optional peer context during `pnpm dedupe`.

--- a/.changeset/pacquet-dedupe-importer-peer-pins.md
+++ b/.changeset/pacquet-dedupe-importer-peer-pins.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Preserve each importer's locked optional peer versions during `pnpm dedupe`.

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers.rs
@@ -2,7 +2,10 @@
 //! "what to add to the importer's direct deps" map. Used by the
 //! orchestrator (`resolve_importer`) inside its hoist loop.
 
-use std::{collections::BTreeMap, path::Path};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    path::Path,
+};
 
 use node_semver::{Range, Version};
 use pacquet_resolving_resolver_base::{
@@ -166,6 +169,20 @@ pub fn get_hoistable_optional_peers(
     all_preferred_versions: &PreferredVersions,
     workspace_root_deps: &[WorkspaceRootDep],
 ) -> BTreeMap<String, String> {
+    get_hoistable_optional_peers_with_locked_versions(
+        all_missing_optional_peers,
+        all_preferred_versions,
+        workspace_root_deps,
+        &HashMap::new(),
+    )
+}
+
+pub(crate) fn get_hoistable_optional_peers_with_locked_versions(
+    all_missing_optional_peers: &BTreeMap<String, Vec<String>>,
+    all_preferred_versions: &PreferredVersions,
+    workspace_root_deps: &[WorkspaceRootDep],
+    locked_peer_versions: &HashMap<String, HashSet<String>>,
+) -> BTreeMap<String, String> {
     let mut optional_dependencies = BTreeMap::new();
     for (peer_name, ranges) in all_missing_optional_peers {
         let Some(selectors) = all_preferred_versions.get(peer_name) else { continue };
@@ -189,6 +206,12 @@ pub fn get_hoistable_optional_peers(
         };
         let mut max_satisfying_version: Option<Version> = None;
         for (version_str, entry) in selectors {
+            if locked_peer_versions
+                .get(peer_name)
+                .is_some_and(|versions| !versions.contains(version_str))
+            {
+                continue;
+            }
             let selector_type = match entry {
                 VersionSelectorEntry::Plain(selector_type) => *selector_type,
                 VersionSelectorEntry::Weighted(weighted) => weighted.selector_type,

--- a/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/hoist_peers/tests.rs
@@ -1,7 +1,10 @@
 //! Tests for [`super::hoist_peers`] and
 //! [`super::get_hoistable_optional_peers`].
 
-use std::{collections::BTreeMap, path::Path};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    path::Path,
+};
 
 use pacquet_resolving_resolver_base::{
     PreferredVersions, VersionSelectorEntry, VersionSelectorType, VersionSelectorWithWeight,
@@ -9,7 +12,8 @@ use pacquet_resolving_resolver_base::{
 use pretty_assertions::assert_eq;
 
 use super::{
-    HoistPeersOptions, MissingPeerInfo, WorkspaceRootDep, get_hoistable_optional_peers, hoist_peers,
+    HoistPeersOptions, MissingPeerInfo, WorkspaceRootDep, get_hoistable_optional_peers,
+    get_hoistable_optional_peers_with_locked_versions, hoist_peers,
 };
 
 fn preferred(entries: &[(&str, &[(&str, VersionSelectorEntry)])]) -> PreferredVersions {
@@ -266,6 +270,24 @@ fn get_hoistable_optional_peers_picks_the_highest_satisfying_version() {
     let mut expected = BTreeMap::new();
     expected.insert("foo".to_string(), "2.1.1".to_string());
     assert_eq!(result, expected);
+}
+
+#[test]
+fn get_hoistable_optional_peers_preserves_the_importers_locked_version() {
+    let missing = BTreeMap::from([("peer".to_string(), vec!["*".to_string()])]);
+    let preferred = PreferredVersions::from([(
+        "peer".to_string(),
+        BTreeMap::from([
+            ("1.0.0".to_string(), VersionSelectorEntry::Plain(VersionSelectorType::Version)),
+            ("2.0.0".to_string(), VersionSelectorEntry::Plain(VersionSelectorType::Version)),
+        ]),
+    )]);
+    let locked = HashMap::from([("peer".to_string(), HashSet::from(["1.0.0".to_string()]))]);
+
+    assert_eq!(
+        get_hoistable_optional_peers_with_locked_versions(&missing, &preferred, &[], &locked,),
+        BTreeMap::from([("peer".to_string(), "1.0.0".to_string())]),
+    );
 }
 
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -968,6 +968,22 @@ impl WorkspaceTreeCtx {
             .collect()
     }
 
+    pub(crate) fn set_direct_locked_peer_names(
+        &self,
+        direct: &[DirectDep],
+        names_by_alias: &HashMap<String, Arc<HashSet<String>>>,
+    ) {
+        let mut tree = lock_recoverable(&self.dependencies_tree);
+        for dep in direct {
+            let Some(names) = names_by_alias.get(&dep.alias) else {
+                continue;
+            };
+            if let Some(node) = tree.get_mut(&dep.node_id) {
+                node.locked_peer_names = Some(Arc::clone(names));
+            }
+        }
+    }
+
     /// Set which dependencies `pacquet update` excludes from reuse. See
     /// [`UpdateReuseScope`].
     #[must_use]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -2534,7 +2534,11 @@ fn level_versions(ctx: &TreeCtx, seeds: &[NodeSeed]) -> BTreeMap<String, Vec<Str
 /// to compare against, so recording them would mark them "changed" on
 /// every install and permanently decline subtree reuse for anything
 /// depending on them.
-pub(crate) fn record_changed_direct_deps(ctx: &TreeCtx, importer_id: &str, wanted: &[WantedSpec]) {
+pub(crate) fn record_changed_direct_deps(
+    ctx: &TreeCtx,
+    importer_id: &str,
+    wanted: &[WantedSpec],
+) -> HashSet<PkgName> {
     let lockfile = ctx.workspace.wanted_lockfile.as_deref();
     let prior = lockfile.and_then(|lockfile| lockfile.importers.get(importer_id));
     let mut changed = lock_recoverable(&ctx.workspace.changed_direct_deps);
@@ -2549,6 +2553,7 @@ pub(crate) fn record_changed_direct_deps(ctx: &TreeCtx, importer_id: &str, wante
             bucket.insert(name);
         }
     }
+    bucket.clone()
 }
 
 /// Whether a `catalog:`-recorded direct dep still resolves to the same

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -839,7 +839,7 @@ fn importer_locked_peer_context(
     let Some(importer) = lockfile.importers.get(importer_id) else {
         let mut versions = HashMap::<String, HashSet<String>>::new();
         for (key, _) in lockfile.snapshots.iter().flatten() {
-            for (name, version) in peer_suffix_versions(key.suffix.peer()) {
+            for (name, version) in locked_peer_versions_for_key(lockfile, key) {
                 versions.entry(name).or_default().insert(version);
             }
         }
@@ -852,13 +852,11 @@ fn importer_locked_peer_context(
         DependencyGroup::Optional,
         DependencyGroup::Dev,
     ]) {
-        let Some(peer_suffix) =
-            dependency.version.ver_peer().map(pacquet_lockfile::PkgVerPeer::peer)
-        else {
+        let Some(key) = dependency.version.resolved_key(alias) else {
             continue;
         };
         let mut names = HashSet::new();
-        for (name, version) in peer_suffix_versions(peer_suffix) {
+        for (name, version) in locked_peer_versions_for_key(lockfile, &key) {
             names.insert(name.clone());
             versions.entry(name).or_default().insert(version);
         }
@@ -869,11 +867,54 @@ fn importer_locked_peer_context(
     ImporterLockedPeerContext { versions, names_by_alias }
 }
 
+fn locked_peer_versions_for_key(
+    lockfile: &pacquet_lockfile::Lockfile,
+    key: &pacquet_lockfile::PkgNameVerPeer,
+) -> Vec<(String, String)> {
+    let explicit = peer_suffix_versions(key.suffix.peer()).collect::<Vec<_>>();
+    if !explicit.is_empty() || !is_hashed_peer_suffix(key.suffix.peer()) {
+        return explicit;
+    }
+    let Some(snapshot) = lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(key))
+    else {
+        return Vec::new();
+    };
+    let Some(metadata) =
+        lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
+    else {
+        return Vec::new();
+    };
+    let peer_names = metadata
+        .peer_dependencies
+        .iter()
+        .flatten()
+        .filter_map(|(name, _)| name.parse::<PkgName>().ok())
+        .collect::<HashSet<_>>();
+    snapshot
+        .dependencies
+        .iter()
+        .chain(snapshot.optional_dependencies.iter())
+        .flatten()
+        .filter(|(name, _)| peer_names.contains(*name))
+        .filter_map(|(name, reference)| {
+            reference
+                .ver_peer()
+                .map(|version| (name.to_string(), version.without_peer().to_string()))
+        })
+        .collect()
+}
+
 fn peer_suffix_versions(peer_suffix: &str) -> impl Iterator<Item = (String, String)> + '_ {
     peer_suffix.match_indices('(').filter_map(|(start, _)| {
         let segment = peer_suffix[start + 1..].split(['(', ')']).next()?;
         let (name, version) = segment.rsplit_once('@')?;
         (!name.is_empty()).then(|| (name.to_string(), version.to_string()))
+    })
+}
+
+fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {
+    peer_suffix.rsplit_once('(').and_then(|(_, tail)| tail.strip_suffix(')')).is_some_and(|hash| {
+        hash.len() == 32 && hash.chars().all(|character| character.is_ascii_hexdigit())
     })
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -44,6 +44,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
 use pacquet_catalogs_types::Catalogs;
+use pacquet_lockfile::PkgName;
 use pacquet_package_manifest::{
     DependencyGroup, PackageManifest, PackageManifestError, safe_read_package_json_from_dir,
 };
@@ -425,14 +426,18 @@ impl ImporterHoistState {
             .with_catalogs(catalogs);
         let ImporterLockedPeerContext {
             versions: locked_peer_versions,
-            names_by_alias: locked_peer_names_by_alias,
+            names_by_alias: mut locked_peer_names_by_alias,
         } = importer_locked_peer_context(
             ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
             importer_id,
         );
         let locked_peer_versions = Arc::new(locked_peer_versions);
         let locked_peer_names = Arc::new(locked_peer_versions.keys().cloned().collect());
-        record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
+        let changed_direct_deps = record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
+        discard_changed_direct_dep_peer_context(
+            &mut locked_peer_names_by_alias,
+            &changed_direct_deps,
+        );
         let wanted_specifier_by_alias: BTreeMap<String, String> = initial_wanted
             .iter()
             .map(|(alias, range, ..)| (alias.clone(), range.clone()))
@@ -805,6 +810,15 @@ impl ImporterHoistState {
         let peers_result = resolve_peers(&mut resolved_tree, peers_opts);
         ResolveImporterResult { resolved_tree, peers_result }
     }
+}
+
+fn discard_changed_direct_dep_peer_context(
+    names_by_alias: &mut HashMap<String, Arc<HashSet<String>>>,
+    changed_direct_deps: &HashSet<PkgName>,
+) {
+    names_by_alias.retain(|alias, _| {
+        alias.parse::<PkgName>().is_ok_and(|name| !changed_direct_deps.contains(&name))
+    });
 }
 
 struct ImporterLockedPeerContext {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -336,6 +336,7 @@ pub(crate) struct ImporterHoistState {
     /// peer walk resolves them at their tree position instead of the
     /// importer root.
     hoisted_peer_provider_node_ids: HashSet<crate::NodeId>,
+    hoisted_optional_peer_node_ids: HashSet<crate::NodeId>,
     parent_pkg_aliases: HashSet<String>,
     all_missing_optional_peers: BTreeMap<String, Vec<String>>,
     all_preferred_versions: PreferredVersions,
@@ -422,10 +423,14 @@ impl ImporterHoistState {
             .with_patched_dependencies(patched_dependencies)
             .with_resolution_mode(pick_lowest_direct, subdep_published_by)
             .with_catalogs(catalogs);
-        let locked_peer_versions = Arc::new(importer_locked_peer_versions(
+        let ImporterLockedPeerContext {
+            versions: locked_peer_versions,
+            names_by_alias: locked_peer_names_by_alias,
+        } = importer_locked_peer_context(
             ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
             importer_id,
-        ));
+        );
+        let locked_peer_versions = Arc::new(locked_peer_versions);
         let locked_peer_names = Arc::new(locked_peer_versions.keys().cloned().collect());
         record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
         let wanted_specifier_by_alias: BTreeMap<String, String> = initial_wanted
@@ -447,6 +452,7 @@ impl ImporterHoistState {
             &ParentPkgAliases::root(parent_pkg_aliases.clone()),
         )
         .await?;
+        ctx.workspace().set_direct_locked_peer_names(&direct, &locked_peer_names_by_alias);
         parent_pkg_aliases.extend(direct.iter().map(|dep| dep.alias.clone()));
         Ok(ImporterHoistState {
             importer_id: importer_id.to_string(),
@@ -455,6 +461,7 @@ impl ImporterHoistState {
             workspace_root_deps: Arc::default(),
             wanted_specifier_by_alias,
             hoisted_peer_provider_node_ids: HashSet::new(),
+            hoisted_optional_peer_node_ids: HashSet::new(),
             parent_pkg_aliases,
             all_missing_optional_peers: BTreeMap::new(),
             all_preferred_versions,
@@ -505,6 +512,7 @@ impl ImporterHoistState {
             modules_dir: self.modules_dir.clone(),
             hoist_missing_scope: None,
             hoisted_peer_provider_node_ids: self.hoisted_peer_provider_node_ids.clone(),
+            hoisted_optional_peer_node_ids: self.hoisted_optional_peer_node_ids.clone(),
             ..ResolvePeersOptions::default()
         }
     }
@@ -767,6 +775,8 @@ impl ImporterHoistState {
             &ParentPkgAliases::root(self.parent_pkg_aliases.clone()),
         )
         .await?;
+        self.hoisted_optional_peer_node_ids
+            .extend(new_direct.iter().map(|dep| dep.node_id.clone()));
         self.direct.extend(new_direct);
         update_preferred_versions_with_ctx(
             &self.ctx,
@@ -781,8 +791,10 @@ impl ImporterHoistState {
     /// pass would be discarded), together with the `NodeIds` of the peer
     /// providers among them (see
     /// [`ResolvePeersOptions::hoisted_peer_provider_node_ids`]).
-    pub(crate) fn into_direct(self) -> (Vec<DirectDep>, HashSet<crate::NodeId>) {
-        (self.direct, self.hoisted_peer_provider_node_ids)
+    pub(crate) fn into_direct(
+        self,
+    ) -> (Vec<DirectDep>, HashSet<crate::NodeId>, HashSet<crate::NodeId>) {
+        (self.direct, self.hoisted_peer_provider_node_ids, self.hoisted_optional_peer_node_ids)
     }
 
     /// Run the final per-importer peer pass and emit the result. Used
@@ -795,12 +807,20 @@ impl ImporterHoistState {
     }
 }
 
-fn importer_locked_peer_versions(
+struct ImporterLockedPeerContext {
+    versions: HashMap<String, HashSet<String>>,
+    names_by_alias: HashMap<String, Arc<HashSet<String>>>,
+}
+
+fn importer_locked_peer_context(
     wanted_lockfile: Option<&pacquet_lockfile::Lockfile>,
     importer_id: &str,
-) -> HashMap<String, HashSet<String>> {
+) -> ImporterLockedPeerContext {
     let Some(lockfile) = wanted_lockfile else {
-        return HashMap::new();
+        return ImporterLockedPeerContext {
+            versions: HashMap::new(),
+            names_by_alias: HashMap::new(),
+        };
     };
     let Some(importer) = lockfile.importers.get(importer_id) else {
         let mut versions = HashMap::<String, HashSet<String>>::new();
@@ -809,10 +829,11 @@ fn importer_locked_peer_versions(
                 versions.entry(name).or_default().insert(version);
             }
         }
-        return versions;
+        return ImporterLockedPeerContext { versions, names_by_alias: HashMap::new() };
     };
     let mut versions = HashMap::<String, HashSet<String>>::new();
-    for (_, dependency) in importer.dependencies_by_groups([
+    let mut names_by_alias = HashMap::new();
+    for (alias, dependency) in importer.dependencies_by_groups([
         DependencyGroup::Prod,
         DependencyGroup::Optional,
         DependencyGroup::Dev,
@@ -822,11 +843,16 @@ fn importer_locked_peer_versions(
         else {
             continue;
         };
+        let mut names = HashSet::new();
         for (name, version) in peer_suffix_versions(peer_suffix) {
+            names.insert(name.clone());
             versions.entry(name).or_default().insert(version);
         }
+        if !names.is_empty() {
+            names_by_alias.insert(alias.to_string(), Arc::new(names));
+        }
     }
-    versions
+    ImporterLockedPeerContext { versions, names_by_alias }
 }
 
 fn peer_suffix_versions(peer_suffix: &str) -> impl Iterator<Item = (String, String)> + '_ {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -26,7 +26,7 @@ use crate::{
     dependencies_graph::MissingPeer,
     hoist_peers::{
         DependencyOverrider, HoistPeersOptions, MissingPeerInfo, WorkspaceRootDep,
-        get_hoistable_optional_peers, hoist_peers,
+        get_hoistable_optional_peers_with_locked_versions, hoist_peers,
     },
     parent_pkg_aliases::ParentPkgAliases,
     resolve_dependency_tree::{
@@ -95,7 +95,7 @@ pub struct ResolveImporterOptions {
     /// each newly-resolved `name@version` lands as a plain
     /// [`VersionSelectorType::Version`] entry so the [`hoist_peers`]
     /// (required-peer) picker can reuse a version a sibling already
-    /// brought. The [`get_hoistable_optional_peers`] picker instead
+    /// brought. The [`fn@crate::get_hoistable_optional_peers`] picker instead
     /// reads a snapshot of `allPreferredVersions` taken *before* any
     /// run-resolved version is folded in, so an optional peer is never
     /// hoisted against a deep-tree provider pnpm can't see. Pass the
@@ -340,6 +340,7 @@ pub(crate) struct ImporterHoistState {
     all_missing_optional_peers: BTreeMap<String, Vec<String>>,
     all_preferred_versions: PreferredVersions,
     locked_peer_names: Arc<HashSet<String>>,
+    locked_peer_versions: Arc<HashMap<String, HashSet<String>>>,
     seen_workspace_package_versions: HashSet<(String, String)>,
     override_bare_specifier: Option<Arc<DependencyOverrider>>,
     /// `auto_install_peers || dedupe_peer_dependents` — upstream's
@@ -421,8 +422,11 @@ impl ImporterHoistState {
             .with_patched_dependencies(patched_dependencies)
             .with_resolution_mode(pick_lowest_direct, subdep_published_by)
             .with_catalogs(catalogs);
-        let locked_peer_names =
-            Arc::new(locked_peer_names(ctx.workspace().wanted_lockfile().map(AsRef::as_ref)));
+        let locked_peer_versions = Arc::new(importer_locked_peer_versions(
+            ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
+            importer_id,
+        ));
+        let locked_peer_names = Arc::new(locked_peer_versions.keys().cloned().collect());
         record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
         let wanted_specifier_by_alias: BTreeMap<String, String> = initial_wanted
             .iter()
@@ -455,6 +459,7 @@ impl ImporterHoistState {
             all_missing_optional_peers: BTreeMap::new(),
             all_preferred_versions,
             locked_peer_names,
+            locked_peer_versions,
             seen_workspace_package_versions: HashSet::new(),
             override_bare_specifier,
             hoist_peers: auto_install_peers || dedupe_peer_dependents,
@@ -735,10 +740,11 @@ impl ImporterHoistState {
         }
         let workspace_root_deps: &[WorkspaceRootDep] =
             if self.resolve_peers_from_workspace_root { &self.workspace_root_deps } else { &[] };
-        let hoisted_optional = get_hoistable_optional_peers(
+        let hoisted_optional = get_hoistable_optional_peers_with_locked_versions(
             &self.all_missing_optional_peers,
             &self.all_preferred_versions,
             workspace_root_deps,
+            &self.locked_peer_versions,
         );
         if hoisted_optional.is_empty() {
             return Ok(false);
@@ -789,53 +795,45 @@ impl ImporterHoistState {
     }
 }
 
-fn locked_peer_names(wanted_lockfile: Option<&pacquet_lockfile::Lockfile>) -> HashSet<String> {
+fn importer_locked_peer_versions(
+    wanted_lockfile: Option<&pacquet_lockfile::Lockfile>,
+    importer_id: &str,
+) -> HashMap<String, HashSet<String>> {
     let Some(lockfile) = wanted_lockfile else {
-        return HashSet::new();
+        return HashMap::new();
     };
-    let mut names = HashSet::new();
-    for (key, snapshot) in lockfile.snapshots.iter().flatten() {
-        let peer_suffix = key.suffix.peer();
-        if peer_suffix.is_empty() {
-            continue;
+    let Some(importer) = lockfile.importers.get(importer_id) else {
+        let mut versions = HashMap::<String, HashSet<String>>::new();
+        for (key, _) in lockfile.snapshots.iter().flatten() {
+            for (name, version) in peer_suffix_versions(key.suffix.peer()) {
+                versions.entry(name).or_default().insert(version);
+            }
         }
-        names.extend(peer_suffix_names(peer_suffix));
-        if is_hashed_peer_suffix(peer_suffix)
-            && let Some(metadata) =
-                lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
-        {
-            let resolved_names = snapshot
-                .dependencies
-                .iter()
-                .chain(snapshot.optional_dependencies.iter())
-                .flatten()
-                .map(|(name, _)| name.to_string())
-                .collect::<HashSet<_>>();
-            names.extend(
-                metadata
-                    .peer_dependencies
-                    .iter()
-                    .flatten()
-                    .map(|(name, _)| name)
-                    .filter(|name| resolved_names.contains(*name))
-                    .cloned(),
-            );
+        return versions;
+    };
+    let mut versions = HashMap::<String, HashSet<String>>::new();
+    for (_, dependency) in importer.dependencies_by_groups([
+        DependencyGroup::Prod,
+        DependencyGroup::Optional,
+        DependencyGroup::Dev,
+    ]) {
+        let Some(peer_suffix) =
+            dependency.version.ver_peer().map(pacquet_lockfile::PkgVerPeer::peer)
+        else {
+            continue;
+        };
+        for (name, version) in peer_suffix_versions(peer_suffix) {
+            versions.entry(name).or_default().insert(version);
         }
     }
-    names
+    versions
 }
 
-fn peer_suffix_names(peer_suffix: &str) -> impl Iterator<Item = String> + '_ {
+fn peer_suffix_versions(peer_suffix: &str) -> impl Iterator<Item = (String, String)> + '_ {
     peer_suffix.match_indices('(').filter_map(|(start, _)| {
         let segment = peer_suffix[start + 1..].split(['(', ')']).next()?;
-        let (name, _) = segment.rsplit_once('@')?;
-        (!name.is_empty()).then(|| name.to_string())
-    })
-}
-
-fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {
-    peer_suffix.rsplit_once('(').and_then(|(_, tail)| tail.strip_suffix(')')).is_some_and(|hash| {
-        hash.len() == 32 && hash.chars().all(|character| character.is_ascii_hexdigit())
+        let (name, version) = segment.rsplit_once('@')?;
+        (!name.is_empty()).then(|| (name.to_string(), version.to_string()))
     })
 }
 
@@ -850,7 +848,7 @@ fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {
 ///
 /// Peers whose consumers are *all* optional are returned as the second
 /// component, keyed by peer name with the deduplicated range list the
-/// outer loop's [`get_hoistable_optional_peers`] needs.
+/// outer loop's [`fn@crate::get_hoistable_optional_peers`] needs.
 fn partition_missing_peers(
     missing: &HashMap<String, Vec<MissingPeer>>,
     parent_pkg_aliases: &HashSet<String>,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -12,10 +12,54 @@ use pacquet_resolving_resolver_base::{
 };
 use pretty_assertions::assert_eq;
 
+use super::{ImporterLockedPeerContext, importer_locked_peer_context};
 use crate::{
     DepPath, ResolveDependencyTreeError, resolve_importer,
     resolve_importer::{ResolveImporterError, ResolveImporterOptions},
 };
+
+#[test]
+fn locked_peer_context_is_recorded_by_direct_alias() {
+    use pacquet_lockfile::{
+        ComVer, ImporterDepVersion, Lockfile, LockfileVersion, PkgName, PkgVerPeer,
+        ProjectSnapshot, ResolvedDependencySpec,
+    };
+
+    let consumer = PkgName::parse("consumer").unwrap();
+    let lockfile = Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
+        importers: HashMap::from([(
+            "app".to_string(),
+            ProjectSnapshot {
+                dependencies: Some(HashMap::from([(
+                    consumer,
+                    ResolvedDependencySpec {
+                        specifier: "1.0.0".to_string(),
+                        version: ImporterDepVersion::Regular(
+                            "1.0.0(peer@2.0.0)".parse::<PkgVerPeer>().unwrap(),
+                        ),
+                    },
+                )])),
+                ..ProjectSnapshot::default()
+            },
+        )]),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        packages: None,
+        snapshots: None,
+    };
+
+    let ImporterLockedPeerContext { versions, names_by_alias } =
+        importer_locked_peer_context(Some(&lockfile), "app");
+
+    assert_eq!(versions["peer"], HashSet::from(["2.0.0".to_string()]));
+    assert_eq!(names_by_alias["consumer"].as_ref(), &HashSet::from(["peer".to_string()]));
+}
 
 #[test]
 fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -180,7 +180,13 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
         )])),
     };
 
-    assert_eq!(locked_peer_names(Some(&lockfile)), HashSet::from(["peer".to_string()]));
+    let ImporterLockedPeerContext { versions, names_by_alias } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from([("peer".to_string(), HashSet::from(["1.0.0".to_string()]))]),
+    );
+    assert!(names_by_alias.is_empty());
 }
 
 fn locked_peer_names(wanted_lockfile: Option<&pacquet_lockfile::Lockfile>) -> HashSet<String> {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -14,7 +14,7 @@ use pretty_assertions::assert_eq;
 
 use crate::{
     DepPath, ResolveDependencyTreeError, resolve_importer,
-    resolve_importer::{ResolveImporterError, ResolveImporterOptions, locked_peer_names},
+    resolve_importer::{ResolveImporterError, ResolveImporterOptions},
 };
 
 #[test]
@@ -113,6 +113,56 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
     };
 
     assert_eq!(locked_peer_names(Some(&lockfile)), HashSet::from(["peer".to_string()]));
+}
+
+fn locked_peer_names(wanted_lockfile: Option<&pacquet_lockfile::Lockfile>) -> HashSet<String> {
+    let Some(lockfile) = wanted_lockfile else {
+        return HashSet::new();
+    };
+    let mut names = HashSet::new();
+    for (key, snapshot) in lockfile.snapshots.iter().flatten() {
+        let peer_suffix = key.suffix.peer();
+        if peer_suffix.is_empty() {
+            continue;
+        }
+        names.extend(peer_suffix_names(peer_suffix));
+        if is_hashed_peer_suffix(peer_suffix)
+            && let Some(metadata) =
+                lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
+        {
+            let resolved_names = snapshot
+                .dependencies
+                .iter()
+                .chain(snapshot.optional_dependencies.iter())
+                .flatten()
+                .map(|(name, _)| name.to_string())
+                .collect::<HashSet<_>>();
+            names.extend(
+                metadata
+                    .peer_dependencies
+                    .iter()
+                    .flatten()
+                    .map(|(name, _)| name)
+                    .filter(|name| resolved_names.contains(*name))
+                    .cloned(),
+            );
+        }
+    }
+    names
+}
+
+fn peer_suffix_names(peer_suffix: &str) -> impl Iterator<Item = String> + '_ {
+    peer_suffix.match_indices('(').filter_map(|(start, _)| {
+        let segment = peer_suffix[start + 1..].split(['(', ')']).next()?;
+        let (name, _) = segment.rsplit_once('@')?;
+        (!name.is_empty()).then(|| name.to_string())
+    })
+}
+
+fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {
+    peer_suffix.rsplit_once('(').and_then(|(_, tail)| tail.strip_suffix(')')).is_some_and(|hash| {
+        hash.len() == 32 && hash.chars().all(|character| character.is_ascii_hexdigit())
+    })
 }
 
 struct StubResolver {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -12,7 +12,10 @@ use pacquet_resolving_resolver_base::{
 };
 use pretty_assertions::assert_eq;
 
-use super::{ImporterLockedPeerContext, importer_locked_peer_context};
+use super::{
+    ImporterLockedPeerContext, discard_changed_direct_dep_peer_context,
+    importer_locked_peer_context,
+};
 use crate::{
     DepPath, ResolveDependencyTreeError, resolve_importer,
     resolve_importer::{ResolveImporterError, ResolveImporterOptions},
@@ -59,6 +62,27 @@ fn locked_peer_context_is_recorded_by_direct_alias() {
 
     assert_eq!(versions["peer"], HashSet::from(["2.0.0".to_string()]));
     assert_eq!(names_by_alias["consumer"].as_ref(), &HashSet::from(["peer".to_string()]));
+}
+
+#[test]
+fn changed_direct_dependency_discards_prior_peer_context() {
+    use pacquet_lockfile::PkgName;
+    use std::sync::Arc;
+
+    let mut names_by_alias = HashMap::from([
+        ("changed".to_string(), Arc::new(HashSet::from(["old-peer".to_string()]))),
+        ("unchanged".to_string(), Arc::new(HashSet::from(["peer".to_string()]))),
+    ]);
+
+    discard_changed_direct_dep_peer_context(
+        &mut names_by_alias,
+        &HashSet::from([PkgName::parse("changed").unwrap()]),
+    );
+
+    assert_eq!(
+        names_by_alias,
+        HashMap::from([("unchanged".to_string(), Arc::new(HashSet::from(["peer".to_string()])),)]),
+    );
 }
 
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -184,6 +184,11 @@ pub struct ResolvePeersOptions {
     /// resolved them.
     pub hoisted_peer_provider_node_ids: std::collections::HashSet<NodeId>,
 
+    /// Importer-level dependencies installed solely to satisfy optional
+    /// peers. A reused direct dependency only sees these providers when
+    /// its wanted-lockfile peer suffix recorded the same peer name.
+    pub hoisted_optional_peer_node_ids: std::collections::HashSet<NodeId>,
+
     /// Final `NodeId → DepPath` map produced by a previous
     /// peer-resolution pass over the same tree
     /// ([`ResolvePeersResult::paths_by_node_id`]). `Some` activates
@@ -263,6 +268,7 @@ impl Default for ResolvePeersOptions {
             project_dir: None,
             modules_dir: None,
             hoist_missing_scope: None,
+            hoisted_optional_peer_node_ids: std::collections::HashSet::new(),
             hoisted_peer_provider_node_ids: std::collections::HashSet::new(),
             resolved_peer_provider_paths: None,
             collect_paths_by_node_id: false,
@@ -304,6 +310,7 @@ pub struct ResolvePeersResult {
 pub struct ImporterPeerInput {
     pub id: String,
     pub direct: Vec<DirectDep>,
+    pub hoisted_optional_peer_node_ids: std::collections::HashSet<NodeId>,
     pub root_dir: PathBuf,
     /// Absolute path of this importer's `node_modules` directory.
     /// Threaded into [`ResolvePeersOptions::modules_dir`] while this
@@ -499,6 +506,10 @@ pub fn resolve_peers_workspace(
         // the `excludeLinksFromLockfile` link-remap inside
         // `resolve_node` uses the correct importer-scoped target.
         walker.opts.modules_dir.clone_from(&importer.modules_dir);
+        walker
+            .opts
+            .hoisted_optional_peer_node_ids
+            .clone_from(&importer.hoisted_optional_peer_node_ids);
         walker.current_provider_sources = importer_provider_sources(importer, root_importer);
         let importer_parents = if root_importer.is_some_and(|root| root.id != importer.id) {
             let mut refs = root_parents.clone().unwrap_or_default();
@@ -628,6 +639,23 @@ struct ParentRef {
 /// requirement against the alias and `peerDependencies.next` against
 /// the real name.
 type ParentRefs = HashMap<String, ParentRef>;
+
+fn scoped_hoisted_optional_parent_refs(
+    parent_refs: &ParentRefs,
+    locked_peer_names: &HashSet<String>,
+    hoisted_optional_peer_node_ids: &HashSet<NodeId>,
+) -> ParentRefs {
+    parent_refs
+        .iter()
+        .filter(|(name, parent)| {
+            parent.node_id.as_ref().is_none_or(|parent_node_id| {
+                !hoisted_optional_peer_node_ids.contains(parent_node_id)
+                    || locked_peer_names.contains(*name)
+            })
+        })
+        .map(|(name, parent)| (name.clone(), parent.clone()))
+        .collect()
+}
 
 /// One importer whose direct dependencies count as "current" peer
 /// providers for the must-win guard of locked-peer-provider reuse.
@@ -1096,6 +1124,17 @@ impl Walker<'_> {
         let children_map = self.realize_children(&node_id);
         let tree_node = self.tree.dependencies_tree[&node_id].clone();
         let pkg = self.tree.packages[&tree_node.resolved_package_id].clone();
+        let scoped_parent_refs;
+        let parent_parent_refs = if let Some(locked_peer_names) = &tree_node.locked_peer_names {
+            scoped_parent_refs = scoped_hoisted_optional_parent_refs(
+                parent_parent_refs,
+                locked_peer_names,
+                &self.opts.hoisted_optional_peer_node_ids,
+            );
+            &scoped_parent_refs
+        } else {
+            parent_parent_refs
+        };
         let (pkg_name, _pkg_version) = pkg_name_version(&pkg.result);
 
         let mut current_parent_node_ids = parent_node_ids.to_vec();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    ImporterPeerInput, NodeRecord, ResolvePeersOptions, Walker, importer_relative_link_dep_path,
-    peer_segment_names, resolve_peers, resolve_peers_workspace, satisfies_with_prereleases,
+    ImporterPeerInput, NodeRecord, ParentRef, ResolvePeersOptions, Walker,
+    importer_relative_link_dep_path, peer_segment_names, resolve_peers, resolve_peers_workspace,
+    satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
 };
 use crate::{
     dependencies_graph::{DependenciesGraph, PeerDependencyIssues},
@@ -28,6 +29,35 @@ const PATCHED_WORKFLOWS_SDK: &str = concat!(
     "(better-sqlite3@12.8.0)",
     "(express@4.21.2)",
 );
+
+#[test]
+fn locked_direct_dep_only_sees_its_locked_hoisted_optional_peers() {
+    let debug = NodeId::next();
+    let supports_color = NodeId::next();
+    let regular = NodeId::next();
+    let parent = |version: &str, node_id| ParentRef {
+        version: version.to_string(),
+        node_id: Some(node_id),
+        alias: None,
+        depth: 0,
+        occurrence: 0,
+    };
+    let parent_refs = HashMap::from([
+        ("debug".to_string(), parent("4.4.3", debug.clone())),
+        ("supports-color".to_string(), parent("8.1.1", supports_color.clone())),
+        ("regular".to_string(), parent("1.0.0", regular)),
+    ]);
+
+    let scoped = scoped_hoisted_optional_parent_refs(
+        &parent_refs,
+        &HashSet::from(["supports-color".to_string()]),
+        &HashSet::from([debug, supports_color]),
+    );
+
+    assert!(!scoped.contains_key("debug"));
+    assert!(scoped.contains_key("supports-color"));
+    assert!(scoped.contains_key("regular"));
+}
 
 #[test]
 fn importer_relative_self_link_keeps_an_empty_target() {
@@ -1416,6 +1446,7 @@ fn pruned_hoisted_provider_falls_back_in_workspace_pass() {
 
     let importer = ImporterPeerInput {
         id: ".".to_string(),
+        hoisted_optional_peer_node_ids: HashSet::new(),
         direct: vec![
             DirectDep {
                 alias: "consumer".to_string(),
@@ -1481,6 +1512,7 @@ fn workspace_importers_get_distinct_instances_for_different_peer_versions() {
     let importers = [
         ImporterPeerInput {
             id: "project-a".to_string(),
+            hoisted_optional_peer_node_ids: HashSet::new(),
             direct: vec![
                 DirectDep {
                     alias: "consumer".to_string(),
@@ -1498,6 +1530,7 @@ fn workspace_importers_get_distinct_instances_for_different_peer_versions() {
         },
         ImporterPeerInput {
             id: "project-b".to_string(),
+            hoisted_optional_peer_node_ids: HashSet::new(),
             direct: vec![
                 DirectDep {
                     alias: "consumer".to_string(),
@@ -1566,6 +1599,7 @@ fn a_shared_consumer_keeps_the_first_importers_peer_provider_variant() {
     let importers = [
         ImporterPeerInput {
             id: ".".to_string(),
+            hoisted_optional_peer_node_ids: HashSet::new(),
             direct: vec![
                 DirectDep {
                     alias: "plugin".to_string(),
@@ -1588,6 +1622,7 @@ fn a_shared_consumer_keeps_the_first_importers_peer_provider_variant() {
         },
         ImporterPeerInput {
             id: "app".to_string(),
+            hoisted_optional_peer_node_ids: HashSet::new(),
             direct: vec![
                 DirectDep {
                     alias: "plugin".to_string(),
@@ -1701,6 +1736,7 @@ fn linked_peer_provider_uses_root_relative_snapshot_ref_in_workspace_fallback() 
     let consumer = NodeId::next();
     let importer = ImporterPeerInput {
         id: "apps/nested/app".to_string(),
+        hoisted_optional_peer_node_ids: HashSet::new(),
         direct: vec![
             DirectDep {
                 alias: "consumer".to_string(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -316,11 +316,12 @@ where
     for ((importer, state), (project_dir, modules_dir)) in
         importers.iter().zip(states).zip(input_dirs)
     {
-        let (direct, importer_provider_node_ids) = state.into_direct();
+        let (direct, importer_provider_node_ids, importer_optional_node_ids) = state.into_direct();
         hoisted_peer_provider_node_ids.extend(importer_provider_node_ids);
         per_importer_inputs.push(ImporterPeerInput {
             id: importer.id.clone(),
             direct,
+            hoisted_optional_peer_node_ids: importer_optional_node_ids,
             root_dir: project_dir,
             modules_dir,
         });

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -183,6 +183,9 @@ pub struct DependenciesTreeNode {
     /// TODO: the resolver does not compute this yet; only
     /// `resolve_peers` consumes it.
     pub dependency_names_whose_current_provider_must_win: Option<HashSet<String>>,
+    /// Peer names recorded on this direct dependency's wanted-lockfile
+    /// suffix. `None` for transitive or freshly resolved occurrences.
+    pub locked_peer_names: Option<Arc<HashSet<String>>>,
 }
 
 impl DependenciesTreeNode {
@@ -202,6 +205,7 @@ impl DependenciesTreeNode {
             previous_dep_path: None,
             locked_peer_context: None,
             dependency_names_whose_current_provider_must_win: None,
+            locked_peer_names: None,
         }
     }
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

Preserves each reused direct dependency's locked optional-peer context during
Rust `pnpm dedupe`. Optional peers may still be hoisted at the importer level,
but the final peer walk exposes a hoisted provider to a locked direct
dependency only when that dependency's own lockfile suffix recorded the peer.
This prevents one consumer's `debug` context from leaking into another
consumer that was locked with only `supports-color`.

The comparison uses n8n migrated to pnpm v11, with both implementations
starting from the same pnpm-v11-installed workspace. Package-manager fallback
is disabled with `PNPM_CONFIG_PM_ON_FAIL=ignore`; without it, n8n's
`packageManager` field can delegate the purported Rust run to another pnpm
binary.

The n8n Daytona, CodSpeed, and sandbox-client recursive
`debug`/`supports-color` differences are eliminated. The remaining comparison
output is unrelated package-version selection and lockfile metadata
serialization, including the separately tracked catalog behavior. No
TypeScript change is needed because TypeScript pnpm already preserves these
per-dependent contexts.

Related to pnpm/pnpm#13305.

## Squash Commit Body

```text
Scope importer-hoisted optional peers to each reused direct dependency's
locked peer suffix. This preserves distinct peer contexts for dependencies
that share an importer without preventing optional-peer deduplication.

Track the hoisted providers per importer so a shared leaf NodeId cannot affect
an unrelated workspace project.

Related to pnpm/pnpm#13305.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm dedupe` to preserve lockfile-selected optional peer dependency versions for direct dependencies.
  * Made optional-peer hoisting and deduplication lockfile-aware, avoiding selection of versions outside the locked context.
  * Enhanced peer resolution scoping so locked direct dependencies only consider the relevant hoisted optional peers.
* **Tests**
  * Added regression tests covering lockfile-aware optional peer selection and correct scoping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->