### PR TITLE
feat: support integrity-addressed registry revisions

### DIFF
--- a/.changeset/tidy-ravens-revise.md
+++ b/.changeset/tidy-ravens-revise.md
@@ -12,4 +12,4 @@
 "pnpm": minor
 ---
 
-Added support for registry replacement tarballs using standard integrity values, explicit revision fields, registry routing from the `registries` setting, non-redirecting integrity-addressed URLs, and canonical safe-integer revision numbers.
+Added support for registry replacement tarballs using standard integrity values, explicit revision fields, registry routing from the `registries` setting, non-redirecting integrity-addressed URLs, canonical safe-integer revision numbers, and pnpr proxying for immutable upstream revision artifacts.

--- a/.changeset/tidy-ravens-revise.md
+++ b/.changeset/tidy-ravens-revise.md
@@ -1,9 +1,11 @@
 ---
-"@pnpm/crypto.integrity": minor
+"@pnpm/lockfile.types": minor
 "@pnpm/lockfile.utils": minor
+"@pnpm/resolving.npm-resolver": minor
+"@pnpm/resolving.registry.types": minor
+"@pnpm/resolving.resolver-base": minor
 "@pnpm/resolving.tarball-url": minor
-"@pnpm/store.index": minor
 "pnpm": minor
 ---
 
-Added initial support for revision-aware registry tarballs using SRI options and integrity-addressed URLs.
+Added initial support for registry replacement tarballs using standard integrity values, explicit revision fields, and integrity-addressed URLs.

--- a/.changeset/tidy-ravens-revise.md
+++ b/.changeset/tidy-ravens-revise.md
@@ -1,6 +1,8 @@
 ---
 "@pnpm/lockfile.types": minor
 "@pnpm/lockfile.utils": minor
+"@pnpm/fetching.tarball-fetcher": minor
+"@pnpm/network.fetch": patch
 "@pnpm/resolving.npm-resolver": minor
 "@pnpm/resolving.registry.types": minor
 "@pnpm/resolving.resolver-base": minor
@@ -8,4 +10,4 @@
 "pnpm": minor
 ---
 
-Added initial support for registry replacement tarballs using standard integrity values, explicit revision fields, and integrity-addressed URLs.
+Added initial support for registry replacement tarballs using standard integrity values, explicit revision fields, non-redirecting integrity-addressed URLs, and canonical safe-integer revision numbers.

--- a/.changeset/tidy-ravens-revise.md
+++ b/.changeset/tidy-ravens-revise.md
@@ -3,11 +3,13 @@
 "@pnpm/lockfile.utils": minor
 "@pnpm/fetching.tarball-fetcher": minor
 "@pnpm/network.fetch": patch
+"@pnpm/pnpr": minor
 "@pnpm/resolving.npm-resolver": minor
 "@pnpm/resolving.registry.types": minor
 "@pnpm/resolving.resolver-base": minor
 "@pnpm/resolving.tarball-url": minor
+"pacquet": minor
 "pnpm": minor
 ---
 
-Added initial support for registry replacement tarballs using standard integrity values, explicit revision fields, non-redirecting integrity-addressed URLs, and canonical safe-integer revision numbers.
+Added support for registry replacement tarballs using standard integrity values, explicit revision fields, registry routing from the `registries` setting, non-redirecting integrity-addressed URLs, and canonical safe-integer revision numbers.

--- a/.changeset/tidy-ravens-revise.md
+++ b/.changeset/tidy-ravens-revise.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/crypto.integrity": minor
+"@pnpm/lockfile.utils": minor
+"@pnpm/resolving.tarball-url": minor
+"@pnpm/store.index": minor
+"pnpm": minor
+---
+
+Added initial support for revision-aware registry tarballs using SRI options and integrity-addressed URLs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,6 +4570,7 @@ version = "0.0.1"
 dependencies = [
  "base64 0.23.1",
  "sha2",
+ "ssri",
  "tempfile",
 ]
 
@@ -5060,6 +5061,7 @@ dependencies = [
  "derive_more",
  "indexmap 2.14.0",
  "libc",
+ "miette 7.6.0",
  "node-semver",
  "pipe-trait",
  "pnpm-catalogs-types",
@@ -5077,6 +5079,7 @@ dependencies = [
  "ssri",
  "tempfile",
  "text-block-macros",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5960,6 +5960,7 @@ dependencies = [
  "pnpm-catalogs-types",
  "pnpm-config",
  "pnpm-config-dir",
+ "pnpm-crypto-hash",
  "pnpm-env-replace",
  "pnpm-lockfile",
  "pnpm-lockfile-verification",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8905,6 +8905,9 @@ importers:
       '@pnpm/resolving.resolver-base':
         specifier: workspace:*
         version: link:../resolver-base
+      '@pnpm/resolving.tarball-url':
+        specifier: workspace:*
+        version: link:../tarball-url
       '@pnpm/store.cafs':
         specifier: workspace:*
         version: link:../../store/cafs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9085,6 +9085,9 @@ importers:
 
   pnpm11/resolving/tarball-url:
     dependencies:
+      '@pnpm/crypto.integrity':
+        specifier: workspace:*
+        version: link:../../crypto/integrity
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8768,6 +8768,9 @@ importers:
       '@pnpm/resolving.resolver-base':
         specifier: workspace:*
         version: link:../resolver-base
+      '@pnpm/resolving.tarball-url':
+        specifier: workspace:*
+        version: link:../tarball-url
       '@pnpm/store.cafs':
         specifier: workspace:*
         version: link:../../store/cafs

--- a/pnpm/crates/auth-commands/src/login/test_web_login_errors.rs
+++ b/pnpm/crates/auth-commands/src/login/test_web_login_errors.rs
@@ -116,8 +116,9 @@ async fn should_surface_a_non_404_web_login_http_error_as_web_login_failed() {
 
 /// A web-login probe that never reaches the registry surfaces as a transport
 /// error (`LoginError::Request`), exercising the `Transport` arm of
-/// `From<WebLoginFlowError>`. Binding then dropping an ephemeral loopback
-/// socket yields a port that refuses the connection.
+/// `From<WebLoginFlowError>`. A loopback listener that never accepts keeps the
+/// endpoint deterministic while a short-lived client turns the stalled
+/// request into a transport timeout.
 #[tokio::test]
 async fn should_surface_a_web_login_transport_failure_as_a_request_error() {
     web_auth_fake!(FakeHost, RecordingReporter);
@@ -125,14 +126,18 @@ async fn should_surface_a_web_login_transport_failure_as_a_request_error() {
     reset();
     reset_login();
 
-    let addr = {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
-        listener.local_addr().expect("read the assigned port")
-    };
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind an ephemeral port");
+    let addr = listener.local_addr().expect("read the assigned port");
     let registry = format!("http://{addr}/");
     let config_dir = Path::new("/mock/config");
+    let http_client = pnpm_network::ThrottledClient::from_client(
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(25))
+            .build()
+            .expect("build short-lived client"),
+    );
 
-    let err = login::<FakeHost, RecordingReporter>(&client(), opts(&registry, config_dir))
+    let err = login::<FakeHost, RecordingReporter>(&http_client, opts(&registry, config_dir))
         .await
         .unwrap_err();
 

--- a/pnpm/crates/auth-commands/src/login/test_web_login_errors.rs
+++ b/pnpm/crates/auth-commands/src/login/test_web_login_errors.rs
@@ -130,11 +130,16 @@ async fn should_surface_a_web_login_transport_failure_as_a_request_error() {
     let addr = listener.local_addr().expect("read the assigned port");
     let registry = format!("http://{addr}/");
     let config_dir = Path::new("/mock/config");
-    let http_client = pnpm_network::ThrottledClient::from_client(
+    let build_client = |redirect| {
         reqwest::Client::builder()
             .timeout(std::time::Duration::from_millis(25))
+            .redirect(redirect)
             .build()
-            .expect("build short-lived client"),
+            .expect("build short-lived client")
+    };
+    let http_client = pnpm_network::ThrottledClient::from_clients(
+        build_client(reqwest::redirect::Policy::limited(10)),
+        build_client(reqwest::redirect::Policy::none()),
     );
 
     let err = login::<FakeHost, RecordingReporter>(&http_client, opts(&registry, config_dir))

--- a/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe/tests.rs
@@ -209,6 +209,7 @@ fn resolved_dep_hint() -> pnpm_package_manager::ResolvedPackageHint<'static> {
         tarball_url: "https://registry.example/dep/-/dep-2.0.0.tgz",
         unpacked_size: None,
         file_count: None,
+        revision: None,
         from_registry: true,
     }
 }

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -1059,6 +1059,7 @@ fn convert_package_metadata(
             LockfileResolution::Tarball(TarballResolution {
                 tarball: format!("file:{}", relative_path(ctx.deploy_dir, &resolved)),
                 integrity: resolution.integrity.clone(),
+                revision: None,
                 git_hosted: resolution.git_hosted,
                 path: resolution.path.as_ref().map(|_| relative_path(ctx.deploy_dir, &resolved)),
             })

--- a/pnpm/crates/cli/src/cli_args/deploy/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy/tests.rs
@@ -77,6 +77,7 @@ fn convert_package_metadata_rebases_file_tarball_resolution_to_deploy_dir() {
                     .parse()
                     .expect("parse integrity"),
             ),
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1211,6 +1211,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
                         &pkg.integrity,
                         pkg.unpacked_size,
                         pkg.file_count,
+                        pkg.revision.is_some(),
                     );
                 })
                 .await

--- a/pnpm/crates/cli/src/cli_args/install/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/install/tests.rs
@@ -282,6 +282,7 @@ fn registry_rewrite_updates_explicit_tarball_resolution_urls() {
     let mut resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "http://server-registry.test/foo/-/foo-1.0.0.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });

--- a/pnpm/crates/cli/src/cli_args/sbom/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom/tests.rs
@@ -18,6 +18,7 @@ fn registry_package(
             integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                 .parse()
                 .expect("parse integrity"),
+            revision: None,
         }),
         version: None,
         engines: None,
@@ -288,8 +289,10 @@ fn integrity_string_publishes_only_verified_hashes() {
     const HASH: &str = "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==";
     let hash = || HASH.parse::<ssri::Integrity>().expect("parse integrity");
 
-    let registry =
-        LockfileResolution::Registry(pnpm_lockfile::RegistryResolution { integrity: hash() });
+    let registry = LockfileResolution::Registry(pnpm_lockfile::RegistryResolution {
+        integrity: hash(),
+        revision: None,
+    });
     assert_eq!(integrity_string(&registry).as_deref(), Some(HASH));
 
     let binary = LockfileResolution::Binary(pnpm_lockfile::BinaryResolution {

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -10,6 +10,7 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pnpm_crypto_hash::integrity_addressed_tarball_path;
 use pnpm_lockfile::{Lockfile, PkgName, ProjectSnapshot, SnapshotEntry};
 use pnpm_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
@@ -19,6 +20,7 @@ use pnpr::TokenBackend;
 use std::{
     fmt::Write as _,
     fs,
+    io::Write as _,
     net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
     path::Path,
     process::Command,
@@ -74,6 +76,42 @@ fn start_pnpr(registry_url: &str) -> (String, String) {
     (format!("http://{addr}/"), token)
 }
 
+fn start_pnpr_registry(upstream_url: &str) -> String {
+    let upstream_url = upstream_url.to_string();
+    let storage = tempfile::tempdir().expect("pnpr storage").keep();
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind pnpr");
+    listener.set_nonblocking(true).expect("set pnpr listener non-blocking");
+    let addr = listener.local_addr().expect("pnpr addr");
+
+    thread::Builder::new()
+        .name("pnpr-registry".to_string())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("pnpr runtime");
+            runtime.block_on(async move {
+                let mut config = pnpr::Config::proxy(addr, storage);
+                config.public_url = format!("http://{addr}");
+                config.upstreams.get_mut("npmjs").unwrap().url = upstream_url;
+                config.registries = pnpr::Registries::new(
+                    std::iter::once((
+                        "npmjs".to_string(),
+                        pnpr::Registry::Upstream { patterns: Vec::new() },
+                    ))
+                    .collect(),
+                    Some("npmjs".to_string()),
+                );
+                let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener");
+                let _ = pnpr::serve_listener(config, listener).await;
+            });
+        })
+        .expect("spawn pnpr registry thread");
+
+    wait_until_ready(addr);
+    format!("http://{addr}")
+}
+
 fn configure_pnpr_auth(npmrc_path: &std::path::Path, pnpr_url: &str, token: &str) {
     let authority =
         pnpr_url.strip_prefix("http://").expect("test pnpr URL uses http").trim_end_matches('/');
@@ -114,6 +152,80 @@ fn point_npmrc_registry_at(npmrc_path: &Path, registry_url: &str) {
         .collect::<Vec<_>>()
         .join("\n");
     fs::write(npmrc_path, npmrc).expect("rewrite .npmrc");
+}
+
+fn revision_fixture_tarball() -> Vec<u8> {
+    let manifest = br#"{"name":"revision-pkg","version":"1.0.0","main":"index.js"}"#;
+    let mut tar = tar::Builder::new(Vec::new());
+    for (path, body) in [
+        ("package/package.json", manifest.as_slice()),
+        ("package/index.js", b"module.exports = 'revision'\n".as_slice()),
+    ] {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append_data(&mut header, path, body).expect("append package file");
+    }
+    let tar = tar.into_inner().expect("finish package tar");
+    let mut gzip = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    gzip.write_all(&tar).expect("compress package tar");
+    gzip.finish().expect("finish package tarball")
+}
+
+#[test]
+fn revision_install_and_frozen_reinstall_work_through_pnpr() {
+    let mut upstream = mockito::Server::new();
+    let tarball = revision_fixture_tarball();
+    let integrity =
+        ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512).chain(&tarball).result();
+    let revision_path = integrity_addressed_tarball_path(&integrity).unwrap();
+    let packument = serde_json::json!({
+        "name": "revision-pkg",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": { "1.0.0": {
+            "name": "revision-pkg",
+            "version": "1.0.0",
+            "dist": {
+                "tarball": format!("{}/{}", upstream.url(), revision_path),
+                "integrity": integrity.to_string(),
+                "revision": 2,
+            },
+        } },
+    });
+    let packument_mock =
+        upstream.mock("GET", "/revision-pkg").with_body(packument.to_string()).expect(1).create();
+    let tarball_mock = upstream
+        .mock("GET", format!("/{revision_path}").as_str())
+        .with_body(&tarball)
+        .expect(1)
+        .create();
+    let registry = start_pnpr_registry(&upstream.url());
+
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, store_dir, mock_instance, .. } = npmrc_info;
+    point_npmrc_registry_at(&npmrc_path, &registry);
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "revision-pkg": "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+    assert!(workspace.join("node_modules/revision-pkg/index.js").exists());
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(lockfile.contains("revision: 2"), "{lockfile}");
+    assert!(!lockfile.contains("tarball:"), "{lockfile}");
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+    fs::remove_dir_all(&store_dir).expect("remove client store");
+    pacquet_at(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert!(workspace.join("node_modules/revision-pkg/index.js").exists());
+
+    packument_mock.assert();
+    tarball_mock.assert();
+    drop((root, mock_instance));
 }
 
 #[test]

--- a/pnpm/crates/crypto-hash/Cargo.toml
+++ b/pnpm/crates/crypto-hash/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 [dependencies]
 base64 = { workspace = true }
 sha2   = { workspace = true }
+ssri   = { workspace = true }
 
 # Match pnpm-store-dir's MSVC-aware feature gate so this crate
 # inherits the `asm` backend on every target where it compiles.

--- a/pnpm/crates/crypto-hash/src/lib.rs
+++ b/pnpm/crates/crypto-hash/src/lib.rs
@@ -36,6 +36,19 @@ pub fn integrity_addressed_tarball_path(integrity: &Integrity) -> Option<String>
     Some(format!("-/tarballs/sha512/{}", URL_SAFE_NO_PAD.encode(digest)))
 }
 
+/// Parse the digest segment of an integrity-addressed sha512 tarball path.
+#[must_use]
+pub fn integrity_addressed_tarball_integrity(digest: &str) -> Option<Integrity> {
+    if digest.len() != 86 {
+        return None;
+    }
+    let bytes = URL_SAFE_NO_PAD.decode(digest).ok()?;
+    if bytes.len() != 64 || URL_SAFE_NO_PAD.encode(&bytes) != digest {
+        return None;
+    }
+    format!("sha512-{}", BASE64.encode(bytes)).parse().ok()
+}
+
 /// Compute the `sha256-<base64>` digest of `input`.
 ///
 /// Produces `` `sha256-${base64}` ``. This is the shape pnpm writes for

--- a/pnpm/crates/crypto-hash/src/lib.rs
+++ b/pnpm/crates/crypto-hash/src/lib.rs
@@ -7,9 +7,34 @@
 //! one place avoids duplicating the sha2 dependency in every consumer
 //! (lockfile, registry, store-dir).
 
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use base64::{
+    Engine as _,
+    engine::general_purpose::{STANDARD as BASE64, URL_SAFE_NO_PAD},
+};
 use sha2::{Digest, Sha256};
+use ssri::{Algorithm, Integrity};
 use std::{io, path::Path};
+
+/// Build the registry-relative path for a complete, canonical sha512 SRI.
+///
+/// Integrity-addressed registry tarballs accept exactly one sha512 hash. The
+/// digest must decode to all 64 bytes and round-trip through canonical padded
+/// base64 before it is rendered as unpadded base64url in the request path.
+#[must_use]
+pub fn integrity_addressed_tarball_path(integrity: &Integrity) -> Option<String> {
+    let [hash] = integrity.hashes.as_slice() else { return None };
+    if hash.algorithm != Algorithm::Sha512 {
+        return None;
+    }
+    if hash.digest.len() != 88 {
+        return None;
+    }
+    let digest = BASE64.decode(&hash.digest).ok()?;
+    if digest.len() != 64 || BASE64.encode(&digest) != hash.digest {
+        return None;
+    }
+    Some(format!("-/tarballs/sha512/{}", URL_SAFE_NO_PAD.encode(digest)))
+}
 
 /// Compute the `sha256-<base64>` digest of `input`.
 ///

--- a/pnpm/crates/crypto-hash/src/tests.rs
+++ b/pnpm/crates/crypto-hash/src/tests.rs
@@ -1,7 +1,9 @@
 use super::{
     create_hash, create_hash_from_file, create_hex_hash, create_hex_hash_bytes,
-    create_hex_hash_from_file, create_short_hash, shorten_virtual_store_name,
+    create_hex_hash_from_file, create_short_hash, integrity_addressed_tarball_path,
+    shorten_virtual_store_name,
 };
+use ssri::Integrity;
 
 /// Pinned vector against the shell oracle:
 ///
@@ -77,4 +79,25 @@ fn shorten_triggered_by_uppercase_unless_file_protocol() {
 
     let file_proto = "file+path+with+Caps".to_string();
     assert_eq!(shorten_virtual_store_name(file_proto.clone(), 120), file_proto);
+}
+
+#[test]
+fn integrity_address_requires_one_complete_canonical_sha512_hash() {
+    let digest = format!("{}==", "A".repeat(86));
+    let integrity: Integrity = format!("sha512-{digest}").parse().unwrap();
+    assert_eq!(
+        integrity_addressed_tarball_path(&integrity),
+        Some(format!("-/tarballs/sha512/{}", "A".repeat(86))),
+    );
+
+    for malformed in [
+        "sha512-AAAA",
+        &format!("sha512-{}", "A".repeat(1024 * 1024)),
+        &format!("sha512-{}", "A".repeat(86)),
+        &format!("sha256-{}=", "A".repeat(43)),
+        &format!("sha512-{digest} sha512-{digest}"),
+    ] {
+        let integrity: Integrity = malformed.parse().unwrap();
+        assert_eq!(integrity_addressed_tarball_path(&integrity), None, "{malformed}");
+    }
 }

--- a/pnpm/crates/crypto-hash/src/tests.rs
+++ b/pnpm/crates/crypto-hash/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     create_hash, create_hash_from_file, create_hex_hash, create_hex_hash_bytes,
-    create_hex_hash_from_file, create_short_hash, integrity_addressed_tarball_path,
-    shorten_virtual_store_name,
+    create_hex_hash_from_file, create_short_hash, integrity_addressed_tarball_integrity,
+    integrity_addressed_tarball_path, shorten_virtual_store_name,
 };
 use ssri::Integrity;
 
@@ -99,5 +99,25 @@ fn integrity_address_requires_one_complete_canonical_sha512_hash() {
     ] {
         let integrity: Integrity = malformed.parse().unwrap();
         assert_eq!(integrity_addressed_tarball_path(&integrity), None, "{malformed}");
+    }
+}
+
+#[test]
+fn integrity_address_digest_round_trips_to_canonical_sha512() {
+    let digest = "A".repeat(86);
+    let integrity = integrity_addressed_tarball_integrity(&digest).unwrap();
+    assert_eq!(
+        integrity_addressed_tarball_path(&integrity),
+        Some(format!("-/tarballs/sha512/{digest}")),
+    );
+
+    for malformed in [
+        "A".repeat(85),
+        "A".repeat(87),
+        format!("{}=", "A".repeat(85)),
+        format!("{}+", "A".repeat(85)),
+        format!("{}!", "A".repeat(85)),
+    ] {
+        assert_eq!(integrity_addressed_tarball_integrity(&malformed), None, "{malformed}");
     }
 }

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -93,6 +93,7 @@ fn side_effects_key_for_git_hosted_tarball_matches_warm_lookup() {
     let resolution = pnpm_lockfile::LockfileResolution::Tarball(pnpm_lockfile::TarballResolution {
         tarball: pkg_id.to_string(),
         integrity: Some(integrity.parse().expect("parse integrity")),
+        revision: None,
         git_hosted: Some(true),
         path: None,
     });
@@ -916,6 +917,7 @@ fn using_side_effects_cache_skips_rebuild() {
                         integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                             .parse()
                             .expect("parse integrity"),
+                        revision: None,
                     },
                 ),
                 version: None,
@@ -1059,6 +1061,7 @@ fn corrupt_side_effects_cache_falls_back_to_rebuild() {
                         integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                             .parse()
                             .expect("parse integrity"),
+                        revision: None,
                     },
                 ),
                 version: None,
@@ -1175,6 +1178,7 @@ fn materialization_failure_on_incomplete_slot_is_fatal() {
                         integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                             .parse()
                             .expect("parse integrity"),
+                        revision: None,
                     },
                 ),
                 version: None,
@@ -1708,6 +1712,7 @@ async fn write_path_populates_side_effects_row() {
                 resolution: pnpm_lockfile::LockfileResolution::Registry(
                     pnpm_lockfile::RegistryResolution {
                         integrity: integrity_str.parse().expect("parse integrity"),
+                        revision: None,
                     },
                 ),
                 version: None,
@@ -1869,6 +1874,7 @@ async fn write_path_disabled_skips_upload() {
                 resolution: pnpm_lockfile::LockfileResolution::Registry(
                     pnpm_lockfile::RegistryResolution {
                         integrity: integrity_str.parse().expect("parse integrity"),
+                        revision: None,
                     },
                 ),
                 version: None,
@@ -1976,6 +1982,7 @@ async fn frozen_store_skips_side_effects_upload() {
                 resolution: pnpm_lockfile::LockfileResolution::Registry(
                     pnpm_lockfile::RegistryResolution {
                         integrity: integrity_str.parse().expect("parse integrity"),
+                        revision: None,
                     },
                 ),
                 version: None,
@@ -2105,6 +2112,7 @@ async fn upload_error_does_not_interrupt_install() {
                 resolution: pnpm_lockfile::LockfileResolution::Registry(
                     pnpm_lockfile::RegistryResolution {
                         integrity: integrity_str.parse().expect("parse integrity"),
+                        revision: None,
                     },
                 ),
                 version: None,
@@ -2310,6 +2318,7 @@ async fn write_path_cache_key_includes_patch_hash() {
                 resolution: pnpm_lockfile::LockfileResolution::Registry(
                     pnpm_lockfile::RegistryResolution {
                         integrity: integrity_str.parse().expect("parse integrity"),
+                        revision: None,
                     },
                 ),
                 version: None,

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -22,6 +22,7 @@ fn metadata_with_integrity(integrity: &str) -> PackageMetadata {
     PackageMetadata {
         resolution: LockfileResolution::Registry(RegistryResolution {
             integrity: integrity.parse().expect("parse integrity"),
+            revision: None,
         }),
         version: None,
         engines: None,
@@ -662,6 +663,7 @@ fn git_hosted_tarball_metadata() -> PackageMetadata {
             tarball: "https://codeload.github.com/foo/bar/tar.gz/f43f6a1cefff47fb361c88cf4b943fdbcaafe540"
                 .to_string(),
             integrity: None,
+            revision: None,
             git_hosted: Some(true),
             path: None,
         }),
@@ -733,6 +735,7 @@ fn tarball_metadata_without_integrity() -> PackageMetadata {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz".to_string(),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/deps-restorer/src/current_lockfile/tests.rs
+++ b/pnpm/crates/deps-restorer/src/current_lockfile/tests.rs
@@ -58,6 +58,7 @@ fn package_metadata(name: &str) -> PackageMetadata {
         resolution: LockfileResolution::Tarball(TarballResolution {
             integrity: None,
             tarball: format!("https://example.test/{name}.tgz"),
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/deps-restorer/src/deps_graph/tests.rs
+++ b/pnpm/crates/deps-restorer/src/deps_graph/tests.rs
@@ -29,7 +29,10 @@ fn integrity() -> Integrity {
 
 fn registry_metadata() -> PackageMetadata {
     PackageMetadata {
-        resolution: LockfileResolution::Registry(RegistryResolution { integrity: integrity() }),
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity(),
+            revision: None,
+        }),
         version: None,
         engines: None,
         cpu: None,

--- a/pnpm/crates/deps-restorer/src/hoist/tests.rs
+++ b/pnpm/crates/deps-restorer/src/hoist/tests.rs
@@ -41,7 +41,10 @@ fn integrity() -> Integrity {
 
 fn metadata(has_bin: bool) -> PackageMetadata {
     PackageMetadata {
-        resolution: LockfileResolution::Registry(RegistryResolution { integrity: integrity() }),
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity(),
+            revision: None,
+        }),
         version: None,
         engines: None,
         cpu: None,

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
@@ -13,7 +13,9 @@ use pnpm_git_fetcher::{GitFetchOutput, GitFetcher, GitFetcherError, GitHostedTar
 use pnpm_graph_hasher::{host_arch, host_libc, host_platform};
 use pnpm_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, LockfileResolution,
-    PackageKey, PackageMetadata, PlatformSelector, SnapshotEntry, is_git_hosted_tarball_url,
+    PackageKey, PackageMetadata, PlatformSelector, SnapshotEntry, TarballUrlOptions,
+    integrity_addressed_registry_tarball_url, is_git_hosted_tarball_url,
+    is_integrity_addressed_registry_tarball_url, npm_tarball_url, registry_server_type,
     select_platform_variant,
 };
 use pnpm_network::ThrottledClient;
@@ -176,13 +178,19 @@ pub enum InstallPackageBySnapshotError {
     MissingTarballIntegrity { package_key: String },
 
     #[display(
-        "Cannot install package \"{package_key}\": it was resolved from the named registry '{registry_name}:', which is not present in the namedRegistries setting."
+        "Cannot install package \"{package_key}\": its registry prefix '{registry_name}:' is not declared by the registries setting."
     )]
     #[diagnostic(
         code(ERR_PNPM_MISSING_NAMED_REGISTRY),
-        help("Add '{registry_name}' to the namedRegistries setting in pnpm-workspace.yaml.")
+        help("Add a registries entry with \"prefix: {registry_name}\" to pnpm-workspace.yaml.")
     )]
     MissingNamedRegistry { package_key: String, registry_name: String },
+
+    #[display(
+        "Cannot install package \"{package_key}\": its lockfile entry with a revision {reason}."
+    )]
+    #[diagnostic(code(ERR_PNPM_INVALID_TARBALL_REVISION))]
+    InvalidTarballRevision { package_key: String, reason: &'static str },
 
     #[display(
         "Package `{package_key}` uses a `{resolution_kind}` resolution, which pnpm does not yet support."
@@ -420,6 +428,11 @@ impl InstallPackageBySnapshot<'_> {
         let cas_paths = match (custom_cas_paths, resolution) {
             (Some(paths), _) => paths,
             (None, LockfileResolution::Tarball(_) | LockfileResolution::Registry(_)) => {
+                let revision_addressed = match resolution {
+                    LockfileResolution::Tarball(tarball) => tarball.revision.is_some(),
+                    LockfileResolution::Registry(registry) => registry.revision.is_some(),
+                    _ => false,
+                };
                 let (tarball_url, integrity) =
                     tarball_url_and_integrity(resolution, package_key, config)?;
                 let tarball_url = local_file_tarball_install_url(tarball_url, self.workspace_root);
@@ -450,13 +463,24 @@ impl InstallPackageBySnapshot<'_> {
                         // `clone()` is cheap (refs + `Arc`s) and lets us
                         // retry through `run_without_mem_cache` below if
                         // the shared download failed.
-                        match download.clone().run_with_mem_cache::<Reporter>(mem_cache).await {
+                        let result = if revision_addressed {
+                            download
+                                .clone()
+                                .run_revision_addressed_with_mem_cache::<Reporter>(mem_cache)
+                                .await
+                        } else {
+                            download.clone().run_with_mem_cache::<Reporter>(mem_cache).await
+                        };
+                        match result {
                             Ok(cas_paths) => Ok((*cas_paths).clone()),
-                            Err(TarballError::SiblingFetchFailed { .. }) => {
+                            Err(TarballError::SiblingFetchFailed { .. }) if !revision_addressed => {
                                 download.run_without_mem_cache::<Reporter>().await
                             }
                             Err(err) => Err(err),
                         }
+                    }
+                    _ if revision_addressed => {
+                        download.run_revision_addressed_without_mem_cache::<Reporter>().await
                     }
                     _ => download.run_without_mem_cache::<Reporter>().await,
                 }
@@ -744,6 +768,27 @@ pub fn tarball_url_and_integrity<'a>(
         LockfileResolution::Tarball(tarball_resolution) => {
             let tarball_url = tarball_resolution.tarball.as_str();
             let integrity = resolution.checkable_integrity();
+            if tarball_resolution.revision.is_some() {
+                if tarball_url.starts_with("file:") || tarball_resolution.is_git_hosted() {
+                    return Err(invalid_tarball_revision(
+                        package_key,
+                        "does not identify a registry tarball",
+                    ));
+                }
+                let Some(integrity) = integrity else {
+                    return Err(invalid_tarball_revision(
+                        package_key,
+                        "has invalid or missing integrity",
+                    ));
+                };
+                let (registry, _) = registry_and_version(package_key, config)?;
+                if !is_integrity_addressed_registry_tarball_url(tarball_url, integrity, &registry) {
+                    return Err(invalid_tarball_revision(
+                        package_key,
+                        "has a mismatched tarball URL",
+                    ));
+                }
+            }
             if integrity.is_none() && !unverified_fetch_is_allowed(tarball_url) {
                 return Err(InstallPackageBySnapshotError::MissingTarballIntegrity {
                     package_key: package_key.to_string(),
@@ -751,41 +796,36 @@ pub fn tarball_url_and_integrity<'a>(
             }
             Ok((tarball_url.pipe(Cow::Borrowed), integrity))
         }
-        LockfileResolution::Registry(_) => {
+        LockfileResolution::Registry(registry_resolution) => {
             let Some(integrity) = resolution.checkable_integrity() else {
+                if registry_resolution.revision.is_some() {
+                    return Err(invalid_tarball_revision(
+                        package_key,
+                        "has invalid or missing integrity",
+                    ));
+                }
                 return Err(InstallPackageBySnapshotError::MissingTarballIntegrity {
                     package_key: package_key.to_string(),
                 });
             };
-            let name = package_key.name.to_string();
-            // A registry-qualified key (`<name>@<registryName>:<version>`)
-            // reconstructs its tarball from its named registry; everything
-            // else routes by scope.
-            let (registry, version) =
-                if let Some((registry_name, version)) = package_key.suffix.registry_qualified() {
-                    let registry = pnpm_resolving_npm_resolver::BUILTIN_REGISTRIES_BY_PREFIX
-                        .iter()
-                        .find(|(name, _)| *name == registry_name)
-                        .map(|(_, url)| (*url).to_string())
-                        .pipe(|builtin| {
-                            config.registries_by_prefix.get(registry_name).cloned().or(builtin)
-                        })
-                        .ok_or_else(|| InstallPackageBySnapshotError::MissingNamedRegistry {
-                            package_key: package_key.to_string(),
-                            registry_name: registry_name.to_string(),
-                        })?;
-                    (registry, version.to_string())
-                } else {
-                    let registries: HashMap<String, String> =
-                        config.resolved_registries().into_iter().collect();
-                    (
-                        pick_registry_for_package(&registries, &name, None),
-                        package_key.suffix.version().to_string(),
-                    )
-                };
-            let registry = registry.strip_suffix('/').unwrap_or(&registry);
-            let bare_name = package_key.name.bare.as_str();
-            let tarball_url = format!("{registry}/{name}/-/{bare_name}-{version}.tgz");
+            let (registry, version) = registry_and_version(package_key, config)?;
+            let tarball_url = match registry_resolution.revision {
+                Some(_) => integrity_addressed_registry_tarball_url(integrity, &registry)
+                    .ok_or_else(|| {
+                        invalid_tarball_revision(package_key, "has invalid or missing integrity")
+                    })?,
+                None => npm_tarball_url(
+                    &package_key.name.to_string(),
+                    &version,
+                    TarballUrlOptions {
+                        registry: &registry,
+                        server_type: registry_server_type(
+                            &config.registry_options_by_url,
+                            &registry,
+                        ),
+                    },
+                ),
+            };
             Ok((Cow::Owned(tarball_url), Some(integrity)))
         }
         // Caller (`run`) only invokes this helper for the tarball /
@@ -798,6 +838,40 @@ pub fn tarball_url_and_integrity<'a>(
         | LockfileResolution::Custom(_) => {
             unreachable!("tarball_url_and_integrity called with non-tarball resolution");
         }
+    }
+}
+
+fn registry_and_version(
+    package_key: &PackageKey,
+    config: &Config,
+) -> Result<(String, String), InstallPackageBySnapshotError> {
+    if let Some((registry_name, version)) = package_key.suffix.registry_qualified() {
+        let registry = pnpm_resolving_npm_resolver::BUILTIN_REGISTRIES_BY_PREFIX
+            .iter()
+            .find(|(name, _)| *name == registry_name)
+            .map(|(_, url)| (*url).to_string())
+            .pipe(|builtin| config.registries_by_prefix.get(registry_name).cloned().or(builtin))
+            .ok_or_else(|| InstallPackageBySnapshotError::MissingNamedRegistry {
+                package_key: package_key.to_string(),
+                registry_name: registry_name.to_string(),
+            })?;
+        return Ok((registry, version.to_string()));
+    }
+    let name = package_key.name.to_string();
+    let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
+    Ok((
+        pick_registry_for_package(&registries, &name, None),
+        package_key.suffix.version().to_string(),
+    ))
+}
+
+fn invalid_tarball_revision(
+    package_key: &PackageKey,
+    reason: &'static str,
+) -> InstallPackageBySnapshotError {
+    InstallPackageBySnapshotError::InvalidTarballRevision {
+        package_key: package_key.to_string(),
+        reason,
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
@@ -10,7 +10,7 @@ use pnpm_graph_hasher::{host_arch, host_libc, host_platform};
 use pnpm_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, LockfileResolution,
     PackageKey, PlatformAssetResolution, PlatformAssetTarget, RegistryResolution,
-    TarballResolution,
+    TarballResolution, TarballRevision,
 };
 use pnpm_package_is_installable::SupportedArchitectures;
 use pnpm_reporter::{LogEvent, ProgressMessage, Reporter};
@@ -56,13 +56,102 @@ fn registry_resolution_uses_scoped_registry_tarball_base() {
         .insert("@private".to_string(), "https://private.example/npm/".to_string());
 
     let integrity = DUMMY_SHA512.parse().expect("parse integrity");
-    let resolution = LockfileResolution::Registry(RegistryResolution { integrity });
+    let resolution = LockfileResolution::Registry(RegistryResolution { integrity, revision: None });
     let package_key: PackageKey = "@private/foo@1.0.0".parse().expect("parse package key");
 
     let (tarball_url, _) = tarball_url_and_integrity(&resolution, &package_key, &config)
         .expect("a registry resolution is always fetchable");
 
     assert_eq!(tarball_url.as_ref(), "https://private.example/npm/@private/foo/-/foo-1.0.0.tgz");
+}
+
+#[test]
+fn registry_revision_uses_the_scoped_registry_digest_route() {
+    let mut config = Config::new();
+    config.registry = "https://default.example/npm/".to_string();
+    config
+        .registries_by_scope
+        .insert("@private".to_string(), "https://private.example/npm/".to_string());
+    let resolution = LockfileResolution::Registry(RegistryResolution {
+        integrity: DUMMY_SHA512.parse().expect("parse integrity"),
+        revision: Some(TarballRevision::try_from(2).unwrap()),
+    });
+    let package_key: PackageKey = "@private/foo@1.0.0".parse().expect("parse package key");
+
+    let (tarball_url, _) = tarball_url_and_integrity(&resolution, &package_key, &config)
+        .expect("a revision with complete integrity is fetchable");
+
+    assert_eq!(
+        tarball_url.as_ref(),
+        format!("https://private.example/npm/-/tarballs/sha512/{}", "A".repeat(86)),
+    );
+}
+
+#[test]
+fn registry_revision_uses_the_registry_declared_for_its_prefix() {
+    let mut config = Config::new();
+    config
+        .registries_by_prefix
+        .insert("work".to_string(), "https://registry.example/workspace/npm/".to_string());
+    let resolution = LockfileResolution::Registry(RegistryResolution {
+        integrity: DUMMY_SHA512.parse().expect("parse integrity"),
+        revision: Some(TarballRevision::try_from(4).unwrap()),
+    });
+    let package_key: PackageKey = "foo@work:1.0.0".parse().expect("parse package key");
+
+    let (tarball_url, _) = tarball_url_and_integrity(&resolution, &package_key, &config)
+        .expect("a prefixed registry revision is fetchable");
+
+    assert_eq!(
+        tarball_url.as_ref(),
+        format!("https://registry.example/workspace/npm/-/tarballs/sha512/{}", "A".repeat(86)),
+    );
+}
+
+#[test]
+fn tarball_revision_rejects_a_url_outside_its_effective_registry() {
+    let config = Config::new();
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: format!("https://attacker.example/-/tarballs/sha512/{}", "A".repeat(86)),
+        integrity: Some(DUMMY_SHA512.parse().expect("parse integrity")),
+        revision: Some(TarballRevision::try_from(1).unwrap()),
+        git_hosted: None,
+        path: None,
+    });
+    let package_key: PackageKey = "foo@1.0.0".parse().expect("parse package key");
+
+    let err = tarball_url_and_integrity(&resolution, &package_key, &config)
+        .expect_err("a revision URL from another registry must be rejected");
+
+    assert!(
+        matches!(err, InstallPackageBySnapshotError::InvalidTarballRevision { .. }),
+        "got {err:?}",
+    );
+}
+
+#[test]
+fn tarball_revision_rejects_non_registry_tarballs() {
+    let config = Config::new();
+    let package_key: PackageKey = "foo@1.0.0".parse().expect("parse package key");
+    for (tarball, git_hosted) in
+        [("file:../foo.tgz", None), ("https://codeload.github.com/foo/bar/tar.gz/abc", Some(true))]
+    {
+        let resolution = LockfileResolution::Tarball(TarballResolution {
+            tarball: tarball.to_string(),
+            integrity: Some(DUMMY_SHA512.parse().expect("parse integrity")),
+            revision: Some(TarballRevision::try_from(1).unwrap()),
+            git_hosted,
+            path: None,
+        });
+
+        let err = tarball_url_and_integrity(&resolution, &package_key, &config)
+            .expect_err("a revision must identify a registry tarball");
+
+        assert!(
+            matches!(err, InstallPackageBySnapshotError::InvalidTarballRevision { .. }),
+            "got {err:?}",
+        );
+    }
 }
 
 /// The exemption follows the URL, not the lockfile's `gitHosted`
@@ -89,6 +178,7 @@ fn tarball_resolution_without_integrity_resolves_to_an_unverified_download() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: tarball.to_string(),
         integrity: None,
+        revision: None,
         git_hosted: Some(true),
         path: None,
     });
@@ -111,6 +201,7 @@ fn remote_tarball_resolution_without_integrity_is_refused() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: tarball.to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -143,13 +234,17 @@ fn empty_integrity_is_refused_like_a_missing_one() {
             LockfileResolution::Tarball(TarballResolution {
                 tarball: tarball.to_string(),
                 integrity: Some(empty.clone()),
+                revision: None,
                 git_hosted: None,
                 path: None,
             }),
             format!("pkg-from-tarball@{tarball}"),
         ),
         (
-            LockfileResolution::Registry(pnpm_lockfile::RegistryResolution { integrity: empty }),
+            LockfileResolution::Registry(pnpm_lockfile::RegistryResolution {
+                integrity: empty,
+                revision: None,
+            }),
             "acme@1.0.0".to_string(),
         ),
     ];
@@ -463,12 +558,13 @@ fn synthesize_runtime_manifest_preserves_scoped_name() {
 /// fixtures below. The download never runs in these tests (the mem
 /// cache short-circuits, or `offline` blocks), so the exact digest is
 /// irrelevant — it only has to satisfy [`ssri::Integrity`]'s parser.
-const DUMMY_SHA512: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+const DUMMY_SHA512: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
 
 fn registry_metadata() -> pnpm_lockfile::PackageMetadata {
     pnpm_lockfile::PackageMetadata {
         resolution: LockfileResolution::Registry(pnpm_lockfile::RegistryResolution {
             integrity: DUMMY_SHA512.parse().expect("parse integrity"),
+            revision: None,
         }),
         version: None,
         engines: None,
@@ -849,6 +945,7 @@ async fn custom_fetcher_delegate_rewrites_the_resolution() {
     metadata.resolution = LockfileResolution::Tarball(pnpm_lockfile::TarballResolution {
         tarball: "https://original.test/foo-1.0.0.tgz".to_string(),
         integrity: Some(DUMMY_SHA512.parse().expect("parse integrity")),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -1377,6 +1474,7 @@ async fn an_unpinned_delegate_to_a_directory_keeps_its_resolution() {
     let unpinned = LockfileResolution::Tarball(pnpm_lockfile::TarballResolution {
         tarball: "https://registry.test/pkg.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry.rs
@@ -157,6 +157,10 @@ impl InstallPackageFromRegistry<'_> {
         let symlink_path = node_modules_dir.join(alias);
 
         if first_visit {
+            let revision_addressed = matches!(
+                &resolution.resolution,
+                LockfileResolution::Tarball(tarball) if tarball.revision.is_some(),
+            );
             let (tarball_url, integrity) = extract_tarball(&resolution.resolution)?;
             let unpacked_size = manifest_unpacked_size(resolution.manifest.as_deref());
             let file_count = manifest_file_count(resolution.manifest.as_deref());
@@ -170,7 +174,7 @@ impl InstallPackageFromRegistry<'_> {
             }));
 
             // TODO: skip when it already exists in store?
-            let cas_paths = DownloadTarballToStore {
+            let download = DownloadTarballToStore {
                 http_client,
                 store_dir: &config.store_dir,
                 store_index: store_index.cloned(),
@@ -194,9 +198,12 @@ impl InstallPackageFromRegistry<'_> {
                 // dedupe set with it.
                 progress_reported: None,
                 append_manifest: None,
+            };
+            let cas_paths = if revision_addressed {
+                download.run_revision_addressed_with_mem_cache::<Reporter>(tarball_mem_cache).await
+            } else {
+                download.run_with_mem_cache::<Reporter>(tarball_mem_cache).await
             }
-            .run_with_mem_cache::<Reporter>(tarball_mem_cache)
-            .await
             .map_err(InstallPackageFromRegistryError::DownloadTarballToStore)?;
 
             tracing::info!(target: "pacquet::import", ?save_path, ?symlink_path, "Import package");

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -592,6 +592,7 @@ async fn install_returns_unsupported_resolution_when_name_ver_missing() {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: "https://example.com/foo.tar.gz".to_string(),
             integrity: None,
+            revision: None,
             git_hosted: Some(true),
             path: None,
         }),
@@ -672,6 +673,7 @@ async fn install_rejects_traversal_manifest_name() {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: "https://example.com/foo.tar.gz".to_string(),
             integrity: None,
+            revision: None,
             git_hosted: Some(true),
             path: None,
         }),

--- a/pnpm/crates/deps-restorer/src/installability/tests.rs
+++ b/pnpm/crates/deps-restorer/src/installability/tests.rs
@@ -67,6 +67,7 @@ fn synthetic_metadata(
         resolution: LockfileResolution::Tarball(TarballResolution {
             integrity: None,
             tarball: "https://example.test/pkg.tgz".to_string(),
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/deps-restorer/src/link_bins/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_bins/tests.rs
@@ -643,6 +643,7 @@ fn build_has_bin_set_includes_runtime_resolutions_even_when_has_bin_is_absent() 
         metadata_with_resolution(
             LockfileResolution::Registry(RegistryResolution {
                 integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==".parse().expect("parse integrity"),
+                revision: None,
             }),
             Some(true),
         ),
@@ -652,6 +653,7 @@ fn build_has_bin_set_includes_runtime_resolutions_even_when_has_bin_is_absent() 
         metadata_with_resolution(
             LockfileResolution::Registry(RegistryResolution {
                 integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==".parse().expect("parse integrity"),
+                revision: None,
             }),
             None,
         ),

--- a/pnpm/crates/deps-restorer/src/package_map/tests.rs
+++ b/pnpm/crates/deps-restorer/src/package_map/tests.rs
@@ -500,6 +500,7 @@ fn graph_node(name: &str, version: &str, dir: &Path) -> DependenciesGraphNode {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: String::new(),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout/tests.rs
@@ -73,6 +73,7 @@ fn slot_dir_uses_gvs_layout_when_gvs_on() {
                 integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                     .parse()
                     .expect("parse integrity"),
+                revision: None,
             }),
             version: None,
             engines: None,
@@ -127,6 +128,7 @@ fn slot_dir_prefixes_unscoped_with_at_slash_under_gvs() {
                 integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
                     .parse()
                     .expect("parse integrity"),
+                revision: None,
             }),
             version: None,
             engines: None,
@@ -173,6 +175,7 @@ fn slot_dir_engine_agnostic_with_empty_allow_build_policy() {
                 integrity: "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
                     .parse()
                     .expect("parse integrity"),
+                revision: None,
             }),
             version: None,
             engines: None,
@@ -230,6 +233,7 @@ fn slot_dir_engine_specific_when_snapshot_is_built() {
                 integrity: "sha512-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
                     .parse()
                     .expect("parse integrity"),
+                revision: None,
             }),
             version: None,
             engines: None,
@@ -350,6 +354,7 @@ fn cross_pinning_siblings_get_distinct_slots() {
             PackageMetadata {
                 resolution: LockfileResolution::Registry(RegistryResolution {
                     integrity: integrity_str.parse().expect("parse integrity"),
+                    revision: None,
                 }),
                 version: None,
                 engines: None,
@@ -425,6 +430,7 @@ fn full_pkg_id_keeps_patch_hash_when_present() {
                 integrity: "sha512-PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP"
                     .parse()
                     .expect("parse integrity"),
+                revision: None,
             }),
             version: None,
             engines: None,
@@ -473,6 +479,7 @@ fn gvs_version_segment_anchors_directory_deps() {
         LockfileResolution::Tarball(TarballResolution {
             tarball: "file:vendor/dep.tgz".to_string(),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -502,6 +509,7 @@ fn a_file_snapshot_without_metadata_is_still_scoped() {
         LockfileResolution::Tarball(TarballResolution {
             tarball: "file:packages/b".to_string(),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -612,6 +620,7 @@ fn link_hash_matches_the_shared_typescript_fixture() {
         package_metadata(
             LockfileResolution::Registry(RegistryResolution {
                 integrity: fixture.package.integrity.parse().expect("parse fixture integrity"),
+                revision: None,
             }),
             Some(&fixture.package.version),
         ),
@@ -678,6 +687,7 @@ fn snapshots_with_link_deps_get_a_slot_per_link_target() {
             LockfileResolution::Tarball(TarballResolution {
                 tarball: "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz".to_string(),
                 integrity: None,
+                revision: None,
                 git_hosted: None,
                 path: None,
             }),
@@ -795,6 +805,7 @@ fn link_deps_resolving_to_one_directory_share_a_slot_across_projects() {
             LockfileResolution::Tarball(TarballResolution {
                 tarball: "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz".to_string(),
                 integrity: None,
+                revision: None,
                 git_hosted: None,
                 path: None,
             }),
@@ -836,6 +847,7 @@ fn snapshots_without_link_deps_keep_their_slot() {
             LockfileResolution::Tarball(TarballResolution {
                 tarball: "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz".to_string(),
                 integrity: None,
+                revision: None,
                 git_hosted: None,
                 path: None,
             }),
@@ -1104,6 +1116,7 @@ fn registry_metadata(lead: &str) -> PackageMetadata {
     PackageMetadata {
         resolution: LockfileResolution::Registry(RegistryResolution {
             integrity: integrity.parse().expect("parse integrity"),
+            revision: None,
         }),
         version: None,
         engines: None,

--- a/pnpm/crates/env-installer/src/errors.rs
+++ b/pnpm/crates/env-installer/src/errors.rs
@@ -1,6 +1,6 @@
 use derive_more::{Display, Error};
 use pnpm_diagnostics::miette::{self, Diagnostic};
-use pnpm_lockfile::{LoadLockfileError, SaveLockfileError};
+use pnpm_lockfile::{LoadLockfileError, LockfileFormError, SaveLockfileError};
 use pnpm_package_manager::ImportIndexedDirError;
 use pnpm_resolving_resolver_base::ResolveError;
 use pnpm_tarball::TarballError;
@@ -13,6 +13,9 @@ use std::{io, path::PathBuf};
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum ConfigDepError {
+    #[diagnostic(transparent)]
+    LockfileForm(#[error(source)] LockfileFormError),
+
     /// The `ERR_PNPM_CONFIG_DEP_NO_INTEGRITY` error: a config
     /// dependency was declared without an integrity checksum.
     #[display(r#"Your config dependency called "{name}" doesn't have an integrity checksum"#)]

--- a/pnpm/crates/env-installer/src/manifest_lockfile.rs
+++ b/pnpm/crates/env-installer/src/manifest_lockfile.rs
@@ -1,5 +1,6 @@
 use pnpm_lockfile::{
-    BundledDependencies, LockfileFormOptions, PackageMetadata, PeerDependencyMeta, StringOrList,
+    BundledDependencies, LockfileFormError, LockfileFormOptions, PackageMetadata,
+    PeerDependencyMeta, StringOrList,
 };
 use pnpm_resolving_resolver_base::ResolveResult;
 use serde_json::Value;
@@ -11,9 +12,9 @@ pub(crate) fn package_metadata(
     result: &ResolveResult,
     registry: &str,
     lockfile_include_tarball_url: bool,
-) -> PackageMetadata {
+) -> Result<PackageMetadata, LockfileFormError> {
     let manifest = result.manifest.as_deref();
-    PackageMetadata {
+    Ok(PackageMetadata {
         resolution: result.resolution.to_lockfile_form(
             name,
             version,
@@ -22,7 +23,7 @@ pub(crate) fn package_metadata(
                 server_type: None,
                 include_tarball_url: lockfile_include_tarball_url,
             },
-        ),
+        )?,
         version: None,
         engines: read_engines(manifest),
         cpu: read_string_list(manifest, "cpu"),
@@ -37,7 +38,7 @@ pub(crate) fn package_metadata(
         bundled_dependencies: BundledDependencies::from_manifest(manifest),
         peer_dependencies: read_string_map(manifest, "peerDependencies"),
         peer_dependencies_meta: read_peer_dependencies_meta(manifest),
-    }
+    })
 }
 
 pub(crate) fn read_dependency_map(manifest: Option<&Value>, key: &str) -> HashMap<String, String> {

--- a/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/resolve_and_install_config_deps.rs
@@ -180,11 +180,11 @@ async fn resolve_one(
     }
     env_lockfile.packages.insert(
         key.clone(),
-        registry_package_metadata(resolution.to_lockfile_form(
-            name,
-            &version,
-            npm_lockfile_form(registry),
-        )),
+        registry_package_metadata(
+            resolution
+                .to_lockfile_form(name, &version, npm_lockfile_form(registry))
+                .map_err(ConfigDepError::LockfileForm)?,
+        ),
     );
 
     // A pinned dependency covers only itself, so its optional subdeps stay out
@@ -220,10 +220,12 @@ fn migrate_into_lockfile(
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball,
         integrity: Some(integrity),
+        revision: None,
         git_hosted: None,
         path: None,
     })
-    .to_lockfile_form(name, version, npm_lockfile_form(registry));
+    .to_lockfile_form(name, version, npm_lockfile_form(registry))
+    .map_err(ConfigDepError::LockfileForm)?;
     env_lockfile.packages.insert(key.clone(), registry_package_metadata(resolution));
     env_lockfile.snapshots.insert(key, SnapshotEntry::default());
     Ok(())

--- a/pnpm/crates/env-installer/src/resolve_optional_subdeps.rs
+++ b/pnpm/crates/env-installer/src/resolve_optional_subdeps.rs
@@ -91,7 +91,8 @@ pub async fn resolve_optional_subdeps(
 
         env_lockfile.packages.insert(
             pkg_key.clone(),
-            package_metadata(subdep_name, &subdep_version, &result, registry, false),
+            package_metadata(subdep_name, &subdep_version, &result, registry, false)
+                .map_err(ConfigDepError::LockfileForm)?,
         );
         env_lockfile
             .snapshots

--- a/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
+++ b/pnpm/crates/env-installer/src/resolve_package_manager_integrities.rs
@@ -90,7 +90,8 @@ pub async fn resolve_package_manager_integrities(
         }
         let registry = opts.pick_registry(&package.name);
         let mut metadata =
-            package_metadata(&package.name, &package.version, &package.result, registry, false);
+            package_metadata(&package.name, &package.version, &package.result, registry, false)
+                .map_err(ConfigDepError::LockfileForm)?;
         metadata.resolution = strip_registry_tarball_url(metadata.resolution);
         env_lockfile.packages.insert(package.key.clone(), metadata);
 
@@ -144,10 +145,11 @@ fn strip_registry_tarball_url(resolution: LockfileResolution) -> LockfileResolut
         LockfileResolution::Tarball(TarballResolution {
             tarball,
             integrity: Some(integrity),
+            revision: None,
             git_hosted: None | Some(false),
             path: None,
         }) if !tarball.starts_with("file:") => {
-            LockfileResolution::Registry(RegistryResolution { integrity })
+            LockfileResolution::Registry(RegistryResolution { integrity, revision: None })
         }
         other => other,
     }

--- a/pnpm/crates/env-installer/src/tests.rs
+++ b/pnpm/crates/env-installer/src/tests.rs
@@ -213,12 +213,14 @@ impl Resolver for FixtureResolver {
                             "https://mirror-pool-7.example.com/registry/{name}/-/{name}-{version}.tgz",
                         ),
                         integrity: Some(ssri::Integrity::from(id.as_bytes())),
+                        revision: None,
                         git_hosted: None,
                         path: None,
                     })
                 } else {
                     LockfileResolution::Registry(RegistryResolution {
                         integrity: ssri::Integrity::from(id.as_bytes()),
+                        revision: None,
                     })
                 },
                 resolved_via: "npm-registry".to_string(),
@@ -1451,6 +1453,7 @@ fn prune_drops_orphan_packages_and_snapshots() {
         PackageMetadata {
             resolution: LockfileResolution::Registry(RegistryResolution {
                 integrity: ssri::Integrity::from(b"x"),
+                revision: None,
             }),
             version: None,
             engines: None,

--- a/pnpm/crates/lockfile/Cargo.toml
+++ b/pnpm/crates/lockfile/Cargo.toml
@@ -22,6 +22,7 @@ pnpm-resolving-parse-wanted-dependency = { workspace = true }
 derive_more      = { workspace = true }
 indexmap         = { workspace = true }
 libc             = { workspace = true }
+miette           = { workspace = true }
 node-semver      = { workspace = true }
 pipe-trait       = { workspace = true }
 serde            = { workspace = true }
@@ -29,6 +30,7 @@ serde-saphyr     = { workspace = true }
 serde_json       = { workspace = true }
 ssri             = { workspace = true }
 split-first-char = { workspace = true }
+url              = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/lockfile/src/env_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile/tests.rs
@@ -11,6 +11,7 @@ fn pkg_metadata(integrity_source: &[u8]) -> PackageMetadata {
     PackageMetadata {
         resolution: LockfileResolution::Registry(RegistryResolution {
             integrity: ssri::Integrity::from(integrity_source),
+            revision: None,
         }),
         version: None,
         engines: None,

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -1,4 +1,4 @@
-use derive_more::{Display, Error, From, TryInto};
+use derive_more::{Display, Error, From, Into, TryInto};
 use pipe_trait::Pipe;
 use pnpm_crypto_hash::integrity_addressed_tarball_path;
 use pnpm_diagnostics::miette::Diagnostic;
@@ -64,7 +64,9 @@ pub struct RegistryResolution {
 pub const MAX_TARBALL_REVISION: u64 = 9_007_199_254_740_991;
 
 /// A positive registry artifact revision in JavaScript's safe-integer range.
-#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Into,
+)]
 #[serde(try_from = "u64", into = "u64")]
 pub struct TarballRevision(u64);
 
@@ -84,12 +86,6 @@ impl TryFrom<u64> for TarballRevision {
         } else {
             Err(InvalidTarballRevisionError { revision })
         }
-    }
-}
-
-impl From<TarballRevision> for u64 {
-    fn from(revision: TarballRevision) -> Self {
-        revision.0
     }
 }
 

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -1,5 +1,7 @@
-use derive_more::{Display, From, TryInto};
+use derive_more::{Display, Error, From, TryInto};
 use pipe_trait::Pipe;
+use pnpm_crypto_hash::integrity_addressed_tarball_path;
+use pnpm_diagnostics::miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use ssri::Integrity;
 use std::{
@@ -14,6 +16,8 @@ pub struct TarballResolution {
     pub tarball: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub integrity: Option<Integrity>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<TarballRevision>,
     /// `true` for tarballs sourced from a git host (codeload.github.com /
     /// gitlab.com / bitbucket.org). Such tarballs need preparation
     /// (preparePackage / packlist) on extraction, and their cached content
@@ -52,6 +56,63 @@ impl TarballResolution {
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct RegistryResolution {
     pub integrity: Integrity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<TarballRevision>,
+}
+
+/// Largest registry revision every pnpm implementation can represent exactly.
+pub const MAX_TARBALL_REVISION: u64 = 9_007_199_254_740_991;
+
+/// A positive registry artifact revision in JavaScript's safe-integer range.
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(try_from = "u64", into = "u64")]
+pub struct TarballRevision(u64);
+
+impl TarballRevision {
+    #[must_use]
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl TryFrom<u64> for TarballRevision {
+    type Error = InvalidTarballRevisionError;
+
+    fn try_from(revision: u64) -> Result<Self, Self::Error> {
+        if (1..=MAX_TARBALL_REVISION).contains(&revision) {
+            Ok(Self(revision))
+        } else {
+            Err(InvalidTarballRevisionError { revision })
+        }
+    }
+}
+
+impl From<TarballRevision> for u64 {
+    fn from(revision: TarballRevision) -> Self {
+        revision.0
+    }
+}
+
+#[derive(Debug, Display, Error, Clone, Copy)]
+#[display("tarball revision {revision} is not a positive integer at most {MAX_TARBALL_REVISION}")]
+pub struct InvalidTarballRevisionError {
+    pub revision: u64,
+}
+
+/// A resolver-produced tarball revision that cannot be represented as the
+/// compact, integrity-addressed lockfile form required by the RFC.
+#[derive(Debug, Display, Error, Diagnostic, Clone, Copy)]
+#[non_exhaustive]
+pub enum LockfileFormError {
+    #[display("Cannot serialize a tarball revision without integrity.")]
+    #[diagnostic(code(ERR_PNPM_INVALID_TARBALL_REVISION))]
+    RevisionWithoutIntegrity,
+
+    #[display(
+        "Cannot serialize tarball revision {revision}: its URL does not match its integrity and registry."
+    )]
+    #[diagnostic(code(ERR_PNPM_INVALID_TARBALL_REVISION))]
+    RevisionUrlMismatch { revision: TarballRevision },
 }
 
 /// For local directory on a filesystem.
@@ -361,18 +422,30 @@ impl LockfileResolution {
     /// derived URL (e.g. private registries with non-standard tarball paths).
     /// Non-tarball resolutions and integrity-less tarballs pass through
     /// unchanged.
-    #[must_use]
     pub fn to_lockfile_form(
         &self,
         name: &str,
         version: &str,
         opts: LockfileFormOptions<'_>,
-    ) -> LockfileResolution {
+    ) -> Result<LockfileResolution, LockfileFormError> {
         let LockfileFormOptions { registry, server_type, include_tarball_url } = opts;
-        let LockfileResolution::Tarball(tarball) = self else { return self.clone() };
-        let Some(integrity) = tarball.integrity.as_ref() else { return self.clone() };
+        let LockfileResolution::Tarball(tarball) = self else { return Ok(self.clone()) };
+        let Some(integrity) = tarball.integrity.as_ref() else {
+            return if tarball.revision.is_some() {
+                Err(LockfileFormError::RevisionWithoutIntegrity)
+            } else {
+                Ok(self.clone())
+            };
+        };
 
         let git_hosted = tarball.is_git_hosted();
+        let integrity_addressed =
+            is_integrity_addressed_registry_tarball_url(&tarball.tarball, integrity, registry);
+        if let Some(revision) = tarball.revision
+            && !integrity_addressed
+        {
+            return Err(LockfileFormError::RevisionUrlMismatch { revision });
+        }
         // A standard registry tarball whose URL can be rebuilt from name+version+
         // registry is written as just `{integrity}` — pnpm derives the URL on
         // demand. Every other tarball must keep its URL or it can no longer be
@@ -380,6 +453,7 @@ impl LockfileResolution {
         // tarballs, and non-standard registry URLs (npm Enterprise, GitHub Packages
         // `/download/` URLs). `include_tarball_url` forces the URL to be kept.
         if !include_tarball_url
+            && tarball.revision.is_none()
             && !git_hosted
             && !tarball.tarball.starts_with("file:")
             && is_canonical_registry_tarball_url(
@@ -389,20 +463,28 @@ impl LockfileResolution {
                 TarballUrlOptions { registry, server_type },
             )
         {
-            return LockfileResolution::Registry(RegistryResolution {
+            return Ok(LockfileResolution::Registry(RegistryResolution {
                 integrity: integrity.clone(),
-            });
+                revision: tarball.revision,
+            }));
+        }
+        if !git_hosted && !tarball.tarball.starts_with("file:") && integrity_addressed {
+            return Ok(LockfileResolution::Registry(RegistryResolution {
+                integrity: integrity.clone(),
+                revision: tarball.revision,
+            }));
         }
         // The kept-URL form carries the `git_hosted` marker and the subdirectory
         // `path` (`repo#commit&path:/sub/dir`, only ever set on git-hosted tarballs)
         // so a git-hosted monorepo tarball still unpacks the right subfolder.
         // See <https://github.com/pnpm/pnpm/issues/12304>.
-        LockfileResolution::Tarball(TarballResolution {
+        Ok(LockfileResolution::Tarball(TarballResolution {
             tarball: tarball.tarball.clone(),
             integrity: Some(integrity.clone()),
+            revision: tarball.revision,
             git_hosted: git_hosted.then_some(true),
             path: tarball.path.clone(),
-        })
+        }))
     }
 }
 
@@ -543,6 +625,34 @@ pub struct LockfileFormOptions<'a> {
     pub server_type: Option<RegistryServerType>,
     /// Keep the tarball URL even when it is reconstructible.
     pub include_tarball_url: bool,
+}
+
+/// Build an integrity-addressed tarball URL relative to `registry`.
+#[must_use]
+pub fn integrity_addressed_registry_tarball_url(
+    integrity: &Integrity,
+    registry: &str,
+) -> Option<String> {
+    let path = integrity_addressed_tarball_path(integrity)?;
+    let registry =
+        if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") };
+    url::Url::parse(&registry).ok()?.join(&path).ok().map(Into::into)
+}
+
+/// Whether `tarball` is the exact digest route derived from `registry` and `integrity`.
+#[must_use]
+pub fn is_integrity_addressed_registry_tarball_url(
+    tarball: &str,
+    integrity: &Integrity,
+    registry: &str,
+) -> bool {
+    let Some(expected) = integrity_addressed_registry_tarball_url(integrity, registry) else {
+        return false;
+    };
+    match (url::Url::parse(tarball), url::Url::parse(&expected)) {
+        (Ok(actual), Ok(expected)) => actual == expected,
+        _ => false,
+    }
 }
 
 /// Derive the canonical npm registry tarball URL for `name@version`. Port of

--- a/pnpm/crates/lockfile/src/resolution.rs
+++ b/pnpm/crates/lockfile/src/resolution.rs
@@ -642,6 +642,9 @@ pub fn is_integrity_addressed_registry_tarball_url(
     integrity: &Integrity,
     registry: &str,
 ) -> bool {
+    if !tarball.contains("/-/tarballs/sha512/") {
+        return false;
+    }
     let Some(expected) = integrity_addressed_registry_tarball_url(integrity, registry) else {
         return false;
     };

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -813,6 +813,11 @@ fn integrity_addressed_tarball_url_is_relative_to_the_declared_registry() {
         &integrity(REVISION_SHA512),
         registry,
     ));
+    assert!(!is_integrity_addressed_registry_tarball_url(
+        "https://registry.example.test/npm/private/foo/-/foo-1.0.0.tgz",
+        &integrity(REVISION_SHA512),
+        registry,
+    ));
 }
 
 #[test]

--- a/pnpm/crates/lockfile/src/resolution/tests.rs
+++ b/pnpm/crates/lockfile/src/resolution/tests.rs
@@ -1,9 +1,11 @@
 use super::{
     BinaryArchive, BinaryResolution, BinarySpec, DirectoryResolution, GitResolution,
-    LockfileFormOptions, LockfileResolution, PlatformAssetResolution, PlatformAssetTarget,
-    PlatformSelector, RegistryOptions, RegistryResolution, RegistryServerType, TarballResolution,
-    TarballUrlOptions, VariationsResolution, is_git_hosted_tarball_url, libc_matches,
-    npm_tarball_url, registry_server_type, select_platform_variant,
+    LockfileFormError, LockfileFormOptions, LockfileResolution, PlatformAssetResolution,
+    PlatformAssetTarget, PlatformSelector, RegistryOptions, RegistryResolution, RegistryServerType,
+    TarballResolution, TarballRevision, TarballUrlOptions, VariationsResolution,
+    integrity_addressed_registry_tarball_url, is_git_hosted_tarball_url,
+    is_integrity_addressed_registry_tarball_url, libc_matches, npm_tarball_url,
+    registry_server_type, select_platform_variant,
 };
 use crate::serialize_yaml;
 use pretty_assertions::assert_eq;
@@ -70,6 +72,7 @@ fn deserialize_tarball_resolution() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -85,6 +88,7 @@ fn deserialize_tarball_resolution() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -103,6 +107,7 @@ fn deserialize_tarball_resolution_with_git_hosted() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: Some(true),
         path: None,
     });
@@ -122,6 +127,7 @@ fn is_git_hosted_follows_the_url_over_a_contradicting_flag() {
         let resolution = TarballResolution {
             tarball: git_hosted_url.clone(),
             integrity: None,
+            revision: None,
             git_hosted: flag,
             path: None,
         };
@@ -131,6 +137,7 @@ fn is_git_hosted_follows_the_url_over_a_contradicting_flag() {
     let plain = TarballResolution {
         tarball: "https://example.com/pkg-1.0.0.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     };
@@ -146,6 +153,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("https://codeload.github.com/foo/bar/tar.gz/{GIT_COMMIT}"),
         integrity: None,
+        revision: None,
         git_hosted: Some(true),
         path: None,
     });
@@ -161,6 +169,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
             "https://gitlab.com/foo/bar/-/archive/{GIT_COMMIT}/bar-{GIT_COMMIT}.tar.gz",
         ),
         integrity: None,
+        revision: None,
         git_hosted: Some(true),
         path: None,
     });
@@ -172,6 +181,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("https://bitbucket.org/foo/bar/get/{GIT_COMMIT}.tar.gz"),
         integrity: None,
+        revision: None,
         git_hosted: Some(true),
         path: None,
     });
@@ -185,6 +195,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -198,6 +209,7 @@ fn deserialize_tarball_resolution_backfills_git_hosted() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/zip/abc1234".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -249,6 +261,7 @@ fn serialize_tarball_resolution() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -261,6 +274,7 @@ fn serialize_tarball_resolution() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "file:ts-pipe-compose-0.2.1.tgz".to_string(),
         integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -281,6 +295,7 @@ fn deserialize_tarball_resolution_with_path() {
     let expected = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: Some(true),
         path: Some("packages/sub".to_string()),
     });
@@ -292,6 +307,7 @@ fn serialize_tarball_resolution_with_path() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: Some(true),
         path: Some("packages/sub".to_string()),
     });
@@ -306,6 +322,7 @@ fn serialize_tarball_resolution_with_git_hosted() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: integrity("sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==").into(),
+        revision: None,
         git_hosted: Some(true),
         path: None,
     });
@@ -326,6 +343,7 @@ fn deserialize_registry_resolution() {
         integrity: integrity(
             "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
         ),
+        revision: None,
     });
     assert_eq!(received, expected);
 }
@@ -336,11 +354,37 @@ fn serialize_registry_resolution() {
         integrity: integrity(
             "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==",
         ),
+        revision: None,
     });
     let received = render_resolution(&resolution);
     eprintln!("RECEIVED:\n{received}");
     let expected = "resolution: {integrity: sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==}";
     assert_eq!(received, expected);
+}
+
+#[test]
+fn registry_revision_round_trips_in_the_compact_lockfile_form() {
+    let resolution: LockfileResolution =
+        serde_saphyr::from_str(&format!("integrity: {REVISION_SHA512}\nrevision: 2"))
+            .expect("deserialize registry revision");
+    let expected = LockfileResolution::Registry(RegistryResolution {
+        integrity: integrity(REVISION_SHA512),
+        revision: Some(TarballRevision::try_from(2).unwrap()),
+    });
+    assert_eq!(resolution, expected);
+    assert_eq!(
+        render_resolution(&resolution),
+        format!("resolution: {{integrity: {REVISION_SHA512}, revision: 2}}"),
+    );
+}
+
+#[test]
+fn registry_revision_rejects_values_outside_the_positive_safe_integer_range() {
+    for revision in ["0", "-1", "1.5", "9007199254740992", "'1'"] {
+        let yaml = format!("integrity: {REVISION_SHA512}\nrevision: {revision}");
+        let result = serde_saphyr::from_str::<LockfileResolution>(&yaml);
+        assert!(result.is_err(), "revision {revision} must be rejected; got {result:?}");
+    }
 }
 
 #[test]
@@ -749,6 +793,110 @@ fn libc_matches_truth_table() {
 }
 
 const SHA512: &str = "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg==";
+const REVISION_SHA512: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+
+#[test]
+fn integrity_addressed_tarball_url_is_relative_to_the_declared_registry() {
+    let registry = "https://registry.example.test/npm/private";
+    let expected = format!("{registry}/-/tarballs/sha512/{}", "A".repeat(86));
+    assert_eq!(
+        integrity_addressed_registry_tarball_url(&integrity(REVISION_SHA512), registry),
+        Some(expected.clone()),
+    );
+    assert!(is_integrity_addressed_registry_tarball_url(
+        &expected,
+        &integrity(REVISION_SHA512),
+        registry,
+    ));
+    assert!(!is_integrity_addressed_registry_tarball_url(
+        &format!("{expected}?token=untrusted"),
+        &integrity(REVISION_SHA512),
+        registry,
+    ));
+}
+
+#[test]
+fn to_lockfile_form_always_compacts_an_integrity_addressed_revision() {
+    let registry = "https://registry.example.test/npm/private/";
+    let tarball = integrity_addressed_registry_tarball_url(&integrity(REVISION_SHA512), registry)
+        .expect("complete sha512 integrity");
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball,
+        integrity: Some(integrity(REVISION_SHA512)),
+        revision: Some(TarballRevision::try_from(3).unwrap()),
+        git_hosted: None,
+        path: None,
+    });
+    assert_eq!(
+        resolution.to_lockfile_form("foo", "1.0.0", undeclared_form(registry, true)).unwrap(),
+        LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity(REVISION_SHA512),
+            revision: Some(TarballRevision::try_from(3).unwrap()),
+        }),
+    );
+}
+
+#[test]
+fn to_lockfile_form_always_normalizes_an_integrity_addressed_url_without_a_revision() {
+    let registry = "https://registry.example.test/npm/private/";
+    let tarball = integrity_addressed_registry_tarball_url(&integrity(REVISION_SHA512), registry)
+        .expect("complete sha512 integrity");
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball,
+        integrity: Some(integrity(REVISION_SHA512)),
+        revision: None,
+        git_hosted: None,
+        path: None,
+    });
+
+    assert_eq!(
+        resolution.to_lockfile_form("foo", "1.0.0", undeclared_form(registry, true)).unwrap(),
+        LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity(REVISION_SHA512),
+            revision: None,
+        }),
+    );
+}
+
+#[test]
+fn to_lockfile_form_rejects_a_revision_with_a_mismatched_url() {
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: format!("https://attacker.example/-/tarballs/sha512/{}", "A".repeat(86)),
+        integrity: Some(integrity(REVISION_SHA512)),
+        revision: Some(TarballRevision::try_from(3).unwrap()),
+        git_hosted: None,
+        path: None,
+    });
+
+    assert!(matches!(
+        resolution.to_lockfile_form(
+            "foo",
+            "1.0.0",
+            undeclared_form("https://registry.example.test/", false),
+        ),
+        Err(LockfileFormError::RevisionUrlMismatch { .. }),
+    ));
+}
+
+#[test]
+fn to_lockfile_form_rejects_a_revision_without_integrity() {
+    let resolution = LockfileResolution::Tarball(TarballResolution {
+        tarball: "https://registry.example.test/-/tarballs/sha512/digest".to_string(),
+        integrity: None,
+        revision: Some(TarballRevision::try_from(3).unwrap()),
+        git_hosted: None,
+        path: None,
+    });
+
+    assert!(matches!(
+        resolution.to_lockfile_form(
+            "foo",
+            "1.0.0",
+            undeclared_form("https://registry.example.test/", false),
+        ),
+        Err(LockfileFormError::RevisionWithoutIntegrity),
+    ));
+}
 
 /// A reconstructible registry tarball URL is dropped, leaving only the
 /// integrity, so the path-preserving cases below are not just returning the
@@ -758,17 +906,19 @@ fn to_lockfile_form_drops_reconstructible_registry_tarball() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz".to_string(),
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: None,
         path: None,
     });
-    let actual = resolution.to_lockfile_form(
-        "foo",
-        "1.0.0",
-        undeclared_form("https://registry.npmjs.org/", false),
-    );
+    let actual = resolution
+        .to_lockfile_form("foo", "1.0.0", undeclared_form("https://registry.npmjs.org/", false))
+        .unwrap();
     assert_eq!(
         actual,
-        LockfileResolution::Registry(RegistryResolution { integrity: integrity(SHA512) }),
+        LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity(SHA512),
+            revision: None
+        }),
     );
 }
 
@@ -781,14 +931,13 @@ fn to_lockfile_form_keeps_git_hosted_subdirectory_path() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: Some(true),
         path: Some("/packages/foo".to_string()),
     });
-    let actual = resolution.to_lockfile_form(
-        "foo",
-        "1.0.0",
-        undeclared_form("https://registry.npmjs.org/", false),
-    );
+    let actual = resolution
+        .to_lockfile_form("foo", "1.0.0", undeclared_form("https://registry.npmjs.org/", false))
+        .unwrap();
     assert_eq!(actual, resolution);
 }
 
@@ -799,14 +948,13 @@ fn to_lockfile_form_keeps_git_hosted_subdirectory_path_when_including_tarball_ur
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://codeload.github.com/foo/bar/tar.gz/abc1234".to_string(),
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: Some(true),
         path: Some("/packages/foo".to_string()),
     });
-    let actual = resolution.to_lockfile_form(
-        "foo",
-        "1.0.0",
-        undeclared_form("https://registry.npmjs.org/", true),
-    );
+    let actual = resolution
+        .to_lockfile_form("foo", "1.0.0", undeclared_form("https://registry.npmjs.org/", true))
+        .unwrap();
     assert_eq!(actual, resolution);
 }
 
@@ -819,14 +967,17 @@ fn to_lockfile_form_keeps_scoped_tarball_with_percent_encoded_scope_separator() 
         let resolution = LockfileResolution::Tarball(TarballResolution {
             tarball: tarball_url.to_string(),
             integrity: Some(integrity(SHA512)),
+            revision: None,
             git_hosted: None,
             path: None,
         });
-        let actual = resolution.to_lockfile_form(
-            "@babel/core",
-            "7.0.0",
-            undeclared_form("https://npm.example.com/", false),
-        );
+        let actual = resolution
+            .to_lockfile_form(
+                "@babel/core",
+                "7.0.0",
+                undeclared_form("https://npm.example.com/", false),
+            )
+            .unwrap();
         assert_eq!(actual, resolution, "{tarball_url} must survive verbatim");
     }
 }
@@ -840,17 +991,23 @@ fn to_lockfile_form_drops_scoped_tarball_with_percent_encoding_on_the_public_reg
         let resolution = LockfileResolution::Tarball(TarballResolution {
             tarball: tarball_url.to_string(),
             integrity: Some(integrity(SHA512)),
+            revision: None,
             git_hosted: None,
             path: None,
         });
-        let actual = resolution.to_lockfile_form(
-            "@babel/core",
-            "7.0.0",
-            undeclared_form("https://registry.npmjs.org/", false),
-        );
+        let actual = resolution
+            .to_lockfile_form(
+                "@babel/core",
+                "7.0.0",
+                undeclared_form("https://registry.npmjs.org/", false),
+            )
+            .unwrap();
         assert_eq!(
             actual,
-            LockfileResolution::Registry(RegistryResolution { integrity: integrity(SHA512) }),
+            LockfileResolution::Registry(RegistryResolution {
+                integrity: integrity(SHA512),
+                revision: None
+            }),
             "{tarball_url} must be dropped",
         );
     }
@@ -866,19 +1023,19 @@ fn to_lockfile_form_keeps_tarball_with_trailing_scheme_separator() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: tarball.clone(),
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: None,
         path: None,
     });
-    let actual = resolution.to_lockfile_form(
-        "foo",
-        "1.0.0",
-        undeclared_form("https://registry.npmjs.org/", false),
-    );
+    let actual = resolution
+        .to_lockfile_form("foo", "1.0.0", undeclared_form("https://registry.npmjs.org/", false))
+        .unwrap();
     assert_eq!(
         actual,
         LockfileResolution::Tarball(TarballResolution {
             tarball,
             integrity: Some(integrity(SHA512)),
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -1005,13 +1162,18 @@ fn to_lockfile_form_drops_the_artifactory_url_of_a_scoped_package() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball,
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: None,
         path: None,
     });
-    let actual = resolution.to_lockfile_form("@acme/widget", "1.2.3", artifactory_form(false));
+    let actual =
+        resolution.to_lockfile_form("@acme/widget", "1.2.3", artifactory_form(false)).unwrap();
     assert_eq!(
         actual,
-        LockfileResolution::Registry(RegistryResolution { integrity: integrity(SHA512) }),
+        LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity(SHA512),
+            revision: None
+        }),
     );
 }
 
@@ -1023,10 +1185,12 @@ fn to_lockfile_form_keeps_the_npm_layout_url_on_an_artifactory_registry() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball,
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: None,
         path: None,
     });
-    let actual = resolution.to_lockfile_form("@acme/widget", "1.2.3", artifactory_form(false));
+    let actual =
+        resolution.to_lockfile_form("@acme/widget", "1.2.3", artifactory_form(false)).unwrap();
     assert_eq!(actual, resolution);
 }
 
@@ -1036,14 +1200,13 @@ fn to_lockfile_form_keeps_the_artifactory_url_on_a_registry_left_on_the_npm_layo
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball,
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: None,
         path: None,
     });
-    let actual = resolution.to_lockfile_form(
-        "@acme/widget",
-        "1.2.3",
-        undeclared_form(ARTIFACTORY_REGISTRY, false),
-    );
+    let actual = resolution
+        .to_lockfile_form("@acme/widget", "1.2.3", undeclared_form(ARTIFACTORY_REGISTRY, false))
+        .unwrap();
     assert_eq!(actual, resolution);
 }
 
@@ -1053,10 +1216,12 @@ fn to_lockfile_form_keeps_the_artifactory_url_when_include_tarball_url_is_set() 
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball,
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: None,
         path: None,
     });
-    let actual = resolution.to_lockfile_form("@acme/widget", "1.2.3", artifactory_form(true));
+    let actual =
+        resolution.to_lockfile_form("@acme/widget", "1.2.3", artifactory_form(true)).unwrap();
     assert_eq!(actual, resolution);
 }
 
@@ -1087,6 +1252,7 @@ fn to_lockfile_form_drops_the_encoded_scoped_path_only_when_the_registry_is_decl
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("{registry}@babel%2Fcore/-/core-7.0.0.tgz"),
         integrity: Some(integrity(SHA512)),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -1097,11 +1263,16 @@ fn to_lockfile_form_drops_the_encoded_scoped_path_only_when_the_registry_is_decl
         include_tarball_url: false,
     };
     assert_eq!(
-        resolution.to_lockfile_form("@babel/core", "7.0.0", declared_npm),
-        LockfileResolution::Registry(RegistryResolution { integrity: integrity(SHA512) }),
+        resolution.to_lockfile_form("@babel/core", "7.0.0", declared_npm).unwrap(),
+        LockfileResolution::Registry(RegistryResolution {
+            integrity: integrity(SHA512),
+            revision: None
+        }),
     );
     assert_eq!(
-        resolution.to_lockfile_form("@babel/core", "7.0.0", undeclared_form(registry, false)),
+        resolution
+            .to_lockfile_form("@babel/core", "7.0.0", undeclared_form(registry, false))
+            .unwrap(),
         resolution,
     );
 }

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -44,8 +44,7 @@ use std::{
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 /// Fallback `User-Agent` for the install client's no-config
-/// constructors ([`ThrottledClient::new_for_installs`],
-/// [`ThrottledClient::from_client`]) and for the case where a
+/// constructors ([`ThrottledClient::new_for_installs`]) and for the case where a
 /// configured user-agent string cannot be encoded as an HTTP header
 /// value.
 ///
@@ -550,18 +549,13 @@ impl ThrottledClient {
         })
     }
 
-    /// Construct a throttled client wrapping a pre-built [`Client`].
-    /// Useful for tests that want different timeout values than
-    /// [`Self::new_for_installs`] sets — e.g. sub-second connect
-    /// timeouts so firewalled / unreachable URLs fail within the
-    /// test-suite budget instead of waiting on TCP retry.
+    /// Construct a throttled client wrapping aligned pre-built clients.
+    /// `client_without_redirects` must carry the same TLS, proxy, timeout,
+    /// headers, and protocol settings as `client`, differing only in its
+    /// redirect policy.
     #[must_use]
-    pub fn from_client(client: Client) -> Self {
+    pub fn from_clients(client: Client, client_without_redirects: Client) -> Self {
         let semaphore = PrioritySemaphore::new(default_network_concurrency());
-        let client_without_redirects = Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .expect("build no-redirect HTTP client");
         ThrottledClient {
             semaphore,
             client_without_redirects,

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -168,12 +168,14 @@ impl Default for NetworkSettings {
 pub struct ThrottledClient {
     semaphore: PrioritySemaphore,
     client: Client,
+    client_without_redirects: Client,
     /// Per-registry clients keyed by nerf-darted URI. Empty when no
     /// `//host/:cert=…` / `:key=…` / `:ca=…` / `:cafile=…` /
     /// `:certfile=…` / `:keyfile=…` `.npmrc` entries are present —
     /// in which case `acquire_for_url` short-circuits to the default
     /// client without paying the routing cost.
     per_registry: HashMap<String, Client>,
+    per_registry_without_redirects: HashMap<String, Client>,
     /// Pre-built routing table cloned from [`PerRegistryTls`] so the
     /// hot path can call `pick_for_url` without holding a reference
     /// to `PerRegistryTls` (which lives on `Config`). Empty when
@@ -477,7 +479,8 @@ impl ThrottledClient {
         let extra_ca_certs = load_node_extra_ca_certs();
 
         let make_builder = |effective_tls: &TlsConfig,
-                            trust_roots: TrustRoots|
+                            trust_roots: TrustRoots,
+                            forbid_redirects: bool|
          -> Result<reqwest::ClientBuilder, ForInstallsError> {
             let mut builder = default_client_builder(settings);
             if let Some(url) = https.clone() {
@@ -495,37 +498,50 @@ impl ThrottledClient {
             if trust_roots == TrustRoots::Bundled {
                 builder = builder.tls_certs_only(bundled_root_certs().iter().cloned());
             }
-            if let Some(guard) = redirect_guard {
+            if forbid_redirects {
+                builder = builder.redirect(reqwest::redirect::Policy::none());
+            } else if let Some(guard) = redirect_guard {
                 builder = builder.redirect(allowlist_redirect_policy(Arc::clone(guard)));
             }
             Ok(builder)
         };
 
-        let build_client = |effective_tls: &TlsConfig| -> Result<Client, ForInstallsError> {
-            match make_builder(effective_tls, TrustRoots::Platform)?.build() {
+        let build_client = |effective_tls: &TlsConfig,
+                            forbid_redirects: bool|
+         -> Result<Client, ForInstallsError> {
+            match make_builder(effective_tls, TrustRoots::Platform, forbid_redirects)?.build() {
                 Ok(client) => Ok(client),
-                Err(platform) => make_builder(effective_tls, TrustRoots::Bundled)?
-                    .build()
-                    .map_err(|bundled| ForInstallsError::ClientBuild { platform, bundled }),
+                Err(platform) => {
+                    make_builder(effective_tls, TrustRoots::Bundled, forbid_redirects)?
+                        .build()
+                        .map_err(|bundled| ForInstallsError::ClientBuild { platform, bundled })
+                }
             }
         };
 
-        let default_client = build_client(tls)?;
+        let default_client = build_client(tls, false)?;
+        let default_client_without_redirects = build_client(tls, true)?;
         // Build one client per per-registry override. Each gets a
         // merged `TlsConfig` where the per-registry fields shadow
         // their top-level counterparts field-by-field. `strict_ssl` and
         // `local_address` are top-level-only, so the per-registry client
         // still honors the top-level values.
         let mut per_registry_clients = HashMap::with_capacity(per_registry.iter().count());
+        let mut per_registry_clients_without_redirects =
+            HashMap::with_capacity(per_registry.iter().count());
         for (uri, override_) in per_registry.iter() {
             let merged = merge_tls(tls, override_);
-            per_registry_clients.insert(uri.to_string(), build_client(&merged)?);
+            per_registry_clients.insert(uri.to_string(), build_client(&merged, false)?);
+            per_registry_clients_without_redirects
+                .insert(uri.to_string(), build_client(&merged, true)?);
         }
 
         Ok(ThrottledClient {
             semaphore: PrioritySemaphore::new(settings.network_concurrency),
             client: default_client,
+            client_without_redirects: default_client_without_redirects,
             per_registry: per_registry_clients,
+            per_registry_without_redirects: per_registry_clients_without_redirects,
             routing: per_registry.clone(),
             host_socket_limit: None,
             fetch_warn_timeout: settings.fetch_warn_timeout,
@@ -542,10 +558,16 @@ impl ThrottledClient {
     #[must_use]
     pub fn from_client(client: Client) -> Self {
         let semaphore = PrioritySemaphore::new(default_network_concurrency());
+        let client_without_redirects = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("build no-redirect HTTP client");
         ThrottledClient {
             semaphore,
+            client_without_redirects,
             client,
             per_registry: HashMap::new(),
+            per_registry_without_redirects: HashMap::new(),
             routing: PerRegistryTls::default(),
             host_socket_limit: None,
             fetch_warn_timeout: Duration::from_millis(DEFAULT_FETCH_WARN_TIMEOUT_MS),
@@ -589,6 +611,25 @@ impl ThrottledClient {
         url: &str,
         priority: u64,
     ) -> ThrottledClientGuard<'_> {
+        self.acquire_for_url_with_priority_and_redirects(url, priority, true).await
+    }
+
+    /// [`Self::acquire_for_url_with_priority`] using a client that returns the
+    /// first redirect response instead of following it.
+    pub async fn acquire_for_url_without_redirects_with_priority(
+        &self,
+        url: &str,
+        priority: u64,
+    ) -> ThrottledClientGuard<'_> {
+        self.acquire_for_url_with_priority_and_redirects(url, priority, false).await
+    }
+
+    async fn acquire_for_url_with_priority_and_redirects(
+        &self,
+        url: &str,
+        priority: u64,
+        follow_redirects: bool,
+    ) -> ThrottledClientGuard<'_> {
         // Acquire the per-origin `maxSockets` permit *before* the global
         // concurrency permit: a request queued behind a saturated origin must
         // not hold a global slot while it waits, or a burst to one origin would
@@ -598,11 +639,13 @@ impl ThrottledClient {
             None => None,
         };
         let permit = self.semaphore.acquire(priority).await;
-        let client = self
-            .routing
-            .pick_for_url(url)
-            .and_then(|key| self.per_registry.get(key))
-            .unwrap_or(&self.client);
+        let (client, per_registry) = if follow_redirects {
+            (&self.client, &self.per_registry)
+        } else {
+            (&self.client_without_redirects, &self.per_registry_without_redirects)
+        };
+        let client =
+            self.routing.pick_for_url(url).and_then(|key| per_registry.get(key)).unwrap_or(client);
         ThrottledClientGuard { _permit: permit, _host_permit: host_permit, client }
     }
 }

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -487,6 +487,39 @@ async fn authorization_is_retained_on_same_origin_redirect() {
 }
 
 #[tokio::test]
+async fn no_redirect_client_returns_the_first_redirect_response() {
+    let mut registry = mockito::Server::new_async().await;
+    let start_mock = registry
+        .mock("GET", "/start")
+        .with_status(302)
+        .with_header("location", "/final")
+        .expect(1)
+        .create_async()
+        .await;
+    let final_mock = registry
+        .mock("GET", "/final")
+        .with_status(200)
+        .with_body("must not be fetched")
+        .expect(0)
+        .create_async()
+        .await;
+    let url = format!("{}/start", registry.url());
+    let client = ThrottledClient::default();
+
+    let response = client
+        .acquire_for_url_without_redirects_with_priority(&url, 0)
+        .await
+        .get(&url)
+        .send()
+        .await
+        .expect("the redirect response itself is successful HTTP transport");
+
+    assert_eq!(response.status(), 302);
+    start_mock.assert_async().await;
+    final_mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn https_target_uses_configured_proxy() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind proxy");
     let proxy_addr = listener.local_addr().expect("proxy address");

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -520,6 +520,43 @@ async fn no_redirect_client_returns_the_first_redirect_response() {
 }
 
 #[tokio::test]
+async fn from_clients_uses_the_supplied_no_redirect_configuration() {
+    let mut registry = mockito::Server::new_async().await;
+    let start_mock = registry
+        .mock("GET", "/start")
+        .match_header("user-agent", "strict-client")
+        .with_status(302)
+        .with_header("location", "/final")
+        .expect(1)
+        .create_async()
+        .await;
+    let final_mock = registry.mock("GET", "/final").expect(0).create_async().await;
+    let client = reqwest::Client::builder()
+        .user_agent("ordinary-client")
+        .build()
+        .expect("build ordinary client");
+    let client_without_redirects = reqwest::Client::builder()
+        .user_agent("strict-client")
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("build strict client");
+    let client = ThrottledClient::from_clients(client, client_without_redirects);
+    let url = format!("{}/start", registry.url());
+
+    let response = client
+        .acquire_for_url_without_redirects_with_priority(&url, 0)
+        .await
+        .get(&url)
+        .send()
+        .await
+        .expect("strict client returns the redirect response");
+
+    assert_eq!(response.status(), 302);
+    start_mock.assert_async().await;
+    final_mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn https_target_uses_configured_proxy() {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind proxy");
     let proxy_addr = listener.local_addr().expect("proxy address");

--- a/pnpm/crates/package-manager/src/build_resolution_verifiers/tests.rs
+++ b/pnpm/crates/package-manager/src/build_resolution_verifiers/tests.rs
@@ -62,6 +62,7 @@ async fn offline_config_threads_to_resolution_verifier() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("{registry}acme/-/acme-1.0.0.tgz"),
         integrity: Some(FAKE_INTEGRITY.parse::<Integrity>().expect("parse integrity")),
+        revision: None,
         git_hosted: None,
         path: None,
     });

--- a/pnpm/crates/package-manager/src/build_snapshot.rs
+++ b/pnpm/crates/package-manager/src/build_snapshot.rs
@@ -2,7 +2,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_lockfile::{
     LockfileResolution, PackageKey, PackageMetadata, ParsePkgVerPeerError, PkgName, PkgNameVerPeer,
-    PkgVerPeer, RegistryResolution, SnapshotDepRef, SnapshotEntry,
+    PkgVerPeer, RegistryResolution, SnapshotDepRef, SnapshotEntry, TarballRevision,
 };
 use pnpm_registry::PackageVersion;
 use std::collections::HashMap;
@@ -25,6 +25,17 @@ pub enum BuildSnapshotError {
     )]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_BUILD_SNAPSHOT_MISSING_INTEGRITY))]
     MissingIntegrity { name: String, version: String },
+
+    #[display(
+        "Package `{name}@{version}` was returned from the registry with an invalid revision: {source}"
+    )]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_BUILD_SNAPSHOT_INVALID_REVISION))]
+    InvalidRevision {
+        name: String,
+        version: String,
+        #[error(source)]
+        source: serde_json::Error,
+    },
 
     #[display("Failed to parse package name `{name}`: {source}")]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_BUILD_SNAPSHOT_PARSE_NAME))]
@@ -79,6 +90,17 @@ pub fn build_package_snapshot(
             name: package.name.clone(),
             version: package.version.to_string(),
         })?;
+    let revision = package
+        .dist
+        .revision
+        .clone()
+        .map(serde_json::from_value::<TarballRevision>)
+        .transpose()
+        .map_err(|source| BuildSnapshotError::InvalidRevision {
+            name: package.name.clone(),
+            version: package.version.to_string(),
+            source,
+        })?;
 
     let mut dependencies: HashMap<PkgName, SnapshotDepRef> = HashMap::new();
     for (dep_name, ver_peer) in resolved_dependencies {
@@ -88,7 +110,7 @@ pub fn build_package_snapshot(
     }
 
     let metadata = PackageMetadata {
-        resolution: LockfileResolution::Registry(RegistryResolution { integrity, revision: None }),
+        resolution: LockfileResolution::Registry(RegistryResolution { integrity, revision }),
         version: None,
         engines: None,
         cpu: None,

--- a/pnpm/crates/package-manager/src/build_snapshot.rs
+++ b/pnpm/crates/package-manager/src/build_snapshot.rs
@@ -5,6 +5,7 @@ use pnpm_lockfile::{
     PkgVerPeer, RegistryResolution, SnapshotDepRef, SnapshotEntry, TarballRevision,
 };
 use pnpm_registry::PackageVersion;
+use pnpm_resolving_npm_resolver::InvalidTarballRevisionMetadataError;
 use std::collections::HashMap;
 
 /// Result of converting a resolved [`PackageVersion`] into the v9 lockfile
@@ -26,16 +27,8 @@ pub enum BuildSnapshotError {
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_BUILD_SNAPSHOT_MISSING_INTEGRITY))]
     MissingIntegrity { name: String, version: String },
 
-    #[display(
-        "Package `{name}@{version}` was returned from the registry with an invalid revision: {source}"
-    )]
-    #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_BUILD_SNAPSHOT_INVALID_REVISION))]
-    InvalidRevision {
-        name: String,
-        version: String,
-        #[error(source)]
-        source: serde_json::Error,
-    },
+    #[diagnostic(transparent)]
+    InvalidRevision(#[error(source)] InvalidTarballRevisionMetadataError),
 
     #[display("Failed to parse package name `{name}`: {source}")]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_BUILD_SNAPSHOT_PARSE_NAME))]
@@ -96,10 +89,11 @@ pub fn build_package_snapshot(
         .clone()
         .map(serde_json::from_value::<TarballRevision>)
         .transpose()
-        .map_err(|source| BuildSnapshotError::InvalidRevision {
-            name: package.name.clone(),
-            version: package.version.to_string(),
-            source,
+        .map_err(|source| {
+            BuildSnapshotError::InvalidRevision(InvalidTarballRevisionMetadataError::new(
+                &package.dist.tarball,
+                source.to_string(),
+            ))
         })?;
 
     let mut dependencies: HashMap<PkgName, SnapshotDepRef> = HashMap::new();

--- a/pnpm/crates/package-manager/src/build_snapshot.rs
+++ b/pnpm/crates/package-manager/src/build_snapshot.rs
@@ -88,7 +88,7 @@ pub fn build_package_snapshot(
     }
 
     let metadata = PackageMetadata {
-        resolution: LockfileResolution::Registry(RegistryResolution { integrity }),
+        resolution: LockfileResolution::Registry(RegistryResolution { integrity, revision: None }),
         version: None,
         engines: None,
         cpu: None,

--- a/pnpm/crates/package-manager/src/build_snapshot/tests.rs
+++ b/pnpm/crates/package-manager/src/build_snapshot/tests.rs
@@ -99,5 +99,9 @@ fn returns_error_when_revision_is_invalid() {
 
     let err = build_package_snapshot(&pkg, &HashMap::new())
         .expect_err("should fail with an invalid revision");
-    assert!(matches!(err, BuildSnapshotError::InvalidRevision { .. }));
+    assert!(matches!(err, BuildSnapshotError::InvalidRevision(_)));
+    assert_eq!(
+        miette::Diagnostic::code(&err).map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_MALFORMED_METADATA"),
+    );
 }

--- a/pnpm/crates/package-manager/src/build_snapshot/tests.rs
+++ b/pnpm/crates/package-manager/src/build_snapshot/tests.rs
@@ -20,6 +20,7 @@ fn make_package(name: &str, version: &str) -> PackageVersion {
             )),
             shasum: None,
             tarball: format!("https://registry.npmjs.org/{name}/-/{name}-{version}.tgz"),
+            revision: None,
             file_count: None,
             unpacked_size: None,
             attestations: None,

--- a/pnpm/crates/package-manager/src/build_snapshot/tests.rs
+++ b/pnpm/crates/package-manager/src/build_snapshot/tests.rs
@@ -1,6 +1,6 @@
 use super::{BuildSnapshotError, build_package_snapshot, registry_package_key};
 use node_semver::Version;
-use pnpm_lockfile::{LockfileResolution, PkgName, PkgVerPeer};
+use pnpm_lockfile::{LockfileResolution, PkgName, PkgVerPeer, TarballRevision};
 use pnpm_registry::{PackageDistribution, PackageVersion};
 use pretty_assertions::assert_eq;
 use ssri::Integrity;
@@ -52,12 +52,17 @@ fn builds_package_key_for_scoped_name() {
 
 #[test]
 fn builds_metadata_with_registry_resolution_and_no_deps() {
-    let pkg = make_package("lodash", "4.17.21");
+    let mut pkg = make_package("lodash", "4.17.21");
+    pkg.dist.revision = Some(serde_json::json!(2));
     let built = build_package_snapshot(&pkg, &HashMap::new()).unwrap();
 
     assert_eq!(built.package_key.to_string(), "lodash@4.17.21");
     dbg!(&built.metadata.resolution);
-    assert!(matches!(built.metadata.resolution, LockfileResolution::Registry(_)));
+    assert!(matches!(
+        built.metadata.resolution,
+        LockfileResolution::Registry(registry)
+            if registry.revision == Some(TarballRevision::try_from(2).unwrap())
+    ));
     dbg!(&built.snapshot.dependencies);
     assert!(built.snapshot.dependencies.is_none());
 }
@@ -85,4 +90,14 @@ fn returns_error_when_integrity_is_missing() {
         build_package_snapshot(&pkg, &HashMap::new()).expect_err("should fail without integrity");
     eprintln!("err={err:?}");
     assert!(matches!(err, BuildSnapshotError::MissingIntegrity { .. }));
+}
+
+#[test]
+fn returns_error_when_revision_is_invalid() {
+    let mut pkg = make_package("broken", "1.0.0");
+    pkg.dist.revision = Some(serde_json::json!(0));
+
+    let err = build_package_snapshot(&pkg, &HashMap::new())
+        .expect_err("should fail with an invalid revision");
+    assert!(matches!(err, BuildSnapshotError::InvalidRevision { .. }));
 }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -10,10 +10,11 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
+use miette::Diagnostic;
 use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
 use pnpm_catalogs_types::Catalogs;
 use pnpm_lockfile::{
-    BundledDependencies, CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile,
+    BundledDependencies, CatalogSnapshots, ComVer, ImporterDepVersion, Lockfile, LockfileFormError,
     LockfileFormOptions, LockfileResolution, LockfileSettings, LockfileVersion, PackageKey,
     PackageMetadata, ParseImporterDepVersionError, ParsePkgNameSuffixError, ParsePkgVerPeerError,
     PeerDependencyMeta, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot, RegistryOptions,
@@ -153,9 +154,12 @@ pub struct GraphToLockfileOptions<'a> {
 }
 
 /// Error returned while converting a resolver graph into a lockfile.
-#[derive(Debug, Display, Error)]
+#[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum DependenciesGraphToLockfileError {
+    #[diagnostic(transparent)]
+    LockfileForm(#[error(source)] LockfileFormError),
+
     #[display(
         "Failed to serialize importer dependency {alias:?} from dependency path {dep_path:?}: {source}"
     )]
@@ -717,7 +721,8 @@ fn build_packages_and_snapshots(
         let snapshot = build_snapshot_entry(node, graph, optional_overrides);
         snapshots.insert(snapshot_key, snapshot);
 
-        packages.entry(metadata_key).or_insert_with_key(|key| {
+        if let std::collections::hash_map::Entry::Vacant(entry) = packages.entry(metadata_key) {
+            let key = entry.key();
             // A registry-qualified key names its registry; that registry —
             // not the scope-routed default — decides whether the tarball
             // URL is canonical and can be dropped from the entry.
@@ -744,7 +749,8 @@ fn build_packages_and_snapshots(
                     server_type: registry_server_type(sources.registry_options_by_url, registry),
                     include_tarball_url,
                 },
-            );
+            )
+            .map_err(DependenciesGraphToLockfileError::LockfileForm)?;
             // `deprecated` is the only registry-mutable field of a
             // published version; an unchanged resolution must not lose
             // a recorded deprecation to a registry serving it
@@ -755,8 +761,8 @@ fn build_packages_and_snapshots(
             {
                 metadata.deprecated.clone_from(&previous.deprecated);
             }
-            metadata
-        });
+            entry.insert(metadata);
+        }
     }
 
     Ok((packages, snapshots))
@@ -774,7 +780,7 @@ fn build_package_metadata(
     node: &DependenciesGraphNode,
     metadata_key: &PackageKey,
     lockfile_form: LockfileFormOptions<'_>,
-) -> PackageMetadata {
+) -> Result<PackageMetadata, LockfileFormError> {
     let manifest = node.resolve_result.manifest.as_deref();
 
     let engines = manifest
@@ -829,7 +835,7 @@ fn build_package_metadata(
         &metadata_key.name.to_string(),
         &resolution_version,
         lockfile_form,
-    );
+    )?;
 
     // Record `version` only for non-registry packages (depPath carries
     // a `:`), and only when the manifest declares one and the resolution
@@ -846,7 +852,7 @@ fn build_package_metadata(
     })
     .flatten();
 
-    PackageMetadata {
+    Ok(PackageMetadata {
         resolution,
         version,
         engines,
@@ -859,7 +865,7 @@ fn build_package_metadata(
         bundled_dependencies,
         peer_dependencies,
         peer_dependencies_meta,
-    }
+    })
 }
 
 /// Read a JSON array field off the resolver's manifest fragment and flatten it

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -99,6 +99,7 @@ const FAKE_INTEGRITY: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 fn make_registry_resolution() -> LockfileResolution {
     LockfileResolution::Registry(RegistryResolution {
         integrity: Integrity::from_str(FAKE_INTEGRITY).expect("parse fake integrity"),
+        revision: None,
     })
 }
 
@@ -868,6 +869,7 @@ fn git_hosted_node(alias: &str) -> (DepPath, DependenciesGraphNode) {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: GIT_TARBALL_URL.to_string(),
             integrity: None,
+            revision: None,
             git_hosted: Some(true),
             path: None,
         }),
@@ -2712,6 +2714,7 @@ fn make_named_registry_node(
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: tarball_url.to_string(),
             integrity: Some(Integrity::from_str(FAKE_INTEGRITY).expect("parse fake integrity")),
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -2906,6 +2909,7 @@ fn unchanged_resolutions_keep_their_previous_package_metadata() {
             "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
         )
         .expect("parse fake integrity"),
+        revision: None,
     });
     let previous = std::collections::HashMap::from([(
         "react@17.0.2".parse::<PackageKey>().unwrap(),

--- a/pnpm/crates/package-manager/src/fast_update_catalog_versions/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalog_versions/tests.rs
@@ -34,6 +34,7 @@ impl Resolver for StubResolver {
                 resolution: LockfileResolution::Tarball(TarballResolution {
                     tarball: "https://registry.npmjs.org/target/-/target-2.0.0.tgz".to_string(),
                     integrity: Some("sha512-dGFyZ2V0LTI=".parse().expect("integrity")),
+                    revision: None,
                     git_hosted: None,
                     path: None,
                 }),

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -414,15 +414,21 @@ fn rewrite_lockfile(
             pick_registry_for_package(context.registries, &old_key.name.to_string(), None);
         let metadata = package_metadata(
             &replacement.manifest,
-            replacement.resolution.to_lockfile_form(
-                &old_key.name.to_string(),
-                &new_key.suffix.version().to_string(),
-                LockfileFormOptions {
-                    registry: &registry,
-                    server_type: registry_server_type(context.registry_options_by_url, &registry),
-                    include_tarball_url: context.lockfile_include_tarball_url,
-                },
-            ),
+            replacement
+                .resolution
+                .to_lockfile_form(
+                    &old_key.name.to_string(),
+                    &new_key.suffix.version().to_string(),
+                    LockfileFormOptions {
+                        registry: &registry,
+                        server_type: registry_server_type(
+                            context.registry_options_by_url,
+                            &registry,
+                        ),
+                        include_tarball_url: context.lockfile_include_tarball_url,
+                    },
+                )
+                .ok()?,
         );
         if let Some(existing) = packages.get(&metadata_key)
             && existing != &metadata

--- a/pnpm/crates/package-manager/src/fast_update_overrides/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides/tests.rs
@@ -40,6 +40,7 @@ impl Resolver for StubResolver {
                 resolution: LockfileResolution::Tarball(TarballResolution {
                     tarball: "https://registry.npmjs.org/target/-/target-2.0.0.tgz".to_string(),
                     integrity: Some("sha512-dGFyZ2V0LTI=".parse().expect("integrity")),
+                    revision: None,
                     git_hosted: None,
                     path: None,
                 }),

--- a/pnpm/crates/package-manager/src/minimum_release_age/tests.rs
+++ b/pnpm/crates/package-manager/src/minimum_release_age/tests.rs
@@ -20,6 +20,7 @@ fn violation(name: &str, version: &str, code: &'static str) -> ResolutionPolicyV
             integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
                 .parse::<Integrity>()
                 .expect("valid integrity"),
+            revision: None,
         }),
         code,
         reason: format!("{name}@{version} is too new"),

--- a/pnpm/crates/package-manager/src/patch/tests.rs
+++ b/pnpm/crates/package-manager/src/patch/tests.rs
@@ -488,6 +488,7 @@ fn resolution_kind_names_non_patchable_resolution_shapes() {
     let tarball = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://registry.test/foo/-/foo-1.0.0.tgz".to_string(),
         integrity: Some("sha512-aGVsbG8=".parse().expect("integrity")),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -495,6 +496,7 @@ fn resolution_kind_names_non_patchable_resolution_shapes() {
 
     let registry = LockfileResolution::Registry(RegistryResolution {
         integrity: "sha512-aGVsbG8=".parse().expect("integrity"),
+        revision: None,
     });
     assert_eq!(resolution_kind(&registry), "registry");
 

--- a/pnpm/crates/package-manager/src/prefetching_resolver.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver.rs
@@ -329,6 +329,10 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         let Ok((package_url, integrity)) = extract_tarball(&result.resolution) else {
             return;
         };
+        let revision_addressed = matches!(
+            &result.resolution,
+            LockfileResolution::Tarball(tarball) if tarball.revision.is_some(),
+        );
         // The npm picker's `dist.tarball` is the canonical URL the
         // install path will look up in `MemCache`. Tarball-resolver
         // and git-resolver paths can leave `name_ver` unset (they
@@ -385,7 +389,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             //
             // Result is intentionally discarded — the `MemCache`
             // carries success / failure state to the install path.
-            let _ = DownloadTarballToStore {
+            let download = DownloadTarballToStore {
                 http_client: &http_client,
                 store_dir,
                 store_index,
@@ -406,9 +410,12 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
                 offline,
                 progress_reported: Some(progress_reported),
                 append_manifest: None,
-            }
-            .run_with_mem_cache::<Reporter>(&mem_cache)
-            .await;
+            };
+            let _ = if revision_addressed {
+                download.run_revision_addressed_with_mem_cache::<Reporter>(&mem_cache).await
+            } else {
+                download.run_with_mem_cache::<Reporter>(&mem_cache).await
+            };
         });
     }
 

--- a/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver/tests.rs
@@ -26,6 +26,7 @@ fn result_with_manifest(name: &str, manifest: serde_json::Value) -> ResolveResul
         resolution: LockfileResolution::Tarball(TarballResolution {
             integrity: None,
             tarball: "https://registry.example/not-compatible.tgz".to_string(),
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -52,6 +53,7 @@ fn alias_tarball_result(alias: &str, manifest: serde_json::Value) -> ResolveResu
         resolution: LockfileResolution::Tarball(TarballResolution {
             integrity: None,
             tarball: "https://registry.example/not-compatible.tgz".to_string(),
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -72,6 +74,7 @@ fn anonymous_tarball_result(manifest: serde_json::Value) -> ResolveResult {
         resolution: LockfileResolution::Tarball(TarballResolution {
             integrity: None,
             tarball: "https://registry.example/not-compatible.tgz".to_string(),
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -255,6 +258,7 @@ async fn resolve_populates_integrity_before_skipping_optional_prefetch() {
     result.resolution = LockfileResolution::Tarball(TarballResolution {
         integrity: None,
         tarball: tarball_url,
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -315,6 +319,7 @@ fn integrity_pinned_result(tarball_url: &str) -> ResolveResult {
     result.resolution = LockfileResolution::Tarball(TarballResolution {
         integrity: Some("sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==".parse().unwrap()),
         tarball: tarball_url.to_string(),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -338,6 +343,7 @@ async fn populates_integrity_with_prefetching_off() {
     result.resolution = LockfileResolution::Tarball(TarballResolution {
         integrity: None,
         tarball: format!("{}{tarball_path}", server.url()),
+        revision: None,
         git_hosted: None,
         path: None,
     });

--- a/pnpm/crates/package-manager/src/resolution_observer.rs
+++ b/pnpm/crates/package-manager/src/resolution_observer.rs
@@ -42,6 +42,9 @@ pub struct ResolvedPackageHint<'a> {
     /// registry published one. The per-file term of the download
     /// priority's pipeline-work estimate.
     pub file_count: Option<usize>,
+    /// Registry artifact revision. Its presence selects the immutable
+    /// one-request, no-redirect download policy on the client.
+    pub revision: Option<u64>,
     /// Whether the package resolved from a registry (npm / named / jsr), so
     /// [`Self::tarball_url`] is the registry packument's `dist.tarball`. A
     /// server router must classify such a package by its *registry* route, not
@@ -109,6 +112,12 @@ impl ObservingResolver {
         let name = name_ver.name.to_string();
         let version = name_ver.suffix.to_string();
         let integrity = integrity.to_string();
+        let revision = match &result.resolution {
+            pnpm_lockfile::LockfileResolution::Tarball(tarball) => {
+                tarball.revision.map(pnpm_lockfile::TarballRevision::get)
+            }
+            _ => None,
+        };
         self.observer.on_resolved(ResolvedPackageHint {
             id: &id,
             name: &name,
@@ -117,6 +126,7 @@ impl ObservingResolver {
             tarball_url,
             unpacked_size: manifest_unpacked_size(result.manifest.as_deref()),
             file_count: manifest_file_count(result.manifest.as_deref()),
+            revision,
             from_registry: is_registry_resolution(&result.resolved_via),
         });
     }

--- a/pnpm/crates/package-manager/src/tarball_prefetch.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch.rs
@@ -38,6 +38,7 @@ struct PendingPrefetch {
     package_id: String,
     package_url: String,
     integrity: String,
+    revision_addressed: bool,
 }
 
 /// Drop every pending entry whose `(integrity, package_id)` row already
@@ -82,6 +83,7 @@ pub(crate) struct TarballDownload {
     pub integrity: Integrity,
     pub package_unpacked_size: Option<usize>,
     pub package_file_count: Option<usize>,
+    pub revision_addressed: bool,
 }
 
 /// [`tokio::spawn`] a single tarball download into the shared mem cache
@@ -111,10 +113,11 @@ pub(crate) fn spawn_tarball_download(download: TarballDownload) {
         integrity,
         package_unpacked_size,
         package_file_count,
+        revision_addressed,
     } = download;
 
     tokio::spawn(async move {
-        let _ = DownloadTarballToStore {
+        let download = DownloadTarballToStore {
             http_client: &http_client,
             store_dir,
             store_index,
@@ -139,9 +142,12 @@ pub(crate) fn spawn_tarball_download(download: TarballDownload) {
             // progress as it consumes each tarball from the mem cache.
             progress_reported: None,
             append_manifest: None,
-        }
-        .run_with_mem_cache::<SilentReporter>(&mem_cache)
-        .await;
+        };
+        let _ = if revision_addressed {
+            download.run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache).await
+        } else {
+            download.run_with_mem_cache::<SilentReporter>(&mem_cache).await
+        };
     });
 }
 
@@ -243,6 +249,7 @@ impl TarballPrefetcher {
         integrity: &str,
         unpacked_size: Option<usize>,
         file_count: Option<usize>,
+        revision_addressed: bool,
     ) {
         let integrity = match integrity.parse::<Integrity>() {
             Ok(integrity) => integrity,
@@ -277,6 +284,7 @@ impl TarballPrefetcher {
             integrity,
             package_unpacked_size: unpacked_size,
             package_file_count: file_count,
+            revision_addressed,
         });
     }
 
@@ -310,18 +318,24 @@ impl TarballPrefetcher {
             let package_id = package_key.pkg_id();
             let integrity =
                 integrity.expect("registry resolutions always carry an integrity").to_string();
+            let revision_addressed = matches!(
+                &metadata.resolution,
+                LockfileResolution::Registry(registry) if registry.revision.is_some(),
+            );
             pending.push(PendingPrefetch {
                 store_key: store_index_key(&integrity, &package_id),
                 package_id,
                 package_url: tarball_url.into_owned(),
                 integrity,
+                revision_addressed,
             });
         }
         for entry in without_store_hits(self.store_index.clone(), pending).await {
-            let PendingPrefetch { package_id, package_url, integrity, .. } = entry;
+            let PendingPrefetch { package_id, package_url, integrity, revision_addressed, .. } =
+                entry;
             // The lockfile records no dist size hints, so the downloads
             // queue without a work estimate.
-            self.prefetch(package_id, package_url, &integrity, None, None);
+            self.prefetch(package_id, package_url, &integrity, None, None, revision_addressed);
         }
     }
 

--- a/pnpm/crates/package-manager/src/tarball_prefetch.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch.rs
@@ -9,7 +9,7 @@
 //! progress as it consumes each tarball.
 //!
 //! Each download lands its result in the shared [`MemCache`] keyed by
-//! tarball URL; the later install pass picks it up via
+//! tarball URL and fetch policy; the later install pass picks it up via
 //! [`DownloadTarballToStore::run_with_mem_cache`] (an immediate
 //! `CacheValue::Available` hit, or a brief park on the per-URL `Notify`
 //! while the prefetch finishes).
@@ -26,9 +26,13 @@ use pnpm_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex, StoreIndexError,
     StoreIndexWriter, store_index_key,
 };
-use pnpm_tarball::{DownloadTarballToStore, MemCache, RetryOpts};
+use pnpm_tarball::{DownloadTarballToStore, MemCache, RetryOpts, TarballError};
 use ssri::Integrity;
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+};
 
 /// One registry lockfile entry [`TarballPrefetcher::prefetch_lockfile`]
 /// may spawn a download for, staged so the whole batch can be filtered
@@ -95,6 +99,14 @@ pub(crate) struct TarballDownload {
 /// → imported` progress itself as it consumes each tarball, so the
 /// prefetch must not emit a competing, out-of-order set.
 pub(crate) fn spawn_tarball_download(download: TarballDownload) {
+    tokio::spawn(async move {
+        let _ = run_tarball_download(download).await;
+    });
+}
+
+async fn run_tarball_download(
+    download: TarballDownload,
+) -> Result<Arc<HashMap<String, PathBuf>>, TarballError> {
     let TarballDownload {
         http_client,
         mem_cache,
@@ -116,39 +128,37 @@ pub(crate) fn spawn_tarball_download(download: TarballDownload) {
         revision_addressed,
     } = download;
 
-    tokio::spawn(async move {
-        let download = DownloadTarballToStore {
-            http_client: &http_client,
-            store_dir,
-            store_index,
-            store_index_writer,
-            verify_store_integrity,
-            strict_store_pkg_content_check,
-            verified_files_cache,
-            package_integrity: Some(&integrity),
-            package_unpacked_size,
-            package_file_count,
-            package_url: &package_url,
-            package_id: &package_id,
-            requester: &requester,
-            prefetched_cas_paths: None,
-            retry_opts,
-            auth_headers: &auth_headers,
-            ignore_file_pattern: None,
-            offline,
-            // The client prefetch routes through `SilentReporter`, so
-            // there's no install reporter to dedup progress events
-            // against — the frozen materialization install emits its own
-            // progress as it consumes each tarball from the mem cache.
-            progress_reported: None,
-            append_manifest: None,
-        };
-        let _ = if revision_addressed {
-            download.run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache).await
-        } else {
-            download.run_with_mem_cache::<SilentReporter>(&mem_cache).await
-        };
-    });
+    let download = DownloadTarballToStore {
+        http_client: &http_client,
+        store_dir,
+        store_index,
+        store_index_writer,
+        verify_store_integrity,
+        strict_store_pkg_content_check,
+        verified_files_cache,
+        package_integrity: Some(&integrity),
+        package_unpacked_size,
+        package_file_count,
+        package_url: &package_url,
+        package_id: &package_id,
+        requester: &requester,
+        prefetched_cas_paths: None,
+        retry_opts,
+        auth_headers: &auth_headers,
+        ignore_file_pattern: None,
+        offline,
+        // The client prefetch routes through `SilentReporter`, so
+        // there's no install reporter to dedup progress events
+        // against — the frozen materialization install emits its own
+        // progress as it consumes each tarball from the mem cache.
+        progress_reported: None,
+        append_manifest: None,
+    };
+    if revision_addressed {
+        download.run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache).await
+    } else {
+        download.run_with_mem_cache::<SilentReporter>(&mem_cache).await
+    }
 }
 
 /// Fires background tarball downloads on the pnpr client as resolved
@@ -157,7 +167,8 @@ pub(crate) fn spawn_tarball_download(download: TarballDownload) {
 /// finished lockfile.
 ///
 /// Mirrors the local fresh-install [`crate::PrefetchingResolver`] —
-/// each download lands in the shared [`MemCache`] keyed by tarball URL,
+/// each download lands in the shared [`MemCache`] keyed by tarball URL and
+/// fetch policy,
 /// and the frozen materialization install the client runs afterward
 /// picks it up from the cache. It carries its own store-index writer so
 /// freshly-downloaded tarballs are recorded in `index.db` (the frozen

--- a/pnpm/crates/package-manager/src/tarball_prefetch/tests.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch/tests.rs
@@ -29,6 +29,7 @@ fn pending(package_id: &str, integrity: &str) -> PendingPrefetch {
         package_id: package_id.to_string(),
         package_url: format!("https://registry.example.com/{package_id}.tgz"),
         integrity: integrity.to_string(),
+        revision_addressed: false,
     }
 }
 

--- a/pnpm/crates/package-manager/src/tarball_prefetch/tests.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch/tests.rs
@@ -1,6 +1,11 @@
-use super::{PendingPrefetch, without_store_hits};
-use pnpm_store_dir::{CafsFileInfo, PackageFilesIndex, StoreIndex, store_index_key};
-use std::collections::HashMap;
+use super::{PendingPrefetch, TarballDownload, run_tarball_download, without_store_hits};
+use pnpm_network::{AuthHeaders, ThrottledClient};
+use pnpm_store_dir::{
+    CafsFileInfo, PackageFilesIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex,
+    store_index_key,
+};
+use pnpm_tarball::{MemCache, RetryOpts, TarballError};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tempfile::tempdir;
 
 fn sample_index() -> PackageFilesIndex {
@@ -62,4 +67,85 @@ async fn without_store_hits_keeps_everything_when_no_index_is_readable() {
     let remaining = without_store_hits(None, vec![warm, cold]).await;
 
     assert_eq!(remaining.len(), 2);
+}
+
+fn revision_download(
+    store_dir: &'static StoreDir,
+    package_url: String,
+    integrity: ssri::Integrity,
+) -> TarballDownload {
+    TarballDownload {
+        http_client: Arc::new(ThrottledClient::default()),
+        mem_cache: Arc::new(MemCache::new()),
+        store_dir,
+        store_index: None,
+        store_index_writer: None,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        auth_headers: Arc::new(AuthHeaders::default()),
+        retry_opts: RetryOpts {
+            retries: 2,
+            factor: 1,
+            min_timeout: Duration::ZERO,
+            max_timeout: Duration::ZERO,
+        },
+        requester: Arc::from(""),
+        offline: false,
+        verify_store_integrity: true,
+        strict_store_pkg_content_check: true,
+        package_id: "revision-pkg@1.0.0".to_string(),
+        package_url,
+        integrity,
+        package_unpacked_size: None,
+        package_file_count: None,
+        revision_addressed: true,
+    }
+}
+
+#[tokio::test]
+async fn revision_prefetch_does_not_follow_redirects() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("GET", "/revision.tgz")
+        .with_status(302)
+        .with_header("location", "/redirected.tgz")
+        .expect(1)
+        .create_async()
+        .await;
+    let redirected = server.mock("GET", "/redirected.tgz").expect(0).create_async().await;
+    let store = tempdir().unwrap();
+    let store_dir = Box::leak(Box::new(StoreDir::new(store.path())));
+    let integrity = format!("sha512-{}==", "A".repeat(86)).parse().unwrap();
+
+    let err = run_tarball_download(revision_download(
+        store_dir,
+        format!("{}/revision.tgz", server.url()),
+        integrity,
+    ))
+    .await
+    .expect_err("revision prefetch must reject the redirect");
+
+    assert!(matches!(err, TarballError::HttpStatus(_)), "got {err:?}");
+    redirect.assert_async().await;
+    redirected.assert_async().await;
+}
+
+#[tokio::test]
+async fn revision_prefetch_does_not_retry_a_transient_failure() {
+    let mut server = mockito::Server::new_async().await;
+    let failure =
+        server.mock("GET", "/revision.tgz").with_status(503).expect(1).create_async().await;
+    let store = tempdir().unwrap();
+    let store_dir = Box::leak(Box::new(StoreDir::new(store.path())));
+    let integrity = format!("sha512-{}==", "A".repeat(86)).parse().unwrap();
+
+    let err = run_tarball_download(revision_download(
+        store_dir,
+        format!("{}/revision.tgz", server.url()),
+        integrity,
+    ))
+    .await
+    .expect_err("revision prefetch must not retry the transient failure");
+
+    assert!(matches!(err, TarballError::HttpStatus(_)), "got {err:?}");
+    failure.assert_async().await;
 }

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -23,7 +23,7 @@ use derive_more::{Display, Error, From};
 use futures_util::StreamExt as _;
 use pnpm_catalogs_types::Catalogs;
 use pnpm_config::{RegistryDeclaration, ResolutionMode, TrustPolicy};
-use pnpm_lockfile::Lockfile;
+use pnpm_lockfile::{Lockfile, TarballRevision};
 use pnpm_lockfile_verification::{RenderedViolation, VerifyError};
 use reqwest::Client;
 
@@ -280,7 +280,7 @@ pub struct ResolvedPackage {
     pub file_count: Option<usize>,
     /// Registry artifact revision, when the server resolved an immutable
     /// integrity-addressed artifact.
-    pub revision: Option<u64>,
+    pub revision: Option<TarballRevision>,
 }
 
 #[derive(Debug, Display, Error, From)]
@@ -592,7 +592,7 @@ enum Frame {
         #[serde(rename = "fileCount", default)]
         file_count: Option<usize>,
         #[serde(default)]
-        revision: Option<u64>,
+        revision: Option<TarballRevision>,
     },
     /// Boxed: the lockfile dwarfs the other variants, so keeping it
     /// behind a pointer keeps the enum small.

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -278,6 +278,9 @@ pub struct ResolvedPackage {
     /// published one. The per-file term of the download priority's
     /// pipeline-work estimate.
     pub file_count: Option<usize>,
+    /// Registry artifact revision, when the server resolved an immutable
+    /// integrity-addressed artifact.
+    pub revision: Option<u64>,
 }
 
 #[derive(Debug, Display, Error, From)]
@@ -526,6 +529,7 @@ impl PnprClient {
                         tarball,
                         unpacked_size,
                         file_count,
+                        revision,
                     } => {
                         on_package(ResolvedPackage {
                             id,
@@ -535,6 +539,7 @@ impl PnprClient {
                             tarball,
                             unpacked_size,
                             file_count,
+                            revision,
                         });
                     }
                     Frame::Done { lockfile, stats } => {
@@ -586,6 +591,8 @@ enum Frame {
         unpacked_size: Option<usize>,
         #[serde(rename = "fileCount", default)]
         file_count: Option<usize>,
+        #[serde(default)]
+        revision: Option<u64>,
     },
     /// Boxed: the lockfile dwarfs the other variants, so keeping it
     /// behind a pointer keeps the enum small.

--- a/pnpm/crates/pnpr-client/src/tests.rs
+++ b/pnpm/crates/pnpr-client/src/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
 use pnpm_config::{ResolutionMode, TrustPolicy};
+use pnpm_lockfile::TarballRevision;
 use serde_json::json;
 
 use super::{
@@ -130,7 +131,17 @@ fn a_package_frame_parses_its_fetch_hint() {
     assert_eq!(tarball, "https://r.test/acme/-/acme-1.0.0.tgz");
     assert_eq!(unpacked_size, Some(123456));
     assert_eq!(file_count, Some(42));
-    assert_eq!(revision, Some(3));
+    assert_eq!(revision, Some(TarballRevision::try_from(3).unwrap()));
+}
+
+#[test]
+fn package_frames_reject_invalid_revisions() {
+    for revision in [0, 9_007_199_254_740_992_u64] {
+        let line = format!(
+            r#"{{"type":"package","id":"acme@1.0.0","name":"acme","version":"1.0.0","integrity":"sha512-abc","tarball":"https://r.test/acme/-/acme-1.0.0.tgz","revision":{revision}}}"#,
+        );
+        assert!(matches!(parse_frame(line.as_bytes()), Err(PnprClientError::Protocol(_)),));
+    }
 }
 
 #[test]

--- a/pnpm/crates/pnpr-client/src/tests.rs
+++ b/pnpm/crates/pnpr-client/src/tests.rs
@@ -109,9 +109,17 @@ fn tarball_mismatch_maps_to_the_generic_envelope() {
 
 #[test]
 fn a_package_frame_parses_its_fetch_hint() {
-    let line = br#"{"type":"package","id":"acme@1.0.0","name":"acme","version":"1.0.0","integrity":"sha512-abc","tarball":"https://r.test/acme/-/acme-1.0.0.tgz","unpackedSize":123456,"fileCount":42}"#;
-    let Frame::Package { id, name, version, integrity, tarball, unpacked_size, file_count } =
-        parse_frame(line).expect("frame parses")
+    let line = br#"{"type":"package","id":"acme@1.0.0","name":"acme","version":"1.0.0","integrity":"sha512-abc","tarball":"https://r.test/acme/-/acme-1.0.0.tgz","unpackedSize":123456,"fileCount":42,"revision":3}"#;
+    let Frame::Package {
+        id,
+        name,
+        version,
+        integrity,
+        tarball,
+        unpacked_size,
+        file_count,
+        revision,
+    } = parse_frame(line).expect("frame parses")
     else {
         panic!("expected a package frame");
     };
@@ -122,6 +130,7 @@ fn a_package_frame_parses_its_fetch_hint() {
     assert_eq!(tarball, "https://r.test/acme/-/acme-1.0.0.tgz");
     assert_eq!(unpacked_size, Some(123456));
     assert_eq!(file_count, Some(42));
+    assert_eq!(revision, Some(3));
 }
 
 #[test]

--- a/pnpm/crates/real-hoist/src/tests.rs
+++ b/pnpm/crates/real-hoist/src/tests.rs
@@ -523,6 +523,7 @@ fn pkg_metadata_with_peer(peer_name: &str) -> pnpm_lockfile::PackageMetadata {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: format!("https://example.invalid/{peer_name}-host.tgz"),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/registry/src/package_distribution.rs
+++ b/pnpm/crates/registry/src/package_distribution.rs
@@ -7,6 +7,8 @@ pub struct PackageDistribution {
     pub integrity: Option<Integrity>,
     pub shasum: Option<String>,
     pub tarball: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<serde_json::Value>,
     pub file_count: Option<usize>,
     pub unpacked_size: Option<usize>,
 
@@ -54,3 +56,6 @@ impl PartialEq for PackageDistribution {
         self.integrity == other.integrity
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/registry/src/package_distribution/tests.rs
+++ b/pnpm/crates/registry/src/package_distribution/tests.rs
@@ -1,0 +1,20 @@
+use super::PackageDistribution;
+
+#[test]
+fn revision_is_excluded_from_content_equality() {
+    let integrity: ssri::Integrity = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+        .parse()
+        .unwrap();
+    let first = PackageDistribution {
+        integrity: Some(integrity.clone()),
+        revision: Some(serde_json::json!(1)),
+        ..PackageDistribution::default()
+    };
+    let second = PackageDistribution {
+        integrity: Some(integrity),
+        revision: Some(serde_json::json!(2)),
+        ..PackageDistribution::default()
+    };
+
+    assert_eq!(first, second);
+}

--- a/pnpm/crates/resolving-default-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-default-resolver/src/tests.rs
@@ -12,6 +12,7 @@ fn fake_resolution() -> LockfileResolution {
         integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
             .parse::<Integrity>()
             .expect("parse fake integrity"),
+        revision: None,
     })
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse.rs
@@ -7,8 +7,8 @@ use node_semver::{Range, Version};
 use pnpm_lockfile::{
     BundledDependencies, Lockfile, LockfileResolution, PkgName, PkgNameVer, PkgNameVerPeer,
     ProjectSnapshot, RegistryContext, ResolvedDependencySpec, SnapshotEntry, StringOrList,
-    TarballResolution, TarballUrlOptions, npm_tarball_url, pick_registry_for_package,
-    registry_server_type,
+    TarballResolution, TarballUrlOptions, integrity_addressed_registry_tarball_url,
+    npm_tarball_url, pick_registry_for_package, registry_server_type,
 };
 use pnpm_resolving_parse_wanted_dependency::git_specifiers_are_equivalent;
 use pnpm_resolving_resolver_base::{CurrentPkg, PkgResolutionId, ResolveResult};
@@ -49,8 +49,12 @@ pub(crate) fn current_pkg_from_lockfile(
             if registry.is_empty() {
                 return None;
             }
-            LockfileResolution::Tarball(TarballResolution {
-                tarball: npm_tarball_url(
+            let tarball = match registry_resolution.revision {
+                Some(_) => integrity_addressed_registry_tarball_url(
+                    &registry_resolution.integrity,
+                    &registry,
+                )?,
+                None => npm_tarball_url(
                     &name,
                     &tarball_version,
                     TarballUrlOptions {
@@ -61,7 +65,11 @@ pub(crate) fn current_pkg_from_lockfile(
                         ),
                     },
                 ),
+            };
+            LockfileResolution::Tarball(TarballResolution {
+                tarball,
                 integrity: Some(registry_resolution.integrity.clone()),
+                revision: registry_resolution.revision,
                 git_hosted: None,
                 path: None,
             })

--- a/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lockfile_reuse/tests.rs
@@ -9,7 +9,7 @@ fn registry_context(registries: HashMap<String, String>) -> pnpm_lockfile::Regis
 use pnpm_lockfile::{
     BundledDependencies, ComVer, GitResolution, ImporterDepVersion, Lockfile, LockfileResolution,
     LockfileVersion, PackageMetadata, PkgName, PkgNameVerPeer, PkgVerPeer, ProjectSnapshot,
-    RegistryResolution, ResolvedDependencySpec, StringOrList, TarballResolution,
+    RegistryResolution, ResolvedDependencySpec, StringOrList, TarballResolution, TarballRevision,
 };
 
 use super::{reusable_importer_dep, synthesize_reused_result};
@@ -59,6 +59,7 @@ fn registry_metadata() -> PackageMetadata {
             integrity: "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
                 .parse()
                 .expect("parse integrity"),
+            revision: None,
         }),
         version: None,
         engines: None,
@@ -227,6 +228,7 @@ fn does_not_reuse_directory_resolutions() {
     metadata.resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://example.test/pkg.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -323,12 +325,45 @@ fn current_pkg_routes_a_scoped_package_to_its_scope_registry() {
 }
 
 #[test]
+fn current_pkg_materializes_a_revision_from_the_registry_prefix_declaration() {
+    let key: PkgNameVerPeer = "pkg@work:1.0.0".parse().expect("parse key");
+    let mut metadata = registry_metadata();
+    let LockfileResolution::Registry(registry_resolution) = &mut metadata.resolution else {
+        unreachable!("registry_metadata returns a registry resolution");
+    };
+    registry_resolution.integrity =
+        "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+            .parse()
+            .expect("parse integrity");
+    registry_resolution.revision = Some(TarballRevision::try_from(7).unwrap());
+    let mut lockfile = empty_lockfile();
+    lockfile.packages = Some(HashMap::from([(key.clone(), metadata)]));
+    let mut context = registry_context(default_registry());
+    context
+        .registries_by_prefix
+        .insert("work".to_string(), "https://registry.example.test/work/npm/".to_string());
+
+    let current_pkg = super::current_pkg_from_lockfile(&lockfile, &key, &context)
+        .expect("declared prefix makes the revision reusable");
+
+    let LockfileResolution::Tarball(tarball) = current_pkg.resolution else {
+        panic!("registry resolution must materialize as a tarball");
+    };
+    assert_eq!(
+        tarball.tarball,
+        format!("https://registry.example.test/work/npm/-/tarballs/sha512/{}", "A".repeat(86)),
+    );
+    assert_eq!(tarball.revision, Some(TarballRevision::try_from(7).unwrap()));
+}
+
+#[test]
 fn current_pkg_passes_a_recorded_tarball_resolution_through() {
     let key: PkgNameVerPeer = "pkg@1.0.0".parse().expect("parse key");
     let mut metadata = registry_metadata();
     metadata.resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://example.test/pkg-1.0.0.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: None,
         path: None,
     });

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -292,6 +292,7 @@ fn fake_result(name: &str, version: &str, manifest: serde_json::Value) -> Resolv
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: format!("https://registry.example/{name}-{version}.tgz"),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/test_support.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/test_support.rs
@@ -105,6 +105,7 @@ pub(super) fn resolve_result(name: &str, version: &str) -> ResolveResult {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: format!("https://registry.example/{name}-{version}.tgz"),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -143,6 +143,7 @@ fn fake_result(
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: format!("https://registry.example/{name}-{version}.tgz"),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -260,6 +261,7 @@ fn importer_scoped_update_lockfile(
             integrity: "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
                 .parse()
                 .expect("parse integrity"),
+            revision: None,
         }),
         version: None,
         engines: None,
@@ -1626,6 +1628,7 @@ fn lockfile_with_package(key: &str) -> pnpm_lockfile::Lockfile {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: format!("https://registry.example/{key}.tgz"),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),
@@ -2099,6 +2102,7 @@ fn reuse_graph_lockfile(
             integrity: "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
                 .parse()
                 .expect("parse integrity"),
+            revision: None,
         }),
         version: None,
         engines: None,
@@ -3272,6 +3276,7 @@ fn reuse_steal_lockfile() -> pnpm_lockfile::Lockfile {
             integrity: "sha512-gf6ZldcfCDyNXPRiW3lQjEP1Z9rrUM/4Cn7BZbv3SdTA82zxWRP8OmLwvGR974uuENhGCFgFdN11z3n1Ofpprg=="
                 .parse()
                 .expect("parse integrity"),
+            revision: None,
         }),
         version: None,
         engines: None,

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -335,6 +335,7 @@ fn fake_result(name: &str, version: &str, manifest: serde_json::Value) -> Resolv
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: format!("https://registry.example/{name}-{version}.tgz"),
             integrity: None,
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
+++ b/pnpm/crates/resolving-git-resolver/src/git_resolver.rs
@@ -316,6 +316,7 @@ async fn pick_resolution<Probe: GitProbe + ?Sized>(
             return LockfileResolution::Tarball(TarballResolution {
                 tarball,
                 integrity: None,
+                revision: None,
                 git_hosted: Some(true),
                 path: spec.path.clone(),
             });

--- a/pnpm/crates/resolving-local-resolver/src/local_resolver.rs
+++ b/pnpm/crates/resolving-local-resolver/src/local_resolver.rs
@@ -257,6 +257,7 @@ async fn resolve_spec(
             resolution: LockfileResolution::Tarball(TarballResolution {
                 tarball: spec.id.as_str().to_string(),
                 integrity: Some(integrity),
+                revision: None,
                 git_hosted: None,
                 path: None,
             }),

--- a/pnpm/crates/resolving-local-resolver/tests/resolve.rs
+++ b/pnpm/crates/resolving-local-resolver/tests/resolve.rs
@@ -425,6 +425,7 @@ async fn resolve_file_with_different_integrity_force_fetch() {
                     .parse()
                     .expect("parse"),
             ),
+            revision: None,
             git_hosted: None,
             path: None,
         }),

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -450,7 +450,7 @@ impl NpmResolutionVerifier {
                     return ResolutionVerification::Err {
                         code: MISSING_NAMED_REGISTRY_VIOLATION_CODE,
                         reason: format!(
-                            "was resolved from the named registry '{registry_name}:', which is not present in the namedRegistries setting",
+                            "has registry prefix '{registry_name}:', which is not declared by the registries setting",
                         ),
                     };
                 }
@@ -1327,6 +1327,7 @@ fn project_trust_package_version(version: &PackageVersion) -> PackageVersion {
             integrity: None,
             shasum: None,
             tarball: String::new(),
+            revision: None,
             file_count: None,
             unpacked_size: None,
             attestations,

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -31,13 +31,14 @@ fn fake_integrity() -> Integrity {
 }
 
 fn registry_resolution() -> LockfileResolution {
-    LockfileResolution::Registry(RegistryResolution { integrity: fake_integrity() })
+    LockfileResolution::Registry(RegistryResolution { integrity: fake_integrity(), revision: None })
 }
 
 fn tarball_resolution(tarball: &str, integrity: Option<Integrity>) -> LockfileResolution {
     LockfileResolution::Tarball(TarballResolution {
         tarball: tarball.to_string(),
         integrity,
+        revision: None,
         git_hosted: None,
         path: None,
     })
@@ -229,6 +230,7 @@ async fn verifies_tarball_url_when_no_policy_active() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://attacker.example/aged-pkg-1.0.0.tgz".to_string(),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -300,6 +302,7 @@ async fn private_scope_verifier_ignores_public_mirror_and_writes_private_mirror(
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: public_tarball.clone(),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -439,7 +442,7 @@ async fn empty_integrity_counts_as_missing() {
     let name: PkgName = "foo".parse().expect("parse");
     for resolution in [
         tarball_resolution("https://registry.example/foo/-/foo-1.0.0.tgz", Some(empty.clone())),
-        LockfileResolution::Registry(RegistryResolution { integrity: empty }),
+        LockfileResolution::Registry(RegistryResolution { integrity: empty, revision: None }),
     ] {
         let result = verifier.verify(&resolution, ctx(&name, "1.0.0")).await;
         let ResolutionVerification::Err { code, .. } = result else {
@@ -505,6 +508,7 @@ async fn integrity_is_required_despite_a_git_hosted_claim() {
     let forged = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://attacker.example/evil-1.0.0.tgz".to_string(),
         integrity: None,
+        revision: None,
         git_hosted: Some(true),
         path: None,
     });
@@ -559,6 +563,7 @@ async fn verify_flags_tarball_url_mismatch() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://attacker.example/aged-pkg-1.0.0.tgz".to_string(),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -616,6 +621,7 @@ async fn tarball_url_default_port_and_scheme_difference_is_a_match() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: "https://cdn.example.test/aged-pkg/-/aged-pkg-1.0.0.tgz".to_string(),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -1101,6 +1107,7 @@ async fn verify_routes_via_named_registry_prefix() {
     let tarball = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("{server_url}/acme/-/acme-1.0.0.tgz"),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -1584,6 +1591,7 @@ async fn binding_check_records_dist_stats_into_the_sink() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: tarball_url.clone(),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -1620,6 +1628,7 @@ async fn propagates_metadata_fetch_failure_instead_of_a_tampering_mismatch() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("{server_url}/private-pkg/-/private-pkg-1.0.0.tgz"),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -1669,6 +1678,7 @@ async fn version_absent_from_fetched_metadata_stays_tarball_url_mismatch() {
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("{server_url}/present-pkg/-/present-pkg-2.0.0.tgz"),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -1735,6 +1745,7 @@ async fn registry_supports_time_field_reads_version_time_from_abbreviated_meta()
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("{server_url}/aged-pkg/-/aged-pkg-1.0.0.tgz"),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });
@@ -1795,6 +1806,7 @@ async fn without_registry_supports_time_field_abbreviated_time_is_not_consulted(
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: format!("{server_url}/aged-pkg/-/aged-pkg-1.0.0.tgz"),
         integrity: Some(fake_integrity()),
+        revision: None,
         git_hosted: None,
         path: None,
     });

--- a/pnpm/crates/resolving-npm-resolver/src/errors.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/errors.rs
@@ -205,6 +205,24 @@ pub struct InvalidTarballIntegrityError {
     pub shasum: String,
 }
 
+/// Raised when a registry marks a tarball as a replacement revision but its
+/// revision number or integrity-addressed URL violates the metadata contract.
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("Tarball \"{tarball}\" has invalid revision metadata: {reason}")]
+#[diagnostic(code(ERR_PNPM_MALFORMED_METADATA))]
+pub struct InvalidTarballRevisionMetadataError {
+    #[error(not(source))]
+    pub tarball: String,
+    pub reason: String,
+}
+
+impl InvalidTarballRevisionMetadataError {
+    #[must_use]
+    pub fn new(tarball: &str, reason: impl Into<String>) -> Self {
+        Self { tarball: redact_and_sanitize(tarball), reason: reason.into() }
+    }
+}
+
 impl InvalidTarballIntegrityError {
     #[must_use]
     pub fn new(tarball: &str, shasum: &str) -> Self {

--- a/pnpm/crates/resolving-npm-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/lib.rs
@@ -44,7 +44,9 @@ pub use create_npm_resolution_verifier::{
     CreateNpmResolutionVerifierOptions, DistStats, NpmResolutionVerifier, ObservedDistStats,
     create_npm_resolution_verifier, observed_dist_stats_sink,
 };
-pub use errors::{FetchMetadataError, InvalidTarballIntegrityError};
+pub use errors::{
+    FetchMetadataError, InvalidTarballIntegrityError, InvalidTarballRevisionMetadataError,
+};
 pub use fetch_attestation_published_at::{FetchAttestationOptions, fetch_attestation_published_at};
 pub use fetch_full_metadata::{
     FetchFullMetadataOptions, FetchFullMetadataOutcome, fetch_full_metadata,

--- a/pnpm/crates/resolving-npm-resolver/src/named_registry.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/named_registry.rs
@@ -21,7 +21,7 @@ pub use pnpm_config::BUILTIN_REGISTRIES_BY_PREFIX;
 /// `ERR_PNPM_INVALID_NAMED_REGISTRY_URL` code.
 ///
 /// Surfaced at resolver construction so a malformed URL in the
-/// user's `pnpm-workspace.yaml#namedRegistries` fails fast instead of
+/// user's `pnpm-workspace.yaml#registries` fails fast instead of
 /// turning into a confusing 404 during resolution.
 #[derive(Debug, Display, Error, Diagnostic, PartialEq, Eq)]
 #[non_exhaustive]
@@ -45,7 +45,7 @@ pub enum MergeNamedRegistriesError {
     )]
     #[diagnostic(
         code(ERR_PNPM_RESERVED_NAMED_REGISTRY_NAME),
-        help("Rename the entry in the namedRegistries setting.")
+        help("Change the prefix on the corresponding registries entry.")
     )]
     ReservedAlias {
         #[error(not(source))]
@@ -56,7 +56,7 @@ pub enum MergeNamedRegistriesError {
     )]
     #[diagnostic(
         code(ERR_PNPM_RESERVED_NAMED_REGISTRY_NAME),
-        help("Rename the entry in the namedRegistries setting.")
+        help("Change the prefix on the corresponding registries entry.")
     )]
     MalformedAlias {
         #[error(not(source))]

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -30,7 +30,10 @@ use node_semver::Version;
 use pnpm_config::{
     DEFAULT_JSR_REGISTRY, NeedsFullMetadataFor, TrustPolicy, version_policy::PackageVersionPolicy,
 };
-use pnpm_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
+use pnpm_lockfile::{
+    LockfileResolution, PkgName, PkgNameVer, TarballResolution, TarballRevision,
+    is_integrity_addressed_registry_tarball_url,
+};
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_and_sanitize};
 use pnpm_registry::{Package, PackageDistribution, PackageVersion, RangeSpecStyle};
 use pnpm_resolving_resolver_base::{
@@ -42,7 +45,10 @@ use pnpm_resolving_resolver_base::{
 use ssri::{Algorithm, Integrity};
 
 use crate::{
-    errors::{AllVersionsBlockedError, GuardRepickLimitError, InvalidTarballIntegrityError},
+    errors::{
+        AllVersionsBlockedError, GuardRepickLimitError, InvalidTarballIntegrityError,
+        InvalidTarballRevisionMetadataError,
+    },
     named_registry::pick_registry_for_package,
     parse_bare_specifier::{parse_bare_specifier, parse_jsr_specifier_to_registry_package_spec},
     pick_package::{
@@ -854,9 +860,38 @@ pub(crate) fn build_resolve_result(
     // mixing the two shapes would force a Registry → URL
     // reconstruction with no payoff: at resolve time we already have
     // the URL the install path needs.
+    let integrity = dist_integrity(&picked.dist)?;
+    let revision = picked
+        .dist
+        .revision
+        .as_ref()
+        .map(|revision| {
+            revision
+                .as_u64()
+                .ok_or_else(|| "the revision is not a positive safe integer".to_string())
+                .and_then(|revision| {
+                    TarballRevision::try_from(revision).map_err(|error| error.to_string())
+                })
+        })
+        .transpose()
+        .map_err(|reason| {
+            Box::new(InvalidTarballRevisionMetadataError::new(&picked.dist.tarball, reason))
+                as ResolveError
+        })?;
+    if revision.is_some()
+        && !integrity.as_ref().is_some_and(|integrity| {
+            is_integrity_addressed_registry_tarball_url(&picked.dist.tarball, integrity, registry)
+        })
+    {
+        return Err(Box::new(InvalidTarballRevisionMetadataError::new(
+            &picked.dist.tarball,
+            "the URL does not match its complete sha512 integrity and registry",
+        )));
+    }
     let resolution = LockfileResolution::Tarball(TarballResolution {
         tarball: picked.dist.tarball.clone(),
-        integrity: dist_integrity(&picked.dist)?,
+        integrity,
+        revision,
         git_hosted: None,
         path: None,
     });

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -6,7 +6,7 @@ use std::{
 
 use chrono::TimeZone;
 use pnpm_config::{TrustPolicy, version_policy::create_package_version_policy};
-use pnpm_lockfile::LockfileResolution;
+use pnpm_lockfile::{LockfileResolution, TarballRevision};
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_resolving_resolver_base::{
     LatestQuery, PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
@@ -18,7 +18,7 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use crate::{
-    errors::InvalidTarballIntegrityError,
+    errors::{InvalidTarballIntegrityError, InvalidTarballRevisionMetadataError},
     npm_resolver::NpmResolver,
     pick_package::{
         InMemoryPackageMetaCache, shared_packument_fetch_locker, shared_picked_manifest_cache,
@@ -1890,6 +1890,104 @@ fn shasum_only_package_body(shasum: &str) -> String {
         },
     })
     .to_string()
+}
+
+fn revision_package_body(tarball: &str, revision: &serde_json::Value) -> String {
+    json!({
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "modified": "2025-01-15T12:00:00.000Z",
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": {
+                    "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                    "tarball": tarball,
+                    "revision": revision,
+                },
+            },
+        },
+    })
+    .to_string()
+}
+
+#[tokio::test]
+async fn revision_metadata_is_validated_and_preserved() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let tarball = format!("{}-/tarballs/sha512/{}", registry, "A".repeat(86));
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(revision_package_body(&tarball, &json!(2)))
+        .create_async()
+        .await;
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted =
+        WantedDependency { alias: Some("acme".to_string()), ..WantedDependency::default() };
+    let result = resolver.resolve(&wanted, &ResolveOptions::default()).await.unwrap().unwrap();
+
+    mock.assert_async().await;
+    let LockfileResolution::Tarball(resolution) = result.resolution else {
+        panic!("expected a tarball resolution");
+    };
+    assert_eq!(resolution.tarball, tarball);
+    assert_eq!(resolution.revision.map(TarballRevision::get), Some(2));
+}
+
+#[tokio::test]
+async fn malformed_revision_metadata_has_the_malformed_metadata_error() {
+    for revision in
+        [json!(0), json!(-1), json!(1.5), json!(9_007_199_254_740_992_u64), json!("1"), json!("01")]
+    {
+        let mut server = mockito::Server::new_async().await;
+        let registry = format!("{}/", server.url());
+        let tarball = format!("{}-/tarballs/sha512/{}", registry, "A".repeat(86));
+        server
+            .mock("GET", "/acme")
+            .with_status(200)
+            .with_body(revision_package_body(&tarball, &revision))
+            .create_async()
+            .await;
+        let (resolver, _tempdir) = build_resolver(&registry);
+
+        let wanted =
+            WantedDependency { alias: Some("acme".to_string()), ..WantedDependency::default() };
+        let error = match resolver.resolve(&wanted, &ResolveOptions::default()).await {
+            Ok(result) => panic!("revision {revision} must fail the resolve; got {result:?}"),
+            Err(error) => error,
+        };
+
+        let error = error
+            .downcast_ref::<InvalidTarballRevisionMetadataError>()
+            .expect("revision metadata error");
+        assert_eq!(error.tarball, tarball);
+    }
+}
+
+#[tokio::test]
+async fn revision_metadata_rejects_a_tarball_from_another_registry() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let tarball = format!("https://attacker.example/-/tarballs/sha512/{}", "A".repeat(86));
+    server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(revision_package_body(&tarball, &json!(1)))
+        .create_async()
+        .await;
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let wanted =
+        WantedDependency { alias: Some("acme".to_string()), ..WantedDependency::default() };
+    let error = resolver
+        .resolve(&wanted, &ResolveOptions::default())
+        .await
+        .expect_err("a revision URL from another registry must fail the resolve");
+
+    assert!(error.downcast_ref::<InvalidTarballRevisionMetadataError>().is_some());
 }
 
 #[tokio::test]

--- a/pnpm/crates/resolving-resolver-base/src/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/tests.rs
@@ -12,6 +12,7 @@ fn fake_resolution() -> LockfileResolution {
         integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
             .parse::<Integrity>()
             .expect("parse fake integrity"),
+        revision: None,
     })
 }
 

--- a/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
+++ b/pnpm/crates/resolving-tarball-resolver/src/tarball_resolver.rs
@@ -269,6 +269,7 @@ impl TarballResolver {
             resolution: LockfileResolution::Tarball(TarballResolution {
                 tarball: resolved_url,
                 integrity,
+                revision: None,
                 git_hosted: None,
                 path: None,
             }),

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -616,6 +616,7 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
     store_dir: &'static StoreDir,
     auth_headers: &AuthHeaders,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
+    revision_addressed: bool,
 ) -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
     let network_error =
         |error| TarballError::FetchTarball(NetworkError { url: package_url.to_string(), error });
@@ -663,7 +664,13 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
             url: pnpm_network::redact_url_credentials(package_url),
         });
     }
-    let client = http_client.acquire_for_url_with_priority(package_url, download_priority).await;
+    let client = if revision_addressed {
+        http_client
+            .acquire_for_url_without_redirects_with_priority(package_url, download_priority)
+            .await
+    } else {
+        http_client.acquire_for_url_with_priority(package_url, download_priority).await
+    };
     let mut request = client.get(package_url);
     // Resolve the per-URL auth header and attach it. Tarball hosts that
     // differ from the metadata host still pick up the header keyed at
@@ -945,13 +952,14 @@ pub fn download_priority(unpacked_size: Option<usize>, file_count: Option<usize>
 /// part-way through extraction stay on disk. That's safe: the CAFS is
 /// content-addressed, so re-extracting the same bytes produces
 /// identical paths and `write_cas_file` is idempotent.
-// 12 arguments — over the default clippy threshold but each is
+// 13 arguments — over the default clippy threshold but each is
 // distinct: client + URL + integrity describe the request, ID +
 // requester are the reporter dimensions, progress_key dedups the
 // package-status emit, unpacked-size is allocation hinting,
 // download_priority is queue ordering, store_dir + retry_opts +
 // auth_headers are install-scoped, and ignore_file_pattern is the
-// per-fetch archive filter. Bundling into a struct would just push
+// per-fetch archive filter, and revision_addressed selects the immutable
+// request policy. Bundling into a struct would just push
 // the same fields into a wrapper.
 #[expect(
     clippy::too_many_arguments,
@@ -970,7 +978,9 @@ pub(crate) async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
     auth_headers: &AuthHeaders,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
     progress_key: Option<(&SharedReportedProgressKeys, &str)>,
+    revision_addressed: bool,
 ) -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
+    let max_retries = if revision_addressed { 0 } else { retry_opts.retries };
     let mut attempt: u32 = 0;
     loop {
         let result = fetch_and_extract_once::<Reporter>(
@@ -984,6 +994,7 @@ pub(crate) async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
             store_dir,
             auth_headers,
             ignore_file_pattern.clone(),
+            revision_addressed,
         )
         .await;
         match result {
@@ -995,7 +1006,7 @@ pub(crate) async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
                 return Ok(value);
             }
             Err(err) if !is_transient_error(&err) => return Err(err),
-            Err(err) if attempt >= retry_opts.retries => {
+            Err(err) if attempt >= max_retries => {
                 tracing::warn!(
                     target: "pacquet::download",
                     ?package_url,
@@ -1011,7 +1022,7 @@ pub(crate) async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
                     target: "pacquet::download",
                     ?package_url,
                     attempt = attempt + 1,
-                    max_attempts = retry_opts.retries + 1,
+                    max_attempts = max_retries + 1,
                     ?delay,
                     ?err,
                     "Tarball fetch failed; retrying after backoff",
@@ -1027,7 +1038,7 @@ pub(crate) async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
                     level: LogLevel::Debug,
                     attempt: attempt + 1,
                     error: tarball_error_to_request_retry(&err),
-                    max_retries: retry_opts.retries,
+                    max_retries,
                     method: "GET".to_string(),
                     timeout: u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
                     url: package_url.to_string(),

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -198,6 +198,23 @@ impl<'a> DownloadTarballToStore<'a> {
         self,
         mem_cache: &'a MemCache,
     ) -> Result<Arc<HashMap<String, PathBuf>>, TarballError> {
+        self.run_with_mem_cache_inner::<Reporter>(mem_cache, false).await
+    }
+
+    /// Execute a registry revision fetch with the shared in-memory cache.
+    /// The network path performs exactly one GET and rejects redirects.
+    pub async fn run_revision_addressed_with_mem_cache<Reporter: self::Reporter>(
+        self,
+        mem_cache: &'a MemCache,
+    ) -> Result<Arc<HashMap<String, PathBuf>>, TarballError> {
+        self.run_with_mem_cache_inner::<Reporter>(mem_cache, true).await
+    }
+
+    async fn run_with_mem_cache_inner<Reporter: self::Reporter>(
+        self,
+        mem_cache: &'a MemCache,
+        revision_addressed: bool,
+    ) -> Result<Arc<HashMap<String, PathBuf>>, TarballError> {
         let &DownloadTarballToStore {
             package_url,
             package_id,
@@ -234,64 +251,45 @@ impl<'a> DownloadTarballToStore<'a> {
         // QUESTION: I see no copying from existing store_dir, is there such mechanism?
         // TODO: If it's not implemented yet, implement it
 
-        // `DashMap::get` returns a `Ref` that holds a shard read guard for
-        // its entire lifetime. Holding it across `.await` deadlocks: while
-        // this task is parked, another task on the same worker can call
-        // `mem_cache.insert` for a key that hashes to the same shard,
-        // block on the write side, and starve every worker. Clone the
-        // inner `Arc` out and drop the `Ref` immediately.
-        let existing = mem_cache.get(package_url).map(|entry| Arc::clone(entry.value()));
-        if let Some(cache_lock) = existing {
-            // `pnpm:progress` fires exactly once per URL — only the
-            // first writer's `run_without_mem_cache` call emits.
-            // Later waiters on the same cache slot do not re-trigger
-            // the emit.
-            //
-            // Read-lock the state read: the variant inspection below
-            // doesn't mutate anything, and a `write().await` would
-            // serialize every late visitor for a popular tarball
-            // (e.g. dozens of peer-suffix variants of the same
-            // package) behind a single exclusive guard, even though
-            // they're all just observing the in-progress / available
-            // flag. The owner branch below is the only writer; the
-            // RwLock's reader-writer fairness guarantees the owner
-            // still makes progress.
-            let notify = match &*cache_lock.read().await {
-                CacheValue::Available(cas_paths) => {
-                    // The first owner already reported its package
-                    // status. If the caller supplied a shared
-                    // progress set, this emit is skipped for keys the
-                    // owner reported; otherwise preserve the legacy
-                    // per-caller cache-hit progress.
-                    emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
-                    return Ok(Arc::clone(cas_paths));
-                }
-                CacheValue::InProgress(notify) => Arc::clone(notify),
-                CacheValue::Failed => {
-                    // The owner already finished and failed; surface
-                    // immediately rather than parking on the Notify.
-                    return Err(TarballError::SiblingFetchFailed { url: package_url.to_string() });
-                }
-            };
-
-            tracing::info!(target: "pacquet::download", ?package_url, "Wait for cache");
-            loop {
-                // Register with the `Notify` *before* re-checking the
-                // slot. `notify_waiters` stores no permit — it wakes
-                // only `Notified` futures already registered at that
-                // instant — and the read guard from the `InProgress`
-                // observation above is released before this point, so
-                // the owner's flip-and-notify can land in between.
-                // Checking first and registering after loses that
-                // wakeup and parks this task forever (nothing ever
-                // notifies the slot again once it is terminal).
-                let notified = notify.notified();
-                let mut notified = std::pin::pin!(notified);
-                notified.as_mut().enable();
-                match &*cache_lock.read().await {
+        // Claim ownership atomically so concurrent callers cannot both start
+        // the one network fetch for this URL. The entry guard is dropped when
+        // this match returns, before either branch awaits the cache lock.
+        let (cache_lock, owner_notify) = match mem_cache.entry(package_url.to_string()) {
+            dashmap::mapref::entry::Entry::Occupied(entry) => (Arc::clone(entry.get()), None),
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let notify = Arc::new(Notify::new());
+                let cache_lock = notify
+                    .pipe_ref(Arc::clone)
+                    .pipe(CacheValue::InProgress)
+                    .pipe(RwLock::new)
+                    .pipe(Arc::new);
+                entry.insert(Arc::clone(&cache_lock));
+                (cache_lock, Some(notify))
+            }
+        };
+        match owner_notify {
+            None => {
+                // `pnpm:progress` fires exactly once per URL — only the
+                // first writer's `run_without_mem_cache` call emits.
+                // Later waiters on the same cache slot do not re-trigger
+                // the emit.
+                //
+                // Read-lock the state read: the variant inspection below
+                // doesn't mutate anything, and a `write().await` would
+                // serialize every late visitor for a popular tarball
+                // (e.g. dozens of peer-suffix variants of the same
+                // package) behind a single exclusive guard, even though
+                // they're all just observing the in-progress / available
+                // flag. The owner branch below is the only writer; the
+                // RwLock's reader-writer fairness guarantees the owner
+                // still makes progress.
+                let notify = match &*cache_lock.read().await {
                     CacheValue::Available(cas_paths) => {
-                        // Same rationale as the pre-wait `Available`
-                        // branch above.
+                        // The first owner already reported its package
+                        // status. If the caller supplied a shared
+                        // progress set, this emit is skipped for keys the
+                        // owner reported; otherwise preserve the legacy
+                        // per-caller cache-hit progress.
                         emit_progress_found_in_store::<Reporter>(
                             package_id,
                             requester,
@@ -299,57 +297,85 @@ impl<'a> DownloadTarballToStore<'a> {
                         );
                         return Ok(Arc::clone(cas_paths));
                     }
+                    CacheValue::InProgress(notify) => Arc::clone(notify),
                     CacheValue::Failed => {
+                        // The owner already finished and failed; surface
+                        // immediately rather than parking on the Notify.
                         return Err(TarballError::SiblingFetchFailed {
                             url: package_url.to_string(),
                         });
                     }
-                    // The owner notifies only after flipping the slot
-                    // to `Available` or `Failed`, so a wake with the
-                    // slot still `InProgress` cannot happen — but a
-                    // stale registration completing early is harmless
-                    // either way: re-register and park again.
-                    CacheValue::InProgress(_) => {}
-                }
-                notified.await;
-            }
-        } else {
-            let notify = Arc::new(Notify::new());
-            let cache_lock = notify
-                .pipe_ref(Arc::clone)
-                .pipe(CacheValue::InProgress)
-                .pipe(RwLock::new)
-                .pipe(Arc::new);
-            if mem_cache.insert(package_url.to_string(), Arc::clone(&cache_lock)).is_some() {
-                tracing::warn!(target: "pacquet::download", ?package_url, "Race condition detected when writing to cache");
-            }
+                };
 
-            // Run the actual fetch and cleanup in either branch. On
-            // error the cache slot must transition to `Failed` and
-            // we must `notify_waiters` so concurrent requesters
-            // wake up and surface a sibling-fetch error instead of
-            // parking on the Notify forever (the original deadlock).
-            // Removing the `mem_cache` entry afterwards lets a
-            // freshly-started fetch (e.g., via `pacquet add` after
-            // a transient network failure) retry without inheriting
-            // the failed slot.
-            let result = self.run_without_mem_cache::<Reporter>().await;
-            match result {
-                Ok(cas_paths) => {
-                    let cas_paths = Arc::new(cas_paths);
-                    let mut cache_write = cache_lock.write().await;
-                    *cache_write = CacheValue::Available(Arc::clone(&cas_paths));
-                    drop(cache_write);
-                    notify.notify_waiters();
-                    Ok(cas_paths)
+                tracing::info!(target: "pacquet::download", ?package_url, "Wait for cache");
+                loop {
+                    // Register with the `Notify` *before* re-checking the
+                    // slot. `notify_waiters` stores no permit — it wakes
+                    // only `Notified` futures already registered at that
+                    // instant — and the read guard from the `InProgress`
+                    // observation above is released before this point, so
+                    // the owner's flip-and-notify can land in between.
+                    // Checking first and registering after loses that
+                    // wakeup and parks this task forever (nothing ever
+                    // notifies the slot again once it is terminal).
+                    let notified = notify.notified();
+                    let mut notified = std::pin::pin!(notified);
+                    notified.as_mut().enable();
+                    match &*cache_lock.read().await {
+                        CacheValue::Available(cas_paths) => {
+                            // Same rationale as the pre-wait `Available`
+                            // branch above.
+                            emit_progress_found_in_store::<Reporter>(
+                                package_id,
+                                requester,
+                                progress_key,
+                            );
+                            return Ok(Arc::clone(cas_paths));
+                        }
+                        CacheValue::Failed => {
+                            return Err(TarballError::SiblingFetchFailed {
+                                url: package_url.to_string(),
+                            });
+                        }
+                        // The owner notifies only after flipping the slot
+                        // to `Available` or `Failed`, so a wake with the
+                        // slot still `InProgress` cannot happen — but a
+                        // stale registration completing early is harmless
+                        // either way: re-register and park again.
+                        CacheValue::InProgress(_) => {}
+                    }
+                    notified.await;
                 }
-                Err(err) => {
-                    let mut cache_write = cache_lock.write().await;
-                    *cache_write = CacheValue::Failed;
-                    drop(cache_write);
-                    mem_cache.remove(package_url);
-                    notify.notify_waiters();
-                    Err(err)
+            }
+            Some(notify) => {
+                // Run the actual fetch and cleanup in either branch. On
+                // error the cache slot must transition to `Failed` and
+                // we must `notify_waiters` so concurrent requesters
+                // wake up and surface a sibling-fetch error instead of
+                // parking on the Notify forever (the original deadlock).
+                // Ordinary fetches remove the failed slot so a later caller
+                // can retry. A revision-addressed fetch keeps it terminal for
+                // this install, preserving the protocol's one-GET contract.
+                let result = self.run_without_mem_cache_inner::<Reporter>(revision_addressed).await;
+                match result {
+                    Ok(cas_paths) => {
+                        let cas_paths = Arc::new(cas_paths);
+                        let mut cache_write = cache_lock.write().await;
+                        *cache_write = CacheValue::Available(Arc::clone(&cas_paths));
+                        drop(cache_write);
+                        notify.notify_waiters();
+                        Ok(cas_paths)
+                    }
+                    Err(err) => {
+                        let mut cache_write = cache_lock.write().await;
+                        *cache_write = CacheValue::Failed;
+                        drop(cache_write);
+                        if !revision_addressed {
+                            mem_cache.remove(package_url);
+                        }
+                        notify.notify_waiters();
+                        Err(err)
+                    }
                 }
             }
         }
@@ -358,6 +384,21 @@ impl<'a> DownloadTarballToStore<'a> {
     /// Execute the subroutine without an in-memory cache.
     pub async fn run_without_mem_cache<Reporter: self::Reporter>(
         &self,
+    ) -> Result<HashMap<String, PathBuf>, TarballError> {
+        self.run_without_mem_cache_inner::<Reporter>(false).await
+    }
+
+    /// Execute a registry revision fetch without the in-memory cache.
+    /// The network path performs exactly one GET and rejects redirects.
+    pub async fn run_revision_addressed_without_mem_cache<Reporter: self::Reporter>(
+        &self,
+    ) -> Result<HashMap<String, PathBuf>, TarballError> {
+        self.run_without_mem_cache_inner::<Reporter>(true).await
+    }
+
+    async fn run_without_mem_cache_inner<Reporter: self::Reporter>(
+        &self,
+        revision_addressed: bool,
     ) -> Result<HashMap<String, PathBuf>, TarballError> {
         let &DownloadTarballToStore {
             store_dir,
@@ -418,7 +459,9 @@ impl<'a> DownloadTarballToStore<'a> {
                 return Ok(cas_paths);
             }
         }
-        self.fetch_and_extract_inner::<Reporter>(false).await.map(|result| result.files_map)
+        self.fetch_and_extract_inner::<Reporter>(false, revision_addressed)
+            .await
+            .map(|result| result.files_map)
     }
 
     /// Fetch the requested archive, verify any expected integrity, and return its CAFS files.
@@ -427,12 +470,13 @@ impl<'a> DownloadTarballToStore<'a> {
     pub async fn fetch_and_extract<Reporter: self::Reporter>(
         &self,
     ) -> Result<FetchedTarball, TarballError> {
-        self.fetch_and_extract_inner::<Reporter>(true).await
+        self.fetch_and_extract_inner::<Reporter>(true, false).await
     }
 
     async fn fetch_and_extract_inner<Reporter: self::Reporter>(
         &self,
         record_computed_integrity: bool,
+        revision_addressed: bool,
     ) -> Result<FetchedTarball, TarballError> {
         let &DownloadTarballToStore {
             http_client,
@@ -502,6 +546,7 @@ impl<'a> DownloadTarballToStore<'a> {
                 auth_headers,
                 ignore_file_pattern,
                 progress_key,
+                revision_addressed,
             )
             .await?;
 
@@ -638,6 +683,7 @@ impl FetchTarballForResolution<'_> {
                 auth_headers,
                 None,
                 None,
+                false,
             )
             .await?;
         apply_placeholder_manifest(store_dir, &mut cas_paths, &mut pkg_files_idx)?;

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -151,7 +151,8 @@ pub enum CacheValue {
 
 /// Internal in-memory cache of tarballs.
 ///
-/// The key of this hashmap is the url of each tarball.
+/// The key is the tarball URL, prefixed for revision-addressed fetches so
+/// redirect and retry policies never share a result.
 pub type MemCache = DashMap<String, Arc<RwLock<CacheValue>>>;
 
 /// Install-scoped set of store-index cache keys

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -185,13 +185,13 @@ impl<'a> DownloadTarballToStore<'a> {
     ///
     /// # Caller invariant: stable filter per URL
     ///
-    /// The cache is keyed on `package_url` alone, as pnpm's
-    /// `tarballCache` is, so a second caller fetching the same URL with
-    /// a different [`ignore_file_pattern`] silently receives the map the
-    /// first caller's filter produced. Every fetch of a URL must use the
-    /// same filter. Nothing enforces this; today it holds because URLs
-    /// encode `(name, version, integrity)` and filters are keyed by
-    /// package name.
+    /// The cache is keyed on `package_url` and whether the request uses the
+    /// revision-addressed network policy. Within either policy, a second
+    /// caller fetching the same URL with a different [`ignore_file_pattern`]
+    /// silently receives the map the first caller's filter produced. Every
+    /// fetch of a URL must use the same filter. Nothing enforces this; today
+    /// it holds because URLs encode `(name, version, integrity)` and filters
+    /// are keyed by package name.
     ///
     /// [`ignore_file_pattern`]: DownloadTarballToStore::ignore_file_pattern
     pub async fn run_with_mem_cache<Reporter: self::Reporter>(
@@ -223,6 +223,11 @@ impl<'a> DownloadTarballToStore<'a> {
             requester,
             ..
         } = &self;
+        let mem_cache_key = if revision_addressed {
+            format!("revision-addressed:{package_url}")
+        } else {
+            package_url.to_string()
+        };
         let cache_key = store_index_cache_key(package_integrity, package_id);
         let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
 
@@ -244,7 +249,7 @@ impl<'a> DownloadTarballToStore<'a> {
             emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
             let cas_paths = Arc::clone(cas_paths);
             let cache_lock = Arc::new(RwLock::new(CacheValue::Available(Arc::clone(&cas_paths))));
-            mem_cache.insert(package_url.to_string(), cache_lock);
+            mem_cache.insert(mem_cache_key, cache_lock);
             return Ok(cas_paths);
         }
 
@@ -254,7 +259,7 @@ impl<'a> DownloadTarballToStore<'a> {
         // Claim ownership atomically so concurrent callers cannot both start
         // the one network fetch for this URL. The entry guard is dropped when
         // this match returns, before either branch awaits the cache lock.
-        let (cache_lock, owner_notify) = match mem_cache.entry(package_url.to_string()) {
+        let (cache_lock, owner_notify) = match mem_cache.entry(mem_cache_key.clone()) {
             dashmap::mapref::entry::Entry::Occupied(entry) => (Arc::clone(entry.get()), None),
             dashmap::mapref::entry::Entry::Vacant(entry) => {
                 let notify = Arc::new(Notify::new());
@@ -371,7 +376,7 @@ impl<'a> DownloadTarballToStore<'a> {
                         *cache_write = CacheValue::Failed;
                         drop(cache_write);
                         if !revision_addressed {
-                            mem_cache.remove(package_url);
+                            mem_cache.remove(&mem_cache_key);
                         }
                         notify.notify_waiters();
                         Err(err)

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -357,7 +357,7 @@ impl<'a> DownloadTarballToStore<'a> {
                 // error the cache slot must transition to `Failed` and
                 // we must `notify_waiters` so concurrent requesters
                 // wake up and surface a sibling-fetch error instead of
-                // parking on the Notify forever (the original deadlock).
+                // parking on the Notify forever.
                 // Ordinary fetches remove the failed slot so a later caller
                 // can retry. A revision-addressed fetch keeps it terminal for
                 // this install, preserving the protocol's one-GET contract.

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1873,6 +1873,7 @@ async fn download_pipeline_extracts_via_streaming_path_for_large_unpacked_hint()
             &AuthHeaders::default(),
             None,
             None,
+            false,
         )
         .await
         .expect("download with a large unpacked-size hint");
@@ -2312,6 +2313,7 @@ async fn retries_then_succeeds_on_transient_5xx() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect("transient 503 should be followed by a successful retry");
@@ -2320,6 +2322,147 @@ async fn retries_then_succeeds_on_transient_5xx() {
     assert!(cas_paths.contains_key("package.json"));
     fail.assert_async().await;
     ok.assert_async().await;
+    drop(store_dir_keep);
+}
+
+#[tokio::test]
+async fn revision_addressed_tarball_does_not_retry_a_transient_failure() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let digest = "A".repeat(86);
+    let path = format!("/-/tarballs/sha512/{digest}");
+    let mock = server.mock("GET", path.as_str()).with_status(503).expect(1).create_async().await;
+    let url = format!("{}{path}", server.url());
+    let expected = integrity(&format!("sha512-{digest}=="));
+
+    let err = fetch_and_extract_with_retry::<SilentReporter>(
+        &ThrottledClient::default(),
+        &url,
+        Some(&expected),
+        None,
+        0,
+        "test-pkg",
+        "",
+        store_path,
+        fast_retry_opts(),
+        &AuthHeaders::default(),
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect_err("a revision-addressed 503 must fail after one request");
+
+    assert!(matches!(err, TarballError::HttpStatus(_)), "got {err:?}");
+    mock.assert_async().await;
+    drop(store_dir_keep);
+}
+
+#[tokio::test]
+async fn revision_addressed_tarball_does_not_follow_a_redirect() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let digest = "A".repeat(86);
+    let path = format!("/-/tarballs/sha512/{digest}");
+    let redirect = server
+        .mock("GET", path.as_str())
+        .with_status(302)
+        .with_header("location", "/redirected.tgz")
+        .expect(1)
+        .create_async()
+        .await;
+    let redirected = server
+        .mock("GET", "/redirected.tgz")
+        .with_status(200)
+        .with_body(FASTIFY_ERROR_TARBALL)
+        .expect(0)
+        .create_async()
+        .await;
+    let url = format!("{}{path}", server.url());
+    let expected = integrity(&format!("sha512-{digest}=="));
+
+    let err = fetch_and_extract_with_retry::<SilentReporter>(
+        &ThrottledClient::default(),
+        &url,
+        Some(&expected),
+        None,
+        0,
+        "test-pkg",
+        "",
+        store_path,
+        fast_retry_opts(),
+        &AuthHeaders::default(),
+        None,
+        None,
+        true,
+    )
+    .await
+    .expect_err("a revision-addressed redirect must not be followed");
+
+    assert!(matches!(err, TarballError::HttpStatus(_)), "got {err:?}");
+    redirect.assert_async().await;
+    redirected.assert_async().await;
+    drop(store_dir_keep);
+}
+
+#[tokio::test]
+async fn revision_addressed_mem_cache_does_not_retry_a_failed_prefetch() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let digest = "A".repeat(86);
+    let path = format!("/-/tarballs/sha512/{digest}");
+    let mock = server.mock("GET", path.as_str()).with_status(503).expect(1).create_async().await;
+    let url = format!("{}{path}", server.url());
+    let expected = integrity(&format!("sha512-{digest}=="));
+    let client = ThrottledClient::default();
+    let mem_cache = MemCache::default();
+    let auth_headers = AuthHeaders::default();
+    let verified_files_cache = SharedVerifiedFilesCache::default();
+    let download = || DownloadTarballToStore {
+        http_client: &client,
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        strict_store_pkg_content_check: true,
+        verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
+        package_integrity: Some(&expected),
+        package_unpacked_size: None,
+        package_file_count: None,
+        package_url: &url,
+        package_id: "test-pkg",
+        requester: "",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &auth_headers,
+        ignore_file_pattern: None,
+        offline: false,
+        progress_reported: None,
+        append_manifest: None,
+    };
+
+    let (first, second) = futures_util::future::join(
+        download().run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache),
+        download().run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache),
+    )
+    .await;
+    let first = first.expect_err("the first revision-addressed consumer must fail");
+    let second = second.expect_err("the second revision-addressed consumer must fail");
+    assert!(
+        matches!(&first, TarballError::HttpStatus(_))
+            && matches!(&second, TarballError::SiblingFetchFailed { .. })
+            || matches!(&second, TarballError::HttpStatus(_))
+                && matches!(&first, TarballError::SiblingFetchFailed { .. }),
+        "one consumer must own the request and the other inherit its failure; got {first:?} and {second:?}",
+    );
+
+    let later = download()
+        .run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache)
+        .await
+        .expect_err("a later consumer must inherit the terminal failure");
+    assert!(matches!(later, TarballError::SiblingFetchFailed { .. }), "got {later:?}");
+
+    mock.assert_async().await;
     drop(store_dir_keep);
 }
 
@@ -2357,6 +2500,7 @@ async fn retries_integrity_mismatch_until_exhausted() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("integrity mismatch should exhaust the retry budget");
@@ -2612,6 +2756,7 @@ async fn fails_fast_on_404() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("404 must fail-fast without retry");
@@ -2651,6 +2796,7 @@ async fn retries_other_4xx_codes() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("non-401/403/404 4xx should exhaust the retry budget");
@@ -2685,6 +2831,7 @@ async fn retry_exhaustion_returns_last_error() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("permanent 500s should exhaust the retry budget");
@@ -2885,6 +3032,7 @@ async fn zero_retries_makes_a_single_attempt() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("retries=0 must surface the first failure");
@@ -2932,6 +3080,7 @@ async fn fetch_attaches_authorization_header_when_creds_match_tarball_url() {
         &auth_headers,
         None,
         None,
+        false,
     )
     .await
     .expect("server should accept the request once the bearer header is attached");
@@ -2974,6 +3123,7 @@ async fn fetch_attaches_authorization_header_when_scope_creds_match_package_id()
         &auth_headers,
         None,
         None,
+        false,
     )
     .await
     .expect("server should accept the request once the scoped bearer header is attached");
@@ -3030,6 +3180,7 @@ async fn retry_re_attaches_authorization_header_on_each_attempt() {
         &auth_headers,
         None,
         None,
+        false,
     )
     .await
     .expect("retry attempt should also carry the bearer header");
@@ -3465,6 +3616,7 @@ async fn fetching_progress_and_fetched_events_fire_during_download() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect("transient 503 should be followed by a successful retry");
@@ -3557,6 +3709,7 @@ async fn started_fires_for_connection_level_failures() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("connect-refused must surface as a TarballError");
@@ -3774,6 +3927,7 @@ async fn request_retry_event_fires_per_retried_attempt() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect("transient 503 should be followed by a successful retry");
@@ -4676,6 +4830,7 @@ async fn in_progress_events_fire_only_for_big_tarballs() {
             &AuthHeaders::default(),
             None,
             None,
+            false,
         )
         .await
         .expect("the download should succeed");
@@ -4738,6 +4893,7 @@ async fn streaming_download_extracts_a_big_pinned_tarball() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect("a well-formed pinned tarball must download and extract");
@@ -4809,6 +4965,7 @@ async fn chunked_download_extracts_a_body_past_the_buffering_threshold() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect("a chunked body must download and extract");
@@ -4859,6 +5016,7 @@ async fn oversized_non_gzip_body_reports_the_integrity_verdict_first() {
             &AuthHeaders::default(),
             None,
             None,
+            false,
         )
         .await
         .expect_err("a body that is not an archive must fail")
@@ -4909,6 +5067,7 @@ async fn streaming_download_integrity_mismatch_retries_and_fails() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("an integrity mismatch must exhaust the retry budget");
@@ -4949,6 +5108,7 @@ async fn streaming_download_corrupt_archive_retries_and_fails() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("a corrupt archive must exhaust the retry budget");
@@ -4990,6 +5150,7 @@ async fn streaming_download_tampered_and_corrupt_body_reports_integrity() {
         &AuthHeaders::default(),
         None,
         None,
+        false,
     )
     .await
     .expect_err("a tampered body must exhaust the retry budget");

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -2467,6 +2467,68 @@ async fn revision_addressed_mem_cache_does_not_retry_a_failed_prefetch() {
 }
 
 #[tokio::test]
+async fn revision_addressed_mem_cache_does_not_reuse_a_redirect_permitting_fetch() {
+    let (store_dir_keep, store_path) = tempdir_with_leaked_path();
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("GET", "/-/tarballs/sha512/digest")
+        .with_status(302)
+        .with_header("location", "/redirected.tgz")
+        .expect(2)
+        .create_async()
+        .await;
+    let redirected = server
+        .mock("GET", "/redirected.tgz")
+        .with_status(200)
+        .with_body(FASTIFY_ERROR_TARBALL)
+        .expect(1)
+        .create_async()
+        .await;
+    let url = format!("{}/-/tarballs/sha512/digest", server.url());
+    let expected = integrity(FASTIFY_ERROR_INTEGRITY);
+    let client = ThrottledClient::default();
+    let mem_cache = MemCache::default();
+    let auth_headers = AuthHeaders::default();
+    let verified_files_cache = SharedVerifiedFilesCache::default();
+    let download = || DownloadTarballToStore {
+        http_client: &client,
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        strict_store_pkg_content_check: true,
+        verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
+        package_integrity: Some(&expected),
+        package_unpacked_size: None,
+        package_file_count: None,
+        package_url: &url,
+        package_id: "test-pkg",
+        requester: "",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &auth_headers,
+        ignore_file_pattern: None,
+        offline: false,
+        progress_reported: None,
+        append_manifest: None,
+    };
+
+    download()
+        .run_with_mem_cache::<SilentReporter>(&mem_cache)
+        .await
+        .expect("an ordinary fetch may follow the redirect");
+    let err = download()
+        .run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache)
+        .await
+        .expect_err("a revision fetch must make its own request and reject the redirect");
+
+    assert!(matches!(err, TarballError::HttpStatus(_)), "got {err:?}");
+    redirect.assert_async().await;
+    redirected.assert_async().await;
+    drop(store_dir_keep);
+}
+
+#[tokio::test]
 async fn retries_integrity_mismatch_until_exhausted() {
     let (store_dir_keep, store_path) = tempdir_with_leaked_path();
     let mut server = mockito::Server::new_async().await;

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -153,13 +153,19 @@ fn allocate_tarball_buffer_rejects_absurd_content_length() {
 /// could stall for minutes of TCP retry. One-second bounds are
 /// plenty for loopback and keep the failure mode deterministic.
 fn fast_fail_client() -> ThrottledClient {
-    let client = reqwest::Client::builder()
-        .no_proxy()
-        .connect_timeout(std::time::Duration::from_secs(1))
-        .timeout(std::time::Duration::from_secs(1))
-        .build()
-        .expect("build reqwest client");
-    ThrottledClient::from_client(client)
+    let build = |redirect| {
+        reqwest::Client::builder()
+            .no_proxy()
+            .connect_timeout(std::time::Duration::from_secs(1))
+            .timeout(std::time::Duration::from_secs(1))
+            .redirect(redirect)
+            .build()
+            .expect("build reqwest client")
+    };
+    ThrottledClient::from_clients(
+        build(reqwest::redirect::Policy::limited(10)),
+        build(reqwest::redirect::Policy::none()),
+    )
 }
 
 /// Pin `walk_reqwest_chain`'s contract: a `NetworkError` formed

--- a/pnpm/tasks/micro-benchmark/src/workspace_resolution.rs
+++ b/pnpm/tasks/micro-benchmark/src/workspace_resolution.rs
@@ -170,6 +170,7 @@ fn graph_resolver(shape: Shape, size: Size) -> GraphResolver {
                     resolution: LockfileResolution::Tarball(TarballResolution {
                         tarball: format!("https://registry.example/{name}-1.0.0.tgz"),
                         integrity: None,
+                        revision: None,
                         git_hosted: None,
                         path: None,
                     }),
@@ -204,6 +205,7 @@ fn graph_resolver(shape: Shape, size: Size) -> GraphResolver {
                 resolution: LockfileResolution::Tarball(TarballResolution {
                     tarball: format!("https://registry.example/{name}-1.0.0.tgz"),
                     integrity: None,
+                    revision: None,
                     git_hosted: None,
                     path: None,
                 }),

--- a/pnpm11/crypto/integrity/src/index.ts
+++ b/pnpm11/crypto/integrity/src/index.ts
@@ -13,11 +13,7 @@ export interface ParsedIntegrity {
  * @throws PnpmError if the integrity format is invalid
  */
 export function parseIntegrity (integrity: string): ParsedIntegrity {
-  const optionSeparator = integrity.indexOf('?')
-  const hashExpression = optionSeparator === -1
-    ? integrity
-    : integrity.slice(0, optionSeparator)
-  const match = hashExpression.match(INTEGRITY_REGEX)
+  const match = integrity.match(INTEGRITY_REGEX)
   if (!match) {
     throw new PnpmError('INVALID_INTEGRITY', `Invalid integrity format: expected "algo-base64hash", got "${integrity}"`)
   }

--- a/pnpm11/crypto/integrity/src/index.ts
+++ b/pnpm11/crypto/integrity/src/index.ts
@@ -13,7 +13,11 @@ export interface ParsedIntegrity {
  * @throws PnpmError if the integrity format is invalid
  */
 export function parseIntegrity (integrity: string): ParsedIntegrity {
-  const match = integrity.match(INTEGRITY_REGEX)
+  const optionSeparator = integrity.indexOf('?')
+  const hashExpression = optionSeparator === -1
+    ? integrity
+    : integrity.slice(0, optionSeparator)
+  const match = hashExpression.match(INTEGRITY_REGEX)
   if (!match) {
     throw new PnpmError('INVALID_INTEGRITY', `Invalid integrity format: expected "algo-base64hash", got "${integrity}"`)
   }

--- a/pnpm11/crypto/integrity/test/index.ts
+++ b/pnpm11/crypto/integrity/test/index.ts
@@ -10,6 +10,12 @@ describe('parseIntegrity', () => {
     expect(result.hexDigest).toBe('f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7')
   })
 
+  it('excludes SRI options from the digest', () => {
+    const integrity = 'sha512-9/u6bgY2+JDlb7vzKD5STG+jIErimDgtYkdB0NxmODJuKCxBvl5CVNiCB3LFUYosWowMf37aGVlKfrU5RT4e1w=='
+    expect(parseIntegrity(`${integrity}?r1`)).toEqual(parseIntegrity(integrity))
+    expect(parseIntegrity(`${integrity}?r1?provider-option`)).toEqual(parseIntegrity(integrity))
+  })
+
   it('parses a valid sha256 integrity string', () => {
     // "hello" hashed with sha256, base64 encoded
     const integrity = 'sha256-LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ='

--- a/pnpm11/crypto/integrity/test/index.ts
+++ b/pnpm11/crypto/integrity/test/index.ts
@@ -10,12 +10,6 @@ describe('parseIntegrity', () => {
     expect(result.hexDigest).toBe('f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7')
   })
 
-  it('excludes SRI options from the digest', () => {
-    const integrity = 'sha512-9/u6bgY2+JDlb7vzKD5STG+jIErimDgtYkdB0NxmODJuKCxBvl5CVNiCB3LFUYosWowMf37aGVlKfrU5RT4e1w=='
-    expect(parseIntegrity(`${integrity}?r1`)).toEqual(parseIntegrity(integrity))
-    expect(parseIntegrity(`${integrity}?r1?provider-option`)).toEqual(parseIntegrity(integrity))
-  })
-
   it('parses a valid sha256 integrity string', () => {
     // "hello" hashed with sha256, base64 encoded
     const integrity = 'sha256-LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ='

--- a/pnpm11/fetching/tarball-fetcher/src/index.ts
+++ b/pnpm11/fetching/tarball-fetcher/src/index.ts
@@ -104,6 +104,7 @@ async function fetchFromTarball (
     filesIndexFile: opts.filesIndexFile,
     pkg: opts.pkg,
     redirect: resolution.revision == null ? undefined : 'manual',
+    retry: resolution.revision == null ? undefined : { retries: 0 },
     appendManifest: opts.appendManifest,
     ignoreFilePattern: opts.ignoreFilePattern,
   })

--- a/pnpm11/fetching/tarball-fetcher/src/index.ts
+++ b/pnpm11/fetching/tarball-fetcher/src/index.ts
@@ -83,6 +83,7 @@ async function fetchFromTarball (
   resolution: {
     integrity?: string
     registry?: string
+    revision?: number
     tarball: string
   },
   opts: FetchOptions
@@ -102,6 +103,7 @@ async function fetchFromTarball (
     registry: resolution.registry,
     filesIndexFile: opts.filesIndexFile,
     pkg: opts.pkg,
+    redirect: resolution.revision == null ? undefined : 'manual',
     appendManifest: opts.appendManifest,
     ignoreFilePattern: opts.ignoreFilePattern,
   })

--- a/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -27,6 +27,7 @@ export type DownloadOptions = {
   onStart?: (totalSize: number | null, attempt: number) => void
   onProgress?: (downloaded: number) => void
   integrity?: string
+  redirect?: RequestRedirect
   storeIndex: StoreIndex
   pkg?: FetchOptions['pkg']
 } & Pick<FetchOptions, 'appendManifest' | 'readManifest' | 'filesIndexFile' | 'ignoreFilePattern'>
@@ -75,6 +76,7 @@ export function createDownloader (
           resolve(await fetch(attempt))
         } catch (error: any) { // eslint-disable-line
           if (
+            (opts.redirect === 'manual' && error.response?.status >= 300 && error.response.status < 400) ||
             error.response?.status === 401 ||
             error.response?.status === 403 ||
             error.response?.status === 404 ||
@@ -131,6 +133,7 @@ export function createDownloader (
           // Hence, we tell fetch to not retry,
           // and we perform the retries from this function instead.
           retry: { retries: 0 },
+          redirect: opts.redirect,
           timeout: gotOpts.timeout,
         })
 

--- a/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -4,7 +4,7 @@ import util from 'node:util'
 import { requestRetryLogger } from '@pnpm/core-loggers'
 import { FetchError, redactUrlForDisplay } from '@pnpm/error'
 import type { FetchOptions, FetchResult } from '@pnpm/fetching.fetcher-base'
-import type { FetchFromRegistry, GetAuthHeader } from '@pnpm/fetching.types'
+import type { FetchFromRegistry, GetAuthHeader, RetryTimeoutOptions } from '@pnpm/fetching.types'
 import { globalWarn } from '@pnpm/logger'
 import type { Cafs } from '@pnpm/store.cafs-types'
 import type { StoreIndex } from '@pnpm/store.index'
@@ -28,6 +28,7 @@ export type DownloadOptions = {
   onProgress?: (downloaded: number) => void
   integrity?: string
   redirect?: RequestRedirect
+  retry?: Pick<RetryTimeoutOptions, 'retries'>
   storeIndex: StoreIndex
   pkg?: FetchOptions['pkg']
 } & Pick<FetchOptions, 'appendManifest' | 'readManifest' | 'filesIndexFile' | 'ignoreFilePattern'>
@@ -68,7 +69,8 @@ export function createDownloader (
   return async function download (url: string, opts: DownloadOptions): Promise<FetchResult> {
     const authHeaderValue = opts.getAuthHeaderByURI(url, { pkgName: opts.pkg?.name })
 
-    const op = retry.operation(retryOpts)
+    const downloadRetryOpts = { ...retryOpts, ...opts.retry }
+    const op = retry.operation(downloadRetryOpts)
 
     return new Promise<FetchResult>((resolve, reject) => {
       op.attempt(async (attempt) => {
@@ -109,7 +111,7 @@ export function createDownloader (
           requestRetryLogger.debug({
             attempt,
             error: errorInfo,
-            maxRetries: retryOpts.retries,
+            maxRetries: downloadRetryOpts.retries,
             method: 'GET',
             timeout,
             url,

--- a/pnpm11/fetching/tarball-fetcher/test/fetch.ts
+++ b/pnpm11/fetching/tarball-fetcher/test/fetch.ts
@@ -237,9 +237,9 @@ test('retry when tarball size does not match content-length', async () => {
   expect(result.filesMap).toBeTruthy()
 })
 
-test('verifies a tarball while ignoring its registry revision SRI option', async () => {
+test('verifies a registry replacement tarball from its digest URL', async () => {
   const tarballContent = fs.readFileSync(tarballPath)
-  const integrity = `${ssri.fromData(tarballContent, { algorithms: ['sha512'] })}?r1`
+  const integrity = ssri.fromData(tarballContent, { algorithms: ['sha512'] }).toString()
   const digest = ssri.parse(integrity)['sha512'][0].digest
   const tarball = `${registry}/-/tarballs/sha512/${Buffer.from(digest, 'base64').toString('base64url')}`
   const mockPool = mockAgent.get(registry)
@@ -254,6 +254,7 @@ test('verifies a tarball while ignoring its registry revision SRI option', async
 
   const result = await fetch.remoteTarball(cafs, {
     integrity,
+    revision: 1,
     tarball,
   }, {
     filesIndexFile,

--- a/pnpm11/fetching/tarball-fetcher/test/fetch.ts
+++ b/pnpm11/fetching/tarball-fetcher/test/fetch.ts
@@ -301,6 +301,32 @@ test('does not follow redirects for a registry replacement tarball', async () =>
   expect(mockAgent.pendingInterceptors()).toHaveLength(1)
 })
 
+test('does not retry a failed registry replacement tarball request', async () => {
+  const integrity = `sha512-${'A'.repeat(86)}==`
+  const tarballPathname = `/-/tarballs/sha512/${'A'.repeat(86)}`
+  const mockPool = mockAgent.get(registry)
+  mockPool.intercept({
+    path: tarballPathname,
+    method: 'GET',
+  }).reply(503, '')
+
+  process.chdir(temporaryDirectory())
+
+  await expect(fetch.remoteTarball(cafs, {
+    integrity,
+    revision: 1,
+    tarball: `${registry}${tarballPathname}`,
+  }, {
+    filesIndexFile,
+    lockfileDir: process.cwd(),
+    pkg,
+  })).rejects.toMatchObject({
+    attempts: 1,
+    code: 'ERR_PNPM_FETCH_503',
+  })
+  expect(mockAgent.pendingInterceptors()).toHaveLength(0)
+})
+
 test('fail when integrity check fails two times in a row', async () => {
   const wrongTarball = f.find('babel-helper-hoist-variables-7.0.0-alpha.10.tgz')
   const wrongTarballContent = fs.readFileSync(wrongTarball)

--- a/pnpm11/fetching/tarball-fetcher/test/fetch.ts
+++ b/pnpm11/fetching/tarball-fetcher/test/fetch.ts
@@ -237,6 +237,33 @@ test('retry when tarball size does not match content-length', async () => {
   expect(result.filesMap).toBeTruthy()
 })
 
+test('verifies a tarball while ignoring its registry revision SRI option', async () => {
+  const tarballContent = fs.readFileSync(tarballPath)
+  const integrity = `${ssri.fromData(tarballContent, { algorithms: ['sha512'] })}?r1`
+  const digest = ssri.parse(integrity)['sha512'][0].digest
+  const tarball = `${registry}/-/tarballs/sha512/${Buffer.from(digest, 'base64').toString('base64url')}`
+  const mockPool = mockAgent.get(registry)
+  mockPool.intercept({
+    path: new URL(tarball).pathname,
+    method: 'GET',
+  }).reply(200, tarballContent, {
+    headers: { 'Content-Length': tarballSize.toString() },
+  })
+
+  process.chdir(temporaryDirectory())
+
+  const result = await fetch.remoteTarball(cafs, {
+    integrity,
+    tarball,
+  }, {
+    filesIndexFile,
+    lockfileDir: process.cwd(),
+    pkg,
+  })
+
+  expect(result.filesMap).toBeTruthy()
+})
+
 test('fail when integrity check fails two times in a row', async () => {
   const wrongTarball = f.find('babel-helper-hoist-variables-7.0.0-alpha.10.tgz')
   const wrongTarballContent = fs.readFileSync(wrongTarball)

--- a/pnpm11/fetching/tarball-fetcher/test/fetch.ts
+++ b/pnpm11/fetching/tarball-fetcher/test/fetch.ts
@@ -265,6 +265,42 @@ test('verifies a registry replacement tarball from its digest URL', async () => 
   expect(result.filesMap).toBeTruthy()
 })
 
+test('does not follow redirects for a registry replacement tarball', async () => {
+  const tarballContent = fs.readFileSync(tarballPath)
+  const integrity = ssri.fromData(tarballContent, { algorithms: ['sha512'] }).toString()
+  const digest = ssri.parse(integrity)['sha512'][0].digest
+  const tarballPathname = `/-/tarballs/sha512/${Buffer.from(digest, 'base64').toString('base64url')}`
+  const mockPool = mockAgent.get(registry)
+  mockPool.intercept({
+    path: tarballPathname,
+    method: 'GET',
+  }).reply(302, '', {
+    headers: { location: '/redirected.tgz' },
+  })
+  mockPool.intercept({
+    path: '/redirected.tgz',
+    method: 'GET',
+  }).reply(200, tarballContent, {
+    headers: { 'Content-Length': tarballSize.toString() },
+  })
+
+  process.chdir(temporaryDirectory())
+
+  await expect(fetch.remoteTarball(cafs, {
+    integrity,
+    revision: 1,
+    tarball: `${registry}${tarballPathname}`,
+  }, {
+    filesIndexFile,
+    lockfileDir: process.cwd(),
+    pkg,
+  })).rejects.toMatchObject({
+    attempts: 1,
+    code: 'ERR_PNPM_FETCH_302',
+  })
+  expect(mockAgent.pendingInterceptors()).toHaveLength(1)
+})
+
 test('fail when integrity check fails two times in a row', async () => {
   const wrongTarball = f.find('babel-helper-hoist-variables-7.0.0-alpha.10.tgz')
   const wrongTarballContent = fs.readFileSync(wrongTarball)

--- a/pnpm11/lockfile/types/src/index.ts
+++ b/pnpm11/lockfile/types/src/index.ts
@@ -90,6 +90,7 @@ export interface TarballResolution {
   type?: undefined
   tarball: string
   integrity?: string
+  revision?: number
   path?: string
   /**
    * True for tarballs sourced from a git host (codeload.github.com /
@@ -162,6 +163,7 @@ export interface VariationsResolution {
 
 export type LockfileResolution = Resolution | VariationsResolution | {
   integrity: string
+  revision?: number
 }
 
 export type PackageSnapshot = LockfilePackageInfo & LockfilePackageSnapshot

--- a/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
@@ -34,6 +34,17 @@ export function pkgSnapshotToResolution (
       `Cannot install package "${depPath}": its lockfile entry has an invalid "revision" field.`)
   }
   if (
+    resolution.revision != null &&
+    (
+      Boolean(resolution.type) ||
+      resolution.tarball?.startsWith('file:') ||
+      resolution.gitHosted === true
+    )
+  ) {
+    throw new PnpmError('INVALID_TARBALL_REVISION',
+      `Cannot install package "${depPath}": its lockfile entry with a revision does not identify a registry tarball.`)
+  }
+  if (
     Boolean(resolution.type) ||
     resolution.tarball?.startsWith('file:') ||
     resolution.gitHosted === true
@@ -55,8 +66,8 @@ export function pkgSnapshotToResolution (
     registry = normalizeRegistriesByPrefix(opts.registriesByPrefix)[registryName]
     if (!registry) {
       throw new PnpmError('MISSING_NAMED_REGISTRY',
-        `Cannot install package "${depPath}": it was resolved from the named registry '${registryName}:', which is not present in the registriesByPrefix setting.`,
-        { hint: `Add '${registryName}' to the registriesByPrefix setting in pnpm-workspace.yaml.` })
+        `Cannot install package "${depPath}": its registry prefix '${registryName}:' is not declared by the registries setting.`,
+        { hint: `Add a registries entry with "prefix: ${registryName}" to pnpm-workspace.yaml.` })
     }
   } else if (name != null && name[0] === '@') {
     registry = opts.registriesByScope[name.split('/')[0]]

--- a/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
@@ -5,7 +5,10 @@ import * as dp from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
 import type { PackageSnapshot, TarballResolution } from '@pnpm/lockfile.types'
 import type { Resolution } from '@pnpm/resolving.resolver-base'
-import { getNpmTarballUrl } from '@pnpm/resolving.tarball-url'
+import {
+  getIntegrityAddressedTarballUrl,
+  getNpmTarballUrl,
+} from '@pnpm/resolving.tarball-url'
 import type { RegistryContext } from '@pnpm/types'
 
 import { nameVerFromPkgSnapshot } from './nameVerFromPkgSnapshot.js'
@@ -57,7 +60,9 @@ export function pkgSnapshotToResolution (
   }
   let tarball!: string
   if (!resolution.tarball) {
-    tarball = getTarball(registry)
+    tarball = resolution.integrity == null
+      ? getTarball(registry)
+      : getIntegrityAddressedTarballUrl(resolution.integrity, registry) ?? getTarball(registry)
   } else {
     tarball = new url.URL(resolution.tarball,
       registry.endsWith('/') ? registry : `${registry}/`

--- a/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
@@ -4,7 +4,10 @@ import * as dp from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
 import type { PackageSnapshot, TarballResolution } from '@pnpm/lockfile.types'
 import type { Resolution } from '@pnpm/resolving.resolver-base'
-import { getNpmTarballUrl } from '@pnpm/resolving.tarball-url'
+import {
+  getIntegrityAddressedTarballUrl,
+  getNpmTarballUrl,
+} from '@pnpm/resolving.tarball-url'
 import type { Registries } from '@pnpm/types'
 
 import { nameVerFromPkgSnapshot } from './nameVerFromPkgSnapshot.js'
@@ -48,7 +51,9 @@ export function pkgSnapshotToResolution (
   }
   let tarball!: string
   if (!resolution.tarball) {
-    tarball = getTarball(registry)
+    tarball = resolution.integrity == null
+      ? getTarball(registry)
+      : getIntegrityAddressedTarballUrl(resolution.integrity, registry) ?? getTarball(registry)
   } else {
     tarball = new url.URL(resolution.tarball,
       registry.endsWith('/') ? registry : `${registry}/`

--- a/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
@@ -8,6 +8,8 @@ import type { Resolution } from '@pnpm/resolving.resolver-base'
 import {
   getIntegrityAddressedTarballUrl,
   getNpmTarballUrl,
+  isIntegrityAddressedRegistryTarballUrl,
+  isValidTarballRevision,
 } from '@pnpm/resolving.tarball-url'
 import type { RegistryContext } from '@pnpm/types'
 
@@ -26,6 +28,10 @@ export function pkgSnapshotToResolution (
     // Avoid URL string-coercion from malformed YAML lockfile values.
     throw new PnpmError('INVALID_TARBALL_RESOLUTION',
       `Cannot install package "${depPath}": its lockfile entry has a non-string "tarball" field.`)
+  }
+  if (resolution.revision != null && !isValidTarballRevision(resolution.revision)) {
+    throw new PnpmError('INVALID_TARBALL_REVISION',
+      `Cannot install package "${depPath}": its lockfile entry has an invalid "revision" field.`)
   }
   if (
     Boolean(resolution.type) ||
@@ -60,10 +66,29 @@ export function pkgSnapshotToResolution (
   }
   let tarball!: string
   if (!resolution.tarball) {
-    tarball = resolution.integrity == null
-      ? getTarball(registry)
-      : getIntegrityAddressedTarballUrl(resolution.integrity, registry) ?? getTarball(registry)
+    if (resolution.revision == null) {
+      tarball = getTarball(registry)
+    } else {
+      const integrityTarball = resolution.integrity == null
+        ? undefined
+        : getIntegrityAddressedTarballUrl(resolution.integrity, registry)
+      if (integrityTarball == null) {
+        throw new PnpmError('INVALID_TARBALL_REVISION',
+          `Cannot install package "${depPath}": its lockfile entry with a revision has invalid or missing integrity.`)
+      }
+      tarball = integrityTarball
+    }
   } else {
+    if (
+      resolution.revision != null &&
+      (
+        resolution.integrity == null ||
+        !isIntegrityAddressedRegistryTarballUrl(resolution.tarball, resolution.integrity, registry)
+      )
+    ) {
+      throw new PnpmError('INVALID_TARBALL_REVISION',
+        `Cannot install package "${depPath}": its lockfile entry with a revision has a mismatched tarball URL.`)
+    }
     tarball = new url.URL(resolution.tarball,
       registry.endsWith('/') ? registry : `${registry}/`
     ).toString()

--- a/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/src/pkgSnapshotToResolution.ts
@@ -7,6 +7,8 @@ import type { Resolution } from '@pnpm/resolving.resolver-base'
 import {
   getIntegrityAddressedTarballUrl,
   getNpmTarballUrl,
+  isIntegrityAddressedRegistryTarballUrl,
+  isValidTarballRevision,
 } from '@pnpm/resolving.tarball-url'
 import type { Registries } from '@pnpm/types'
 
@@ -22,6 +24,10 @@ export function pkgSnapshotToResolution (
     // Avoid URL string-coercion from malformed YAML lockfile values.
     throw new PnpmError('INVALID_TARBALL_RESOLUTION',
       `Cannot install package "${depPath}": its lockfile entry has a non-string "tarball" field.`)
+  }
+  if (resolution.revision != null && !isValidTarballRevision(resolution.revision)) {
+    throw new PnpmError('INVALID_TARBALL_REVISION',
+      `Cannot install package "${depPath}": its lockfile entry has an invalid "revision" field.`)
   }
   if (
     Boolean(resolution.type) ||
@@ -51,10 +57,29 @@ export function pkgSnapshotToResolution (
   }
   let tarball!: string
   if (!resolution.tarball) {
-    tarball = resolution.integrity == null
-      ? getTarball(registry)
-      : getIntegrityAddressedTarballUrl(resolution.integrity, registry) ?? getTarball(registry)
+    if (resolution.revision == null) {
+      tarball = getTarball(registry)
+    } else {
+      const integrityTarball = resolution.integrity == null
+        ? undefined
+        : getIntegrityAddressedTarballUrl(resolution.integrity, registry)
+      if (integrityTarball == null) {
+        throw new PnpmError('INVALID_TARBALL_REVISION',
+          `Cannot install package "${depPath}": its lockfile entry with a revision has invalid or missing integrity.`)
+      }
+      tarball = integrityTarball
+    }
   } else {
+    if (
+      resolution.revision != null &&
+      (
+        resolution.integrity == null ||
+        !isIntegrityAddressedRegistryTarballUrl(resolution.tarball, resolution.integrity, registry)
+      )
+    ) {
+      throw new PnpmError('INVALID_TARBALL_REVISION',
+        `Cannot install package "${depPath}": its lockfile entry with a revision has a mismatched tarball URL.`)
+    }
     tarball = new url.URL(resolution.tarball,
       registry.endsWith('/') ? registry : `${registry}/`
     ).toString()

--- a/pnpm11/lockfile/utils/src/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/src/toLockfileResolution.ts
@@ -1,8 +1,10 @@
+import { PnpmError } from '@pnpm/error'
 import type { LockfileResolution } from '@pnpm/lockfile.types'
 import { type GitResolution, isGitHostedTarballUrl, type Resolution, type TarballResolution } from '@pnpm/resolving.resolver-base'
 import {
   isCanonicalRegistryTarballUrl,
   isIntegrityAddressedRegistryTarballUrl,
+  isValidTarballRevision,
 } from '@pnpm/resolving.tarball-url'
 import type { RegistryServerType } from '@pnpm/types'
 
@@ -25,7 +27,7 @@ export function toLockfileResolution (
   opts: ToLockfileResolutionOptions
 ): LockfileResolution {
   const { registry, serverType, lockfileIncludeTarballUrl } = opts
-  if (resolution.type !== undefined || !resolution['integrity']) {
+  if (resolution.type !== undefined) {
     // Nothing checks a git checkout against a hash — the commit pins the
     // content — so an `integrity` some other tool recorded on a git
     // resolution is dropped rather than written back, instead of standing
@@ -33,6 +35,17 @@ export function toLockfileResolution (
     if (resolution.type === 'git' && 'integrity' in resolution) {
       const { integrity: _integrity, ...rest } = resolution as GitResolution & { integrity?: string }
       return rest
+    return resolution as LockfileResolution
+  }
+  const revision = (resolution as TarballResolution).revision
+  if (revision != null && !isValidTarballRevision(revision)) {
+    throw new PnpmError('INVALID_TARBALL_REVISION',
+      `Cannot serialize invalid tarball revision "${String(revision)}".`)
+  }
+  if (!resolution['integrity']) {
+    if (revision != null) {
+      throw new PnpmError('INVALID_TARBALL_REVISION',
+        'Cannot serialize a tarball revision without integrity.')
     }
     return resolution as LockfileResolution
   }
@@ -41,7 +54,10 @@ export function toLockfileResolution (
   // from external state) so we don't blow up on a missing field.
   const tarball = resolution['tarball'] as string | undefined
   if (tarball == null) {
-    return { integrity: resolution['integrity'] }
+    return {
+      integrity: resolution['integrity'],
+      ...(revision == null ? {} : { revision }),
+    }
   }
   // Honor the resolver-supplied flag, with a URL fallback for resolutions
   // that didn't go through the git resolver (e.g. config-dep migrations or
@@ -64,7 +80,10 @@ export function toLockfileResolution (
       isIntegrityAddressedRegistryTarballUrl(tarball, resolution['integrity'], registry)
     )
   ) {
-    return { integrity: resolution['integrity'] }
+    return {
+      integrity: resolution['integrity'],
+      ...(revision == null ? {} : { revision }),
+    }
   }
   // The kept-URL form carries the `gitHosted` marker and the subdirectory `path`
   // (`repo#commit&path:/sub/dir`, only ever set on git-hosted tarballs) so a
@@ -74,6 +93,7 @@ export function toLockfileResolution (
   return {
     integrity: resolution['integrity'],
     tarball,
+    ...(revision == null ? {} : { revision }),
     ...(gitHosted ? { gitHosted: true } : {}),
     ...(path == null ? {} : { path }),
   }

--- a/pnpm11/lockfile/utils/src/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/src/toLockfileResolution.ts
@@ -27,7 +27,16 @@ export function toLockfileResolution (
   opts: ToLockfileResolutionOptions
 ): LockfileResolution {
   const { registry, serverType, lockfileIncludeTarballUrl } = opts
+  const revision = (resolution as TarballResolution).revision
+  if (revision != null && !isValidTarballRevision(revision)) {
+    throw new PnpmError('INVALID_TARBALL_REVISION',
+      `Cannot serialize invalid tarball revision "${String(revision)}".`)
+  }
   if (resolution.type !== undefined) {
+    if (revision != null) {
+      throw new PnpmError('INVALID_TARBALL_REVISION',
+        'Cannot serialize a tarball revision for a non-registry resolution.')
+    }
     // Nothing checks a git checkout against a hash — the commit pins the
     // content — so an `integrity` some other tool recorded on a git
     // resolution is dropped rather than written back, instead of standing
@@ -37,11 +46,6 @@ export function toLockfileResolution (
       return rest
     }
     return resolution as LockfileResolution
-  }
-  const revision = (resolution as TarballResolution).revision
-  if (revision != null && !isValidTarballRevision(revision)) {
-    throw new PnpmError('INVALID_TARBALL_REVISION',
-      `Cannot serialize invalid tarball revision "${String(revision)}".`)
   }
   if (!resolution['integrity']) {
     if (revision != null) {
@@ -55,9 +59,12 @@ export function toLockfileResolution (
   // from external state) so we don't blow up on a missing field.
   const tarball = resolution['tarball'] as string | undefined
   if (tarball == null) {
+    if (revision != null) {
+      throw new PnpmError('INVALID_TARBALL_REVISION',
+        `Cannot serialize tarball revision ${revision} without its integrity-addressed URL.`)
+    }
     return {
       integrity: resolution['integrity'],
-      ...(revision == null ? {} : { revision }),
     }
   }
   const integrityAddressed = tarball.includes('/-/tarballs/sha512/') &&
@@ -65,6 +72,12 @@ export function toLockfileResolution (
   if (revision != null && !integrityAddressed) {
     throw new PnpmError('INVALID_TARBALL_REVISION',
       `Cannot serialize tarball revision ${revision}: its URL does not match its integrity and registry.`)
+  }
+  if (integrityAddressed) {
+    return {
+      integrity: resolution['integrity'],
+      ...(revision == null ? {} : { revision }),
+    }
   }
   // Honor the resolver-supplied flag, with a URL fallback for resolutions
   // that didn't go through the git resolver (e.g. config-dep migrations or
@@ -82,14 +95,10 @@ export function toLockfileResolution (
     !lockfileIncludeTarballUrl &&
     !gitHosted &&
     !tarball.startsWith('file:') &&
-    (
-      isCanonicalRegistryTarballUrl(tarball, pkg, { registry, serverType }) ||
-      integrityAddressed
-    )
+    isCanonicalRegistryTarballUrl(tarball, pkg, { registry, serverType })
   ) {
     return {
       integrity: resolution['integrity'],
-      ...(revision == null ? {} : { revision }),
     }
   }
   // The kept-URL form carries the `gitHosted` marker and the subdirectory `path`
@@ -100,7 +109,6 @@ export function toLockfileResolution (
   return {
     integrity: resolution['integrity'],
     tarball,
-    ...(revision == null ? {} : { revision }),
     ...(gitHosted ? { gitHosted: true } : {}),
     ...(path == null ? {} : { path }),
   }

--- a/pnpm11/lockfile/utils/src/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/src/toLockfileResolution.ts
@@ -1,6 +1,9 @@
 import type { LockfileResolution } from '@pnpm/lockfile.types'
 import { type GitResolution, isGitHostedTarballUrl, type Resolution, type TarballResolution } from '@pnpm/resolving.resolver-base'
-import { isCanonicalRegistryTarballUrl } from '@pnpm/resolving.tarball-url'
+import {
+  isCanonicalRegistryTarballUrl,
+  isIntegrityAddressedRegistryTarballUrl,
+} from '@pnpm/resolving.tarball-url'
 import type { RegistryServerType } from '@pnpm/types'
 
 export interface ToLockfileResolutionOptions {
@@ -56,7 +59,10 @@ export function toLockfileResolution (
     !lockfileIncludeTarballUrl &&
     !gitHosted &&
     !tarball.startsWith('file:') &&
-    isCanonicalRegistryTarballUrl(tarball, pkg, { registry, serverType })
+    (
+      isCanonicalRegistryTarballUrl(tarball, pkg, { registry, serverType }) ||
+      isIntegrityAddressedRegistryTarballUrl(tarball, resolution['integrity'], registry)
+    )
   ) {
     return { integrity: resolution['integrity'] }
   }

--- a/pnpm11/lockfile/utils/src/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/src/toLockfileResolution.ts
@@ -1,8 +1,10 @@
+import { PnpmError } from '@pnpm/error'
 import type { LockfileResolution } from '@pnpm/lockfile.types'
 import { isGitHostedTarballUrl, type Resolution, type TarballResolution } from '@pnpm/resolving.resolver-base'
 import {
   isCanonicalRegistryTarballUrl,
   isIntegrityAddressedRegistryTarballUrl,
+  isValidTarballRevision,
 } from '@pnpm/resolving.tarball-url'
 
 export function toLockfileResolution (
@@ -14,7 +16,19 @@ export function toLockfileResolution (
   registry: string,
   lockfileIncludeTarballUrl?: boolean
 ): LockfileResolution {
-  if (resolution.type !== undefined || !resolution['integrity']) {
+  if (resolution.type !== undefined) {
+    return resolution as LockfileResolution
+  }
+  const revision = (resolution as TarballResolution).revision
+  if (revision != null && !isValidTarballRevision(revision)) {
+    throw new PnpmError('INVALID_TARBALL_REVISION',
+      `Cannot serialize invalid tarball revision "${String(revision)}".`)
+  }
+  if (!resolution['integrity']) {
+    if (revision != null) {
+      throw new PnpmError('INVALID_TARBALL_REVISION',
+        'Cannot serialize a tarball revision without integrity.')
+    }
     return resolution as LockfileResolution
   }
   // Tarball-typed resolutions are guaranteed to carry a tarball URL by the
@@ -22,7 +36,10 @@ export function toLockfileResolution (
   // from external state) so we don't blow up on a missing field.
   const tarball = resolution['tarball'] as string | undefined
   if (tarball == null) {
-    return { integrity: resolution['integrity'] }
+    return {
+      integrity: resolution['integrity'],
+      ...(revision == null ? {} : { revision }),
+    }
   }
   // Honor the resolver-supplied flag, with a URL fallback for resolutions
   // that didn't go through the git resolver (e.g. config-dep migrations or
@@ -45,7 +62,10 @@ export function toLockfileResolution (
       isIntegrityAddressedRegistryTarballUrl(tarball, resolution['integrity'], registry)
     )
   ) {
-    return { integrity: resolution['integrity'] }
+    return {
+      integrity: resolution['integrity'],
+      ...(revision == null ? {} : { revision }),
+    }
   }
   // The kept-URL form carries the `gitHosted` marker and the subdirectory `path`
   // (`repo#commit&path:/sub/dir`, only ever set on git-hosted tarballs) so a
@@ -55,6 +75,7 @@ export function toLockfileResolution (
   return {
     integrity: resolution['integrity'],
     tarball,
+    ...(revision == null ? {} : { revision }),
     ...(gitHosted ? { gitHosted: true } : {}),
     ...(path == null ? {} : { path }),
   }

--- a/pnpm11/lockfile/utils/src/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/src/toLockfileResolution.ts
@@ -35,6 +35,7 @@ export function toLockfileResolution (
     if (resolution.type === 'git' && 'integrity' in resolution) {
       const { integrity: _integrity, ...rest } = resolution as GitResolution & { integrity?: string }
       return rest
+    }
     return resolution as LockfileResolution
   }
   const revision = (resolution as TarballResolution).revision
@@ -59,6 +60,12 @@ export function toLockfileResolution (
       ...(revision == null ? {} : { revision }),
     }
   }
+  const integrityAddressed = tarball.includes('/-/tarballs/sha512/') &&
+    isIntegrityAddressedRegistryTarballUrl(tarball, resolution['integrity'], registry)
+  if (revision != null && !integrityAddressed) {
+    throw new PnpmError('INVALID_TARBALL_REVISION',
+      `Cannot serialize tarball revision ${revision}: its URL does not match its integrity and registry.`)
+  }
   // Honor the resolver-supplied flag, with a URL fallback for resolutions
   // that didn't go through the git resolver (e.g. config-dep migrations or
   // legacy lockfiles read by callers that don't enrich the field).
@@ -77,7 +84,7 @@ export function toLockfileResolution (
     !tarball.startsWith('file:') &&
     (
       isCanonicalRegistryTarballUrl(tarball, pkg, { registry, serverType }) ||
-      isIntegrityAddressedRegistryTarballUrl(tarball, resolution['integrity'], registry)
+      integrityAddressed
     )
   ) {
     return {

--- a/pnpm11/lockfile/utils/src/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/src/toLockfileResolution.ts
@@ -1,6 +1,9 @@
 import type { LockfileResolution } from '@pnpm/lockfile.types'
 import { isGitHostedTarballUrl, type Resolution, type TarballResolution } from '@pnpm/resolving.resolver-base'
-import { isCanonicalRegistryTarballUrl } from '@pnpm/resolving.tarball-url'
+import {
+  isCanonicalRegistryTarballUrl,
+  isIntegrityAddressedRegistryTarballUrl,
+} from '@pnpm/resolving.tarball-url'
 
 export function toLockfileResolution (
   pkg: {
@@ -37,7 +40,10 @@ export function toLockfileResolution (
     !lockfileIncludeTarballUrl &&
     !gitHosted &&
     !tarball.startsWith('file:') &&
-    isCanonicalRegistryTarballUrl(tarball, pkg, registry)
+    (
+      isCanonicalRegistryTarballUrl(tarball, pkg, registry) ||
+      isIntegrityAddressedRegistryTarballUrl(tarball, resolution['integrity'], registry)
+    )
   ) {
     return { integrity: resolution['integrity'] }
   }

--- a/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
@@ -193,7 +193,7 @@ test('pkgSnapshotToResolution() hydrates an integrity-only resolution from the c
   })
 })
 
-test.each([0, -1, 1.5, '1'])(
+test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1', '01'])(
   'pkgSnapshotToResolution() rejects malformed revision %s',
   (revision) => {
     expect(() => pkgSnapshotToResolution('foo@1.0.0', {

--- a/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
@@ -3,7 +3,7 @@ import { pkgSnapshotToResolution } from '@pnpm/lockfile.utils'
 
 const GIT_TARBALL = 'https://codeload.github.com/foo/bar/tar.gz/0123456789abcdef0123456789abcdef01234567'
 const LEGACY_GIT_TARBALL = 'https://codeload.github.com/kevva/is-negative/tar.gz/0123456789abcdef0123456789abcdef01234567'
-const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==?r2`
+const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==`
 
 test('pkgSnapshotToResolution() fails closed on a non-string tarball', () => {
   // A tampered lockfile (YAML) could carry a non-string `tarball` that `new URL()` would
@@ -105,29 +105,47 @@ test('pkgSnapshotToResolution() converts git-hosted and file: tarball snapshots'
   })
 })
 
-test('pkgSnapshotToResolution() hydrates a revision-aware integrity from the effective registry', () => {
+test('pkgSnapshotToResolution() hydrates a resolution with a revision from the effective registry', () => {
   expect(pkgSnapshotToResolution('@scope/foo@1.0.0', {
     resolution: {
       integrity: REVISION_INTEGRITY,
+      revision: 2,
     },
   }, {
     default: 'https://registry.npmjs.org/',
     '@scope': 'https://registry.example/~main',
   })).toEqual({
     integrity: REVISION_INTEGRITY,
+    revision: 2,
     tarball: `https://registry.example/~main/-/tarballs/sha512/${'A'.repeat(86)}`,
   })
 })
 
-test('pkgSnapshotToResolution() treats unrecognized SRI options as legacy integrity', () => {
+test('pkgSnapshotToResolution() hydrates an integrity-only resolution from the canonical URL', () => {
   expect(pkgSnapshotToResolution('foo@1.0.0', {
     resolution: {
-      integrity: `sha512-${'A'.repeat(86)}==?v1`,
+      integrity: REVISION_INTEGRITY,
     },
   }, {
     default: 'https://registry.npmjs.org/',
   })).toEqual({
-    integrity: `sha512-${'A'.repeat(86)}==?v1`,
+    integrity: REVISION_INTEGRITY,
     tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
   })
 })
+
+test.each([0, -1, 1.5, '1'])(
+  'pkgSnapshotToResolution() rejects malformed revision %s',
+  (revision) => {
+    expect(() => pkgSnapshotToResolution('foo@1.0.0', {
+      resolution: {
+        integrity: REVISION_INTEGRITY,
+        revision,
+      } as never,
+    }, {
+      default: 'https://registry.npmjs.org/',
+    })).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+    }))
+  }
+)

--- a/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
@@ -208,3 +208,20 @@ test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1', '01'])(
     }))
   }
 )
+
+test.each([
+  { tarball: 'file:../foo.tgz' },
+  { tarball: 'https://codeload.github.com/foo/bar/tar.gz/abc', gitHosted: true },
+])('pkgSnapshotToResolution() rejects a revision on a non-registry tarball', (resolution) => {
+  expect(() => pkgSnapshotToResolution('foo@1.0.0', {
+    resolution: {
+      ...resolution,
+      integrity: REVISION_INTEGRITY,
+      revision: 1,
+    },
+  }, {
+    registriesByScope: { default: 'https://registry.npmjs.org/' },
+  })).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+  }))
+})

--- a/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
@@ -209,6 +209,22 @@ test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1', '01'])(
   }
 )
 
+test.each([{}, [], 1, true])(
+  'pkgSnapshotToResolution() rejects non-string revision integrity %#',
+  (integrity) => {
+    expect(() => pkgSnapshotToResolution('foo@1.0.0', {
+      resolution: {
+        integrity,
+        revision: 2,
+      } as never,
+    }, {
+      registriesByScope: { default: 'https://registry.npmjs.org/' },
+    })).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+    }))
+  }
+)
+
 test.each([
   { tarball: 'file:../foo.tgz' },
   { tarball: 'https://codeload.github.com/foo/bar/tar.gz/abc', gitHosted: true },

--- a/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
@@ -4,7 +4,7 @@ import { pkgSnapshotToResolution } from '@pnpm/lockfile.utils'
 
 const GIT_TARBALL = 'https://codeload.github.com/foo/bar/tar.gz/0123456789abcdef0123456789abcdef01234567'
 const LEGACY_GIT_TARBALL = 'https://codeload.github.com/kevva/is-negative/tar.gz/0123456789abcdef0123456789abcdef01234567'
-const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==?r2`
+const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==`
 
 test('pkgSnapshotToResolution() fails closed on a non-string tarball', () => {
   // A tampered lockfile (YAML) could carry a non-string `tarball` that `new URL()` would
@@ -162,10 +162,11 @@ test('pkgSnapshotToResolution() rejects an alias that only exists on Object.prot
   }
 })
 
-test('pkgSnapshotToResolution() hydrates a revision-aware integrity from the effective registry', () => {
+test('pkgSnapshotToResolution() hydrates a resolution with a revision from the effective registry', () => {
   expect(pkgSnapshotToResolution('@scope/foo@1.0.0', {
     resolution: {
       integrity: REVISION_INTEGRITY,
+      revision: 2,
     },
   }, {
     registriesByScope: {
@@ -174,19 +175,36 @@ test('pkgSnapshotToResolution() hydrates a revision-aware integrity from the eff
     },
   })).toEqual({
     integrity: REVISION_INTEGRITY,
+    revision: 2,
     tarball: `https://registry.example/~main/-/tarballs/sha512/${'A'.repeat(86)}`,
   })
 })
 
-test('pkgSnapshotToResolution() treats unrecognized SRI options as legacy integrity', () => {
+test('pkgSnapshotToResolution() hydrates an integrity-only resolution from the canonical URL', () => {
   expect(pkgSnapshotToResolution('foo@1.0.0', {
     resolution: {
-      integrity: `sha512-${'A'.repeat(86)}==?v1`,
+      integrity: REVISION_INTEGRITY,
     },
   }, {
     registriesByScope: { default: 'https://registry.npmjs.org/' },
   })).toEqual({
-    integrity: `sha512-${'A'.repeat(86)}==?v1`,
+    integrity: REVISION_INTEGRITY,
     tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
   })
 })
+
+test.each([0, -1, 1.5, '1'])(
+  'pkgSnapshotToResolution() rejects malformed revision %s',
+  (revision) => {
+    expect(() => pkgSnapshotToResolution('foo@1.0.0', {
+      resolution: {
+        integrity: REVISION_INTEGRITY,
+        revision,
+      } as never,
+    }, {
+      registriesByScope: { default: 'https://registry.npmjs.org/' },
+    })).toThrow(expect.objectContaining({
+      code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+    }))
+  }
+)

--- a/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
@@ -4,6 +4,7 @@ import { pkgSnapshotToResolution } from '@pnpm/lockfile.utils'
 
 const GIT_TARBALL = 'https://codeload.github.com/foo/bar/tar.gz/0123456789abcdef0123456789abcdef01234567'
 const LEGACY_GIT_TARBALL = 'https://codeload.github.com/kevva/is-negative/tar.gz/0123456789abcdef0123456789abcdef01234567'
+const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==?r2`
 
 test('pkgSnapshotToResolution() fails closed on a non-string tarball', () => {
   // A tampered lockfile (YAML) could carry a non-string `tarball` that `new URL()` would
@@ -159,4 +160,33 @@ test('pkgSnapshotToResolution() rejects an alias that only exists on Object.prot
       expect.objectContaining({ code: 'ERR_PNPM_MISSING_NAMED_REGISTRY' })
     )
   }
+})
+
+test('pkgSnapshotToResolution() hydrates a revision-aware integrity from the effective registry', () => {
+  expect(pkgSnapshotToResolution('@scope/foo@1.0.0', {
+    resolution: {
+      integrity: REVISION_INTEGRITY,
+    },
+  }, {
+    registriesByScope: {
+      default: 'https://registry.npmjs.org/',
+      '@scope': 'https://registry.example/~main',
+    },
+  })).toEqual({
+    integrity: REVISION_INTEGRITY,
+    tarball: `https://registry.example/~main/-/tarballs/sha512/${'A'.repeat(86)}`,
+  })
+})
+
+test('pkgSnapshotToResolution() treats unrecognized SRI options as legacy integrity', () => {
+  expect(pkgSnapshotToResolution('foo@1.0.0', {
+    resolution: {
+      integrity: `sha512-${'A'.repeat(86)}==?v1`,
+    },
+  }, {
+    registriesByScope: { default: 'https://registry.npmjs.org/' },
+  })).toEqual({
+    integrity: `sha512-${'A'.repeat(86)}==?v1`,
+    tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+  })
 })

--- a/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
+++ b/pnpm11/lockfile/utils/test/pkgSnapshotToResolution.ts
@@ -3,6 +3,7 @@ import { pkgSnapshotToResolution } from '@pnpm/lockfile.utils'
 
 const GIT_TARBALL = 'https://codeload.github.com/foo/bar/tar.gz/0123456789abcdef0123456789abcdef01234567'
 const LEGACY_GIT_TARBALL = 'https://codeload.github.com/kevva/is-negative/tar.gz/0123456789abcdef0123456789abcdef01234567'
+const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==?r2`
 
 test('pkgSnapshotToResolution() fails closed on a non-string tarball', () => {
   // A tampered lockfile (YAML) could carry a non-string `tarball` that `new URL()` would
@@ -101,5 +102,32 @@ test('pkgSnapshotToResolution() converts git-hosted and file: tarball snapshots'
     version: '1.0.0',
   }, { default: 'https://registry.npmjs.org/' })).toEqual({
     tarball: 'file:local-pkg-1.0.0.tgz',
+  })
+})
+
+test('pkgSnapshotToResolution() hydrates a revision-aware integrity from the effective registry', () => {
+  expect(pkgSnapshotToResolution('@scope/foo@1.0.0', {
+    resolution: {
+      integrity: REVISION_INTEGRITY,
+    },
+  }, {
+    default: 'https://registry.npmjs.org/',
+    '@scope': 'https://registry.example/~main',
+  })).toEqual({
+    integrity: REVISION_INTEGRITY,
+    tarball: `https://registry.example/~main/-/tarballs/sha512/${'A'.repeat(86)}`,
+  })
+})
+
+test('pkgSnapshotToResolution() treats unrecognized SRI options as legacy integrity', () => {
+  expect(pkgSnapshotToResolution('foo@1.0.0', {
+    resolution: {
+      integrity: `sha512-${'A'.repeat(86)}==?v1`,
+    },
+  }, {
+    default: 'https://registry.npmjs.org/',
+  })).toEqual({
+    integrity: `sha512-${'A'.repeat(86)}==?v1`,
+    tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
   })
 })

--- a/pnpm11/lockfile/utils/test/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/test/toLockfileResolution.ts
@@ -3,7 +3,7 @@ import { pkgSnapshotToResolution, toLockfileResolution } from '@pnpm/lockfile.ut
 
 const REGISTRY = 'https://registry.npmjs.org/'
 const GIT_TARBALL = 'https://codeload.github.com/foo/bar/tar.gz/0123456789abcdef0123456789abcdef01234567'
-const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==?r1`
+const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==`
 const REVISION_TARBALL = `https://registry.npmjs.org/-/tarballs/sha512/${'A'.repeat(86)}`
 
 test('keeps the tarball when lockfileIncludeTarballUrl is true', () => {
@@ -40,6 +40,38 @@ test('drops the tarball for standard registry URLs when lockfileIncludeTarballUr
 test('drops a validated integrity-addressed registry tarball URL', () => {
   expect(toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, revision: 1, tarball: REVISION_TARBALL },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+  })
+})
+
+test('keeps an integrity-addressed URL whose registry or digest does not match', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, revision: 1, tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}` },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+    tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}`,
+  })
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, revision: 1, tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}` },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+    tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}`,
+  })
+})
+
+test('normalizes an original served from the digest route to integrity only', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
     { integrity: REVISION_INTEGRITY, tarball: REVISION_TARBALL },
     REGISTRY
   )).toEqual({
@@ -47,23 +79,14 @@ test('drops a validated integrity-addressed registry tarball URL', () => {
   })
 })
 
-test('keeps an integrity-addressed URL whose registry or digest does not match', () => {
-  expect(toLockfileResolution(
+test.each([0, -1, 1.5])('rejects malformed revision %s', (revision) => {
+  expect(() => toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
-    { integrity: REVISION_INTEGRITY, tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}` },
+    { integrity: REVISION_INTEGRITY, revision, tarball: REVISION_TARBALL },
     REGISTRY
-  )).toEqual({
-    integrity: REVISION_INTEGRITY,
-    tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}`,
-  })
-  expect(toLockfileResolution(
-    { name: 'foo', version: '1.0.0' },
-    { integrity: REVISION_INTEGRITY, tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}` },
-    REGISTRY
-  )).toEqual({
-    integrity: REVISION_INTEGRITY,
-    tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}`,
-  })
+  )).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+  }))
 })
 
 test('keeps the tarball for non-standard registry URLs when lockfileIncludeTarballUrl is false', () => {

--- a/pnpm11/lockfile/utils/test/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/test/toLockfileResolution.ts
@@ -3,7 +3,7 @@ import { toLockfileResolution } from '@pnpm/lockfile.utils'
 
 const REGISTRY = 'https://registry.npmjs.org/'
 const GIT_TARBALL = 'https://codeload.github.com/foo/bar/tar.gz/0123456789abcdef0123456789abcdef01234567'
-const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==?r1`
+const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==`
 const REVISION_TARBALL = `https://registry.npmjs.org/-/tarballs/sha512/${'A'.repeat(86)}`
 
 test('keeps the tarball when lockfileIncludeTarballUrl is true', () => {
@@ -42,6 +42,38 @@ test('drops the tarball for standard registry URLs when lockfileIncludeTarballUr
 test('drops a validated integrity-addressed registry tarball URL', () => {
   expect(toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, revision: 1, tarball: REVISION_TARBALL },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+  })
+})
+
+test('keeps an integrity-addressed URL whose registry or digest does not match', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, revision: 1, tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}` },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+    tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}`,
+  })
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, revision: 1, tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}` },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+    tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}`,
+  })
+})
+
+test('normalizes an original served from the digest route to integrity only', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
     { integrity: REVISION_INTEGRITY, tarball: REVISION_TARBALL },
     REGISTRY
   )).toEqual({
@@ -49,23 +81,14 @@ test('drops a validated integrity-addressed registry tarball URL', () => {
   })
 })
 
-test('keeps an integrity-addressed URL whose registry or digest does not match', () => {
-  expect(toLockfileResolution(
+test.each([0, -1, 1.5])('rejects malformed revision %s', (revision) => {
+  expect(() => toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
-    { integrity: REVISION_INTEGRITY, tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}` },
+    { integrity: REVISION_INTEGRITY, revision, tarball: REVISION_TARBALL },
     REGISTRY
-  )).toEqual({
-    integrity: REVISION_INTEGRITY,
-    tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}`,
-  })
-  expect(toLockfileResolution(
-    { name: 'foo', version: '1.0.0' },
-    { integrity: REVISION_INTEGRITY, tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}` },
-    REGISTRY
-  )).toEqual({
-    integrity: REVISION_INTEGRITY,
-    tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}`,
-  })
+  )).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+  }))
 })
 
 test('keeps the tarball for non-standard registry URLs when lockfileIncludeTarballUrl is false', () => {

--- a/pnpm11/lockfile/utils/test/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/test/toLockfileResolution.ts
@@ -48,6 +48,27 @@ test('drops a validated integrity-addressed registry tarball URL', () => {
   })
 })
 
+test('drops a revision URL even when lockfileIncludeTarballUrl is true', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, revision: 1, tarball: REVISION_TARBALL },
+    { registry: REGISTRY, lockfileIncludeTarballUrl: true }
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+  })
+})
+
+test('rejects a revision without an integrity-addressed URL', () => {
+  expect(() => toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, revision: 1 } as never,
+    { registry: REGISTRY }
+  )).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+  }))
+})
+
 test('rejects a revision whose URL registry or digest does not match', () => {
   expect(() => toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
@@ -69,7 +90,7 @@ test('normalizes an original served from the digest route to integrity only', ()
   expect(toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
     { integrity: REVISION_INTEGRITY, tarball: REVISION_TARBALL },
-    { registry: REGISTRY }
+    { registry: REGISTRY, lockfileIncludeTarballUrl: true }
   )).toEqual({
     integrity: REVISION_INTEGRITY,
   })

--- a/pnpm11/lockfile/utils/test/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/test/toLockfileResolution.ts
@@ -41,49 +41,45 @@ test('drops a validated integrity-addressed registry tarball URL', () => {
   expect(toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
     { integrity: REVISION_INTEGRITY, revision: 1, tarball: REVISION_TARBALL },
-    REGISTRY
+    { registry: REGISTRY }
   )).toEqual({
     integrity: REVISION_INTEGRITY,
     revision: 1,
   })
 })
 
-test('keeps an integrity-addressed URL whose registry or digest does not match', () => {
-  expect(toLockfileResolution(
+test('rejects a revision whose URL registry or digest does not match', () => {
+  expect(() => toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
     { integrity: REVISION_INTEGRITY, revision: 1, tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}` },
-    REGISTRY
-  )).toEqual({
-    integrity: REVISION_INTEGRITY,
-    revision: 1,
-    tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}`,
-  })
-  expect(toLockfileResolution(
+    { registry: REGISTRY }
+  )).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+  }))
+  expect(() => toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
     { integrity: REVISION_INTEGRITY, revision: 1, tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}` },
-    REGISTRY
-  )).toEqual({
-    integrity: REVISION_INTEGRITY,
-    revision: 1,
-    tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}`,
-  })
+    { registry: REGISTRY }
+  )).toThrow(expect.objectContaining({
+    code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
+  }))
 })
 
 test('normalizes an original served from the digest route to integrity only', () => {
   expect(toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
     { integrity: REVISION_INTEGRITY, tarball: REVISION_TARBALL },
-    REGISTRY
+    { registry: REGISTRY }
   )).toEqual({
     integrity: REVISION_INTEGRITY,
   })
 })
 
-test.each([0, -1, 1.5])('rejects malformed revision %s', (revision) => {
+test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1', '01'])('rejects malformed revision %s', (revision) => {
   expect(() => toLockfileResolution(
     { name: 'foo', version: '1.0.0' },
-    { integrity: REVISION_INTEGRITY, revision, tarball: REVISION_TARBALL },
-    REGISTRY
+    { integrity: REVISION_INTEGRITY, revision, tarball: REVISION_TARBALL } as never,
+    { registry: REGISTRY }
   )).toThrow(expect.objectContaining({
     code: 'ERR_PNPM_INVALID_TARBALL_REVISION',
   }))

--- a/pnpm11/lockfile/utils/test/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/test/toLockfileResolution.ts
@@ -3,6 +3,8 @@ import { toLockfileResolution } from '@pnpm/lockfile.utils'
 
 const REGISTRY = 'https://registry.npmjs.org/'
 const GIT_TARBALL = 'https://codeload.github.com/foo/bar/tar.gz/0123456789abcdef0123456789abcdef01234567'
+const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==?r1`
+const REVISION_TARBALL = `https://registry.npmjs.org/-/tarballs/sha512/${'A'.repeat(86)}`
 
 test('keeps the tarball when lockfileIncludeTarballUrl is true', () => {
   expect(toLockfileResolution(
@@ -34,6 +36,35 @@ test('drops the tarball for standard registry URLs when lockfileIncludeTarballUr
     false
   )).toEqual({
     integrity: 'sha512-AAAA',
+  })
+})
+
+test('drops a validated integrity-addressed registry tarball URL', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, tarball: REVISION_TARBALL },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+  })
+})
+
+test('keeps an integrity-addressed URL whose registry or digest does not match', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}` },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}`,
+  })
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}` },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}`,
   })
 })
 

--- a/pnpm11/lockfile/utils/test/toLockfileResolution.ts
+++ b/pnpm11/lockfile/utils/test/toLockfileResolution.ts
@@ -3,6 +3,8 @@ import { pkgSnapshotToResolution, toLockfileResolution } from '@pnpm/lockfile.ut
 
 const REGISTRY = 'https://registry.npmjs.org/'
 const GIT_TARBALL = 'https://codeload.github.com/foo/bar/tar.gz/0123456789abcdef0123456789abcdef01234567'
+const REVISION_INTEGRITY = `sha512-${'A'.repeat(86)}==?r1`
+const REVISION_TARBALL = `https://registry.npmjs.org/-/tarballs/sha512/${'A'.repeat(86)}`
 
 test('keeps the tarball when lockfileIncludeTarballUrl is true', () => {
   expect(toLockfileResolution(
@@ -32,6 +34,35 @@ test('drops the tarball for standard registry URLs when lockfileIncludeTarballUr
     { registry: REGISTRY, lockfileIncludeTarballUrl: false }
   )).toEqual({
     integrity: 'sha512-AAAA',
+  })
+})
+
+test('drops a validated integrity-addressed registry tarball URL', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, tarball: REVISION_TARBALL },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+  })
+})
+
+test('keeps an integrity-addressed URL whose registry or digest does not match', () => {
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}` },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    tarball: `https://attacker.example/-/tarballs/sha512/${'A'.repeat(86)}`,
+  })
+  expect(toLockfileResolution(
+    { name: 'foo', version: '1.0.0' },
+    { integrity: REVISION_INTEGRITY, tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}` },
+    REGISTRY
+  )).toEqual({
+    integrity: REVISION_INTEGRITY,
+    tarball: `https://registry.npmjs.org/-/tarballs/sha512/${'B'.repeat(86)}`,
   })
 })
 

--- a/pnpm11/network/fetch/src/fetchFromRegistry.ts
+++ b/pnpm11/network/fetch/src/fetchFromRegistry.ts
@@ -111,7 +111,11 @@ export function createFetchFromRegistry (defaultOpts: CreateFetchFromRegistryOpt
         retry: opts?.retry,
         timeout: opts?.timeout ?? 60000,
       })
-      if (!isRedirect(response.status) || redirects >= MAX_FOLLOWED_REDIRECTS) {
+      if (
+        opts?.redirect === 'manual' ||
+        !isRedirect(response.status) ||
+        redirects >= MAX_FOLLOWED_REDIRECTS
+      ) {
         return response
       }
 

--- a/pnpm11/network/fetch/test/fetchFromRegistry.test.ts
+++ b/pnpm11/network/fetch/test/fetchFromRegistry.test.ts
@@ -116,6 +116,28 @@ test('authorization headers are not removed before redirection if the target is 
   }
 })
 
+test('manual redirect mode returns the redirect response without following it', async () => {
+  setupMockAgent()
+  try {
+    const mockPool = getMockAgent().get('http://registry.pnpm.io')
+    mockPool.intercept({
+      path: '/-/tarballs/sha512/digest',
+      method: 'GET',
+    }).reply(302, '', { headers: { location: '/redirected' } })
+
+    const fetchFromRegistry = createFetchFromRegistry({})
+    const response = await fetchFromRegistry(
+      'http://registry.pnpm.io/-/tarballs/sha512/digest',
+      { redirect: 'manual' }
+    )
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/redirected')
+  } finally {
+    await teardownMockAgent()
+  }
+})
+
 test('switch to the correct agent for requests on redirect from http: to https:', async () => {
   // This test uses real network - no mock needed
   const fetchFromRegistry = createFetchFromRegistry({})

--- a/pnpm11/resolving/npm-resolver/package.json
+++ b/pnpm11/resolving/npm-resolver/package.json
@@ -45,6 +45,7 @@
     "@pnpm/resolving.registry.pkg-metadata-filter": "workspace:*",
     "@pnpm/resolving.registry.types": "workspace:*",
     "@pnpm/resolving.resolver-base": "workspace:*",
+    "@pnpm/resolving.tarball-url": "workspace:*",
     "@pnpm/store.cafs": "workspace:*",
     "@pnpm/store.index": "workspace:*",
     "@pnpm/types": "workspace:*",

--- a/pnpm11/resolving/npm-resolver/package.json
+++ b/pnpm11/resolving/npm-resolver/package.json
@@ -48,6 +48,7 @@
     "@pnpm/resolving.registry.pkg-metadata-filter": "workspace:*",
     "@pnpm/resolving.registry.types": "workspace:*",
     "@pnpm/resolving.resolver-base": "workspace:*",
+    "@pnpm/resolving.tarball-url": "workspace:*",
     "@pnpm/store.cafs": "workspace:*",
     "@pnpm/store.index": "workspace:*",
     "@pnpm/types": "workspace:*",

--- a/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
+++ b/pnpm11/resolving/npm-resolver/src/createNpmResolutionVerifier.ts
@@ -221,7 +221,7 @@ export function createNpmResolutionVerifier (
         return {
           ok: false,
           code: MISSING_NAMED_REGISTRY_VIOLATION_CODE,
-          reason: `was resolved from the named registry '${registryName}:', which is not present in the registriesByPrefix setting`,
+          reason: `has registry prefix '${registryName}:', which is not declared by the registries setting`,
         }
       }
       registry = namedRegistry

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -29,6 +29,10 @@ import type {
 import {
   EXISTING_VERSION_SELECTOR_WEIGHT,
 } from '@pnpm/resolving.resolver-base'
+import {
+  isIntegrityAddressedRegistryTarballUrl,
+  isValidTarballRevision,
+} from '@pnpm/resolving.tarball-url'
 import { storeIndexKey } from '@pnpm/store.index'
 import type {
   DependencyManifest,
@@ -701,10 +705,7 @@ async function resolveNpm (
 
   warnOnceOnHeldBackUpdate(ctx, opts, spec, meta, pickedPackage.version)
   const id = `${pickedPackage.name}@${pickedPackage.version}` as PkgResolutionId
-  const resolution = {
-    integrity: getIntegrity(pickedPackage.dist),
-    tarball: normalizeRegistryUrl(pickedPackage.dist.tarball),
-  }
+  const resolution = createRegistryTarballResolution(pickedPackage.dist, registry)
   let normalizedBareSpecifier: string | undefined
   if (opts.calcSpecifier) {
     normalizedBareSpecifier = spec.normalizedBareSpecifier ?? calcSpecifier({
@@ -862,10 +863,7 @@ async function pickFromSimpleRegistry (
     throw new NoMatchingVersionError({ wantedDependency, packageMeta: meta, registry })
   }
   warnOnceOnHeldBackUpdate(ctx, opts, spec, meta, pickedPackage.version)
-  const resolution = {
-    integrity: getIntegrity(pickedPackage.dist),
-    tarball: normalizeRegistryUrl(pickedPackage.dist.tarball),
-  }
+  const resolution = createRegistryTarballResolution(pickedPackage.dist, registry)
   const publishedAt = meta.time?.[pickedPackage.version]
   return {
     id: `${pickedPackage.name}@${pickedPackage.version}` as PkgResolutionId,
@@ -1185,6 +1183,33 @@ function getIntegrity (dist: {
     throw new PnpmError('INVALID_TARBALL_INTEGRITY', `Tarball "${dist.tarball}" has invalid shasum specified in its metadata: ${dist.shasum}`)
   }
   return integrity.toString()
+}
+
+function createRegistryTarballResolution (
+  dist: PackageInRegistry['dist'],
+  registry: string
+): TarballResolution {
+  const integrity = getIntegrity(dist)
+  const tarball = normalizeRegistryUrl(dist.tarball)
+  if (dist.revision == null) {
+    return { integrity, tarball }
+  }
+  if (!isValidTarballRevision(dist.revision)) {
+    throw new PnpmError('MALFORMED_METADATA',
+      `Tarball "${dist.tarball}" has an invalid revision in its metadata: ${String(dist.revision)}`)
+  }
+  if (
+    integrity == null ||
+    !isIntegrityAddressedRegistryTarballUrl(tarball, integrity, registry)
+  ) {
+    throw new PnpmError('MALFORMED_METADATA',
+      `Tarball "${dist.tarball}" has revision ${dist.revision} but is not addressed by its complete integrity.`)
+  }
+  return {
+    integrity,
+    revision: dist.revision,
+    tarball,
+  }
 }
 
 function createVersionSpec (version: string, pinnedVersion?: PinnedVersion): string {

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { isWellFormedRegistryName, RESERVED_VERSION_PREFIXES } from '@pnpm/deps.path'
-import { PnpmError } from '@pnpm/error'
+import { PnpmError, redactUrlForDisplay } from '@pnpm/error'
 import type {
   FetchFromRegistry,
   GetAuthHeader,
@@ -840,7 +840,7 @@ function mergeNamedRegistries (userDefined?: Record<string, string>): Record<str
         RESERVED_VERSION_PREFIXES.has(alias)
           ? `'${alias}' cannot be used as a named registry alias: it is a reserved dependency specifier prefix.`
           : `'${alias}' cannot be used as a named registry alias: aliases must start with a letter and contain only letters, digits, ".", "_", and "-".`,
-        { hint: 'Rename the entry in the registriesByPrefix setting.' }
+        { hint: 'Change the prefix on the corresponding registries entry.' }
       )
     }
     if (typeof url !== 'string' || !isValidHttpUrl(url)) {
@@ -1304,14 +1304,14 @@ function createRegistryTarballResolution (
   }
   if (!isValidTarballRevision(dist.revision)) {
     throw new PnpmError('MALFORMED_METADATA',
-      `Tarball "${dist.tarball}" has an invalid revision in its metadata: ${String(dist.revision)}`)
+      `Tarball "${redactUrlForDisplay(dist.tarball)}" has an invalid revision in its metadata: ${String(dist.revision)}`)
   }
   if (
     integrity == null ||
     !isIntegrityAddressedRegistryTarballUrl(tarball, integrity, registry)
   ) {
     throw new PnpmError('MALFORMED_METADATA',
-      `Tarball "${dist.tarball}" has revision ${dist.revision} but is not addressed by its complete integrity.`)
+      `Tarball "${redactUrlForDisplay(dist.tarball)}" has revision ${dist.revision} but is not addressed by its complete integrity.`)
   }
   return {
     integrity,

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -31,6 +31,10 @@ import type {
 import {
   EXISTING_VERSION_SELECTOR_WEIGHT,
 } from '@pnpm/resolving.resolver-base'
+import {
+  isIntegrityAddressedRegistryTarballUrl,
+  isValidTarballRevision,
+} from '@pnpm/resolving.tarball-url'
 import { storeIndexKey } from '@pnpm/store.index'
 import type {
   DependencyManifest,
@@ -767,10 +771,7 @@ async function resolveNpm (
 
   warnOnceOnHeldBackUpdate(ctx, opts, spec, meta, pickedPackage.version)
   const id = `${pickedPackage.name}@${pickedPackage.version}` as PkgResolutionId
-  const resolution = {
-    integrity: getIntegrity(pickedPackage.dist),
-    tarball: normalizeRegistryUrl(pickedPackage.dist.tarball),
-  }
+  const resolution = createRegistryTarballResolution(pickedPackage.dist, registry)
   let normalizedBareSpecifier: string | undefined
   if (opts.calcSpecifier) {
     normalizedBareSpecifier = spec.normalizedBareSpecifier ?? calcSpecifier({
@@ -943,10 +944,7 @@ async function pickFromSimpleRegistry (
     throw new NoMatchingVersionError({ wantedDependency, packageMeta: meta, registry })
   }
   warnOnceOnHeldBackUpdate(ctx, opts, spec, meta, pickedPackage.version)
-  const resolution = {
-    integrity: getIntegrity(pickedPackage.dist),
-    tarball: normalizeRegistryUrl(pickedPackage.dist.tarball),
-  }
+  const resolution = createRegistryTarballResolution(pickedPackage.dist, registry)
   const publishedAt = meta.time?.[pickedPackage.version]
   return {
     id: `${pickedPackage.name}@${pickedPackage.version}` as PkgResolutionId,
@@ -1293,6 +1291,33 @@ function getIntegrity (dist: {
     throw new PnpmError('INVALID_TARBALL_INTEGRITY', `Tarball "${dist.tarball}" has invalid shasum specified in its metadata: ${dist.shasum}`)
   }
   return integrity.toString()
+}
+
+function createRegistryTarballResolution (
+  dist: PackageInRegistry['dist'],
+  registry: string
+): TarballResolution {
+  const integrity = getIntegrity(dist)
+  const tarball = normalizeRegistryUrl(dist.tarball)
+  if (dist.revision == null) {
+    return { integrity, tarball }
+  }
+  if (!isValidTarballRevision(dist.revision)) {
+    throw new PnpmError('MALFORMED_METADATA',
+      `Tarball "${dist.tarball}" has an invalid revision in its metadata: ${String(dist.revision)}`)
+  }
+  if (
+    integrity == null ||
+    !isIntegrityAddressedRegistryTarballUrl(tarball, integrity, registry)
+  ) {
+    throw new PnpmError('MALFORMED_METADATA',
+      `Tarball "${dist.tarball}" has revision ${dist.revision} but is not addressed by its complete integrity.`)
+  }
+  return {
+    integrity,
+    revision: dist.revision,
+    tarball,
+  }
 }
 
 /**

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -39,6 +39,8 @@ const registries = {
 const fetch = createFetchFromRegistry({})
 const getAuthHeader = () => undefined
 const createResolveFromNpm = createNpmResolver.bind(null, fetch, getAuthHeader)
+const REVISION_INTEGRITY = 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ=='
+const REVISION_DIGEST = Buffer.from(REVISION_INTEGRITY.slice('sha512-'.length), 'base64').toString('base64url')
 
 afterEach(async () => {
   await teardownMockAgent()
@@ -79,6 +81,109 @@ test('resolveFromNpm()', async () => {
   expect(meta.name).toBeTruthy()
   expect(meta.versions).toBeTruthy()
   expect(meta['dist-tags']).toBeTruthy()
+})
+
+test('resolveFromNpm() validates and preserves a registry tarball revision', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      versions: {
+        ...isPositiveMeta.versions,
+        '1.0.0': {
+          ...isPositiveMeta.versions['1.0.0'],
+          dist: {
+            ...isPositiveMeta.versions['1.0.0'].dist,
+            integrity: REVISION_INTEGRITY,
+            revision: 1,
+            tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+          },
+        },
+      },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+
+  const result = await resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '1.0.0' },
+    {}
+  )
+
+  expect(result!.resolution).toStrictEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+    tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+  })
+})
+
+test.each([0, -1, 1.5, '1'])('resolveFromNpm() rejects malformed registry revision %s', async (revision) => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      versions: {
+        ...isPositiveMeta.versions,
+        '1.0.0': {
+          ...isPositiveMeta.versions['1.0.0'],
+          dist: {
+            ...isPositiveMeta.versions['1.0.0'].dist,
+            integrity: REVISION_INTEGRITY,
+            revision,
+            tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+          },
+        },
+      },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+
+  await expect(resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '1.0.0' },
+    {}
+  )).rejects.toMatchObject({
+    code: 'ERR_PNPM_MALFORMED_METADATA',
+  })
+})
+
+test('resolveFromNpm() rejects a revision whose tarball URL does not match its integrity', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      versions: {
+        ...isPositiveMeta.versions,
+        '1.0.0': {
+          ...isPositiveMeta.versions['1.0.0'],
+          dist: {
+            ...isPositiveMeta.versions['1.0.0'].dist,
+            integrity: REVISION_INTEGRITY,
+            revision: 1,
+            tarball: `${registries.default}-/tarballs/sha512/${'A'.repeat(86)}`,
+          },
+        },
+      },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+
+  await expect(resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '1.0.0' },
+    {}
+  )).rejects.toMatchObject({
+    code: 'ERR_PNPM_MALFORMED_METADATA',
+  })
 })
 
 test('resolveFromNpm() strips port 80 from http tarball URLs', async () => {

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -84,7 +84,7 @@ test('resolveFromNpm()', async () => {
 })
 
 test('resolveFromNpm() validates and preserves a registry tarball revision', async () => {
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
     .intercept({ path: '/is-positive', method: 'GET' })
     .reply(200, {
       ...isPositiveMeta,
@@ -96,7 +96,7 @@ test('resolveFromNpm() validates and preserves a registry tarball revision', asy
             ...isPositiveMeta.versions['1.0.0'].dist,
             integrity: REVISION_INTEGRITY,
             revision: 1,
-            tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+            tarball: `${registriesByScope.default}-/tarballs/sha512/${REVISION_DIGEST}`,
           },
         },
       },
@@ -105,7 +105,7 @@ test('resolveFromNpm() validates and preserves a registry tarball revision', asy
   const { resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir: temporaryDirectory(),
-    registries,
+    registriesByScope,
   })
 
   const result = await resolveFromNpm(
@@ -116,12 +116,12 @@ test('resolveFromNpm() validates and preserves a registry tarball revision', asy
   expect(result!.resolution).toStrictEqual({
     integrity: REVISION_INTEGRITY,
     revision: 1,
-    tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+    tarball: `${registriesByScope.default}-/tarballs/sha512/${REVISION_DIGEST}`,
   })
 })
 
-test.each([0, -1, 1.5, '1'])('resolveFromNpm() rejects malformed registry revision %s', async (revision) => {
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
+test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1', '01'])('resolveFromNpm() rejects malformed registry revision %s', async (revision) => {
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
     .intercept({ path: '/is-positive', method: 'GET' })
     .reply(200, {
       ...isPositiveMeta,
@@ -133,7 +133,7 @@ test.each([0, -1, 1.5, '1'])('resolveFromNpm() rejects malformed registry revisi
             ...isPositiveMeta.versions['1.0.0'].dist,
             integrity: REVISION_INTEGRITY,
             revision,
-            tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+            tarball: `${registriesByScope.default}-/tarballs/sha512/${REVISION_DIGEST}`,
           },
         },
       },
@@ -142,7 +142,7 @@ test.each([0, -1, 1.5, '1'])('resolveFromNpm() rejects malformed registry revisi
   const { resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir: temporaryDirectory(),
-    registries,
+    registriesByScope,
   })
 
   await expect(resolveFromNpm(
@@ -154,7 +154,7 @@ test.each([0, -1, 1.5, '1'])('resolveFromNpm() rejects malformed registry revisi
 })
 
 test('resolveFromNpm() rejects a revision whose tarball URL does not match its integrity', async () => {
-  getMockAgent().get(registries.default.replace(/\/$/, ''))
+  getMockAgent().get(registriesByScope.default.replace(/\/$/, ''))
     .intercept({ path: '/is-positive', method: 'GET' })
     .reply(200, {
       ...isPositiveMeta,
@@ -166,7 +166,7 @@ test('resolveFromNpm() rejects a revision whose tarball URL does not match its i
             ...isPositiveMeta.versions['1.0.0'].dist,
             integrity: REVISION_INTEGRITY,
             revision: 1,
-            tarball: `${registries.default}-/tarballs/sha512/${'A'.repeat(86)}`,
+            tarball: `${registriesByScope.default}-/tarballs/sha512/${'A'.repeat(86)}`,
           },
         },
       },
@@ -175,7 +175,7 @@ test('resolveFromNpm() rejects a revision whose tarball URL does not match its i
   const { resolveFromNpm } = createResolveFromNpm({
     storeDir: temporaryDirectory(),
     cacheDir: temporaryDirectory(),
-    registries,
+    registriesByScope,
   })
 
   await expect(resolveFromNpm(

--- a/pnpm11/resolving/npm-resolver/test/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/index.ts
@@ -39,6 +39,8 @@ const registriesByScope = {
 const fetch = createFetchFromRegistry({})
 const getAuthHeader = () => undefined
 const createResolveFromNpm = createNpmResolver.bind(null, fetch, getAuthHeader)
+const REVISION_INTEGRITY = 'sha512-9cI+DmhNhA8ioT/3EJFnt0s1yehnAECyIOXdT+2uQGzcEEBaj8oNmVWj33+ZjPndMIFRQh8JeJlEu1uv5/J7pQ=='
+const REVISION_DIGEST = Buffer.from(REVISION_INTEGRITY.slice('sha512-'.length), 'base64').toString('base64url')
 
 afterEach(async () => {
   await teardownMockAgent()
@@ -79,6 +81,109 @@ test('resolveFromNpm()', async () => {
   expect(meta.name).toBeTruthy()
   expect(meta.versions).toBeTruthy()
   expect(meta['dist-tags']).toBeTruthy()
+})
+
+test('resolveFromNpm() validates and preserves a registry tarball revision', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      versions: {
+        ...isPositiveMeta.versions,
+        '1.0.0': {
+          ...isPositiveMeta.versions['1.0.0'],
+          dist: {
+            ...isPositiveMeta.versions['1.0.0'].dist,
+            integrity: REVISION_INTEGRITY,
+            revision: 1,
+            tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+          },
+        },
+      },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+
+  const result = await resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '1.0.0' },
+    {}
+  )
+
+  expect(result!.resolution).toStrictEqual({
+    integrity: REVISION_INTEGRITY,
+    revision: 1,
+    tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+  })
+})
+
+test.each([0, -1, 1.5, '1'])('resolveFromNpm() rejects malformed registry revision %s', async (revision) => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      versions: {
+        ...isPositiveMeta.versions,
+        '1.0.0': {
+          ...isPositiveMeta.versions['1.0.0'],
+          dist: {
+            ...isPositiveMeta.versions['1.0.0'].dist,
+            integrity: REVISION_INTEGRITY,
+            revision,
+            tarball: `${registries.default}-/tarballs/sha512/${REVISION_DIGEST}`,
+          },
+        },
+      },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+
+  await expect(resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '1.0.0' },
+    {}
+  )).rejects.toMatchObject({
+    code: 'ERR_PNPM_MALFORMED_METADATA',
+  })
+})
+
+test('resolveFromNpm() rejects a revision whose tarball URL does not match its integrity', async () => {
+  getMockAgent().get(registries.default.replace(/\/$/, ''))
+    .intercept({ path: '/is-positive', method: 'GET' })
+    .reply(200, {
+      ...isPositiveMeta,
+      versions: {
+        ...isPositiveMeta.versions,
+        '1.0.0': {
+          ...isPositiveMeta.versions['1.0.0'],
+          dist: {
+            ...isPositiveMeta.versions['1.0.0'].dist,
+            integrity: REVISION_INTEGRITY,
+            revision: 1,
+            tarball: `${registries.default}-/tarballs/sha512/${'A'.repeat(86)}`,
+          },
+        },
+      },
+    })
+
+  const { resolveFromNpm } = createResolveFromNpm({
+    storeDir: temporaryDirectory(),
+    cacheDir: temporaryDirectory(),
+    registries,
+  })
+
+  await expect(resolveFromNpm(
+    { alias: 'is-positive', bareSpecifier: '1.0.0' },
+    {}
+  )).rejects.toMatchObject({
+    code: 'ERR_PNPM_MALFORMED_METADATA',
+  })
 })
 
 test('resolveFromNpm() strips port 80 from http tarball URLs', async () => {

--- a/pnpm11/resolving/npm-resolver/tsconfig.json
+++ b/pnpm11/resolving/npm-resolver/tsconfig.json
@@ -83,6 +83,9 @@
     },
     {
       "path": "../resolver-base"
+    },
+    {
+      "path": "../tarball-url"
     }
   ]
 }

--- a/pnpm11/resolving/npm-resolver/tsconfig.json
+++ b/pnpm11/resolving/npm-resolver/tsconfig.json
@@ -74,6 +74,9 @@
     },
     {
       "path": "../resolver-base"
+    },
+    {
+      "path": "../tarball-url"
     }
   ]
 }

--- a/pnpm11/resolving/registry/types/src/index.ts
+++ b/pnpm11/resolving/registry/types/src/index.ts
@@ -50,6 +50,7 @@ export interface PackageInRegistry extends PackageManifest {
   }>
   dist: {
     integrity?: string
+    revision?: number
     shasum: string
     tarball: string
     unpackedSize?: number

--- a/pnpm11/resolving/resolver-base/src/index.ts
+++ b/pnpm11/resolving/resolver-base/src/index.ts
@@ -18,6 +18,7 @@ export interface TarballResolution {
   type?: undefined
   tarball: string
   integrity?: string
+  revision?: number
   path?: string
   /**
    * True for tarballs sourced from a git host (codeload.github.com /

--- a/pnpm11/resolving/tarball-url/package.json
+++ b/pnpm11/resolving/tarball-url/package.json
@@ -33,6 +33,7 @@
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
+    "@pnpm/crypto.integrity": "workspace:*",
     "@pnpm/types": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm11/resolving/tarball-url/src/index.ts
+++ b/pnpm11/resolving/tarball-url/src/index.ts
@@ -1,8 +1,11 @@
 import { Buffer } from 'node:buffer'
+import util from 'node:util'
 
+import { formatIntegrity, parseIntegrity } from '@pnpm/crypto.integrity'
 import type { RegistryServerType } from '@pnpm/types'
 
 const PUBLIC_NPM_REGISTRY = 'https://registry.npmjs.org/'
+const SHA512_INTEGRITY_LENGTH = 'sha512-'.length + 88
 
 /**
  * registry.npmjs.org is the one registry whose layout pnpm knows without being
@@ -27,37 +30,6 @@ export interface IntegrityAddress {
   digest: Buffer
 }
 
-export function parseIntegrityAddress (integrity: string): IntegrityAddress | undefined {
-  const algorithmSeparator = integrity.indexOf('-')
-  if (algorithmSeparator === -1 || integrity.indexOf('-', algorithmSeparator + 1) !== -1) {
-    return undefined
-  }
-  const algorithm = integrity.slice(0, algorithmSeparator)
-  if (algorithm !== 'sha512') return undefined
-
-  const encodedDigest = integrity.slice(algorithmSeparator + 1)
-  if (encodedDigest.length !== 88) return undefined
-  const digest = Buffer.from(encodedDigest, 'base64')
-  if (digest.byteLength !== 64 || digest.toString('base64') !== encodedDigest) return undefined
-
-  return {
-    algorithm,
-    digest,
-  }
-}
-
-export function getIntegrityAddressedTarballUrl (
-  integrity: string,
-  registry: string
-): string | undefined {
-  const parsed = parseIntegrityAddress(integrity)
-  if (parsed == null) return undefined
-  return new URL(
-    `-/tarballs/${parsed.algorithm}/${parsed.digest.toString('base64url')}`,
-    normalizeRegistry(registry)
-  ).toString()
-}
-
 export function isIntegrityAddressedRegistryTarballUrl (
   tarball: string,
   integrity: string,
@@ -69,6 +41,40 @@ export function isIntegrityAddressedRegistryTarballUrl (
     return new URL(tarball).toString() === expected
   } catch {
     return false
+  }
+}
+
+export function getIntegrityAddressedTarballUrl (
+  integrity: unknown,
+  registry: string
+): string | undefined {
+  const parsed = parseIntegrityAddress(integrity)
+  if (parsed == null) return undefined
+  return new URL(
+    `-/tarballs/${parsed.algorithm}/${parsed.digest.toString('base64url')}`,
+    normalizeRegistry(registry)
+  ).toString()
+}
+
+export function parseIntegrityAddress (integrity: unknown): IntegrityAddress | undefined {
+  if (typeof integrity !== 'string' || integrity.length !== SHA512_INTEGRITY_LENGTH) return undefined
+  let parsed: ReturnType<typeof parseIntegrity>
+  try {
+    parsed = parseIntegrity(integrity)
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ERR_PNPM_INVALID_INTEGRITY') {
+      return undefined
+    }
+    throw err
+  }
+  if (
+    parsed.algorithm !== 'sha512' ||
+    parsed.hexDigest.length !== 128 ||
+    formatIntegrity(parsed.algorithm, parsed.hexDigest) !== integrity
+  ) return undefined
+  return {
+    algorithm: parsed.algorithm,
+    digest: Buffer.from(parsed.hexDigest, 'hex'),
   }
 }
 

--- a/pnpm11/resolving/tarball-url/src/index.ts
+++ b/pnpm11/resolving/tarball-url/src/index.ts
@@ -1,3 +1,5 @@
+import { Buffer } from 'node:buffer'
+
 import type { RegistryServerType } from '@pnpm/types'
 
 const PUBLIC_NPM_REGISTRY = 'https://registry.npmjs.org/'
@@ -19,6 +21,65 @@ export interface TarballUrlOptions {
    */
   serverType?: RegistryServerType
 }
+
+export interface RevisionAwareIntegrity {
+  algorithm: 'sha512'
+  contentIntegrity: string
+  digest: Buffer
+  revision: string
+}
+
+export function parseRevisionAwareIntegrity (integrity: string): RevisionAwareIntegrity | undefined {
+  const optionSeparator = integrity.indexOf('?')
+  if (optionSeparator === -1 || optionSeparator !== integrity.lastIndexOf('?')) return undefined
+
+  const option = integrity.slice(optionSeparator + 1)
+  if (!isCanonicalRevisionOption(option)) return undefined
+
+  const contentIntegrity = integrity.slice(0, optionSeparator)
+  const algorithmSeparator = contentIntegrity.indexOf('-')
+  if (algorithmSeparator === -1 || contentIntegrity.indexOf('-', algorithmSeparator + 1) !== -1) {
+    return undefined
+  }
+  const algorithm = contentIntegrity.slice(0, algorithmSeparator)
+  if (algorithm !== 'sha512') return undefined
+
+  const encodedDigest = contentIntegrity.slice(algorithmSeparator + 1)
+  const digest = Buffer.from(encodedDigest, 'base64')
+  if (digest.byteLength !== 64 || digest.toString('base64') !== encodedDigest) return undefined
+
+  return {
+    algorithm,
+    contentIntegrity,
+    digest,
+    revision: option.slice(1),
+  }
+}
+
+export function getIntegrityAddressedTarballUrl (
+  integrity: string,
+  registry: string
+): string | undefined {
+  const parsed = parseRevisionAwareIntegrity(integrity)
+  if (parsed == null) return undefined
+  return new URL(
+    `-/tarballs/${parsed.algorithm}/${parsed.digest.toString('base64url')}`,
+    normalizeRegistry(registry)
+  ).toString()
+}
+
+export function isIntegrityAddressedRegistryTarballUrl (
+  tarball: string,
+  integrity: string,
+  registry: string
+): boolean {
+  const expected = getIntegrityAddressedTarballUrl(integrity, registry)
+  if (expected == null) return false
+  try {
+    return new URL(tarball).toString() === expected
+  } catch {
+    return false
+  }
 
 /**
  * Build the canonical tarball URL of an npm package — i.e. the URL pnpm derives
@@ -82,6 +143,16 @@ function effectiveServerType (opts: TarballUrlOptions): RegistryServerType | und
 function normalizeRegistry (registry?: string): string {
   if (!registry) return PUBLIC_NPM_REGISTRY
   return registry.endsWith('/') ? registry : `${registry}/`
+}
+
+function isCanonicalRevisionOption (option: string): boolean {
+  if (option === 'r0') return true
+  if (option.length < 2 || option[0] !== 'r' || option[1] === '0') return false
+  for (let index = 1; index < option.length; index++) {
+    const code = option.charCodeAt(index)
+    if (code < 48 || code > 57) return false
+  }
+  return true
 }
 
 function removeBuildMetadataFromVersion (version: string): string {

--- a/pnpm11/resolving/tarball-url/src/index.ts
+++ b/pnpm11/resolving/tarball-url/src/index.ts
@@ -1,3 +1,65 @@
+import { Buffer } from 'node:buffer'
+
+export interface RevisionAwareIntegrity {
+  algorithm: 'sha512'
+  contentIntegrity: string
+  digest: Buffer
+  revision: string
+}
+
+export function parseRevisionAwareIntegrity (integrity: string): RevisionAwareIntegrity | undefined {
+  const optionSeparator = integrity.indexOf('?')
+  if (optionSeparator === -1 || optionSeparator !== integrity.lastIndexOf('?')) return undefined
+
+  const option = integrity.slice(optionSeparator + 1)
+  if (!isCanonicalRevisionOption(option)) return undefined
+
+  const contentIntegrity = integrity.slice(0, optionSeparator)
+  const algorithmSeparator = contentIntegrity.indexOf('-')
+  if (algorithmSeparator === -1 || contentIntegrity.indexOf('-', algorithmSeparator + 1) !== -1) {
+    return undefined
+  }
+  const algorithm = contentIntegrity.slice(0, algorithmSeparator)
+  if (algorithm !== 'sha512') return undefined
+
+  const encodedDigest = contentIntegrity.slice(algorithmSeparator + 1)
+  const digest = Buffer.from(encodedDigest, 'base64')
+  if (digest.byteLength !== 64 || digest.toString('base64') !== encodedDigest) return undefined
+
+  return {
+    algorithm,
+    contentIntegrity,
+    digest,
+    revision: option.slice(1),
+  }
+}
+
+export function getIntegrityAddressedTarballUrl (
+  integrity: string,
+  registry: string
+): string | undefined {
+  const parsed = parseRevisionAwareIntegrity(integrity)
+  if (parsed == null) return undefined
+  return new URL(
+    `-/tarballs/${parsed.algorithm}/${parsed.digest.toString('base64url')}`,
+    normalizeRegistry(registry)
+  ).toString()
+}
+
+export function isIntegrityAddressedRegistryTarballUrl (
+  tarball: string,
+  integrity: string,
+  registry: string
+): boolean {
+  const expected = getIntegrityAddressedTarballUrl(integrity, registry)
+  if (expected == null) return false
+  try {
+    return new URL(tarball).toString() === expected
+  } catch {
+    return false
+  }
+}
+
 /**
  * Build the canonical tarball URL of an npm package — i.e. the URL pnpm derives
  * from a package's name, version, and registry. Vendored from the
@@ -45,6 +107,16 @@ export function isCanonicalRegistryTarballUrl (
 function normalizeRegistry (registry?: string): string {
   if (!registry) return 'https://registry.npmjs.org/'
   return registry.endsWith('/') ? registry : `${registry}/`
+}
+
+function isCanonicalRevisionOption (option: string): boolean {
+  if (option === 'r0') return true
+  if (option.length < 2 || option[0] !== 'r' || option[1] === '0') return false
+  for (let index = 1; index < option.length; index++) {
+    const code = option.charCodeAt(index)
+    if (code < 48 || code > 57) return false
+  }
+  return true
 }
 
 function removeBuildMetadataFromVersion (version: string): string {

--- a/pnpm11/resolving/tarball-url/src/index.ts
+++ b/pnpm11/resolving/tarball-url/src/index.ts
@@ -22,37 +22,26 @@ export interface TarballUrlOptions {
   serverType?: RegistryServerType
 }
 
-export interface RevisionAwareIntegrity {
+export interface IntegrityAddress {
   algorithm: 'sha512'
-  contentIntegrity: string
   digest: Buffer
-  revision: string
 }
 
-export function parseRevisionAwareIntegrity (integrity: string): RevisionAwareIntegrity | undefined {
-  const optionSeparator = integrity.indexOf('?')
-  if (optionSeparator === -1 || optionSeparator !== integrity.lastIndexOf('?')) return undefined
-
-  const option = integrity.slice(optionSeparator + 1)
-  if (!isCanonicalRevisionOption(option)) return undefined
-
-  const contentIntegrity = integrity.slice(0, optionSeparator)
-  const algorithmSeparator = contentIntegrity.indexOf('-')
-  if (algorithmSeparator === -1 || contentIntegrity.indexOf('-', algorithmSeparator + 1) !== -1) {
+export function parseIntegrityAddress (integrity: string): IntegrityAddress | undefined {
+  const algorithmSeparator = integrity.indexOf('-')
+  if (algorithmSeparator === -1 || integrity.indexOf('-', algorithmSeparator + 1) !== -1) {
     return undefined
   }
-  const algorithm = contentIntegrity.slice(0, algorithmSeparator)
+  const algorithm = integrity.slice(0, algorithmSeparator)
   if (algorithm !== 'sha512') return undefined
 
-  const encodedDigest = contentIntegrity.slice(algorithmSeparator + 1)
+  const encodedDigest = integrity.slice(algorithmSeparator + 1)
   const digest = Buffer.from(encodedDigest, 'base64')
   if (digest.byteLength !== 64 || digest.toString('base64') !== encodedDigest) return undefined
 
   return {
     algorithm,
-    contentIntegrity,
     digest,
-    revision: option.slice(1),
   }
 }
 
@@ -60,7 +49,7 @@ export function getIntegrityAddressedTarballUrl (
   integrity: string,
   registry: string
 ): string | undefined {
-  const parsed = parseRevisionAwareIntegrity(integrity)
+  const parsed = parseIntegrityAddress(integrity)
   if (parsed == null) return undefined
   return new URL(
     `-/tarballs/${parsed.algorithm}/${parsed.digest.toString('base64url')}`,
@@ -80,6 +69,13 @@ export function isIntegrityAddressedRegistryTarballUrl (
   } catch {
     return false
   }
+}
+
+export function isValidTarballRevision (revision: unknown): revision is number {
+  return typeof revision === 'number' &&
+    Number.isSafeInteger(revision) &&
+    revision > 0
+}
 
 /**
  * Build the canonical tarball URL of an npm package — i.e. the URL pnpm derives
@@ -143,16 +139,6 @@ function effectiveServerType (opts: TarballUrlOptions): RegistryServerType | und
 function normalizeRegistry (registry?: string): string {
   if (!registry) return PUBLIC_NPM_REGISTRY
   return registry.endsWith('/') ? registry : `${registry}/`
-}
-
-function isCanonicalRevisionOption (option: string): boolean {
-  if (option === 'r0') return true
-  if (option.length < 2 || option[0] !== 'r' || option[1] === '0') return false
-  for (let index = 1; index < option.length; index++) {
-    const code = option.charCodeAt(index)
-    if (code < 48 || code > 57) return false
-  }
-  return true
 }
 
 function removeBuildMetadataFromVersion (version: string): string {

--- a/pnpm11/resolving/tarball-url/src/index.ts
+++ b/pnpm11/resolving/tarball-url/src/index.ts
@@ -36,6 +36,7 @@ export function parseIntegrityAddress (integrity: string): IntegrityAddress | un
   if (algorithm !== 'sha512') return undefined
 
   const encodedDigest = integrity.slice(algorithmSeparator + 1)
+  if (encodedDigest.length !== 88) return undefined
   const digest = Buffer.from(encodedDigest, 'base64')
   if (digest.byteLength !== 64 || digest.toString('base64') !== encodedDigest) return undefined
 

--- a/pnpm11/resolving/tarball-url/src/index.ts
+++ b/pnpm11/resolving/tarball-url/src/index.ts
@@ -1,36 +1,25 @@
 import { Buffer } from 'node:buffer'
 
-export interface RevisionAwareIntegrity {
+export interface IntegrityAddress {
   algorithm: 'sha512'
-  contentIntegrity: string
   digest: Buffer
-  revision: string
 }
 
-export function parseRevisionAwareIntegrity (integrity: string): RevisionAwareIntegrity | undefined {
-  const optionSeparator = integrity.indexOf('?')
-  if (optionSeparator === -1 || optionSeparator !== integrity.lastIndexOf('?')) return undefined
-
-  const option = integrity.slice(optionSeparator + 1)
-  if (!isCanonicalRevisionOption(option)) return undefined
-
-  const contentIntegrity = integrity.slice(0, optionSeparator)
-  const algorithmSeparator = contentIntegrity.indexOf('-')
-  if (algorithmSeparator === -1 || contentIntegrity.indexOf('-', algorithmSeparator + 1) !== -1) {
+export function parseIntegrityAddress (integrity: string): IntegrityAddress | undefined {
+  const algorithmSeparator = integrity.indexOf('-')
+  if (algorithmSeparator === -1 || integrity.indexOf('-', algorithmSeparator + 1) !== -1) {
     return undefined
   }
-  const algorithm = contentIntegrity.slice(0, algorithmSeparator)
+  const algorithm = integrity.slice(0, algorithmSeparator)
   if (algorithm !== 'sha512') return undefined
 
-  const encodedDigest = contentIntegrity.slice(algorithmSeparator + 1)
+  const encodedDigest = integrity.slice(algorithmSeparator + 1)
   const digest = Buffer.from(encodedDigest, 'base64')
   if (digest.byteLength !== 64 || digest.toString('base64') !== encodedDigest) return undefined
 
   return {
     algorithm,
-    contentIntegrity,
     digest,
-    revision: option.slice(1),
   }
 }
 
@@ -38,7 +27,7 @@ export function getIntegrityAddressedTarballUrl (
   integrity: string,
   registry: string
 ): string | undefined {
-  const parsed = parseRevisionAwareIntegrity(integrity)
+  const parsed = parseIntegrityAddress(integrity)
   if (parsed == null) return undefined
   return new URL(
     `-/tarballs/${parsed.algorithm}/${parsed.digest.toString('base64url')}`,
@@ -58,6 +47,12 @@ export function isIntegrityAddressedRegistryTarballUrl (
   } catch {
     return false
   }
+}
+
+export function isValidTarballRevision (revision: unknown): revision is number {
+  return typeof revision === 'number' &&
+    Number.isSafeInteger(revision) &&
+    revision > 0
 }
 
 /**
@@ -107,16 +102,6 @@ export function isCanonicalRegistryTarballUrl (
 function normalizeRegistry (registry?: string): string {
   if (!registry) return 'https://registry.npmjs.org/'
   return registry.endsWith('/') ? registry : `${registry}/`
-}
-
-function isCanonicalRevisionOption (option: string): boolean {
-  if (option === 'r0') return true
-  if (option.length < 2 || option[0] !== 'r' || option[1] === '0') return false
-  for (let index = 1; index < option.length; index++) {
-    const code = option.charCodeAt(index)
-    if (code < 48 || code > 57) return false
-  }
-  return true
 }
 
 function removeBuildMetadataFromVersion (version: string): string {

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -5,7 +5,8 @@ import {
   getNpmTarballUrl,
   isCanonicalRegistryTarballUrl,
   isIntegrityAddressedRegistryTarballUrl,
-  parseRevisionAwareIntegrity,
+  isValidTarballRevision,
+  parseIntegrityAddress,
 } from '../src/index.js'
 
 const SHA512_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=='
@@ -75,40 +76,33 @@ describe('isCanonicalRegistryTarballUrl', () => {
   })
 })
 
-describe('revision-aware integrity tarball URLs', () => {
-  test.each(['r0', 'r1', 'r42'])('parses canonical revision option %s', (revision) => {
-    const integrity = `sha512-${SHA512_BASE64}?${revision}`
-    expect(parseRevisionAwareIntegrity(integrity)).toEqual({
+describe('integrity-addressed tarball URLs', () => {
+  test('parses a complete standard sha512 integrity', () => {
+    const integrity = `sha512-${SHA512_BASE64}`
+    expect(parseIntegrityAddress(integrity)).toEqual({
       algorithm: 'sha512',
-      contentIntegrity: `sha512-${SHA512_BASE64}`,
       digest: Buffer.alloc(64),
-      revision: revision.slice(1),
     })
   })
 
   test.each([
-    `sha512-${SHA512_BASE64}`,
-    `sha512-${SHA512_BASE64}?`,
-    `sha512-${SHA512_BASE64}?r01`,
-    `sha512-${SHA512_BASE64}?r-1`,
-    `sha512-${SHA512_BASE64}?r${'foo'}`,
-    `sha512-${SHA512_BASE64}?v1`,
-    `sha512-${SHA512_BASE64}?r1?other`,
-    'sha512-AAAA?r1',
-    `sha256-${SHA512_BASE64}?r1`,
+    `sha512-${SHA512_BASE64}?r1`,
+    'sha512-AAAA',
+    `sha256-${SHA512_BASE64}`,
+    `${SHA512_BASE64}`,
   ])('does not recognize %s', (integrity) => {
-    expect(parseRevisionAwareIntegrity(integrity)).toBeUndefined()
+    expect(parseIntegrityAddress(integrity)).toBeUndefined()
   })
 
   test('derives a base64url digest URL relative to a path-prefixed registry', () => {
-    const integrity = `sha512-${SHA512_BASE64}?r2`
+    const integrity = `sha512-${SHA512_BASE64}`
     expect(getIntegrityAddressedTarballUrl(integrity, 'https://registry.example/~main')).toBe(
       `https://registry.example/~main/-/tarballs/sha512/${'A'.repeat(86)}`
     )
   })
 
   test('validates the complete metadata pair against the configured registry', () => {
-    const integrity = `sha512-${SHA512_BASE64}?r2`
+    const integrity = `sha512-${SHA512_BASE64}`
     const tarball = getIntegrityAddressedTarballUrl(integrity, 'https://registry.example/~main/')!
     expect(isIntegrityAddressedRegistryTarballUrl(
       tarball,
@@ -126,4 +120,15 @@ describe('revision-aware integrity tarball URLs', () => {
       'https://registry.example/~main/'
     )).toBe(false)
   })
+
+  test.each([1, 42, Number.MAX_SAFE_INTEGER])('accepts positive safe-integer revision %s', (revision) => {
+    expect(isValidTarballRevision(revision)).toBe(true)
+  })
+
+  test.each([undefined, null, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1'])(
+    'rejects malformed revision %s',
+    (revision) => {
+      expect(isValidTarballRevision(revision)).toBe(false)
+    }
+  )
 })

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -5,7 +5,8 @@ import {
   getNpmTarballUrl,
   isCanonicalRegistryTarballUrl,
   isIntegrityAddressedRegistryTarballUrl,
-  parseRevisionAwareIntegrity,
+  isValidTarballRevision,
+  parseIntegrityAddress,
 } from '../src/index.js'
 
 const SHA512_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=='
@@ -153,40 +154,33 @@ test('the public npm registry keeps its encoded-path leniency without being decl
   expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, { registry })).toBe(true)
 })
 
-describe('revision-aware integrity tarball URLs', () => {
-  test.each(['r0', 'r1', 'r42'])('parses canonical revision option %s', (revision) => {
-    const integrity = `sha512-${SHA512_BASE64}?${revision}`
-    expect(parseRevisionAwareIntegrity(integrity)).toEqual({
+describe('integrity-addressed tarball URLs', () => {
+  test('parses a complete standard sha512 integrity', () => {
+    const integrity = `sha512-${SHA512_BASE64}`
+    expect(parseIntegrityAddress(integrity)).toEqual({
       algorithm: 'sha512',
-      contentIntegrity: `sha512-${SHA512_BASE64}`,
       digest: Buffer.alloc(64),
-      revision: revision.slice(1),
     })
   })
 
   test.each([
-    `sha512-${SHA512_BASE64}`,
-    `sha512-${SHA512_BASE64}?`,
-    `sha512-${SHA512_BASE64}?r01`,
-    `sha512-${SHA512_BASE64}?r-1`,
-    `sha512-${SHA512_BASE64}?r${'foo'}`,
-    `sha512-${SHA512_BASE64}?v1`,
-    `sha512-${SHA512_BASE64}?r1?other`,
-    'sha512-AAAA?r1',
-    `sha256-${SHA512_BASE64}?r1`,
+    `sha512-${SHA512_BASE64}?r1`,
+    'sha512-AAAA',
+    `sha256-${SHA512_BASE64}`,
+    `${SHA512_BASE64}`,
   ])('does not recognize %s', (integrity) => {
-    expect(parseRevisionAwareIntegrity(integrity)).toBeUndefined()
+    expect(parseIntegrityAddress(integrity)).toBeUndefined()
   })
 
   test('derives a base64url digest URL relative to a path-prefixed registry', () => {
-    const integrity = `sha512-${SHA512_BASE64}?r2`
+    const integrity = `sha512-${SHA512_BASE64}`
     expect(getIntegrityAddressedTarballUrl(integrity, 'https://registry.example/~main')).toBe(
       `https://registry.example/~main/-/tarballs/sha512/${'A'.repeat(86)}`
     )
   })
 
   test('validates the complete metadata pair against the configured registry', () => {
-    const integrity = `sha512-${SHA512_BASE64}?r2`
+    const integrity = `sha512-${SHA512_BASE64}`
     const tarball = getIntegrityAddressedTarballUrl(integrity, 'https://registry.example/~main/')!
     expect(isIntegrityAddressedRegistryTarballUrl(
       tarball,
@@ -204,4 +198,15 @@ describe('revision-aware integrity tarball URLs', () => {
       'https://registry.example/~main/'
     )).toBe(false)
   })
+
+  test.each([1, 42, Number.MAX_SAFE_INTEGER])('accepts positive safe-integer revision %s', (revision) => {
+    expect(isValidTarballRevision(revision)).toBe(true)
+  })
+
+  test.each([undefined, null, 0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1, '1'])(
+    'rejects malformed revision %s',
+    (revision) => {
+      expect(isValidTarballRevision(revision)).toBe(false)
+    }
+  )
 })

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -164,16 +164,16 @@ describe('integrity-addressed tarball URLs', () => {
   })
 
   test.each([
-    `sha512-${SHA512_BASE64}?r1`,
-    'sha512-AAAA',
-    `sha512-${'A'.repeat(1024 * 1024)}`,
-    `sha256-${SHA512_BASE64}`,
-    `${SHA512_BASE64}`,
-    {},
-    [],
-    1,
-    true,
-  ])('does not recognize %s', (integrity) => {
+    { name: 'a revision suffix', integrity: `sha512-${SHA512_BASE64}?r1` },
+    { name: 'a truncated digest', integrity: 'sha512-AAAA' },
+    { name: 'an oversized digest', integrity: `sha512-${'A'.repeat(1024 * 1024)}` },
+    { name: 'a different algorithm', integrity: `sha256-${SHA512_BASE64}` },
+    { name: 'a missing algorithm', integrity: SHA512_BASE64 },
+    { name: 'an object', integrity: {} },
+    { name: 'an array', integrity: [] },
+    { name: 'a number', integrity: 1 },
+    { name: 'a boolean', integrity: true },
+  ])('does not recognize $name', ({ integrity }) => {
     expect(parseIntegrityAddress(integrity)).toBeUndefined()
   })
 

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -169,6 +169,10 @@ describe('integrity-addressed tarball URLs', () => {
     `sha512-${'A'.repeat(1024 * 1024)}`,
     `sha256-${SHA512_BASE64}`,
     `${SHA512_BASE64}`,
+    {},
+    [],
+    1,
+    true,
   ])('does not recognize %s', (integrity) => {
     expect(parseIntegrityAddress(integrity)).toBeUndefined()
   })

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from '@jest/globals'
 
-import { getNpmTarballUrl, isCanonicalRegistryTarballUrl } from '../src/index.js'
+import {
+  getIntegrityAddressedTarballUrl,
+  getNpmTarballUrl,
+  isCanonicalRegistryTarballUrl,
+  isIntegrityAddressedRegistryTarballUrl,
+  parseRevisionAwareIntegrity,
+} from '../src/index.js'
+
+const SHA512_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=='
 
 describe('getNpmTarballUrl', () => {
   test('create simple URL', () => {
@@ -64,5 +72,58 @@ describe('isCanonicalRegistryTarballUrl', () => {
   test('is false when the version differs', () => {
     const tarball = getNpmTarballUrl('lodash', '4.17.20', { registry })
     expect(isCanonicalRegistryTarballUrl(tarball, { name: 'lodash', version: '4.17.21' }, registry)).toBe(false)
+  })
+})
+
+describe('revision-aware integrity tarball URLs', () => {
+  test.each(['r0', 'r1', 'r42'])('parses canonical revision option %s', (revision) => {
+    const integrity = `sha512-${SHA512_BASE64}?${revision}`
+    expect(parseRevisionAwareIntegrity(integrity)).toEqual({
+      algorithm: 'sha512',
+      contentIntegrity: `sha512-${SHA512_BASE64}`,
+      digest: Buffer.alloc(64),
+      revision: revision.slice(1),
+    })
+  })
+
+  test.each([
+    `sha512-${SHA512_BASE64}`,
+    `sha512-${SHA512_BASE64}?`,
+    `sha512-${SHA512_BASE64}?r01`,
+    `sha512-${SHA512_BASE64}?r-1`,
+    `sha512-${SHA512_BASE64}?r${'foo'}`,
+    `sha512-${SHA512_BASE64}?v1`,
+    `sha512-${SHA512_BASE64}?r1?other`,
+    'sha512-AAAA?r1',
+    `sha256-${SHA512_BASE64}?r1`,
+  ])('does not recognize %s', (integrity) => {
+    expect(parseRevisionAwareIntegrity(integrity)).toBeUndefined()
+  })
+
+  test('derives a base64url digest URL relative to a path-prefixed registry', () => {
+    const integrity = `sha512-${SHA512_BASE64}?r2`
+    expect(getIntegrityAddressedTarballUrl(integrity, 'https://registry.example/~main')).toBe(
+      `https://registry.example/~main/-/tarballs/sha512/${'A'.repeat(86)}`
+    )
+  })
+
+  test('validates the complete metadata pair against the configured registry', () => {
+    const integrity = `sha512-${SHA512_BASE64}?r2`
+    const tarball = getIntegrityAddressedTarballUrl(integrity, 'https://registry.example/~main/')!
+    expect(isIntegrityAddressedRegistryTarballUrl(
+      tarball,
+      integrity,
+      'https://registry.example/~main/'
+    )).toBe(true)
+    expect(isIntegrityAddressedRegistryTarballUrl(
+      tarball,
+      integrity,
+      'https://other-registry.example/~main/'
+    )).toBe(false)
+    expect(isIntegrityAddressedRegistryTarballUrl(
+      `${tarball}?token=attacker-controlled`,
+      integrity,
+      'https://registry.example/~main/'
+    )).toBe(false)
   })
 })

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from '@jest/globals'
 
-import { getNpmTarballUrl, isCanonicalRegistryTarballUrl } from '../src/index.js'
+import {
+  getIntegrityAddressedTarballUrl,
+  getNpmTarballUrl,
+  isCanonicalRegistryTarballUrl,
+  isIntegrityAddressedRegistryTarballUrl,
+  parseRevisionAwareIntegrity,
+} from '../src/index.js'
+
+const SHA512_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=='
 
 describe('getNpmTarballUrl', () => {
   test('create simple URL', () => {
@@ -143,4 +151,57 @@ test('the public npm registry keeps its encoded-path leniency without being decl
   const registry = 'https://registry.npmjs.org/'
   const tarball = 'https://registry.npmjs.org/@babel%2Fcore/-/core-7.0.0.tgz'
   expect(isCanonicalRegistryTarballUrl(tarball, { name: '@babel/core', version: '7.0.0' }, { registry })).toBe(true)
+})
+
+describe('revision-aware integrity tarball URLs', () => {
+  test.each(['r0', 'r1', 'r42'])('parses canonical revision option %s', (revision) => {
+    const integrity = `sha512-${SHA512_BASE64}?${revision}`
+    expect(parseRevisionAwareIntegrity(integrity)).toEqual({
+      algorithm: 'sha512',
+      contentIntegrity: `sha512-${SHA512_BASE64}`,
+      digest: Buffer.alloc(64),
+      revision: revision.slice(1),
+    })
+  })
+
+  test.each([
+    `sha512-${SHA512_BASE64}`,
+    `sha512-${SHA512_BASE64}?`,
+    `sha512-${SHA512_BASE64}?r01`,
+    `sha512-${SHA512_BASE64}?r-1`,
+    `sha512-${SHA512_BASE64}?r${'foo'}`,
+    `sha512-${SHA512_BASE64}?v1`,
+    `sha512-${SHA512_BASE64}?r1?other`,
+    'sha512-AAAA?r1',
+    `sha256-${SHA512_BASE64}?r1`,
+  ])('does not recognize %s', (integrity) => {
+    expect(parseRevisionAwareIntegrity(integrity)).toBeUndefined()
+  })
+
+  test('derives a base64url digest URL relative to a path-prefixed registry', () => {
+    const integrity = `sha512-${SHA512_BASE64}?r2`
+    expect(getIntegrityAddressedTarballUrl(integrity, 'https://registry.example/~main')).toBe(
+      `https://registry.example/~main/-/tarballs/sha512/${'A'.repeat(86)}`
+    )
+  })
+
+  test('validates the complete metadata pair against the configured registry', () => {
+    const integrity = `sha512-${SHA512_BASE64}?r2`
+    const tarball = getIntegrityAddressedTarballUrl(integrity, 'https://registry.example/~main/')!
+    expect(isIntegrityAddressedRegistryTarballUrl(
+      tarball,
+      integrity,
+      'https://registry.example/~main/'
+    )).toBe(true)
+    expect(isIntegrityAddressedRegistryTarballUrl(
+      tarball,
+      integrity,
+      'https://other-registry.example/~main/'
+    )).toBe(false)
+    expect(isIntegrityAddressedRegistryTarballUrl(
+      `${tarball}?token=attacker-controlled`,
+      integrity,
+      'https://registry.example/~main/'
+    )).toBe(false)
+  })
 })

--- a/pnpm11/resolving/tarball-url/test/index.test.ts
+++ b/pnpm11/resolving/tarball-url/test/index.test.ts
@@ -166,6 +166,7 @@ describe('integrity-addressed tarball URLs', () => {
   test.each([
     `sha512-${SHA512_BASE64}?r1`,
     'sha512-AAAA',
+    `sha512-${'A'.repeat(1024 * 1024)}`,
     `sha256-${SHA512_BASE64}`,
     `${SHA512_BASE64}`,
   ])('does not recognize %s', (integrity) => {

--- a/pnpm11/resolving/tarball-url/tsconfig.json
+++ b/pnpm11/resolving/tarball-url/tsconfig.json
@@ -11,6 +11,9 @@
   "references": [
     {
       "path": "../../core/types"
+    },
+    {
+      "path": "../../crypto/integrity"
     }
   ]
 }

--- a/pnpm11/store/index/src/index.ts
+++ b/pnpm11/store/index/src/index.ts
@@ -63,7 +63,25 @@ export function packForStorage (data: unknown): Uint8Array {
  * Integrity strings never contain tabs, so this is unambiguous.
  */
 export function storeIndexKey (integrity: string, pkgId: string): string {
-  return `${integrity}\t${pkgId}`
+  return `${contentAddress(integrity)}\t${pkgId}`
+}
+
+function contentAddress (value: string): string {
+  return value
+    .split(/(\s+)/)
+    .map((hash) => {
+      if (
+        !hash.startsWith('sha1-') &&
+        !hash.startsWith('sha256-') &&
+        !hash.startsWith('sha384-') &&
+        !hash.startsWith('sha512-')
+      ) {
+        return hash
+      }
+      const optionSeparator = hash.indexOf('?')
+      return optionSeparator === -1 ? hash : hash.slice(0, optionSeparator)
+    })
+    .join('')
 }
 
 export function gitHostedStoreIndexKey (pkgId: string, opts: { built: boolean }): string {

--- a/pnpm11/store/index/src/index.ts
+++ b/pnpm11/store/index/src/index.ts
@@ -63,25 +63,7 @@ export function packForStorage (data: unknown): Uint8Array {
  * Integrity strings never contain tabs, so this is unambiguous.
  */
 export function storeIndexKey (integrity: string, pkgId: string): string {
-  return `${contentAddress(integrity)}\t${pkgId}`
-}
-
-function contentAddress (value: string): string {
-  return value
-    .split(/(\s+)/)
-    .map((hash) => {
-      if (
-        !hash.startsWith('sha1-') &&
-        !hash.startsWith('sha256-') &&
-        !hash.startsWith('sha384-') &&
-        !hash.startsWith('sha512-')
-      ) {
-        return hash
-      }
-      const optionSeparator = hash.indexOf('?')
-      return optionSeparator === -1 ? hash : hash.slice(0, optionSeparator)
-    })
-    .join('')
+  return `${integrity}\t${pkgId}`
 }
 
 export function gitHostedStoreIndexKey (pkgId: string, opts: { built: boolean }): string {

--- a/pnpm11/store/index/test/index.ts
+++ b/pnpm11/store/index/test/index.ts
@@ -48,22 +48,6 @@ test('StoreIndex entries() iterates all SQLite entries', () => {
   }
 })
 
-test('storeIndexKey excludes SRI options from the content address', () => {
-  const integrity = 'sha512-AAAA'
-  expect(storeIndexKey(`${integrity}?r0`, 'foo@1.0.0')).toBe(
-    storeIndexKey(`${integrity}?r2`, 'foo@1.0.0')
-  )
-  expect(storeIndexKey(`${integrity}?r0?provider`, 'foo@1.0.0')).toBe(
-    storeIndexKey(integrity, 'foo@1.0.0')
-  )
-  expect(storeIndexKey('sha256-AAAA?r0  sha512-BBBB?r1', 'foo@1.0.0')).toBe(
-    storeIndexKey('sha256-AAAA  sha512-BBBB', 'foo@1.0.0')
-  )
-  expect(storeIndexKey('https://example.com/foo.tgz?revision=1', 'built')).toBe(
-    'https://example.com/foo.tgz?revision=1\tbuilt'
-  )
-})
-
 // The immutable open only works on a runtime that honors the immutable URI;
 // this is purely a Node-version property, independent of platform.
 const supportsImmutableUri = nodeSupportsImmutableSqliteUri()

--- a/pnpm11/store/index/test/index.ts
+++ b/pnpm11/store/index/test/index.ts
@@ -48,6 +48,22 @@ test('StoreIndex entries() iterates all SQLite entries', () => {
   }
 })
 
+test('storeIndexKey excludes SRI options from the content address', () => {
+  const integrity = 'sha512-AAAA'
+  expect(storeIndexKey(`${integrity}?r0`, 'foo@1.0.0')).toBe(
+    storeIndexKey(`${integrity}?r2`, 'foo@1.0.0')
+  )
+  expect(storeIndexKey(`${integrity}?r0?provider`, 'foo@1.0.0')).toBe(
+    storeIndexKey(integrity, 'foo@1.0.0')
+  )
+  expect(storeIndexKey('sha256-AAAA?r0  sha512-BBBB?r1', 'foo@1.0.0')).toBe(
+    storeIndexKey('sha256-AAAA  sha512-BBBB', 'foo@1.0.0')
+  )
+  expect(storeIndexKey('https://example.com/foo.tgz?revision=1', 'built')).toBe(
+    'https://example.com/foo.tgz?revision=1\tbuilt'
+  )
+})
+
 // The immutable open only works on a runtime that honors the immutable URI;
 // this is purely a Node-version property, independent of platform.
 const supportsImmutableUri = nodeSupportsImmutableSqliteUri()

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -28,6 +28,7 @@ backend-postgres = ["dep:sqlx", "sqlx/postgres"]
 pnpm-catalogs-types          = { workspace = true }
 pnpm-config                  = { workspace = true }
 pnpm-config-dir              = { workspace = true }
+pnpm-crypto-hash             = { workspace = true }
 pnpm-env-replace             = { workspace = true }
 pnpm-lockfile                = { workspace = true }
 pnpm-lockfile-verification   = { workspace = true }

--- a/pnpr/crates/pnpr/src/policy.rs
+++ b/pnpr/crates/pnpr/src/policy.rs
@@ -292,6 +292,12 @@ impl PackageRules {
         self.rules.iter().any(|rule| rule.publish.is_some() || rule.unpublish.is_some())
     }
 
+    /// Whether any package carries an explicit access policy.
+    #[must_use]
+    pub fn refines_access(&self) -> bool {
+        self.rules.iter().any(|rule| rule.access.is_some())
+    }
+
     /// The effective permissions for `package`: the **most specific**
     /// matching entry's fields, each falling back to the registry-level
     /// default. Selection is order-free — the restricted pattern language

--- a/pnpr/crates/pnpr/src/resolver.rs
+++ b/pnpr/crates/pnpr/src/resolver.rs
@@ -73,7 +73,7 @@ use axum::{
 use indexmap::IndexMap;
 use pnpm_config::Config as PacquetConfig;
 use pnpm_lockfile::{
-    Lockfile, LockfileResolution, TarballResolution, is_git_hosted_tarball_url,
+    Lockfile, LockfileResolution, TarballResolution, TarballRevision, is_git_hosted_tarball_url,
     pick_registry_for_package,
 };
 use pnpm_lockfile_verification::{collect_resolution_policy_violations, hash_lockfile};
@@ -914,6 +914,7 @@ impl TarballRouter {
             metadata.resolution = LockfileResolution::Tarball(TarballResolution {
                 tarball: routed_url,
                 integrity: Some(integrity.clone()),
+                revision: None,
                 git_hosted: None,
                 path: None,
             });
@@ -1058,6 +1059,11 @@ fn package_frame(router: &TarballRouter, hint: &ResolvedPackageHint<'_>) -> serd
     if let Some(count) = hint.file_count {
         frame["fileCount"] = serde_json::Value::from(count);
     }
+    if tarball_url == hint.tarball_url
+        && let Some(revision) = hint.revision
+    {
+        frame["revision"] = serde_json::Value::from(revision);
+    }
     frame
 }
 
@@ -1101,12 +1107,24 @@ fn frozen_package_frames(
         };
         let name = package_key.name.to_string();
         let version = package_key.suffix.version().to_string();
-        let tarball_url = router.route_url(&name, &version, &tarball_url);
+        let upstream_tarball_url = tarball_url;
+        let tarball_url = router.route_url(&name, &version, &upstream_tarball_url);
         if !seen_urls.insert(tarball_url.clone()) {
             continue;
         }
         let id = format!("{name}@{version}");
         let integrity = integrity.to_string();
+        let revision = if tarball_url == upstream_tarball_url {
+            match &snapshot.resolution {
+                LockfileResolution::Tarball(tarball) => tarball.revision.map(TarballRevision::get),
+                LockfileResolution::Registry(registry) => {
+                    registry.revision.map(TarballRevision::get)
+                }
+                _ => None,
+            }
+        } else {
+            None
+        };
         let stats = dist_stats.get(&(name.clone(), version.clone())).map(|entry| *entry.value());
         let frame = package_frame(
             router,
@@ -1118,6 +1136,7 @@ fn frozen_package_frames(
                 tarball_url: &tarball_url,
                 unpacked_size: stats.and_then(|stats| stats.unpacked_size),
                 file_count: stats.and_then(|stats| stats.file_count),
+                revision,
                 // The URL is already routed (canonical → endpoint above), so
                 // re-routing by registry would be redundant; route_url is a
                 // no-op on an already-routed URL.

--- a/pnpr/crates/pnpr/src/resolver/tests.rs
+++ b/pnpr/crates/pnpr/src/resolver/tests.rs
@@ -905,7 +905,7 @@ fn a_package_frame_carries_unpacked_size_and_omits_it_when_unknown() {
         tarball_router: tarball_router(&registry, Identity::Anonymous),
     };
 
-    let hint = |unpacked_size, file_count| ResolvedPackageHint {
+    let hint = |unpacked_size, file_count, revision| ResolvedPackageHint {
         id: "acme@1.0.0",
         name: "acme",
         version: "1.0.0",
@@ -913,20 +913,23 @@ fn a_package_frame_carries_unpacked_size_and_omits_it_when_unknown() {
         tarball_url: "https://r.test/acme/-/acme-1.0.0.tgz",
         unpacked_size,
         file_count,
+        revision,
         from_registry: false,
     };
-    observer.on_resolved(hint(Some(123_456), Some(42)));
-    observer.on_resolved(hint(None, None));
+    observer.on_resolved(hint(Some(123_456), Some(42), Some(3)));
+    observer.on_resolved(hint(None, None, None));
 
     let sized: serde_json::Value =
         serde_json::from_slice(&rx.try_recv().expect("sized frame sent")).unwrap();
     assert_eq!(sized["unpackedSize"], serde_json::json!(123_456));
     assert_eq!(sized["fileCount"], serde_json::json!(42));
+    assert_eq!(sized["revision"], serde_json::json!(3));
 
     let unsized_frame: serde_json::Value =
         serde_json::from_slice(&rx.try_recv().expect("unsized frame sent")).unwrap();
     assert!(unsized_frame.get("unpackedSize").is_none());
     assert!(unsized_frame.get("fileCount").is_none());
+    assert!(unsized_frame.get("revision").is_none());
     assert_eq!(unsized_frame["tarball"], serde_json::json!("https://r.test/acme/-/acme-1.0.0.tgz"));
 }
 
@@ -950,6 +953,7 @@ fn package_frames_route_private_alias_tarballs_to_gateway() {
             tarball_url: "https://npm.corp.example/acme/-/acme-1.0.0.tgz",
             unpacked_size: None,
             file_count: None,
+            revision: Some(3),
             from_registry: false,
         },
     );
@@ -957,6 +961,7 @@ fn package_frames_route_private_alias_tarballs_to_gateway() {
 
     assert!(tarball.contains("/~corp/acme/-/acme-1.0.0.tgz"));
     assert!(!tarball.contains("npm.corp.example"));
+    assert!(frame.get("revision").is_none());
 }
 
 #[test]
@@ -983,6 +988,7 @@ fn package_frame_routes_split_domain_registry_tarball_by_registry() {
             tarball_url: "https://cdn.split-domain.example/acme-1.0.0.tgz",
             unpacked_size: None,
             file_count: None,
+            revision: None,
             from_registry: true,
         },
     );
@@ -1013,6 +1019,7 @@ fn package_frame_strips_signed_token_from_public_registry_tarball() {
             tarball_url: "https://registry.npmjs.org/acme/-/acme-1.0.0.tgz?token=secret",
             unpacked_size: None,
             file_count: None,
+            revision: None,
             from_registry: true,
         },
     );
@@ -1103,6 +1110,7 @@ fn osv_checkable_tarball_does_not_trust_git_hosted_flag_or_strict_url_parsing() 
         LockfileResolution::Tarball(TarballResolution {
             tarball: url.to_string(),
             integrity: None,
+            revision: None,
             git_hosted,
             path: None,
         })

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -17,7 +17,8 @@ use crate::{
     streaming,
     upstream::{
         CacheValidators, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
-        extract_version_manifest, rewrite_tarball_urls, tarball_basename,
+        extract_upstream_version_manifest, extract_version_manifest, rewrite_tarball_urls,
+        rewrite_upstream_tarball_urls, tarball_basename,
     },
 };
 use axum::{
@@ -35,6 +36,7 @@ use axum::{
 };
 use chrono::Utc;
 use indexmap::IndexMap;
+use pnpm_crypto_hash::integrity_addressed_tarball_integrity;
 use serde_json::{Value, json};
 use ssri::Integrity;
 use std::{
@@ -736,6 +738,7 @@ async fn get_tarball_scoped(
 /// 4-segment GET:
 /// * `/-/package/{pkg}/dist-tags` — packument's `dist-tags` object.
 /// * `/-/org/{scope}/team` — the teams of the registry claiming `@scope`.
+/// * `/-/tarballs/sha512/{digest}` — immutable artifact through the default registry.
 /// * `/~<name>/-/v1/search` — search through a registry endpoint.
 /// * `/~<name>/@scope/{pkg}/{version}` — scoped version manifest through a
 ///   registry endpoint.
@@ -745,6 +748,15 @@ async fn get_four_segments(
     OriginalUri(uri): OriginalUri,
     Path((a, b, c, d)): Path<(String, String, String, String)>,
 ) -> Response {
+    if a == "-" && b == "tarballs" && c == "sha512" {
+        let Some(registry) = default_registry_target(&state) else { return not_found() };
+        let response = serve_revision_tarball(&state, &identity, &registry, &d).await;
+        return if revision_registry_is_private(&state, &registry) {
+            private_no_cache(response)
+        } else {
+            response
+        };
+    }
     if a == "-" && b == "package" && d == "dist-tags" {
         let response = get_dist_tags(&state, &identity, None, &c).await;
         return private_if_caller_gated(&state, &c, response);
@@ -776,6 +788,7 @@ async fn get_four_segments(
 /// * `/~<name>/-/package/<pkg>/dist-tags` — dist-tags through a registry
 ///   endpoint.
 /// * `/~<name>/-/org/{scope}/team` — org teams through a registry endpoint.
+/// * `/~<name>/-/tarballs/sha512/{digest}` — immutable artifact through an upstream.
 ///
 /// Every other 5-segment GET is a not-found catchall (the route exists so
 /// DELETE/PUT can sit on the same path).
@@ -788,6 +801,9 @@ async fn get_five_segments(
         return private_no_cache(get_team_members(&state, &identity, None, &c, &d));
     }
     if let Some(registry) = a.strip_prefix('~').filter(|registry| !registry.is_empty()) {
+        if b == "-" && c == "tarballs" && d == "sha512" {
+            return private_no_cache(serve_revision_tarball(&state, &identity, registry, &e).await);
+        }
         if b.starts_with('@') && d == "-" {
             let full = format!("{b}/{c}");
             return private_no_cache(
@@ -1329,8 +1345,21 @@ async fn serve_registry_version_manifest(
             return not_found();
         }
     }
-    let Some(manifest) = extract_version_manifest(&packument, &name, version_or_tag, tarball_base)
-    else {
+    let revision_registry = match &resolved_source {
+        RegistrySource::Upstream(source) => revision_source_registry(state, registry, source),
+        RegistrySource::Hosted(_) | RegistrySource::Unclaimed | RegistrySource::NotFound => None,
+    };
+    let manifest = match revision_registry {
+        Some(source_registry) => extract_upstream_version_manifest(
+            &packument,
+            &name,
+            version_or_tag,
+            source_registry,
+            tarball_base,
+        ),
+        None => extract_version_manifest(&packument, &name, version_or_tag, tarball_base),
+    };
+    let Some(manifest) = manifest else {
         return not_found();
     };
     match serde_json::to_vec(&manifest) {
@@ -1377,6 +1406,39 @@ fn authorized_upstream<'a>(
         })));
     }
     state.inner.upstreams.get(upstream).ok_or_else(|| Box::new(not_found()))
+}
+
+fn authorized_revision_upstream<'a>(
+    state: &'a AppState,
+    identity: &Identity,
+    registry: &str,
+) -> Result<&'a Upstream, Box<Response>> {
+    if !matches!(state.inner.config.registries.get(registry), Some(Registry::Upstream { .. })) {
+        return Err(Box::new(not_found()));
+    }
+    let Some(config) = state.inner.config.upstreams.get(registry) else {
+        return Err(Box::new(not_found()));
+    };
+    if config.rules.refines_access() {
+        return Err(Box::new(not_found()));
+    }
+    authorized_upstream(state, identity, registry)
+}
+
+fn revision_registry_is_private(state: &AppState, registry: &str) -> bool {
+    state.inner.config.upstreams.get(registry).is_some_and(|config| config.access.is_some())
+}
+
+fn revision_source_registry<'a>(
+    state: &'a AppState,
+    addressed_registry: &str,
+    source: &str,
+) -> Option<&'a str> {
+    if addressed_registry != source {
+        return None;
+    }
+    let config = state.inner.config.upstreams.get(source)?;
+    (!config.rules.refines_access()).then_some(config.url.as_str())
 }
 
 /// The disposable cache namespace for an upstream registry's `/~<name>/` route —
@@ -1638,6 +1700,7 @@ async fn serve_packument_via_upstream(
     upstream: &str,
     name: &PackageName,
     tarball_base: &str,
+    revision_registry: Option<&str>,
 ) -> Response {
     let bytes = match load_upstream_packument_for(state, identity, upstream, name).await {
         Ok(Some(bytes)) => bytes,
@@ -1648,6 +1711,7 @@ async fn serve_packument_via_upstream(
         name,
         &bytes,
         tarball_base,
+        revision_registry,
         state.inner.osv_index.as_ref(),
         wants_abbreviated(headers),
     ) {
@@ -1797,6 +1861,66 @@ async fn serve_tarball_via_upstream(
     match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
         Ok(body) => tarball_response(body, None),
         Err(err) => error_response(&tarball_stream_error(err, &name, &filename)),
+    }
+}
+
+async fn serve_revision_tarball(
+    state: &AppState,
+    identity: &Identity,
+    registry: &str,
+    digest: &str,
+) -> Response {
+    let Some(integrity) = integrity_addressed_tarball_integrity(digest) else {
+        return not_found();
+    };
+    let upstream = match authorized_revision_upstream(state, identity, registry) {
+        Ok(upstream) => upstream,
+        Err(response) => return *response,
+    };
+    let namespace = upstream_cache_namespace(state, registry);
+    if upstream.caches() {
+        match state.inner.storage.open_upstream_revision_tarball(&namespace, digest).await {
+            Ok(Some((file, len))) => {
+                return tarball_response(streaming::stream_file(file), Some(len));
+            }
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(?err, %registry, %digest, "revision tarball cache open failed");
+            }
+        }
+    }
+    let response = match upstream.fetch_revision_tarball_response(digest).await {
+        Ok(FetchOutcome::Ok(response)) => response,
+        Ok(FetchOutcome::NotFound) => return not_found(),
+        Err(err) => return error_response(&err),
+    };
+    let write =
+        match state.inner.storage.open_upstream_revision_tarball_tmp(&namespace, digest).await {
+            Ok(write) => write,
+            Err(err) => return error_response(&err),
+        };
+    if !upstream.caches() {
+        return match streaming::download_verified_to_temp(
+            response,
+            write,
+            &integrity,
+            MAX_TARBALL_BYTES,
+        )
+        .await
+        {
+            Ok((file, len, tmp_path)) => {
+                tarball_response(streaming::stream_file_and_remove(file, tmp_path), Some(len))
+            }
+            Err(err) => {
+                error_response(&tarball_stream_error_for_package(err, "registry revision", digest))
+            }
+        };
+    }
+    match streaming::stream_verified_to_cache(response, write, &integrity, MAX_TARBALL_BYTES) {
+        Ok(body) => tarball_response(body, None),
+        Err(err) => {
+            error_response(&tarball_stream_error_for_package(err, "registry revision", digest))
+        }
     }
 }
 
@@ -1962,8 +2086,17 @@ async fn serve_registry_packument(
             {
                 return error_response(&err);
             }
-            serve_packument_via_upstream(state, identity, headers, source, &name, tarball_base)
-                .await
+            let revision_registry = revision_source_registry(state, registry, source);
+            serve_packument_via_upstream(
+                state,
+                identity,
+                headers,
+                source,
+                &name,
+                tarball_base,
+                revision_registry,
+            )
+            .await
         }
         // A hosted denial answers per its gate tier (see `hosted_gate`): a
         // registry-default denial is a not-found mask, an explicit
@@ -2094,6 +2227,7 @@ async fn serve_hosted_packument(
             name,
             &bytes,
             tarball_base,
+            None,
             state.inner.osv_index.as_ref(),
             wants_abbreviated(headers),
         ) {
@@ -2212,7 +2346,7 @@ fn expected_tarball_dist(
     // legitimate registry, so fail closed rather than pick by iteration order.
     if matches.next().is_some() {
         return Err(tarball_integrity_error(
-            name,
+            name.as_str(),
             filename,
             "packument declares the same dist.tarball basename for multiple versions".to_string(),
         ));
@@ -2223,18 +2357,26 @@ fn expected_tarball_dist(
     // neither stays unservable: bytes never leave unverified.
     let integrity = if let Some(declared) = dist.integrity.as_deref() {
         streaming::parse_integrity(declared).map_err(|err| {
-            tarball_integrity_error(name, filename, format!("malformed dist.integrity: {err}"))
+            tarball_integrity_error(
+                name.as_str(),
+                filename,
+                format!("malformed dist.integrity: {err}"),
+            )
         })?
     } else {
         let shasum = dist.shasum.as_deref().ok_or_else(|| {
             tarball_integrity_error(
-                name,
+                name.as_str(),
                 filename,
                 format!("packument has no dist.integrity or dist.shasum for {version:?}"),
             )
         })?;
         Integrity::from_hex(shasum, ssri::Algorithm::Sha1).map_err(|err| {
-            tarball_integrity_error(name, filename, format!("malformed dist.shasum: {err}"))
+            tarball_integrity_error(
+                name.as_str(),
+                filename,
+                format!("malformed dist.shasum: {err}"),
+            )
         })?
     };
     Ok(Some(TarballDist { version: version.clone(), integrity }))
@@ -2245,25 +2387,35 @@ fn tarball_stream_error(
     name: &PackageName,
     filename: &str,
 ) -> RegistryError {
+    tarball_stream_error_for_package(err, name.as_str(), filename)
+}
+
+fn tarball_stream_error_for_package(
+    err: streaming::TarballStreamError,
+    package: &str,
+    filename: &str,
+) -> RegistryError {
     match err {
         streaming::TarballStreamError::Upstream { url, source } => {
             RegistryError::Upstream { url, source }
         }
         streaming::TarballStreamError::Io(err) => RegistryError::Io(err),
-        streaming::TarballStreamError::Integrity(err) => {
-            tarball_integrity_error(name, filename, format!("integrity verification failed: {err}"))
-        }
+        streaming::TarballStreamError::Integrity(err) => tarball_integrity_error(
+            package,
+            filename,
+            format!("integrity verification failed: {err}"),
+        ),
         streaming::TarballStreamError::TooLarge { limit, received } => tarball_integrity_error(
-            name,
+            package,
             filename,
             format!("tarball body exceeds {limit} byte limit (received {received} bytes)"),
         ),
     }
 }
 
-fn tarball_integrity_error(name: &PackageName, filename: &str, reason: String) -> RegistryError {
+fn tarball_integrity_error(package: &str, filename: &str, reason: String) -> RegistryError {
     RegistryError::TarballIntegrity {
-        package: name.as_str().to_string(),
+        package: package.to_string(),
         filename: filename.to_string(),
         reason,
     }
@@ -4185,12 +4337,18 @@ fn packument_response(
     name: &PackageName,
     bytes: &[u8],
     tarball_base: &str,
+    revision_registry: Option<&str>,
     osv_index: Option<&Arc<crate::resolver::OsvIndex>>,
     abbreviated: bool,
 ) -> Result<Response, RegistryError> {
     let mut doc: Value = serde_json::from_slice(bytes)?;
     filter_osv_vulnerable_versions(&mut doc, name, osv_index);
-    rewrite_tarball_urls(&mut doc, name, tarball_base);
+    match revision_registry {
+        Some(source_registry) => {
+            rewrite_upstream_tarball_urls(&mut doc, name, source_registry, tarball_base);
+        }
+        None => rewrite_tarball_urls(&mut doc, name, tarball_base),
+    }
     let last_modified = packument_last_modified(&doc);
     let (body, content_type) = if abbreviated {
         let trimmed = abbreviate_packument(&doc, Utc::now());

--- a/pnpr/crates/pnpr/src/storage.rs
+++ b/pnpr/crates/pnpr/src/storage.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use axum::body::Body;
 use object_store::UpdateVersion;
+use pnpm_crypto_hash::integrity_addressed_tarball_integrity;
 use std::{
     io::{ErrorKind, SeekFrom},
     path::{Path, PathBuf},
@@ -635,6 +636,24 @@ impl Storage {
         self.cached.namespaced(namespace).open_tarball(name, filename).await
     }
 
+    pub async fn open_upstream_revision_tarball_tmp(
+        &self,
+        namespace: &str,
+        digest: &str,
+    ) -> Result<TarballWrite> {
+        validate_revision_digest(digest)?;
+        self.cached.namespaced(namespace).open_revision_tarball_tmp(digest).await
+    }
+
+    pub async fn open_upstream_revision_tarball(
+        &self,
+        namespace: &str,
+        digest: &str,
+    ) -> Result<Option<(fs::File, u64)>> {
+        validate_revision_digest(digest)?;
+        self.cached.namespaced(namespace).open_revision_tarball(digest).await
+    }
+
     /// Promote a tmp tarball written by the publish flow to its final
     /// home: a rename on the fs backend, an upload on the S3 backend.
     pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<TarballFinalize> {
@@ -699,6 +718,14 @@ impl Storage {
     /// sorts by staging time).
     pub async fn list_staged_ids(&self) -> Result<Vec<String>> {
         self.hosted.list_staged_ids().await
+    }
+}
+
+fn validate_revision_digest(digest: &str) -> Result<()> {
+    if integrity_addressed_tarball_integrity(digest).is_some() {
+        Ok(())
+    } else {
+        Err(RegistryError::BadRequest { reason: "invalid sha512 revision digest".to_string() })
     }
 }
 
@@ -819,6 +846,24 @@ impl Store {
 
     async fn open_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<TarballWrite> {
         let final_path = self.tarball_path(name, filename);
+        self.open_tarball_tmp_at(final_path).await
+    }
+
+    async fn open_revision_tarball(&self, digest: &str) -> Result<Option<(fs::File, u64)>> {
+        let file = match fs::File::open(self.revision_tarball_path(digest)).await {
+            Ok(file) => file,
+            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+        let len = file.metadata().await?.len();
+        Ok(Some((file, len)))
+    }
+
+    async fn open_revision_tarball_tmp(&self, digest: &str) -> Result<TarballWrite> {
+        self.open_tarball_tmp_at(self.revision_tarball_path(digest)).await
+    }
+
+    async fn open_tarball_tmp_at(&self, final_path: PathBuf) -> Result<TarballWrite> {
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).await?;
         }
@@ -929,6 +974,10 @@ impl Store {
 
     fn tarball_path(&self, name: &PackageName, filename: &str) -> PathBuf {
         self.package_dir(name).join(filename)
+    }
+
+    fn revision_tarball_path(&self, digest: &str) -> PathBuf {
+        self.root.join(".revisions").join("sha512").join(digest)
     }
 
     async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -8,7 +8,7 @@ use pnpm_lockfile::{
     TarballRevision, integrity_addressed_registry_tarball_url,
     is_integrity_addressed_registry_tarball_url,
 };
-use pnpm_network::ThrottledClient;
+use pnpm_network::{ThrottledClient, read_limited_body};
 use reqwest::{
     StatusCode,
     header::{self, HeaderMap, HeaderValue},
@@ -21,6 +21,8 @@ use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
+
+const UPSTREAM_ERROR_BODY_LIMIT: usize = 64 * 1024;
 
 /// Wraps a shared [`ThrottledClient`] (so the registry inherits pnpm's
 /// tuned reqwest defaults: `User-Agent: pnpm`, HTTP/1.1, hickory DNS,
@@ -360,9 +362,23 @@ impl Upstream {
         if status.is_server_error() {
             self.breaker.record_failure();
         }
-        let body = response.text().await.unwrap_or_default();
+        let body = read_upstream_error_body(response).await;
         Err(RegistryError::UpstreamStatus { url: url.to_string(), status: status.as_u16(), body })
     }
+}
+
+async fn read_upstream_error_body(response: reqwest::Response) -> String {
+    let Ok(body) = read_limited_body(response, UPSTREAM_ERROR_BODY_LIMIT).await else {
+        return String::new();
+    };
+    let mut text = String::from_utf8_lossy(&body.bytes).into_owned();
+    if body.truncated {
+        if !text.is_empty() && !text.chars().next_back().is_some_and(char::is_whitespace) {
+            text.push(' ');
+        }
+        text.push_str("(response body truncated)");
+    }
+    text
 }
 
 /// Rewrite every `dist.tarball` in `value` to a URL served by *this*

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -443,12 +443,14 @@ fn rewrite_dist_tarball(
         }
         integrity_addressed_registry_tarball_url(&integrity, public_url)
     });
-    let Some(tarball_value) = dist.get_mut("tarball") else { return };
-    if !tarball_value.is_string() {
+    if let Some(revision_url) = revision_url {
+        let Some(tarball_value) = dist.get_mut("tarball") else { return };
+        *tarball_value = Value::String(revision_url);
         return;
     }
-    if let Some(revision_url) = revision_url {
-        *tarball_value = Value::String(revision_url);
+    dist.remove("revision");
+    let Some(tarball_value) = dist.get_mut("tarball") else { return };
+    if !tarball_value.is_string() {
         return;
     }
     let filename = tarball_value

--- a/pnpr/crates/pnpr/src/upstream.rs
+++ b/pnpr/crates/pnpr/src/upstream.rs
@@ -4,6 +4,10 @@ use crate::{
     package_name::PackageName,
 };
 use chrono::{DateTime, Timelike, Utc};
+use pnpm_lockfile::{
+    TarballRevision, integrity_addressed_registry_tarball_url,
+    is_integrity_addressed_registry_tarball_url,
+};
 use pnpm_network::ThrottledClient;
 use reqwest::{
     StatusCode,
@@ -11,6 +15,7 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use ssri::Integrity;
 use std::{
     fmt,
     sync::{Arc, Mutex},
@@ -302,6 +307,25 @@ impl Upstream {
         Ok(FetchOutcome::Ok(response))
     }
 
+    /// Fetch an immutable sha512 registry artifact without following redirects.
+    pub async fn fetch_revision_tarball_response(
+        &self,
+        digest: &str,
+    ) -> Result<FetchOutcome<reqwest::Response>> {
+        self.ensure_available()?;
+        let url = format!("{}/-/tarballs/sha512/{digest}", self.base.trim_end_matches('/'));
+        let client = self.client.acquire_for_url_without_redirects_with_priority(&url, 0).await;
+        let request = client.get(&url).timeout(self.timeout).headers(self.headers.clone());
+        let response = self.run(request, &url).await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            self.breaker.record_success();
+            return Ok(FetchOutcome::NotFound);
+        }
+        let response = self.checked(response, &url).await?;
+        self.breaker.record_success();
+        Ok(FetchOutcome::Ok(response))
+    }
+
     /// Fail fast with [`RegistryError::UpstreamUnavailable`] when the
     /// breaker is open, so callers never pay a request to a known-down
     /// upstream.
@@ -362,16 +386,40 @@ impl Upstream {
 /// and single-version manifest shape (`{ dist: ... }` at the top level)
 /// so a single helper covers both endpoints.
 pub fn rewrite_tarball_urls(value: &mut Value, pkg: &PackageName, public_url: &str) {
+    rewrite_tarball_urls_from_registry(value, pkg, None, public_url);
+}
+
+/// Rewrite tarball URLs from an upstream registry, preserving valid revision routes.
+pub fn rewrite_upstream_tarball_urls(
+    value: &mut Value,
+    pkg: &PackageName,
+    source_registry: &str,
+    public_url: &str,
+) {
+    rewrite_tarball_urls_from_registry(value, pkg, Some(source_registry), public_url);
+}
+
+fn rewrite_tarball_urls_from_registry(
+    value: &mut Value,
+    pkg: &PackageName,
+    source_registry: Option<&str>,
+    public_url: &str,
+) {
     let public_url = public_url.trim_end_matches('/');
     if let Some(versions) = value.get_mut("versions").and_then(Value::as_object_mut) {
         for manifest in versions.values_mut() {
-            rewrite_dist_tarball(manifest, pkg, public_url);
+            rewrite_dist_tarball(manifest, pkg, source_registry, public_url);
         }
     }
-    rewrite_dist_tarball(value, pkg, public_url);
+    rewrite_dist_tarball(value, pkg, source_registry, public_url);
 }
 
-fn rewrite_dist_tarball(value: &mut Value, pkg: &PackageName, public_url: &str) {
+fn rewrite_dist_tarball(
+    value: &mut Value,
+    pkg: &PackageName,
+    source_registry: Option<&str>,
+    public_url: &str,
+) {
     // Every string `dist.tarball` must be rewritten to a route on *this*
     // server, where integrity and OSV are enforced — never passed through.
     // When the upstream URL has no usable basename (e.g. it ends in `/`), fall
@@ -385,8 +433,22 @@ fn rewrite_dist_tarball(value: &mut Value, pkg: &PackageName, public_url: &str) 
     let Some(dist) = value.get_mut("dist").and_then(Value::as_object_mut) else {
         return;
     };
+    let revision_url = source_registry.and_then(|source_registry| {
+        let revision = dist.get("revision")?.as_u64()?;
+        TarballRevision::try_from(revision).ok()?;
+        let integrity: Integrity = dist.get("integrity")?.as_str()?.parse().ok()?;
+        let tarball = dist.get("tarball")?.as_str()?;
+        if !is_integrity_addressed_registry_tarball_url(tarball, &integrity, source_registry) {
+            return None;
+        }
+        integrity_addressed_registry_tarball_url(&integrity, public_url)
+    });
     let Some(tarball_value) = dist.get_mut("tarball") else { return };
     if !tarball_value.is_string() {
+        return;
+    }
+    if let Some(revision_url) = revision_url {
+        *tarball_value = Value::String(revision_url);
         return;
     }
     let filename = tarball_value
@@ -421,13 +483,40 @@ pub fn extract_version_manifest(
     version_or_tag: &str,
     public_url: &str,
 ) -> Option<Value> {
+    extract_version_manifest_from_registry(packument, pkg, version_or_tag, None, public_url)
+}
+
+/// Extract a version manifest while preserving valid upstream revision routes.
+pub fn extract_upstream_version_manifest(
+    packument: &Value,
+    pkg: &PackageName,
+    version_or_tag: &str,
+    source_registry: &str,
+    public_url: &str,
+) -> Option<Value> {
+    extract_version_manifest_from_registry(
+        packument,
+        pkg,
+        version_or_tag,
+        Some(source_registry),
+        public_url,
+    )
+}
+
+fn extract_version_manifest_from_registry(
+    packument: &Value,
+    pkg: &PackageName,
+    version_or_tag: &str,
+    source_registry: Option<&str>,
+    public_url: &str,
+) -> Option<Value> {
     let resolved = packument
         .get("dist-tags")
         .and_then(|tags| tags.get(version_or_tag))
         .and_then(Value::as_str)
         .unwrap_or(version_or_tag);
     let mut manifest = packument.get("versions")?.get(resolved)?.clone();
-    rewrite_tarball_urls(&mut manifest, pkg, public_url);
+    rewrite_tarball_urls_from_registry(&mut manifest, pkg, source_registry, public_url);
     Some(manifest)
 }
 

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    CacheValidators, CircuitBreaker, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
-    extract_version_manifest, rewrite_tarball_urls, rewrite_upstream_tarball_urls,
-    tarball_basename,
+    CacheValidators, CircuitBreaker, FetchOutcome, PackumentFetch, UPSTREAM_ERROR_BODY_LIMIT,
+    Upstream, abbreviate_packument, extract_version_manifest, rewrite_tarball_urls,
+    rewrite_upstream_tarball_urls, tarball_basename,
 };
 use crate::{config::UpstreamConfig, error::RegistryError, package_name::PackageName};
 use chrono::{DateTime, TimeZone, Utc};
@@ -84,6 +84,7 @@ async fn fetch_revision_tarball_rejects_redirects_and_forwards_headers() {
         .match_header("x-org", "acme")
         .with_status(302)
         .with_header("location", "/redirected.tgz")
+        .with_body("x".repeat(UPSTREAM_ERROR_BODY_LIMIT + 1))
         .expect(1)
         .create_async()
         .await;
@@ -92,7 +93,11 @@ async fn fetch_revision_tarball_rejects_redirects_and_forwards_headers() {
     let upstream = upstream(server.url(), auth_and_custom_headers());
     let result = upstream.fetch_revision_tarball_response("digest").await;
 
-    assert!(matches!(result, Err(RegistryError::UpstreamStatus { status: 302, .. })));
+    assert!(matches!(
+        result,
+        Err(RegistryError::UpstreamStatus { status: 302, body, .. })
+            if body == format!("{} (response body truncated)", "x".repeat(UPSTREAM_ERROR_BODY_LIMIT))
+    ));
     redirect.assert_async().await;
     redirected.assert_async().await;
 }

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     CacheValidators, CircuitBreaker, FetchOutcome, PackumentFetch, Upstream, abbreviate_packument,
-    extract_version_manifest, rewrite_tarball_urls, tarball_basename,
+    extract_version_manifest, rewrite_tarball_urls, rewrite_upstream_tarball_urls,
+    tarball_basename,
 };
 use crate::{config::UpstreamConfig, error::RegistryError, package_name::PackageName};
 use chrono::{DateTime, TimeZone, Utc};
@@ -72,6 +73,28 @@ async fn fetch_tarball_response_forwards_configured_headers() {
 
     assert!(matches!(outcome, FetchOutcome::Ok(_)));
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn fetch_revision_tarball_rejects_redirects_and_forwards_headers() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("GET", "/-/tarballs/sha512/digest")
+        .match_header("authorization", "Bearer secret-token")
+        .match_header("x-org", "acme")
+        .with_status(302)
+        .with_header("location", "/redirected.tgz")
+        .expect(1)
+        .create_async()
+        .await;
+    let redirected = server.mock("GET", "/redirected.tgz").expect(0).create_async().await;
+
+    let upstream = upstream(server.url(), auth_and_custom_headers());
+    let result = upstream.fetch_revision_tarball_response("digest").await;
+
+    assert!(matches!(result, Err(RegistryError::UpstreamStatus { status: 302, .. })));
+    redirect.assert_async().await;
+    redirected.assert_async().await;
 }
 
 #[tokio::test]
@@ -197,6 +220,65 @@ fn rewrites_npm_form_tarball() {
         "http://127.0.0.1:4873/foo/-/foo-1.0.0.tgz",
     );
     assert_eq!(doc["versions"]["1.0.0"]["dist"]["shasum"], "abc");
+}
+
+#[test]
+fn preserves_valid_upstream_revision_route_on_the_public_registry() {
+    let digest = "A".repeat(86);
+    let mut doc = json!({
+        "versions": {
+            "1.0.0": {
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": format!("https://upstream.test/npm/-/tarballs/sha512/{digest}"),
+                    "integrity": format!("sha512-{digest}=="),
+                    "revision": 2,
+                }
+            }
+        }
+    });
+    let name = PackageName::parse("foo").unwrap();
+
+    rewrite_upstream_tarball_urls(
+        &mut doc,
+        &name,
+        "https://upstream.test/npm/",
+        "http://pnpr.test/~corp/",
+    );
+
+    assert_eq!(
+        doc["versions"]["1.0.0"]["dist"]["tarball"],
+        format!("http://pnpr.test/~corp/-/tarballs/sha512/{digest}"),
+    );
+    assert_eq!(doc["versions"]["1.0.0"]["dist"]["revision"], 2);
+}
+
+#[test]
+fn does_not_preserve_an_invalid_upstream_revision_route() {
+    let digest = "A".repeat(86);
+    let name = PackageName::parse("foo").unwrap();
+    for (revision, tarball) in [
+        (json!(0), format!("https://upstream.test/-/tarballs/sha512/{digest}")),
+        (json!(2), format!("https://other.test/-/tarballs/sha512/{digest}")),
+    ] {
+        let mut doc = json!({
+            "version": "1.0.0",
+            "dist": {
+                "tarball": tarball,
+                "integrity": format!("sha512-{digest}=="),
+                "revision": revision,
+            }
+        });
+
+        rewrite_upstream_tarball_urls(
+            &mut doc,
+            &name,
+            "https://upstream.test/",
+            "http://pnpr.test/~corp/",
+        );
+
+        assert_eq!(doc["dist"]["tarball"], format!("http://pnpr.test/~corp/foo/-/{digest}"));
+    }
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/upstream/tests.rs
+++ b/pnpr/crates/pnpr/src/upstream/tests.rs
@@ -278,6 +278,7 @@ fn does_not_preserve_an_invalid_upstream_revision_route() {
         );
 
         assert_eq!(doc["dist"]["tarball"], format!("http://pnpr.test/~corp/foo/-/{digest}"));
+        assert!(doc["dist"].get("revision").is_none());
     }
 }
 

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4,6 +4,7 @@ use axum::{
 };
 use flate2::read::GzDecoder;
 use futures_util::stream;
+use pnpm_crypto_hash::integrity_addressed_tarball_path;
 use pnpr::{
     AccessList, AuthState, Config, HostedConfig, MaxUsers, PackagePattern, PackageRule,
     PackageRules, PublicRoute, Registries, Registry, router, router_with_auth,
@@ -933,6 +934,160 @@ async fn upstream_endpoint_serves_packument_with_endpoint_rewritten_tarballs() {
         "http://example.test/~npmjs/foo/-/foo-1.0.0.tgz",
     );
     mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn upstream_endpoint_preserves_and_serves_revision_tarballs() {
+    let mut upstream = mockito::Server::new_async().await;
+    let bytes = b"immutable-revision-tarball";
+    let integrity_text = sha512_integrity(bytes);
+    let integrity = integrity_text.parse().unwrap();
+    let revision_path = integrity_addressed_tarball_path(&integrity).unwrap();
+    let packument = json!({
+        "name": "foo",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": { "1.0.0": { "name": "foo", "version": "1.0.0", "dist": {
+            "tarball": format!("{}/{}", upstream.url(), revision_path),
+            "integrity": integrity_text,
+            "revision": 2,
+        } } },
+    });
+    let packument_mock = upstream
+        .mock("GET", "/foo")
+        .match_header("x-upstream-auth", "secret")
+        .with_body(packument.to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let tarball_mock = upstream
+        .mock("GET", format!("/{revision_path}").as_str())
+        .match_header("x-upstream-auth", "secret")
+        .with_body(bytes)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let mut config = upstream_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
+    config
+        .upstreams
+        .get_mut("npmjs")
+        .unwrap()
+        .headers
+        .insert("x-upstream-auth", HeaderValue::from_static("secret"));
+    config.registries = Registries::new(
+        std::iter::once(("npmjs".to_string(), Registry::Upstream { patterns: Vec::new() }))
+            .collect(),
+        Some("npmjs".to_string()),
+    );
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+    let authorization = format!("Bearer {token}");
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/~npmjs/foo")
+                .header(header::AUTHORIZATION, &authorization)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(body["versions"]["1.0.0"]["dist"]["revision"], 2);
+    assert_eq!(
+        body["versions"]["1.0.0"]["dist"]["tarball"],
+        format!("http://example.test/~npmjs/{revision_path}"),
+    );
+
+    for path in [format!("/~npmjs/{revision_path}"), format!("/{revision_path}")] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(&path)
+                    .header(header::AUTHORIZATION, &authorization)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        assert_eq!(response.headers().get(header::CACHE_CONTROL).unwrap(), "private, no-store");
+        assert_eq!(body_bytes(response.into_body()).await, bytes);
+    }
+
+    packument_mock.assert_async().await;
+    tarball_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn upstream_revision_tarball_does_not_follow_redirects() {
+    let mut upstream = mockito::Server::new_async().await;
+    let integrity = sha512_integrity(b"expected revision tarball").parse().unwrap();
+    let revision_path = integrity_addressed_tarball_path(&integrity).unwrap();
+    let redirect = upstream
+        .mock("GET", format!("/{revision_path}").as_str())
+        .with_status(302)
+        .with_header("location", "/redirected.tgz")
+        .expect(1)
+        .create_async()
+        .await;
+    let redirected = upstream.mock("GET", "/redirected.tgz").expect(0).create_async().await;
+
+    let tmp = TempDir::new().unwrap();
+    let config = upstream_endpoint_config(&upstream.url(), tmp.path().to_path_buf(), "alice");
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+    let response = app
+        .oneshot(
+            Request::get(format!("/~npmjs/{revision_path}"))
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+    redirect.assert_async().await;
+    redirected.assert_async().await;
+}
+
+#[tokio::test]
+async fn revision_tarballs_require_a_concrete_registry_without_package_access_rules() {
+    let mut upstream = mockito::Server::new_async().await;
+    let integrity = sha512_integrity(b"unreachable revision tarball").parse().unwrap();
+    let revision_path = integrity_addressed_tarball_path(&integrity).unwrap();
+    let tarball =
+        upstream.mock("GET", format!("/{revision_path}").as_str()).expect(0).create_async().await;
+
+    let tmp = TempDir::new().unwrap();
+    let router_app = router_with_auth(
+        router_config(&upstream.url(), &upstream.url(), tmp.path().join("router")),
+        AuthState::in_memory(),
+    );
+    for path in [format!("/~main/{revision_path}"), format!("/{revision_path}")] {
+        let response = router_app
+            .clone()
+            .oneshot(Request::get(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    let mut config = config_for(&upstream.url(), tmp.path().join("package-access"));
+    config.upstreams.get_mut("npmjs").unwrap().rules =
+        PackageRules::new(vec![access_rule("restricted", "$authenticated")], None);
+    let response = router_with_auth(config, AuthState::in_memory())
+        .oneshot(Request::get(format!("/~npmjs/{revision_path}")).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    tarball.assert_async().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Implements the client transport and lockfile slice of [pnpm/rfcs pull request 19](https://github.com/pnpm/rfcs/pull/19), updated through RFC commit `aa8f5970`, in the TypeScript pnpm CLI, the Rust pnpm CLI (pacquet), and pnpr's upstream proxy.

- Accepts registry replacement artifacts only when `dist.revision` is a positive safe integer and the tarball is the exact SHA-512 digest route relative to the effective registry.
- Writes compact `{ integrity, revision }` lockfile resolutions, hydrates their digest URLs on read, and normalizes digest routes without a revision to integrity-only resolutions.
- Fetches a frozen revision with one authenticated GET, rejecting every redirect without retry or fallback. Concurrent Rust consumers share that single terminal request result without reusing ordinary redirect-permitting cache entries.
- Uses the current `registries` setting as the routing source: scope entries select the effective registry, prefix entries reconstruct registry-qualified lockfile packages, and registry path prefixes are retained.
- Adds pnpr support for concrete upstream registries: valid revision metadata is preserved and rebased to pnpr's digest endpoint, then fetched with forwarded authentication, verified against the route-derived SHA-512 integrity, and cached by digest.
- Carries revision metadata through the pnpr resolver protocol so pacquet prefetch and restore paths preserve the strict fetch policy.
- Rejects malformed metadata and invalid lockfile combinations consistently in both implementations.

pnpr's digest route deliberately requires one concrete upstream registry with registry-level access. A digest URL contains no package identity, so pnpr routers and per-package access rules cannot safely select or authorize a source; clients can use pnpm's `registries` setting to route packages or scopes directly to pnpr's concrete `/~registry/` endpoints.

The RFC's broader revision-selection lifecycle remains follow-up work: `<version>+rN`, `dist.revisions`, historical verification, and `pnpm update --patches`. The exact lockfile compatibility gate also remains unresolved in the RFC. pnpr publishing and hosted revision history remain follow-up work.

Validation completed locally:

- 529 focused TypeScript tests across the resolver, fetcher, lockfile, URL, and network packages.
- TypeScript bundle compile plus the pre-push typecheck, lint, spellcheck, and metadata checks.
- Rust `just ready`: 9,179 tests passed, with 5 skipped; workspace check and clippy passed.
- End-to-end pacquet/pnpr coverage for initial resolution, compact lockfile output, install, deletion of the client store, and frozen reinstall from pnpr's verified digest cache.
- pnpr integration coverage for authenticated header forwarding, path-prefixed upstreams, cache reuse, integrity validation, redirect rejection, and fail-closed router/per-package ACL handling.
- Rust formatting, documentation, dylint, typo, and TOML checks from the pre-push hook.
- Changeset status and whitespace checks.

## Squash Commit Body

```text
Add registry replacement-tarball support to the TypeScript and Rust pnpm implementations. Validate explicit positive safe-integer revision metadata against complete SHA-512 integrity-addressed registry URLs, compact and hydrate revision resolutions in the lockfile, and enforce a single authenticated non-redirecting fetch with no retry or fallback.

Route revision URLs through the normalized scope and prefix maps derived from the registries setting, preserving registry path prefixes. Let pnpr proxy immutable revision artifacts for concrete upstream registries with forwarded authentication, integrity verification, and digest caching. Carry revision metadata through pnpr's resolver protocol so pacquet uses the same strict fetch behavior for direct and proxied resolution paths.

Leave revision selection and history, patch refresh commands, pnpr hosted publishing, and the RFC's unresolved lockfile compatibility gate for follow-up work.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for immutable registry tarballs addressed by SHA-512 integrity values and revision numbers.
  * pnpr can proxy, cache, and serve integrity-addressed upstream tarballs while preserving lockfile metadata.
  * Registry routing now supports revision-based tarball resolution and frozen reinstalls.
  * Large gzip archives can be processed incrementally during download.

* **Bug Fixes**
  * Revision-addressed downloads no longer follow redirects or retry failed requests.
  * Added validation for malformed revisions, mismatched integrity data, and unsupported tarball sources.
  * Improved diagnostics for invalid lockfile metadata and registry configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->