### PR TITLE
test: make override status fixture platform-independent

### DIFF
--- a/pnpm11/deps/status/test/checkDepsStatus.test.ts
+++ b/pnpm11/deps/status/test/checkDepsStatus.test.ts
@@ -1402,15 +1402,16 @@ describe('checkDepsStatus - treatLocalFileDepsAsOutdated', () => {
   it('does not report registry and link: overrides as outdated', async () => {
     const lastValidatedTimestamp = Date.now() - 10_000
     const overrides = { bar: '^2.0.0', baz: 'link:../baz' }
+    const lockfile = { ...currentLockfile, overrides }
     const workspaceState = mockWorkspaceState(lastValidatedTimestamp)
     workspaceState.settings = { ...workspaceState.settings, overrides }
     jest.mocked(loadWorkspaceState).mockReturnValue(workspaceState)
     mockUpToDateSingleProjectStats(lastValidatedTimestamp)
+    jest.mocked(lockfileFs.readCurrentLockfile).mockResolvedValue(lockfile)
+    jest.mocked(lockfileFs.readWantedLockfile).mockResolvedValue(lockfile)
 
     const opts: CheckDepsStatusOptions = {
-      rootProjectManifest: {
-        dependencies: { foo: '^1.0.0' },
-      },
+      rootProjectManifest: {},
       rootProjectManifestDir: '/project',
       pnpmfile: [],
       treatLocalFileDepsAsOutdated: true,


### PR DESCRIPTION
## Summary

Makes the `checkDepsStatus` registry and `link:` override test internally consistent across platforms.

The test recorded overrides in the mocked workspace state but omitted them from its mocked lockfile, and also used a manifest dependency absent from that lockfile. It passed only while timestamp and path handling avoided deeper lockfile validation. Windows reached that validation while running the checks for pnpm/pnpm#13464 and correctly reported the inconsistent fixture as stale.

This change supplies matching current and wanted lockfiles and removes the unrelated manifest dependency. It changes tests only; no TypeScript/Rust runtime parity work or changeset is needed.

## Squash Commit Body

```text
Make the registry and link override status test independent of whether
platform-specific timestamp and path handling reaches lockfile validation.
Keep the mocked workspace state, lockfiles, and manifest mutually consistent
so the test isolates local-file override classification.

Related to pnpm/pnpm#13464.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787867662&installation_model_id=426870&pr_number=13476&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13476&signature=3a35f266171d723c85c93c7a68857ca2ae4e97ce4251f717ea862750d2f541f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated dependency status coverage to verify registry and `link:` overrides are correctly recognized as up to date.
  * Improved test setup to consistently apply override settings across lockfile and workspace state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->