### PR TITLE
perf: reuse lockfile for compatible dependency ranges

### DIFF
--- a/.changeset/fast-catalog-ranges.md
+++ b/.changeset/fast-catalog-ranges.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Speed up installs after compatible catalog range changes by retaining the locked version without resolving the dependency graph again.
+Speed up installs after compatible catalog or direct dependency range changes by retaining the locked version without resolving the dependency graph again.

--- a/.changeset/fast-catalog-ranges.md
+++ b/.changeset/fast-catalog-ranges.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Speed up installs after compatible catalog range changes by retaining the locked version without resolving the dependency graph again.

--- a/pnpm/crates/cli/tests/custom_resolvers.rs
+++ b/pnpm/crates/cli/tests/custom_resolvers.rs
@@ -101,8 +101,19 @@ fn should_refresh_resolution_forces_re_resolution_past_the_frozen_path() {
     pacquet.with_arg("install").assert().success();
     assert_eq!(installed_version(&workspace), "100.0.0");
 
-    // Second install: manifest and lockfile are unchanged, so without
-    // the hook the install would go frozen and re-resolve nothing.
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/dep-of-pkg-with-1-dep": ">=100.0.0 <101",
+            },
+        })
+        .to_string(),
+    )
+    .expect("update dependency range");
+
+    // Second install: the changed range still accepts the locked version,
+    // so without the hook the install would keep that resolution.
     // `shouldRefreshResolution` returning true must force the
     // fresh-resolve path, where the custom resolver now overrides the
     // pinned version.
@@ -115,6 +126,10 @@ fn should_refresh_resolution_forces_re_resolution_past_the_frozen_path() {
     assert!(
         lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
         "lockfile records the refreshed resolution: {lockfile}",
+    );
+    assert!(
+        lockfile.contains("specifier: '>=100.0.0 <101'"),
+        "lockfile records the updated range: {lockfile}",
     );
 
     drop((root, mock_instance)); // cleanup

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -16,6 +16,65 @@ fn pacquet_at(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
 }
 
+#[test]
+fn compatible_catalog_range_update_reuses_the_locked_peer_snapshot() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let manifest_path = workspace.join("package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/has-optional-peer-with-peer": "catalog:"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!(
+            "{workspace_yaml}trustLockfile: true\nfetchRetries: 0\nfetchTimeout: 1000\ncatalog:\n  '@pnpm.e2e/has-optional-peer-with-peer': ^1.0.0\n",
+        ),
+    )
+    .expect("write initial catalog");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let workspace_yaml = fs::read_to_string(&workspace_yaml_path).expect("read initial catalog");
+    fs::write(
+        &workspace_yaml_path,
+        workspace_yaml.replace(
+            "'@pnpm.e2e/has-optional-peer-with-peer': ^1.0.0",
+            "'@pnpm.e2e/has-optional-peer-with-peer': '>=1.0.0 <2'",
+        ),
+    )
+    .expect("update catalog range");
+    let dead_registry = dead_registry_url();
+    let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let npmrc = npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    let entry = &wanted.catalogs.expect("catalog snapshots")["default"]["@pnpm.e2e/has-optional-peer-with-peer"];
+    assert_eq!(entry.specifier, ">=1.0.0 <2");
+    assert_eq!(entry.version, "1.0.0");
+
+    drop((root, mock_instance));
+}
+
 /// A `registry=` URL on a localhost port with nothing listening, so any
 /// resolution attempt against it fails fast with a connection refusal.
 fn dead_registry_url() -> String {

--- a/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/lockfile_resolution_reuse.rs
@@ -17,6 +17,70 @@ fn pacquet_at(workspace: &Path) -> Command {
 }
 
 #[test]
+fn compatible_package_range_update_skips_resolution() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+    let manifest_path = workspace.join("package.json");
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/has-optional-peer-with-peer": "^1.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!("{workspace_yaml}trustLockfile: true\nfetchRetries: 0\nfetchTimeout: 1000\n"),
+    )
+    .expect("enable trusted lockfile");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    fs::write(
+        &manifest_path,
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/has-optional-peer-with-peer": ">=1.0.0 <2"
+            }
+        })
+        .to_string(),
+    )
+    .expect("update dependency range");
+    let dead_registry = dead_registry_url();
+    let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    let npmrc = npmrc
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("registry="))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(&npmrc_path, format!("registry={dead_registry}\n{npmrc}\n"))
+        .expect("rewrite .npmrc with a dead registry");
+
+    let assert = pacquet_at(&workspace).with_arg("install").assert().success();
+    assert!(
+        String::from_utf8_lossy(&assert.get_output().stdout)
+            .contains("Lockfile is up to date, resolution step is skipped"),
+    );
+
+    let wanted = pacquet_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    let name = "@pnpm.e2e/has-optional-peer-with-peer".parse().expect("package name");
+    assert_eq!(
+        wanted.importers["."].dependencies.as_ref().expect("dependencies")[&name].specifier,
+        ">=1.0.0 <2",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn compatible_catalog_range_update_reuses_the_locked_peer_snapshot() {
     let CommandTempCwd { workspace, root, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/package-manager/src/fast_update_catalogs.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs.rs
@@ -15,7 +15,11 @@ pub(crate) fn try_fast_update_catalogs(
     overrides_use_catalogs: bool,
 ) -> FastCatalogUpdate {
     let Some(lockfile_catalogs) = lockfile.catalogs.as_ref() else {
-        return FastCatalogUpdate::Unchanged;
+        return if catalogs.is_empty() {
+            FastCatalogUpdate::Unchanged
+        } else {
+            FastCatalogUpdate::Unsupported
+        };
     };
 
     let mut changed = false;

--- a/pnpm/crates/package-manager/src/fast_update_catalogs.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs.rs
@@ -14,6 +14,9 @@ pub(crate) fn try_fast_update_catalogs(
     catalogs: &Catalogs,
     overrides_use_catalogs: bool,
 ) -> FastCatalogUpdate {
+    if !catalog_references_have_snapshots(lockfile, catalogs) {
+        return FastCatalogUpdate::Unsupported;
+    }
     let Some(lockfile_catalogs) = lockfile.catalogs.as_ref() else {
         return if catalogs.is_empty() {
             FastCatalogUpdate::Unchanged
@@ -70,6 +73,33 @@ pub(crate) fn try_fast_update_catalogs(
     let mut candidate = lockfile.clone();
     candidate.catalogs = (!updated_catalogs.is_empty()).then_some(updated_catalogs);
     FastCatalogUpdate::Updated(Box::new(candidate))
+}
+
+fn catalog_references_have_snapshots(lockfile: &Lockfile, catalogs: &Catalogs) -> bool {
+    lockfile.importers.values().all(|importer| {
+        [
+            importer.dependencies.as_ref(),
+            importer.dev_dependencies.as_ref(),
+            importer.optional_dependencies.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .flat_map(|dependencies| dependencies.iter())
+        .all(|(alias, dependency)| {
+            let Some(catalog_name) = dependency.specifier.strip_prefix("catalog:") else {
+                return true;
+            };
+            let catalog_name = if catalog_name.is_empty() { "default" } else { catalog_name };
+            let alias = alias.to_string();
+            catalogs.get(catalog_name).and_then(|catalog| catalog.get(&alias)).is_some()
+                && lockfile
+                    .catalogs
+                    .as_ref()
+                    .and_then(|catalogs| catalogs.get(catalog_name))
+                    .and_then(|catalog| catalog.get(&alias))
+                    .is_some()
+        })
+    })
 }
 
 fn catalog_entry_is_referenced(lockfile: &Lockfile, catalog_name: &str, alias: &str) -> bool {

--- a/pnpm/crates/package-manager/src/fast_update_catalogs.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs.rs
@@ -1,0 +1,93 @@
+use node_semver::{Range, Version};
+use pacquet_catalogs_types::Catalogs;
+use pacquet_lockfile::{Lockfile, PkgName};
+use std::collections::BTreeMap;
+
+pub(crate) enum FastCatalogUpdate {
+    Unchanged,
+    Updated(Box<Lockfile>),
+    Unsupported,
+}
+
+pub(crate) fn try_fast_update_catalogs(
+    lockfile: &Lockfile,
+    catalogs: &Catalogs,
+    overrides_use_catalogs: bool,
+) -> FastCatalogUpdate {
+    let Some(lockfile_catalogs) = lockfile.catalogs.as_ref() else {
+        return FastCatalogUpdate::Unchanged;
+    };
+
+    let mut changed = false;
+    let mut updated_catalogs = BTreeMap::new();
+    for (catalog_name, entries) in lockfile_catalogs {
+        let mut updated_entries = BTreeMap::new();
+        for (alias, entry) in entries {
+            let Some(specifier) = catalogs.get(catalog_name).and_then(|catalog| catalog.get(alias))
+            else {
+                if catalog_entry_is_referenced(lockfile, catalog_name, alias) {
+                    return FastCatalogUpdate::Unsupported;
+                }
+                changed = true;
+                continue;
+            };
+            if specifier == &entry.specifier {
+                updated_entries.insert(alias.clone(), entry.clone());
+                continue;
+            }
+            let (Ok(version), Ok(range)) =
+                (Version::parse(&entry.version), Range::parse(specifier))
+            else {
+                return FastCatalogUpdate::Unsupported;
+            };
+            if !version.satisfies(&range) {
+                return FastCatalogUpdate::Unsupported;
+            }
+            changed = true;
+            updated_entries.insert(
+                alias.clone(),
+                pacquet_lockfile::ResolvedCatalogEntry {
+                    specifier: specifier.clone(),
+                    version: entry.version.clone(),
+                },
+            );
+        }
+        if !updated_entries.is_empty() {
+            updated_catalogs.insert(catalog_name.clone(), updated_entries);
+        }
+    }
+    if !changed {
+        return FastCatalogUpdate::Unchanged;
+    }
+    if overrides_use_catalogs {
+        return FastCatalogUpdate::Unsupported;
+    }
+
+    let mut candidate = lockfile.clone();
+    candidate.catalogs = (!updated_catalogs.is_empty()).then_some(updated_catalogs);
+    FastCatalogUpdate::Updated(Box::new(candidate))
+}
+
+fn catalog_entry_is_referenced(lockfile: &Lockfile, catalog_name: &str, alias: &str) -> bool {
+    let Ok(alias) = PkgName::parse(alias) else { return true };
+    let protocol = if catalog_name == "default" {
+        "catalog:".to_string()
+    } else {
+        format!("catalog:{catalog_name}")
+    };
+    lockfile.importers.values().any(|importer| {
+        [
+            importer.dependencies.as_ref(),
+            importer.dev_dependencies.as_ref(),
+            importer.optional_dependencies.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|dependencies| {
+            dependencies.get(&alias).is_some_and(|dependency| dependency.specifier == protocol)
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/fast_update_catalogs/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs/tests.rs
@@ -124,6 +124,24 @@ importers:
 }
 
 #[test]
+fn configured_catalogs_require_existing_lockfile_snapshots() {
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+importers:
+  .: {}
+",
+    );
+    let catalogs =
+        Catalogs::from([("default".to_string(), [("foo".to_string(), "^1".to_string())].into())]);
+
+    assert!(matches!(
+        try_fast_update_catalogs(&lockfile, &catalogs, false),
+        FastCatalogUpdate::Unsupported
+    ));
+}
+
+#[test]
 fn removes_an_unreferenced_stale_snapshot() {
     let lockfile = lockfile(
         r"

--- a/pnpm/crates/package-manager/src/fast_update_catalogs/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs/tests.rs
@@ -1,0 +1,172 @@
+use super::{FastCatalogUpdate, try_fast_update_catalogs};
+use pacquet_catalogs_types::Catalogs;
+use pacquet_lockfile::Lockfile;
+
+fn lockfile(source: &str) -> Lockfile {
+    serde_saphyr::from_str(source).expect("parse lockfile")
+}
+
+#[test]
+fn retains_a_version_that_satisfies_the_updated_range() {
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    foo:
+      specifier: ^1.0.0
+      version: 1.1.0
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 'catalog:'
+        version: 1.1.0
+",
+    );
+    let catalogs = Catalogs::from([(
+        "default".to_string(),
+        [("foo".to_string(), ">=1 <2".to_string())].into(),
+    )]);
+
+    let FastCatalogUpdate::Updated(updated) = try_fast_update_catalogs(&lockfile, &catalogs, false)
+    else {
+        panic!("compatible catalog update should succeed");
+    };
+    let entry = &updated.catalogs.expect("catalog snapshots")["default"]["foo"];
+    assert_eq!(entry.specifier, ">=1 <2");
+    assert_eq!(entry.version, "1.1.0");
+}
+
+#[test]
+fn rejects_an_updated_range_that_excludes_the_locked_version() {
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    foo:
+      specifier: ^1.0.0
+      version: 1.1.0
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 'catalog:'
+        version: 1.1.0
+",
+    );
+    let catalogs =
+        Catalogs::from([("default".to_string(), [("foo".to_string(), "^2".to_string())].into())]);
+
+    assert!(matches!(
+        try_fast_update_catalogs(&lockfile, &catalogs, false),
+        FastCatalogUpdate::Unsupported
+    ));
+}
+
+#[test]
+fn rejects_a_malformed_locked_version() {
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    foo:
+      specifier: ^1.0.0
+      version: not-a-version
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 'catalog:'
+        version: 1.1.0
+",
+    );
+    let catalogs = Catalogs::from([(
+        "default".to_string(),
+        [("foo".to_string(), ">=1 <2".to_string())].into(),
+    )]);
+
+    assert!(matches!(
+        try_fast_update_catalogs(&lockfile, &catalogs, false),
+        FastCatalogUpdate::Unsupported
+    ));
+}
+
+#[test]
+fn catalog_backed_overrides_do_not_disable_reuse_when_catalogs_are_unchanged() {
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    foo:
+      specifier: ^1.0.0
+      version: 1.1.0
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 'catalog:'
+        version: 1.1.0
+",
+    );
+    let catalogs = Catalogs::from([(
+        "default".to_string(),
+        [("foo".to_string(), "^1.0.0".to_string())].into(),
+    )]);
+
+    assert!(matches!(
+        try_fast_update_catalogs(&lockfile, &catalogs, true),
+        FastCatalogUpdate::Unchanged
+    ));
+}
+
+#[test]
+fn removes_an_unreferenced_stale_snapshot() {
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    foo:
+      specifier: ^1.0.0
+      version: 1.1.0
+importers:
+  .: {}
+",
+    );
+
+    let FastCatalogUpdate::Updated(updated) =
+        try_fast_update_catalogs(&lockfile, &Catalogs::new(), false)
+    else {
+        panic!("unreferenced snapshot should be removable");
+    };
+    assert!(updated.catalogs.is_none());
+}
+
+#[test]
+fn rejects_removing_a_snapshot_still_referenced_by_an_importer() {
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    foo:
+      specifier: ^1.0.0
+      version: 1.1.0
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 'catalog:'
+        version: 1.1.0
+",
+    );
+
+    assert!(matches!(
+        try_fast_update_catalogs(&lockfile, &Catalogs::new(), false),
+        FastCatalogUpdate::Unsupported
+    ));
+}

--- a/pnpm/crates/package-manager/src/fast_update_catalogs/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs/tests.rs
@@ -192,9 +192,10 @@ importers:
 }
 
 #[test]
-fn rejects_removing_a_snapshot_still_referenced_by_an_importer() {
-    let lockfile = lockfile(
-        r"
+fn rejects_removing_a_snapshot_referenced_by_the_default_catalog() {
+    for specifier in ["catalog:", "catalog:default"] {
+        let lockfile = lockfile(&format!(
+            r"
 lockfileVersion: '9.0'
 catalogs:
   default:
@@ -205,13 +206,15 @@ importers:
   .:
     dependencies:
       foo:
-        specifier: 'catalog:'
+        specifier: '{specifier}'
         version: 1.1.0
 ",
-    );
+        ));
 
-    assert!(matches!(
-        try_fast_update_catalogs(&lockfile, &Catalogs::new(), false),
-        FastCatalogUpdate::Unsupported
-    ));
+        let update = try_fast_update_catalogs(&lockfile, &Catalogs::new(), false);
+        assert!(
+            matches!(update, FastCatalogUpdate::Unsupported),
+            "default catalog reference {specifier} should prevent snapshot removal",
+        );
+    }
 }

--- a/pnpm/crates/package-manager/src/fast_update_catalogs/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_catalogs/tests.rs
@@ -142,6 +142,33 @@ importers:
 }
 
 #[test]
+fn referenced_catalog_entries_require_lockfile_snapshots() {
+    let lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+catalogs:
+  default:
+    bar:
+      specifier: ^1
+      version: 1.0.0
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 'catalog:'
+        version: 1.0.0
+",
+    );
+    let catalogs =
+        Catalogs::from([("default".to_string(), [("foo".to_string(), "^1".to_string())].into())]);
+
+    assert!(matches!(
+        try_fast_update_catalogs(&lockfile, &catalogs, false),
+        FastCatalogUpdate::Unsupported
+    ));
+}
+
+#[test]
 fn removes_an_unreferenced_stale_snapshot() {
     let lockfile = lockfile(
         r"

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -11,14 +11,9 @@ pub(crate) fn try_fast_update_importers(
     let mut changed = false;
     for (importer_id, manifest) in manifests {
         let importer = candidate.importers.get_mut(importer_id)?;
-        let mut manifest_specifiers = HashMap::new();
-        for (alias, specifier) in manifest.dependencies([
-            DependencyGroup::Dev,
-            DependencyGroup::Prod,
-            DependencyGroup::Optional,
-        ]) {
-            manifest_specifiers.insert(alias, specifier);
-        }
+        let manifest_specifiers = manifest
+            .dependencies([DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional])
+            .collect::<HashMap<_, _>>();
         for (alias, specifier) in manifest_specifiers {
             let alias = PkgName::parse(alias).ok()?;
             let dependency = importer_dependency_mut(importer, &alias)?;
@@ -41,17 +36,13 @@ fn importer_dependency_mut<'a>(
     importer: &'a mut ProjectSnapshot,
     alias: &PkgName,
 ) -> Option<&'a mut ResolvedDependencySpec> {
-    if importer
-        .optional_dependencies
-        .as_ref()
-        .is_some_and(|dependencies| dependencies.contains_key(alias))
-    {
-        return importer.optional_dependencies.as_mut()?.get_mut(alias);
-    }
-    if importer.dependencies.as_ref().is_some_and(|dependencies| dependencies.contains_key(alias)) {
-        return importer.dependencies.as_mut()?.get_mut(alias);
-    }
-    importer.dev_dependencies.as_mut()?.get_mut(alias)
+    [
+        importer.optional_dependencies.as_mut(),
+        importer.dependencies.as_mut(),
+        importer.dev_dependencies.as_mut(),
+    ]
+    .into_iter()
+    .find_map(|group| group.and_then(|dependencies| dependencies.get_mut(alias)))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -1,0 +1,58 @@
+use node_semver::Range;
+use pacquet_lockfile::{Lockfile, PkgName, ProjectSnapshot, ResolvedDependencySpec};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use std::collections::HashMap;
+
+pub(crate) fn try_fast_update_importers(
+    lockfile: &Lockfile,
+    manifests: &[(String, &PackageManifest)],
+) -> Option<Lockfile> {
+    let mut candidate = lockfile.clone();
+    let mut changed = false;
+    for (importer_id, manifest) in manifests {
+        let importer = candidate.importers.get_mut(importer_id)?;
+        let mut manifest_specifiers = HashMap::new();
+        for (alias, specifier) in manifest.dependencies([
+            DependencyGroup::Dev,
+            DependencyGroup::Prod,
+            DependencyGroup::Optional,
+        ]) {
+            manifest_specifiers.insert(alias, specifier);
+        }
+        for (alias, specifier) in manifest_specifiers {
+            let alias = PkgName::parse(alias).ok()?;
+            let dependency = importer_dependency_mut(importer, &alias)?;
+            if dependency.specifier == specifier {
+                continue;
+            }
+            let range = Range::parse(specifier).ok()?;
+            let version = dependency.version.ver_peer()?.version_semver()?;
+            if !version.satisfies(&range) {
+                return None;
+            }
+            dependency.specifier = specifier.to_string();
+            changed = true;
+        }
+    }
+    changed.then_some(candidate)
+}
+
+fn importer_dependency_mut<'a>(
+    importer: &'a mut ProjectSnapshot,
+    alias: &PkgName,
+) -> Option<&'a mut ResolvedDependencySpec> {
+    if importer
+        .optional_dependencies
+        .as_ref()
+        .is_some_and(|dependencies| dependencies.contains_key(alias))
+    {
+        return importer.optional_dependencies.as_mut()?.get_mut(alias);
+    }
+    if importer.dependencies.as_ref().is_some_and(|dependencies| dependencies.contains_key(alias)) {
+        return importer.dependencies.as_mut()?.get_mut(alias);
+    }
+    importer.dev_dependencies.as_mut()?.get_mut(alias)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1,0 +1,58 @@
+use super::try_fast_update_importers;
+use pacquet_lockfile::Lockfile;
+use pacquet_package_manifest::PackageManifest;
+use serde_json::json;
+use std::path::PathBuf;
+
+fn lockfile() -> Lockfile {
+    serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  foo@1.1.0: {}
+",
+    )
+    .expect("parse lockfile")
+}
+
+fn manifest(specifier: &str) -> PackageManifest {
+    PackageManifest::from_value(
+        PathBuf::from("/project/package.json"),
+        json!({ "dependencies": { "foo": specifier } }),
+    )
+}
+
+#[test]
+fn updates_a_compatible_dependency_range() {
+    let manifest = manifest(">=1 <2");
+    let updated = try_fast_update_importers(&lockfile(), &[(".".to_string(), &manifest)])
+        .expect("compatible range should update");
+    assert_eq!(
+        updated.importers["."].dependencies.as_ref().expect("dependencies")
+            [&"foo".parse().expect("package name")]
+            .specifier,
+        ">=1 <2",
+    );
+}
+
+#[test]
+fn rejects_an_incompatible_dependency_range() {
+    let manifest = manifest("^2");
+    assert!(try_fast_update_importers(&lockfile(), &[(".".to_string(), &manifest)]).is_none());
+}
+
+#[test]
+fn rejects_a_non_semver_dependency_specifier() {
+    let manifest = manifest("latest");
+    assert!(try_fast_update_importers(&lockfile(), &[(".".to_string(), &manifest)]).is_none());
+}

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1226,6 +1226,37 @@ where
         // would hide the change of a real install creating `pnpm-lock.yaml`.
         let existing_wanted_lockfile = lockfile;
         let lockfile = lockfile.or(synthesized_lockfile.as_ref());
+        let fast_updated_lockfile =
+            if !frozen_lockfile && !dry_run && prefer_frozen_lockfile && mutation.is_full_install()
+            {
+                match lockfile.and_then(|lockfile| {
+                    crate::fast_update_importers::try_fast_update_importers(
+                        lockfile,
+                        &manifest_freshness_inputs,
+                    )
+                }) {
+                    Some(candidate)
+                        if check_lockfile_freshness(
+                            &candidate,
+                            &manifest_freshness_inputs,
+                            config,
+                            &catalogs,
+                            pnpmfile_hook.as_ref(),
+                            ignore_manifest_check,
+                            true,
+                        )
+                        .await
+                        .is_ok() =>
+                    {
+                        Some(candidate)
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            };
+        let lockfile_was_fast_updated = fast_updated_lockfile.is_some();
+        let lockfile = fast_updated_lockfile.as_ref().or(lockfile);
 
         // One per-install packument cache shared with both the
         // lockfile-verifier (below) and the resolver in
@@ -1811,7 +1842,7 @@ where
                 prefix: prefix.clone(),
                 stage: Stage::ImportingDone,
             }));
-            if lockfile_synthesized_from_current && config.lockfile {
+            if (lockfile_synthesized_from_current || lockfile_was_fast_updated) && config.lockfile {
                 wanted_lockfile
                     .save_to_path(&workspace_root.join(Lockfile::FILE_NAME))
                     .map_err(InstallError::SaveWantedLockfile)?;
@@ -2468,11 +2499,11 @@ where
         // handles the common case; this branch covers the rare path where
         // `.modules.yaml` was wiped or inconsistent and the frozen install
         // had to relink.
-        if lockfile_synthesized_from_current
+        if (lockfile_synthesized_from_current || lockfile_was_fast_updated)
             && config.lockfile
-            && let Some(synthesized) = synthesized_lockfile.as_ref()
+            && let Some(updated) = lockfile
         {
-            synthesized
+            updated
                 .save_to_path(&workspace_root.join(Lockfile::FILE_NAME))
                 .map_err(InstallError::SaveWantedLockfile)?;
         }

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -2485,7 +2485,8 @@ where
         // handles the common case; this branch covers the rare path where
         // `.modules.yaml` was wiped or inconsistent and the frozen install
         // had to relink.
-        if (lockfile_synthesized_from_current || lockfile_was_fast_updated)
+        if take_frozen_path
+            && (lockfile_synthesized_from_current || lockfile_was_fast_updated)
             && config.lockfile
             && let Some(updated) = lockfile
         {

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1226,35 +1226,21 @@ where
         // would hide the change of a real install creating `pnpm-lock.yaml`.
         let existing_wanted_lockfile = lockfile;
         let lockfile = lockfile.or(synthesized_lockfile.as_ref());
-        let fast_updated_lockfile =
-            if !frozen_lockfile && !dry_run && prefer_frozen_lockfile && mutation.is_full_install()
-            {
-                match lockfile.and_then(|lockfile| {
-                    crate::fast_update_importers::try_fast_update_importers(
-                        lockfile,
-                        &manifest_freshness_inputs,
-                    )
-                }) {
-                    Some(candidate)
-                        if check_lockfile_freshness(
-                            &candidate,
-                            &manifest_freshness_inputs,
-                            config,
-                            &catalogs,
-                            pnpmfile_hook.as_ref(),
-                            ignore_manifest_check,
-                            true,
-                        )
-                        .await
-                        .is_ok() =>
-                    {
-                        Some(candidate)
-                    }
-                    _ => None,
-                }
-            } else {
-                None
-            };
+        let can_fast_update_importers =
+            !frozen_lockfile && !dry_run && prefer_frozen_lockfile && mutation.is_full_install();
+        let fast_updated_lockfile = if can_fast_update_importers {
+            try_fast_update_importer_lockfile(FastUpdateImporterLockfileOptions {
+                lockfile,
+                manifests: &manifest_freshness_inputs,
+                config,
+                catalogs: &catalogs,
+                pnpmfile_hook: pnpmfile_hook.as_ref(),
+                ignore_manifest_check,
+            })
+            .await
+        } else {
+            None
+        };
         let lockfile_was_fast_updated = fast_updated_lockfile.is_some();
         let lockfile = fast_updated_lockfile.as_ref().or(lockfile);
 
@@ -2634,6 +2620,35 @@ where
 
         Ok(())
     }
+}
+
+struct FastUpdateImporterLockfileOptions<'a, 'manifest> {
+    lockfile: Option<&'a Lockfile>,
+    manifests: &'a [(String, &'manifest PackageManifest)],
+    config: &'a Config,
+    catalogs: &'a Catalogs,
+    pnpmfile_hook: Option<&'a Arc<dyn pacquet_hooks::PnpmfileHooks>>,
+    ignore_manifest_check: bool,
+}
+
+async fn try_fast_update_importer_lockfile(
+    opts: FastUpdateImporterLockfileOptions<'_, '_>,
+) -> Option<Lockfile> {
+    let lockfile = opts.lockfile?;
+    let candidate =
+        crate::fast_update_importers::try_fast_update_importers(lockfile, opts.manifests)?;
+    check_lockfile_freshness(
+        &candidate,
+        opts.manifests,
+        opts.config,
+        opts.catalogs,
+        opts.pnpmfile_hook,
+        opts.ignore_manifest_check,
+        true,
+    )
+    .await
+    .ok()?;
+    Some(candidate)
 }
 
 /// Run every gate the frozen-lockfile dispatch consults before

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -5,6 +5,7 @@ use crate::{
     LinkVirtualStoreBins, LinkVirtualStoreBinsError, PrefetchContext, PrefetchingResolver,
     SkippedSnapshots, SymlinkDirectDependencies, SymlinkDirectDependenciesError,
     VersionPolicyError, VersionsOverrider, VirtualStoreLayout, dependencies_graph_to_lockfile,
+    fast_update_catalogs::{FastCatalogUpdate, try_fast_update_catalogs},
     fast_update_overrides::{FastOverrideOptions, try_fast_update_overrides},
     link_root_component_members,
     store_init::init_store_dir_best_effort,
@@ -1382,6 +1383,18 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             update_reuse_scopes_by_importer.clear();
         }
 
+        let overrides_use_catalogs = config
+            .overrides
+            .as_ref()
+            .is_some_and(|overrides| overrides.values().any(|value| value.starts_with("catalog:")));
+        let catalog_update = wanted_lockfile.map_or(FastCatalogUpdate::Unchanged, |lockfile| {
+            try_fast_update_catalogs(lockfile, &catalogs, overrides_use_catalogs)
+        });
+        let (catalogs_match, fast_catalog_seed) = match catalog_update {
+            FastCatalogUpdate::Unchanged => (true, None),
+            FastCatalogUpdate::Updated(lockfile) => (false, Some(*lockfile)),
+            FastCatalogUpdate::Unsupported => (false, None),
+        };
         let reusable_settings_lockfile = wanted_lockfile
             .filter(|lockfile| lockfile.package_extensions_checksum == package_extensions_checksum);
         let override_settings_match = reusable_settings_lockfile.is_some_and(|lockfile| {
@@ -1389,6 +1402,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         });
         let fast_override_seed = if let (Some(lockfile), Some(parsed), Some(resolved)) =
             (reusable_settings_lockfile, parsed_overrides.as_deref(), resolved_overrides.as_ref())
+            && catalogs_match
+            && !overrides_use_catalogs
             && !override_settings_match
             && pnpmfile_hook.is_none()
             && custom_resolvers_raw.is_empty()
@@ -1436,9 +1451,14 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // Exact generic registry overrides may instead use a
         // dependency-shape-verified rewritten seed. Every unsupported
         // override shape falls back to withholding the seed.
-        let lockfile_reuse_seed = fast_override_seed
-            .as_ref()
-            .or_else(|| override_settings_match.then_some(reusable_settings_lockfile).flatten());
+        let fast_catalog_seed = fast_catalog_seed
+            .filter(|_| override_settings_match && reusable_settings_lockfile.is_some());
+        let lockfile_reuse_seed =
+            fast_override_seed.as_ref().or(fast_catalog_seed.as_ref()).or_else(|| {
+                (catalogs_match && override_settings_match)
+                    .then_some(reusable_settings_lockfile)
+                    .flatten()
+            });
         // Reused subtrees never stream their manifests through the
         // versions overrider, so only a resolution with no reuse at all
         // collects the complete declared-range set the convergence

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -14,6 +14,7 @@ mod current_lockfile;
 mod dependencies_graph_to_lockfile;
 mod deps_graph;
 mod fast_update_catalogs;
+mod fast_update_importers;
 mod fast_update_overrides;
 mod graph_sequencer;
 mod hoist;

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -13,6 +13,7 @@ mod create_virtual_store;
 mod current_lockfile;
 mod dependencies_graph_to_lockfile;
 mod deps_graph;
+mod fast_update_catalogs;
 mod fast_update_overrides;
 mod graph_sequencer;
 mod hoist;

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -108,6 +108,7 @@ import {
 import { linkPackages } from './link.js'
 import { reportPeerDependencyIssues } from './reportPeerDependencyIssues.js'
 import { tryFastUpdateCatalogs } from './tryFastUpdateCatalogs.js'
+import { hasChangedProjectSpecifiers, tryFastUpdateImporters } from './tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
 import { tryFastUpdateOverrides } from './tryFastUpdateOverrides.js'
 import { validateModules } from './validateModules.js'
@@ -692,8 +693,14 @@ export async function mutateModules (
     const _isWantedDepBareSpecifierSame = isWantedDepBareSpecifierSame.bind(null, ctx.wantedLockfile.catalogs, opts.catalogs)
     const upToDateLockfileMajorVersion = ctx.wantedLockfile.lockfileVersion.toString().startsWith(`${LOCKFILE_MAJOR_VERSION}.`)
     let didFastUpdateOverrides = false
+    const contextProjects = Object.values(ctx.projects)
+    const hasChangedSpecifiers = outdatedLockfileSettingName == null &&
+      hasChangedProjectSpecifiers(ctx.wantedLockfile, contextProjects)
     const canTryFastUpdateLockfile =
-      (outdatedLockfileSettingName === 'catalogs' || outdatedLockfileSettingName === 'overrides') &&
+      (outdatedLockfileSettingName === 'catalogs' ||
+        outdatedLockfileSettingName === 'overrides' ||
+        hasChangedSpecifiers) &&
+      !frozenLockfile &&
       installsOnly &&
       !isCheckOnlyInstall(opts) &&
       opts.preferFrozenLockfile &&
@@ -720,15 +727,16 @@ export async function mutateModules (
       await verifyLockfilePromise
       const overridesUseCatalogs = Object.values(opts.overrides)
         .some((specifier) => parseCatalogProtocol(specifier) != null)
+      const lockfileCatalogs = ctx.wantedLockfile.catalogs == null
+        ? {}
+        : Object.fromEntries(Object.entries(ctx.wantedLockfile.catalogs).map(([catalogName, catalog]) => [
+          catalogName,
+          Object.fromEntries(Object.entries(catalog).map(([alias, entry]) => [alias, entry.specifier])),
+        ]))
       const onlyChangedSetting = getOutdatedLockfileSetting(ctx.wantedLockfile, {
         ...lockfileSettings,
-        catalogs: ctx.wantedLockfile.catalogs == null
-          ? {}
-          : Object.fromEntries(Object.entries(ctx.wantedLockfile.catalogs).map(([catalogName, catalog]) => [
-            catalogName,
-            Object.fromEntries(Object.entries(catalog).map(([alias, entry]) => [alias, entry.specifier])),
-          ])),
-        overrides: ctx.wantedLockfile.overrides,
+        catalogs: changedSetting === 'catalogs' ? lockfileCatalogs : opts.catalogs,
+        overrides: changedSetting === 'overrides' ? ctx.wantedLockfile.overrides : overridesMap,
       }) == null
       const isLockfileUpToDate = (lockfile: LockfileObject) => allProjectsAreUpToDate(Object.values(ctx.projects), {
         catalogs: opts.catalogs,
@@ -749,6 +757,9 @@ export async function mutateModules (
                 catalogs: opts.catalogs,
                 overrides: opts.overrides,
               })
+            }
+            if (changedSetting == null) {
+              return tryFastUpdateImporters(candidate, contextProjects)
             }
             const { publishedBy, publishedByExclude } = getPublishedByPolicy(opts)
             return tryFastUpdateOverrides(candidate, {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -107,6 +107,8 @@ import {
 } from './extendInstallOptions.js'
 import { linkPackages } from './link.js'
 import { reportPeerDependencyIssues } from './reportPeerDependencyIssues.js'
+import { tryFastUpdateCatalogs } from './tryFastUpdateCatalogs.js'
+import { tryFastUpdateLockfile } from './tryFastUpdateLockfile.js'
 import { tryFastUpdateOverrides } from './tryFastUpdateOverrides.js'
 import { validateModules } from './validateModules.js'
 import { verifyLockfileResolutions } from './verifyLockfileResolutions.js'
@@ -690,8 +692,8 @@ export async function mutateModules (
     const _isWantedDepBareSpecifierSame = isWantedDepBareSpecifierSame.bind(null, ctx.wantedLockfile.catalogs, opts.catalogs)
     const upToDateLockfileMajorVersion = ctx.wantedLockfile.lockfileVersion.toString().startsWith(`${LOCKFILE_MAJOR_VERSION}.`)
     let didFastUpdateOverrides = false
-    const canTryFastUpdateOverrides =
-      outdatedLockfileSettingName === 'overrides' &&
+    const canTryFastUpdateLockfile =
+      (outdatedLockfileSettingName === 'catalogs' || outdatedLockfileSettingName === 'overrides') &&
       installsOnly &&
       !isCheckOnlyInstall(opts) &&
       opts.preferFrozenLockfile &&
@@ -713,55 +715,67 @@ export async function mutateModules (
       !isEmptyLockfile(ctx.wantedLockfile) &&
       (!opts.pruneLockfileImporters || Object.keys(ctx.wantedLockfile.importers).length === Object.keys(ctx.projects).length) &&
       ctx.wantedLockfile.time == null
-    if (canTryFastUpdateOverrides) {
+    if (canTryFastUpdateLockfile) {
+      const changedSetting = outdatedLockfileSettingName
       await verifyLockfilePromise
-      const { publishedBy, publishedByExclude } = getPublishedByPolicy(opts)
+      const overridesUseCatalogs = Object.values(opts.overrides)
+        .some((specifier) => parseCatalogProtocol(specifier) != null)
+      const onlyChangedSetting = getOutdatedLockfileSetting(ctx.wantedLockfile, {
+        ...lockfileSettings,
+        catalogs: ctx.wantedLockfile.catalogs == null
+          ? {}
+          : Object.fromEntries(Object.entries(ctx.wantedLockfile.catalogs).map(([catalogName, catalog]) => [
+            catalogName,
+            Object.fromEntries(Object.entries(catalog).map(([alias, entry]) => [alias, entry.specifier])),
+          ])),
+        overrides: ctx.wantedLockfile.overrides,
+      }) == null
+      const isLockfileUpToDate = (lockfile: LockfileObject) => allProjectsAreUpToDate(Object.values(ctx.projects), {
+        catalogs: opts.catalogs,
+        autoInstallPeers: opts.autoInstallPeers,
+        excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
+        linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
+        wantedLockfile: lockfile,
+        workspacePackages: ctx.workspacePackages,
+        lockfileDir: opts.lockfileDir,
+      })
       if (
-        // The helper reports only the first mismatch, so checking with the
-        // lockfile's overrides proves overrides were the only stale setting.
-        getOutdatedLockfileSetting(ctx.wantedLockfile, {
-          ...lockfileSettings,
-          overrides: ctx.wantedLockfile.overrides,
-        }) == null &&
-        await allProjectsAreUpToDate(Object.values(ctx.projects), {
-          catalogs: opts.catalogs,
-          autoInstallPeers: opts.autoInstallPeers,
-          excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
-          linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
-          wantedLockfile: ctx.wantedLockfile,
-          workspacePackages: ctx.workspacePackages,
-          lockfileDir: opts.lockfileDir,
-        }) &&
-        await tryFastUpdateOverrides(ctx.wantedLockfile, {
-          lockfileDir: opts.lockfileDir,
-          lockfileIncludeTarballUrl: opts.lockfileIncludeTarballUrl,
-          overrides: overridesMap,
-          parsedOverrides: opts.parsedOverrides,
-          readPackageHook: opts.readPackageHook,
-          registries: ctx.registries,
-          requestPackage: opts.storeController.requestPackage,
-          publishedBy,
-          publishedByExclude,
-          trustPolicy: opts.trustPolicy,
-          trustPolicyExclude: opts.trustPolicyExclude
-            ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
-            : undefined,
-          trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
-          isLockfileUpToDate: (lockfile) => allProjectsAreUpToDate(Object.values(ctx.projects), {
-            catalogs: opts.catalogs,
-            autoInstallPeers: opts.autoInstallPeers,
-            excludeLinksFromLockfile: opts.excludeLinksFromLockfile,
-            linkWorkspacePackages: opts.linkWorkspacePackagesDepth >= 0,
-            wantedLockfile: lockfile,
-            workspacePackages: ctx.workspacePackages,
-            lockfileDir: opts.lockfileDir,
-          }),
+        onlyChangedSetting &&
+        (changedSetting === 'catalogs' || !overridesUseCatalogs) &&
+        await tryFastUpdateLockfile(ctx.wantedLockfile, {
+          update: async (candidate) => {
+            if (changedSetting === 'catalogs') {
+              return tryFastUpdateCatalogs(candidate, {
+                catalogs: opts.catalogs,
+                overrides: opts.overrides,
+              })
+            }
+            const { publishedBy, publishedByExclude } = getPublishedByPolicy(opts)
+            return tryFastUpdateOverrides(candidate, {
+              lockfileDir: opts.lockfileDir,
+              lockfileIncludeTarballUrl: opts.lockfileIncludeTarballUrl,
+              overrides: overridesMap,
+              parsedOverrides: opts.parsedOverrides,
+              readPackageHook: opts.readPackageHook,
+              registries: ctx.registries,
+              requestPackage: opts.storeController.requestPackage,
+              publishedBy,
+              publishedByExclude,
+              trustPolicy: opts.trustPolicy,
+              trustPolicyExclude: opts.trustPolicyExclude
+                ? createPackageVersionPolicyOrThrow(opts.trustPolicyExclude, 'trustPolicyExclude')
+                : undefined,
+              trustPolicyIgnoreAfter: opts.trustPolicyIgnoreAfter,
+              isLockfileUpToDate,
+            })
+          },
+          isLockfileUpToDate,
           verifyLockfile: (lockfile) => verifyLockfileResolutions(lockfile, []),
         })
       ) {
         outdatedLockfileSettingName = null
         ctx.wantedLockfileIsModified = true
-        didFastUpdateOverrides = true
+        didFastUpdateOverrides = changedSetting === 'overrides'
       }
     }
     const outdatedLockfileSettings = outdatedLockfileSettingName != null

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
@@ -1,0 +1,54 @@
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
+import type { Catalogs } from '@pnpm/catalogs.types'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import semver from 'semver'
+
+export function tryFastUpdateCatalogs (
+  lockfile: LockfileObject,
+  opts: {
+    catalogs: Catalogs
+    overrides: Record<string, string>
+  }
+): boolean {
+  if (Object.values(opts.overrides).some((specifier) => parseCatalogProtocol(specifier) != null)) {
+    return false
+  }
+
+  let changed = false
+  const catalogs = Object.fromEntries(
+    Object.entries(lockfile.catalogs ?? {}).flatMap(([catalogName, catalog]) => {
+      const entries = Object.entries(catalog).flatMap(([alias, entry]) => {
+        const specifier = opts.catalogs[catalogName]?.[alias]
+        if (specifier == null) {
+          if (catalogEntryIsReferenced(lockfile.importers, catalogName, alias)) return [[alias, entry]]
+          changed = true
+          return []
+        }
+        if (specifier === entry.specifier) return [[alias, entry]]
+        if (
+          semver.valid(entry.version) == null ||
+          semver.validRange(specifier) == null ||
+          !semver.satisfies(entry.version, specifier)
+        ) {
+          return [[alias, entry]]
+        }
+        changed = true
+        return [[alias, { specifier, version: entry.version }]]
+      })
+      return entries.length === 0 ? [] : [[catalogName, Object.fromEntries(entries)]]
+    })
+  )
+
+  if (!changed) return false
+  lockfile.catalogs = Object.keys(catalogs).length === 0 ? undefined : catalogs
+  return true
+}
+
+function catalogEntryIsReferenced (
+  importers: LockfileObject['importers'],
+  catalogName: string,
+  alias: string
+): boolean {
+  const protocol = catalogName === 'default' ? 'catalog:' : `catalog:${catalogName}`
+  return Object.values(importers).some((importer) => importer.specifiers[alias] === protocol)
+}

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateCatalogs.ts
@@ -13,6 +13,17 @@ export function tryFastUpdateCatalogs (
   if (Object.values(opts.overrides).some((specifier) => parseCatalogProtocol(specifier) != null)) {
     return false
   }
+  if (Object.values(lockfile.importers).some((importer) =>
+    Object.entries(importer.specifiers).some(([alias, specifier]) => {
+      const catalogName = parseCatalogProtocol(specifier)
+      return catalogName != null && (
+        opts.catalogs[catalogName]?.[alias] == null ||
+        lockfile.catalogs?.[catalogName]?.[alias] == null
+      )
+    })
+  )) {
+    return false
+  }
 
   let changed = false
   const catalogs = Object.fromEntries(

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -24,7 +24,11 @@ export function tryFastUpdateImporters (
   lockfile: LockfileObject,
   projects: Project[]
 ): boolean {
-  let changed = false
+  const updates: Array<{
+    alias: string
+    specifier: string
+    specifiers: Record<string, string>
+  }> = []
   for (const project of projects) {
     const importer = lockfile.importers[project.id]
     if (importer == null) return false
@@ -43,11 +47,17 @@ export function tryFastUpdateImporters (
       ) {
         return false
       }
-      importer.specifiers[alias] = specifier
-      changed = true
+      updates.push({
+        alias,
+        specifier,
+        specifiers: importer.specifiers,
+      })
     }
   }
-  return changed
+  for (const update of updates) {
+    update.specifiers[update.alias] = update.specifier
+  }
+  return updates.length > 0
 }
 
 function getManifestSpecifiers (manifest: ProjectManifest): Record<string, string> {

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -1,0 +1,59 @@
+import * as dp from '@pnpm/deps.path'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import type { ProjectId, ProjectManifest } from '@pnpm/types'
+import semver from 'semver'
+
+interface Project {
+  id: ProjectId
+  manifest: ProjectManifest
+}
+
+export function hasChangedProjectSpecifiers (
+  lockfile: LockfileObject,
+  projects: Project[]
+): boolean {
+  return projects.some((project) => {
+    const importer = lockfile.importers[project.id]
+    if (importer == null) return false
+    return Object.entries(getManifestSpecifiers(project.manifest))
+      .some(([alias, specifier]) => importer.specifiers[alias] !== specifier)
+  })
+}
+
+export function tryFastUpdateImporters (
+  lockfile: LockfileObject,
+  projects: Project[]
+): boolean {
+  let changed = false
+  for (const project of projects) {
+    const importer = lockfile.importers[project.id]
+    if (importer == null) return false
+    for (const [alias, specifier] of Object.entries(getManifestSpecifiers(project.manifest))) {
+      if (importer.specifiers[alias] === specifier) continue
+      const reference =
+        importer.optionalDependencies?.[alias] ??
+        importer.dependencies?.[alias] ??
+        importer.devDependencies?.[alias]
+      const version = reference == null ? null : dp.removeSuffix(reference)
+      if (
+        semver.validRange(specifier) == null ||
+        version == null ||
+        semver.valid(version) == null ||
+        !semver.satisfies(version, specifier)
+      ) {
+        return false
+      }
+      importer.specifiers[alias] = specifier
+      changed = true
+    }
+  }
+  return changed
+}
+
+function getManifestSpecifiers (manifest: ProjectManifest): Record<string, string> {
+  return {
+    ...manifest.devDependencies,
+    ...manifest.dependencies,
+    ...manifest.optionalDependencies,
+  }
+}

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateLockfile.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateLockfile.ts
@@ -1,0 +1,19 @@
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import { clone } from 'ramda'
+
+export async function tryFastUpdateLockfile (
+  lockfile: LockfileObject,
+  opts: {
+    update: (candidate: LockfileObject) => boolean | Promise<boolean>
+    isLockfileUpToDate: (candidate: LockfileObject) => Promise<boolean>
+    verifyLockfile?: (candidate: LockfileObject) => Promise<void>
+  }
+): Promise<boolean> {
+  const candidate = clone(lockfile)
+  if (!await opts.update(candidate)) return false
+  if (!await opts.isLockfileUpToDate(candidate)) return false
+  await opts.verifyLockfile?.(candidate)
+
+  Object.assign(lockfile, candidate)
+  return true
+}

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -3,11 +3,69 @@ import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import { prepareEmpty } from '@pnpm/prepare'
 import type { StoreController } from '@pnpm/store.controller-types'
-import type { ProjectManifest, ProjectRootDir } from '@pnpm/types'
+import type { ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 
 import { tryFastUpdateCatalogs } from '../../src/install/tryFastUpdateCatalogs.js'
+import { tryFastUpdateImporters } from '../../src/install/tryFastUpdateImporters.js'
 import { tryFastUpdateLockfile } from '../../src/install/tryFastUpdateLockfile.js'
 import { testDefaults } from '../utils/index.js'
+
+test('a compatible package range update retains the locked peer snapshot without resolution', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/has-optional-peer-with-peer': '^1.0.0',
+    },
+  }
+  const options = testDefaults()
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  manifest.dependencies!['@pnpm.e2e/has-optional-peer-with-peer'] = '>=1.0.0 <2'
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  expect(project.readLockfile().importers['.' as ProjectId].dependencies!['@pnpm.e2e/has-optional-peer-with-peer']).toStrictEqual({
+    specifier: '>=1.0.0 <2',
+    version: '1.0.0',
+  })
+})
+
+test('an incompatible package range update falls back without mutating the lockfile', () => {
+  const lockfile = {
+    importers: {
+      '.': {
+        dependencies: {
+          foo: '1.0.0',
+        },
+        specifiers: {
+          foo: '^1.0.0',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+  } as LockfileObject
+
+  expect(tryFastUpdateImporters(lockfile, [{
+    id: '.' as ProjectId,
+    manifest: {
+      dependencies: {
+        foo: '^2.0.0',
+      },
+    },
+  }])).toBe(false)
+  expect(lockfile.importers['.' as ProjectId].specifiers.foo).toBe('^1.0.0')
+})
 
 test('a compatible catalog range update retains the locked peer snapshot without resolution', async () => {
   const project = prepareEmpty()
@@ -87,6 +145,49 @@ test('an incompatible catalog range update falls back to resolution', async () =
   expect(requestedPackages).toContain('@pnpm.e2e/foobarqar')
 })
 
+test('simultaneous catalog and override changes fall back to resolution', async () => {
+  prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/parent-of-pkg-with-1-dep': 'catalog:',
+    },
+  }
+  const options = testDefaults({
+    catalogs: {
+      default: {
+        '@pnpm.e2e/parent-of-pkg-with-1-dep': '^1.0.0',
+      },
+    },
+    overrides: {
+      '@pnpm.e2e/pkg-with-1-dep': '100.0.0',
+    },
+  })
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  options.catalogs = {
+    default: {
+      '@pnpm.e2e/parent-of-pkg-with-1-dep': '>=1 <2',
+    },
+  }
+  options.overrides = {
+    '@pnpm.e2e/pkg-with-1-dep': '100.1.0',
+  }
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages.length).toBeGreaterThan(0)
+})
+
 test('a catalog snapshot still referenced by an importer is not removed', () => {
   const lockfile = {
     catalogs: {
@@ -112,6 +213,36 @@ test('a catalog snapshot still referenced by an importer is not removed', () => 
     overrides: {},
   })).toBe(false)
   expect(lockfile.catalogs).toHaveProperty(['default', 'foo'])
+})
+
+test('a referenced catalog entry missing from the snapshots falls back', () => {
+  const lockfile = {
+    catalogs: {
+      default: {
+        bar: {
+          specifier: '^1.0.0',
+          version: '1.0.0',
+        },
+      },
+    },
+    importers: {
+      '.': {
+        specifiers: {
+          foo: 'catalog:',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+  } as LockfileObject
+
+  expect(tryFastUpdateCatalogs(lockfile, {
+    catalogs: {
+      default: {
+        foo: '^1.0.0',
+      },
+    },
+    overrides: {},
+  })).toBe(false)
 })
 
 test('an unreferenced stale catalog snapshot is removed', () => {

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -1,0 +1,215 @@
+import { expect, test } from '@jest/globals'
+import { mutateModulesInSingleProject } from '@pnpm/installing.deps-installer'
+import type { LockfileObject } from '@pnpm/lockfile.types'
+import { prepareEmpty } from '@pnpm/prepare'
+import type { StoreController } from '@pnpm/store.controller-types'
+import type { ProjectManifest, ProjectRootDir } from '@pnpm/types'
+
+import { tryFastUpdateCatalogs } from '../../src/install/tryFastUpdateCatalogs.js'
+import { tryFastUpdateLockfile } from '../../src/install/tryFastUpdateLockfile.js'
+import { testDefaults } from '../utils/index.js'
+
+test('a compatible catalog range update retains the locked peer snapshot without resolution', async () => {
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/has-optional-peer-with-peer': 'catalog:',
+    },
+  }
+  const options = testDefaults({
+    catalogs: {
+      default: {
+        '@pnpm.e2e/has-optional-peer-with-peer': '^1.0.0',
+      },
+    },
+  })
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  options.catalogs = {
+    default: {
+      '@pnpm.e2e/has-optional-peer-with-peer': '>=1.0.0 <2',
+    },
+  }
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toStrictEqual([])
+  expect(project.readLockfile().catalogs.default['@pnpm.e2e/has-optional-peer-with-peer']).toStrictEqual({
+    specifier: '>=1.0.0 <2',
+    version: '1.0.0',
+  })
+})
+
+test('an incompatible catalog range update falls back to resolution', async () => {
+  prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/foobarqar': 'catalog:',
+    },
+  }
+  const options = testDefaults({
+    catalogs: {
+      default: {
+        '@pnpm.e2e/foobarqar': '1.0.0',
+      },
+    },
+  })
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const requestedPackages = trackRequestedPackages(options.storeController)
+  options.catalogs = {
+    default: {
+      '@pnpm.e2e/foobarqar': '1.0.1',
+    },
+  }
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  expect(requestedPackages).toContain('@pnpm.e2e/foobarqar')
+})
+
+test('a catalog snapshot still referenced by an importer is not removed', () => {
+  const lockfile = {
+    catalogs: {
+      default: {
+        foo: {
+          specifier: '^1.0.0',
+          version: '1.0.0',
+        },
+      },
+    },
+    importers: {
+      '.': {
+        specifiers: {
+          foo: 'catalog:',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+  } as LockfileObject
+
+  expect(tryFastUpdateCatalogs(lockfile, {
+    catalogs: {},
+    overrides: {},
+  })).toBe(false)
+  expect(lockfile.catalogs).toHaveProperty(['default', 'foo'])
+})
+
+test('an unreferenced stale catalog snapshot is removed', () => {
+  const lockfile = {
+    catalogs: {
+      default: {
+        foo: {
+          specifier: '^1.0.0',
+          version: '1.0.0',
+        },
+      },
+    },
+    importers: {
+      '.': {
+        specifiers: {},
+      },
+    },
+    lockfileVersion: '9.0',
+  } as LockfileObject
+
+  expect(tryFastUpdateCatalogs(lockfile, {
+    catalogs: {},
+    overrides: {},
+  })).toBe(true)
+  expect(lockfile.catalogs).toBeUndefined()
+})
+
+test('a failed candidate validation leaves the lockfile unchanged', async () => {
+  const lockfile = {
+    catalogs: {
+      default: {
+        foo: {
+          specifier: '^1.0.0',
+          version: '1.0.0',
+        },
+      },
+    },
+    importers: {
+      '.': {
+        specifiers: {
+          foo: 'catalog:',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+  } as LockfileObject
+
+  expect(await tryFastUpdateLockfile(lockfile, {
+    update: (candidate) => tryFastUpdateCatalogs(candidate, {
+      catalogs: {
+        default: {
+          foo: '>=1 <2',
+        },
+      },
+      overrides: {},
+    }),
+    isLockfileUpToDate: async () => false,
+  })).toBe(false)
+  expect(lockfile.catalogs?.default.foo.specifier).toBe('^1.0.0')
+})
+
+test('a malformed catalog version falls back without changing the snapshot', () => {
+  const lockfile = {
+    catalogs: {
+      default: {
+        foo: {
+          specifier: '^1.0.0',
+          version: 'not-a-version',
+        },
+      },
+    },
+    importers: {
+      '.': {
+        specifiers: {
+          foo: 'catalog:',
+        },
+      },
+    },
+    lockfileVersion: '9.0',
+  } as LockfileObject
+
+  expect(tryFastUpdateCatalogs(lockfile, {
+    catalogs: {
+      default: {
+        foo: '>=1 <2',
+      },
+    },
+    overrides: {},
+  })).toBe(false)
+  expect(lockfile.catalogs?.default.foo.specifier).toBe('^1.0.0')
+})
+
+function trackRequestedPackages (storeController: StoreController): string[] {
+  const requestedPackages: string[] = []
+  const requestPackage = storeController.requestPackage
+  storeController.requestPackage = async (wantedDependency, requestOptions) => {
+    requestedPackages.push(wantedDependency.alias!)
+    return requestPackage(wantedDependency, requestOptions)
+  }
+  return requestedPackages
+}

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -188,7 +188,7 @@ test('simultaneous catalog and override changes fall back to resolution', async 
   expect(requestedPackages.length).toBeGreaterThan(0)
 })
 
-test('a catalog snapshot still referenced by an importer is not removed', () => {
+test.each(['catalog:', 'catalog:default'])('a default catalog snapshot referenced as %s is not removed', (specifier) => {
   const lockfile = {
     catalogs: {
       default: {
@@ -201,7 +201,7 @@ test('a catalog snapshot still referenced by an importer is not removed', () => 
     importers: {
       '.': {
         specifiers: {
-          foo: 'catalog:',
+          foo: specifier,
         },
       },
     },

--- a/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
+++ b/pnpm11/installing/deps-installer/test/install/catalogFastUpdate.ts
@@ -46,9 +46,11 @@ test('an incompatible package range update falls back without mutating the lockf
     importers: {
       '.': {
         dependencies: {
+          bar: '1.0.0',
           foo: '1.0.0',
         },
         specifiers: {
+          bar: '^1.0.0',
           foo: '^1.0.0',
         },
       },
@@ -60,11 +62,15 @@ test('an incompatible package range update falls back without mutating the lockf
     id: '.' as ProjectId,
     manifest: {
       dependencies: {
-        foo: '^2.0.0',
+        foo: '>=1.0.0 <2',
+        bar: '^2.0.0',
       },
     },
   }])).toBe(false)
-  expect(lockfile.importers['.' as ProjectId].specifiers.foo).toBe('^1.0.0')
+  expect(lockfile.importers['.' as ProjectId].specifiers).toStrictEqual({
+    bar: '^1.0.0',
+    foo: '^1.0.0',
+  })
 })
 
 test('a compatible catalog range update retains the locked peer snapshot without resolution', async () => {


### PR DESCRIPTION
## Summary

- Reuse the locked version when a direct dependency or catalog range changes but still accepts that version, avoiding a dependency-graph resolution.
- Support `dependencies`, `devDependencies`, and `optionalDependencies`; retain the normal resolution fallback for incompatible ranges, non-semver specs, dependency-group changes, and other resolution-sensitive edits.
- Remove stale, unreferenced catalog snapshots without resolving, while requiring every referenced catalog entry to have a matching configured entry and lockfile snapshot.
- Apply the same behavior to the TypeScript CLI and Rust pnpm implementation, with transactional validation before committing a fast lockfile update.
- Add unit and integration coverage, including peer-bearing packages, simultaneous settings drift, and an unavailable registry to prove compatible updates make zero package requests.

This implements the first conservative dependency-range optimizations from [pnpm/pnpm#13474](https://github.com/pnpm/pnpm/issues/13474). The broader fast-path roadmap remains a design task.

## Squash Commit Body

```text
Direct dependency and catalog range edits currently force the dependency graph
to be resolved even when every locked version remains valid.

Add transactional fast paths that rewrite only compatible importer specifiers
or catalog snapshots, then validate importer state and lockfile resolutions
before committing them. Stale catalog snapshots may be removed when no
importer references them. Ambiguous or resolution-sensitive cases continue
through the normal resolver.

Implement the same conservative rules in the TypeScript CLI and Rust pnpm
implementation. Tests cover compatible and incompatible direct and catalog
ranges, stale and missing snapshots, simultaneous settings changes, atomic
rollback, malformed versions, peer-bearing packages, and operation while the
registry is unavailable.

Related to pnpm/pnpm#13474.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Installs are faster by retaining compatible lockfile catalog snapshots and skipping unnecessary dependency graph resolution.
  * Fresh-lockfile installs now also benefit from safe fast-updates to keep lockfile changes minimal.
* **New Features**
  * Fast lockfile updates can now reconcile catalogs, overrides, and importer specifiers when compatibility checks pass.
* **Bug Fixes**
  * If catalog snapshots are missing, malformed, excluded by updated ranges, or incompatible (including when registries are unreachable), pnpm correctly falls back to normal resolution.
* **Tests**
  * Added integration/unit coverage for reuse vs. fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->