### PR TITLE
fix: update catalogs for explicit dist tags

### DIFF
--- a/.changeset/catalog-dist-tag-update.md
+++ b/.changeset/catalog-dist-tag-update.md
@@ -1,0 +1,5 @@
+---
+"pnpm": patch
+---
+
+Fixed catalog updates with explicit dist tags, so commands like `pnpm update package@beta` keep the dependency using `catalog:` in `package.json` and update the catalog entry instead of writing the resolved specifier directly to the project manifest.

--- a/.changeset/catalog-dist-tag-update.md
+++ b/.changeset/catalog-dist-tag-update.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed catalog updates with explicit dist tags, so commands like `pnpm update package@beta` keep the dependency using `catalog:` in `package.json` and update the catalog entry instead of writing the resolved specifier directly to the project manifest.
+
+This change is implemented for the TypeScript CLI path. Rust/pacquet parity is deferred because the triaged issue identifies this catalog update flow as TypeScript-only for now.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5895,6 +5895,9 @@ importers:
 
   pnpm11/installing/deps-resolver:
     dependencies:
+      '@pnpm/catalogs.protocol-parser':
+        specifier: workspace:*
+        version: link:../../catalogs/protocol-parser
       '@pnpm/catalogs.resolver':
         specifier: workspace:*
         version: link:../../catalogs/resolver

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1422,7 +1422,7 @@ function getPerDepCatalogName (
 }
 
 function isExplicitDistTagSpecifier (bareSpecifier: string | undefined): boolean {
-  return bareSpecifier != null && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
+  return bareSpecifier != null && bareSpecifier !== 'latest' && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
 }
 
 export async function addDependenciesToPackage (

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -977,7 +977,8 @@ export async function mutateModules (
           if (
             wantedDep.prevSpecifier != null &&
             parseCatalogProtocol(wantedDep.prevSpecifier) != null &&
-            wantedDep.bareSpecifier !== wantedDep.prevSpecifier
+            wantedDep.bareSpecifier !== wantedDep.prevSpecifier &&
+            isExplicitDistTagSpecifier(wantedDep.bareSpecifier)
           ) continue
           const perDepCatalogName = getPerDepCatalogName(wantedDep, opts.saveCatalogName)
           const catalogBareSpecifier = `catalog:${perDepCatalogName === 'default' ? '' : perDepCatalogName}`
@@ -1418,6 +1419,10 @@ function getPerDepCatalogName (
     }
   }
   return globalSaveCatalogName ?? 'default'
+}
+
+function isExplicitDistTagSpecifier (bareSpecifier: string | undefined): boolean {
+  return bareSpecifier != null && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
 }
 
 export async function addDependenciesToPackage (

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -974,6 +974,11 @@ export async function mutateModules (
           // Promoting it into a catalog rewrites the entry to `catalog:`, which
           // breaks that round-trip and strands it in `devDependencies`.
           if (wantedDep.bareSpecifier?.startsWith('runtime:')) continue
+          if (
+            wantedDep.prevSpecifier != null &&
+            parseCatalogProtocol(wantedDep.prevSpecifier) != null &&
+            wantedDep.bareSpecifier !== wantedDep.prevSpecifier
+          ) continue
           const perDepCatalogName = getPerDepCatalogName(wantedDep, opts.saveCatalogName)
           const catalogBareSpecifier = `catalog:${perDepCatalogName === 'default' ? '' : perDepCatalogName}`
           const catalog = resolveFromCatalog(opts.catalogs, { ...wantedDep, bareSpecifier: catalogBareSpecifier })

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1897,6 +1897,53 @@ describe('update', () => {
     expect(Object.keys(readLockfile().snapshots)).toEqual(['@pnpm.e2e/foo@100.1.0'])
   })
 
+  test('update with dist tag works on cataloged dependency', async () => {
+    await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'beta' })
+
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }])
+
+    const catalogs = {
+      default: { '@pnpm.e2e/foo': '1.0.0' },
+    }
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs,
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    const { updatedCatalogs, updatedManifest } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['@pnpm.e2e/foo@beta'],
+      {
+        ...mutateOpts,
+        dir: path.join(process.cwd(), 'project1'),
+        allowNew: false,
+        update: true,
+      })
+
+    expect(updatedManifest).toEqual({
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    })
+    expect(updatedCatalogs).toEqual({
+      default: {
+        '@pnpm.e2e/foo': '100.1.0',
+      },
+    })
+
+    expect(Object.keys(readLockfile().snapshots)).toEqual(['@pnpm.e2e/foo@100.1.0'])
+  })
+
   test('update --latest works on named catalog dependency', async () => {
     await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
 

--- a/pnpm11/installing/deps-resolver/package.json
+++ b/pnpm11/installing/deps-resolver/package.json
@@ -32,6 +32,7 @@
     ".test": "cross-env NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules --disable-warning=ExperimentalWarning --disable-warning=DEP0169\" jest"
   },
   "dependencies": {
+    "@pnpm/catalogs.protocol-parser": "workspace:*",
     "@pnpm/catalogs.resolver": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/config.version-policy": "workspace:*",

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -35,6 +35,7 @@ import {
 } from '@pnpm/types'
 import { isSubdir } from 'is-subdir'
 import { difference, zipWith } from 'ramda'
+import semver from 'semver'
 
 import { depPathToRef } from './depPathToRef.js'
 import { getCatalogSnapshots } from './getCatalogSnapshots.js'
@@ -384,7 +385,9 @@ export async function resolveDependencies (
       if (dep.normalizedBareSpecifier == null) continue
       updatedCatalogs ??= {}
       updatedCatalogs[dep.catalogLookup.catalogName] ??= {}
-      updatedCatalogs[dep.catalogLookup.catalogName][dep.alias] = dep.normalizedBareSpecifier
+      updatedCatalogs[dep.catalogLookup.catalogName][dep.alias] = isExplicitDistTagSpecifier(dep.wantedDependency?.bareSpecifier)
+        ? dep.version
+        : dep.normalizedBareSpecifier
     }
   }
 
@@ -443,6 +446,10 @@ export async function resolveDependencies (
     wantedToBeSkippedPackageIds,
     resolutionPolicyViolations,
   }
+}
+
+function isExplicitDistTagSpecifier (bareSpecifier: string | undefined): boolean {
+  return bareSpecifier != null && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
 }
 
 function treeHasLockedPeerContexts (dependenciesTree: DependenciesTree<ResolvedPackage>): boolean {

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -449,7 +449,7 @@ export async function resolveDependencies (
 }
 
 function isExplicitDistTagSpecifier (bareSpecifier: string | undefined): boolean {
-  return bareSpecifier != null && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
+  return bareSpecifier != null && bareSpecifier !== 'latest' && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
 }
 
 function treeHasLockedPeerContexts (dependenciesTree: DependenciesTree<ResolvedPackage>): boolean {

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -762,9 +762,7 @@ async function resolveDependenciesOfImporterDependency (
   // workspace. Replacing catalog protocol while resolving importers here before
   // resolving dependencies of packages outside of the workspace/monorepo.
   const originalBareSpecifier = extendedWantedDep.wantedDependency.bareSpecifier
-  const originalPrevSpecifier = 'prevSpecifier' in extendedWantedDep.wantedDependency
-    ? extendedWantedDep.wantedDependency.prevSpecifier
-    : undefined
+  const originalPrevSpecifier = (extendedWantedDep.wantedDependency as WantedDependency & { prevSpecifier?: string }).prevSpecifier
   const catalogSpecifier = originalPrevSpecifier != null &&
     parseCatalogProtocol(originalPrevSpecifier) != null &&
     isExplicitDistTagSpecifier(originalBareSpecifier)

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -765,7 +765,9 @@ async function resolveDependenciesOfImporterDependency (
   const originalPrevSpecifier = 'prevSpecifier' in extendedWantedDep.wantedDependency
     ? extendedWantedDep.wantedDependency.prevSpecifier
     : undefined
-  const catalogSpecifier = originalPrevSpecifier != null && parseCatalogProtocol(originalPrevSpecifier) != null
+  const catalogSpecifier = originalPrevSpecifier != null &&
+    parseCatalogProtocol(originalPrevSpecifier) != null &&
+    isExplicitDistTagSpecifier(originalBareSpecifier)
     ? originalPrevSpecifier
     : originalBareSpecifier
   const catalogLookup = matchCatalogResolveResult(ctx.catalogResolver({
@@ -828,6 +830,10 @@ function filterMissingPeersFromPkgAddresses (
       return false
     }, pkgAddress.missingPeers ?? {}),
   }))
+}
+
+function isExplicitDistTagSpecifier (bareSpecifier: string | undefined): boolean {
+  return bareSpecifier != null && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
 }
 
 function getPublishedByDate (pkgAddresses: PkgAddress[], timeFromLockfile: Record<string, string> = {}): { publishedBy: Date, newTime: Record<string, string> } {

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -831,7 +831,7 @@ function filterMissingPeersFromPkgAddresses (
 }
 
 function isExplicitDistTagSpecifier (bareSpecifier: string | undefined): boolean {
-  return bareSpecifier != null && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
+  return bareSpecifier != null && bareSpecifier !== 'latest' && !bareSpecifier.includes(':') && semver.validRange(bareSpecifier) == null
 }
 
 function getPublishedByDate (pkgAddresses: PkgAddress[], timeFromLockfile: Record<string, string> = {}): { publishedBy: Date, newTime: Record<string, string> } {

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import util from 'node:util'
 
+import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
 import { type CatalogResolution, type CatalogResolver, matchCatalogResolveResult } from '@pnpm/catalogs.resolver'
 import {
   deprecationLogger,
@@ -760,20 +761,29 @@ async function resolveDependenciesOfImporterDependency (
   // The catalog protocol is only usable in importers (i.e. packages in the
   // workspace. Replacing catalog protocol while resolving importers here before
   // resolving dependencies of packages outside of the workspace/monorepo.
-  const catalogLookup = matchCatalogResolveResult(ctx.catalogResolver(extendedWantedDep.wantedDependency), {
+  const originalBareSpecifier = extendedWantedDep.wantedDependency.bareSpecifier
+  const originalPrevSpecifier = 'prevSpecifier' in extendedWantedDep.wantedDependency
+    ? extendedWantedDep.wantedDependency.prevSpecifier
+    : undefined
+  const catalogSpecifier = originalPrevSpecifier != null && parseCatalogProtocol(originalPrevSpecifier) != null
+    ? originalPrevSpecifier
+    : originalBareSpecifier
+  const catalogLookup = matchCatalogResolveResult(ctx.catalogResolver({
+    ...extendedWantedDep.wantedDependency,
+    bareSpecifier: catalogSpecifier,
+  }), {
     found: (result) => result.resolution,
     unused: () => undefined,
     misconfiguration: (result) => {
       throw result.error
     },
   })
-  const originalBareSpecifier = extendedWantedDep.wantedDependency.bareSpecifier
 
   // The lockfile from a previous installation may have already resolved this
   // cataloged dependency. Reuse the exact version in the lockfile catalog
   // snapshot to ensure all projects using the same cataloged dependency get the
   // same version.
-  if (catalogLookup != null) {
+  if (catalogLookup != null && originalBareSpecifier === catalogSpecifier) {
     extendedWantedDep.wantedDependency.bareSpecifier = catalogLookup.specifier
     extendedWantedDep.preferredVersion = getCatalogExistingVersionFromSnapshot(catalogLookup, ctx.wantedLockfile, extendedWantedDep.wantedDependency)
   }
@@ -796,7 +806,7 @@ async function resolveDependenciesOfImporterDependency (
   if (result.resolveDependencyResult != null && catalogLookup != null) {
     result.resolveDependencyResult.catalogLookup = {
       ...catalogLookup,
-      userSpecifiedBareSpecifier: originalBareSpecifier,
+      userSpecifiedBareSpecifier: catalogSpecifier,
     }
   }
 

--- a/pnpm11/installing/deps-resolver/tsconfig.json
+++ b/pnpm11/installing/deps-resolver/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../../catalogs/protocol-parser"
+    },
+    {
       "path": "../../catalogs/resolver"
     },
     {


### PR DESCRIPTION
Fixes pnpm/pnpm#13399.

## Summary

`pnpm update package@beta` previously treated the explicit dist tag as a direct dependency specifier even when the current dependency was cataloged. That bypassed the catalog lookup path, so the project manifest could be rewritten instead of keeping `catalog:` and updating the workspace catalog entry.

This keeps the previous catalog specifier as the manifest-facing specifier while resolving the explicit tag, then attaches catalog metadata so `updatedCatalogs` receives the resolved version.

## Squash Commit Body

```text
When a cataloged dependency was updated with an explicit dist tag, for example
`pnpm update effect@beta`, the wanted dependency carried the tag as its bare
specifier and the previous `catalog:` specifier separately. The resolver only
looked for catalog metadata on the current bare specifier, so it bypassed the
catalog path and treated the update as a direct manifest edit.

Use the previous catalog specifier for catalog lookup metadata while still
resolving the explicit tag supplied by the user. This preserves `catalog:` in
package.json and writes the resolved version to the catalog update map.

Fixes pnpm/pnpm#13399.
```

## Validation

- `git diff --check` passed.
- Added regression coverage in `pnpm11/installing/deps-installer/test/catalogs.ts` for `pnpm update package@beta` on a cataloged dependency.
- Could not run the focused pnpm test locally on this host: the filesystem is at 100% usage with ~210 MB free, and Corepack/pnpm setup failed before dependency install (`Cannot find module '/root/.cache/node/corepack/v1/pnpm/12.0.0-alpha.21/bin/pnpm.mjs'`).

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. *(TypeScript CLI path only per triage for pnpm/pnpm#13399.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. *(No docs update needed for this bug fix.)*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787895368&installation_model_id=426870&pr_number=13478&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13478&signature=0a95b8c535ff701cf13cca26b65d0c9eb8f13b40b3a5c8e83da85c89e295fa6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed catalog-managed dependency updates using explicit dist tags so the project manifest keeps the `catalog:` specifier, while the catalog entry is updated instead of writing a resolved specifier.
  * Refined catalog reconciliation and dependency resolution for dist-tag-like specifiers, improving lockfile reuse behavior.
* **Tests**
  * Added a new test covering dist-tag updates for cataloged dependencies, including updated catalog entry values and expected lockfile snapshot keys.
* **Documentation**
  * Added a changeset documenting the catalog dist-tag update fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->