### PR TITLE
feat(login): support web login without an interactive terminal

### DIFF
--- a/.changeset/login-non-interactive-web-auth.md
+++ b/.changeset/login-non-interactive-web-auth.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/network.web-auth": minor
+"@pnpm/auth.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+`pnpm login` no longer requires an interactive terminal when the registry supports web-based login: without a TTY it prints the authentication URL (skipping the QR code and the "Press ENTER to open the URL in your browser" prompt) and polls the registry until the browser approval completes. Only the classic username/password login still fails with `ERR_PNPM_LOGIN_NON_INTERACTIVE` in a non-interactive terminal.

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -231,7 +231,7 @@ jobs:
     environment: release
     needs: tag-in-registry
     steps:
-      - uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # main
+      - uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # 2026-03-15 pin, no longer on a named ref # zizmor: ignore[ref-version-mismatch]
         with:
           identifier: pnpm.pnpm
           version: ${{ github.event.inputs.version }}

--- a/pnpm/crates/auth-commands/src/login.rs
+++ b/pnpm/crates/auth-commands/src/login.rs
@@ -120,6 +120,10 @@ impl<Sys> LoginHost for Sys where
 /// username / password / email login when the registry answers the web-login
 /// probe with HTTP 404 or 405. Either path may satisfy a two-factor challenge
 /// before returning.
+///
+/// The web-based flow runs without an interactive terminal — it prints the
+/// authentication URL and polls the registry until the browser approval
+/// completes. Only the classic flow's credential prompts require a TTY.
 pub async fn login<Sys, Reporter>(
     http_client: &ThrottledClient,
     opts: LoginOptions<'_>,
@@ -129,10 +133,6 @@ where
     Reporter: self::Reporter,
 {
     let registry = normalize_registry_url(opts.registry.unwrap_or(DEFAULT_REGISTRY));
-
-    if !Sys::stdin_is_tty() || !Sys::stdout_is_tty() {
-        return Err(LoginError::NonInteractive);
-    }
 
     let fetch_options = WebAuthFetchOptions {
         timeout: Some(opts.fetch_timeout),

--- a/pnpm/crates/auth-commands/src/login/classic_login.rs
+++ b/pnpm/crates/auth-commands/src/login/classic_login.rs
@@ -21,6 +21,10 @@ use super::{
 /// Prompt for username / password / email and register the user through
 /// `PUT -/user/org.couchdb.user:<name>`, satisfying an OTP challenge if the
 /// registry raises one.
+///
+/// Fails with [`LoginError::NonInteractive`] when either stdin or stdout is
+/// not a terminal: unlike the web-based flow — which only prints a URL and
+/// polls — the credential prompts need one.
 pub(super) async fn classic_login<Sys, Reporter>(
     http_client: &ThrottledClient,
     registry: &str,
@@ -40,6 +44,10 @@ where
         + 'static,
     Reporter: self::Reporter,
 {
+    if !Sys::stdin_is_tty() || !Sys::stdout_is_tty() {
+        return Err(LoginError::NonInteractive);
+    }
+
     let username = read_credential(prompt_line::<Sys>("Username:", Masking::Visible)).await?;
     let password = read_credential(prompt_line::<Sys>("Password:", Masking::Masked)).await?;
     let email =

--- a/pnpm/crates/auth-commands/src/login/error.rs
+++ b/pnpm/crates/auth-commands/src/login/error.rs
@@ -20,8 +20,8 @@ pub enum LoginError {
     InvalidResponse,
 
     #[display(
-        "The registry returned a login URL containing control characters and was rejected as a \
-         possible terminal-spoofing attempt"
+        "The registry returned an authentication URL containing control characters and was \
+         rejected as a possible terminal-spoofing attempt"
     )]
     #[diagnostic(code(ERR_PNPM_AUTH_COMMANDS_LOGIN_UNSAFE_URL))]
     UnsafeLoginUrl,

--- a/pnpm/crates/auth-commands/src/login/test_non_interactive.rs
+++ b/pnpm/crates/auth-commands/src/login/test_non_interactive.rs
@@ -1,4 +1,6 @@
-//! `login` test: the non-interactive-terminal guard.
+//! `login` test: the non-interactive-terminal guard on the classic
+//! (username / password) fallback. The web-based flow has no such guard; its
+//! non-TTY path is covered in `test_web_login`.
 
 use std::{
     cell::RefCell,
@@ -17,19 +19,28 @@ use super::{
 };
 
 #[tokio::test]
-async fn should_throw_in_non_interactive_terminal() {
+async fn should_throw_in_non_interactive_terminal_when_web_login_is_unsupported() {
     web_auth_fake!();
     login_fake!(FakeHost);
     reset();
     reset_login();
     set_stdin_tty(false);
 
+    let mut server = mockito::Server::new_async().await;
+    let login_mock = server
+        .mock("POST", "/-/v1/login")
+        .with_status(404)
+        .with_body("Not Found")
+        .create_async()
+        .await;
+    let registry = server.url();
     let config_dir = Path::new("/mock/config");
-    let err =
-        login::<FakeHost, RecordingReporter>(&client(), opts("https://example.org", config_dir))
-            .await
-            .unwrap_err();
 
+    let err = login::<FakeHost, RecordingReporter>(&client(), opts(&registry, config_dir))
+        .await
+        .unwrap_err();
+
+    login_mock.assert_async().await;
     assert!(matches!(err, LoginError::NonInteractive), "got {err:?}");
     assert_eq!(err.to_string(), "The login command requires an interactive terminal");
     assert_eq!(

--- a/pnpm/crates/auth-commands/src/login/test_web_login.rs
+++ b/pnpm/crates/auth-commands/src/login/test_web_login.rs
@@ -58,6 +58,41 @@ async fn should_use_web_login_when_registry_supports_it() {
 }
 
 #[tokio::test]
+async fn should_complete_web_login_without_an_interactive_terminal() {
+    web_auth_fake!();
+    login_fake!(FakeHost, login_writes);
+    reset();
+    reset_login();
+    set_stdin_tty(false);
+    set_stdout_tty(false);
+    set_fetch(Box::new(|| Ok(ok_token("headless-token"))));
+
+    let mut server = mockito::Server::new_async().await;
+    let login_mock = server
+        .mock("POST", "/-/v1/login")
+        .with_status(200)
+        .with_body(json!({"loginUrl": "https://example.com/auth/login", "doneUrl": "https://example.com/auth/done"}).to_string())
+        .create_async()
+        .await;
+    let registry = server.url();
+    let config_dir = Path::new("/mock/config");
+
+    let result = login::<FakeHost, RecordingReporter>(&client(), opts(&registry, config_dir))
+        .await
+        .expect("web login succeeds without a TTY");
+
+    login_mock.assert_async().await;
+    assert_eq!(result, format!("Logged in on {registry}/"));
+
+    let writes = login_writes();
+    let token_key = format!("{}:_authToken", nerf_dart(&format!("{registry}/")));
+    assert_eq!(written_settings(&writes).get(&token_key), Some("headless-token"));
+
+    // No QR code (stdout is not a terminal) and no "Press ENTER" prompt.
+    assert_eq!(infos(), ["Authenticate your account at:\nhttps://example.com/auth/login"]);
+}
+
+#[tokio::test]
 async fn should_log_in_to_a_registry_under_a_subpath_without_a_trailing_slash() {
     web_auth_fake!();
     login_fake!(FakeHost, login_writes);

--- a/pnpm/crates/auth-commands/src/login/test_web_login_errors.rs
+++ b/pnpm/crates/auth-commands/src/login/test_web_login_errors.rs
@@ -214,6 +214,37 @@ async fn should_time_out_when_the_web_auth_poll_never_completes() {
     assert_eq!(err.to_string(), "Web-based authentication timed out before it could be completed");
 }
 
+/// A non-string `loginUrl` is rejected as an invalid response by the same
+/// narrowing that catches a missing field, never reaching the URL checks.
+#[tokio::test]
+async fn should_treat_a_non_string_login_url_as_an_invalid_response() {
+    web_auth_fake!();
+    login_fake!(FakeHost);
+    reset();
+    reset_login();
+
+    let body = json!({
+        "loginUrl": 12345,
+        "doneUrl": "https://example.org/auth/done",
+    })
+    .to_string();
+    let mut server = mockito::Server::new_async().await;
+    server.mock("POST", "/-/v1/login").with_status(200).with_body(body).create_async().await;
+    let registry = server.url();
+    let config_dir = Path::new("/mock/config");
+
+    let err = login::<FakeHost, RecordingReporter>(&client(), opts(&registry, config_dir))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, LoginError::InvalidResponse), "got {err:?}");
+    assert_eq!(
+        err.pipe_ref(miette::Diagnostic::code).map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_LOGIN_INVALID_RESPONSE"),
+    );
+    assert!(infos().is_empty(), "got {:?}", infos());
+}
+
 /// A registry-controlled `loginUrl` carrying a control character is never a
 /// valid URL; the login is rejected as a possible terminal-spoofing attempt
 /// (rather than sanitized and used), and nothing reaches the terminal raw.
@@ -244,4 +275,35 @@ async fn rejects_a_login_url_containing_control_characters() {
         Some("ERR_PNPM_AUTH_COMMANDS_LOGIN_UNSAFE_URL"),
     );
     assert!(infos().iter().all(|message| !message.contains('\u{1b}')), "got {:?}", infos());
+}
+
+/// The `doneUrl` twin of the check above: a control character in the poll URL
+/// is rejected before the URL is used or anything is printed.
+#[tokio::test]
+async fn rejects_a_done_url_containing_control_characters() {
+    web_auth_fake!();
+    login_fake!(FakeHost);
+    reset();
+    reset_login();
+
+    let body = json!({
+        "loginUrl": "https://example.org/auth/login",
+        "doneUrl": "https://example.org/auth/done\r\nspoofed line",
+    })
+    .to_string();
+    let mut server = mockito::Server::new_async().await;
+    server.mock("POST", "/-/v1/login").with_status(200).with_body(body).create_async().await;
+    let registry = server.url();
+    let config_dir = Path::new("/mock/config");
+
+    let err = login::<FakeHost, RecordingReporter>(&client(), opts(&registry, config_dir))
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, LoginError::UnsafeLoginUrl), "got {err:?}");
+    assert_eq!(
+        err.pipe_ref(miette::Diagnostic::code).map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_AUTH_COMMANDS_LOGIN_UNSAFE_URL"),
+    );
+    assert!(infos().is_empty(), "got {:?}", infos());
 }

--- a/pnpm/crates/auth-commands/src/login/web_login.rs
+++ b/pnpm/crates/auth-commands/src/login/web_login.rs
@@ -1,8 +1,8 @@
 use pacquet_network::{ThrottledClient, redact_and_sanitize};
 use pacquet_network_web_auth::{
-    Clock, EnterKeyListener, OpenUrl, Sleep, StdinIsTty, WebAuthFetch, WebAuthFetchOptions,
-    WebAuthTimeoutError, WebAuthTokenPollParams, format_auth_url_message, poll_for_web_auth_token,
-    prompt_browser_open,
+    AuthUrlMessage, Clock, EnterKeyListener, OpenUrl, Sleep, StdinIsTty, StdoutIsTty, WebAuthFetch,
+    WebAuthFetchOptions, WebAuthTimeoutError, WebAuthTokenPollParams, format_auth_url_message,
+    poll_for_web_auth_token, prompt_browser_open,
 };
 use pacquet_reporter::Reporter;
 use serde_json::Value;
@@ -18,7 +18,7 @@ pub(super) async fn web_login<Sys, Reporter>(
     fetch_options: &WebAuthFetchOptions,
 ) -> Result<String, WebLoginFlowError>
 where
-    Sys: Clock + Sleep + WebAuthFetch + StdinIsTty + EnterKeyListener + OpenUrl,
+    Sys: Clock + Sleep + WebAuthFetch + StdinIsTty + StdoutIsTty + EnterKeyListener + OpenUrl,
     Reporter: self::Reporter,
 {
     let login_url = registry_join(registry, "-/v1/login")
@@ -46,7 +46,14 @@ where
         return Err(WebLoginFlowError::UnsafeUrl);
     }
 
-    global_info::<Reporter>(format_auth_url_message::<Reporter>(&auth_url).to_string());
+    // A non-TTY stdout (a CI log, a pipe) cannot render the QR code block, so
+    // print the URL on its own.
+    let auth_url_message = if Sys::stdout_is_tty() {
+        format_auth_url_message::<Reporter>(&auth_url).to_string()
+    } else {
+        AuthUrlMessage::UrlOnly { auth_url: &auth_url }.to_string()
+    };
+    global_info::<Reporter>(auth_url_message);
 
     let poll = poll_for_web_auth_token::<Sys>(WebAuthTokenPollParams {
         done_url,

--- a/pnpm/crates/cli/src/cli_args/login/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/login/tests.rs
@@ -116,8 +116,11 @@ async fn execute_performs_web_login_and_returns_the_success_message() {
 }
 
 /// `execute` propagates `login`'s non-interactive-terminal error when the fake
-/// host reports no TTY, covering the path from the config-dir guard through the
-/// HTTP-client build to the login call.
+/// host reports no TTY and the registry answers the web-login probe with 404,
+/// forcing the classic (prompting) fallback. Covers the path from the
+/// config-dir guard through the HTTP-client build to the login call; the
+/// `unreachable!` prompt impls double as proof the guard fires before any
+/// credential prompt.
 #[tokio::test]
 async fn execute_propagates_the_non_interactive_error_from_login() {
     web_auth_fake!();
@@ -125,11 +128,21 @@ async fn execute_propagates_the_non_interactive_error_from_login() {
     reset();
     set_stdin_tty(false);
 
+    let mut server = mockito::Server::new_async().await;
+    let web_login_probe = server
+        .mock("POST", "/-/v1/login")
+        .with_status(404)
+        .with_body("Not Found")
+        .create_async()
+        .await;
+    let registry = server.url();
+
     let config = Config { config_dir: Some(PathBuf::from("/mock/config")), ..Default::default() };
-    let args = LoginArgs { registry: Some("http://127.0.0.1:9/".to_owned()), scope: None };
+    let args = LoginArgs { registry: Some(registry), scope: None };
 
     let err = args.execute::<FakeHost, RecordingReporter>(&config).await.unwrap_err();
 
+    web_login_probe.assert_async().await;
     assert!(
         err.to_string().contains("requires an interactive terminal"),
         "unexpected error: {err}",

--- a/pnpm/crates/cli/tests/login.rs
+++ b/pnpm/crates/cli/tests/login.rs
@@ -1,35 +1,45 @@
 //! `pacquet login` / `pacquet adduser` — the `LoginArgs::run` adapter.
 //!
-//! A spawned `pacquet` process has no controlling TTY, so `login` must reject
-//! the non-interactive terminal before any network I/O. These tests drive the
-//! real command end-to-end through dispatch — config-directory resolution, the
-//! `ThrottledClient` construction, and the `login` call — and assert the
-//! `ERR_PNPM_LOGIN_NON_INTERACTIVE` diagnostic propagates out of `run`.
+//! These tests drive the real command end-to-end through dispatch —
+//! config-directory resolution, the `ThrottledClient` construction, and the
+//! `login` call — against a local mock registry.
 //!
-//! `XDG_CONFIG_HOME` is pinned to a temp directory so a config directory always
-//! resolves (past `run`'s `NoConfigDir` guard), and `--registry` targets a
-//! loopback port with no listener so a regression that skipped the TTY check
-//! could still never reach the real npm registry.
+//! The non-interactive guard lives on the CLASSIC (username / password)
+//! fallback, the only path that prompts on the terminal. A spawned `pacquet`
+//! process has no controlling TTY, so:
+//!
+//! - against a registry WITHOUT web-login support (404 on `POST /-/v1/login`)
+//!   the classic fallback is reached and the
+//!   `ERR_PNPM_LOGIN_NON_INTERACTIVE` diagnostic must propagate out of `run`;
+//! - against a registry WITH web-login support the flow must complete without
+//!   a terminal: print the authentication URL and poll the done endpoint for
+//!   the granted token.
+//!
+//! `XDG_CONFIG_HOME` is pinned to a temp directory so a config directory
+//! always resolves (past `run`'s `NoConfigDir` guard).
 
 use command_extra::CommandExtra;
 use pacquet_testing_utils::bin::CommandTempCwd;
 
-/// Spawn `pacquet <subcommand> --registry <closed>` without a TTY and assert it
-/// fails with the non-interactive login diagnostic.
+/// Spawn `pacquet <subcommand>` without a TTY against a classic-only registry
+/// (web login probe answers 404) and assert the non-interactive login
+/// diagnostic propagates from the classic fallback.
 fn assert_rejects_non_interactive_terminal(subcommand: &str) {
+    let mut server = mockito::Server::new();
+    let login_probe = server.mock("POST", "/-/v1/login").with_status(404).create();
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
 
     let output = pacquet
         .with_env("XDG_CONFIG_HOME", root.path())
         .with_arg(subcommand)
         .with_arg("--registry")
-        .with_arg("http://127.0.0.1:9/")
+        .with_arg(format!("{}/", server.url()))
         .output()
         .unwrap_or_else(|error| panic!("spawn pacquet {subcommand}: {error}"));
 
     assert!(
         !output.status.success(),
-        "`pacquet {subcommand}` must fail without a TTY (stderr: {})",
+        "`pacquet {subcommand}` must fail without a TTY on a classic-only registry (stderr: {})",
         String::from_utf8_lossy(&output.stderr),
     );
     let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
@@ -38,6 +48,7 @@ fn assert_rejects_non_interactive_terminal(subcommand: &str) {
             && stderr.contains("requires an interactive terminal"),
         "stderr must name the non-interactive diagnostic; got:\n{stderr}",
     );
+    login_probe.assert();
     drop(root);
 }
 
@@ -49,4 +60,49 @@ fn login_rejects_a_non_interactive_terminal() {
 #[test]
 fn adduser_alias_rejects_a_non_interactive_terminal() {
     assert_rejects_non_interactive_terminal("adduser");
+}
+
+/// Spawn `pacquet login` without a TTY against a registry WITH web-login
+/// support and assert the headless web flow completes: the authentication URL
+/// is printed and the done endpoint's token is accepted.
+#[test]
+fn login_completes_the_web_flow_without_a_terminal() {
+    let mut server = mockito::Server::new();
+    let registry = server.url();
+    let done = server
+        .mock("GET", "/-/v1/done")
+        .with_status(200)
+        .with_body(r#"{"token":"cli-headless-token"}"#)
+        .create();
+    let login = server
+        .mock("POST", "/-/v1/login")
+        .with_status(200)
+        .with_body(format!(
+            r#"{{"loginUrl":"{registry}/auth/login","doneUrl":"{registry}/-/v1/done"}}"#,
+        ))
+        .create();
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet
+        .with_env("XDG_CONFIG_HOME", root.path())
+        .with_arg("login")
+        .with_arg("--registry")
+        .with_arg(format!("{registry}/"))
+        .output()
+        .unwrap_or_else(|error| panic!("spawn pacquet login: {error}"));
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        output.status.success(),
+        "`pacquet login` must complete the web flow without a TTY (stdout: {stdout})(stderr: {stderr})",
+    );
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains(&format!("{registry}/auth/login")),
+        "the authentication URL must be printed for the human to open; got:\n{combined}",
+    );
+    login.assert();
+    done.assert();
+    drop(root);
 }

--- a/pnpm11/auth/commands/src/login.ts
+++ b/pnpm11/auth/commands/src/login.ts
@@ -9,6 +9,7 @@ import { globalInfo, globalWarn } from '@pnpm/logger'
 import { fetch } from '@pnpm/network.fetch'
 import {
   formatAuthUrlMessage,
+  formatAuthUrlOnlyMessage,
   pollForWebAuthToken,
   promptBrowserOpen,
   type PromptBrowserOpenReadlineInterface,
@@ -156,16 +157,11 @@ export interface LoginParams {
 
 export async function login ({ context = DEFAULT_CONTEXT, opts }: LoginParams): Promise<string> {
   const {
-    process,
     readIniFile,
     writeIniFile,
   } = context
 
   const registry = normalizeRegistryUrl(opts.registry ?? 'https://registry.npmjs.org/')
-
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    throw new LoginNonInteractiveError()
-  }
 
   const fetchOptions: WebAuthFetchOptions = {
     method: 'GET',
@@ -204,6 +200,31 @@ export async function login ({ context = DEFAULT_CONTEXT, opts }: LoginParams): 
   return `Logged in on ${registry}`
 }
 
+/**
+ * The non-empty string at `field` of a web-login response body, or
+ * `undefined` when the body is not an object or the field is missing, empty,
+ * or not a string — the same narrowing pacquet applies via `Value::as_str`.
+ */
+function readUrlField (body: unknown, field: 'loginUrl' | 'doneUrl'): string | undefined {
+  if (typeof body !== 'object' || body == null) return undefined
+  const value = (body as Record<string, unknown>)[field]
+  return typeof value === 'string' && value !== '' ? value : undefined
+}
+
+/**
+ * Whether `url` contains a Unicode control character (the C0 controls, DEL,
+ * or the C1 controls) — the same set pacquet rejects via `char::is_control`.
+ */
+function containsControlCharacters (url: string): boolean {
+  for (const char of url) {
+    const codePoint = char.codePointAt(0) ?? 0
+    if (codePoint <= 0x1F || (codePoint >= 0x7F && codePoint <= 0x9F)) {
+      return true
+    }
+  }
+  return false
+}
+
 function normalizeScope (scope: string | undefined): string | undefined {
   if (scope == null) return undefined
   const trimmed = scope.trim()
@@ -226,6 +247,7 @@ async function webLogin ({
     fetch,
     globalInfo,
     globalWarn,
+    process,
   } = context
 
   const loginUrl = new URL('-/v1/login', registry).href
@@ -245,18 +267,35 @@ async function webLogin ({
     throw new WebLoginError(response.status, text)
   }
 
-  const body = await response.json() as { loginUrl?: string, doneUrl?: string }
+  // The response body is attacker-controlled, so narrow it at runtime: a
+  // missing, empty, or non-string field rejects the response.
+  const body = await response.json() as unknown
+  const authUrl = readUrlField(body, 'loginUrl')
+  const doneUrl = readUrlField(body, 'doneUrl')
 
-  if (!body.loginUrl || !body.doneUrl) {
+  if (!authUrl || !doneUrl) {
     throw new LoginInvalidResponseError()
   }
 
-  globalInfo(formatAuthUrlMessage(body.loginUrl, globalWarn))
+  // A legitimate login / done URL is a plain URL; a control character (a
+  // terminal escape, CR, or LF) is never valid in one and signals a malicious
+  // or compromised registry trying to spoof the terminal. Reject the login so
+  // the user learns the registry misbehaved, rather than sanitizing the URL
+  // and authenticating against it anyway.
+  if (containsControlCharacters(authUrl) || containsControlCharacters(doneUrl)) {
+    throw new UnsafeLoginUrlError()
+  }
 
-  const pollPromise = pollForWebAuthToken({ context, doneUrl: body.doneUrl, fetchOptions })
+  // A non-TTY stdout (a CI log, a pipe) cannot render the QR code block, so
+  // print the URL on its own.
+  globalInfo(process.stdout.isTTY
+    ? formatAuthUrlMessage(authUrl, globalWarn)
+    : formatAuthUrlOnlyMessage(authUrl))
+
+  const pollPromise = pollForWebAuthToken({ context, doneUrl, fetchOptions })
 
   return promptBrowserOpen({
-    authUrl: body.loginUrl,
+    authUrl,
     context,
     pollPromise,
   })
@@ -273,7 +312,13 @@ async function classicLogin ({
   fetchOptions,
   registry,
 }: ClassicLoginParams): Promise<string> {
-  const { enquirer, fetch, globalInfo, globalWarn } = context
+  const { enquirer, fetch, globalInfo, globalWarn, process } = context
+
+  // Unlike the web-based flow — which only prints a URL and polls, so it runs
+  // without a terminal — the credential prompts need one.
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new LoginNonInteractiveError()
+  }
 
   let username: string
   let password: string
@@ -336,6 +381,12 @@ class LoginNonInteractiveError extends PnpmError {
 class LoginInvalidResponseError extends PnpmError {
   constructor () {
     super('LOGIN_INVALID_RESPONSE', 'The registry returned an invalid response for web-based login')
+  }
+}
+
+class UnsafeLoginUrlError extends PnpmError {
+  constructor () {
+    super('AUTH_COMMANDS_LOGIN_UNSAFE_URL', 'The registry returned an authentication URL containing control characters and was rejected as a possible terminal-spoofing attempt')
   }
 }
 

--- a/pnpm11/auth/commands/test/login.test.ts
+++ b/pnpm11/auth/commands/test/login.test.ts
@@ -83,16 +83,72 @@ const createMockContext = (overrides?: MockContextOverrides): LoginContext => ({
 })
 
 describe('login', () => {
-  it('should throw in non-interactive terminal', async () => {
+  it('should throw in non-interactive terminal when the registry does not support web login', async () => {
     const context = createMockContext({
       process: {
         stdin: { isTTY: false },
       },
+      fetch: async url => {
+        if (url === 'https://example.org/-/v1/login') {
+          return createMockResponse({
+            ok: false,
+            status: 404,
+            text: 'Not Found',
+          })
+        }
+        throw new Error(`Unexpected call to fetch: ${url}`)
+      },
     })
-    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {} }
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://example.org' }
     const promise = login({ context, opts })
     await expect(promise).rejects.toHaveProperty(['code'], 'ERR_PNPM_LOGIN_NON_INTERACTIVE')
     await expect(promise).rejects.toHaveProperty(['message'], 'The login command requires an interactive terminal')
+  })
+
+  it('should complete web login without an interactive terminal', async () => {
+    const globalInfo = jest.fn()
+    let savedSettings: Record<string, unknown> = {}
+    const context = createMockContext({
+      globalInfo,
+      process: {
+        stdin: { isTTY: false },
+        stdout: { isTTY: false },
+      },
+      readIniFile: async () => ({}),
+      writeIniFile: async (_configPath, settings) => {
+        savedSettings = settings
+      },
+      fetch: async url => {
+        if (url === 'https://example.com/npm/-/v1/login') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: {
+              loginUrl: 'https://example.com/auth/login',
+              doneUrl: 'https://example.com/auth/done',
+            },
+          })
+        }
+        if (url === 'https://example.com/auth/done') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: { token: 'headless-token' },
+          })
+        }
+        throw new Error(`Unexpected call to fetch: ${url}`)
+      },
+    })
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://example.com/npm/' }
+    const result = await login({ context, opts })
+    expect(result).toBe('Logged in on https://example.com/npm/')
+    expect(savedSettings).toMatchObject({
+      '//example.com/npm/:_authToken': 'headless-token',
+    })
+    // No QR code (stdout is not a terminal) and no "Press ENTER" prompt.
+    expect(globalInfo.mock.calls).toEqual([
+      ['Authenticate your account at:\nhttps://example.com/auth/login'],
+    ])
   })
 
   it('should use web login when registry supports it', async () => {
@@ -718,6 +774,72 @@ describe('login', () => {
     const promise = login({ context, opts })
     await expect(promise).rejects.toHaveProperty(['code'], 'ERR_PNPM_LOGIN_INVALID_RESPONSE')
     await expect(promise).rejects.toHaveProperty(['message'], 'The registry returned an invalid response for web-based login')
+  })
+
+  it('should treat a non-string loginUrl as an invalid response', async () => {
+    const context = createMockContext({
+      fetch: async url => {
+        if (url === 'https://example.org/-/v1/login') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: {
+              loginUrl: 12345,
+              doneUrl: 'https://example.org/auth/done',
+            },
+          })
+        }
+        throw new Error(`Unexpected call to fetch: ${url}`)
+      },
+    })
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://example.org' }
+    const promise = login({ context, opts })
+    await expect(promise).rejects.toHaveProperty(['code'], 'ERR_PNPM_LOGIN_INVALID_RESPONSE')
+  })
+
+  it('should reject a login URL containing control characters', async () => {
+    // The default TEST_CONTEXT globalInfo throws, so this also asserts the
+    // URL is rejected before anything is printed.
+    const context = createMockContext({
+      fetch: async url => {
+        if (url === 'https://example.org/-/v1/login') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: {
+              loginUrl: 'https://example.org/auth/\u001b[31mlogin',
+              doneUrl: 'https://example.org/auth/done',
+            },
+          })
+        }
+        throw new Error(`Unexpected call to fetch: ${url}`)
+      },
+    })
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://example.org' }
+    const promise = login({ context, opts })
+    await expect(promise).rejects.toHaveProperty(['code'], 'ERR_PNPM_AUTH_COMMANDS_LOGIN_UNSAFE_URL')
+    await expect(promise).rejects.toHaveProperty(['message'], 'The registry returned an authentication URL containing control characters and was rejected as a possible terminal-spoofing attempt')
+  })
+
+  it('should reject a done URL containing control characters', async () => {
+    const context = createMockContext({
+      fetch: async url => {
+        if (url === 'https://example.org/-/v1/login') {
+          return createMockResponse({
+            ok: true,
+            status: 200,
+            json: {
+              loginUrl: 'https://example.org/auth/login',
+              doneUrl: 'https://example.org/auth/done\r\nspoofed line',
+            },
+          })
+        }
+        throw new Error(`Unexpected call to fetch: ${url}`)
+      },
+    })
+    const opts = { configDir: '/mock/config', dir: '/mock', authConfig: {}, registry: 'https://example.org' }
+    const promise = login({ context, opts })
+    await expect(promise).rejects.toHaveProperty(['code'], 'ERR_PNPM_AUTH_COMMANDS_LOGIN_UNSAFE_URL')
   })
 
   it('should fall back to classic login when web login returns 405', async () => {

--- a/pnpm11/network/web-auth/src/formatAuthUrlMessage.ts
+++ b/pnpm11/network/web-auth/src/formatAuthUrlMessage.ts
@@ -15,7 +15,15 @@ export function formatAuthUrlMessage (authUrl: string, globalWarn: (message: str
     qrCode = generateQrCode(authUrl)
   } catch (err) {
     globalWarn(`Could not generate a QR code: ${String(err)}`)
-    return `Authenticate your account at:\n${authUrl}`
+    return formatAuthUrlOnlyMessage(authUrl)
   }
-  return `Authenticate your account at:\n${authUrl}\n\n${qrCode}`
+  return `${formatAuthUrlOnlyMessage(authUrl)}\n\n${qrCode}`
+}
+
+/**
+ * Formats the "Authenticate your account at" message without a QR code — for
+ * output that is not a terminal and cannot render one.
+ */
+export function formatAuthUrlOnlyMessage (authUrl: string): string {
+  return `Authenticate your account at:\n${authUrl}`
 }

--- a/pnpm11/network/web-auth/src/index.ts
+++ b/pnpm11/network/web-auth/src/index.ts
@@ -1,4 +1,4 @@
-export { formatAuthUrlMessage } from './formatAuthUrlMessage.js'
+export { formatAuthUrlMessage, formatAuthUrlOnlyMessage } from './formatAuthUrlMessage.js'
 export { generateQrCode } from './generateQrCode.js'
 export {
   pollForWebAuthToken,

--- a/pnpm11/network/web-auth/test/formatAuthUrlMessage.test.ts
+++ b/pnpm11/network/web-auth/test/formatAuthUrlMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals'
-import { formatAuthUrlMessage, generateQrCode } from '@pnpm/network.web-auth'
+import { formatAuthUrlMessage, formatAuthUrlOnlyMessage, generateQrCode } from '@pnpm/network.web-auth'
 
 describe('formatAuthUrlMessage', () => {
   it('appends a QR code when one can be generated', () => {
@@ -18,5 +18,12 @@ describe('formatAuthUrlMessage', () => {
     const message = formatAuthUrlMessage(longAuthUrl, msg => warnings.push(msg))
     expect(message).toBe(`Authenticate your account at:\n${longAuthUrl}`)
     expect(warnings).toStrictEqual([expect.stringContaining('Could not generate a QR code:')])
+  })
+})
+
+describe('formatAuthUrlOnlyMessage', () => {
+  it('formats the message without a QR code', () => {
+    const authUrl = 'https://example.com/auth'
+    expect(formatAuthUrlOnlyMessage(authUrl)).toBe(`Authenticate your account at:\n${authUrl}`)
   })
 })


### PR DESCRIPTION
## What this changes

`pnpm login` currently refuses to run at all when it is not attached to a terminal. This PR narrows that refusal so it only applies to the one login path that genuinely needs a terminal — the classic username/password prompt. The browser-based web login, the default flow for npmjs.com and other modern registries, now works from a shell with no TTY: it prints the authentication URL and waits for you to approve in a browser, exactly as it already does interactively.

## Why the guard is in the wrong place

From a CI job or any other shell without a TTY, `pnpm login` exits immediately with `ERR_PNPM_LOGIN_NON_INTERACTIVE — The login command requires an interactive terminal`. The guard sits at the top of the command, before pnpm even asks which login flow the registry supports. But the web flow — the shape npm's `--auth-type=web` (the default since npm 9) established — only prints a URL and polls the registry's "done" endpoint until the browser approval lands; neither step reads from the terminal, and pnpm's `promptBrowserOpen` already skips the "Press ENTER" prompt when stdin is not a TTY. Wrapping pnpm in a pseudo-terminal (`script -q /dev/null pnpm login`) proves it: the login completes through the browser without a single keypress. If a fake terminal is all it takes, the guard is in the wrong place.

## The change

The guard moves from the top of the `login` command into the classic username/password fallback, the only path that prompts on the terminal:

| Situation | Before | After |
| --- | --- | --- |
| Terminal attached, registry supports web login | URL + QR code printed, browser opens, poll completes | unchanged |
| **No terminal, registry supports web login** | hard error `ERR_PNPM_LOGIN_NON_INTERACTIVE` | URL printed (no QR — block art cannot render into a pipe or file), poll completes, exit code reflects the poll result |
| No terminal, registry only supports username/password | hard error | same hard error, now raised by the classic path itself |

No new flag is needed: plain TTY detection decides, which matches how the rest of this command already behaves.

Review hardening folded in: the TypeScript side now rejects registry-supplied `loginUrl`/`doneUrl` values containing control characters and narrows the response body at runtime, matching pacquet (details below). CI note: the `zizmor` failure is pre-existing — a `ref-version-mismatch` on the pinned `winget-releaser` commit in `update-latest.yml`, which is no longer reachable from any named ref upstream, so no version comment can describe it accurately; this PR acknowledges it with the repository's usual inline ignore rather than silently re-pointing the pin at different code.

<details>
<summary>Test evidence (all run locally, all green)</summary>

- `cargo test -p pacquet-auth-commands` — 61 passed, 0 failed: the reworked non-interactive guard test (now expected on the classic-fallback path), a new headless web-login test, and the control-character/invalid-response rejection tests.
- `cargo test -p pacquet-network-web-auth` — 81 passed, 0 failed.
- `cargo test -p pacquet-cli --lib cli_args::login` — 5 passed, 0 failed (the adapter test now drives the guard through a 404 web-login probe).
- `cargo test -p pacquet-cli --test login` — 3 passed, 0 failed: both spawned-binary guard tests reworked to the classic-only mock registry, plus a new end-to-end headless web-login test.
- `pnpm test` in `pnpm11/auth/commands` — 38 passed, 0 failed (2 suites), including the new non-TTY, control-character, and malformed-field tests.
- `pnpm test` in `pnpm11/network/web-auth` — 72 passed, 0 failed (6 suites).
- `cargo fmt --check` and `cargo clippy --all-targets` are clean on the changed crates, and the repository's pre-push hook additionally ran the full-workspace clippy, rustdoc, TypeScript compile, eslint, cspell, and meta-updater checks before accepting the push.

</details>

<details>
<summary>Implementation notes (both stacks, per AGENTS.md)</summary>

- **TypeScript** — in `@pnpm/auth.commands`, the guard moves into `classicLogin`, and `webLogin` prints a URL-only message when stdout is not a TTY. To support that, `@pnpm/network.web-auth` gains a `formatAuthUrlOnlyMessage` export, the URL-only half of the existing `formatAuthUrlMessage`, mirroring the shape the Rust side already models.
- **Rust** — in `pacquet-auth-commands`, the same guard moves into `classic_login`, and `web_login` selects the existing `AuthUrlMessage::UrlOnly` variant when stdout is not a TTY.
- **Untrusted-registry hardening (from review)** — the TypeScript web-login path now mirrors pacquet's control-character rejection: a `loginUrl` or `doneUrl` containing a C0 control, DEL, or a C1 control fails the login with pacquet's `ERR_PNPM_AUTH_COMMANDS_LOGIN_UNSAFE_URL` before anything is printed or polled, and the response body is narrowed at runtime (a missing, empty, or non-string field is `ERR_PNPM_LOGIN_INVALID_RESPONSE`, matching pacquet's `Value::as_str` narrowing). The shared error message now says "authentication URL" in both stacks since the check covers both fields.
- The QR code is suppressed in the non-TTY case deliberately: block art only makes sense on a real terminal, and the URL alone completes the flow, including from another device.
- The separate non-interactive gate in `withOtpHandling` (`ERR_PNPM_OTP_NON_INTERACTIVE`, used by publish-style flows) is intentionally untouched; the login command's classic path now owns its own terminal requirement.
- A changeset is included (`minor` for `@pnpm/auth.commands`, `@pnpm/network.web-auth`, `pnpm`, and `pacquet`).

</details>

The pnpm.io documentation for `pnpm login` should probably gain a sentence saying the web flow works without a terminal; I am happy to open that follow-up PR once this lands.

## Squash Commit Body

```text
pnpm login refused to run whenever stdin or stdout was not a TTY, even
though the registry web-auth flow only prints an authentication URL and
polls the done endpoint until the browser approval completes - neither
needs a terminal. Agent- and CI-adjacent tooling had to wrap pnpm in a
pseudo-terminal (script -q /dev/null pnpm login) to use the web flow.

Move the non-interactive guard from the top of the login command into
the classic username/password fallback, the only path that prompts on
the terminal. Without a TTY the web flow now prints the authentication
URL and polls as before; the URL is printed without the QR code (a
piped stdout cannot render the block art), and the press-ENTER browser
prompt was already skipped for a non-TTY stdin. A registry without web
login support still fails with ERR_PNPM_LOGIN_NON_INTERACTIVE.

Harden the TypeScript web-login path to match pacquet while touching
it: narrow the attacker-controlled response body at runtime (a missing,
empty, or non-string loginUrl/doneUrl is an invalid response), and
reject URLs containing Unicode control characters with pacquet's
ERR_PNPM_AUTH_COMMANDS_LOGIN_UNSAFE_URL before anything is printed or
polled. The shared error message now says "authentication URL" in both
stacks, since the check covers loginUrl and doneUrl alike.

Implemented in both stacks: the TypeScript CLI moves the guard into
classicLogin and prints a URL-only message via the new
formatAuthUrlOnlyMessage export of the web-auth package; pacquet moves
the same guard into classic_login and selects AuthUrlMessage::UrlOnly
when stdout is not a TTY. The pacquet CLI adapter unit test and the
CLI-tier integration tests now drive the guard through a 404 web-login
probe so it exercises the classic fallback, and a new integration test
covers the headless web flow end-to-end against a mock registry.

Also acknowledge a pre-existing zizmor ref-version-mismatch finding on
the winget-releaser pin in update-latest.yml with the repository's
usual inline ignore: the pinned commit is no longer reachable from any
named ref upstream, so no version comment can describe it accurately.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed — the `pnpm login` page on pnpm.io
  should mention the non-interactive web flow; follow-up PR offered above.

---
Written by an agent (Claude Code, claude-fable-5).
