### PR TITLE
chore: update dependencies, Node.js, pnpm, and GitHub Actions

### DIFF
--- a/.github/actions/binstall/action.yml
+++ b/.github/actions/binstall/action.yml
@@ -12,7 +12,7 @@ runs:
 
   steps:
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-binstall
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install pnpm and Node
       uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
-        runtime: node@26.5.0
+        runtime: node@26.5.1
 
     - name: Install Rust Toolchain
       uses: ./.github/actions/rustup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
             test_chunk: '1'
             test_chunk_total: '1'
             garnet: true
-          - node: '26.5.0'
+          - node: '26.5.1'
             node_major: '26'
             platform: blacksmith-8vcpu-ubuntu-2404
             platform_label: ubuntu

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -59,7 +59,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -73,4 +73,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,7 +93,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GHCR
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pacquet-cargo-unused.yml
+++ b/.github/workflows/pacquet-cargo-unused.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/rustup
 
       - name: Install cargo-unused-features
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-unused-features
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install cargo-udeps
         if: steps.filter.outputs.src == 'true'
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-udeps
 

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -149,7 +149,7 @@ jobs:
         continue-on-error: true
 
       - name: Install just
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: just
 
@@ -157,7 +157,7 @@ jobs:
         run: just install
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-nextest
 
@@ -308,7 +308,7 @@ jobs:
 
       - name: Install cargo-deny
         if: github.event_name == 'merge_group' || steps.filter.outputs.src == 'true'
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-deny
 

--- a/.github/workflows/pacquet-codecov.yml
+++ b/.github/workflows/pacquet-codecov.yml
@@ -65,12 +65,12 @@ jobs:
         uses: ./.github/actions/rustup
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-llvm-cov
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cargo-nextest
 
@@ -93,7 +93,7 @@ jobs:
         continue-on-error: true
 
       - name: Install just
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: just
 

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -244,7 +244,7 @@ jobs:
           packages: hyperfine@1.18.0
 
       - name: Install just
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: just
 

--- a/.github/workflows/pacquet-micro-benchmark.yml
+++ b/.github/workflows/pacquet-micro-benchmark.yml
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Install critcmp
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: critcmp
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install pnpm and Node
         uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
-          runtime: node@26.5.0
+          runtime: node@26.5.1
       - name: Build TypeScript executable artifacts
         run: pn --filter=@pnpm/exe run build-artifacts
 
@@ -353,7 +353,7 @@ jobs:
       - name: Install pnpm and Node
         uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
-          runtime: node@26.5.0
+          runtime: node@26.5.1
       # The publish phase is split into three sequential steps to control which packages
       # use trusted publishing (OIDC) vs. a static token. `pnpm publish` currently bails
       # out of OIDC as soon as a static `_authToken` is configured, so the only way to
@@ -491,7 +491,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cross
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cross
 
@@ -951,7 +951,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cross
-        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        uses: taiki-e/install-action@065d6a08a14e61e89fb0a4c10eecdbdef39c7d8e # v2.85.4
         with:
           tool: cross
 
@@ -1293,7 +1293,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GHCR
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Triage with Oz agent
-        uses: warpdotdev/oz-agent-action@851b4af8e23dbc2c9558ab0e240c589b0f59e490 # v1.0.26
+        uses: warpdotdev/oz-agent-action@99833e32658973924e0e3184120f697882f71e0b # v1.0.27
         id: triage
         timeout-minutes: 20
         env:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-branch": "pn pretest && pn lint && git remote set-branches --add origin main && git fetch origin main && pn test-pkgs-branch",
     "ci:test-branch": "pn prepare-fixtures && pn test-pkgs-branch",
     "test-pkgs-branch": "pn remove-temp-dir && pn --workspace-concurrency=1 --filter=...[origin/main] --no-sort --if-present .test",
-    "compile-only": "tsgo --build pnpm11/workspace/workspace-manifest-reader pnpm11/workspace/projects-reader && pnx node@runtime:26.5.0 pnpm11/__utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
+    "compile-only": "tsgo --build pnpm11/workspace/workspace-manifest-reader pnpm11/workspace/projects-reader && pnx node@runtime:26.5.1 pnpm11/__utils__/scripts/src/typecheck-only.ts && pn -F=pnpm compile",
     "compile": "pn compile-only && pn update-manifests",
     "build:pnpm": "cargo build --release --bin pnpm",
     "make-lcov": "shx mkdir -p coverage && lcov-result-merger 'pnpm11/**/coverage/lcov.info' 'coverage/lcov.info'",
@@ -59,16 +59,16 @@
     "shx": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@12.0.0-beta.0",
+  "packageManager": "pnpm@12.0.0-beta.1",
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "12.0.0-beta.0",
+      "version": "12.0.0-beta.1",
       "onFail": "download"
     },
     "runtime": {
       "name": "node",
-      "version": "26.5.0",
+      "version": "26.5.1",
       "onFail": "download"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,115 +7,115 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 12.0.0-beta.0
-        version: 12.0.0-beta.0
+        specifier: 12.0.0-beta.1
+        version: 12.0.0-beta.1
       pnpm:
-        specifier: 12.0.0-beta.0
-        version: 12.0.0-beta.0
+        specifier: 12.0.0-beta.1
+        version: 12.0.0-beta.1
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-beta.0':
-    resolution: {integrity: sha512-4SD+m77kd+MDmYRlLJ+oD0vI5h5nVerb6R0ROoc50gn6+5b8qKMT93HCyBrEGsoXoTypnPdJMYEgY0IYZJYqFw==}
+  '@pnpm/exe.darwin-arm64@12.0.0-beta.1':
+    resolution: {integrity: sha512-8vye6K8E9N6BF7FQF5mUuCEbuRij0Ss+9UEZ+4kqMSEjF1lGDJSuiUDnJdd7MqmuXqPnf42bRrcQAi4qmMyBhA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.0.0-beta.0':
-    resolution: {integrity: sha512-I4+Y/jlkfoaO1Smddjo1nWz9QWl5wlPUsAR2GBYkK2xX3NPkQ3GABfCllOquFHmbE7/N07S6YdNToKlaL7hrmQ==}
+  '@pnpm/exe.darwin-x64@12.0.0-beta.1':
+    resolution: {integrity: sha512-ovRhBE4iy/HC2IHugeTMhuLQYKeFEiNU+N8zlUX0WYTQyCHhR7ijQ4VB0n+YGfsGiL65pSYAqozJnsqFIiWajA==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-beta.0':
-    resolution: {integrity: sha512-lNrx63U1BiyxQc/Qvwyb+yxTm2ngLYXpmaX+xeD06BneuryRL/FIaJNObTxSJDerg99dFw2LiBfRRjGoPjZI0w==}
+  '@pnpm/exe.linux-arm64-musl@12.0.0-beta.1':
+    resolution: {integrity: sha512-Ey+cWXAqZiMofihJxXW9i5NNhvqNG2vMTK/OioLlEMiyOCZyoAt1bVF7JMW6hWpYHhoiCS8N23HZP79njZzVmg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.0.0-beta.0':
-    resolution: {integrity: sha512-H4LO3S8CIwuaiT96LH0vd8M4NhEPwRJ6RBu5EiHwM4WOxR4WJS15K8HvcEqIrEcqe4VbcwsW3ORYcyTfQpaoQw==}
+  '@pnpm/exe.linux-arm64@12.0.0-beta.1':
+    resolution: {integrity: sha512-zzr0AaHn60mzo2i73ssMVS9EnEBY8yQ7CbhEm7H/5SBYkgR/Bwp00/rvtVfpm4al8DpmoP8k2oexyPd59hPsGg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-beta.0':
-    resolution: {integrity: sha512-AXEBIuzBjf67a2Pbvst9kjdXuQg66UfqYVC4STB1qrWXAgTgo1h+SI/3gwaYS1+VYphqdNSLIVeoP7LkW3NO0A==}
+  '@pnpm/exe.linux-x64-musl@12.0.0-beta.1':
+    resolution: {integrity: sha512-HEWHIQ/R/kzvPynMFGv9IjoZnNXupyXf/C//Dpgz3lMXGJQRJRKRzr4/9WbB7Yx2TzSgut/SCdWt/1wfZCoBMw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.0.0-beta.0':
-    resolution: {integrity: sha512-B1DLP2mEYfO2+vFnQKdPz/7DJ6+gpP9OHN0CN2a0AQg6ujWNsej+hSDM3lM7fNq2i2h7cYX7+YV/9qnXzZyuJw==}
+  '@pnpm/exe.linux-x64@12.0.0-beta.1':
+    resolution: {integrity: sha512-GftlzkN9hQfqadEhQpzdDyT24uEVJK8SqQtu/aIYscaP1gbn6hf9vgeju6n/juVZPB4gt2tr3KtailSjDwP1jg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.0.0-beta.0':
-    resolution: {integrity: sha512-l71yiuwQrRtPo4Dg8sx2eLz5V5JhGy4p6fwH4EDTOhOFcMPoFiOECsUgx7FB+Gm3YGj6aK8QxOWeCMSf6VHTRQ==}
+  '@pnpm/exe.win32-arm64@12.0.0-beta.1':
+    resolution: {integrity: sha512-OujEPfyDbclhUY6lFJdEovz/Gr6eP/Mrlr3SeQgZnnlx7Ti1vd9M89cebQRYxfVg0meXP1TIwziIkIqZmCKeCw==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.0.0-beta.0':
-    resolution: {integrity: sha512-veFo6sbnqcClJU6BUoJW0C5b9SXfJxArqOXyNbIlrGw/THs1flPq85RB0u1OxeqGv8FUJbYb5lB1DjRU3ke2+A==}
+  '@pnpm/exe.win32-x64@12.0.0-beta.1':
+    resolution: {integrity: sha512-77fXIkk41hC8WsOEFtSZdPEiVNPixW94aRYOYW/r+8zpPJSMbHZx6oFSrVkZmLX9cbmUQ4LC+CV3AT9RnddBwA==}
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0-beta.0':
-    resolution: {integrity: sha512-qn9r22lI+RImUOyXPw+N5LTcV02RxR6IKVwd+WFZGCVeEGdv/nKjzLsxoWSlEkjWLH7eqdEVQ+bwMbV07MShtQ==}
+  '@pnpm/exe@12.0.0-beta.1':
+    resolution: {integrity: sha512-a8P3V65xsF9XgsnGXealxzJdUpjo/G6sqaq7jJ3MM7q2zMMNwNX7Mn5Z04m0ov1oO2X2SfbrjjVdSYFuGq3+SA==}
     engines: {node: '>=18.*'}
     hasBin: true
 
-  pnpm@12.0.0-beta.0:
-    resolution: {integrity: sha512-7embBf5LfXQU1+62tBT8rJj7rWJlOLKDdei6FWI29VPPl+dsDSdA4TilU6KNzt0iWDG7sr+XxVP4WZkNQYXCFg==}
+  pnpm@12.0.0-beta.1:
+    resolution: {integrity: sha512-Y5ip1gQ0FzmFQnZiA3frjhXVOAkRcGKTB9oe1AstEWFHg3hoHnb3FC967E0gq55Lj3LS44rjQJdjKetU7zJelQ==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-beta.0':
+  '@pnpm/exe.darwin-arm64@12.0.0-beta.1':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.0.0-beta.0':
+  '@pnpm/exe.darwin-x64@12.0.0-beta.1':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.0.0-beta.0':
+  '@pnpm/exe.linux-arm64-musl@12.0.0-beta.1':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.0.0-beta.0':
+  '@pnpm/exe.linux-arm64@12.0.0-beta.1':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.0.0-beta.0':
+  '@pnpm/exe.linux-x64-musl@12.0.0-beta.1':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.0.0-beta.0':
+  '@pnpm/exe.linux-x64@12.0.0-beta.1':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.0.0-beta.0':
+  '@pnpm/exe.win32-arm64@12.0.0-beta.1':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.0.0-beta.0':
+  '@pnpm/exe.win32-x64@12.0.0-beta.1':
     optional: true
 
-  '@pnpm/exe@12.0.0-beta.0':
+  '@pnpm/exe@12.0.0-beta.1':
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-beta.0
-      '@pnpm/exe.darwin-x64': 12.0.0-beta.0
-      '@pnpm/exe.linux-arm64': 12.0.0-beta.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-beta.0
-      '@pnpm/exe.linux-x64': 12.0.0-beta.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0-beta.0
-      '@pnpm/exe.win32-arm64': 12.0.0-beta.0
-      '@pnpm/exe.win32-x64': 12.0.0-beta.0
+      '@pnpm/exe.darwin-arm64': 12.0.0-beta.1
+      '@pnpm/exe.darwin-x64': 12.0.0-beta.1
+      '@pnpm/exe.linux-arm64': 12.0.0-beta.1
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-beta.1
+      '@pnpm/exe.linux-x64': 12.0.0-beta.1
+      '@pnpm/exe.linux-x64-musl': 12.0.0-beta.1
+      '@pnpm/exe.win32-arm64': 12.0.0-beta.1
+      '@pnpm/exe.win32-x64': 12.0.0-beta.1
 
-  pnpm@12.0.0-beta.0:
+  pnpm@12.0.0-beta.1:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-beta.0
-      '@pnpm/exe.darwin-x64': 12.0.0-beta.0
-      '@pnpm/exe.linux-arm64': 12.0.0-beta.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-beta.0
-      '@pnpm/exe.linux-x64': 12.0.0-beta.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0-beta.0
-      '@pnpm/exe.win32-arm64': 12.0.0-beta.0
-      '@pnpm/exe.win32-x64': 12.0.0-beta.0
+      '@pnpm/exe.darwin-arm64': 12.0.0-beta.1
+      '@pnpm/exe.darwin-x64': 12.0.0-beta.1
+      '@pnpm/exe.linux-arm64': 12.0.0-beta.1
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-beta.1
+      '@pnpm/exe.linux-x64': 12.0.0-beta.1
+      '@pnpm/exe.linux-x64-musl': 12.0.0-beta.1
+      '@pnpm/exe.win32-arm64': 12.0.0-beta.1
+      '@pnpm/exe.win32-x64': 12.0.0-beta.1
 
 ---
 lockfileVersion: '9.0'
@@ -337,17 +337,17 @@ catalogs:
       specifier: 7.0.0-dev.20260707.2
       version: 7.0.0-dev.20260707.2
     '@yarnpkg/core':
-      specifier: 4.9.0
-      version: 4.9.0
+      specifier: 4.9.1
+      version: 4.9.1
     '@yarnpkg/extensions':
-      specifier: 2.0.6
-      version: 2.0.6
+      specifier: 2.0.7
+      version: 2.0.7
     '@yarnpkg/lockfile':
       specifier: ^1.1.0
       version: 1.1.0
     '@yarnpkg/nm':
-      specifier: 4.1.0
-      version: 4.1.0
+      specifier: 4.1.1
+      version: 4.1.1
     '@yarnpkg/pnp':
       specifier: ^4.1.7
       version: 4.1.7
@@ -595,8 +595,8 @@ catalogs:
       specifier: ^4.0.8
       version: 4.0.8
     msgpackr:
-      specifier: 2.0.4
-      version: 2.0.4
+      specifier: 2.0.5
+      version: 2.0.5
     nm-prune:
       specifier: ^5.0.0
       version: 5.0.0
@@ -985,8 +985,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.0
       node:
-        specifier: runtime:26.5.0
-        version: runtime:26.5.0
+        specifier: runtime:26.5.1
+        version: runtime:26.5.1
       rimraf:
         specifier: 'catalog:'
         version: 6.1.3
@@ -5061,7 +5061,7 @@ importers:
         version: link:../../core/types
       '@yarnpkg/extensions':
         specifier: 'catalog:'
-        version: 2.0.6(@yarnpkg/core@4.9.0(typanion@3.14.0))
+        version: 2.0.7(@yarnpkg/core@4.9.1(typanion@3.14.0))
       normalize-path:
         specifier: 'catalog:'
         version: 3.0.0
@@ -5089,7 +5089,7 @@ importers:
         version: 7.7.1
       '@yarnpkg/core':
         specifier: 'catalog:'
-        version: 4.9.0(typanion@3.14.0)
+        version: 4.9.1(typanion@3.14.0)
 
   pnpm11/hooks/types:
     dependencies:
@@ -5352,7 +5352,7 @@ importers:
         version: link:../../workspace/workspace-manifest-writer
       '@yarnpkg/core':
         specifier: 'catalog:'
-        version: 4.9.0(typanion@3.14.0)
+        version: 4.9.1(typanion@3.14.0)
       '@yarnpkg/lockfile':
         specifier: 'catalog:'
         version: 1.1.0
@@ -5864,7 +5864,7 @@ importers:
         version: 7.7.1
       '@yarnpkg/core':
         specifier: 'catalog:'
-        version: 4.9.0(typanion@3.14.0)
+        version: 4.9.1(typanion@3.14.0)
       ci-info:
         specifier: 'catalog:'
         version: 4.4.0
@@ -5981,7 +5981,7 @@ importers:
         version: link:../../workspace/spec-parser
       '@yarnpkg/core':
         specifier: 'catalog:'
-        version: 4.9.0(typanion@3.14.0)
+        version: 4.9.1(typanion@3.14.0)
       graph-cycles:
         specifier: 'catalog:'
         version: 3.0.0
@@ -6464,7 +6464,7 @@ importers:
         version: link:../../../lockfile/utils
       '@yarnpkg/nm':
         specifier: 'catalog:'
-        version: 4.1.0(typanion@3.14.0)
+        version: 4.1.1(typanion@3.14.0)
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -9386,7 +9386,7 @@ importers:
         version: link:../../core/error
       msgpackr:
         specifier: 'catalog:'
-        version: 2.0.4
+        version: 2.0.5
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -11266,11 +11266,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+  '@napi-rs/wasm-runtime@1.2.0':
+    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
     peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      '@emnapi/core': ^2.0.0-alpha.3
+      '@emnapi/runtime': ^2.0.0-alpha.3
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -12197,8 +12198,8 @@ packages:
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
-  '@types/node@26.1.1':
-    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -12515,15 +12516,15 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@yarnpkg/core@4.9.0':
-    resolution: {integrity: sha512-vhJEVo423jAZBtU5CDe2HEkyNkEYfgMfukNQk1uyYFkP3OmCsuLzpyqbJCEXIg6Fy3YTrQg7kSCnjHbLed3toA==}
+  '@yarnpkg/core@4.9.1':
+    resolution: {integrity: sha512-P8H10ehQBFWL5eR1y/8nLRzFHx1yumgE9P1DQjJ+EIVvqeWo0MjbwQ+ZJjPDT+HqVDslE+e6I/9GrJ7Arbx/8A==}
     engines: {node: '>=18.12.0'}
 
-  '@yarnpkg/extensions@2.0.6':
-    resolution: {integrity: sha512-3LciOqpKIuoc9MmYoX3k+NmCdcrvw7HqZT4N/AW3sYkujxfbFA9Ml01JNqu4InzdV9V9NcyFkAKAorCjhY8w6Q==}
+  '@yarnpkg/extensions@2.0.7':
+    resolution: {integrity: sha512-W4NK2qnraaHzZlGdeNVJdDYJzG6ZIpkrfBum7S2xyhgQb3WA3Jz4RaKpqFol1P3Y7/xFZuivmITAObSHKym8Kw==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
-      '@yarnpkg/core': ^4.4.2
+      '@yarnpkg/core': ^4.9.1
 
   '@yarnpkg/fslib@3.1.5':
     resolution: {integrity: sha512-hXaPIWl5GZA+rXcx+yaKWUuePJruZuD+3A5A2X6paEBfFsyCD7oEp88lSMj1ym1ehBWUmhNH/YGOp+SrbmSBPg==}
@@ -12538,12 +12539,12 @@ packages:
   '@yarnpkg/lockfile@1.1.0':
     resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
 
-  '@yarnpkg/nm@4.1.0':
-    resolution: {integrity: sha512-slWZlvsHftX7OFZ8ag45YsnGusuXgW7leCNSl4pmeaMjLNPQ67c8nKbFiZw5ivak+z1KcSoRa3gbqnN7S7ispQ==}
+  '@yarnpkg/nm@4.1.1':
+    resolution: {integrity: sha512-N8odmuYhQnEQFnrhQMluUC8Y83baFsTg7eNB6lq6GPcZuhVo5WjLfXwtW1CbQK3Ou5BGRFbnl7jlWcpJlAgM5Q==}
     engines: {node: '>=18.12.0'}
 
-  '@yarnpkg/parsers@3.0.3':
-    resolution: {integrity: sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==}
+  '@yarnpkg/parsers@3.1.0':
+    resolution: {integrity: sha512-WoxUM/Be4hfsX06FxsvpGgfYqwgivMV7/Ol7aFuSfSmY6rRaiju4QxOEe9RUS0iYcSHWl5i9AhB1cMoE0p+XiA==}
     engines: {node: '>=18.12.0'}
 
   '@yarnpkg/pnp@4.1.7':
@@ -12624,8 +12625,8 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.17.0:
-    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -12841,8 +12842,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.11.4:
-    resolution: {integrity: sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==}
+  baseline-browser-mapping@2.11.7:
+    resolution: {integrity: sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -13463,8 +13464,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.396:
-    resolution: {integrity: sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==}
+  electron-to-chromium@1.5.398:
+    resolution: {integrity: sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -13494,8 +13495,8 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.24.3:
-    resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
+  enhanced-resolve@5.24.4:
+    resolution: {integrity: sha512-GVoi+ICHocoOIU7qVVM48wOJziRsqrsyqlI0Ce0LdowRn6v3bcH2zUa9kp85ncx0nwIb9/HOCOLS3fdThDG/XQ==}
     engines: {node: '>=10.13.0'}
 
   enquirer@2.4.1:
@@ -15137,8 +15138,8 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
@@ -15205,8 +15206,8 @@ packages:
     resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
-  msgpackr@2.0.4:
-    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
+  msgpackr@2.0.5:
+    resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
 
   mute-stream@1.0.0:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
@@ -15272,7 +15273,7 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
-  node@runtime:26.5.0:
+  node@runtime:26.5.1:
     resolution:
       type: variations
       variants:
@@ -15280,9 +15281,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-JFZ51EYpEte5pfFnqBBXligSgXt8+LKcIux5MnGS7eA=
+            integrity: sha256-C6/oFrF7yu4oXnnjJbekTupgXRLYGyyqeM3crfXRtfY=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
@@ -15290,9 +15291,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-7pIFWaqiORVpz/TXN+O4OWNDDjoU3t2Rv+D/UxcbWvk=
+            integrity: sha256-9Dh98LRlVlFtGavy8taAZIGsg2iqf52Wuv7UIqVqHQE=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
@@ -15300,9 +15301,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-mCkzlMlFok5k4AtBd78HXslj6nCzTR0uJL1KcXFtM08=
+            integrity: sha256-B31ck2ho2rGdIfd/HnHOE2l+gLPoajmdyrI4kCouv5M=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
@@ -15310,9 +15311,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-MI5f6JqCRhulps8V/1Ihss29euh2AKpyuzw/vcZkEtE=
+            integrity: sha256-IRlLv0HBjZ7Cd1RcTRTM6Fl9V6nZ9JTDI9gSGiXeM+g=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -15320,9 +15321,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-ftjaaaLvAIhT4o+v4Tz+2drA/gHg74OxqOxbm4VX7Sg=
+            integrity: sha256-z1GN0ncup+UEba9KS6njSPzgHiuXQfMrohtLvYe4368=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
@@ -15330,9 +15331,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-1nOVmxOQ4dCGX9euj7mBsWaX22NFoQsU4TDDAs9MvCg=
+            integrity: sha256-r1pY/KDD/BMMamSb1sKfSwABRQVet6NkveGJq98VFvU=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
@@ -15340,9 +15341,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-IrX0etaueIN+TCuEYBmWXOGga6FD3hdhAilKG/RPxnc=
+            integrity: sha256-KwfwnCGNRzomRCv/WpAVH1P3t8CiO60kTtosJjA6K6c=
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
@@ -15350,10 +15351,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-wM+lh3tt50MwHmIvWrxNJvsP+HmK3/yP/9KIX0JgCLo=
-            prefix: node-v26.5.0-win-arm64
+            integrity: sha256-Rn9CUiii/cyDozD184sSS1tDtC9QM9eEi05Hyb7MNvk=
+            prefix: node-v26.5.1-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-win-arm64.zip
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
@@ -15361,10 +15362,10 @@ packages:
             archive: zip
             bin:
               node: node.exe
-            integrity: sha256-07InfbzM/fJO9jApKPZPSEz/HXem08qjoo9NIM6RWPY=
-            prefix: node-v26.5.0-win-x64
+            integrity: sha256-xDLJlrlcv3Vo8ToPuzdSbehKJ+OlxSDDvhXwWpoWghI=
+            prefix: node-v26.5.1-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v26.5.0/node-v26.5.0-win-x64.zip
+            url: https://nodejs.org/download/release/v26.5.1/node-v26.5.1-win-x64.zip
           targets:
             - cpu: x64
               os: win32
@@ -15372,9 +15373,9 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-GrMa72VhGRaT82bKzXW7zvoDAeSaGLwFVUwhiTu9tJA=
+            integrity: sha256-NPYguNrW6MkYhiPkayDxoHKD3LGzLrpHHvsIylc0RLM=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-arm64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-arm64-musl.tar.gz
           targets:
             - cpu: arm64
               os: linux
@@ -15383,14 +15384,14 @@ packages:
             archive: tarball
             bin:
               node: bin/node
-            integrity: sha256-APE5hBGkIWxabsqtO4JaDaXsAOee6MFzq2WglNl7mtg=
+            integrity: sha256-lcqQm7uAaIJixbJ9mM7Xh4vez/LPH2IGn6fJxhr8Cls=
             type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v26.5.0/node-v26.5.0-linux-x64-musl.tar.gz
+            url: https://unofficial-builds.nodejs.org/download/release/v26.5.1/node-v26.5.1-linux-x64-musl.tar.gz
           targets:
             - cpu: x64
               os: linux
               libc: musl
-    version: 26.5.0
+    version: 26.5.1
     hasBin: true
 
   nopt@1.0.10:
@@ -15812,8 +15813,8 @@ packages:
     resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
     engines: {node: '>=10'}
 
-  pnpm@11.17.0:
-    resolution: {integrity: sha512-zKPOozKtJUu4QUX5ZtGfSHlhUhA0b8kseaBH8joNezzKPDeS8AdrofGDHSd++88KkRmzGppg7Kf7PWIx8zHvcg==}
+  pnpm@11.18.0:
+    resolution: {integrity: sha512-M9g8d9qC9J+6g2klxvG4QRgewxMrZwY5vQEvcHX1x89jTF+HAUfBmq50ePrAHfCdiJLogEVIlu3SPumzN1dWPA==}
     engines: {node: '>=22.13'}
     hasBin: true
 
@@ -17841,7 +17842,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@10.2.2)
-      minimatch: 10.2.5
+      minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
 
@@ -18208,7 +18209,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -18245,7 +18246,7 @@ snapshots:
 
   '@lazy-node/types-path@1.0.3(ts-toolbelt@9.6.0)':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       ts-type: 3.0.13(ts-toolbelt@9.6.0)
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -18269,7 +18270,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
@@ -18631,7 +18632,7 @@ snapshots:
     dependencies:
       command-exists: 1.2.9
       cross-spawn: 7.0.6
-      pnpm: 11.17.0
+      pnpm: 11.18.0
 
   '@pnpm/fetch@1001.0.0(@pnpm/logger@1001.0.1)(supports-color@10.2.2)':
     dependencies:
@@ -19608,7 +19609,7 @@ snapshots:
   '@tufjs/models@4.1.0':
     dependencies:
       '@tufjs/canonical-json': 2.0.0
-      minimatch: 10.2.5
+      minimatch: 10.2.6
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -19617,7 +19618,7 @@ snapshots:
 
   '@types/adm-zip@0.5.8':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/archy@0.0.36': {}
 
@@ -19648,18 +19649,18 @@ snapshots:
 
   '@types/byline@4.2.36':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
       '@types/keyv': 3.1.4
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       '@types/responselike': 1.0.3
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/debug@4.1.13':
     dependencies:
@@ -19674,11 +19675,11 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/hosted-git-info@3.0.5': {}
 
@@ -19686,7 +19687,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/ini@4.1.1': {}
 
@@ -19719,11 +19720,11 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/libnpmpublish@11.2.0':
     dependencies:
@@ -19755,7 +19756,7 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       form-data: 4.0.6
 
   '@types/node@18.19.130':
@@ -19766,7 +19767,7 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@26.1.1':
+  '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
 
@@ -19778,7 +19779,7 @@ snapshots:
 
   '@types/npm-registry-fetch@8.0.9':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       '@types/node-fetch': 2.6.13
       '@types/npm-package-arg': 6.1.4
       '@types/npmlog': 7.0.0
@@ -19786,7 +19787,7 @@ snapshots:
 
   '@types/npmlog@7.0.0':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/object-hash@3.0.6': {}
 
@@ -19806,7 +19807,7 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/retry@0.12.5': {}
 
@@ -19816,7 +19817,7 @@ snapshots:
 
   '@types/ssri@7.1.5':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/stack-utils@2.0.3': {}
 
@@ -19826,7 +19827,7 @@ snapshots:
 
   '@types/tar-stream@3.1.4':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/touch@3.1.5':
     dependencies:
@@ -19842,7 +19843,7 @@ snapshots:
 
   '@types/write-file-atomic@4.0.3':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -19919,7 +19920,7 @@ snapshots:
       '@typescript-eslint/types': 8.65.0
       '@typescript-eslint/visitor-keys': 8.65.0
       debug: 4.4.3(supports-color@10.2.2)
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -20034,7 +20035,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
@@ -20046,14 +20047,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@yarnpkg/core@4.9.0(typanion@3.14.0)':
+  '@yarnpkg/core@4.9.1(typanion@3.14.0)':
     dependencies:
       '@arcanis/slice-ansi': 1.1.1
       '@types/semver': 7.7.1
       '@types/treeify': 1.0.3
       '@yarnpkg/fslib': 3.1.5
       '@yarnpkg/libzip': 3.2.2(@yarnpkg/fslib@3.1.5)
-      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/parsers': 3.1.0
       '@yarnpkg/shell': 4.1.3(typanion@3.14.0)
       camelcase: 5.3.1
       chalk: 4.1.2
@@ -20077,9 +20078,9 @@ snapshots:
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/extensions@2.0.6(@yarnpkg/core@4.9.0(typanion@3.14.0))':
+  '@yarnpkg/extensions@2.0.7(@yarnpkg/core@4.9.1(typanion@3.14.0))':
     dependencies:
-      '@yarnpkg/core': 4.9.0(typanion@3.14.0)
+      '@yarnpkg/core': 4.9.1(typanion@3.14.0)
 
   '@yarnpkg/fslib@3.1.5':
     dependencies:
@@ -20093,17 +20094,17 @@ snapshots:
 
   '@yarnpkg/lockfile@1.1.0': {}
 
-  '@yarnpkg/nm@4.1.0(typanion@3.14.0)':
+  '@yarnpkg/nm@4.1.1(typanion@3.14.0)':
     dependencies:
-      '@yarnpkg/core': 4.9.0(typanion@3.14.0)
+      '@yarnpkg/core': 4.9.1(typanion@3.14.0)
       '@yarnpkg/fslib': 3.1.5
       '@yarnpkg/pnp': 4.1.7
     transitivePeerDependencies:
       - typanion
 
-  '@yarnpkg/parsers@3.0.3':
+  '@yarnpkg/parsers@3.1.0':
     dependencies:
-      js-yaml: 3.15.0
+      js-yaml: '@zkochan/js-yaml@0.0.11'
       tslib: 2.8.1
 
   '@yarnpkg/pnp@4.1.7':
@@ -20114,7 +20115,7 @@ snapshots:
   '@yarnpkg/shell@4.0.0(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/fslib': 3.1.5
-      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/parsers': 3.1.0
       chalk: 3.0.0
       clipanion: 3.2.0-rc.6(typanion@3.14.0)
       cross-spawn: 7.0.6
@@ -20127,7 +20128,7 @@ snapshots:
   '@yarnpkg/shell@4.1.3(typanion@3.14.0)':
     dependencies:
       '@yarnpkg/fslib': 3.1.5
-      '@yarnpkg/parsers': 3.0.3
+      '@yarnpkg/parsers': 3.1.0
       chalk: 4.1.2
       clipanion: 3.2.0-rc.6(typanion@3.14.0)
       cross-spawn: 7.0.6
@@ -20201,11 +20202,11 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-jsx@5.3.2(acorn@8.17.0):
+  acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
 
-  acorn@8.17.0: {}
+  acorn@8.18.0: {}
 
   adm-zip@0.6.0: {}
 
@@ -20418,7 +20419,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.4: {}
+  baseline-browser-mapping@2.11.7: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -20480,9 +20481,9 @@ snapshots:
 
   browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.11.4
+      baseline-browser-mapping: 2.11.7
       caniuse-lite: 1.0.30001806
-      electron-to-chromium: 1.5.396
+      electron-to-chromium: 1.5.398
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
@@ -21077,7 +21078,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.396: {}
+  electron-to-chromium@1.5.398: {}
 
   emittery@0.13.1: {}
 
@@ -21102,7 +21103,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.24.3:
+  enhanced-resolve@5.24.4:
     dependencies:
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
       tapable: 2.3.3
@@ -21282,7 +21283,7 @@ snapshots:
       eslint: 10.8.0(jiti@2.6.1)(supports-color@10.2.2)
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       is-glob: 4.0.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       stable-hash-x: 0.2.0
       unrs-resolver: 1.12.2
@@ -21305,7 +21306,7 @@ snapshots:
   eslint-plugin-n@18.2.2(eslint@10.8.0(jiti@2.6.1)(supports-color@10.2.2))(typescript@6.0.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.6.1)(supports-color@10.2.2))
-      enhanced-resolve: 5.24.3
+      enhanced-resolve: 5.24.4
       eslint: 10.8.0(jiti@2.6.1)(supports-color@10.2.2)
       eslint-plugin-es-x: 7.8.0(eslint@10.8.0(jiti@2.6.1)(supports-color@10.2.2))
       get-tsconfig: 4.14.0
@@ -21378,7 +21379,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -21388,14 +21389,14 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 5.0.1
 
   esprima@4.0.1: {}
@@ -21825,14 +21826,14 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -22057,7 +22058,7 @@ snapshots:
 
   ignore-walk@8.0.0:
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 10.2.6
 
   ignore@5.3.2: {}
 
@@ -22475,7 +22476,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
@@ -22660,7 +22661,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
@@ -22706,7 +22707,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -23218,7 +23219,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.8
 
@@ -23300,7 +23301,7 @@ snapshots:
       '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
-  msgpackr@2.0.4:
+  msgpackr@2.0.5:
     optionalDependencies:
       msgpackr-extract: 3.0.4
 
@@ -23375,7 +23376,7 @@ snapshots:
 
   node-releases@2.0.51: {}
 
-  node@runtime:26.5.0: {}
+  node@runtime:26.5.1: {}
 
   nopt@1.0.10:
     dependencies:
@@ -23779,7 +23780,7 @@ snapshots:
     dependencies:
       find-up: 5.0.0
 
-  pnpm@11.17.0: {}
+  pnpm@11.18.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -24676,7 +24677,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.6
       glob: 13.0.6
-      minimatch: 10.2.5
+      minimatch: 10.2.6
 
   text-decoder@1.2.7:
     dependencies:
@@ -24735,7 +24736,7 @@ snapshots:
 
   ts-type@3.0.13(ts-toolbelt@9.6.0):
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       ts-toolbelt: 9.6.0
       tslib: 2.8.1
       typedarray-dts: 1.0.0
@@ -24959,7 +24960,7 @@ snapshots:
   upath2@3.1.23(ts-toolbelt@9.6.0):
     dependencies:
       '@lazy-node/types-path': 1.0.3(ts-toolbelt@9.6.0)
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       path-is-network-drive: 1.0.24
       path-strip-sep: 1.0.21
       tslib: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -176,10 +176,10 @@ catalog:
   '@types/zkochan__table': npm:@types/table@6.3.2
   '@typescript-eslint/utils': ^8.65.0
   '@typescript/native-preview': 7.0.0-dev.20260707.2
-  '@yarnpkg/core': 4.9.0
-  '@yarnpkg/extensions': 2.0.6
+  '@yarnpkg/core': 4.9.1
+  '@yarnpkg/extensions': 2.0.7
   '@yarnpkg/lockfile': ^1.1.0
-  '@yarnpkg/nm': 4.1.0
+  '@yarnpkg/nm': 4.1.1
   '@yarnpkg/pnp': ^4.1.7
   '@zkochan/cmd-shim': ^9.0.6
   '@zkochan/retry': ^0.2.0
@@ -275,7 +275,7 @@ catalog:
   mdast-util-to-string: ^4.0.0
   memoize: ^11.0.0
   micromatch: ^4.0.8
-  msgpackr: 2.0.4
+  msgpackr: 2.0.5
   nm-prune: ^5.0.0
   normalize-newline: 5.0.0
   # normalize-package-data 9.x requires Node.js ^22.22.2 || ^24.15.0 || >=26.0.0,


### PR DESCRIPTION
This automated PR bumps the project's dependencies and pinned versions:

- Updates all dependencies to their latest versions and refreshes the lockfile.
- Bumps Node.js to the latest 26.x release, propagated into the CI, release, and benchmark workflows via the meta-updater.
- Bumps pnpm to the latest `next-12` release (`packageManager` and `devEngines.packageManager`).
- Updates the GitHub Actions pinned in the workflow files.

Created by the [pnpm/update](https://github.com/pnpm/update) action.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787900382&installation_model_id=426870&pr_number=13480&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13480&signature=2eba016a36c18f9965ef73d57b4c5cb0094502e8b7f22c52fa4d12a5c7bf6fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI, benchmark, and release workflows to newer pinned tooling/action revisions for Rust tooling installs and container registry login.
  * Refreshed Node.js automation to **26.5.1** (including `compile-only` and package metadata), and bumped pnpm workspace tooling metadata.
  * Updated CodeQL and issue triage agent workflow action pins to newer revisions.
  * Refreshed workspace dependency pins (including **msgpackr to 2.0.5** and Yarn-related packages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->