### PR TITLE
fix(release): resume pacquet beta publish

### DIFF
--- a/.github/scripts/npm-package-publication-state.sh
+++ b/.github/scripts/npm-package-publication-state.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -u
+
+package_spec=$1
+
+if output=$(cd "${RUNNER_TEMP:-/tmp}" && npm view "$package_spec" version 2>&1); then
+  echo published
+elif grep -Eq '^npm (ERR!|error) code E404$' <<< "$output"; then
+  echo missing
+else
+  echo '::error::npm view failed' >&2
+  while IFS= read -r line; do
+    printf 'npm view output: %s\n' "$line" >&2
+  done <<< "$output"
+  exit 1
+fi

--- a/.github/scripts/npm-package-publication-state.test.sh
+++ b/.github/scripts/npm-package-publication-state.test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+test_tmp=$(mktemp -d)
+trap 'rm -rf "$test_tmp"' EXIT
+fake_bin="$test_tmp/bin"
+mkdir "$fake_bin"
+
+cat > "$fake_bin/npm" <<'EOF'
+#!/usr/bin/env bash
+case "$2" in
+  published)
+    echo 1.0.0
+    ;;
+  missing)
+    echo 'npm error code E404' >&2
+    exit 1
+    ;;
+  missing-legacy)
+    echo 'npm ERR! code E404' >&2
+    exit 1
+    ;;
+  network)
+    echo 'npm error code ECONNRESET' >&2
+    exit 1
+    ;;
+  auth)
+    echo 'npm error code E403' >&2
+    exit 1
+    ;;
+  server)
+    echo 'npm error code E500' >&2
+    exit 1
+    ;;
+  misleading-e404)
+    printf 'npm error code E403\nproxy response mentioned E404\n::warning::forged\n' >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$fake_bin/npm"
+
+assert_state() {
+  local expected=$1
+  local package_spec=$2
+  local actual
+  actual=$(PATH="$fake_bin:$PATH" RUNNER_TEMP="$test_tmp" "$script_dir/npm-package-publication-state.sh" "$package_spec")
+  test "$actual" = "$expected"
+}
+
+assert_failure() {
+  local package_spec=$1
+  local output
+  if output=$(PATH="$fake_bin:$PATH" RUNNER_TEMP="$test_tmp" "$script_dir/npm-package-publication-state.sh" "$package_spec" 2>&1); then
+    echo "expected npm view failure for $package_spec" >&2
+    exit 1
+  fi
+  grep -q '^::error::npm view failed$' <<< "$output"
+  if tail -n +2 <<< "$output" | grep -q '^::'; then
+    echo "npm output produced a workflow command for $package_spec" >&2
+    exit 1
+  fi
+}
+
+assert_state published published
+assert_state missing missing
+assert_state missing missing-legacy
+assert_failure network
+assert_failure auth
+assert_failure server
+assert_failure misleading-e404

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Install pnpm
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
         install: false
     - name: Audit

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,7 +67,7 @@ jobs:
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
         runtime: node@26.5.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Install pnpm
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
     - name: Compile TypeScript
       run: pn compile-only
     - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
         persist-credentials: false
     - name: Install pnpm
       uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
+    - name: Test release publication guard
+      run: .github/scripts/npm-package-publication-state.test.sh
     - name: Compile TypeScript
       run: pn compile-only
     - name: Lint

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -57,7 +57,7 @@ jobs:
         persist-credentials: false
 
     - name: Install pnpm and Node
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
         runtime: node@26.3.0
 

--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/rustup

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -128,7 +128,7 @@ jobs:
           save-cache: ${{ github.ref_name == 'main' }}
 
       - name: Install pnpm (for compatibility check)
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           install: false
 

--- a/.github/workflows/pacquet-codecov.yml
+++ b/.github/workflows/pacquet-codecov.yml
@@ -78,7 +78,7 @@ jobs:
         run: rustup component add llvm-tools-preview
 
       - name: Install pnpm (for compatibility check)
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           install: false
 

--- a/.github/workflows/pacquet-integrated-benchmark.yml
+++ b/.github/workflows/pacquet-integrated-benchmark.yml
@@ -223,7 +223,7 @@ jobs:
           save-cache: false # it's insufficient
 
       - name: Install pnpm
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           install: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
       - name: Install pnpm and Node
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           runtime: node@26.5.0
       - name: Build TypeScript executable artifacts
@@ -355,7 +355,7 @@ jobs:
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
       - name: Install pnpm and Node
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           runtime: node@26.5.0
       # The publish phase is split into three sequential steps to control which packages
@@ -642,7 +642,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           runtime: node@22
           install: false
@@ -754,6 +754,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      # Required by pnpm/setup to resolve the pnpm 11 GitHub release asset.
+      contents: read
       # Required for npm trusted publishing and provenance attestations via OIDC.
       id-token: write
     needs:
@@ -766,7 +768,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           runtime: node@22
           install: false
@@ -808,7 +810,18 @@ jobs:
         env:
           TAG: ${{ needs.plan.outputs.rust_tag }}
         run: |
+          set -euo pipefail
           for package in pnpm/npm/pacquet-* pnpm/npm/napi.* pnpm/npm/napi pnpm/npm/pnpm-exe pnpm/npm/pnpm; do
+            name=$(jq -r '.publishConfig.name // .name' "$package/package.json")
+            version=$(jq -r '.version' "$package/package.json")
+            if output=$(cd "$RUNNER_TEMP" && npm view "$name@$version" version 2>&1); then
+              echo "$name@$version is already published; skipping"
+              continue
+            fi
+            if ! grep -q 'E404' <<< "$output"; then
+              echo "::error::npm view $name@$version failed: $output"
+              exit 1
+            fi
             pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
           done
 
@@ -1052,7 +1065,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           runtime: node@22
           install: false
@@ -1151,6 +1164,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      # Required by pnpm/setup to resolve the pnpm 11 GitHub release asset.
+      contents: read
       # Required for npm trusted publishing and provenance attestations via OIDC.
       id-token: write
     needs:
@@ -1163,7 +1178,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm and Node
-        uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+        uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
         with:
           runtime: node@22
           install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,17 +94,13 @@ jobs:
         run: |
           set -eu
           needs_release() {
-            local out
-            # Query from outside the checkout: npm enforces the repository's
-            # devEngines (which pin pnpm) for any command run inside it.
-            if out=$(cd "${RUNNER_TEMP:-/tmp}" && npm view "$1" version 2>&1); then
-              echo false
-            elif echo "$out" | grep -q 'E404'; then
-              echo true
-            else
-              echo "::error::npm view $1 failed: $out"
-              exit 1
-            fi
+            local state
+            state=$(.github/scripts/npm-package-publication-state.sh "$1")
+            case "$state" in
+              published) echo false ;;
+              missing) echo true ;;
+              *) echo "::error::Unexpected npm publication state"; exit 1 ;;
+            esac
           }
 
           TS_VERSION=$(jq -r .version pnpm11/pnpm/package.json)
@@ -814,15 +810,19 @@ jobs:
           for package in pnpm/npm/pacquet-* pnpm/npm/napi.* pnpm/npm/napi pnpm/npm/pnpm-exe pnpm/npm/pnpm; do
             name=$(jq -r '.publishConfig.name // .name' "$package/package.json")
             version=$(jq -r '.version' "$package/package.json")
-            if output=$(cd "$RUNNER_TEMP" && npm view "$name@$version" version 2>&1); then
-              echo "$name@$version is already published; skipping"
-              continue
-            fi
-            if ! grep -q 'E404' <<< "$output"; then
-              echo "::error::npm view $name@$version failed: $output"
-              exit 1
-            fi
-            pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
+            state=$(.github/scripts/npm-package-publication-state.sh "$name@$version")
+            case "$state" in
+              published)
+                echo "$name@$version is already published; skipping"
+                ;;
+              missing)
+                pnpm publish "$package/" --tag "$TAG" --access public --provenance --no-git-checks
+                ;;
+              *)
+                echo "::error::Unexpected npm publication state"
+                exit 1
+                ;;
+            esac
           done
 
   github-release-rust:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         api_token: ${{ secrets.GARNET_API_TOKEN }}
     - name: Install pnpm and Node
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
         runtime: node@${{ inputs.node }}
     - name: Verify Node version

--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -27,10 +27,7 @@ env:
   # The pnpm that operates this workflow, never the version being released:
   # validate and verify-upgrade decide what the release is measured against, and
   # tag-in-registry holds the publish token. Bump deliberately, to a version that
-  # has already proven itself as `latest`. Until this moves to v12, the
-  # `pnpm/setup` steps below stay pinned to 77cf0683 — the last revision of the
-  # action able to install pnpm 11; newer revisions only install the
-  # standalone pnpm v12+.
+  # has already proven itself as `latest`.
   RELEASE_TOOL_PNPM_VERSION: 11.13.1
 
 jobs:
@@ -40,11 +37,12 @@ jobs:
     permissions: {}
     steps:
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
         install: false
+        token: ''
     # The latest-<major> tag is derived from the version instead of being
     # hardcoded per release branch, so dispatching this workflow from the wrong
     # branch cannot point a newer line's tag at an older release
@@ -99,11 +97,12 @@ jobs:
     permissions: {}
     steps:
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
         install: false
+        token: ''
     - name: Verify upgrading onto the new version
       if: ${{ !inputs.skip_upgrade_check }}
       env:
@@ -201,11 +200,12 @@ jobs:
       with:
         api_token: ${{ secrets.GARNET_API_TOKEN }}
     - name: Install pnpm and Node
-      uses: pnpm/setup@77cf06832101b3ac8c65caaf76a21643936d07a4
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
         version: ${{ env.RELEASE_TOOL_PNPM_VERSION }}
         runtime: node@26.5.0
         install: false
+        token: ''
     - name: Update tag
       env:
         # Written to pnpm's config below, not passed as

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -39,7 +39,7 @@ jobs:
     # pnpm/update runs the install itself, so the action's auto-install would
     # be wasted work.
     - name: Install pnpm
-      uses: pnpm/setup@6bfbb82d278149277735183e1ac2cd4353ebfe4f
+      uses: pnpm/setup@6523ce966bcf7a1061ce6401e5c6e0b60466bd31
       with:
         install: false
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": "12.0.0-alpha.21",
+      "version": "11.18.0",
       "onFail": "download"
     },
     "runtime": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,115 +7,194 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       '@pnpm/exe':
-        specifier: 12.0.0-alpha.21
-        version: 12.0.0-alpha.21
+        specifier: 11.18.0
+        version: 11.18.0
       pnpm:
-        specifier: 12.0.0-alpha.21
-        version: 12.0.0-alpha.21
+        specifier: 11.18.0
+        version: 11.18.0
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.21':
-    resolution: {integrity: sha512-htN4V0Rp09hATY/iRi/rPsW2JAA1xEJDO88oyk+U5y7y/AkmAGY8vPMbzyn9a64SWG2DQ2sDVvanjZzJl8fJbA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.21':
-    resolution: {integrity: sha512-X/PMw4flt0M5sPm2iRdDBhyG5B573D83wcas4nXqjGRhhs1rkSwwEefSqJdgKuQWnriAs+MoUQcpZwOX/AtZ3A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.21':
-    resolution: {integrity: sha512-4JDnh+nOiYDKSke8Paos2QziSLwVzqJIJ6jgyC4bTOGxSf/VG2bHrUJrUN7GBdIvb2thfOsL6UgBQ/qHhr/3GQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.21':
-    resolution: {integrity: sha512-IxkciU38hrjhSfQN15lcUmy2PsvH/Jvy06MQXuBNQL2q6ru4Z8rAFjem6G8BJfmQrY03U440zNObKuZutm0S/w==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.21':
-    resolution: {integrity: sha512-8lrSEAxQeCYdTNzLIGglhJTgLNDBWlFuGHBlwL+ftiBts+bNCVqS31ZX6O2/V+MCFyM4PjkOdxmWf/wdp58TxA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/exe.linux-x64@12.0.0-alpha.21':
-    resolution: {integrity: sha512-5YPpAqyx6wlNyAOjb65+dPAGTyka/KxQ56Ost0cpxrpfCShurxdiL00rTbHIs/HEGU4thqFz3tILv6bcGBl/Aw==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.21':
-    resolution: {integrity: sha512-GBoDyfpOT1duVxQEMSsSlTE6w6yCZyk6LXNTJnUGBKZM3c2ml+9xdbMQhZjVlm4S8/vr7PBsWLeVvVlWfSmRqA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/exe.win32-x64@12.0.0-alpha.21':
-    resolution: {integrity: sha512-Lg6+4EJSW/Mf5hifyadKsiUO1Ngir+z4596t+KuXlaB4BOW1YUXEJ+M7IAUhG+qVvsRL5LBTTeSrODqOx288IQ==}
-    cpu: [x64]
-    os: [win32]
-
-  '@pnpm/exe@12.0.0-alpha.21':
-    resolution: {integrity: sha512-DaSQ71MQVv1jVw0pAqnCdaMBSbDmNpOZSfd7Lt8ikkGGmIHVGyOrIsukZXUzvhyHvAko2rBwjTdneIwVh2layA==}
-    engines: {node: '>=18.*'}
+  '@pnpm/exe@11.18.0':
+    resolution: {integrity: sha512-9aPgeTanPblPLGE0V+SSTFAEmN1aF0y3OE+iNUO/RW5oXoZfyPS34hSDDwDmVy8yokA/+EuwQZENMDxaaICysA==}
     hasBin: true
 
-  pnpm@12.0.0-alpha.21:
-    resolution: {integrity: sha512-6YdWM5/Es6G/Bn4dcqHJh506Hkfn8VGpQ/9vspHeYu795La5wgh2gMK7kUb58d/U8s8fj1MVoglXyFnor9a19A==}
-    engines: {node: '>=18.*'}
+  '@pnpm/linux-arm64@11.18.0':
+    resolution: {integrity: sha512-cWOEr5xbmURZpj2XZo/3pqsrtDTzqms8g27Z4ciB1+cdj3SF8APtzyC/zJkJ6+gTnRwS0rIValnulSwDDKiasA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.18.0':
+    resolution: {integrity: sha512-9wgEko4X/jxDOpM+zcu5CcJtam2+nEvkuE1YRRALdEk4hwzJdjbCgl9xXKIVED19ZCYpAuF1zAtxiXcukxk3xA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/linuxstatic-arm64@11.18.0':
+    resolution: {integrity: sha512-4FJPL48jwvh+GvK13hMeqqsI+1tIIrm3iNMx2URM5UaFHJDvhj2SrBMgn2th9Lmgo7gH4RykxGiYyGJJRl+rjw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/linuxstatic-x64@11.18.0':
+    resolution: {integrity: sha512-nrP+OrT7BAyEno2xcaKZdOuY5kgkLQOiH7irBft2Q3/bLpEsidUscmWgtdGF2xahmfNx5FTzxwurX9zMLOId3g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/macos-arm64@11.18.0':
+    resolution: {integrity: sha512-KTDxK6c21u78EeH55TjPKPvOUhh1qW5zSYLJasxnIBWVK8bxzGFBwuccvdbPlwgu7c6iGrXR4dAeVn3RRty/IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.18.0':
+    resolution: {integrity: sha512-4EMrx19KBBDx0ufwlTUypDQMPIyQtaf85j7Y8HeHs2KeyF6pFnIhP2PbZH8YuO/JJ9Obb2AcK3T3wqyX6nQrhg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.18.0':
+    resolution: {integrity: sha512-uBeq9G2ArsVV6es+cAqP4DwiZaykNjC5nRBOOPLn28Tr5ZplqqSpoFi6kvgM7P/fz1/VCyKj2fsBMZOR8B5lpQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  pnpm@11.18.0:
+    resolution: {integrity: sha512-M9g8d9qC9J+6g2klxvG4QRgewxMrZwY5vQEvcHX1x89jTF+HAUfBmq50ePrAHfCdiJLogEVIlu3SPumzN1dWPA==}
+    engines: {node: '>=22.13'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.0.0-alpha.21':
-    optional: true
-
-  '@pnpm/exe.darwin-x64@12.0.0-alpha.21':
-    optional: true
-
-  '@pnpm/exe.linux-arm64-musl@12.0.0-alpha.21':
-    optional: true
-
-  '@pnpm/exe.linux-arm64@12.0.0-alpha.21':
-    optional: true
-
-  '@pnpm/exe.linux-x64-musl@12.0.0-alpha.21':
-    optional: true
-
-  '@pnpm/exe.linux-x64@12.0.0-alpha.21':
-    optional: true
-
-  '@pnpm/exe.win32-arm64@12.0.0-alpha.21':
-    optional: true
-
-  '@pnpm/exe.win32-x64@12.0.0-alpha.21':
-    optional: true
-
-  '@pnpm/exe@12.0.0-alpha.21':
+  '@pnpm/exe@11.18.0':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+      detect-libc: 2.1.2
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.21
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.21
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.21
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.21
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.21
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.21
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.21
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.21
+      '@pnpm/linux-arm64': 11.18.0
+      '@pnpm/linux-x64': 11.18.0
+      '@pnpm/linuxstatic-arm64': 11.18.0
+      '@pnpm/linuxstatic-x64': 11.18.0
+      '@pnpm/macos-arm64': 11.18.0
+      '@pnpm/win-arm64': 11.18.0
+      '@pnpm/win-x64': 11.18.0
 
-  pnpm@12.0.0-alpha.21:
+  '@pnpm/linux-arm64@11.18.0':
+    optional: true
+
+  '@pnpm/linux-x64@11.18.0':
+    optional: true
+
+  '@pnpm/linuxstatic-arm64@11.18.0':
+    optional: true
+
+  '@pnpm/linuxstatic-x64@11.18.0':
+    optional: true
+
+  '@pnpm/macos-arm64@11.18.0':
+    optional: true
+
+  '@pnpm/win-arm64@11.18.0':
+    optional: true
+
+  '@pnpm/win-x64@11.18.0':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0-alpha.21
-      '@pnpm/exe.darwin-x64': 12.0.0-alpha.21
-      '@pnpm/exe.linux-arm64': 12.0.0-alpha.21
-      '@pnpm/exe.linux-arm64-musl': 12.0.0-alpha.21
-      '@pnpm/exe.linux-x64': 12.0.0-alpha.21
-      '@pnpm/exe.linux-x64-musl': 12.0.0-alpha.21
-      '@pnpm/exe.win32-arm64': 12.0.0-alpha.21
-      '@pnpm/exe.win32-x64': 12.0.0-alpha.21
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  detect-libc@2.1.2: {}
+
+  pnpm@11.18.0: {}
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
## Summary

- pin `devEngines.packageManager` to pnpm 11.18.0 so `publishConfig.name` rewrites the workspace package `pacquet` to its published name `pnpm`
- update every `pnpm/setup` use to the latest commit, which supports pnpm v11 release archives
- skip package versions already present on npm so the partially completed `12.0.0-beta.0` release resumes at the missing root package
- fail the release when the npm publication probe returns anything other than success or a genuine 404

After this merges, move `v12.0.0-beta.0` to the merge commit and push the tag again. The release workflow will skip the native and wrapper packages already published, publish `pnpm@12.0.0-beta.0`, and then create the draft GitHub release from the moved tag.

## Squash Commit Body

```text
The first pnpm 12 beta release used pnpm 12.0.0-alpha.21 to publish a wrapper whose workspace name is `pacquet`. That version predates `publishConfig.name`, so npm trusted publishing was attempted for `pacquet` instead of `pnpm` and the root package failed after all native packages had already been published.

Use pnpm 11.18.0, the released TypeScript CLI that supports `publishConfig.name`, for release tooling. Update every `pnpm/setup` consumer to the revision that can install v11 from GitHub release archives. Make the Rust publishing loop query each effective published name and skip versions already on npm, while preserving hard failures for registry errors other than 404. This allows a moved beta tag to resume the partial release and reach the dependent GitHub release job.
```

## Checklist

- [x] No TypeScript/Rust behavior parity change is needed; this changes release automation only.
- [x] No changeset is needed because no published package behavior changes.
- [x] Verified pnpm 11.18.0 packs the generated wrapper as `pnpm@12.0.0-beta.0`.
- [x] No documentation update is needed.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release/publishing reliability by detecting whether a specific npm package version is already present and skipping publishes when appropriate.
  * Publishing now stops on unexpected npm registry states and surfaces failures more explicitly (instead of continuing).

* **Chores**
  * Refreshed CI/release automation by pinning a newer `pnpm/setup` action revision across workflows, including necessary publishing permission adjustments.
  * Updated the required package manager version.
  * Added automated coverage for the npm publication-state check logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->