### PR TITLE
fix(lockfile): parse large lockfiles

### DIFF
--- a/.changeset/large-lockfiles-parse.md
+++ b/.changeset/large-lockfiles-parse.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed parsing large lockfiles that exceed the YAML parser's default structural budget [pnpm/pnpm#12857](https://github.com/pnpm/pnpm/issues/12857).

--- a/pnpm/crates/lockfile/src/load_lockfile.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile.rs
@@ -9,6 +9,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
+const DEFAULT_YAML_MAX_EVENTS: usize = 1_000_000;
+const DEFAULT_YAML_MAX_NODES: usize = 250_000;
+
 /// Error when reading lockfile the filesystem.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
@@ -112,12 +115,20 @@ impl Lockfile {
         if main.trim().is_empty() {
             return Ok(None);
         }
-        serde_saphyr::from_str::<Self>(main)
-            .map(|mut lockfile| {
-                lockfile.reconstruct_missing_directory_resolutions();
-                Some(lockfile)
-            })
-            .map_err(|source| LoadLockfileError::parse_yaml(file_path, &source))
+        serde_saphyr::from_str_with_options::<Self>(
+            main,
+            serde_saphyr::options! {
+                budget: serde_saphyr::budget! {
+                    max_events: main.len().max(DEFAULT_YAML_MAX_EVENTS),
+                    max_nodes: main.len().max(DEFAULT_YAML_MAX_NODES),
+                },
+            },
+        )
+        .map(|mut lockfile| {
+            lockfile.reconstruct_missing_directory_resolutions();
+            Some(lockfile)
+        })
+        .map_err(|source| LoadLockfileError::parse_yaml(file_path, &source))
     }
 
     fn load_from_path(file_path: &Path) -> Result<Option<Self>, LoadLockfileError> {

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use pacquet_diagnostics::miette::Diagnostic;
 use pretty_assertions::assert_eq;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt::Write, path::Path};
 use tempfile::tempdir;
 use text_block_macros::text_block;
 
@@ -96,6 +96,22 @@ fn env_only_lockfile_loads_as_none() {
     let result = Lockfile::load_current_from_virtual_store_dir(&virtual_store_dir)
         .expect("env-only lockfile should not error");
     assert!(result.is_none(), "expected None for env-only lockfile, got: {result:?}");
+}
+
+#[test]
+fn parses_lockfile_larger_than_default_yaml_node_budget() {
+    const IMPORTER_COUNT: usize = 130_000;
+
+    let mut content = String::from("lockfileVersion: '9.0'\n\nimporters:\n");
+    for index in 0..IMPORTER_COUNT {
+        writeln!(content, "  project-{index}: {{}}").expect("write importer");
+    }
+
+    let lockfile = Lockfile::parse(&content, Path::new(Lockfile::FILE_NAME))
+        .expect("parse large lockfile")
+        .expect("large lockfile should be present");
+
+    assert_eq!(lockfile.importers.len(), IMPORTER_COUNT);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Scale pacquet's YAML event and node budgets with the lockfile size so valid large lockfiles can be parsed.
- Preserve the parser's depth, alias, anchor, merge-key, scalar, and comment limits.
- Add a regression test whose generated lockfile exceeds `serde-saphyr`'s default 250,000-node budget.
- The TypeScript CLI already handles these lockfiles, so no TypeScript change is needed.

Fixes pnpm/pnpm#12857.

## Squash Commit Body

```text
Pacquet parsed lockfiles with serde-saphyr's default structural budgets, which reject valid large lockfiles after 250,000 YAML nodes.

Set the event and node budgets to the greater of their defaults and the lockfile's byte length. This keeps the structural work allowance proportional to an input that is already in memory while retaining the parser's other resource limits.

Add a regression test that parses a generated lockfile above the previous node limit.

Fixes pnpm/pnpm#12857.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787909350&installation_model_id=426870&pr_number=13485&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13485&signature=87e6313322b54f0f0131211b925ff07b5c76977a13083790015a6dc9988b8e81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large lockfiles can now be parsed successfully, even when they exceed the YAML parser’s default structural limits.
  * Prevents entries from being dropped when processing lockfiles with very large numbers of importers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->