### PR TITLE
fix(napi): respect in-memory manifest changes

### DIFF
--- a/.changeset/fix-napi-in-memory-repeat-install.md
+++ b/.changeset/fix-napi-in-memory-repeat-install.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/napi": patch
+---
+
+Fixed repeat installs ignoring changes in caller-supplied in-memory project manifests.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4615,6 +4615,7 @@ dependencies = [
  "pacquet-resolving-tarball-resolver",
  "pacquet-store-dir",
  "pacquet-tarball",
+ "pacquet-testing-utils",
  "pacquet-workspace",
  "serde",
  "serde_json",

--- a/pnpm/crates/napi/Cargo.toml
+++ b/pnpm/crates/napi/Cargo.toml
@@ -53,7 +53,8 @@ tokio       = { workspace = true }
 napi-build = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
+pacquet-testing-utils = { workspace = true }
+tempfile              = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -244,6 +244,12 @@ enum EngineMode {
     PeerIssues(pacquet_package_manager::PeerIssuesSink),
 }
 
+impl EngineMode {
+    fn disable_optimistic_repeat_install(&self) -> bool {
+        matches!(self, Self::Install | Self::PeerIssues(_))
+    }
+}
+
 fn run_install_inner(
     options: &InstallOptions,
     pnpmfile_hook: Option<Arc<dyn PnpmfileHooks>>,
@@ -393,10 +399,12 @@ fn run_install_inner(
                     EngineMode::Install | EngineMode::Rebuild(_) => None,
                 },
                 catalogs_override: None,
-                // The optimistic repeat-install fast path skips
-                // resolution entirely — a peer-issue query must never
-                // short-circuit that way.
-                disable_optimistic_repeat_install: matches!(mode, EngineMode::PeerIssues(_)),
+                // The optimistic repeat-install fast path uses on-disk
+                // manifest mtimes as its freshness signal. NAPI installs use
+                // caller-supplied manifests that can change without touching
+                // package.json, so they must continue to the lockfile
+                // freshness check. Peer-issue queries must always resolve too.
+                disable_optimistic_repeat_install: mode.disable_optimistic_repeat_install(),
                 pnpmfile_hook_override: pnpmfile_hook,
                 workspace_projects_override,
             };

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -1,8 +1,12 @@
+use std::collections::HashMap;
+
 use pacquet_network::NoProxySetting;
+use pacquet_testing_utils::registry::TestRegistry;
 
 use super::{
-    InstallOptions, NetworkConfigInput, NodeApiProject, ProxyConfigInput, build_overlay,
-    reject_non_object_manifests, reject_unsupported_install_options,
+    EngineMode, InstallOptions, NetworkConfigInput, NodeApiProject, ProxyConfigInput,
+    build_overlay, reject_non_object_manifests, reject_unsupported_install_options,
+    run_install_inner,
 };
 use crate::config::{ConfigOverlay, resolve_config};
 
@@ -158,6 +162,46 @@ fn newly_supported_install_options_are_accepted() {
     options.network_config = Some(NetworkConfigInput { max_sockets: Some(20), ..network_config() });
     assert!(reject_unsupported_install_options(&options).is_ok());
     assert_eq!(build_overlay(&options).expect("overlay").max_sockets, Some(20));
+}
+
+#[test]
+fn repeat_install_uses_changed_in_memory_manifest() {
+    let registry = TestRegistry::start();
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).expect("create project dir");
+    std::fs::write(project_dir.join("package.json"), "{}\n").expect("write package.json");
+
+    let project_dir_string = project_dir.to_string_lossy().into_owned();
+    let mut options = install_options();
+    options.dir = project_dir_string.clone();
+    options.projects = vec![NodeApiProject {
+        root_dir: project_dir_string,
+        manifest: serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/foo": "100.0.0"
+            }
+        }),
+    }];
+    options.store_dir = Some(temp_dir.path().join("store").to_string_lossy().into_owned());
+    options.registries = Some(HashMap::from([("default".to_string(), registry.url())]));
+
+    run_install_inner(&options, None, EngineMode::Install).expect("first install");
+    assert!(project_dir.join("node_modules/@pnpm.e2e/foo").exists());
+
+    options.projects[0].manifest = serde_json::json!({
+        "dependencies": {
+            "@pnpm.e2e/bar": "100.0.0",
+            "@pnpm.e2e/foo": "100.0.0"
+        }
+    });
+
+    run_install_inner(&options, None, EngineMode::Install).expect("second install");
+    assert!(project_dir.join("node_modules/@pnpm.e2e/bar").exists());
+    assert_eq!(
+        std::fs::read_to_string(project_dir.join("package.json")).expect("read package.json"),
+        "{}\n",
+    );
 }
 
 fn install_options() -> InstallOptions {


### PR DESCRIPTION
## Summary

- Disable the optimistic repeat-install shortcut for NAPI installs because its on-disk manifest timestamp cannot detect changes to caller-supplied manifests.
- Continue through the normal lockfile freshness checks without writing the supplied manifest to package.json.
- Add a regression test that changes the in-memory manifest between installs and verifies the new dependency is materialized while package.json remains unchanged.

This is specific to the NAPI embedding boundary. The TypeScript CLI reads its authoritative manifests from disk, so no corresponding TypeScript change is needed.

## Squash Commit Body

```text
NAPI consumers provide authoritative project manifests in memory. The optimistic repeat-install path uses package.json mtimes as its freshness signal, so it could report an install as already up to date when only the supplied manifest changed.

Disable that shortcut for NAPI installs so the normal lockfile freshness checks compare the supplied manifests and materialize newly requested dependencies. Rebuilds retain the existing fast-path behavior.
```

## Validation

- `just ready` (7,458 tests passed; 4 skipped)
- Regression test was verified to fail with the old NAPI fast-path behavior.
- JavaScript commit and pre-push hooks were unavailable in this worktree because `commitlint` and `tsgo` are not installed; no TypeScript files are changed.

## Checklist

- [x] This is NAPI-specific; no TypeScript CLI port is needed.
- [x] Added a changeset for `@pnpm/napi`.
- [x] Added a regression test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787910166&installation_model_id=426870&pr_number=13488&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13488&signature=39f4831ef7c78b656f6f831731eb60710361bf4e6666caaaa18aae2d42135418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeat installs now recognize changes to in-memory project manifests.
  * Newly added dependencies are installed correctly on subsequent installs.
  * Install operations continue to respect lockfile freshness checks when needed.
  * In-memory manifest changes do not overwrite the project’s existing `package.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->