### PR TITLE
fix(napi): support trustLockfile option

### DIFF
--- a/.changeset/napi-trust-lockfile.md
+++ b/.changeset/napi-trust-lockfile.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/napi": minor
+---
+
+Added the `trustLockfile` install option to skip verifying lockfile resolutions against current registry metadata.

--- a/pnpm/crates/napi/src/config.rs
+++ b/pnpm/crates/napi/src/config.rs
@@ -99,6 +99,9 @@ pub struct ConfigOverlay {
     pub dangerously_allow_all_builds: Option<bool>,
     /// When `true`, skip all dependency and project lifecycle scripts.
     pub ignore_scripts: Option<bool>,
+    /// When `true`, trust lockfile resolutions without verifying them against
+    /// current registry metadata.
+    pub trust_lockfile: Option<bool>,
     /// `engineStrict` — fail the install when a dependency's `engines` /
     /// platform constraint the host does not satisfy is required.
     pub engine_strict: Option<bool>,
@@ -363,6 +366,9 @@ fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorks
     }
     if let Some(value) = overlay.ignore_scripts {
         config.ignore_scripts = value;
+    }
+    if let Some(value) = overlay.trust_lockfile {
+        config.trust_lockfile = value;
     }
     if let Some(value) = overlay.engine_strict {
         config.engine_strict = value;

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -96,6 +96,9 @@ pub struct InstallOptions {
     pub depth: Option<u32>,
     pub include_optional_deps: Option<bool>,
     pub ignore_scripts: Option<bool>,
+    /// Trust lockfile resolutions without verifying them against current
+    /// registry metadata.
+    pub trust_lockfile: Option<bool>,
     pub network_concurrency: Option<u32>,
     pub fetch_retries: Option<u32>,
     pub fetch_retry_factor: Option<u32>,
@@ -528,6 +531,7 @@ fn build_overlay(options: &InstallOptions) -> napi::Result<ConfigOverlay> {
         allow_builds: options.allow_builds.clone().map(|map| map.into_iter().collect()),
         dangerously_allow_all_builds: options.dangerously_allow_all_builds,
         ignore_scripts: options.ignore_scripts,
+        trust_lockfile: options.trust_lockfile,
         engine_strict: options.engine_strict,
         node_version: options.node_version.clone(),
         minimum_release_age: options.minimum_release_age.map(u64::from),

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -36,6 +36,7 @@ fn build_overlay_maps_supported_install_options() {
     options.node_version = Some("18.20.4".to_string());
     options.minimum_release_age = Some(60);
     options.minimum_release_age_exclude = Some(vec!["left-pad".to_string()]);
+    options.trust_lockfile = Some(false);
     options.network_config = Some(NetworkConfigInput {
         ca: Some(serde_json::json!(["cert-a", "cert-b"])),
         cert: Some(serde_json::json!("client-cert")),
@@ -67,6 +68,7 @@ fn build_overlay_maps_supported_install_options() {
     assert_eq!(overlay.node_version, Some("18.20.4".to_string()));
     assert_eq!(overlay.minimum_release_age, Some(60));
     assert_eq!(overlay.minimum_release_age_exclude, Some(vec!["left-pad".to_string()]));
+    assert_eq!(overlay.trust_lockfile, Some(false));
     assert_eq!(overlay.network_concurrency, Some(12));
     assert_eq!(overlay.max_sockets, Some(7));
     assert_eq!(overlay.fetch_retries, Some(4));
@@ -88,6 +90,12 @@ fn build_overlay_maps_supported_install_options() {
     assert_eq!(tls.key, Some("client-key".to_string()));
     assert_eq!(tls.strict_ssl, Some(false));
     assert_eq!(tls.local_address.map(|ip| ip.to_string()), Some("127.0.0.1".to_string()));
+}
+
+#[test]
+fn build_overlay_preserves_the_trust_lockfile_default() {
+    let options = install_options();
+    assert_eq!(build_overlay(&options).expect("overlay").trust_lockfile, None);
 }
 
 #[test]
@@ -247,6 +255,7 @@ fn install_options() -> InstallOptions {
         depth: None,
         include_optional_deps: None,
         ignore_scripts: None,
+        trust_lockfile: None,
         network_concurrency: None,
         fetch_retries: None,
         fetch_retry_factor: None,

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -93,9 +93,15 @@ fn build_overlay_maps_supported_install_options() {
 }
 
 #[test]
-fn build_overlay_preserves_the_trust_lockfile_default() {
-    let options = install_options();
-    assert_eq!(build_overlay(&options).expect("overlay").trust_lockfile, None);
+fn resolved_config_applies_trust_lockfile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    for (trust_lockfile, expected) in [(Some(false), false), (Some(true), true), (None, false)] {
+        let mut options = install_options();
+        options.trust_lockfile = trust_lockfile;
+        let overlay = build_overlay(&options).expect("overlay");
+        assert_eq!(resolve_config(dir.path(), &overlay).expect("config").trust_lockfile, expected);
+    }
 }
 
 #[test]

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -135,6 +135,11 @@ export interface InstallOptions extends SharedEngineOptions {
   includeOptionalDeps?: boolean
   ignoreScripts?: boolean
   /**
+   * Trust lockfile resolutions without verifying them against current registry
+   * metadata.
+   */
+  trustLockfile?: boolean
+  /**
    * Re-resolve the whole dependency graph to the highest in-range version
    * (pnpm's `update: true` / `depth: Infinity`). The binding takes no package
    * selectors, so an update always targets every dependency.


### PR DESCRIPTION
Expose trustLockfile through the NAPI InstallOptions and config overlay.

This lets embedders such as Bit explicitly trust existing lockfiles while migrating to pnpm v12. The NAPI and pnpm CLI defaults remain unchanged.

Tests:
- cargo test -p pacquet-napi install::tests
- repository pre-push checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787914054&installation_model_id=426870&pr_number=13489&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13489&signature=d36f50ab9ca59611f35c92f757f805e7bb7a945799e81dfa8535b834af51fdeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `trustLockfile` install setting.
  * When enabled, lockfile resolutions are trusted without verifying them against current registry metadata.
  * Available via the installation API and updated type definitions.

* **Tests**
  * Added coverage to confirm the install option is correctly applied to the resolved configuration, including default behavior when the option is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->