### PR TITLE
fix(pacquet): align deprecated package reporting

### DIFF
--- a/.changeset/fair-warnings-report.md
+++ b/.changeset/fair-warnings-report.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Aligned deprecated package warnings with pnpm by reporting each package only on its first resolution and shortening direct dependency warnings during recursive installs.

--- a/.changeset/quiet-policy-order.md
+++ b/.changeset/quiet-policy-order.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Kept the lockfile policy verdict ahead of the frozen-install message when package statistics arrive while verification is still running.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -72,6 +72,7 @@ impl CliArgs {
             self.command.default_reporter_summary_scope(),
             self.command.reports_scope(self.recursive),
             false,
+            self.recursive,
         );
     }
 

--- a/pnpm/crates/cli/src/cli_args/reporter.rs
+++ b/pnpm/crates/cli/src/cli_args/reporter.rs
@@ -39,11 +39,13 @@ pub(crate) fn configure_default_reporter(
     summary_scope: SummaryScope,
     reports_scope: bool,
     hide_added_pkgs_progress: bool,
+    is_recursive: bool,
 ) {
     pacquet_default_reporter::set_cwd(dir.to_string_lossy().into_owned());
     pacquet_default_reporter::set_summary_scope(summary_scope);
     pacquet_default_reporter::set_reports_scope(reports_scope);
     pacquet_default_reporter::set_hide_added_pkgs_progress(hide_added_pkgs_progress);
+    pacquet_default_reporter::set_is_recursive(is_recursive);
     if matches!(reporter, ReporterType::AppendOnly) {
         pacquet_default_reporter::force_append_only();
     }

--- a/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -55,7 +55,7 @@ pub(crate) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
         format!("create the package-manager env directory at {}", env_root.display())
     })?;
     let env = {
-        let _lock = package_manager_env_lock::<Reporter>(config);
+        let _lock = package_manager_env_lock::<Reporter>(config).await?;
         // Resolve the package-manager closure into the env lockfile (a no-op
         // when this spec+version is already recorded there).
         config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false)
@@ -114,8 +114,11 @@ async fn install_pnpm_from_env_with_config<Reporter: self::Reporter + 'static>(
     // we want, so ask the cache again before paying for the download.
     if let Some(slot) = compute_engine_slot(config, env, package_name, version) {
         let pkg_dir = package_dir(&slot, package_name);
-        if pkg_dir.join("package.json").exists() {
-            return link_cached_engine_bins(&slot, package_name, package.links_native_binary);
+        if pkg_dir.join("package.json").exists()
+            && let Ok(bin_dir) =
+                link_cached_engine_bins(&slot, package_name, package.links_native_binary)
+        {
+            return Ok(bin_dir);
         }
     }
 
@@ -177,9 +180,16 @@ fn engine_install_lock<Reporter: self::Reporter>(
     acquire_install_lock::<Reporter>(&path, "the pnpm engine install")
 }
 
-fn package_manager_env_lock<Reporter: self::Reporter>(config: &Config) -> Option<DirLock> {
+async fn package_manager_env_lock<Reporter: self::Reporter>(
+    config: &Config,
+) -> miette::Result<Option<DirLock>> {
     let path = config.store_dir.tmp().join("engine-locks/package-manager-env.lock");
-    acquire_install_lock::<Reporter>(&path, "the package-manager environment")
+    tokio::task::spawn_blocking(move || {
+        acquire_install_lock::<Reporter>(&path, "the package-manager environment")
+    })
+    .await
+    .into_diagnostic()
+    .wrap_err("wait for the package-manager environment lock")
 }
 
 fn acquire_install_lock<Reporter: self::Reporter>(path: &Path, subject: &str) -> Option<DirLock> {

--- a/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
+++ b/pnpm/crates/cli/src/cli_args/with/install_pnpm_to_store.rs
@@ -54,15 +54,19 @@ pub(crate) async fn install_pnpm_to_store<Reporter: self::Reporter + 'static>(
     fs::create_dir_all(env_root).into_diagnostic().wrap_err_with(|| {
         format!("create the package-manager env directory at {}", env_root.display())
     })?;
-    // Resolve the package-manager closure into the env lockfile (a no-op
-    // when this spec+version is already recorded there).
-    config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false).await?;
-    let env = EnvLockfile::read(env_root)
-        .map_err(miette::Report::new)
-        .wrap_err("read the package-manager env lockfile")?
-        .ok_or_else(|| {
-            miette::miette!("the package-manager env lockfile is missing after resolution")
-        })?;
+    let env = {
+        let _lock = package_manager_env_lock::<Reporter>(config);
+        // Resolve the package-manager closure into the env lockfile (a no-op
+        // when this spec+version is already recorded there).
+        config_deps::sync_package_manager_dependencies(config, env_root, spec, version, false)
+            .await?;
+        EnvLockfile::read(env_root)
+            .map_err(miette::Report::new)
+            .wrap_err("read the package-manager env lockfile")?
+            .ok_or_else(|| {
+                miette::miette!("the package-manager env lockfile is missing after resolution")
+            })?
+    };
     install_pnpm_from_env::<Reporter>(config, &env, version).await
 }
 
@@ -90,8 +94,11 @@ async fn install_pnpm_from_env_with_config<Reporter: self::Reporter + 'static>(
     // then re-derives the slot from the install's own symlink).
     if let Some(slot) = compute_engine_slot(config, env, package_name, version) {
         let pkg_dir = package_dir(&slot, package_name);
-        if pkg_dir.join("package.json").exists() {
-            return link_cached_engine_bins(&slot, package_name, package.links_native_binary);
+        if pkg_dir.join("package.json").exists()
+            && let Ok(bin_dir) =
+                link_cached_engine_bins(&slot, package_name, package.links_native_binary)
+        {
+            return Ok(bin_dir);
         }
     }
 
@@ -165,6 +172,17 @@ fn engine_install_lock<Reporter: self::Reporter>(
     package_name: &str,
     version: &str,
 ) -> Option<DirLock> {
+    let name = format!("{}@{version}.lock", package_name.replace('/', "+"));
+    let path = config.store_dir.tmp().join("engine-locks").join(name);
+    acquire_install_lock::<Reporter>(&path, "the pnpm engine install")
+}
+
+fn package_manager_env_lock<Reporter: self::Reporter>(config: &Config) -> Option<DirLock> {
+    let path = config.store_dir.tmp().join("engine-locks/package-manager-env.lock");
+    acquire_install_lock::<Reporter>(&path, "the package-manager environment")
+}
+
+fn acquire_install_lock<Reporter: self::Reporter>(path: &Path, subject: &str) -> Option<DirLock> {
     /// Long enough for a cold install of the engine over a slow link,
     /// short enough that a wedged host isn't hung on indefinitely.
     const WAIT: Duration = Duration::from_mins(5);
@@ -172,9 +190,7 @@ fn engine_install_lock<Reporter: self::Reporter>(
     /// installing never has its lock stolen by one that gave up waiting.
     const ABANDONED_AFTER: Duration = Duration::from_mins(30);
 
-    let name = format!("{}@{version}.lock", package_name.replace('/', "+"));
-    let path = config.store_dir.tmp().join("engine-locks").join(name);
-    let error = match DirLock::acquire(path.clone(), WAIT, ABANDONED_AFTER) {
+    let error = match DirLock::acquire(path.to_path_buf(), WAIT, ABANDONED_AFTER) {
         Ok(lock) => return lock,
         Err(error) => error,
     };
@@ -184,7 +200,7 @@ fn engine_install_lock<Reporter: self::Reporter>(
     Reporter::emit(&LogEvent::Pnpm(PnpmLog {
         level: LogLevel::Warn,
         message: format!(
-            "Could not lock the pnpm engine install at {}: {error}. Installing without it, which is unsafe if another pnpm is installing the same version.",
+            "Could not lock {subject} at {}: {error}. Installing without it, which is unsafe if another pnpm is installing concurrently.",
             path.display(),
         ),
         prefix: String::new(),

--- a/pnpm/crates/default-reporter/src/lib.rs
+++ b/pnpm/crates/default-reporter/src/lib.rs
@@ -38,6 +38,7 @@ static FORCE_APPEND_ONLY: OnceLock<bool> = OnceLock::new();
 static SUMMARY_SCOPE: OnceLock<SummaryScope> = OnceLock::new();
 static REPORTS_SCOPE: OnceLock<bool> = OnceLock::new();
 static HIDE_ADDED_PKGS_PROGRESS: OnceLock<bool> = OnceLock::new();
+static IS_RECURSIVE: OnceLock<bool> = OnceLock::new();
 
 /// Which prefixes contribute to the packages-diff summary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,6 +89,14 @@ pub fn set_reports_scope(reports_scope: bool) {
 /// configured value is retained.
 pub fn set_hide_added_pkgs_progress(hide_added_pkgs_progress: bool) {
     let _ = HIDE_ADDED_PKGS_PROGRESS.set(hide_added_pkgs_progress);
+}
+
+/// Configure whether the running command operates recursively.
+///
+/// This must be called before the reporter is initialized. Only the first
+/// configured value is retained.
+pub fn set_is_recursive(is_recursive: bool) {
+    let _ = IS_RECURSIVE.set(is_recursive);
 }
 
 fn cwd() -> String {
@@ -157,6 +166,7 @@ impl Sink {
                 summary_scope: SUMMARY_SCOPE.get().copied().unwrap_or(SummaryScope::CurrentPrefix),
                 reports_scope: REPORTS_SCOPE.get().copied().unwrap_or(false),
                 hide_added_pkgs_progress: HIDE_ADDED_PKGS_PROGRESS.get().copied().unwrap_or(false),
+                is_recursive: IS_RECURSIVE.get().copied().unwrap_or(false),
                 ..state::ReporterOptions::default()
             },
         );

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -390,7 +390,7 @@ impl ReporterState {
     }
 
     pub fn handle(&mut self, event: &LogEvent) -> Output {
-        if matches!(event, LogEvent::Stats(_) | LogEvent::Summary(_) | LogEvent::ExecutionTime(_)) {
+        if matches!(event, LogEvent::Summary(_) | LogEvent::ExecutionTime(_)) {
             self.flush_pending_lockfile_message();
         }
         match event {

--- a/pnpm/crates/default-reporter/src/state.rs
+++ b/pnpm/crates/default-reporter/src/state.rs
@@ -5,7 +5,7 @@
 //! path per log channel.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt::Write as _,
     path::{Component, Path, PathBuf},
 };
@@ -56,6 +56,8 @@ pub struct ReporterOptions {
     /// lives in the reporter because the `pnpm:scope` event itself is
     /// command-agnostic.
     pub reports_scope: bool,
+    /// Whether direct dependency warnings use workspace-relative prefixes.
+    pub is_recursive: bool,
 }
 
 impl Default for ReporterOptions {
@@ -66,6 +68,7 @@ impl Default for ReporterOptions {
             hide_progress_prefix: false,
             summary_scope: SummaryScope::CurrentPrefix,
             reports_scope: false,
+            is_recursive: false,
         }
     }
 }
@@ -262,6 +265,7 @@ pub struct ReporterState {
     summary_scope: SummaryScope,
 
     reports_scope: bool,
+    is_recursive: bool,
     scope_slot: BlockSlot,
 
     lifecycle: HashMap<String, LifecycleEntry>,
@@ -281,12 +285,6 @@ pub struct ReporterState {
 
     deprecated_subdeps: Vec<DeprecationLog>,
     deprecated_slot: BlockSlot,
-    /// Package ids already reported as a direct-dependency deprecation.
-    /// pnpm reports each deprecated package once, on first resolution;
-    /// pacquet's resolver re-emits a package it later meets at a
-    /// shallower depth, so the "already said this" bookkeeping lives
-    /// here instead.
-    reported_direct_deprecations: HashSet<String>,
 }
 
 const MAX_SHOWN_WARNINGS: usize = 5;
@@ -343,6 +341,7 @@ impl ReporterState {
             hide_progress_prefix,
             summary_scope,
             reports_scope,
+            is_recursive,
         } = options;
         let mut diff = HashMap::new();
         for kind in SUMMARY_ORDER {
@@ -372,6 +371,7 @@ impl ReporterState {
             summary_rendered: false,
             summary_scope,
             reports_scope,
+            is_recursive,
             scope_slot: BlockSlot::default(),
             lifecycle: HashMap::new(),
             lifecycle_slots: HashMap::new(),
@@ -386,7 +386,6 @@ impl ReporterState {
             collapsed_warn_slot: BlockSlot::default(),
             deprecated_subdeps: Vec::new(),
             deprecated_slot: BlockSlot::default(),
-            reported_direct_deprecations: HashSet::new(),
         }
     }
 
@@ -1212,14 +1211,7 @@ impl ReporterState {
     /// `resolution_done` summary.
     fn on_deprecation(&mut self, log: &DeprecationLog) {
         if log.depth == 0 {
-            // A package that already went out as a subdependency is
-            // really a direct one; drop the pending summary entry so it
-            // isn't counted twice.
-            self.deprecated_subdeps.retain(|pending| pending.pkg_id != log.pkg_id);
-            if !self.reported_direct_deprecations.insert(log.pkg_id.clone()) {
-                return;
-            }
-            if log.prefix.is_empty() || log.prefix == self.cwd {
+            if !self.is_recursive && log.prefix == self.cwd {
                 self.push_block(format!(
                     "{} {} {}@{}: {}",
                     self.colors.warn_label(),
@@ -1240,9 +1232,7 @@ impl ReporterState {
                 );
                 self.push_block(zoom_out(&self.cwd, &log.prefix, &msg));
             }
-        } else if !self.reported_direct_deprecations.contains(&log.pkg_id)
-            && !self.deprecated_subdeps.iter().any(|pending| pending.pkg_id == log.pkg_id)
-        {
+        } else {
             self.deprecated_subdeps.push(log.clone());
         }
     }
@@ -1257,7 +1247,6 @@ impl ReporterState {
             .map(|log| format!("{}@{}", log.pkg_name, log.pkg_version))
             .collect();
         names.sort();
-        names.dedup();
         let count = names.len();
         let msg = format!(
             "{} {} {}",

--- a/pnpm/crates/default-reporter/src/tests.rs
+++ b/pnpm/crates/default-reporter/src/tests.rs
@@ -3,7 +3,7 @@ use pacquet_reporter::{
     PromptAction, StatsLog, StatsMessage,
 };
 
-use super::{Colors, LogEvent, Output, ReporterState, Sink, is_coalesceable};
+use super::{LogEvent, Output, Sink, is_coalesceable};
 
 #[test]
 fn progress_and_in_progress_downloads_coalesce() {
@@ -86,54 +86,4 @@ fn prompt_renders_only_the_latest_buffered_frame() {
     let output = String::from_utf8(writes).expect("utf8 output");
     assert!(output.contains("latest"));
     assert!(!output.contains("stale"));
-}
-
-/// pnpm reports each deprecated package once, on first resolution.
-/// pacquet's resolver re-emits a package it later meets at a shallower
-/// depth, so the reporter has to fold the repeats away: one line per
-/// package, and a package that turns out to be direct must not also be
-/// counted among the deprecated subdependencies.
-#[test]
-fn a_deprecated_package_is_reported_once_even_when_re_emitted() {
-    use pacquet_reporter::{DeprecationLog, Stage, StageLog};
-
-    let deprecation = |pkg_id: &str, depth: i32, prefix: &str| {
-        LogEvent::Deprecation(DeprecationLog {
-            level: LogLevel::Debug,
-            pkg_name: "glob".to_string(),
-            pkg_version: "10.5.0".to_string(),
-            pkg_id: pkg_id.to_string(),
-            prefix: prefix.to_string(),
-            deprecated: "no longer supported".to_string(),
-            depth,
-        })
-    };
-
-    let mut state = ReporterState::new("/repo".to_string(), 120, Colors { enabled: false }, true);
-    let mut rendered = String::new();
-    let mut record = |output: Output| {
-        if let Output::Lines(lines) = output {
-            for line in lines {
-                rendered.push_str(&line);
-                rendered.push('\n');
-            }
-        }
-    };
-
-    // First met deep in the tree, then again as a direct dependency of
-    // two workspace projects.
-    record(state.handle(&deprecation("glob@10.5.0", 3, "/repo/packages/a")));
-    record(state.handle(&deprecation("glob@10.5.0", 0, "/repo")));
-    record(state.handle(&deprecation("glob@10.5.0", 0, "/repo/packages/b")));
-    record(state.handle(&LogEvent::Stage(StageLog {
-        level: LogLevel::Debug,
-        prefix: "/repo".to_string(),
-        stage: Stage::ResolutionDone,
-    })));
-
-    assert_eq!(rendered.matches("deprecated").count(), 1, "rendered:\n{rendered}");
-    assert!(
-        !rendered.contains("deprecated subdependencies found"),
-        "a direct deprecation must not also be summarized as a subdependency:\n{rendered}",
-    );
 }

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -990,6 +990,17 @@ fn direct_deprecation_renders_immediately_with_the_message() {
     assert_eq!(frame, "[WARN] deprecated express@0.14.1: no longer supported");
 }
 
+#[test]
+fn recursive_direct_deprecation_is_zoomed_and_omits_the_message() {
+    let mut reporter =
+        state_with_options(ReporterOptions { is_recursive: true, ..ReporterOptions::default() });
+    let frame = render(&mut reporter, vec![deprecation("express", "0.14.1", 0, CWD)]);
+    assert_eq!(
+        frame,
+        pacquet_default_reporter::format::zoom_out(CWD, CWD, "[WARN] deprecated express@0.14.1",),
+    );
+}
+
 /// Upstream's zoomed variant carries only `deprecated name@version` — the
 /// deprecation text is dropped.
 #[test]

--- a/pnpm/crates/default-reporter/tests/render.rs
+++ b/pnpm/crates/default-reporter/tests/render.rs
@@ -685,6 +685,20 @@ fn append_only_waits_for_a_terminal_lockfile_policy_verdict() {
     }));
     assert!(matches!(pending, Output::None));
 
+    let stats = reporter.handle(&LogEvent::Stats(StatsLog {
+        level: LogLevel::Debug,
+        message: StatsMessage::Added { added: 1, prefix: CWD.to_string() },
+    }));
+    match stats {
+        Output::Lines(lines) => {
+            assert!(!lines.iter().any(|line| line.contains("Lockfile is up to date")));
+        }
+        Output::None => {}
+        Output::Frame(_) => {
+            panic!("install stats should not flush the pending frozen-install message");
+        }
+    }
+
     let started = reporter.handle(&LogEvent::LockfileVerification(LockfileVerificationLog {
         level: LogLevel::Debug,
         message: LockfileVerificationMessage::Started { entries: 2, lockfile_path: None },

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -777,10 +777,6 @@ pub struct WorkspaceTreeCtx {
     /// deprecation check but drops the notification. See
     /// [`DeprecationLogFn`].
     deprecation_log: Option<DeprecationLogFn>,
-    /// Per-package shallowest depth at which a deprecation was emitted.
-    /// Re-emits when the same package appears at a shallower depth so a
-    /// direct dependency is never misclassified as transitive.
-    deprecation_depths: Mutex<HashMap<String, i32>>,
     /// The install's `autoInstallPeers` setting. It widens which of a
     /// resolved package's `dependencies` its own `peerDependencies`
     /// shadow — see [`peer_shadowed_dependencies`].
@@ -858,7 +854,6 @@ impl Default for WorkspaceTreeCtx {
             read_package_log: None,
             skipped_optional_log: None,
             allowed_deprecated_versions: BTreeMap::new(),
-            deprecation_depths: Mutex::new(HashMap::new()),
             deprecation_log: None,
             auto_install_peers: false,
             registries: HashMap::new(),
@@ -1900,7 +1895,7 @@ where
     } else {
         extract_peer_dependencies(&result, &children_owner.peer_shadowed)
     };
-    if let Some(existing) = packages.get_mut(&id) {
+    let package_is_new = if let Some(existing) = packages.get_mut(&id) {
         existing.optional = existing.optional && current_is_optional;
         // A fresh claim can shadow a different set of dependencies than
         // the occurrence that populated the envelope did, which moves
@@ -1909,6 +1904,7 @@ where
             register_peer_dep_names(ctx, &peer_dependencies);
             existing.peer_dependencies = peer_dependencies;
         }
+        false
     } else {
         register_peer_dep_names(ctx, &peer_dependencies);
         packages.insert(
@@ -1921,10 +1917,13 @@ where
                 is_leaf,
             },
         );
-    }
+        true
+    };
     drop(packages);
 
-    emit_deprecation_if_needed(ctx, &result, &id, depth);
+    if package_is_new {
+        emit_deprecation_if_needed(ctx, &result, &id, depth);
+    }
 
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
@@ -3107,10 +3106,11 @@ where
     let is_leaf = child_refs.is_empty() && peer_dependencies.is_empty();
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
-    {
+    let package_is_new = {
         let mut packages = lock_recoverable(&ctx.workspace.packages);
         if let Some(existing) = packages.get_mut(&id) {
             existing.optional = existing.optional && current_is_optional;
+            false
         } else {
             {
                 let mut all_peers = lock_recoverable(&ctx.workspace.all_peer_dep_names);
@@ -3128,10 +3128,13 @@ where
                     is_leaf,
                 },
             );
+            true
         }
-    }
+    };
 
-    emit_deprecation_if_needed(ctx, &result, &id, depth);
+    if package_is_new {
+        emit_deprecation_if_needed(ctx, &result, &id, depth);
+    }
 
     let next_ancestors: Vec<String> =
         ancestor_ids.iter().cloned().chain(std::iter::once(id.clone())).collect();
@@ -3565,10 +3568,8 @@ fn is_empty_or_absent(value: Option<&Value>) -> bool {
     value.and_then(Value::as_object).is_none_or(serde_json::Map::is_empty)
 }
 
-/// Emits a [`Deprecation`] when the manifest carries a non-empty
-/// `deprecated` field not covered by `allowedDeprecatedVersions`.
-/// Re-emits at a shallower depth so a direct dependency is never
-/// misclassified as transitive.
+/// Emits a [`Deprecation`] when a newly-resolved package's manifest carries
+/// a non-empty `deprecated` field not covered by `allowedDeprecatedVersions`.
 fn emit_deprecation_if_needed(
     ctx: &TreeCtx,
     result: &pacquet_resolving_resolver_base::ResolveResult,
@@ -3586,15 +3587,6 @@ fn emit_deprecation_if_needed(
     };
     if is_deprecation_allowed(&pkg_name, &pkg_version, &ctx.workspace.allowed_deprecated_versions) {
         return;
-    }
-    {
-        let mut depths = lock_recoverable(&ctx.workspace.deprecation_depths);
-        if let Some(prev) = depths.get(id)
-            && depth >= *prev
-        {
-            return;
-        }
-        depths.insert(id.to_string(), depth);
     }
     let Some(log) = ctx.workspace.deprecation_log.as_ref() else {
         return;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1611,6 +1611,67 @@ async fn deprecated_manifests_notify_the_deprecation_sink_unless_allowed() {
     }
 }
 
+#[tokio::test]
+async fn deprecated_package_is_reported_only_on_its_first_occurrence() {
+    let (_transitive_tmp, transitive_manifest) =
+        fake_manifest(serde_json::json!({ "wrapper": "1.0.0" }));
+    let (_direct_tmp, direct_manifest) = fake_manifest(serde_json::json!({ "old": "1.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: "transitive".to_string(), manifest: &transitive_manifest },
+        WorkspaceImporter { id: "direct".to_string(), manifest: &direct_manifest },
+    ];
+    let resolver = RecordingResolver {
+        table: HashMap::from([
+            (
+                ("wrapper".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "wrapper",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "wrapper",
+                        "version": "1.0.0",
+                        "dependencies": { "old": "1.0.0" },
+                    }),
+                ),
+            ),
+            (
+                ("old".to_string(), "1.0.0".to_string()),
+                fake_result(
+                    "old",
+                    "1.0.0",
+                    None,
+                    serde_json::json!({
+                        "name": "old",
+                        "version": "1.0.0",
+                        "deprecated": "use new instead",
+                    }),
+                ),
+            ),
+        ]),
+        seen: Mutex::new(HashMap::new()),
+    };
+    let notifications = std::sync::Arc::new(Mutex::new(Vec::new()));
+    let sink = std::sync::Arc::clone(&notifications);
+    let mut opts = workspace_opts(false, false);
+    opts.deprecation_log = Some(std::sync::Arc::new(move |deprecation: crate::Deprecation| {
+        sink.lock().unwrap().push(deprecation);
+    }));
+
+    resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+        importer_opts(std::path::PathBuf::from("/repo").join(&importer.id), None)
+    })
+    .await
+    .expect("resolve a deprecated package reached at two depths");
+
+    let notifications = notifications.lock().unwrap();
+    let [deprecation] = notifications.as_slice() else {
+        panic!("expected one deprecation from the first occurrence: {notifications:?}");
+    };
+    assert_eq!(deprecation.depth, 1);
+    assert_eq!(deprecation.prefix, "/repo/transitive");
+}
+
 /// A dependency reused from the wanted lockfile still notifies the
 /// deprecation sink: the synthesized manifest round-trips the
 /// lockfile's `deprecated` metadata precisely so warm installs keep

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -1669,7 +1669,10 @@ async fn deprecated_package_is_reported_only_on_its_first_occurrence() {
         panic!("expected one deprecation from the first occurrence: {notifications:?}");
     };
     assert_eq!(deprecation.depth, 1);
-    assert_eq!(deprecation.prefix, "/repo/transitive");
+    assert_eq!(
+        deprecation.prefix,
+        std::path::PathBuf::from("/repo").join("transitive").display().to_string(),
+    );
 }
 
 /// A dependency reused from the wanted lockfile still notifies the


### PR DESCRIPTION
## Summary

Aligns pacquet's deprecated-package reporting with the TypeScript pnpm CLI:

- emits a deprecation event only for the package's first resolved occurrence, preserving its original depth and prefix;
- renders direct dependency deprecations through the workspace-relative form during recursive installs;
- removes reporter-side deduplication that is not present in the TypeScript reporter.

- serializes package-manager environment writes during concurrent cold-cache engine installs, preventing Windows lockfile replacement races and waiting when an engine cache entry is only partially materialized without blocking async executor workers;
- keeps the lockfile-policy verdict ahead of frozen-install output when package statistics arrive during concurrent verification.

The TypeScript CLI already has the intended deprecation behavior, so that parity fix changes only pacquet. The concurrency follow-up completes the existing pacquet-only package-manager switching fix.

## Squash Commit Body

```text
Pacquet re-emitted deprecated packages when the same package was encountered at a shallower depth. This could change a transitive warning into a direct warning and required Rust-only deduplication in the default reporter. Emit only when inserting a package into the shared resolved-package map, matching the TypeScript resolver's packageIsNew gate.

Thread the recursive command state into the default reporter so direct dependency warnings use pnpm's workspace-relative form and omit the deprecation reason during recursive installs. Remove reporter-side deduplication so event folding matches the TypeScript reporter.

Serialize package-manager environment resolution before reading or replacing its shared lockfile, acquiring blocking filesystem locks on Tokio’s blocking pool. Treat incomplete or broken cache entries as misses both before and after the engine-install lock so installation can recover safely.

Keep package statistics from prematurely flushing the pending frozen-install message, preserving the lockfile-policy verdict order while verification and materialization run concurrently.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787915817&installation_model_id=426870&pr_number=13490&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13490&signature=af0a2af0b4429529a3e46cfd83a776baa0c319a1f9779dc3d403ba5fc998f0ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecated package warnings are now emitted only on first occurrence during dependency resolution, preventing duplicates across reuse and multiple reachability paths.
  * Recursive installs adjust direct-deprecation rendering for cleaner output.
  * Frozen-install messaging no longer races with lockfile policy verdicts; order is preserved.
  * Improved install reliability by serializing package-manager env lockfile access and making cached-bin linking best-effort.
* **Tests**
  * Added regression coverage for “first occurrence only” deprecation reporting and recursive direct-deprecation rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->