### PR TITLE
perf(resolver): make multi-importer peer-hoist discovery linear

### DIFF
--- a/.changeset/workspace-hoist-discovery-linear.md
+++ b/.changeset/workspace-hoist-discovery-linear.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed quadratic time and memory use when resolving large multi-project workspaces from scratch. Peer-hoist discovery no longer snapshots the whole dependency tree and rebuilds the full dependency graph once per project; on a workspace with 331 projects sharing a 5,000-package graph, full resolution dropped from ~65 s and ~3.7 GiB to ~1.4 s and ~1.1 GiB.
+Fixed quadratic time and memory use when resolving a large multi-project workspace from scratch. Resolving a workspace with hundreds of projects sharing thousands of packages previously took minutes and several gigabytes of memory; it now completes in seconds.

--- a/.changeset/workspace-hoist-discovery-linear.md
+++ b/.changeset/workspace-hoist-discovery-linear.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed quadratic time and memory use when resolving large multi-project workspaces from scratch. Peer-hoist discovery no longer snapshots the whole dependency tree and rebuilds the full dependency graph once per project; on a workspace with 331 projects sharing a 5,000-package graph, full resolution dropped from ~65 s and ~3.7 GiB to ~1.4 s and ~1.1 GiB.

--- a/pnpm/crates/cli/tests/deploy.rs
+++ b/pnpm/crates/cli/tests/deploy.rs
@@ -269,8 +269,9 @@ fn force_deploy_rejects_out_of_scope_target_without_deleting_it() {
         .expect("run pacquet deploy");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let flattened = flatten_miette_report(&stderr);
     assert!(
-        stderr.contains("unsafe target") && stderr.contains("outside the workspace"),
+        flattened.contains("unsafe target") && flattened.contains("outside the workspace"),
         "unexpected stderr:\n{stderr}",
     );
     assert_eq!(fs::read_to_string(outside.join("keep.txt")).unwrap(), "keep");
@@ -301,10 +302,7 @@ fn deploy_all_files_rejects_symlink_escape() {
         .expect("run pacquet deploy");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    // miette wraps the message, and where it wraps depends on how long the
-    // temp path is, so match against whitespace-collapsed output rather than
-    // a phrase that a line break can land inside.
-    let flattened = stderr.split_whitespace().collect::<Vec<_>>().join(" ");
+    let flattened = flatten_miette_report(&stderr);
     assert!(
         flattened.contains("ERR_PNPM_DIRECTORY_FETCHER_PATH_ESCAPE")
             && flattened.contains("resolves outside source directory"),
@@ -337,8 +335,10 @@ fn deploy_rejects_symlinked_target_parent() {
         .expect("run pacquet deploy");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let flattened = flatten_miette_report(&stderr);
     assert!(
-        stderr.contains("ERR_PNPM_INVALID_DEPLOY_TARGET") && stderr.contains("contains a symlink"),
+        flattened.contains("ERR_PNPM_INVALID_DEPLOY_TARGET")
+            && flattened.contains("contains a symlink"),
         "unexpected stderr:\n{stderr}",
     );
     assert!(
@@ -366,9 +366,10 @@ fn deploy_rejects_linked_target_parent() {
         .expect("run pacquet deploy");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let flattened = flatten_miette_report(&stderr);
     assert!(
-        stderr.contains("ERR_PNPM_INVALID_DEPLOY_TARGET")
-            && stderr.contains("contains a symlink or junction"),
+        flattened.contains("ERR_PNPM_INVALID_DEPLOY_TARGET")
+            && flattened.contains("contains a symlink or junction"),
         "unexpected stderr:\n{stderr}",
     );
     assert!(
@@ -498,6 +499,17 @@ fn legacy_deploy_without_lockfile_installs_selected_project_at_root() {
     assert!(!deploy_dir.join("pnpm-lock.yaml").exists());
 
     drop((root, mock_instance));
+}
+
+/// Undo miette's report wrapping so phrase assertions don't depend on
+/// where the temp-path length lands the wrap point: drop the box-gutter
+/// glyphs and collapse the message back onto one line.
+fn flatten_miette_report(stderr: &str) -> String {
+    stderr
+        .split_whitespace()
+        .filter(|token| !matches!(*token, "│" | "×" | "╰─▶"))
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn pacquet_cmd(workspace: &Path) -> Command {

--- a/pnpm/crates/resolving-deps-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-deps-resolver/Cargo.toml
@@ -43,3 +43,7 @@ tokio             = { workspace = true, features = ["macros", "rt-multi-thread"]
 
 [lints]
 workspace = true
+
+[[bench]]
+name    = "workspace_full_resolution"
+harness = false

--- a/pnpm/crates/resolving-deps-resolver/benches/workspace_full_resolution.rs
+++ b/pnpm/crates/resolving-deps-resolver/benches/workspace_full_resolution.rs
@@ -1,0 +1,222 @@
+//! Regression benchmark for the large multi-importer full-resolution path.
+//!
+//! This models the Bit workspace that exposed the regression:
+//!
+//! - 331 component importers;
+//! - a shared 5,000-package layered dependency graph;
+//! - 20 direct roots per importer;
+//! - peer hoisting enabled, which runs the importer peer-discovery barrier;
+//! - no wanted lockfile, so the whole graph is resolved.
+//!
+//! Run once (the benchmark intentionally has no statistical harness because a
+//! regressed run can take minutes and several GiB):
+//!
+//! ```text
+//! cargo bench -p pacquet-resolving-deps-resolver --bench workspace_full_resolution
+//! ```
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    hint::black_box,
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+    time::Instant,
+};
+
+use pacquet_lockfile::{LockfileResolution, PkgName, PkgNameVer, TarballResolution};
+use pacquet_package_manifest::{DependencyGroup, PackageManifest};
+use pacquet_resolving_deps_resolver::{
+    ResolveImporterOptions, UpdateDepth, UpdateReuseScope, WorkspaceImporter,
+    WorkspaceResolveOptions, resolve_workspace,
+};
+use pacquet_resolving_resolver_base::{
+    LatestQuery, PkgResolutionId, PreferredVersions, ResolveError, ResolveFuture,
+    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, WantedDependency,
+};
+
+const IMPORTER_COUNT: usize = 331;
+const LAYER_COUNT: usize = 250;
+const PACKAGES_PER_LAYER: usize = 20;
+const CHILDREN_PER_PACKAGE: usize = 4;
+
+struct GraphResolver {
+    packages: HashMap<String, ResolveResult>,
+}
+
+impl Resolver for GraphResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let result = wanted.alias.as_ref().and_then(|alias| self.packages.get(alias)).cloned();
+        Box::pin(async move { Ok::<_, ResolveError>(result) })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+fn package_name(layer: usize, index: usize) -> String {
+    format!("pkg-{layer:02}-{index:02}")
+}
+
+fn dependencies_for_package(layer: usize, index: usize) -> serde_json::Value {
+    if layer + 1 == LAYER_COUNT {
+        return serde_json::Value::Object(serde_json::Map::new());
+    }
+    let dependencies = (0..CHILDREN_PER_PACKAGE)
+        .map(|offset| {
+            let child = package_name(layer + 1, (index + offset) % PACKAGES_PER_LAYER);
+            (child, serde_json::Value::String("1.0.0".to_string()))
+        })
+        .collect();
+    serde_json::Value::Object(dependencies)
+}
+
+fn graph_resolver() -> GraphResolver {
+    let packages = (0..LAYER_COUNT)
+        .flat_map(|layer| {
+            (0..PACKAGES_PER_LAYER).map(move |index| {
+                let name = package_name(layer, index);
+                let name_ver = PkgNameVer::new(
+                    PkgName::parse(&name).expect("benchmark package name is valid"),
+                    node_semver::Version::from_str("1.0.0")
+                        .expect("benchmark package version is valid"),
+                );
+                let manifest = serde_json::json!({
+                    "name": name,
+                    "version": "1.0.0",
+                    "dependencies": dependencies_for_package(layer, index),
+                });
+                let result = ResolveResult {
+                    id: PkgResolutionId::from(&name_ver),
+                    name_ver: Some(name_ver),
+                    latest: Some("1.0.0".to_string()),
+                    published_at: None,
+                    manifest: Some(Arc::new(manifest)),
+                    resolution: LockfileResolution::Tarball(TarballResolution {
+                        tarball: format!("https://registry.example/{name}-1.0.0.tgz"),
+                        integrity: None,
+                        git_hosted: None,
+                        path: None,
+                    }),
+                    resolved_via: "npm-registry".to_string(),
+                    normalized_bare_specifier: None,
+                    alias: Some(name.clone()),
+                    policy_violation: None,
+                };
+                (name, result)
+            })
+        })
+        .collect();
+    GraphResolver { packages }
+}
+
+fn importer_manifest(index: usize) -> PackageManifest {
+    let dependencies = (0..PACKAGES_PER_LAYER)
+        .map(|root| (package_name(0, root), serde_json::Value::String("1.0.0".to_string())))
+        .collect();
+    PackageManifest::from_value(
+        PathBuf::from(format!("/workspace/component-{index:03}/package.json")),
+        serde_json::json!({
+            "name": format!("component-{index:03}"),
+            "version": "1.0.0",
+            "dependencies": serde_json::Value::Object(dependencies),
+        }),
+    )
+}
+
+fn importer_options(importer: &WorkspaceImporter<'_>) -> ResolveImporterOptions {
+    ResolveImporterOptions {
+        auto_install_peers: true,
+        auto_install_peers_from_highest_match: false,
+        resolve_peers_from_workspace_root: false,
+        dedupe_peers: true,
+        dedupe_peer_dependents: true,
+        all_preferred_versions: PreferredVersions::new(),
+        override_bare_specifier: None,
+        patched_dependencies: None,
+        base_opts: ResolveOptions {
+            project_dir: PathBuf::from("/workspace").join(&importer.id),
+            ..ResolveOptions::default()
+        },
+        pick_lowest_direct: false,
+        subdep_published_by: None,
+        catalogs: pacquet_catalogs_types::Catalogs::new(),
+        exclude_links_from_lockfile: false,
+        lockfile_dir: Some(PathBuf::from("/workspace")),
+        modules_dir: Some(PathBuf::from("/workspace/node_modules")),
+        peers_suffix_max_length: 1000,
+        catalog_server: false,
+        manifest_hook: None,
+        pnpmfile_hook: None,
+    }
+}
+
+fn workspace_options() -> WorkspaceResolveOptions {
+    WorkspaceResolveOptions {
+        dedupe_peers: true,
+        dedupe_injected_deps: true,
+        dedupe_peer_dependents: true,
+        resolve_peers_from_workspace_root: false,
+        exclude_links_from_lockfile: false,
+        lockfile_dir: PathBuf::from("/workspace"),
+        peers_suffix_max_length: 1000,
+        manifest_hook: None,
+        pick_lowest_direct: false,
+        time_based: false,
+        wanted_lockfile: None,
+        update_reuse_scope: UpdateReuseScope::All,
+        update_reuse_scopes_by_importer: BTreeMap::new(),
+        update_depth: UpdateDepth::UNLIMITED,
+        pnpmfile_hook: None,
+        read_package_log: None,
+        skipped_optional_log: None,
+        allowed_deprecated_versions: BTreeMap::new(),
+        deprecation_log: None,
+        auto_install_peers: true,
+        registries: HashMap::new(),
+    }
+}
+
+fn main() {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("create benchmark runtime");
+    let manifests: Vec<_> = (0..IMPORTER_COUNT).map(importer_manifest).collect();
+    let importer_ids: Vec<_> =
+        (0..IMPORTER_COUNT).map(|index| format!("components/component-{index:03}")).collect();
+    let importers: Vec<_> = importer_ids
+        .iter()
+        .zip(&manifests)
+        .map(|(id, manifest)| WorkspaceImporter { id: id.clone(), manifest })
+        .collect();
+    let resolver = graph_resolver();
+
+    let started = Instant::now();
+    let result = runtime
+        .block_on(resolve_workspace(
+            &resolver,
+            &importers,
+            &[DependencyGroup::Prod],
+            workspace_options(),
+            importer_options,
+        ))
+        .expect("benchmark workspace resolves");
+    let elapsed = started.elapsed();
+    black_box(&result);
+
+    println!(
+        "full workspace resolution: {IMPORTER_COUNT} importers, {} packages, {} graph nodes in {elapsed:.2?}",
+        resolver.packages.len(),
+        result.peers.graph.len(),
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lib.rs
@@ -35,12 +35,15 @@
 //!    `(pkgIdWithPatchHash, peer-suffix)` combination) and the entry
 //!    point for the install layer.
 //!
-//! 3. **Hoist loop** ([`fn@resolve_importer`]). Runs passes 1–2,
-//!    aggregates missing required and optional peers via
-//!    [`fn@hoist_peers`] / [`fn@get_hoistable_optional_peers`], extends
-//!    the tree with hoisted picks via
-//!    [`extend_tree`], and re-runs the peer pass
-//!    until both pass-1 and pass-2 reach a fixed point.
+//! 3. **Hoist loop** ([`fn@resolve_importer`]). Runs pass 1 plus a
+//!    graph-free discovery variant of pass 2 (one persistent
+//!    discovery engine per workspace resolve, so repeat walks
+//!    short-circuit on already-settled subtrees), aggregates missing
+//!    required and optional peers via [`fn@hoist_peers`] /
+//!    [`fn@get_hoistable_optional_peers`], extends the tree with
+//!    hoisted picks via [`extend_tree`], and re-runs discovery until
+//!    both reach a fixed point. The full pass 2 then runs once per
+//!    install.
 //!
 //! Notable design points:
 //!

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -731,6 +731,13 @@ pub struct WorkspaceTreeCtx {
     /// revision of its last sync to skip re-syncing an unchanged
     /// context.
     revision: std::sync::atomic::AtomicU64,
+    /// Bumped whenever a children-ownership change rewrites an existing
+    /// occurrence node's children in `dependencies_tree` (see
+    /// [`fn@make_non_owner_nodes_lazy`]). Such a rewrite invalidates
+    /// walk state derived from the previous children, so the discovery
+    /// engine rebuilds its view instead of merging when this advanced
+    /// since its last sync.
+    children_rewrites: std::sync::atomic::AtomicU64,
     packages: Mutex<HashMap<String, ResolvedPackage>>,
     /// `(name, version)` of every registry-resolved package, in
     /// insertion order — one entry per `packages` insert whose result
@@ -846,6 +853,7 @@ impl Default for WorkspaceTreeCtx {
     fn default() -> Self {
         WorkspaceTreeCtx {
             revision: std::sync::atomic::AtomicU64::new(0),
+            children_rewrites: std::sync::atomic::AtomicU64::new(0),
             packages: Mutex::new(HashMap::new()),
             resolved_versions_log: Mutex::new(Vec::new()),
             workspace_package_versions: Mutex::new(HashSet::new()),
@@ -929,12 +937,18 @@ impl WorkspaceTreeCtx {
                 pending_node_ids.extend(children.values().cloned());
             }
         }
-        let dependencies_tree: HashMap<_, _> = reachable_node_ids
+        let reachable_dependencies_tree: HashMap<_, _> = reachable_node_ids
             .iter()
             .filter_map(|node_id| {
                 dependencies_tree.get(node_id).cloned().map(|node| (node_id.clone(), node))
             })
             .collect();
+        // Release before taking the next guard so this function never
+        // holds two of the context's locks at once — `snapshot` takes
+        // `packages` before `dependencies_tree`, so overlapping here
+        // would create a reversed acquisition order.
+        drop(dependencies_tree);
+        let dependencies_tree = reachable_dependencies_tree;
 
         let all_children = lock_recoverable(&self.children_by_id);
         let mut pending_pkg_ids: Vec<String> = reachable_pkg_ids.iter().cloned().collect();
@@ -1067,6 +1081,15 @@ impl WorkspaceTreeCtx {
 
     pub(crate) fn bump_revision(&self) {
         self.revision.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// See the `children_rewrites` field doc.
+    pub(crate) fn children_rewrites(&self) -> u64 {
+        self.children_rewrites.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn record_children_rewrite(&self) {
+        self.children_rewrites.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Fold the context's growth since the last sync into `tree`, the
@@ -2941,6 +2964,7 @@ fn remember_node_parent_ids(ctx: &TreeCtx, node_id: &NodeId, parent_ids: Arc<Vec
 fn make_non_owner_nodes_lazy(ctx: &TreeCtx, pkg_id: &str, owner_node_id: &NodeId) {
     let parent_ids_by_node = lock_recoverable(&ctx.workspace.node_parent_ids_by_id).clone();
     let mut tree = lock_recoverable(&ctx.workspace.dependencies_tree);
+    let mut rewrote_any = false;
     for (node_id, node) in tree.iter_mut() {
         if node_id == owner_node_id || node.resolved_package_id != pkg_id {
             continue;
@@ -2950,6 +2974,10 @@ fn make_non_owner_nodes_lazy(ctx: &TreeCtx, pkg_id: &str, owner_node_id: &NodeId
         };
         node.children =
             crate::resolved_tree::TreeChildren::Lazy { parent_ids: Arc::clone(parent_ids) };
+        rewrote_any = true;
+    }
+    if rewrote_any {
+        ctx.workspace.record_children_rewrite();
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -900,12 +900,12 @@ impl WorkspaceTreeCtx {
     /// Snapshot only the part of the occurrence tree reachable from one
     /// importer's direct dependencies.
     ///
-    /// A workspace resolve keeps every importer's occurrence nodes in this
-    /// shared context. Hoist discovery runs a peer pass per importer, so
-    /// cloning the whole context for every pass retains
-    /// `importer_count * workspace_node_count` nodes at the initial
-    /// workspace barrier. Large component workspaces turn that into
-    /// quadratic time and multi-gigabyte memory use.
+    /// A workspace resolve keeps every importer's occurrence nodes in
+    /// this shared context, so a full [`Self::snapshot`] taken for one
+    /// importer retains every other importer's nodes too. The
+    /// reachable-only snapshot keeps per-importer consumers (the
+    /// workspace-root hoistable-deps scan) proportional to that
+    /// importer's own subtree.
     ///
     /// Realized edges provide the occurrence-node closure. Lazy edges are
     /// materialized by the peer walker from `children_by_id`, so their

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -726,7 +726,19 @@ struct ChildrenOwnerEntry {
 /// every importer's walk contributes entries to one combined tree
 /// without colliding.
 pub struct WorkspaceTreeCtx {
+    /// Bumped whenever an [`fn@extend_tree`] call may mutate the shared
+    /// maps. The peer-hoist discovery engine compares it against the
+    /// revision of its last sync to skip re-syncing an unchanged
+    /// context.
+    revision: std::sync::atomic::AtomicU64,
     packages: Mutex<HashMap<String, ResolvedPackage>>,
+    /// `(name, version)` of every registry-resolved package, in
+    /// insertion order — one entry per `packages` insert whose result
+    /// carries a `name_ver`. Lets each importer's preferred-versions
+    /// fold consume only the entries appended since its previous round
+    /// (see [`TreeCtx::resolved_versions_since`]) instead of rescanning
+    /// the whole `packages` map every round.
+    resolved_versions_log: Mutex<Vec<(String, String)>>,
     workspace_package_versions: Mutex<HashSet<(String, String)>>,
     dependencies_tree: Mutex<HashMap<NodeId, DependenciesTreeNode>>,
     all_peer_dep_names: Mutex<HashSet<String>>,
@@ -833,7 +845,9 @@ struct OwnerMissingRecord {
 impl Default for WorkspaceTreeCtx {
     fn default() -> Self {
         WorkspaceTreeCtx {
+            revision: std::sync::atomic::AtomicU64::new(0),
             packages: Mutex::new(HashMap::new()),
+            resolved_versions_log: Mutex::new(Vec::new()),
             workspace_package_versions: Mutex::new(HashSet::new()),
             dependencies_tree: Mutex::new(HashMap::new()),
             all_peer_dep_names: Mutex::new(HashSet::new()),
@@ -997,9 +1011,11 @@ impl WorkspaceTreeCtx {
         importer_id: &str,
         missing_by_pkg: &HashMap<String, HashSet<String>>,
     ) {
-        let owners = lock_recoverable(&self.children_owner_by_id).clone();
+        // Lock order: `children_owner_by_id` before
+        // `first_walk_missing_by_pkg`, the only place both are held.
+        let owners = lock_recoverable(&self.children_owner_by_id);
         let mut record = lock_recoverable(&self.first_walk_missing_by_pkg);
-        for (pkg_id, ChildrenOwnerEntry { owner, .. }) in &owners {
+        for (pkg_id, ChildrenOwnerEntry { owner, .. }) in owners.iter() {
             if owner.importer_id != importer_id {
                 continue;
             }
@@ -1032,6 +1048,111 @@ impl WorkspaceTreeCtx {
         lock_recoverable(&self.first_walk_missing_by_pkg)
             .iter()
             .map(|(pkg_id, entry)| (pkg_id.clone(), entry.names.clone()))
+            .collect()
+    }
+
+    /// Append a freshly-inserted package's `(name, version)` to the
+    /// resolved-versions log. Call once per new `packages` entry.
+    fn record_resolved_version(&self, result: &pacquet_resolving_resolver_base::ResolveResult) {
+        if let Some(name_ver) = result.name_ver.as_ref() {
+            lock_recoverable(&self.resolved_versions_log)
+                .push((name_ver.name.to_string(), name_ver.suffix.to_string()));
+        }
+    }
+
+    /// See the `revision` field doc.
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub(crate) fn bump_revision(&self) {
+        self.revision.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Fold the context's growth since the last sync into `tree`, the
+    /// peer-hoist discovery engine's persistent view of the workspace.
+    ///
+    /// The shared maps grow monotonically during the hoist rounds, so
+    /// the sync inserts entries `tree` doesn't have yet and lowers node
+    /// depths that shrank. The exceptions are a children-owner change,
+    /// which can rewrite an existing package's recorded child list or
+    /// peer-dependency split: those invalidate walk results already
+    /// derived from the old values, so the sync reports them as
+    /// unmergeable (`false`) and the engine rebuilds its view from
+    /// scratch. A replaced `children_by_id` `Arc` with equal contents
+    /// (an ownership handover that re-recorded the same children) is
+    /// re-pointed without invalidating.
+    pub(crate) fn sync_discovery_tree(&self, tree: &mut ResolvedTree) -> bool {
+        use std::collections::hash_map::Entry;
+        {
+            let children_by_id = lock_recoverable(&self.children_by_id);
+            for (pkg_id, spec) in children_by_id.iter() {
+                match tree.children_by_id.entry(pkg_id.clone()) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(Arc::clone(spec));
+                    }
+                    Entry::Occupied(mut entry) => {
+                        if Arc::ptr_eq(entry.get(), spec) {
+                            continue;
+                        }
+                        if **entry.get() != **spec {
+                            return false;
+                        }
+                        entry.insert(Arc::clone(spec));
+                    }
+                }
+            }
+        }
+        {
+            let packages = lock_recoverable(&self.packages);
+            for (pkg_id, pkg) in packages.iter() {
+                match tree.packages.entry(pkg_id.clone()) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(pkg.clone());
+                    }
+                    Entry::Occupied(entry) => {
+                        if entry.get().peer_dependencies != pkg.peer_dependencies {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        {
+            let dependencies_tree = lock_recoverable(&self.dependencies_tree);
+            for (node_id, node) in dependencies_tree.iter() {
+                match tree.dependencies_tree.entry(node_id.clone()) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(node.clone());
+                    }
+                    Entry::Occupied(mut entry) => {
+                        if entry.get().depth > node.depth {
+                            entry.get_mut().depth = node.depth;
+                        }
+                    }
+                }
+            }
+        }
+        tree.all_peer_dep_names.extend(lock_recoverable(&self.all_peer_dep_names).iter().cloned());
+        true
+    }
+
+    /// `NodeId → pkgIdWithPatchHash` for the given peer-provider nodes,
+    /// keeping only nodes the shared context resolved eagerly (a node
+    /// the peer walker realized lazily has no context entry and is
+    /// dropped, matching the hoist loop's providers-that-existed-before-
+    /// the-pass filter).
+    pub(crate) fn provider_pkg_ids<'node_ids>(
+        &self,
+        node_ids: impl Iterator<Item = &'node_ids NodeId>,
+    ) -> HashMap<NodeId, String> {
+        let dependencies_tree = lock_recoverable(&self.dependencies_tree);
+        let packages = lock_recoverable(&self.packages);
+        node_ids
+            .filter_map(|node_id| {
+                let pkg_id = &dependencies_tree.get(node_id)?.resolved_package_id;
+                packages.contains_key(pkg_id).then(|| (node_id.clone(), pkg_id.clone()))
+            })
             .collect()
     }
 
@@ -1444,18 +1565,15 @@ impl TreeCtx {
         self.workspace.snapshot_reachable_from(direct)
     }
 
-    /// Return every registry version resolved so far.
+    /// Return every registry version resolved since the caller's
+    /// previous call, advancing `cursor` past them. A caller starting
+    /// from `0` sees the full workspace-wide history.
     #[must_use]
-    pub fn resolved_versions(&self) -> Vec<(String, String)> {
-        lock_recoverable(&self.workspace.packages)
-            .values()
-            .filter_map(|pkg| {
-                pkg.result
-                    .name_ver
-                    .as_ref()
-                    .map(|name_ver| (name_ver.name.to_string(), name_ver.suffix.to_string()))
-            })
-            .collect()
+    pub fn resolved_versions_since(&self, cursor: &mut usize) -> Vec<(String, String)> {
+        let log = lock_recoverable(&self.workspace.resolved_versions_log);
+        let fresh = log[*cursor..].to_vec();
+        *cursor = log.len();
+        fresh
     }
 
     pub(crate) fn newly_seen_workspace_package_versions(
@@ -1492,6 +1610,7 @@ pub async fn extend_tree<Chain>(
 where
     Chain: Resolver + ?Sized,
 {
+    ctx.workspace.bump_revision();
     // Direct deps reuse via the importer's recorded resolution when a
     // prior lockfile exists; without one the gate is a no-op.
     let reuse = if ctx.workspace.wanted_lockfile.is_some() {
@@ -2000,6 +2119,7 @@ where
     drop(packages);
 
     if package_is_new {
+        ctx.workspace.record_resolved_version(&result);
         emit_deprecation_if_needed(ctx, &result, &id, depth);
     }
 
@@ -3211,6 +3331,7 @@ where
     };
 
     if package_is_new {
+        ctx.workspace.record_resolved_version(&result);
         emit_deprecation_if_needed(ctx, &result, &id, depth);
     }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -883,6 +883,78 @@ impl WorkspaceTreeCtx {
         }
     }
 
+    /// Snapshot only the part of the occurrence tree reachable from one
+    /// importer's direct dependencies.
+    ///
+    /// A workspace resolve keeps every importer's occurrence nodes in this
+    /// shared context. Hoist discovery runs a peer pass per importer, so
+    /// cloning the whole context for every pass retains
+    /// `importer_count * workspace_node_count` nodes at the initial
+    /// workspace barrier. Large component workspaces turn that into
+    /// quadratic time and multi-gigabyte memory use.
+    ///
+    /// Realized edges provide the occurrence-node closure. Lazy edges are
+    /// materialized by the peer walker from `children_by_id`, so their
+    /// package closure is collected separately and included here too.
+    #[must_use]
+    pub fn snapshot_reachable_from(&self, direct: Vec<DirectDep>) -> ResolvedTree {
+        let dependencies_tree = lock_recoverable(&self.dependencies_tree);
+        let mut reachable_node_ids = HashSet::new();
+        let mut reachable_pkg_ids = HashSet::new();
+        let mut pending_node_ids: Vec<NodeId> =
+            direct.iter().map(|dep| dep.node_id.clone()).collect();
+        while let Some(node_id) = pending_node_ids.pop() {
+            if !reachable_node_ids.insert(node_id.clone()) {
+                continue;
+            }
+            let Some(node) = dependencies_tree.get(&node_id) else {
+                continue;
+            };
+            reachable_pkg_ids.insert(node.resolved_package_id.clone());
+            if let crate::resolved_tree::TreeChildren::Realized(children) = &node.children {
+                pending_node_ids.extend(children.values().cloned());
+            }
+        }
+        let dependencies_tree: HashMap<_, _> = reachable_node_ids
+            .iter()
+            .filter_map(|node_id| {
+                dependencies_tree.get(node_id).cloned().map(|node| (node_id.clone(), node))
+            })
+            .collect();
+
+        let all_children = lock_recoverable(&self.children_by_id);
+        let mut pending_pkg_ids: Vec<String> = reachable_pkg_ids.iter().cloned().collect();
+        let mut children_by_id = HashMap::new();
+        while let Some(pkg_id) = pending_pkg_ids.pop() {
+            let Some(children) = all_children.get(&pkg_id) else {
+                continue;
+            };
+            children_by_id.insert(pkg_id, Arc::clone(children));
+            for child in children.iter() {
+                if reachable_pkg_ids.insert(child.pkg_id.clone()) {
+                    pending_pkg_ids.push(child.pkg_id.clone());
+                }
+            }
+        }
+        drop(all_children);
+
+        let packages = lock_recoverable(&self.packages);
+        let packages = reachable_pkg_ids
+            .into_iter()
+            .filter_map(|pkg_id| packages.get(&pkg_id).cloned().map(|pkg| (pkg_id, pkg)))
+            .collect();
+
+        ResolvedTree {
+            direct,
+            packages,
+            dependencies_tree,
+            all_peer_dep_names: lock_recoverable(&self.all_peer_dep_names).clone(),
+            policy_violations: lock_recoverable(&self.policy_violations).clone(),
+            applied_patches: lock_recoverable(&self.applied_patches).clone(),
+            children_by_id,
+        }
+    }
+
     /// Attach a `readPackageHook` applied to every resolved manifest
     /// before it enters the wanted-dep cache. See [`ManifestHook`] for
     /// the signature.
@@ -1364,6 +1436,12 @@ impl TreeCtx {
     #[must_use]
     pub fn snapshot(&self, direct: Vec<DirectDep>) -> ResolvedTree {
         self.workspace.snapshot(direct)
+    }
+
+    /// Build an importer-scoped snapshot for a peer-hoist pass.
+    #[must_use]
+    pub fn snapshot_reachable_from(&self, direct: Vec<DirectDep>) -> ResolvedTree {
+        self.workspace.snapshot_reachable_from(direct)
     }
 
     /// Return every registry version resolved so far.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -6,8 +6,14 @@ use pacquet_resolving_resolver_base::{
 };
 
 use super::{
-    ResolveDependencyTreeOptions, extract_children, landed_on_prior_entry, resolve_dependency_tree,
+    ResolveDependencyTreeOptions, WorkspaceTreeCtx, extract_children, landed_on_prior_entry,
+    resolve_dependency_tree,
 };
+use crate::{
+    DirectDep, NodeId,
+    resolved_tree::{DependenciesTreeNode, TreeChildren},
+};
+use std::collections::BTreeMap;
 
 #[test]
 fn dependency_engines_runtime_is_walked_as_a_runtime_dependency() {
@@ -39,6 +45,49 @@ fn dependency_engines_runtime_is_walked_as_a_runtime_dependency() {
         extract_children(&result).unwrap(),
         vec![("node".to_string(), "runtime:22.19.0".to_string(), false)],
     );
+}
+
+#[test]
+fn importer_snapshot_excludes_other_importers_occurrence_nodes() {
+    let workspace = WorkspaceTreeCtx::default();
+    let root = NodeId::next();
+    let child = NodeId::next();
+    let unrelated = NodeId::next();
+    workspace.dependencies_tree.lock().unwrap().extend([
+        (
+            root.clone(),
+            DependenciesTreeNode::new(
+                "root@1.0.0".to_string(),
+                TreeChildren::Realized(BTreeMap::from([("child".to_string(), child.clone())])),
+                0,
+                true,
+            ),
+        ),
+        (
+            child.clone(),
+            DependenciesTreeNode::new("child@1.0.0".to_string(), TreeChildren::empty(), 1, true),
+        ),
+        (
+            unrelated.clone(),
+            DependenciesTreeNode::new(
+                "unrelated@1.0.0".to_string(),
+                TreeChildren::empty(),
+                0,
+                true,
+            ),
+        ),
+    ]);
+
+    let snapshot = workspace.snapshot_reachable_from(vec![DirectDep {
+        alias: "root".to_string(),
+        node_id: root.clone(),
+        id: "root@1.0.0".to_string(),
+    }]);
+
+    assert_eq!(snapshot.dependencies_tree.len(), 2);
+    assert!(snapshot.dependencies_tree.contains_key(&root));
+    assert!(snapshot.dependencies_tree.contains_key(&child));
+    assert!(!snapshot.dependencies_tree.contains_key(&unrelated));
 }
 
 fn manifest_result(manifest: serde_json::Value) -> ResolveResult {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -90,6 +90,98 @@ fn importer_snapshot_excludes_other_importers_occurrence_nodes() {
     assert!(!snapshot.dependencies_tree.contains_key(&unrelated));
 }
 
+#[test]
+fn importer_snapshot_follows_lazy_edges_for_the_package_closure() {
+    use super::lock_recoverable;
+    use crate::resolved_tree::ChildEdge;
+    use std::sync::Arc;
+
+    let workspace = WorkspaceTreeCtx::default();
+    let root = NodeId::next();
+    lock_recoverable(&workspace.dependencies_tree).insert(
+        root.clone(),
+        DependenciesTreeNode::new(
+            "root@1.0.0".to_string(),
+            TreeChildren::Lazy { parent_ids: Arc::new(Vec::new()) },
+            0,
+            true,
+        ),
+    );
+    for pkg_id in ["root@1.0.0", "lazy-child@1.0.0", "foreign@1.0.0"] {
+        lock_recoverable(&workspace.packages).insert(pkg_id.to_string(), snapshot_package(pkg_id));
+    }
+    lock_recoverable(&workspace.children_by_id).insert(
+        "root@1.0.0".to_string(),
+        Arc::new(vec![ChildEdge {
+            alias: "lazy-child".to_string(),
+            pkg_id: "lazy-child@1.0.0".to_string(),
+            optional: false,
+        }]),
+    );
+    lock_recoverable(&workspace.children_by_id)
+        .insert("foreign@1.0.0".to_string(), Arc::new(Vec::new()));
+
+    let snapshot = workspace.snapshot_reachable_from(vec![DirectDep {
+        alias: "root".to_string(),
+        node_id: root,
+        id: "root@1.0.0".to_string(),
+    }]);
+
+    assert!(
+        snapshot.packages.contains_key("lazy-child@1.0.0"),
+        "a package reachable only through a lazy edge must stay in the snapshot",
+    );
+    assert!(snapshot.children_by_id.contains_key("root@1.0.0"));
+    assert!(!snapshot.packages.contains_key("foreign@1.0.0"));
+    assert!(!snapshot.children_by_id.contains_key("foreign@1.0.0"));
+}
+
+#[test]
+fn ownership_rewrite_of_existing_nodes_bumps_children_rewrites() {
+    use super::{TreeCtx, lock_recoverable, make_non_owner_nodes_lazy};
+    use std::sync::Arc;
+
+    let workspace = Arc::new(WorkspaceTreeCtx::default());
+    let ctx = TreeCtx::with_workspace(Arc::clone(&workspace), ResolveOptions::default());
+    let owner = NodeId::next();
+    let other = NodeId::next();
+    lock_recoverable(&workspace.dependencies_tree).extend([
+        (
+            owner.clone(),
+            DependenciesTreeNode::new("pkg@1.0.0".to_string(), TreeChildren::empty(), 0, true),
+        ),
+        (
+            other.clone(),
+            DependenciesTreeNode::new("pkg@1.0.0".to_string(), TreeChildren::empty(), 1, true),
+        ),
+    ]);
+    lock_recoverable(&workspace.node_parent_ids_by_id)
+        .insert(other.clone(), Arc::new(vec!["parent@1.0.0".to_string()]));
+
+    make_non_owner_nodes_lazy(&ctx, "absent@1.0.0", &owner);
+    assert_eq!(workspace.children_rewrites(), 0, "no occurrence rewritten, nothing to invalidate");
+
+    make_non_owner_nodes_lazy(&ctx, "pkg@1.0.0", &owner);
+    assert_eq!(workspace.children_rewrites(), 1);
+    assert!(
+        matches!(
+            lock_recoverable(&workspace.dependencies_tree).get(&other).unwrap().children,
+            TreeChildren::Lazy { .. },
+        ),
+        "the non-owner occurrence flips to lazy",
+    );
+}
+
+fn snapshot_package(pkg_id: &str) -> super::ResolvedPackage {
+    super::ResolvedPackage {
+        id: pkg_id.to_string(),
+        result: std::sync::Arc::new(manifest_result(serde_json::json!({}))),
+        peer_dependencies: BTreeMap::new(),
+        optional: false,
+        is_leaf: false,
+    }
+}
+
 fn manifest_result(manifest: serde_json::Value) -> ResolveResult {
     ResolveResult {
         id: PkgResolutionId::from("parent@1.0.0"),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -362,8 +362,10 @@ pub(crate) struct ImporterHoistState {
 }
 
 pub(crate) struct RequiredRound {
-    snapshot: ResolvedTree,
-    original_node_ids: HashSet<crate::NodeId>,
+    /// Peer providers that existed before this pass began. Retaining only
+    /// this compact lookup lets the importer-scoped tree be dropped after
+    /// the peer walk instead of keeping one full tree per workspace importer.
+    provider_pkg_ids: HashMap<crate::NodeId, String>,
     peers_result: ResolvePeersResult,
 }
 
@@ -496,7 +498,7 @@ impl ImporterHoistState {
     ) -> Result<Vec<WorkspaceRootDep>, ResolveImporterError> {
         build_workspace_root_deps(
             &self.direct,
-            &self.ctx.snapshot(self.direct.clone()),
+            &self.ctx.snapshot_reachable_from(self.direct.clone()),
             &self.wanted_specifier_by_alias,
             &self.project_dir,
         )
@@ -595,7 +597,7 @@ impl ImporterHoistState {
         &self,
         hoist_missing_scope: Option<Arc<HoistMissingScope>>,
     ) -> RequiredRound {
-        let mut snapshot = self.ctx.snapshot(self.direct.clone());
+        let mut snapshot = self.ctx.snapshot_reachable_from(self.direct.clone());
         let original_node_ids: HashSet<crate::NodeId> =
             snapshot.dependencies_tree.keys().cloned().collect();
         let peers_result = {
@@ -603,10 +605,19 @@ impl ImporterHoistState {
             opts.hoist_missing_scope = hoist_missing_scope;
             resolve_peers(&mut snapshot, opts)
         };
+        let provider_pkg_ids = peers_result
+            .resolved_peer_providers_by_alias
+            .values()
+            .filter(|node_id| original_node_ids.contains(*node_id))
+            .filter_map(|node_id| {
+                let pkg_id = snapshot.dependencies_tree.get(node_id)?.resolved_package_id.clone();
+                snapshot.packages.contains_key(&pkg_id).then(|| (node_id.clone(), pkg_id))
+            })
+            .collect();
         self.ctx
             .workspace()
             .record_first_walk_missing(&self.importer_id, &peers_result.missing_names_by_pkg);
-        RequiredRound { snapshot, original_node_ids, peers_result }
+        RequiredRound { provider_pkg_ids, peers_result }
     }
 
     async fn complete_required_round<Chain>(
@@ -618,7 +629,7 @@ impl ImporterHoistState {
         Chain: Resolver + ?Sized,
     {
         loop {
-            let RequiredRound { snapshot, original_node_ids, peers_result } =
+            let RequiredRound { provider_pkg_ids, peers_result } =
                 first_round.take().unwrap_or_else(|| {
                     self.resolve_required_round(Some(Arc::new(HoistMissingScope {
                         importer_id: self.importer_id.clone(),
@@ -635,8 +646,7 @@ impl ImporterHoistState {
             );
             self.append_resolved_peer_providers(
                 &peers_result.resolved_peer_providers_by_alias,
-                &snapshot,
-                &original_node_ids,
+                &provider_pkg_ids,
                 &missing_required,
             );
             for (name, ranges) in fresh_optional {
@@ -710,8 +720,7 @@ impl ImporterHoistState {
     fn append_resolved_peer_providers(
         &mut self,
         providers: &BTreeMap<String, crate::NodeId>,
-        snapshot: &ResolvedTree,
-        original_node_ids: &HashSet<crate::NodeId>,
+        provider_pkg_ids: &HashMap<crate::NodeId, String>,
         missing_required: &BTreeMap<String, MissingPeerInfo>,
     ) {
         if !self.auto_install_peers {
@@ -721,17 +730,13 @@ impl ImporterHoistState {
             if self.parent_pkg_aliases.contains(alias) || missing_required.contains_key(alias) {
                 continue;
             }
-            if !original_node_ids.contains(node_id) {
+            let Some(pkg_id) = provider_pkg_ids.get(node_id) else {
                 continue;
-            }
-            let Some(tree_node) = snapshot.dependencies_tree.get(node_id) else { continue };
-            if !snapshot.packages.contains_key(&tree_node.resolved_package_id) {
-                continue;
-            }
+            };
             self.direct.push(DirectDep {
                 alias: alias.clone(),
                 node_id: node_id.clone(),
-                id: tree_node.resolved_package_id.clone(),
+                id: pkg_id.clone(),
             });
             self.hoisted_peer_provider_node_ids.insert(node_id.clone());
             self.parent_pkg_aliases.insert(alias.clone());

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -4,7 +4,9 @@
 //!
 //! Two nested fixed-point loops:
 //!
-//! 1. **Inner / required pass.** Run [`fn@crate::resolve_peers`] over the
+//! 1. **Inner / required pass.** Run a peer-hoist discovery pass (a
+//!    graph-free peer walk through the shared
+//!    [`crate::resolve_peers::PeerHoistDiscovery`] engine) over the
 //!    growing tree, collect peers that are required (not optional) and
 //!    not already direct deps, pick a specifier per peer via
 //!    [`fn@crate::hoist_peers`], and extend the tree with those picks.
@@ -34,8 +36,8 @@ use crate::{
         importer_direct_wanted_specs, record_changed_direct_deps, unwrap_package_name,
     },
     resolve_peers::{
-        HoistMissingScope, ResolvePeersOptions, ResolvePeersResult, apply_hoist_missing_scope,
-        resolve_peers,
+        HoistMissingScope, PeerDiscoveryResult, PeerHoistDiscovery, ResolvePeersOptions,
+        ResolvePeersResult, apply_hoist_missing_scope, resolve_peers,
     },
     resolved_tree::ResolvedTree,
 };
@@ -302,8 +304,9 @@ where
     // Single importer, so it *is* the workspace root.
     let root_deps = Arc::new(state.hoistable_root_deps()?);
     state.set_workspace_root_deps(root_deps);
+    let mut peer_discovery = PeerHoistDiscovery::new();
     loop {
-        state.run_required_round(resolver).await?;
+        state.run_required_round(resolver, &mut peer_discovery).await?;
         if !state.hoist_optional_round(resolver).await? {
             break;
         }
@@ -341,6 +344,9 @@ pub(crate) struct ImporterHoistState {
     parent_pkg_aliases: HashSet<String>,
     all_missing_optional_peers: BTreeMap<String, Vec<String>>,
     all_preferred_versions: PreferredVersions,
+    /// This importer's read position in the workspace's
+    /// resolved-versions log. See [`TreeCtx::resolved_versions_since`].
+    resolved_versions_cursor: usize,
     locked_peer_names: Arc<HashSet<String>>,
     locked_peer_versions: Arc<HashMap<String, HashSet<String>>>,
     seen_workspace_package_versions: HashSet<(String, String)>,
@@ -366,7 +372,7 @@ pub(crate) struct RequiredRound {
     /// this compact lookup lets the importer-scoped tree be dropped after
     /// the peer walk instead of keeping one full tree per workspace importer.
     provider_pkg_ids: HashMap<crate::NodeId, String>,
-    peers_result: ResolvePeersResult,
+    discovery: PeerDiscoveryResult,
 }
 
 impl ImporterHoistState {
@@ -472,6 +478,7 @@ impl ImporterHoistState {
             parent_pkg_aliases,
             all_missing_optional_peers: BTreeMap::new(),
             all_preferred_versions,
+            resolved_versions_cursor: 0,
             locked_peer_names,
             locked_peer_versions,
             seen_workspace_package_versions: HashSet::new(),
@@ -532,6 +539,7 @@ impl ImporterHoistState {
     pub(crate) async fn run_required_round<Chain>(
         &mut self,
         resolver: &Chain,
+        peer_discovery: &mut PeerHoistDiscovery,
     ) -> Result<(), ResolveImporterError>
     where
         Chain: Resolver + ?Sized,
@@ -540,24 +548,34 @@ impl ImporterHoistState {
             return Ok(());
         }
         self.begin_required_round();
-        self.complete_required_round(resolver, None).await
+        self.complete_required_round(resolver, None, peer_discovery).await
     }
 
-    pub(crate) fn prepare_initial_required_round(&mut self) -> Option<RequiredRound> {
+    pub(crate) fn prepare_initial_required_round(
+        &mut self,
+        peer_discovery: &mut PeerHoistDiscovery,
+    ) -> Option<RequiredRound> {
         if !self.hoist_peers {
             return None;
         }
         self.begin_required_round();
-        Some(self.resolve_required_round(None))
+        Some(self.resolve_required_round(None, peer_discovery))
     }
 
-    pub(crate) fn apply_owner_missing_scope(&self, round: &mut RequiredRound) {
+    /// The caller snapshots the two context maps once per barrier and
+    /// shares them across every importer's scope.
+    pub(crate) fn apply_owner_missing_scope(
+        &self,
+        round: &mut RequiredRound,
+        first_importer_by_pkg: &Arc<HashMap<String, String>>,
+        first_walk_missing_by_pkg: &Arc<HashMap<String, HashSet<String>>>,
+    ) {
         apply_hoist_missing_scope(
-            &mut round.peers_result,
+            &mut round.discovery,
             &HoistMissingScope {
                 importer_id: self.importer_id.clone(),
-                first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
-                first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
+                first_importer_by_pkg: Arc::clone(first_importer_by_pkg),
+                first_walk_missing_by_pkg: Arc::clone(first_walk_missing_by_pkg),
                 locked_peer_names: Arc::clone(&self.locked_peer_names),
             },
         );
@@ -567,11 +585,12 @@ impl ImporterHoistState {
         &mut self,
         resolver: &Chain,
         round: RequiredRound,
+        peer_discovery: &mut PeerHoistDiscovery,
     ) -> Result<(), ResolveImporterError>
     where
         Chain: Resolver + ?Sized,
     {
-        self.complete_required_round(resolver, Some(round)).await
+        self.complete_required_round(resolver, Some(round), peer_discovery).await
     }
 
     fn begin_required_round(&mut self) {
@@ -583,6 +602,7 @@ impl ImporterHoistState {
         update_preferred_versions_with_ctx(
             &self.ctx,
             &mut self.all_preferred_versions,
+            &mut self.resolved_versions_cursor,
             &mut self.seen_workspace_package_versions,
         );
         // The hoist input must not see missing peers declared inside a
@@ -596,56 +616,57 @@ impl ImporterHoistState {
     fn resolve_required_round(
         &self,
         hoist_missing_scope: Option<Arc<HoistMissingScope>>,
+        peer_discovery: &mut PeerHoistDiscovery,
     ) -> RequiredRound {
-        let mut snapshot = self.ctx.snapshot_reachable_from(self.direct.clone());
-        let original_node_ids: HashSet<crate::NodeId> =
-            snapshot.dependencies_tree.keys().cloned().collect();
-        let peers_result = {
+        let discovery = {
             let mut opts = self.peers_opts();
             opts.hoist_missing_scope = hoist_missing_scope;
-            resolve_peers(&mut snapshot, opts)
+            peer_discovery.discover(self.ctx.workspace(), &self.direct, opts)
         };
-        let provider_pkg_ids = peers_result
-            .resolved_peer_providers_by_alias
-            .values()
-            .filter(|node_id| original_node_ids.contains(*node_id))
-            .filter_map(|node_id| {
-                let pkg_id = snapshot.dependencies_tree.get(node_id)?.resolved_package_id.clone();
-                snapshot.packages.contains_key(&pkg_id).then(|| (node_id.clone(), pkg_id))
-            })
-            .collect();
+        let provider_pkg_ids = self
+            .ctx
+            .workspace()
+            .provider_pkg_ids(discovery.resolved_peer_providers_by_alias.values());
         self.ctx
             .workspace()
-            .record_first_walk_missing(&self.importer_id, &peers_result.missing_names_by_pkg);
-        RequiredRound { provider_pkg_ids, peers_result }
+            .record_first_walk_missing(&self.importer_id, &discovery.missing_names_by_pkg);
+        RequiredRound { provider_pkg_ids, discovery }
     }
 
     async fn complete_required_round<Chain>(
         &mut self,
         resolver: &Chain,
         mut first_round: Option<RequiredRound>,
+        peer_discovery: &mut PeerHoistDiscovery,
     ) -> Result<(), ResolveImporterError>
     where
         Chain: Resolver + ?Sized,
     {
         loop {
-            let RequiredRound { provider_pkg_ids, peers_result } =
+            let RequiredRound { provider_pkg_ids, discovery } =
                 first_round.take().unwrap_or_else(|| {
-                    self.resolve_required_round(Some(Arc::new(HoistMissingScope {
-                        importer_id: self.importer_id.clone(),
-                        first_importer_by_pkg: self.ctx.workspace().first_importer_by_pkg(),
-                        first_walk_missing_by_pkg: self.ctx.workspace().first_walk_missing_by_pkg(),
-                        locked_peer_names: Arc::clone(&self.locked_peer_names),
-                    })))
+                    self.resolve_required_round(
+                        Some(Arc::new(HoistMissingScope {
+                            importer_id: self.importer_id.clone(),
+                            first_importer_by_pkg: Arc::new(
+                                self.ctx.workspace().first_importer_by_pkg(),
+                            ),
+                            first_walk_missing_by_pkg: Arc::new(
+                                self.ctx.workspace().first_walk_missing_by_pkg(),
+                            ),
+                            locked_peer_names: Arc::clone(&self.locked_peer_names),
+                        })),
+                        peer_discovery,
+                    )
                 });
 
             let (missing_required, fresh_optional) = partition_missing_peers(
-                &peers_result.peer_dependency_issues.missing,
+                &discovery.peer_dependency_issues.missing,
                 &self.parent_pkg_aliases,
                 self.auto_install_peers_from_highest_match,
             );
             self.append_resolved_peer_providers(
-                &peers_result.resolved_peer_providers_by_alias,
+                &discovery.resolved_peer_providers_by_alias,
                 &provider_pkg_ids,
                 &missing_required,
             );
@@ -711,6 +732,7 @@ impl ImporterHoistState {
             update_preferred_versions_with_ctx(
                 &self.ctx,
                 &mut self.all_preferred_versions,
+                &mut self.resolved_versions_cursor,
                 &mut self.seen_workspace_package_versions,
             );
         }
@@ -791,6 +813,7 @@ impl ImporterHoistState {
         update_preferred_versions_with_ctx(
             &self.ctx,
             &mut self.all_preferred_versions,
+            &mut self.resolved_versions_cursor,
             &mut self.seen_workspace_package_versions,
         );
         Ok(true)
@@ -1148,13 +1171,16 @@ fn build_workspace_root_deps(
 /// Add every newly-resolved `name@version` from `ctx` to
 /// `preferred` as a plain [`VersionSelectorType::Version`] entry.
 /// Idempotent: only inserts when no entry exists for `(name, version)`.
+/// `resolved_versions_cursor` scopes the fold to versions resolved
+/// since the caller's previous round.
 fn update_preferred_versions_with_ctx(
     ctx: &TreeCtx,
     preferred: &mut PreferredVersions,
+    resolved_versions_cursor: &mut usize,
     seen_workspace_package_versions: &mut HashSet<(String, String)>,
 ) {
     for (name, version) in ctx
-        .resolved_versions()
+        .resolved_versions_since(resolved_versions_cursor)
         .into_iter()
         .chain(ctx.newly_seen_workspace_package_versions(seen_workspace_package_versions))
     {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -345,6 +345,7 @@ pub(crate) struct PeerHoistDiscovery {
     tree: ResolvedTree,
     caches: PeerDiscoveryCaches,
     synced_revision: Option<u64>,
+    synced_children_rewrites: Option<u64>,
 }
 
 impl PeerHoistDiscovery {
@@ -353,12 +354,20 @@ impl PeerHoistDiscovery {
             tree: ResolvedTree::default(),
             caches: PeerDiscoveryCaches::default(),
             synced_revision: None,
+            synced_children_rewrites: None,
         }
     }
 
     /// Run one discovery pass over `direct` (an importer's current
     /// direct-dep envelopes), refreshing the persistent tree view from
     /// `workspace` first when the context changed since the last pass.
+    ///
+    /// A children-ownership handover that rewrote existing occurrence
+    /// nodes ([`crate::WorkspaceTreeCtx::children_rewrites`]) discards
+    /// the whole view: the retained realized children and the walk
+    /// verdicts derived from them predate the rewrite, and an
+    /// incremental sync cannot tell which of them the rewrite
+    /// invalidated.
     pub(crate) fn discover(
         &mut self,
         workspace: &crate::resolve_dependency_tree::WorkspaceTreeCtx,
@@ -367,12 +376,17 @@ impl PeerHoistDiscovery {
     ) -> PeerDiscoveryResult {
         let revision = workspace.revision();
         if self.synced_revision != Some(revision) {
-            if !workspace.sync_discovery_tree(&mut self.tree) {
+            let children_rewrites = workspace.children_rewrites();
+            let stale = self
+                .synced_children_rewrites
+                .is_some_and(|synced| synced != children_rewrites);
+            if stale || !workspace.sync_discovery_tree(&mut self.tree) {
                 self.tree = ResolvedTree::default();
                 self.caches = PeerDiscoveryCaches::default();
                 let rebuilt = workspace.sync_discovery_tree(&mut self.tree);
                 debug_assert!(rebuilt, "a sync into an empty tree has nothing to conflict with");
             }
+            self.synced_children_rewrites = Some(children_rewrites);
             self.synced_revision = Some(revision);
         }
         let (result, caches) =
@@ -1573,10 +1587,8 @@ impl Walker<'_> {
         self.node_missing_peers_of_children.insert(node_id.clone(), missing_from_children.clone());
 
         if !missing_from_children.is_empty() {
-            let mut merged = match subtree_missing_by_pkg.take() {
-                Some(arc) => Arc::try_unwrap(arc).unwrap_or_else(|shared| (*shared).clone()),
-                None => HashMap::new(),
-            };
+            let mut merged =
+                subtree_missing_by_pkg.take().map(Arc::unwrap_or_clone).unwrap_or_default();
             merged.entry(pkg.id.clone()).or_default().extend(missing_from_children.keys().cloned());
             subtree_missing_by_pkg = Some(Arc::new(merged));
         }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -377,9 +377,8 @@ impl PeerHoistDiscovery {
         let revision = workspace.revision();
         if self.synced_revision != Some(revision) {
             let children_rewrites = workspace.children_rewrites();
-            let stale = self
-                .synced_children_rewrites
-                .is_some_and(|synced| synced != children_rewrites);
+            let stale =
+                self.synced_children_rewrites.is_some_and(|synced| synced != children_rewrites);
             if stale || !workspace.sync_discovery_tree(&mut self.tree) {
                 self.tree = ResolvedTree::default();
                 self.caches = PeerDiscoveryCaches::default();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -222,8 +222,10 @@ pub struct HoistMissingScope {
     /// The importer whose hoist input is being computed.
     pub importer_id: String,
     /// `pkg id → children-owner importer id`, from
-    /// [`crate::WorkspaceTreeCtx::first_importer_by_pkg`].
-    pub first_importer_by_pkg: HashMap<String, String>,
+    /// [`crate::WorkspaceTreeCtx::first_importer_by_pkg`]. Held by
+    /// `Arc` (like the map below) so the workspace barrier snapshots
+    /// the context once and shares it across every importer's scope.
+    pub first_importer_by_pkg: Arc<HashMap<String, String>>,
     /// Per package: the missing-peer names reported under the current
     /// children-owner context, from
     /// [`crate::WorkspaceTreeCtx::first_walk_missing_by_pkg`]. A
@@ -233,7 +235,7 @@ pub struct HoistMissingScope {
     /// filtered it out at walk time. Misses the owner walk could not
     /// satisfy stay visible to every importer (and each hoists its
     /// own copy).
-    pub first_walk_missing_by_pkg: HashMap<String, std::collections::HashSet<String>>,
+    pub first_walk_missing_by_pkg: Arc<HashMap<String, std::collections::HashSet<String>>>,
     /// Peers represented by the wanted lockfile must remain eligible
     /// for importer-local hoisting during lockfile re-resolution.
     pub locked_peer_names: Arc<std::collections::HashSet<String>>,
@@ -288,7 +290,6 @@ pub struct ResolvePeersResult {
     /// the importer's hidden direct-dep set.
     pub resolved_peer_providers_by_alias: BTreeMap<String, NodeId>,
     pub peer_dependency_issues: PeerDependencyIssues,
-    missing_ancestor_pkg_ids: HashMap<String, Vec<Vec<String>>>,
     /// Per resolved package: the union of missing-peer names its
     /// occurrences' children reported in this walk. The hoist loop
     /// persists the owner-context map per package so non-owner importers
@@ -300,6 +301,167 @@ pub struct ResolvePeersResult {
     /// [`ResolvePeersOptions::resolved_peer_provider_paths`] to run a
     /// locked-peer-provider reuse pass.
     pub paths_by_node_id: HashMap<NodeId, DepPath>,
+}
+
+/// What one peer-hoist discovery pass reports back to the hoist loop —
+/// the subset of [`ResolvePeersResult`] the loop actually consumes, so
+/// discovery never has to build a [`DependenciesGraph`].
+#[derive(Debug, Default)]
+pub(crate) struct PeerDiscoveryResult {
+    /// See [`ResolvePeersResult::resolved_peer_providers_by_alias`].
+    pub(crate) resolved_peer_providers_by_alias: BTreeMap<String, NodeId>,
+    pub(crate) peer_dependency_issues: PeerDependencyIssues,
+    /// Ancestor `pkgIdWithPatchHash` chains recorded per missing-peer
+    /// issue, consumed by [`fn@apply_hoist_missing_scope`].
+    pub(crate) missing_ancestor_pkg_ids: HashMap<String, Vec<Vec<String>>>,
+    /// See [`ResolvePeersResult::missing_names_by_pkg`].
+    pub(crate) missing_names_by_pkg: HashMap<String, std::collections::HashSet<String>>,
+}
+
+/// Walker state that stays valid across peer-hoist discovery passes of
+/// one workspace resolve: the walked tree grows monotonically between
+/// passes ([`crate::WorkspaceTreeCtx::sync_discovery_tree`] rebuilds
+/// the engine's view on the incompatible exceptions), so a subtree
+/// verdict recorded under one importer's walk short-circuits every
+/// compatible revisit — [`Walker::find_hit`] re-validates each
+/// [`PeersCacheItem`] against the current parent context, and a hoisted
+/// provider that newly satisfies a cached missing peer rejects the
+/// stale item. This is the same sharing
+/// [`fn@resolve_peers_workspace`] already applies across importers
+/// within its single final pass.
+#[derive(Debug, Default)]
+pub(crate) struct PeerDiscoveryCaches {
+    node_dep_paths: HashMap<NodeId, DepPath>,
+    pure_pkgs: HashSet<String>,
+    peers_cache: HashMap<String, Vec<PeersCacheItem>>,
+    parent_pkgs_of_node: HashMap<NodeId, HashMap<String, ParentPkgInfo>>,
+}
+
+/// Peer-hoist discovery engine: one persistent tree view + walker
+/// caches shared by every hoist round of a workspace resolve. Replaces
+/// the per-round full snapshot + full [`fn@resolve_peers`] walk that
+/// made multi-importer hoist discovery quadratic in workspace size.
+pub(crate) struct PeerHoistDiscovery {
+    tree: ResolvedTree,
+    caches: PeerDiscoveryCaches,
+    synced_revision: Option<u64>,
+}
+
+impl PeerHoistDiscovery {
+    pub(crate) fn new() -> Self {
+        PeerHoistDiscovery {
+            tree: ResolvedTree::default(),
+            caches: PeerDiscoveryCaches::default(),
+            synced_revision: None,
+        }
+    }
+
+    /// Run one discovery pass over `direct` (an importer's current
+    /// direct-dep envelopes), refreshing the persistent tree view from
+    /// `workspace` first when the context changed since the last pass.
+    pub(crate) fn discover(
+        &mut self,
+        workspace: &crate::resolve_dependency_tree::WorkspaceTreeCtx,
+        direct: &[DirectDep],
+        opts: ResolvePeersOptions,
+    ) -> PeerDiscoveryResult {
+        let revision = workspace.revision();
+        if self.synced_revision != Some(revision) {
+            if !workspace.sync_discovery_tree(&mut self.tree) {
+                self.tree = ResolvedTree::default();
+                self.caches = PeerDiscoveryCaches::default();
+                let rebuilt = workspace.sync_discovery_tree(&mut self.tree);
+                debug_assert!(rebuilt, "a sync into an empty tree has nothing to conflict with");
+            }
+            self.synced_revision = Some(revision);
+        }
+        let (result, caches) =
+            discover_peers(&mut self.tree, direct, std::mem::take(&mut self.caches), opts);
+        self.caches = caches;
+        result
+    }
+}
+
+/// Walk `direct` in discovery mode: peer matching, caches, and issue
+/// collection run exactly as in [`fn@resolve_peers`], but no
+/// [`DependenciesGraph`] is built and no final depPath pass runs. The
+/// per-importer driver mirrors [`fn@resolve_peers_workspace`]'s
+/// per-importer section.
+fn discover_peers(
+    tree: &mut ResolvedTree,
+    direct: &[DirectDep],
+    caches: PeerDiscoveryCaches,
+    opts: ResolvePeersOptions,
+) -> (PeerDiscoveryResult, PeerDiscoveryCaches) {
+    let current_provider_sources = vec![CurrentProviderSource {
+        direct_node_ids_by_alias: direct
+            .iter()
+            .map(|dep| (dep.alias.clone(), dep.node_id.clone()))
+            .collect(),
+        declared_direct_dependencies: opts.declared_direct_dependencies.clone(),
+        explicitly_requested_direct_dependencies: opts
+            .explicitly_requested_direct_dependencies
+            .clone(),
+    }];
+    let mut walker =
+        Walker::new(tree, opts, HashMap::new(), current_provider_sources, caches, true);
+
+    let importer_parents = walker.build_importer_parents_from(direct);
+    let parent_chain_names: Vec<String> = Vec::new();
+    let parent_node_ids: Vec<NodeId> = Vec::new();
+    let parent_pkg_ids_chain: Vec<String> = Vec::new();
+    let importer_parent_dep_paths = walker.parent_dep_paths_from_refs(&importer_parents);
+    let (own_direct, provider_direct): (Vec<&DirectDep>, Vec<&DirectDep>) = direct
+        .iter()
+        .partition(|dep| !walker.opts.hoisted_peer_provider_node_ids.contains(&dep.node_id));
+    let mut result = PeerDiscoveryResult::default();
+    for dep in &own_direct {
+        walker.parent_pkgs_of_node.insert(dep.node_id.clone(), importer_parent_dep_paths.clone());
+    }
+    let fold_output = |result: &mut PeerDiscoveryResult, output: NodeOutput| {
+        for (peer_alias, peer_node_id) in output.auto_install_resolved_peers {
+            result.resolved_peer_providers_by_alias.insert(peer_alias, peer_node_id);
+        }
+        let Some(subtree_missing) = output.subtree_missing_by_pkg else { return };
+        for (pkg_id, names) in subtree_missing.iter() {
+            result
+                .missing_names_by_pkg
+                .entry(pkg_id.clone())
+                .or_default()
+                .extend(names.iter().cloned());
+        }
+    };
+    for dep in &own_direct {
+        let output = walker.resolve_node(
+            dep.node_id.clone(),
+            &importer_parents,
+            &parent_chain_names,
+            &parent_node_ids,
+            &parent_pkg_ids_chain,
+        );
+        fold_output(&mut result, output);
+    }
+    // See ResolvePeersOptions::hoisted_peer_provider_node_ids — a
+    // provider is normally resolved at its tree position during the
+    // walk above; only one whose position was pruned still needs the
+    // root-context fallback.
+    for dep in &provider_direct {
+        if walker.visited_this_call.contains(&dep.node_id) {
+            continue;
+        }
+        walker.parent_pkgs_of_node.insert(dep.node_id.clone(), importer_parent_dep_paths.clone());
+        let output = walker.resolve_node(
+            dep.node_id.clone(),
+            &importer_parents,
+            &parent_chain_names,
+            &parent_node_ids,
+            &parent_pkg_ids_chain,
+        );
+        fold_output(&mut result, output);
+    }
+    result.peer_dependency_issues = std::mem::take(&mut walker.issues);
+    result.missing_ancestor_pkg_ids = std::mem::take(&mut walker.missing_ancestor_pkg_ids);
+    (result, walker.into_caches())
 }
 
 /// One importer's input to the multi-importer [`fn@resolve_peers_workspace`]
@@ -354,32 +516,19 @@ pub fn resolve_peers(tree: &mut ResolvedTree, opts: ResolvePeersOptions) -> Reso
             .explicitly_requested_direct_dependencies
             .clone(),
     }];
-    let walker = Walker {
+    let walker = Walker::new(
         tree,
         opts,
-        graph: DependenciesGraph::new(),
-        issues: PeerDependencyIssues::default(),
-        missing_ancestor_pkg_ids: HashMap::new(),
-        node_dep_paths: HashMap::new(),
-        node_external_peers: HashMap::new(),
-        node_missing_peers: HashMap::new(),
-        node_missing_peers_of_children: HashMap::new(),
-        resolved_peer_providers_by_alias: BTreeMap::new(),
-        in_progress: HashSet::new(),
-        pending_peer_edges: Vec::new(),
-        pure_pkgs: HashSet::new(),
-        peers_cache: HashMap::new(),
-        parent_pkgs_of_node: HashMap::new(),
-        node_records: HashMap::new(),
-        next_record_order: 0,
         node_ids_by_previous_dep_path,
         current_provider_sources,
-    };
+        PeerDiscoveryCaches::default(),
+        false,
+    );
     walker.walk()
 }
 
 pub(crate) fn apply_hoist_missing_scope(
-    result: &mut ResolvePeersResult,
+    result: &mut PeerDiscoveryResult,
     scope: &HoistMissingScope,
 ) {
     result.peer_dependency_issues.missing.retain(|peer_name, issues| {
@@ -463,27 +612,14 @@ pub fn resolve_peers_workspace(
     opts: ResolvePeersOptions,
 ) -> WorkspaceResolvePeersResult {
     let node_ids_by_previous_dep_path = build_node_ids_by_previous_dep_path(tree, &opts);
-    let mut walker = Walker {
+    let mut walker = Walker::new(
         tree,
         opts,
-        graph: DependenciesGraph::new(),
-        issues: PeerDependencyIssues::default(),
-        missing_ancestor_pkg_ids: HashMap::new(),
-        node_dep_paths: HashMap::new(),
-        node_external_peers: HashMap::new(),
-        node_missing_peers: HashMap::new(),
-        node_missing_peers_of_children: HashMap::new(),
-        resolved_peer_providers_by_alias: BTreeMap::new(),
-        in_progress: HashSet::new(),
-        pending_peer_edges: Vec::new(),
-        pure_pkgs: HashSet::new(),
-        peers_cache: HashMap::new(),
-        parent_pkgs_of_node: HashMap::new(),
-        node_records: HashMap::new(),
-        next_record_order: 0,
         node_ids_by_previous_dep_path,
-        current_provider_sources: Vec::new(),
-    };
+        Vec::new(),
+        PeerDiscoveryCaches::default(),
+        false,
+    );
 
     let mut direct_dependencies_by_importer: BTreeMap<String, BTreeMap<String, DepPath>> =
         BTreeMap::new();
@@ -545,7 +681,7 @@ pub fn resolve_peers_workspace(
         // walk above; only one whose position was pruned still needs the
         // root-context fallback.
         for dep in &provider_direct {
-            if walker.node_dep_paths.contains_key(&dep.node_id) {
+            if walker.visited_this_call.contains(&dep.node_id) {
                 continue;
             }
             walker
@@ -751,6 +887,62 @@ struct Walker<'tree> {
     /// providers for the must-win guard. Swapped per importer by the
     /// workspace entry point.
     current_provider_sources: Vec<CurrentProviderSource>,
+    /// `true` for a peer-hoist discovery pass: the walk records no
+    /// graph entries, node records, or pending edges, and the caller
+    /// runs none of the final depPath/graph passes. Everything that
+    /// decides *what* resolves or goes missing is unchanged.
+    discovery: bool,
+    /// Nodes this call resolved (any return path except the cycle
+    /// re-entry). Distinguishes them from nodes only known through the
+    /// persistent [`PeerDiscoveryCaches`], so the pruned-provider
+    /// fallback keeps its per-call meaning.
+    visited_this_call: HashSet<NodeId>,
+}
+
+impl<'tree> Walker<'tree> {
+    fn new(
+        tree: &'tree mut ResolvedTree,
+        opts: ResolvePeersOptions,
+        node_ids_by_previous_dep_path: HashMap<DepPath, NodeId>,
+        current_provider_sources: Vec<CurrentProviderSource>,
+        caches: PeerDiscoveryCaches,
+        discovery: bool,
+    ) -> Self {
+        let PeerDiscoveryCaches { node_dep_paths, pure_pkgs, peers_cache, parent_pkgs_of_node } =
+            caches;
+        Walker {
+            tree,
+            opts,
+            graph: DependenciesGraph::new(),
+            issues: PeerDependencyIssues::default(),
+            missing_ancestor_pkg_ids: HashMap::new(),
+            node_dep_paths,
+            node_external_peers: HashMap::new(),
+            node_missing_peers: HashMap::new(),
+            node_missing_peers_of_children: HashMap::new(),
+            resolved_peer_providers_by_alias: BTreeMap::new(),
+            in_progress: HashSet::new(),
+            pending_peer_edges: Vec::new(),
+            pure_pkgs,
+            peers_cache,
+            parent_pkgs_of_node,
+            node_records: HashMap::new(),
+            next_record_order: 0,
+            node_ids_by_previous_dep_path,
+            current_provider_sources,
+            discovery,
+            visited_this_call: HashSet::new(),
+        }
+    }
+
+    fn into_caches(self) -> PeerDiscoveryCaches {
+        PeerDiscoveryCaches {
+            node_dep_paths: self.node_dep_paths,
+            pure_pkgs: self.pure_pkgs,
+            peers_cache: self.peers_cache,
+            parent_pkgs_of_node: self.parent_pkgs_of_node,
+        }
+    }
 }
 
 /// Per-peer-name snapshot stored on [`Walker::parent_pkgs_of_node`].
@@ -777,12 +969,18 @@ struct ParentPkgInfo {
 /// current parent context *does* provide, the contexts are
 /// incompatible and the item must be rejected. `missing_peers_of_children`
 /// is the subset exposed as the package's children report.
+#[derive(Debug)]
 struct PeersCacheItem {
     dep_path: DepPath,
     resolved_peers: HashMap<String, NodeId>,
     auto_install_resolved_peers: HashMap<String, NodeId>,
     missing_peers: HashMap<String, MissingPeerInfo>,
     missing_peers_of_children: HashMap<String, MissingPeerInfo>,
+    /// See [`NodeOutput::subtree_missing_by_pkg`]. Replayed on a cache
+    /// hit so a discovery pass that never descends into the cached
+    /// subtree still reports the same per-package missing breakdown a
+    /// full walk of it would.
+    subtree_missing_by_pkg: SubtreeMissingByPkg,
 }
 
 /// One `parent → child` edge whose target wasn't walked yet at the
@@ -831,6 +1029,12 @@ struct MissingPeerInfo {
     optional: bool,
 }
 
+/// Per-package missing-peer breakdown of a node's whole subtree:
+/// `pkgIdWithPatchHash → missing-peer names its occurrences' children
+/// reported`. `None` when the subtree misses nothing (the common
+/// case), so pure trees never allocate.
+type SubtreeMissingByPkg = Option<Arc<HashMap<String, HashSet<String>>>>;
+
 /// Output of [`Walker::resolve_node`] — the per-node result the parent
 /// folds into its own state.
 struct NodeOutput {
@@ -843,6 +1047,10 @@ struct NodeOutput {
     /// subtree. This feeds the auto-install-peers loop.
     auto_install_resolved_peers: HashMap<String, NodeId>,
     missing_peers: HashMap<String, MissingPeerInfo>,
+    /// [`ResolvePeersResult::missing_names_by_pkg`]'s per-subtree
+    /// slice, propagated bottom-up so discovery can aggregate it from
+    /// the importer's direct deps alone.
+    subtree_missing_by_pkg: SubtreeMissingByPkg,
 }
 
 impl Walker<'_> {
@@ -881,7 +1089,7 @@ impl Walker<'_> {
         // walk above; only one whose position was pruned still needs the
         // root-context fallback.
         for dep in &provider_direct {
-            if self.node_dep_paths.contains_key(&dep.node_id) {
+            if self.visited_this_call.contains(&dep.node_id) {
                 continue;
             }
             self.parent_pkgs_of_node.insert(dep.node_id.clone(), importer_parent_dep_paths.clone());
@@ -928,7 +1136,6 @@ impl Walker<'_> {
             direct_dependencies_by_alias: direct_by_alias,
             resolved_peer_providers_by_alias,
             peer_dependency_issues: self.issues,
-            missing_ancestor_pkg_ids: self.missing_ancestor_pkg_ids,
             missing_names_by_pkg,
             paths_by_node_id,
         }
@@ -1022,10 +1229,6 @@ impl Walker<'_> {
         refs
     }
 
-    #[expect(
-        clippy::needless_pass_by_value,
-        reason = "resolve_node is the recursive walk's core; threading &NodeId would ripple a borrow through every recursive call site for negligible gain on this small enum"
-    )]
     fn resolve_node(
         &mut self,
         node_id: NodeId,
@@ -1060,22 +1263,31 @@ impl Walker<'_> {
             if tree_node_depth == -1 {
                 let dep_path = DepPath::from(pkg_id);
                 self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
+                self.visited_this_call.insert(node_id);
                 return NodeOutput {
                     dep_path,
                     external_resolved_peers: HashMap::new(),
                     auto_install_resolved_peers: HashMap::new(),
                     missing_peers: HashMap::new(),
+                    subtree_missing_by_pkg: None,
                 };
             }
             let pkg_peer_dependencies_empty =
                 self.tree.packages[&pkg_id].peer_dependencies.is_empty();
             let bare_dep_path = DepPath::from(pkg_id.clone());
+            // Discovery builds no graph, so the graph-entry half of the
+            // gate (an output-completeness requirement) doesn't apply.
             if self.pure_pkgs.contains(&pkg_id)
                 && pkg_peer_dependencies_empty
-                && self.graph.get(&bare_dep_path).is_some_and(|node| node.depth <= tree_node_depth)
+                && (self.discovery
+                    || self
+                        .graph
+                        .get(&bare_dep_path)
+                        .is_some_and(|node| node.depth <= tree_node_depth))
             {
                 let dep_path = bare_dep_path;
                 self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
+                self.visited_this_call.insert(node_id.clone());
                 // Lower the existing graph entry's `depth` if this
                 // occurrence reached the package shallower than the
                 // previous walk(s). The same minimum-depth tie-break
@@ -1093,6 +1305,7 @@ impl Walker<'_> {
                     external_resolved_peers: HashMap::new(),
                     auto_install_resolved_peers: HashMap::new(),
                     missing_peers: HashMap::new(),
+                    subtree_missing_by_pkg: None,
                 };
             }
         }
@@ -1112,6 +1325,7 @@ impl Walker<'_> {
                 external_resolved_peers: HashMap::new(),
                 auto_install_resolved_peers: HashMap::new(),
                 missing_peers: HashMap::new(),
+                subtree_missing_by_pkg: None,
             };
         }
         self.in_progress.insert(node_id.clone());
@@ -1213,6 +1427,7 @@ impl Walker<'_> {
             let auto_install_resolved_peers = cached.auto_install_resolved_peers.clone();
             let missing = cached.missing_peers.clone();
             let missing_of_children = cached.missing_peers_of_children.clone();
+            let subtree_missing_by_pkg = cached.subtree_missing_by_pkg.clone();
             // Re-emit the missing-peer issues against the current
             // parent chain so each occurrence of the package shows up
             // in the diagnostic. Without this, the first walk's parent
@@ -1253,11 +1468,13 @@ impl Walker<'_> {
                 node.depth = tree_node.depth;
             }
             self.in_progress.remove(&node_id);
+            self.visited_this_call.insert(node_id);
             return NodeOutput {
                 dep_path,
                 external_resolved_peers: resolved,
                 auto_install_resolved_peers,
                 missing_peers: missing,
+                subtree_missing_by_pkg,
             };
         }
 
@@ -1271,6 +1488,7 @@ impl Walker<'_> {
         let mut auto_install_resolved_peers: HashMap<String, NodeId> = HashMap::new();
         let mut missing_from_children: HashMap<String, MissingPeerInfo> = HashMap::new();
         let mut child_dep_paths: BTreeMap<String, DepPath> = BTreeMap::new();
+        let mut subtree_missing_by_pkg: SubtreeMissingByPkg = None;
         let child_entries = ordered_child_entries(&children_map, &child_parent_refs);
         for (alias, child_node_id) in &child_entries {
             let child_output = self.resolve_node(
@@ -1280,6 +1498,7 @@ impl Walker<'_> {
                 &current_parent_node_ids,
                 &child_parent_pkg_ids_chain,
             );
+            merge_subtree_missing(&mut subtree_missing_by_pkg, child_output.subtree_missing_by_pkg);
             child_dep_paths.insert(alias.clone(), child_output.dep_path);
             for (peer_alias, peer_node_id) in child_output.auto_install_resolved_peers {
                 auto_install_resolved_peers.insert(peer_alias, peer_node_id);
@@ -1348,81 +1567,21 @@ impl Walker<'_> {
         // cycle the graph insert hits via `child_dep_paths` can find
         // this node's depPath).
         self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
+        self.visited_this_call.insert(node_id.clone());
         self.node_external_peers.insert(node_id.clone(), all_resolved_peers.clone());
         self.node_missing_peers.insert(node_id.clone(), all_missing_peers.clone());
         self.node_missing_peers_of_children.insert(node_id.clone(), missing_from_children.clone());
 
-        // The children's depPath edges become this node's graph children.
-        // Resolved peers become extra edges, aliased by peer name. If a
-        // peer's depPath isn't known yet — typically a later sibling
-        // direct dep — defer the edge to the post-walk patch pass; the
-        // install layer drives off `graph_children`, so skipping the
-        // edge entirely would leave the peer un-symlinked in the
-        // parent's slot.
-        let mut graph_children = BTreeMap::new();
-        for (alias, child_node_id) in
-            self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id)
-        {
-            self.add_graph_child_or_pending(&mut graph_children, &dep_path, alias, child_node_id);
-        }
-        for (alias, child_dep_path) in child_dep_paths {
-            graph_children.insert(alias, child_dep_path);
-        }
-        for (peer_alias, peer_node_id) in &all_resolved_peers {
-            self.add_graph_child_or_pending(
-                &mut graph_children,
-                &dep_path,
-                peer_alias.clone(),
-                peer_node_id.clone(),
-            );
-        }
-
-        // Compute transitive peer set: peers visible in this subtree
-        // that are NOT declared in this package's own peerDependencies.
-        let mut transitive_peer_dependencies: HashSet<String> = HashSet::new();
-        for peer_alias in all_resolved_peers.keys() {
-            if !pkg.peer_dependencies.contains_key(peer_alias) {
-                transitive_peer_dependencies.insert(peer_alias.clone());
-            }
-        }
-        for peer_alias in all_missing_peers.keys() {
-            if !pkg.peer_dependencies.contains_key(peer_alias) {
-                transitive_peer_dependencies.insert(peer_alias.clone());
-            }
+        if !missing_from_children.is_empty() {
+            let mut merged = match subtree_missing_by_pkg.take() {
+                Some(arc) => Arc::try_unwrap(arc).unwrap_or_else(|shared| (*shared).clone()),
+                None => HashMap::new(),
+            };
+            merged.entry(pkg.id.clone()).or_default().extend(missing_from_children.keys().cloned());
+            subtree_missing_by_pkg = Some(Arc::new(merged));
         }
 
         let is_pure = all_resolved_peers.is_empty() && all_missing_peers.is_empty();
-
-        // Capture this node's NodeId-level edges + metadata for the
-        // post-walk [`Walker::build_final_dep_paths`] rebuild. Edges are
-        // the node's regular children overlaid with its *own* resolved
-        // peers — this node's own peer resolution, not the descendants'
-        // peers bubbled up for the suffix. A peer a descendant resolved
-        // (e.g. `debug`'s optional `supports-color`) is symlinked at the
-        // descendant that declares it, so it must not appear in this
-        // node's dependencies. Carries NodeIds so the rebuild can
-        // resolve each to its corrected final depPath.
-        let mut record_edges =
-            self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id);
-        record_edges.extend(children_map.clone());
-        for (peer_alias, peer_node_id) in &own_resolved_peers {
-            record_edges.insert(peer_alias.clone(), peer_node_id.clone());
-        }
-        let optional_child_aliases = self.optional_child_aliases(&pkg.id, &record_edges);
-        let record_order = self.next_record_order;
-        self.next_record_order += 1;
-        self.node_records.insert(
-            node_id.clone(),
-            NodeRecord {
-                edges: record_edges,
-                optional_child_aliases: optional_child_aliases.clone(),
-                transitive_peer_dependencies: transitive_peer_dependencies.clone(),
-                depth: tree_node.depth,
-                installable: tree_node.installable,
-                is_pure,
-                order: record_order,
-            },
-        );
 
         // Record this walk's outcome in the per-`pkgIdWithPatchHash`
         // caches. Pure subtrees go in [`Self::pure_pkgs`] for the
@@ -1452,33 +1611,111 @@ impl Walker<'_> {
                 auto_install_resolved_peers: auto_install_resolved_peers.clone(),
                 missing_peers: all_missing_peers.clone(),
                 missing_peers_of_children: missing_from_children,
+                subtree_missing_by_pkg: subtree_missing_by_pkg.clone(),
             });
         }
 
-        // Multiple visits with the same depPath collapse onto the same
-        // graph entry. On a conflict, keep the entry with the smallest
-        // `depth` so install order matches.
-        self.graph
-            .entry(dep_path.clone())
-            .and_modify(|node| {
-                if node.depth > tree_node.depth {
-                    node.depth = tree_node.depth;
+        if !self.discovery {
+            // The children's depPath edges become this node's graph children.
+            // Resolved peers become extra edges, aliased by peer name. If a
+            // peer's depPath isn't known yet — typically a later sibling
+            // direct dep — defer the edge to the post-walk patch pass; the
+            // install layer drives off `graph_children`, so skipping the
+            // edge entirely would leave the peer un-symlinked in the
+            // parent's slot.
+            let mut graph_children = BTreeMap::new();
+            for (alias, child_node_id) in
+                self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id)
+            {
+                self.add_graph_child_or_pending(
+                    &mut graph_children,
+                    &dep_path,
+                    alias,
+                    child_node_id,
+                );
+            }
+            for (alias, child_dep_path) in child_dep_paths {
+                graph_children.insert(alias, child_dep_path);
+            }
+            for (peer_alias, peer_node_id) in &all_resolved_peers {
+                self.add_graph_child_or_pending(
+                    &mut graph_children,
+                    &dep_path,
+                    peer_alias.clone(),
+                    peer_node_id.clone(),
+                );
+            }
+
+            // Compute transitive peer set: peers visible in this subtree
+            // that are NOT declared in this package's own peerDependencies.
+            let mut transitive_peer_dependencies: HashSet<String> = HashSet::new();
+            for peer_alias in all_resolved_peers.keys() {
+                if !pkg.peer_dependencies.contains_key(peer_alias) {
+                    transitive_peer_dependencies.insert(peer_alias.clone());
                 }
-            })
-            .or_insert(DependenciesGraphNode {
-                dep_path: dep_path.clone(),
-                resolved_package_id: pkg.id.clone(),
-                resolve_result: Arc::clone(&pkg.result),
-                children: graph_children,
-                optional_children: optional_child_aliases,
-                peer_dependencies: pkg.peer_dependencies.clone(),
-                transitive_peer_dependencies,
-                resolved_peer_names: all_resolved_peers.keys().cloned().collect(),
-                depth: tree_node.depth,
-                installable: tree_node.installable,
-                is_pure,
-                optional: pkg.optional,
-            });
+            }
+            for peer_alias in all_missing_peers.keys() {
+                if !pkg.peer_dependencies.contains_key(peer_alias) {
+                    transitive_peer_dependencies.insert(peer_alias.clone());
+                }
+            }
+
+            // Capture this node's NodeId-level edges + metadata for the
+            // post-walk [`Walker::build_final_dep_paths`] rebuild. Edges are
+            // the node's regular children overlaid with its *own* resolved
+            // peers — this node's own peer resolution, not the descendants'
+            // peers bubbled up for the suffix. A peer a descendant resolved
+            // (e.g. `debug`'s optional `supports-color`) is symlinked at the
+            // descendant that declares it, so it must not appear in this
+            // node's dependencies. Carries NodeIds so the rebuild can
+            // resolve each to its corrected final depPath.
+            let mut record_edges =
+                self.previously_resolved_children(parent_node_ids, parent_pkg_ids_chain, &pkg.id);
+            record_edges.extend(children_map.clone());
+            for (peer_alias, peer_node_id) in &own_resolved_peers {
+                record_edges.insert(peer_alias.clone(), peer_node_id.clone());
+            }
+            let optional_child_aliases = self.optional_child_aliases(&pkg.id, &record_edges);
+            let record_order = self.next_record_order;
+            self.next_record_order += 1;
+            self.node_records.insert(
+                node_id.clone(),
+                NodeRecord {
+                    edges: record_edges,
+                    optional_child_aliases: optional_child_aliases.clone(),
+                    transitive_peer_dependencies: transitive_peer_dependencies.clone(),
+                    depth: tree_node.depth,
+                    installable: tree_node.installable,
+                    is_pure,
+                    order: record_order,
+                },
+            );
+
+            // Multiple visits with the same depPath collapse onto the same
+            // graph entry. On a conflict, keep the entry with the smallest
+            // `depth` so install order matches.
+            self.graph
+                .entry(dep_path.clone())
+                .and_modify(|node| {
+                    if node.depth > tree_node.depth {
+                        node.depth = tree_node.depth;
+                    }
+                })
+                .or_insert(DependenciesGraphNode {
+                    dep_path: dep_path.clone(),
+                    resolved_package_id: pkg.id.clone(),
+                    resolve_result: Arc::clone(&pkg.result),
+                    children: graph_children,
+                    optional_children: optional_child_aliases,
+                    peer_dependencies: pkg.peer_dependencies.clone(),
+                    transitive_peer_dependencies,
+                    resolved_peer_names: all_resolved_peers.keys().cloned().collect(),
+                    depth: tree_node.depth,
+                    installable: tree_node.installable,
+                    is_pure,
+                    optional: pkg.optional,
+                });
+        }
 
         self.in_progress.remove(&node_id);
 
@@ -1492,6 +1729,7 @@ impl Walker<'_> {
             external_resolved_peers: external_to_report,
             auto_install_resolved_peers,
             missing_peers: all_missing_peers,
+            subtree_missing_by_pkg,
         }
     }
 
@@ -2604,6 +2842,24 @@ impl Walker<'_> {
 /// Whether every entry in `parents` has `occurrence == 0`.
 fn parent_pkgs_have_single_occurrence(parents: &HashMap<String, ParentPkgInfo>) -> bool {
     parents.values().all(|info| info.occurrence == 0)
+}
+
+/// Union `addition` into `target`, keeping the no-miss case
+/// allocation-free and sharing a lone child's map by refcount.
+fn merge_subtree_missing(target: &mut SubtreeMissingByPkg, addition: SubtreeMissingByPkg) {
+    let Some(addition) = addition else { return };
+    match target {
+        None => *target = Some(addition),
+        Some(existing) => {
+            if Arc::ptr_eq(existing, &addition) {
+                return;
+            }
+            let merged = Arc::make_mut(existing);
+            for (pkg_id, names) in addition.iter() {
+                merged.entry(pkg_id.clone()).or_default().extend(names.iter().cloned());
+            }
+        }
+    }
 }
 
 fn merge_preferred_child_edges(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,10 +1,9 @@
 use super::{
-    ImporterPeerInput, NodeRecord, ParentRef, ResolvePeersOptions, Walker,
+    ImporterPeerInput, NodeRecord, ParentRef, PeerDiscoveryCaches, ResolvePeersOptions, Walker,
     importer_relative_link_dep_path, peer_segment_names, resolve_peers, resolve_peers_workspace,
     satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
 };
 use crate::{
-    dependencies_graph::{DependenciesGraph, PeerDependencyIssues},
     node_id::NodeId,
     resolved_tree::{
         DependenciesTreeNode, DirectDep, PeerDep, ResolvedPackage, ResolvedTree, TreeChildren,
@@ -2054,27 +2053,14 @@ fn tree_node(pkg_id: &str, children: BTreeMap<String, NodeId>, depth: i32) -> De
 }
 
 fn walker_for_tests(tree: &mut ResolvedTree) -> Walker<'_> {
-    Walker {
+    Walker::new(
         tree,
-        opts: ResolvePeersOptions::default(),
-        graph: DependenciesGraph::new(),
-        issues: PeerDependencyIssues::default(),
-        missing_ancestor_pkg_ids: HashMap::new(),
-        node_dep_paths: HashMap::new(),
-        node_external_peers: HashMap::new(),
-        node_missing_peers: HashMap::new(),
-        node_missing_peers_of_children: HashMap::new(),
-        resolved_peer_providers_by_alias: BTreeMap::new(),
-        in_progress: HashSet::new(),
-        pending_peer_edges: Vec::new(),
-        pure_pkgs: HashSet::new(),
-        peers_cache: HashMap::new(),
-        parent_pkgs_of_node: HashMap::new(),
-        node_records: HashMap::new(),
-        next_record_order: 0,
-        node_ids_by_previous_dep_path: HashMap::new(),
-        current_provider_sources: Vec::new(),
-    }
+        ResolvePeersOptions::default(),
+        HashMap::new(),
+        Vec::new(),
+        PeerDiscoveryCaches::default(),
+        false,
+    )
 }
 
 fn package(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -2052,6 +2052,36 @@ fn tree_node(pkg_id: &str, children: BTreeMap<String, NodeId>, depth: i32) -> De
     DependenciesTreeNode::new(pkg_id.to_string(), TreeChildren::Realized(children), depth, true)
 }
 
+#[test]
+fn discovery_engine_rebuilds_after_a_children_ownership_rewrite() {
+    use super::PeerHoistDiscovery;
+    use crate::resolve_dependency_tree::WorkspaceTreeCtx;
+
+    let workspace = WorkspaceTreeCtx::default();
+    let mut engine = PeerHoistDiscovery::new();
+    engine.discover(&workspace, &[], ResolvePeersOptions::default());
+
+    // A marker in the persistent caches makes reset-vs-merge observable.
+    engine.caches.pure_pkgs.insert("marker@1.0.0".to_string());
+    // Production rewrites happen inside `extend_tree`, which always
+    // bumps the revision; mirror that pairing.
+    workspace.record_children_rewrite();
+    workspace.bump_revision();
+    engine.discover(&workspace, &[], ResolvePeersOptions::default());
+    assert!(
+        engine.caches.pure_pkgs.is_empty(),
+        "an ownership rewrite must discard walk state derived before it",
+    );
+
+    engine.caches.pure_pkgs.insert("marker@1.0.0".to_string());
+    workspace.bump_revision();
+    engine.discover(&workspace, &[], ResolvePeersOptions::default());
+    assert!(
+        engine.caches.pure_pkgs.contains("marker@1.0.0"),
+        "a rewrite-free revision bump merges instead of rebuilding",
+    );
+}
+
 fn walker_for_tests(tree: &mut ResolvedTree) -> Walker<'_> {
     Walker::new(
         tree,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     resolve_importer::{ImporterHoistState, ResolveImporterError, ResolveImporterOptions},
     resolve_peers::{
-        ImporterPeerInput, ResolvePeersOptions, WorkspaceResolvePeersResult,
+        ImporterPeerInput, PeerHoistDiscovery, ResolvePeersOptions, WorkspaceResolvePeersResult,
         resolve_peers_workspace,
     },
     resolved_tree::ResolvedTree,
@@ -287,16 +287,33 @@ where
     for state in &mut states {
         state.set_workspace_root_deps(Arc::clone(&root_deps));
     }
-    let mut initial_required_rounds: Vec<_> =
-        states.iter_mut().map(ImporterHoistState::prepare_initial_required_round).collect();
+    // One discovery engine serves every hoist round of the workspace:
+    // its persistent tree view + walker caches are what keep the
+    // barrier below linear in workspace size (each importer's pass
+    // short-circuits on the subtree verdicts recorded by the passes
+    // before it).
+    let mut peer_discovery = PeerHoistDiscovery::new();
+    let mut initial_required_rounds: Vec<_> = states
+        .iter_mut()
+        .map(|state| state.prepare_initial_required_round(&mut peer_discovery))
+        .collect();
+    // The context is quiescent between the prepare barrier above and
+    // the completes below, so one snapshot of the owner-scope maps
+    // serves every importer.
+    let first_importer_by_pkg = Arc::new(workspace.first_importer_by_pkg());
+    let first_walk_missing_by_pkg = Arc::new(workspace.first_walk_missing_by_pkg());
     for (state, round) in states.iter().zip(&mut initial_required_rounds) {
         if let Some(round) = round {
-            state.apply_owner_missing_scope(round);
+            state.apply_owner_missing_scope(
+                round,
+                &first_importer_by_pkg,
+                &first_walk_missing_by_pkg,
+            );
         }
     }
     for (state, round) in states.iter_mut().zip(initial_required_rounds) {
         if let Some(round) = round {
-            state.complete_initial_required_round(resolver, round).await?;
+            state.complete_initial_required_round(resolver, round, &mut peer_discovery).await?;
         }
     }
     loop {
@@ -308,9 +325,12 @@ where
             break;
         }
         for state in &mut states {
-            state.run_required_round(resolver).await?;
+            state.run_required_round(resolver, &mut peer_discovery).await?;
         }
     }
+    // Release the engine's tree view before the merged-tree snapshot
+    // below clones the context again, so the two never coexist at peak.
+    drop(peer_discovery);
     let mut per_importer_inputs: Vec<ImporterPeerInput> = Vec::with_capacity(importers.len());
     let mut hoisted_peer_provider_node_ids = std::collections::HashSet::new();
     for ((importer, state), (project_dir, modules_dir)) in

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -49,7 +49,7 @@ pub struct ResolvedTree {
 
 /// One entry on [`ResolvedTree::children_by_id`] — the resolved
 /// shape of a package's children list as recorded by the first walk.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChildEdge {
     /// Install alias in `node_modules` (the manifest key under
     /// `dependencies` / `optionalDependencies`).


### PR DESCRIPTION
## Summary

Fixes the multi-importer full-resolution regression observed when pnpm is used through `@pnpm/napi` by Bit.

- add a deterministic pnpm-side benchmark reproducing the Bit-sized workload (331 importers, 5,000 shared packages, peer-hoist discovery, no lockfile reuse)
- replace the hoist loop's per-importer, per-round full tree snapshot + full peer pass with a `PeerHoistDiscovery` engine shared by every hoist round of one workspace resolve: one persistent tree view incrementally synced from the workspace context, plus persistent walker caches (`purePkgs`, `peersCache`, parent contexts) so a subtree settled by one importer's pass short-circuits every compatible revisit — the same sharing the final `resolve_peers_workspace` pass already applies within its single call
- rebuild the discovery view whenever the sync cannot merge safely: a children-ownership handover that rewrote existing occurrence nodes (tracked by a rewrite counter), a re-recorded child list, or a changed peer split
- discovery mode skips `DependenciesGraph` construction entirely; the hoist loop only consumes missing peers and resolved providers, and each peers-cache item carries its subtree's per-package missing breakdown so the owner-scope report stays exact under cross-round cache hits
- remove the remaining per-importer O(workspace) barrier costs: the children-owner map deep clone in `record_first_walk_missing`, the whole-`packages` rescan in the preferred-versions fold (now an append-only log read through a per-importer cursor), and the per-importer owner-scope map clones (now snapshotted once per barrier)
- fix the environment-sensitive stderr assertions in the CLI deploy tests that fail whenever miette's wrap point lands inside the asserted phrase

Benchmark (`cargo bench -p pacquet-resolving-deps-resolver --bench workspace_full_resolution`):

|        | resolver time | peak RSS |
| ------ | ------------- | -------- |
| before | 65.1 s        | 3.76 GiB |
| after  | 1.55 s        | 1.14 GiB |

On the real Bit workspace driven through `@pnpm/napi`, a warm repeat `bd install` drops from ~4 minutes to ~65 s total, of which the engine accounts for 1.5 s (frozen path); the rest is Bit's own component loading and compilation.

This is a pure engine-side performance fix with no user-visible behavior change, so no TypeScript-side port is needed.

## Squash Commit Body

```text
The auto-install-peers hoist loop cloned the workspace tree and ran a
full peer pass - DependenciesGraph construction included - once per
importer per round, making a from-scratch resolve of a large component
workspace quadratic in both time and memory (the regression Bit hit
through the napi engine).

Replace the per-round snapshot + full pass with a PeerHoistDiscovery
engine shared by every hoist round of one workspace resolve:

- discovery walks share one persistent tree view, incrementally synced
  from the workspace context; a children-ownership handover that
  rewrites existing occurrence nodes (tracked by a rewrite counter), a
  re-recorded child list, or a changed peer split discards the whole
  view instead of merging;
- the walker's purePkgs / peersCache / parent-context maps persist
  across rounds and importers, so a subtree settled by one importer's
  pass short-circuits every compatible revisit - the same sharing the
  final resolve_peers_workspace pass already applies within one call;
- discovery skips graph construction entirely: the hoist loop only
  consumes missing peers and resolved providers, and each peers-cache
  item carries its subtree's per-package missing breakdown so the
  owner-scope report stays exact under cross-round cache hits.

Also drop the remaining per-importer O(workspace) costs in the initial
barrier: record_first_walk_missing no longer deep-clones the
children-owner map, the preferred-versions fold reads an append-only
resolved-versions log through a per-importer cursor, and the
owner-scope maps are snapshotted once per barrier. The CLI deploy
tests' stderr assertions are also made robust to miette's
path-length-dependent line wrapping.

cargo bench -p pacquet-resolving-deps-resolver --bench workspace_full_resolution
(331 importers, 5,000 shared packages, peer hoisting, no lockfile):
before 65.1s / 3.76 GiB peak RSS; after 1.55s / 1.14 GiB.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787920668&installation_model_id=426870&pr_number=13491&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13491&signature=82d0d1f36ff43cd6af2201f67eec1aad9f8a4763204d7fd368609a4fd72f60c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
