### PR TITLE
fix(resolver): attribute override-caused NO_MATCHING_VERSION to the override entry

### DIFF
--- a/.changeset/override-no-matching-version.md
+++ b/.changeset/override-no-matching-version.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"@pnpm/installing.deps-installer": patch
+"@pnpm/cli.default-reporter": patch
+"pnpm": patch
+---
+
+When an `overrides` entry points at a version that does not exist on the registry, `pnpm install` now reports the override entry itself (and the latest version matching its selector) instead of attributing the failure to whichever package happened to depend on it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4971,6 +4971,7 @@ dependencies = [
  "node-semver",
  "pacquet-catalogs-resolver",
  "pacquet-catalogs-types",
+ "pacquet-config-parse-overrides",
  "pacquet-deps-path",
  "pacquet-fs",
  "pacquet-hooks",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5907,6 +5907,9 @@ importers:
       '@pnpm/catalogs.types':
         specifier: workspace:*
         version: link:../../catalogs/types
+      '@pnpm/config.parse-overrides':
+        specifier: workspace:*
+        version: link:../../config/parse-overrides
       '@pnpm/config.version-policy':
         specifier: workspace:*
         version: link:../../config/version-policy

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1511,6 +1511,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             update_depth: update_seed_policy.max_depth(),
             auto_install_peers: config.auto_install_peers,
             registries,
+            parsed_overrides: parsed_overrides.clone().map(Arc::<[_]>::from),
             allowed_deprecated_versions: config.allowed_deprecated_versions.clone(),
             deprecation_log: Some(deprecation_log_fn::<Reporter>()),
         };

--- a/pnpm/crates/resolving-deps-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-deps-resolver/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace  = true
 [dependencies]
 pacquet-catalogs-resolver                 = { workspace = true }
 pacquet-catalogs-types                    = { workspace = true }
+pacquet-config-parse-overrides            = { workspace = true }
 pacquet-deps-path                         = { workspace = true }
 pacquet-fs                                = { workspace = true }
 pacquet-hooks                             = { workspace = true }

--- a/pnpm/crates/resolving-deps-resolver/benches/workspace_full_resolution.rs
+++ b/pnpm/crates/resolving-deps-resolver/benches/workspace_full_resolution.rs
@@ -251,6 +251,7 @@ fn workspace_options() -> WorkspaceResolveOptions {
         deprecation_log: None,
         auto_install_peers: true,
         registries: HashMap::new(),
+        parsed_overrides: None,
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -269,6 +269,39 @@ pub struct Deprecation {
 /// [`crate::WorkspaceResolveOptions::deprecation_log`].
 pub type DeprecationLogFn = Arc<dyn Fn(Deprecation) + Send + Sync>;
 
+/// `ERR_PNPM_NO_MATCHING_VERSION` reframed around a user override whose
+/// forced specifier no registry version satisfies. Mirrors the TypeScript
+/// CLI: names the override entry rather than the parent dependency, and
+/// points at the highest version the registry actually offers for the
+/// override selector's range (when that selector carries one).
+#[derive(Debug, Display, Error)]
+#[display(
+    "Override \"{selector}\": \"{new_bare_specifier}\" targets a version of {name} that does not exist on the registry."
+)]
+pub struct OverrideNoMatchingVersionError {
+    name: String,
+    selector: String,
+    new_bare_specifier: String,
+    selector_range: Option<String>,
+    best: Option<String>,
+}
+
+impl Diagnostic for OverrideNoMatchingVersionError {
+    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new("ERR_PNPM_NO_MATCHING_VERSION"))
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        match (&self.selector_range, &self.best) {
+            (Some(range), Some(best)) => Some(Box::new(format!(
+                "The latest release of {} matching \"{}\" is \"{}\".",
+                self.name, range, best
+            ))),
+            _ => None,
+        }
+    }
+}
+
 /// Error envelope returned by the tree walker.
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum ResolveDependencyTreeError {
@@ -281,6 +314,17 @@ pub enum ResolveDependencyTreeError {
     /// raised with the `ERR_PNPM_NO_MATCHING_VERSION` code.
     #[diagnostic(transparent)]
     NoMatchingVersion(#[error(source)] NoMatchingVersionError),
+
+    /// Reframed `ERR_PNPM_NO_MATCHING_VERSION` for the override-caused case:
+    /// the user's override forced a specifier no registry version satisfies.
+    /// Names the override entry (and, when the override selector carries a
+    /// range, the highest matching version) instead of the parent dependency
+    /// that happened to depend on it. Boxed so the variant does not bloat the
+    /// enum (and the `Result` Err types that carry it) past
+    /// `clippy::result_large_err`.
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    OverrideNoMatchingVersion(#[error(source)] Box<OverrideNoMatchingVersionError>),
 
     /// The registry answered the metadata request with a non-2xx status,
     /// raised with the matching `ERR_PNPM_FETCH_<status>` code.
@@ -825,6 +869,11 @@ pub struct WorkspaceTreeCtx {
     /// point doesn't thread registries (then `currentPkg` is withheld
     /// for `Registry`-shaped entries rather than sent without a URL).
     registries: HashMap<String, String>,
+    /// Parsed `pnpm.overrides`. Used to reframe
+    /// `ERR_PNPM_NO_MATCHING_VERSION` onto the responsible override entry
+    /// when an override forces a version the registry does not serve.
+    /// `None` when no overrides are configured.
+    parsed_overrides: Option<Arc<[pacquet_config_parse_overrides::VersionOverride]>>,
     /// `pkg id → importer id` of the importer whose occurrence owns
     /// that package's shared children context. Ownership is chosen by
     /// update-active status followed by `(depth, importer order, parent path)`:
@@ -901,6 +950,7 @@ impl Default for WorkspaceTreeCtx {
             deprecation_log: None,
             auto_install_peers: false,
             registries: HashMap::new(),
+            parsed_overrides: None,
             first_importer_by_pkg: Mutex::new(HashMap::new()),
             first_walk_missing_by_pkg: Mutex::new(HashMap::new()),
             changed_direct_deps: Mutex::new(HashMap::new()),
@@ -1326,6 +1376,18 @@ impl WorkspaceTreeCtx {
     #[must_use]
     pub fn with_registries(mut self, registries: HashMap<String, String>) -> Self {
         self.registries = registries;
+        self
+    }
+
+    /// Attach parsed `pnpm.overrides`, used to reframe
+    /// `ERR_PNPM_NO_MATCHING_VERSION` onto the responsible override entry
+    /// when an override forces a version the registry does not serve.
+    #[must_use]
+    pub fn with_parsed_overrides(
+        mut self,
+        parsed_overrides: Option<Arc<[pacquet_config_parse_overrides::VersionOverride]>>,
+    ) -> Self {
+        self.parsed_overrides = parsed_overrides;
         self
     }
 
@@ -2573,7 +2635,10 @@ where
     } else {
         opts
     };
-    let mut result = resolver.resolve(wanted, opts).await.map_err(map_resolve_error)?;
+    let mut result = resolver
+        .resolve(wanted, opts)
+        .await
+        .map_err(|err| map_resolve_error(err, wanted, ctx.workspace.parsed_overrides.as_deref()))?;
     let Some(result_inner) = result.as_mut() else {
         return Err(ResolveDependencyTreeError::SpecNotSupported {
             specifier: render_specifier(wanted),
@@ -2678,11 +2743,24 @@ fn fallback_manifest(
 /// that carry one. The chain hands back a type-erased
 /// [`ResolveError`], which drops the `miette::Diagnostic` facet, so the codes
 /// that are part of pnpm's public contract are recovered by downcast; every
-/// other failure keeps the generic envelope.
-fn map_resolve_error(err: ResolveError) -> ResolveDependencyTreeError {
+/// other failure keeps the generic envelope. When the failure is an
+/// override-forced `NoMatchingVersion`, reframe it onto the override entry
+/// (see [`reframe_override_no_matching_version`]).
+fn map_resolve_error(
+    err: ResolveError,
+    wanted: &WantedDependency,
+    overrides: Option<&[pacquet_config_parse_overrides::VersionOverride]>,
+) -> ResolveDependencyTreeError {
     let err = match err.downcast::<NoMatchingVersionError>() {
         Ok(no_matching_version) => {
-            return ResolveDependencyTreeError::NoMatchingVersion(*no_matching_version);
+            return match reframe_override_no_matching_version(
+                wanted,
+                &no_matching_version,
+                overrides,
+            ) {
+                Some(reframed) => reframed,
+                None => ResolveDependencyTreeError::NoMatchingVersion(*no_matching_version),
+            };
         }
         Err(err) => err,
     };
@@ -2690,6 +2768,57 @@ fn map_resolve_error(err: ResolveError) -> ResolveDependencyTreeError {
         Ok(response) => ResolveDependencyTreeError::RegistryResponse(*response),
         Err(err) => ResolveDependencyTreeError::Resolve(err.to_string()),
     }
+}
+
+/// When `ERR_PNPM_NO_MATCHING_VERSION` was forced by a user override — i.e.
+/// the failing `(alias, bare_specifier)` matches an override's
+/// `(target_pkg.name, new_bare_specifier)` — reframe the error around the
+/// override entry. Returns `None` when no override is responsible, so the
+/// caller falls back to the plain typed error.
+fn reframe_override_no_matching_version(
+    wanted: &WantedDependency,
+    specific: &NoMatchingVersionError,
+    overrides: Option<&[pacquet_config_parse_overrides::VersionOverride]>,
+) -> Option<ResolveDependencyTreeError> {
+    let overrides = overrides?;
+    let alias = wanted.alias.as_deref()?;
+    let bare_specifier = wanted.bare_specifier.as_deref()?;
+    let matched = overrides.iter().find(|override_entry| {
+        override_entry.target_pkg.name == alias
+            && override_entry.new_bare_specifier == bare_specifier
+    })?;
+    let selector_range = matched.target_pkg.bare_specifier.clone();
+    let best =
+        selector_range.as_deref().and_then(|range| max_satisfying(&specific.versions, range));
+    Some(ResolveDependencyTreeError::OverrideNoMatchingVersion(Box::new(
+        OverrideNoMatchingVersionError {
+            name: alias.to_string(),
+            selector: matched.selector.clone(),
+            new_bare_specifier: matched.new_bare_specifier.clone(),
+            selector_range,
+            best,
+        },
+    )))
+}
+
+/// Highest version in `versions` that satisfies `range`, or `None` when the
+/// range is invalid or no version matches. Used to point the user from a
+/// broken override at the version the registry actually offers for its
+/// selector.
+fn max_satisfying(versions: &[String], range: &str) -> Option<String> {
+    let parsed_range = node_semver::Range::parse(range).ok()?;
+    let mut best: Option<(node_semver::Version, String)> = None;
+    for version in versions {
+        let Ok(parsed) = node_semver::Version::parse(version) else { continue };
+        if !parsed.satisfies(&parsed_range) {
+            continue;
+        }
+        match &best {
+            Some((current, _)) if current >= &parsed => {}
+            _ => best = Some((parsed, version.clone())),
+        }
+    }
+    best.map(|(_, raw)| raw)
 }
 
 /// Speculatively warm a freshly-seeded node's children resolutions so

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tests.rs
@@ -1,13 +1,13 @@
 use pacquet_lockfile::{DirectoryResolution, LockfileResolution, PkgNameVerPeer};
 use pacquet_package_manifest::{DependencyGroup, PackageManifest};
 use pacquet_resolving_resolver_base::{
-    LatestQuery, PkgResolutionId, ResolveFuture, ResolveLatestFuture, ResolveOptions,
-    ResolveResult, Resolver, WantedDependency,
+    LatestQuery, NoMatchingVersionError, PkgResolutionId, ResolveFuture, ResolveLatestFuture,
+    ResolveOptions, ResolveResult, Resolver, WantedDependency,
 };
 
 use super::{
     ResolveDependencyTreeOptions, WorkspaceTreeCtx, extract_children, landed_on_prior_entry,
-    resolve_dependency_tree,
+    max_satisfying, reframe_override_no_matching_version, resolve_dependency_tree,
 };
 use crate::{
     DirectDep, NodeId,
@@ -870,4 +870,99 @@ mod fallback_manifest {
             serde_json::json!({ "name": "sub", "version": "0.0.0" }),
         );
     }
+}
+
+fn acme_no_match_error(bare_specifier: &str, versions: &[&str]) -> NoMatchingVersionError {
+    NoMatchingVersionError {
+        dep: format!("acme@{bare_specifier}"),
+        registry: "https://example.com/".to_string(),
+        published_versions: String::new(),
+        versions: versions.iter().map(|v| (*v).to_string()).collect(),
+    }
+}
+
+fn override_entry(
+    selector: &str,
+    target_name: &str,
+    target_range: Option<&str>,
+    new_spec: &str,
+) -> pacquet_config_parse_overrides::VersionOverride {
+    pacquet_config_parse_overrides::VersionOverride {
+        selector: selector.to_string(),
+        parent_pkg: None,
+        target_pkg: pacquet_config_parse_overrides::PackageSelector {
+            name: target_name.to_string(),
+            bare_specifier: target_range.map(str::to_string),
+        },
+        new_bare_specifier: new_spec.to_string(),
+        converge: false,
+    }
+}
+
+#[test]
+fn override_reframe_names_the_override_and_latest_matching_version() {
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.5.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let specific = acme_no_match_error("^1.5.0", &["1.0.0", "1.1.0"]);
+    let overrides = vec![override_entry("acme@^1", "acme", Some("^1"), "^1.5.0")];
+
+    let reframed = reframe_override_no_matching_version(&wanted, &specific, Some(&overrides))
+        .expect("a matching override reframes the error");
+
+    assert_eq!(
+        reframed.to_string(),
+        "Override \"acme@^1\": \"^1.5.0\" targets a version of acme that does not exist on the registry."
+    );
+    assert_eq!(
+        miette::Diagnostic::code(&reframed).map(|c| c.to_string()),
+        Some("ERR_PNPM_NO_MATCHING_VERSION".to_string()),
+    );
+    assert_eq!(
+        miette::Diagnostic::help(&reframed).map(|h| h.to_string()),
+        Some("The latest release of acme matching \"^1\" is \"1.1.0\".".to_string()),
+    );
+}
+
+#[test]
+fn override_reframe_omits_help_when_selector_has_no_range() {
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("2.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let specific = acme_no_match_error("2.0.0", &["1.0.0", "1.1.0"]);
+    let overrides = vec![override_entry("acme", "acme", None, "2.0.0")];
+
+    let reframed = reframe_override_no_matching_version(&wanted, &specific, Some(&overrides))
+        .expect("a matching override reframes the error");
+
+    assert_eq!(
+        reframed.to_string(),
+        "Override \"acme\": \"2.0.0\" targets a version of acme that does not exist on the registry."
+    );
+    assert!(miette::Diagnostic::help(&reframed).is_none());
+}
+
+#[test]
+fn override_reframe_returns_none_when_no_override_matches() {
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.5.0".to_string()),
+        ..WantedDependency::default()
+    };
+    let specific = acme_no_match_error("^1.5.0", &["1.0.0", "1.1.0"]);
+    let overrides = vec![override_entry("acme@^1", "acme", Some("^1"), "^3.0.0")];
+
+    assert!(reframe_override_no_matching_version(&wanted, &specific, Some(&overrides)).is_none());
+}
+
+#[test]
+fn max_satisfying_picks_the_highest_version_in_range() {
+    let versions = ["1.0.0".to_string(), "1.1.0".to_string(), "2.0.0".to_string()];
+    assert_eq!(max_satisfying(&versions, "^1"), Some("1.1.0".to_string()));
+    assert_eq!(max_satisfying(&versions, "^2"), Some("2.0.0".to_string()));
+    assert_eq!(max_satisfying(&versions, "^3"), None);
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -148,6 +148,11 @@ pub struct WorkspaceResolveOptions {
     /// its tarball URL when building the `currentPkg` payload custom
     /// resolvers receive.
     pub registries: HashMap<String, String>,
+    /// Parsed `pnpm.overrides`. Used to reframe
+    /// `ERR_PNPM_NO_MATCHING_VERSION` onto the responsible override
+    /// entry when an override forces a version the registry does not
+    /// serve.
+    pub parsed_overrides: Option<Arc<[pacquet_config_parse_overrides::VersionOverride]>>,
 }
 
 /// Result of [`fn@resolve_workspace`]. The combined
@@ -201,6 +206,7 @@ where
         update_depth,
         auto_install_peers,
         registries,
+        parsed_overrides,
     } = opts;
     let workspace = Arc::new(
         WorkspaceTreeCtx::default()
@@ -216,7 +222,8 @@ where
             .with_allowed_deprecated_versions(allowed_deprecated_versions)
             .with_deprecation_log(deprecation_log)
             .with_auto_install_peers(auto_install_peers)
-            .with_registries(registries),
+            .with_registries(registries)
+            .with_parsed_overrides(parsed_overrides),
     );
 
     // Build every importer's options up front so the `time-based`

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -217,6 +217,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         update_depth: crate::UpdateDepth::UNLIMITED,
         auto_install_peers: false,
         registries: HashMap::new(),
+        parsed_overrides: None,
     }
 }
 
@@ -1279,6 +1280,7 @@ impl FailureShape {
                 dep: format!("{alias}@{range}"),
                 registry: "https://registry.example/".to_string(),
                 published_versions: format!(r#"The latest release of {alias} is "2.0.0"."#),
+                versions: Vec::new(),
             }),
             FailureShape::RegistryResponse => {
                 Box::new(RegistryResponseError::new(RegistryResponseErrorOptions {

--- a/pnpm/crates/resolving-resolver-base/src/errors.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors.rs
@@ -34,12 +34,22 @@ pub struct NoMatchingVersionError {
     /// What the registry *does* publish: the latest release, the other
     /// dist-tags, and how to list every version.
     pub published_versions: String,
+    /// Every published version key, for callers that need to compute a
+    /// satisfying version themselves (e.g. pointing an override at the
+    /// highest version its selector actually admits).
+    #[error(not(source))]
+    pub versions: Vec<String>,
 }
 
 impl NoMatchingVersionError {
     #[must_use]
     pub fn new(dep: String, registry: String, meta: &Package) -> Self {
-        Self { dep, registry, published_versions: describe_published_versions(meta) }
+        Self {
+            dep,
+            registry,
+            published_versions: describe_published_versions(meta),
+            versions: meta.versions.keys().cloned().collect(),
+        }
     }
 }
 

--- a/pnpm11/cli/default-reporter/src/reportError.ts
+++ b/pnpm11/cli/default-reporter/src/reportError.ts
@@ -146,7 +146,7 @@ function formatNoMatchingVersion (err: Error, msg: { packageMeta?: PackageMeta }
   // so we just echo it through without the registry-metadata appendix.
   const meta = msg.packageMeta
   if (!meta) {
-    return { title: err.message }
+    return { title: err.message, body: (err as { hint?: string }).hint }
   }
   const latestVersion = meta['dist-tags'].latest
   let output = `The latest release of ${meta.name} is "${latestVersion}".`

--- a/pnpm11/installing/deps-installer/src/getPeerDependencyIssues.ts
+++ b/pnpm11/installing/deps-installer/src/getPeerDependencyIssues.ts
@@ -81,6 +81,7 @@ export async function getPeerDependencyIssues (
           ignoredOptionalDependencies: opts.ignoredOptionalDependencies,
         }),
       },
+      parsedOverrides: overrides,
       overrideBareSpecifier: createDependencyOverrider(overrides, lockfileDir),
       linkWorkspacePackagesDepth: opts.linkWorkspacePackagesDepth ?? (opts.saveWorkspaceProtocol ? 0 : -1),
       lockfileDir,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -1690,6 +1690,7 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
       hooks: {
         readPackage: opts.readPackageHook,
       },
+      parsedOverrides: opts.parsedOverrides,
       overrideBareSpecifier: createDependencyOverrider(opts.parsedOverrides, opts.lockfileDir),
       linkWorkspacePackagesDepth: opts.linkWorkspacePackagesDepth ?? (opts.saveWorkspaceProtocol ? 0 : -1),
       lockfileDir: opts.lockfileDir,

--- a/pnpm11/installing/deps-installer/test/install/overrides.ts
+++ b/pnpm11/installing/deps-installer/test/install/overrides.ts
@@ -482,6 +482,34 @@ test('versions are replaced with versions specified through overrides option', a
   )
 })
 
+test('an override that targets a nonexistent version reports the override entry, not the parent dependency', async () => {
+  prepareEmpty()
+
+  const overrides = {
+    '@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0': '999.0.0',
+  }
+  let error: unknown
+  try {
+    await addDependenciesToPackage({},
+      ['@pnpm.e2e/pkg-with-1-dep@100.0.0'],
+      testDefaults({ overrides })
+    )
+  } catch (err) {
+    error = err
+  }
+  const { code, message, hint, pkgsStack } = error as PnpmError
+
+  expect(code).toBe('ERR_PNPM_NO_MATCHING_VERSION')
+  expect(message).toBe(
+    'Override "@pnpm.e2e/dep-of-pkg-with-1-dep@^100.0.0": "999.0.0" targets a version of @pnpm.e2e/dep-of-pkg-with-1-dep that does not exist on the registry.'
+  )
+  expect(message).not.toContain('while fetching it from')
+  expect(hint).toBe(
+    'The latest release of @pnpm.e2e/dep-of-pkg-with-1-dep matching "^100.0.0" is "100.1.0".'
+  )
+  expect(pkgsStack).toBeUndefined()
+})
+
 test('when adding a new dependency that is present in the overrides, use the spec from the override', async () => {
   prepareEmpty()
 

--- a/pnpm11/installing/deps-resolver/package.json
+++ b/pnpm11/installing/deps-resolver/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@pnpm/catalogs.resolver": "workspace:*",
     "@pnpm/catalogs.types": "workspace:*",
+    "@pnpm/config.parse-overrides": "workspace:*",
     "@pnpm/config.version-policy": "workspace:*",
     "@pnpm/constants": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",

--- a/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencies.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { type CatalogResolution, type CatalogResolver, matchCatalogResolveResult } from '@pnpm/catalogs.resolver'
+import type { VersionOverride } from '@pnpm/config.parse-overrides'
 import {
   deprecationLogger,
   progressLogger,
@@ -197,6 +198,7 @@ export interface ResolutionContext {
   force: boolean
   preferWorkspacePackages?: boolean
   readPackageHook?: ReadPackageHook
+  parsedOverrides?: VersionOverride[]
   overrideBareSpecifier?: (name: string, bareSpecifier: string, dir?: string) => string | undefined
   engineStrict: boolean
   nodeVersion?: string
@@ -1983,6 +1985,11 @@ async function resolveDependency (
             'If the version was intentionally removed from the registry, update the dependent package or remove the entries from the lockfile.'
         }
       }
+      const overrideError = toOverrideNoMatchingVersionError(err, wantedDependency, ctx.parsedOverrides)
+      if (overrideError != null) {
+        overrideError.prefix = options.prefix
+        throw overrideError
+      }
       err.package = wantedDependencyDetails
       err.prefix = options.prefix
       err.pkgsStack = getPkgsInfoFromIds(options.parentIds, ctx.resolvedPkgsById)
@@ -2461,4 +2468,43 @@ const NON_EXOTIC_RESOLVED_VIA = new Set([
 
 function isExoticDep (resolvedVia: string): boolean {
   return !NON_EXOTIC_RESOLVED_VIA.has(resolvedVia)
+}
+
+interface RegistryPackageMeta {
+  versions?: Record<string, unknown>
+}
+
+/**
+ * When `ERR_PNPM_NO_MATCHING_VERSION` is caused by a user override whose
+ * `newBareSpecifier` does not exist on the registry, reframe the error around
+ * the override entry itself. The dependency stack that normally accompanies
+ * resolution failures (e.g. "at minimatch@9.0.9") is irrelevant here — the
+ * user wrote the override and needs to know which entry is broken and what
+ * version the registry actually offers for its selector. Returns `null` when
+ * the failure is not override-caused, so the caller falls back to the original
+ * error with its full stack.
+ */
+function toOverrideNoMatchingVersionError (
+  err: { code?: string, packageMeta?: RegistryPackageMeta },
+  wantedDependency: { alias?: string, bareSpecifier?: string },
+  parsedOverrides?: readonly VersionOverride[]
+): PnpmError | null {
+  if (err.code !== 'ERR_PNPM_NO_MATCHING_VERSION') return null
+  const alias = wantedDependency.alias
+  const spec = wantedDependency.bareSpecifier
+  if (!parsedOverrides?.length || !alias || !spec) return null
+  const override = parsedOverrides.find((candidate) =>
+    candidate.targetPkg.name === alias && candidate.newBareSpecifier === spec)
+  if (override == null) return null
+  const selectorRange = override.targetPkg.bareSpecifier
+  const versions = err.packageMeta?.versions ? Object.keys(err.packageMeta.versions) : []
+  const best = selectorRange && versions.length > 0 ? semver.maxSatisfying(versions, selectorRange) : null
+  const hint = best != null
+    ? `The latest release of ${override.targetPkg.name} matching "${selectorRange}" is "${best}".`
+    : undefined
+  return new PnpmError(
+    'NO_MATCHING_VERSION',
+    `Override "${override.selector}": "${override.newBareSpecifier}" targets a version of ${override.targetPkg.name} that does not exist on the registry.`,
+    hint != null ? { hint } : undefined
+  )
 }

--- a/pnpm11/installing/deps-resolver/src/resolveDependencyTree.ts
+++ b/pnpm11/installing/deps-resolver/src/resolveDependencyTree.ts
@@ -1,5 +1,6 @@
 import { resolveFromCatalog } from '@pnpm/catalogs.resolver'
 import type { Catalogs } from '@pnpm/catalogs.types'
+import type { VersionOverride } from '@pnpm/config.parse-overrides'
 import { createPackageVersionPolicyOrThrow, getPublishedByPolicy } from '@pnpm/config.version-policy'
 import type { LockfileObject } from '@pnpm/lockfile.types'
 import { globalWarn } from '@pnpm/logger'
@@ -126,6 +127,7 @@ export interface ResolveDependenciesOptions {
   hooks: {
     readPackage?: ReadPackageHook
   }
+  parsedOverrides?: VersionOverride[]
   overrideBareSpecifier?: (name: string, bareSpecifier: string, dir?: string) => string | undefined
   nodeVersion?: string
   registries: Registries
@@ -210,6 +212,7 @@ export async function resolveDependencyTree<T> (
     pnpmVersion: opts.pnpmVersion,
     preferWorkspacePackages: opts.preferWorkspacePackages,
     readPackageHook: opts.hooks.readPackage,
+    parsedOverrides: opts.parsedOverrides,
     overrideBareSpecifier: opts.overrideBareSpecifier,
     registries: opts.registries,
     namedRegistryPrefixes: Array.from(


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once the automated code reviewers
(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
pass before expecting human review. -->

## Summary

When an `overrides` entry points at a version that doesn't exist on the registry, `ERR_PNPM_NO_MATCHING_VERSION` used to print the override-forced specifier as if the parent dependency had requested it — e.g. `No matching version found for brace-expansion@^2.1.4 ... at minimatch@9.0.9` — sending users hunting through transitive manifests for a typo they actually wrote in `pnpm-workspace.yaml`.

This PR detects, at the resolution-error site, that the failing `(alias, bareSpecifier)` matches a user override's `(targetPkg.name, newBareSpecifier)` and reframes the error around the override entry: names the override selector + forced specifier, points at the highest registry version matching the override's selector, and drops the irrelevant dependency stack.

Implemented in **both** stacks (TS CLI + the Rust `pnpm/` port).

## Squash Commit Body

```text
An override pointing at a nonexistent registry version made pnpm print
ERR_PNPM_NO_MATCHING_VERSION with the override-forced specifier attributed
to whichever package depended on it, plus the full dependency stack.
Reframe the error onto the override entry when the failing
(alias, bareSpecifier) matches a user override's
(targetPkg.name, newBareSpecifier): name the override selector and forced
specifier, surface the highest version the registry offers for the
override selector's range, and drop the dependency stack.

TypeScript CLI (pnpm11):
- installing.deps-resolver: at the resolution-error catch site, detect the
  override match and throw a fresh PnpmError('NO_MATCHING_VERSION', ...)
  with a hint carrying the latest matching version. Thread parsedOverrides
  through ResolveDependenciesOptions / ResolutionContext from the install
  layer and getPeerDependencyIssues.
- cli.default-reporter: formatNoMatchingVersion renders err.hint in the
  no-packageMeta branch.

Rust port (pnpm/):
- resolving-resolver-base: NoMatchingVersionError gains a versions field
  (populated from the packument at construction) so the reframe can compute
  the highest version satisfying the override selector without re-fetching.
- resolving-deps-resolver: thread parsed overrides through
  WorkspaceResolveOptions into the shared WorkspaceTreeCtx (workspace-wide,
  like manifest_hook) so the ~20 test-facing options literals need no
  changes. In map_resolve_error — where the npm resolver's typed
  NoMatchingVersionError is already recovered by downcast — match the
  failing spec against the overrides and, on match, build an
  OverrideNoMatchingVersion diagnostic (same code, override-focused
  message, miette help with the best version). The variant is boxed to
  stay under clippy::result_large_err.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
<!-- No doc update needed: this changes an error message, not a flag/command/setting. -->

---
Written by an agent (opencode, glm-5.2).
