### PR TITLE
feat(cli): warn on global operations under sudo, refuse them in v12

### DIFF
--- a/.changeset/refuse-sudo-global.md
+++ b/.changeset/refuse-sudo-global.md
@@ -1,0 +1,6 @@
+---
+"pnpm": minor
+"pacquet": minor
+---
+
+Running `pnpm setup`, `pnpm self-update`, or a command that modifies the global installation (such as `pnpm add --global`) through `sudo` now fails with `ERR_PNPM_SUDO_NOT_SUPPORTED` instead of silently operating on the root user's home directory. pnpm keeps global packages and configuration in the invoking user's home directory, so these commands never need root permissions. Read-only global commands (such as `pnpm bin --global`) still work under sudo.

--- a/.changeset/refuse-sudo-global.md
+++ b/.changeset/refuse-sudo-global.md
@@ -1,5 +1,4 @@
 ---
-"pnpm": minor
 "pacquet": minor
 ---
 

--- a/.changeset/warn-sudo-global.md
+++ b/.changeset/warn-sudo-global.md
@@ -1,0 +1,5 @@
+---
+"pnpm": minor
+---
+
+Running `pnpm setup`, `pnpm self-update`, or a command that modifies the global installation (such as `pnpm add --global`) through `sudo` now prints a warning. pnpm keeps global packages and configuration in the invoking user's home directory, so running these commands as root silently operates on the root user's home directory instead of yours. They will fail with `ERR_PNPM_SUDO_NOT_SUPPORTED` in pnpm v12. Read-only global commands (such as `pnpm bin --global`) are unaffected.

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -74,6 +74,7 @@ pub mod stage;
 pub mod star;
 pub mod stars;
 pub mod store;
+pub mod sudo_guard;
 pub mod supported_architectures;
 pub mod team;
 pub mod undeprecate;

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -203,7 +203,7 @@ impl ConfigArgs {
 /// Resolve the effective `global` boolean from the `--location` / `--global`
 /// flags. Mirrors pnpm's handler: `--location` wins, otherwise config
 /// operations default to global.
-fn resolve_global(flags: ConfigFlags) -> bool {
+pub(super) fn resolve_global(flags: ConfigFlags) -> bool {
     match flags.location {
         Some(ConfigLocation::Global) => true,
         Some(ConfigLocation::Project) => false,

--- a/pnpm/crates/cli/src/cli_args/sudo_guard.rs
+++ b/pnpm/crates/cli/src/cli_args/sudo_guard.rs
@@ -1,0 +1,92 @@
+//! Refuse commands that write to home-directory locations (global
+//! installs, `pnpm setup`, `pnpm self-update`) when pnpm is executed
+//! through `sudo`. Those commands would target root's home directory,
+//! which is never what a user coming from `sudo npm install -g` wants.
+//!
+//! Mirrors `checkSudo` in pnpm's `pnpm/src/checkSudo.ts` — the
+//! condition, the command set, the error code, the message, and the
+//! hint are identical.
+
+use super::cli_command::CliCommand;
+
+#[cfg(unix)]
+use super::config::{ConfigArgs, ConfigSubcommand};
+#[cfg(unix)]
+use derive_more::{Display, Error};
+#[cfg(unix)]
+use miette::Diagnostic;
+
+pub(crate) fn check_sudo(command: &CliCommand) -> miette::Result<()> {
+    #[cfg(unix)]
+    {
+        // SAFETY: geteuid is always safe to call.
+        let euid = unsafe { libc::geteuid() };
+        let sudo_user = std::env::var("SUDO_USER").ok();
+        check_sudo_as(command, euid, sudo_user.as_deref())?;
+    }
+    #[cfg(not(unix))]
+    let _ = command;
+    Ok(())
+}
+
+#[cfg(unix)]
+const SUDO_HINT: &str = "pnpm installs global packages and writes global configuration inside your home directory, so they do not require root permissions, and running this command as root would target the root user's home directory instead of yours. Rerun the command without sudo. If you really intend to manage the root user's own global packages, run pnpm from a session where the SUDO_USER environment variable is not set (for example: sudo env -u SUDO_USER pnpm ...).";
+
+#[cfg(unix)]
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("Running \"{operation}\" with sudo is not supported")]
+#[diagnostic(code(ERR_PNPM_SUDO_NOT_SUPPORTED), help("{SUDO_HINT}"))]
+pub struct SudoNotSupportedError {
+    operation: String,
+}
+
+#[cfg(unix)]
+fn check_sudo_as(
+    command: &CliCommand,
+    euid: libc::uid_t,
+    sudo_user: Option<&str>,
+) -> Result<(), SudoNotSupportedError> {
+    if euid != 0 {
+        return Ok(());
+    }
+    if !sudo_user.is_some_and(|user| !user.is_empty() && user != "root") {
+        return Ok(());
+    }
+    match sudo_blocked_operation(command) {
+        Some(operation) => Err(SudoNotSupportedError { operation }),
+        None => Ok(()),
+    }
+}
+
+/// The user-facing name of the blocked operation, or `None` when the
+/// command is allowed under sudo. Global commands that only read
+/// (`pnpm bin -g`, `pnpm list -g`, `pnpm config get -g`, ...) stay
+/// allowed.
+#[cfg(unix)]
+fn sudo_blocked_operation(command: &CliCommand) -> Option<String> {
+    let global_write = |global: bool, name: &str| global.then(|| format!("pnpm {name} --global"));
+    match command {
+        CliCommand::Setup(_) => Some("pnpm setup".to_string()),
+        CliCommand::SelfUpdate(_) => Some("pnpm self-update".to_string()),
+        CliCommand::Add(args) => global_write(args.global, "add"),
+        CliCommand::ApproveBuilds(args) => global_write(args.global, "approve-builds"),
+        CliCommand::Remove(args) => global_write(args.global, "remove"),
+        CliCommand::Runtime(args) => global_write(args.global, "runtime"),
+        CliCommand::Update(args) => global_write(args.global, "update"),
+        // `pnpm link` with no arguments links the current project into the
+        // global directory.
+        CliCommand::Link(args) if args.package_paths.is_empty() => {
+            Some("pnpm link --global".to_string())
+        }
+        CliCommand::Config(ConfigArgs { command: ConfigSubcommand::Set(args), .. }) => {
+            global_write(args.flags.global, "config set")
+        }
+        CliCommand::Config(ConfigArgs { command: ConfigSubcommand::Delete(args), .. }) => {
+            global_write(args.flags.global, "config delete")
+        }
+        _ => None,
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/sudo_guard.rs
+++ b/pnpm/crates/cli/src/cli_args/sudo_guard.rs
@@ -3,9 +3,10 @@
 //! through `sudo`. Those commands would target root's home directory,
 //! which is never what a user coming from `sudo npm install -g` wants.
 //!
-//! Mirrors `checkSudo` in pnpm's `pnpm/src/checkSudo.ts` — the
-//! condition, the command set, the error code, the message, and the
-//! hint are identical.
+//! `checkSudo` in pnpm v11's `pnpm11/pnpm/src/checkSudo.ts` detects the
+//! same commands under the same condition, but only warns there:
+//! refusing them is a breaking change, so it lands in v12 while v11
+//! gives users a release to migrate.
 
 use super::cli_command::CliCommand;
 

--- a/pnpm/crates/cli/src/cli_args/sudo_guard.rs
+++ b/pnpm/crates/cli/src/cli_args/sudo_guard.rs
@@ -78,11 +78,14 @@ fn sudo_blocked_operation(command: &CliCommand) -> Option<String> {
         CliCommand::Link(args) if args.package_paths.is_empty() => {
             Some("pnpm link --global".to_string())
         }
+        // Config writes default to the global config file when no
+        // `--location` is given, so gate on the effective scope, not the
+        // `--global` flag alone.
         CliCommand::Config(ConfigArgs { command: ConfigSubcommand::Set(args), .. }) => {
-            global_write(args.flags.global, "config set")
+            global_write(super::config::resolve_global(args.flags), "config set")
         }
         CliCommand::Config(ConfigArgs { command: ConfigSubcommand::Delete(args), .. }) => {
-            global_write(args.flags.global, "config delete")
+            global_write(super::config::resolve_global(args.flags), "config delete")
         }
         _ => None,
     }

--- a/pnpm/crates/cli/src/cli_args/sudo_guard/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sudo_guard/tests.rs
@@ -1,0 +1,81 @@
+use super::{check_sudo_as, sudo_blocked_operation};
+use crate::cli_args::cli_command::{CliArgs, CliCommand};
+use clap::Parser;
+
+fn command(argv: &[&str]) -> CliCommand {
+    CliArgs::try_parse_from(argv).expect("parses").command
+}
+
+#[test]
+fn allowed_when_not_root() {
+    assert!(check_sudo_as(&command(&["pnpm", "setup"]), 1000, Some("alice")).is_ok());
+}
+
+#[test]
+fn allowed_for_plain_root_without_sudo() {
+    assert!(check_sudo_as(&command(&["pnpm", "setup"]), 0, None).is_ok());
+}
+
+#[test]
+fn allowed_when_root_sudoed_to_itself() {
+    assert!(check_sudo_as(&command(&["pnpm", "setup"]), 0, Some("root")).is_ok());
+}
+
+#[test]
+fn setup_is_blocked_under_sudo() {
+    let err = check_sudo_as(&command(&["pnpm", "setup"]), 0, Some("alice")).expect_err("blocked");
+    assert_eq!(err.to_string(), r#"Running "pnpm setup" with sudo is not supported"#);
+}
+
+#[test]
+fn self_update_is_blocked_under_sudo() {
+    assert!(check_sudo_as(&command(&["pnpm", "self-update"]), 0, Some("alice")).is_err());
+}
+
+#[test]
+fn global_add_is_blocked_under_sudo() {
+    let err = check_sudo_as(&command(&["pnpm", "add", "--global", "foo"]), 0, Some("alice"))
+        .expect_err("blocked");
+    assert_eq!(err.to_string(), r#"Running "pnpm add --global" with sudo is not supported"#);
+}
+
+#[test]
+fn local_add_is_allowed_under_sudo() {
+    assert!(check_sudo_as(&command(&["pnpm", "add", "foo"]), 0, Some("alice")).is_ok());
+}
+
+#[test]
+fn read_only_global_commands_are_allowed_under_sudo() {
+    assert!(check_sudo_as(&command(&["pnpm", "bin", "--global"]), 0, Some("alice")).is_ok());
+    assert!(check_sudo_as(&command(&["pnpm", "root", "--global"]), 0, Some("alice")).is_ok());
+    assert!(check_sudo_as(&command(&["pnpm", "list", "--global"]), 0, Some("alice")).is_ok());
+}
+
+#[test]
+fn config_writes_are_blocked_but_reads_allowed() {
+    assert!(
+        check_sudo_as(
+            &command(&["pnpm", "config", "set", "--global", "store-dir", "/tmp/store"]),
+            0,
+            Some("alice"),
+        )
+        .is_err()
+    );
+    assert!(
+        check_sudo_as(
+            &command(&["pnpm", "config", "get", "--global", "store-dir"]),
+            0,
+            Some("alice")
+        )
+        .is_ok()
+    );
+}
+
+#[test]
+fn bare_link_targets_the_global_dir_and_is_blocked() {
+    assert_eq!(
+        sudo_blocked_operation(&command(&["pnpm", "link"])),
+        Some("pnpm link --global".to_string()),
+    );
+    assert_eq!(sudo_blocked_operation(&command(&["pnpm", "link", "../foo"])), None);
+}

--- a/pnpm/crates/cli/src/cli_args/sudo_guard/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sudo_guard/tests.rs
@@ -71,6 +71,42 @@ fn config_writes_are_blocked_but_reads_allowed() {
     );
 }
 
+/// `--location` wins, otherwise config writes default to the global config
+/// file — a bare `sudo pnpm config set` must not slip past the guard.
+#[test]
+fn config_writes_are_gated_on_the_effective_scope() {
+    assert_eq!(
+        sudo_blocked_operation(&command(&["pnpm", "config", "set", "store-dir", "/tmp/store"])),
+        Some("pnpm config set --global".to_string()),
+    );
+    assert_eq!(
+        sudo_blocked_operation(&command(&[
+            "pnpm",
+            "config",
+            "set",
+            "--location=global",
+            "store-dir",
+            "/tmp/store",
+        ])),
+        Some("pnpm config set --global".to_string()),
+    );
+    assert_eq!(
+        sudo_blocked_operation(&command(&[
+            "pnpm",
+            "config",
+            "set",
+            "--location=project",
+            "store-dir",
+            "/tmp/store",
+        ])),
+        None,
+    );
+    assert_eq!(
+        sudo_blocked_operation(&command(&["pnpm", "config", "delete", "store-dir"])),
+        Some("pnpm config delete --global".to_string()),
+    );
+}
+
 #[test]
 fn bare_link_targets_the_global_dir_and_is_blocked() {
     assert_eq!(

--- a/pnpm/crates/cli/src/cli_args/sudo_guard/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sudo_guard/tests.rs
@@ -17,7 +17,7 @@ fn allowed_for_plain_root_without_sudo() {
 }
 
 #[test]
-fn allowed_when_root_sudoed_to_itself() {
+fn allowed_when_sudo_user_is_root() {
     assert!(check_sudo_as(&command(&["pnpm", "setup"]), 0, Some("root")).is_ok());
 }
 

--- a/pnpm/crates/cli/src/cli_args/sudo_guard/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/sudo_guard/tests.rs
@@ -59,15 +59,15 @@ fn config_writes_are_blocked_but_reads_allowed() {
             0,
             Some("alice"),
         )
-        .is_err()
+        .is_err(),
     );
     assert!(
         check_sudo_as(
             &command(&["pnpm", "config", "get", "--global", "store-dir"]),
             0,
-            Some("alice")
+            Some("alice"),
         )
-        .is_ok()
+        .is_ok(),
     );
 }
 

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -111,6 +111,7 @@ fn run_cli() -> miette::Result<()> {
     args.apply_workspace_root()?;
     args.promote_recursive_by_default();
     args.configure_reporter();
+    cli_args::sudo_guard::check_sudo(&args.command)?;
     if let Some(plan) = cli_args::pre_command::pre_command_plan(&args, &config_overrides)?
         && block_on_runtime(
             "pacquet-pre-command",

--- a/pnpm11/pnpm/src/checkSudo.test.ts
+++ b/pnpm11/pnpm/src/checkSudo.test.ts
@@ -18,7 +18,7 @@ test('allowed for plain root without sudo', () => {
   }).not.toThrow()
 })
 
-test('allowed when root sudoed to itself', () => {
+test('allowed when SUDO_USER is root', () => {
   expect(() => {
     checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: { SUDO_USER: 'root' }, geteuid: rootUid })
   }).not.toThrow()

--- a/pnpm11/pnpm/src/checkSudo.test.ts
+++ b/pnpm11/pnpm/src/checkSudo.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@jest/globals'
+
+import { checkSudo } from './checkSudo.js'
+
+const rootUid = () => 0
+const userUid = () => 1000
+const sudoEnv = { SUDO_USER: 'alice' }
+
+test('allowed when not running as root', () => {
+  expect(() => {
+    checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: sudoEnv, geteuid: userUid })
+  }).not.toThrow()
+})
+
+test('allowed for plain root without sudo', () => {
+  expect(() => {
+    checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: {}, geteuid: rootUid })
+  }).not.toThrow()
+})
+
+test('allowed when root sudoed to itself', () => {
+  expect(() => {
+    checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: { SUDO_USER: 'root' }, geteuid: rootUid })
+  }).not.toThrow()
+})
+
+test('setup and self-update are blocked under sudo', () => {
+  expect(() => {
+    checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: sudoEnv, geteuid: rootUid })
+  }).toThrow('Running "pnpm setup" with sudo is not supported')
+  expect(() => {
+    checkSudo({ cmd: 'self-update', cliParams: [], isGlobal: false, env: sudoEnv, geteuid: rootUid })
+  }).toThrow('Running "pnpm self-update" with sudo is not supported')
+})
+
+test('global add is blocked under sudo with the expected error code', () => {
+  let thrownCode: string | undefined
+  try {
+    checkSudo({ cmd: 'add', cliParams: ['foo'], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+  } catch (err: any) { // eslint-disable-line
+    thrownCode = err.code
+  }
+  expect(thrownCode).toBe('ERR_PNPM_SUDO_NOT_SUPPORTED')
+})
+
+test('local add is allowed under sudo', () => {
+  expect(() => {
+    checkSudo({ cmd: 'add', cliParams: ['foo'], isGlobal: false, env: sudoEnv, geteuid: rootUid })
+  }).not.toThrow()
+})
+
+test('read-only global commands are allowed under sudo', () => {
+  for (const cmd of ['bin', 'root', 'prefix', 'list', 'outdated']) {
+    expect(() => {
+      checkSudo({ cmd, cliParams: [], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+    }).not.toThrow()
+  }
+})
+
+test('global config writes are blocked but reads allowed', () => {
+  expect(() => {
+    checkSudo({ cmd: 'config', cliParams: ['set', 'store-dir', '/tmp/store'], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+  }).toThrow('Running "pnpm config set --global" with sudo is not supported')
+  expect(() => {
+    checkSudo({ cmd: 'config', cliParams: ['get', 'store-dir'], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+  }).not.toThrow()
+})
+
+test('bare link targets the global directory and is blocked', () => {
+  expect(() => {
+    checkSudo({ cmd: 'link', cliParams: [], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+  }).toThrow('Running "pnpm link --global" with sudo is not supported')
+})

--- a/pnpm11/pnpm/src/checkSudo.test.ts
+++ b/pnpm11/pnpm/src/checkSudo.test.ts
@@ -1,97 +1,65 @@
 import { expect, test } from '@jest/globals'
 
-import { checkSudo } from './checkSudo.js'
+import { sudoBlockedOperation } from './checkSudo.js'
 
 const rootUid = () => 0
 const userUid = () => 1000
 const sudoEnv = { SUDO_USER: 'alice' }
 
-test('allowed when not running as root', () => {
-  expect(() => {
-    checkSudo({ cmd: 'setup', cliParams: [], env: sudoEnv, geteuid: userUid })
-  }).not.toThrow()
+test('nothing reported when not running as root', () => {
+  expect(sudoBlockedOperation({ cmd: 'setup', cliParams: [], env: sudoEnv, geteuid: userUid })).toBeUndefined()
 })
 
-test('allowed for plain root without sudo', () => {
-  expect(() => {
-    checkSudo({ cmd: 'setup', cliParams: [], env: {}, geteuid: rootUid })
-  }).not.toThrow()
+test('nothing reported for plain root without sudo', () => {
+  expect(sudoBlockedOperation({ cmd: 'setup', cliParams: [], env: {}, geteuid: rootUid })).toBeUndefined()
 })
 
-test('allowed when SUDO_USER is root', () => {
-  expect(() => {
-    checkSudo({ cmd: 'setup', cliParams: [], env: { SUDO_USER: 'root' }, geteuid: rootUid })
-  }).not.toThrow()
+test('nothing reported when SUDO_USER is root', () => {
+  expect(sudoBlockedOperation({ cmd: 'setup', cliParams: [], env: { SUDO_USER: 'root' }, geteuid: rootUid })).toBeUndefined()
 })
 
-test('setup and self-update are blocked under sudo', () => {
-  expect(() => {
-    checkSudo({ cmd: 'setup', cliParams: [], env: sudoEnv, geteuid: rootUid })
-  }).toThrow('Running "pnpm setup" with sudo is not supported')
-  expect(() => {
-    checkSudo({ cmd: 'self-update', cliParams: [], env: sudoEnv, geteuid: rootUid })
-  }).toThrow('Running "pnpm self-update" with sudo is not supported')
+test('setup and self-update are reported under sudo', () => {
+  expect(sudoBlockedOperation({ cmd: 'setup', cliParams: [], env: sudoEnv, geteuid: rootUid })).toBe('pnpm setup')
+  expect(sudoBlockedOperation({ cmd: 'self-update', cliParams: [], env: sudoEnv, geteuid: rootUid })).toBe('pnpm self-update')
 })
 
-test('global add is blocked under sudo with the expected error code', () => {
-  let thrownCode: string | undefined
-  try {
-    checkSudo({ cmd: 'add', cliParams: ['foo'], global: true, env: sudoEnv, geteuid: rootUid })
-  } catch (err: any) { // eslint-disable-line
-    thrownCode = err.code
-  }
-  expect(thrownCode).toBe('ERR_PNPM_SUDO_NOT_SUPPORTED')
+test('global add is reported under sudo', () => {
+  expect(sudoBlockedOperation({ cmd: 'add', cliParams: ['foo'], global: true, env: sudoEnv, geteuid: rootUid })).toBe('pnpm add --global')
 })
 
-test('local add is allowed under sudo', () => {
-  expect(() => {
-    checkSudo({ cmd: 'add', cliParams: ['foo'], env: sudoEnv, geteuid: rootUid })
-  }).not.toThrow()
+test('local add is not reported under sudo', () => {
+  expect(sudoBlockedOperation({ cmd: 'add', cliParams: ['foo'], env: sudoEnv, geteuid: rootUid })).toBeUndefined()
 })
 
-test('read-only global commands are allowed under sudo', () => {
+test('read-only global commands are not reported under sudo', () => {
   for (const cmd of ['bin', 'root', 'prefix', 'list', 'outdated']) {
-    expect(() => {
-      checkSudo({ cmd, cliParams: [], global: true, env: sudoEnv, geteuid: rootUid })
-    }).not.toThrow()
+    expect(sudoBlockedOperation({ cmd, cliParams: [], global: true, env: sudoEnv, geteuid: rootUid })).toBeUndefined()
   }
 })
 
-test('config writes are blocked even without an explicit --global because they default to the global config', () => {
-  expect(() => {
-    checkSudo({ cmd: 'config', cliParams: ['set', 'store-dir', '/tmp/store'], env: sudoEnv, geteuid: rootUid })
-  }).toThrow('Running "pnpm config set --global" with sudo is not supported')
-  expect(() => {
-    checkSudo({ cmd: 'config', cliParams: ['delete', 'store-dir'], global: true, env: sudoEnv, geteuid: rootUid })
-  }).toThrow('Running "pnpm config delete --global" with sudo is not supported')
-  expect(() => {
-    checkSudo({ cmd: 'set', cliParams: ['store-dir=/tmp/store'], env: sudoEnv, geteuid: rootUid })
-  }).toThrow('Running "pnpm config set --global" with sudo is not supported')
+test('config writes are reported even without an explicit --global because they default to the global config', () => {
+  expect(sudoBlockedOperation({ cmd: 'config', cliParams: ['set', 'store-dir', '/tmp/store'], env: sudoEnv, geteuid: rootUid }))
+    .toBe('pnpm config set --global')
+  expect(sudoBlockedOperation({ cmd: 'config', cliParams: ['delete', 'store-dir'], global: true, env: sudoEnv, geteuid: rootUid }))
+    .toBe('pnpm config delete --global')
+  expect(sudoBlockedOperation({ cmd: 'set', cliParams: ['store-dir=/tmp/store'], env: sudoEnv, geteuid: rootUid }))
+    .toBe('pnpm config set --global')
 })
 
-test('config writes scoped to the project are allowed under sudo', () => {
-  expect(() => {
-    checkSudo({ cmd: 'config', cliParams: ['set', 'store-dir', '/tmp/store'], location: 'project', env: sudoEnv, geteuid: rootUid })
-  }).not.toThrow()
+test('config writes scoped to the project are not reported under sudo', () => {
+  expect(sudoBlockedOperation({ cmd: 'config', cliParams: ['set', 'store-dir', '/tmp/store'], location: 'project', env: sudoEnv, geteuid: rootUid }))
+    .toBeUndefined()
 })
 
-test('config reads are allowed under sudo', () => {
-  expect(() => {
-    checkSudo({ cmd: 'config', cliParams: ['get', 'store-dir'], global: true, env: sudoEnv, geteuid: rootUid })
-  }).not.toThrow()
-  expect(() => {
-    checkSudo({ cmd: 'config', cliParams: ['list'], env: sudoEnv, geteuid: rootUid })
-  }).not.toThrow()
+test('config reads are not reported under sudo', () => {
+  expect(sudoBlockedOperation({ cmd: 'config', cliParams: ['get', 'store-dir'], global: true, env: sudoEnv, geteuid: rootUid })).toBeUndefined()
+  expect(sudoBlockedOperation({ cmd: 'config', cliParams: ['list'], env: sudoEnv, geteuid: rootUid })).toBeUndefined()
 })
 
-test('bare link targets the global directory and is blocked', () => {
-  expect(() => {
-    checkSudo({ cmd: 'link', cliParams: [], global: true, env: sudoEnv, geteuid: rootUid })
-  }).toThrow('Running "pnpm link --global" with sudo is not supported')
+test('bare link targets the global directory and is reported', () => {
+  expect(sudoBlockedOperation({ cmd: 'link', cliParams: [], global: true, env: sudoEnv, geteuid: rootUid })).toBe('pnpm link --global')
 })
 
-test('link --global with a package path is a global write and is blocked', () => {
-  expect(() => {
-    checkSudo({ cmd: 'link', cliParams: ['../foo'], global: true, env: sudoEnv, geteuid: rootUid })
-  }).toThrow('Running "pnpm link --global" with sudo is not supported')
+test('link --global with a package path is a global write and is reported', () => {
+  expect(sudoBlockedOperation({ cmd: 'link', cliParams: ['../foo'], global: true, env: sudoEnv, geteuid: rootUid })).toBe('pnpm link --global')
 })

--- a/pnpm11/pnpm/src/checkSudo.test.ts
+++ b/pnpm11/pnpm/src/checkSudo.test.ts
@@ -8,35 +8,35 @@ const sudoEnv = { SUDO_USER: 'alice' }
 
 test('allowed when not running as root', () => {
   expect(() => {
-    checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: sudoEnv, geteuid: userUid })
+    checkSudo({ cmd: 'setup', cliParams: [], env: sudoEnv, geteuid: userUid })
   }).not.toThrow()
 })
 
 test('allowed for plain root without sudo', () => {
   expect(() => {
-    checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: {}, geteuid: rootUid })
+    checkSudo({ cmd: 'setup', cliParams: [], env: {}, geteuid: rootUid })
   }).not.toThrow()
 })
 
 test('allowed when SUDO_USER is root', () => {
   expect(() => {
-    checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: { SUDO_USER: 'root' }, geteuid: rootUid })
+    checkSudo({ cmd: 'setup', cliParams: [], env: { SUDO_USER: 'root' }, geteuid: rootUid })
   }).not.toThrow()
 })
 
 test('setup and self-update are blocked under sudo', () => {
   expect(() => {
-    checkSudo({ cmd: 'setup', cliParams: [], isGlobal: false, env: sudoEnv, geteuid: rootUid })
+    checkSudo({ cmd: 'setup', cliParams: [], env: sudoEnv, geteuid: rootUid })
   }).toThrow('Running "pnpm setup" with sudo is not supported')
   expect(() => {
-    checkSudo({ cmd: 'self-update', cliParams: [], isGlobal: false, env: sudoEnv, geteuid: rootUid })
+    checkSudo({ cmd: 'self-update', cliParams: [], env: sudoEnv, geteuid: rootUid })
   }).toThrow('Running "pnpm self-update" with sudo is not supported')
 })
 
 test('global add is blocked under sudo with the expected error code', () => {
   let thrownCode: string | undefined
   try {
-    checkSudo({ cmd: 'add', cliParams: ['foo'], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+    checkSudo({ cmd: 'add', cliParams: ['foo'], global: true, env: sudoEnv, geteuid: rootUid })
   } catch (err: any) { // eslint-disable-line
     thrownCode = err.code
   }
@@ -45,29 +45,53 @@ test('global add is blocked under sudo with the expected error code', () => {
 
 test('local add is allowed under sudo', () => {
   expect(() => {
-    checkSudo({ cmd: 'add', cliParams: ['foo'], isGlobal: false, env: sudoEnv, geteuid: rootUid })
+    checkSudo({ cmd: 'add', cliParams: ['foo'], env: sudoEnv, geteuid: rootUid })
   }).not.toThrow()
 })
 
 test('read-only global commands are allowed under sudo', () => {
   for (const cmd of ['bin', 'root', 'prefix', 'list', 'outdated']) {
     expect(() => {
-      checkSudo({ cmd, cliParams: [], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+      checkSudo({ cmd, cliParams: [], global: true, env: sudoEnv, geteuid: rootUid })
     }).not.toThrow()
   }
 })
 
-test('global config writes are blocked but reads allowed', () => {
+test('config writes are blocked even without an explicit --global because they default to the global config', () => {
   expect(() => {
-    checkSudo({ cmd: 'config', cliParams: ['set', 'store-dir', '/tmp/store'], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+    checkSudo({ cmd: 'config', cliParams: ['set', 'store-dir', '/tmp/store'], env: sudoEnv, geteuid: rootUid })
   }).toThrow('Running "pnpm config set --global" with sudo is not supported')
   expect(() => {
-    checkSudo({ cmd: 'config', cliParams: ['get', 'store-dir'], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+    checkSudo({ cmd: 'config', cliParams: ['delete', 'store-dir'], global: true, env: sudoEnv, geteuid: rootUid })
+  }).toThrow('Running "pnpm config delete --global" with sudo is not supported')
+  expect(() => {
+    checkSudo({ cmd: 'set', cliParams: ['store-dir=/tmp/store'], env: sudoEnv, geteuid: rootUid })
+  }).toThrow('Running "pnpm config set --global" with sudo is not supported')
+})
+
+test('config writes scoped to the project are allowed under sudo', () => {
+  expect(() => {
+    checkSudo({ cmd: 'config', cliParams: ['set', 'store-dir', '/tmp/store'], location: 'project', env: sudoEnv, geteuid: rootUid })
+  }).not.toThrow()
+})
+
+test('config reads are allowed under sudo', () => {
+  expect(() => {
+    checkSudo({ cmd: 'config', cliParams: ['get', 'store-dir'], global: true, env: sudoEnv, geteuid: rootUid })
+  }).not.toThrow()
+  expect(() => {
+    checkSudo({ cmd: 'config', cliParams: ['list'], env: sudoEnv, geteuid: rootUid })
   }).not.toThrow()
 })
 
 test('bare link targets the global directory and is blocked', () => {
   expect(() => {
-    checkSudo({ cmd: 'link', cliParams: [], isGlobal: true, env: sudoEnv, geteuid: rootUid })
+    checkSudo({ cmd: 'link', cliParams: [], global: true, env: sudoEnv, geteuid: rootUid })
+  }).toThrow('Running "pnpm link --global" with sudo is not supported')
+})
+
+test('link --global with a package path is a global write and is blocked', () => {
+  expect(() => {
+    checkSudo({ cmd: 'link', cliParams: ['../foo'], global: true, env: sudoEnv, geteuid: rootUid })
   }).toThrow('Running "pnpm link --global" with sudo is not supported')
 })

--- a/pnpm11/pnpm/src/checkSudo.test.ts
+++ b/pnpm11/pnpm/src/checkSudo.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
+import { streamParser } from '@pnpm/logger'
 
-import { sudoBlockedOperation } from './checkSudo.js'
+import { checkSudo, type CheckSudoOptions, sudoBlockedOperation } from './checkSudo.js'
 
 const rootUid = () => 0
 const userUid = () => 1000
@@ -63,3 +64,41 @@ test('bare link targets the global directory and is reported', () => {
 test('link --global with a package path is a global write and is reported', () => {
   expect(sudoBlockedOperation({ cmd: 'link', cliParams: ['../foo'], global: true, env: sudoEnv, geteuid: rootUid })).toBe('pnpm link --global')
 })
+
+test('the warning goes to the log stream when a reporter prints logs', () => {
+  const logs: string[] = []
+  const reporter = (log: any) => { // eslint-disable-line
+    if (log.name === 'pnpm:global') logs.push(log.message)
+  }
+  streamParser.on('data', reporter)
+  try {
+    checkSudo({ cmd: 'setup', cliParams: [], env: sudoEnv, geteuid: rootUid })
+  } finally {
+    streamParser.removeListener('data', reporter)
+  }
+  expect(logs).toHaveLength(1)
+  expect(logs[0]).toContain('Running "pnpm setup" with sudo is not supported and will fail in pnpm v12')
+})
+
+test('the warning goes to stderr when no reporter is subscribed (--json, --parseable)', () => {
+  expect(warningsPrintedByCheckSudo({ cmd: 'setup', cliParams: [], env: sudoEnv, geteuid: rootUid, printLogs: false }))
+    .toEqual([expect.stringContaining('Running "pnpm setup" with sudo is not supported and will fail in pnpm v12')])
+})
+
+test('nothing is printed when the command is allowed under sudo', () => {
+  expect(warningsPrintedByCheckSudo({ cmd: 'add', cliParams: ['foo'], env: sudoEnv, geteuid: rootUid, printLogs: false }))
+    .toEqual([])
+})
+
+function warningsPrintedByCheckSudo (opts: CheckSudoOptions): string[] {
+  const printed: string[] = []
+  const consoleWarn = jest.spyOn(console, 'warn').mockImplementation((message) => {
+    printed.push(String(message))
+  })
+  try {
+    checkSudo(opts)
+  } finally {
+    consoleWarn.mockRestore()
+  }
+  return printed
+}

--- a/pnpm11/pnpm/src/checkSudo.ts
+++ b/pnpm11/pnpm/src/checkSudo.ts
@@ -1,0 +1,42 @@
+import { PnpmError } from '@pnpm/error'
+
+export interface CheckSudoOptions {
+  cmd: string | null
+  cliParams: string[]
+  isGlobal: boolean
+  env?: NodeJS.ProcessEnv
+  geteuid?: () => number
+}
+
+/**
+ * Refuses to run commands that write to home-directory locations (global
+ * installs, `pnpm setup`, `pnpm self-update`) when pnpm is executed through
+ * `sudo`. Those commands would target root's home directory, which is never
+ * what a user coming from `sudo npm install -g` wants.
+ */
+export function checkSudo (opts: CheckSudoOptions): void {
+  const env = opts.env ?? process.env
+  const geteuid = opts.geteuid ?? process.geteuid?.bind(process)
+  if (geteuid == null || geteuid() !== 0) return
+  if (!env.SUDO_USER || env.SUDO_USER === 'root') return
+  const operation = sudoBlockedOperation(opts)
+  if (operation == null) return
+  throw new PnpmError('SUDO_NOT_SUPPORTED', `Running "${operation}" with sudo is not supported`, {
+    hint: 'pnpm installs global packages and writes global configuration inside your home directory, so they do not require root permissions, and running this command as root would target the root user\'s home directory instead of yours. Rerun the command without sudo. If you really intend to manage the root user\'s own global packages, run pnpm from a session where the SUDO_USER environment variable is not set (for example: sudo env -u SUDO_USER pnpm ...).',
+  })
+}
+
+const READ_ONLY_GLOBAL_COMMANDS = new Set([
+  'audit', 'bin', 'get', 'la', 'licenses', 'list', 'll', 'ls', 'outdated', 'prefix', 'root', 'why',
+])
+
+function sudoBlockedOperation ({ cmd, cliParams, isGlobal }: CheckSudoOptions): string | undefined {
+  if (cmd === 'setup' || cmd === 'self-update') return `pnpm ${cmd}`
+  if (!isGlobal || cmd == null) return undefined
+  if (READ_ONLY_GLOBAL_COMMANDS.has(cmd)) return undefined
+  if (cmd === 'config') {
+    if (cliParams[0] === 'set' || cliParams[0] === 'delete') return `pnpm config ${cliParams[0]} --global`
+    return undefined
+  }
+  return `pnpm ${cmd} --global`
+}

--- a/pnpm11/pnpm/src/checkSudo.ts
+++ b/pnpm11/pnpm/src/checkSudo.ts
@@ -1,4 +1,4 @@
-import { PnpmError } from '@pnpm/error'
+import { globalWarn } from '@pnpm/logger'
 
 export interface CheckSudoOptions {
   cmd: string | null
@@ -10,29 +10,35 @@ export interface CheckSudoOptions {
 }
 
 /**
- * Refuses to run commands that write to home-directory locations (global
+ * Warns about commands that write to home-directory locations (global
  * installs, global config writes, `pnpm setup`, `pnpm self-update`) when pnpm
- * is executed through `sudo`. Those commands would target root's home
- * directory, which is never what a user coming from `sudo npm install -g`
- * wants.
+ * is executed through `sudo`. Those commands target root's home directory,
+ * which is never what a user coming from `sudo npm install -g` wants.
+ *
+ * pnpm v12 refuses to run them; v11 only warns, so setups that rely on the
+ * current behavior keep working until the next major.
  */
 export function checkSudo (opts: CheckSudoOptions): void {
-  const env = opts.env ?? process.env
-  const geteuid = opts.geteuid ?? process.geteuid?.bind(process)
-  if (geteuid == null || geteuid() !== 0) return
-  if (!env.SUDO_USER || env.SUDO_USER === 'root') return
   const operation = sudoBlockedOperation(opts)
   if (operation == null) return
-  throw new PnpmError('SUDO_NOT_SUPPORTED', `Running "${operation}" with sudo is not supported`, {
-    hint: 'pnpm installs global packages and writes global configuration inside your home directory, so they do not require root permissions, and running this command as root would target the root user\'s home directory instead of yours. Rerun the command without sudo. If you really intend to manage the root user\'s own global packages, run pnpm from a session where the SUDO_USER environment variable is not set (for example: sudo env -u SUDO_USER pnpm ...).',
-  })
+  globalWarn(`Running "${operation}" with sudo is not supported and will fail in pnpm v12. pnpm installs global packages and writes global configuration inside your home directory, so they do not require root permissions, and running this command as root targets the root user's home directory instead of yours. Rerun the command without sudo. If you really intend to manage the root user's own global packages, run pnpm from a session where the SUDO_USER environment variable is not set (for example: sudo env -u SUDO_USER pnpm ...).`)
 }
 
 const READ_ONLY_GLOBAL_COMMANDS = new Set([
   'audit', 'bin', 'get', 'la', 'licenses', 'list', 'll', 'ls', 'outdated', 'prefix', 'root', 'why',
 ])
 
-function sudoBlockedOperation ({ cmd, cliParams, global: globalFlag, location }: CheckSudoOptions): string | undefined {
+/**
+ * The user-facing name of the operation that sudo makes meaningless, or
+ * `undefined` when the command is fine under sudo. Global commands that only
+ * read (`pnpm bin -g`, `pnpm list -g`, `pnpm config get -g`, ...) stay allowed.
+ */
+export function sudoBlockedOperation (opts: CheckSudoOptions): string | undefined {
+  const env = opts.env ?? process.env
+  const geteuid = opts.geteuid ?? process.geteuid?.bind(process)
+  if (geteuid == null || geteuid() !== 0) return undefined
+  if (!env.SUDO_USER || env.SUDO_USER === 'root') return undefined
+  const { cmd, cliParams, global: globalFlag, location } = opts
   if (cmd === 'setup' || cmd === 'self-update') return `pnpm ${cmd}`
   if (cmd === 'config' || cmd === 'set') {
     const subcommand = cmd === 'set' ? 'set' : cliParams[0]

--- a/pnpm11/pnpm/src/checkSudo.ts
+++ b/pnpm11/pnpm/src/checkSudo.ts
@@ -3,16 +3,18 @@ import { PnpmError } from '@pnpm/error'
 export interface CheckSudoOptions {
   cmd: string | null
   cliParams: string[]
-  isGlobal: boolean
+  global?: boolean
+  location?: string
   env?: NodeJS.ProcessEnv
   geteuid?: () => number
 }
 
 /**
  * Refuses to run commands that write to home-directory locations (global
- * installs, `pnpm setup`, `pnpm self-update`) when pnpm is executed through
- * `sudo`. Those commands would target root's home directory, which is never
- * what a user coming from `sudo npm install -g` wants.
+ * installs, global config writes, `pnpm setup`, `pnpm self-update`) when pnpm
+ * is executed through `sudo`. Those commands would target root's home
+ * directory, which is never what a user coming from `sudo npm install -g`
+ * wants.
  */
 export function checkSudo (opts: CheckSudoOptions): void {
   const env = opts.env ?? process.env
@@ -30,13 +32,18 @@ const READ_ONLY_GLOBAL_COMMANDS = new Set([
   'audit', 'bin', 'get', 'la', 'licenses', 'list', 'll', 'ls', 'outdated', 'prefix', 'root', 'why',
 ])
 
-function sudoBlockedOperation ({ cmd, cliParams, isGlobal }: CheckSudoOptions): string | undefined {
+function sudoBlockedOperation ({ cmd, cliParams, global: globalFlag, location }: CheckSudoOptions): string | undefined {
   if (cmd === 'setup' || cmd === 'self-update') return `pnpm ${cmd}`
-  if (!isGlobal || cmd == null) return undefined
-  if (READ_ONLY_GLOBAL_COMMANDS.has(cmd)) return undefined
-  if (cmd === 'config') {
-    if (cliParams[0] === 'set' || cliParams[0] === 'delete') return `pnpm config ${cliParams[0]} --global`
-    return undefined
+  if (cmd === 'config' || cmd === 'set') {
+    const subcommand = cmd === 'set' ? 'set' : cliParams[0]
+    if (subcommand !== 'set' && subcommand !== 'delete') return undefined
+    // Config writes default to the global config file when no `--location`
+    // is given, so gate on the effective scope, not the `--global` flag
+    // alone. Mirrors the scope resolution in the config command handler.
+    const effectiveGlobal = location != null ? location === 'global' : globalFlag !== false
+    return effectiveGlobal ? `pnpm config ${subcommand} --global` : undefined
   }
+  if (globalFlag !== true || cmd == null) return undefined
+  if (READ_ONLY_GLOBAL_COMMANDS.has(cmd)) return undefined
   return `pnpm ${cmd} --global`
 }

--- a/pnpm11/pnpm/src/checkSudo.ts
+++ b/pnpm11/pnpm/src/checkSudo.ts
@@ -1,3 +1,4 @@
+import { formatWarn } from '@pnpm/cli.default-reporter'
 import { globalWarn } from '@pnpm/logger'
 
 export interface CheckSudoOptions {
@@ -7,21 +8,23 @@ export interface CheckSudoOptions {
   location?: string
   env?: NodeJS.ProcessEnv
   geteuid?: () => number
+  /**
+   * `false` when no reporter is subscribed to the log stream (`--json`,
+   * `--parseable`), in which case the warning goes straight to stderr rather
+   * than into a stream nobody reads. stdout stays machine-parseable either way.
+   */
+  printLogs?: boolean
 }
 
-/**
- * Warns about commands that write to home-directory locations (global
- * installs, global config writes, `pnpm setup`, `pnpm self-update`) when pnpm
- * is executed through `sudo`. Those commands target root's home directory,
- * which is never what a user coming from `sudo npm install -g` wants.
- *
- * pnpm v12 refuses to run them; v11 only warns, so setups that rely on the
- * current behavior keep working until the next major.
- */
 export function checkSudo (opts: CheckSudoOptions): void {
   const operation = sudoBlockedOperation(opts)
   if (operation == null) return
-  globalWarn(`Running "${operation}" with sudo is not supported and will fail in pnpm v12. pnpm installs global packages and writes global configuration inside your home directory, so they do not require root permissions, and running this command as root targets the root user's home directory instead of yours. Rerun the command without sudo. If you really intend to manage the root user's own global packages, run pnpm from a session where the SUDO_USER environment variable is not set (for example: sudo env -u SUDO_USER pnpm ...).`)
+  const message = `Running "${operation}" with sudo is not supported and will fail in pnpm v12. pnpm installs global packages and writes global configuration inside your home directory, so they do not require root permissions, and running this command as root targets the root user's home directory instead of yours. Rerun the command without sudo. If you really intend to manage the root user's own global packages, run pnpm from a session where the SUDO_USER environment variable is not set (for example: sudo env -u SUDO_USER pnpm ...).`
+  if (opts.printLogs === false) {
+    console.warn(formatWarn(message))
+  } else {
+    globalWarn(message)
+  }
 }
 
 const READ_ONLY_GLOBAL_COMMANDS = new Set([

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -25,6 +25,7 @@ import { isEmpty } from 'ramda'
 import semver from 'semver'
 
 import { checkForUpdates } from './checkForUpdates.js'
+import { checkSudo } from './checkSudo.js'
 import { NOT_IMPLEMENTED_COMMAND_SET, overridableByScriptCommands, pnpmCmds, recursiveByDefaultCommands, skipPackageManagerCheckForCommand } from './cmd/index.js'
 import { formatUnknownOptionsError } from './formatError.js'
 import { getConfig, installConfigDepsAndLoadHooks } from './getConfig.js'
@@ -106,6 +107,7 @@ export async function main (inputArgv: string[]): Promise<void> {
     if (cmd === 'link' && cliParams.length === 0) {
       cliOptions.global = true
     }
+    checkSudo({ cmd, cliParams, isGlobal: cliOptions.global === true })
     ;({ config, context } = await getConfig(cliOptions, {
       excludeReporter: false,
       globalDirShouldAllowWrite,

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -107,7 +107,7 @@ export async function main (inputArgv: string[]): Promise<void> {
     if (cmd === 'link' && cliParams.length === 0) {
       cliOptions.global = true
     }
-    checkSudo({ cmd, cliParams, isGlobal: cliOptions.global === true })
+    checkSudo({ cmd, cliParams, global: cliOptions.global, location: cliOptions.location })
     ;({ config, context } = await getConfig(cliOptions, {
       excludeReporter: false,
       globalDirShouldAllowWrite,

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -107,7 +107,6 @@ export async function main (inputArgv: string[]): Promise<void> {
     if (cmd === 'link' && cliParams.length === 0) {
       cliOptions.global = true
     }
-    checkSudo({ cmd, cliParams, global: cliOptions.global, location: cliOptions.location })
     ;({ config, context } = await getConfig(cliOptions, {
       excludeReporter: false,
       globalDirShouldAllowWrite,
@@ -215,6 +214,8 @@ export async function main (inputArgv: string[]): Promise<void> {
     })
     global[REPORTER_INITIALIZED] = reporterType
   }
+
+  checkSudo({ cmd, cliParams, global: cliOptions.global, location: cliOptions.location })
 
   // Commands with scriptOverride: if the current project's package.json has a
   // script with the same name, run the script instead of the built-in command.

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -215,7 +215,7 @@ export async function main (inputArgv: string[]): Promise<void> {
     global[REPORTER_INITIALIZED] = reporterType
   }
 
-  checkSudo({ cmd, cliParams, global: cliOptions.global, location: cliOptions.location })
+  checkSudo({ cmd, cliParams, global: cliOptions.global, location: cliOptions.location, printLogs })
 
   // Commands with scriptOverride: if the current project's package.json has a
   // script with the same name, run the script instead of the built-in command.


### PR DESCRIPTION
## Summary

Flags commands that write to home-directory locations when pnpm is executed through `sudo`. When the effective uid is 0 and `SUDO_USER` names a non-root user, `pnpm setup`, `pnpm self-update`, and global writes (`add`, `remove`, `update`, `runtime`, `approve-builds`, bare `link`, `config set`/`config delete` resolving to the global scope) are detected — with a hint explaining that pnpm's globals live in the invoking user's home directory and how to opt out for genuine root use (`sudo env -u SUDO_USER pnpm ...`).

**The two stacks deliberately differ in severity, because refusing these commands is a breaking change:**

- **pnpm v11 (TypeScript) warns** and names the upcoming removal. Provisioning scripts, Ansible/cloud-init `become` steps, and CI bootstraps that run `sudo pnpm setup` or `sudo pnpm add -g` keep working through the v11 line.
- **pnpm v12 (pacquet) fails** with `ERR_PNPM_SUDO_NOT_SUPPORTED`.

Read-only global commands (`bin -g`, `root -g`, `list -g`, `config get -g`, ...) are untouched in both stacks, and plain root sessions without `SUDO_USER` (containers, CI) are unaffected — the guard keys on `SUDO_USER` precisely so that root-by-design environments never see it.

This is the alternative direction to pnpm/pnpm#13096, which resolved `SUDO_USER`'s home and redirected all home-derived paths there. That approach writes root-owned files into the invoking user's home (there is no `SUDO_UID` chown), overrides explicit `sudo -H`/`sudo -i` intent, and diverges from where the ecosystem settled: npm 9 deleted its `SUDO_UID` chown machinery ([npm/cli#5710](https://github.com/npm/cli/pull/5710)) and tells users not to use sudo, and Homebrew refuses root outright. Telling the user plainly is the honest behavior — `sudo pnpm install -g` is an npm-prefix habit that has no meaningful interpretation for pnpm.

## Squash Commit Body

```text
pnpm keeps global packages and configuration in the invoking user's
home directory, so 'sudo pnpm add -g', 'sudo pnpm setup', and
'sudo pnpm self-update' never do what the user wants: they target
root's home and leave root-owned files behind. Other package managers
settled on the same direction - npm 9 removed its SUDO_UID chown
machinery (npm/cli#5710) and tells users not to use sudo, and Homebrew
refuses root outright.

Both stacks detect the same situation: effective uid 0, SUDO_USER
naming a non-root user, and a command that mutates home-directory
state - setup, self-update, or a global write (add, remove, update,
runtime, approve-builds, bare link, config set/delete resolving to
the global scope). They differ only in severity, because refusing
these commands is a breaking change: pnpm v11 warns and names the
v12 removal, so existing provisioning scripts keep working, while
pacquet (v12) fails with ERR_PNPM_SUDO_NOT_SUPPORTED. Read-only
global commands (bin, root, prefix, list, outdated, config get, ...)
still work, and plain root sessions without SUDO_USER are unaffected.

The TypeScript check lives in pnpm11/pnpm/src/checkSudo.ts and runs
once the reporter is initialized, so the warning is not published to
a bus nobody is subscribed to yet. The pacquet check lives in
crates/cli/src/cli_args/sudo_guard.rs and runs before the
pre-command package-manager switch, so pnpm never delegates to a
downloaded CLI as root either.

Related to pnpm/pnpm#13096.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * pnpm now detects `sudo` usage on Unix systems and warns or blocks commands that modify global state, including setup, self-update, global installs, and global configuration changes.
  * Read-only global commands and project-scoped operations remain supported.
  * Blocked operations provide guidance and the `ERR_PNPM_SUDO_NOT_SUPPORTED` error code.
* **Bug Fixes**
  * Prevented global state from being written to the root user’s home directory under `sudo`.
* **Tests**
  * Added coverage for privilege detection and effective configuration scope handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->