### PR TITLE
ci: run all TS test jobs in parallel without a smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,21 +122,9 @@ jobs:
     with:
       os: blacksmith-8vcpu-windows-2025
 
-  test-smoke:
-    name: TS CI / Test / ubuntu
-    needs: [compile-and-lint, build-pnpr-linux]
-    uses: ./.github/workflows/test.yml
-    with:
-      node: '24.0.0'
-      node_major: '24'
-      platform: blacksmith-8vcpu-ubuntu-2404
-      garnet: true
-    secrets:
-      GARNET_API_TOKEN: ${{ secrets.GARNET_API_TOKEN }}
-
   test:
     name: TS CI / Test / ${{ matrix.platform_label }}
-    needs: test-smoke
+    needs: [compile-and-lint, build-pnpr-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -147,6 +135,13 @@ jobs:
             platform_label: ubuntu
             test_chunk: '1'
             test_chunk_total: '1'
+          - node: '24.0.0'
+            node_major: '24'
+            platform: blacksmith-8vcpu-ubuntu-2404
+            platform_label: ubuntu
+            test_chunk: '1'
+            test_chunk_total: '1'
+            garnet: true
           - node: '26.5.0'
             node_major: '26'
             platform: blacksmith-8vcpu-ubuntu-2404
@@ -160,10 +155,10 @@ jobs:
       platform: ${{ matrix.platform }}
       test_chunk: ${{ matrix.test_chunk }}
       test_chunk_total: ${{ matrix.test_chunk_total }}
+      garnet: ${{ matrix.garnet == true }}
+    secrets:
+      GARNET_API_TOKEN: ${{ secrets.GARNET_API_TOKEN }}
 
-  # Windows is the slowest platform. Gate it only on compile-and-lint so its
-  # shards run in parallel with the ubuntu smoke job, instead of waiting for
-  # the smoke job like the other Node.js versions do.
   test-windows:
     name: TS CI / Test / ${{ matrix.platform_label }}
     needs: [compile-and-lint, build-pnpr-windows]
@@ -213,7 +208,6 @@ jobs:
       - compile-and-lint
       - build-pnpr-linux
       - build-pnpr-windows
-      - test-smoke
       - test
       - test-windows
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
## Summary

Removes the smoke-test gate from TS CI. Previously the ubuntu Node 24 job (`test-smoke`) had to pass before the Node 22 and Node 26 test jobs even started, adding a full test cycle of latency to every green run. Now the Node 24 (garnet) leg is folded into the `test` matrix, and every test job — all three ubuntu Node.js versions and all three Windows chunks — gates only on `Compile & Lint` plus its platform's pnpr build, so they all run in parallel.

The trade-off: a broken build now surfaces on all six test jobs at once instead of costing a single smoke run first.

## Squash Commit Body

```text
The ubuntu Node 24 smoke job previously gated the Node 22/26 test runs,
delaying them by a full test cycle. Fold the Node 24 (garnet) leg into
the test matrix (garnet flag carried as a matrix field) and gate every
test job only on compile-and-lint plus its platform's pnpr build, so
all Node.js versions and all Windows chunks start in parallel. The
trade-off is that a broken build now surfaces on all test jobs at once
instead of costing a single smoke run.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (CI-only
  change to the TS workflow; nothing to port.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. (No published package changed — CI only.)
- [x] Added or updated tests. (Not applicable — workflow change.)
- [x] Updated the documentation if needed. (Not applicable.)

---
Written by an agent (Claude Code, claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787997886&installation_model_id=426870&pr_number=13496&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13496&signature=2d5d6a48e44bc48fd5567e2657a86501d273a5249c09d14eca51cddeb9ef0f56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated Ubuntu test coverage into the main test workflow.
  * Added Node.js 24 smoke testing to the standard test matrix.
  * Updated the overall CI success checks to reflect the streamlined workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->