### PR TITLE
fix(lockfile): parse lockfiles above the default YAML scalar budget

### DIFF
--- a/.changeset/huge-lockfiles-scalar-budget.md
+++ b/.changeset/huge-lockfiles-scalar-budget.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed parsing very large lockfiles that exceed the YAML parser's default 64 MiB scalar-text budget.

--- a/pnpm/crates/lockfile/src/load_lockfile.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile.rs
@@ -11,6 +11,8 @@ use std::{
 
 const DEFAULT_YAML_MAX_EVENTS: usize = 1_000_000;
 const DEFAULT_YAML_MAX_NODES: usize = 250_000;
+const DEFAULT_YAML_MAX_SCALAR_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_YAML_MAX_READER_INPUT_BYTES: usize = 256 * 1024 * 1024;
 
 /// Error when reading lockfile the filesystem.
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -118,9 +120,18 @@ impl Lockfile {
         serde_saphyr::from_str_with_options::<Self>(
             main,
             serde_saphyr::options! {
+                // Every size-proportional budget is raised to the document's
+                // byte length: none of these dimensions can exceed the size of
+                // an input that is already in memory, so a valid lockfile must
+                // never trip them, however large. The remaining defaults
+                // (aliases, anchors, depth, documents) bound YAML shapes the
+                // lockfile emitter never produces and stay as security caps.
                 budget: serde_saphyr::budget! {
                     max_events: main.len().max(DEFAULT_YAML_MAX_EVENTS),
                     max_nodes: main.len().max(DEFAULT_YAML_MAX_NODES),
+                    max_total_scalar_bytes: main.len().max(DEFAULT_YAML_MAX_SCALAR_BYTES),
+                    max_total_comment_bytes: main.len().max(DEFAULT_YAML_MAX_SCALAR_BYTES),
+                    max_reader_input_bytes: Some(main.len().max(DEFAULT_YAML_MAX_READER_INPUT_BYTES)),
                 },
             },
         )

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -124,7 +124,7 @@ fn parses_lockfile_larger_than_default_yaml_scalar_byte_budget() {
     for index in 0..IMPORTER_COUNT {
         writeln!(
             content,
-            "  padded-project-directory-name/deeply/nested/workspace-component-{index:07}: {{}}"
+            "  padded-project-directory-name/deeply/nested/workspace-component-{index:07}: {{}}",
         )
         .expect("write importer");
     }

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -115,6 +115,29 @@ fn parses_lockfile_larger_than_default_yaml_node_budget() {
 }
 
 #[test]
+fn parses_lockfile_larger_than_default_yaml_scalar_byte_budget() {
+    const IMPORTER_COUNT: usize = 1_000_000;
+
+    // Each importer line contributes ~100 bytes of scalar text, pushing the
+    // document past the parser's 64 MiB default scalar budget.
+    let mut content = String::from("lockfileVersion: '9.0'\n\nimporters:\n");
+    for index in 0..IMPORTER_COUNT {
+        writeln!(
+            content,
+            "  padded-project-directory-name/deeply/nested/workspace-component-{index:07}: {{}}"
+        )
+        .expect("write importer");
+    }
+    assert!(content.len() > 64 * 1024 * 1024, "fixture must exceed the default scalar budget");
+
+    let lockfile = Lockfile::parse(&content, Path::new(Lockfile::FILE_NAME))
+        .expect("parse large lockfile")
+        .expect("large lockfile should be present");
+
+    assert_eq!(lockfile.importers.len(), IMPORTER_COUNT);
+}
+
+#[test]
 fn parse_error_does_not_include_lockfile_content() {
     let dir = tempdir().expect("create tempdir");
     let secret = "aws_secret_access_key = marker-secret";


### PR DESCRIPTION
## Summary

Pacquet failed to parse very large lockfiles with `The lockfile at "…" is broken: budget breached: ScalarBytes { total_scalar_bytes: 67108969 }`. pnpm/pnpm#13485 scaled the event and node budgets with the document's byte length, but serde-saphyr's other size-proportional budgets kept their defaults, so a ~100 MB lockfile (a real bit.cloud workspace, ~700k lines) still failed at the 64 MiB scalar-text default.

This raises every size-proportional budget dimension (scalar bytes, comment bytes, reader input bytes) to the greater of its default and the document's byte length — none of these dimensions can exceed the size of an input that is already in memory, so a valid lockfile can never trip them. The remaining defaults (aliases, anchors, depth, documents) bound YAML shapes the lockfile emitter never produces and stay as security caps.

## Squash Commit Body

```text
The node/event budgets already scale with the document's byte length
(pnpm/pnpm#13485), but a ~100 MB lockfile still failed with "budget
breached: ScalarBytes" at serde-saphyr's 64 MiB scalar-text default.
Scale every size-proportional budget dimension (scalar bytes, comment
bytes, reader input bytes) the same way: none of them can exceed the
size of an input that is already in memory, so a valid lockfile can
never trip them. The remaining defaults (aliases, anchors, depth,
documents) bound YAML shapes the lockfile emitter never produces and
stay as security caps.

Add a regression test that parses a generated lockfile above the
64 MiB scalar budget.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: the TypeScript CLI's YAML parser has no structural budgets,
  so there is nothing to mirror.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788000372&installation_model_id=426870&pr_number=13497&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13497&signature=bc14c118cb08c32cf4b6f47aef82dcf00fe875530ea7c80f4deca0c708244444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lockfile parsing for exceptionally large lockfiles exceeding the previous 64 MiB scalar content limit.
  * Preserved safeguards against excessively complex or oversized YAML input while allowing valid large lockfiles to load successfully.

* **Tests**
  * Added coverage confirming large lockfiles parse correctly and retain all importer entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->