### PR TITLE
docs(github): ask PR authors to confirm no linked PR solves the issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,8 @@ Explain what changed and why. Reference issues here too (Closes pnpm/pnpm#123).
 
 <!-- Mark items with [x] once done. Remove items that don't apply. -->
 
+- [ ] I checked the referenced issue and verified that none of the PRs
+  already linked to it solves it.
 - [ ] The change is implemented in both the TypeScript CLI and the Rust
   `pnpm/` port, or the description notes what still needs porting.
 - [ ] Added a changeset (`pnpm changeset`) if this PR changes any published


### PR DESCRIPTION
## Summary

Contributors keep submitting parallel PRs for the same issue — e.g. pnpm/pnpm#13114 and pnpm/pnpm#13124 both fixed pnpm/pnpm#13108, and the former ended up closed as superseded after both authors and reviewers had spent time on it. GitHub already cross-links every PR that references an issue on the issue's timeline, so this adds a checklist item asking authors to check those links and confirm no already-linked PR solves the issue before submitting.

## Squash Commit Body

```text
Multiple contributors keep submitting parallel PRs for the same issue
(e.g. pnpm/pnpm#13114 was superseded by pnpm/pnpm#13124 for issue
pnpm/pnpm#13108). GitHub already cross-links every PR that references
an issue on the issue's timeline, so add a checklist item prompting
authors to check those links before submitting.
```

## Checklist

- [ ] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port — n/a, repository meta file.
- [ ] Added a changeset — n/a, no published package affected.
- [ ] Added or updated tests — n/a.
- [ ] Updated the documentation if needed — n/a.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788003347&installation_model_id=426870&pr_number=13498&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13498&signature=6492512150d6a88e248e737c2813fc4cd40b9885117f2edc9d105e2f8119a8c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request checklist with an item to verify the referenced issue and check for existing solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->