### PR TITLE
docs(contributing): address duplicate and unvetted AI-assisted PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
-<!-- A maintainer will only start reviewing once the automated code reviewers
-(CodeRabbit and Qodo) have approved and CI is green. Please wait for those to
-pass before expecting human review. -->
+<!-- A maintainer will only start reviewing once CodeRabbit has approved and
+CI is green. Please wait for those to pass before expecting human review. -->
 
 ## Summary
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,8 +250,8 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 - In GitHub, send a pull request to `pnpm:main`.
 - Wait for the automated reviewers. A human reviewer will only start the review
-  process once the AI reviewers (CodeRabbit and Qodo) have approved the PR and
-  CI is green, so address their findings first.
+  process once CodeRabbit has approved the PR and CI is green, so address its
+  findings first.
 - If we suggest changes then:
 
   - Make the required updates.
@@ -279,6 +279,9 @@ than any other kind of contribution. Before submitting, make sure that:
 - You ran the relevant tests locally and they pass.
 - The PR does only what it says: no drive-by reformatting, unrelated fixes, or
   invented refactors padding the diff.
+- Agent-written PRs, issues, and comments disclose it with a footer naming the
+  agent and the model, e.g.
+  `Written by an agent (Claude Code, claude-opus-4-7).`
 
 PRs that appear to be unreviewed agent output — duplicating an existing PR,
 failing to compile, or not addressing the referenced issue — may be closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@
 - [Working with Git Worktrees](#working-with-git-worktrees)
 - [Running Tests](#running-tests)
 - [Submitting a Pull Request (PR)](#submitting-a-pull-request-pr)
+  - [AI-assisted contributions](#ai-assisted-contributions)
   - [After your pull request is merged](#after-your-pull-request-is-merged)
 - [Coding Style Guidelines](#coding-style-guidelines)
 - [Commit Message Guidelines](#commit-message-guidelines)
@@ -216,8 +217,12 @@ pnpm --filter core run test test/lockfile.ts -t "lockfile has dev deps even when
 
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-- Search [GitHub](https://github.com/pnpm/pnpm/pulls) for an open or closed PR
-  that relates to your submission. You don't want to duplicate effort.
+- Check whether the issue you are fixing already has a PR. GitHub automatically
+  cross-links every PR that references an issue on the issue's timeline, so open
+  the issue and look at its linked pull requests. If a PR already solves the
+  issue, contribute by reviewing or improving that PR instead of opening a
+  competing one — duplicate PRs are closed in favor of the first viable one, and
+  the effort spent on them (yours and the reviewers') is wasted.
 - Make your changes in a new git branch:
 
   ```shell
@@ -244,6 +249,9 @@ Before you submit your Pull Request (PR) consider the following guidelines:
   ```
 
 - In GitHub, send a pull request to `pnpm:main`.
+- Wait for the automated reviewers. A human reviewer will only start the review
+  process once the AI reviewers (CodeRabbit and Qodo) have approved the PR and
+  CI is green, so address their findings first.
 - If we suggest changes then:
 
   - Make the required updates.
@@ -256,6 +264,25 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     ```
 
 That's it! Thank you for your contribution!
+
+### AI-assisted contributions
+
+We use AI coding agents ourselves and welcome contributions made with them. But
+you, the contributor, are responsible for what you submit — an agent's output is
+a draft, not a finished PR. Maintainer review time is the scarcest resource this
+project has, and a stream of unvetted agent-generated PRs consumes it faster
+than any other kind of contribution. Before submitting, make sure that:
+
+- You checked the issue's linked PRs and are not duplicating an existing fix.
+  Agents will happily produce a patch for an issue that is already solved.
+- You understand the change and can answer review questions about it yourself.
+- You ran the relevant tests locally and they pass.
+- The PR does only what it says: no drive-by reformatting, unrelated fixes, or
+  invented refactors padding the diff.
+
+PRs that appear to be unreviewed agent output — duplicating an existing PR,
+failing to compile, or not addressing the referenced issue — may be closed
+without detailed review.
 
 ### After your pull request is merged
 


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13498. Contributors — increasingly with AI agents — keep submitting parallel PRs for issues that already have a fix in flight (e.g. pnpm/pnpm#13114 was superseded by pnpm/pnpm#13124 for issue pnpm/pnpm#13108), which multiplies maintainer review work. This updates CONTRIBUTING.md (and aligns the PR template) to:

- strengthen the duplicate-PR guidance: check the PRs automatically linked on the issue's timeline instead of vaguely "searching GitHub", and contribute to an existing PR rather than opening a competing one;
- add an "AI-assisted contributions" section: agents are welcome, but the contributor owns the output — verify it isn't a duplicate, understand the change, run the tests, keep the diff focused, and disclose agent authorship with the standard footer; PRs that appear to be unreviewed agent output may be closed without detailed review;
- document the review order: a human reviewer only starts once CodeRabbit has approved and CI is green. CodeRabbit is the single required AI approval (Qodo ignores Dependabot/Renovate PRs, so a two-reviewer gate could never be satisfied for dependency updates); the PR template's header comment is updated to match.

## Squash Commit Body

```text
Strengthen the duplicate-PR guidance to point at the issue's
automatically linked PRs, add an AI-assisted contributions section
(agents are welcome, but contributors own the output — check linked
PRs, understand the change, run the tests, keep the diff focused,
disclose agent authorship with the standard footer), and document that
human review starts only after CodeRabbit approves and CI is green.
CodeRabbit is the single required AI approval — Qodo ignores
Dependabot/Renovate PRs, so a two-reviewer gate could never be
satisfied for dependency updates; the PR template is aligned
accordingly.
```

## Checklist

- [ ] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port — n/a, documentation only.
- [ ] Added a changeset — n/a, no published package affected.
- [ ] Added or updated tests — n/a.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributing guide with an “AI-assisted contributions” section and linked it from the table of contents.
  * Clarified the pull request workflow to wait for CodeRabbit approval and ensure CI is green before human review.
  * Added expectations for understanding the change, running relevant tests locally, avoiding duplicated or unrelated changes, and disclosing AI assistance in agent-written PRs/issues/comments.
  * Updated guidance on when AI-like submissions may be closed without detailed review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->