### PR TITLE
fix(lockfile): emit over-long dependency-path keys in explicit form

### DIFF
--- a/.changeset/long-snapshot-keys-explicit.md
+++ b/.changeset/long-snapshot-keys-explicit.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed writing lockfiles with dependency paths longer than 1024 characters (long peer suffixes in large workspaces): such keys are now emitted in explicit `? <key>` form, matching the TypeScript CLI. Inline keys of that length are invalid YAML, so pnpm could not re-read the lockfile it had just written and every subsequent install re-resolved from scratch.

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -137,21 +137,19 @@ fn parses_lockfile_larger_than_default_yaml_scalar_byte_budget() {
     assert_eq!(lockfile.importers.len(), IMPORTER_COUNT);
 }
 
-/// A snapshot key whose peer suffix pushes it past YAML's 1024-character
-/// simple-key limit must round-trip: emitted in explicit `? <key>` form
-/// and parsed back. An inline key of that length is invalid YAML, so an
-/// emitter regression here makes every subsequent install re-resolve
-/// from scratch after failing to read the lockfile it just wrote.
+// A regression here makes every subsequent install re-resolve from
+// scratch after failing to read the lockfile it just wrote.
 #[test]
 fn snapshot_key_over_simple_key_limit_round_trips() {
-    let peers: String = (0..40)
-        .map(|index| format!("(@scope/very-long-peer-dependency-name-{index:02}@33.44.55)"))
-        .collect();
-    let long_key = format!("@scope/pkg@1.0.0{peers}");
+    let long_key = (0..40).fold(String::from("@scope/pkg@1.0.0"), |mut key, index| {
+        write!(key, "(@scope/very-long-peer-dependency-name-{index:02}@33.44.55)")
+            .expect("write peer suffix");
+        key
+    });
     assert!(long_key.len() > 1024, "fixture key must exceed the simple-key limit");
 
     let content = format!(
-        "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {{}}\n\nsnapshots:\n\n  ? '{long_key}'\n  : {{}}\n"
+        "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {{}}\n\nsnapshots:\n\n  ? '{long_key}'\n  : {{}}\n",
     );
     let lockfile = Lockfile::parse(&content, Path::new(Lockfile::FILE_NAME))
         .expect("parse lockfile with explicit long key")

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -137,6 +137,36 @@ fn parses_lockfile_larger_than_default_yaml_scalar_byte_budget() {
     assert_eq!(lockfile.importers.len(), IMPORTER_COUNT);
 }
 
+/// A snapshot key whose peer suffix pushes it past YAML's 1024-character
+/// simple-key limit must round-trip: emitted in explicit `? <key>` form
+/// and parsed back. An inline key of that length is invalid YAML, so an
+/// emitter regression here makes every subsequent install re-resolve
+/// from scratch after failing to read the lockfile it just wrote.
+#[test]
+fn snapshot_key_over_simple_key_limit_round_trips() {
+    let peers: String = (0..40)
+        .map(|index| format!("(@scope/very-long-peer-dependency-name-{index:02}@33.44.55)"))
+        .collect();
+    let long_key = format!("@scope/pkg@1.0.0{peers}");
+    assert!(long_key.len() > 1024, "fixture key must exceed the simple-key limit");
+
+    let content = format!(
+        "lockfileVersion: '9.0'\n\nimporters:\n\n  .: {{}}\n\nsnapshots:\n\n  ? '{long_key}'\n  : {{}}\n"
+    );
+    let lockfile = Lockfile::parse(&content, Path::new(Lockfile::FILE_NAME))
+        .expect("parse lockfile with explicit long key")
+        .expect("lockfile should be present");
+    let key: PackageKey = long_key.parse().expect("parse long snapshot key");
+    assert!(lockfile.snapshots.as_ref().expect("snapshots").contains_key(&key));
+
+    let emitted = lockfile.to_yaml_string().expect("emit lockfile");
+    assert!(emitted.contains("? '@scope/pkg@1.0.0"), "long key must be emitted in explicit form");
+    let reparsed = Lockfile::parse(&emitted, Path::new(Lockfile::FILE_NAME))
+        .expect("reparse emitted lockfile")
+        .expect("reparsed lockfile should be present");
+    assert_eq!(reparsed, lockfile);
+}
+
 #[test]
 fn parse_error_does_not_include_lockfile_content() {
     let dir = tempdir().expect("create tempdir");

--- a/pnpm/crates/lockfile/src/yaml_emit.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit.rs
@@ -251,6 +251,13 @@ fn next_line(level: usize, double_line: bool) -> String {
     line
 }
 
+/// The `state.dump.length > 1024` threshold of js-yaml's explicit-pair
+/// rule: YAML caps a *simple* key at 1024 characters (the `:` must appear
+/// within that lookahead), so a longer rendered key is emitted in explicit
+/// `? <key>` / `: <value>` form. Peer-suffixed snapshot keys in large
+/// workspaces exceed this even with `peersSuffixMaxLength` applied.
+const EXPLICIT_KEY_THRESHOLD: usize = 1024;
+
 fn write_block_mapping(
     map: &serde_json::Map<String, Value>,
     level: usize,
@@ -262,8 +269,16 @@ fn write_block_mapping(
         if !compact || !result.is_empty() {
             result.push_str(&next_line(level, double_line));
         }
-        result.push_str(&write_scalar(key, level + 1, true, true));
-        let rendered = render(value, level + 1, true, false, Some(key), false);
+        let rendered_key = write_scalar(key, level + 1, true, true);
+        let explicit_pair = rendered_key.chars().count() > EXPLICIT_KEY_THRESHOLD;
+        if explicit_pair {
+            result.push_str("? ");
+            result.push_str(&rendered_key);
+            result.push_str(&next_line(level, false));
+        } else {
+            result.push_str(&rendered_key);
+        }
+        let rendered = render(value, level + 1, true, explicit_pair, Some(key), false);
         result.push(':');
         if !rendered.starts_with('\n') {
             result.push(' ');

--- a/pnpm/crates/lockfile/src/yaml_emit.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit.rs
@@ -251,11 +251,10 @@ fn next_line(level: usize, double_line: bool) -> String {
     line
 }
 
-/// The `state.dump.length > 1024` threshold of js-yaml's explicit-pair
-/// rule: YAML caps a *simple* key at 1024 characters (the `:` must appear
-/// within that lookahead), so a longer rendered key is emitted in explicit
-/// `? <key>` / `: <value>` form. Peer-suffixed snapshot keys in large
-/// workspaces exceed this even with `peersSuffixMaxLength` applied.
+/// A rendered key longer than this (measured in UTF-16 code units,
+/// matching js-yaml's `state.dump.length > 1024`) is emitted as an
+/// explicit `? <key>` / `: <value>` pair: YAML caps a *simple* key at
+/// 1024 characters, so an inline key of that length would not re-parse.
 const EXPLICIT_KEY_THRESHOLD: usize = 1024;
 
 fn write_block_mapping(
@@ -270,7 +269,7 @@ fn write_block_mapping(
             result.push_str(&next_line(level, double_line));
         }
         let rendered_key = write_scalar(key, level + 1, true, true);
-        let explicit_pair = rendered_key.chars().count() > EXPLICIT_KEY_THRESHOLD;
+        let explicit_pair = rendered_key.encode_utf16().count() > EXPLICIT_KEY_THRESHOLD;
         if explicit_pair {
             result.push_str("? ");
             result.push_str(&rendered_key);

--- a/pnpm/crates/lockfile/src/yaml_emit/tests.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit/tests.rs
@@ -96,3 +96,12 @@ fn key_at_simple_key_limit_renders_inline() {
     let yaml = to_string(&json!({ &key: { "b": "c" } })).unwrap();
     assert_eq!(yaml, format!("{key}:\n  b: c\n"));
 }
+
+// The threshold counts UTF-16 code units like js-yaml's `.length`: 513
+// astral characters are 513 Rust chars but 1026 code units.
+#[test]
+fn key_length_is_measured_in_utf16_code_units() {
+    let key = "\u{1F600}".repeat(513);
+    let yaml = to_string(&json!({ &key: { "b": "c" } })).unwrap();
+    assert_eq!(yaml, format!("? {key}\n: b: c\n"));
+}

--- a/pnpm/crates/lockfile/src/yaml_emit/tests.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit/tests.rs
@@ -82,3 +82,17 @@ fn timestamp_strings_are_quoted() {
     let yaml = to_string(&json!({ "t": "2021-01-01" })).unwrap();
     assert_eq!(yaml, "t: '2021-01-01'\n");
 }
+
+#[test]
+fn key_over_simple_key_limit_renders_as_explicit_pair() {
+    let long_key = "k".repeat(1030);
+    let yaml = to_string(&json!({ &long_key: { "b": "c" } })).unwrap();
+    assert_eq!(yaml, format!("? {long_key}\n: b: c\n"));
+}
+
+#[test]
+fn key_at_simple_key_limit_renders_inline() {
+    let key = "k".repeat(1024);
+    let yaml = to_string(&json!({ &key: { "b": "c" } })).unwrap();
+    assert_eq!(yaml, format!("{key}:\n  b: c\n"));
+}


### PR DESCRIPTION
## Summary

YAML caps a *simple key* at 1024 characters (the `:` indicator must appear within that lookahead), and pacquet's parser enforces the spec — but the lockfile emitter wrote peer-suffixed dependency-path keys of any length inline. In a large bit.cloud workspace (~40k snapshots, peer suffixes near the `peersSuffixMaxLength` cap), 151 snapshot keys exceeded the limit, so the engine wrote a `pnpm-lock.yaml` / `<virtual-store>/lock.yaml` it could not re-read. The broken current lockfile then silently disabled incremental materialization: every subsequent install re-imported all ~38k packages (~6 minutes instead of seconds), which users perceived as installs hanging.

This ports js-yaml's explicit-pair rule (`state.dump.length > 1024` in the dumper the TypeScript CLI uses): keys whose rendered form exceeds 1024 characters are emitted as `? '<key>'` with the value on the following `: ` line. That form round-trips through pacquet's parser and is byte-compatible with what the TypeScript CLI writes for the same lockfile.

No TypeScript-side change is needed — js-yaml already implements this rule.

Verified on the affected workspace: the current lockfile parses again and repeat installs dropped from ~6 minutes of re-linking to the incremental path.

## Squash Commit Body

```text
YAML caps a simple key at 1024 characters (the ':' must appear within
that lookahead), and the parser enforces it — but the emitter wrote
peer-suffixed snapshot keys of any length inline. A large workspace
whose dep paths exceed the limit got a lockfile the engine could not
re-read, so every subsequent install silently fell back to a full
re-link. Port js-yaml's explicit-pair rule: keys whose rendered form
exceeds 1024 characters are emitted as '? <key>' with the value on the
following ': ' line, which round-trips and matches what the TypeScript
CLI writes.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: js-yaml already emits explicit pairs for over-long keys.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788006970&installation_model_id=426870&pr_number=13500&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13500&signature=3365327efb69de57b57ac7f6d79a6361977f49e44504bb4c811a0bb5033d024a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pnpm lockfile writing when dependency keys exceed YAML’s 1024-character limit, ensuring they remain valid and re-importable.
  * Updated the key-length cutoff to match YAML’s measurement rules (UTF-16 code units), improving consistency for long and non-BMP characters.
  * Prevented follow-up installs from unnecessarily re-resolving dependencies after large lockfile updates.
* **Tests**
  * Expanded and refined lockfile/YAML emission coverage for threshold and long-key scenarios.
* **Release**
  * Included in a patch release of the `pacquet` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->