### PR TITLE
fix(resolver): let the dependencies range win over devDependencies

### DIFF
--- a/.changeset/prod-spec-wins-over-dev.md
+++ b/.changeset/prod-spec-wins-over-dev.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed resolution of a direct dependency declared in both `dependencies` and `devDependencies`: the `dependencies` specifier now wins, matching the TypeScript CLI. The `devDependencies` range was resolved instead, recording a lockfile importer entry whose version did not satisfy its specifier — which failed the lockfile up-to-date check and forced a full re-resolve on every install.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -468,10 +468,12 @@ pub(crate) fn importer_injected_dependency_names(manifest: &PackageManifest) -> 
 ///
 /// An alias declared in several groups yields one spec, merged by
 /// spreading the groups in order: `peerDependencies` first (when
-/// `auto_install_peers`), then `dependencies` < `devDependencies` <
+/// `auto_install_peers`), then `devDependencies` < `dependencies` <
 /// `optionalDependencies`, a later group's range replacing an earlier
-/// one — so an importer's own regular dep (e.g. a `workspace:*`
-/// devDependency) wins over its peer range.
+/// one — matching `filterDependenciesByType` in
+/// `@pnpm/pkg-manifest.utils` (`{...dev, ...prod, ...optional}`), so a
+/// regular dep wins over a devDependency of the same alias, and either
+/// wins over its peer range.
 ///
 /// Shared by [`fn@crate::resolve_importer`] (which walks them) and the
 /// `time-based` cutoff pre-pass in [`fn@crate::resolve_workspace`]
@@ -493,7 +495,7 @@ where
         groups.push(DependencyGroup::Peer);
     }
     groups.extend(
-        [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional]
+        [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional]
             .into_iter()
             .filter(|group| included.contains(group)),
     );

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -2796,6 +2796,27 @@ mod importer_wanted_specs {
         .unwrap();
         assert_eq!(wanted, vec![("foo".to_string(), "^2.0.0".to_string(), true, false)]);
     }
+
+    /// Matches `filterDependenciesByType` in `@pnpm/pkg-manifest.utils`
+    /// (`{...dev, ...prod, ...optional}`): the regular range wins. The dev
+    /// range winning instead records an importer entry whose resolved
+    /// version can't satisfy the `dependencies` specifier, permanently
+    /// failing the prefer-frozen freshness check.
+    #[test]
+    fn regular_dep_range_wins_over_dev_range_of_same_alias() {
+        let (_tmp, manifest) = manifest_with(serde_json::json!({
+            "dependencies": { "foo": "1.0.0" },
+            "devDependencies": { "foo": "2.0.0" },
+        }));
+        let wanted = importer_direct_wanted_specs(
+            &manifest,
+            ALL_GROUPS,
+            false,
+            &pacquet_catalogs_types::Catalogs::new(),
+        )
+        .unwrap();
+        assert_eq!(wanted, vec![("foo".to_string(), "1.0.0".to_string(), false, false)]);
+    }
 }
 
 mod peer_own_dep_shadowing {


### PR DESCRIPTION
## Summary

`importer_direct_wanted_specs` merged an importer manifest's dependency groups with `devDependencies` overriding `dependencies`. The TypeScript CLI's `filterDependenciesByType` (`pnpm11/pkg-manifest/utils/src/index.ts`) spreads `{...devDependencies, ...dependencies, ...optionalDependencies}` — the regular range wins.

When a name is declared in both groups (observed in a bit.cloud workspace: `@types/node` at `18.16.1` in `dependencies` and `22.10.5` in `devDependencies`), pacquet resolved the dev range but recorded the importer entry under `dependencies` with the prod specifier — a lockfile that fails its own up-to-date check (`the importer resolution is broken at dependency "@types/node": version "22.10.5" doesn't satisfy range "18.16.1"`). The prefer-frozen fast path then never engaged and every install re-resolved the whole workspace (~7 minutes per repeat install in that workspace, down to 16 seconds with this fix).

Note while cross-checking parity: `pnpm11/pkg-manifest/utils/src/filterDependenciesByType.ts` is a dead file (not exported; `index.ts` defines its own copy inline) whose spread order contradicts the live implementation — worth deleting separately.

## Squash Commit Body

```text
importer_direct_wanted_specs merged the manifest's dependency groups
with devDependencies overriding dependencies, while the TypeScript
CLI's filterDependenciesByType spreads {...dev, ...prod, ...optional}.
For a name declared in both groups pacquet resolved the dev range but
recorded the importer entry under dependencies with the prod
specifier, producing a lockfile that fails its own up-to-date check
(version doesn't satisfy range) and re-resolves on every install.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: aligns pacquet with the TypeScript CLI's existing behavior.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788006988&installation_model_id=426870&pr_number=13501&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13501&signature=c2c2e6eb25712739c7252353792dcdaa267770011c50c98d895398c33d27f9cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Regular dependency version ranges now take precedence when the same package is listed in both regular and development dependencies.
  - Lockfile checks are more reliable and avoid unnecessary full dependency re-resolution during installation.

- **Tests**
  - Added coverage to verify the correct version range and dependency status are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->