### PR TITLE
fix(resolver): stop replaying cached subtrees' peer providers across importers

### DIFF
--- a/.changeset/no-cross-importer-peer-provider-replay.md
+++ b/.changeset/no-cross-importer-peer-provider-replay.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed peer resolution creating far more peer variants than the TypeScript CLI in multi-importer workspaces: a dependency subtree first resolved under one importer no longer hands the peer providers it resolved to every other importer that shares it. Those importers now bind such peers against their own context (or the workspace root), matching the TypeScript resolver. In a large bit.cloud workspace this cut a from-scratch install from 25,534 to 20,791 lockfile snapshots.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -980,7 +980,9 @@ struct ParentPkgInfo {
     occurrence: u32,
 }
 
-/// One cached resolution of a non-pure subtree.
+/// One cached resolution of a non-pure subtree: the part of a walk's
+/// verdict that holds in any compatible parent context, so a revisit —
+/// by the same walk or another importer's — can reuse it.
 ///
 /// `dep_path` is the value [`Walker::resolve_node`] would otherwise
 /// recompute. `resolved_peers` is the external peer set (excluding
@@ -991,6 +993,12 @@ struct ParentPkgInfo {
 /// current parent context *does* provide, the contexts are
 /// incompatible and the item must be rejected. `missing_peers_of_children`
 /// is the subset exposed as the package's children report.
+///
+/// The peer *providers* the walk resolved to are deliberately not part
+/// of the verdict: they belong to the resolving walk's own context —
+/// pnpm's resolver gives a not-new package `resolvedPeers: {}`
+/// (`resolveDependencies.ts`) — so only the walk that first resolved a
+/// subtree promotes its providers to importer level.
 #[derive(Debug)]
 struct PeersCacheItem {
     dep_path: DepPath,
@@ -1002,6 +1010,20 @@ struct PeersCacheItem {
     /// subtree still reports the same per-package missing breakdown a
     /// full walk of it would.
     subtree_missing_by_pkg: SubtreeMissingByPkg,
+}
+
+impl PeersCacheItem {
+    /// The [`NodeOutput`] a cache hit hands the reusing walk; output
+    /// fields the verdict doesn't carry come back empty.
+    fn to_node_output(&self) -> NodeOutput {
+        NodeOutput {
+            dep_path: self.dep_path.clone(),
+            external_resolved_peers: self.resolved_peers.clone(),
+            auto_install_resolved_peers: HashMap::new(),
+            missing_peers: self.missing_peers.clone(),
+            subtree_missing_by_pkg: self.subtree_missing_by_pkg.clone(),
+        }
+    }
 }
 
 /// One `parent → child` edge whose target wasn't walked yet at the
@@ -1474,17 +1496,8 @@ impl Walker<'_> {
         // view) because a node's own children count as parents for
         // its own descendants' peer resolution.
         if let Some(cached) = self.find_hit(&child_parent_refs, &pkg.id) {
-            let dep_path = cached.dep_path.clone();
-            let resolved = cached.resolved_peers.clone();
-            // Providers resolved by the cached walk belong to that walk's
-            // context: a not-new package contributes no resolved peers to
-            // its consumer (pnpm's `resolveDependencies.ts`), so only the
-            // walk that first resolved a subtree promotes providers to
-            // importer level.
-            let auto_install_resolved_peers = HashMap::new();
-            let missing = cached.missing_peers.clone();
+            let output = cached.to_node_output();
             let missing_of_children = cached.missing_peers_of_children.clone();
-            let subtree_missing_by_pkg = cached.subtree_missing_by_pkg.clone();
             // Re-emit the missing-peer issues against the current
             // parent chain so each occurrence of the package shows up
             // in the diagnostic. Without this, the first walk's parent
@@ -1495,7 +1508,7 @@ impl Walker<'_> {
             {
                 let mut chain_with_self = parent_pkg_ids_chain.to_vec();
                 chain_with_self.push(pkg.id.clone());
-                for (peer_name, info) in &missing {
+                for (peer_name, info) in &output.missing_peers {
                     if self.missing_issue_suppressed(&chain_with_self, peer_name) {
                         continue;
                     }
@@ -1511,28 +1524,23 @@ impl Walker<'_> {
                     );
                 }
             }
-            self.node_dep_paths.insert(node_id.clone(), dep_path.clone());
-            self.node_external_peers.insert(node_id.clone(), resolved.clone());
-            self.node_missing_peers.insert(node_id.clone(), missing.clone());
+            self.node_dep_paths.insert(node_id.clone(), output.dep_path.clone());
+            self.node_external_peers
+                .insert(node_id.clone(), output.external_resolved_peers.clone());
+            self.node_missing_peers.insert(node_id.clone(), output.missing_peers.clone());
             self.node_missing_peers_of_children.insert(node_id.clone(), missing_of_children);
             // Same depth tie-break as the `purePkgs` fast path and the
             // non-fast `entry(...).and_modify(...)` write below — a
             // shallower revisit through the cache must still lower the
             // existing graph entry's `depth`.
-            if let Some(node) = self.graph.get_mut(&dep_path)
+            if let Some(node) = self.graph.get_mut(&output.dep_path)
                 && node.depth > tree_node.depth
             {
                 node.depth = tree_node.depth;
             }
             self.in_progress.remove(&node_id);
             self.visited_this_call.insert(node_id);
-            return NodeOutput {
-                dep_path,
-                external_resolved_peers: resolved,
-                auto_install_resolved_peers,
-                missing_peers: missing,
-                subtree_missing_by_pkg,
-            };
+            return output;
         }
 
         // Recurse into children first (post-order). Collect each child's

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -995,7 +995,6 @@ struct ParentPkgInfo {
 struct PeersCacheItem {
     dep_path: DepPath,
     resolved_peers: HashMap<String, NodeId>,
-    auto_install_resolved_peers: HashMap<String, NodeId>,
     missing_peers: HashMap<String, MissingPeerInfo>,
     missing_peers_of_children: HashMap<String, MissingPeerInfo>,
     /// See [`NodeOutput::subtree_missing_by_pkg`]. Replayed on a cache
@@ -1477,7 +1476,17 @@ impl Walker<'_> {
         if let Some(cached) = self.find_hit(&child_parent_refs, &pkg.id) {
             let dep_path = cached.dep_path.clone();
             let resolved = cached.resolved_peers.clone();
-            let auto_install_resolved_peers = cached.auto_install_resolved_peers.clone();
+            // A cache hit reuses a subtree another context walked, so the
+            // providers that subtree's peers resolved to belong to *that*
+            // context and must not bubble into this one. pnpm's resolver
+            // does the same: a not-new package contributes
+            // `resolvedPeers: {}` to its consumer (resolveDependencies.ts),
+            // so only the walk that first resolved a subtree promotes its
+            // peer providers to importer level. Replaying them here would
+            // install the owner context's provider — possibly a version
+            // this importer's own consumers reject — ahead of the
+            // workspace-root fallback the final pass would otherwise bind.
+            let auto_install_resolved_peers = HashMap::new();
             let missing = cached.missing_peers.clone();
             let missing_of_children = cached.missing_peers_of_children.clone();
             let subtree_missing_by_pkg = cached.subtree_missing_by_pkg.clone();
@@ -1660,7 +1669,6 @@ impl Walker<'_> {
             self.peers_cache.entry(pkg.id.clone()).or_default().push(PeersCacheItem {
                 dep_path: dep_path.clone(),
                 resolved_peers: all_resolved_peers.clone(),
-                auto_install_resolved_peers: auto_install_resolved_peers.clone(),
                 missing_peers: all_missing_peers.clone(),
                 missing_peers_of_children: missing_from_children,
                 subtree_missing_by_pkg: subtree_missing_by_pkg.clone(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -1476,16 +1476,11 @@ impl Walker<'_> {
         if let Some(cached) = self.find_hit(&child_parent_refs, &pkg.id) {
             let dep_path = cached.dep_path.clone();
             let resolved = cached.resolved_peers.clone();
-            // A cache hit reuses a subtree another context walked, so the
-            // providers that subtree's peers resolved to belong to *that*
-            // context and must not bubble into this one. pnpm's resolver
-            // does the same: a not-new package contributes
-            // `resolvedPeers: {}` to its consumer (resolveDependencies.ts),
-            // so only the walk that first resolved a subtree promotes its
-            // peer providers to importer level. Replaying them here would
-            // install the owner context's provider — possibly a version
-            // this importer's own consumers reject — ahead of the
-            // workspace-root fallback the final pass would otherwise bind.
+            // Providers resolved by the cached walk belong to that walk's
+            // context: a not-new package contributes no resolved peers to
+            // its consumer (pnpm's `resolveDependencies.ts`), so only the
+            // walk that first resolved a subtree promotes providers to
+            // importer level.
             let auto_install_resolved_peers = HashMap::new();
             let missing = cached.missing_peers.clone();
             let missing_of_children = cached.missing_peers_of_children.clone();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -479,8 +479,7 @@ fn resolved_peer_providers_from_direct_outputs_are_last_write_wins() {
     assert_eq!(result.resolved_peer_providers_by_alias.get("peer"), Some(&second_peer));
 }
 
-/// Why a cache hit reports no providers is documented at the
-/// `peersCache` hit in `Walker::resolve_node`.
+/// See [`PeersCacheItem`] for why a cache hit reports no providers.
 #[test]
 fn cached_subtree_reuse_reports_no_peer_providers() {
     let peerx = NodeId::leaf("peerx@1.0.0");

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -479,6 +479,80 @@ fn resolved_peer_providers_from_direct_outputs_are_last_write_wins() {
     assert_eq!(result.resolved_peer_providers_by_alias.get("peer"), Some(&second_peer));
 }
 
+/// A discovery pass that reuses another pass's cached subtree must not
+/// re-report that subtree's resolved peer providers: pnpm's resolver
+/// gives a not-new package `resolvedPeers: {}`, so only the importer
+/// whose walk first resolved a subtree promotes its providers. A
+/// replay would hand one importer's provider (here `peerpkg@2.0.0`,
+/// internal to `mid`) to every later importer that shares the subtree,
+/// shadowing the workspace-root fallback for consumers the sharing
+/// importer resolves itself.
+#[test]
+fn cached_subtree_reuse_reports_no_peer_providers() {
+    let peerx = NodeId::leaf("peerx@1.0.0");
+    let peerpkg = NodeId::leaf("peerpkg@2.0.0");
+    let consumer = NodeId::next();
+    let mid = NodeId::next();
+
+    let mut mid_children = BTreeMap::new();
+    mid_children.insert("peerpkg".to_string(), peerpkg.clone());
+    mid_children.insert("consumer".to_string(), consumer.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "mid".to_string(),
+                node_id: mid.clone(),
+                id: "mid@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "peerx".to_string(),
+                node_id: peerx.clone(),
+                id: "peerx@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from([
+            ("peerx@1.0.0".to_string(), package("peerx", "1.0.0", &[], true)),
+            ("peerpkg@2.0.0".to_string(), package("peerpkg", "2.0.0", &[], true)),
+            (
+                "consumer@1.0.0".to_string(),
+                package("consumer", "1.0.0", &[("peerpkg", "*"), ("peerx", "*")], false),
+            ),
+            ("mid@1.0.0".to_string(), package("mid", "1.0.0", &[], false)),
+        ]),
+        dependencies_tree: HashMap::from([
+            (peerx, tree_node("peerx@1.0.0", BTreeMap::new(), 0)),
+            (peerpkg, tree_node("peerpkg@2.0.0", BTreeMap::new(), 1)),
+            (consumer, tree_node("consumer@1.0.0", BTreeMap::new(), 1)),
+            (mid, tree_node("mid@1.0.0", mid_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from(["peerpkg".to_string(), "peerx".to_string()]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::new(),
+        children_by_id: HashMap::new(),
+    };
+    let direct = tree.direct.clone();
+
+    let (first, caches) = super::discover_peers(
+        &mut tree,
+        &direct,
+        PeerDiscoveryCaches::default(),
+        ResolvePeersOptions::default(),
+    );
+    assert!(
+        first.resolved_peer_providers_by_alias.contains_key("peerpkg"),
+        "the walk that resolves the subtree reports its providers",
+    );
+
+    let (second, _) =
+        super::discover_peers(&mut tree, &direct, caches, ResolvePeersOptions::default());
+    assert_eq!(
+        second.resolved_peer_providers_by_alias.get("peerpkg"),
+        None,
+        "a cached-subtree reuse must not re-report the owner walk's providers",
+    );
+}
+
 #[test]
 fn peer_name_cycle_collapses_provider_suffixes() {
     let loader = NodeId::next();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -479,14 +479,8 @@ fn resolved_peer_providers_from_direct_outputs_are_last_write_wins() {
     assert_eq!(result.resolved_peer_providers_by_alias.get("peer"), Some(&second_peer));
 }
 
-/// A discovery pass that reuses another pass's cached subtree must not
-/// re-report that subtree's resolved peer providers: pnpm's resolver
-/// gives a not-new package `resolvedPeers: {}`, so only the importer
-/// whose walk first resolved a subtree promotes its providers. A
-/// replay would hand one importer's provider (here `peerpkg@2.0.0`,
-/// internal to `mid`) to every later importer that shares the subtree,
-/// shadowing the workspace-root fallback for consumers the sharing
-/// importer resolves itself.
+/// Why a cache hit reports no providers is documented at the
+/// `peersCache` hit in [`Walker::resolve_node`].
 #[test]
 fn cached_subtree_reuse_reports_no_peer_providers() {
     let peerx = NodeId::leaf("peerx@1.0.0");

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -480,7 +480,7 @@ fn resolved_peer_providers_from_direct_outputs_are_last_write_wins() {
 }
 
 /// Why a cache hit reports no providers is documented at the
-/// `peersCache` hit in [`Walker::resolve_node`].
+/// `peersCache` hit in `Walker::resolve_node`.
 #[test]
 fn cached_subtree_reuse_reports_no_peer_providers() {
     let peerx = NodeId::leaf("peerx@1.0.0");

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -2523,12 +2523,11 @@ async fn a_workspace_range_root_dep_is_offered_as_a_peer_provider() {
     );
 }
 
-/// Workspace-level outcome lock for the rule tested by
-/// `resolve_peers::tests::cached_subtree_reuse_reports_no_peer_providers`
-/// (which is the regression test — this fixture resolves to the
-/// workspace root through the miss-hoist path with or without the
-/// fix, so it pins the end-to-end binding rather than discriminating
-/// the cache-replay code path).
+/// End-to-end companion of
+/// `resolve_peers::tests::cached_subtree_reuse_reports_no_peer_providers`:
+/// pkg-b reuses two foreign-owned subtrees — `mid`, whose walk resolved
+/// `peerpkg`, and `s2wrap`, whose consumer's miss the owning importer
+/// satisfied from its own ancestors (hiding it from pkg-b's hoist).
 #[tokio::test]
 async fn importer_sharing_foreign_subtrees_binds_peers_from_workspace_root() {
     let mut table = HashMap::new();
@@ -2584,6 +2583,23 @@ async fn importer_sharing_foreign_subtrees_binds_peers_from_workspace_root() {
             }),
         ),
     );
+    // pkg-b reaches `s2wrap` through `bwrap` so both importers see it at
+    // depth 1 and the children-owner claim falls to pkg-a2 (lower
+    // importer order) — a direct depth-0 reference would make pkg-b the
+    // owner and no cross-importer sharing would occur.
+    table.insert(
+        ("bwrap".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "bwrap",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "bwrap",
+                "version": "1.0.0",
+                "dependencies": { "s2wrap": "1.0.0" },
+            }),
+        ),
+    );
     table.insert(
         ("consumer2".to_string(), "1.0.0".to_string()),
         fake_result(
@@ -2627,7 +2643,7 @@ async fn importer_sharing_foreign_subtrees_binds_peers_from_workspace_root() {
         fake_manifest(serde_json::json!({ "mid": "1.0.0", "peerx": "1.0.0" }));
     let (tmp_a2, a2_manifest) = fake_manifest(serde_json::json!({ "holder": "1.0.0" }));
     let (tmp_b, b_manifest) =
-        fake_manifest(serde_json::json!({ "mid": "1.0.0", "s2wrap": "1.0.0", "peerx": "1.0.0" }));
+        fake_manifest(serde_json::json!({ "mid": "1.0.0", "bwrap": "1.0.0", "peerx": "1.0.0" }));
     let importers = [
         WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
         WorkspaceImporter { id: "pkg-a".to_string(), manifest: &a_manifest },
@@ -2673,8 +2689,8 @@ async fn importer_sharing_foreign_subtrees_binds_peers_from_workspace_root() {
     let b_direct =
         result.peers.direct_dependencies_by_importer.get("pkg-b").expect("pkg-b importer");
     assert_eq!(
-        b_direct.get("s2wrap").map(std::string::ToString::to_string),
-        Some("s2wrap@1.0.0(peerpkg@1.0.0)".to_string()),
+        b_direct.get("bwrap").map(std::string::ToString::to_string),
+        Some("bwrap@1.0.0(peerpkg@1.0.0)".to_string()),
         "pkg-b's own consumers must not inherit a reused subtree's provider",
     );
     assert_eq!(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -2522,3 +2522,170 @@ async fn a_workspace_range_root_dep_is_offered_as_a_peer_provider() {
         result.peers.graph.keys().map(|key| key.as_str().to_string()).collect::<Vec<_>>(),
     );
 }
+
+/// A subtree reused from another importer's walk must not promote the
+/// peer providers that walk resolved: pnpm's resolver gives a not-new
+/// package `resolvedPeers: {}`, so only the importer that first walked
+/// a subtree installs its providers at importer level. Replaying them
+/// would put the owner context's provider version ahead of the
+/// workspace-root fallback for the reusing importer's own consumers.
+///
+/// `pkg-b` reuses two foreign-owned subtrees: `mid` (whose walk
+/// resolved `peerpkg@2.0.0` internally) and `s2wrap` (whose consumer's
+/// miss the owner importer satisfied from its own ancestors, so the
+/// owner scope hides it from pkg-b's hoist). With no visible miss and
+/// no replayed provider, pkg-b's consumer must fall back to the
+/// workspace root's `peerpkg@1.0.0`.
+#[tokio::test]
+async fn reused_subtree_does_not_promote_owner_peer_providers() {
+    let mut table = HashMap::new();
+    table.insert(
+        ("mid".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "mid",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "mid",
+                "version": "1.0.0",
+                "dependencies": { "peerpkg": "2.0.0", "consumer": "1.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("consumer".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "consumer",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "consumer",
+                "version": "1.0.0",
+                "peerDependencies": { "peerpkg": "*", "peerx": "*" },
+            }),
+        ),
+    );
+    table.insert(
+        ("holder".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "holder",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "holder",
+                "version": "1.0.0",
+                "dependencies": { "peerpkg": "2.0.0", "s2wrap": "1.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("s2wrap".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "s2wrap",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "s2wrap",
+                "version": "1.0.0",
+                "dependencies": { "consumer2": "1.0.0" },
+            }),
+        ),
+    );
+    table.insert(
+        ("consumer2".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "consumer2",
+            "1.0.0",
+            None,
+            serde_json::json!({
+                "name": "consumer2",
+                "version": "1.0.0",
+                "peerDependencies": { "peerpkg": "*" },
+            }),
+        ),
+    );
+    for version in ["1.0.0", "2.0.0"] {
+        table.insert(
+            ("peerpkg".to_string(), version.to_string()),
+            fake_result(
+                "peerpkg",
+                version,
+                None,
+                serde_json::json!({ "name": "peerpkg", "version": version }),
+            ),
+        );
+    }
+    // `peerx` keeps `mid`'s subtree non-pure: `consumer` resolves it
+    // against the importer's own direct dep, so the subtree's verdict
+    // enters the peers cache (pure subtrees bypass it) and pkg-b's
+    // revisit exercises the cache-replay path under test.
+    table.insert(
+        ("peerx".to_string(), "1.0.0".to_string()),
+        fake_result(
+            "peerx",
+            "1.0.0",
+            None,
+            serde_json::json!({ "name": "peerx", "version": "1.0.0" }),
+        ),
+    );
+    let resolver = RecordingResolver { table, seen: Mutex::new(HashMap::new()) };
+    let (tmp_root, root_manifest) = fake_manifest(serde_json::json!({ "peerpkg": "1.0.0" }));
+    let (tmp_a, a_manifest) =
+        fake_manifest(serde_json::json!({ "mid": "1.0.0", "peerx": "1.0.0" }));
+    let (tmp_a2, a2_manifest) = fake_manifest(serde_json::json!({ "holder": "1.0.0" }));
+    let (tmp_b, b_manifest) =
+        fake_manifest(serde_json::json!({ "mid": "1.0.0", "s2wrap": "1.0.0", "peerx": "1.0.0" }));
+    let importers = [
+        WorkspaceImporter { id: ".".to_string(), manifest: &root_manifest },
+        WorkspaceImporter { id: "pkg-a".to_string(), manifest: &a_manifest },
+        WorkspaceImporter { id: "pkg-a2".to_string(), manifest: &a2_manifest },
+        WorkspaceImporter { id: "pkg-b".to_string(), manifest: &b_manifest },
+    ];
+    let dirs = [tmp_root.path(), tmp_a.path(), tmp_a2.path(), tmp_b.path()];
+
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    opts.resolve_peers_from_workspace_root = true;
+    let mut next = 0;
+    let result = resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        let dir = dirs[next].to_path_buf();
+        next += 1;
+        let mut opts = importer_opts(dir, None);
+        opts.auto_install_peers = true;
+        opts.resolve_peers_from_workspace_root = true;
+        opts
+    })
+    .await
+    .unwrap();
+
+    // Under pkg-a2, `consumer2` binds to holder's peerpkg@2.0.0.
+    let a2_direct =
+        result.peers.direct_dependencies_by_importer.get("pkg-a2").expect("pkg-a2 importer");
+    assert_eq!(
+        a2_direct.get("holder").map(std::string::ToString::to_string),
+        Some("holder@1.0.0".to_string()),
+        "holder satisfies its subtree's peer internally",
+    );
+    let a_direct =
+        result.peers.direct_dependencies_by_importer.get("pkg-a").expect("pkg-a importer");
+    assert_eq!(
+        a_direct.get("mid").map(std::string::ToString::to_string),
+        Some("mid@1.0.0(peerx@1.0.0)".to_string()),
+        "consumer's peerx resolves against pkg-a's direct dep",
+    );
+
+    // Under pkg-b, `consumer2` has no provider in its own tree: its peer
+    // must fall back to the workspace root's peerpkg@1.0.0, not bind to
+    // the peerpkg@2.0.0 provider a reused subtree's walk resolved.
+    let b_direct =
+        result.peers.direct_dependencies_by_importer.get("pkg-b").expect("pkg-b importer");
+    assert_eq!(
+        b_direct.get("s2wrap").map(std::string::ToString::to_string),
+        Some("s2wrap@1.0.0(peerpkg@1.0.0)".to_string()),
+        "pkg-b's own consumers must not inherit a reused subtree's provider",
+    );
+    assert_eq!(
+        b_direct.get("mid").map(std::string::ToString::to_string),
+        Some("mid@1.0.0(peerx@1.0.0)".to_string()),
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -2523,21 +2523,14 @@ async fn a_workspace_range_root_dep_is_offered_as_a_peer_provider() {
     );
 }
 
-/// A subtree reused from another importer's walk must not promote the
-/// peer providers that walk resolved: pnpm's resolver gives a not-new
-/// package `resolvedPeers: {}`, so only the importer that first walked
-/// a subtree installs its providers at importer level. Replaying them
-/// would put the owner context's provider version ahead of the
-/// workspace-root fallback for the reusing importer's own consumers.
-///
-/// `pkg-b` reuses two foreign-owned subtrees: `mid` (whose walk
-/// resolved `peerpkg@2.0.0` internally) and `s2wrap` (whose consumer's
-/// miss the owner importer satisfied from its own ancestors, so the
-/// owner scope hides it from pkg-b's hoist). With no visible miss and
-/// no replayed provider, pkg-b's consumer must fall back to the
-/// workspace root's `peerpkg@1.0.0`.
+/// Workspace-level outcome lock for the rule tested by
+/// `resolve_peers::tests::cached_subtree_reuse_reports_no_peer_providers`
+/// (which is the regression test — this fixture resolves to the
+/// workspace root through the miss-hoist path with or without the
+/// fix, so it pins the end-to-end binding rather than discriminating
+/// the cache-replay code path).
 #[tokio::test]
-async fn reused_subtree_does_not_promote_owner_peer_providers() {
+async fn importer_sharing_foreign_subtrees_binds_peers_from_workspace_root() {
     let mut table = HashMap::new();
     table.insert(
         ("mid".to_string(), "1.0.0".to_string()),


### PR DESCRIPTION
## Summary

In multi-importer workspaces pacquet resolved far more peer variants than the TypeScript CLI. In a bit.cloud workspace (114 importers), a from-scratch install materialized 25,534 lockfile snapshots vs the TypeScript CLI's 20,219 — with consumers declaring `@testing-library/react: ^12.0.0` split into variants for both 12.1.5 *and* 13.4.0 (which doesn't satisfy the range), 535 snapshots carrying the 13.4.0 suffix vs the TypeScript CLI's 41.

Root cause: the peer walker's `peersCache` hit path replayed the cached walk's `auto_install_resolved_peers`, so a subtree first resolved under one importer handed the peer providers it bound to every other importer sharing it. Combined with the owner-scope miss suppression (the sharing importer's copy of the miss is hidden because the owner's walk satisfied it), the sharing importer neither hoisted the peer from the workspace root nor bound it in its own context — it inherited the owner context's provider verbatim.

The TypeScript resolver gives a not-new package `resolvedPeers: {}` (`resolveDependencies.ts`), so only the walk that first resolves a subtree promotes its providers to importer level; every other importer binds such peers against its own context (or the workspace-root fallback). This PR matches that: a cache hit replays no providers.

Measured on the affected workspace: snapshots 25,534 → 20,791, out-of-range peer-suffix variants 535 → 43, install `added` count 43,870 → 20,665 (combined with forwarding `dedupePeers` on the bit side).

The `resolvePeers` behavior this aligns with is unchanged between pnpm v10 and v12, so this is a pacquet-side divergence introduced by the discovery cache, not a v12 design decision.

## Squash Commit Body

```text
The peers-cache hit path replayed the cached walk's
auto_install_resolved_peers, so a subtree first resolved under one
importer handed the peer providers it bound to every importer sharing
it. Combined with the owner-scope miss suppression, the sharing
importer neither hoisted the peer from the workspace root nor bound it
in its own context — it inherited the owner context's provider, even
one the consumer's declared range rejects. pnpm's resolver gives a
not-new package resolvedPeers: {} (resolveDependencies.ts), so only
the walk that first resolves a subtree promotes its providers; match
that by replaying no providers on a cache hit.

In a bit.cloud workspace with 114 importers this halved peer-variant
fanout: 25,534 -> 20,791 snapshots (TypeScript CLI: 20,219), with
`@testing-library/react@13.4.0`-suffixed variants dropping from 535 to
43 (TypeScript: 41).
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: aligns pacquet with the TypeScript resolver's existing
  not-new `resolvedPeers: {}` semantics.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788012443&installation_model_id=426870&pr_number=13502&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13502&signature=1900d48cfe0eb7cb2e8c50b5a9adae818b4b6e8ded01c14d326f25b908443614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed peer dependency resolution in multi-importer workspaces so peer providers are no longer incorrectly reused across different importer resolution contexts.
  * Ensured cached peer results don’t promote installer-level providers in subsequent walks, keeping bindings consistent with the TypeScript resolver and falling back to the workspace root when applicable.
  * Reduced redundant lockfile snapshots during fresh installs in large workspaces.
* **Tests**
  * Updated and strengthened regression coverage to verify correct peer-binding behavior across importer and subtree reuse scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->