### PR TITLE
perf(resolver): avoid repeated packument filtering and semver parsing during version picking

### DIFF
--- a/.changeset/perf-resolver-caches.md
+++ b/.changeset/perf-resolver-caches.md
@@ -1,7 +1,8 @@
 ---
 "@pnpm/resolving.npm-resolver": patch
 "@pnpm/resolving.registry.pkg-metadata-filter": patch
+"pacquet": patch
 "pnpm": patch
 ---
 
-Dependency resolution is ~13% faster: package metadata is now filtered once per packument instead of once per dependency edge when `minimumReleaseAge` is active, and parsed semver versions/ranges are cached instead of re-parsed on every comparison.
+Dependency resolution is faster: package metadata is now filtered once per packument instead of once per dependency edge when `minimumReleaseAge` is active, and parsed semver versions and ranges are reused instead of re-parsed on every comparison.

--- a/.changeset/perf-resolver-caches.md
+++ b/.changeset/perf-resolver-caches.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"@pnpm/resolving.registry.pkg-metadata-filter": patch
+"pnpm": patch
+---
+
+Dependency resolution is ~13% faster: package metadata is now filtered once per packument instead of once per dependency edge when `minimumReleaseAge` is active, and parsed semver versions/ranges are cached instead of re-parsed on every comparison.

--- a/pnpm/crates/registry/src/lib.rs
+++ b/pnpm/crates/registry/src/lib.rs
@@ -5,7 +5,7 @@ mod package_version;
 mod package_versions;
 mod range_spec_style;
 
-pub use package::Package;
+pub use package::{DerivedPackuments, Package};
 pub use package_distribution::{AttestationsDist, PackageDistribution, ProvenanceMeta};
 pub use package_tag::PackageTag;
 pub use package_version::{Approver, NpmUser, PackageVersion, TrustedPublisher};

--- a/pnpm/crates/registry/src/package.rs
+++ b/pnpm/crates/registry/src/package.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
 };
 
 use pacquet_network::{AuthHeaders, ThrottledClient};
@@ -62,6 +62,12 @@ pub struct Package {
     #[serde(skip_serializing, skip_deserializing)]
     pub mutex: Arc<Mutex<u8>>,
 
+    /// Packuments derived from this one by a policy filter, keyed by
+    /// the deriving code's opaque policy key. See
+    /// [`DerivedPackuments`].
+    #[serde(skip_serializing, skip_deserializing)]
+    pub derived: DerivedPackuments,
+
     /// `true` once a release-age upgrade fetch for this document answered
     /// `304 Not Modified` in this process: the registry holds no fuller
     /// form than what is already cached, so re-asking within the install
@@ -100,6 +106,72 @@ impl PartialEq for Package {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name
     }
+}
+
+/// Memo of the packuments derived from one document by a policy
+/// filter, hung on the document they derive from so the derived copies
+/// die with it.
+///
+/// A pick runs for every dependency edge and re-derives the same view
+/// each time, and a derivation allocates a whole versions map, so the
+/// per-edge cost is what this removes. The key is opaque here: the
+/// deriving code (the resolver's publish-date filter) folds every input
+/// its output depends on into the key, because one packument can be
+/// served to installs running different policies.
+///
+/// A single install derives one view per packument, so the memo is
+/// capped rather than grown: a long-lived host (the napi bindings, a
+/// daemon) runs many installs against one shared meta cache, and an
+/// uncapped memo would retain a derived copy from every one of them.
+#[derive(Debug, Default, Clone)]
+pub struct DerivedPackuments(Arc<Mutex<DerivedMemo>>);
+
+/// Derived packuments in insertion order, so the eviction that keeps
+/// [`DerivedPackuments`] bounded drops the oldest policy.
+type DerivedMemo = Vec<(String, Arc<Package>)>;
+
+const MAX_DERIVED_PACKUMENTS: usize = 4;
+
+impl DerivedPackuments {
+    /// The packument stored under `policy_key`, derived with `derive`
+    /// on the first request for that key.
+    ///
+    /// `derive` runs outside the lock, so two threads racing on the
+    /// same key can both run it; the loser drops its copy and takes the
+    /// winner's, which keeps every caller of one key on one `Arc`.
+    pub fn get_or_derive(
+        &self,
+        policy_key: &str,
+        derive: impl FnOnce() -> Package,
+    ) -> Arc<Package> {
+        if let Some(derived) = self.get(policy_key) {
+            return derived;
+        }
+        let derived = Arc::new(derive());
+        let mut memo = self.lock();
+        if let Some(winner) = find(&memo, policy_key) {
+            return winner;
+        }
+        if memo.len() >= MAX_DERIVED_PACKUMENTS {
+            memo.remove(0);
+        }
+        memo.push((policy_key.to_string(), Arc::clone(&derived)));
+        derived
+    }
+
+    fn get(&self, policy_key: &str) -> Option<Arc<Package>> {
+        find(&self.lock(), policy_key)
+    }
+
+    /// A poisoned memo is still readable: every entry is a fully-built
+    /// packument, and a panic mid-`push` can't leave a half-written one.
+    fn lock(&self) -> MutexGuard<'_, DerivedMemo> {
+        self.0.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+fn find(memo: &DerivedMemo, policy_key: &str) -> Option<Arc<Package>> {
+    memo.iter().find(|(key, _)| key == policy_key).map(|(_, derived)| Arc::clone(derived))
 }
 
 impl Package {

--- a/pnpm/crates/registry/src/package/tests.rs
+++ b/pnpm/crates/registry/src/package/tests.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use node_semver::Version;
 use pretty_assertions::assert_eq;
 
-use super::{AuthHeaders, Package, PackageVersion, ThrottledClient};
+use super::{AuthHeaders, DerivedPackuments, Package, PackageVersion, ThrottledClient};
 use crate::{RangeSpecStyle, package_distribution::PackageDistribution};
 
 #[test]
@@ -140,6 +140,7 @@ fn package_with_versions(name: &str, versions: &[&str], latest: &str) -> Package
         homepage: None,
         mutex: std::sync::Arc::default(),
         release_age_upgrade_checked: false,
+        derived: DerivedPackuments::default(),
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -25,7 +25,9 @@ use dashmap::DashMap;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName, is_git_hosted_tarball_url};
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials};
-use pacquet_registry::{Approver, NpmUser, Package, PackageDistribution, PackageVersion};
+use pacquet_registry::{
+    Approver, DerivedPackuments, NpmUser, Package, PackageDistribution, PackageVersion,
+};
 use pacquet_resolving_resolver_base::{
     ResolutionVerification, ResolutionVerifier, VerifyCtx, VerifyFuture, parse_packument_timestamp,
 };
@@ -1027,6 +1029,7 @@ fn project_trust_meta(meta: &Package) -> Package {
         homepage: None,
         mutex: std::sync::Arc::new(std::sync::Mutex::new(0)),
         release_age_upgrade_checked: false,
+        derived: DerivedPackuments::default(),
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -58,7 +58,7 @@ use std::{
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pacquet_network::MetadataCacheScope;
-use pacquet_registry::{Package, PackageVersions};
+use pacquet_registry::{DerivedPackuments, Package, PackageVersions};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
@@ -502,6 +502,7 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
         homepage: index.homepage,
         mutex: Arc::default(),
         release_age_upgrade_checked: false,
+        derived: DerivedPackuments::default(),
     })
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -400,11 +400,16 @@ pub fn filter_pkg_metadata_by_publish_date(
 /// Every input the filter's output depends on, in one string: the same
 /// packument is served to installs whose cutoff or trusted versions
 /// differ, and they must not read each other's view.
+///
+/// The cutoff goes in at the precision it is compared at: it comes from
+/// `Utc::now()` and packument timestamps parse to the same resolution,
+/// so a key rounded to the millisecond would let two cutoffs that keep
+/// different versions share one derived packument.
 fn publish_date_policy_key(
     cutoff: chrono::DateTime<chrono::Utc>,
     trusted_versions: Option<&[String]>,
 ) -> String {
-    let mut key = cutoff.timestamp_millis().to_string();
+    let mut key = format!("{}.{}", cutoff.timestamp(), cutoff.timestamp_subsec_nanos());
     for trusted in trusted_versions.unwrap_or_default() {
         key.push('\0');
         key.push_str(trusted);

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta.rs
@@ -34,7 +34,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
 use pacquet_config::version_policy::{PackageVersionPolicy, PolicyMatch};
-use pacquet_registry::{Package, PackageVersion, PackageVersions};
+use pacquet_registry::{DerivedPackuments, Package, PackageVersion, PackageVersions};
 use pacquet_resolving_resolver_base::{
     VersionSelectorEntry, VersionSelectorType, VersionSelectors, parse_packument_timestamp,
 };
@@ -153,9 +153,9 @@ where
     PickFn: Fn(&PickVersionByVersionRangeOptions<'_>) -> Option<String>,
 {
     // "Owned-after-filter" shape: when publishedBy is active and a
-    // maturity filter applies, swap `meta` for a filtered clone —
+    // maturity filter applies, swap `meta` for the filtered view —
     // otherwise borrow the input through.
-    let filtered;
+    let filtered: Arc<Package>;
     let meta_ref: &Package = match opts.published_by {
         Some(cutoff) => {
             let exclude_result = opts
@@ -169,7 +169,7 @@ where
                     _ => None,
                 };
                 filtered = filter_pkg_metadata_by_publish_date(meta, cutoff, trusted);
-                &filtered
+                filtered.as_ref()
             } else {
                 // Abbreviated metadata has no per-version `time`. The
                 // missing-time error signals the orchestrator, which
@@ -267,6 +267,7 @@ fn without_version(meta: &Package, version: &str) -> Package {
         homepage: meta.homepage.clone(),
         mutex: Arc::default(),
         release_age_upgrade_checked: false,
+        derived: DerivedPackuments::default(),
     }
 }
 
@@ -375,12 +376,43 @@ pub fn pick_lowest_version_by_version_range(
 /// `latest`, matching prerelease/release status, and preferring
 /// non-deprecated versions when both are present).
 ///
+/// The result is memoized on `meta` (see [`DerivedPackuments`]) and
+/// shared between callers, so it is handed back behind an [`Arc`]:
+/// every caller of one cutoff and trusted-version list gets the same
+/// document, whose version manifests are the ones `meta` holds.
+///
 /// Panics if `meta.time` is `None` — the caller (the publishedBy
 /// branch in [`pick_package_from_meta`]) only invokes this with full
 /// metadata. The abbreviated-metadata path takes the `meta.modified`
 /// shortcut above and never reaches this function.
 #[must_use]
 pub fn filter_pkg_metadata_by_publish_date(
+    meta: &Package,
+    cutoff: chrono::DateTime<chrono::Utc>,
+    trusted_versions: Option<&[String]>,
+) -> Arc<Package> {
+    let policy_key = publish_date_policy_key(cutoff, trusted_versions);
+    meta.derived.get_or_derive(&policy_key, || {
+        filter_pkg_metadata_by_publish_date_uncached(meta, cutoff, trusted_versions)
+    })
+}
+
+/// Every input the filter's output depends on, in one string: the same
+/// packument is served to installs whose cutoff or trusted versions
+/// differ, and they must not read each other's view.
+fn publish_date_policy_key(
+    cutoff: chrono::DateTime<chrono::Utc>,
+    trusted_versions: Option<&[String]>,
+) -> String {
+    let mut key = cutoff.timestamp_millis().to_string();
+    for trusted in trusted_versions.unwrap_or_default() {
+        key.push('\0');
+        key.push_str(trusted);
+    }
+    key
+}
+
+fn filter_pkg_metadata_by_publish_date_uncached(
     meta: &Package,
     cutoff: chrono::DateTime<chrono::Utc>,
     trusted_versions: Option<&[String]>,
@@ -437,6 +469,7 @@ fn filter_pkg_metadata_versions_with_latest_bound(
         homepage: meta.homepage.clone(),
         mutex: std::sync::Arc::clone(&meta.mutex),
         release_age_upgrade_checked: false,
+        derived: DerivedPackuments::default(),
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -541,6 +541,23 @@ fn filter_is_memoized_per_packument_and_stays_bounded() {
 }
 
 #[test]
+fn filter_memo_separates_cutoffs_inside_one_millisecond() {
+    let mut pkg = make_package("acme", &[("1.0.0", None), ("1.1.0", None)], &[("latest", "1.1.0")]);
+    pkg.time = Some(make_time_map(&[
+        ("1.0.0", "2020-01-01T00:00:00.000Z"),
+        ("1.1.0", "2020-04-01T00:00:00.000400Z"),
+    ]));
+
+    let before =
+        filter_pkg_metadata_by_publish_date(&pkg, parse_iso("2020-04-01T00:00:00.000300Z"), None);
+    let after =
+        filter_pkg_metadata_by_publish_date(&pkg, parse_iso("2020-04-01T00:00:00.000500Z"), None);
+
+    assert!(!before.versions.contains_key("1.1.0"), "published after the earlier cutoff");
+    assert!(after.versions.contains_key("1.1.0"), "published before the later cutoff");
+}
+
+#[test]
 fn generic_version_filter_keeps_unbounded_latest_repopulation() {
     let pkg = make_package("acme", &[("1.0.0", None), ("2.0.0", None)], &[("latest", "1.0.0")]);
 

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package_from_meta/tests.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use node_semver::Version;
 use pacquet_config::version_policy::create_package_version_policy;
-use pacquet_registry::{Package, PackageDistribution, PackageVersion};
+use pacquet_registry::{DerivedPackuments, Package, PackageDistribution, PackageVersion};
 use pacquet_resolving_resolver_base::{
     VersionSelectorEntry, VersionSelectorType, VersionSelectorWithWeight, VersionSelectors,
 };
@@ -59,6 +59,7 @@ fn make_package(
         homepage: None,
         mutex: std::sync::Arc::default(),
         release_age_upgrade_checked: false,
+        derived: DerivedPackuments::default(),
     }
 }
 
@@ -514,6 +515,29 @@ fn filter_latest_fallback_does_not_exceed_original_tag_target() {
     let filtered = filter_pkg_metadata_by_publish_date(&pkg_without_safe_fallback, cutoff, None);
 
     assert_eq!(filtered.dist_tag("latest"), None);
+}
+
+#[test]
+fn filter_is_memoized_per_packument_and_stays_bounded() {
+    let mut pkg = make_package("acme", &[("1.0.0", None)], &[("latest", "1.0.0")]);
+    pkg.time = Some(make_time_map(&[("1.0.0", "2020-01-01T00:00:00.000Z")]));
+    let cutoff = parse_iso("2020-04-01T00:00:00.000Z");
+
+    let first = filter_pkg_metadata_by_publish_date(&pkg, cutoff, None);
+    let second = filter_pkg_metadata_by_publish_date(&pkg, cutoff, None);
+    assert!(Arc::ptr_eq(&first, &second), "same policy reuses the derived packument");
+
+    let trusted = filter_pkg_metadata_by_publish_date(&pkg, cutoff, Some(&["9.9.9".to_string()]));
+    assert!(!Arc::ptr_eq(&first, &trusted), "trusted versions are part of the policy");
+
+    // Distinct cutoffs past the cap evict the oldest entry, so the
+    // original policy is derived again instead of growing the memo.
+    for minutes in 1..=4 {
+        let other = cutoff + chrono::Duration::minutes(minutes);
+        let _ = filter_pkg_metadata_by_publish_date(&pkg, other, None);
+    }
+    let after_eviction = filter_pkg_metadata_by_publish_date(&pkg, cutoff, None);
+    assert!(!Arc::ptr_eq(&first, &after_eviction), "the memo is bounded");
 }
 
 #[test]

--- a/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
+++ b/pnpm/crates/resolving-resolver-base/src/errors/tests.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use chrono::{TimeDelta, Utc};
 use miette::Diagnostic;
-use pacquet_registry::{Package, PackageDistribution, PackageVersion};
+use pacquet_registry::{DerivedPackuments, Package, PackageDistribution, PackageVersion};
 
 use super::{
     NoMatchingVersionError, RegistryResponseError, RegistryResponseErrorOptions, stringify_date,
@@ -43,6 +43,7 @@ fn make_package(name: &str, versions: &[&str], dist_tags: &[(&str, &str)]) -> Pa
         homepage: None,
         mutex: std::sync::Arc::default(),
         release_age_upgrade_checked: false,
+        derived: DerivedPackuments::default(),
     }
 }
 

--- a/pnpm11/resolving/npm-resolver/src/clearMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/clearMeta.ts
@@ -69,20 +69,19 @@ export function clearMeta (pkg: PackageMeta): PackageMeta {
   return condensed
 }
 
-// Equivalent to ramda's pick(ABBREVIATED_VERSION_FIELDS, info) but without
-// the per-call `in` checks and currying overhead — this runs for every
-// version of every packument an install parses. The `!== undefined` presence
-// check is safe because version objects come from JSON, which can't encode
-// undefined.
+// Hand-rolled rather than delegated to a generic field picker because it runs
+// for every version of every packument an install parses. Testing the value
+// for `undefined` is equivalent to testing for the key's presence: version
+// objects come from JSON, which cannot encode undefined.
 function pickAbbreviatedVersionFields (info: PackageInRegistry): PackageInRegistry {
-  const out: Record<string, unknown> = {}
+  const picked: Partial<Record<keyof PackageInRegistry, unknown>> = {}
   for (const field of ABBREVIATED_VERSION_FIELDS) {
-    const value = info[field as keyof PackageInRegistry]
+    const value = info[field]
     if (value !== undefined) {
-      out[field] = value
+      picked[field] = value
     }
   }
-  return out as unknown as PackageInRegistry
+  return picked as PackageInRegistry
 }
 
 /**

--- a/pnpm11/resolving/npm-resolver/src/clearMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/clearMeta.ts
@@ -1,5 +1,4 @@
-import type { PackageMeta } from '@pnpm/resolving.registry.types'
-import { pick } from 'ramda'
+import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
 
 // The list taken from https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md#abbreviated-version-object
 // with the addition of 'libc'
@@ -52,7 +51,7 @@ export function clearMeta (pkg: PackageMeta): PackageMeta {
   // prototype of the map (js/prototype-polluting-assignment).
   const versions: PackageMeta['versions'] = Object.create(null)
   for (const [version, info] of Object.entries(pkg.versions ?? {})) {
-    versions[version] = pick(ABBREVIATED_VERSION_FIELDS, info)
+    versions[version] = pickAbbreviatedVersionFields(info)
   }
 
   const condensed: PackageMeta = {
@@ -68,6 +67,22 @@ export function clearMeta (pkg: PackageMeta): PackageMeta {
   condensedPackuments.set(pkg, condensed)
   condensedPackuments.set(condensed, condensed)
   return condensed
+}
+
+// Equivalent to ramda's pick(ABBREVIATED_VERSION_FIELDS, info) but without
+// the per-call `in` checks and currying overhead — this runs for every
+// version of every packument an install parses. The `!== undefined` presence
+// check is safe because version objects come from JSON, which can't encode
+// undefined.
+function pickAbbreviatedVersionFields (info: PackageInRegistry): PackageInRegistry {
+  const out: Record<string, unknown> = {}
+  for (const field of ABBREVIATED_VERSION_FIELDS) {
+    const value = info[field as keyof PackageInRegistry]
+    if (value !== undefined) {
+      out[field] = value
+    }
+  }
+  return out as unknown as PackageInRegistry
 }
 
 /**

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -301,16 +301,15 @@ export async function pickPackage (
     }
     let diskMeta: PackageMeta | null | undefined
     if (ctx.offline === true || ctx.preferOffline === true || opts.pickLowestVersion) {
-      // Concurrent offline picks of one package all miss the pre-queue
-      // in-memory cache check and queue behind the same limiter, so each
-      // would re-read and re-parse the mirror. Offline entries are always
-      // disk-sourced, so re-checking the cache once inside the queue is
-      // equivalent to having arrived after the first caller cached it. The
-      // promotion also happens inside the queue: promoting only after
-      // `await limit()` would race with the next dequeued task's cache
-      // check. (maybeUpgradeAbbreviatedMetaForReleaseAge short-circuits
-      // when offline, so a later in-memory cache hit returns this same
-      // meta without any network access.)
+      // Concurrent offline picks of one package all miss the pre-queue cache
+      // check and queue behind this limiter, so the check is repeated inside
+      // the queue and the promotion happens before the limiter releases —
+      // otherwise every queued pick re-reads and re-parses the mirror. Serving
+      // a queued pick from the cache is equivalent to it having arrived after
+      // the first caller cached it: offline entries are always disk-sourced
+      // and maybeUpgradeAbbreviatedMetaForReleaseAge short-circuits when
+      // offline, so an in-memory hit returns this same meta with no network
+      // access.
       diskMeta = await limit(async () => {
         if (ctx.offline !== true) return loadMetaCondensed()
         const cached = ctx.metaCache.get(cacheKey)

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -305,21 +305,25 @@ export async function pickPackage (
       // in-memory cache check and queue behind the same limiter, so each
       // would re-read and re-parse the mirror. Offline entries are always
       // disk-sourced, so re-checking the cache once inside the queue is
-      // equivalent to having arrived after the first caller cached it.
+      // equivalent to having arrived after the first caller cached it. The
+      // promotion also happens inside the queue: promoting only after
+      // `await limit()` would race with the next dequeued task's cache
+      // check. (maybeUpgradeAbbreviatedMetaForReleaseAge short-circuits
+      // when offline, so a later in-memory cache hit returns this same
+      // meta without any network access.)
       diskMeta = await limit(async () => {
-        if (ctx.offline === true) {
-          const cached = ctx.metaCache.get(cacheKey)
-          if (cached != null) return cached
+        if (ctx.offline !== true) return loadMetaCondensed()
+        const cached = ctx.metaCache.get(cacheKey)
+        if (cached != null) return cached
+        const meta = await loadMetaCondensed()
+        if (meta != null) {
+          cacheDiskLoadedMeta(ctx.metaCache, cacheKey, meta)
         }
-        return loadMetaCondensed()
+        return meta
       })
 
       if (ctx.offline) {
         if (diskMeta != null) {
-          // maybeUpgradeAbbreviatedMetaForReleaseAge short-circuits when
-          // offline, so a later in-memory cache hit returns this same meta
-          // without any network access.
-          cacheDiskLoadedMeta(ctx.metaCache, cacheKey, diskMeta)
           return {
             meta: diskMeta,
             pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, diskMeta),

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -301,7 +301,18 @@ export async function pickPackage (
     }
     let diskMeta: PackageMeta | null | undefined
     if (ctx.offline === true || ctx.preferOffline === true || opts.pickLowestVersion) {
-      diskMeta = await limit(loadMetaCondensed)
+      // Concurrent offline picks of one package all miss the pre-queue
+      // in-memory cache check and queue behind the same limiter, so each
+      // would re-read and re-parse the mirror. Offline entries are always
+      // disk-sourced, so re-checking the cache once inside the queue is
+      // equivalent to having arrived after the first caller cached it.
+      diskMeta = await limit(async () => {
+        if (ctx.offline === true) {
+          const cached = ctx.metaCache.get(cacheKey)
+          if (cached != null) return cached
+        }
+        return loadMetaCondensed()
+      })
 
       if (ctx.offline) {
         if (diskMeta != null) {

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -124,12 +124,16 @@ function parseModifiedDate (modified: string | undefined): Date | null {
   return date
 }
 
+// This is a performance optimization; working with string-ish semver
+// causes lots of allocations and repeated work. The same ranges and versions
+// are tested over and over across a dependency graph, so both parses are
+// cached. The caches are capped so long-lived processes (daemons, store
+// servers) can't grow them without bound.
+const SEMVER_CACHE_MAX_SIZE = 50_000
+
 const semverRangeCache = new Map<string, semver.Range | null>()
 
-// This is a performance optimization; working with string-ish semver
-// causes lots of allocations and repeated work, but caching the Range
-// and ensuring we give it a SemVer instance greatly speeds things up.
-function semverSatisfiesLoose (version: string, range: string): boolean {
+function parseRangeLoose (range: string): semver.Range | null {
   let semverRange = semverRangeCache.get(range)
   if (semverRange === undefined) {
     try {
@@ -137,18 +141,64 @@ function semverSatisfiesLoose (version: string, range: string): boolean {
     } catch {
       semverRange = null
     }
+    if (semverRangeCache.size >= SEMVER_CACHE_MAX_SIZE) semverRangeCache.clear()
     semverRangeCache.set(range, semverRange)
   }
+  return semverRange
+}
 
-  if (semverRange) {
+const semverInstanceCache = new Map<string, semver.SemVer | null>()
+
+function parseSemverLoose (version: string): semver.SemVer | null {
+  let parsed = semverInstanceCache.get(version)
+  if (parsed === undefined) {
     try {
-      return semverRange.test(new semver.SemVer(version, true))
+      parsed = new semver.SemVer(version, true)
     } catch {
-      return false
+      parsed = null
+    }
+    if (semverInstanceCache.size >= SEMVER_CACHE_MAX_SIZE) semverInstanceCache.clear()
+    semverInstanceCache.set(version, parsed)
+  }
+  return parsed
+}
+
+function semverSatisfiesLoose (version: string, range: string): boolean {
+  const semverRange = parseRangeLoose(range)
+  if (semverRange == null) return false
+  const parsedVersion = parseSemverLoose(version)
+  return parsedVersion != null && semverRange.test(parsedVersion)
+}
+
+// Cache-reusing replacements for semver.maxSatisfying/minSatisfying with
+// loose parsing: those re-parse the range and every version string on each
+// call, which dominates resolution time on large packuments.
+function maxSatisfyingLoose (versions: string[], range: string): string | null {
+  return findSatisfyingLoose(versions, range, (candidate, best) => candidate.compare(best) > 0)
+}
+
+function minSatisfyingLoose (versions: string[], range: string): string | null {
+  return findSatisfyingLoose(versions, range, (candidate, best) => candidate.compare(best) < 0)
+}
+
+function findSatisfyingLoose (
+  versions: string[],
+  range: string,
+  isBetter: (candidate: semver.SemVer, best: semver.SemVer) => boolean
+): string | null {
+  const semverRange = parseRangeLoose(range)
+  if (semverRange == null) return null
+  let bestVersion: string | null = null
+  let bestParsed: semver.SemVer | null = null
+  for (const version of versions) {
+    const parsed = parseSemverLoose(version)
+    if (parsed == null || !semverRange.test(parsed)) continue
+    if (bestParsed == null || isBetter(parsed, bestParsed)) {
+      bestVersion = version
+      bestParsed = parsed
     }
   }
-
-  return false
+  return bestVersion
 }
 
 export function pickLowestVersionByVersionRange (
@@ -157,7 +207,7 @@ export function pickLowestVersionByVersionRange (
   if (preferredVersionSelectors != null && Object.keys(preferredVersionSelectors).length > 0) {
     const prioritizedPreferredVersions = prioritizePreferredVersions(meta, versionRange, preferredVersionSelectors)
     for (const preferredVersions of prioritizedPreferredVersions) {
-      const preferredVersion = semver.minSatisfying(preferredVersions, versionRange, true)
+      const preferredVersion = minSatisfyingLoose(preferredVersions, versionRange)
       if (preferredVersion) {
         return preferredVersion
       }
@@ -166,7 +216,7 @@ export function pickLowestVersionByVersionRange (
   if (versionRange === '*') {
     return Object.keys(meta.versions).sort(semver.compare)[0]
   }
-  return semver.minSatisfying(Object.keys(meta.versions), versionRange, true)
+  return minSatisfyingLoose(Object.keys(meta.versions), versionRange)
 }
 
 export function pickVersionByVersionRange ({ meta, versionRange, preferredVersionSelectors }: PickVersionByVersionRangeOptions): string | null {
@@ -178,7 +228,7 @@ export function pickVersionByVersionRange ({ meta, versionRange, preferredVersio
       if (preferredVersions.includes(latest) && semverSatisfiesLoose(latest, versionRange)) {
         return latest
       }
-      const preferredVersion = semver.maxSatisfying(preferredVersions, versionRange, true)
+      const preferredVersion = maxSatisfyingLoose(preferredVersions, versionRange)
       if (preferredVersion) {
         return preferredVersion
       }
@@ -192,7 +242,7 @@ export function pickVersionByVersionRange ({ meta, versionRange, preferredVersio
     return latest
   }
 
-  const maxVersion = semver.maxSatisfying(versions, versionRange, true)
+  const maxVersion = maxSatisfyingLoose(versions, versionRange)
 
   // if the selected version is deprecated, try to find a non-deprecated one that satisfies the range
   if (maxVersion && meta.versions[maxVersion].deprecated && versions.length > 1) {
@@ -200,7 +250,7 @@ export function pickVersionByVersionRange ({ meta, versionRange, preferredVersio
       .filter((versionMeta) => !versionMeta.deprecated)
       .map((versionMeta) => versionMeta.version)
 
-    const maxNonDeprecatedVersion = semver.maxSatisfying(nonDeprecatedVersions, versionRange, true)
+    const maxNonDeprecatedVersion = maxSatisfyingLoose(nonDeprecatedVersions, versionRange)
     if (maxNonDeprecatedVersion) return maxNonDeprecatedVersion
   }
   return maxVersion

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -124,83 +124,6 @@ function parseModifiedDate (modified: string | undefined): Date | null {
   return date
 }
 
-// This is a performance optimization; working with string-ish semver
-// causes lots of allocations and repeated work. The same ranges and versions
-// are tested over and over across a dependency graph, so both parses are
-// cached. The caches are capped so long-lived processes (daemons, store
-// servers) can't grow them without bound.
-const SEMVER_CACHE_MAX_SIZE = 50_000
-
-const semverRangeCache = new Map<string, semver.Range | null>()
-
-function parseRangeLoose (range: string): semver.Range | null {
-  let semverRange = semverRangeCache.get(range)
-  if (semverRange === undefined) {
-    try {
-      semverRange = new semver.Range(range, true)
-    } catch {
-      semverRange = null
-    }
-    if (semverRangeCache.size >= SEMVER_CACHE_MAX_SIZE) semverRangeCache.clear()
-    semverRangeCache.set(range, semverRange)
-  }
-  return semverRange
-}
-
-const semverInstanceCache = new Map<string, semver.SemVer | null>()
-
-function parseSemverLoose (version: string): semver.SemVer | null {
-  let parsed = semverInstanceCache.get(version)
-  if (parsed === undefined) {
-    try {
-      parsed = new semver.SemVer(version, true)
-    } catch {
-      parsed = null
-    }
-    if (semverInstanceCache.size >= SEMVER_CACHE_MAX_SIZE) semverInstanceCache.clear()
-    semverInstanceCache.set(version, parsed)
-  }
-  return parsed
-}
-
-function semverSatisfiesLoose (version: string, range: string): boolean {
-  const semverRange = parseRangeLoose(range)
-  if (semverRange == null) return false
-  const parsedVersion = parseSemverLoose(version)
-  return parsedVersion != null && semverRange.test(parsedVersion)
-}
-
-// Cache-reusing replacements for semver.maxSatisfying/minSatisfying with
-// loose parsing: those re-parse the range and every version string on each
-// call, which dominates resolution time on large packuments.
-function maxSatisfyingLoose (versions: string[], range: string): string | null {
-  return findSatisfyingLoose(versions, range, (candidate, best) => candidate.compare(best) > 0)
-}
-
-function minSatisfyingLoose (versions: string[], range: string): string | null {
-  return findSatisfyingLoose(versions, range, (candidate, best) => candidate.compare(best) < 0)
-}
-
-function findSatisfyingLoose (
-  versions: string[],
-  range: string,
-  isBetter: (candidate: semver.SemVer, best: semver.SemVer) => boolean
-): string | null {
-  const semverRange = parseRangeLoose(range)
-  if (semverRange == null) return null
-  let bestVersion: string | null = null
-  let bestParsed: semver.SemVer | null = null
-  for (const version of versions) {
-    const parsed = parseSemverLoose(version)
-    if (parsed == null || !semverRange.test(parsed)) continue
-    if (bestParsed == null || isBetter(parsed, bestParsed)) {
-      bestVersion = version
-      bestParsed = parsed
-    }
-  }
-  return bestVersion
-}
-
 export function pickLowestVersionByVersionRange (
   { meta, versionRange, preferredVersionSelectors }: PickVersionByVersionRangeOptions
 ): string | null {
@@ -325,3 +248,79 @@ class PreferredVersionsPrioritizer {
       .map((weight) => versionsByWeight[parseInt(weight, 10)])
   }
 }
+
+function semverSatisfiesLoose (version: string, range: string): boolean {
+  const semverRange = parseRangeLoose(range)
+  if (semverRange == null) return false
+  const parsedVersion = parseSemverLoose(version)
+  return parsedVersion != null && semverRange.test(parsedVersion)
+}
+
+// semver's own maxSatisfying/minSatisfying re-parse the range and every
+// version string on each call, which dominates resolution time on large
+// packuments; these reuse the parse caches instead.
+function maxSatisfyingLoose (versions: string[], range: string): string | null {
+  return findSatisfyingLoose(versions, range, (candidate, best) => candidate.compare(best) > 0)
+}
+
+function minSatisfyingLoose (versions: string[], range: string): string | null {
+  return findSatisfyingLoose(versions, range, (candidate, best) => candidate.compare(best) < 0)
+}
+
+function findSatisfyingLoose (
+  versions: string[],
+  range: string,
+  isBetter: (candidate: semver.SemVer, best: semver.SemVer) => boolean
+): string | null {
+  const semverRange = parseRangeLoose(range)
+  if (semverRange == null) return null
+  let bestVersion: string | null = null
+  let bestParsed: semver.SemVer | null = null
+  for (const version of versions) {
+    const parsed = parseSemverLoose(version)
+    if (parsed == null || !semverRange.test(parsed)) continue
+    if (bestParsed == null || isBetter(parsed, bestParsed)) {
+      bestVersion = version
+      bestParsed = parsed
+    }
+  }
+  return bestVersion
+}
+
+function parseRangeLoose (range: string): semver.Range | null {
+  let semverRange = semverRangeCache.get(range)
+  if (semverRange === undefined) {
+    try {
+      semverRange = new semver.Range(range, true)
+    } catch {
+      semverRange = null
+    }
+    if (semverRangeCache.size >= SEMVER_CACHE_MAX_SIZE) semverRangeCache.clear()
+    semverRangeCache.set(range, semverRange)
+  }
+  return semverRange
+}
+
+function parseSemverLoose (version: string): semver.SemVer | null {
+  let parsed = semverInstanceCache.get(version)
+  if (parsed === undefined) {
+    try {
+      parsed = new semver.SemVer(version, true)
+    } catch {
+      parsed = null
+    }
+    if (semverInstanceCache.size >= SEMVER_CACHE_MAX_SIZE) semverInstanceCache.clear()
+    semverInstanceCache.set(version, parsed)
+  }
+  return parsed
+}
+
+// Working with string-ish semver causes lots of allocations and repeated
+// work, and a dependency graph tests the same ranges and versions over and
+// over, so both parses are cached. Parse failures are cached as null, so a
+// malformed version string is never re-parsed either. The caches are dropped
+// wholesale once they grow past this size, so a long-lived process (daemon,
+// store server) can't retain them without bound.
+const SEMVER_CACHE_MAX_SIZE = 50_000
+const semverRangeCache = new Map<string, semver.Range | null>()
+const semverInstanceCache = new Map<string, semver.SemVer | null>()

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises'
 
 import { expect, jest, test } from '@jest/globals'
 import { ABBREVIATED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
+import gfs from '@pnpm/fs.graceful-fs'
 import type { PackageMeta } from '@pnpm/resolving.registry.types'
 import { temporaryDirectory } from 'tempy'
 
@@ -139,6 +140,38 @@ test('offline resolution promotes the disk-loaded packument into the in-memory c
   rmSync(pkgMirror)
   const second = await pickPackage(ctx, spec, opts)
   expect(second.pickedPackage?.version).toBe('1.0.0')
+})
+
+test('simultaneous offline picks of one package read and parse the mirror once', async () => {
+  const meta = fooMeta()
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, undefined))
+
+  const ctx = {
+    fetch: async () => {
+      throw new Error('offline resolution must not hit the network')
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+    offline: true,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '^1.0.0' }
+  const opts = { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined }
+
+  const readFileSpy = jest.spyOn(gfs, 'readFile')
+  try {
+    // All picks start before any completes, so every one misses the pre-queue
+    // in-memory cache check and queues behind the per-package limiter. The
+    // first dequeued pick must promote the parsed mirror before the limiter
+    // releases; the rest are then served from the in-memory cache.
+    const picks = await Promise.all(Array.from({ length: 10 }, async () => pickPackage(ctx, spec, opts)))
+    expect(picks.every((pick) => pick.pickedPackage?.version === '1.0.0')).toBe(true)
+    const mirrorReads = readFileSpy.mock.calls.filter(([file]) => file === pkgMirror).length
+    expect(mirrorReads).toBe(1)
+  } finally {
+    readFileSpy.mockRestore()
+  }
 })
 
 test('prefer-offline resolution promotes the disk-loaded packument into the in-memory cache', async () => {

--- a/pnpm11/resolving/npm-resolver/test/pickVersionByVersionRange.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/pickVersionByVersionRange.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@jest/globals'
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
+import semver from 'semver'
+
+import { pickLowestVersionByVersionRange, pickVersionByVersionRange } from '../src/pickPackageFromMeta.js'
+
+// Deliberately mixes prereleases, build metadata, an unparseable entry, and a
+// version only a loose parse accepts, because the pickers select over whatever
+// keys a registry puts in `versions`.
+const VERSIONS = [
+  '0.0.1',
+  '1.0.0-alpha.1',
+  '1.0.0-beta.2',
+  '1.0.0',
+  '1.0.10',
+  '1.2.0',
+  '1.2.3+build.1',
+  '1.10.0',
+  '2.0.0-rc.1',
+  '2.0.0',
+  '3.0.0',
+  'v4.0.0',
+  'not-a-version',
+]
+
+const RANGES = [
+  '*',
+  '^1.0.0',
+  '~1.2.0',
+  '1.x',
+  '>=1.0.0 <2.0.0',
+  '1.0.0 || 3.0.0',
+  '>=1.0.0-alpha.1 <2.0.0',
+  '2.0.0-rc.1',
+  '<=1.2',
+  '4.0.0',
+  '^9.0.0',
+  'not-a-range',
+]
+
+// No `latest` tag, so the pickers can't take their dist-tag shortcut and every
+// range goes through the version scan the semver calls used to do.
+function metaWithoutLatest (versions: string[]): PackageMeta {
+  const meta: PackageMeta = {
+    name: 'pick-version',
+    'dist-tags': {},
+    versions: {},
+  }
+  for (const version of versions) {
+    meta.versions[version] = {
+      name: 'pick-version',
+      version,
+      dist: { tarball: `https://registry.npmjs.org/pick-version/-/pick-version-${version}.tgz`, shasum: '' },
+    }
+  }
+  return meta
+}
+
+test.each(RANGES)('the highest satisfying version of %s matches semver.maxSatisfying', (versionRange) => {
+  const meta = metaWithoutLatest(VERSIONS)
+  expect(pickVersionByVersionRange({ meta, versionRange })).toBe(semver.maxSatisfying(VERSIONS, versionRange, true))
+})
+
+test.each(RANGES.filter((versionRange) => versionRange !== '*'))(
+  'the lowest satisfying version of %s matches semver.minSatisfying',
+  (versionRange) => {
+    const meta = metaWithoutLatest(VERSIONS)
+    expect(pickLowestVersionByVersionRange({ meta, versionRange })).toBe(semver.minSatisfying(VERSIONS, versionRange, true))
+  }
+)
+
+test('a range satisfied by equal versions keeps the first of them, as semver does', () => {
+  // `1.2.3+build.1` and `1.2.3+build.2` compare equal (build metadata is
+  // ignored), so the winner is decided by which one is seen first.
+  const versions = ['1.2.3+build.1', '1.2.3+build.2']
+  const meta = metaWithoutLatest(versions)
+  expect(pickVersionByVersionRange({ meta, versionRange: '1.2.3' }))
+    .toBe(semver.maxSatisfying(versions, '1.2.3', true))
+  expect(pickLowestVersionByVersionRange({ meta, versionRange: '1.2.3' }))
+    .toBe(semver.minSatisfying(versions, '1.2.3', true))
+})
+
+test('a packument of only unparseable versions satisfies nothing', () => {
+  const meta = metaWithoutLatest(['not-a-version', 'also-not-a-version'])
+  expect(pickVersionByVersionRange({ meta, versionRange: '^1.0.0' })).toBeNull()
+  expect(pickLowestVersionByVersionRange({ meta, versionRange: '^1.0.0' })).toBeNull()
+})

--- a/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
@@ -8,7 +8,14 @@ import semver from 'semver'
  * versions map and parses a Date per version, so memoize per packument
  * object; the key carries the cutoff and trusted versions because a shared
  * meta cache can serve one packument to installs with different policies.
+ *
+ * A single install computes one cutoff, so one entry per packument covers
+ * it. The per-packument map is still capped: a long-lived process (store
+ * server, daemon) computes a fresh cutoff per install while a shared meta
+ * cache keeps the packument alive, which would otherwise grow the map and
+ * retain a filtered copy per install indefinitely.
  */
+const MAX_POLICIES_PER_PACKUMENT = 4
 const filteredMetaCache = new WeakMap<PackageMetadataWithTime, Map<string, PackageMetadataWithTime>>()
 
 export function filterPkgMetadataByPublishDate (
@@ -27,6 +34,10 @@ export function filterPkgMetadataByPublishDate (
   let filtered = byPolicy.get(policyKey)
   if (filtered == null) {
     filtered = filterPkgMetadataByPublishDateUncached(pkgDoc, publishedBy, trustedVersions)
+    if (byPolicy.size >= MAX_POLICIES_PER_PACKUMENT) {
+      // Map preserves insertion order, so the first key is the oldest policy.
+      byPolicy.delete(byPolicy.keys().next().value!)
+    }
     byPolicy.set(policyKey, filtered)
   }
   return filtered

--- a/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
@@ -5,19 +5,28 @@ import semver from 'semver'
 /**
  * A pick runs for every dependency edge, so the same packument is filtered
  * against the same cutoff many times per install. Filtering allocates a new
- * versions map and parses a Date per version, so memoize per packument
- * object; the key carries the cutoff and trusted versions because a shared
- * meta cache can serve one packument to installs with different policies.
+ * versions map and parses a Date per version, so the result is memoized per
+ * packument object; the key carries the cutoff and the trusted versions
+ * because a shared meta cache can serve one packument to installs with
+ * different policies.
  *
- * A single install computes one cutoff, so one entry per packument covers
- * it. The per-packument map is still capped: a long-lived process (store
- * server, daemon) computes a fresh cutoff per install while a shared meta
- * cache keeps the packument alive, which would otherwise grow the map and
- * retain a filtered copy per install indefinitely.
+ * A single install computes one cutoff, so one entry per packument covers it.
+ * The per-packument map is capped anyway: a long-lived process (store server,
+ * daemon) computes a fresh cutoff per install while a shared meta cache keeps
+ * the packument alive, which would otherwise retain a filtered copy per
+ * install indefinitely.
  */
 const MAX_POLICIES_PER_PACKUMENT = 4
 const filteredMetaCache = new WeakMap<PackageMetadataWithTime, Map<string, PackageMetadataWithTime>>()
 
+/**
+ * Returns the packument narrowed to the versions published at or before
+ * `publishedBy`, plus any `trustedVersions`, with each dist-tag moved to the
+ * best version still within date.
+ *
+ * The returned document is shared between callers and must be treated as
+ * read-only; its version manifests are the very objects held by `pkgDoc`.
+ */
 export function filterPkgMetadataByPublishDate (
   pkgDoc: PackageMetadataWithTime,
   publishedBy: Date,
@@ -48,7 +57,11 @@ function filterPkgMetadataByPublishDateUncached (
   publishedBy: Date,
   trustedVersions?: string[]
 ): PackageMetadataWithTime {
-  const versionsWithinDate: PackageMetadataWithTime['versions'] = {}
+  // Null-prototype so a registry-controlled version like `__proto__` becomes
+  // an own key instead of reassigning the map's prototype
+  // (js/prototype-polluting-assignment), and so a lookup of an inherited
+  // member name can't be mistaken for a version that is within date.
+  const versionsWithinDate: PackageMetadataWithTime['versions'] = Object.create(null)
   for (const version in pkgDoc.versions) {
     if (!Object.hasOwn(pkgDoc.versions, version)) continue
     const timeStr = pkgDoc.time[version]
@@ -57,7 +70,7 @@ function filterPkgMetadataByPublishDateUncached (
     }
   }
 
-  const distTagsWithinDate: PackageMetadataWithTime['dist-tags'] = {}
+  const distTagsWithinDate: PackageMetadataWithTime['dist-tags'] = Object.create(null)
   const allDistTags = pkgDoc['dist-tags'] ?? {}
   const parsedSemverCache = new Map<string, semver.SemVer>()
   function tryParseSemver (semverStr: string): semver.SemVer | null {
@@ -84,6 +97,7 @@ function filterPkgMetadataByPublishDateUncached (
     if (!originalSemVer) continue
     const originalIsPrerelease = (originalSemVer.prerelease.length > 0)
     let bestVersion: string | undefined
+    let bestParsed: semver.SemVer | undefined
     for (const candidate in versionsWithinDate) {
       if (!Object.hasOwn(versionsWithinDate, candidate)) continue
       const candidateParsed = tryParseSemver(candidate)
@@ -93,27 +107,23 @@ function filterPkgMetadataByPublishDateUncached (
         (tag !== 'latest' && candidateParsed.major !== originalSemVer.major) ||
         (candidateParsed.prerelease.length > 0) !== originalIsPrerelease
       ) continue
-      if (!bestVersion) {
+      if (bestVersion == null || bestParsed == null) {
         bestVersion = candidate
-      } else {
-        try {
-          const candidateIsDeprecated = pkgDoc.versions[candidate].deprecated != null
-          const bestVersionIsDeprecated = pkgDoc.versions[bestVersion].deprecated != null
-          // Compare the already-parsed instances: bestVersion always parsed
-          // successfully when it became the best candidate, and reusing the
-          // cached SemVer avoids semver.gt re-parsing both strings.
-          const bestParsed = tryParseSemver(bestVersion)
-          if (
-            bestParsed != null && (
-              (candidateParsed.compare(bestParsed) > 0 && (bestVersionIsDeprecated === candidateIsDeprecated)) ||
-              (bestVersionIsDeprecated && !candidateIsDeprecated)
-            )
-          ) {
-            bestVersion = candidate
-          }
-        } catch (_err) {
-          globalWarn(`Failed to compare semver versions ${candidate} and ${bestVersion} from packument of ${pkgDoc.name}, skipping candidate version.`)
+        bestParsed = candidateParsed
+        continue
+      }
+      try {
+        const candidateIsDeprecated = pkgDoc.versions[candidate].deprecated != null
+        const bestVersionIsDeprecated = pkgDoc.versions[bestVersion].deprecated != null
+        if (
+          (candidateParsed.compare(bestParsed) > 0 && (bestVersionIsDeprecated === candidateIsDeprecated)) ||
+          (bestVersionIsDeprecated && !candidateIsDeprecated)
+        ) {
+          bestVersion = candidate
+          bestParsed = candidateParsed
         }
+      } catch (_err) {
+        globalWarn(`Failed to compare semver versions ${candidate} and ${bestVersion} from packument of ${pkgDoc.name}, skipping candidate version.`)
       }
     }
     if (bestVersion) {

--- a/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
@@ -2,7 +2,37 @@ import { globalWarn } from '@pnpm/logger'
 import type { PackageMetadataWithTime } from '@pnpm/resolving.registry.types'
 import semver from 'semver'
 
+/**
+ * A pick runs for every dependency edge, so the same packument is filtered
+ * against the same cutoff many times per install. Filtering allocates a new
+ * versions map and parses a Date per version, so memoize per packument
+ * object; the key carries the cutoff and trusted versions because a shared
+ * meta cache can serve one packument to installs with different policies.
+ */
+const filteredMetaCache = new WeakMap<PackageMetadataWithTime, Map<string, PackageMetadataWithTime>>()
+
 export function filterPkgMetadataByPublishDate (
+  pkgDoc: PackageMetadataWithTime,
+  publishedBy: Date,
+  trustedVersions?: string[]
+): PackageMetadataWithTime {
+  let byPolicy = filteredMetaCache.get(pkgDoc)
+  if (byPolicy == null) {
+    byPolicy = new Map()
+    filteredMetaCache.set(pkgDoc, byPolicy)
+  }
+  const policyKey = trustedVersions == null
+    ? String(publishedBy.getTime())
+    : `${publishedBy.getTime()}\x00${trustedVersions.join('\x00')}`
+  let filtered = byPolicy.get(policyKey)
+  if (filtered == null) {
+    filtered = filterPkgMetadataByPublishDateUncached(pkgDoc, publishedBy, trustedVersions)
+    byPolicy.set(policyKey, filtered)
+  }
+  return filtered
+}
+
+function filterPkgMetadataByPublishDateUncached (
   pkgDoc: PackageMetadataWithTime,
   publishedBy: Date,
   trustedVersions?: string[]
@@ -58,9 +88,15 @@ export function filterPkgMetadataByPublishDate (
         try {
           const candidateIsDeprecated = pkgDoc.versions[candidate].deprecated != null
           const bestVersionIsDeprecated = pkgDoc.versions[bestVersion].deprecated != null
+          // Compare the already-parsed instances: bestVersion always parsed
+          // successfully when it became the best candidate, and reusing the
+          // cached SemVer avoids semver.gt re-parsing both strings.
+          const bestParsed = tryParseSemver(bestVersion)
           if (
-            (semver.gt(candidate, bestVersion, true) && (bestVersionIsDeprecated === candidateIsDeprecated)) ||
-            (bestVersionIsDeprecated && !candidateIsDeprecated)
+            bestParsed != null && (
+              (candidateParsed.compare(bestParsed) > 0 && (bestVersionIsDeprecated === candidateIsDeprecated)) ||
+              (bestVersionIsDeprecated && !candidateIsDeprecated)
+            )
           ) {
             bestVersion = candidate
           }

--- a/pnpm11/resolving/registry/pkg-metadata-filter/test/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/test/index.ts
@@ -139,3 +139,35 @@ test('filtering is memoized per packument and the per-packument policy cache sta
   }
   expect(filterPkgMetadataByPublishDate(doc, cutoff)).not.toBe(first)
 })
+
+test('a version or dist-tag named __proto__ stays an own key of the filtered metadata', () => {
+  // Parsed from JSON, the way a registry response is: an object literal would
+  // apply `__proto__` as the prototype instead of keeping it as a key.
+  const doc = JSON.parse(`{
+    "name": "proto-pkg",
+    "versions": {
+      "__proto__": {
+        "name": "proto-pkg",
+        "version": "1.0.0",
+        "polluted": true,
+        "dist": { "tarball": "https://registry.npmjs.org/proto-pkg/-/proto-pkg-1.0.0.tgz", "shasum": "" }
+      },
+      "1.0.0": {
+        "name": "proto-pkg",
+        "version": "1.0.0",
+        "dist": { "tarball": "https://registry.npmjs.org/proto-pkg/-/proto-pkg-1.0.0.tgz", "shasum": "" }
+      }
+    },
+    "dist-tags": { "latest": "1.0.0", "__proto__": "1.0.0" },
+    "time": { "__proto__": "2020-01-01T00:00:00.000Z", "1.0.0": "2020-01-01T00:00:00.000Z" }
+  }`)
+
+  const filtered = filterPkgMetadataByPublishDate(doc, new Date('2020-04-01T00:00:00.000Z'))
+
+  expect(Object.keys(filtered.versions)).toContain('__proto__')
+  expect(Object.keys(filtered['dist-tags'])).toContain('__proto__')
+  // Assigning `__proto__` to a plain object would have made the malicious
+  // version manifest the prototype of the map, exposing its fields as
+  // versions.
+  expect('polluted' in filtered.versions).toBe(false)
+})

--- a/pnpm11/resolving/registry/pkg-metadata-filter/test/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/test/index.ts
@@ -104,3 +104,38 @@ test('latest fallback does not exceed the original dist-tag target', () => {
   }, cutoff)
   expect(withoutSafeFallback['dist-tags'].latest).toBeUndefined()
 })
+
+test('filtering is memoized per packument and the per-packument policy cache stays bounded', () => {
+  const name = 'memoized-pkg'
+  const doc = {
+    name,
+    versions: {
+      '1.0.0': {
+        name,
+        version: '1.0.0',
+        dist: { tarball: `https://registry.npmjs.org/${name}/-/${name}-1.0.0.tgz`, shasum: '' },
+      },
+    },
+    'dist-tags': {
+      latest: '1.0.0',
+    },
+    time: {
+      '1.0.0': '2020-01-01T00:00:00.000Z',
+    },
+  }
+  const cutoff = new Date('2020-04-01T00:00:00.000Z')
+
+  const first = filterPkgMetadataByPublishDate(doc, cutoff)
+  expect(filterPkgMetadataByPublishDate(doc, cutoff)).toBe(first)
+  // The key is the cutoff's value, not the Date object's identity.
+  expect(filterPkgMetadataByPublishDate(doc, new Date(cutoff.getTime()))).toBe(first)
+  // A different cutoff gets its own slot.
+  expect(filterPkgMetadataByPublishDate(doc, new Date('2020-06-01T00:00:00.000Z'))).not.toBe(first)
+
+  // Exceeding the per-packument cap with distinct cutoffs evicts the oldest
+  // entry instead of growing forever: the original cutoff is recomputed.
+  for (let i = 1; i <= 4; i++) {
+    filterPkgMetadataByPublishDate(doc, new Date(cutoff.getTime() + i * 60_000))
+  }
+  expect(filterPkgMetadataByPublishDate(doc, cutoff)).not.toBe(first)
+})


### PR DESCRIPTION
## Summary

Dependency resolution spends a large share of its CPU time redoing identical work: with `minimumReleaseAge` on by default, `filterPkgMetadataByPublishDate` re-filters the same packument once per dependency edge instead of once per packument, and the version pickers re-parse the same semver strings and ranges thousands of times per install. CPU profiles of a full resolution of the `pnpm11/benchmarks` fixture (1246 packages, hot cache) attributed ~25% of the run to `pickPackageFromMeta`, dominated by these two costs.

This PR removes the recomputation without changing any observable behavior:

- **Memoize `filterPkgMetadataByPublishDate`** per packument object (WeakMap), keyed by cutoff date + trusted versions so a shared meta cache serving installs with different policies can't cross-contaminate. This is the dominant win (−11% alone).
- **Cache parsed `SemVer` and `Range` instances** in `pickPackageFromMeta`, and replace `semver.maxSatisfying`/`minSatisfying` (which re-parse the range and every version on every call) with cache-reusing equivalents (−4% alone).
- **Dedupe offline mirror loads**: concurrent offline picks of the same package queued behind the per-package limiter each re-read and re-parsed the mirror file (176 of 1311 loads in the fixture were duplicates); the limiter now re-checks the in-memory cache.
- **Condense packuments with a direct field loop** in `clearMeta` instead of ramda's curried `pick` (~2M field checks per install on the fixture).

Benchmarks (hyperfine, offline so runs are deterministic, fixture from `pnpm11/benchmarks`):

| Scenario | Before | After | Change |
|---|---|---|---|
| Full resolution (`install --offline --lockfile-only`, hot cache) | 4.27s ± 0.20 | 3.73s ± 0.07 | **1.14× ± 0.06 (−12.5%)** |
| Fresh install, offline, hot store (resolve + link)¹ | 5.88s ± 0.21 | 5.07s ± 0.07 | 1.16× ± 0.04 (−13.7%) |
| Frozen-lockfile restore (does not resolve) | 1.97s | 2.01s | 1.00× (no change) |

¹ measured on the pre-rebase base; the resolution-only row is measured on current `main`.

Correctness evidence: the optimized build produces a byte-identical `pnpm-lock.yaml` to `main` on the fixture; all existing `@pnpm/resolving.npm-resolver` (287) and `@pnpm/resolving.registry.pkg-metadata-filter` tests pass, including the test added in pnpm/pnpm#13044 for the `latest`-fallback bound, which exercises the memoized path.

### pacquet

The same three costs were checked against the Rust resolver. Two were already
paid off there: `cached_range` memoizes parsed ranges and `max_satisfying` /
`min_satisfying` are loops that reuse it, and `pick_package` already re-checks
the in-memory cache after acquiring the per-mirror permit and promotes the
mirror before releasing it, so concurrent offline picks already read the mirror
once.

The filter memoization was missing, so this PR adds it: the derived packument is
memoized on the document it derives from (`DerivedPackuments`, hung on
`Package`, so the derived copies die with it), keyed by cutoff plus trusted
versions, and capped at four policies so a long-lived host (the napi bindings, a
daemon) holding one shared meta cache can't retain a derived copy per install.
Offline resolution of the same fixture:

| Scenario | Before | After | Change |
|---|---|---|---|
| Full resolution (`install --offline --lockfile-only`, hot cache) | 167.6ms ± 5.0 | 161.9ms ± 4.9 | 1.04× ± 0.04 |
| — CPU time | 166.6ms | 152.0ms | −8.8% |

(hyperfine, 50 runs, lockfile removed before each run; the resulting
`pnpm-lock.yaml` is byte-identical between the two binaries.) The win is
proportional to how many packuments carry per-version `time`: 22 of 1126 on this
fresh cache, and every packument under `resolutionMode=time-based` or
`trustPolicy=no-downgrade`, which force full metadata.

Not mirrored: the version-instance cache. Rust's `Version::parse` is cheap
enough that a process-global map keyed by version string is not obviously a win,
and the expensive half of that optimization — the range parse — is already
cached in pacquet. `clearMeta` has no pacquet counterpart: version manifests
stay as unhydrated JSON fragments there, so nothing is condensed per field.

### Prototype pollution in the filtered maps

`versionsWithinDate` and `distTagsWithinDate` were plain objects populated with
registry-controlled keys, so a version or dist-tag named `__proto__` reassigned
the map's prototype instead of becoming an own key — which also let the
malicious manifest's own fields read back as versions within date. Both are now
null-prototype, matching `clearMeta`. Reported by Copilot on this PR; covered by
a test that fails on the plain-object form.

## Squash Commit Body

```text
Resolution re-derived the same data once per dependency edge instead of
once per packument:

- filterPkgMetadataByPublishDate ran on every pick (every edge) with
  minimumReleaseAge active — the default since it is 1440 min — parsing
  a Date per version and rebuilding the versions map each time. It is
  now memoized per packument object in a WeakMap, keyed by cutoff and
  trusted versions so one packument served under different policies
  still filters per policy. Sharing the returned object is safe: callers
  already shared the inner version manifests, and the packument objects
  the resolver passes in are themselves cached and treated as read-only.

- pickPackageFromMeta re-parsed version strings and ranges on every
  satisfies/maxSatisfying call. Parsed SemVer and Range instances are
  now cached in capped Maps (cleared at 50k entries so long-lived
  processes cannot grow them without bound), and maxSatisfying/
  minSatisfying are replaced with loops that reuse the caches. The
  dist-tag repopulation loop in the publish-date filter likewise
  compares already-parsed instances instead of calling semver.gt on
  strings.

- Concurrent offline picks of one package all miss the pre-queue
  in-memory cache check, then each re-read and re-parsed the mirror
  behind the per-package limiter (176 of 1311 loads on the benchmark
  fixture were duplicates). The limiter callback now re-checks the
  cache; offline entries are always disk-sourced, so this is equivalent
  to arriving after the first caller cached it.

- clearMeta condensed every version object through ramda's curried
  pick; a direct field loop does the same with no per-field dispatch.
  The presence check via undefined-comparison matches the previous
  behavior because version objects come from JSON, which cannot encode
  undefined.

Resolution of the 1246-package benchmark fixture is 12.5% faster on
top of current main (4.27s -> 3.73s, hyperfine, offline hot cache);
the resulting lockfile is byte-identical. Attribution: filter
memoization -11%, semver caches -4%, the rest ~-1%.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(The filter
  memoization is now in both stacks; the other items were already in pacquet or
  don't apply there — see the pacquet section.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(A regression test for simultaneous offline picks
  — one mirror read for N concurrent picks, fails on the pre-fix code — and a
  test of the filter memoization contract incl. bounded per-packument policy
  cache.)*

---
Written by an agent (Claude Code, claude-fable-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved dependency resolution with minimum release age by filtering package metadata once per packument.
  - Reduced repeated semantic version parsing and comparisons through bounded caching.
  - Improved dist-tag best-version selection by reusing parsed versions.
- **Bug Fixes**
  - Prevented a race during offline or preferred-offline resolution, ensuring metadata is cached consistently.
- **Tests**
  - Added coverage for offline concurrency, version selection, and publish-date filtering memoization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
