### PR TITLE
fix(scripts): accept the leading -- forwarded by pnpm run bump

### DIFF
--- a/pnpm11/__utils__/scripts/src/bump.ts
+++ b/pnpm11/__utils__/scripts/src/bump.ts
@@ -53,7 +53,10 @@ function main (): void {
 
 export function parseSelectedProducts (argv: readonly string[]): Set<Product> {
   const selected = new Set<Product>()
-  for (let i = 0; i < argv.length; i++) {
+  // `pnpm run bump -- --release …` forwards the `--` separator to the script,
+  // so a single leading `--` is part of the normal calling convention.
+  const start = argv[0] === '--' ? 1 : 0
+  for (let i = start; i < argv.length; i++) {
     // Fail closed: an unrecognized token (e.g. a `--releases` typo) must not be
     // silently skipped, which would leave the selection empty and release
     // every product. Only "--release <product>" is accepted; no args at all

--- a/pnpm11/__utils__/scripts/test/bump.ts
+++ b/pnpm11/__utils__/scripts/test/bump.ts
@@ -35,6 +35,16 @@ describe('parseSelectedProducts', () => {
     expect(parseSelectedProducts([])).toEqual(new Set())
   })
 
+  test('skips the leading `--` separator forwarded by `pnpm run bump -- …`', () => {
+    expect(parseSelectedProducts(['--', '--release', 'pnpm', '--release', 'pnpr']))
+      .toEqual(new Set(['pnpm', 'pnpr']))
+    expect(parseSelectedProducts(['--'])).toEqual(new Set())
+  })
+
+  test('rejects a `--` that is not in the leading position', () => {
+    expect(() => parseSelectedProducts(['--release', 'pnpm', '--'])).toThrow(/Unexpected bump argument/)
+  })
+
   test('throws on an unknown product', () => {
     expect(() => parseSelectedProducts(['--release', 'bogus'])).toThrow(/Unknown --release product/)
   })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

The create-release-pr workflow failed in [run 30568952176](https://github.com/pnpm/pnpm/actions/runs/30568952176/job/90960451217) with `Unexpected bump argument: --`. The workflow invokes `pnpm run bump -- --release <product>…`, and `pnpm run` (both stacks, identically) forwards everything after the script name to the script verbatim — including the `--` separator itself. The fail-closed parser in `bump.ts` rejected that literal `--`.

This PR makes `parseSelectedProducts` skip a single leading `--`, since it is part of the normal `pnpm run bump -- …` calling convention. A `--` in any other position, and any other unrecognized token, still fails closed, so the misspelled-flag protection (which is the reason the parser is strict) is unchanged.

## Squash Commit Body

```text
pnpm run forwards everything after the script name to the script verbatim,
including the -- separator itself, so the create-release-pr workflow's
`pnpm run bump -- --release <product>` invocations delivered a literal --
as the first argument and the fail-closed parser rejected it. This slipped
through because `node -e '…' -- args` consumes the -- itself, while
`node script.ts -- args` passes it into process.argv.

parseSelectedProducts now skips a single leading --; a -- in any other
position, and any other unrecognized token, still fails closed.
```

## Checklist

- [x] Added or updated tests.

(No changeset: `@pnpm/scripts` is a private, unpublished package. Not applicable to the Rust port: this is a repo release-tooling script.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788027239&installation_model_id=426870&pr_number=13507&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13507&signature=60c3da525877ef3a51994345293bd2c8723d6c1b0c14e1282e3c85b676d41c8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line argument handling when using a forwarded `--` separator.
  * Prevented the separator from being incorrectly interpreted as a release selector.
  * Invalid separator placement continues to produce a clear error.

* **Tests**
  * Added coverage for valid and invalid `--` separator usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->