### PR TITLE
ci: let update-lockfile self-update pnpm to same-day releases

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -44,12 +44,17 @@ jobs:
         install: false
 
     - name: Update dependencies, Node.js, pnpm, and GitHub Actions
-      uses: pnpm/update@76f98d727df25f56f9bbd38e60ad663fd785d3d4 #v0.0.0  v0
+      uses: pnpm/update@9a256174a439f3447aa0a6b9ca3c971428b1d617 #v0.0.0  v0
       with:
         update-deps: latest
         refresh-lockfile: true
         github-actions: true
         update-pnpm: next-12
+        # Follow next-12 as soon as a release is published: pnpm 12's default
+        # 24-hour minimumReleaseAge would otherwise hold a same-day release
+        # back from self-update (the repo's minimumReleaseAgeExclude is
+        # deliberately ignored there).
+        update-pnpm-minimum-release-age: 0
         post-update: pnpm update-manifests
         branch: chore/update-lockfile
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}


### PR DESCRIPTION
## Summary

The update-lockfile workflow could never bump the pnpm pin to a release published the same day: pnpm 12 defaults `minimumReleaseAge` to 24 hours, and `pnpm self-update` deliberately ignores the repository's `minimumReleaseAgeExclude` (repo config must not decide whether the binary may be replaced), so with no user-level config on CI the `next-12` dist-tag silently resolved to the newest *mature* release. This is why three runs after publishing `pnpm@12.0.0-beta.1` (e.g. [run 30571699202](https://github.com/pnpm/pnpm/actions/runs/30571699202)) all reported "already set to use pnpm v12.0.0-beta.0".

This bumps the pinned `pnpm/update` action to the release that adds the `update-pnpm-minimum-release-age` input ([pnpm/update#3](https://github.com/pnpm/update/pull/3)) and sets it to `0`, which exports `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` for the self-update step only — env-level policy is the sanctioned override channel for self-update. The dependency-update pass keeps the repository's own release-age settings.

## Squash Commit Body

```text
Bump pnpm/update to the release that adds the
update-pnpm-minimum-release-age input (pnpm/update#3), and set it to 0.
pnpm 12 defaults minimumReleaseAge to 24 hours and self-update
deliberately ignores the repo's minimumReleaseAgeExclude, so the job
could never bump the pin to a pnpm release published the same day: the
next-12 dist-tag silently resolved to the newest mature version
instead. The 0 override is scoped to the self-update step; the
dependency update keeps the repo's own release-age settings.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. (Workflow-only change; no product code touched.)
- [x] Added or updated tests. (Covered by bats tests in pnpm/update; no testable code in this repo changed.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788030975&installation_model_id=426870&pr_number=13509&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13509&signature=bb76dfaea0c8ad50fd2fb6d9804ce70313f2120b63b765090ebef34a5e03f1d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated lockfile maintenance workflow to use a pinned action revision.
  * Adjusted pnpm self-update eligibility settings for the automated updater.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->