### PR TITLE
fix(deps-resolver): don't download unsupported-platform optional deps on fresh install

### DIFF
--- a/.changeset/optional-platform-prefetch.md
+++ b/.changeset/optional-platform-prefetch.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fresh installs no longer download the tarballs of platform-specific optional dependencies that don't match the current platform. Registry manifests list such packages in both `dependencies` and `optionalDependencies` (npm merges the two at publish time), and the resolver followed the duplicate as a non-optional dependency, bypassing the platform check that skips the download.
+Fresh installs no longer download the tarballs of platform-specific optional dependencies that don't match the current platform.

--- a/.changeset/optional-platform-prefetch.md
+++ b/.changeset/optional-platform-prefetch.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fresh installs no longer download the tarballs of platform-specific optional dependencies that don't match the current platform. Registry manifests list such packages in both `dependencies` and `optionalDependencies` (npm merges the two at publish time), and the resolver followed the duplicate as a non-optional dependency, bypassing the platform check that skips the download.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -3753,16 +3753,10 @@ fn render_specifier(wanted: &WantedDependency) -> String {
 /// `current_is_optional` so [`ResolvedPackage::optional`] reflects
 /// whether every path to the node went through an optional edge.
 ///
-/// A name listed in both maps yields **one** optional edge with the
-/// `dependencies` range: npm merges `optionalDependencies` into
-/// `dependencies` at publish time, so registry manifests routinely list
-/// the same name in both. This mirrors the TS resolver's
-/// `{...optionalDependencies, ...dependencies}` merge with the optional
-/// flag taken from `optionalDependencies` membership
-/// (`getNonDevWantedDependencies`). A second non-optional edge for the
-/// same name would defeat every optional-edge gate downstream — most
-/// visibly the platform gate that stops the tarball prefetch of
-/// unsupported-platform optional dependencies.
+/// A name listed in both maps yields one optional edge with the
+/// `dependencies` range — npm merges `optionalDependencies` into
+/// `dependencies` at publish time, so registry manifests routinely
+/// list the same name in both.
 ///
 /// Names the manifest bundles are dropped: npm ships them inside the
 /// package's own tarball, so resolving them again would install a

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -3748,11 +3748,21 @@ fn render_specifier(wanted: &WantedDependency) -> String {
 /// (via [`extract_peer_dependencies`]) so the peer-resolution stage
 /// can compute the correct depPath suffix once everything is walked.
 ///
-/// Each entry carries an `optional` flag describing which manifest
-/// group it came from — `false` for `dependencies`, `true` for
-/// `optionalDependencies`. The walker propagates this through
+/// Each entry carries an `optional` flag — `true` when the name appears
+/// in `optionalDependencies`. The walker propagates this through
 /// `current_is_optional` so [`ResolvedPackage::optional`] reflects
 /// whether every path to the node went through an optional edge.
+///
+/// A name listed in both maps yields **one** optional edge with the
+/// `dependencies` range: npm merges `optionalDependencies` into
+/// `dependencies` at publish time, so registry manifests routinely list
+/// the same name in both. This mirrors the TS resolver's
+/// `{...optionalDependencies, ...dependencies}` merge with the optional
+/// flag taken from `optionalDependencies` membership
+/// (`getNonDevWantedDependencies`). A second non-optional edge for the
+/// same name would defeat every optional-edge gate downstream — most
+/// visibly the platform gate that stops the tarball prefetch of
+/// unsupported-platform optional dependencies.
 ///
 /// Names the manifest bundles are dropped: npm ships them inside the
 /// package's own tarball, so resolving them again would install a
@@ -3765,7 +3775,16 @@ fn extract_children(
     let bundled = bundled_dependency_names(manifest);
     let mut out = Vec::new();
     collect_deps(manifest, "dependencies", false, &parent, &bundled, &mut out)?;
-    collect_deps(manifest, "optionalDependencies", true, &parent, &bundled, &mut out)?;
+    let mut optional = Vec::new();
+    collect_deps(manifest, "optionalDependencies", true, &parent, &bundled, &mut optional)?;
+    let dependency_positions: HashMap<String, usize> =
+        out.iter().enumerate().map(|(index, (name, ..))| (name.clone(), index)).collect();
+    for spec in optional {
+        match dependency_positions.get(&spec.0) {
+            Some(&index) => out[index].2 = true,
+            None => out.push(spec),
+        }
+    }
     for (name, specifier) in engines_runtime_dependencies(manifest, "engines", "dependencies") {
         out.push((name.to_string(), specifier, false));
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -3771,12 +3771,14 @@ fn extract_children(
     collect_deps(manifest, "dependencies", false, &parent, &bundled, &mut out)?;
     let mut optional = Vec::new();
     collect_deps(manifest, "optionalDependencies", true, &parent, &bundled, &mut optional)?;
-    let dependency_positions: HashMap<String, usize> =
-        out.iter().enumerate().map(|(index, (name, ..))| (name.clone(), index)).collect();
-    for spec in optional {
-        match dependency_positions.get(&spec.0) {
-            Some(&index) => out[index].2 = true,
-            None => out.push(spec),
+    if !optional.is_empty() {
+        let dependency_positions: HashMap<String, usize> =
+            out.iter().enumerate().map(|(index, (name, ..))| (name.clone(), index)).collect();
+        for spec in optional {
+            match dependency_positions.get(&spec.0) {
+                Some(&index) => out[index].2 = true,
+                None => out.push(spec),
+            }
         }
     }
     for (name, specifier) in engines_runtime_dependencies(manifest, "engines", "dependencies") {

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -2711,6 +2711,61 @@ mod optional_propagation {
             "child reached only via a parent's optionalDependencies edge is optional",
         );
     }
+
+    /// npm merges `optionalDependencies` into `dependencies` at publish
+    /// time, so a registry manifest lists the same child in both maps.
+    #[tokio::test]
+    async fn dep_listed_in_both_manifest_groups_yields_one_optional_edge() {
+        let mut table = HashMap::default();
+        table.insert(
+            ("regular".to_string(), "^1.0.0".to_string()),
+            fake_result(
+                "regular",
+                "1.0.0",
+                serde_json::json!({
+                    "name": "regular",
+                    "version": "1.0.0",
+                    "dependencies": { "plat": "1.0.0" },
+                    "optionalDependencies": { "plat": "1.0.0" }
+                }),
+            ),
+        );
+        table.insert(
+            ("plat".to_string(), "1.0.0".to_string()),
+            fake_result("plat", "1.0.0", serde_json::json!({ "name": "plat", "version": "1.0.0" })),
+        );
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) =
+            manifest_with_groups(serde_json::json!({ "regular": "^1.0.0" }), serde_json::json!({}));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod, DependencyGroup::Optional],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions::default(),
+                patched_dependencies: None,
+                manifest_hook: None,
+                overrides_hook: None,
+                pnpmfile_hook: None,
+                read_package_log: None,
+                auto_install_peers: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            tree.packages.get("plat@1.0.0").expect("plat resolved").optional,
+            "the merged edge carries optional: true",
+        );
+        let plat_calls =
+            resolver.calls.lock().unwrap().iter().filter(|(alias, _)| alias == "plat").count();
+        assert_eq!(
+            plat_calls, 1,
+            "one merged edge resolves once; a duplicate non-optional edge would resolve again and defeat the optional-edge gates (e.g. the unsupported-platform prefetch skip)",
+        );
+    }
 }
 
 mod importer_wanted_specs {

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -2725,13 +2725,16 @@ mod optional_propagation {
                 serde_json::json!({
                     "name": "regular",
                     "version": "1.0.0",
-                    "dependencies": { "plat": "1.0.0" },
-                    "optionalDependencies": { "plat": "1.0.0" }
+                    "dependencies": { "plat": "^1.0.0" },
+                    "optionalDependencies": { "plat": "^2.0.0" }
                 }),
             ),
         );
+        // Only the `dependencies` range resolves: a merge that kept the
+        // `optionalDependencies` range would miss the table and drop the
+        // edge as an optional resolution failure.
         table.insert(
-            ("plat".to_string(), "1.0.0".to_string()),
+            ("plat".to_string(), "^1.0.0".to_string()),
             fake_result("plat", "1.0.0", serde_json::json!({ "name": "plat", "version": "1.0.0" })),
         );
         let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };


### PR DESCRIPTION
## Summary

On a fresh (no-lockfile) install, pacquet downloaded the tarballs of **every** platform-specific optional dependency — e.g. all seven `@typescript/native-preview-*` packages on a `linux-x64` host — instead of only the one matching the current platform.

Root cause: the npm registry merges `optionalDependencies` into `dependencies` at publish time, so a registry manifest lists each platform package in *both* maps. `extract_children` in the deps resolver collected the two maps without deduplicating, producing two resolve edges per platform package: one optional and one non-optional. The non-optional edge bypassed `PrefetchingResolver::should_skip_prefetch`'s platform gate (which only applies to `optional: true` edges), so the tarball prefetch fired for every platform variant. The resulting lockfile was still correct (the lockfile writer dedupes downstream), so the damage was limited to wasted bandwidth and store writes on fresh resolves.

The fix mirrors the TypeScript resolver's `{...optionalDependencies, ...dependencies}` merge in `getNonDevWantedDependencies`: a name listed in both maps now yields one edge with the `dependencies` range, flagged optional. The TypeScript CLI is unaffected (its object merge already collapses the duplicate), verified by byte-identical lockfiles between the two stacks on the repro; this is a Rust-only fix and the changeset targets `pacquet` only.

## Squash Commit Body

```text
On a fresh install, extract_children collected a resolved package's
dependencies and optionalDependencies without deduplicating. npm merges
optionalDependencies into dependencies at publish time, so registry
manifests list every platform-specific optional dependency in both maps,
and each got two resolve edges: one optional, one non-optional. The
non-optional edge bypassed the platform gate in
PrefetchingResolver::should_skip_prefetch (it only applies to optional
edges), so fresh installs prefetched the tarball of every platform
variant, e.g. all seven `@typescript/native-preview-*` packages on a
linux-x64 host. The lockfile came out correct regardless; only the
downloads were wasted.

Fold the duplicate into one optional edge keeping the dependencies
range, mirroring the TypeScript resolver's
{...optionalDependencies, ...dependencies} merge in
getNonDevWantedDependencies. The TypeScript CLI is unaffected: its
object-spread merge already collapses the duplicate key, confirmed by
byte-identical lockfiles between the two stacks on the repro.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only bug; the TypeScript CLI already dedupes via object merge.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788033279&installation_model_id=426870&pr_number=13510&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13510&signature=d256bf516024b751f6c841db866814cec3714fa7c8bbc6bc4887a8539b85f73f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fresh installs downloading optional packages that aren’t compatible with the current platform.
  * When the same package is declared in both standard and optional dependency sections, it now produces a single optional resolution (and avoids duplicate resolution).
* **Tests**
  * Added coverage to verify merged dependency declarations yield one optional edge and that resolution runs only once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->