### PR TITLE
perf(resolver): adopt the indexed pnpm-meta-v1 metadata mirror with lazy version hydration

### DIFF
--- a/.changeset/indexed-metadata-mirror.md
+++ b/.changeset/indexed-metadata-mirror.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/resolving.npm-resolver": minor
+"@pnpm/resolving.registry.pkg-metadata-filter": patch
+"pnpm": minor
+---
+
+Resolution reads far less registry metadata from the cache: the on-disk metadata mirror now uses the indexed layout the Rust CLI already writes (`pacquet-meta-v1`), so loading a packument parses only a small index and the manifests of the versions an install actually picks, instead of every version of every package. Mirrors written by older pnpm versions are still read, and mirrors written by either CLI flavor are now shared instead of being treated as cache misses. Resolving a 1246-package fixture from a warm cache got about 16% faster from this change alone.

--- a/.changeset/indexed-metadata-mirror.md
+++ b/.changeset/indexed-metadata-mirror.md
@@ -4,4 +4,4 @@
 "pnpm": minor
 ---
 
-Resolution reads far less registry metadata from the cache: the on-disk metadata mirror now uses the indexed layout the Rust CLI already writes (`pacquet-meta-v1`), so loading a packument parses only a small index and the manifests of the versions an install actually picks, instead of every version of every package. Mirrors written by older pnpm versions are still read, and mirrors written by either CLI flavor are now shared instead of being treated as cache misses. Resolving a 1246-package fixture from a warm cache got about 16% faster from this change alone.
+Dependency resolution loads cached registry metadata faster: the on-disk metadata cache now uses the same indexed layout as the Rust-based pnpm CLI, and caches written by either CLI flavor are shared instead of refetched. Caches written by older pnpm versions are still read.

--- a/.changeset/indexed-metadata-mirror.md
+++ b/.changeset/indexed-metadata-mirror.md
@@ -1,7 +1,7 @@
 ---
-"@pnpm/resolving.npm-resolver": minor
+"@pnpm/resolving.npm-resolver": patch
 "@pnpm/resolving.registry.pkg-metadata-filter": patch
-"pnpm": minor
+"pnpm": patch
 ---
 
 Dependency resolution loads cached registry metadata faster: the on-disk metadata cache now uses the same indexed layout as the Rust-based pnpm CLI, and caches written by either CLI flavor are shared instead of refetched. Caches written by older pnpm versions are still read.

--- a/.changeset/indexed-metadata-mirror.md
+++ b/.changeset/indexed-metadata-mirror.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/resolving.npm-resolver": patch
+"@pnpm/resolving.registry.pkg-metadata-filter": patch
+"@pnpm/constants": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Dependency resolution loads cached registry metadata faster: the on-disk metadata cache now uses an indexed layout that both the TypeScript and the Rust-based pnpm CLI read and write, so a cache written by either one is shared instead of refetched. The cache moved to `<cache-dir>/v12/`, because the format is not backwards compatible — the first install re-downloads metadata, and the old `v11` directory can be reclaimed with `pnpm store prune`. A cache entry that turns out to be damaged is refetched instead of being resolved from, and reports a clear error when `--offline` leaves nothing to refetch from.

--- a/.changeset/indexed-metadata-mirror.md
+++ b/.changeset/indexed-metadata-mirror.md
@@ -1,7 +1,8 @@
 ---
 "@pnpm/resolving.npm-resolver": patch
 "@pnpm/resolving.registry.pkg-metadata-filter": patch
+"pacquet": patch
 "pnpm": patch
 ---
 
-Dependency resolution loads cached registry metadata faster: the on-disk metadata cache now uses the same indexed layout as the Rust-based pnpm CLI, and caches written by either CLI flavor are shared instead of refetched. Caches written by older pnpm versions are still read.
+Dependency resolution loads cached registry metadata faster: the on-disk metadata cache now uses the same indexed layout as the Rust-based pnpm CLI, and caches written by either CLI flavor are shared instead of refetched. Caches written by older pnpm versions are still read. A cache entry that turns out to be damaged is now refetched instead of being resolved from, and reports a clear error when `--offline` leaves nothing to refetch from.

--- a/.changeset/indexed-metadata-mirror.md
+++ b/.changeset/indexed-metadata-mirror.md
@@ -1,8 +1,9 @@
 ---
 "@pnpm/resolving.npm-resolver": patch
 "@pnpm/resolving.registry.pkg-metadata-filter": patch
+"@pnpm/constants": patch
 "pacquet": patch
 "pnpm": patch
 ---
 
-Dependency resolution loads cached registry metadata faster: the on-disk metadata cache now uses the same indexed layout as the Rust-based pnpm CLI, and caches written by either CLI flavor are shared instead of refetched. Caches written by older pnpm versions are still read. A cache entry that turns out to be damaged is now refetched instead of being resolved from, and reports a clear error when `--offline` leaves nothing to refetch from.
+Dependency resolution loads cached registry metadata faster: the on-disk metadata cache now uses an indexed layout that both the TypeScript and the Rust-based pnpm CLI read and write, so a cache written by either one is shared instead of refetched. The cache moved to `<cache-dir>/v12/`, because the format is not backwards compatible — the first install re-downloads metadata, and the old `v11` directory can be reclaimed with `pnpm store prune`. A cache entry that turns out to be damaged is refetched instead of being resolved from, and reports a clear error when `--offline` leaves nothing to refetch from.

--- a/pnpm/crates/cli/src/cli_args/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/cache.rs
@@ -212,11 +212,17 @@ impl CacheCommand {
 
                     let mut cached_versions = Vec::new();
                     let mut non_cached_versions = Vec::new();
+                    // A fragment the index vouched for that no longer parses
+                    // means a damaged file, which the resolver refuses to
+                    // read at all — listing the versions around it would
+                    // report a cache that no install will use.
+                    let mut damaged = false;
 
                     for (version, json_frag) in meta_object.versions.fragments() {
                         let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&json_frag)
                         else {
-                            continue;
+                            damaged = true;
+                            break;
                         };
                         let Some(integrity) = manifest
                             .get("dist")
@@ -238,6 +244,9 @@ impl CacheCommand {
                         } else {
                             non_cached_versions.push(version.clone());
                         }
+                    }
+                    if damaged {
+                        continue;
                     }
 
                     // The output groups versions per registry. The registry

--- a/pnpm/crates/cli/src/cli_args/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/cache.rs
@@ -195,11 +195,17 @@ impl CacheCommand {
 
                     let mut cached_versions = Vec::new();
                     let mut non_cached_versions = Vec::new();
+                    // A fragment the index vouched for that no longer parses
+                    // means a damaged file, which the resolver refuses to
+                    // read at all — listing the versions around it would
+                    // report a cache that no install will use.
+                    let mut damaged = false;
 
                     for (version, json_frag) in meta_object.versions.fragments() {
                         let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&json_frag)
                         else {
-                            continue;
+                            damaged = true;
+                            break;
                         };
                         let Some(integrity) = manifest
                             .get("dist")
@@ -221,6 +227,9 @@ impl CacheCommand {
                         } else {
                             non_cached_versions.push(version.clone());
                         }
+                    }
+                    if damaged {
+                        continue;
                     }
 
                     // The output groups versions per registry. The registry

--- a/pnpm/crates/cli/tests/cache.rs
+++ b/pnpm/crates/cli/tests/cache.rs
@@ -190,6 +190,58 @@ fn should_view_package_cache() {
     assert!(info.get("cachedAt").is_some());
 }
 
+/// A damaged file is what the resolver refuses to read, so `cache view`
+/// must not report the versions around the damage as cached.
+#[test]
+fn should_omit_a_package_whose_cache_file_is_damaged() {
+    let cwd = CommandTempCwd::init().add_mocked_registry();
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let url_str = cwd.npmrc_info.mock_instance.url();
+    let registry_name =
+        pacquet_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
+    fs::create_dir_all(cache_dir.join(&registry_name)).unwrap();
+
+    let meta: pacquet_registry::Package = serde_json::from_str(
+        r#"{
+            "name": "is-positive",
+            "dist-tags": {"latest": "1.0.0"},
+            "versions": {
+                "1.0.0": {
+                    "name": "is-positive",
+                    "version": "1.0.0",
+                    "dist": {"integrity": "sha512-BBBBBBBBBBBB", "tarball": "https://r/is-positive-1.0.0.tgz"}
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+    let mirror = cache_dir.join(&registry_name).join("is-positive.jsonl");
+    pacquet_resolving_npm_resolver::mirror::save_meta_indexed(&mirror, &meta, None).unwrap();
+
+    // An unescaped quote inside the integrity string: the same number of
+    // bytes, so the index spans still address this fragment, but its own
+    // bytes no longer parse.
+    let mut bytes = fs::read(&mirror).unwrap();
+    let marker = b"sha512-BBBB";
+    let at = bytes.windows(marker.len()).position(|window| window == marker).unwrap();
+    bytes[at + 3] = b'"';
+    fs::write(&mirror, &bytes).unwrap();
+
+    let output = cwd
+        .pacquet
+        .with_args(["cache", "view", "is-positive"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let key = registry_name.replace('+', ":");
+    assert!(json.get(&key).is_none(), "damaged cache file should be omitted, got {stdout}");
+}
+
 #[test]
 fn import_populates_metadata_cache() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/cache.rs
+++ b/pnpm/crates/cli/tests/cache.rs
@@ -7,7 +7,7 @@ use std::fs;
 fn should_list_registries() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
 
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     fs::create_dir_all(cache_dir.join("registry.npmjs.org")).unwrap();
     fs::create_dir_all(cache_dir.join("registry.yarnpkg.com")).unwrap();
 
@@ -30,7 +30,7 @@ fn should_list_registries() {
 fn should_list_packages() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
 
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name =
         pacquet_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
@@ -57,7 +57,7 @@ fn should_list_packages() {
 fn should_list_only_files_not_directories() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
 
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name =
         pacquet_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
@@ -92,7 +92,7 @@ fn should_list_only_files_not_directories() {
 fn should_delete_packages() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
 
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name =
         pacquet_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
@@ -149,7 +149,7 @@ fn should_delete_packages_from_all_metadata_dirs() {
 #[test]
 fn should_view_package_cache() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name =
         pacquet_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
@@ -195,7 +195,7 @@ fn should_view_package_cache() {
 #[test]
 fn should_omit_a_package_whose_cache_file_is_damaged() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name =
         pacquet_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
@@ -264,7 +264,7 @@ fn import_populates_metadata_cache() {
 
     let registry_name =
         pacquet_resolving_npm_resolver::mirror::get_registry_name(&mock_instance.url()).unwrap();
-    let cache_metadata_dir = cache_dir.join("v11").join("metadata").join(&registry_name);
+    let cache_metadata_dir = cache_dir.join("v12").join("metadata").join(&registry_name);
 
     assert!(cache_metadata_dir.exists(), "metadata cache directory must exist");
     assert!(

--- a/pnpm/crates/cli/tests/suite/cache.rs
+++ b/pnpm/crates/cli/tests/suite/cache.rs
@@ -10,7 +10,7 @@ use std::{
 fn should_list_registries() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
 
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     fs::create_dir_all(cache_dir.join("registry.npmjs.org")).unwrap();
     fs::create_dir_all(cache_dir.join("registry.yarnpkg.com")).unwrap();
 
@@ -33,7 +33,7 @@ fn should_list_registries() {
 fn should_list_packages() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
 
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name = pnpm_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
     fs::create_dir_all(cache_dir.join(&registry_name)).unwrap();
@@ -59,7 +59,7 @@ fn should_list_packages() {
 fn should_list_only_files_not_directories() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
 
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name = pnpm_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
     fs::create_dir_all(cache_dir.join(&registry_name)).unwrap();
@@ -93,7 +93,7 @@ fn should_list_only_files_not_directories() {
 fn should_delete_packages() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
 
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name = pnpm_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
     fs::create_dir_all(cache_dir.join(&registry_name)).unwrap();
@@ -148,7 +148,7 @@ fn should_delete_packages_from_all_metadata_dirs() {
 #[test]
 fn should_view_package_cache() {
     let cwd = CommandTempCwd::init().add_mocked_registry();
-    let cache_dir = cwd.npmrc_info.cache_dir.join("v11").join("metadata");
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
     let url_str = cwd.npmrc_info.mock_instance.url();
     let registry_name = pnpm_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
     fs::create_dir_all(cache_dir.join(&registry_name)).unwrap();
@@ -188,6 +188,57 @@ fn should_view_package_cache() {
     assert!(info.get("cachedAt").is_some());
 }
 
+/// A damaged file is what the resolver refuses to read, so `cache view`
+/// must not report the versions around the damage as cached.
+#[test]
+fn should_omit_a_package_whose_cache_file_is_damaged() {
+    let cwd = CommandTempCwd::init().add_mocked_registry();
+    let cache_dir = cwd.npmrc_info.cache_dir.join("v12").join("metadata");
+    let url_str = cwd.npmrc_info.mock_instance.url();
+    let registry_name = pnpm_resolving_npm_resolver::mirror::get_registry_name(&url_str).unwrap();
+    fs::create_dir_all(cache_dir.join(&registry_name)).unwrap();
+
+    let meta: pnpm_registry::Package = serde_json::from_str(
+        r#"{
+            "name": "is-positive",
+            "dist-tags": {"latest": "1.0.0"},
+            "versions": {
+                "1.0.0": {
+                    "name": "is-positive",
+                    "version": "1.0.0",
+                    "dist": {"integrity": "sha512-BBBBBBBBBBBB", "tarball": "https://r/is-positive-1.0.0.tgz"}
+                }
+            }
+        }"#,
+    )
+    .unwrap();
+    let mirror = cache_dir.join(&registry_name).join("is-positive.jsonl");
+    pnpm_resolving_npm_resolver::mirror::save_meta_indexed(&mirror, &meta, None).unwrap();
+
+    // An unescaped quote inside the integrity string: the same number of
+    // bytes, so the index spans still address this fragment, but its own
+    // bytes no longer parse.
+    let mut bytes = fs::read(&mirror).unwrap();
+    let marker = b"sha512-BBBB";
+    let at = bytes.windows(marker.len()).position(|window| window == marker).unwrap();
+    bytes[at + 3] = b'"';
+    fs::write(&mirror, &bytes).unwrap();
+
+    let output = cwd
+        .pacquet
+        .with_args(["cache", "view", "is-positive"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout = String::from_utf8(output).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let key = registry_name.replace('+', ":");
+    assert!(json.get(&key).is_none(), "damaged cache file should be omitted, got {stdout}");
+}
+
 #[test]
 fn import_populates_metadata_cache() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -210,7 +261,7 @@ fn import_populates_metadata_cache() {
 
     let registry_name =
         pnpm_resolving_npm_resolver::mirror::get_registry_name(&mock_instance.url()).unwrap();
-    let cache_metadata_dir = cache_dir.join("v11").join("metadata").join(&registry_name);
+    let cache_metadata_dir = cache_dir.join("v12").join("metadata").join(&registry_name);
 
     assert!(cache_metadata_dir.exists(), "metadata cache directory must exist");
     assert!(

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -10,15 +10,26 @@
 //! for the typed form, and the hydrated manifest is cached per slot so
 //! repeated lookups parse once.
 //!
-//! A fragment that fails to decode behaves as if the version were
-//! absent from the packument (with a `tracing::warn`), mirroring the
-//! tolerance of JavaScript package managers, which never validate
-//! version entries they don't pick.
+//! A registry-served fragment that fails to decode behaves as if the
+//! version were absent from the packument (with a `tracing::warn`),
+//! mirroring the tolerance of JavaScript package managers, which never
+//! validate version entries they don't pick. A fragment read out of an
+//! indexed on-disk mirror is different: the index vouched for the span,
+//! so a decode failure means the local file is damaged rather than that
+//! the version is missing. Those are recorded in
+//! [`PackageVersions::has_corrupt_mirror_fragment`], which the resolver
+//! reads to treat the whole mirror as unreadable — silently resolving a
+//! different version off damaged local data would be worse than the
+//! refetch, and the etag lives in the intact headers record, so nothing
+//! else would ever repair the file.
 
 use std::{
     borrow::Cow,
     collections::HashMap,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -38,6 +49,9 @@ struct DeprecatedProbe {
 #[derive(Debug, Default, Clone)]
 pub struct PackageVersions {
     slots: HashMap<String, VersionSlot>,
+    /// Shared with every clone and filtered view, so corruption stays
+    /// visible through whichever handle the resolver ends up holding.
+    corrupt_mirror_fragment: Arc<AtomicBool>,
 }
 
 #[derive(Debug)]
@@ -92,6 +106,13 @@ impl FragmentSource {
             FragmentSource::None => None,
         }
     }
+
+    /// Whether the fragment comes from an indexed on-disk mirror,
+    /// where a decode failure means a damaged file rather than a
+    /// version the registry served badly.
+    fn is_mirror_span(&self) -> bool {
+        matches!(self, FragmentSource::BufferSpan { .. })
+    }
 }
 
 impl Clone for VersionSlot {
@@ -114,10 +135,17 @@ impl VersionSlot {
         }
     }
 
-    fn hydrate(&self, version: &str) -> Option<Arc<PackageVersion>> {
+    fn hydrate(
+        &self,
+        version: &str,
+        corrupt_mirror_fragment: &AtomicBool,
+    ) -> Option<Arc<PackageVersion>> {
         self.parsed
             .get_or_init(|| {
-                let json = self.source.json()?;
+                let Some(json) = self.source.json() else {
+                    self.report_undecodable(version, corrupt_mirror_fragment);
+                    return None;
+                };
                 match serde_json::from_str::<PackageVersion>(&json) {
                     Ok(parsed) => Some(Arc::new(parsed)),
                     Err(error) => {
@@ -127,11 +155,24 @@ impl VersionSlot {
                             version,
                             "skipping registry version with an undecodable manifest",
                         );
+                        self.report_undecodable(version, corrupt_mirror_fragment);
                         None
                     }
                 }
             })
             .clone()
+    }
+
+    fn report_undecodable(&self, version: &str, corrupt_mirror_fragment: &AtomicBool) {
+        if !self.source.is_mirror_span() {
+            return;
+        }
+        tracing::debug!(
+            target: "pacquet_registry",
+            version,
+            "metadata mirror fragment is damaged; the mirror will be treated as unreadable",
+        );
+        corrupt_mirror_fragment.store(true, Ordering::Relaxed);
     }
 }
 
@@ -141,7 +182,16 @@ impl PackageVersions {
     /// fragment fails to decode.
     #[must_use]
     pub fn get(&self, version: &str) -> Option<Arc<PackageVersion>> {
-        self.slots.get(version)?.hydrate(version)
+        self.slots.get(version)?.hydrate(version, &self.corrupt_mirror_fragment)
+    }
+
+    /// Whether hydrating any version so far read a damaged fragment of
+    /// an indexed on-disk mirror. Lazy, like the hydration it reports
+    /// on: a corrupt fragment nobody touched goes unnoticed, exactly as
+    /// its version going unpicked means nothing was resolved from it.
+    #[must_use]
+    pub fn has_corrupt_mirror_fragment(&self) -> bool {
+        self.corrupt_mirror_fragment.load(Ordering::Relaxed)
     }
 
     /// Whether the packument lists `version`. Never hydrates.
@@ -167,11 +217,18 @@ impl PackageVersions {
         if let Some(parsed) = slot.parsed.get() {
             return parsed.as_ref().is_some_and(|manifest| manifest.deprecated.is_some());
         }
-        let Some(json) = slot.source.json() else { return false };
+        let Some(json) = slot.source.json() else {
+            slot.report_undecodable(version, &self.corrupt_mirror_fragment);
+            return false;
+        };
         if !json.contains(r#""deprecated""#) {
             return false;
         }
-        serde_json::from_str::<DeprecatedProbe>(&json).is_ok_and(|probe| probe.deprecated.is_some())
+        let Ok(probe) = serde_json::from_str::<DeprecatedProbe>(&json) else {
+            slot.report_undecodable(version, &self.corrupt_mirror_fragment);
+            return false;
+        };
+        probe.deprecated.is_some()
     }
 
     /// Version strings, in `HashMap` order. Never hydrates.
@@ -194,7 +251,9 @@ impl PackageVersions {
     /// representation, so this belongs only on cold paths (the trust
     /// verifier's history scan, tests).
     pub fn iter(&self) -> impl Iterator<Item = (&String, Arc<PackageVersion>)> {
-        self.slots.iter().filter_map(|(version, slot)| Some((version, slot.hydrate(version)?)))
+        self.slots.iter().filter_map(|(version, slot)| {
+            Some((version, slot.hydrate(version, &self.corrupt_mirror_fragment)?))
+        })
     }
 
     /// Filtered copy keeping only the versions `keep` accepts. Slots
@@ -210,6 +269,7 @@ impl PackageVersions {
                 .filter(|(version, _)| keep(version))
                 .map(|(version, slot)| (version.clone(), slot.clone()))
                 .collect(),
+            corrupt_mirror_fragment: Arc::clone(&self.corrupt_mirror_fragment),
         }
     }
 }
@@ -243,6 +303,7 @@ impl PackageVersions {
                     )
                 })
                 .collect(),
+            corrupt_mirror_fragment: Arc::default(),
         }
     }
 
@@ -283,6 +344,7 @@ impl From<HashMap<String, PackageVersion>> for PackageVersions {
                 .into_iter()
                 .map(|(version, manifest)| (version, VersionSlot::from_parsed(manifest)))
                 .collect(),
+            corrupt_mirror_fragment: Arc::default(),
         }
     }
 }
@@ -309,6 +371,7 @@ impl<'de> Deserialize<'de> for PackageVersions {
                     )
                 })
                 .collect(),
+            corrupt_mirror_fragment: Arc::default(),
         })
     }
 }

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -11,16 +11,27 @@
 //! asks for the typed form, and the hydrated manifest is cached per
 //! slot so repeated lookups parse once.
 //!
-//! A fragment that fails to decode behaves as if the version were
-//! absent from the packument (with a `tracing::warn`), mirroring the
-//! tolerance of JavaScript package managers, which never validate
-//! version entries they don't pick.
+//! A registry-served fragment that fails to decode behaves as if the
+//! version were absent from the packument (with a `tracing::warn`),
+//! mirroring the tolerance of JavaScript package managers, which never
+//! validate version entries they don't pick. A fragment read out of an
+//! indexed on-disk mirror is different: the index vouched for the span,
+//! so a decode failure means the local file is damaged rather than that
+//! the version is missing. Those are recorded in
+//! [`PackageVersions::has_corrupt_mirror_fragment`], which the resolver
+//! reads to treat the whole mirror as unreadable — silently resolving a
+//! different version off damaged local data would be worse than the
+//! refetch, and the etag lives in the intact headers record, so nothing
+//! else would ever repair the file.
 
 use std::{
     borrow::Cow,
     collections::HashMap,
     fs::File,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -40,6 +51,9 @@ struct DeprecatedProbe {
 #[derive(Debug, Default, Clone)]
 pub struct PackageVersions {
     slots: Vec<(String, VersionSlot)>,
+    /// Shared with every clone and filtered view, so corruption stays
+    /// visible through whichever handle the resolver ends up holding.
+    corrupt_mirror_fragment: Arc<AtomicBool>,
 }
 
 #[derive(Debug)]
@@ -143,6 +157,13 @@ impl FragmentSource {
             FragmentSource::None => None,
         }
     }
+
+    /// Whether the fragment comes from an indexed on-disk mirror,
+    /// where a decode failure means a damaged file rather than a
+    /// version the registry served badly.
+    fn is_mirror_span(&self) -> bool {
+        matches!(self, FragmentSource::FileSpan { .. })
+    }
 }
 
 /// Fill `buf` from `file` at the absolute `offset`. The handle's read
@@ -196,10 +217,17 @@ impl VersionSlot {
         }
     }
 
-    fn hydrate(&self, version: &str) -> Option<Arc<PackageVersion>> {
+    fn hydrate(
+        &self,
+        version: &str,
+        corrupt_mirror_fragment: &AtomicBool,
+    ) -> Option<Arc<PackageVersion>> {
         self.parsed
             .get_or_init(|| {
-                let json = self.source.json()?;
+                let Some(json) = self.source.json() else {
+                    self.report_undecodable(version, corrupt_mirror_fragment);
+                    return None;
+                };
                 match serde_json::from_str::<PackageVersion>(&json) {
                     Ok(parsed) => Some(Arc::new(parsed)),
                     Err(error) => {
@@ -209,11 +237,24 @@ impl VersionSlot {
                             version,
                             "skipping registry version with an undecodable manifest",
                         );
+                        self.report_undecodable(version, corrupt_mirror_fragment);
                         None
                     }
                 }
             })
             .clone()
+    }
+
+    fn report_undecodable(&self, version: &str, corrupt_mirror_fragment: &AtomicBool) {
+        if !self.source.is_mirror_span() {
+            return;
+        }
+        tracing::debug!(
+            target: "pnpm_registry",
+            version,
+            "metadata mirror fragment is damaged; the mirror will be treated as unreadable",
+        );
+        corrupt_mirror_fragment.store(true, Ordering::Relaxed);
     }
 }
 
@@ -223,7 +264,16 @@ impl PackageVersions {
     /// fragment fails to decode.
     #[must_use]
     pub fn get(&self, version: &str) -> Option<Arc<PackageVersion>> {
-        self.slot(version)?.hydrate(version)
+        self.slot(version)?.hydrate(version, &self.corrupt_mirror_fragment)
+    }
+
+    /// Whether hydrating any version so far read a damaged fragment of
+    /// an indexed on-disk mirror. Lazy, like the hydration it reports
+    /// on: a corrupt fragment nobody touched goes unnoticed, exactly as
+    /// its version going unpicked means nothing was resolved from it.
+    #[must_use]
+    pub fn has_corrupt_mirror_fragment(&self) -> bool {
+        self.corrupt_mirror_fragment.load(Ordering::Relaxed)
     }
 
     /// Whether the packument lists `version`. Never hydrates.
@@ -249,11 +299,18 @@ impl PackageVersions {
         if let Some(parsed) = slot.parsed.get() {
             return parsed.as_ref().is_some_and(|manifest| manifest.deprecated.is_some());
         }
-        let Some(json) = slot.source.json() else { return false };
+        let Some(json) = slot.source.json() else {
+            slot.report_undecodable(version, &self.corrupt_mirror_fragment);
+            return false;
+        };
         if !json.contains(r#""deprecated""#) {
             return false;
         }
-        serde_json::from_str::<DeprecatedProbe>(&json).is_ok_and(|probe| probe.deprecated.is_some())
+        let Ok(probe) = serde_json::from_str::<DeprecatedProbe>(&json) else {
+            slot.report_undecodable(version, &self.corrupt_mirror_fragment);
+            return false;
+        };
+        probe.deprecated.is_some()
     }
 
     /// Version strings in lexical order. Never hydrates.
@@ -276,7 +333,9 @@ impl PackageVersions {
     /// representation, so this belongs only on cold paths (the trust
     /// verifier's history scan, tests).
     pub fn iter(&self) -> impl Iterator<Item = (&String, Arc<PackageVersion>)> {
-        self.slots.iter().filter_map(|(version, slot)| Some((version, slot.hydrate(version)?)))
+        self.slots.iter().filter_map(|(version, slot)| {
+            Some((version, slot.hydrate(version, &self.corrupt_mirror_fragment)?))
+        })
     }
 
     /// Filtered copy keeping only the versions `keep` accepts. Slots
@@ -292,6 +351,7 @@ impl PackageVersions {
                 .filter(|(version, _)| keep(version))
                 .map(|(version, slot)| (version.clone(), slot.clone()))
                 .collect(),
+            corrupt_mirror_fragment: Arc::clone(&self.corrupt_mirror_fragment),
         }
     }
 
@@ -305,7 +365,7 @@ impl PackageVersions {
         if !slots.is_sorted_by(|left, right| left.0 <= right.0) {
             slots.sort_unstable_by(|left, right| left.0.cmp(&right.0));
         }
-        PackageVersions { slots }
+        PackageVersions { slots, corrupt_mirror_fragment: Arc::default() }
     }
 }
 

--- a/pnpm/crates/registry/src/package_versions/tests.rs
+++ b/pnpm/crates/registry/src/package_versions/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{Package, PackageVersion};
 
@@ -44,6 +44,60 @@ fn undecodable_fragment_behaves_as_absent() {
     assert!(package.versions.get("9.9.9").is_none());
     assert!(package.versions.get("1.0.0").is_some());
     assert_eq!(package.versions.iter().count(), 1);
+    assert!(!package.versions.has_corrupt_mirror_fragment());
+}
+
+/// A mirror-backed packument whose valid fragment sits before a
+/// damaged one, plus the two spans that address them.
+fn mirror_versions() -> crate::PackageVersions {
+    const VALID: &str = r#"{"name": "foo", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/foo-1.0.0.tgz"}}"#;
+    const DAMAGED: &str = "{not json at all}";
+    let buffer = Arc::new(format!("{VALID}{DAMAGED}").into_bytes());
+    let valid_len = u32::try_from(VALID.len()).unwrap();
+    crate::PackageVersions::from_buffer_spans(
+        &buffer,
+        [
+            ("1.0.0".to_string(), 0, valid_len),
+            ("2.0.0".to_string(), u64::from(valid_len), u32::try_from(DAMAGED.len()).unwrap()),
+        ],
+    )
+}
+
+#[test]
+fn a_damaged_mirror_fragment_is_reported_once_hydrated() {
+    let versions = mirror_versions();
+
+    assert!(versions.get("1.0.0").is_some());
+    assert!(!versions.has_corrupt_mirror_fragment());
+
+    assert!(versions.get("2.0.0").is_none());
+    assert!(versions.has_corrupt_mirror_fragment());
+}
+
+/// The publish-date filter hands out a filtered view of the same
+/// fragments, so damage found through either handle has to be visible
+/// from the one the resolver checks.
+#[test]
+fn a_filtered_view_shares_the_damage_report() {
+    let versions = mirror_versions();
+    let filtered = versions.filtered(|version| version == "2.0.0");
+
+    assert!(filtered.get("2.0.0").is_none());
+    assert!(filtered.has_corrupt_mirror_fragment());
+    assert!(versions.has_corrupt_mirror_fragment());
+}
+
+#[test]
+fn probing_a_damaged_mirror_fragment_for_deprecation_reports_it() {
+    const DAMAGED: &str = r#"{"deprecated": "use 2.x",,}"#;
+    let buffer = Arc::new(DAMAGED.as_bytes().to_vec());
+    let versions = crate::PackageVersions::from_buffer_spans(
+        &buffer,
+        [("1.0.0".to_string(), 0, u32::try_from(DAMAGED.len()).unwrap())],
+    );
+
+    assert!(!versions.is_deprecated("1.0.0"));
+    assert!(versions.has_corrupt_mirror_fragment());
 }
 
 #[test]

--- a/pnpm/crates/registry/src/package_versions/tests.rs
+++ b/pnpm/crates/registry/src/package_versions/tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, io::Write};
 
 use crate::{Package, PackageVersion};
 
@@ -66,6 +66,68 @@ fn undecodable_fragment_behaves_as_absent() {
     assert!(package.versions.get("9.9.9").is_none());
     assert!(package.versions.get("1.0.0").is_some());
     assert_eq!(package.versions.iter().count(), 1);
+    assert!(!package.versions.has_corrupt_mirror_fragment());
+}
+
+/// A mirror-backed packument whose valid fragment sits before a
+/// damaged one, plus the two spans that address them.
+fn mirror_versions() -> crate::PackageVersions {
+    const VALID: &str = r#"{"name": "foo", "version": "1.0.0", "dist": {"integrity": "sha512-a", "tarball": "https://r/foo-1.0.0.tgz"}}"#;
+    const DAMAGED: &str = "{not json at all}";
+    let valid_len = u32::try_from(VALID.len()).unwrap();
+    mirror_spans(
+        &format!("{VALID}{DAMAGED}"),
+        [
+            ("1.0.0".to_string(), 0, valid_len),
+            ("2.0.0".to_string(), u64::from(valid_len), u32::try_from(DAMAGED.len()).unwrap()),
+        ],
+    )
+}
+
+/// Spans over `fragments`, served from a held-open file the way an
+/// indexed mirror load serves them.
+fn mirror_spans(
+    fragments: &str,
+    spans: impl IntoIterator<Item = (String, u64, u32)>,
+) -> crate::PackageVersions {
+    let mut file = tempfile::tempfile().expect("create the mirror file");
+    file.write_all(fragments.as_bytes()).expect("write the fragments");
+    let held = super::MirrorFile::try_hold(file, usize::MAX).expect("hold the mirror file");
+    crate::PackageVersions::from_file_spans(&held, spans)
+}
+
+#[test]
+fn a_damaged_mirror_fragment_is_reported_once_hydrated() {
+    let versions = mirror_versions();
+
+    assert!(versions.get("1.0.0").is_some());
+    assert!(!versions.has_corrupt_mirror_fragment());
+
+    assert!(versions.get("2.0.0").is_none());
+    assert!(versions.has_corrupt_mirror_fragment());
+}
+
+/// The publish-date filter hands out a filtered view of the same
+/// fragments, so damage found through either handle has to be visible
+/// from the one the resolver checks.
+#[test]
+fn a_filtered_view_shares_the_damage_report() {
+    let versions = mirror_versions();
+    let filtered = versions.filtered(|version| version == "2.0.0");
+
+    assert!(filtered.get("2.0.0").is_none());
+    assert!(filtered.has_corrupt_mirror_fragment());
+    assert!(versions.has_corrupt_mirror_fragment());
+}
+
+#[test]
+fn probing_a_damaged_mirror_fragment_for_deprecation_reports_it() {
+    const DAMAGED: &str = r#"{"deprecated": "use 2.x",,}"#;
+    let versions =
+        mirror_spans(DAMAGED, [("1.0.0".to_string(), 0, u32::try_from(DAMAGED.len()).unwrap())]);
+
+    assert!(!versions.is_deprecated("1.0.0"));
+    assert!(versions.has_corrupt_mirror_fragment());
 }
 
 #[test]

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -123,7 +123,7 @@ pub struct CreateNpmResolutionVerifierOptions {
     pub auth_headers: Arc<AuthHeaders>,
     /// Root of pnpm's on-disk metadata mirror. When set, the verifier
     /// reads conditional headers from
-    /// `<cache_dir>/v11/metadata-full/<registry>/<pkg>.jsonl` and
+    /// `<cache_dir>/v12/metadata-full/<registry>/<pkg>.jsonl` and
     /// writes 200 responses back; when `None`, every fetch is
     /// unconditional.
     pub cache_dir: Option<PathBuf>,
@@ -737,7 +737,7 @@ impl NpmResolutionVerifier {
     ///    cold cache; the full-meta fallback below is hundreds of KB
     ///    bigger per package.
     /// 2. **On-disk full-meta mirror.** If a previous verification
-    ///    populated `<cache_dir>/v11/metadata-full/.../<name>.jsonl`,
+    ///    populated `<cache_dir>/v12/metadata-full/.../<name>.jsonl`,
     ///    take the per-version timestamp from there with no network.
     /// 3. **Npm attestation endpoint.** Small payload, just this
     ///    version's Sigstore-anchored timestamp. Wins on cold cache

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -115,7 +115,7 @@ pub struct CreateNpmResolutionVerifierOptions {
     pub auth_headers: Arc<AuthHeaders>,
     /// Root of pnpm's on-disk metadata mirror. When set, the verifier
     /// reads conditional headers from
-    /// `<cache_dir>/v11/metadata-full/<registry>/<pkg>.jsonl` and
+    /// `<cache_dir>/v12/metadata-full/<registry>/<pkg>.jsonl` and
     /// writes 200 responses back; when `None`, every fetch is
     /// unconditional.
     pub cache_dir: Option<PathBuf>,
@@ -599,7 +599,7 @@ impl NpmResolutionVerifier {
     ///    cold cache; the full-meta fallback below is hundreds of KB
     ///    bigger per package.
     /// 2. **On-disk full-meta mirror.** If a previous verification
-    ///    populated `<cache_dir>/v11/metadata-full/.../<name>.jsonl`,
+    ///    populated `<cache_dir>/v12/metadata-full/.../<name>.jsonl`,
     ///    take the per-version timestamp from there with no network.
     /// 3. **Npm attestation endpoint.** Small payload, just this
     ///    version's Sigstore-anchored timestamp. Wins on cold cache

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -310,7 +310,7 @@ async fn private_scope_verifier_ignores_public_mirror_and_writes_private_mirror(
 
     let private_path = get_pkg_mirror_path(
         cache.path(),
-        "v11/metadata-private/private-scope/metadata",
+        "v12/metadata-private/private-scope/metadata",
         &registry,
         "acme",
     )

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -312,7 +312,7 @@ async fn private_scope_verifier_ignores_public_mirror_and_writes_private_mirror(
 
     let private_path = get_pkg_mirror_path(
         cache.path(),
-        "v11/metadata-private/private-scope/metadata",
+        "v12/metadata-private/private-scope/metadata",
         &registry,
         "acme",
     )

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -1,8 +1,8 @@
 //! Cache-aware metadata fetcher.
 //!
 //! When a cache directory is configured, the fetcher consults a
-//! shared mirror under `<cache_dir>/v11/metadata-full/` (full) or
-//! `<cache_dir>/v11/metadata/` (abbreviated), keyed by
+//! shared mirror under `<cache_dir>/v12/metadata-full/` (full) or
+//! `<cache_dir>/v12/metadata/` (abbreviated), keyed by
 //! `full_metadata`. It issues a conditional GET against the upstream
 //! registry, and either reads the cached body (304) or writes the
 //! new body back (2xx). Without a cache directory it falls through
@@ -49,7 +49,7 @@ pub struct FetchFullMetadataCachedOptions<'a> {
     pub http_client: &'a ThrottledClient,
     pub auth_headers: &'a AuthHeaders,
     /// When `Some`, the fetcher consults the on-disk mirror under
-    /// the matching `<cache_dir>/v11/metadata...` subdirectory.
+    /// the matching `<cache_dir>/v12/metadata...` subdirectory.
     /// When `None`, the fetcher short-circuits to an unconditional
     /// GET.
     pub cache_dir: Option<&'a Path>,

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -1,8 +1,8 @@
 //! Cache-aware metadata fetcher.
 //!
 //! When a cache directory is configured, the fetcher consults a
-//! shared mirror under `<cache_dir>/v11/metadata-full/` (full) or
-//! `<cache_dir>/v11/metadata/` (abbreviated), keyed by
+//! shared mirror under `<cache_dir>/v12/metadata-full/` (full) or
+//! `<cache_dir>/v12/metadata/` (abbreviated), keyed by
 //! `full_metadata`. It issues a conditional GET against the upstream
 //! registry, and either reads the cached body (304) or writes the
 //! new body back (2xx). Without a cache directory it falls through
@@ -49,7 +49,7 @@ pub struct FetchFullMetadataCachedOptions<'a> {
     pub http_client: &'a ThrottledClient,
     pub auth_headers: &'a AuthHeaders,
     /// When `Some`, the fetcher consults the on-disk mirror under
-    /// the matching `<cache_dir>/v11/metadata...` subdirectory.
+    /// the matching `<cache_dir>/v12/metadata...` subdirectory.
     /// When `None`, the fetcher short-circuits to an unconditional
     /// GET.
     pub cache_dir: Option<&'a Path>,
@@ -76,6 +76,30 @@ pub struct FetchFullMetadataCachedOptions<'a> {
 pub async fn fetch_full_metadata_cached(
     pkg_name: &str,
     opts: &FetchFullMetadataCachedOptions<'_>,
+) -> Result<Package, FetchMetadataError> {
+    fetch_metadata_cached(pkg_name, opts, false).await
+}
+
+/// [`fetch_full_metadata_cached`] with the conditional-request cache
+/// deliberately skipped: no validator is sent and the mirror is never
+/// read, so the registry can only answer with a body, which is then
+/// written over the mirror.
+///
+/// For replacing a mirror whose fragments turned out to be damaged. A
+/// conditional request cannot do that — the etag lives in the intact
+/// headers record, so the registry keeps answering `304` and the
+/// damaged file survives every install.
+pub(crate) async fn fetch_full_metadata_bypassing_cache(
+    pkg_name: &str,
+    opts: &FetchFullMetadataCachedOptions<'_>,
+) -> Result<Package, FetchMetadataError> {
+    fetch_metadata_cached(pkg_name, opts, true).await
+}
+
+async fn fetch_metadata_cached(
+    pkg_name: &str,
+    opts: &FetchFullMetadataCachedOptions<'_>,
+    bypass_cache: bool,
 ) -> Result<Package, FetchMetadataError> {
     let base_meta_dir = if opts.full_metadata {
         if opts.filter_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }
@@ -123,10 +147,11 @@ pub async fn fetch_full_metadata_cached(
         });
     }
 
-    let cache_headers = load_meta_headers_async(mirror_path.as_deref()).await;
+    let cache_headers =
+        if bypass_cache { None } else { load_meta_headers_async(mirror_path.as_deref()).await };
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     let should_filter_metadata = opts.full_metadata && opts.filter_metadata;
-    let cache_bypass = AtomicBool::new(false);
+    let cache_bypass = AtomicBool::new(bypass_cache);
 
     // A body retry re-enters this closure from the top, so the bypass has to
     // outlive the attempt that discovered the loss: re-validating against a

--- a/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/fetch_full_metadata_cached.rs
@@ -69,6 +69,30 @@ pub async fn fetch_full_metadata_cached(
     pkg_name: &str,
     opts: &FetchFullMetadataCachedOptions<'_>,
 ) -> Result<Package, FetchMetadataError> {
+    fetch_metadata_cached(pkg_name, opts, false).await
+}
+
+/// [`fetch_full_metadata_cached`] with the conditional-request cache
+/// deliberately skipped: no validator is sent and the mirror is never
+/// read, so the registry can only answer with a body, which is then
+/// written over the mirror.
+///
+/// For replacing a mirror whose fragments turned out to be damaged. A
+/// conditional request cannot do that — the etag lives in the intact
+/// headers record, so the registry keeps answering `304` and the
+/// damaged file survives every install.
+pub(crate) async fn fetch_full_metadata_bypassing_cache(
+    pkg_name: &str,
+    opts: &FetchFullMetadataCachedOptions<'_>,
+) -> Result<Package, FetchMetadataError> {
+    fetch_metadata_cached(pkg_name, opts, true).await
+}
+
+async fn fetch_metadata_cached(
+    pkg_name: &str,
+    opts: &FetchFullMetadataCachedOptions<'_>,
+    bypass_cache: bool,
+) -> Result<Package, FetchMetadataError> {
     let base_meta_dir = if opts.full_metadata {
         if opts.filter_metadata { FULL_FILTERED_META_DIR } else { FULL_META_DIR }
     } else {
@@ -104,10 +128,11 @@ pub async fn fetch_full_metadata_cached(
         // No cache dir — fetch fresh without reading or writing a mirror.
         None => None,
     };
-    let cache_headers = load_meta_headers_async(mirror_path.as_deref()).await;
+    let cache_headers =
+        if bypass_cache { None } else { load_meta_headers_async(mirror_path.as_deref()).await };
     let accept = if opts.full_metadata { ACCEPT_FULL_DOC } else { ACCEPT_ABBREVIATED_DOC };
     let should_filter_metadata = opts.full_metadata && opts.filter_metadata;
-    let cache_bypass = AtomicBool::new(false);
+    let cache_bypass = AtomicBool::new(bypass_cache);
 
     // A body retry re-enters this closure from the top, so the bypass has to
     // outlive the attempt that discovered the loss: re-validating against a

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -14,10 +14,10 @@
 //!
 //! ## File layout
 //!
-//! Pacquet's indexed format:
+//! The indexed format, shared with the TypeScript CLI:
 //!
 //! ```text
-//! pacquet-meta-v1 <headers_len> <index_len>\n
+//! pnpm-meta-v1 <headers_len> <index_len>\n
 //! <headers JSON>           # MetaHeaders: etag, modified
 //! <index JSON>             # MirrorIndex: name, dist-tags, time,
 //!                          #   homepage, versions: [version, off, len]
@@ -30,7 +30,7 @@
 //! one span read per version it actually hydrates — never the whole
 //! body.
 //!
-//! pnpm's two-line NDJSON format is also readable and is used when
+//! The two-line NDJSON format is also readable and is used when
 //! writing filtered full metadata.
 //!
 //! Plus the constants and name-encoding rules:
@@ -64,13 +64,13 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 /// Mirror directory for the **abbreviated** metadata cache.
-pub const ABBREVIATED_META_DIR: &str = "v11/metadata";
+pub const ABBREVIATED_META_DIR: &str = "v12/metadata";
 
 /// Mirror directory for the **full** metadata cache.
-pub const FULL_META_DIR: &str = "v11/metadata-full";
+pub const FULL_META_DIR: &str = "v12/metadata-full";
 
 /// Mirror directory for the filtered full metadata cache.
-pub const FULL_FILTERED_META_DIR: &str = "v11/metadata-full-filtered";
+pub const FULL_FILTERED_META_DIR: &str = "v12/metadata-full-filtered";
 
 /// Cached headers persisted as the mirror's first line. The cached
 /// metadata fetcher feeds these into `If-None-Match` /
@@ -121,25 +121,25 @@ pub enum SaveMetaError {
 
 /// Mirror root for descriptor-scoped private metadata. A
 /// [`MetadataCacheScope::Private`] route stores its packuments under
-/// `<cache_dir>/v11/metadata-private/<descriptor-id>/<meta-suffix>/...`
+/// `<cache_dir>/v12/metadata-private/<descriptor-id>/<meta-suffix>/...`
 /// so one caller's private metadata never lands in the global mirror
 /// every other caller reads.
-const PRIVATE_META_ROOT: &str = "v11/metadata-private";
+const PRIVATE_META_ROOT: &str = "v12/metadata-private";
 
 /// The mirror directory `base_meta_dir` resolves to under `scope`.
 ///
 /// * [`MetadataCacheScope::Public`] keeps the global directory unchanged
 ///   (the CLI and public routes).
 /// * [`MetadataCacheScope::Private`] relocates it under
-///   `v11/metadata-private/<descriptor-id>/` keyed by the descriptor id,
+///   `v12/metadata-private/<descriptor-id>/` keyed by the descriptor id,
 ///   preserving the abbreviated/full/filtered split via the suffix after
-///   `v11/`.
+///   `v12/`.
 #[must_use]
 pub fn scoped_meta_dir(scope: &MetadataCacheScope, base_meta_dir: &str) -> String {
     match scope {
         MetadataCacheScope::Public => base_meta_dir.to_string(),
         MetadataCacheScope::Private { descriptor_id } => {
-            let suffix = base_meta_dir.strip_prefix("v11/").unwrap_or(base_meta_dir);
+            let suffix = base_meta_dir.strip_prefix("v12/").unwrap_or(base_meta_dir);
             format!("{PRIVATE_META_ROOT}/{descriptor_id}/{suffix}")
         }
     }
@@ -212,7 +212,7 @@ pub fn encode_pkg_name(pkg_name: &str) -> String {
 
 /// Magic + format version. The trailing space separates it from the
 /// two record lengths on the same line.
-const MIRROR_MAGIC: &str = "pacquet-meta-v1";
+const MIRROR_FORMAT_ID: &str = "pnpm-meta-v1";
 
 /// Top-level packument fields persisted in the mirror's index record.
 /// Everything else a registry serves at the top level is neither read
@@ -286,7 +286,7 @@ pub fn save_meta_indexed(
     .map_err(|error| SaveMetaError::Encode(EncodeMetaError(error)))?;
 
     let mut contents = String::with_capacity(headers.len() + index.len() + 64);
-    let _ = writeln!(contents, "{MIRROR_MAGIC} {} {}", headers.len(), index.len());
+    let _ = writeln!(contents, "{MIRROR_FORMAT_ID} {} {}", headers.len(), index.len());
     contents.push_str(&headers);
     contents.push_str(&index);
     let mut bytes = contents.into_bytes();
@@ -388,10 +388,10 @@ fn meta_modified(meta: &Package) -> Option<String> {
     })
 }
 
-/// Parse the `pacquet-meta-v1 <headers_len> <index_len>` line.
+/// Parse the `pnpm-meta-v1 <headers_len> <index_len>` line.
 /// `None` for anything else, including pnpm's NDJSON format.
-fn parse_mirror_magic(line: &str) -> Option<(usize, usize)> {
-    let rest = line.strip_prefix(MIRROR_MAGIC)?.strip_prefix(' ')?;
+fn parse_format_line(line: &str) -> Option<(usize, usize)> {
+    let rest = line.strip_prefix(MIRROR_FORMAT_ID)?.strip_prefix(' ')?;
     let (headers_len, index_len) = rest.split_once(' ')?;
     Some((headers_len.parse().ok()?, index_len.parse().ok()?))
 }
@@ -413,7 +413,7 @@ fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
     let chunk = &buf[..filled];
     let newline = chunk.iter().position(|&byte| byte == b'\n')?;
     let line = std::str::from_utf8(&chunk[..newline]).ok()?;
-    let Some((headers_len, _)) = parse_mirror_magic(line) else {
+    let Some((headers_len, _)) = parse_format_line(line) else {
         return serde_json::from_str(line).ok();
     };
     // The headers record is ~100 bytes of etag + timestamp. Bound the
@@ -461,7 +461,7 @@ pub fn load_meta(pkg_mirror: &Path) -> Option<Package> {
     let contents = fs::read(pkg_mirror).ok()?;
     let newline = contents.iter().position(|&byte| byte == b'\n')?;
     let line = std::str::from_utf8(&contents[..newline]).ok()?;
-    let Some((headers_len, index_len)) = parse_mirror_magic(line) else {
+    let Some((headers_len, index_len)) = parse_format_line(line) else {
         let headers: MetaHeaders = serde_json::from_slice(&contents[..newline]).ok()?;
         let mut meta: Package = serde_json::from_slice(&contents[newline + 1..]).ok()?;
         meta.etag = headers.etag;

--- a/pnpm/crates/resolving-npm-resolver/src/mirror.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror.rs
@@ -14,10 +14,10 @@
 //!
 //! ## File layout
 //!
-//! Pacquet's indexed format:
+//! The indexed format, shared with the TypeScript CLI:
 //!
 //! ```text
-//! pacquet-meta-v1 <headers_len> <index_len>\n
+//! pnpm-meta-v1 <headers_len> <index_len>\n
 //! <headers JSON>           # MetaHeaders: etag, modified
 //! <index JSON>             # MirrorIndex: name, dist-tags, time,
 //!                          #   homepage, versions: [version, off, len]
@@ -30,7 +30,7 @@
 //! one span read per version it actually hydrates — never the whole
 //! body.
 //!
-//! pnpm's two-line NDJSON format is also readable and is used when
+//! The two-line NDJSON format is also readable and is used when
 //! writing filtered full metadata.
 //!
 //! Plus the constants and name-encoding rules:
@@ -64,13 +64,13 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 /// Mirror directory for the **abbreviated** metadata cache.
-pub const ABBREVIATED_META_DIR: &str = "v11/metadata";
+pub const ABBREVIATED_META_DIR: &str = "v12/metadata";
 
 /// Mirror directory for the **full** metadata cache.
-pub const FULL_META_DIR: &str = "v11/metadata-full";
+pub const FULL_META_DIR: &str = "v12/metadata-full";
 
 /// Mirror directory for the filtered full metadata cache.
-pub const FULL_FILTERED_META_DIR: &str = "v11/metadata-full-filtered";
+pub const FULL_FILTERED_META_DIR: &str = "v12/metadata-full-filtered";
 
 /// Cached headers persisted as the mirror's first line. The cached
 /// metadata fetcher feeds these into `If-None-Match` /
@@ -137,25 +137,25 @@ const MAX_FRAGMENT_LEN: u32 = 16 * 1024 * 1024;
 
 /// Mirror root for descriptor-scoped private metadata. A
 /// [`MetadataCacheScope::Private`] route stores its packuments under
-/// `<cache_dir>/v11/metadata-private/<descriptor-id>/<meta-suffix>/...`
+/// `<cache_dir>/v12/metadata-private/<descriptor-id>/<meta-suffix>/...`
 /// so one caller's private metadata never lands in the global mirror
 /// every other caller reads.
-const PRIVATE_META_ROOT: &str = "v11/metadata-private";
+const PRIVATE_META_ROOT: &str = "v12/metadata-private";
 
 /// The mirror directory `base_meta_dir` resolves to under `scope`.
 ///
 /// * [`MetadataCacheScope::Public`] keeps the global directory unchanged
 ///   (the CLI and public routes).
 /// * [`MetadataCacheScope::Private`] relocates it under
-///   `v11/metadata-private/<descriptor-id>/` keyed by the descriptor id,
+///   `v12/metadata-private/<descriptor-id>/` keyed by the descriptor id,
 ///   preserving the abbreviated/full/filtered split via the suffix after
-///   `v11/`.
+///   `v12/`.
 #[must_use]
 pub fn scoped_meta_dir(scope: &MetadataCacheScope, base_meta_dir: &str) -> String {
     match scope {
         MetadataCacheScope::Public => base_meta_dir.to_string(),
         MetadataCacheScope::Private { descriptor_id } => {
-            let suffix = base_meta_dir.strip_prefix("v11/").unwrap_or(base_meta_dir);
+            let suffix = base_meta_dir.strip_prefix("v12/").unwrap_or(base_meta_dir);
             format!("{PRIVATE_META_ROOT}/{descriptor_id}/{suffix}")
         }
     }
@@ -228,7 +228,7 @@ pub fn encode_pkg_name(pkg_name: &str) -> String {
 
 /// Magic + format version. The trailing space separates it from the
 /// two record lengths on the same line.
-const MIRROR_MAGIC: &str = "pacquet-meta-v1";
+const MIRROR_FORMAT_ID: &str = "pnpm-meta-v1";
 
 /// Top-level packument fields persisted in the mirror's index record.
 /// Everything else a registry serves at the top level is neither read
@@ -303,7 +303,7 @@ pub fn save_meta_indexed(
     .map_err(|error| SaveMetaError::Encode(EncodeMetaError(error)))?;
 
     let mut contents = String::with_capacity(headers.len() + index.len() + 64);
-    let _ = writeln!(contents, "{MIRROR_MAGIC} {} {}", headers.len(), index.len());
+    let _ = writeln!(contents, "{MIRROR_FORMAT_ID} {} {}", headers.len(), index.len());
     contents.push_str(&headers);
     contents.push_str(&index);
     let mut bytes = contents.into_bytes();
@@ -453,10 +453,10 @@ fn raise_open_file_limit_once() {
 #[cfg(not(unix))]
 fn raise_open_file_limit_once() {}
 
-/// Parse the `pacquet-meta-v1 <headers_len> <index_len>` line.
+/// Parse the `pnpm-meta-v1 <headers_len> <index_len>` line.
 /// `None` for anything else, including pnpm's NDJSON format.
-fn parse_mirror_magic(line: &str) -> Option<(usize, usize)> {
-    let rest = line.strip_prefix(MIRROR_MAGIC)?.strip_prefix(' ')?;
+fn parse_format_line(line: &str) -> Option<(usize, usize)> {
+    let rest = line.strip_prefix(MIRROR_FORMAT_ID)?.strip_prefix(' ')?;
     let (headers_len, index_len) = rest.split_once(' ')?;
     Some((headers_len.parse().ok()?, index_len.parse().ok()?))
 }
@@ -478,7 +478,7 @@ fn read_mirror_headers(file: &mut File) -> Option<MetaHeaders> {
     let chunk = &buf[..filled];
     let newline = chunk.iter().position(|&byte| byte == b'\n')?;
     let line = std::str::from_utf8(&chunk[..newline]).ok()?;
-    let Some((headers_len, _)) = parse_mirror_magic(line) else {
+    let Some((headers_len, _)) = parse_format_line(line) else {
         return serde_json::from_str(line).ok();
     };
     if headers_len > MAX_HEADERS_LEN {
@@ -547,7 +547,7 @@ fn load_meta_with_hold_cap(pkg_mirror: &Path, hold_cap: usize) -> Option<Package
     let prefix = &prefix[..filled];
     let newline = prefix.iter().position(|&byte| byte == b'\n')?;
     let line = std::str::from_utf8(&prefix[..newline]).ok()?;
-    let Some((headers_len, index_len)) = parse_mirror_magic(line) else {
+    let Some((headers_len, index_len)) = parse_format_line(line) else {
         // Legacy NDJSON mirror — the whole body is the packument.
         let contents = fs::read(pkg_mirror).ok()?;
         let newline = contents.iter().position(|&byte| byte == b'\n')?;

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -26,12 +26,12 @@ fn scoped_meta_dir_private_namespaces_by_descriptor() {
     let scope = MetadataCacheScope::Private { descriptor_id: "abc123".to_string() };
     assert_eq!(
         scoped_meta_dir(&scope, ABBREVIATED_META_DIR),
-        "v11/metadata-private/abc123/metadata",
+        "v12/metadata-private/abc123/metadata",
     );
-    assert_eq!(scoped_meta_dir(&scope, FULL_META_DIR), "v11/metadata-private/abc123/metadata-full");
+    assert_eq!(scoped_meta_dir(&scope, FULL_META_DIR), "v12/metadata-private/abc123/metadata-full");
     assert_eq!(
         scoped_meta_dir(&scope, FULL_FILTERED_META_DIR),
-        "v11/metadata-private/abc123/metadata-full-filtered",
+        "v12/metadata-private/abc123/metadata-full-filtered",
     );
     // Distinct descriptors never share a directory.
     let other = MetadataCacheScope::Private { descriptor_id: "def456".to_string() };
@@ -84,16 +84,16 @@ fn get_pkg_mirror_path_composes_full_path() {
     let dir = PathBuf::from("/cache");
     let got = get_pkg_mirror_path(&dir, FULL_META_DIR, "https://registry.npmjs.org/", "lodash")
         .expect("compose");
-    assert_eq!(got, PathBuf::from("/cache/v11/metadata-full/registry.npmjs.org/lodash.jsonl"));
+    assert_eq!(got, PathBuf::from("/cache/v12/metadata-full/registry.npmjs.org/lodash.jsonl"));
 }
 
 /// Constants match upstream's `core/constants/src/index.ts` slugs.
 /// Any drift would silently fork the cache layout from pnpm's.
 #[test]
 fn constants_match_upstream() {
-    assert_eq!(FULL_META_DIR, "v11/metadata-full");
-    assert_eq!(FULL_FILTERED_META_DIR, "v11/metadata-full-filtered");
-    assert_eq!(ABBREVIATED_META_DIR, "v11/metadata");
+    assert_eq!(FULL_META_DIR, "v12/metadata-full");
+    assert_eq!(FULL_FILTERED_META_DIR, "v12/metadata-full-filtered");
+    assert_eq!(ABBREVIATED_META_DIR, "v12/metadata");
 }
 
 /// Build a minimal `Package` fixture for the round-trip tests.
@@ -200,7 +200,7 @@ fn load_meta_past_the_hold_cap_buffers_fragments_instead_of_missing() {
 fn load_meta_rejects_oversized_declared_record_lengths() {
     let dir = TempDir::new().expect("tmp dir");
     let mirror = dir.path().join("acme.jsonl");
-    std::fs::write(&mirror, "pacquet-meta-v1 128 999999999999\n{}{}").expect("write");
+    std::fs::write(&mirror, "pnpm-meta-v1 128 999999999999\n{}{}").expect("write");
     assert!(load_meta(&mirror).is_none());
 }
 
@@ -230,7 +230,7 @@ fn load_meta_past_the_hold_cap_skips_a_sparse_gap_between_spans() {
         fragment.len(),
     );
     let contents =
-        format!("pacquet-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len());
+        format!("pnpm-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len());
     std::fs::write(&mirror, &contents).expect("write");
     let file = std::fs::OpenOptions::new().write(true).open(&mirror).expect("open");
     file.set_len(contents.len() as u64 + far_offset + 16).expect("extend sparsely");
@@ -255,7 +255,7 @@ fn load_meta_treats_an_oversized_fragment_span_as_absent() {
         32 * 1024 * 1024,
     );
     let contents =
-        format!("pacquet-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len());
+        format!("pnpm-meta-v1 {} {}\n{headers}{index}{fragment}", headers.len(), index.len());
     std::fs::write(&mirror, &contents).expect("write");
     // A sparse tail makes the file size cover the declared span
     // without paying for the bytes, like a corrupt mirror would.

--- a/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/mirror/tests.rs
@@ -26,12 +26,12 @@ fn scoped_meta_dir_private_namespaces_by_descriptor() {
     let scope = MetadataCacheScope::Private { descriptor_id: "abc123".to_string() };
     assert_eq!(
         scoped_meta_dir(&scope, ABBREVIATED_META_DIR),
-        "v11/metadata-private/abc123/metadata",
+        "v12/metadata-private/abc123/metadata",
     );
-    assert_eq!(scoped_meta_dir(&scope, FULL_META_DIR), "v11/metadata-private/abc123/metadata-full");
+    assert_eq!(scoped_meta_dir(&scope, FULL_META_DIR), "v12/metadata-private/abc123/metadata-full");
     assert_eq!(
         scoped_meta_dir(&scope, FULL_FILTERED_META_DIR),
-        "v11/metadata-private/abc123/metadata-full-filtered",
+        "v12/metadata-private/abc123/metadata-full-filtered",
     );
     // Distinct descriptors never share a directory.
     let other = MetadataCacheScope::Private { descriptor_id: "def456".to_string() };
@@ -84,16 +84,16 @@ fn get_pkg_mirror_path_composes_full_path() {
     let dir = PathBuf::from("/cache");
     let got = get_pkg_mirror_path(&dir, FULL_META_DIR, "https://registry.npmjs.org/", "lodash")
         .expect("compose");
-    assert_eq!(got, PathBuf::from("/cache/v11/metadata-full/registry.npmjs.org/lodash.jsonl"));
+    assert_eq!(got, PathBuf::from("/cache/v12/metadata-full/registry.npmjs.org/lodash.jsonl"));
 }
 
 /// Constants match upstream's `core/constants/src/index.ts` slugs.
 /// Any drift would silently fork the cache layout from pnpm's.
 #[test]
 fn constants_match_upstream() {
-    assert_eq!(FULL_META_DIR, "v11/metadata-full");
-    assert_eq!(FULL_FILTERED_META_DIR, "v11/metadata-full-filtered");
-    assert_eq!(ABBREVIATED_META_DIR, "v11/metadata");
+    assert_eq!(FULL_META_DIR, "v12/metadata-full");
+    assert_eq!(FULL_FILTERED_META_DIR, "v12/metadata-full-filtered");
+    assert_eq!(ABBREVIATED_META_DIR, "v12/metadata");
 }
 
 /// Build a minimal `Package` fixture for the round-trip tests.

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -62,7 +62,8 @@ use tokio::sync::Semaphore;
 
 use crate::{
     FetchFullMetadataCachedOptions, FetchFullMetadataOptions, FetchFullMetadataOutcome,
-    FetchMetadataError, fetch_full_metadata, fetch_full_metadata_cached,
+    FetchMetadataError, fetch_full_metadata,
+    fetch_full_metadata_cached::{fetch_full_metadata_bypassing_cache, fetch_full_metadata_cached},
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
         get_pkg_mirror_path, load_meta, load_meta_async, save_meta_indexed, save_meta_ndjson,
@@ -548,6 +549,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             // keeps the behavior intact.
             if let Ok((picked_meta, Some(picked))) =
                 pick_from_meta_fast(&picker_opts, spec, Arc::clone(meta), opts.blocked_versions)
+                && !meta.versions.has_corrupt_mirror_fragment()
             {
                 // Promote the disk-loaded packument into the
                 // install-scoped in-memory cache so later resolves
@@ -585,6 +587,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         if let Some(ref meta) = meta_cached_in_store
             && let Ok((picked_meta, Some(picked))) =
                 pick_from_meta_fast(&picker_opts, spec, Arc::clone(meta), opts.blocked_versions)
+            && !meta.versions.has_corrupt_mirror_fragment()
         {
             // Same rationale as the version-spec fast path above —
             // promote the disk-loaded packument into the
@@ -641,15 +644,23 @@ pub async fn pick_package<Cache: PackageMetaCache>(
 
         if ctx.offline {
             if let Some(meta) = meta_cached_in_store {
-                // maybe_upgrade_abbreviated_meta_for_release_age
-                // short-circuits when offline, so a later cache hit
-                // returns this same meta without any network access.
-                if !opts.dry_run {
-                    ctx.meta_cache.set_unverified(cache_key.clone(), Arc::clone(&meta));
-                }
+                let disk_meta = Arc::clone(&meta);
                 let (meta, picked) =
                     pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
-                return Ok(PickPackageResult { meta, picked_package: picked });
+                // A damaged fragment makes the mirror as unusable
+                // offline as a missing one, and there is no network to
+                // heal it from — fall through to the same error a
+                // missing mirror raises. Checked after the pick because
+                // hydration, and so the damage, is lazy.
+                if !meta.versions.has_corrupt_mirror_fragment() {
+                    // maybe_upgrade_abbreviated_meta_for_release_age
+                    // short-circuits when offline, so a later cache hit
+                    // returns this same meta without any network access.
+                    if !opts.dry_run {
+                        ctx.meta_cache.set_unverified(cache_key.clone(), disk_meta);
+                    }
+                    return Ok(PickPackageResult { meta, picked_package: picked });
+                }
             }
             return Err(PickPackageError::NoOfflineMeta {
                 spec_name: spec.name.clone(),
@@ -679,7 +690,8 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             }
             let (picked_meta, picked) =
                 pick_from_meta(&picker_opts, spec, Arc::clone(&meta), opts.blocked_versions)?;
-            if picked.is_some() {
+            let corrupt_mirror = picked_meta.versions.has_corrupt_mirror_fragment();
+            if picked.is_some() && !corrupt_mirror {
                 // A cache hit re-runs the release-age upgrade check, so
                 // serving this meta from memory can't bypass the upgrade.
                 // The upgrade branch above already cached the registry-
@@ -693,8 +705,12 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             // Fall through to fetch when disk had the meta but no
             // version satisfied the spec — the disk copy may be
             // stale. Restore the (possibly upgraded) meta for later
-            // paths that reuse the in-store load.
-            meta_cached_in_store = Some(meta);
+            // paths that reuse the in-store load, unless a damaged
+            // fragment made it unusable: the fetch below has to replace
+            // it, so it must not resurface as a fallback.
+            if !corrupt_mirror {
+                meta_cached_in_store = Some(meta);
+            }
         }
     }
 
@@ -715,69 +731,100 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         retry_opts: ctx.retry_opts,
     };
 
-    let fetch_result = fetch_full_metadata_cached(&spec.name, &fetch_opts).await;
-    let meta = match fetch_result {
-        Ok(meta) => Arc::new(meta),
-        Err(error) => {
-            // The fetcher already saved a 200 to disk before it
-            // returned (when it returned Ok). If it returned Err,
-            // try the disk fallback: an existing mirror is good
-            // enough to pick from, even if the latest sync failed.
-            //
-            // A private route must fail closed on a `401`/`403`/
-            // private-`404`: a revoked credential or a hidden private
-            // package must not keep serving the last cached packument,
-            // even from its own (same-namespace) mirror. Only a transport
-            // failure (`5xx`/timeout/network) falls back, and only within
-            // the scoped mirror `pkg_mirror` already points at. A public
-            // route (the CLI / public registries) keeps the original
-            // fall-back-on-any-error behavior.
-            let allow_fallback =
-                matches!(scope, MetadataCacheScope::Public) || !error.is_access_denied();
-            let disk_fallback = if allow_fallback {
-                match meta_cached_in_store {
-                    Some(meta) => Some(meta),
-                    None => load_meta_async(pkg_mirror.as_deref()).await.map(Arc::new),
+    // A `304` answers from the on-disk mirror, whose fragments hydrate
+    // lazily, so a damaged one only surfaces once a version is picked.
+    // The etag lives in the mirror's intact headers record, so
+    // re-validating would keep answering `304` and the damage would
+    // outlive every install; one retry with the cache bypassed makes the
+    // registry send a body, which rewrites the file. A bypassing request
+    // sends no validator and so cannot be answered with another `304` —
+    // the loop runs at most twice.
+    let mut bypass_cache = false;
+    let (meta, picked_meta, picked) = loop {
+        let fetch_result = if bypass_cache {
+            fetch_full_metadata_bypassing_cache(&spec.name, &fetch_opts).await
+        } else {
+            fetch_full_metadata_cached(&spec.name, &fetch_opts).await
+        };
+        let meta = match fetch_result {
+            Ok(meta) => Arc::new(meta),
+            Err(error) => {
+                // The fetcher already saved a 200 to disk before it
+                // returned (when it returned Ok). If it returned Err,
+                // try the disk fallback: an existing mirror is good
+                // enough to pick from, even if the latest sync failed.
+                //
+                // A private route must fail closed on a `401`/`403`/
+                // private-`404`: a revoked credential or a hidden private
+                // package must not keep serving the last cached packument,
+                // even from its own (same-namespace) mirror. Only a transport
+                // failure (`5xx`/timeout/network) falls back, and only within
+                // the scoped mirror `pkg_mirror` already points at. A public
+                // route (the CLI / public registries) keeps the original
+                // fall-back-on-any-error behavior.
+                let allow_fallback =
+                    matches!(scope, MetadataCacheScope::Public) || !error.is_access_denied();
+                let disk_fallback = if allow_fallback {
+                    match meta_cached_in_store.take() {
+                        Some(meta) => Some(meta),
+                        None => load_meta_async(pkg_mirror.as_deref()).await.map(Arc::new),
+                    }
+                } else {
+                    None
+                };
+                if let Some(disk) = disk_fallback {
+                    tracing::debug!(
+                        target: "pnpm_resolving_npm_resolver::pick_package",
+                        ?error,
+                        pkg_name = %spec.name,
+                        "metadata fetch failed; falling back to on-disk mirror",
+                    );
+                    let (meta, picked) =
+                        pick_from_meta(&picker_opts, spec, disk, opts.blocked_versions)?;
+                    // A damaged fragment makes this fallback mirror as
+                    // useless as a missing one; surface the fetch
+                    // failure that sent us here rather than a pick made
+                    // off it.
+                    if !meta.versions.has_corrupt_mirror_fragment() {
+                        return Ok(PickPackageResult { meta, picked_package: picked });
+                    }
                 }
-            } else {
-                None
-            };
-            if let Some(disk) = disk_fallback {
-                tracing::debug!(
-                    target: "pnpm_resolving_npm_resolver::pick_package",
-                    ?error,
-                    pkg_name = %spec.name,
-                    "metadata fetch failed; falling back to on-disk mirror",
-                );
-                let (meta, picked) =
-                    pick_from_meta(&picker_opts, spec, disk, opts.blocked_versions)?;
-                return Ok(PickPackageResult { meta, picked_package: picked });
+                return Err(error.into());
             }
-            return Err(error.into());
-        }
-    };
+        };
 
-    let upgrade = maybe_upgrade_abbreviated_meta_for_release_age(
-        ctx,
-        spec,
-        opts,
-        full_metadata,
-        &cache_key,
-        meta,
-    )
-    .await?;
-    let mut meta = upgrade.meta;
-    if upgrade.upgraded
-        && !opts.dry_run
-        && let Some(reloaded) = pkg_mirror
-            .as_deref()
-            .and_then(|path| persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata))
-    {
-        meta = Arc::new(reloaded);
-    }
-    if upgrade.upgraded {
-        ctx.fetch_locker.mark_release_age_upgrade_checked(&cache_key, &meta);
-    }
+        let upgrade = maybe_upgrade_abbreviated_meta_for_release_age(
+            ctx,
+            spec,
+            opts,
+            full_metadata,
+            &cache_key,
+            meta,
+        )
+        .await?;
+        let mut meta = upgrade.meta;
+        if upgrade.upgraded
+            && !opts.dry_run
+            && let Some(reloaded) = pkg_mirror.as_deref().and_then(|path| {
+                persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata)
+            })
+        {
+            meta = Arc::new(reloaded);
+        }
+        if upgrade.upgraded {
+            ctx.fetch_locker.mark_release_age_upgrade_checked(&cache_key, &meta);
+        }
+
+        // Picking before the in-memory cache write keeps a document
+        // whose mirror turns out to be damaged from being cached at all.
+        let (picked_meta, picked) =
+            pick_from_meta(&picker_opts, spec, Arc::clone(&meta), opts.blocked_versions)?;
+        if picked_meta.versions.has_corrupt_mirror_fragment() && !bypass_cache {
+            bypass_cache = true;
+            continue;
+        }
+        break (meta, picked_meta, picked);
+    };
 
     // Worth flagging: a dry-run is meant to gate the on-disk save, but
     // `fetch_full_metadata_cached` already wrote the response body to
@@ -789,8 +836,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     if !opts.dry_run {
         ctx.meta_cache.set(cache_key, Arc::clone(&meta));
     }
-    let (meta, picked) = pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
-    Ok(PickPackageResult { meta, picked_package: picked })
+    Ok(PickPackageResult { meta: picked_meta, picked_package: picked })
 }
 
 /// Shared cache-hit path. Invoked once on the optimistic pre-permit
@@ -799,11 +845,12 @@ pub async fn pick_package<Cache: PackageMetaCache>(
 /// re-fetching). Extracting it keeps the two call sites identical so
 /// the upgrade-and-persist side-effects can't drift.
 ///
-/// Returns `Ok(None)` when the hit must not be terminal: the entry is
-/// a registry-unverified disk promotion (see
-/// [`PackageMetaCache::set_unverified`]) whose pick failed, and the
-/// resolver isn't offline. The caller then falls through to the disk +
-/// network flow, whose fetch replaces the entry with a verified one.
+/// Returns `Ok(None)` when the hit must not be terminal, and the caller
+/// falls through to the disk + network flow that replaces the entry:
+/// either the entry is a registry-unverified disk promotion (see
+/// [`PackageMetaCache::set_unverified`]) whose pick failed and the
+/// resolver isn't offline, or the pick hydrated a damaged fragment of
+/// the mirror the entry came from.
 ///
 /// The argument list is wide because the helper consumes everything
 /// the per-call frame already computed (cache key, derived
@@ -850,6 +897,14 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
         ctx.fetch_locker.mark_release_age_upgrade_checked(cache_key, &meta);
     }
     let (meta, picked) = pick_from_meta(picker_opts, spec, meta, opts.blocked_versions)?;
+    // A cached disk promotion whose fragments turn out to be damaged
+    // must not be served: offline resolution falls through to the same
+    // error a missing mirror raises, and online resolution to the fetch
+    // that replaces the file. Hydration is lazy, so an entry cached
+    // after a clean pick can still surface damage on a later one.
+    if meta.versions.has_corrupt_mirror_fragment() {
+        return Ok(None);
+    }
     if picked.is_none() && !ctx.offline && !registry_verified {
         return Ok(None);
     }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package.rs
@@ -62,7 +62,8 @@ use tokio::sync::Semaphore;
 
 use crate::{
     FetchFullMetadataCachedOptions, FetchFullMetadataOptions, FetchFullMetadataOutcome,
-    FetchMetadataError, fetch_full_metadata, fetch_full_metadata_cached,
+    FetchMetadataError, fetch_full_metadata,
+    fetch_full_metadata_cached::{fetch_full_metadata_bypassing_cache, fetch_full_metadata_cached},
     mirror::{
         ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR, clear_meta,
         get_pkg_mirror_path, load_meta_async, save_meta_indexed, save_meta_ndjson, scoped_meta_dir,
@@ -512,6 +513,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             // keeps the behavior intact.
             if let Ok((picked_meta, Some(picked))) =
                 pick_from_meta_fast(&picker_opts, spec, Arc::clone(meta), opts.blocked_versions)
+                && !meta.versions.has_corrupt_mirror_fragment()
             {
                 // Promote the disk-loaded packument into the
                 // install-scoped in-memory cache so later resolves
@@ -549,6 +551,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         if let Some(ref meta) = meta_cached_in_store
             && let Ok((picked_meta, Some(picked))) =
                 pick_from_meta_fast(&picker_opts, spec, Arc::clone(meta), opts.blocked_versions)
+            && !meta.versions.has_corrupt_mirror_fragment()
         {
             // Same rationale as the version-spec fast path above —
             // promote the disk-loaded packument into the
@@ -604,15 +607,23 @@ pub async fn pick_package<Cache: PackageMetaCache>(
 
         if ctx.offline {
             if let Some(meta) = meta_cached_in_store {
-                // maybe_upgrade_abbreviated_meta_for_release_age
-                // short-circuits when offline, so a later cache hit
-                // returns this same meta without any network access.
-                if !opts.dry_run {
-                    ctx.meta_cache.set_unverified(cache_key.clone(), Arc::clone(&meta));
-                }
+                let disk_meta = Arc::clone(&meta);
                 let (meta, picked) =
                     pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
-                return Ok(PickPackageResult { meta, picked_package: picked });
+                // A damaged fragment makes the mirror as unusable
+                // offline as a missing one, and there is no network to
+                // heal it from — fall through to the same error a
+                // missing mirror raises. Checked after the pick because
+                // hydration, and so the damage, is lazy.
+                if !meta.versions.has_corrupt_mirror_fragment() {
+                    // maybe_upgrade_abbreviated_meta_for_release_age
+                    // short-circuits when offline, so a later cache hit
+                    // returns this same meta without any network access.
+                    if !opts.dry_run {
+                        ctx.meta_cache.set_unverified(cache_key.clone(), disk_meta);
+                    }
+                    return Ok(PickPackageResult { meta, picked_package: picked });
+                }
             }
             return Err(PickPackageError::NoOfflineMeta {
                 spec_name: spec.name.clone(),
@@ -640,7 +651,8 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             }
             let (picked_meta, picked) =
                 pick_from_meta(&picker_opts, spec, Arc::clone(&meta), opts.blocked_versions)?;
-            if picked.is_some() {
+            let corrupt_mirror = picked_meta.versions.has_corrupt_mirror_fragment();
+            if picked.is_some() && !corrupt_mirror {
                 // A cache hit re-runs the release-age upgrade check, so
                 // serving this meta from memory can't bypass the upgrade.
                 // The upgrade branch above already cached the registry-
@@ -654,8 +666,12 @@ pub async fn pick_package<Cache: PackageMetaCache>(
             // Fall through to fetch when disk had the meta but no
             // version satisfied the spec — the disk copy may be
             // stale. Restore the (possibly upgraded) meta for later
-            // paths that reuse the in-store load.
-            meta_cached_in_store = Some(meta);
+            // paths that reuse the in-store load, unless a damaged
+            // fragment made it unusable: the fetch below has to replace
+            // it, so it must not resurface as a fallback.
+            if !corrupt_mirror {
+                meta_cached_in_store = Some(meta);
+            }
         }
     }
 
@@ -674,64 +690,95 @@ pub async fn pick_package<Cache: PackageMetaCache>(
         retry_opts: ctx.retry_opts,
     };
 
-    let fetch_result = fetch_full_metadata_cached(&spec.name, &fetch_opts).await;
-    let meta = match fetch_result {
-        Ok(meta) => Arc::new(meta),
-        Err(error) => {
-            // The fetcher already saved a 200 to disk before it
-            // returned (when it returned Ok). If it returned Err,
-            // try the disk fallback: an existing mirror is good
-            // enough to pick from, even if the latest sync failed.
-            //
-            // A private route must fail closed on a `401`/`403`/
-            // private-`404`: a revoked credential or a hidden private
-            // package must not keep serving the last cached packument,
-            // even from its own (same-namespace) mirror. Only a transport
-            // failure (`5xx`/timeout/network) falls back, and only within
-            // the scoped mirror `pkg_mirror` already points at. A public
-            // route (the CLI / public registries) keeps the original
-            // fall-back-on-any-error behavior.
-            let allow_fallback =
-                matches!(scope, MetadataCacheScope::Public) || !error.is_access_denied();
-            let disk_fallback = if allow_fallback {
-                match meta_cached_in_store {
-                    Some(meta) => Some(meta),
-                    None => load_meta_async(pkg_mirror.as_deref()).await.map(Arc::new),
+    // A `304` answers from the on-disk mirror, whose fragments hydrate
+    // lazily, so a damaged one only surfaces once a version is picked.
+    // The etag lives in the mirror's intact headers record, so
+    // re-validating would keep answering `304` and the damage would
+    // outlive every install; one retry with the cache bypassed makes the
+    // registry send a body, which rewrites the file. A bypassing request
+    // sends no validator and so cannot be answered with another `304` —
+    // the loop runs at most twice.
+    let mut bypass_cache = false;
+    let (meta, picked_meta, picked) = loop {
+        let fetch_result = if bypass_cache {
+            fetch_full_metadata_bypassing_cache(&spec.name, &fetch_opts).await
+        } else {
+            fetch_full_metadata_cached(&spec.name, &fetch_opts).await
+        };
+        let meta = match fetch_result {
+            Ok(meta) => Arc::new(meta),
+            Err(error) => {
+                // The fetcher already saved a 200 to disk before it
+                // returned (when it returned Ok). If it returned Err,
+                // try the disk fallback: an existing mirror is good
+                // enough to pick from, even if the latest sync failed.
+                //
+                // A private route must fail closed on a `401`/`403`/
+                // private-`404`: a revoked credential or a hidden private
+                // package must not keep serving the last cached packument,
+                // even from its own (same-namespace) mirror. Only a transport
+                // failure (`5xx`/timeout/network) falls back, and only within
+                // the scoped mirror `pkg_mirror` already points at. A public
+                // route (the CLI / public registries) keeps the original
+                // fall-back-on-any-error behavior.
+                let allow_fallback =
+                    matches!(scope, MetadataCacheScope::Public) || !error.is_access_denied();
+                let disk_fallback = if allow_fallback {
+                    match meta_cached_in_store.take() {
+                        Some(meta) => Some(meta),
+                        None => load_meta_async(pkg_mirror.as_deref()).await.map(Arc::new),
+                    }
+                } else {
+                    None
+                };
+                if let Some(disk) = disk_fallback {
+                    tracing::debug!(
+                        target: "pacquet_resolving_npm_resolver::pick_package",
+                        ?error,
+                        pkg_name = %spec.name,
+                        "metadata fetch failed; falling back to on-disk mirror",
+                    );
+                    let (meta, picked) =
+                        pick_from_meta(&picker_opts, spec, disk, opts.blocked_versions)?;
+                    // A damaged fragment makes this fallback mirror as
+                    // useless as a missing one; surface the fetch
+                    // failure that sent us here rather than a pick made
+                    // off it.
+                    if !meta.versions.has_corrupt_mirror_fragment() {
+                        return Ok(PickPackageResult { meta, picked_package: picked });
+                    }
                 }
-            } else {
-                None
-            };
-            if let Some(disk) = disk_fallback {
-                tracing::debug!(
-                    target: "pacquet_resolving_npm_resolver::pick_package",
-                    ?error,
-                    pkg_name = %spec.name,
-                    "metadata fetch failed; falling back to on-disk mirror",
-                );
-                let (meta, picked) =
-                    pick_from_meta(&picker_opts, spec, disk, opts.blocked_versions)?;
-                return Ok(PickPackageResult { meta, picked_package: picked });
+                return Err(error.into());
             }
-            return Err(error.into());
-        }
-    };
+        };
 
-    let upgrade = maybe_upgrade_abbreviated_meta_for_release_age(
-        ctx,
-        spec,
-        opts,
-        full_metadata,
-        &cache_key,
-        meta,
-    )
-    .await?;
-    let meta = upgrade.meta;
-    if upgrade.upgraded
-        && !opts.dry_run
-        && let Some(path) = pkg_mirror.as_deref()
-    {
-        persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
-    }
+        let upgrade = maybe_upgrade_abbreviated_meta_for_release_age(
+            ctx,
+            spec,
+            opts,
+            full_metadata,
+            &cache_key,
+            meta,
+        )
+        .await?;
+        let meta = upgrade.meta;
+        if upgrade.upgraded
+            && !opts.dry_run
+            && let Some(path) = pkg_mirror.as_deref()
+        {
+            persist_upgraded_to_mirror(path, &meta, use_filtered_full_metadata);
+        }
+
+        // Picking before the in-memory cache write keeps a document
+        // whose mirror turns out to be damaged from being cached at all.
+        let (picked_meta, picked) =
+            pick_from_meta(&picker_opts, spec, Arc::clone(&meta), opts.blocked_versions)?;
+        if picked_meta.versions.has_corrupt_mirror_fragment() && !bypass_cache {
+            bypass_cache = true;
+            continue;
+        }
+        break (meta, picked_meta, picked);
+    };
 
     // Worth flagging: a dry-run is meant to gate the on-disk save, but
     // `fetch_full_metadata_cached` already wrote the response body to
@@ -743,8 +790,7 @@ pub async fn pick_package<Cache: PackageMetaCache>(
     if !opts.dry_run {
         ctx.meta_cache.set(cache_key, Arc::clone(&meta));
     }
-    let (meta, picked) = pick_from_meta(&picker_opts, spec, meta, opts.blocked_versions)?;
-    Ok(PickPackageResult { meta, picked_package: picked })
+    Ok(PickPackageResult { meta: picked_meta, picked_package: picked })
 }
 
 /// Shared cache-hit path. Invoked once on the optimistic pre-permit
@@ -753,11 +799,12 @@ pub async fn pick_package<Cache: PackageMetaCache>(
 /// re-fetching). Extracting it keeps the two call sites identical so
 /// the upgrade-and-persist side-effects can't drift.
 ///
-/// Returns `Ok(None)` when the hit must not be terminal: the entry is
-/// a registry-unverified disk promotion (see
-/// [`PackageMetaCache::set_unverified`]) whose pick failed, and the
-/// resolver isn't offline. The caller then falls through to the disk +
-/// network flow, whose fetch replaces the entry with a verified one.
+/// Returns `Ok(None)` when the hit must not be terminal, and the caller
+/// falls through to the disk + network flow that replaces the entry:
+/// either the entry is a registry-unverified disk promotion (see
+/// [`PackageMetaCache::set_unverified`]) whose pick failed and the
+/// resolver isn't offline, or the pick hydrated a damaged fragment of
+/// the mirror the entry came from.
 ///
 /// The argument list is wide because the helper consumes everything
 /// the per-call frame already computed (cache key, derived
@@ -799,6 +846,14 @@ async fn handle_cache_hit<Cache: PackageMetaCache>(
         ctx.meta_cache.set(cache_key.to_string(), Arc::clone(&meta));
     }
     let (meta, picked) = pick_from_meta(picker_opts, spec, meta, opts.blocked_versions)?;
+    // A cached disk promotion whose fragments turn out to be damaged
+    // must not be served: offline resolution falls through to the same
+    // error a missing mirror raises, and online resolution to the fetch
+    // that replaces the file. Hydration is lazy, so an entry cached
+    // after a clean pick can still surface damage on a later one.
+    if meta.versions.has_corrupt_mirror_fragment() {
+        return Ok(None);
+    }
     if picked.is_none() && !ctx.offline && !registry_verified {
         return Ok(None);
     }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use pacquet_network::{
     AuthHeaders, MetadataCacheScope, RetryOpts, ThrottledClient, UpstreamRouteHook,
@@ -1722,4 +1722,131 @@ async fn public_scope_falls_back_to_mirror_on_401() {
         .expect("ok");
     assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.1.0");
     mock.assert_async().await;
+}
+
+/// Damages the fragment of `acme@1.1.0` in the mirror `persist_meta_to_mirror`
+/// wrote, leaving the file length and the index spans intact so only the
+/// fragment's own bytes fail to parse. Returns the damaged file's bytes.
+fn damage_mirror_fragment(cache_dir: &Path, registry: &str) -> Vec<u8> {
+    let path = get_pkg_mirror_path(cache_dir, ABBREVIATED_META_DIR, registry, "acme")
+        .expect("mirror path");
+    let mut bytes = std::fs::read(&path).expect("read mirror");
+    // An unescaped quote inside 1.1.0's integrity string: still the same
+    // number of bytes, no longer parsable JSON.
+    let marker = b"sha512-BBBB";
+    let at = bytes
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .expect("1.1.0 fragment in the mirror");
+    bytes[at + 3] = b'"';
+    std::fs::write(&path, &bytes).expect("write damaged mirror");
+    bytes
+}
+
+/// Offline, a damaged fragment leaves the mirror as unusable as a missing
+/// one — and there is no network to replace it from.
+#[tokio::test]
+async fn offline_over_a_damaged_mirror_fragment_errors() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/acme").expect(0).create_async().await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let preloaded: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
+    damage_mirror_fragment(cache_dir.path(), &registry);
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: true,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let err = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect_err("offline + damaged mirror = error");
+    assert!(matches!(err, PickPackageError::NoOfflineMeta { .. }), "got {err:?}");
+    mock.assert_async().await;
+}
+
+/// The etag lives in the mirror's intact headers record, so a conditional
+/// request keeps answering `304` over a damaged body. Online, the resolver
+/// has to ask again with the cache bypassed and rewrite the file.
+#[tokio::test]
+async fn a_damaged_fragment_behind_a_304_is_replaced_by_a_bypassing_refetch() {
+    let mut server = mockito::Server::new_async().await;
+    let conditional = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", r#"W/"cached""#)
+        .match_header("cache-control", mockito::Matcher::Missing)
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+    let bypassing = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", mockito::Matcher::Missing)
+        .match_header("cache-control", "no-cache")
+        .with_status(200)
+        .with_header("etag", r#"W/"fresh""#)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let mut preloaded: pacquet_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    preloaded.etag = Some(r#"W/"cached""#.to_string());
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
+    let damaged = damage_mirror_fragment(cache_dir.path(), &registry);
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.1.0");
+    conditional.assert_async().await;
+    bypassing.assert_async().await;
+
+    let path = get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+        .expect("mirror path");
+    let healed = std::fs::read(&path).expect("read mirror");
+    assert_ne!(healed, damaged, "the bypassing refetch rewrites the damaged mirror");
+    let reloaded = load_meta(&path).expect("reload the healed mirror");
+    assert!(reloaded.versions.get("1.1.0").is_some());
+    assert!(!reloaded.versions.has_corrupt_mirror_fragment());
 }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use pnpm_network::{
     AuthHeaders, MetadataCacheScope, RetryOpts, ThrottledClient, UpstreamRouteHook,
@@ -1901,7 +1901,7 @@ async fn private_scope_writes_descriptor_namespaced_mirror() {
 
     let scoped = get_pkg_mirror_path(
         cache_dir.path(),
-        "v11/metadata-private/deadbeef/metadata",
+        "v12/metadata-private/deadbeef/metadata",
         &registry,
         "acme",
     )
@@ -1927,7 +1927,7 @@ async fn private_scope_fails_closed_on_401_without_disk_fallback() {
     // serve from.
     persist_meta_to_mirror(
         cache_dir.path(),
-        "v11/metadata-private/deadbeef/metadata",
+        "v12/metadata-private/deadbeef/metadata",
         &registry,
         &preloaded,
     )
@@ -1994,4 +1994,133 @@ async fn public_scope_falls_back_to_mirror_on_401() {
         .expect("ok");
     assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.1.0");
     mock.assert_async().await;
+}
+
+/// Damages the fragment of `acme@1.1.0` in the mirror `persist_meta_to_mirror`
+/// wrote, leaving the file length and the index spans intact so only the
+/// fragment's own bytes fail to parse. Returns the damaged file's bytes.
+fn damage_mirror_fragment(cache_dir: &Path, registry: &str) -> Vec<u8> {
+    let path = get_pkg_mirror_path(cache_dir, ABBREVIATED_META_DIR, registry, "acme")
+        .expect("mirror path");
+    let mut bytes = std::fs::read(&path).expect("read mirror");
+    // An unescaped quote inside 1.1.0's integrity string: still the same
+    // number of bytes, no longer parsable JSON.
+    let marker = b"sha512-BBBB";
+    let at = bytes
+        .windows(marker.len())
+        .position(|window| window == marker)
+        .expect("1.1.0 fragment in the mirror");
+    bytes[at + 3] = b'"';
+    std::fs::write(&path, &bytes).expect("write damaged mirror");
+    bytes
+}
+
+/// Offline, a damaged fragment leaves the mirror as unusable as a missing
+/// one — and there is no network to replace it from.
+#[tokio::test]
+async fn offline_over_a_damaged_mirror_fragment_errors() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server.mock("GET", "/acme").expect(0).create_async().await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let preloaded: pnpm_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
+    damage_mirror_fragment(cache_dir.path(), &registry);
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: true,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        needs_full_metadata_for: None,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let err = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect_err("offline + damaged mirror = error");
+    assert!(matches!(err, PickPackageError::NoOfflineMeta { .. }), "got {err:?}");
+    mock.assert_async().await;
+}
+
+/// The etag lives in the mirror's intact headers record, so a conditional
+/// request keeps answering `304` over a damaged body. Online, the resolver
+/// has to ask again with the cache bypassed and rewrite the file.
+#[tokio::test]
+async fn a_damaged_fragment_behind_a_304_is_replaced_by_a_bypassing_refetch() {
+    let mut server = mockito::Server::new_async().await;
+    let conditional = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", r#"W/"cached""#)
+        .match_header("cache-control", mockito::Matcher::Missing)
+        .with_status(304)
+        .expect(1)
+        .create_async()
+        .await;
+    let bypassing = server
+        .mock("GET", "/acme")
+        .match_header("if-none-match", mockito::Matcher::Missing)
+        .match_header("cache-control", "no-cache")
+        .with_status(200)
+        .with_header("etag", r#"W/"fresh""#)
+        .with_body(PACKAGE_BODY)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let cache_dir = TempDir::new().expect("tempdir");
+    let registry = format!("{}/", server.url());
+    let mut preloaded: pnpm_registry::Package =
+        serde_json::from_str(PACKAGE_BODY).expect("parse packument");
+    preloaded.etag = Some(r#"W/"cached""#.to_string());
+    persist_meta_to_mirror(cache_dir.path(), ABBREVIATED_META_DIR, &registry, &preloaded)
+        .expect("warm mirror");
+    let damaged = damage_mirror_fragment(cache_dir.path(), &registry);
+
+    let http_client = ThrottledClient::default();
+    let auth_headers = AuthHeaders::default();
+    let meta_cache = InMemoryPackageMetaCache::default();
+    let fetch_locker = shared_packument_fetch_locker();
+    let ctx = PickPackageContext {
+        http_client: &http_client,
+        auth_headers: &auth_headers,
+        meta_cache: &meta_cache,
+        fetch_locker: &fetch_locker,
+        cache_dir: Some(cache_dir.path()),
+        offline: false,
+        prefer_offline: false,
+        ignore_missing_time_field: false,
+        full_metadata: false,
+        filter_metadata: false,
+        needs_full_metadata_for: None,
+        retry_opts: RetryOpts::default(),
+    };
+
+    let result = pick_package(&ctx, &range_spec("acme", "^1.0.0"), &default_opts(&registry))
+        .await
+        .expect("ok");
+    assert_eq!(result.picked_package.expect("picked").version.to_string(), "1.1.0");
+    conditional.assert_async().await;
+    bypassing.assert_async().await;
+
+    let path = get_pkg_mirror_path(cache_dir.path(), ABBREVIATED_META_DIR, &registry, "acme")
+        .expect("mirror path");
+    let healed = std::fs::read(&path).expect("read mirror");
+    assert_ne!(healed, damaged, "the bypassing refetch rewrites the damaged mirror");
+    let reloaded = load_meta(&path).expect("reload the healed mirror");
+    assert!(reloaded.versions.get("1.1.0").is_some());
+    assert!(!reloaded.versions.has_corrupt_mirror_fragment());
 }

--- a/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/pick_package/tests.rs
@@ -1631,7 +1631,7 @@ async fn private_scope_writes_descriptor_namespaced_mirror() {
 
     let scoped = get_pkg_mirror_path(
         cache_dir.path(),
-        "v11/metadata-private/deadbeef/metadata",
+        "v12/metadata-private/deadbeef/metadata",
         &registry,
         "acme",
     )
@@ -1657,7 +1657,7 @@ async fn private_scope_fails_closed_on_401_without_disk_fallback() {
     // serve from.
     persist_meta_to_mirror(
         cache_dir.path(),
-        "v11/metadata-private/deadbeef/metadata",
+        "v12/metadata-private/deadbeef/metadata",
         &registry,
         &preloaded,
     )

--- a/pnpm11/cache/api/src/cacheView.ts
+++ b/pnpm11/cache/api/src/cacheView.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { PackageMeta } from '@pnpm/resolving.npm-resolver'
+import { loadMeta } from '@pnpm/resolving.npm-resolver'
 import { StoreIndex, storeIndexKey } from '@pnpm/store.index'
 import getRegistryName from 'encode-registry'
 import { glob } from 'tinyglobby'
@@ -19,26 +19,18 @@ export async function cacheView (opts: { cacheDir: string, storeDir: string, reg
     cwd: opts.cacheDir,
     expandDirectories: false,
   })).sort()
+  const cachedMetaFiles = await Promise.all(metaFilePaths.map(async (filePath) => {
+    const fullPath = path.join(opts.cacheDir, filePath)
+    // Every version is read below, so hydrate up front: the loader then
+    // reports a damaged mirror as a miss instead of throwing partway
+    // through, and the entry is skipped like an unreadable file.
+    const meta = await loadMeta(fullPath, { hydrateEagerly: true })
+    return { filePath, meta, mtime: statMtime(fullPath) }
+  }))
   const metaFilesByPath: Record<string, CachedVersions> = {}
   const storeIndex = new StoreIndex(opts.storeDir)
   try {
-    for (const filePath of metaFilePaths) {
-      let metaObject: PackageMeta | null
-      const fullPath = path.join(opts.cacheDir, filePath)
-      let mtime: Date | undefined
-      try {
-        const raw = fs.readFileSync(fullPath, 'utf8')
-        mtime = fs.statSync(fullPath).mtime
-        const newlineIdx = raw.indexOf('\n')
-        if (newlineIdx !== -1) {
-          // NDJSON format: line 1 = headers, line 2 = metadata
-          metaObject = JSON.parse(raw.slice(newlineIdx + 1)) as PackageMeta
-        } else {
-          metaObject = JSON.parse(raw) as PackageMeta
-        }
-      } catch {
-        continue
-      }
+    for (const { filePath, meta: metaObject, mtime } of cachedMetaFiles) {
       if (!metaObject) continue
       const cachedVersions: string[] = []
       const nonCachedVersions: string[] = []
@@ -66,4 +58,12 @@ export async function cacheView (opts: { cacheDir: string, storeDir: string, reg
     storeIndex.close()
   }
   return JSON.stringify(metaFilesByPath, null, 2)
+}
+
+function statMtime (filePath: string): Date | undefined {
+  try {
+    return fs.statSync(filePath).mtime
+  } catch {
+    return undefined
+  }
 }

--- a/pnpm11/cache/commands/test/cacheView.cmd.test.ts
+++ b/pnpm11/cache/commands/test/cacheView.cmd.test.ts
@@ -1,7 +1,9 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { beforeEach, describe, expect, test } from '@jest/globals'
 import { cache } from '@pnpm/cache.commands'
+import { ABBREVIATED_META_DIR } from '@pnpm/constants'
 import { prepare } from '@pnpm/prepare'
 import { REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import { rimrafSync } from '@zkochan/rimraf'
@@ -91,6 +93,28 @@ describe('cache view', () => {
         ],
       },
     })
+  })
+
+  // A damaged file is what the resolver refuses to read, so listing the
+  // versions around the damage would report a cache no install will use.
+  test('omits a package whose cache file is damaged', async () => {
+    const mirror = path.join(cacheDir, ABBREVIATED_META_DIR, 'registry.npmjs.org', 'is-negative.jsonl')
+    const bytes = fs.readFileSync(mirror)
+    const at = bytes.indexOf(Buffer.from('"integrity"'))
+    expect(at).toBeGreaterThan(-1)
+    // Same byte count, so the index spans still address the fragment, but
+    // its own bytes no longer parse.
+    bytes.fill('x', at, at + 11)
+    fs.writeFileSync(mirror, bytes)
+
+    const result = await cache.handler({
+      cacheDir,
+      cliOptions: {},
+      pnpmHomeDir: process.cwd(),
+      storeDir,
+    }, ['view', 'is-negative'])
+
+    expect(JSON.parse(result!)['registry.npmjs.org']).toBeUndefined()
   })
 
   test('lists all metadata for requested package should specify a package name', async () => {

--- a/pnpm11/core/constants/src/index.ts
+++ b/pnpm11/core/constants/src/index.ts
@@ -16,9 +16,11 @@ export const WORKSPACE_MANIFEST_FILENAME = 'pnpm-workspace.yaml'
 // about all the packages published by the same name, not just the manifest
 // of one package/version
 //
-// Cache files use NDJSON format: line 1 is cache headers (etag, modified),
-// line 2 is the registry metadata JSON.
-export const ABBREVIATED_META_DIR = 'v11/metadata'
-export const FULL_META_DIR = 'v11/metadata-full'
-export const FULL_FILTERED_META_DIR = 'v11/metadata-full-filtered'
+// The version prefix is bumped whenever the file format changes, so a pnpm
+// version that predates the change never reads files it cannot parse (and
+// never overwrites them with the format it knows). `v12` is the indexed
+// layout in `resolving/npm-resolver`'s mirror module; `v11` was NDJSON.
+export const ABBREVIATED_META_DIR = 'v12/metadata'
+export const FULL_META_DIR = 'v12/metadata-full'
+export const FULL_FILTERED_META_DIR = 'v12/metadata-full-filtered'
 

--- a/pnpm11/core/constants/src/index.ts
+++ b/pnpm11/core/constants/src/index.ts
@@ -35,8 +35,11 @@ export const BUILTIN_REGISTRIES_BY_PREFIX: Readonly<Record<string, string>> = Ob
 // about all the packages published by the same name, not just the manifest
 // of one package/version
 //
-// Cache files use NDJSON format: line 1 is cache headers (etag, modified),
-// line 2 is the registry metadata JSON.
-export const ABBREVIATED_META_DIR = 'v11/metadata'
-export const FULL_META_DIR = 'v11/metadata-full'
-export const FULL_FILTERED_META_DIR = 'v11/metadata-full-filtered'
+// The version prefix is bumped whenever the file format changes, so a pnpm
+// version that predates the change never reads files it cannot parse (and
+// never overwrites them with the format it knows). `v12` is the indexed
+// layout in `resolving/npm-resolver`'s mirror module; `v11` was NDJSON.
+export const ABBREVIATED_META_DIR = 'v12/metadata'
+export const FULL_META_DIR = 'v12/metadata-full'
+export const FULL_FILTERED_META_DIR = 'v12/metadata-full-filtered'
+

--- a/pnpm11/resolving/npm-resolver/src/clearMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/clearMeta.ts
@@ -69,11 +69,21 @@ export function clearMeta (pkg: PackageMeta): PackageMeta {
   return condensed
 }
 
+/**
+ * Marks a document as already condensed, so {@link clearMeta} returns it
+ * unchanged. A lazily-loaded indexed mirror (see `mirror.ts`) condenses each
+ * version manifest as it is hydrated; running `clearMeta` over it would parse
+ * every version just to rebuild what the getters already provide.
+ */
+export function markMetaCondensed (meta: PackageMeta): void {
+  condensedPackuments.set(meta, meta)
+}
+
 // Hand-rolled rather than delegated to a generic field picker because it runs
 // for every version of every packument an install parses. Testing the value
 // for `undefined` is equivalent to testing for the key's presence: version
 // objects come from JSON, which cannot encode undefined.
-function pickAbbreviatedVersionFields (info: PackageInRegistry): PackageInRegistry {
+export function pickAbbreviatedVersionFields (info: PackageInRegistry): PackageInRegistry {
   const picked: Partial<Record<keyof PackageInRegistry, unknown>> = {}
   for (const field of ABBREVIATED_VERSION_FIELDS) {
     const value = info[field]

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -7,7 +7,8 @@ import {
   type FetchMetadataFromFromRegistryOptions,
   type FetchMetadataResult,
 } from './fetch.js'
-import { getPkgMirrorPath, loadMeta, loadMetaHeaders, prepareJsonForDisk, saveMeta } from './pickPackage.js'
+import { loadMeta, loadMetaHeaders, prepareIndexedForDisk, saveMeta } from './mirror.js'
+import { getPkgMirrorPath } from './pickPackage.js'
 
 export interface FetchMetadataCachedOptions {
   registry: string
@@ -91,7 +92,12 @@ async function fetchMetadataCached (
   // requires cache headers loaded from a mirror — so a null mirror here is an
   // unreachable invariant breach.
   if (pkgMirror == null) throw new Error(`Unexpected 304 for ${pkgName} without a metadata cache`)
-  const cached = await loadMeta(pkgMirror)
+  // Unlike the resolver, callers of this function get the document itself and
+  // have nowhere to fall back to when a lazily-hydrated fragment turns out
+  // corrupt — and the etag lives in the intact headers record, so the mirror
+  // would keep 304-validating and never self-heal. Surfacing that corruption
+  // here makes it a cache miss the refetch below rewrites.
+  const cached = await loadMeta(pkgMirror, { hydrateEagerly: true })
   if (cached != null) return cached
 
   // The mirror vanished between the headers read and this read (concurrent
@@ -115,7 +121,7 @@ async function fetchMetadataCached (
   // the speedup.
   function persistAndReturn (fetched: FetchMetadataResult): PackageMeta {
     if (pkgMirror != null) {
-      saveMeta(pkgMirror, prepareJsonForDisk(fetched.meta, fetched.etag, fetched.jsonText)).catch(() => {})
+      saveMeta(pkgMirror, prepareIndexedForDisk(fetched.meta, fetched.etag)).catch(() => {})
     }
     return fetched.meta
   }

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -6,7 +6,8 @@ import {
   type FetchMetadataFromFromRegistryOptions,
   type FetchMetadataResult,
 } from './fetch.js'
-import { getPkgMirrorPath, loadMeta, loadMetaHeaders, prepareJsonForDisk, saveMeta } from './pickPackage.js'
+import { loadMeta, loadMetaHeaders, prepareIndexedForDisk, saveMeta } from './mirror.js'
+import { getPkgMirrorPath } from './pickPackage.js'
 
 export interface FetchMetadataCachedOptions {
   registry: string
@@ -102,7 +103,7 @@ async function fetchMetadataCached (
   // the speedup.
   function persistAndReturn (fetched: FetchMetadataResult): PackageMeta {
     if (pkgMirror != null) {
-      saveMeta(pkgMirror, prepareJsonForDisk(fetched.meta, fetched.etag, fetched.jsonText)).catch(() => {})
+      saveMeta(pkgMirror, prepareIndexedForDisk(fetched.meta, fetched.etag)).catch(() => {})
     }
     return fetched.meta
   }

--- a/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
+++ b/pnpm11/resolving/npm-resolver/src/fetchFullMetadataCached.ts
@@ -79,7 +79,12 @@ async function fetchMetadataCached (
   // requires cache headers loaded from a mirror — so a null mirror here is an
   // unreachable invariant breach.
   if (pkgMirror == null) throw new Error(`Unexpected 304 for ${pkgName} without a metadata cache`)
-  const cached = await loadMeta(pkgMirror)
+  // Unlike the resolver, callers of this function get the document itself and
+  // have nowhere to fall back to when a lazily-hydrated fragment turns out
+  // corrupt — and the etag lives in the intact headers record, so the mirror
+  // would keep 304-validating and never self-heal. Surfacing that corruption
+  // here makes it a cache miss the refetch below rewrites.
+  const cached = await loadMeta(pkgMirror, { hydrateEagerly: true })
   if (cached != null) return cached
 
   // The mirror vanished between the headers read and this read (concurrent

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -130,6 +130,7 @@ export {
   workspacePrefToNpm,
 }
 export { createNpmResolutionVerifier, type CreateNpmResolutionVerifierOptions } from './createNpmResolutionVerifier.js'
+export { loadMeta, type LoadMetaOptions } from './mirror.js'
 export {
   MINIMUM_RELEASE_AGE_VIOLATION_CODE,
   TRUST_DOWNGRADE_VIOLATION_CODE,

--- a/pnpm11/resolving/npm-resolver/src/index.ts
+++ b/pnpm11/resolving/npm-resolver/src/index.ts
@@ -131,6 +131,7 @@ export {
 }
 export { createNpmResolutionVerifier, type CreateNpmResolutionVerifierOptions } from './createNpmResolutionVerifier.js'
 export { inferRangeSpecStyle } from './inferRangeSpecStyle.js'
+export { loadMeta, type LoadMetaOptions } from './mirror.js'
 export {
   MINIMUM_RELEASE_AGE_VIOLATION_CODE,
   TRUST_DOWNGRADE_VIOLATION_CODE,

--- a/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
+++ b/pnpm11/resolving/npm-resolver/src/memoizeFetchMetadata.ts
@@ -29,14 +29,9 @@ export interface MemoizeFetchMetadataOptions {
  * requests for the same package.
  *
  * Unlike plain memoization, the entry is swapped for a body-less clone once
- * the request settles. `jsonText` — the raw registry response body, up to tens
- * of MB for a popular package — reaches every caller sharing the in-flight
- * request, so a package resolved by many workspace projects at once mirrors
- * that one body to disk instead of each project separately re-serializing
- * `meta`. Retaining bodies past settlement would pin hundreds of MB on large
- * cold-cache graphs, so a later cache-hit caller that writes the mirror falls
- * back to `JSON.stringify(meta)` in `prepareJsonForDisk`, which is equivalent
- * on read: `loadMeta` re-derives `etag` from the headers line.
+ * the request settles: `jsonText` is the raw registry response body, up to
+ * tens of MB for a popular package, and retaining one per package would pin
+ * hundreds of MB on large cold-cache graphs.
  *
  * Because that swap lands a turn after the request settles, both settlement
  * paths write back only while the entry is still their own promise — a `clear`

--- a/pnpm11/resolving/npm-resolver/src/mirror.ts
+++ b/pnpm11/resolving/npm-resolver/src/mirror.ts
@@ -1,13 +1,29 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
+import { PnpmError } from '@pnpm/error'
 import gfs from '@pnpm/fs.graceful-fs'
-import { logger } from '@pnpm/logger'
 import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
 import { fastPathTemp as pathTemp } from 'path-temp'
 import { renameOverwrite } from 'rename-overwrite'
 
 import { markMetaCondensed, pickAbbreviatedVersionFields } from './clearMeta.js'
+
+/**
+ * Reading a lazily-hydrated version manifest throws this when its fragment
+ * bytes are not valid JSON — the index vouched for the span, so the file is
+ * corrupt. Callers treat the whole document like an unreadable mirror (a
+ * cache miss), the same way whole-file corruption reads as `null` from
+ * {@link loadMeta}; corruption discovered lazily must not degrade into
+ * silently missing versions, or a poisoned mirror could keep 304-validating
+ * forever (the etag lives in the intact headers record) and never self-heal.
+ */
+const MALFORMED_FRAGMENT_ERROR_CODE = 'ERR_PNPM_MALFORMED_META_FRAGMENT'
+
+export function isMalformedMirrorFragmentError (err: unknown): boolean {
+  return util.types.isNativeError(err) && 'code' in err && err.code === MALFORMED_FRAGMENT_ERROR_CODE
+}
 
 export interface MetaHeaders {
   etag?: string
@@ -113,7 +129,8 @@ export async function loadMeta (pkgMirror: string, opts?: LoadMetaOptions): Prom
  * filtered view of the document, and mutations of a hydrated manifest (the
  * picker's `name` back-fill, `readPackage` hooks) stick. Returns `null` when
  * a span falls outside the file, so a truncated mirror reads as a cache miss
- * rather than handing out garbage fragments later.
+ * rather than handing out garbage fragments later; a fragment whose bytes
+ * don't parse throws on access (see the malformed-fragment error above).
  */
 function buildLazyVersions (
   pkgMirror: string,
@@ -125,7 +142,7 @@ function buildLazyVersions (
   // A null prototype so a registry-controlled version key named `__proto__`
   // becomes a regular own property (see the same pattern in clearMeta).
   const versions: PackageMeta['versions'] = Object.create(null)
-  const hydrated = new Map<string, PackageInRegistry | undefined>()
+  const hydrated = new Map<string, PackageInRegistry | PnpmError>()
   for (const [version, offset, length] of spans) {
     if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length) || offset < 0 || length < 0) return null
     const start = fragmentBase + offset
@@ -134,22 +151,19 @@ function buildLazyVersions (
     Object.defineProperty(versions, version, {
       enumerable: true,
       configurable: true,
-      get (): PackageInRegistry | undefined {
-        if (hydrated.has(version)) return hydrated.get(version)
-        let manifest: PackageInRegistry | undefined
-        try {
-          manifest = JSON.parse(data.toString('utf8', start, end)) as PackageInRegistry
-          if (condense) {
-            manifest = pickAbbreviatedVersionFields(manifest)
+      get (): PackageInRegistry {
+        let manifest = hydrated.get(version)
+        if (manifest == null) {
+          try {
+            const parsed = JSON.parse(data.toString('utf8', start, end)) as PackageInRegistry
+            if (parsed == null || typeof parsed !== 'object') throw new Error('a version manifest must be an object')
+            manifest = condense ? pickAbbreviatedVersionFields(parsed) : parsed
+          } catch {
+            manifest = new PnpmError('MALFORMED_META_FRAGMENT', `Failed to parse the manifest of ${version} in the package metadata mirror at ${pkgMirror}`)
           }
-        } catch {
-          // The index vouched for this span, so a parse failure means the
-          // fragment bytes are corrupt. Absent looks like an unpublished
-          // version, which the pickers already handle.
-          logger.debug({ message: `Failed to parse the manifest of ${version} in the package mirror at ${pkgMirror}` })
-          manifest = undefined
+          hydrated.set(version, manifest)
         }
-        hydrated.set(version, manifest)
+        if (manifest instanceof PnpmError) throw manifest
         return manifest
       },
     })

--- a/pnpm11/resolving/npm-resolver/src/mirror.ts
+++ b/pnpm11/resolving/npm-resolver/src/mirror.ts
@@ -48,6 +48,13 @@ interface MirrorIndex {
   name: string
   distTags?: Record<string, string>
   time?: PackageMeta['time']
+  /**
+   * Not part of `PackageMeta`, so nothing on this side reads it back — it is
+   * carried through because the Rust stack's `outdated --long` reads it out
+   * of the shared mirror, and rewriting the file without it would blank that
+   * column until the next full response.
+   */
+  homepage?: string
   versions: Array<[version: string, offset: number, length: number]>
 }
 
@@ -70,6 +77,13 @@ export interface LoadMetaOptions {
    * condenses the whole document itself.
    */
   condense?: boolean
+  /**
+   * Parse every fragment before returning, so a corrupt one reads as a cache
+   * miss here instead of throwing at the caller's first access. For callers
+   * that read across all versions anyway and have no fall-through path of
+   * their own, unlike the resolver (see the malformed-fragment error above).
+   */
+  hydrateEagerly?: boolean
 }
 
 /**
@@ -105,6 +119,11 @@ export async function loadMeta (pkgMirror: string, opts?: LoadMetaOptions): Prom
     const index = JSON.parse(data.toString('utf8', indexStart, fragmentBase)) as MirrorIndex
     const versions = buildLazyVersions(pkgMirror, data, fragmentBase, index.versions, opts?.condense === true)
     if (versions == null) return null
+    if (opts?.hydrateEagerly === true) {
+      for (const version in versions) {
+        void versions[version]
+      }
+    }
     const meta: PackageMeta = {
       name: index.name,
       'dist-tags': index.distTags ?? {},
@@ -171,6 +190,9 @@ function buildLazyVersions (
   return versions
 }
 
+/** Matches the bound the Rust stack's `read_mirror_headers` applies. */
+const MAX_HEADERS_LEN = 64 * 1024
+
 /**
  * Reads only the leading records of a mirror file to extract the cache
  * headers (etag, modified) for conditional requests. This avoids reading and
@@ -191,6 +213,10 @@ export async function loadMetaHeaders (pkgMirror: string): Promise<MetaHeaders |
     if (magic == null) {
       return JSON.parse(firstLine) as MetaHeaders
     }
+    // The headers record is an etag plus a timestamp. Bound the declared
+    // length before allocating from it, so a corrupt or hostile mirror can't
+    // turn a cache read into an arbitrarily large allocation.
+    if (magic.headersLen > MAX_HEADERS_LEN) return null
     const headersStart = newlineIdx + 1
     const headersEnd = headersStart + magic.headersLen
     if (headersEnd <= bytesRead) {
@@ -216,10 +242,10 @@ export async function loadMetaHeaders (pkgMirror: string): Promise<MetaHeaders |
  * is kept for `filterMetadata` documents; everything else is mirrored in the
  * indexed layout (see {@link MIRROR_MAGIC}).
  */
-export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined, jsonText?: string): string {
+export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined): string {
   const modified = meta.modified ?? meta.time?.modified
   const headers = JSON.stringify({ etag, modified })
-  const body = jsonText ?? JSON.stringify(meta.etag == null ? meta : { ...meta, etag: undefined })
+  const body = JSON.stringify(meta.etag == null ? meta : { ...meta, etag: undefined })
   return `${headers}\n${body}`
 }
 
@@ -249,6 +275,10 @@ export function prepareIndexedForDisk (meta: PackageMeta, etag: string | undefin
   }
   if (meta.time != null) {
     index.time = meta.time
+  }
+  const { homepage } = meta as PackageMeta & { homepage?: string }
+  if (typeof homepage === 'string') {
+    index.homepage = homepage
   }
   const indexJson = JSON.stringify(index)
   const lead = Buffer.from(

--- a/pnpm11/resolving/npm-resolver/src/mirror.ts
+++ b/pnpm11/resolving/npm-resolver/src/mirror.ts
@@ -1,0 +1,258 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+import gfs from '@pnpm/fs.graceful-fs'
+import { logger } from '@pnpm/logger'
+import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
+import { fastPathTemp as pathTemp } from 'path-temp'
+import { renameOverwrite } from 'rename-overwrite'
+
+import { markMetaCondensed, pickAbbreviatedVersionFields } from './clearMeta.js'
+
+export interface MetaHeaders {
+  etag?: string
+  modified?: string
+}
+
+/**
+ * Magic + format version of the indexed mirror layout, shared with the Rust
+ * stack (`pnpm/crates/resolving-npm-resolver/src/mirror.rs`). The file starts
+ * with `pacquet-meta-v1 <headersLen> <indexLen>\n`, followed by the headers
+ * JSON record, the index JSON record, and the concatenated per-version JSON
+ * fragments the index's `versions` spans point into. Loading such a file only
+ * parses the two records; a version's manifest is parsed on first access.
+ *
+ * Files without the magic line are the two-line NDJSON layout (headers JSON,
+ * newline, packument JSON), which loads eagerly. Both stacks read both
+ * layouts, so mirrors written by either CLI version stay usable.
+ */
+const MIRROR_MAGIC = 'pacquet-meta-v1'
+
+interface MirrorIndex {
+  name: string
+  distTags?: Record<string, string>
+  time?: PackageMeta['time']
+  versions: Array<[version: string, offset: number, length: number]>
+}
+
+/** Parse the `pacquet-meta-v1 <headersLen> <indexLen>` line; `null` for anything else. */
+function parseMirrorMagic (line: string): { headersLen: number, indexLen: number } | null {
+  if (!line.startsWith(`${MIRROR_MAGIC} `)) return null
+  const [headersLen, indexLen, extra] = line.slice(MIRROR_MAGIC.length + 1).split(' ')
+  if (extra != null) return null
+  const parsedHeadersLen = Number.parseInt(headersLen, 10)
+  const parsedIndexLen = Number.parseInt(indexLen, 10)
+  if (!Number.isSafeInteger(parsedHeadersLen) || !Number.isSafeInteger(parsedIndexLen) || parsedHeadersLen < 0 || parsedIndexLen < 0) return null
+  return { headersLen: parsedHeadersLen, indexLen: parsedIndexLen }
+}
+
+export interface LoadMetaOptions {
+  /**
+   * Condense hydrated version manifests to the abbreviated field set (see
+   * `clearMeta`) and mark the returned document as already condensed. Only
+   * affects indexed mirrors: an NDJSON mirror loads eagerly and the caller
+   * condenses the whole document itself.
+   */
+  condense?: boolean
+}
+
+/**
+ * Reads a package's mirrored registry metadata, in either mirror layout.
+ * An indexed mirror yields a document whose `versions` values are parsed
+ * lazily on first property access; enumeration of the version keys does not
+ * parse any manifest. Returns `null` when the file is missing, malformed, or
+ * truncated — the caller treats all three as a cache miss.
+ */
+export async function loadMeta (pkgMirror: string, opts?: LoadMetaOptions): Promise<PackageMeta | null> {
+  let data: Buffer
+  try {
+    data = await gfs.readFile(pkgMirror)
+  } catch {
+    return null
+  }
+  try {
+    const newlineIdx = data.indexOf(10)
+    if (newlineIdx === -1) return null
+    const firstLine = data.toString('utf8', 0, newlineIdx)
+    const magic = parseMirrorMagic(firstLine)
+    if (magic == null) {
+      const headers = JSON.parse(firstLine) as MetaHeaders
+      const meta = JSON.parse(data.toString('utf8', newlineIdx + 1)) as PackageMeta
+      meta.etag = headers.etag
+      return meta
+    }
+    const headersStart = newlineIdx + 1
+    const indexStart = headersStart + magic.headersLen
+    const fragmentBase = indexStart + magic.indexLen
+    if (fragmentBase > data.length) return null
+    const headers = JSON.parse(data.toString('utf8', headersStart, indexStart)) as MetaHeaders
+    const index = JSON.parse(data.toString('utf8', indexStart, fragmentBase)) as MirrorIndex
+    const versions = buildLazyVersions(pkgMirror, data, fragmentBase, index.versions, opts?.condense === true)
+    if (versions == null) return null
+    const meta: PackageMeta = {
+      name: index.name,
+      'dist-tags': index.distTags ?? {},
+      versions,
+      time: index.time,
+      modified: headers.modified,
+      etag: headers.etag,
+    }
+    if (opts?.condense === true) {
+      markMetaCondensed(meta)
+    }
+    return meta
+  } catch {
+    return null
+  }
+}
+
+/**
+ * A versions map whose values parse from their fragment span on first access.
+ * The getters cache in a map shared across the whole document, so a manifest
+ * keeps one identity even when a property descriptor is copied onto a
+ * filtered view of the document, and mutations of a hydrated manifest (the
+ * picker's `name` back-fill, `readPackage` hooks) stick. Returns `null` when
+ * a span falls outside the file, so a truncated mirror reads as a cache miss
+ * rather than handing out garbage fragments later.
+ */
+function buildLazyVersions (
+  pkgMirror: string,
+  data: Buffer,
+  fragmentBase: number,
+  spans: MirrorIndex['versions'],
+  condense: boolean
+): PackageMeta['versions'] | null {
+  // A null prototype so a registry-controlled version key named `__proto__`
+  // becomes a regular own property (see the same pattern in clearMeta).
+  const versions: PackageMeta['versions'] = Object.create(null)
+  const hydrated = new Map<string, PackageInRegistry | undefined>()
+  for (const [version, offset, length] of spans) {
+    if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length) || offset < 0 || length < 0) return null
+    const start = fragmentBase + offset
+    const end = start + length
+    if (end > data.length) return null
+    Object.defineProperty(versions, version, {
+      enumerable: true,
+      configurable: true,
+      get (): PackageInRegistry | undefined {
+        if (hydrated.has(version)) return hydrated.get(version)
+        let manifest: PackageInRegistry | undefined
+        try {
+          manifest = JSON.parse(data.toString('utf8', start, end)) as PackageInRegistry
+          if (condense) {
+            manifest = pickAbbreviatedVersionFields(manifest)
+          }
+        } catch {
+          // The index vouched for this span, so a parse failure means the
+          // fragment bytes are corrupt. Absent looks like an unpublished
+          // version, which the pickers already handle.
+          logger.debug({ message: `Failed to parse the manifest of ${version} in the package mirror at ${pkgMirror}` })
+          manifest = undefined
+        }
+        hydrated.set(version, manifest)
+        return manifest
+      },
+    })
+  }
+  return versions
+}
+
+/**
+ * Reads only the leading records of a mirror file to extract the cache
+ * headers (etag, modified) for conditional requests. This avoids reading and
+ * parsing the version data (which can be megabytes for popular packages).
+ */
+export async function loadMetaHeaders (pkgMirror: string): Promise<MetaHeaders | null> {
+  let fh: fs.FileHandle | undefined
+  try {
+    fh = await fs.open(pkgMirror, 'r')
+    // Magic line plus headers record is ~100 bytes; 1 KB is plenty.
+    const buf = Buffer.alloc(1024)
+    const { bytesRead } = await fh.read(buf, 0, 1024, 0)
+    if (bytesRead === 0) return null
+    const newlineIdx = buf.subarray(0, bytesRead).indexOf(10)
+    if (newlineIdx === -1) return null
+    const firstLine = buf.toString('utf8', 0, newlineIdx)
+    const magic = parseMirrorMagic(firstLine)
+    if (magic == null) {
+      return JSON.parse(firstLine) as MetaHeaders
+    }
+    const headersStart = newlineIdx + 1
+    const headersEnd = headersStart + magic.headersLen
+    if (headersEnd <= bytesRead) {
+      return JSON.parse(buf.toString('utf8', headersStart, headersEnd)) as MetaHeaders
+    }
+    const rest = Buffer.alloc(headersEnd - bytesRead)
+    await fh.read(rest, 0, rest.length, bytesRead)
+    return JSON.parse(buf.toString('utf8', headersStart, bytesRead) + rest.toString('utf8')) as MetaHeaders
+  } catch {
+    return null
+  } finally {
+    await fh?.close()
+  }
+}
+
+/**
+ * Formats metadata for disk storage as two-line NDJSON:
+ *   Line 1: cache headers (etag, modified) — small, fast to read
+ *   Line 2: the registry metadata JSON
+ *
+ * The etag lives only in the headers line (`loadMeta` re-attaches it from
+ * there), so a `meta` that carries one is serialized without it. This layout
+ * is kept for `filterMetadata` documents; everything else is mirrored in the
+ * indexed layout (see {@link MIRROR_MAGIC}).
+ */
+export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined, jsonText?: string): string {
+  const modified = meta.modified ?? meta.time?.modified
+  const headers = JSON.stringify({ etag, modified })
+  const body = jsonText ?? JSON.stringify(meta.etag == null ? meta : { ...meta, etag: undefined })
+  return `${headers}\n${body}`
+}
+
+/**
+ * Serializes metadata in the indexed mirror layout (see {@link MIRROR_MAGIC}).
+ * Reading `meta.versions` here materializes a lazily-loaded document; the
+ * documents that reach the mirror writers come from network fetches, which
+ * are always eager.
+ */
+export function prepareIndexedForDisk (meta: PackageMeta, etag: string | undefined): Buffer {
+  const headers = JSON.stringify({ etag, modified: meta.modified ?? meta.time?.modified } satisfies MetaHeaders)
+  const spans: MirrorIndex['versions'] = []
+  const fragments: Buffer[] = []
+  let offset = 0
+  for (const version of Object.keys(meta.versions ?? {})) {
+    const manifest = meta.versions[version]
+    if (manifest == null) continue
+    const fragment = Buffer.from(JSON.stringify(manifest), 'utf8')
+    spans.push([version, offset, fragment.length])
+    offset += fragment.length
+    fragments.push(fragment)
+  }
+  const index: MirrorIndex = {
+    name: meta.name,
+    distTags: meta['dist-tags'] ?? {},
+    versions: spans,
+  }
+  if (meta.time != null) {
+    index.time = meta.time
+  }
+  const indexJson = JSON.stringify(index)
+  const lead = Buffer.from(
+    `${MIRROR_MAGIC} ${Buffer.byteLength(headers)} ${Buffer.byteLength(indexJson)}\n${headers}${indexJson}`,
+    'utf8'
+  )
+  return Buffer.concat([lead, ...fragments])
+}
+
+const createdDirs = new Set<string>()
+
+export async function saveMeta (pkgMirror: string, content: string | Buffer): Promise<void> {
+  const dir = path.dirname(pkgMirror)
+  if (!createdDirs.has(dir)) {
+    await fs.mkdir(dir, { recursive: true })
+    createdDirs.add(dir)
+  }
+  const temp = pathTemp(pkgMirror)
+  await gfs.writeFile(temp, content, typeof content === 'string' ? 'utf8' : undefined)
+  await renameOverwrite(temp, pkgMirror)
+}

--- a/pnpm11/resolving/npm-resolver/src/mirror.ts
+++ b/pnpm11/resolving/npm-resolver/src/mirror.ts
@@ -31,18 +31,21 @@ export interface MetaHeaders {
 }
 
 /**
- * Magic + format version of the indexed mirror layout, shared with the Rust
- * stack (`pnpm/crates/resolving-npm-resolver/src/mirror.rs`). The file starts
- * with `pacquet-meta-v1 <headersLen> <indexLen>\n`, followed by the headers
- * JSON record, the index JSON record, and the concatenated per-version JSON
+ * Identifies the indexed mirror layout, shared with the Rust stack
+ * (`pnpm/crates/resolving-npm-resolver/src/mirror.rs`). The file starts with
+ * `pnpm-meta-v1 <headersLen> <indexLen>\n`, followed by the headers JSON
+ * record, the index JSON record, and the concatenated per-version JSON
  * fragments the index's `versions` spans point into. Loading such a file only
  * parses the two records; a version's manifest is parsed on first access.
  *
- * Files without the magic line are the two-line NDJSON layout (headers JSON,
- * newline, packument JSON), which loads eagerly. Both stacks read both
- * layouts, so mirrors written by either CLI version stay usable.
+ * A file whose first line isn't this is the two-line NDJSON layout (headers
+ * JSON, newline, packument JSON), which loads eagerly — that is how a
+ * `filterMetadata` document is still written. Reading an unrecognized line as
+ * a cache miss is a backstop, not the compatibility story: a format change
+ * bumps the cache directory (see `ABBREVIATED_META_DIR`) so a pnpm version
+ * that predates it never opens these files at all.
  */
-const MIRROR_MAGIC = 'pacquet-meta-v1'
+const MIRROR_FORMAT_ID = 'pnpm-meta-v1'
 
 interface MirrorIndex {
   name: string
@@ -58,10 +61,10 @@ interface MirrorIndex {
   versions: Array<[version: string, offset: number, length: number]>
 }
 
-/** Parse the `pacquet-meta-v1 <headersLen> <indexLen>` line; `null` for anything else. */
-function parseMirrorMagic (line: string): { headersLen: number, indexLen: number } | null {
-  if (!line.startsWith(`${MIRROR_MAGIC} `)) return null
-  const [headersLen, indexLen, extra] = line.slice(MIRROR_MAGIC.length + 1).split(' ')
+/** Parse the `pnpm-meta-v1 <headersLen> <indexLen>` line; `null` for anything else. */
+function parseFormatLine (line: string): { headersLen: number, indexLen: number } | null {
+  if (!line.startsWith(`${MIRROR_FORMAT_ID} `)) return null
+  const [headersLen, indexLen, extra] = line.slice(MIRROR_FORMAT_ID.length + 1).split(' ')
   if (extra != null) return null
   const parsedHeadersLen = Number.parseInt(headersLen, 10)
   const parsedIndexLen = Number.parseInt(indexLen, 10)
@@ -104,16 +107,16 @@ export async function loadMeta (pkgMirror: string, opts?: LoadMetaOptions): Prom
     const newlineIdx = data.indexOf(10)
     if (newlineIdx === -1) return null
     const firstLine = data.toString('utf8', 0, newlineIdx)
-    const magic = parseMirrorMagic(firstLine)
-    if (magic == null) {
+    const format = parseFormatLine(firstLine)
+    if (format == null) {
       const headers = JSON.parse(firstLine) as MetaHeaders
       const meta = JSON.parse(data.toString('utf8', newlineIdx + 1)) as PackageMeta
       meta.etag = headers.etag
       return meta
     }
     const headersStart = newlineIdx + 1
-    const indexStart = headersStart + magic.headersLen
-    const fragmentBase = indexStart + magic.indexLen
+    const indexStart = headersStart + format.headersLen
+    const fragmentBase = indexStart + format.indexLen
     if (fragmentBase > data.length) return null
     const headers = JSON.parse(data.toString('utf8', headersStart, indexStart)) as MetaHeaders
     const index = JSON.parse(data.toString('utf8', indexStart, fragmentBase)) as MirrorIndex
@@ -202,23 +205,23 @@ export async function loadMetaHeaders (pkgMirror: string): Promise<MetaHeaders |
   let fh: fs.FileHandle | undefined
   try {
     fh = await fs.open(pkgMirror, 'r')
-    // Magic line plus headers record is ~100 bytes; 1 KB is plenty.
+    // Format line plus headers record is ~100 bytes; 1 KB is plenty.
     const buf = Buffer.alloc(1024)
     const { bytesRead } = await fh.read(buf, 0, 1024, 0)
     if (bytesRead === 0) return null
     const newlineIdx = buf.subarray(0, bytesRead).indexOf(10)
     if (newlineIdx === -1) return null
     const firstLine = buf.toString('utf8', 0, newlineIdx)
-    const magic = parseMirrorMagic(firstLine)
-    if (magic == null) {
+    const format = parseFormatLine(firstLine)
+    if (format == null) {
       return JSON.parse(firstLine) as MetaHeaders
     }
     // The headers record is an etag plus a timestamp. Bound the declared
     // length before allocating from it, so a corrupt or hostile mirror can't
     // turn a cache read into an arbitrarily large allocation.
-    if (magic.headersLen > MAX_HEADERS_LEN) return null
+    if (format.headersLen > MAX_HEADERS_LEN) return null
     const headersStart = newlineIdx + 1
-    const headersEnd = headersStart + magic.headersLen
+    const headersEnd = headersStart + format.headersLen
     if (headersEnd <= bytesRead) {
       return JSON.parse(buf.toString('utf8', headersStart, headersEnd)) as MetaHeaders
     }
@@ -240,7 +243,7 @@ export async function loadMetaHeaders (pkgMirror: string): Promise<MetaHeaders |
  * The etag lives only in the headers line (`loadMeta` re-attaches it from
  * there), so a `meta` that carries one is serialized without it. This layout
  * is kept for `filterMetadata` documents; everything else is mirrored in the
- * indexed layout (see {@link MIRROR_MAGIC}).
+ * indexed layout (see {@link MIRROR_FORMAT_ID}).
  */
 export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined): string {
   const modified = meta.modified ?? meta.time?.modified
@@ -250,7 +253,7 @@ export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined)
 }
 
 /**
- * Serializes metadata in the indexed mirror layout (see {@link MIRROR_MAGIC}).
+ * Serializes metadata in the indexed mirror layout (see {@link MIRROR_FORMAT_ID}).
  * Reading `meta.versions` here materializes a lazily-loaded document; the
  * documents that reach the mirror writers come from network fetches, which
  * are always eager.
@@ -282,7 +285,7 @@ export function prepareIndexedForDisk (meta: PackageMeta, etag: string | undefin
   }
   const indexJson = JSON.stringify(index)
   const lead = Buffer.from(
-    `${MIRROR_MAGIC} ${Buffer.byteLength(headers)} ${Buffer.byteLength(indexJson)}\n${headers}${indexJson}`,
+    `${MIRROR_FORMAT_ID} ${Buffer.byteLength(headers)} ${Buffer.byteLength(indexJson)}\n${headers}${indexJson}`,
     'utf8'
   )
   return Buffer.concat([lead, ...fragments])

--- a/pnpm11/resolving/npm-resolver/src/mirror.ts
+++ b/pnpm11/resolving/npm-resolver/src/mirror.ts
@@ -1,0 +1,305 @@
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import util from 'node:util'
+
+import { PnpmError } from '@pnpm/error'
+import gfs from '@pnpm/fs.graceful-fs'
+import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
+import { fastPathTemp as pathTemp } from 'path-temp'
+import { renameOverwrite } from 'rename-overwrite'
+
+import { markMetaCondensed, pickAbbreviatedVersionFields } from './clearMeta.js'
+
+/**
+ * Reading a lazily-hydrated version manifest throws this when its fragment
+ * bytes are not valid JSON — the index vouched for the span, so the file is
+ * corrupt. Callers treat the whole document like an unreadable mirror (a
+ * cache miss), the same way whole-file corruption reads as `null` from
+ * {@link loadMeta}; corruption discovered lazily must not degrade into
+ * silently missing versions, or a poisoned mirror could keep 304-validating
+ * forever (the etag lives in the intact headers record) and never self-heal.
+ */
+const MALFORMED_FRAGMENT_ERROR_CODE = 'ERR_PNPM_MALFORMED_META_FRAGMENT'
+
+export function isMalformedMirrorFragmentError (err: unknown): boolean {
+  return util.types.isNativeError(err) && 'code' in err && err.code === MALFORMED_FRAGMENT_ERROR_CODE
+}
+
+export interface MetaHeaders {
+  etag?: string
+  modified?: string
+}
+
+/**
+ * Identifies the indexed mirror layout, shared with the Rust stack
+ * (`pnpm/crates/resolving-npm-resolver/src/mirror.rs`). The file starts with
+ * `pnpm-meta-v1 <headersLen> <indexLen>\n`, followed by the headers JSON
+ * record, the index JSON record, and the concatenated per-version JSON
+ * fragments the index's `versions` spans point into. Loading such a file only
+ * parses the two records; a version's manifest is parsed on first access.
+ *
+ * A file whose first line isn't this is the two-line NDJSON layout (headers
+ * JSON, newline, packument JSON), which loads eagerly — that is how a
+ * `filterMetadata` document is still written. Reading an unrecognized line as
+ * a cache miss is a backstop, not the compatibility story: a format change
+ * bumps the cache directory (see `ABBREVIATED_META_DIR`) so a pnpm version
+ * that predates it never opens these files at all.
+ */
+const MIRROR_FORMAT_ID = 'pnpm-meta-v1'
+
+interface MirrorIndex {
+  name: string
+  distTags?: Record<string, string>
+  time?: PackageMeta['time']
+  /**
+   * Not part of `PackageMeta`, so nothing on this side reads it back — it is
+   * carried through because the Rust stack's `outdated --long` reads it out
+   * of the shared mirror, and rewriting the file without it would blank that
+   * column until the next full response.
+   */
+  homepage?: string
+  versions: Array<[version: string, offset: number, length: number]>
+}
+
+/** Parse the `pnpm-meta-v1 <headersLen> <indexLen>` line; `null` for anything else. */
+function parseFormatLine (line: string): { headersLen: number, indexLen: number } | null {
+  if (!line.startsWith(`${MIRROR_FORMAT_ID} `)) return null
+  const [headersLen, indexLen, extra] = line.slice(MIRROR_FORMAT_ID.length + 1).split(' ')
+  if (extra != null) return null
+  const parsedHeadersLen = Number.parseInt(headersLen, 10)
+  const parsedIndexLen = Number.parseInt(indexLen, 10)
+  if (!Number.isSafeInteger(parsedHeadersLen) || !Number.isSafeInteger(parsedIndexLen) || parsedHeadersLen < 0 || parsedIndexLen < 0) return null
+  return { headersLen: parsedHeadersLen, indexLen: parsedIndexLen }
+}
+
+export interface LoadMetaOptions {
+  /**
+   * Condense hydrated version manifests to the abbreviated field set (see
+   * `clearMeta`) and mark the returned document as already condensed. Only
+   * affects indexed mirrors: an NDJSON mirror loads eagerly and the caller
+   * condenses the whole document itself.
+   */
+  condense?: boolean
+  /**
+   * Parse every fragment before returning, so a corrupt one reads as a cache
+   * miss here instead of throwing at the caller's first access. For callers
+   * that read across all versions anyway and have no fall-through path of
+   * their own, unlike the resolver (see the malformed-fragment error above).
+   */
+  hydrateEagerly?: boolean
+}
+
+/**
+ * Reads a package's mirrored registry metadata, in either mirror layout.
+ * An indexed mirror yields a document whose `versions` values are parsed
+ * lazily on first property access; enumeration of the version keys does not
+ * parse any manifest. Returns `null` when the file is missing, malformed, or
+ * truncated — the caller treats all three as a cache miss.
+ */
+export async function loadMeta (pkgMirror: string, opts?: LoadMetaOptions): Promise<PackageMeta | null> {
+  let data: Buffer
+  try {
+    data = await gfs.readFile(pkgMirror)
+  } catch {
+    return null
+  }
+  try {
+    const newlineIdx = data.indexOf(10)
+    if (newlineIdx === -1) return null
+    const firstLine = data.toString('utf8', 0, newlineIdx)
+    const format = parseFormatLine(firstLine)
+    if (format == null) {
+      const headers = JSON.parse(firstLine) as MetaHeaders
+      const meta = JSON.parse(data.toString('utf8', newlineIdx + 1)) as PackageMeta
+      meta.etag = headers.etag
+      return meta
+    }
+    const headersStart = newlineIdx + 1
+    const indexStart = headersStart + format.headersLen
+    const fragmentBase = indexStart + format.indexLen
+    if (fragmentBase > data.length) return null
+    const headers = JSON.parse(data.toString('utf8', headersStart, indexStart)) as MetaHeaders
+    const index = JSON.parse(data.toString('utf8', indexStart, fragmentBase)) as MirrorIndex
+    const versions = buildLazyVersions(pkgMirror, data, fragmentBase, index.versions, opts?.condense === true)
+    if (versions == null) return null
+    if (opts?.hydrateEagerly === true) {
+      for (const version in versions) {
+        void versions[version]
+      }
+    }
+    const meta: PackageMeta = {
+      name: index.name,
+      'dist-tags': index.distTags ?? {},
+      versions,
+      time: index.time,
+      modified: headers.modified,
+      etag: headers.etag,
+    }
+    if (opts?.condense === true) {
+      markMetaCondensed(meta)
+    }
+    return meta
+  } catch {
+    return null
+  }
+}
+
+/**
+ * A versions map whose values parse from their fragment span on first access.
+ * The getters cache in a map shared across the whole document, so a manifest
+ * keeps one identity even when a property descriptor is copied onto a
+ * filtered view of the document, and mutations of a hydrated manifest (the
+ * picker's `name` back-fill, `readPackage` hooks) stick. Returns `null` when
+ * a span falls outside the file, so a truncated mirror reads as a cache miss
+ * rather than handing out garbage fragments later; a fragment whose bytes
+ * don't parse throws on access (see the malformed-fragment error above).
+ */
+function buildLazyVersions (
+  pkgMirror: string,
+  data: Buffer,
+  fragmentBase: number,
+  spans: MirrorIndex['versions'],
+  condense: boolean
+): PackageMeta['versions'] | null {
+  // A null prototype so a registry-controlled version key named `__proto__`
+  // becomes a regular own property (see the same pattern in clearMeta).
+  const versions: PackageMeta['versions'] = Object.create(null)
+  const hydrated = new Map<string, PackageInRegistry | PnpmError>()
+  for (const [version, offset, length] of spans) {
+    if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(length) || offset < 0 || length < 0) return null
+    const start = fragmentBase + offset
+    const end = start + length
+    if (end > data.length) return null
+    Object.defineProperty(versions, version, {
+      enumerable: true,
+      configurable: true,
+      get (): PackageInRegistry {
+        let manifest = hydrated.get(version)
+        if (manifest == null) {
+          try {
+            const parsed = JSON.parse(data.toString('utf8', start, end)) as PackageInRegistry
+            if (parsed == null || typeof parsed !== 'object') throw new Error('a version manifest must be an object')
+            manifest = condense ? pickAbbreviatedVersionFields(parsed) : parsed
+          } catch {
+            manifest = new PnpmError('MALFORMED_META_FRAGMENT', `Failed to parse the manifest of ${version} in the package metadata mirror at ${pkgMirror}`)
+          }
+          hydrated.set(version, manifest)
+        }
+        if (manifest instanceof PnpmError) throw manifest
+        return manifest
+      },
+    })
+  }
+  return versions
+}
+
+/** Matches the bound the Rust stack's `read_mirror_headers` applies. */
+const MAX_HEADERS_LEN = 64 * 1024
+
+/**
+ * Reads only the leading records of a mirror file to extract the cache
+ * headers (etag, modified) for conditional requests. This avoids reading and
+ * parsing the version data (which can be megabytes for popular packages).
+ */
+export async function loadMetaHeaders (pkgMirror: string): Promise<MetaHeaders | null> {
+  let fh: fs.FileHandle | undefined
+  try {
+    fh = await fs.open(pkgMirror, 'r')
+    // Format line plus headers record is ~100 bytes; 1 KB is plenty.
+    const buf = Buffer.alloc(1024)
+    const { bytesRead } = await fh.read(buf, 0, 1024, 0)
+    if (bytesRead === 0) return null
+    const newlineIdx = buf.subarray(0, bytesRead).indexOf(10)
+    if (newlineIdx === -1) return null
+    const firstLine = buf.toString('utf8', 0, newlineIdx)
+    const format = parseFormatLine(firstLine)
+    if (format == null) {
+      return JSON.parse(firstLine) as MetaHeaders
+    }
+    // The headers record is an etag plus a timestamp. Bound the declared
+    // length before allocating from it, so a corrupt or hostile mirror can't
+    // turn a cache read into an arbitrarily large allocation.
+    if (format.headersLen > MAX_HEADERS_LEN) return null
+    const headersStart = newlineIdx + 1
+    const headersEnd = headersStart + format.headersLen
+    if (headersEnd <= bytesRead) {
+      return JSON.parse(buf.toString('utf8', headersStart, headersEnd)) as MetaHeaders
+    }
+    const rest = Buffer.alloc(headersEnd - bytesRead)
+    await fh.read(rest, 0, rest.length, bytesRead)
+    return JSON.parse(buf.toString('utf8', headersStart, bytesRead) + rest.toString('utf8')) as MetaHeaders
+  } catch {
+    return null
+  } finally {
+    await fh?.close()
+  }
+}
+
+/**
+ * Formats metadata for disk storage as two-line NDJSON:
+ *   Line 1: cache headers (etag, modified) — small, fast to read
+ *   Line 2: the registry metadata JSON
+ *
+ * The etag lives only in the headers line (`loadMeta` re-attaches it from
+ * there), so a `meta` that carries one is serialized without it. This layout
+ * is kept for `filterMetadata` documents; everything else is mirrored in the
+ * indexed layout (see {@link MIRROR_FORMAT_ID}).
+ */
+export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined): string {
+  const modified = meta.modified ?? meta.time?.modified
+  const headers = JSON.stringify({ etag, modified })
+  const body = JSON.stringify(meta.etag == null ? meta : { ...meta, etag: undefined })
+  return `${headers}\n${body}`
+}
+
+/**
+ * Serializes metadata in the indexed mirror layout (see {@link MIRROR_FORMAT_ID}).
+ * Reading `meta.versions` here materializes a lazily-loaded document; the
+ * documents that reach the mirror writers come from network fetches, which
+ * are always eager.
+ */
+export function prepareIndexedForDisk (meta: PackageMeta, etag: string | undefined): Buffer {
+  const headers = JSON.stringify({ etag, modified: meta.modified ?? meta.time?.modified } satisfies MetaHeaders)
+  const spans: MirrorIndex['versions'] = []
+  const fragments: Buffer[] = []
+  let offset = 0
+  for (const version of Object.keys(meta.versions ?? {})) {
+    const manifest = meta.versions[version]
+    if (manifest == null) continue
+    const fragment = Buffer.from(JSON.stringify(manifest), 'utf8')
+    spans.push([version, offset, fragment.length])
+    offset += fragment.length
+    fragments.push(fragment)
+  }
+  const index: MirrorIndex = {
+    name: meta.name,
+    distTags: meta['dist-tags'] ?? {},
+    versions: spans,
+  }
+  if (meta.time != null) {
+    index.time = meta.time
+  }
+  const { homepage } = meta as PackageMeta & { homepage?: string }
+  if (typeof homepage === 'string') {
+    index.homepage = homepage
+  }
+  const indexJson = JSON.stringify(index)
+  const lead = Buffer.from(
+    `${MIRROR_FORMAT_ID} ${Buffer.byteLength(headers)} ${Buffer.byteLength(indexJson)}\n${headers}${indexJson}`,
+    'utf8'
+  )
+  return Buffer.concat([lead, ...fragments])
+}
+
+const createdDirs = new Set<string>()
+
+export async function saveMeta (pkgMirror: string, content: string | Buffer): Promise<void> {
+  const dir = path.dirname(pkgMirror)
+  if (!createdDirs.has(dir)) {
+    await fs.mkdir(dir, { recursive: true })
+    createdDirs.add(dir)
+  }
+  const temp = pathTemp(pkgMirror)
+  await gfs.writeFile(temp, content, typeof content === 'string' ? 'utf8' : undefined)
+  await renameOverwrite(temp, pkgMirror)
+}

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -17,6 +17,7 @@ import {
   notModifiedWithoutCacheError,
 } from './fetch.js'
 import {
+  isMalformedMirrorFragmentError,
   loadMeta,
   loadMetaHeaders,
   prepareIndexedForDisk,
@@ -287,11 +288,22 @@ export async function pickPackage (
     if (upgrade.upgradedFrom != null) {
       ctx.metaCache.set(cacheKey, metaForCache)
     }
-    const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaForCache)
-    if (pickedPackage != null || ctx.offline === true || !unverifiedDiskPackuments.has(metaForCache)) {
+    let pickedFromCache: PackageInRegistry | null = null
+    let cacheFragmentCorrupt = false
+    try {
+      pickedFromCache = pickMatchingVersionFinal(pickerOpts, spec, metaForCache)
+    } catch (err: unknown) {
+      // A disk-promoted entry with a corrupt fragment: fall through — offline
+      // re-picks below and fails with NO_OFFLINE_META; online revalidates and
+      // the 304 handler refetches past the poisoned mirror.
+      if (!isMalformedMirrorFragmentError(err)) throw err
+      cacheFragmentCorrupt = true
+    }
+    if (!cacheFragmentCorrupt &&
+      (pickedFromCache != null || ctx.offline === true || !unverifiedDiskPackuments.has(metaForCache))) {
       return {
         meta: metaForCache,
-        pickedPackage,
+        pickedPackage: pickedFromCache,
       }
     }
     // Disk-promoted meta that can't satisfy the spec: fall through and
@@ -327,9 +339,18 @@ export async function pickPackage (
 
       if (ctx.offline) {
         if (diskMeta != null) {
+          let pickedPackage: PackageInRegistry | null
+          try {
+            pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
+          } catch (err: unknown) {
+            // A corrupt fragment makes the mirror as unusable offline as a
+            // missing one, and there is no network to heal it from.
+            if (!isMalformedMirrorFragmentError(err)) throw err
+            throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
+          }
           return {
             meta: diskMeta,
-            pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, diskMeta),
+            pickedPackage,
           }
         }
 
@@ -344,7 +365,15 @@ export async function pickPackage (
         if (upgrade.upgradedFrom != null) {
           ctx.metaCache.set(cacheKey, diskMeta)
         }
-        const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
+        let pickedPackage: PackageInRegistry | null
+        try {
+          pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
+        } catch (err: unknown) {
+          // A corrupt fragment: treat like an unusable mirror and let the
+          // network fetch below replace it.
+          if (!isMalformedMirrorFragmentError(err)) throw err
+          pickedPackage = null
+        }
         if (pickedPackage) {
           // A cache hit re-runs maybeUpgradeAbbreviatedMetaForReleaseAge, so
           // serving this meta from memory can't bypass the release-age
@@ -364,10 +393,10 @@ export async function pickPackage (
 
     if (!opts.includeLatestTag && !opts.updateChecksums && spec.type === 'version') {
       diskMeta = diskMeta ?? await limit(loadMetaCondensed)
-      // use the cached meta only if it has the required package version
-      // otherwise it is probably out of date
-      if ((diskMeta?.versions?.[spec.fetchSpec]) != null) {
-        try {
+      try {
+        // use the cached meta only if it has the required package version
+        // otherwise it is probably out of date
+        if ((diskMeta?.versions?.[spec.fetchSpec]) != null) {
           const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, diskMeta)
           if (pickedPackage) {
             cacheDiskLoadedMeta(ctx.metaCache, cacheKey, diskMeta)
@@ -376,12 +405,13 @@ export async function pickPackage (
               pickedPackage,
             }
           }
-        } catch {
-          // Swallow fast-path errors (e.g. ERR_PNPM_MISSING_TIME from
-          // abbreviated meta) and fall through to the network fetch, which
-          // can upgrade to full metadata and run the maturity check on
-          // real `time` data.
         }
+      } catch {
+        // Swallow fast-path errors (ERR_PNPM_MISSING_TIME from abbreviated
+        // meta, a corrupt fragment behind the exact-version read above) and
+        // fall through to the network fetch, which can upgrade to full
+        // metadata, run the maturity check on real `time` data, and replace
+        // a corrupt mirror.
       }
     }
     if (opts.publishedBy && opts.publishedByExclude?.(spec.name) !== true) {
@@ -424,12 +454,24 @@ export async function pickPackage (
 
       // 304: the cached mirror is still current.
       diskMeta = diskMeta ?? await limit(loadMetaCondensed)
-      if (diskMeta != null) return await serveValidatedMeta(diskMeta)
+      if (diskMeta != null) {
+        try {
+          return await serveValidatedMeta(diskMeta)
+        } catch (err: unknown) {
+          // The 304 validated the etag in the intact headers record, but a
+          // version fragment in the local file is corrupt, so the mirror
+          // proves nothing — without this refetch it would keep 304-validating
+          // and never self-heal. Fall through to the cache-bypassing request,
+          // whose persistFreshMeta rewrites the mirror.
+          if (!isMalformedMirrorFragmentError(err)) throw err
+        }
+      }
 
-      // The mirror vanished between the headers read and this read (concurrent
-      // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask
-      // again as a cold cache would, which the registry can only answer with a
-      // body or an error — never another 304.
+      // Either the mirror vanished between the headers read and this read
+      // (concurrent store cleanup, antivirus, ...) or its content turned out
+      // corrupt, so the 304 validates nothing. Ask again as a cold cache
+      // would, which the registry can only answer with a body or an error —
+      // never another 304.
       const refetched = await ctx.fetch(spec.name, {
         authHeaderValue: opts.authHeaderValue,
         cacheBypass: true,
@@ -442,11 +484,20 @@ export async function pickPackage (
       err.spec = spec
       const meta = await loadMetaCondensed() // TODO: add test for this usecase
       if (meta == null) throw err
+      let pickedPackage: PackageInRegistry | null
+      try {
+        pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, meta)
+      } catch (pickErr: unknown) {
+        // A corrupt fragment makes this fallback mirror as useless as a
+        // missing one; surface the original failure.
+        if (!isMalformedMirrorFragmentError(pickErr)) throw pickErr
+        throw err
+      }
       logger.error(err, err)
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
-        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
+        pickedPackage,
       }
     }
 
@@ -472,10 +523,13 @@ export async function pickPackage (
       // bypass the maturity check via the warn-and-skip fallback.
       const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, cached)
       const meta = upgradeMetaForCache(ctx, upgrade, { pkgMirror, dryRun: opts.dryRun })
+      // Pick before caching: a corrupt-fragment throw must not leave the
+      // poisoned document in the in-memory cache.
+      const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, meta)
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
+        pickedPackage,
       }
     }
 

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -406,12 +406,11 @@ export async function pickPackage (
             }
           }
         }
-      } catch {
-        // Swallow fast-path errors (ERR_PNPM_MISSING_TIME from abbreviated
-        // meta, a corrupt fragment behind the exact-version read above) and
-        // fall through to the network fetch, which can upgrade to full
+      } catch (err: unknown) {
+        // Fall through to the network fetch, which can upgrade to full
         // metadata, run the maturity check on real `time` data, and replace
         // a corrupt mirror.
+        if (!isDiskMetaPickError(err)) throw err
       }
     }
     if (opts.publishedBy && opts.publishedByExclude?.(spec.name) !== true) {
@@ -427,8 +426,9 @@ export async function pickPackage (
                 pickedPackage,
               }
             }
-          } catch {
+          } catch (err: unknown) {
             // Same as above — fall through to the network fetch.
+            if (!isDiskMetaPickError(err)) throw err
           }
         }
       }
@@ -769,6 +769,36 @@ function isMissingTimeError (err: unknown): boolean {
     typeof err === 'object' &&
     'code' in err &&
     (err as { code: string }).code === 'ERR_PNPM_MISSING_TIME'
+  )
+}
+
+/**
+ * Errors that mean a pick failed because of the disk-loaded document itself:
+ * abbreviated metadata without `time`, a corrupt lazily-hydrated fragment, an
+ * otherwise malformed document (`pickPackageFromMeta` attributes any
+ * unexpected pick failure to the metadata), or a document whose versions all
+ * fall outside the maturity window (the release-age picker strips
+ * `publishedBy` after filtering, so an emptied document reports no versions).
+ */
+const DISK_META_PICK_ERROR_CODES = new Set([
+  'ERR_PNPM_MISSING_TIME',
+  'ERR_PNPM_MALFORMED_META_FRAGMENT',
+  'ERR_PNPM_MALFORMED_METADATA',
+  'ERR_PNPM_NO_VERSIONS',
+  'ERR_PNPM_UNPUBLISHED_PKG',
+])
+
+/**
+ * Whether the disk fast paths should fall through to the network fetch for
+ * this pick failure — it works from strictly fresher data and rewrites the
+ * mirror. Any other error is unexpected and propagates.
+ */
+function isDiskMetaPickError (err: unknown): boolean {
+  return (
+    err != null &&
+    typeof err === 'object' &&
+    'code' in err &&
+    DISK_META_PICK_ERROR_CODES.has((err as { code: string }).code)
   )
 }
 

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -4,13 +4,10 @@ import path from 'node:path'
 import { ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
 import { createHexHash } from '@pnpm/crypto.hash'
 import { PnpmError } from '@pnpm/error'
-import gfs from '@pnpm/fs.graceful-fs'
 import { globalWarn, logger } from '@pnpm/logger'
 import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
 import getRegistryName from 'encode-registry'
 import pLimit, { type LimitFunction } from 'p-limit'
-import { fastPathTemp as pathTemp } from 'path-temp'
-import { renameOverwrite } from 'rename-overwrite'
 import semver from 'semver'
 
 import { clearMeta, retainsFullMeta } from './clearMeta.js'
@@ -19,6 +16,13 @@ import {
   type FetchMetadataResult,
   notModifiedWithoutCacheError,
 } from './fetch.js'
+import {
+  loadMeta,
+  loadMetaHeaders,
+  prepareIndexedForDisk,
+  prepareJsonForDisk,
+  saveMeta,
+} from './mirror.js'
 import type { RegistryPackageSpec } from './parseBareSpecifier.js'
 import {
   pickLowestVersionByVersionRange,
@@ -296,7 +300,7 @@ export async function pickPackage (
 
   return runLimited(pkgMirror, async (limit) => {
     const loadMetaCondensed = async (): Promise<PackageMeta | null> => {
-      const meta = await loadMeta(pkgMirror)
+      const meta = await loadMeta(pkgMirror, { condense: !retainsFullMeta(ctx) })
       return meta == null ? null : condenseMetaForCache(ctx, meta)
     }
     let diskMeta: PackageMeta | null | undefined
@@ -502,7 +506,7 @@ export async function pickPackage (
         if (!isModifiedValid || modifiedDate > opts.publishedBy) {
           // Save the abbreviated metadata to the abbreviated cache before re-fetching full.
           if (!opts.dryRun) {
-            saveMetaBestEffort(pkgMirror, prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText))
+            saveMetaBestEffort(pkgMirror, prepareMirrorForDisk(ctx, resultToSave))
           }
           const fullFetchResult = await ctx.fetch(spec.name, {
             authHeaderValue: opts.authHeaderValue,
@@ -518,15 +522,7 @@ export async function pickPackage (
 
       meta = condenseMetaForCache(ctx, meta)
       if (!opts.dryRun) {
-        // Mirror the raw registry body, unless the retained form is
-        // deliberately narrower: `filterMetadata` always mirrors the stripped
-        // document, and an upgraded-to-full document mirrors the condensed
-        // form — `time` is all the next install needs from this slot.
-        const writeCondensed = ctx.filterMetadata === true || (resultToSave !== fetched && meta !== resultToSave.meta)
-        const jsonForDisk = writeCondensed
-          ? prepareJsonForDisk(meta, resultToSave.etag)
-          : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
-        saveMetaBestEffort(pkgMirror, jsonForDisk)
+        saveMetaBestEffort(pkgMirror, prepareMirrorForDisk(ctx, resultToSave))
       }
       meta.etag = resultToSave.etag
       // only save meta to cache, when it is fresh
@@ -619,30 +615,40 @@ function upgradeMetaForCache (
   return persistUpgradedMeta(ctx, opts.pkgMirror, upgrade.upgradedFrom)
 }
 
-// A condensing resolver keeps and mirrors the condensed form — the mirror
-// only has to carry `time` into the next install; otherwise the raw response
-// body is written and the unstripped meta is kept.
 function persistUpgradedMeta (
   ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
   pkgMirror: string,
   upgradedFrom: FetchMetadataResult
 ): PackageMeta {
   const metaForCache = condenseMetaForCache(ctx, upgradedFrom.meta)
-  const jsonForDisk = metaForCache === upgradedFrom.meta
-    ? prepareJsonForDisk(upgradedFrom.meta, upgradedFrom.etag, upgradedFrom.jsonText)
-    : prepareJsonForDisk(metaForCache, upgradedFrom.etag)
-  saveMetaBestEffort(pkgMirror, jsonForDisk)
+  saveMetaBestEffort(pkgMirror, prepareMirrorForDisk(ctx, upgradedFrom))
   return metaForCache
+}
+
+/**
+ * How a fetched document is mirrored on disk: a `filterMetadata` resolver
+ * mirrors the `clearMeta`-stripped NDJSON form (that mirror only serves
+ * equally-stripped resolutions), everything else the indexed layout, whose
+ * per-version spans later loads hydrate lazily.
+ */
+function prepareMirrorForDisk (
+  ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
+  result: FetchMetadataResult
+): string | Buffer {
+  if (ctx.filterMetadata === true) {
+    return prepareJsonForDisk(condenseMetaForCache(ctx, result.meta), result.etag)
+  }
+  return prepareIndexedForDisk(result.meta, result.etag)
 }
 
 /**
  * The mirror is an optimization, so a write failure only gets a debug log
  * with the mirror path and the install continues.
  */
-function saveMetaBestEffort (pkgMirror: string, json: string): void {
+function saveMetaBestEffort (pkgMirror: string, content: string | Buffer): void {
   void runLimited(pkgMirror, (limit) => limit(async () => {
     try {
-      await saveMeta(pkgMirror, json)
+      await saveMeta(pkgMirror, content)
     } catch (err: unknown) {
       logger.debug({ message: `Failed to write the package metadata mirror at ${pkgMirror}`, err })
     }
@@ -701,20 +707,7 @@ export function getPkgMirrorPath (cacheDir: string, metaDir: string, registry: s
   return path.join(cacheDir, metaDir, getRegistryName(registry), `${encodePkgName(pkgName)}.jsonl`)
 }
 
-/**
- * Formats metadata for disk storage as two-line NDJSON:
- *   Line 1: cache headers (etag, modified) — small, fast to read
- *   Line 2: the registry metadata JSON
- *
- * The etag lives only in the headers line (`loadMeta` re-attaches it from
- * there), so a `meta` that carries one is serialized without it.
- */
-export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined, jsonText?: string): string {
-  const modified = meta.modified ?? meta.time?.modified
-  const headers = JSON.stringify({ etag, modified })
-  const body = jsonText ?? JSON.stringify(meta.etag == null ? meta : { ...meta, etag: undefined })
-  return `${headers}\n${body}`
-}
+export { loadMeta, loadMetaHeaders, prepareJsonForDisk, saveMeta } from './mirror.js'
 
 function isMissingTimeError (err: unknown): boolean {
   return (
@@ -748,68 +741,6 @@ async function getFileMtime (filePath: string): Promise<Date | null> {
   } catch {
     return null
   }
-}
-
-interface MetaHeaders {
-  etag?: string
-  modified?: string
-}
-
-/**
- * Reads only the first line of the cached NDJSON metadata file to extract
- * the cache headers (etag, modified). This avoids reading and
- * parsing the full metadata (which can be megabytes for popular packages)
- * when we only need conditional-request headers.
- */
-export async function loadMetaHeaders (pkgMirror: string): Promise<MetaHeaders | null> {
-  let fh: fs.FileHandle | undefined
-  try {
-    fh = await fs.open(pkgMirror, 'r')
-    // The first line (headers JSON) is typically ~100 bytes; 1 KB is plenty.
-    const buf = Buffer.alloc(1024)
-    const { bytesRead } = await fh.read(buf, 0, 1024, 0)
-    if (bytesRead === 0) return null
-    const chunk = buf.toString('utf8', 0, bytesRead)
-    const newlineIdx = chunk.indexOf('\n')
-    if (newlineIdx === -1) return null
-    return JSON.parse(chunk.slice(0, newlineIdx)) as MetaHeaders
-  } catch {
-    return null
-  } finally {
-    await fh?.close()
-  }
-}
-
-/**
- * Reads the full metadata from the cached NDJSON file.
- * Line 1: cache headers (etag, modified)
- * Line 2: registry metadata JSON
- */
-export async function loadMeta (pkgMirror: string): Promise<PackageMeta | null> {
-  try {
-    const data = await gfs.readFile(pkgMirror, 'utf8')
-    const newlineIdx = data.indexOf('\n')
-    if (newlineIdx === -1) return null
-    const headers = JSON.parse(data.slice(0, newlineIdx)) as MetaHeaders
-    const meta = JSON.parse(data.slice(newlineIdx + 1)) as PackageMeta
-    meta.etag = headers.etag
-    return meta
-  } catch {
-    return null
-  }
-}
-
-const createdDirs = new Set<string>()
-
-export async function saveMeta (pkgMirror: string, json: string): Promise<void> {
-  const dir = path.dirname(pkgMirror)
-  if (!createdDirs.has(dir)) {
-    await fs.mkdir(dir, { recursive: true })
-    createdDirs.add(dir)
-  }
-  const temp = pathTemp(pkgMirror)
-  await gfs.writeFile(temp, json, 'utf8')
-  await renameOverwrite(temp, pkgMirror)
 }
 
 function validatePackageName (pkgName: string) {

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -1,16 +1,14 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
 import { createHexHash } from '@pnpm/crypto.hash'
 import { PnpmError } from '@pnpm/error'
-import gfs from '@pnpm/fs.graceful-fs'
 import { globalWarn, logger } from '@pnpm/logger'
 import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
 import getRegistryName from 'encode-registry'
 import pLimit, { type LimitFunction } from 'p-limit'
-import { fastPathTemp as pathTemp } from 'path-temp'
-import { renameOverwrite } from 'rename-overwrite'
 import semver from 'semver'
 
 import { clearMeta, retainsFullMeta } from './clearMeta.js'
@@ -19,6 +17,14 @@ import {
   type FetchMetadataResult,
   notModifiedWithoutCacheError,
 } from './fetch.js'
+import {
+  isMalformedMirrorFragmentError,
+  loadMeta,
+  loadMetaHeaders,
+  prepareIndexedForDisk,
+  prepareJsonForDisk,
+  saveMeta,
+} from './mirror.js'
 import type { RegistryPackageSpec } from './parseBareSpecifier.js'
 import {
   pickLowestVersionByVersionRange,
@@ -26,7 +32,6 @@ import {
   type PickPackageFromMetaOptions,
   pickVersionByVersionRange,
 } from './pickPackageFromMeta.js'
-import { dropIncompletePublishTimes } from './publishTimes.js'
 import { toRaw } from './toRaw.js'
 
 export interface PackageMetaCache {
@@ -302,11 +307,22 @@ export async function pickPackage (
     if (upgrade.upgradedFrom != null) {
       ctx.metaCache.set(cacheKey, metaForCache)
     }
-    const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, metaForCache)
-    if (pickedPackage != null || ctx.offline === true || !unverifiedDiskPackuments.has(metaForCache)) {
+    let pickedFromCache: PackageInRegistry | null = null
+    let cacheFragmentCorrupt = false
+    try {
+      pickedFromCache = pickMatchingVersionFinal(pickerOpts, spec, metaForCache)
+    } catch (err: unknown) {
+      // A disk-promoted entry with a corrupt fragment: fall through — offline
+      // re-picks below and fails with NO_OFFLINE_META; online revalidates and
+      // the 304 handler refetches past the poisoned mirror.
+      if (!isMalformedMirrorFragmentError(err)) throw err
+      cacheFragmentCorrupt = true
+    }
+    if (!cacheFragmentCorrupt &&
+      (pickedFromCache != null || ctx.offline === true || !unverifiedDiskPackuments.has(metaForCache))) {
       return {
         meta: metaForCache,
-        pickedPackage,
+        pickedPackage: pickedFromCache,
       }
     }
     // Disk-promoted meta that can't satisfy the spec: fall through and
@@ -315,7 +331,7 @@ export async function pickPackage (
 
   return runLimited(pkgMirror, async (limit) => {
     const loadMetaCondensed = async (): Promise<PackageMeta | null> => {
-      const meta = await loadMeta(pkgMirror)
+      const meta = await loadMeta(pkgMirror, { condense: !retainsFullMeta(ctx) })
       return meta == null ? null : condenseMetaForCache(ctx, meta)
     }
     let diskMeta: PackageMeta | null | undefined
@@ -342,9 +358,18 @@ export async function pickPackage (
 
       if (ctx.offline) {
         if (diskMeta != null) {
+          let pickedPackage: PackageInRegistry | null
+          try {
+            pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
+          } catch (err: unknown) {
+            // A corrupt fragment makes the mirror as unusable offline as a
+            // missing one, and there is no network to heal it from.
+            if (!isMalformedMirrorFragmentError(err)) throw err
+            throw new PnpmError('NO_OFFLINE_META', `Failed to resolve ${toRaw(spec)} in package mirror ${pkgMirror}`)
+          }
           return {
             meta: diskMeta,
-            pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, diskMeta),
+            pickedPackage,
           }
         }
 
@@ -359,7 +384,15 @@ export async function pickPackage (
         if (upgrade.upgradedFrom != null) {
           ctx.metaCache.set(cacheKey, diskMeta)
         }
-        const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
+        let pickedPackage: PackageInRegistry | null
+        try {
+          pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, diskMeta)
+        } catch (err: unknown) {
+          // A corrupt fragment: treat like an unusable mirror and let the
+          // network fetch below replace it.
+          if (!isMalformedMirrorFragmentError(err)) throw err
+          pickedPackage = null
+        }
         if (pickedPackage) {
           // A cache hit re-runs maybeUpgradeAbbreviatedMetaForReleaseAge, so
           // serving this meta from memory can't bypass the release-age
@@ -379,10 +412,10 @@ export async function pickPackage (
 
     if (!opts.includeLatestTag && !opts.updateChecksums && spec.type === 'version') {
       diskMeta = diskMeta ?? await limit(loadMetaCondensed)
-      // use the cached meta only if it has the required package version
-      // otherwise it is probably out of date
-      if ((diskMeta?.versions?.[spec.fetchSpec]) != null) {
-        try {
+      try {
+        // use the cached meta only if it has the required package version
+        // otherwise it is probably out of date
+        if ((diskMeta?.versions?.[spec.fetchSpec]) != null) {
           const pickedPackage = pickMatchingVersionFast(pickerOpts, spec, diskMeta)
           if (pickedPackage) {
             cacheDiskLoadedMeta(ctx.metaCache, cacheKey, diskMeta)
@@ -391,12 +424,12 @@ export async function pickPackage (
               pickedPackage,
             }
           }
-        } catch {
-          // Swallow fast-path errors (e.g. ERR_PNPM_MISSING_TIME from
-          // abbreviated meta) and fall through to the network fetch, which
-          // can upgrade to full metadata and run the maturity check on
-          // real `time` data.
         }
+      } catch (err: unknown) {
+        // Fall through to the network fetch, which can upgrade to full
+        // metadata, run the maturity check on real `time` data, and replace
+        // a corrupt mirror.
+        if (!isDiskMetaPickError(err)) throw err
       }
     }
     if (opts.publishedBy && opts.publishedByExclude?.(spec.name) !== true) {
@@ -412,8 +445,9 @@ export async function pickPackage (
                 pickedPackage,
               }
             }
-          } catch {
+          } catch (err: unknown) {
             // Same as above — fall through to the network fetch.
+            if (!isDiskMetaPickError(err)) throw err
           }
         }
       }
@@ -439,12 +473,24 @@ export async function pickPackage (
 
       // 304: the cached mirror is still current.
       diskMeta = diskMeta ?? await limit(loadMetaCondensed)
-      if (diskMeta != null) return await serveValidatedMeta(diskMeta)
+      if (diskMeta != null) {
+        try {
+          return await serveValidatedMeta(diskMeta)
+        } catch (err: unknown) {
+          // The 304 validated the etag in the intact headers record, but a
+          // version fragment in the local file is corrupt, so the mirror
+          // proves nothing — without this refetch it would keep 304-validating
+          // and never self-heal. Fall through to the cache-bypassing request,
+          // whose persistFreshMeta rewrites the mirror.
+          if (!isMalformedMirrorFragmentError(err)) throw err
+        }
+      }
 
-      // The mirror vanished between the headers read and this read (concurrent
-      // store cleanup, antivirus, ...), so the 304 now validates nothing. Ask
-      // again as a cold cache would, which the registry can only answer with a
-      // body or an error — never another 304.
+      // Either the mirror vanished between the headers read and this read
+      // (concurrent store cleanup, antivirus, ...) or its content turned out
+      // corrupt, so the 304 validates nothing. Ask again as a cold cache
+      // would, which the registry can only answer with a body or an error —
+      // never another 304.
       const refetched = await ctx.fetch(spec.name, {
         authHeaderValue: opts.authHeaderValue,
         cacheBypass: true,
@@ -457,11 +503,20 @@ export async function pickPackage (
       err.spec = spec
       const meta = await loadMetaCondensed() // TODO: add test for this usecase
       if (meta == null) throw err
+      let pickedPackage: PackageInRegistry | null
+      try {
+        pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, meta)
+      } catch (pickErr: unknown) {
+        // A corrupt fragment makes this fallback mirror as useless as a
+        // missing one; surface the original failure.
+        if (!isMalformedMirrorFragmentError(pickErr)) throw pickErr
+        throw err
+      }
       logger.error(err, err)
       logger.debug({ message: `Using cached meta from ${pkgMirror}` })
       return {
         meta,
-        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
+        pickedPackage,
       }
     }
 
@@ -487,10 +542,13 @@ export async function pickPackage (
       // bypass the maturity check via the warn-and-skip fallback.
       const upgrade = await maybeUpgradeAbbreviatedMetaForReleaseAge(ctx, spec, opts, cached)
       const meta = upgradeMetaForCache(ctx, upgrade, { pkgMirror, dryRun: opts.dryRun })
+      // Pick before caching: a corrupt-fragment throw must not leave the
+      // poisoned document in the in-memory cache.
+      const pickedPackage = pickMatchingVersionFinal(pickerOpts, spec, meta)
       ctx.metaCache.set(cacheKey, meta)
       return {
         meta,
-        pickedPackage: pickMatchingVersionFinal(pickerOpts, spec, meta),
+        pickedPackage,
       }
     }
 
@@ -522,7 +580,7 @@ export async function pickPackage (
         if (!isModifiedValid || modifiedDate > opts.publishedBy) {
           // Save the abbreviated metadata to the abbreviated cache before re-fetching full.
           if (!opts.dryRun) {
-            saveMetaBestEffort(pkgMirror, prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText))
+            saveMetaBestEffort(pkgMirror, prepareMirrorForDisk(ctx, resultToSave))
           }
           attemptedReleaseAgeUpgrade = true
           const fullFetchResult = await ctx.fetch(spec.name, {
@@ -542,15 +600,7 @@ export async function pickPackage (
         ctx.releaseAgeUpgradeCheckedPackuments?.add(meta)
       }
       if (!opts.dryRun) {
-        // Mirror the raw registry body, unless the retained form is
-        // deliberately narrower: `filterMetadata` always mirrors the stripped
-        // document, and an upgraded-to-full document mirrors the condensed
-        // form — `time` is all the next install needs from this slot.
-        const writeCondensed = ctx.filterMetadata === true || (resultToSave !== fetched && meta !== resultToSave.meta)
-        const jsonForDisk = writeCondensed
-          ? prepareJsonForDisk(meta, resultToSave.etag)
-          : prepareJsonForDisk(resultToSave.meta, resultToSave.etag, resultToSave.jsonText)
-        saveMetaBestEffort(pkgMirror, jsonForDisk)
+        saveMetaBestEffort(pkgMirror, prepareMirrorForDisk(ctx, resultToSave))
       }
       meta.etag = resultToSave.etag
       // only save meta to cache, when it is fresh
@@ -663,30 +713,55 @@ function upgradeMetaForCache (
   return meta
 }
 
-// A condensing resolver keeps and mirrors the condensed form — the mirror
-// only has to carry `time` into the next install; otherwise the raw response
-// body is written and the unstripped meta is kept.
 function persistUpgradedMeta (
   ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
   pkgMirror: string,
   upgradedFrom: FetchMetadataResult
 ): PackageMeta {
   const metaForCache = condenseMetaForCache(ctx, upgradedFrom.meta)
-  const jsonForDisk = metaForCache === upgradedFrom.meta
-    ? prepareJsonForDisk(upgradedFrom.meta, upgradedFrom.etag, upgradedFrom.jsonText)
-    : prepareJsonForDisk(metaForCache, upgradedFrom.etag)
-  saveMetaBestEffort(pkgMirror, jsonForDisk)
+  saveMetaBestEffort(pkgMirror, prepareMirrorForDisk(ctx, upgradedFrom))
   return metaForCache
+}
+
+/**
+ * Every project of a workspace that joins one in-flight fetch mirrors the
+ * result, so the encoded form is memoized on the result object: encoding it
+ * per project would hold as many copies of a body reaching tens of MB as
+ * there are projects. Keyed on the result rather than its `meta` so the copy
+ * is released with the shared body it stands in for — `memoizeFetchMetadata`
+ * drops the result once the request settles.
+ */
+const encodedMirrors = new WeakMap<FetchMetadataResult, { filtered?: string, indexed?: Buffer }>()
+
+/**
+ * How a fetched document is mirrored on disk: a `filterMetadata` resolver
+ * mirrors the `clearMeta`-stripped NDJSON form (that mirror only serves
+ * equally-stripped resolutions), everything else the indexed layout, whose
+ * per-version spans later loads hydrate lazily.
+ */
+function prepareMirrorForDisk (
+  ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
+  result: FetchMetadataResult
+): string | Buffer {
+  let encoded = encodedMirrors.get(result)
+  if (encoded == null) {
+    encoded = {}
+    encodedMirrors.set(result, encoded)
+  }
+  if (ctx.filterMetadata === true) {
+    return encoded.filtered ??= prepareJsonForDisk(condenseMetaForCache(ctx, result.meta), result.etag)
+  }
+  return encoded.indexed ??= prepareIndexedForDisk(result.meta, result.etag)
 }
 
 /**
  * The mirror is an optimization, so a write failure only gets a debug log
  * with the mirror path and the install continues.
  */
-function saveMetaBestEffort (pkgMirror: string, json: string): void {
+function saveMetaBestEffort (pkgMirror: string, content: string | Buffer): void {
   void runLimited(pkgMirror, (limit) => limit(async () => {
     try {
-      await saveMeta(pkgMirror, json)
+      await saveMeta(pkgMirror, content)
     } catch (err: unknown) {
       logger.debug({ message: `Failed to write the package metadata mirror at ${pkgMirror}`, err })
     }
@@ -745,20 +820,7 @@ export function getPkgMirrorPath (cacheDir: string, metaDir: string, registry: s
   return path.join(cacheDir, metaDir, getRegistryName(registry), `${encodePkgName(pkgName)}.jsonl`)
 }
 
-/**
- * Formats metadata for disk storage as two-line NDJSON:
- *   Line 1: cache headers (etag, modified) — small, fast to read
- *   Line 2: the registry metadata JSON
- *
- * The etag lives only in the headers line (`loadMeta` re-attaches it from
- * there), so a `meta` that carries one is serialized without it.
- */
-export function prepareJsonForDisk (meta: PackageMeta, etag: string | undefined, jsonText?: string): string {
-  const modified = meta.modified ?? meta.time?.modified
-  const headers = JSON.stringify({ etag, modified })
-  const body = jsonText ?? JSON.stringify(meta.etag == null ? meta : { ...meta, etag: undefined })
-  return `${headers}\n${body}`
-}
+export { loadMeta, loadMetaHeaders, prepareJsonForDisk, saveMeta } from './mirror.js'
 
 function isMissingTimeError (err: unknown): boolean {
   return (
@@ -766,6 +828,36 @@ function isMissingTimeError (err: unknown): boolean {
     typeof err === 'object' &&
     'code' in err &&
     (err as { code: string }).code === 'ERR_PNPM_MISSING_TIME'
+  )
+}
+
+/**
+ * Errors that mean a pick failed because of the disk-loaded document itself:
+ * abbreviated metadata without `time`, a corrupt lazily-hydrated fragment, an
+ * otherwise malformed document (`pickPackageFromMeta` attributes any
+ * unexpected pick failure to the metadata), or a document whose versions all
+ * fall outside the maturity window (the release-age picker strips
+ * `publishedBy` after filtering, so an emptied document reports no versions).
+ */
+const DISK_META_PICK_ERROR_CODES = new Set([
+  'ERR_PNPM_MISSING_TIME',
+  'ERR_PNPM_MALFORMED_META_FRAGMENT',
+  'ERR_PNPM_MALFORMED_METADATA',
+  'ERR_PNPM_NO_VERSIONS',
+  'ERR_PNPM_UNPUBLISHED_PKG',
+])
+
+/**
+ * Whether the disk fast paths should fall through to the network fetch for
+ * this pick failure — it works from strictly fresher data and rewrites the
+ * mirror. Any other error is unexpected and propagates.
+ */
+function isDiskMetaPickError (err: unknown): boolean {
+  return (
+    util.types.isNativeError(err) &&
+    'code' in err &&
+    typeof err.code === 'string' &&
+    DISK_META_PICK_ERROR_CODES.has(err.code)
   )
 }
 
@@ -792,69 +884,6 @@ async function getFileMtime (filePath: string): Promise<Date | null> {
   } catch {
     return null
   }
-}
-
-interface MetaHeaders {
-  etag?: string
-  modified?: string
-}
-
-/**
- * Reads only the first line of the cached NDJSON metadata file to extract
- * the cache headers (etag, modified). This avoids reading and
- * parsing the full metadata (which can be megabytes for popular packages)
- * when we only need conditional-request headers.
- */
-export async function loadMetaHeaders (pkgMirror: string): Promise<MetaHeaders | null> {
-  let fh: fs.FileHandle | undefined
-  try {
-    fh = await fs.open(pkgMirror, 'r')
-    // The first line (headers JSON) is typically ~100 bytes; 1 KB is plenty.
-    const buf = Buffer.alloc(1024)
-    const { bytesRead } = await fh.read(buf, 0, 1024, 0)
-    if (bytesRead === 0) return null
-    const chunk = buf.toString('utf8', 0, bytesRead)
-    const newlineIdx = chunk.indexOf('\n')
-    if (newlineIdx === -1) return null
-    return JSON.parse(chunk.slice(0, newlineIdx)) as MetaHeaders
-  } catch {
-    return null
-  } finally {
-    await fh?.close()
-  }
-}
-
-/**
- * Reads the full metadata from the cached NDJSON file.
- * Line 1: cache headers (etag, modified)
- * Line 2: registry metadata JSON
- */
-export async function loadMeta (pkgMirror: string): Promise<PackageMeta | null> {
-  try {
-    const data = await gfs.readFile(pkgMirror, 'utf8')
-    const newlineIdx = data.indexOf('\n')
-    if (newlineIdx === -1) return null
-    const headers = JSON.parse(data.slice(0, newlineIdx)) as MetaHeaders
-    const meta = JSON.parse(data.slice(newlineIdx + 1)) as PackageMeta
-    dropIncompletePublishTimes(meta)
-    meta.etag = headers.etag
-    return meta
-  } catch {
-    return null
-  }
-}
-
-const createdDirs = new Set<string>()
-
-export async function saveMeta (pkgMirror: string, json: string): Promise<void> {
-  const dir = path.dirname(pkgMirror)
-  if (!createdDirs.has(dir)) {
-    await fs.mkdir(dir, { recursive: true })
-    createdDirs.add(dir)
-  }
-  const temp = pathTemp(pkgMirror)
-  await gfs.writeFile(temp, json, 'utf8')
-  await renameOverwrite(temp, pkgMirror)
 }
 
 function validatePackageName (pkgName: string) {

--- a/pnpm11/resolving/npm-resolver/src/pickPackage.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackage.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { ABBREVIATED_META_DIR, FULL_FILTERED_META_DIR, FULL_META_DIR } from '@pnpm/constants'
 import { createHexHash } from '@pnpm/crypto.hash'
@@ -680,6 +681,16 @@ function persistUpgradedMeta (
 }
 
 /**
+ * Every project of a workspace that joins one in-flight fetch mirrors the
+ * result, so the encoded form is memoized on the result object: encoding it
+ * per project would hold as many copies of a body reaching tens of MB as
+ * there are projects. Keyed on the result rather than its `meta` so the copy
+ * is released with the shared body it stands in for — `memoizeFetchMetadata`
+ * drops the result once the request settles.
+ */
+const encodedMirrors = new WeakMap<FetchMetadataResult, { filtered?: string, indexed?: Buffer }>()
+
+/**
  * How a fetched document is mirrored on disk: a `filterMetadata` resolver
  * mirrors the `clearMeta`-stripped NDJSON form (that mirror only serves
  * equally-stripped resolutions), everything else the indexed layout, whose
@@ -689,10 +700,15 @@ function prepareMirrorForDisk (
   ctx: { fullMetadata?: boolean, filterMetadata?: boolean },
   result: FetchMetadataResult
 ): string | Buffer {
-  if (ctx.filterMetadata === true) {
-    return prepareJsonForDisk(condenseMetaForCache(ctx, result.meta), result.etag)
+  let encoded = encodedMirrors.get(result)
+  if (encoded == null) {
+    encoded = {}
+    encodedMirrors.set(result, encoded)
   }
-  return prepareIndexedForDisk(result.meta, result.etag)
+  if (ctx.filterMetadata === true) {
+    return encoded.filtered ??= prepareJsonForDisk(condenseMetaForCache(ctx, result.meta), result.etag)
+  }
+  return encoded.indexed ??= prepareIndexedForDisk(result.meta, result.etag)
 }
 
 /**
@@ -795,10 +811,10 @@ const DISK_META_PICK_ERROR_CODES = new Set([
  */
 function isDiskMetaPickError (err: unknown): boolean {
   return (
-    err != null &&
-    typeof err === 'object' &&
+    util.types.isNativeError(err) &&
     'code' in err &&
-    DISK_META_PICK_ERROR_CODES.has((err as { code: string }).code)
+    typeof err.code === 'string' &&
+    DISK_META_PICK_ERROR_CODES.has(err.code)
   )
 }
 

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -168,10 +168,18 @@ export function pickVersionByVersionRange ({ meta, versionRange, preferredVersio
   const maxVersion = maxSatisfyingLoose(versions, versionRange)
 
   // if the selected version is deprecated, try to find a non-deprecated one that satisfies the range
-  if (maxVersion && meta.versions[maxVersion].deprecated && versions.length > 1) {
-    const nonDeprecatedVersions = versions.map((version) => meta.versions[version])
-      .filter((versionMeta) => !versionMeta.deprecated)
-      .map((versionMeta) => versionMeta.version)
+  // The optional chain covers a corrupt fragment in a lazily-loaded indexed
+  // mirror, whose manifest hydrates to undefined (see the mirror module):
+  // treated as not deprecated here, and the picker's missing-manifest handling
+  // turns it into a failed pick rather than a crash.
+  if (maxVersion && meta.versions[maxVersion]?.deprecated && versions.length > 1) {
+    // Filter by the range before touching manifests, so a lazily-loaded
+    // packument hydrates only the actual candidates instead of every version.
+    const nonDeprecatedVersions = versions.filter((version) => {
+      if (version === maxVersion || !semverSatisfiesLoose(version, versionRange)) return false
+      const manifest = meta.versions[version]
+      return manifest != null && !manifest.deprecated
+    })
 
     const maxNonDeprecatedVersion = maxSatisfyingLoose(nonDeprecatedVersions, versionRange)
     if (maxNonDeprecatedVersion) return maxNonDeprecatedVersion

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -168,10 +168,9 @@ export function pickVersionByVersionRange ({ meta, versionRange, preferredVersio
   const maxVersion = maxSatisfyingLoose(versions, versionRange)
 
   // if the selected version is deprecated, try to find a non-deprecated one that satisfies the range
-  // The optional chain covers a corrupt fragment in a lazily-loaded indexed
-  // mirror, whose manifest hydrates to undefined (see the mirror module):
-  // treated as not deprecated here, and the picker's missing-manifest handling
-  // turns it into a failed pick rather than a crash.
+  // A version key whose manifest is missing (a registry document listing a
+  // version with no object) reads as not deprecated instead of crashing here;
+  // `pickPackageFromMeta` turns it into a failed pick.
   if (maxVersion && meta.versions[maxVersion]?.deprecated && versions.length > 1) {
     // Filter by the range before touching manifests, so a lazily-loaded
     // packument hydrates only the actual candidates instead of every version.

--- a/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
+++ b/pnpm11/resolving/npm-resolver/src/pickPackageFromMeta.ts
@@ -200,10 +200,17 @@ export function pickVersionByVersionRange ({ meta, versionRange, preferredVersio
   const maxVersion = maxSatisfyingLoose(versions, versionRange)
 
   // if the selected version is deprecated, try to find a non-deprecated one that satisfies the range
-  if (maxVersion && meta.versions[maxVersion].deprecated && versions.length > 1) {
-    const nonDeprecatedVersions = versions.map((version) => meta.versions[version])
-      .filter((versionMeta) => !versionMeta.deprecated)
-      .map((versionMeta) => versionMeta.version)
+  // A version key whose manifest is missing (a registry document listing a
+  // version with no object) reads as not deprecated instead of crashing here;
+  // `pickPackageFromMeta` turns it into a failed pick.
+  if (maxVersion && meta.versions[maxVersion]?.deprecated && versions.length > 1) {
+    // Filter by the range before touching manifests, so a lazily-loaded
+    // packument hydrates only the actual candidates instead of every version.
+    const nonDeprecatedVersions = versions.filter((version) => {
+      if (version === maxVersion || !semverSatisfiesLoose(version, versionRange)) return false
+      const manifest = meta.versions[version]
+      return manifest != null && !manifest.deprecated
+    })
 
     const maxNonDeprecatedVersion = maxSatisfyingLoose(nonDeprecatedVersions, versionRange)
     if (maxNonDeprecatedVersion) return maxNonDeprecatedVersion

--- a/pnpm11/resolving/npm-resolver/test/corruptMirror.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/corruptMirror.test.ts
@@ -1,0 +1,119 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { ABBREVIATED_META_DIR } from '@pnpm/constants'
+import type { PackageMeta } from '@pnpm/resolving.registry.types'
+import { temporaryDirectory } from 'tempy'
+
+import type { FetchMetadataOptions } from '../src/fetch.js'
+import { prepareIndexedForDisk } from '../src/mirror.js'
+import type { RegistryPackageSpec } from '../src/parseBareSpecifier.js'
+import { getPkgMirrorPath, type PackageMetaCache, pickPackage } from '../src/pickPackage.js'
+
+const REGISTRY = 'https://registry.npmjs.org/'
+
+function fooMeta (): PackageMeta {
+  return {
+    name: 'foo',
+    'dist-tags': { latest: '2.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'foo',
+        version: '1.0.0',
+        dist: {
+          shasum: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
+        },
+      },
+      '2.0.0': {
+        name: 'foo',
+        version: '2.0.0',
+        dist: {
+          shasum: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          tarball: 'https://registry.npmjs.org/foo/-/foo-2.0.0.tgz',
+        },
+      },
+    },
+  } as unknown as PackageMeta
+}
+
+function createMetaCache (): PackageMetaCache {
+  const store = new Map<string, PackageMeta>()
+  return {
+    get: (key) => store.get(key),
+    set: (key, meta) => {
+      store.set(key, meta)
+    },
+    has: (key) => store.has(key),
+  }
+}
+
+// Writes an indexed mirror whose 2.0.0 fragment (the max satisfying version)
+// is corrupted in place: spans stay valid, the fragment bytes do not parse.
+function writeCorruptMirror (pkgMirror: string): void {
+  const meta = fooMeta()
+  const content = prepareIndexedForDisk(meta, '"etag-corrupt"')
+  const fragmentStart = content.indexOf(Buffer.from(JSON.stringify(meta.versions['2.0.0'])))
+  if (fragmentStart === -1) throw new Error('fragment not found in the serialized mirror')
+  content.fill('x', fragmentStart, fragmentStart + 10)
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, content)
+}
+
+test('offline resolution over a corrupt fragment fails with NO_OFFLINE_META', async () => {
+  const cacheDir = temporaryDirectory()
+  writeCorruptMirror(getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo'))
+
+  const ctx = {
+    fetch: async () => {
+      throw new Error('offline resolution must not hit the network')
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+    offline: true,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '>=1.0.0' }
+
+  await expect(
+    pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
+  ).rejects.toMatchObject({ code: 'ERR_PNPM_NO_OFFLINE_META' })
+})
+
+test('a corrupt fragment behind a 304 triggers a cache-bypassing refetch that heals the mirror', async () => {
+  const cacheDir = temporaryDirectory()
+  const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
+  writeCorruptMirror(pkgMirror)
+  const corruptContent = fs.readFileSync(pkgMirror)
+
+  const meta = fooMeta()
+  type CacheBypassFetchMetadataOptions = FetchMetadataOptions & { cacheBypass?: boolean }
+  const fetchCalls: CacheBypassFetchMetadataOptions[] = []
+  const ctx = {
+    fetch: async (pkgName: string, fetchOpts: CacheBypassFetchMetadataOptions) => {
+      fetchCalls.push(fetchOpts)
+      if (!fetchOpts.cacheBypass) return { notModified: true as const }
+      return { meta, jsonText: JSON.stringify(meta), etag: '"fresh"' }
+    },
+    metaCache: createMetaCache(),
+    cacheDir,
+  }
+  const spec: RegistryPackageSpec = { type: 'range', name: 'foo', fetchSpec: '>=1.0.0' }
+
+  const res = await pickPackage(ctx, spec, { registry: REGISTRY, dryRun: false, preferredVersionSelectors: undefined })
+  expect(res.pickedPackage?.version).toBe('2.0.0')
+  expect(fetchCalls).toHaveLength(2)
+  expect(fetchCalls[0].etag).toBe('"etag-corrupt"')
+  expect(fetchCalls[0].cacheBypass).toBeUndefined()
+  expect(fetchCalls[1].cacheBypass).toBe(true)
+
+  // The mirror rewrite is fire-and-forget; wait for the poisoned bytes to be
+  // replaced by the refetched document.
+  /* eslint-disable no-await-in-loop */
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (!fs.readFileSync(pkgMirror).equals(corruptContent)) break
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  /* eslint-enable no-await-in-loop */
+  expect(fs.readFileSync(pkgMirror).equals(corruptContent)).toBe(false)
+})

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -18,6 +18,7 @@ import {
   prepareJsonForDisk,
   saveMeta,
 } from '../src/pickPackage.js'
+import { parseNdjsonMeta } from './utils/index.js'
 
 const REGISTRY = 'https://registry.npmjs.org/'
 
@@ -200,16 +201,13 @@ test('prefer-offline resolution promotes the disk-loaded packument into the in-m
   expect(second.pickedPackage?.version).toBe('1.0.0')
 })
 
-test('the raw response body is written verbatim to the disk mirror', async () => {
+test('the response body is mirrored in the indexed layout', async () => {
   const meta = fooMeta()
-  // A body distinct from the compact JSON.stringify(meta) so we can prove the
-  // mirror is written from the raw response text, not re-serialized.
-  const rawBody = JSON.stringify(meta, null, 2)
   const cacheDir = temporaryDirectory()
   const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
 
   const ctx = {
-    fetch: async () => ({ meta, jsonText: rawBody, etag: undefined }),
+    fetch: async () => ({ meta, jsonText: JSON.stringify(meta), etag: undefined }),
     metaCache: createMetaCache(),
     cacheDir,
   }
@@ -222,8 +220,10 @@ test('the raw response body is written verbatim to the disk mirror', async () =>
 
   // The mirror is written fire-and-forget, so retry until it appears.
   const mirror = await readMirrorWithRetry(pkgMirror, 100)
-  // The body after the headers line is the raw response text, unchanged.
-  expect(mirror?.slice(mirror.indexOf('\n') + 1)).toBe(rawBody)
+  expect(mirror?.startsWith('pacquet-meta-v1 ')).toBe(true)
+  const persisted = parseNdjsonMeta<PackageMeta>(mirror!)
+  expect(persisted.versions['1.0.0']).toStrictEqual(meta.versions['1.0.0'])
+  expect(persisted['dist-tags']).toStrictEqual(meta['dist-tags'])
 })
 
 test('projects sharing one in-flight fetch mirror the fetched body instead of re-serializing it', async () => {
@@ -272,17 +272,16 @@ test('projects sharing one in-flight fetch mirror the fetched body instead of re
   }
 })
 
-test('a full document fetched for an optional dependency is condensed in memory while the mirror keeps the raw body', async () => {
+test('a full document fetched for an optional dependency is condensed in memory while the mirror keeps full version manifests', async () => {
   const meta = fooMeta()
   meta.versions['1.0.0'].libc = ['glibc']
   meta.versions['1.0.0'].scripts = { postinstall: 'node scripts/build.js' }
   ;(meta as PackageMeta & { readme: string }).readme = '# a readme the size of a novel'
   meta.time = { '1.0.0': '2020-01-01T00:00:00.000Z' }
-  const rawBody = JSON.stringify(meta)
   const cacheDir = temporaryDirectory()
 
   const ctx = {
-    fetch: async () => ({ meta, jsonText: rawBody, etag: undefined }),
+    fetch: async () => ({ meta, jsonText: JSON.stringify(meta), etag: undefined }),
     metaCache: createMetaCache(),
     cacheDir,
   }
@@ -295,10 +294,12 @@ test('a full document fetched for an optional dependency is condensed in memory 
   expect((res.meta as PackageMeta & { readme?: string }).readme).toBeUndefined()
   expect(ctx.metaCache.get(getPkgMetaCacheKey(REGISTRY, 'foo', true, false))).toBe(res.meta)
 
-  // The full-metadata mirror still receives the raw response body.
+  // The full-metadata mirror keeps unstripped version manifests.
   const pkgMirror = getPkgMirrorPath(cacheDir, FULL_META_DIR, REGISTRY, 'foo')
   const mirror = await readMirrorWithRetry(pkgMirror, 100)
-  expect(mirror?.slice(mirror.indexOf('\n') + 1)).toBe(rawBody)
+  const persisted = parseNdjsonMeta<PackageMeta>(mirror!)
+  expect(persisted.versions['1.0.0'].scripts).toStrictEqual({ postinstall: 'node scripts/build.js' })
+  expect(persisted.time).toEqual({ '1.0.0': '2020-01-01T00:00:00.000Z' })
 })
 
 test('a mirror holding a full document is condensed when promoted into the in-memory cache', async () => {

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -18,6 +18,7 @@ import {
   prepareJsonForDisk,
   saveMeta,
 } from '../src/pickPackage.js'
+import { parseNdjsonMeta } from './utils/index.js'
 
 const REGISTRY = 'https://registry.npmjs.org/'
 
@@ -200,16 +201,13 @@ test('prefer-offline resolution promotes the disk-loaded packument into the in-m
   expect(second.pickedPackage?.version).toBe('1.0.0')
 })
 
-test('the raw response body is written verbatim to the disk mirror', async () => {
+test('the response body is mirrored in the indexed layout', async () => {
   const meta = fooMeta()
-  // A body distinct from the compact JSON.stringify(meta) so we can prove the
-  // mirror is written from the raw response text, not re-serialized.
-  const rawBody = JSON.stringify(meta, null, 2)
   const cacheDir = temporaryDirectory()
   const pkgMirror = getPkgMirrorPath(cacheDir, ABBREVIATED_META_DIR, REGISTRY, 'foo')
 
   const ctx = {
-    fetch: async () => ({ meta, jsonText: rawBody, etag: undefined }),
+    fetch: async () => ({ meta, jsonText: JSON.stringify(meta), etag: undefined }),
     metaCache: createMetaCache(),
     cacheDir,
   }
@@ -222,11 +220,13 @@ test('the raw response body is written verbatim to the disk mirror', async () =>
 
   // The mirror is written fire-and-forget, so retry until it appears.
   const mirror = await readMirrorWithRetry(pkgMirror, 100)
-  // The body after the headers line is the raw response text, unchanged.
-  expect(mirror?.slice(mirror.indexOf('\n') + 1)).toBe(rawBody)
+  expect(mirror?.startsWith('pnpm-meta-v1 ')).toBe(true)
+  const persisted = parseNdjsonMeta<PackageMeta>(mirror!)
+  expect(persisted.versions['1.0.0']).toStrictEqual(meta.versions['1.0.0'])
+  expect(persisted['dist-tags']).toStrictEqual(meta['dist-tags'])
 })
 
-test('projects sharing one in-flight fetch mirror the fetched body instead of re-serializing it', async () => {
+test('projects sharing one in-flight fetch encode the mirror once instead of per project', async () => {
   const meta = fooMeta()
   const rawBody = JSON.stringify(meta)
   const cacheDir = temporaryDirectory()
@@ -262,27 +262,28 @@ test('projects sharing one in-flight fetch mirror the fetched body instead of re
     ))
     expect(picks.every((pick) => pick.pickedPackage?.version === '1.0.0')).toBe(true)
     expect(fetches).toBe(1)
-    // Re-serializing per project is what exhausted the heap: the body reaches
-    // tens of MB for a popular package, and every project holds its own copy
-    // until the mirror write limiter drains.
-    const serializations = stringifySpy.mock.calls.filter(([value]) => value === meta).length
-    expect(serializations).toBe(0)
+    // Encoding per project is what exhausted the heap: the body reaches tens
+    // of MB for a popular package, and every project holds its own copy until
+    // the mirror write limiter drains.
+    const versionSerializations = stringifySpy.mock.calls
+      .filter(([value]) => value === meta || value === meta.versions['1.0.0'])
+      .length
+    expect(versionSerializations).toBe(1)
   } finally {
     stringifySpy.mockRestore()
   }
 })
 
-test('a full document fetched for an optional dependency is condensed in memory while the mirror keeps the raw body', async () => {
+test('a full document fetched for an optional dependency is condensed in memory while the mirror keeps full version manifests', async () => {
   const meta = fooMeta()
   meta.versions['1.0.0'].libc = ['glibc']
   meta.versions['1.0.0'].scripts = { postinstall: 'node scripts/build.js' }
   ;(meta as PackageMeta & { readme: string }).readme = '# a readme the size of a novel'
   meta.time = { '1.0.0': '2020-01-01T00:00:00.000Z' }
-  const rawBody = JSON.stringify(meta)
   const cacheDir = temporaryDirectory()
 
   const ctx = {
-    fetch: async () => ({ meta, jsonText: rawBody, etag: undefined }),
+    fetch: async () => ({ meta, jsonText: JSON.stringify(meta), etag: undefined }),
     metaCache: createMetaCache(),
     cacheDir,
   }
@@ -295,10 +296,12 @@ test('a full document fetched for an optional dependency is condensed in memory 
   expect((res.meta as PackageMeta & { readme?: string }).readme).toBeUndefined()
   expect(ctx.metaCache.get(getPkgMetaCacheKey(REGISTRY, 'foo', true, false))).toBe(res.meta)
 
-  // The full-metadata mirror still receives the raw response body.
+  // The full-metadata mirror keeps unstripped version manifests.
   const pkgMirror = getPkgMirrorPath(cacheDir, FULL_META_DIR, REGISTRY, 'foo')
   const mirror = await readMirrorWithRetry(pkgMirror, 100)
-  expect(mirror?.slice(mirror.indexOf('\n') + 1)).toBe(rawBody)
+  const persisted = parseNdjsonMeta<PackageMeta>(mirror!)
+  expect(persisted.versions['1.0.0'].scripts).toStrictEqual({ postinstall: 'node scripts/build.js' })
+  expect(persisted.time).toEqual({ '1.0.0': '2020-01-01T00:00:00.000Z' })
 })
 
 test('a mirror holding a full document is condensed when promoted into the in-memory cache', async () => {

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -220,7 +220,7 @@ test('the response body is mirrored in the indexed layout', async () => {
 
   // The mirror is written fire-and-forget, so retry until it appears.
   const mirror = await readMirrorWithRetry(pkgMirror, 100)
-  expect(mirror?.startsWith('pacquet-meta-v1 ')).toBe(true)
+  expect(mirror?.startsWith('pnpm-meta-v1 ')).toBe(true)
   const persisted = parseNdjsonMeta<PackageMeta>(mirror!)
   expect(persisted.versions['1.0.0']).toStrictEqual(meta.versions['1.0.0'])
   expect(persisted['dist-tags']).toStrictEqual(meta['dist-tags'])

--- a/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/metaCache.test.ts
@@ -226,7 +226,7 @@ test('the response body is mirrored in the indexed layout', async () => {
   expect(persisted['dist-tags']).toStrictEqual(meta['dist-tags'])
 })
 
-test('projects sharing one in-flight fetch mirror the fetched body instead of re-serializing it', async () => {
+test('projects sharing one in-flight fetch encode the mirror once instead of per project', async () => {
   const meta = fooMeta()
   const rawBody = JSON.stringify(meta)
   const cacheDir = temporaryDirectory()
@@ -262,11 +262,13 @@ test('projects sharing one in-flight fetch mirror the fetched body instead of re
     ))
     expect(picks.every((pick) => pick.pickedPackage?.version === '1.0.0')).toBe(true)
     expect(fetches).toBe(1)
-    // Re-serializing per project is what exhausted the heap: the body reaches
-    // tens of MB for a popular package, and every project holds its own copy
-    // until the mirror write limiter drains.
-    const serializations = stringifySpy.mock.calls.filter(([value]) => value === meta).length
-    expect(serializations).toBe(0)
+    // Encoding per project is what exhausted the heap: the body reaches tens
+    // of MB for a popular package, and every project holds its own copy until
+    // the mirror write limiter drains.
+    const versionSerializations = stringifySpy.mock.calls
+      .filter(([value]) => value === meta || value === meta.versions['1.0.0'])
+      .length
+    expect(versionSerializations).toBe(1)
   } finally {
     stringifySpy.mockRestore()
   }

--- a/pnpm11/resolving/npm-resolver/test/mirror.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/mirror.test.ts
@@ -7,6 +7,7 @@ import { temporaryDirectory } from 'tempy'
 
 import { clearMeta } from '../src/clearMeta.js'
 import {
+  isMalformedMirrorFragmentError,
   loadMeta,
   loadMetaHeaders,
   prepareIndexedForDisk,
@@ -115,7 +116,7 @@ test('loadMetaHeaders reads both layouts', async () => {
   expect(await loadMetaHeaders(ndjson)).toStrictEqual({ etag: '"etag-4"', modified: '2021-01-01T00:00:00.000Z' })
 })
 
-test('a corrupt fragment hydrates to undefined without breaking the rest of the document', async () => {
+test('a corrupt fragment throws on access without breaking the rest of the document', async () => {
   const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
   const meta = fixtureMeta()
   const content = prepareIndexedForDisk(meta, undefined)
@@ -130,6 +131,12 @@ test('a corrupt fragment hydrates to undefined without breaking the rest of the 
   const loaded = await loadMeta(pkgMirror)
   expect(loaded).not.toBeNull()
   expect(Object.keys(loaded!.versions)).toStrictEqual(['1.0.0', '2.0.0'])
-  expect(loaded!.versions['1.0.0']).toBeUndefined()
+  let thrown: unknown
+  try {
+    void loaded!.versions['1.0.0']
+  } catch (err: unknown) {
+    thrown = err
+  }
+  expect(isMalformedMirrorFragmentError(thrown)).toBe(true)
   expect(loaded!.versions['2.0.0']).toStrictEqual(meta.versions['2.0.0'])
 })

--- a/pnpm11/resolving/npm-resolver/test/mirror.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/mirror.test.ts
@@ -105,6 +105,24 @@ test('a truncated indexed mirror reads as a cache miss', async () => {
   expect(await loadMeta(pkgMirror)).toBeNull()
 })
 
+test('the index record carries the package-level homepage the Rust stack reads', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = { ...fixtureMeta(), homepage: 'https://example.com/foo' }
+  await saveMeta(pkgMirror, prepareIndexedForDisk(meta, undefined))
+
+  const written = fs.readFileSync(pkgMirror, 'utf8')
+  expect(written).toContain('"homepage":"https://example.com/foo"')
+})
+
+test('an indexed mirror declaring an absurd headers length reads as a cache miss', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, `pacquet-meta-v1 ${Number.MAX_SAFE_INTEGER} 0\n{}`)
+
+  expect(await loadMetaHeaders(pkgMirror)).toBeNull()
+  expect(await loadMeta(pkgMirror)).toBeNull()
+})
+
 test('loadMetaHeaders reads both layouts', async () => {
   const dir = temporaryDirectory()
   const indexed = path.join(dir, 'indexed.jsonl')
@@ -116,17 +134,21 @@ test('loadMetaHeaders reads both layouts', async () => {
   expect(await loadMetaHeaders(ndjson)).toStrictEqual({ etag: '"etag-4"', modified: '2021-01-01T00:00:00.000Z' })
 })
 
+test('an eager load reads a corrupt fragment as a cache miss', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = fixtureMeta()
+  const content = corruptFragmentOf(meta, '1.0.0')
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, content)
+
+  expect(await loadMeta(pkgMirror, { hydrateEagerly: true })).toBeNull()
+})
+
 test('a corrupt fragment throws on access without breaking the rest of the document', async () => {
   const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
   const meta = fixtureMeta()
-  const content = prepareIndexedForDisk(meta, undefined)
-  // Corrupt the bytes of the 1.0.0 fragment in place, keeping the file length
-  // and the index spans intact.
-  const fragmentStart = content.indexOf(Buffer.from(JSON.stringify(meta.versions['1.0.0'])))
-  expect(fragmentStart).toBeGreaterThan(-1)
-  content.fill('x', fragmentStart, fragmentStart + 10)
   fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
-  fs.writeFileSync(pkgMirror, content)
+  fs.writeFileSync(pkgMirror, corruptFragmentOf(meta, '1.0.0'))
 
   const loaded = await loadMeta(pkgMirror)
   expect(loaded).not.toBeNull()
@@ -140,3 +162,14 @@ test('a corrupt fragment throws on access without breaking the rest of the docum
   expect(isMalformedMirrorFragmentError(thrown)).toBe(true)
   expect(loaded!.versions['2.0.0']).toStrictEqual(meta.versions['2.0.0'])
 })
+
+// Serializes `meta` and overwrites the leading bytes of one version's fragment
+// in place, so the file length and the index spans stay intact and only the
+// fragment's own bytes fail to parse.
+function corruptFragmentOf (meta: PackageMeta, version: string): Buffer {
+  const content = prepareIndexedForDisk(meta, undefined)
+  const fragmentStart = content.indexOf(Buffer.from(JSON.stringify(meta.versions[version])))
+  if (fragmentStart === -1) throw new Error(`fragment of ${version} not found in the serialized mirror`)
+  content.fill('x', fragmentStart, fragmentStart + 10)
+  return content
+}

--- a/pnpm11/resolving/npm-resolver/test/mirror.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/mirror.test.ts
@@ -1,0 +1,175 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
+import { temporaryDirectory } from 'tempy'
+
+import { clearMeta } from '../src/clearMeta.js'
+import {
+  isMalformedMirrorFragmentError,
+  loadMeta,
+  loadMetaHeaders,
+  prepareIndexedForDisk,
+  prepareJsonForDisk,
+  saveMeta,
+} from '../src/mirror.js'
+
+function fixtureMeta (): PackageMeta {
+  return {
+    name: 'foo',
+    'dist-tags': { latest: '2.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'foo',
+        version: '1.0.0',
+        dist: { integrity: 'sha512-aaa', shasum: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', tarball: 'https://registry.example/foo/-/foo-1.0.0.tgz' },
+        dependencies: { bar: '^1.0.0' },
+        description: 'not part of the abbreviated field set',
+      } as PackageInRegistry,
+      '2.0.0': {
+        name: 'foo',
+        version: '2.0.0',
+        dist: { integrity: 'sha512-bbb', shasum: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', tarball: 'https://registry.example/foo/-/foo-2.0.0.tgz' },
+      } as PackageInRegistry,
+    },
+    time: {
+      '1.0.0': '2020-01-01T00:00:00.000Z',
+      '2.0.0': '2021-01-01T00:00:00.000Z',
+      modified: '2021-01-01T00:00:00.000Z',
+    },
+    modified: '2021-01-01T00:00:00.000Z',
+  }
+}
+
+test('indexed mirror round-trips through save and load', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = fixtureMeta()
+  await saveMeta(pkgMirror, prepareIndexedForDisk(meta, '"etag-1"'))
+
+  const loaded = await loadMeta(pkgMirror)
+  expect(loaded).not.toBeNull()
+  expect(loaded!.name).toBe('foo')
+  expect(loaded!['dist-tags']).toStrictEqual({ latest: '2.0.0' })
+  expect(loaded!.etag).toBe('"etag-1"')
+  expect(loaded!.modified).toBe('2021-01-01T00:00:00.000Z')
+  expect(loaded!.time).toStrictEqual(meta.time)
+  expect(Object.keys(loaded!.versions)).toStrictEqual(['1.0.0', '2.0.0'])
+  expect(loaded!.versions['1.0.0']).toStrictEqual(meta.versions['1.0.0'])
+  expect(loaded!.versions['2.0.0']).toStrictEqual(meta.versions['2.0.0'])
+})
+
+test('hydrated manifests keep one identity and accept mutation', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  await saveMeta(pkgMirror, prepareIndexedForDisk(fixtureMeta(), undefined))
+
+  const loaded = (await loadMeta(pkgMirror))!
+  const first = loaded.versions['1.0.0']
+  expect(loaded.versions['1.0.0']).toBe(first)
+  first.name = 'renamed'
+  expect(loaded.versions['1.0.0'].name).toBe('renamed')
+
+  const descriptor = Object.getOwnPropertyDescriptor(loaded.versions, '1.0.0')!
+  const copy: PackageMeta['versions'] = {}
+  Object.defineProperty(copy, '1.0.0', descriptor)
+  expect(copy['1.0.0']).toBe(first)
+})
+
+test('condensing load strips manifests to the abbreviated field set and marks the document', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  await saveMeta(pkgMirror, prepareIndexedForDisk(fixtureMeta(), undefined))
+
+  const loaded = (await loadMeta(pkgMirror, { condense: true }))!
+  expect(clearMeta(loaded)).toBe(loaded)
+  expect(loaded.versions['1.0.0'].description).toBeUndefined()
+  expect(loaded.versions['1.0.0'].dependencies).toStrictEqual({ bar: '^1.0.0' })
+})
+
+test('NDJSON mirror still loads', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = fixtureMeta()
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, '"etag-2"'))
+
+  const loaded = await loadMeta(pkgMirror)
+  expect(loaded).not.toBeNull()
+  expect(loaded!.etag).toBe('"etag-2"')
+  expect(loaded!.versions['1.0.0']).toStrictEqual(meta.versions['1.0.0'])
+})
+
+test('a truncated indexed mirror reads as a cache miss', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const content = prepareIndexedForDisk(fixtureMeta(), undefined)
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, content.subarray(0, content.length - 10))
+
+  expect(await loadMeta(pkgMirror)).toBeNull()
+})
+
+test('the index record carries the package-level homepage the Rust stack reads', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = { ...fixtureMeta(), homepage: 'https://example.com/foo' }
+  await saveMeta(pkgMirror, prepareIndexedForDisk(meta, undefined))
+
+  const written = fs.readFileSync(pkgMirror, 'utf8')
+  expect(written).toContain('"homepage":"https://example.com/foo"')
+})
+
+test('an indexed mirror declaring an absurd headers length reads as a cache miss', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, `pnpm-meta-v1 ${Number.MAX_SAFE_INTEGER} 0\n{}`)
+
+  expect(await loadMetaHeaders(pkgMirror)).toBeNull()
+  expect(await loadMeta(pkgMirror)).toBeNull()
+})
+
+test('loadMetaHeaders reads both layouts', async () => {
+  const dir = temporaryDirectory()
+  const indexed = path.join(dir, 'indexed.jsonl')
+  const ndjson = path.join(dir, 'ndjson.jsonl')
+  await saveMeta(indexed, prepareIndexedForDisk(fixtureMeta(), '"etag-3"'))
+  await saveMeta(ndjson, prepareJsonForDisk(fixtureMeta(), '"etag-4"'))
+
+  expect(await loadMetaHeaders(indexed)).toStrictEqual({ etag: '"etag-3"', modified: '2021-01-01T00:00:00.000Z' })
+  expect(await loadMetaHeaders(ndjson)).toStrictEqual({ etag: '"etag-4"', modified: '2021-01-01T00:00:00.000Z' })
+})
+
+test('an eager load reads a corrupt fragment as a cache miss', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = fixtureMeta()
+  const content = corruptFragmentOf(meta, '1.0.0')
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, content)
+
+  expect(await loadMeta(pkgMirror, { hydrateEagerly: true })).toBeNull()
+})
+
+test('a corrupt fragment throws on access without breaking the rest of the document', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = fixtureMeta()
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, corruptFragmentOf(meta, '1.0.0'))
+
+  const loaded = await loadMeta(pkgMirror)
+  expect(loaded).not.toBeNull()
+  expect(Object.keys(loaded!.versions)).toStrictEqual(['1.0.0', '2.0.0'])
+  let thrown: unknown
+  try {
+    void loaded!.versions['1.0.0']
+  } catch (err: unknown) {
+    thrown = err
+  }
+  expect(isMalformedMirrorFragmentError(thrown)).toBe(true)
+  expect(loaded!.versions['2.0.0']).toStrictEqual(meta.versions['2.0.0'])
+})
+
+// Serializes `meta` and overwrites the leading bytes of one version's fragment
+// in place, so the file length and the index spans stay intact and only the
+// fragment's own bytes fail to parse.
+function corruptFragmentOf (meta: PackageMeta, version: string): Buffer {
+  const content = prepareIndexedForDisk(meta, undefined)
+  const fragmentStart = content.indexOf(Buffer.from(JSON.stringify(meta.versions[version])))
+  if (fragmentStart === -1) throw new Error(`fragment of ${version} not found in the serialized mirror`)
+  content.fill('x', fragmentStart, fragmentStart + 10)
+  return content
+}

--- a/pnpm11/resolving/npm-resolver/test/mirror.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/mirror.test.ts
@@ -114,3 +114,22 @@ test('loadMetaHeaders reads both layouts', async () => {
   expect(await loadMetaHeaders(indexed)).toStrictEqual({ etag: '"etag-3"', modified: '2021-01-01T00:00:00.000Z' })
   expect(await loadMetaHeaders(ndjson)).toStrictEqual({ etag: '"etag-4"', modified: '2021-01-01T00:00:00.000Z' })
 })
+
+test('a corrupt fragment hydrates to undefined without breaking the rest of the document', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = fixtureMeta()
+  const content = prepareIndexedForDisk(meta, undefined)
+  // Corrupt the bytes of the 1.0.0 fragment in place, keeping the file length
+  // and the index spans intact.
+  const fragmentStart = content.indexOf(Buffer.from(JSON.stringify(meta.versions['1.0.0'])))
+  expect(fragmentStart).toBeGreaterThan(-1)
+  content.fill('x', fragmentStart, fragmentStart + 10)
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, content)
+
+  const loaded = await loadMeta(pkgMirror)
+  expect(loaded).not.toBeNull()
+  expect(Object.keys(loaded!.versions)).toStrictEqual(['1.0.0', '2.0.0'])
+  expect(loaded!.versions['1.0.0']).toBeUndefined()
+  expect(loaded!.versions['2.0.0']).toStrictEqual(meta.versions['2.0.0'])
+})

--- a/pnpm11/resolving/npm-resolver/test/mirror.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/mirror.test.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
+import { temporaryDirectory } from 'tempy'
+
+import { clearMeta } from '../src/clearMeta.js'
+import {
+  loadMeta,
+  loadMetaHeaders,
+  prepareIndexedForDisk,
+  prepareJsonForDisk,
+  saveMeta,
+} from '../src/mirror.js'
+
+function fixtureMeta (): PackageMeta {
+  return {
+    name: 'foo',
+    'dist-tags': { latest: '2.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'foo',
+        version: '1.0.0',
+        dist: { integrity: 'sha512-aaa', tarball: 'https://registry.example/foo/-/foo-1.0.0.tgz' },
+        dependencies: { bar: '^1.0.0' },
+        description: 'not part of the abbreviated field set',
+      } as PackageInRegistry,
+      '2.0.0': {
+        name: 'foo',
+        version: '2.0.0',
+        dist: { integrity: 'sha512-bbb', tarball: 'https://registry.example/foo/-/foo-2.0.0.tgz' },
+      } as PackageInRegistry,
+    },
+    time: {
+      '1.0.0': '2020-01-01T00:00:00.000Z',
+      '2.0.0': '2021-01-01T00:00:00.000Z',
+      modified: '2021-01-01T00:00:00.000Z',
+    },
+    modified: '2021-01-01T00:00:00.000Z',
+  }
+}
+
+test('indexed mirror round-trips through save and load', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = fixtureMeta()
+  await saveMeta(pkgMirror, prepareIndexedForDisk(meta, '"etag-1"'))
+
+  const loaded = await loadMeta(pkgMirror)
+  expect(loaded).not.toBeNull()
+  expect(loaded!.name).toBe('foo')
+  expect(loaded!['dist-tags']).toStrictEqual({ latest: '2.0.0' })
+  expect(loaded!.etag).toBe('"etag-1"')
+  expect(loaded!.modified).toBe('2021-01-01T00:00:00.000Z')
+  expect(loaded!.time).toStrictEqual(meta.time)
+  expect(Object.keys(loaded!.versions)).toStrictEqual(['1.0.0', '2.0.0'])
+  expect(loaded!.versions['1.0.0']).toStrictEqual(meta.versions['1.0.0'])
+  expect(loaded!.versions['2.0.0']).toStrictEqual(meta.versions['2.0.0'])
+})
+
+test('hydrated manifests keep one identity and accept mutation', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  await saveMeta(pkgMirror, prepareIndexedForDisk(fixtureMeta(), undefined))
+
+  const loaded = (await loadMeta(pkgMirror))!
+  const first = loaded.versions['1.0.0']
+  expect(loaded.versions['1.0.0']).toBe(first)
+  first.name = 'renamed'
+  expect(loaded.versions['1.0.0'].name).toBe('renamed')
+
+  const descriptor = Object.getOwnPropertyDescriptor(loaded.versions, '1.0.0')!
+  const copy: PackageMeta['versions'] = {}
+  Object.defineProperty(copy, '1.0.0', descriptor)
+  expect(copy['1.0.0']).toBe(first)
+})
+
+test('condensing load strips manifests to the abbreviated field set and marks the document', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  await saveMeta(pkgMirror, prepareIndexedForDisk(fixtureMeta(), undefined))
+
+  const loaded = (await loadMeta(pkgMirror, { condense: true }))!
+  expect(clearMeta(loaded)).toBe(loaded)
+  expect(loaded.versions['1.0.0'].description).toBeUndefined()
+  expect(loaded.versions['1.0.0'].dependencies).toStrictEqual({ bar: '^1.0.0' })
+})
+
+test('NDJSON mirror still loads', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const meta = fixtureMeta()
+  await saveMeta(pkgMirror, prepareJsonForDisk(meta, '"etag-2"'))
+
+  const loaded = await loadMeta(pkgMirror)
+  expect(loaded).not.toBeNull()
+  expect(loaded!.etag).toBe('"etag-2"')
+  expect(loaded!.versions['1.0.0']).toStrictEqual(meta.versions['1.0.0'])
+})
+
+test('a truncated indexed mirror reads as a cache miss', async () => {
+  const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
+  const content = prepareIndexedForDisk(fixtureMeta(), undefined)
+  fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
+  fs.writeFileSync(pkgMirror, content.subarray(0, content.length - 10))
+
+  expect(await loadMeta(pkgMirror)).toBeNull()
+})
+
+test('loadMetaHeaders reads both layouts', async () => {
+  const dir = temporaryDirectory()
+  const indexed = path.join(dir, 'indexed.jsonl')
+  const ndjson = path.join(dir, 'ndjson.jsonl')
+  await saveMeta(indexed, prepareIndexedForDisk(fixtureMeta(), '"etag-3"'))
+  await saveMeta(ndjson, prepareJsonForDisk(fixtureMeta(), '"etag-4"'))
+
+  expect(await loadMetaHeaders(indexed)).toStrictEqual({ etag: '"etag-3"', modified: '2021-01-01T00:00:00.000Z' })
+  expect(await loadMetaHeaders(ndjson)).toStrictEqual({ etag: '"etag-4"', modified: '2021-01-01T00:00:00.000Z' })
+})

--- a/pnpm11/resolving/npm-resolver/test/mirror.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/mirror.test.ts
@@ -117,7 +117,7 @@ test('the index record carries the package-level homepage the Rust stack reads',
 test('an indexed mirror declaring an absurd headers length reads as a cache miss', async () => {
   const pkgMirror = path.join(temporaryDirectory(), 'foo.jsonl')
   fs.mkdirSync(path.dirname(pkgMirror), { recursive: true })
-  fs.writeFileSync(pkgMirror, `pacquet-meta-v1 ${Number.MAX_SAFE_INTEGER} 0\n{}`)
+  fs.writeFileSync(pkgMirror, `pnpm-meta-v1 ${Number.MAX_SAFE_INTEGER} 0\n{}`)
 
   expect(await loadMetaHeaders(pkgMirror)).toBeNull()
   expect(await loadMeta(pkgMirror)).toBeNull()

--- a/pnpm11/resolving/npm-resolver/test/mirror.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/mirror.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
+import { expect, test } from '@jest/globals'
 import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
 import { temporaryDirectory } from 'tempy'
 
@@ -21,14 +22,14 @@ function fixtureMeta (): PackageMeta {
       '1.0.0': {
         name: 'foo',
         version: '1.0.0',
-        dist: { integrity: 'sha512-aaa', tarball: 'https://registry.example/foo/-/foo-1.0.0.tgz' },
+        dist: { integrity: 'sha512-aaa', shasum: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', tarball: 'https://registry.example/foo/-/foo-1.0.0.tgz' },
         dependencies: { bar: '^1.0.0' },
         description: 'not part of the abbreviated field set',
       } as PackageInRegistry,
       '2.0.0': {
         name: 'foo',
         version: '2.0.0',
-        dist: { integrity: 'sha512-bbb', tarball: 'https://registry.example/foo/-/foo-2.0.0.tgz' },
+        dist: { integrity: 'sha512-bbb', shasum: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', tarball: 'https://registry.example/foo/-/foo-2.0.0.tgz' },
       } as PackageInRegistry,
     },
     time: {

--- a/pnpm11/resolving/npm-resolver/test/normalizeAbbreviated.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/normalizeAbbreviated.test.ts
@@ -88,20 +88,21 @@ test('a full document served for an abbreviated request is normalized before cac
   expect(savedVersion.dist).toBeDefined()
 })
 
-test('a document served with the abbreviated content type is cached verbatim (registry honored the Accept header)', async () => {
+test('a document served with the abbreviated content type is cached without stripping version fields (registry honored the Accept header)', async () => {
   const cacheDir = temporaryDirectory()
 
-  // The abbreviated document a spec-compliant registry (e.g. npm) returns. It
-  // also carries a custom top-level field to prove the body is stored verbatim
-  // (no re-serialization / stripping) on the happy path.
+  // The abbreviated document a spec-compliant registry (e.g. npm) returns. A
+  // version manifest carries a custom field to prove the mirror preserves
+  // version data it doesn't know about (only top-level fields outside the
+  // indexed layout's records are dropped).
   const abbreviatedDoc = {
     name: 'foo',
     'dist-tags': { latest: '1.0.0' },
-    _cacheUntouchedMarker: 'kept-verbatim',
     versions: {
       '1.0.0': {
         name: 'foo',
         version: '1.0.0',
+        _cacheUntouchedMarker: 'kept-verbatim',
         dependencies: { bar: '^1.0.0' },
         dist: {
           tarball: 'https://registry.npmjs.org/foo/-/foo-1.0.0.tgz',
@@ -126,8 +127,8 @@ test('a document served with the abbreviated content type is cached verbatim (re
   expect(res!.id).toBe('foo@1.0.0')
 
   const cachePath = path.join(cacheDir, `${ABBREVIATED_META_DIR}/registry.npmjs.org/foo.jsonl`)
-  // The registry body is stored untouched: no field stripping and no
-  // re-serialization on the honored-header happy path.
-  const saved = await retryLoadJsonFile<{ _cacheUntouchedMarker?: string }>(cachePath)
-  expect(saved._cacheUntouchedMarker).toBe('kept-verbatim')
+  // Version manifests are mirrored without field stripping on the
+  // honored-header happy path.
+  const saved = await retryLoadJsonFile<{ versions: Record<string, { _cacheUntouchedMarker?: string }> }>(cachePath)
+  expect(saved.versions['1.0.0']._cacheUntouchedMarker).toBe('kept-verbatim')
 })

--- a/pnpm11/resolving/npm-resolver/test/pickVersionFallback.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/pickVersionFallback.test.ts
@@ -5,7 +5,7 @@ import { pickVersionByVersionRange } from '../src/pickPackageFromMeta.js'
 
 // Builds a meta whose versions hydrate through getters, like a lazily-loaded
 // indexed mirror does, recording which versions were hydrated. A null manifest
-// input models a corrupt fragment (hydrates to undefined).
+// input models a version key the document lists without a manifest.
 function lazyMeta (manifests: Record<string, PackageInRegistry | null>): { meta: PackageMeta, hydrated: string[] } {
   const hydrated: string[] = []
   const versions: PackageMeta['versions'] = Object.create(null)
@@ -40,19 +40,18 @@ test('the deprecated fallback hydrates only versions that satisfy the range', ()
   expect(hydrated).not.toContain('1.0.0')
 })
 
-test('a corrupt manifest of the max satisfying version fails the pick instead of crashing', () => {
+test('a missing manifest on the max satisfying version fails the pick instead of crashing', () => {
   const { meta } = lazyMeta({
     '1.0.0': manifest('1.0.0'),
     '2.0.0': null,
   })
 
-  // The version is still chosen (its manifest hydrates to undefined, which the
-  // picker's missing-manifest handling turns into a failed pick downstream);
-  // the deprecated check must not crash on the missing manifest.
+  // The version is still chosen (the picker's missing-manifest handling turns
+  // it into a failed pick downstream); the deprecated check must not crash.
   expect(pickVersionByVersionRange({ meta, versionRange: '>=1.0.0' })).toBe('2.0.0')
 })
 
-test('a corrupt manifest is not offered as the non-deprecated alternative', () => {
+test('a missing manifest is not offered as the non-deprecated alternative', () => {
   const { meta } = lazyMeta({
     '2.0.0': null,
     '2.0.1': manifest('2.0.1', 'use 3.x'),

--- a/pnpm11/resolving/npm-resolver/test/pickVersionFallback.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/pickVersionFallback.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@jest/globals'
+import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
+
+import { pickVersionByVersionRange } from '../src/pickPackageFromMeta.js'
+
+// Builds a meta whose versions hydrate through getters, like a lazily-loaded
+// indexed mirror does, recording which versions were hydrated. A null manifest
+// input models a corrupt fragment (hydrates to undefined).
+function lazyMeta (manifests: Record<string, PackageInRegistry | null>): { meta: PackageMeta, hydrated: string[] } {
+  const hydrated: string[] = []
+  const versions: PackageMeta['versions'] = Object.create(null)
+  for (const [version, manifest] of Object.entries(manifests)) {
+    Object.defineProperty(versions, version, {
+      enumerable: true,
+      configurable: true,
+      get (): PackageInRegistry | undefined {
+        hydrated.push(version)
+        return manifest ?? undefined
+      },
+    })
+  }
+  return {
+    meta: { name: 'foo', 'dist-tags': {}, versions },
+    hydrated,
+  }
+}
+
+function manifest (version: string, deprecated?: string): PackageInRegistry {
+  return { name: 'foo', version, deprecated } as PackageInRegistry
+}
+
+test('the deprecated fallback hydrates only versions that satisfy the range', () => {
+  const { meta, hydrated } = lazyMeta({
+    '1.0.0': manifest('1.0.0'),
+    '2.0.0': manifest('2.0.0'),
+    '2.0.1': manifest('2.0.1', 'use 3.x'),
+  })
+
+  expect(pickVersionByVersionRange({ meta, versionRange: '^2.0.0' })).toBe('2.0.0')
+  expect(hydrated).not.toContain('1.0.0')
+})
+
+test('a corrupt manifest of the max satisfying version fails the pick instead of crashing', () => {
+  const { meta } = lazyMeta({
+    '1.0.0': manifest('1.0.0'),
+    '2.0.0': null,
+  })
+
+  // The version is still chosen (its manifest hydrates to undefined, which the
+  // picker's missing-manifest handling turns into a failed pick downstream);
+  // the deprecated check must not crash on the missing manifest.
+  expect(pickVersionByVersionRange({ meta, versionRange: '>=1.0.0' })).toBe('2.0.0')
+})
+
+test('a corrupt manifest is not offered as the non-deprecated alternative', () => {
+  const { meta } = lazyMeta({
+    '2.0.0': null,
+    '2.0.1': manifest('2.0.1', 'use 3.x'),
+  })
+
+  expect(pickVersionByVersionRange({ meta, versionRange: '^2.0.0' })).toBe('2.0.1')
+})

--- a/pnpm11/resolving/npm-resolver/test/pickVersionFallback.test.ts
+++ b/pnpm11/resolving/npm-resolver/test/pickVersionFallback.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@jest/globals'
+import type { PackageInRegistry, PackageMeta } from '@pnpm/resolving.registry.types'
+
+import { pickVersionByVersionRange } from '../src/pickPackageFromMeta.js'
+
+// Builds a meta whose versions hydrate through getters, like a lazily-loaded
+// indexed mirror does, recording which versions were hydrated. A null manifest
+// input models a version key the document lists without a manifest.
+function lazyMeta (manifests: Record<string, PackageInRegistry | null>): { meta: PackageMeta, hydrated: string[] } {
+  const hydrated: string[] = []
+  const versions: PackageMeta['versions'] = Object.create(null)
+  for (const [version, manifest] of Object.entries(manifests)) {
+    Object.defineProperty(versions, version, {
+      enumerable: true,
+      configurable: true,
+      get (): PackageInRegistry | undefined {
+        hydrated.push(version)
+        return manifest ?? undefined
+      },
+    })
+  }
+  return {
+    meta: { name: 'foo', 'dist-tags': {}, versions },
+    hydrated,
+  }
+}
+
+function manifest (version: string, deprecated?: string): PackageInRegistry {
+  return { name: 'foo', version, deprecated } as PackageInRegistry
+}
+
+test('the deprecated fallback hydrates only versions that satisfy the range', () => {
+  const { meta, hydrated } = lazyMeta({
+    '1.0.0': manifest('1.0.0'),
+    '2.0.0': manifest('2.0.0'),
+    '2.0.1': manifest('2.0.1', 'use 3.x'),
+  })
+
+  expect(pickVersionByVersionRange({ meta, versionRange: '^2.0.0' })).toBe('2.0.0')
+  expect(hydrated).not.toContain('1.0.0')
+})
+
+test('a missing manifest on the max satisfying version fails the pick instead of crashing', () => {
+  const { meta } = lazyMeta({
+    '1.0.0': manifest('1.0.0'),
+    '2.0.0': null,
+  })
+
+  // The version is still chosen (the picker's missing-manifest handling turns
+  // it into a failed pick downstream); the deprecated check must not crash.
+  expect(pickVersionByVersionRange({ meta, versionRange: '>=1.0.0' })).toBe('2.0.0')
+})
+
+test('a missing manifest is not offered as the non-deprecated alternative', () => {
+  const { meta } = lazyMeta({
+    '2.0.0': null,
+    '2.0.1': manifest('2.0.1', 'use 3.x'),
+  })
+
+  expect(pickVersionByVersionRange({ meta, versionRange: '^2.0.0' })).toBe('2.0.1')
+})

--- a/pnpm11/resolving/npm-resolver/test/utils/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/utils/index.ts
@@ -19,14 +19,38 @@ export async function retryLoadJsonFile<T> (filePath: string): Promise<T> {
 }
 
 /**
- * Parses an NDJSON cache file: line 1 = headers, line 2 = metadata.
- * The headers (etag, modified) are merged into the metadata object.
+ * Parses a mirror cache file in either layout: the indexed
+ * `pacquet-meta-v1` form (headers record, index record, version fragments)
+ * or two-line NDJSON (line 1 = headers, line 2 = metadata). The headers
+ * (etag, modified) are merged into the metadata object, and versions are
+ * materialized eagerly so tests can assert on plain objects.
  */
 export function parseNdjsonMeta<T> (data: string): T {
-  const newlineIdx = data.indexOf('\n')
+  const buf = Buffer.from(data, 'utf8')
+  const newlineIdx = buf.indexOf(10)
   if (newlineIdx === -1) return JSON.parse(data) as T
-  const headers = JSON.parse(data.slice(0, newlineIdx))
-  const meta = JSON.parse(data.slice(newlineIdx + 1))
+  const firstLine = buf.toString('utf8', 0, newlineIdx)
+  const magicMatch = /^pacquet-meta-v1 (\d+) (\d+)$/.exec(firstLine)
+  if (magicMatch == null) {
+    const headers = JSON.parse(firstLine)
+    const meta = JSON.parse(buf.toString('utf8', newlineIdx + 1))
+    return { ...meta, ...headers } as T
+  }
+  const headersStart = newlineIdx + 1
+  const indexStart = headersStart + Number.parseInt(magicMatch[1], 10)
+  const fragmentBase = indexStart + Number.parseInt(magicMatch[2], 10)
+  const headers = JSON.parse(buf.toString('utf8', headersStart, indexStart))
+  const index = JSON.parse(buf.toString('utf8', indexStart, fragmentBase))
+  const versions: Record<string, unknown> = {}
+  for (const [version, offset, length] of index.versions as Array<[string, number, number]>) {
+    versions[version] = JSON.parse(buf.toString('utf8', fragmentBase + offset, fragmentBase + offset + length))
+  }
+  const meta: Record<string, unknown> = {
+    name: index.name,
+    'dist-tags': index.distTags ?? {},
+    versions,
+  }
+  if (index.time != null) meta.time = index.time
   return { ...meta, ...headers } as T
 }
 

--- a/pnpm11/resolving/npm-resolver/test/utils/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/utils/index.ts
@@ -19,14 +19,38 @@ export async function retryLoadJsonFile<T> (filePath: string): Promise<T> {
 }
 
 /**
- * Parses an NDJSON cache file: line 1 = headers, line 2 = metadata.
- * The headers (etag, modified) are merged into the metadata object.
+ * Parses a mirror cache file in either layout: the indexed
+ * `pnpm-meta-v1` form (headers record, index record, version fragments)
+ * or two-line NDJSON (line 1 = headers, line 2 = metadata). The headers
+ * (etag, modified) are merged into the metadata object, and versions are
+ * materialized eagerly so tests can assert on plain objects.
  */
 export function parseNdjsonMeta<T> (data: string): T {
-  const newlineIdx = data.indexOf('\n')
+  const buf = Buffer.from(data, 'utf8')
+  const newlineIdx = buf.indexOf(10)
   if (newlineIdx === -1) return JSON.parse(data) as T
-  const headers = JSON.parse(data.slice(0, newlineIdx))
-  const meta = JSON.parse(data.slice(newlineIdx + 1))
+  const firstLine = buf.toString('utf8', 0, newlineIdx)
+  const formatMatch = /^pnpm-meta-v1 (\d+) (\d+)$/.exec(firstLine)
+  if (formatMatch == null) {
+    const headers = JSON.parse(firstLine)
+    const meta = JSON.parse(buf.toString('utf8', newlineIdx + 1))
+    return { ...meta, ...headers } as T
+  }
+  const headersStart = newlineIdx + 1
+  const indexStart = headersStart + Number.parseInt(formatMatch[1], 10)
+  const fragmentBase = indexStart + Number.parseInt(formatMatch[2], 10)
+  const headers = JSON.parse(buf.toString('utf8', headersStart, indexStart))
+  const index = JSON.parse(buf.toString('utf8', indexStart, fragmentBase))
+  const versions: Record<string, unknown> = {}
+  for (const [version, offset, length] of index.versions as Array<[string, number, number]>) {
+    versions[version] = JSON.parse(buf.toString('utf8', fragmentBase + offset, fragmentBase + offset + length))
+  }
+  const meta: Record<string, unknown> = {
+    name: index.name,
+    'dist-tags': index.distTags ?? {},
+    versions,
+  }
+  if (index.time != null) meta.time = index.time
   return { ...meta, ...headers } as T
 }
 

--- a/pnpm11/resolving/npm-resolver/test/utils/index.ts
+++ b/pnpm11/resolving/npm-resolver/test/utils/index.ts
@@ -20,7 +20,7 @@ export async function retryLoadJsonFile<T> (filePath: string): Promise<T> {
 
 /**
  * Parses a mirror cache file in either layout: the indexed
- * `pacquet-meta-v1` form (headers record, index record, version fragments)
+ * `pnpm-meta-v1` form (headers record, index record, version fragments)
  * or two-line NDJSON (line 1 = headers, line 2 = metadata). The headers
  * (etag, modified) are merged into the metadata object, and versions are
  * materialized eagerly so tests can assert on plain objects.
@@ -30,15 +30,15 @@ export function parseNdjsonMeta<T> (data: string): T {
   const newlineIdx = buf.indexOf(10)
   if (newlineIdx === -1) return JSON.parse(data) as T
   const firstLine = buf.toString('utf8', 0, newlineIdx)
-  const magicMatch = /^pacquet-meta-v1 (\d+) (\d+)$/.exec(firstLine)
-  if (magicMatch == null) {
+  const formatMatch = /^pnpm-meta-v1 (\d+) (\d+)$/.exec(firstLine)
+  if (formatMatch == null) {
     const headers = JSON.parse(firstLine)
     const meta = JSON.parse(buf.toString('utf8', newlineIdx + 1))
     return { ...meta, ...headers } as T
   }
   const headersStart = newlineIdx + 1
-  const indexStart = headersStart + Number.parseInt(magicMatch[1], 10)
-  const fragmentBase = indexStart + Number.parseInt(magicMatch[2], 10)
+  const indexStart = headersStart + Number.parseInt(formatMatch[1], 10)
+  const fragmentBase = indexStart + Number.parseInt(formatMatch[2], 10)
   const headers = JSON.parse(buf.toString('utf8', headersStart, indexStart))
   const index = JSON.parse(buf.toString('utf8', indexStart, fragmentBase))
   const versions: Record<string, unknown> = {}

--- a/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
+++ b/pnpm11/resolving/registry/pkg-metadata-filter/src/index.ts
@@ -66,7 +66,15 @@ function filterPkgMetadataByPublishDateUncached (
     if (!Object.hasOwn(pkgDoc.versions, version)) continue
     const timeStr = pkgDoc.time[version]
     if ((timeStr && new Date(timeStr) <= publishedBy) || trustedVersions?.includes(version)) {
-      versionsWithinDate[version] = pkgDoc.versions[version]
+      // Copy the property descriptor, not the value: a lazily-loaded packument
+      // (see npm-resolver's mirror module) backs each version with a getter
+      // that parses its manifest on first access, and reading the value here
+      // would parse every in-date version of every packument up front.
+      Object.defineProperty(
+        versionsWithinDate,
+        version,
+        Object.getOwnPropertyDescriptor(pkgDoc.versions, version)!
+      )
     }
   }
 
@@ -88,7 +96,9 @@ function filterPkgMetadataByPublishDateUncached (
   for (const tag in allDistTags) {
     if (!Object.hasOwn(allDistTags, tag)) continue
     const distTagVersion = allDistTags[tag]
-    if (versionsWithinDate[distTagVersion]) {
+    // `in`, not a value read: presence is all that matters, and reading the
+    // value would hydrate a lazily-loaded manifest for nothing.
+    if (distTagVersion in versionsWithinDate) {
       distTagsWithinDate[tag] = distTagVersion
       continue
     }

--- a/pnpm11/store/controller/src/storeController/prune.ts
+++ b/pnpm11/store/controller/src/storeController/prune.ts
@@ -25,7 +25,7 @@ export async function prune ({ cacheDir, storeDir, storeIndex }: PruneOptions, r
   await pruneGlobalVirtualStore(storeDir)
 
   // 2. Clean up metadata cache
-  // Metadata dirs may be at top level (legacy metadata-*) or under a version prefix (v11/metadata*)
+  // Metadata dirs may be at top level (legacy metadata-*) or under a version prefix (vN/metadata*)
   const metadataDirs = await getSubdirsSafely(cacheDir)
   await Promise.all(metadataDirs.map(async (metadataDir) => {
     if (!metadataDir.startsWith('metadata') && !/^v\d+$/.test(metadataDir)) return


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#13504 (merged), which removed redundant recomputation during version picking. After it, the top CPU hotspot in dependency resolution is `loadMeta`: **23% of a warm-cache resolution (829 ms)** is spent JSON-parsing metadata mirror files. The mirror stored one JSON document per package — 178 MB across the 1246-package benchmark fixture — and parsing a document materializes every version manifest it contains: ~123k manifests per install, of which only ~1,250 (the picked versions) are ever read.

The Rust CLI already solved this with an indexed mirror layout: a small headers record, an index with per-version byte spans, and the version manifests as raw concatenated JSON fragments. Until now the TypeScript CLI could not read that layout, so any mirror written by the Rust CLI was a cache miss for the TypeScript CLI, refetched and rewritten as NDJSON (and vice versa, thrashing shared caches).

This PR makes the indexed layout the shared on-disk contract of both CLIs:

- **Loading parses only the two leading records.** `versions` is built as an object of enumerable parse-once getters over byte spans; a manifest is JSON-parsed (and condensed to the abbreviated field set, when the resolver condenses) on first property access. Hydrated manifests keep a single identity — descriptor copies share the same hydration cache — so the picker's `name` back-fill and `readPackage` hook mutations behave exactly as before. The publish-date filter copies property descriptors instead of values so filtering never forces hydration.
- **The format identifier is `pnpm-meta-v1`** (both CLIs read and write it now, so it no longer carries the pacquet name), and the metadata cache directories move from `v11` to `v12`, following the convention that a format change bumps the directory: a pnpm version that predates the layout never opens these files at all. NDJSON remains the layout for `filterMetadata` documents and is still read everywhere as a fallback.
- **Corruption is handled like an unreadable mirror, in both stacks.** A fragment whose bytes don't parse throws a typed error on access; offline resolution fails with `ERR_PNPM_NO_OFFLINE_META`, the disk fast paths fall through to the network, and a document served from a 304 is refetched once with the conditional cache bypassed, which rewrites the mirror — without this, a locally-damaged file would keep 304-validating forever (the etag lives in the intact headers record) and never self-heal. The Rust resolver previously skipped a damaged fragment as if the version were unpublished; it now applies the same contract.
- **Hardening and memory bounds:** the declared headers length is capped (64 KiB, matching the Rust reader) so a hostile mirror can't force an arbitrarily large allocation; the encoded mirror form is memoized per fetch result so workspace projects sharing one in-flight fetch don't each serialize their own multi-MB copy; `fetchFullMetadataCached` hydrates eagerly for consumers with no fall-through path of their own.
- **`pnpm cache view` reads through the resolver's loader** in both CLIs instead of keeping a second parser in sync with the format.

### Benchmarks

Interleaved paired runs (medians of 8 alternating rounds), offline, warm mirror, 1246-package fixture from `pnpm11/benchmarks`, `minimumReleaseAge` at its default, measured against the pre-change resolver (current `main`):

| Scenario | Before | After | Change |
|---|---|---|---|
| Resolution (`install --offline --lockfile-only`) | 3.82 s | 3.21 s | **1.19× (−16%)** |

CPU profile: `loadMeta` self-time drops 829 ms → 85 ms (plus 93 ms building the span getters); the up-front UTF-8 decode of ~178 MB of mirror text is gone (only accessed fragments decode).

### Correctness evidence

- `pnpm-lock.yaml` is **byte-identical** to the base's across configurations: old bundle + NDJSON cache, new bundle + indexed cache, and new bundle reading an NDJSON cache.
- The `@pnpm/resolving.npm-resolver` suite passes with new coverage for the mirror round-trip, lazy identity/mutation, condensing, NDJSON fallback, truncation-as-miss, headers on both layouts, and the corruption contract end-to-end (offline failure; 304 → cache-bypass refetch rewriting the file); the `pkg-metadata-filter` and Rust `cache view` / resolver suites pass.

### Trade-offs

- **Cold-install writes cost more CPU**: fragments are serialized per version instead of reusing the raw response body (~+5 s user CPU warming the whole fixture cache from scratch, overlapped with network time). A follow-up could scan spans out of the raw body instead.
- The abbreviated mirror grows on disk when a release-age upgrade stores full manifests (~173 MB → ~248 MB on the fixture) — parse cost stays low because loading is lazy.
- The `v11` → `v12` directory bump means the first install after upgrading refills the metadata cache (packuments only; the content-addressable store is unaffected).

## Squash Commit Body

```text
The metadata mirror stored one JSON document per package, so every
resolution parsed every version manifest of every packument it touched:
178MB of JSON for the 1246-package benchmark fixture, of which ~1% (the
picked versions) was ever read. loadMeta was 23% of resolution CPU after
pnpm/pnpm#13504.

The Rust CLI already shipped an indexed mirror layout (headers record,
index record with per-version byte spans, concatenated raw version
fragments); the TypeScript CLI treated those mirrors as cache misses,
so the two stacks thrashed a shared cache. Both CLIs now read and write
the same layout under the format id pnpm-meta-v1, and the metadata
cache directories move from v11 to v12 so a pnpm version that predates
the layout never opens the files at all. NDJSON remains the layout for
filterMetadata documents and is still read as a fallback.

Loading an indexed mirror parses only the two leading records and
builds versions as enumerable parse-once getters over byte spans, so a
manifest keeps one identity across filtered views and hook mutations.
Corruption is treated like an unreadable mirror in both stacks: a
fragment that does not parse throws a typed error, offline resolution
fails with NO_OFFLINE_META, the disk fast paths fall through to the
network (only for errors attributable to the disk copy), and a 304 over
a damaged file escalates to a cache-bypassing refetch that rewrites the
mirror — otherwise the intact etag would keep 304-validating a poisoned
file forever. The declared headers length is bounded, the encoded
mirror form is memoized per fetch result so workspace projects sharing
one in-flight fetch do not each serialize a copy, and cache view reads
through the shared loader in both CLIs.

Resolution of the 1246-package fixture is 16% faster on a warm mirror
(3.82s -> 3.21s, interleaved paired runs, offline); the resulting
lockfile is byte-identical across old-format, new-format, and
mixed-format configurations.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Both in
  this PR: the TypeScript CLI adopts the layout the Rust CLI introduced, and
  the Rust side gains the same corruption contract and `cache view` behavior.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).
