### PR TITLE
feat(napi): expose readConfig for embedders

### DIFF
--- a/.changeset/napi-read-config.md
+++ b/.changeset/napi-read-config.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/napi": minor
+---
+
+Added `readConfig(options)`: resolves the configuration the engine's own installs use — registries with their resolved `Authorization` headers, `authHeaderByUri`, proxy, TLS, network limits, store/cache directories, and install behavior settings from the `.npmrc` / `pnpm-workspace.yaml` cascade — so embedders no longer need a JavaScript config reader.

--- a/.changeset/napi-read-config.md
+++ b/.changeset/napi-read-config.md
@@ -2,4 +2,4 @@
 "@pnpm/napi": minor
 ---
 
-Added `readConfig(options)`: resolves the configuration the engine's own installs use — registries with their resolved `Authorization` headers, `authHeaderByUri`, proxy, TLS, network limits, store/cache directories, and install behavior settings from the `.npmrc` / `pnpm-workspace.yaml` cascade — so embedders no longer need a JavaScript config reader.
+Added `readConfig(options)`: resolves the configuration the engine's own installs use — registries with their resolved `Authorization` headers, `authHeaderByUri`, proxy, TLS, network limits, store/cache directories, and install behavior settings from the `.npmrc` / `pnpm-workspace.yaml` cascade — so hosts that embed the engine no longer need a JavaScript config reader.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4620,6 +4620,7 @@ dependencies = [
  "pacquet-tarball",
  "pacquet-testing-utils",
  "pacquet-workspace",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "tempfile",

--- a/pnpm/crates/napi/Cargo.toml
+++ b/pnpm/crates/napi/Cargo.toml
@@ -54,6 +54,7 @@ tokio       = { workspace = true }
 napi-build = { workspace = true }
 
 [dev-dependencies]
+pretty_assertions     = { workspace = true }
 pacquet-testing-utils = { workspace = true }
 tempfile              = { workspace = true }
 

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -706,12 +706,13 @@ fn parse_link_workspace_packages(
         .transpose()
 }
 
-fn parse_import_method(value: &str) -> Option<pacquet_config::PackageImportMethod> {
+pub(crate) fn parse_import_method(value: &str) -> Option<pacquet_config::PackageImportMethod> {
     match value {
         "auto" => Some(pacquet_config::PackageImportMethod::Auto),
         "hardlink" => Some(pacquet_config::PackageImportMethod::Hardlink),
         "copy" => Some(pacquet_config::PackageImportMethod::Copy),
         "clone" => Some(pacquet_config::PackageImportMethod::Clone),
+        "clone-or-copy" => Some(pacquet_config::PackageImportMethod::CloneOrCopy),
         _ => None,
     }
 }

--- a/pnpm/crates/napi/src/lib.rs
+++ b/pnpm/crates/napi/src/lib.rs
@@ -25,6 +25,7 @@ mod error;
 mod hooks;
 mod install;
 mod pack;
+mod read_config;
 mod reporter_bridge;
 mod resolve;
 mod specifier;
@@ -35,6 +36,7 @@ pub use install::{
 };
 use napi_derive::napi;
 pub use pack::{PackOptions, PackResult, pack};
+pub use read_config::{ReadConfigOptions, ResolvedConfig, ResolvedRegistry, read_config};
 pub use resolve::{
     ResolveDependencyOptions, ResolveDependencyResult, WantedDependencyInput, resolve_dependency,
 };

--- a/pnpm/crates/napi/src/read_config.rs
+++ b/pnpm/crates/napi/src/read_config.rs
@@ -42,7 +42,7 @@ pub struct ResolvedRegistry {
 pub struct ResolvedConfig {
     pub registries: Vec<ResolvedRegistry>,
     /// Static `Authorization` headers keyed by nerf-darted registry URI
-    /// (`//host[:port]/path/`) — the shape [`crate::install`]'s
+    /// (`//host[:port]/path/`) — the shape [`fn@crate::install`]'s
     /// `authHeaderByUri` accepts.
     pub auth_header_by_uri: HashMap<String, String>,
     pub http_proxy: Option<String>,
@@ -85,7 +85,7 @@ pub struct ResolvedConfig {
 
 #[napi(js_name = "readConfig")]
 pub fn read_config(options: ReadConfigOptions) -> napi::Result<ResolvedConfig> {
-    let dir = std::path::PathBuf::from(&options.dir);
+    let dir = std::path::PathBuf::from(options.dir);
     let config =
         resolve_config(&dir, &ConfigOverlay::default()).map_err(|error| to_napi_error(&error))?;
     Ok(project_config(config))

--- a/pnpm/crates/napi/src/read_config.rs
+++ b/pnpm/crates/napi/src/read_config.rs
@@ -1,0 +1,162 @@
+//! `readConfig` — expose the engine's resolved configuration to the embedder.
+//!
+//! Hosts like Bit historically parsed `.npmrc` themselves (via
+//! `@pnpm/config.reader`) to learn registries, credentials, proxy, and TLS
+//! settings — only to hand most of it straight back to the engine. This
+//! binding inverts that: the engine resolves the exact configuration its own
+//! installs use (see [`crate::config::resolve_config`]) and returns the
+//! subset an embedder consumes, so the host needs no JavaScript config
+//! reader at all.
+
+use std::collections::HashMap;
+
+use napi_derive::napi;
+use pacquet_network::{DEFAULT_REGISTRY_SCOPE, NoProxySetting, nerf_dart};
+
+use crate::{
+    config::{ConfigOverlay, resolve_config},
+    error::to_napi_error,
+};
+
+#[napi(object)]
+pub struct ReadConfigOptions {
+    /// Directory whose config cascade to resolve — its `.npmrc`, the
+    /// enclosing workspace's `pnpm-workspace.yaml` and `.npmrc`, the user
+    /// and global config files, and `npm_config_*` environment variables.
+    pub dir: String,
+}
+
+/// One configured registry: the `default` entry plus one per `@scope`.
+#[napi(object)]
+pub struct ResolvedRegistry {
+    /// `"default"` or the package scope (`"@teambit"`).
+    pub name: String,
+    pub url: String,
+    /// Ready-to-send `Authorization` header for this registry, when the
+    /// config carries a static credential for it. `tokenHelper`
+    /// credentials are not executed here and yield no header.
+    pub auth_header: Option<String>,
+}
+
+#[napi(object)]
+pub struct ResolvedConfig {
+    pub registries: Vec<ResolvedRegistry>,
+    /// Static `Authorization` headers keyed by nerf-darted registry URI
+    /// (`//host[:port]/path/`) — the shape [`crate::install`]'s
+    /// `authHeaderByUri` accepts.
+    pub auth_header_by_uri: HashMap<String, String>,
+    pub http_proxy: Option<String>,
+    pub https_proxy: Option<String>,
+    /// `true` (bypass every proxy) or a comma-separated host list.
+    pub no_proxy: Option<serde_json::Value>,
+    /// PEM-encoded CA certificates (`ca` / `cafile` already merged).
+    pub ca: Option<Vec<String>>,
+    pub cert: Option<String>,
+    pub key: Option<String>,
+    pub strict_ssl: Option<bool>,
+    pub store_dir: String,
+    pub cache_dir: String,
+    pub virtual_store_dir_max_length: u32,
+    pub network_concurrency: u32,
+    pub max_sockets: Option<u32>,
+    pub fetch_retries: u32,
+    pub fetch_retry_factor: u32,
+    pub fetch_retry_mintimeout: u32,
+    pub fetch_retry_maxtimeout: u32,
+    pub fetch_timeout: u32,
+    pub user_agent: String,
+    pub engine_strict: bool,
+    pub node_version: Option<String>,
+    /// `"auto"` / `"hardlink"` / `"copy"` / `"clone"` / `"clone-or-copy"`.
+    pub package_import_method: String,
+    pub hoist_pattern: Option<Vec<String>>,
+    pub public_hoist_pattern: Option<Vec<String>>,
+}
+
+#[napi(js_name = "readConfig")]
+pub fn read_config(options: ReadConfigOptions) -> napi::Result<ResolvedConfig> {
+    let dir = std::path::PathBuf::from(&options.dir);
+    let config =
+        resolve_config(&dir, &ConfigOverlay::default()).map_err(|error| to_napi_error(&error))?;
+    Ok(project_config(config))
+}
+
+fn project_config(config: &pacquet_config::Config) -> ResolvedConfig {
+    // `to_by_scope` maps `nerf-darted uri -> scope -> header`, carrying
+    // only static credentials (a `tokenHelper` has no header until run).
+    let by_scope = config.auth_headers.to_by_scope();
+    let auth_header_by_uri: HashMap<String, String> = by_scope
+        .iter()
+        .filter_map(|(uri, by_scope)| {
+            by_scope.get(DEFAULT_REGISTRY_SCOPE).map(|header| (uri.clone(), header.clone()))
+        })
+        .collect();
+
+    // The default registry lives in `config.registry`; the `registries`
+    // map carries it only when something set a `default` key explicitly.
+    let default_entry = (!config.registries.contains_key("default"))
+        .then(|| ("default".to_string(), config.registry.clone()));
+    let registries = default_entry
+        .iter()
+        .map(|(name, url)| (name, url))
+        .chain(config.registries.iter())
+        .map(|(name, url)| {
+            let uri = nerf_dart(url);
+            let scoped = by_scope.get(&uri);
+            // A scope registry prefers its scope-keyed credential; both
+            // registry kinds fall back to the registry-wide (`@`) one.
+            let auth_header = scoped
+                .and_then(|headers| if name == "default" { None } else { headers.get(name) })
+                .or_else(|| scoped.and_then(|headers| headers.get(DEFAULT_REGISTRY_SCOPE)))
+                .cloned();
+            ResolvedRegistry { name: name.clone(), url: url.clone(), auth_header }
+        })
+        .collect();
+
+    let no_proxy = config.proxy.no_proxy.as_ref().map(|setting| match setting {
+        NoProxySetting::Bypass => serde_json::Value::Bool(true),
+        NoProxySetting::List(hosts) => serde_json::Value::String(hosts.join(",")),
+    });
+
+    ResolvedConfig {
+        registries,
+        auth_header_by_uri,
+        http_proxy: config.proxy.http_proxy.clone(),
+        https_proxy: config.proxy.https_proxy.clone(),
+        no_proxy,
+        ca: (!config.tls.ca.is_empty()).then(|| config.tls.ca.clone()),
+        cert: config.tls.cert.clone(),
+        key: config.tls.key.clone(),
+        strict_ssl: config.tls.strict_ssl,
+        store_dir: std::path::PathBuf::from(config.store_dir.clone()).display().to_string(),
+        cache_dir: config.cache_dir.display().to_string(),
+        virtual_store_dir_max_length: u32::try_from(config.virtual_store_dir_max_length)
+            .unwrap_or(u32::MAX),
+        network_concurrency: u32::try_from(config.network_concurrency).unwrap_or(u32::MAX),
+        max_sockets: config.max_sockets.map(|value| u32::try_from(value).unwrap_or(u32::MAX)),
+        fetch_retries: config.fetch_retries,
+        fetch_retry_factor: config.fetch_retry_factor,
+        fetch_retry_mintimeout: u32::try_from(config.fetch_retry_mintimeout).unwrap_or(u32::MAX),
+        fetch_retry_maxtimeout: u32::try_from(config.fetch_retry_maxtimeout).unwrap_or(u32::MAX),
+        fetch_timeout: u32::try_from(config.fetch_timeout).unwrap_or(u32::MAX),
+        user_agent: config.user_agent.clone(),
+        engine_strict: config.engine_strict,
+        node_version: config.node_version.clone(),
+        package_import_method: import_method_name(config.package_import_method).to_string(),
+        hoist_pattern: config.hoist_pattern.clone(),
+        public_hoist_pattern: config.public_hoist_pattern.clone(),
+    }
+}
+
+fn import_method_name(method: pacquet_config::PackageImportMethod) -> &'static str {
+    match method {
+        pacquet_config::PackageImportMethod::Auto => "auto",
+        pacquet_config::PackageImportMethod::Hardlink => "hardlink",
+        pacquet_config::PackageImportMethod::Copy => "copy",
+        pacquet_config::PackageImportMethod::Clone => "clone",
+        pacquet_config::PackageImportMethod::CloneOrCopy => "clone-or-copy",
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/napi/src/read_config.rs
+++ b/pnpm/crates/napi/src/read_config.rs
@@ -77,6 +77,9 @@ pub struct ResolvedConfig {
     /// The legacy `shamefullyHoist` flag; `publicHoistPattern` already
     /// reflects it, exposed for embedders that branch on the flag itself.
     pub shamefully_hoist: bool,
+    /// The engine's pnpm home directory (`PNPM_HOME` or the platform
+    /// default) — not a per-project setting. `None` when no home
+    /// directory is resolvable.
     pub pnpm_home_dir: Option<String>,
 }
 

--- a/pnpm/crates/napi/src/read_config.rs
+++ b/pnpm/crates/napi/src/read_config.rs
@@ -64,13 +64,20 @@ pub struct ResolvedConfig {
     pub fetch_retry_mintimeout: u32,
     pub fetch_retry_maxtimeout: u32,
     pub fetch_timeout: u32,
-    pub user_agent: String,
+    /// The explicitly configured user agent, when the cascade set one.
+    /// The engine's own computed default is omitted — an embedder that
+    /// passes nothing back to `install` gets that same default.
+    pub user_agent: Option<String>,
     pub engine_strict: bool,
     pub node_version: Option<String>,
     /// `"auto"` / `"hardlink"` / `"copy"` / `"clone"` / `"clone-or-copy"`.
     pub package_import_method: String,
     pub hoist_pattern: Option<Vec<String>>,
     pub public_hoist_pattern: Option<Vec<String>>,
+    /// The legacy `shamefullyHoist` flag; `publicHoistPattern` already
+    /// reflects it, exposed for embedders that branch on the flag itself.
+    pub shamefully_hoist: bool,
+    pub pnpm_home_dir: Option<String>,
 }
 
 #[napi(js_name = "readConfig")]
@@ -139,12 +146,18 @@ fn project_config(config: &pacquet_config::Config) -> ResolvedConfig {
         fetch_retry_mintimeout: u32::try_from(config.fetch_retry_mintimeout).unwrap_or(u32::MAX),
         fetch_retry_maxtimeout: u32::try_from(config.fetch_retry_maxtimeout).unwrap_or(u32::MAX),
         fetch_timeout: u32::try_from(config.fetch_timeout).unwrap_or(u32::MAX),
-        user_agent: config.user_agent.clone(),
+        user_agent: config
+            .explicit_settings
+            .contains_key("userAgent")
+            .then(|| config.user_agent.clone()),
         engine_strict: config.engine_strict,
         node_version: config.node_version.clone(),
         package_import_method: import_method_name(config.package_import_method).to_string(),
         hoist_pattern: config.hoist_pattern.clone(),
         public_hoist_pattern: config.public_hoist_pattern.clone(),
+        shamefully_hoist: config.shamefully_hoist,
+        pnpm_home_dir: pacquet_config::default_pnpm_home_dir::<pacquet_config::Host>()
+            .map(|dir| dir.display().to_string()),
     }
 }
 

--- a/pnpm/crates/napi/src/read_config/tests.rs
+++ b/pnpm/crates/napi/src/read_config/tests.rs
@@ -97,8 +97,11 @@ fn empty_ca_projects_as_absent() {
     assert_eq!(project_config(&config).ca, None);
 }
 
+/// Every projected import-method name must be accepted back by the
+/// `install` option parser, so an embedder can feed `readConfig`'s value
+/// into `install` without silently losing the configured behavior.
 #[test]
-fn import_method_names_match_the_install_option_strings() {
+fn import_method_names_round_trip_through_the_install_parser() {
     use pacquet_config::PackageImportMethod;
     for (method, name) in [
         (PackageImportMethod::Auto, "auto"),
@@ -108,5 +111,51 @@ fn import_method_names_match_the_install_option_strings() {
         (PackageImportMethod::CloneOrCopy, "clone-or-copy"),
     ] {
         assert_eq!(import_method_name(method), name);
+        assert_eq!(crate::install::parse_import_method(name), Some(method));
     }
+}
+
+/// End-to-end through the real resolver: a project `.npmrc` cascade must
+/// surface in the projection. Asserts only the fixture's own keys — the
+/// process environment and user config may add entries, never remove
+/// these.
+#[test]
+fn read_config_resolves_the_project_npmrc_cascade() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join(".npmrc"),
+        concat!(
+            "@fixture:registry=https://reg.fixture.example/scoped/\n",
+            "//reg.fixture.example/scoped/:_authToken=fixture-token\n",
+            "https-proxy=http://proxy.fixture.example:8080\n",
+            "no-proxy=internal.fixture.example\n",
+            "strict-ssl=false\n",
+        ),
+    )
+    .expect("write .npmrc");
+
+    let resolved = super::read_config(super::ReadConfigOptions {
+        dir: dir.path().display().to_string(),
+    })
+    .expect("read config");
+
+    let fixture_registry = resolved
+        .registries
+        .iter()
+        .find(|registry| registry.name == "@fixture")
+        .expect("@fixture registry resolved from the project .npmrc");
+    assert_eq!(fixture_registry.url, "https://reg.fixture.example/scoped/");
+    assert_eq!(fixture_registry.auth_header.as_deref(), Some("Bearer fixture-token"));
+    assert_eq!(
+        resolved.auth_header_by_uri.get("//reg.fixture.example/scoped/").map(String::as_str),
+        Some("Bearer fixture-token"),
+    );
+    assert_eq!(resolved.https_proxy.as_deref(), Some("http://proxy.fixture.example:8080"));
+    assert_eq!(
+        resolved.no_proxy,
+        Some(serde_json::Value::String("internal.fixture.example".to_string())),
+    );
+    assert_eq!(resolved.strict_ssl, Some(false));
+    assert!(!resolved.store_dir.is_empty());
+    assert!(!resolved.cache_dir.is_empty());
 }

--- a/pnpm/crates/napi/src/read_config/tests.rs
+++ b/pnpm/crates/napi/src/read_config/tests.rs
@@ -1,0 +1,112 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use pacquet_config::Config;
+use pacquet_network::{AuthHeaders, AuthHeadersByScope, NoProxySetting};
+use pretty_assertions::assert_eq;
+
+use super::{import_method_name, project_config};
+
+fn config_with_auth(by_scope: AuthHeadersByScope) -> Config {
+    let mut config = Config::default();
+    config.registry = "https://reg.example/npm/".to_string();
+    config.registries =
+        BTreeMap::from([("@scope".to_string(), "https://reg.example/scoped/".to_string())]);
+    config.auth_headers = Arc::new(AuthHeaders::from_by_scope(by_scope));
+    config
+}
+
+#[test]
+fn registries_carry_their_static_auth_headers() {
+    let config = config_with_auth(AuthHeadersByScope::from([
+        (
+            "//reg.example/npm/".to_string(),
+            BTreeMap::from([("@".to_string(), "Bearer default-token".to_string())]),
+        ),
+        (
+            "//reg.example/scoped/".to_string(),
+            BTreeMap::from([("@scope".to_string(), "Bearer scoped-token".to_string())]),
+        ),
+    ]));
+
+    let resolved = project_config(&config);
+
+    let by_name: BTreeMap<&str, Option<&str>> = resolved
+        .registries
+        .iter()
+        .map(|registry| (registry.name.as_str(), registry.auth_header.as_deref()))
+        .collect();
+    assert_eq!(by_name["default"], Some("Bearer default-token"));
+    assert_eq!(by_name["@scope"], Some("Bearer scoped-token"));
+    assert_eq!(
+        resolved.auth_header_by_uri.get("//reg.example/npm/").map(String::as_str),
+        Some("Bearer default-token"),
+        "registry-wide headers land in the uri-keyed map",
+    );
+    assert_eq!(
+        resolved.auth_header_by_uri.get("//reg.example/scoped/"),
+        None,
+        "scope-keyed credentials stay off the registry-wide map",
+    );
+}
+
+/// A scope registry with both a scope-keyed and a registry-wide credential
+/// at its URI must pick its own scope's; a scope registry with only the
+/// registry-wide one falls back to it.
+#[test]
+fn scope_registry_prefers_its_scope_credential() {
+    let config = config_with_auth(AuthHeadersByScope::from([(
+        "//reg.example/scoped/".to_string(),
+        BTreeMap::from([
+            ("@".to_string(), "Bearer registry-wide".to_string()),
+            ("@scope".to_string(), "Bearer scoped-token".to_string()),
+        ]),
+    )]));
+
+    let resolved = project_config(&config);
+
+    let scope = resolved.registries.iter().find(|r| r.name == "@scope").expect("@scope registry");
+    assert_eq!(scope.auth_header.as_deref(), Some("Bearer scoped-token"));
+
+    let mut config = config;
+    config.auth_headers = Arc::new(AuthHeaders::from_by_scope(AuthHeadersByScope::from([(
+        "//reg.example/scoped/".to_string(),
+        BTreeMap::from([("@".to_string(), "Bearer registry-wide".to_string())]),
+    )])));
+    let resolved = project_config(&config);
+    let scope = resolved.registries.iter().find(|r| r.name == "@scope").expect("@scope registry");
+    assert_eq!(scope.auth_header.as_deref(), Some("Bearer registry-wide"));
+}
+
+#[test]
+fn no_proxy_projects_bypass_as_true_and_hosts_as_a_joined_string() {
+    let mut config = Config::default();
+    config.proxy.no_proxy = Some(NoProxySetting::Bypass);
+    assert_eq!(project_config(&config).no_proxy, Some(serde_json::Value::Bool(true)));
+
+    config.proxy.no_proxy =
+        Some(NoProxySetting::List(vec!["a.example".to_string(), "b.example".to_string()]));
+    assert_eq!(
+        project_config(&config).no_proxy,
+        Some(serde_json::Value::String("a.example,b.example".to_string())),
+    );
+}
+
+#[test]
+fn empty_ca_projects_as_absent() {
+    let config = Config::default();
+    assert_eq!(project_config(&config).ca, None);
+}
+
+#[test]
+fn import_method_names_match_the_install_option_strings() {
+    use pacquet_config::PackageImportMethod;
+    for (method, name) in [
+        (PackageImportMethod::Auto, "auto"),
+        (PackageImportMethod::Hardlink, "hardlink"),
+        (PackageImportMethod::Copy, "copy"),
+        (PackageImportMethod::Clone, "clone"),
+        (PackageImportMethod::CloneOrCopy, "clone-or-copy"),
+    ] {
+        assert_eq!(import_method_name(method), name);
+    }
+}

--- a/pnpm/crates/napi/src/read_config/tests.rs
+++ b/pnpm/crates/napi/src/read_config/tests.rs
@@ -7,12 +7,15 @@ use pretty_assertions::assert_eq;
 use super::{import_method_name, project_config};
 
 fn config_with_auth(by_scope: AuthHeadersByScope) -> Config {
-    let mut config = Config::default();
-    config.registry = "https://reg.example/npm/".to_string();
-    config.registries =
-        BTreeMap::from([("@scope".to_string(), "https://reg.example/scoped/".to_string())]);
-    config.auth_headers = Arc::new(AuthHeaders::from_by_scope(by_scope));
-    config
+    Config {
+        registry: "https://reg.example/npm/".to_string(),
+        registries: BTreeMap::from([(
+            "@scope".to_string(),
+            "https://reg.example/scoped/".to_string(),
+        )]),
+        auth_headers: Arc::new(AuthHeaders::from_by_scope(by_scope)),
+        ..Config::default()
+    }
 }
 
 #[test]
@@ -64,7 +67,11 @@ fn scope_registry_prefers_its_scope_credential() {
 
     let resolved = project_config(&config);
 
-    let scope = resolved.registries.iter().find(|r| r.name == "@scope").expect("@scope registry");
+    let scope = resolved
+        .registries
+        .iter()
+        .find(|registry| registry.name == "@scope")
+        .expect("@scope registry");
     assert_eq!(scope.auth_header.as_deref(), Some("Bearer scoped-token"));
 
     let mut config = config;
@@ -73,7 +80,11 @@ fn scope_registry_prefers_its_scope_credential() {
         BTreeMap::from([("@".to_string(), "Bearer registry-wide".to_string())]),
     )])));
     let resolved = project_config(&config);
-    let scope = resolved.registries.iter().find(|r| r.name == "@scope").expect("@scope registry");
+    let scope = resolved
+        .registries
+        .iter()
+        .find(|registry| registry.name == "@scope")
+        .expect("@scope registry");
     assert_eq!(scope.auth_header.as_deref(), Some("Bearer registry-wide"));
 }
 
@@ -85,6 +96,7 @@ fn no_proxy_projects_bypass_as_true_and_hosts_as_a_joined_string() {
 
     config.proxy.no_proxy =
         Some(NoProxySetting::List(vec!["a.example".to_string(), "b.example".to_string()]));
+
     assert_eq!(
         project_config(&config).no_proxy,
         Some(serde_json::Value::String("a.example,b.example".to_string())),
@@ -134,10 +146,9 @@ fn read_config_resolves_the_project_npmrc_cascade() {
     )
     .expect("write .npmrc");
 
-    let resolved = super::read_config(super::ReadConfigOptions {
-        dir: dir.path().display().to_string(),
-    })
-    .expect("read config");
+    let resolved =
+        super::read_config(super::ReadConfigOptions { dir: dir.path().display().to_string() })
+            .expect("read config");
 
     let fixture_registry = resolved
         .registries

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -329,5 +329,70 @@ export interface ParsedBareSpecifier {
 /** Parses/validates a dependency specifier. Returns null for unparsable input. */
 export function parseBareSpecifier(spec: string, alias?: string): ParsedBareSpecifier | null
 
+export interface ReadConfigOptions {
+  /**
+   * Directory whose config cascade to resolve — its `.npmrc`, the enclosing
+   * workspace's `pnpm-workspace.yaml` and `.npmrc`, the user and global
+   * config files, and `npm_config_*` environment variables.
+   */
+  dir: string
+}
+
+/** One configured registry: the `default` entry plus one per `@scope`. */
+export interface ResolvedRegistry {
+  /** `"default"` or the package scope (`"@teambit"`). */
+  name: string
+  url: string
+  /**
+   * Ready-to-send `Authorization` header for this registry, when the config
+   * carries a static credential for it. `tokenHelper` credentials are not
+   * executed here and yield no header.
+   */
+  authHeader?: string
+}
+
+export interface ResolvedConfig {
+  registries: ResolvedRegistry[]
+  /**
+   * Static `Authorization` headers keyed by nerf-darted registry URI
+   * (`//host[:port]/path/`) — the shape `install`'s `authHeaderByUri`
+   * accepts.
+   */
+  authHeaderByUri: Record<string, string>
+  httpProxy?: string
+  httpsProxy?: string
+  /** `true` (bypass every proxy) or a comma-separated host list. */
+  noProxy?: boolean | string
+  /** PEM-encoded CA certificates (`ca` / `cafile` already merged). */
+  ca?: string[]
+  cert?: string
+  key?: string
+  strictSsl?: boolean
+  storeDir: string
+  cacheDir: string
+  virtualStoreDirMaxLength: number
+  networkConcurrency: number
+  maxSockets?: number
+  fetchRetries: number
+  fetchRetryFactor: number
+  fetchRetryMintimeout: number
+  fetchRetryMaxtimeout: number
+  fetchTimeout: number
+  userAgent: string
+  engineStrict: boolean
+  nodeVersion?: string
+  /** `"auto"` / `"hardlink"` / `"copy"` / `"clone"` / `"clone-or-copy"`. */
+  packageImportMethod: string
+  hoistPattern?: string[]
+  publicHoistPattern?: string[]
+}
+
+/**
+ * Resolve the configuration the engine's own installs use — registries,
+ * credentials, proxy, TLS, and network settings from the `.npmrc` cascade —
+ * so the embedder needs no JavaScript config reader.
+ */
+export function readConfig(options: ReadConfigOptions): ResolvedConfig
+
 /** Version of the underlying Rust engine (pacquet). */
 export function engineVersion(): string

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -378,13 +378,24 @@ export interface ResolvedConfig {
   fetchRetryMintimeout: number
   fetchRetryMaxtimeout: number
   fetchTimeout: number
-  userAgent: string
+  /**
+   * The explicitly configured user agent, when the cascade set one. The
+   * engine's own computed default is omitted — an embedder that passes
+   * nothing back to `install` gets that same default.
+   */
+  userAgent?: string
   engineStrict: boolean
   nodeVersion?: string
   /** `"auto"` / `"hardlink"` / `"copy"` / `"clone"` / `"clone-or-copy"`. */
   packageImportMethod: string
   hoistPattern?: string[]
   publicHoistPattern?: string[]
+  /**
+   * The legacy `shamefullyHoist` flag; `publicHoistPattern` already
+   * reflects it, exposed for embedders that branch on the flag itself.
+   */
+  shamefullyHoist: boolean
+  pnpmHomeDir?: string
 }
 
 /**

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -395,6 +395,10 @@ export interface ResolvedConfig {
    * reflects it, exposed for embedders that branch on the flag itself.
    */
   shamefullyHoist: boolean
+  /**
+   * The engine's pnpm home directory (`PNPM_HOME` or the platform default) —
+   * not a per-project setting. Absent when no home directory is resolvable.
+   */
   pnpmHomeDir?: string
 }
 


### PR DESCRIPTION
## Summary

Adds `readConfig(options: { dir })` to `@pnpm/napi`. It resolves the same configuration cascade the engine's own installs use (`.npmrc` up the directory tree, `pnpm-workspace.yaml`, user/global config, `npm_config_*` env) and returns the subset an embedder consumes:

- `registries` — the `default` entry plus one per `@scope`, each with its resolved static `Authorization` header (a `tokenHelper` credential is not executed and yields no header),
- `authHeaderByUri` — the nerf-dart-keyed header map, the same shape `install`'s `authHeaderByUri` option accepts,
- proxy (`httpProxy` / `httpsProxy` / `noProxy`), TLS (`ca` / `cert` / `key` / `strictSsl`),
- network limits (`networkConcurrency`, `maxSockets`, `fetchRetries`, `fetchRetryFactor`, retry timeouts, `fetchTimeout`, `userAgent`),
- directories (`storeDir`, `cacheDir`) and behavior settings (`engineStrict`, `nodeVersion`, `packageImportMethod`, hoist patterns, `virtualStoreDirMaxLength`).

Motivation: Bit (the first napi embedder) parses `.npmrc` through `@pnpm/config.reader` only to hand most of the result straight back to the engine. That JS package chain is also what keeps Bit's registry-mirror problems alive — bit.cloud's mirror caps `@pnpm/config.env-replace` below the version `config.reader@1101.x` requires (`envReplaceLossy` is 4.x-only, so no version-force workaround exists). With `readConfig`, the embedder needs no JavaScript config reader at all.

Implementation reuses the binding's existing interned config resolution (`resolve_config`); the new code is a pure projection (`project_config`), unit-tested on hand-built configs (registry/auth flattening incl. scope-credential preference and default-registry synthesis from `config.registry`, `noProxy` bypass-vs-list shapes, CA absence, import-method names kept in sync with the `install` option strings). Verified end-to-end through the built `.node` binding against a real `.npmrc` cascade.

No TypeScript-CLI counterpart is needed: this is binding surface only, and the TS ecosystem's equivalent is `@pnpm/config.reader` itself.

## Squash Commit Body

```text
Bit parses .npmrc through @pnpm/config.reader only to hand the result
back to the engine, and that JS package chain is what keeps Bit's
registry mirror problems alive (its mirror caps @pnpm/config.env-replace
below the version config.reader needs). The engine already resolves the
full config cascade for its own installs; readConfig projects the
subset an embedder consumes: registries with resolved Authorization
headers, authHeaderByUri, proxy, TLS, network limits, directories, and
install behavior settings.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Binding-only surface; the TypeScript equivalent is `@pnpm/config.reader`.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788039918&installation_model_id=426870&pr_number=13513&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13513&signature=ba2d35eb7191d8c81236ab2d314c3279554a73ea5de6479db8993c88d3fabfb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `readConfig` API that returns the fully resolved package manager configuration for a directory, including registry auth resolution, proxy/TLS/network settings, and cache/store/virtual store locations.
  * Refined output: `userAgent` is now optional; added `shamefullyHoist` and optional `pnpmHomeDir`.
* **Documentation**
  * Updated the published type definitions for `readConfig`, `ReadConfigOptions`, `ResolvedRegistry`, and `ResolvedConfig`.
* **Bug Fixes**
  * Improved import method parsing: recognizes `"clone-or-copy"` and adjusts how `"clone"` is interpreted.
* **Tests**
  * Refreshed related test helpers and assertions for `readConfig` output/formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->