### PR TITLE
ci: bump pnpm/update to run self-update before the dependency update

### DIFF
--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -44,7 +44,7 @@ jobs:
         install: false
 
     - name: Update dependencies, Node.js, pnpm, and GitHub Actions
-      uses: pnpm/update@9a256174a439f3447aa0a6b9ca3c971428b1d617 #v0.0.0  v0
+      uses: pnpm/update@fcaa952ef94bad62067a94ac2e5c6234b648e259 #v0.0.0  v0
       with:
         update-deps: latest
         refresh-lockfile: true


### PR DESCRIPTION
## Summary

Bumps the pinned `pnpm/update` action in `update-lockfile.yml` to the current main (`fcaa952`), which includes [pnpm/update#4](https://github.com/pnpm/update/pull/4): `pnpm self-update` now runs before the dependency update, so the refreshed lockfile in the daily update PR is produced by the pnpm version the PR moves the repository onto (the pin bump delegates every later pnpm invocation to the new version).

## Squash Commit Body

```text
Picks up pnpm/update#4: the pin bump now happens first, so the
dependency update and the refreshed lockfile are produced by the pnpm
version the update PR moves the repository onto.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting. (Workflow-only change; no product code touched.)
- [x] Added or updated tests. (Covered by bats tests in pnpm/update; no testable code in this repo changed.)

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788045968&installation_model_id=426870&pr_number=13516&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13516&signature=789ac6e88295e39bc6275a355db6415d480810ec9efb15a89ec59346b8c3a8c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the lockfile maintenance workflow to use a newer pinned action revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->