### PR TITLE
feat(napi): report explicitly set settings from readConfig

### DIFF
--- a/.changeset/napi-explicit-settings.md
+++ b/.changeset/napi-explicit-settings.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/napi": minor
+---
+
+`readConfig` now returns `explicitSettings` — the camelCase names of settings the config cascade set explicitly — so hosts that layer the resolved config over their own defaults can forward only the values the user actually configured.

--- a/pnpm/crates/napi/src/read_config.rs
+++ b/pnpm/crates/napi/src/read_config.rs
@@ -81,6 +81,12 @@ pub struct ResolvedConfig {
     /// default) — not a per-project setting. `None` when no home
     /// directory is resolvable.
     pub pnpm_home_dir: Option<String>,
+    /// The camelCase names of settings the cascade set explicitly
+    /// (`pnpm-workspace.yaml`, the global config, `pnpm_config_*` env
+    /// vars). Every other projected value is an engine default; an
+    /// embedder that layers this config over its own must forward only
+    /// the explicit ones.
+    pub explicit_settings: Vec<String>,
 }
 
 #[napi(js_name = "readConfig")]
@@ -161,6 +167,7 @@ fn project_config(config: &pacquet_config::Config) -> ResolvedConfig {
         shamefully_hoist: config.shamefully_hoist,
         pnpm_home_dir: pacquet_config::default_pnpm_home_dir::<pacquet_config::Host>()
             .map(|dir| dir.display().to_string()),
+        explicit_settings: config.explicit_settings.keys().cloned().collect(),
     }
 }
 

--- a/pnpm/crates/napi/src/read_config/tests.rs
+++ b/pnpm/crates/napi/src/read_config/tests.rs
@@ -170,3 +170,21 @@ fn read_config_resolves_the_project_npmrc_cascade() {
     assert!(!resolved.store_dir.is_empty());
     assert!(!resolved.cache_dir.is_empty());
 }
+
+/// A `pnpm-workspace.yaml` setting must surface both as its resolved
+/// value and as an entry in `explicit_settings`, while an unset sibling
+/// (whose projected value is an engine default) stays off that list.
+#[test]
+fn read_config_reports_explicitly_set_workspace_settings() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("pnpm-workspace.yaml"), "fetchRetries: 7\n")
+        .expect("write pnpm-workspace.yaml");
+
+    let resolved =
+        super::read_config(super::ReadConfigOptions { dir: dir.path().display().to_string() })
+            .expect("read config");
+
+    assert_eq!(resolved.fetch_retries, 7);
+    assert!(resolved.explicit_settings.contains(&"fetchRetries".to_string()));
+    assert!(!resolved.explicit_settings.contains(&"fetchTimeout".to_string()));
+}

--- a/pnpm/npm/napi/index.d.ts
+++ b/pnpm/npm/napi/index.d.ts
@@ -415,6 +415,13 @@ export interface ResolvedConfig {
    * not a per-project setting. Absent when no home directory is resolvable.
    */
   pnpmHomeDir?: string
+  /**
+   * The camelCase names of settings the cascade set explicitly
+   * (`pnpm-workspace.yaml`, the global config, `pnpm_config_*` env vars).
+   * Every other projected value is an engine default; an embedder that
+   * layers this config over its own must forward only the explicit ones.
+   */
+  explicitSettings: string[]
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to the `readConfig` binding: the projection carries the engine's defaults for every numeric network setting (`fetchRetries`, `fetchTimeout`, `maxSockets`, …), so an embedder that merges the resolved config over its own global settings cannot tell a user-configured value from a default — Bit was either forwarding engine defaults as overrides of its global network config, or would have to forward nothing.

`readConfig` now also returns `explicitSettings`: the camelCase names of settings the cascade set explicitly (`pnpm-workspace.yaml`, global config, `pnpm_config_*` env vars), straight from the config's `explicit_settings` tracking that already powers the `userAgent` projection and `shamefullyHoist` derivation. Covered by an end-to-end test asserting a `pnpm-workspace.yaml` `fetchRetries` lands both as the resolved value and on the explicit list, while an unset sibling stays off it.

## Squash Commit Body

```text
Every projected numeric network value carries the engine default when
unset, and Bit merges the projection over its own global network
config - without knowing which values are explicit it either forwards
defaults as overrides or forwards nothing.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Binding-only; the TypeScript ecosystem reads `rawConfig` for the same purpose.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788048931&installation_model_id=426870&pr_number=13518&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13518&signature=9cf55557537cc8314460049906a7d9f4f604fcbb728d98c87788414b7ce2b44e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `explicitSettings` to resolved configuration data.
  - The property lists explicitly configured settings using camelCase names, making it easier to distinguish configured values from defaults.

- **Tests**
  - Added coverage confirming explicitly configured settings are included while unset settings are excluded.

- **Documentation**
  - Documented the new configuration metadata in the release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->