### PR TITLE
fix(git-resolver): make the ls-remote prompt guard reach git

### DIFF
--- a/.changeset/ls-remote-prompt-guard-reaches-git.md
+++ b/.changeset/ls-remote-prompt-guard-reaches-git.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-The `GIT_TERMINAL_PROMPT=0` guard on `git ls-remote` now reaches the spawned git process: git is run directly instead of through graceful-git, which forwards only `cwd` and dropped the environment override, so resolving a private git repository could still block on an interactive credential prompt [#13421](https://github.com/pnpm/pnpm/issues/13421).
+Resolving a private git repository no longer blocks on an interactive credential prompt: `git ls-remote` now fails fast with an authentication error when git has no credentials for the repository [#13421](https://github.com/pnpm/pnpm/issues/13421).

--- a/.changeset/ls-remote-prompt-guard-reaches-git.md
+++ b/.changeset/ls-remote-prompt-guard-reaches-git.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Resolving a private git repository no longer blocks on an interactive credential prompt: `git ls-remote` now fails fast with an authentication error when git has no credentials for the repository [#13421](https://github.com/pnpm/pnpm/issues/13421).
+Resolving a private git repository no longer blocks on an interactive credential prompt: `git ls-remote` now fails fast with an authentication error when git has no credentials for the repository [#13522](https://github.com/pnpm/pnpm/issues/13522).

--- a/.changeset/ls-remote-prompt-guard-reaches-git.md
+++ b/.changeset/ls-remote-prompt-guard-reaches-git.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/resolving.git-resolver": patch
+"pnpm": patch
+---
+
+The `GIT_TERMINAL_PROMPT=0` guard on `git ls-remote` now reaches the spawned git process: git is run directly instead of through graceful-git, which forwards only `cwd` and dropped the environment override, so resolving a private git repository could still block on an interactive credential prompt [#13421](https://github.com/pnpm/pnpm/issues/13421).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,9 +482,6 @@ catalogs:
     graceful-fs:
       specifier: ^4.2.11
       version: 4.2.11
-    graceful-git:
-      specifier: ^5.0.0
-      version: 5.0.0
     graph-cycles:
       specifier: 3.0.0
       version: 3.0.0
@@ -8700,9 +8697,9 @@ importers:
       '@pnpm/resolving.resolver-base':
         specifier: workspace:*
         version: link:../resolver-base
-      graceful-git:
+      execa:
         specifier: 'catalog:'
-        version: 5.0.0
+        version: safe-execa@0.3.0
       hosted-git-info:
         specifier: 'catalog:'
         version: '@pnpm/hosted-git-info@1.0.0'
@@ -14140,10 +14137,6 @@ packages:
   graceful-git@4.0.0:
     resolution: {integrity: sha512-zK/rCH/I0DMKpPBLCElXGI7za3EnXeQFdiK6CTP02Tt1N1L+bMLghZY7cXozlx9M2bx4Q0zrY9ADYP3eI8haIw==}
     engines: {node: '>=18.12'}
-
-  graceful-git@5.0.0:
-    resolution: {integrity: sha512-cmogaKKsYEW06+FriOqkhewEGf9YdMfpK/iSqtW02/GcXhSlsjNrSq1VqrM2zbMfWw0Og+lh5knLd730THxv/A==}
-    engines: {node: '>=22.13'}
 
   graceful-readlink@1.0.1:
     resolution: {integrity: sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==}
@@ -21937,11 +21930,6 @@ snapshots:
     dependencies:
       retry: 0.13.1
       safe-execa: 0.1.4
-
-  graceful-git@5.0.0:
-    dependencies:
-      retry: 0.13.1
-      safe-execa: 0.3.0
 
   graceful-readlink@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -240,7 +240,6 @@ catalog:
   get-port: ^7.2.0
   ghooks: 2.0.4
   graceful-fs: ^4.2.11
-  graceful-git: ^5.0.0
   graph-cycles: 3.0.0
   hosted-git-info: npm:@pnpm/hosted-git-info@1.0.0
   https-proxy-server-express: 0.1.2
@@ -418,7 +417,6 @@ minimumReleaseAgeExclude:
   - '@esbuild/*'
   - express@4.22.1
   - glob@11.1.0
-  - graceful-git
   - handlebars@4.7.9
   - is-inner-link
   - is-subdir

--- a/pnpm11/__typings__/local.d.ts
+++ b/pnpm11/__typings__/local.d.ts
@@ -69,11 +69,6 @@ declare module 'exists-link' {
   export = anything
 }
 
-declare module 'graceful-git' {
-  export const gracefulGit: any
-  export const noRetry: any
-}
-
 declare module 'is-inner-link' {
   export function isInnerLink (parent: string, relativePathToLink: string): Promise<{ isInner: boolean, target: string }>
 }

--- a/pnpm11/resolving/git-resolver/package.json
+++ b/pnpm11/resolving/git-resolver/package.json
@@ -37,7 +37,7 @@
     "@pnpm/error": "workspace:*",
     "@pnpm/network.fetch": "workspace:*",
     "@pnpm/resolving.resolver-base": "workspace:*",
-    "graceful-git": "catalog:",
+    "execa": "catalog:",
     "hosted-git-info": "catalog:",
     "semver": "catalog:"
   },

--- a/pnpm11/resolving/git-resolver/src/index.ts
+++ b/pnpm11/resolving/git-resolver/src/index.ts
@@ -127,7 +127,6 @@ export async function getRepoRefs (repo: string, ref: string | null): Promise<Re
     // This is needed because annotated tags have their own SHA, and we need the commit SHA they point to
     gitArgs.push(`${ref}^{}`)
   }
-  // graceful-git by default retries 10 times, reduce to single retry
   const result = await lsRemote(gitArgs, { retries: 1 })
   const refs: Record<string, string> = {}
   for (const line of result.stdout.split('\n')) {

--- a/pnpm11/resolving/git-resolver/src/lsRemote.ts
+++ b/pnpm11/resolving/git-resolver/src/lsRemote.ts
@@ -5,10 +5,7 @@ import { safeExeca as execa } from 'execa'
  * fails fast on private repos instead of blocking on user input. All
  * ls-remote invocations must go through this function to keep that guarantee.
  *
- * git is spawned directly rather than through graceful-git because
- * graceful-git forwards only `cwd` to the child process, which would drop
- * the `GIT_TERMINAL_PROMPT` override. Failed runs are retried immediately,
- * matching the Rust runner's policy.
+ * Failed runs are retried immediately, matching the Rust runner's policy.
  */
 export async function lsRemote (args: string[], opts: { retries: number }): Promise<{ stdout: string }> {
   let lastErr: unknown

--- a/pnpm11/resolving/git-resolver/src/lsRemote.ts
+++ b/pnpm11/resolving/git-resolver/src/lsRemote.ts
@@ -1,15 +1,28 @@
-import { gracefulGit as git } from 'graceful-git'
+import { safeExeca as execa } from 'execa'
 
 /**
  * Runs `git ls-remote` with interactive credential prompts disabled, so it
  * fails fast on private repos instead of blocking on user input. All
  * ls-remote invocations must go through this function to keep that guarantee.
+ *
+ * git is spawned directly rather than through graceful-git because
+ * graceful-git forwards only `cwd` to the child process, which would drop
+ * the `GIT_TERMINAL_PROMPT` override. Failed runs are retried immediately,
+ * matching the Rust runner's policy.
  */
 export async function lsRemote (args: string[], opts: { retries: number }): Promise<{ stdout: string }> {
-  return git(['ls-remote', ...args], {
-    retries: opts.retries,
-    // Snapshotted per call so changes to auth/proxy env vars made by a
-    // long-lived host process are picked up.
-    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
-  })
+  let lastErr: unknown
+  for (let attempt = 0; attempt <= opts.retries; attempt++) {
+    try {
+      const { stdout } = await execa('git', ['ls-remote', ...args], { // eslint-disable-line no-await-in-loop
+        // Snapshotted per call so changes to auth/proxy env vars made by a
+        // long-lived host process are picked up.
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      })
+      return { stdout: stdout as string }
+    } catch (err: unknown) {
+      lastErr = err
+    }
+  }
+  throw lastErr
 }

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -7,23 +7,24 @@ import isWindows from 'is-windows'
 jest.unstable_mockModule('@pnpm/network.fetch', () => ({
   fetchWithDispatcher: jest.fn(),
 }))
-jest.unstable_mockModule('graceful-git', () => ({
-  gracefulGit: jest.fn(),
+jest.unstable_mockModule('execa', () => ({
+  safeExeca: jest.fn(),
 }))
 const { fetchWithDispatcher } = await import('@pnpm/network.fetch')
-const { gracefulGit: git } = await import('graceful-git')
+const { safeExeca: execa } = await import('execa')
 const { createGitResolver } = await import('@pnpm/resolving.git-resolver')
 
 const resolveFromGit = createGitResolver({})
 
 beforeEach(() => {
-  jest.mocked(git).mockImplementation(lsRemoteFromFixture)
+  mockGit(lsRemoteFromFixture)
   mockFetchAsPublic()
 })
 
 test('resolveFromGit() passes GIT_TERMINAL_PROMPT=0 to prevent interactive credential prompts', async () => {
   await resolveFromGit({ bareSpecifier: 'zkochan/is-negative#master' })
-  expect(jest.mocked(git)).toHaveBeenCalledWith(
+  expect(jest.mocked(execa)).toHaveBeenCalledWith(
+    'git',
     expect.any(Array),
     expect.objectContaining({
       env: expect.objectContaining({
@@ -206,7 +207,7 @@ test('resolveFromGit() with sub folder', async () => {
   jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {
     return { ok: true } as any // eslint-disable-line @typescript-eslint/no-explicit-any
   })
-  jest.mocked(git).mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     if (args.includes('--exit-code')) {
       return { stdout: `${headCommit}\tHEAD` }
     }
@@ -230,7 +231,7 @@ test('resolveFromGit() with both sub folder and branch', async () => {
   jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {
     return { ok: true } as any // eslint-disable-line @typescript-eslint/no-explicit-any
   })
-  jest.mocked(git).mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     if (args.includes('--exit-code')) {
       return { stdout: `${betaCommit}\tHEAD` }
     }
@@ -382,7 +383,7 @@ test('resolveFromGit() gitlab tarball uses /-/archive/ URL without encoded slash
   jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {
     return { ok: true } as any // eslint-disable-line @typescript-eslint/no-explicit-any
   })
-  jest.mocked(git).mockImplementation(async () => ({ stdout: `${headCommit}\tHEAD` }))
+  mockGit(async () => ({ stdout: `${headCommit}\tHEAD` }))
   const resolveResult = await resolveFromGit({ bareSpecifier: 'https://gitlab.com/pnpmjs/git-resolver' })
   expect(resolveResult).toStrictEqual({
     id: `https://gitlab.com/pnpmjs/git-resolver/-/archive/${headCommit}/git-resolver-${headCommit}.tar.gz`,
@@ -509,7 +510,7 @@ test('resolveFromGit() normalizes full url (alternative form 2)', async () => {
 // current implementation does not try git ls-remote on bareSpecifier with full commit hash, this fake repo url will pass.
 test('resolveFromGit() private repo with commit hash', async () => {
   // parseBareSpecifier will try to access the repository with --exit-code
-  git.mockImplementation(() => {
+  mockGit(() => {
     throw new Error('private')
   })
   mockFetchAsPrivate()
@@ -527,7 +528,7 @@ test('resolveFromGit() private repo with commit hash', async () => {
 })
 
 test('resolve a private repository using the HTTPS protocol without auth token', async () => {
-  jest.mocked(git).mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     // Probes use --exit-code, resolution calls use --. Fail probes, succeed resolution.
     if (args.includes('--exit-code')) {
       throw new Error('access denied')
@@ -557,7 +558,7 @@ test('resolve over HTTPS when the visibility probe fails but anonymous HTTPS git
   // lockfile for every environment without SSH keys.
   mockFetchAsPrivate()
   const gitCalls: string[][] = []
-  jest.mocked(git).mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     gitCalls.push(args)
     if (args.some((arg) => arg.includes('git@'))) throw new Error('Permission denied (publickey)')
     return { stdout: '0'.repeat(40) + '\tHEAD' }
@@ -578,7 +579,7 @@ test('resolve over HTTPS when the visibility probe fails but anonymous HTTPS git
 
 test('resolve an explicit SSH specifier over SSH when only SSH access works', async () => {
   mockFetchAsPrivate()
-  jest.mocked(git).mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     if (!args.includes('git@github.com:foo/bar.git')) throw new Error('access denied')
     return { stdout: '0'.repeat(40) + '\tHEAD' }
   })
@@ -595,9 +596,21 @@ test('resolve an explicit SSH specifier over SSH when only SSH access works', as
   })
 })
 
+test('the terminal credential prompt is disabled when a private repository is probed and resolved', async () => {
+  mockFetchAsPrivate()
+  let invocations = 0
+  mockGit(async () => {
+    invocations++
+    return { stdout: '0'.repeat(40) + '\tHEAD' }
+  })
+  await resolveFromGit({ bareSpecifier: 'git+https://github.com/foo/bar.git' })
+  // The access probe and the ref resolution both shell out to git.
+  expect(invocations).toBe(2)
+})
+
 test('resolve a private repository using the HTTPS protocol with a commit hash', async () => {
   mockFetchAsPrivate()
-  jest.mocked(git).mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     expect(args).toContain('ls-remote')
     expect(args).toContain('https://github.com/foo/bar.git')
     return {
@@ -620,7 +633,7 @@ test('resolve a private repository using the HTTPS protocol with a commit hash',
 })
 
 test('resolve a private repository using the HTTPS protocol and an auth token', async () => {
-  git.mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     if (!args.includes('https://0000000000000000000000000000000000000000:x-oauth-basic@github.com/foo/bar.git')) throw new Error('')
     return { stdout: '0000000000000000000000000000000000000000\tHEAD' }
   })
@@ -639,7 +652,7 @@ test('resolve a private repository using the HTTPS protocol and an auth token', 
 })
 
 test('resolve an internal repository using SSH protocol with range semver', async () => {
-  git.mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     if (!args.includes('ssh://git@example.com/org/repo.git')) throw new Error('')
     return {
       stdout: '0000000000000000000000000000000000000000\tHEAD\n\
@@ -661,7 +674,7 @@ cba04669e621b85fbdb33371604de1a2898e68e9\trefs/tags/v0.0.39',
 })
 
 test('resolve an internal repository using SSH protocol with range semver and SCP-like URL', async () => {
-  git.mockImplementation(async (args: string[]) => {
+  mockGit(async (args: string[]) => {
     if (!args.includes('ssh://git@example.com/org/repo.git')) throw new Error('')
     return {
       stdout: '0000000000000000000000000000000000000000\tHEAD\n\
@@ -681,6 +694,16 @@ cba04669e621b85fbdb33371604de1a2898e68e9\trefs/tags/v0.0.39',
     resolvedVia: 'git-repository',
   })
 })
+
+function mockGit (run: (args: string[]) => Promise<{ stdout: string }>): void {
+  jest.mocked(execa).mockImplementation(async (file: string, args: string[], opts: { env?: Record<string, string> }) => {
+    // Every git invocation has to disable the terminal credential prompt,
+    // otherwise a repository that needs credentials blocks the command.
+    expect(file).toBe('git')
+    expect(opts.env?.GIT_TERMINAL_PROMPT).toBe('0')
+    return run(args)
+  })
+}
 
 function mockFetchAsPublic (): void {
   jest.mocked(fetchWithDispatcher).mockImplementation(async (_url, _opts) => {

--- a/pnpm11/resolving/git-resolver/test/index.ts
+++ b/pnpm11/resolving/git-resolver/test/index.ts
@@ -13,6 +13,7 @@ jest.unstable_mockModule('execa', () => ({
 const { fetchWithDispatcher } = await import('@pnpm/network.fetch')
 const { safeExeca: execa } = await import('execa')
 const { createGitResolver } = await import('@pnpm/resolving.git-resolver')
+const { lsRemote } = await import('../lib/lsRemote.js')
 
 const resolveFromGit = createGitResolver({})
 
@@ -284,8 +285,8 @@ test('resolveFromGit() with commit from non-github repo', async () => {
 // TODO: make it pass on CI servers
 test.skip('resolveFromGit() with commit from non-github repo with no commit', async () => {
   const localPath = path.resolve('..', '..')
-  const result = await git(['rev-parse', 'origin/master'], { retries: 0 })
-  const hash: string = result.stdout.trim()
+  const result = await execa('git', ['rev-parse', 'origin/master'])
+  const hash = (result.stdout as string).trim()
   const resolveResult = await resolveFromGit({ bareSpecifier: `git+file://${localPath}` })
   expect(resolveResult).toStrictEqual({
     id: `git+file://${localPath}#${hash}`,
@@ -320,7 +321,7 @@ test.skip('resolveFromGit() bitbucket with commit', async () => {
 // Stopped working. Environmental issue.
 test.skip('resolveFromGit() bitbucket with no commit', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'bitbucket:pnpmjs/git-resolver' })
-  const result = await git(['ls-remote', '--refs', 'https://bitbucket.org/pnpmjs/git-resolver.git', 'master'], { retries: 0 })
+  const result = await lsRemote(['--refs', 'https://bitbucket.org/pnpmjs/git-resolver.git', 'master'], { retries: 0 })
   const hash: string = result.stdout.trim().split('\t')[0]
   expect(resolveResult).toStrictEqual({
     id: `https://bitbucket.org/pnpmjs/git-resolver/get/${hash}.tar.gz`,
@@ -335,7 +336,7 @@ test.skip('resolveFromGit() bitbucket with no commit', async () => {
 // Stopped working. Environmental issue.
 test.skip('resolveFromGit() bitbucket with branch', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'bitbucket:pnpmjs/git-resolver#master' })
-  const result = await git(['ls-remote', '--refs', 'https://bitbucket.org/pnpmjs/git-resolver.git', 'master'], { retries: 0 })
+  const result = await lsRemote(['--refs', 'https://bitbucket.org/pnpmjs/git-resolver.git', 'master'], { retries: 0 })
   const hash: string = result.stdout.trim().split('\t')[0]
   expect(resolveResult).toStrictEqual({
     id: `https://bitbucket.org/pnpmjs/git-resolver/get/${hash}.tar.gz`,
@@ -413,7 +414,7 @@ test.skip('resolveFromGit() gitlab with commit', async () => {
 // This test stopped working. Probably an environmental issue.
 test.skip('resolveFromGit() gitlab with no commit', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'gitlab:pnpm/git-resolver' })
-  const result = await git(['ls-remote', '--refs', 'https://gitlab.com/pnpm/git-resolver.git', 'master'], { retries: 0 })
+  const result = await lsRemote(['--refs', 'https://gitlab.com/pnpm/git-resolver.git', 'master'], { retries: 0 })
   const hash: string = result.stdout.trim().split('\t')[0]
   expect(resolveResult).toStrictEqual({
     id: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
@@ -428,7 +429,7 @@ test.skip('resolveFromGit() gitlab with no commit', async () => {
 // This test stopped working. Probably an environmental issue.
 test.skip('resolveFromGit() gitlab with branch', async () => {
   const resolveResult = await resolveFromGit({ bareSpecifier: 'gitlab:pnpm/git-resolver#master' })
-  const result = await git(['ls-remote', '--refs', 'https://gitlab.com/pnpm/git-resolver.git', 'master'], { retries: 0 })
+  const result = await lsRemote(['--refs', 'https://gitlab.com/pnpm/git-resolver.git', 'master'], { retries: 0 })
   const hash: string = result.stdout.trim().split('\t')[0]
   expect(resolveResult).toStrictEqual({
     id: `https://gitlab.com/api/v4/projects/pnpm%2Fgit-resolver/repository/archive.tar.gz?ref=${hash}`,
@@ -696,13 +697,13 @@ cba04669e621b85fbdb33371604de1a2898e68e9\trefs/tags/v0.0.39',
 })
 
 function mockGit (run: (args: string[]) => Promise<{ stdout: string }>): void {
-  jest.mocked(execa).mockImplementation(async (file: string, args: string[], opts: { env?: Record<string, string> }) => {
+  jest.mocked(execa).mockImplementation(((file: string, args?: readonly string[], opts?: { env?: NodeJS.ProcessEnv }) => {
     // Every git invocation has to disable the terminal credential prompt,
     // otherwise a repository that needs credentials blocks the command.
     expect(file).toBe('git')
-    expect(opts.env?.GIT_TERMINAL_PROMPT).toBe('0')
-    return run(args)
-  })
+    expect(opts?.env?.GIT_TERMINAL_PROMPT).toBe('0')
+    return run(args ? [...args] : [])
+  }) as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 function mockFetchAsPublic (): void {

--- a/pnpm11/resolving/git-resolver/test/parsePref.test.ts
+++ b/pnpm11/resolving/git-resolver/test/parsePref.test.ts
@@ -3,8 +3,8 @@ import { expect, jest, test } from '@jest/globals'
 jest.unstable_mockModule('@pnpm/network.fetch', () => ({
   fetchWithDispatcher: jest.fn(async () => ({ ok: true })),
 }))
-jest.unstable_mockModule('graceful-git', () => ({
-  gracefulGit: jest.fn(async () => ({ stdout: '' })),
+jest.unstable_mockModule('execa', () => ({
+  safeExeca: jest.fn(async () => ({ stdout: '' })),
 }))
 const { parseBareSpecifier } = await import('../lib/parseBareSpecifier.js')
 


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#13522. Related to pnpm/pnpm#13421.

#13471 added `GIT_TERMINAL_PROMPT=0` to the options `lsRemote` passes to graceful-git, but graceful-git forwards only `cwd` to the process it spawns:

```js
// graceful-git@5.0.0 (latest), index.js
export async function noRetry (args, opts) {
  opts = opts || {}
  return safeExeca('git', args, {cwd: opts.cwd || process.cwd()})
}
```

So the variable never reached git, and a repository that needs credentials still made git prompt on the terminal — the hang from #13421 was still there in the TypeScript CLI. Verified end-to-end against a local server answering 401 with `WWW-Authenticate: Basic`, using the built resolver:

- current main: `fatal: could not read Username for '…': Device not configured` (git tried to open the terminal; in an interactive terminal this prompts and blocks)
- this PR: `fatal: could not read Username for '…': terminal prompts disabled` (fails fast, ~100 ms)

`lsRemote` now spawns git through safe-execa directly with the guard in the child environment. The call sites and their `{ retries }` signature are unchanged; failed runs are retried immediately, matching the Rust runner's policy. Since git-resolver was graceful-git's only consumer, the dependency is removed (catalog entry, `minimumReleaseAgeExclude` entry, and the ambient module declaration go with it).

An alternative would be teaching graceful-git to forward `env` and bumping it here; I went with the direct spawn so the fix is self-contained and doesn't wait on an external release, but happy to switch if that's preferred.

**Why the tests didn't catch it:** the test added in #13471 mocks the `graceful-git` module and asserts the `env` option was handed to it — that passes regardless of whether graceful-git forwards it. The mocks now sit on the process-spawn boundary (safe-execa), and the shared mock asserts `GIT_TERMINAL_PROMPT=0` on every invocation, so stripping the guard fails 25 tests. The test from #13471 is kept under the same name, re-targeted at that boundary.

**Rust:** not affected — the runner already sets the variable on the `Command` itself, and its tests cover it. TypeScript-only change.

## Squash Commit Body

```text
#13471 passed GIT_TERMINAL_PROMPT=0 in the options given to
graceful-git, but graceful-git forwards only `cwd` to the process it
spawns, so the override never reached git: a repository that needs
credentials still made git prompt on the terminal, and `pnpm outdated`
with a private GitHub Actions repo (as well as resolving a private git
dependency) still hung.

Spawn git through safe-execa directly with the guard in the child
environment, keeping the single-retry policy of the ref-read call site.
The regression went unnoticed because the test mocked graceful-git and
asserted that the env option was handed to it, not that it reached git;
the mocks now sit on the process-spawn boundary and every invocation is
checked, so dropping the guard fails 25 tests.

The Rust runner sets the variable on the Command itself and was already
correct.

Fixes pnpm/pnpm#13522
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/13523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788078655&installation_model_id=426870&pr_number=13523&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F13523&signature=5d5431b1a372f94f1ad19f5be7ffb98f808aa7ee8ccbdf2acd04c7b85d1f0b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private Git repository resolution now fails fast with an authentication error instead of waiting for interactive credentials.
  * Git repository checks no longer trigger terminal prompts, preventing commands from hanging.
  * Git operations retry transient failures and report the final error when all attempts fail.
  * Improved reliability when probing private repositories and resolving branches, tags, and commits.
  * Git-based dependency resolution now behaves more predictably when authentication or repository access fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->